### PR TITLE
ci: pin vyper

### DIFF
--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           python-version: 3.11
       - name: Install Vyper
-        run: pip install vyper~=0.4.0
+        run: pip install vyper==0.4.0
 
       - name: Forge RPC cache
         uses: actions/cache@v3


### PR DESCRIPTION
CI is failing because test fixtures depend on vyper version.