### PR TITLE
fix(docker): use cross main, build docker only on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,6 @@
 name: docker
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
-  schedule:
-    - cron: "0 0 * * *"
   # Trigger without any parameters a proactive rebuild
   workflow_dispatch: {}
   workflow_call:
@@ -22,7 +17,7 @@ env:
 jobs:
   build:
     name: build and push
-    runs-on: Linux-20.04
+    runs-on: Linux-22.04
     permissions:
       id-token: write
       packages: write
@@ -34,7 +29,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - uses: taiki-e/install-action@cross
+      - name: Install cross main
+        id: cross_main
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Login into registry ${{ env.REGISTRY }}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #10032 
- install cross main (using cargo) instead 0.2.5 (using taiki-e/install-action@cross) (see https://github.com/cross-rs/cross/issues/1639#issuecomment-2708228372) to prevent ring 0.17.13 crate issue https://github.com/briansmith/ring/issues/2463
- update docker runner to 22.04
- optimize CI runs, update docker workflow to be triggered only through release workflow or manually (no need to be individually scheduled)
- release from branch tested and passed in https://github.com/foundry-rs/foundry/actions/runs/13738406294

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes