### PR TITLE
Fix Grammar in Documentation and Improve Code Readability in evm.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ To use the latest pinned nightly locally, use the following command:
 foundryup --version nightly-e15e33a07c0920189fc336391f538c3dad53da73
 ````
 
-To use the latest pinned nightly on your CI, modify your Foundry installation step to use an specific version:
+To use the latest pinned nightly on your CI, modify your Foundry installation step to use a specific version:
 
 ```
 - name: Install Foundry

--- a/crates/anvil/src/evm.rs
+++ b/crates/anvil/src/evm.rs
@@ -76,6 +76,6 @@ mod tests {
             .any(|&addr| addr == PRECOMPILE_ADDR));
 
         let result = evm.transact().unwrap();
-        assert!(result.result.is_success());
+        assert!(result.is_success());
     }
 }


### PR DESCRIPTION
1. CHANGES IN CHANGELOG.md
Old:
"To use the latest pinned nightly on your CI, modify your Foundry installation step to use an specific version:"
New:
"To use the latest pinned nightly on your CI, modify your Foundry installation step to use a specific version:"
Reason for Change:
The phrase "an specific version" is grammatically incorrect. The correct form is "a specific version", as "specific" starts with a consonant sound.
2. CHANGES IN crates/anvil/src/evm.rs
Old:
assert!(result.result.is_success());
New:
assert!(result.is_success());
Reason for Change:
The previous code redundantly accessed result.result.is_success(), whereas result.is_success() is the correct and more concise way to check if the operation succeeded.
