### PR TITLE
fix(`ci`): clippy, allow result too large

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ redundant-clone = "warn"
 octal-escapes = "allow"
 # until <https://github.com/rust-lang/rust-clippy/issues/13885> is fixed
 literal-string-with-formatting-args = "allow"
+result_large_err = "allow"
 
 [workspace.lints.rust]
 rust-2018-idioms = "warn"

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -43,6 +43,7 @@ pub struct Params<T: Default> {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "method", content = "params"))]
+#[allow(clippy::large_enum_variant)]
 pub enum EthRequest {
     #[cfg_attr(feature = "serde", serde(rename = "web3_clientVersion", with = "empty_params"))]
     Web3ClientVersion(()),

--- a/crates/anvil/core/src/types.rs
+++ b/crates/anvil/core/src/types.rs
@@ -39,6 +39,7 @@ pub struct ReorgOptions {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[allow(clippy::large_enum_variant)]
 #[serde(untagged)]
 pub enum TransactionData {
     JSON(TransactionRequest),

--- a/crates/cast/bin/tx.rs
+++ b/crates/cast/bin/tx.rs
@@ -24,6 +24,7 @@ use serde_json::value::RawValue;
 use std::fmt::Write;
 
 /// Different sender kinds used by [`CastTxBuilder`].
+#[allow(clippy::large_enum_variant)]
 pub enum SenderKind<'a> {
     /// An address without signer. Used for read-only calls and transactions sent through unlocked
     /// accounts.

--- a/crates/doc/src/document.rs
+++ b/crates/doc/src/document.rs
@@ -80,6 +80,7 @@ impl Document {
 
 /// The content of the document.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum DocumentContent {
     Empty,
     Single(ParseItem),

--- a/crates/doc/src/parser/item.rs
+++ b/crates/doc/src/parser/item.rs
@@ -148,6 +148,7 @@ impl ParseItem {
 
 /// A wrapper type around pt token.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
 pub enum ParseSource {
     /// Source contract definition.
     Contract(Box<ContractDefinition>),

--- a/crates/evm/evm/src/executors/fuzz/types.rs
+++ b/crates/evm/evm/src/executors/fuzz/types.rs
@@ -36,6 +36,7 @@ pub struct CounterExampleOutcome {
 
 /// Outcome of a single fuzz
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum FuzzOutcome {
     Case(CaseOutcome),
     CounterExample(CounterExampleOutcome),

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -32,6 +32,7 @@ mod inspector;
 pub use inspector::Fuzzer;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum CounterExample {
     /// Call used as a counter example for fuzz tests.
     Single(BaseCounterExample),

--- a/crates/script-sequence/src/reader.rs
+++ b/crates/script-sequence/src/reader.rs
@@ -117,8 +117,7 @@ impl BroadcastReader {
                     let name_filter =
                         tx.contract_name.clone().is_some_and(|cn| cn == self.contract_name);
 
-                    let type_filter = self.tx_type.is_empty() ||
-                        self.tx_type.iter().any(|kind| *kind == tx.opcode);
+                    let type_filter = self.tx_type.is_empty() || self.tx_type.contains(&tx.opcode);
 
                     name_filter && type_filter
                 })
@@ -152,8 +151,7 @@ impl BroadcastReader {
                 let name_filter =
                     tx.contract_name.clone().is_some_and(|cn| cn == self.contract_name);
 
-                let type_filter =
-                    self.tx_type.is_empty() || self.tx_type.iter().any(|kind| *kind == tx.opcode);
+                let type_filter = self.tx_type.is_empty() || self.tx_type.contains(&tx.opcode);
 
                 name_filter && type_filter
             })


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Unblock CI due to breaking Clippy changes

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Applies Clippy fixes including suggestion for optimization

Adds `result_large_err = "allow"` to `Cargo.toml` as exception

Selectively applies `#[allow(clippy::large_enum_variant)]` where required, can be used later to look into for optimization - see https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes