### PR TITLE
feat: add `x86_64-musl` and `aarch64-musl` release targets

### DIFF
--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -67,17 +67,31 @@ class Expanded:
 
 profile = os.environ.get("PROFILE")
 is_pr = os.environ.get("EVENT_NAME") == "pull_request"
-t_linux_x86_gnu = Target("ubuntu-latest", "x86_64-unknown-linux-gnu", "linux-amd64")
-t_linux_x86_musl = Target("ubuntu-latest", "x86_64-unknown-linux-musl", "linux-amd64")
+t_linux_x86 = [
+    Target("ubuntu-latest", "x86_64-unknown-linux-gnu", "linux-amd64"),
+    Target("ubuntu-latest", "x86_64-unknown-linux-musl", "linux-amd64"),
+]
+t_linux_arm = [
+    Target("ubuntu-latest", "aarch64-unknown-linux-gnu", "linux-aarch64"),
+    Target("ubuntu-latest", "aarch64-unknown-linux-musl", "linux-aarch64"),
+]
+# t_linux_x86_gnu = Target("ubuntu-latest", "x86_64-unknown-linux-gnu", "linux-amd64")
+# t_linux_x86_musl = Target("ubuntu-latest", "x86_64-unknown-linux-musl", "linux-amd64")
 # TODO: Figure out how to make this work
 # t_linux_arm = Target("ubuntu-latest", "aarch64-unknown-linux-gnu", "linux-aarch64")
 t_macos = Target("macos-latest", "aarch64-apple-darwin", "macosx-aarch64")
 t_windows = Target("windows-latest", "x86_64-pc-windows-msvc", "windows-amd64")
-targets = (
-    [t_linux_x86_gnu, t_linux_x86_musl, t_windows]
-    if is_pr
-    else [t_linux_x86_gnu, t_linux_x86_musl, t_macos, t_windows]
-)
+# targets = (
+#     [t_linux_x86_gnu, t_linux_x86_musl, t_windows]
+#     if is_pr
+#     else [t_linux_x86_gnu, t_linux_x86_musl, t_macos, t_windows]
+# )
+targets = t_linux_arm
+# targets = (
+#     [t_linux_x86_gnu, t_linux_x86_musl, t_windows]
+#     if is_pr
+#     else [t_linux_x86_gnu, t_linux_x86_musl, t_macos, t_windows]
+# )
 
 config = [
     Case(
@@ -113,8 +127,8 @@ def main():
         for case in config:
             if is_pr and (
                 not case.pr_cross_platform
-                and target != t_linux_x86_gnu
-                and target != t_linux_x86_musl
+                and target not in t_linux_arm
+                # and target != t_linux_x86_musl
             ):
                 continue
 

--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -67,31 +67,35 @@ class Expanded:
 
 profile = os.environ.get("PROFILE")
 is_pr = os.environ.get("EVENT_NAME") == "pull_request"
-t_linux_x86 = [
-    Target("ubuntu-latest", "x86_64-unknown-linux-gnu", "linux-amd64"),
-    Target("ubuntu-latest", "x86_64-unknown-linux-musl", "linux-amd64"),
-]
-t_linux_arm = [
-    Target("ubuntu-latest", "aarch64-unknown-linux-gnu", "linux-aarch64"),
-    Target("ubuntu-latest", "aarch64-unknown-linux-musl", "linux-aarch64"),
-]
-# t_linux_x86_gnu = Target("ubuntu-latest", "x86_64-unknown-linux-gnu", "linux-amd64")
-# t_linux_x86_musl = Target("ubuntu-latest", "x86_64-unknown-linux-musl", "linux-amd64")
-# TODO: Figure out how to make this work
-# t_linux_arm = Target("ubuntu-latest", "aarch64-unknown-linux-gnu", "linux-aarch64")
+
+# Linux targets
+# Defined here in a granular way for having easy management if required
+t_linux_x86_gnu = Target(
+    "ubuntu-latest", "x86_64-unknown-linux-gnu", "linux-amd64"
+)  # x86-gnu
+t_linux_x86_musl = Target(
+    "ubuntu-latest", "x86_64-unknown-linux-musl", "linux-amd64"
+)  # x86-musl
+t_linux_aarch64_gnu = Target(
+    "ubuntu-latest", "aarch64-unknown-linux-gnu", "linux-aarch64"
+)  # aarch64-gnu
+t_linux_aarch64_musl = Target(
+    "ubuntu-latest", "aarch64-unknown-linux-musl", "linux-aarch64"
+)  # aarch64-musl
+t_linux_x86 = [t_linux_x86_gnu, t_linux_x86_musl]  # all x86 linux targets
+t_linux_aarch64 = [
+    t_linux_aarch64_gnu,
+    t_linux_aarch64_musl,
+]  # all aarch64 linux targets
+t_linux = [*t_linux_x86, *t_linux_aarch64]  # all linux targets
+
+# MacOs targets
 t_macos = Target("macos-latest", "aarch64-apple-darwin", "macosx-aarch64")
+
+# Windows targets
 t_windows = Target("windows-latest", "x86_64-pc-windows-msvc", "windows-amd64")
-# targets = (
-#     [t_linux_x86_gnu, t_linux_x86_musl, t_windows]
-#     if is_pr
-#     else [t_linux_x86_gnu, t_linux_x86_musl, t_macos, t_windows]
-# )
-targets = t_linux_arm
-# targets = (
-#     [t_linux_x86_gnu, t_linux_x86_musl, t_windows]
-#     if is_pr
-#     else [t_linux_x86_gnu, t_linux_x86_musl, t_macos, t_windows]
-# )
+
+targets = [*t_linux, t_windows] if is_pr else [*t_linux, t_macos, t_windows]
 
 config = [
     Case(
@@ -125,11 +129,7 @@ def main():
     expanded = []
     for target in targets:
         for case in config:
-            if is_pr and (
-                not case.pr_cross_platform
-                and target not in t_linux_arm
-                # and target != t_linux_x86_musl
-            ):
+            if is_pr and (not case.pr_cross_platform and target not in t_linux):
                 continue
 
             for partition in range(1, case.n_partitions + 1):

--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -67,35 +67,12 @@ class Expanded:
 
 profile = os.environ.get("PROFILE")
 is_pr = os.environ.get("EVENT_NAME") == "pull_request"
-
-# Linux targets
-# Defined here in a granular way for having easy management if required
-t_linux_x86_gnu = Target(
-    "ubuntu-latest", "x86_64-unknown-linux-gnu", "linux-amd64"
-)  # x86-gnu
-t_linux_x86_musl = Target(
-    "ubuntu-latest", "x86_64-unknown-linux-musl", "linux-amd64"
-)  # x86-musl
-t_linux_aarch64_gnu = Target(
-    "ubuntu-latest", "aarch64-unknown-linux-gnu", "linux-aarch64"
-)  # aarch64-gnu
-t_linux_aarch64_musl = Target(
-    "ubuntu-latest", "aarch64-unknown-linux-musl", "linux-aarch64"
-)  # aarch64-musl
-t_linux_x86 = [t_linux_x86_gnu, t_linux_x86_musl]  # all x86 linux targets
-t_linux_aarch64 = [
-    t_linux_aarch64_gnu,
-    t_linux_aarch64_musl,
-]  # all aarch64 linux targets
-t_linux = [*t_linux_x86, *t_linux_aarch64]  # all linux targets
-
-# MacOs targets
+t_linux_x86 = Target("ubuntu-latest", "x86_64-unknown-linux-gnu", "linux-amd64")
+# TODO: Figure out how to make this work
+# t_linux_arm = Target("ubuntu-latest", "aarch64-unknown-linux-gnu", "linux-aarch64")
 t_macos = Target("macos-latest", "aarch64-apple-darwin", "macosx-aarch64")
-
-# Windows targets
 t_windows = Target("windows-latest", "x86_64-pc-windows-msvc", "windows-amd64")
-
-targets = [*t_linux, t_windows] if is_pr else [*t_linux, t_macos, t_windows]
+targets = [t_linux_x86, t_windows] if is_pr else [t_linux_x86, t_macos, t_windows]
 
 config = [
     Case(
@@ -129,7 +106,7 @@ def main():
     expanded = []
     for target in targets:
         for case in config:
-            if is_pr and (not case.pr_cross_platform and target not in t_linux):
+            if is_pr and (not case.pr_cross_platform and target != t_linux_x86):
                 continue
 
             for partition in range(1, case.n_partitions + 1):
@@ -143,7 +120,7 @@ def main():
                     s = f"{partition}/{case.n_partitions}"
                     name += f" ({s})"
                     flags += f" --partition count:{s}"
-
+                
                 if profile == "isolate":
                     flags += " --features=isolate-by-default"
                 name += os_str

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,17 @@ jobs:
             platform: linux
             arch: amd64
           - runner: Linux-20.04
+            target: x86_64-unknown-linux-musl
+            svm_target_platform: linux-amd64
+            platform: linux
+            arch: amd64
+          - runner: Linux-20.04
             target: aarch64-unknown-linux-gnu
+            svm_target_platform: linux-aarch64
+            platform: linux
+            arch: arm64
+          - runner: Linux-20.04
+            target: aarch64-unknown-linux-musl
             svm_target_platform: linux-aarch64
             platform: linux
             arch: arm64


### PR DESCRIPTION
## Motivation

Add binaries `x86_64-musl` and `aarch64-musl` targets.

Closes #9974 

## Solution

Add `musl` targets in release.yml file.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes