### PR TITLE
chore: revert musl release until fixed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,17 +95,7 @@ jobs:
             platform: linux
             arch: amd64
           - runner: Linux-20.04
-            target: x86_64-unknown-linux-musl
-            svm_target_platform: linux-amd64
-            platform: linux
-            arch: amd64
-          - runner: Linux-20.04
             target: aarch64-unknown-linux-gnu
-            svm_target_platform: linux-aarch64
-            platform: linux
-            arch: arm64
-          - runner: Linux-20.04
-            target: aarch64-unknown-linux-musl
             svm_target_platform: linux-aarch64
             platform: linux
             arch: arm64


### PR DESCRIPTION

This reverts commit ef4553e2041fb7a74081a55b295185e6ac38368e.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- revert musl until fixed and tested
- closes #10082
- musl fails with cargo build due to missing deps but can be built with cross as in https://github.com/foundry-rs/foundry/commit/da8202c4a24d4902272f7121e47103513618bdd0
- release should be treated differently as they upload same `foundry_nightly_linux_amd64` archive as for gnu

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes