### PR TITLE
fix: `forge script --verifier sourcify` is ignored when `ETHERSCAN_API_KEY` env var is defined

### DIFF
--- a/crates/forge/tests/cli/utils.rs
+++ b/crates/forge/tests/cli/utils.rs
@@ -109,6 +109,56 @@ impl EnvExternalities {
         })
     }
 
+    pub fn sepolia_etherscan() -> Option<Self> {
+        Some(Self {
+            chain: NamedChain::Sepolia,
+            rpc: network_rpc_key("sepolia")?,
+            pk: network_private_key("sepolia")?,
+            etherscan: etherscan_key(NamedChain::Sepolia)?,
+            verifier: "etherscan".to_string(),
+        })
+    }
+
+    pub fn sepolia_sourcify() -> Option<Self> {
+        Some(Self {
+            chain: NamedChain::Sepolia,
+            rpc: network_rpc_key("sepolia")?,
+            pk: network_private_key("sepolia")?,
+            etherscan: String::new(),
+            verifier: "sourcify".to_string(),
+        })
+    }
+    
+    pub fn sepolia_sourcify_with_etherscan_api_key_set() -> Option<Self> {
+        Some(Self {
+            chain: NamedChain::Sepolia,
+            rpc: network_rpc_key("sepolia")?,
+            pk: network_private_key("sepolia")?,
+            etherscan: etherscan_key(NamedChain::Sepolia)?,
+            verifier: "sourcify".to_string(),
+        })
+    }
+
+    pub fn sepolia_blockscout() -> Option<Self> {
+        Some(Self {
+            chain: NamedChain::Sepolia,
+            rpc: network_rpc_key("sepolia")?,
+            pk: network_private_key("sepolia")?,
+            etherscan: String::new(),
+            verifier: "blockscout".to_string(),
+        })
+    }
+    
+    pub fn sepolia_blockscout_with_etherscan_api_key_set() -> Option<Self> {
+        Some(Self {
+            chain: NamedChain::Sepolia,
+            rpc: network_rpc_key("sepolia")?,
+            pk: network_private_key("sepolia")?,
+            etherscan: etherscan_key(NamedChain::Sepolia)?,
+            verifier: "blockscout".to_string(),
+        })
+    }
+
     pub fn sepolia_empty_verifier() -> Option<Self> {
         Some(Self {
             chain: NamedChain::Sepolia,

--- a/crates/forge/tests/cli/utils.rs
+++ b/crates/forge/tests/cli/utils.rs
@@ -99,16 +99,6 @@ impl EnvExternalities {
         })
     }
 
-    pub fn sepolia() -> Option<Self> {
-        Some(Self {
-            chain: NamedChain::Sepolia,
-            rpc: network_rpc_key("sepolia")?,
-            pk: network_private_key("sepolia")?,
-            etherscan: etherscan_key(NamedChain::Sepolia)?,
-            verifier: "etherscan".to_string(),
-        })
-    }
-
     pub fn sepolia_etherscan() -> Option<Self> {
         Some(Self {
             chain: NamedChain::Sepolia,
@@ -128,7 +118,7 @@ impl EnvExternalities {
             verifier: "sourcify".to_string(),
         })
     }
-    
+
     pub fn sepolia_sourcify_with_etherscan_api_key_set() -> Option<Self> {
         Some(Self {
             chain: NamedChain::Sepolia,
@@ -148,7 +138,7 @@ impl EnvExternalities {
             verifier: "blockscout".to_string(),
         })
     }
-    
+
     pub fn sepolia_blockscout_with_etherscan_api_key_set() -> Option<Self> {
         Some(Self {
             chain: NamedChain::Sepolia,

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -274,6 +274,32 @@ forgetest!(can_create_verify_random_contract_sepolia, |prj, cmd| {
     create_verify_on_chain(EnvExternalities::sepolia(), prj, cmd);
 });
 
+// tests `create --verify --verifier etherscan` on Sepolia testnet
+forgetest!(can_verify_random_contract_sepolia_etherscan, |prj, cmd| {
+    verify_on_chain(EnvExternalities::sepolia_etherscan(), prj, cmd);
+});
+
+// tests `create --verify --verifier sourcify` on Sepolia testnet
+forgetest!(can_verify_random_contract_sepolia_sourcify, |prj, cmd| {
+    verify_on_chain(EnvExternalities::sepolia_sourcify(), prj, cmd);
+});
+
+// tests `create --verify --verifier sourcify` with etherscan api key set
+// <https://github.com/foundry-rs/foundry/issues/10000>
+forgetest!(can_verify_random_contract_sepolia_sourcify_with_etherscan_api_key_set, |prj, cmd| {
+    verify_on_chain(EnvExternalities::sepolia_sourcify_with_etherscan_api_key_set(), prj, cmd);
+});
+
+// tests `create --verify --verifier blockscout` on Sepolia testnet
+forgetest!(can_verify_random_contract_sepolia_blockscout, |prj, cmd| {
+    verify_on_chain(EnvExternalities::sepolia_blockscout(), prj, cmd);
+});
+
+// tests `create --verify --verifier blockscout` on Sepolia testnet with etherscan api key set
+forgetest!(can_verify_random_contract_sepolia_blockscout_with_etherscan_api_key_set, |prj, cmd| {
+    verify_on_chain(EnvExternalities::sepolia_blockscout_with_etherscan_api_key_set(), prj, cmd);
+});
+
 // tests `create && contract-verify --guess-constructor-args && verify-check` on Goerli testnet if
 // correct env vars are set
 forgetest!(can_guess_constructor_args, |prj, cmd| {

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -263,40 +263,37 @@ forgetest!(can_verify_random_contract_optimism_kovan, |prj, cmd| {
 
 // tests `create && contract-verify && verify-check` on Sepolia testnet if correct env vars are set
 forgetest!(can_verify_random_contract_sepolia, |prj, cmd| {
-    verify_on_chain(EnvExternalities::sepolia(), prj, cmd);
+    // Implicitly tests `--verifier etherscan` on Sepolia testnet
+    verify_on_chain(EnvExternalities::sepolia_etherscan(), prj, cmd);
 });
 
 // tests `create --verify on Sepolia testnet if correct env vars are set
 // SEPOLIA_RPC_URL=https://rpc.sepolia.org
 // TEST_PRIVATE_KEY=0x...
-// ETHERSCAN_API_KEY=
-forgetest!(can_create_verify_random_contract_sepolia, |prj, cmd| {
-    create_verify_on_chain(EnvExternalities::sepolia(), prj, cmd);
-});
-
-// tests `create --verify --verifier etherscan` on Sepolia testnet
-forgetest!(can_verify_random_contract_sepolia_etherscan, |prj, cmd| {
-    verify_on_chain(EnvExternalities::sepolia_etherscan(), prj, cmd);
+// ETHERSCAN_API_KEY=<API_KEY>
+forgetest!(can_create_verify_random_contract_sepolia_etherscan, |prj, cmd| {
+    // Implicitly tests `--verifier etherscan` on Sepolia testnet
+    create_verify_on_chain(EnvExternalities::sepolia_etherscan(), prj, cmd);
 });
 
 // tests `create --verify --verifier sourcify` on Sepolia testnet
-forgetest!(can_verify_random_contract_sepolia_sourcify, |prj, cmd| {
+forgetest!(can_create_verify_random_contract_sepolia_sourcify, |prj, cmd| {
     verify_on_chain(EnvExternalities::sepolia_sourcify(), prj, cmd);
 });
 
 // tests `create --verify --verifier sourcify` with etherscan api key set
 // <https://github.com/foundry-rs/foundry/issues/10000>
-forgetest!(can_verify_random_contract_sepolia_sourcify_with_etherscan_api_key_set, |prj, cmd| {
+forgetest!(can_create_verify_random_contract_sepolia_sourcify_with_etherscan_api_key_set, |prj, cmd| {
     verify_on_chain(EnvExternalities::sepolia_sourcify_with_etherscan_api_key_set(), prj, cmd);
 });
 
 // tests `create --verify --verifier blockscout` on Sepolia testnet
-forgetest!(can_verify_random_contract_sepolia_blockscout, |prj, cmd| {
+forgetest!(can_create_verify_random_contract_sepolia_blockscout, |prj, cmd| {
     verify_on_chain(EnvExternalities::sepolia_blockscout(), prj, cmd);
 });
 
 // tests `create --verify --verifier blockscout` on Sepolia testnet with etherscan api key set
-forgetest!(can_verify_random_contract_sepolia_blockscout_with_etherscan_api_key_set, |prj, cmd| {
+forgetest!(can_create_verify_random_contract_sepolia_blockscout_with_etherscan_api_key_set, |prj, cmd| {
     verify_on_chain(EnvExternalities::sepolia_blockscout_with_etherscan_api_key_set(), prj, cmd);
 });
 

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -170,25 +170,35 @@ pub enum VerificationProviderType {
 impl VerificationProviderType {
     /// Returns the corresponding `VerificationProvider` for the key
     pub fn client(&self, key: Option<&str>) -> Result<Box<dyn VerificationProvider>> {
-        if key.as_ref().is_some_and(|k| !k.is_empty()) && matches!(self, Self::Sourcify) {
+        // 1. If `--verifier sourcify` is set, always use Sourcify.
+        if matches!(self, Self::Sourcify) {
+            sh_println!(
+            "Attempting to verify on Sourcify. Pass the --etherscan-api-key <API_KEY> to verify on Etherscan, \
+            or use the --verifier flag to verify on another provider."
+        )?;
+            return Ok(Box::<SourcifyVerificationProvider>::default());
+        }
+
+        // 2. If `--verifier etherscan` is explicitly set, enforce the API key requirement.
+        if matches!(self, Self::Etherscan) {
+            if key.as_ref().is_none_or(|key| key.is_empty()) {
+                eyre::bail!("ETHERSCAN_API_KEY must be set to use Etherscan as a verifier")
+            }
             return Ok(Box::<EtherscanVerificationProvider>::default());
         }
-        match self {
-            Self::Etherscan => {
-                if key.as_ref().is_none_or(|key| key.is_empty()) {
-                    eyre::bail!("ETHERSCAN_API_KEY must be set")
-                }
-                Ok(Box::<EtherscanVerificationProvider>::default())
-            }
-            Self::Sourcify => {
-                sh_println!(
-                    "Attempting to verify on Sourcify, pass the --etherscan-api-key <API_KEY> to verify on Etherscan OR use the --verifier flag to verify on any other provider"
-                )?;
-                Ok(Box::<SourcifyVerificationProvider>::default())
-            }
-            Self::Blockscout => Ok(Box::<EtherscanVerificationProvider>::default()),
-            Self::Oklink => Ok(Box::<EtherscanVerificationProvider>::default()),
-            Self::Custom => Ok(Box::<EtherscanVerificationProvider>::default()),
+
+        // 3. If `--verifier blockscout | oklink | custom` is explicitly set, use the chosen
+        //    verifier.
+        if matches!(self, Self::Blockscout | Self::Oklink | Self::Custom) {
+            return Ok(Box::<EtherscanVerificationProvider>::default());
         }
+
+        // 4. If no `--verifier` is specified but `ETHERSCAN_API_KEY` is set, default to Etherscan.
+        if key.as_ref().is_some_and(|k| !k.is_empty()) {
+            return Ok(Box::<EtherscanVerificationProvider>::default());
+        }
+
+        // 5. If no valid provider is specified, bail.
+        eyre::bail!("No valid verification provider specified")
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/10000

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Reorders the way we check for the `--verifiers`:

If `--verifier` is passed explicitly we always use that specified verifier.
If `--verifier` is passed (excluding `etherscan`) and we have an `ETHERSCAN_API_KEY` defined in the environment we always use the specified identifier, ignoring the `ETHERSCAN_API_KEY`.
If `--verifier etherscan` is set, perform a hard check against whether the `ETHERSCAN_API_KEY` is set.
If no `--verifier` is specified but `ETHERSCAN_API_KEY` is set, default to Etherscan.

This should satisfy all conditions.

## PR Checklist

Manually tested against sandbox in https://github.com/foundry-rs/foundry/issues/10000 under different conditions

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes