### PR TITLE
fix(cast): clarify docs for the cast call --data flag

### DIFF
--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -38,7 +38,7 @@ pub struct CallArgs {
     /// The arguments of the function to call.
     args: Vec<String>,
 
-    /// Data for the transaction.
+    /// Raw hex-encoded data for the transaction. Used instead of [SIG] and [ARGS].
     #[arg(
         long,
         conflicts_with_all = &["sig", "args"]


### PR DESCRIPTION
## Motivation

The usage of `cast call --data` wasn't clear for me, probably for others too.

## Solution

Extended the docs.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes