### PR TITLE
fix(verfy): add blockscout exception for resp status 0 when contract not indexed

### DIFF
--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -102,9 +102,11 @@ impl VerificationProvider for EtherscanVerificationProvider {
                         return Ok(None)
                     }
 
-                    if resp.result.starts_with("Unable to locate ContractCode at") {
+                    if resp.result.starts_with("Unable to locate ContractCode at") ||
+                        resp.result.starts_with("The address is not a smart contract")
+                    {
                         warn!("{}", resp.result);
-                        return Err(eyre!("Etherscan could not detect the deployment."))
+                        return Err(eyre!("Could not detect the deployment."))
                     }
 
                     warn!("Failed verify submission: {:?}", resp);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #9976 
- blockscout chiado returns response with status 0 and err message "The address is not a smart contract", hence we don't retry but exit
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- retry if resp status 0 and "The address is not a smart contract" message
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes