### PR TITLE
fix: normalize signature s value

### DIFF
--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -276,6 +276,7 @@ fn sign_with_wallet(
 fn sign_p256(private_key: &U256, digest: &B256) -> Result {
     let signing_key = parse_private_key_p256(private_key)?;
     let signature: P256Signature = signing_key.sign_prehash(digest.as_slice())?;
+    let signature = signature.normalize_s().unwrap_or(signature);
     let r_bytes: [u8; 32] = signature.r().to_bytes().into();
     let s_bytes: [u8; 32] = signature.s().to_bytes().into();
 


### PR DESCRIPTION
closes #10179

see issue for problem statement,

TLDR this should be normalized, normalized_s returns None for low s values hence the unwrap_or