### PR TITLE
feat: bump revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,10 +90,10 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1715ed2a977d3ca4b39ffe0fc69f9f5b0e81382b348bdb5172abaa77a10f0b6d"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "alloy-trie",
  "auto_impl",
  "c-kzg",
@@ -114,10 +114,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "660705969af143897d83937d73f53c741c1587f49c27c2cfce594e188fcbc1e4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "serde",
 ]
 
@@ -184,8 +184,6 @@ checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arbitrary",
- "rand 0.8.5",
  "serde",
 ]
 
@@ -197,11 +195,28 @@ checksum = "9b15b13d38b366d01e818fe8e710d4d702ef7499eacd44926a06171dd9585d0c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arbitrary",
  "k256",
- "rand 0.8.5",
  "serde",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5591581ca2ab0b3e7226a4047f9a1bfcf431da1d0cce3752fda609fea3c27e37"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.11.1",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "once_cell",
+ "serde",
 ]
 
 [[package]]
@@ -215,14 +230,30 @@ dependencies = [
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "auto_impl",
  "c-kzg",
  "derive_more 2.0.1",
  "either",
  "once_cell",
  "serde",
- "sha2",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-evm"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips 0.12.4",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "auto_impl",
+ "derive_more 1.0.0",
+ "op-revm",
+ "revm",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -231,11 +262,23 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "738b6d7da21955cfdebeb7bcf300040b79e51c58a22e5f029ae989a8d834a3f3"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "alloy-trie",
  "serde",
+]
+
+[[package]]
+name = "alloy-hardforks"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/hardforks?rev=ae4176c#ae4176c0027171d38832644f63f05f4f80861c6e"
+dependencies = [
+ "alloy-chains",
+ "alloy-eip2124",
+ "alloy-primitives",
+ "auto_impl",
+ "dyn-clone",
 ]
 
 [[package]]
@@ -272,13 +315,13 @@ checksum = "f10b0bc0657b018ee4f3758f889d066af6b1f20f57cd825b540182029090c151"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -297,9 +340,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cac4aeeabbbc16623d0745ae3b5a515d727ce8ef4ec4b6a886c3634d8b298fe"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "serde",
 ]
 
@@ -362,7 +405,7 @@ checksum = "d06ffafc44e68c8244feb51919895c679c153a0b143c182e1ffe8cce998abf15"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -476,7 +519,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "serde",
 ]
 
@@ -488,7 +531,7 @@ checksum = "2852d7350760c3fbfc60ee3396b95a66ea57afe3aeecee72bf1171ac6b1d5d18"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "serde",
 ]
 
@@ -500,7 +543,7 @@ checksum = "f726ebb03d5918a946d0a6e17829cabd90ffe928664dc3f7fdbba1be511760de"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 0.12.4",
 ]
 
 [[package]]
@@ -520,10 +563,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05bfe640e4708c5a83dfcc65b5e4a0deb6ddcb18897dd49862ddc3964e06ff8"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "derive_more 2.0.1",
  "jsonwebtoken",
  "rand 0.8.5",
@@ -539,11 +582,11 @@ checksum = "c24a3b6c552b74c4abdbaa45fd467a230f5564f62c6adae16972dd90b6b4dca5"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
@@ -559,7 +602,7 @@ checksum = "e25f16f6bfe65c23d873741aa343830de270db42c982822e23689d11f2f4d812"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -573,8 +616,19 @@ checksum = "9415e7e3f32a93a38ecb83aa449f7326081b5b362964291463f8f2060b4b8a31"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "serde",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8732058f5ca28c1d53d241e8504620b997ef670315d7c8afab856b3e3b80d945"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -978,7 +1032,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-genesis",
  "alloy-json-abi",
  "alloy-json-rpc",
@@ -989,7 +1043,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -1045,12 +1099,12 @@ version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "alloy-trie",
  "bytes",
  "foundry-common",
@@ -1240,6 +1294,12 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -1558,7 +1618,7 @@ dependencies = [
  "http 1.2.0",
  "once_cell",
  "percent-encoding",
- "sha2",
+ "sha2 0.10.8",
  "time",
  "tracing",
 ]
@@ -1804,6 +1864,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -1873,6 +1939,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,7 +1966,6 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
- "arbitrary",
  "serde",
 ]
 
@@ -1899,6 +1980,15 @@ dependencies = [
  "serde",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1953,7 +2043,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2",
+ "sha2 0.10.8",
  "tinyvec",
 ]
 
@@ -2073,7 +2163,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -2341,7 +2431,7 @@ dependencies = [
  "hmac",
  "k256",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "thiserror 1.0.69",
 ]
 
@@ -2357,7 +2447,7 @@ dependencies = [
  "once_cell",
  "pbkdf2 0.12.2",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.10.8",
  "thiserror 1.0.69",
 ]
 
@@ -2375,7 +2465,7 @@ dependencies = [
  "generic-array",
  "ripemd",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "sha3",
  "thiserror 1.0.69",
 ]
@@ -2811,6 +2901,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,7 +3024,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -3227,7 +3328,7 @@ dependencies = [
  "scrypt",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "sha3",
  "thiserror 1.0.69",
  "uuid 0.8.2",
@@ -3422,7 +3523,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-macro-expander",
@@ -3546,13 +3647,13 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-json-abi",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "alloy-signer",
  "clap",
  "dialoguer",
@@ -3641,7 +3742,7 @@ dependencies = [
  "itertools 0.14.0",
  "regex",
  "reqwest",
- "revm-primitives",
+ "revm-primitives 15.2.0",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -3742,7 +3843,7 @@ version = "1.0.0"
 dependencies = [
  "alloy-chains",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-provider",
@@ -3782,7 +3883,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-json-abi",
  "alloy-json-rpc",
  "alloy-network",
@@ -3791,7 +3892,7 @@ dependencies = [
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
@@ -3838,11 +3939,11 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "chrono",
  "comfy-table",
  "foundry-macros",
- "revm-primitives",
+ "revm-primitives 15.2.0",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -3874,7 +3975,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "solar-parse",
  "svm-rs",
  "svm-rs-builds",
@@ -3978,7 +4079,7 @@ dependencies = [
  "path-slash",
  "regex",
  "reqwest",
- "revm-primitives",
+ "revm-primitives 15.2.0",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -4058,6 +4159,7 @@ version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-json-abi",
  "alloy-network",
@@ -4156,8 +4258,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7beb856e73f59015823eb221a98b7c22b58bc4e7066c9c86774ebe74e61dd6"
+source = "git+https://github.com/foundry-rs/foundry-fork-db?rev=e60b89c#e60b89c09942eada380b9577a60d5655fbc40ff6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4857,6 +4958,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -5611,7 +5721,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2",
+ "sha2 0.10.8",
  "signature",
 ]
 
@@ -5734,6 +5844,52 @@ dependencies = [
  "bitflags 2.9.0",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
+dependencies = [
+ "arrayref",
+ "base64 0.13.1",
+ "digest 0.9.0",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.9.9",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -5899,7 +6055,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "shlex",
  "tempfile",
  "toml 0.5.11",
@@ -6348,10 +6504,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d297150146a63778a29400320700e804ec6e1e4d6ec99857cdbbaf17b3de9241"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "derive_more 1.0.0",
  "serde",
  "thiserror 2.0.12",
@@ -6364,16 +6520,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7095f87d34fc814e3de06a7af8ffff9121993f322231647f84df304821cc0275"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 0.12.4",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 0.12.4",
  "derive_more 1.0.0",
  "op-alloy-consensus",
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "op-revm"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0bce0ed6dd4f417e31ded4afa9dda6f9ee7c9c95c14f36f383f8bdc3af2356"
+dependencies = [
+ "auto_impl",
+ "once_cell",
+ "revm",
+ "serde",
+]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opener"
@@ -6426,7 +6600,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -6607,7 +6781,7 @@ checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
 dependencies = [
  "once_cell",
  "pest",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -6638,6 +6812,7 @@ checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
@@ -7421,16 +7596,118 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "19.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc5bef3c95fadf3b6a24a253600348380c169ef285f9780a793bb7090c8990d"
+version = "20.0.0-alpha.3"
+source = "git+https://github.com/bluealloy/revm?rev=9e39df5#9e39df5dbc5fdc98779c644629b28b8bee75794a"
+dependencies = [
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives 16.0.0-alpha.2",
+ "revm-state",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/bluealloy/revm?rev=9e39df5#9e39df5dbc5fdc98779c644629b28b8bee75794a"
+dependencies = [
+ "bitvec",
+ "phf",
+ "revm-primitives 16.0.0-alpha.2",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/bluealloy/revm?rev=9e39df5#9e39df5dbc5fdc98779c644629b28b8bee75794a"
 dependencies = [
  "auto_impl",
  "cfg-if",
- "dyn-clone",
- "once_cell",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-primitives 16.0.0-alpha.2",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/bluealloy/revm?rev=9e39df5#9e39df5dbc5fdc98779c644629b28b8bee75794a"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "revm-database-interface",
+ "revm-primitives 16.0.0-alpha.2",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/bluealloy/revm?rev=9e39df5#9e39df5dbc5fdc98779c644629b28b8bee75794a"
+dependencies = [
+ "alloy-eips 0.11.1",
+ "auto_impl",
+ "revm-bytecode",
+ "revm-database-interface",
+ "revm-primitives 16.0.0-alpha.2",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/bluealloy/revm?rev=9e39df5#9e39df5dbc5fdc98779c644629b28b8bee75794a"
+dependencies = [
+ "auto_impl",
+ "revm-primitives 16.0.0-alpha.2",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "1.0.0-alpha.3"
+source = "git+https://github.com/bluealloy/revm?rev=9e39df5#9e39df5dbc5fdc98779c644629b28b8bee75794a"
+dependencies = [
+ "auto_impl",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
  "revm-interpreter",
  "revm-precompile",
+ "revm-primitives 16.0.0-alpha.2",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "1.0.0-alpha.3"
+source = "git+https://github.com/bluealloy/revm?rev=9e39df5#9e39df5dbc5fdc98779c644629b28b8bee75794a"
+dependencies = [
+ "auto_impl",
+ "revm-context",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives 16.0.0-alpha.2",
+ "revm-state",
  "serde",
  "serde_json",
 ]
@@ -7438,8 +7715,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a43423d81f4bef634469bfb2d9ebe36a9ea9167f20ab3a7d1ff1e05fa63099"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=2a365e3#2a365e34e220a6273fbe3ea27eda3d7f1208f8de"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -7455,31 +7731,33 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "15.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcab7ef2064057acfc84731205f4bc77f4ec1b35630800b26ff6a185731c5ab"
+version = "16.0.0-alpha.3"
+source = "git+https://github.com/bluealloy/revm?rev=9e39df5#9e39df5dbc5fdc98779c644629b28b8bee75794a"
 dependencies = [
- "revm-primitives",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-primitives 16.0.0-alpha.2",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "16.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6caa1a7ff2cc4a09a263fcf9de99151706f323d30f33d519ed329f017a02b046"
+version = "17.0.0-alpha.3"
+source = "git+https://github.com/bluealloy/revm?rev=9e39df5#9e39df5dbc5fdc98779c644629b28b8bee75794a"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
  "c-kzg",
  "cfg-if",
  "k256",
+ "libsecp256k1",
  "once_cell",
  "p256",
- "revm-primitives",
+ "revm-context-interface",
+ "revm-primitives 16.0.0-alpha.2",
  "ripemd",
  "secp256k1",
- "sha2",
+ "sha2 0.10.8",
  "substrate-bn",
 ]
 
@@ -7495,11 +7773,30 @@ dependencies = [
  "auto_impl",
  "bitflags 2.9.0",
  "bitvec",
- "c-kzg",
  "cfg-if",
  "dyn-clone",
  "enumn",
  "hex",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "16.0.0-alpha.2"
+source = "git+https://github.com/bluealloy/revm?rev=9e39df5#9e39df5dbc5fdc98779c644629b28b8bee75794a"
+dependencies = [
+ "alloy-primitives",
+ "enumn",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/bluealloy/revm?rev=9e39df5#9e39df5dbc5fdc98779c644629b28b8bee75794a"
+dependencies = [
+ "bitflags 2.9.0",
+ "revm-bytecode",
+ "revm-primitives 16.0.0-alpha.2",
  "serde",
 ]
 
@@ -7920,7 +8217,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "salsa20",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -7956,10 +8253,11 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
+ "bitcoin_hashes",
  "rand 0.8.5",
  "secp256k1-sys",
 ]
@@ -8232,6 +8530,19 @@ name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
 
 [[package]]
 name = "sha2"
@@ -8583,7 +8894,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "thiserror 2.0.12",
  "tokio",
  "toml_edit",
@@ -8742,7 +9053,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "tempfile",
  "thiserror 2.0.12",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,16 +189,17 @@ foundry-linking = { path = "crates/linking" }
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.11.0", default-features = false }
 foundry-compilers = { version = "0.13.3", default-features = false }
-foundry-fork-db = "0.12"
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-fork-db", rev = "e60b89c" }
 solang-parser = "=0.3.3"
 solar-parse = { version = "=0.1.1", default-features = false }
 
 ## revm
-revm = { version = "19.4.0", default-features = false }
+revm = { version = "20.0.0-alpha.3", default-features = false }
 revm-primitives = { version = "15.1.0", default-features = false }
 revm-inspectors = { version = "0.16.0", features = ["serde"] }
 
 ## alloy
+alloy-evm = { path = "../evm/crates/evm" }
 alloy-consensus = { version = "0.12.1", default-features = false }
 alloy-contract = { version = "0.12.1", default-features = false }
 alloy-eips = { version = "0.12.1", default-features = false }
@@ -316,6 +317,8 @@ vergen = { version = "8", default-features = false }
 yansi = { version = "1.0", features = ["detect-tty", "detect-env"] }
 
 [patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "9e39df5" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "2a365e3" }
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
 # alloy-json-abi = { path = "../../alloy-rs/core/crates/json-abi" }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -33,7 +33,7 @@ use foundry_evm_core::{
     abi::Vm::stopExpectSafeMemoryCall,
     backend::{DatabaseError, DatabaseExt, RevertDiagnostic},
     constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME},
-    utils::new_evm_with_existing_context,
+    utils::new_evm_with_context,
     InspectorExt,
 };
 use foundry_evm_traces::{TracingInspector, TracingInspectorConfig};
@@ -161,7 +161,7 @@ where
         l1_block_info,
     };
 
-    let mut evm = new_evm_with_existing_context(inner, &mut *inspector);
+    let mut evm = new_evm_with_context(inner, &mut *inspector);
 
     let res = f(&mut evm)?;
 
@@ -1368,7 +1368,7 @@ impl Inspector<&mut dyn DatabaseExt> for Cheatcodes {
                             outcome.result.output = error.abi_encode().into();
                             outcome
                         }
-                    }
+                    };
                 } else {
                     // Call didn't revert, reset `assume_no_revert` state.
                     self.assume_no_revert = None;
@@ -1820,7 +1820,7 @@ impl Cheatcodes {
         let (key, target_address) = if interpreter.current_opcode() == op::SLOAD {
             (try_or_return!(interpreter.stack().peek(0)), interpreter.contract().target_address)
         } else {
-            return
+            return;
         };
 
         let Ok(value) = ecx.sload(target_address, key) else {

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -19,6 +19,7 @@ foundry-common.workspace = true
 foundry-config.workspace = true
 foundry-evm-abi.workspace = true
 
+alloy-evm.workspace = true
 alloy-dyn-abi = { workspace = true, features = ["arbitrary", "eip712"] }
 alloy-genesis.workspace = true
 alloy-json-abi.workspace = true
@@ -43,7 +44,6 @@ revm = { workspace = true, features = [
     "optional_block_gas_limit",
     "optional_no_base_fee",
     "arbitrary",
-    "optimism",
     "c-kzg",
     "blst",
 ] }

--- a/crates/evm/core/src/backend/error.rs
+++ b/crates/evm/core/src/backend/error.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::Address;
 pub use foundry_fork_db::{DatabaseError, DatabaseResult};
-use revm::primitives::EVMError;
-use std::convert::Infallible;
+use revm::context::result::EVMError;
+use std::{convert::Infallible, fmt::Display};
 
 pub type BackendResult<T> = Result<T, BackendError>;
 
@@ -53,8 +53,8 @@ impl From<Infallible> for BackendError {
 }
 
 // Note: this is mostly necessary to use some revm internals that return an [EVMError]
-impl<T: Into<Self>> From<EVMError<T>> for BackendError {
-    fn from(err: EVMError<T>) -> Self {
+impl<T: Into<Self>, TxError: Display> From<EVMError<T, TxError>> for BackendError {
+    fn from(err: EVMError<T, TxError>) -> Self {
         match err {
             EVMError::Database(err) => err.into(),
             EVMError::Custom(err) => Self::msg(err),

--- a/crates/evm/core/src/backend/in_memory_db.rs
+++ b/crates/evm/core/src/backend/in_memory_db.rs
@@ -4,8 +4,9 @@ use crate::state_snapshot::StateSnapshots;
 use alloy_primitives::{Address, B256, U256};
 use foundry_fork_db::DatabaseError;
 use revm::{
-    db::{CacheDB, DatabaseRef, EmptyDB},
-    primitives::{Account, AccountInfo, Bytecode, HashMap as Map},
+    database::{CacheDB, DatabaseRef, EmptyDB},
+    primitives::HashMap as Map,
+    state::{Account, AccountInfo, Bytecode},
     Database, DatabaseCommit,
 };
 

--- a/crates/evm/core/src/backend/snapshot.rs
+++ b/crates/evm/core/src/backend/snapshot.rs
@@ -1,9 +1,8 @@
 use alloy_primitives::{map::AddressHashMap, B256, U256};
-use revm::{
-    primitives::{AccountInfo, Env, HashMap},
-    JournaledState,
-};
+use revm::{context::JournalInit, primitives::HashMap, state::AccountInfo, Journal};
 use serde::{Deserialize, Serialize};
+
+use crate::Env;
 
 /// A minimal abstraction of a state at a certain point in time
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -18,14 +17,14 @@ pub struct StateSnapshot {
 pub struct BackendStateSnapshot<T> {
     pub db: T,
     /// The journaled_state state at a specific point
-    pub journaled_state: JournaledState,
+    pub journaled_state: JournalInit,
     /// Contains the env at the time of the snapshot
     pub env: Env,
 }
 
 impl<T> BackendStateSnapshot<T> {
     /// Takes a new state snapshot.
-    pub fn new(db: T, journaled_state: JournaledState, env: Env) -> Self {
+    pub fn new(db: T, journaled_state: JournalInit, env: Env) -> Self {
         Self { db, journaled_state, env }
     }
 
@@ -36,7 +35,7 @@ impl<T> BackendStateSnapshot<T> {
     /// those logs that are missing in the snapshot's journaled_state, since the current
     /// journaled_state includes the same logs, we can simply replace use that See also
     /// `DatabaseExt::revert`.
-    pub fn merge(&mut self, current: &JournaledState) {
+    pub fn merge<DB>(&mut self, current: &Journal<DB>) {
         self.journaled_state.logs.clone_from(&current.logs);
     }
 }

--- a/crates/evm/core/src/buffer.rs
+++ b/crates/evm/core/src/buffer.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::U256;
-use revm::interpreter::opcode;
+use revm::bytecode::opcode;
 
 /// Used to keep track of which buffer is currently active to be drawn by the debugger.
 #[derive(Debug, PartialEq)]

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -1,0 +1,61 @@
+use alloy_evm::EvmEnv;
+use revm::{
+    context::{BlockEnv, CfgEnv, ContextTr, JournalTr, TxEnv},
+    Context, Database,
+};
+
+/// Helper container type for [`EvmEnv`] and [`TxEnv`].
+#[derive(Clone, Debug, Default)]
+pub struct Env {
+    pub evm_env: EvmEnv,
+    pub tx: TxEnv,
+}
+
+/// Helper struct with mutable references to the block and cfg environments.
+pub struct EnvMut<'a> {
+    pub block: &'a mut BlockEnv,
+    pub cfg: &'a mut CfgEnv,
+    pub tx: &'a mut TxEnv,
+}
+
+impl EnvMut<'_> {
+    /// Returns a copy of the environment.
+    pub fn to_owned(&self) -> Env {
+        Env {
+            evm_env: EvmEnv { cfg_env: self.cfg.to_owned(), block_env: self.block.to_owned() },
+            tx: self.tx.to_owned(),
+        }
+    }
+}
+
+pub trait AsEnvMut {
+    fn as_env_mut(&mut self) -> EnvMut<'_>;
+}
+
+impl AsEnvMut for EnvMut<'_> {
+    fn as_env_mut(&mut self) -> EnvMut<'_> {
+        EnvMut {
+            block: self.block,
+            cfg: self.cfg,
+            tx: self.tx,
+        }
+    }
+}
+
+impl AsEnvMut for Env {
+    fn as_env_mut(&mut self) -> EnvMut<'_> {
+        EnvMut {
+            block: &mut self.evm_env.block_env,
+            cfg: &mut self.evm_env.cfg_env,
+            tx: &mut self.tx,
+        }
+    }
+}
+
+impl<DB: Database, J: JournalTr<Database = DB>, C> AsEnvMut
+    for Context<BlockEnv, TxEnv, CfgEnv, DB, J, C>
+{
+    fn as_env_mut(&mut self) -> EnvMut<'_> {
+        EnvMut { block: &mut self.block, cfg: &mut self.cfg, tx: &mut self.tx }
+    }
+}

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -1,11 +1,12 @@
-use crate::utils::apply_chain_and_block_specific_env_changes;
+use crate::{utils::apply_chain_and_block_specific_env_changes, Env};
 use alloy_consensus::BlockHeader;
+use alloy_evm::EvmEnv;
 use alloy_primitives::{Address, U256};
 use alloy_provider::{network::BlockResponse, Network, Provider};
 use alloy_rpc_types::BlockNumberOrTag;
 use eyre::WrapErr;
 use foundry_common::NON_ARCHIVE_NODE_WARNING;
-use revm::primitives::{BlockEnv, CfgEnv, Env, TxEnv};
+use revm::context::{BlockEnv, CfgEnv, TxEnv};
 
 /// Initializes a REVM block environment based on a forked
 /// ethereum provider.
@@ -57,20 +58,22 @@ pub async fn environment<N: Network, P: Provider<N>>(
     cfg.disable_block_gas_limit = disable_block_gas_limit;
 
     let mut env = Env {
-        cfg,
-        block: BlockEnv {
-            number: U256::from(block.header().number()),
-            timestamp: U256::from(block.header().timestamp()),
-            coinbase: block.header().beneficiary(),
-            difficulty: block.header().difficulty(),
-            prevrandao: block.header().mix_hash(),
-            basefee: U256::from(block.header().base_fee_per_gas().unwrap_or_default()),
-            gas_limit: U256::from(block.header().gas_limit()),
-            ..Default::default()
+        evm_env: EvmEnv {
+            cfg_env: cfg,
+            block_env: BlockEnv {
+                number: block.header().number(),
+                timestamp: block.header().timestamp(),
+                beneficiary: block.header().beneficiary(),
+                difficulty: block.header().difficulty(),
+                prevrandao: block.header().mix_hash(),
+                basefee: block.header().base_fee_per_gas().unwrap_or_default(),
+                gas_limit: block.header().gas_limit(),
+                ..Default::default()
+            },
         },
         tx: TxEnv {
             caller: origin,
-            gas_price: U256::from(gas_price.unwrap_or(fork_gas_price)),
+            gas_price: gas_price.unwrap_or(fork_gas_price),
             chain_id: Some(override_chain_id.unwrap_or(rpc_chain_id)),
             gas_limit: block.header().gas_limit() as u64,
             ..Default::default()

--- a/crates/evm/core/src/fork/mod.rs
+++ b/crates/evm/core/src/fork/mod.rs
@@ -1,5 +1,5 @@
+use crate::Env;
 use super::opts::EvmOpts;
-use revm::primitives::Env;
 
 mod init;
 pub use init::environment;

--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -3,6 +3,8 @@
 //! The design is similar to the single `SharedBackend`, `BackendHandler` but supports multiple
 //! concurrently active pairs at once.
 
+use crate::Env;
+
 use super::CreateFork;
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{map::HashMap, U256};
@@ -16,7 +18,6 @@ use futures::{
     task::{Context, Poll},
     Future, FutureExt, StreamExt,
 };
-use revm::primitives::Env;
 use std::{
     fmt::{self, Write},
     pin::Pin,
@@ -150,7 +151,7 @@ impl MultiFork {
     }
 
     /// Updates block number and timestamp of given fork with new values.
-    pub fn update_block(&self, fork: ForkId, number: U256, timestamp: U256) -> eyre::Result<()> {
+    pub fn update_block(&self, fork: ForkId, number: u64, timestamp: u64) -> eyre::Result<()> {
         trace!(?fork, ?number, ?timestamp, "update fork block");
         self.handler
             .clone()
@@ -200,7 +201,7 @@ enum Request {
     /// Returns the environment of the fork.
     GetEnv(ForkId, GetEnvSender),
     /// Updates the block number and timestamp of the fork.
-    UpdateBlock(ForkId, U256, U256),
+    UpdateBlock(ForkId, u64, u64),
     /// Shutdowns the entire `MultiForkHandler`, see `ShutDownMultiFork`
     ShutDown(OneshotSender<()>),
     /// Returns the Fork Url for the `ForkId` if it exists.
@@ -302,10 +303,10 @@ impl MultiForkHandler {
 
     /// Update fork block number and timestamp. Used to preserve values set by `roll` and `warp`
     /// cheatcodes when new fork selected.
-    fn update_block(&mut self, fork_id: ForkId, block_number: U256, block_timestamp: U256) {
+    fn update_block(&mut self, fork_id: ForkId, block_number: u64, block_timestamp: u64) {
         if let Some(fork) = self.forks.get_mut(&fork_id) {
-            fork.opts.env.block.number = block_number;
-            fork.opts.env.block.timestamp = block_timestamp;
+            fork.opts.env.block_env.number = block_number;
+            fork.opts.env.block_env.timestamp = block_timestamp;
         }
     }
 
@@ -519,18 +520,16 @@ async fn create_fork(mut fork: CreateFork) -> eyre::Result<(ForkId, CreatedFork,
     // Initialise the fork environment.
     let (env, block) = fork.evm_opts.fork_evm_env(&fork.url).await?;
     fork.env = env;
-    let meta = BlockchainDbMeta::new(fork.env.clone(), fork.url.clone());
+    let chain_id = env.cfg_env.chain_id;
+    let meta = BlockchainDbMeta::new(fork.env.block_env.clone(), fork.url.clone());
 
     // We need to use the block number from the block because the env's number can be different on
     // some L2s (e.g. Arbitrum).
     let number = block.header().number();
 
     // Determine the cache path if caching is enabled.
-    let cache_path = if fork.enable_caching {
-        Config::foundry_block_cache_dir(meta.cfg_env.chain_id, number)
-    } else {
-        None
-    };
+    let cache_path =
+        if fork.enable_caching { Config::foundry_block_cache_dir(chain_id, number) } else { None };
 
     let db = BlockchainDb::new(meta, cache_path);
     let (backend, handler) = SharedBackend::new(provider, db, Some(number.into()));

--- a/crates/evm/core/src/ic.rs
+++ b/crates/evm/core/src/ic.rs
@@ -1,9 +1,6 @@
 use alloy_primitives::map::rustc_hash::FxHashMap;
 use eyre::Result;
-use revm::interpreter::{
-    opcode::{PUSH0, PUSH1, PUSH32},
-    OpCode,
-};
+use revm::bytecode::opcode::{OpCode, PUSH0, PUSH1, PUSH32};
 use revm_inspectors::opcode::immediate_size;
 use serde::Serialize;
 
@@ -117,7 +114,7 @@ pub fn decode_instructions(code: &[u8]) -> Result<Vec<Instruction<'_>>> {
     while pc < code.len() {
         let op = OpCode::new(code[pc]);
         pc += 1;
-        let immediate_size = op.map(|op| immediate_size(op, &code[pc..])).unwrap_or(0) as usize;
+        let immediate_size = op.map(|op| op.info().immediate_size()).unwrap_or(0) as usize;
 
         if pc + immediate_size > code.len() {
             eyre::bail!("incomplete sequence of bytecode");

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -6,10 +6,11 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 use crate::constants::DEFAULT_CREATE2_DEPLOYER;
+use alloy_evm::eth::EthEvmContext;
 use alloy_primitives::Address;
 use auto_impl::auto_impl;
 use backend::DatabaseExt;
-use revm::{inspectors::NoOpInspector, interpreter::CreateInputs, EvmContext, Inspector};
+use revm::{inspector::NoOpInspector, interpreter::CreateInputs, EvmContext, Inspector};
 use revm_inspectors::access_list::AccessListInspector;
 
 #[macro_use]
@@ -26,24 +27,27 @@ pub mod backend;
 pub mod buffer;
 pub mod constants;
 pub mod decode;
+pub mod env;
 pub mod fork;
 pub mod opcodes;
 pub mod opts;
 pub mod precompiles;
 pub mod state_snapshot;
 pub mod utils;
+pub use env::*;
+use utils::FoundryEvmCtx;
 
 /// An extension trait that allows us to add additional hooks to Inspector for later use in
 /// handlers.
 #[auto_impl(&mut, Box)]
-pub trait InspectorExt: for<'a> Inspector<&'a mut dyn DatabaseExt> {
+pub trait InspectorExt: for<'a> Inspector<FoundryEvmCtx<'a>> {
     /// Determines whether the `DEFAULT_CREATE2_DEPLOYER` should be used for a CREATE2 frame.
     ///
     /// If this function returns true, we'll replace CREATE2 frame with a CALL frame to CREATE2
     /// factory.
     fn should_use_create2_factory(
         &mut self,
-        _context: &mut EvmContext<&mut dyn DatabaseExt>,
+        _context: &mut FoundryEvmCtx,
         _inputs: &mut CreateInputs,
     ) -> bool {
         false

--- a/crates/evm/core/src/opcodes.rs
+++ b/crates/evm/core/src/opcodes.rs
@@ -1,6 +1,6 @@
 //! Opcode utils
 
-use revm::interpreter::OpCode;
+use revm::bytecode::opcode::OpCode;
 
 /// Returns true if the opcode modifies memory.
 /// <https://bluealloy.github.io/revm/crates/interpreter/memory.html#opcodes>

--- a/crates/evm/core/src/precompiles.rs
+++ b/crates/evm/core/src/precompiles.rs
@@ -1,8 +1,5 @@
 use alloy_primitives::{address, Address, Bytes, B256};
-use revm::{
-    precompile::{secp256r1::p256_verify as revm_p256_verify, PrecompileWithAddress},
-    primitives::{Precompile, PrecompileResult},
-};
+use revm::precompile::{secp256r1::p256_verify as revm_p256_verify, PrecompileResult, PrecompileWithAddress};
 
 /// The ECRecover precompile address.
 pub const EC_RECOVER: Address = address!("0000000000000000000000000000000000000001");
@@ -70,4 +67,4 @@ pub fn p256_verify(input: &Bytes, gas_limit: u64) -> PrecompileResult {
 
 /// [EIP-7212](https://eips.ethereum.org/EIPS/eip-7212#specification) secp256r1 precompile.
 pub const ODYSSEY_P256: PrecompileWithAddress =
-    PrecompileWithAddress(ODYSSEY_P256_ADDRESS, Precompile::Standard(p256_verify));
+    PrecompileWithAddress(ODYSSEY_P256_ADDRESS, p256_verify);

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -1,30 +1,35 @@
 pub use crate::ic::*;
 use crate::{
     backend::DatabaseExt, constants::DEFAULT_CREATE2_DEPLOYER_CODEHASH, precompiles::ODYSSEY_P256,
-    InspectorExt,
+    AsEnvMut, Env, EnvMut, InspectorExt,
 };
 use alloy_consensus::BlockHeader;
+use alloy_evm::{eth::EthEvmContext, EvmEnv};
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_network::{AnyTxEnvelope, TransactionResponse};
-use alloy_primitives::{Address, Selector, TxKind, B256, U256};
+use alloy_primitives::{Address, Bytes, Selector, TxKind, B256, U256};
 use alloy_provider::{network::BlockResponse, Network};
 use alloy_rpc_types::{Transaction, TransactionRequest};
 use foundry_common::is_impersonated_tx;
 use foundry_config::NamedChain;
 use foundry_fork_db::DatabaseError;
 use revm::{
-    handler::register::EvmHandler,
-    interpreter::{
-        return_ok, CallInputs, CallOutcome, CallScheme, CallValue, CreateInputs, CreateOutcome,
-        Gas, InstructionResult, InterpreterResult,
+    context::{result::EVMError, ContextTr, Evm, EvmData},
+    handler::{
+        instructions::EthInstructions, register::EvmHandler, EthFrame, EthPrecompiles, Frame,
+        PrecompileProvider,
     },
-    precompile::secp256r1::P256VERIFY,
+    interpreter::{
+        interpreter::EthInterpreter, return_ok, CallInputs, CallOutcome, CallScheme, CallValue,
+        CreateInputs, CreateOutcome, FrameInput, Gas, InstructionResult, InterpreterResult,
+    },
+    precompile::{secp256r1::P256VERIFY, PrecompileError},
     primitives::{CreateScheme, EVMError, HandlerCfg, SpecId, KECCAK_EMPTY},
-    FrameOrResult, FrameResult,
+    FrameOrResult, FrameResult, Journal, MainBuilder,
 };
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
-pub use revm::primitives::EvmState as StateChangeset;
+pub use revm::state::EvmState as StateChangeset;
 
 /// Depending on the configured chain id and block number this should apply any specific changes
 ///
@@ -33,10 +38,11 @@ pub use revm::primitives::EvmState as StateChangeset;
 ///
 /// Should be called with proper chain id (retrieved from provider if not provided).
 pub fn apply_chain_and_block_specific_env_changes<N: Network>(
-    env: &mut revm::primitives::Env,
+    env: &mut impl AsEnvMut,
     block: &N::BlockResponse,
 ) {
     use NamedChain::*;
+    let env = env.as_env_mut();
     if let Ok(chain) = NamedChain::try_from(env.cfg.chain_id) {
         let block_number = block.header().number();
 
@@ -75,7 +81,7 @@ pub fn apply_chain_and_block_specific_env_changes<N: Network>(
                         serde_json::from_value::<U256>(l1_block_number).ok()
                     })
                 {
-                    env.block.number = l1_block_number;
+                    env.block.number = l1_block_number.to();
                 }
             }
             _ => {}
@@ -101,10 +107,10 @@ pub fn get_function<'a>(
 
 /// Configures the env for the given RPC transaction.
 /// Accounts for an impersonated transaction by resetting the `env.tx.caller` field to `tx.from`.
-pub fn configure_tx_env(env: &mut revm::primitives::Env, tx: &Transaction<AnyTxEnvelope>) {
+pub fn configure_tx_env(mut env: impl AsEnvMut, tx: &Transaction<AnyTxEnvelope>) {
     let impersonated_from = is_impersonated_tx(&tx.inner).then_some(tx.from());
     if let AnyTxEnvelope::Ethereum(tx) = &tx.inner.inner() {
-        configure_tx_req_env(env, &tx.clone().into(), impersonated_from).expect("cannot fail");
+        configure_tx_req_env(env.as_env_mut(), &tx.clone().into(), impersonated_from).expect("cannot fail");
     }
 }
 
@@ -112,7 +118,7 @@ pub fn configure_tx_env(env: &mut revm::primitives::Env, tx: &Transaction<AnyTxE
 /// `impersonated_from` is the address of the impersonated account. This helps account for an
 /// impersonated transaction by resetting the `env.tx.caller` field to `impersonated_from`.
 pub fn configure_tx_req_env(
-    env: &mut revm::primitives::Env,
+    env: EnvMut<'_>,
     tx: &TransactionRequest,
     impersonated_from: Option<Address>,
 ) -> eyre::Result<()> {
@@ -136,7 +142,7 @@ pub fn configure_tx_req_env(
     } = *tx;
 
     // If no `to` field then set create kind: https://eips.ethereum.org/EIPS/eip-2470#deployment-transaction
-    env.tx.transact_to = to.unwrap_or(TxKind::Create);
+    env.tx.kind = to.unwrap_or(TxKind::Create);
     // If the transaction is impersonated, we need to set the caller to the from
     // address Ref: https://github.com/foundry-rs/foundry/issues/9541
     env.tx.caller =
@@ -148,15 +154,15 @@ pub fn configure_tx_req_env(
     env.tx.chain_id = chain_id;
 
     // Type 1, EIP-2930
-    env.tx.access_list = access_list.clone().unwrap_or_default().0.into_iter().collect();
+    env.tx.access_list = access_list.clone().unwrap_or_default();
 
     // Type 2, EIP-1559
-    env.tx.gas_price = U256::from(gas_price.or(max_fee_per_gas).unwrap_or_default());
-    env.tx.gas_priority_fee = max_priority_fee_per_gas.map(U256::from);
+    env.tx.gas_price = gas_price.or(max_fee_per_gas).unwrap_or_default();
+    env.tx.gas_priority_fee = max_priority_fee_per_gas;
 
     // Type 3, EIP-4844
     env.tx.blob_hashes = blob_versioned_hashes.clone().unwrap_or_default();
-    env.tx.max_fee_per_blob_gas = max_fee_per_blob_gas.map(U256::from);
+    env.tx.max_fee_per_blob_gas = max_fee_per_blob_gas.unwrap_or_default();
 
     // Type 4, EIP-7702
     if let Some(authorization_list) = authorization_list {
@@ -241,7 +247,7 @@ pub fn create2_handler_register<I: InspectorExt>(
                         gas: Gas::new(gas_limit),
                     },
                     memory_offset: 0..0,
-                })))
+                })));
             } else if code_hash != DEFAULT_CREATE2_DEPLOYER_CODEHASH {
                 return Ok(FrameOrResult::Result(FrameResult::Call(CallOutcome {
                     result: InterpreterResult {
@@ -250,7 +256,7 @@ pub fn create2_handler_register<I: InspectorExt>(
                         gas: Gas::new(gas_limit),
                     },
                     memory_offset: 0..0,
-                })))
+                })));
             }
 
             // Handle potential inspector override.
@@ -306,65 +312,118 @@ pub fn create2_handler_register<I: InspectorExt>(
         });
 }
 
-/// Adds Odyssey P256 precompile to the list of loaded precompiles.
-pub fn odyssey_handler_register<EXT, DB: revm::Database>(handler: &mut EvmHandler<'_, EXT, DB>) {
-    let prev = handler.pre_execution.load_precompiles.clone();
-    handler.pre_execution.load_precompiles = Arc::new(move || {
-        let mut loaded_precompiles = prev();
-
-        loaded_precompiles.extend([ODYSSEY_P256, P256VERIFY]);
-
-        loaded_precompiles
-    });
+/// [`PrecompileProvider`] wrapper that enables [`P256VERIFY`] if `odyssey` is enabled.
+pub struct MaybeOdysseyPrecompiles {
+    inner: EthPrecompiles,
+    odyssey: bool,
 }
+
+impl MaybeOdysseyPrecompiles {
+    /// Creates a new instance of the [`MaybeOdysseyPrecompiles`].
+    pub fn new(odyssey: bool) -> Self {
+        Self { inner: EthPrecompiles::default(), odyssey }
+    }
+}
+
+impl<CTX: ContextTr> PrecompileProvider<CTX> for MaybeOdysseyPrecompiles {
+    type Output = InterpreterResult;
+
+    fn set_spec(&mut self, spec: <<CTX as ContextTr>::Cfg as revm::context::Cfg>::Spec) {
+        PrecompileProvider::<CTX>::set_spec(&mut self.inner, spec);
+    }
+
+    fn run(
+        &mut self,
+        context: &mut CTX,
+        address: &Address,
+        bytes: &Bytes,
+        gas_limit: u64,
+    ) -> Result<Option<Self::Output>, revm::precompile::PrecompileError> {
+        if self.odyssey && address == P256VERIFY {
+            let mut result = InterpreterResult {
+                result: InstructionResult::Return,
+                gas: Gas::new(gas_limit),
+                output: Bytes::new(),
+            };
+
+            match P256VERIFY.precompile()(bytes, gas_limit) {
+                Ok(output) => {
+                    let underflow = result.gas.record_cost(output.gas_used);
+                    result.result = InstructionResult::Return;
+                    result.output = output.bytes;
+                }
+                Err(e) => {
+                    if let PrecompileError::Fatal(_) = e {
+                        return Err(e);
+                    }
+                    result.result = if e.is_oog() {
+                        InstructionResult::PrecompileOOG
+                    } else {
+                        InstructionResult::PrecompileError
+                    };
+                }
+            }
+        }
+
+        self.inner.run(context, address, bytes, gas_limit)
+    }
+
+    fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
+        if self.odyssey {
+            Box::new(*self.inner.warm_addresses().chain(core::iter::once(P256VERIFY.address())))
+        } else {
+            self.inner.warm_addresses()
+        }
+    }
+
+    fn contains(&self, address: &Address) -> bool {
+        if self.odyssey && address == P256VERIFY {
+            true
+        } else {
+            self.inner.contains(address)
+        }
+    }
+}
+
+/// [`revm::Context`] type used by Foundry.
+pub type FoundryEvmCtx<'a> = EthEvmContext<&'a mut dyn DatabaseExt>;
+
+/// Type alias for revm's EVM used by Foundry.
+pub type FoundryEvm<'db, INSP> = Evm<
+    FoundryEvmCtx<'db>,
+    INSP,
+    EthInstructions<EthInterpreter, FoundryEvmCtx<'db>>,
+    MaybeOdysseyPrecompiles,
+>;
 
 /// Creates a new EVM with the given inspector.
 pub fn new_evm_with_inspector<'evm, 'i, 'db, I: InspectorExt + ?Sized>(
     db: &'db mut dyn DatabaseExt,
-    env: revm::primitives::EnvWithHandlerCfg,
+    env: Env,
     inspector: &'i mut I,
-) -> revm::Evm<'evm, &'i mut I, &'db mut dyn DatabaseExt> {
-    let revm::primitives::EnvWithHandlerCfg { env, handler_cfg } = env;
-
-    // NOTE: We could use `revm::Evm::builder()` here, but on the current patch it has some
-    // performance issues.
-    /*
-    revm::Evm::builder()
-        .with_db(db)
-        .with_env(env)
-        .with_external_context(inspector)
-        .with_handler_cfg(handler_cfg)
-        .append_handler_register(revm::inspector_handle_register)
-        .append_handler_register(create2_handler_register)
-        .build()
-    */
-
-    let mut handler = revm::Handler::new(handler_cfg);
-    handler.append_handler_register_plain(revm::inspector_handle_register);
-    if inspector.is_odyssey() {
-        handler.append_handler_register_plain(odyssey_handler_register);
-    }
-    handler.append_handler_register_plain(create2_handler_register);
-
-    let context = revm::Context::new(revm::EvmContext::new_with_env(db, env), inspector);
-
-    revm::Evm::new(context, handler)
+) -> FoundryEvm<'db, &'i mut I> {
+    new_evm_with_context(
+        FoundryEvmCtx {
+            journaled_state: Journal::new(env.evm_env.cfg_env.spec, db),
+            block: env.evm_env.block_env,
+            cfg: env.evm_env.cfg_env,
+            tx: env.tx,
+            chain: (),
+            error: Ok(()),
+        },
+        inspector,
+    )
 }
 
-pub fn new_evm_with_existing_context<'a>(
-    inner: revm::InnerEvmContext<&'a mut dyn DatabaseExt>,
-    inspector: &'a mut dyn InspectorExt,
-) -> revm::Evm<'a, &'a mut dyn InspectorExt, &'a mut dyn DatabaseExt> {
-    let handler_cfg = HandlerCfg::new(inner.spec_id());
-
-    let mut handler = revm::Handler::new(handler_cfg);
-    handler.append_handler_register_plain(revm::inspector_handle_register);
-    if inspector.is_odyssey() {
-        handler.append_handler_register_plain(odyssey_handler_register);
-    }
+pub fn new_evm_with_context<'db, 'i, I: InspectorExt + ?Sized>(
+    ctx: FoundryEvmCtx<'db>,
+    inspector: &'i mut I,
+) -> FoundryEvm<'db, &'i mut I> {
     handler.append_handler_register_plain(create2_handler_register);
 
-    let context =
-        revm::Context::new(revm::EvmContext { inner, precompiles: Default::default() }, inspector);
-    revm::Evm::new(context, handler)
+    Evm {
+        data: EvmData { ctx, inspector },
+        instruction: EthInstructions::default(),
+        precompiles: MaybeOdysseyPrecompiles::new(inspector.is_odyssey()),
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Bumps revm to https://github.com/bluealloy/revm/commit/9e39df5dbc5fdc98779c644629b28b8bee75794a

Depends on https://github.com/foundry-rs/foundry-fork-db/pull/44, https://github.com/paradigmxyz/revm-inspectors/pull/246

## Solution

At this point this PR only partially migrates `foundry-evm-core` crate. The most impactful change is that `Evm` type is not longer present. Instead block. cfg and tx envs are stored along with transactions on a larget `Context` type which also holds db and journal and thus not very nice to pass around.

This PR addresses this by re-introducing `Env` type internally, and the mutable borrowing of `Env` is solved via a helper `EnvMut`: https://github.com/foundry-rs/foundry/blob/664809e96035e370c3d25118a98f262b308eae40/crates/evm/core/src/env.rs#L7-L33

The idea here is to avoid migrating entire codebase to completely new environment types and refactor this later if we see a nicer approach.

Another big blocker is changed `JournaledState` structure which we don't have decision on yet. I've partially updated code to use `JournalInit` but this approach is likely not sound for some cases.


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes