### PR TITLE
doc: refactor Function case to use write_section method

### DIFF
--- a/crates/doc/src/writer/as_doc.rs
+++ b/crates/doc/src/writer/as_doc.rs
@@ -235,14 +235,8 @@ impl AsDoc for Document {
                     }
 
                     ParseSource::Function(func) => {
-                        // TODO: cleanup
-                        // Write function docs
-                        writer.writeln_doc(
-                            &item.comments.exclude_tags(&[CommentTag::Param, CommentTag::Return]),
-                        )?;
-
-                        // Write function header
-                        writer.write_code(&item.code)?;
+                        // Write function docs and code
+                        writer.write_section(&item.comments.exclude_tags(&[CommentTag::Param, CommentTag::Return]), &item.code)?;
 
                         // Write function parameter comments in a table
                         let params =


### PR DESCRIPTION
## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
In crates/doc/src/writer/as_doc.rs, there was a TODO comment in the ParseSource::Function case indicating that cleanup was needed. The implementation for this case used separate method calls for writing documentation and code, while other similar cases used the more concise write_section method.
This PR aims to improve code consistency and maintainability by standardizing the approach used across different parse source types.
## Solution
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
The solution replaces multiple method calls with a single call to write_section, which handles both writing documentation and code in one operation:
- Removed the TODO comment
- Replaced separate calls to writeln_doc and write_code with a single write_section call
- Maintained the exact same functionality
- Made the code more consistent with the patterns used for other parse source types in the same file

This change brings the Function case in line with the implementation pattern used for Struct, Event, Error, and other parse source types.

## PR Checklist
- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes