### PR TITLE
feat(forge build): add `--use-literal-content` CLI flag

### DIFF
--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -78,6 +78,11 @@ pub struct BuildOpts {
     #[serde(skip)]
     pub via_ir: bool,
 
+    /// Changes compilation to only use literal content and not URLs.
+    #[arg(long, help_heading = "Compiler options")]
+    #[serde(skip)]
+    pub use_literal_content: bool,
+
     /// Do not append any metadata to the bytecode.
     ///
     /// This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
@@ -220,6 +225,10 @@ impl Provider for BuildOpts {
 
         if self.via_ir {
             dict.insert("via_ir".to_string(), true.into());
+        }
+
+        if self.use_literal_content {
+            dict.insert("use_literal_content".to_string(), true.into());
         }
 
         if self.no_metadata {

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -487,6 +487,18 @@ forgetest!(can_set_optimizer_runs, |prj, cmd| {
     assert_eq!(config.optimizer_runs, Some(300));
 });
 
+// test that use_literal_content works
+forgetest!(can_set_use_literal_content, |prj, cmd| {
+    // explicitly set use_literal_content
+    prj.update_config(|config| config.use_literal_content = false);
+
+    let config = cmd.config();
+    assert_eq!(config.use_literal_content, false);
+
+    let config = prj.config_from_output(["--use-literal-content"]);
+    assert_eq!(config.use_literal_content, true);
+});
+
 // <https://github.com/foundry-rs/foundry/issues/9665>
 forgetest!(enable_optimizer_when_runs_set, |prj, cmd| {
     // explicitly set optimizer runs


### PR DESCRIPTION
Closes https://github.com/foundry-rs/foundry/issues/10103

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation -> I'm not sure if these changes are auto generated in the docs, if not please lmk. [docs page](https://book.getfoundry.sh/reference/forge/forge-build#compiler-options)