### PR TITLE
chore: remove unfulfilled clippy::large_enum_variant expectations

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -36,7 +36,6 @@ pub struct Params<T: Default> {
 /// Represents ethereum JSON-RPC API
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(tag = "method", content = "params")]
-#[expect(clippy::large_enum_variant)]
 pub enum EthRequest {
     #[serde(rename = "web3_clientVersion", with = "empty_params")]
     Web3ClientVersion(()),

--- a/crates/anvil/core/src/types.rs
+++ b/crates/anvil/core/src/types.rs
@@ -37,7 +37,6 @@ pub struct ReorgOptions {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
-#[expect(clippy::large_enum_variant)]
 pub enum TransactionData {
     JSON(TransactionRequest),
     Raw(Bytes),

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -25,7 +25,6 @@ use serde_json::value::RawValue;
 use std::fmt::Write;
 
 /// Different sender kinds used by [`CastTxBuilder`].
-#[expect(clippy::large_enum_variant)]
 pub enum SenderKind<'a> {
     /// An address without signer. Used for read-only calls and transactions sent through unlocked
     /// accounts.

--- a/crates/evm/evm/src/executors/fuzz/types.rs
+++ b/crates/evm/evm/src/executors/fuzz/types.rs
@@ -36,7 +36,6 @@ pub struct CounterExampleOutcome {
 
 /// Outcome of a single fuzz
 #[derive(Debug)]
-#[expect(clippy::large_enum_variant)]
 pub enum FuzzOutcome {
     Case(CaseOutcome),
     CounterExample(CounterExampleOutcome),

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -32,7 +32,6 @@ mod inspector;
 pub use inspector::Fuzzer;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[expect(clippy::large_enum_variant)]
 pub enum CounterExample {
     /// Call used as a counter example for fuzz tests.
     Single(BaseCounterExample),


### PR DESCRIPTION
 ## Motivation

The codebase contained multiple `#[expect(clippy::large_enum_variant)]` annotations that were no longer relevant.

These expectations were not fulfilled because the lints were either already resolved or never triggered in the first place.

Error:

![Pasted Graphic 20](https://github.com/user-attachments/assets/24c72a67-1073-4b36-847e-a5940e3a24c8)


## Solution

-Removed unnecessary `#[expect(clippy::large_enum_variant)]` annotations from multiple crates.

## Tests
`cargo clippy`

![Pasted Graphic 21](https://github.com/user-attachments/assets/9b926bb9-331e-4cf3-9a21-71efd0279066)

`cargo build`

![image](https://github.com/user-attachments/assets/3d2b67c3-e977-40b5-ac94-13b038fdf9f0)


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes