### PR TITLE
fix(forge): base url for verification providers other than etherscan

### DIFF
--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -138,6 +138,7 @@ impl VerifyBytecodeArgs {
         // Etherscan client
         let etherscan = EtherscanVerificationProvider.client(
             self.etherscan.chain.unwrap_or_default(),
+            &self.verifier.verifier,
             self.verifier.verifier_url.as_deref(),
             self.etherscan.key().as_deref(),
             &config,

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    provider::{VerificationContext, VerificationProvider},
+    provider::{VerificationContext, VerificationProvider, VerificationProviderType},
     retry::RETRY_CHECK_ON_VERIFY,
     verify::{VerifyArgs, VerifyCheckArgs},
 };
@@ -152,6 +152,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
         let config = args.load_config()?;
         let etherscan = self.client(
             args.etherscan.chain.unwrap_or_default(),
+            &args.verifier.verifier,
             args.verifier.verifier_url.as_deref(),
             args.etherscan.key().as_deref(),
             &config,
@@ -220,6 +221,7 @@ impl EtherscanVerificationProvider {
         let config = args.load_config()?;
         let etherscan = self.client(
             args.etherscan.chain.unwrap_or_default(),
+            &args.verifier.verifier,
             args.verifier.verifier_url.as_deref(),
             args.etherscan.key().as_deref(),
             &config,
@@ -251,6 +253,7 @@ impl EtherscanVerificationProvider {
     pub(crate) fn client(
         &self,
         chain: Chain,
+        verifier_type: &VerificationProviderType,
         verifier_url: Option<&str>,
         etherscan_key: Option<&str>,
         config: &Config,
@@ -275,10 +278,13 @@ impl EtherscanVerificationProvider {
         builder = if let Some(api_url) = api_url {
             // we don't want any trailing slashes because this can cause cloudflare issues: <https://github.com/foundry-rs/foundry/pull/6079>
             let api_url = api_url.trim_end_matches('/');
-            builder
-                .with_chain_id(chain)
-                .with_api_url(api_url)?
-                .with_url(base_url.unwrap_or(api_url))?
+            let base_url = if *verifier_type != VerificationProviderType::Etherscan {
+                // If verifier is not Etherscan then set base url as api url without trialing /api.
+                api_url.strip_prefix("/api").unwrap_or(api_url)
+            } else {
+                base_url.unwrap_or(api_url)
+            };
+            builder.with_chain_id(chain).with_api_url(api_url)?.with_url(base_url)?
         } else {
             builder.chain(chain)?
         };
@@ -384,6 +390,7 @@ impl EtherscanVerificationProvider {
         let provider = get_provider(&context.config)?;
         let client = self.client(
             args.etherscan.chain.unwrap_or_default(),
+            &args.verifier.verifier,
             args.verifier.verifier_url.as_deref(),
             args.etherscan.key.as_deref(),
             &context.config,
@@ -490,6 +497,7 @@ mod tests {
         let client = etherscan
             .client(
                 args.etherscan.chain.unwrap_or_default(),
+                &args.verifier.verifier,
                 args.verifier.verifier_url.as_deref(),
                 args.etherscan.key().as_deref(),
                 &config,
@@ -517,6 +525,7 @@ mod tests {
         let client = etherscan
             .client(
                 args.etherscan.chain.unwrap_or_default(),
+                &args.verifier.verifier,
                 args.verifier.verifier_url.as_deref(),
                 args.etherscan.key().as_deref(),
                 &config,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- address provider base url display issue from #10029 (https://github.com/foundry-rs/foundry/issues/10029#issuecomment-2708899816)
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes