### PR TITLE
feat(anvil): add eth_simulateV1 rpc call

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -4,6 +4,7 @@ use alloy_rpc_types::{
     anvil::{Forking, MineOptions},
     pubsub::{Params as SubscriptionParams, SubscriptionKind},
     request::TransactionRequest,
+    simulate::SimulatePayload,
     state::StateOverride,
     trace::{
         filter::TraceFilter,
@@ -183,6 +184,9 @@ pub enum EthRequest {
         #[cfg_attr(feature = "serde", serde(default))] Option<BlockId>,
         #[cfg_attr(feature = "serde", serde(default))] Option<StateOverride>,
     ),
+
+    #[cfg_attr(feature = "serde", serde(rename = "eth_simulateV1"))]
+    EthSimulateV1(SimulatePayload, #[cfg_attr(feature = "serde", serde(default))] Option<BlockId>),
 
     #[cfg_attr(feature = "serde", serde(rename = "eth_createAccessList"))]
     EthCreateAccessList(

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -96,9 +96,11 @@ use serde::Serialize;
 /// The client version: `anvil/v{major}.{minor}.{patch}`
 pub const CLIENT_VERSION: &str = concat!("anvil/v", env!("CARGO_PKG_VERSION"));
 
+// TODO: I feel like this enum should go somewhere more proper. Where would be best?
 #[derive(Serialize)]
+#[serde(untagged)]
 pub enum SimulatedBlockResponse {
-    AnvilInternal(Vec<SimulatedBlock<SerializableBlock>>),
+    AnvilInternal(Vec<SimulatedBlock<alloy_consensus::Header>>),
     Forked(Vec<SimulatedBlock<WithOtherFields<alloy_rpc_types::Block<WithOtherFields<alloy_rpc_types::Transaction<alloy_network::AnyTxEnvelope>>, alloy_rpc_types::Header<alloy_network::AnyHeader>>>>>)
 }
 

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1,5 +1,5 @@
 use super::{
-    backend::{db::SerializableBlock, mem::{state, BlockRequest, State}},
+    backend::mem::{state, BlockRequest, State},
     sign::build_typed_transaction,
 };
 use crate::{
@@ -30,7 +30,7 @@ use crate::{
     revm::primitives::{BlobExcessGasAndPrice, Output},
     ClientFork, LoggingManager, Miner, MiningMode, StorageInfo,
 };
-use alloy_consensus::{transaction::eip4844::TxEip4844Variant, Account};
+use alloy_consensus::{transaction::eip4844::TxEip4844Variant, Account, Header};
 use alloy_dyn_abi::TypedData;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_network::{
@@ -100,7 +100,7 @@ pub const CLIENT_VERSION: &str = concat!("anvil/v", env!("CARGO_PKG_VERSION"));
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum SimulatedBlockResponse {
-    AnvilInternal(Vec<SimulatedBlock<alloy_consensus::Header>>),
+    AnvilInternal(Vec<SimulatedBlock<alloy_rpc_types::Block<alloy_rpc_types::Transaction, Header>>>),
     Forked(Vec<SimulatedBlock<WithOtherFields<alloy_rpc_types::Block<WithOtherFields<alloy_rpc_types::Transaction<alloy_network::AnyTxEnvelope>>, alloy_rpc_types::Header<alloy_network::AnyHeader>>>>>)
 }
 

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -14,6 +14,7 @@ use alloy_provider::{
 };
 use alloy_rpc_types::{
     request::TransactionRequest,
+    simulate::{SimulatePayload, SimulatedBlock},
     trace::{
         geth::{GethDebugTracingOptions, GethTrace},
         parity::LocalizedTransactionTrace as Trace,
@@ -199,7 +200,23 @@ impl ClientFork {
         Ok(res)
     }
 
-    /// Sends `eth_call`
+    /// Sends `eth_simulateV1`
+    pub async fn simulate_v1(
+        &self,
+        request: &SimulatePayload,
+        block: Option<BlockNumber>,
+    ) -> Result<Vec<SimulatedBlock<WithOtherFields<alloy_rpc_types::Block<WithOtherFields<alloy_rpc_types::Transaction<alloy_network::AnyTxEnvelope>>, alloy_rpc_types::Header<alloy_network::AnyHeader>>>>>, TransportError> {
+        let mut simulate_call = self.provider().simulate(request);
+        if let Some(n) = block {
+            simulate_call = simulate_call.number(n.as_number().unwrap());
+        }
+
+        let res = simulate_call.await?;
+
+        Ok(res)
+    }
+
+    /// Sends `eth_estimateGas`
     pub async fn estimate_gas(
         &self,
         request: &WithOtherFields<TransactionRequest>,

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1492,13 +1492,15 @@ impl Backend {
                 pending_transaction: PendingTransaction::with_impersonated(
                                          build_typed_transaction(TypedTransactionRequest::EIP1559(TxEip1559 {
                                             nonce: t.nonce.unwrap_or_default(),
-                                            max_fee_per_gas: t.max_fee_per_gas.unwrap_or_default(),
+                                            // TODO: how to do gwei conversion? the number below
+                                            // for now should be 100 gwei
+                                            max_fee_per_gas: t.max_fee_per_gas.unwrap_or(100000000000),
                                             max_priority_fee_per_gas: t.max_priority_fee_per_gas.unwrap_or_default(),
-                                            gas_limit: t.gas.unwrap_or_default(),
-                                            value: t.value.unwrap_or(U256::ZERO),
+                                            gas_limit: t.gas.unwrap_or(30000000),
+                                            value: t.value.unwrap_or_default(),
                                             input: t.input.clone().into_input().unwrap_or_default(),
                                             to: t.to.unwrap_or_default(),
-                                            chain_id: 0,
+                                            chain_id: self.env.read().cfg.chain_id,
                                             access_list: t.access_list.clone().unwrap_or_default(),
                                          }), PrimitiveSignature::from_scalars_and_parity(
                 B256::with_last_byte(1),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

https://github.com/foundry-rs/foundry/issues/9593

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

A `simulate` function was added to the memory backend which calls upon the existing snapshot, revert, and block mining functionalities to replicate the behavior of `eth_simulateV1`. Alloy conveniently provides most of the needed types for `eth_simulateV1`, so its mostly just a matter of type conversion.

This is probably not the most efficient or beautiful solution, but for my surface level knowledge of the repo it seemed like a reasonable enough approach. Please let me know if there is some way better.

I am not a professional rust developer, so I probably did some unusual things. Please point out what I should do to improve!

Currently missing features of `eth_simulateV1` on this PR:
* ability to respond to block tag (I spent hours on this and couldn't figure out how to get the database memory management correct)
* 

Additional issues:
* When constructing the simulation, there are some issues that can occur:
   * If a transaction is "invalid" (ex. the account calling doesnt have enough eth for gas, or the base fee is too low, what is reccomended way to solve?)
   * If a `gas_limit` is not specified, what should be used as the gas limit? should it be auto set to the block max limit, or should the block gas limit be set higher somehow?
* Please see the TODOs throughout the repo on other things I ran into misc problems/questions about

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes