### PR TITLE
fix(receipt): use `from` address

### DIFF
--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -879,6 +879,41 @@ revertReason         [..]Transaction too old, data: "0x08c379a000000000000000000
 "#]]);
 });
 
+// tests that the revert reason is loaded using the correct `from` address.
+casttest!(revert_reason_from, |_prj, cmd| {
+    let rpc = next_rpc_endpoint(NamedChain::Sepolia);
+    // https://sepolia.etherscan.io/tx/0x10ee70cf9f5ced5c515e8d53bfab5ea9f5c72cd61b25fba455c8355ee286c4e4
+    cmd.args([
+        "receipt",
+        "0x10ee70cf9f5ced5c515e8d53bfab5ea9f5c72cd61b25fba455c8355ee286c4e4",
+        "--rpc-url",
+        rpc.as_str(),
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+
+blockHash            0x32663d7730c9ea8e1de6d99854483e25fcc05bb56c91c0cc82f9f04944fbffc1
+blockNumber          7823353
+contractAddress      
+cumulativeGasUsed    7500797
+effectiveGasPrice    14296851013
+from                 0x3583fF95f96b356d716881C871aF7Eb55ea34a93
+gasUsed              25815
+logs                 []
+logsBloom            0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+root                 
+status               0 (failed)
+transactionHash      0x10ee70cf9f5ced5c515e8d53bfab5ea9f5c72cd61b25fba455c8355ee286c4e4
+transactionIndex     96
+type                 0
+blobGasPrice         
+blobGasUsed          
+to                   0x91b5d4111a4C038153b24e31F75ccdC47123595d
+revertReason         Counter is too large, data: "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000014436f756e74657220697320746f6f206c61726765000000000000000000000000"
+
+"#]]);
+});
+
 // tests that `cast --parse-bytes32-address` command is working correctly.
 casttest!(parse_bytes32_address, |_prj, cmd| {
     cmd.args([

--- a/crates/common/src/transactions.rs
+++ b/crates/common/src/transactions.rs
@@ -57,11 +57,10 @@ impl TransactionReceiptWithRevertReason {
             .ok_or_else(|| eyre::eyre!("transaction not found"))?;
 
         if let Some(block_hash) = self.receipt.block_hash {
-            match provider
-                .call(&transaction.inner.inner.into())
-                .block(BlockId::Hash(block_hash.into()))
-                .await
-            {
+            let mut call_request: WithOtherFields<TransactionRequest> =
+                transaction.inner.inner.clone().into();
+            call_request.set_from(transaction.inner.from);
+            match provider.call(&call_request).block(BlockId::Hash(block_hash.into())).await {
                 Err(e) => return Ok(extract_revert_reason(e.to_string())),
                 Ok(_) => eyre::bail!("no revert reason as transaction succeeded"),
             }


### PR DESCRIPTION
## Motivation
When calling `cast receipt`, the failure reason is generated via `eth_call`. However, the `from` address during this call is not correctly set to the one in the transaction. This leads to spurious "Ownable: caller is not the owner" errors, which do not represent the true failure reason for the transaction. 

## Solution

This PR fixes the above issue by setting  the `from` value correctly, before invoking `eth_call`. Included is a unit test for a transaction on Sepolia to demonstrate the difference. Without the PR, the revert reason was incorrectly reported as "Ownable: caller is not the owner" instead of the actual revert reason "Counter is too large".

## PR Checklist

- [x] Added Tests
~- [ ] Added Documentation~
~- [ ] Breaking changes~