### PR TITLE
feat(anvil): add genesis number to configuration and update related structures

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -331,6 +331,17 @@ Genesis Timestamp
             self.get_genesis_timestamp().green()
         );
 
+        let _ = write!(
+            s,
+            r#"
+Genesis Number
+==================
+
+{}
+"#,
+            self.get_genesis_number().green()
+        );
+
         s
     }
 
@@ -652,6 +663,11 @@ impl NodeConfig {
             self.genesis_timestamp = Some(timestamp.into());
         }
         self
+    }
+
+    /// Returns the genesis number
+    pub fn get_genesis_number(&self) -> u64 {
+        self.genesis.as_ref().and_then(|g| g.number).unwrap_or(0)
     }
 
     /// Sets the hardfork
@@ -1033,6 +1049,7 @@ impl NodeConfig {
         }
 
         let genesis = GenesisConfig {
+            number: self.get_genesis_number(),
             timestamp: self.get_genesis_timestamp(),
             balance: self.genesis_balance,
             accounts: self.genesis_accounts.iter().map(|acc| acc.address()).collect(),

--- a/crates/anvil/src/eth/backend/genesis.rs
+++ b/crates/anvil/src/eth/backend/genesis.rs
@@ -12,6 +12,8 @@ use tokio::sync::RwLockWriteGuard;
 /// Genesis settings
 #[derive(Clone, Debug, Default)]
 pub struct GenesisConfig {
+    /// The initial number for the genesis block
+    pub number: u64,
     /// The initial timestamp for the genesis block
     pub timestamp: u64,
     /// Balance for genesis accounts

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -241,7 +241,7 @@ impl Backend {
                 env.handler_cfg.spec_id,
                 fees.is_eip1559().then(|| fees.base_fee()),
                 genesis.timestamp,
-                genesis.number
+                genesis.number,
             )
         };
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -241,6 +241,7 @@ impl Backend {
                 env.handler_cfg.spec_id,
                 fees.is_eip1559().then(|| fees.base_fee()),
                 genesis.timestamp,
+                genesis.number
             )
         };
 

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -271,7 +271,13 @@ pub struct BlockchainStorage {
 
 impl BlockchainStorage {
     /// Creates a new storage with a genesis block
-    pub fn new(env: &Env, spec_id: SpecId, base_fee: Option<u64>, timestamp: u64) -> Self {
+    pub fn new(
+        env: &Env,
+        spec_id: SpecId,
+        base_fee: Option<u64>,
+        timestamp: u64,
+        genesis_number: u64,
+    ) -> Self {
         let is_shanghai = spec_id >= SpecId::SHANGHAI;
         let is_cancun = spec_id >= SpecId::CANCUN;
         let is_prague = spec_id >= SpecId::PRAGUE;
@@ -294,7 +300,7 @@ impl BlockchainStorage {
         let block = Block::new::<MaybeImpersonatedTransaction>(partial_header, vec![]);
         let genesis_hash = block.header.hash_slow();
         let best_hash = genesis_hash;
-        let best_number: U64 = U64::from(0u64);
+        let best_number: U64 = U64::from(genesis_number);
 
         let mut blocks = B256HashMap::default();
         blocks.insert(genesis_hash, block);
@@ -440,10 +446,20 @@ pub struct Blockchain {
 
 impl Blockchain {
     /// Creates a new storage with a genesis block
-    pub fn new(env: &Env, spec_id: SpecId, base_fee: Option<u64>, timestamp: u64) -> Self {
+    pub fn new(
+        env: &Env,
+        spec_id: SpecId,
+        base_fee: Option<u64>,
+        timestamp: u64,
+        genesis_number: u64,
+    ) -> Self {
         Self {
             storage: Arc::new(RwLock::new(BlockchainStorage::new(
-                env, spec_id, base_fee, timestamp,
+                env,
+                spec_id,
+                base_fee,
+                timestamp,
+                genesis_number,
             ))),
         }
     }

--- a/crates/anvil/tests/it/genesis.rs
+++ b/crates/anvil/tests/it/genesis.rs
@@ -30,7 +30,7 @@ async fn can_apply_genesis() {
       "balance": "0xffffffffffffffffffffffffff"
     }
   },
-  "number": "0x0",
+  "number": 73,
   "gasUsed": "0x0",
   "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
 }
@@ -47,4 +47,7 @@ async fn can_apply_genesis() {
 
     let expected: U256 = U256::from_str_radix("ffffffffffffffffffffffffff", 16).unwrap();
     assert_eq!(balance, expected);
+
+    let block_number = provider.get_block_number().await.unwrap();
+    assert_eq!(block_number, 73u64);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes https://github.com/foundry-rs/foundry/issues/10080 by setting the genesis block number from the genesis.json file correctly

## Solution

- Introduced `genesis.number` in `GenesisConfig` to store the genesis block number.
- Added `get_genesis_number` method to retrieve the genesis number.
- Updated `setup` function to initialize the genesis number.
- Modified `BlockchainStorage` and `Blockchain` constructors to accept and utilize the genesis number.
- Adjusted tests to reflect the new genesis number functionality.

## PR Checklist

- [x] Added Tests (more like edited the existing ones)
- [ ] Added Documentation
- [ ] Breaking changes