### PR TITLE
fix(`forge test --debug`): do not panic when user specifies both `--match-path` and `<PATH>` , bail instead

### DIFF
--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -274,7 +274,7 @@ impl CoverageArgs {
 
         let known_contracts = runner.known_contracts.clone();
 
-        let filter = self.test.filter(&config);
+        let filter = self.test.filter(&config)?;
         let outcome = self.test.run_tests(runner, config, verbosity, &filter, output).await?;
 
         outcome.ensure_ok(false)?;

--- a/crates/forge/bin/cmd/watch.rs
+++ b/crates/forge/bin/cmd/watch.rs
@@ -263,7 +263,7 @@ pub async fn watch_gas_snapshot(args: GasSnapshotArgs) -> Result<()> {
 /// test`
 pub async fn watch_test(args: TestArgs) -> Result<()> {
     let config: Config = args.build.load_config()?;
-    let filter = args.filter(&config);
+    let filter = args.filter(&config)?;
     // Marker to check whether to override the command.
     let no_reconfigure = filter.args().test_pattern.is_some() ||
         filter.args().path_pattern.is_some() ||


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/10079

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Related: https://github.com/foundry-rs/book/pull/1477

Instead of panicking we instead should bail cleanly

```
Error: Can not supply both --match-path and |path|
```

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes