### PR TITLE
fix(forge): use etherscan verifier if key provided

### DIFF
--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -278,8 +278,14 @@ impl EtherscanVerificationProvider {
         builder = if let Some(api_url) = api_url {
             // we don't want any trailing slashes because this can cause cloudflare issues: <https://github.com/foundry-rs/foundry/pull/6079>
             let api_url = api_url.trim_end_matches('/');
-            let base_url = if *verifier_type != VerificationProviderType::Etherscan {
-                // If verifier is not Etherscan then set base url as api url without trialing /api.
+
+            // Verifier is etherscan if explicitly set or if no verifier set (default sourcify) but
+            // API key passed.
+            let is_etherscan = matches!(verifier_type, VerificationProviderType::Etherscan) ||
+                (matches!(verifier_type, VerificationProviderType::Sourcify) &&
+                    etherscan_key.is_some());
+            let base_url = if !is_etherscan {
+                // If verifier is not Etherscan then set base url as api url without /api suffix.
                 api_url.strip_prefix("/api").unwrap_or(api_url)
             } else {
                 base_url.unwrap_or(api_url)

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -281,9 +281,8 @@ impl EtherscanVerificationProvider {
 
             // Verifier is etherscan if explicitly set or if no verifier set (default sourcify) but
             // API key passed.
-            let is_etherscan = matches!(verifier_type, VerificationProviderType::Etherscan) ||
-                (matches!(verifier_type, VerificationProviderType::Sourcify) &&
-                    etherscan_key.is_some());
+            let is_etherscan = verifier_type.is_etherscan() ||
+                (verifier_type.is_sourcify() && etherscan_key.is_some());
             let base_url = if !is_etherscan {
                 // If verifier is not Etherscan then set base url as api url without /api suffix.
                 api_url.strip_prefix("/api").unwrap_or(api_url)

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -170,8 +170,9 @@ pub enum VerificationProviderType {
 impl VerificationProviderType {
     /// Returns the corresponding `VerificationProvider` for the key
     pub fn client(&self, key: Option<&str>) -> Result<Box<dyn VerificationProvider>> {
-        // 1. If `--verifier sourcify` is set, always use Sourcify.
-        if matches!(self, Self::Sourcify) {
+        let has_key = key.as_ref().is_some_and(|k| !k.is_empty());
+        // 1. If `--verifier sourcify` is set and no API key provided, use Sourcify.
+        if !has_key && matches!(self, Self::Sourcify) {
             sh_println!(
             "Attempting to verify on Sourcify. Pass the --etherscan-api-key <API_KEY> to verify on Etherscan, \
             or use the --verifier flag to verify on another provider."
@@ -181,7 +182,7 @@ impl VerificationProviderType {
 
         // 2. If `--verifier etherscan` is explicitly set, enforce the API key requirement.
         if matches!(self, Self::Etherscan) {
-            if key.as_ref().is_none_or(|key| key.is_empty()) {
+            if !has_key {
                 eyre::bail!("ETHERSCAN_API_KEY must be set to use Etherscan as a verifier")
             }
             return Ok(Box::<EtherscanVerificationProvider>::default());
@@ -194,7 +195,7 @@ impl VerificationProviderType {
         }
 
         // 4. If no `--verifier` is specified but `ETHERSCAN_API_KEY` is set, default to Etherscan.
-        if key.as_ref().is_some_and(|k| !k.is_empty()) {
+        if has_key {
             return Ok(Box::<EtherscanVerificationProvider>::default());
         }
 

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -171,8 +171,8 @@ impl VerificationProviderType {
     /// Returns the corresponding `VerificationProvider` for the key
     pub fn client(&self, key: Option<&str>) -> Result<Box<dyn VerificationProvider>> {
         let has_key = key.as_ref().is_some_and(|k| !k.is_empty());
-        // 1. If `--verifier sourcify` is set and no API key provided, use Sourcify.
-        if !has_key && matches!(self, Self::Sourcify) {
+        // 1. If no verifier or `--verifier sourcify` is set and no API key provided, use Sourcify.
+        if !has_key && self.is_sourcify() {
             sh_println!(
             "Attempting to verify on Sourcify. Pass the --etherscan-api-key <API_KEY> to verify on Etherscan, \
             or use the --verifier flag to verify on another provider."
@@ -181,7 +181,7 @@ impl VerificationProviderType {
         }
 
         // 2. If `--verifier etherscan` is explicitly set, enforce the API key requirement.
-        if matches!(self, Self::Etherscan) {
+        if self.is_etherscan() {
             if !has_key {
                 eyre::bail!("ETHERSCAN_API_KEY must be set to use Etherscan as a verifier")
             }
@@ -201,5 +201,13 @@ impl VerificationProviderType {
 
         // 5. If no valid provider is specified, bail.
         eyre::bail!("No valid verification provider specified. Pass the --verifier flag to specify a provider or set the ETHERSCAN_API_KEY environment variable to use Etherscan as a verifier.")
+    }
+
+    pub fn is_sourcify(&self) -> bool {
+        matches!(self, Self::Sourcify)
+    }
+
+    pub fn is_etherscan(&self) -> bool {
+        matches!(self, Self::Etherscan)
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #10056  : since Sourcify is default now it should check also if an API Key was provided. If so, then should not verify on Sourcify but continue checking and will eventually be set as etherscan
- the test suites (that deploy and verify contracts) are not performed by CI as they need private keys, so should be run locally (might look into running them with gh secrets as part of CI but would add additional time and effort to manage those accounts)
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes