### PR TITLE
chore: remove experimental from cheatcodes

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -721,7 +721,7 @@
         ]
       },
       "group": "evm",
-      "status": "experimental",
+      "status": "stable",
       "safety": "unsafe"
     },
     {
@@ -3581,7 +3581,7 @@
         ]
       },
       "group": "evm",
-      "status": "experimental",
+      "status": "stable",
       "safety": "unsafe"
     },
     {
@@ -3601,7 +3601,7 @@
         ]
       },
       "group": "evm",
-      "status": "experimental",
+      "status": "stable",
       "safety": "unsafe"
     },
     {
@@ -6687,7 +6687,7 @@
         ]
       },
       "group": "evm",
-      "status": "experimental",
+      "status": "stable",
       "safety": "unsafe"
     },
     {
@@ -10553,7 +10553,7 @@
         ]
       },
       "group": "evm",
-      "status": "experimental",
+      "status": "stable",
       "safety": "unsafe"
     },
     {

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -549,23 +549,23 @@ interface Vm {
     function store(address target, bytes32 slot, bytes32 value) external;
 
     /// Marks the slots of an account and the account address as cold.
-    #[cheatcode(group = Evm, safety = Unsafe, status = Experimental)]
+    #[cheatcode(group = Evm, safety = Unsafe)]
     function cool(address target) external;
 
     /// Utility cheatcode to set an EIP-2930 access list for all subsequent transactions.
-    #[cheatcode(group = Evm, safety = Unsafe, status = Experimental)]
+    #[cheatcode(group = Evm, safety = Unsafe)]
     function accessList(AccessListItem[] calldata accessList) external;
 
     /// Utility cheatcode to remove any EIP-2930 access list set by `accessList` cheatcode.
-    #[cheatcode(group = Evm, safety = Unsafe, status = Experimental)]
+    #[cheatcode(group = Evm, safety = Unsafe)]
     function noAccessList() external;
 
     /// Utility cheatcode to mark specific storage slot as warm, simulating a prior read.
-    #[cheatcode(group = Evm, safety = Unsafe, status = Experimental)]
+    #[cheatcode(group = Evm, safety = Unsafe)]
     function warmSlot(address target, bytes32 slot) external;
 
     /// Utility cheatcode to mark specific storage slot as cold, simulating no prior read.
-    #[cheatcode(group = Evm, safety = Unsafe, status = Experimental)]
+    #[cheatcode(group = Evm, safety = Unsafe)]
     function coolSlot(address target, bytes32 slot) external;
 
     // -------- Call Manipulation --------


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- due to forge-std script issue, the cheatcodes marked as experimental are not included (so `vm.cool` wasn't ever exposed)
- remove experimental from `vm.cool` and the newly added cheatcodes and follow up with a better way to handle `forge-std` experimental cheatcodes

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes