### PR TITLE
feat(`cast`): make unsigned raw txs

### DIFF
--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1110,6 +1110,32 @@ casttest!(mktx_signer_from_match, |_prj, cmd| {
 "#]]);
 });
 
+casttest!(mktx_raw_unsigned, |_prj, cmd| {
+    cmd.args([
+        "mktx",
+        "--from",
+        "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+        "--chain",
+        "1",
+        "--nonce",
+        "0",
+        "--gas-limit",
+        "21000",
+        "--gas-price",
+        "10000000000",
+        "--priority-gas-price",
+        "1000000000",
+        "0x0000000000000000000000000000000000000001",
+        "--raw-unsigned",
+    ])
+    .assert_success()
+    .stdout_eq(str![[
+        r#"0x02e80180843b9aca008502540be4008252089400000000000000000000000000000000000000018080c0
+
+"#
+    ]]);
+});
+
 // tests that the raw encoded transaction is returned
 casttest!(tx_raw, |_prj, cmd| {
     let rpc = next_http_rpc_endpoint();

--- a/crates/forge/bin/cmd/bind_json.rs
+++ b/crates/forge/bin/cmd/bind_json.rs
@@ -104,7 +104,7 @@ impl BindJsonArgs {
                 let ast = parser.parse_file().map_err(|e| e.emit())?;
 
                 let mut visitor = PreprocessorVisitor::new();
-                visitor.visit_source_unit(&ast);
+                let _ = visitor.visit_source_unit(&ast);
                 visitor.update(&sess, &mut content);
 
                 source.content = Arc::new(content);

--- a/crates/forge/bin/cmd/geiger.rs
+++ b/crates/forge/bin/cmd/geiger.rs
@@ -129,7 +129,7 @@ fn try_lint_file(
     let mut parser = solar_parse::Parser::from_file(sess, &arena, path)?;
     let ast = parser.parse_file().map_err(|e| e.emit())?;
     let mut visitor = Visitor::new(sess, unsafe_cheatcodes);
-    visitor.visit_source_unit(&ast);
+    let _ = visitor.visit_source_unit(&ast);
     Ok(visitor.count)
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #9741 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Add `--raw-unsigned` flag to `mktx`
- If `--raw-unsigned` flag is provided, it relaxes the signer requirement but still requires `--from` to correctly build unsigned tx.
- Returns RLP-encoded unsigned tx

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes