### PR TITLE
chore: bump `revm` to `20.0.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-evm"
+version = "0.1.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40fe575395f20dc9527c2dc65350786492e9723d2035e9f716269b65be34c9c"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "auto_impl",
+ "derive_more 2.0.1",
+ "op-revm",
+ "revm",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "alloy-genesis"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +251,19 @@ dependencies = [
  "alloy-serde",
  "alloy-trie",
  "serde",
+]
+
+[[package]]
+name = "alloy-hardforks"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e61d55f42faedd980ee3e391aa9ff8ae0fc20723fa1c6d69ac06e06d08fbade"
+dependencies = [
+ "alloy-chains",
+ "alloy-eip2124",
+ "alloy-primitives",
+ "auto_impl",
+ "dyn-clone",
 ]
 
 [[package]]
@@ -4287,6 +4318,7 @@ version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-json-abi",
  "alloy-network",
@@ -6672,6 +6704,7 @@ dependencies = [
  "auto_impl",
  "once_cell",
  "revm",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,8 +185,6 @@ checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arbitrary",
- "rand 0.8.5",
  "serde",
 ]
 
@@ -198,9 +196,7 @@ checksum = "9b15b13d38b366d01e818fe8e710d4d702ef7499eacd44926a06171dd9585d0c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arbitrary",
  "k256",
- "rand 0.8.5",
  "serde",
  "thiserror 2.0.12",
 ]
@@ -223,7 +219,7 @@ dependencies = [
  "either",
  "once_cell",
  "serde",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1011,7 +1007,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.19",
  "yansi",
 ]
 
@@ -1032,6 +1028,7 @@ dependencies = [
  "foundry-common",
  "foundry-evm",
  "op-alloy-consensus",
+ "op-revm",
  "rand 0.8.5",
  "revm",
  "serde",
@@ -1094,6 +1091,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-r1cs-std",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1162,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1199,16 @@ checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1177,6 +1237,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-relations",
+ "ark-std 0.5.0",
+ "educe",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+dependencies = [
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+ "tracing",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1315,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1357,22 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -1557,7 +1714,7 @@ dependencies = [
  "http 1.3.1",
  "once_cell",
  "percent-encoding",
- "sha2",
+ "sha2 0.10.8",
  "time",
  "tracing",
 ]
@@ -1896,6 +2053,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,7 +2080,6 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
- "arbitrary",
  "serde",
 ]
 
@@ -1922,6 +2094,15 @@ dependencies = [
  "serde",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1976,7 +2157,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2",
+ "sha2 0.10.8",
  "tinyvec",
 ]
 
@@ -2206,7 +2387,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.19",
  "walkdir",
  "yansi",
 ]
@@ -2401,7 +2582,7 @@ dependencies = [
  "hmac",
  "k256",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "thiserror 1.0.69",
 ]
 
@@ -2417,7 +2598,7 @@ dependencies = [
  "once_cell",
  "pbkdf2 0.12.2",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.10.8",
  "thiserror 1.0.69",
 ]
 
@@ -2435,7 +2616,7 @@ dependencies = [
  "generic-array",
  "ripemd",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "sha3",
  "thiserror 1.0.69",
 ]
@@ -2856,6 +3037,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2968,7 +3160,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -3073,6 +3265,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3156,6 +3360,26 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "enumn"
@@ -3245,7 +3469,7 @@ dependencies = [
  "scrypt",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "sha3",
  "thiserror 1.0.69",
  "uuid 0.8.2",
@@ -3488,6 +3712,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
+ "revm",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -3548,7 +3773,7 @@ dependencies = [
  "thiserror 2.0.12",
  "toml 0.8.20",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -3649,7 +3874,6 @@ dependencies = [
  "itertools 0.14.0",
  "regex",
  "reqwest",
- "revm-primitives",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -3778,7 +4002,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.19",
  "tracing-tracy",
  "yansi",
 ]
@@ -3848,7 +4072,7 @@ dependencies = [
  "chrono",
  "comfy-table",
  "foundry-macros",
- "revm-primitives",
+ "revm",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -3880,7 +4104,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "solar-parse",
  "svm-rs",
  "svm-rs-builds",
@@ -3984,7 +4208,7 @@ dependencies = [
  "path-slash",
  "regex",
  "reqwest",
- "revm-primitives",
+ "revm",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -4161,8 +4385,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7beb856e73f59015823eb221a98b7c22b58bc4e7066c9c86774ebe74e61dd6"
+source = "git+https://github.com/foundry-rs/foundry-fork-db?rev=c168d11#c168d119f593e0447891def5efe814ada4a92575"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4220,7 +4443,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -4845,6 +5068,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -5601,7 +5833,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2",
+ "sha2 0.10.8",
  "signature",
 ]
 
@@ -5689,9 +5921,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "lazycell"
@@ -5740,6 +5969,52 @@ dependencies = [
  "bitflags 2.9.0",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
+dependencies = [
+ "arrayref",
+ "base64 0.22.1",
+ "digest 0.9.0",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.9.9",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -5807,7 +6082,7 @@ dependencies = [
  "generator",
  "scoped-tls",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -5919,7 +6194,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "shlex",
  "tempfile",
  "toml 0.5.11",
@@ -6390,6 +6665,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-revm"
+version = "1.0.0"
+source = "git+https://github.com/bluealloy/revm.git?rev=0953b17#0953b17f08fa4ba40ba845f97e5d2c353c376f32"
+dependencies = [
+ "auto_impl",
+ "once_cell",
+ "revm",
+]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "opener"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6440,7 +6731,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -6621,7 +6912,7 @@ checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
 dependencies = [
  "once_cell",
  "pest",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -6652,6 +6943,7 @@ checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
@@ -7446,25 +7738,125 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "19.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c175ecec83bba464aa8406502fe5bf670491c2ace81a153264891d43bc7fa332"
+version = "20.0.0"
+source = "git+https://github.com/bluealloy/revm.git?rev=0953b17#0953b17f08fa4ba40ba845f97e5d2c353c376f32"
 dependencies = [
- "auto_impl",
- "cfg-if",
- "dyn-clone",
- "once_cell",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
  "revm-interpreter",
  "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "1.0.0"
+source = "git+https://github.com/bluealloy/revm.git?rev=0953b17#0953b17f08fa4ba40ba845f97e5d2c353c376f32"
+dependencies = [
+ "bitvec",
+ "phf",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "1.0.0"
+source = "git+https://github.com/bluealloy/revm.git?rev=0953b17#0953b17f08fa4ba40ba845f97e5d2c353c376f32"
+dependencies = [
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "1.0.0"
+source = "git+https://github.com/bluealloy/revm.git?rev=0953b17#0953b17f08fa4ba40ba845f97e5d2c353c376f32"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "1.0.0"
+source = "git+https://github.com/bluealloy/revm.git?rev=0953b17#0953b17f08fa4ba40ba845f97e5d2c353c376f32"
+dependencies = [
+ "alloy-eips",
+ "auto_impl",
+ "revm-bytecode",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "1.0.0"
+source = "git+https://github.com/bluealloy/revm.git?rev=0953b17#0953b17f08fa4ba40ba845f97e5d2c353c376f32"
+dependencies = [
+ "auto_impl",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "1.0.0"
+source = "git+https://github.com/bluealloy/revm.git?rev=0953b17#0953b17f08fa4ba40ba845f97e5d2c353c376f32"
+dependencies = [
+ "auto_impl",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "1.0.0"
+source = "git+https://github.com/bluealloy/revm.git?rev=0953b17#0953b17f08fa4ba40ba845f97e5d2c353c376f32"
+dependencies = [
+ "auto_impl",
+ "revm-context",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-interpreter",
+ "revm-primitives",
+ "revm-state",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "revm-inspectors"
-version = "0.16.0"
+version = "0.17.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a43423d81f4bef634469bfb2d9ebe36a9ea9167f20ab3a7d1ff1e05fa63099"
+checksum = "b1504e2851a11562fb350a9f408e5783351650aef11790aea0b0d0d9ab961c40"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -7480,51 +7872,56 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "15.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcab7ef2064057acfc84731205f4bc77f4ec1b35630800b26ff6a185731c5ab"
+version = "16.0.0"
+source = "git+https://github.com/bluealloy/revm.git?rev=0953b17#0953b17f08fa4ba40ba845f97e5d2c353c376f32"
 dependencies = [
+ "revm-bytecode",
+ "revm-context-interface",
  "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "16.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99743c3a2cac341084cc15ac74286c4bf34a0941ebf60aa420cfdb9f81f72f9f"
+version = "17.0.0"
+source = "git+https://github.com/bluealloy/revm.git?rev=0953b17#0953b17f08fa4ba40ba845f97e5d2c353c376f32"
 dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
  "aurora-engine-modexp",
  "blst",
  "c-kzg",
  "cfg-if",
  "k256",
+ "libsecp256k1",
  "once_cell",
  "p256",
  "revm-primitives",
  "ripemd",
  "secp256k1",
- "sha2",
- "substrate-bn",
+ "sha2 0.10.8",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "15.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f987564210317706def498421dfba2ae1af64a8edce82c6102758b48133fcb"
+version = "16.0.0"
+source = "git+https://github.com/bluealloy/revm.git?rev=0953b17#0953b17f08fa4ba40ba845f97e5d2c353c376f32"
 dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
  "alloy-primitives",
- "auto_impl",
- "bitflags 2.9.0",
- "bitvec",
- "c-kzg",
- "cfg-if",
- "dyn-clone",
  "enumn",
- "hex",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "1.0.0"
+source = "git+https://github.com/bluealloy/revm.git?rev=0953b17#0953b17f08fa4ba40ba845f97e5d2c353c376f32"
+dependencies = [
+ "bitflags 2.9.0",
+ "revm-bytecode",
+ "revm-primitives",
  "serde",
 ]
 
@@ -7909,7 +8306,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "salsa20",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -7935,10 +8332,11 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
+ "bitcoin_hashes",
  "rand 0.8.5",
  "secp256k1-sys",
 ]
@@ -8207,6 +8605,19 @@ name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
 
 [[package]]
 name = "sha2"
@@ -8562,7 +8973,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "thiserror 2.0.12",
  "tokio",
  "toml_edit",
@@ -8570,12 +8981,6 @@ dependencies = [
  "zip",
  "zip-extract",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -8690,19 +9095,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-bn"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
-dependencies = [
- "byteorder",
- "crunchy",
- "lazy_static",
- "rand 0.8.5",
- "rustc-hex",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8799,7 +9191,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "tempfile",
  "thiserror 2.0.12",
  "url",
@@ -9432,7 +9824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
 dependencies = [
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -9455,6 +9847,15 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
  "tracing-core",
 ]
 
@@ -9483,7 +9884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eaa1852afa96e0fe9e44caa53dc0bd2d9d05e0f2611ce09f97f8677af56e4ba"
 dependencies = [
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.19",
  "tracy-client",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,6 @@ foldhash.opt-level = 3
 keccak.opt-level = 3
 revm-interpreter.opt-level = 3
 revm-precompile.opt-level = 3
-revm-primitives.opt-level = 3
 revm.opt-level = 3
 ruint.opt-level = 3
 sha2.opt-level = 3
@@ -195,9 +194,9 @@ solang-parser = "=0.3.3"
 solar-parse = { version = "=0.1.1", default-features = false }
 
 ## revm
-revm = { version = "19.4.0", default-features = false }
-revm-primitives = { version = "15.1.0", default-features = false }
-revm-inspectors = { version = "0.16.0", features = ["serde"] }
+revm = { version = "20.0.0", default-features = false }
+revm-inspectors = { version = "0.17.0-alpha.1", features = ["serde"] }
+op-revm = { version = "1.0.0", default-features = false }
 
 ## alloy
 alloy-consensus = { version = "0.12.1", default-features = false }
@@ -346,3 +345,10 @@ yansi = { version = "1.0", features = ["detect-tty", "detect-env"] }
 # alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "7fab7ee" }
 # alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "7fab7ee" }
 # alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "7fab7ee" }
+
+## revm
+revm = { git = "https://github.com/bluealloy/revm.git", rev = "0953b17" }
+op-revm = { git = "https://github.com/bluealloy/revm.git", rev = "0953b17" }
+
+## foundry
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-fork-db", rev = "c168d11" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,7 @@ alloy-sol-macro-input = "0.8.22"
 alloy-sol-types = "0.8.22"
 
 alloy-chains = "0.1"
+alloy-evm = "0.1.0-alpha.3"
 alloy-rlp = "0.3"
 alloy-trie = "0.7.0"
 

--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -21,6 +21,7 @@ revm = { workspace = true, default-features = false, features = [
     "memory_limit",
     "c-kzg",
 ] }
+op-revm.workspace = true
 
 alloy-primitives = { workspace = true, features = ["serde", "rlp"] }
 alloy-rpc-types = { workspace = true, features = ["anvil", "trace"] }

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -23,10 +23,7 @@ use alloy_serde::{OtherFields, WithOtherFields};
 use bytes::BufMut;
 use foundry_evm::traces::CallTraceNode;
 use op_alloy_consensus::{TxDeposit, DEPOSIT_TX_TYPE_ID};
-use revm::{
-    interpreter::InstructionResult,
-    primitives::{OptimismFields, TxEnv},
-};
+use revm::{context::TxEnv, interpreter::InstructionResult, primitives::OptimismFields};
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, Mul};
 

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -23,6 +23,7 @@ use alloy_serde::{OtherFields, WithOtherFields};
 use bytes::BufMut;
 use foundry_evm::traces::CallTraceNode;
 use op_alloy_consensus::{TxDeposit, DEPOSIT_TX_TYPE_ID};
+use op_revm::OpTransaction;
 use revm::{context::TxEnv, interpreter::InstructionResult, primitives::OptimismFields};
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, Mul};
@@ -391,10 +392,10 @@ impl PendingTransaction {
                 let TxLegacy { nonce, gas_price, gas_limit, value, to, input, .. } = tx.tx();
                 TxEnv {
                     caller,
-                    transact_to: transact_to(to),
+                    kind: transact_to(to),
                     data: input.clone(),
                     chain_id,
-                    nonce: Some(*nonce),
+                    nonce: *nonce,
                     value: (*value),
                     gas_price: U256::from(*gas_price),
                     gas_priority_fee: None,
@@ -417,10 +418,10 @@ impl PendingTransaction {
                 } = tx.tx();
                 TxEnv {
                     caller,
-                    transact_to: transact_to(to),
+                    kind: transact_to(to),
                     data: input.clone(),
                     chain_id: Some(*chain_id),
-                    nonce: Some(*nonce),
+                    nonce: *nonce,
                     value: *value,
                     gas_price: U256::from(*gas_price),
                     gas_priority_fee: None,
@@ -444,10 +445,10 @@ impl PendingTransaction {
                 } = tx.tx();
                 TxEnv {
                     caller,
-                    transact_to: transact_to(to),
+                    kind: transact_to(to),
                     data: input.clone(),
                     chain_id: Some(*chain_id),
-                    nonce: Some(*nonce),
+                    nonce: *nonce,
                     value: *value,
                     gas_price: U256::from(*max_fee_per_gas),
                     gas_priority_fee: Some(U256::from(*max_priority_fee_per_gas)),
@@ -473,10 +474,10 @@ impl PendingTransaction {
                 } = tx.tx().tx();
                 TxEnv {
                     caller,
-                    transact_to: TxKind::Call(*to),
+                    kind: TxKind::Call(*to),
                     data: input.clone(),
                     chain_id: Some(*chain_id),
-                    nonce: Some(*nonce),
+                    nonce: *nonce,
                     value: *value,
                     gas_price: U256::from(*max_fee_per_gas),
                     gas_priority_fee: Some(U256::from(*max_priority_fee_per_gas)),
@@ -502,16 +503,16 @@ impl PendingTransaction {
                 } = tx.tx();
                 TxEnv {
                     caller,
-                    transact_to: TxKind::Call(*to),
+                    kind: TxKind::Call(*to),
                     data: input.clone(),
                     chain_id: Some(*chain_id),
-                    nonce: Some(*nonce),
+                    nonce: *nonce,
                     value: *value,
                     gas_price: U256::from(*max_fee_per_gas),
                     gas_priority_fee: Some(U256::from(*max_priority_fee_per_gas)),
                     gas_limit: *gas_limit,
                     access_list: access_list.clone().into(),
-                    authorization_list: Some(authorization_list.clone().into()),
+                    authorization_list: authorization_list.clone(),
                     ..Default::default()
                 }
             }
@@ -530,10 +531,10 @@ impl PendingTransaction {
                 } = tx;
                 TxEnv {
                     caller,
-                    transact_to: transact_to(kind),
+                    kind: transact_to(kind),
                     data: input.clone(),
                     chain_id,
-                    nonce: Some(*nonce),
+                    nonce: *nonce,
                     value: *value,
                     gas_price: U256::ZERO,
                     gas_priority_fee: None,

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -38,6 +38,7 @@ use foundry_evm::{
     constants::DEFAULT_CREATE2_DEPLOYER,
     revm::primitives::{BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, SpecId, TxEnv},
     utils::apply_chain_and_block_specific_env_changes,
+    Env, EvmEnv,
 };
 use itertools::Itertools;
 use parking_lot::RwLock;
@@ -1009,12 +1010,14 @@ impl NodeConfig {
             cfg.memory_limit = value;
         }
 
-        let env = revm::primitives::Env {
-            cfg: cfg.cfg_env,
-            block: BlockEnv {
-                gas_limit: U256::from(self.gas_limit()),
-                basefee: U256::from(self.get_base_fee()),
-                ..Default::default()
+        let env = Env {
+            evm_env: EvmEnv {
+                cfg_env: cfg.cfg_env,
+                block_env: BlockEnv {
+                    gas_limit: U256::from(self.gas_limit()),
+                    basefee: U256::from(self.get_base_fee()),
+                    ..Default::default()
+                },
             },
             tx: TxEnv { chain_id: self.get_chain_id().into(), ..Default::default() },
         };

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -42,7 +42,7 @@ use foundry_evm::{
 use itertools::Itertools;
 use parking_lot::RwLock;
 use rand::thread_rng;
-use revm::primitives::BlobExcessGasAndPrice;
+use revm::context_interface::block::BlobExcessGasAndPrice;
 use serde_json::{json, Value};
 use std::{
     fmt::Write as FmtWrite,

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -27,7 +27,6 @@ use crate::{
     },
     filter::{EthFilter, Filters, LogsFilter},
     mem::transaction_build,
-    revm::primitives::{BlobExcessGasAndPrice, Output},
     ClientFork, LoggingManager, Miner, MiningMode, StorageInfo,
 };
 use alloy_consensus::{
@@ -79,18 +78,16 @@ use anvil_core::{
 };
 use anvil_rpc::{error::RpcError, response::ResponseResult};
 use foundry_common::provider::ProviderBuilder;
-use foundry_evm::{
-    backend::DatabaseError,
-    decode::RevertDecoder,
-    revm::{
-        db::DatabaseRef,
-        interpreter::{return_ok, return_revert, InstructionResult},
-        primitives::BlockEnv,
-    },
-};
+use foundry_evm::{backend::DatabaseError, decode::RevertDecoder};
 use futures::channel::{mpsc::Receiver, oneshot};
 use parking_lot::RwLock;
-use revm::primitives::Bytecode;
+use revm::{
+    context::BlockEnv,
+    context_interface::{block::BlobExcessGasAndPrice, result::Output},
+    database::DatabaseRef,
+    interpreter::{return_ok, return_revert, InstructionResult},
+    primitives::Bytecode,
+};
 use std::{future::Future, sync::Arc, time::Duration};
 
 /// The client version: `anvil/v{major}.{minor}.{patch}`

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -82,11 +82,11 @@ use foundry_evm::{backend::DatabaseError, decode::RevertDecoder};
 use futures::channel::{mpsc::Receiver, oneshot};
 use parking_lot::RwLock;
 use revm::{
+    bytecode::Bytecode,
     context::BlockEnv,
     context_interface::{block::BlobExcessGasAndPrice, result::Output},
     database::DatabaseRef,
     interpreter::{return_ok, return_revert, InstructionResult},
-    primitives::Bytecode,
 };
 use std::{future::Future, sync::Arc, time::Duration};
 

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -30,7 +30,7 @@ use foundry_evm::{
     traces::CallTraceNode,
     utils::odyssey_handler_register,
 };
-use revm::db::WrapDatabaseRef;
+use revm::database::WrapDatabaseRef;
 use std::sync::Arc;
 
 /// Represents an executed transaction (transacted on the DB)

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -29,7 +29,7 @@ use parking_lot::{
     lock_api::{RwLockReadGuard, RwLockWriteGuard},
     RawRwLock, RwLock,
 };
-use revm::primitives::BlobExcessGasAndPrice;
+use revm::context_interface::block::BlobExcessGasAndPrice;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::RwLock as AsyncRwLock;
 

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -14,7 +14,7 @@ use foundry_evm::{
     fork::database::ForkDbStateSnapshot,
     revm::{primitives::BlockEnv, Database},
 };
-use revm::{db::DbAccount, DatabaseRef};
+use revm::database::{DatabaseRef, DbAccount};
 
 pub use foundry_evm::fork::database::ForkedDatabase;
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -97,8 +97,9 @@ use futures::channel::mpsc::{unbounded, UnboundedSender};
 use op_alloy_consensus::{TxDeposit, DEPOSIT_TX_TYPE_ID};
 use parking_lot::{Mutex, RwLock};
 use revm::{
-    db::WrapDatabaseRef,
-    primitives::{BlobExcessGasAndPrice, HashMap, OptimismFields, ResultAndState},
+    context_interface::block::BlobExcessGasAndPrice,
+    database::WrapDatabaseRef,
+    primitives::{HashMap, OptimismFields, ResultAndState},
 };
 use std::{
     collections::BTreeMap,

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -40,7 +40,7 @@ use foundry_evm::{
     },
 };
 use parking_lot::RwLock;
-use revm::primitives::SpecId;
+use revm::primitives::hardfork::SpecId;
 use std::{collections::VecDeque, fmt, path::PathBuf, sync::Arc, time::Duration};
 // use yansi::Paint;
 

--- a/crates/anvil/src/evm.rs
+++ b/crates/anvil/src/evm.rs
@@ -54,7 +54,7 @@ mod tests {
 
         let db = revm::db::EmptyDB::default();
         let env = Box::<revm::primitives::Env>::default();
-        let spec = SpecId::LATEST;
+        let spec = SpecId::default();
         let handler_cfg = revm::primitives::HandlerCfg::new(spec);
         let inspector = revm::inspectors::NoOpInspector;
         let context = revm::Context::new(revm::EvmContext::new_with_env(db, env), inspector);

--- a/crates/anvil/src/evm.rs
+++ b/crates/anvil/src/evm.rs
@@ -33,7 +33,7 @@ mod tests {
     use crate::{evm::inject_precompiles, PrecompileFactory};
     use alloy_primitives::Address;
     use foundry_evm::revm::primitives::{address, Bytes, Precompile, PrecompileResult, SpecId};
-    use revm::primitives::PrecompileOutput;
+    use revm::precompile::PrecompileOutput;
 
     #[test]
     fn build_evm_with_extra_precompiles() {

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -33,7 +33,7 @@ use foundry_compilers::flatten::Flattener;
 use foundry_config::Chain;
 use futures::{future::Either, FutureExt, StreamExt};
 use rayon::prelude::*;
-use revm::primitives::Eof;
+use revm::bytecode::Eof;
 use std::{
     borrow::Cow,
     fmt::Write,

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -18,7 +18,11 @@ use foundry_evm_core::{
 use foundry_evm_traces::StackSnapshotType;
 use itertools::Itertools;
 use rand::Rng;
-use revm::primitives::{Account, Bytecode, SpecId, KECCAK_EMPTY};
+use revm::{
+    bytecode::Bytecode,
+    primitives::{hardfork::SpecId, KECCAK_EMPTY},
+    state::Account,
+};
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     fmt::Display,

--- a/crates/cheatcodes/src/evm/mapping.rs
+++ b/crates/cheatcodes/src/evm/mapping.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{
     Address, B256, U256,
 };
 use alloy_sol_types::SolValue;
-use revm::interpreter::{opcode, Interpreter};
+use revm::{bytecode::opcode, interpreter::Interpreter};
 
 /// Recorded mapping slots.
 #[derive(Clone, Debug, Default)]

--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -1,6 +1,6 @@
 use crate::{inspector::InnerEcx, Cheatcode, Cheatcodes, CheatsCtxt, Result, Vm::*};
 use alloy_primitives::{Address, Bytes, U256};
-use revm::{interpreter::InstructionResult, primitives::Bytecode};
+use revm::{bytecode::Bytecode, interpreter::InstructionResult};
 use std::{cmp::Ordering, collections::VecDeque};
 
 /// Mocked call data.

--- a/crates/cheatcodes/src/evm/record_debug_step.rs
+++ b/crates/cheatcodes/src/evm/record_debug_step.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{Bytes, U256};
 
 use foundry_evm_traces::CallTraceArena;
-use revm::interpreter::{InstructionResult, OpCode};
+use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
 
 use foundry_evm_core::buffer::{get_buffer_accesses, BufferKind};
 use revm_inspectors::tracing::types::{CallTraceStep, RecordedMemory, TraceMemberOrder};

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -366,9 +366,9 @@ fn deploy_code(
     }
 
     let scheme = if let Some(salt) = salt {
-        revm::primitives::CreateScheme::Create2 { salt }
+        revm::context_interface::CreateScheme::Create2 { salt }
     } else {
-        revm::primitives::CreateScheme::Create
+        revm::context_interface::CreateScheme::Create
     };
 
     let address = executor

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -45,15 +45,16 @@ use itertools::Itertools;
 use proptest::test_runner::{RngAlgorithm, TestRng, TestRunner};
 use rand::Rng;
 use revm::{
+    bytecode::opcode as op,
+    context::BlockEnv,
+    context_interface::{result::EVMError, CreateScheme},
     interpreter::{
-        opcode as op, CallInputs, CallOutcome, CallScheme, CallValue, CreateInputs, CreateOutcome,
+        CallInputs, CallOutcome, CallScheme, CallValue, CreateInputs, CreateOutcome,
         EOFCreateInputs, EOFCreateKind, Gas, InstructionResult, Interpreter, InterpreterAction,
         InterpreterResult,
     },
-    primitives::{
-        BlockEnv, CreateScheme, EVMError, EvmStorageSlot, SignedAuthorization, SpecId,
-        EOF_MAGIC_BYTES,
-    },
+    primitives::{hardfork::SpecId, SignedAuthorization, EOF_MAGIC_BYTES},
+    state::EvmStorageSlot,
     EvmContext, InnerEvmContext, Inspector,
 };
 use serde_json::Value;

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -8,7 +8,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolValue;
 use foundry_wallets::{multi_wallet::MultiWallet, WalletSigner};
 use parking_lot::Mutex;
-use revm::primitives::{Bytecode, SignedAuthorization};
+use revm::{bytecode::Bytecode, SignedAuthorization};
 use std::sync::Arc;
 
 impl Cheatcode for broadcast_0Call {

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -133,11 +133,11 @@ impl Display for CreateScheme {
 }
 
 impl CreateScheme {
-    pub fn eq(&self, create_scheme: revm::primitives::CreateScheme) -> bool {
+    pub fn eq(&self, create_scheme: revm::context_interface::CreateScheme) -> bool {
         matches!(
             (self, create_scheme),
-            (Self::Create, revm::primitives::CreateScheme::Create) |
-                (Self::Create2, revm::primitives::CreateScheme::Create2 { .. })
+            (Self::Create, revm::context_interface::CreateScheme::Create) |
+                (Self::Create2, revm::context_interface::CreateScheme::Create2 { .. })
         )
     }
 }

--- a/crates/common/fmt/Cargo.toml
+++ b/crates/common/fmt/Cargo.toml
@@ -25,7 +25,7 @@ alloy-serde.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
-revm-primitives.workspace = true
+revm.workspace = true
 comfy-table.workspace = true
 yansi.workspace = true
 

--- a/crates/common/fmt/src/eof.rs
+++ b/crates/common/fmt/src/eof.rs
@@ -1,5 +1,5 @@
 use comfy_table::{modifiers::UTF8_ROUND_CORNERS, ContentArrangement, Table};
-use revm_primitives::{
+use revm::bytecode::{
     eof::{EofBody, EofHeader},
     Eof,
 };
@@ -16,8 +16,7 @@ pub fn pretty_eof(eof: &Eof) -> Result<String, fmt::Error> {
                 sum_code_sizes: _,
                 sum_container_sizes: _,
             },
-        body:
-            EofBody { types_section, code_section, container_section, data_section, is_data_filled: _ },
+        body: EofBody { code_info, code_section, container_section, data_section, .. },
         raw: _,
     } = eof;
 
@@ -43,7 +42,7 @@ pub fn pretty_eof(eof: &Eof) -> Result<String, fmt::Error> {
         table.apply_modifier(UTF8_ROUND_CORNERS);
         table.set_content_arrangement(ContentArrangement::Dynamic);
         table.set_header(vec!["", "Inputs", "Outputs", "Max stack height", "Code"]);
-        for (idx, (code, type_section)) in code_section.iter().zip(types_section).enumerate() {
+        for (idx, (code, type_section)) in code_section.iter().zip(code_info).enumerate() {
             table.add_row(vec![
                 &idx.to_string(),
                 &type_section.inputs.to_string(),

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -19,7 +19,8 @@ foundry-compilers = { workspace = true, features = ["svm-solc"] }
 
 alloy-chains = { workspace = true, features = ["serde"] }
 alloy-primitives = { workspace = true, features = ["serde"] }
-revm-primitives.workspace = true
+
+revm.workspace = true
 
 solar-parse.workspace = true
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -9,7 +9,7 @@
 extern crate tracing;
 
 use crate::cache::StorageCachingConfig;
-use alloy_primitives::{address, Address, B256, U256};
+use alloy_primitives::{address, map::AddressHashMap, Address, FixedBytes, B256, U256};
 use eyre::{ContextCompat, WrapErr};
 use figment::{
     providers::{Env, Format, Serialized, Toml},
@@ -39,7 +39,7 @@ use foundry_compilers::{
     RestrictionsWithVersion, VyperLanguage,
 };
 use regex::Regex;
-use revm::primitives::{hardfork::SpecId, map::AddressHashMap, FixedBytes};
+use revm::primitives::hardfork::SpecId;
 use semver::Version;
 use serde::{Deserialize, Serialize, Serializer};
 use std::{

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -39,7 +39,7 @@ use foundry_compilers::{
     RestrictionsWithVersion, VyperLanguage,
 };
 use regex::Regex;
-use revm_primitives::{map::AddressHashMap, FixedBytes, SpecId};
+use revm::primitives::{hardfork::SpecId, map::AddressHashMap, FixedBytes};
 use semver::Version;
 use serde::{Deserialize, Serialize, Serializer};
 use std::{

--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -7,7 +7,7 @@ use foundry_compilers::artifacts::{
     remappings::{Remapping, RemappingError},
     EvmVersion,
 };
-use revm_primitives::SpecId;
+use revm::primitives::hardfork::SpecId;
 use serde::{de::Error, Deserialize, Deserializer};
 use std::{
     io,

--- a/crates/debugger/src/op.rs
+++ b/crates/debugger/src/op.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Bytes;
-use revm::interpreter::opcode;
+use revm::bytecode::opcode;
 
 /// Named parameter of an EVM opcode.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -4,7 +4,7 @@ use crate::{debugger::DebuggerContext, DebugNode, ExitReason};
 use alloy_primitives::{hex, Address};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use foundry_evm_core::buffer::BufferKind;
-use revm::interpreter::OpCode;
+use revm::bytecode::opcode::OpCode;
 use revm_inspectors::tracing::types::{CallKind, CallTraceStep};
 use std::ops::ControlFlow;
 

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -43,9 +43,9 @@ revm = { workspace = true, features = [
     "optional_block_gas_limit",
     "optional_no_base_fee",
     "arbitrary",
-    "optimism",
     "c-kzg",
     "blst",
+    "secp256r1",
 ] }
 revm-inspectors.workspace = true
 

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -20,6 +20,7 @@ foundry-config.workspace = true
 foundry-evm-abi.workspace = true
 
 alloy-dyn-abi = { workspace = true, features = ["arbitrary", "eip712"] }
+alloy-evm.workspace = true
 alloy-genesis.workspace = true
 alloy-json-abi.workspace = true
 alloy-primitives = { workspace = true, features = [

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -14,11 +14,11 @@ use alloy_rpc_types::TransactionRequest;
 use eyre::WrapErr;
 use foundry_fork_db::DatabaseError;
 use revm::{
-    db::DatabaseRef,
-    primitives::{
-        Account, AccountInfo, Bytecode, Env, EnvWithHandlerCfg, HashMap as Map, ResultAndState,
-        SpecId,
-    },
+    bytecode::Bytecode,
+    context_interface::result::ResultAndState,
+    database::DatabaseRef,
+    primitives::{hardfork::SpecId, Env, EnvWithHandlerCfg, HashMap as Map},
+    state::{Account, AccountInfo},
     Database, DatabaseCommit, JournaledState,
 };
 use std::{borrow::Cow, collections::BTreeMap};
@@ -54,7 +54,7 @@ pub struct CowBackend<'a> {
 impl<'a> CowBackend<'a> {
     /// Creates a new `CowBackend` with the given `Backend`.
     pub fn new_borrowed(backend: &'a Backend) -> Self {
-        Self { backend: Cow::Borrowed(backend), is_initialized: false, spec_id: SpecId::LATEST }
+        Self { backend: Cow::Borrowed(backend), is_initialized: false, spec_id: SpecId::default() }
     }
 
     /// Executes the configured transaction of the `env` without committing state changes

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -6,7 +6,7 @@ use crate::{
         diagnostic::RevertDiagnostic, Backend, DatabaseExt, LocalForkId, RevertStateSnapshotAction,
     },
     fork::{CreateFork, ForkId},
-    InspectorExt,
+    Env, InspectorExt,
 };
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{Address, B256, U256};
@@ -17,7 +17,7 @@ use revm::{
     bytecode::Bytecode,
     context_interface::result::ResultAndState,
     database::DatabaseRef,
-    primitives::{hardfork::SpecId, Env, EnvWithHandlerCfg, HashMap as Map},
+    primitives::{hardfork::SpecId, EnvWithHandlerCfg, HashMap as Map},
     state::{Account, AccountInfo},
     Database, DatabaseCommit, JournaledState,
 };

--- a/crates/evm/core/src/backend/error.rs
+++ b/crates/evm/core/src/backend/error.rs
@@ -59,7 +59,6 @@ impl<T: Into<Self>> From<EVMError<T>> for BackendError {
             EVMError::Database(err) => err.into(),
             EVMError::Custom(err) => Self::msg(err),
             EVMError::Header(err) => Self::msg(err.to_string()),
-            EVMError::Precompile(err) => Self::msg(err),
             EVMError::Transaction(err) => Self::msg(err.to_string()),
         }
     }

--- a/crates/evm/core/src/backend/error.rs
+++ b/crates/evm/core/src/backend/error.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::Address;
 pub use foundry_fork_db::{DatabaseError, DatabaseResult};
-use revm::primitives::EVMError;
+use revm::context_interface::result::EVMError;
 use std::convert::Infallible;
 
 pub type BackendResult<T> = Result<T, BackendError>;

--- a/crates/evm/core/src/backend/in_memory_db.rs
+++ b/crates/evm/core/src/backend/in_memory_db.rs
@@ -4,8 +4,10 @@ use crate::state_snapshot::StateSnapshots;
 use alloy_primitives::{Address, B256, U256};
 use foundry_fork_db::DatabaseError;
 use revm::{
-    db::{CacheDB, DatabaseRef, EmptyDB},
-    primitives::{Account, AccountInfo, Bytecode, HashMap as Map},
+    bytecode::Bytecode,
+    database::{CacheDB, DatabaseRef, EmptyDB},
+    primitives::HashMap as Map,
+    state::{Account, AccountInfo},
     Database, DatabaseCommit,
 };
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     fork::{CreateFork, ForkId, MultiFork},
     state_snapshot::StateSnapshots,
     utils::{configure_tx_env, configure_tx_req_env, new_evm_with_inspector},
-    InspectorExt,
+    Env, InspectorExt,
 };
 use alloy_genesis::GenesisAccount;
 use alloy_network::{AnyRpcBlock, AnyTxEnvelope, TransactionResponse};
@@ -20,7 +20,7 @@ use revm::{
     database::{CacheDB, DatabaseRef},
     inspector::NoOpInspector,
     precompile::{PrecompileSpecId, Precompiles},
-    primitives::{hardfork::SpecId, Env, EnvWithHandlerCfg, HashMap as Map, Log, KECCAK_EMPTY},
+    primitives::{hardfork::SpecId, EnvWithHandlerCfg, HashMap as Map, Log, KECCAK_EMPTY},
     state::{Account, AccountInfo, EvmState, EvmStorageSlot},
     Database, DatabaseCommit, JournaledState,
 };

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -2001,7 +2001,7 @@ mod tests {
     use foundry_common::provider::get_http_provider;
     use foundry_config::{Config, NamedChain};
     use foundry_fork_db::cache::{BlockchainDb, BlockchainDbMeta};
-    use revm::DatabaseRef;
+    use revm::database::DatabaseRef;
 
     const ENDPOINT: Option<&str> = option_env!("ETH_RPC_URL");
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1049,8 +1049,8 @@ impl DatabaseExt for Backend {
         if let Some(active_fork_id) = self.active_fork_id() {
             self.forks.update_block(
                 self.ensure_fork_id(active_fork_id).cloned()?,
-                env.block.number,
-                env.block.timestamp,
+                env.evm_env.block_env.number,
+                env.evm_env.block_env.timestamp,
             )?;
         }
 
@@ -1822,8 +1822,8 @@ impl Default for BackendInner {
 
 /// This updates the currently used env with the fork's environment
 pub(crate) fn update_current_env_with_fork_env(current: &mut Env, fork: Env) {
-    current.block = fork.block;
-    current.cfg = fork.cfg;
+    current.evm_env.block_env = fork.evm_env.block_env;
+    current.evm_env.cfg_env = fork.evm_env.cfg_env;
     current.tx.chain_id = fork.tx.chain_id;
 }
 
@@ -1913,15 +1913,15 @@ fn is_contract_in_state(journaled_state: &JournaledState, acc: Address) -> bool 
 
 /// Updates the env's block with the block's data
 fn update_env_block(env: &mut Env, block: &AnyRpcBlock) {
-    env.block.timestamp = U256::from(block.header.timestamp);
-    env.block.coinbase = block.header.beneficiary;
-    env.block.difficulty = block.header.difficulty;
-    env.block.prevrandao = Some(block.header.mix_hash.unwrap_or_default());
-    env.block.basefee = U256::from(block.header.base_fee_per_gas.unwrap_or_default());
-    env.block.gas_limit = U256::from(block.header.gas_limit);
-    env.block.number = U256::from(block.header.number);
+    env.evm_env.block_env.timestamp = block.header.timestamp;
+    env.evm_env.block_env.beneficiary = block.header.beneficiary;
+    env.evm_env.block_env.difficulty = block.header.difficulty;
+    env.evm_env.block_env.prevrandao = Some(block.header.mix_hash.unwrap_or_default());
+    env.evm_env.block_env.basefee = block.header.base_fee_per_gas.unwrap_or_default();
+    env.evm_env.block_env.gas_limit = block.header.gas_limit;
+    env.evm_env.block_env.number = block.header.number;
     if let Some(excess_blob_gas) = block.header.excess_blob_gas {
-        env.block.blob_excess_gas_and_price =
+        env.evm_env.block_env.blob_excess_gas_and_price =
             Some(BlobExcessGasAndPrice::new(excess_blob_gas, false));
     }
 }

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -15,13 +15,13 @@ use eyre::Context;
 use foundry_common::{is_known_system_sender, SYSTEM_TRANSACTION_TYPE};
 pub use foundry_fork_db::{cache::BlockchainDbMeta, BlockchainDb, SharedBackend};
 use revm::{
-    db::{CacheDB, DatabaseRef},
-    inspectors::NoOpInspector,
+    bytecode::Bytecode,
+    context_interface::{block::BlobExcessGasAndPrice, result::ResultAndState},
+    database::{CacheDB, DatabaseRef},
+    inspector::NoOpInspector,
     precompile::{PrecompileSpecId, Precompiles},
-    primitives::{
-        Account, AccountInfo, BlobExcessGasAndPrice, Bytecode, Env, EnvWithHandlerCfg, EvmState,
-        EvmStorageSlot, HashMap as Map, Log, ResultAndState, SpecId, KECCAK_EMPTY,
-    },
+    primitives::{hardfork::SpecId, Env, EnvWithHandlerCfg, HashMap as Map, Log, KECCAK_EMPTY},
+    state::{Account, AccountInfo, EvmState, EvmStorageSlot},
     Database, DatabaseCommit, JournaledState,
 };
 use std::{
@@ -1808,7 +1808,7 @@ impl Default for BackendInner {
             caller: None,
             next_fork_id: Default::default(),
             persistent_accounts: Default::default(),
-            spec_id: SpecId::LATEST,
+            spec_id: SpecId::default(),
             // grant the cheatcode,default test and caller address access to execute cheatcodes
             // itself
             cheatcode_access_accounts: HashSet::from([

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -967,7 +967,7 @@ impl DatabaseExt for Backend {
                             .map(|acc| acc.info.clone())
                             .unwrap_or_default();
 
-                        if !fork.db.accounts.contains_key(&caller) {
+                        if !fork.db.cache.accounts.contains_key(&caller) {
                             // update the caller account which is required by the evm
                             fork.db.insert_account_info(caller, caller_account.clone());
                         }
@@ -1116,7 +1116,7 @@ impl DatabaseExt for Backend {
                     .map(|acc| acc.info.clone())
                     .unwrap_or_default();
 
-                if !fork.db.accounts.contains_key(&caller) {
+                if !fork.db.cache.accounts.contains_key(&caller) {
                     // update the caller account which is required by the evm
                     fork.db.insert_account_info(caller, caller_account.clone());
                 }
@@ -1463,9 +1463,9 @@ impl DatabaseExt for Backend {
 
     fn set_blockhash(&mut self, block_number: U256, block_hash: B256) {
         if let Some(db) = self.active_fork_db_mut() {
-            db.block_hashes.insert(block_number, block_hash);
+            db.cache.block_hashes.insert(block_number, block_hash);
         } else {
-            self.mem_db.block_hashes.insert(block_number, block_hash);
+            self.mem_db.cache.block_hashes.insert(block_number, block_hash);
         }
     }
 }
@@ -1875,17 +1875,17 @@ fn merge_db_account_data<ExtDB: DatabaseRef>(
 ) {
     trace!(?addr, "merging database data");
 
-    let Some(acc) = active.accounts.get(&addr) else { return };
+    let Some(acc) = active.cache.accounts.get(&addr) else { return };
 
     // port contract cache over
-    if let Some(code) = active.contracts.get(&acc.info.code_hash) {
+    if let Some(code) = active.cache.contracts.get(&acc.info.code_hash) {
         trace!("merging contract cache");
-        fork_db.contracts.insert(acc.info.code_hash, code.clone());
+        fork_db.cache.contracts.insert(acc.info.code_hash, code.clone());
     }
 
     // port account storage over
     use std::collections::hash_map::Entry;
-    match fork_db.accounts.entry(addr) {
+    match fork_db.cache.accounts.entry(addr) {
         Entry::Vacant(vacant) => {
             trace!("target account not present - inserting from active");
             // if the fork_db doesn't have the target account
@@ -2042,8 +2042,7 @@ mod tests {
         }
         drop(backend);
 
-        let meta =
-            BlockchainDbMeta { cfg_env: env.cfg, block_env: env.block, hosts: Default::default() };
+        let meta = BlockchainDbMeta { block_env: env.evm_env.block_env, hosts: Default::default() };
 
         let db = BlockchainDb::new(
             meta,

--- a/crates/evm/core/src/backend/snapshot.rs
+++ b/crates/evm/core/src/backend/snapshot.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::{map::AddressHashMap, B256, U256};
 use revm::{
-    primitives::{AccountInfo, Env, HashMap},
+    primitives::{Env, HashMap},
+    state::AccountInfo,
     JournaledState,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/evm/core/src/backend/snapshot.rs
+++ b/crates/evm/core/src/backend/snapshot.rs
@@ -1,9 +1,9 @@
-use alloy_primitives::{map::AddressHashMap, B256, U256};
-use revm::{
-    primitives::{Env, HashMap},
-    state::AccountInfo,
-    JournaledState,
+use crate::Env;
+use alloy_primitives::{
+    map::{AddressHashMap, HashMap},
+    B256, U256,
 };
+use revm::{state::AccountInfo, JournaledState};
 use serde::{Deserialize, Serialize};
 
 /// A minimal abstraction of a state at a certain point in time

--- a/crates/evm/core/src/buffer.rs
+++ b/crates/evm/core/src/buffer.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::U256;
-use revm::interpreter::opcode;
+use revm::bytecode::opcode;
 
 /// Used to keep track of which buffer is currently active to be drawn by the debugger.
 #[derive(Debug, PartialEq)]

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -1,0 +1,57 @@
+use alloy_evm::EvmEnv;
+use revm::{
+    context::{BlockEnv, CfgEnv, ContextTr, JournalTr, TxEnv},
+    Context, Database,
+};
+
+/// Helper container type for [`EvmEnv`] and [`TxEnv`].
+#[derive(Clone, Debug, Default)]
+pub struct Env {
+    pub evm_env: EvmEnv,
+    pub tx: TxEnv,
+}
+
+/// Helper struct with mutable references to the block and cfg environments.
+pub struct EnvMut<'a> {
+    pub block: &'a mut BlockEnv,
+    pub cfg: &'a mut CfgEnv,
+    pub tx: &'a mut TxEnv,
+}
+
+impl EnvMut<'_> {
+    /// Returns a copy of the environment.
+    pub fn to_owned(&self) -> Env {
+        Env {
+            evm_env: EvmEnv { cfg_env: self.cfg.to_owned(), block_env: self.block.to_owned() },
+            tx: self.tx.to_owned(),
+        }
+    }
+}
+
+pub trait AsEnvMut {
+    fn as_env_mut(&mut self) -> EnvMut<'_>;
+}
+
+impl AsEnvMut for EnvMut<'_> {
+    fn as_env_mut(&mut self) -> EnvMut<'_> {
+        EnvMut { block: self.block, cfg: self.cfg, tx: self.tx }
+    }
+}
+
+impl AsEnvMut for Env {
+    fn as_env_mut(&mut self) -> EnvMut<'_> {
+        EnvMut {
+            block: &mut self.evm_env.block_env,
+            cfg: &mut self.evm_env.cfg_env,
+            tx: &mut self.tx,
+        }
+    }
+}
+
+impl<DB: Database, J: JournalTr<Database = DB>, C> AsEnvMut
+    for Context<BlockEnv, TxEnv, CfgEnv, DB, J, C>
+{
+    fn as_env_mut(&mut self) -> EnvMut<'_> {
+        EnvMut { block: &mut self.block, cfg: &mut self.cfg, tx: &mut self.tx }
+    }
+}

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -1,6 +1,6 @@
 use alloy_evm::EvmEnv;
 use revm::{
-    context::{BlockEnv, CfgEnv, ContextTr, JournalTr, TxEnv},
+    context::{BlockEnv, CfgEnv, JournalTr, TxEnv},
     Context, Database,
 };
 

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -1,4 +1,4 @@
-use alloy_evm::EvmEnv;
+pub use alloy_evm::EvmEnv;
 use revm::{
     context::{BlockEnv, CfgEnv, JournalTr, TxEnv},
     Context, Database,

--- a/crates/evm/core/src/fork/database.rs
+++ b/crates/evm/core/src/fork/database.rs
@@ -210,7 +210,12 @@ pub struct ForkDbStateSnapshot {
 
 impl ForkDbStateSnapshot {
     fn get_storage(&self, address: Address, index: U256) -> Option<U256> {
-        self.local.accounts.get(&address).and_then(|account| account.storage.get(&index)).copied()
+        self.local
+            .cache
+            .accounts
+            .get(&address)
+            .and_then(|account| account.storage.get(&index))
+            .copied()
     }
 }
 
@@ -221,7 +226,7 @@ impl DatabaseRef for ForkDbStateSnapshot {
     type Error = DatabaseError;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        match self.local.accounts.get(&address) {
+        match self.local.cache.accounts.get(&address) {
             Some(account) => Ok(Some(account.info.clone())),
             None => {
                 let mut acc = self.state_snapshot.accounts.get(&address).cloned();
@@ -239,7 +244,7 @@ impl DatabaseRef for ForkDbStateSnapshot {
     }
 
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
-        match self.local.accounts.get(&address) {
+        match self.local.cache.accounts.get(&address) {
             Some(account) => match account.storage.get(&index) {
                 Some(entry) => Ok(*entry),
                 None => match self.get_storage(address, index) {
@@ -275,11 +280,7 @@ mod tests {
     async fn fork_db_insert_basic_default() {
         let rpc = foundry_test_utils::rpc::next_http_rpc_endpoint();
         let provider = get_http_provider(rpc.clone());
-        let meta = BlockchainDbMeta {
-            cfg_env: Default::default(),
-            block_env: Default::default(),
-            hosts: BTreeSet::from([rpc]),
-        };
+        let meta = BlockchainDbMeta { block_env: Default::default(), hosts: BTreeSet::from([rpc]) };
         let db = BlockchainDb::new(meta, None);
 
         let backend = SharedBackend::spawn_backend(Arc::new(provider), db.clone(), None).await;

--- a/crates/evm/core/src/fork/database.rs
+++ b/crates/evm/core/src/fork/database.rs
@@ -9,8 +9,9 @@ use alloy_rpc_types::BlockId;
 use foundry_fork_db::{BlockchainDb, DatabaseError, SharedBackend};
 use parking_lot::Mutex;
 use revm::{
-    db::{CacheDB, DatabaseRef},
-    primitives::{Account, AccountInfo, Bytecode},
+    bytecode::Bytecode,
+    database::{CacheDB, DatabaseRef},
+    state::{Account, AccountInfo},
     Database, DatabaseCommit,
 };
 use std::sync::Arc;

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -1,6 +1,5 @@
-use crate::{utils::apply_chain_and_block_specific_env_changes, Env};
+use crate::{utils::apply_chain_and_block_specific_env_changes, Env, EvmEnv};
 use alloy_consensus::BlockHeader;
-use alloy_evm::EvmEnv;
 use alloy_primitives::Address;
 use alloy_provider::{network::BlockResponse, Network, Provider};
 use alloy_rpc_types::BlockNumberOrTag;

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -1,6 +1,6 @@
 use crate::utils::apply_chain_and_block_specific_env_changes;
 use alloy_consensus::BlockHeader;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::Address;
 use alloy_provider::{network::BlockResponse, Network, Provider};
 use alloy_rpc_types::BlockNumberOrTag;
 use eyre::WrapErr;
@@ -62,18 +62,18 @@ pub async fn environment<N: Network, P: Provider<N>>(
     let mut env = Env {
         cfg,
         block: BlockEnv {
-            number: U256::from(block.header().number()),
-            timestamp: U256::from(block.header().timestamp()),
-            coinbase: block.header().beneficiary(),
+            number: block.header().number(),
+            timestamp: block.header().timestamp(),
+            beneficiary: block.header().beneficiary(),
             difficulty: block.header().difficulty(),
             prevrandao: block.header().mix_hash(),
-            basefee: U256::from(block.header().base_fee_per_gas().unwrap_or_default()),
-            gas_limit: U256::from(block.header().gas_limit()),
+            basefee: block.header().base_fee_per_gas().unwrap_or_default(),
+            gas_limit: block.header().gas_limit(),
             ..Default::default()
         },
         tx: TxEnv {
             caller: origin,
-            gas_price: U256::from(gas_price.unwrap_or(fork_gas_price)),
+            gas_price: gas_price.unwrap_or(fork_gas_price),
             chain_id: Some(override_chain_id.unwrap_or(rpc_chain_id)),
             gas_limit: block.header().gas_limit() as u64,
             ..Default::default()

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -5,7 +5,10 @@ use alloy_provider::{network::BlockResponse, Network, Provider};
 use alloy_rpc_types::BlockNumberOrTag;
 use eyre::WrapErr;
 use foundry_common::NON_ARCHIVE_NODE_WARNING;
-use revm::primitives::{BlockEnv, CfgEnv, Env, TxEnv};
+use revm::{
+    context::{BlockEnv, CfgEnv, TxEnv},
+    primitives::Env,
+};
 
 /// Initializes a REVM block environment based on a forked
 /// ethereum provider.

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -1,14 +1,12 @@
-use crate::utils::apply_chain_and_block_specific_env_changes;
+use crate::{utils::apply_chain_and_block_specific_env_changes, Env};
 use alloy_consensus::BlockHeader;
+use alloy_evm::EvmEnv;
 use alloy_primitives::Address;
 use alloy_provider::{network::BlockResponse, Network, Provider};
 use alloy_rpc_types::BlockNumberOrTag;
 use eyre::WrapErr;
 use foundry_common::NON_ARCHIVE_NODE_WARNING;
-use revm::{
-    context::{BlockEnv, CfgEnv, TxEnv},
-    primitives::Env,
-};
+use revm::context::{BlockEnv, CfgEnv, TxEnv};
 
 /// Initializes a REVM block environment based on a forked
 /// ethereum provider.
@@ -60,16 +58,18 @@ pub async fn environment<N: Network, P: Provider<N>>(
     cfg.disable_block_gas_limit = disable_block_gas_limit;
 
     let mut env = Env {
-        cfg,
-        block: BlockEnv {
-            number: block.header().number(),
-            timestamp: block.header().timestamp(),
-            beneficiary: block.header().beneficiary(),
-            difficulty: block.header().difficulty(),
-            prevrandao: block.header().mix_hash(),
-            basefee: block.header().base_fee_per_gas().unwrap_or_default(),
-            gas_limit: block.header().gas_limit(),
-            ..Default::default()
+        evm_env: EvmEnv {
+            cfg_env: cfg,
+            block_env: BlockEnv {
+                number: block.header().number(),
+                timestamp: block.header().timestamp(),
+                beneficiary: block.header().beneficiary(),
+                difficulty: block.header().difficulty(),
+                prevrandao: block.header().mix_hash(),
+                basefee: block.header().base_fee_per_gas().unwrap_or_default(),
+                gas_limit: block.header().gas_limit(),
+                ..Default::default()
+            },
         },
         tx: TxEnv {
             caller: origin,

--- a/crates/evm/core/src/fork/mod.rs
+++ b/crates/evm/core/src/fork/mod.rs
@@ -1,5 +1,5 @@
 use super::opts::EvmOpts;
-use revm::primitives::Env;
+use crate::Env;
 
 mod init;
 pub use init::environment;

--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -4,8 +4,9 @@
 //! concurrently active pairs at once.
 
 use super::CreateFork;
+use crate::Env;
 use alloy_consensus::BlockHeader;
-use alloy_primitives::{map::HashMap, U256};
+use alloy_primitives::map::HashMap;
 use alloy_provider::network::BlockResponse;
 use foundry_common::provider::{ProviderBuilder, RetryProvider};
 use foundry_config::Config;
@@ -16,7 +17,6 @@ use futures::{
     task::{Context, Poll},
     Future, FutureExt, StreamExt,
 };
-use revm::primitives::Env;
 use std::{
     fmt::{self, Write},
     pin::Pin,
@@ -150,7 +150,7 @@ impl MultiFork {
     }
 
     /// Updates block number and timestamp of given fork with new values.
-    pub fn update_block(&self, fork: ForkId, number: U256, timestamp: U256) -> eyre::Result<()> {
+    pub fn update_block(&self, fork: ForkId, number: u64, timestamp: u64) -> eyre::Result<()> {
         trace!(?fork, ?number, ?timestamp, "update fork block");
         self.handler
             .clone()
@@ -200,7 +200,7 @@ enum Request {
     /// Returns the environment of the fork.
     GetEnv(ForkId, GetEnvSender),
     /// Updates the block number and timestamp of the fork.
-    UpdateBlock(ForkId, U256, U256),
+    UpdateBlock(ForkId, u64, u64),
     /// Shutdowns the entire `MultiForkHandler`, see `ShutDownMultiFork`
     ShutDown(OneshotSender<()>),
     /// Returns the Fork Url for the `ForkId` if it exists.
@@ -302,10 +302,10 @@ impl MultiForkHandler {
 
     /// Update fork block number and timestamp. Used to preserve values set by `roll` and `warp`
     /// cheatcodes when new fork selected.
-    fn update_block(&mut self, fork_id: ForkId, block_number: U256, block_timestamp: U256) {
+    fn update_block(&mut self, fork_id: ForkId, block_number: u64, block_timestamp: u64) {
         if let Some(fork) = self.forks.get_mut(&fork_id) {
-            fork.opts.env.block.number = block_number;
-            fork.opts.env.block.timestamp = block_timestamp;
+            fork.opts.env.evm_env.block_env.number = block_number;
+            fork.opts.env.evm_env.block_env.timestamp = block_timestamp;
         }
     }
 
@@ -519,7 +519,7 @@ async fn create_fork(mut fork: CreateFork) -> eyre::Result<(ForkId, CreatedFork,
     // Initialise the fork environment.
     let (env, block) = fork.evm_opts.fork_evm_env(&fork.url).await?;
     fork.env = env;
-    let meta = BlockchainDbMeta::new(fork.env.clone(), fork.url.clone());
+    let meta = BlockchainDbMeta::new(fork.env.clone().evm_env.block_env, fork.url.clone());
 
     // We need to use the block number from the block because the env's number can be different on
     // some L2s (e.g. Arbitrum).
@@ -527,7 +527,7 @@ async fn create_fork(mut fork: CreateFork) -> eyre::Result<(ForkId, CreatedFork,
 
     // Determine the cache path if caching is enabled.
     let cache_path = if fork.enable_caching {
-        Config::foundry_block_cache_dir(meta.cfg_env.chain_id, number)
+        Config::foundry_block_cache_dir(fork.env.evm_env.cfg_env.chain_id, number)
     } else {
         None
     };

--- a/crates/evm/core/src/ic.rs
+++ b/crates/evm/core/src/ic.rs
@@ -1,9 +1,6 @@
 use alloy_primitives::map::rustc_hash::FxHashMap;
 use eyre::Result;
-use revm::interpreter::{
-    opcode::{PUSH0, PUSH1, PUSH32},
-    OpCode,
-};
+use revm::bytecode::opcode::{OpCode, PUSH0, PUSH1, PUSH32};
 use revm_inspectors::opcode::immediate_size;
 use serde::Serialize;
 

--- a/crates/evm/core/src/ic.rs
+++ b/crates/evm/core/src/ic.rs
@@ -1,7 +1,6 @@
 use alloy_primitives::map::rustc_hash::FxHashMap;
 use eyre::Result;
 use revm::bytecode::opcode::{OpCode, PUSH0, PUSH1, PUSH32};
-use revm_inspectors::opcode::immediate_size;
 use serde::Serialize;
 
 /// Maps from program counter to instruction counter.
@@ -114,7 +113,7 @@ pub fn decode_instructions(code: &[u8]) -> Result<Vec<Instruction<'_>>> {
     while pc < code.len() {
         let op = OpCode::new(code[pc]);
         pc += 1;
-        let immediate_size = op.map(|op| immediate_size(op, &code[pc..])).unwrap_or(0) as usize;
+        let immediate_size = op.map(|op| op.info().immediate_size()).unwrap_or(0) as usize;
 
         if pc + immediate_size > code.len() {
             eyre::bail!("incomplete sequence of bytecode");

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -22,6 +22,9 @@ pub mod abi {
 
 mod ic;
 
+pub mod env;
+pub use env::*;
+
 pub mod backend;
 pub mod buffer;
 pub mod constants;

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -9,7 +9,7 @@ use crate::constants::DEFAULT_CREATE2_DEPLOYER;
 use alloy_primitives::Address;
 use auto_impl::auto_impl;
 use backend::DatabaseExt;
-use revm::{inspectors::NoOpInspector, interpreter::CreateInputs, EvmContext, Inspector};
+use revm::{inspector::NoOpInspector, interpreter::CreateInputs, EvmContext, Inspector};
 use revm_inspectors::access_list::AccessListInspector;
 
 #[macro_use]

--- a/crates/evm/core/src/opcodes.rs
+++ b/crates/evm/core/src/opcodes.rs
@@ -1,6 +1,6 @@
 //! Opcode utils
 
-use revm::interpreter::OpCode;
+use revm::bytecode::opcode::OpCode;
 
 /// Returns true if the opcode modifies memory.
 /// <https://bluealloy.github.io/revm/crates/interpreter/memory.html#opcodes>

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -1,6 +1,5 @@
 use super::fork::environment;
-use crate::{constants::DEFAULT_CREATE2_DEPLOYER, fork::CreateFork};
-use alloy_evm::EvmEnv;
+use crate::{constants::DEFAULT_CREATE2_DEPLOYER, fork::CreateFork, EvmEnv};
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{network::AnyRpcBlock, Provider};
 use eyre::WrapErr;

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -5,7 +5,7 @@ use alloy_provider::{network::AnyRpcBlock, Provider};
 use eyre::WrapErr;
 use foundry_common::{provider::ProviderBuilder, ALCHEMY_FREE_TIER_CUPS};
 use foundry_config::{Chain, Config, GasLimit};
-use revm::primitives::{BlockEnv, CfgEnv, TxEnv};
+use revm::context::{BlockEnv, CfgEnv, TxEnv};
 use serde::{Deserialize, Serialize};
 use std::fmt::Write;
 use url::Url;

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -1,5 +1,6 @@
 use super::fork::environment;
 use crate::{constants::DEFAULT_CREATE2_DEPLOYER, fork::CreateFork};
+use alloy_evm::EvmEnv;
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{network::AnyRpcBlock, Provider};
 use eyre::WrapErr;
@@ -106,7 +107,7 @@ impl EvmOpts {
     ///
     /// If a `fork_url` is set, it gets configured with settings fetched from the endpoint (chain
     /// id, )
-    pub async fn evm_env(&self) -> eyre::Result<revm::primitives::Env> {
+    pub async fn evm_env(&self) -> eyre::Result<crate::Env> {
         if let Some(ref fork_url) = self.fork_url {
             Ok(self.fork_evm_env(fork_url).await?.0)
         } else {
@@ -116,10 +117,7 @@ impl EvmOpts {
 
     /// Returns the `revm::Env` that is configured with settings retrieved from the endpoint.
     /// And the block that was used to configure the environment.
-    pub async fn fork_evm_env(
-        &self,
-        fork_url: &str,
-    ) -> eyre::Result<(revm::primitives::Env, AnyRpcBlock)> {
+    pub async fn fork_evm_env(&self, fork_url: &str) -> eyre::Result<(crate::Env, AnyRpcBlock)> {
         let provider = ProviderBuilder::new(fork_url)
             .compute_units_per_second(self.get_compute_units_per_second())
             .build()?;
@@ -145,7 +143,7 @@ impl EvmOpts {
     }
 
     /// Returns the `revm::Env` configured with only local settings
-    pub fn local_evm_env(&self) -> revm::primitives::Env {
+    pub fn local_evm_env(&self) -> crate::Env {
         let mut cfg = CfgEnv::default();
         cfg.chain_id = self.env.chain_id.unwrap_or(foundry_common::DEV_CHAIN_ID);
         cfg.limit_contract_code_size = self.env.code_size_limit.or(Some(usize::MAX));
@@ -156,20 +154,22 @@ impl EvmOpts {
         cfg.disable_eip3607 = true;
         cfg.disable_block_gas_limit = self.disable_block_gas_limit;
 
-        revm::primitives::Env {
-            block: BlockEnv {
-                number: U256::from(self.env.block_number),
-                coinbase: self.env.block_coinbase,
-                timestamp: U256::from(self.env.block_timestamp),
-                difficulty: U256::from(self.env.block_difficulty),
-                prevrandao: Some(self.env.block_prevrandao),
-                basefee: U256::from(self.env.block_base_fee_per_gas),
-                gas_limit: U256::from(self.gas_limit()),
-                ..Default::default()
+        crate::Env {
+            evm_env: EvmEnv {
+                cfg_env: cfg,
+                block_env: BlockEnv {
+                    number: self.env.block_number,
+                    beneficiary: self.env.block_coinbase,
+                    timestamp: self.env.block_timestamp,
+                    difficulty: U256::from(self.env.block_difficulty),
+                    prevrandao: Some(self.env.block_prevrandao),
+                    basefee: self.env.block_base_fee_per_gas,
+                    gas_limit: self.gas_limit(),
+                    ..Default::default()
+                },
             },
-            cfg,
             tx: TxEnv {
-                gas_price: U256::from(self.env.gas_price.unwrap_or_default()),
+                gas_price: self.env.gas_price.unwrap_or_default().into(),
                 gas_limit: self.gas_limit(),
                 caller: self.sender,
                 ..Default::default()
@@ -190,9 +190,9 @@ impl EvmOpts {
     ///
     /// for `mainnet` and `--fork-block-number 14435000` on mac the corresponding storage cache will
     /// be at `~/.foundry/cache/mainnet/14435000/storage.json`.
-    pub fn get_fork(&self, config: &Config, env: revm::primitives::Env) -> Option<CreateFork> {
+    pub fn get_fork(&self, config: &Config, env: crate::Env) -> Option<CreateFork> {
         let url = self.fork_url.clone()?;
-        let enable_caching = config.enable_caching(&url, env.cfg.chain_id);
+        let enable_caching = config.enable_caching(&url, env.evm_env.cfg_env.chain_id);
         Some(CreateFork { url, enable_caching, env, evm_opts: self.clone() })
     }
 

--- a/crates/evm/core/src/precompiles.rs
+++ b/crates/evm/core/src/precompiles.rs
@@ -1,7 +1,6 @@
 use alloy_primitives::{address, Address, Bytes, B256};
-use revm::{
-    precompile::{secp256r1::p256_verify as revm_p256_verify, PrecompileWithAddress},
-    primitives::{Precompile, PrecompileResult},
+use revm::precompile::{
+    secp256r1::p256_verify as revm_p256_verify, PrecompileResult, PrecompileWithAddress,
 };
 
 /// The ECRecover precompile address.
@@ -70,4 +69,4 @@ pub fn p256_verify(input: &Bytes, gas_limit: u64) -> PrecompileResult {
 
 /// [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md) secp256r1 precompile.
 pub const ODYSSEY_P256: PrecompileWithAddress =
-    PrecompileWithAddress(ODYSSEY_P256_ADDRESS, Precompile::Standard(p256_verify));
+    PrecompileWithAddress(ODYSSEY_P256_ADDRESS, p256_verify);

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -13,13 +13,14 @@ use foundry_common::is_impersonated_tx;
 use foundry_config::NamedChain;
 use foundry_fork_db::DatabaseError;
 use revm::{
+    context_interface::{result::EVMError, CreateScheme},
     handler::register::EvmHandler,
     interpreter::{
         return_ok, CallInputs, CallOutcome, CallScheme, CallValue, CreateInputs, CreateOutcome,
         Gas, InstructionResult, InterpreterResult,
     },
     precompile::secp256r1::P256VERIFY,
-    primitives::{CreateScheme, EVMError, HandlerCfg, SpecId, KECCAK_EMPTY},
+    primitives::{hardfork::SpecId, HandlerCfg, KECCAK_EMPTY},
     FrameOrResult, FrameResult,
 };
 use std::{cell::RefCell, rc::Rc, sync::Arc};

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -14,18 +14,17 @@ use foundry_config::NamedChain;
 use foundry_fork_db::DatabaseError;
 use revm::{
     context_interface::{result::EVMError, CreateScheme},
-    handler::register::EvmHandler,
+    handler::{register::EvmHandler, FrameOrResult, FrameResult},
     interpreter::{
         return_ok, CallInputs, CallOutcome, CallScheme, CallValue, CreateInputs, CreateOutcome,
         Gas, InstructionResult, InterpreterResult,
     },
     precompile::secp256r1::P256VERIFY,
     primitives::{hardfork::SpecId, HandlerCfg, KECCAK_EMPTY},
-    FrameOrResult, FrameResult,
 };
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
-pub use revm::primitives::EvmState as StateChangeset;
+pub use revm::state::EvmState as StateChangeset;
 
 /// Depending on the configured chain id and block number this should apply any specific changes
 ///

--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -4,7 +4,7 @@ use alloy_primitives::map::rustc_hash::FxHashSet;
 use eyre::ensure;
 use foundry_compilers::artifacts::sourcemap::{SourceElement, SourceMap};
 use foundry_evm_core::utils::IcPcMap;
-use revm::interpreter::opcode;
+use revm::bytecode::opcode;
 
 /// Attempts to find anchors for the given items using the given source map and bytecode.
 pub fn find_anchors(

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -1,6 +1,6 @@
 use crate::{executors::Executor, inspectors::InspectorStackBuilder};
 use foundry_evm_core::backend::Backend;
-use revm::primitives::{Env, EnvWithHandlerCfg, SpecId};
+use revm::primitives::{hardfork::SpecId, Env, EnvWithHandlerCfg};
 
 /// The builder that allows to configure an evm [`Executor`] which a stack of optional
 /// [`revm::Inspector`]s, such as [`Cheatcodes`].

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -27,7 +27,7 @@ impl Default for ExecutorBuilder {
         Self {
             stack: InspectorStackBuilder::new(),
             gas_limit: None,
-            spec_id: SpecId::LATEST,
+            spec_id: SpecId::default(),
             legacy_assertions: false,
         }
     }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     executors::{Executor, RawCallResult},
     inspectors::Fuzzer,
 };
-use alloy_primitives::{Address, Bytes, FixedBytes, Selector, U256};
+use alloy_primitives::{map::HashMap, Address, Bytes, FixedBytes, Selector, U256};
 use alloy_sol_types::{sol, SolCall};
 use eyre::{eyre, ContextCompat, Result};
 use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
@@ -30,7 +30,6 @@ use proptest::{
     test_runner::{TestCaseError, TestRunner},
 };
 use result::{assert_after_invariant, assert_invariants, can_continue};
-use revm::primitives::HashMap;
 use shrink::shrink_sequence;
 use std::{
     cell::RefCell,

--- a/crates/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/evm/evm/src/executors/invariant/replay.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::executors::Executor;
 use alloy_dyn_abi::JsonAbiExt;
-use alloy_primitives::{map::HashMap, Log};
+use alloy_primitives::{map::HashMap, Log, U256};
 use eyre::Result;
 use foundry_common::{ContractsByAddress, ContractsByArtifact};
 use foundry_evm_coverage::HitMaps;
@@ -16,7 +16,6 @@ use foundry_evm_traces::{load_contracts, TraceKind, TraceMode, Traces};
 use indicatif::ProgressBar;
 use parking_lot::RwLock;
 use proptest::test_runner::TestError;
-use revm::primitives::U256;
 use std::sync::Arc;
 
 /// Replays a call sequence for collecting logs and traces.

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -29,11 +29,13 @@ use foundry_evm_core::{
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_traces::{SparsedTraceArena, TraceMode};
 use revm::{
-    db::{DatabaseCommit, DatabaseRef},
+    bytecode::Bytecode,
+    context::{BlockEnv, TxEnv},
+    context_interface::result::{ExecutionResult, Output, ResultAndState},
+    database::{DatabaseCommit, DatabaseRef},
     interpreter::{return_ok, InstructionResult},
     primitives::{
-        AuthorizationList, BlockEnv, Bytecode, Env, EnvWithHandlerCfg, ExecutionResult, Output,
-        ResultAndState, SignedAuthorization, SpecId, TxEnv, TxKind,
+        hardfork::SpecId, AuthorizationList, Env, EnvWithHandlerCfg, SignedAuthorization, TxKind,
     },
 };
 use std::{
@@ -112,7 +114,7 @@ impl Executor {
         // do not fail.
         backend.insert_account_info(
             CHEATCODE_ADDRESS,
-            revm::primitives::AccountInfo {
+            revm::state::AccountInfo {
                 code: Some(Bytecode::new_raw(Bytes::from_static(&[0]))),
                 // Also set the code hash manually so that it's not computed later.
                 // The code hash value does not matter, as long as it's not zero or `KECCAK_EMPTY`.
@@ -817,7 +819,7 @@ impl Default for RawCallResult {
             coverage: None,
             transactions: None,
             state_changeset: HashMap::default(),
-            env: EnvWithHandlerCfg::new_with_spec_id(Box::default(), SpecId::LATEST),
+            env: EnvWithHandlerCfg::new_with_spec_id(Box::default(), SpecId::default()),
             cheatcodes: Default::default(),
             out: None,
             chisel_state: None,

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -18,7 +18,7 @@ use revm::{
         CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, EOFCreateInputs,
         EOFCreateKind, Gas, InstructionResult, Interpreter, InterpreterResult,
     },
-    primitives::{Env, EnvWithHandlerCfg, HashMap, TxKind},
+    primitives::{Env, EnvWithHandlerCfg, HashMap},
     state::{Account, AccountStatus},
     EvmContext, Inspector, JournaledState,
 };

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -8,15 +8,18 @@ use foundry_evm_core::{backend::DatabaseExt, InspectorExt};
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_traces::{SparsedTraceArena, TraceMode};
 use revm::{
+    context::{
+        result::{ExecutionResult, Output},
+        BlockEnv,
+    },
+    context_interface::CreateScheme,
     inspectors::CustomPrintTracer,
     interpreter::{
         CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, EOFCreateInputs,
         EOFCreateKind, Gas, InstructionResult, Interpreter, InterpreterResult,
     },
-    primitives::{
-        Account, AccountStatus, BlockEnv, CreateScheme, Env, EnvWithHandlerCfg, ExecutionResult,
-        HashMap, Output, TransactTo,
-    },
+    primitives::{Env, EnvWithHandlerCfg, HashMap, TxKind},
+    state::{Account, AccountStatus},
     EvmContext, Inspector, JournaledState,
 };
 use std::{
@@ -571,7 +574,7 @@ impl InspectorStackRefMut<'_> {
     fn transact_inner(
         &mut self,
         ecx: &mut EvmContext<&mut dyn DatabaseExt>,
-        transact_to: TransactTo,
+        transact_to: TxKind,
         caller: Address,
         input: Bytes,
         gas_limit: u64,

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -11,7 +11,9 @@ extern crate tracing;
 pub mod executors;
 pub mod inspectors;
 
-pub use foundry_evm_core::{backend, constants, decode, fork, opts, utils, InspectorExt};
+pub use foundry_evm_core::{
+    backend, constants, decode, fork, opts, utils, Env, EnvMut, EvmEnv, InspectorExt,
+};
 pub use foundry_evm_coverage as coverage;
 pub use foundry_evm_fuzz as fuzz;
 pub use foundry_evm_traces as traces;

--- a/crates/evm/fuzz/src/strategies/param.rs
+++ b/crates/evm/fuzz/src/strategies/param.rs
@@ -235,7 +235,7 @@ mod tests {
     };
     use foundry_common::abi::get_func;
     use foundry_config::FuzzDictionaryConfig;
-    use revm::db::{CacheDB, EmptyDB};
+    use revm::database::{CacheDB, EmptyDB};
 
     #[test]
     fn can_fuzz_array() {

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -9,9 +9,9 @@ use foundry_config::FuzzDictionaryConfig;
 use foundry_evm_core::utils::StateChangeset;
 use parking_lot::{lock_api::RwLockReadGuard, RawRwLock, RwLock};
 use revm::{
-    db::{CacheDB, DatabaseRef, DbAccount},
-    interpreter::opcode,
-    primitives::AccountInfo,
+    bytecode::opcode,
+    database::{CacheDB, DatabaseRef, DbAccount},
+    state::AccountInfo,
 };
 use std::{collections::BTreeMap, fmt, sync::Arc};
 

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -58,6 +58,8 @@ alloy-serde.workspace = true
 alloy-signer.workspace = true
 alloy-transport.workspace = true
 
+revm.workspace = true
+
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_complete = "4"
 clap_complete_fig = "4"

--- a/crates/forge/src/cmd/inspect.rs
+++ b/crates/forge/src/cmd/inspect.rs
@@ -1,4 +1,3 @@
-use crate::revm::primitives::Eof;
 use alloy_json_abi::{EventParam, InternalType, JsonAbi, Param};
 use alloy_primitives::{hex, keccak256, Address};
 use clap::Parser;
@@ -19,6 +18,7 @@ use foundry_compilers::artifacts::{
     CompactBytecode, StorageLayout,
 };
 use regex::Regex;
+use revm::bytecode::Eof;
 use serde_json::{Map, Value};
 use std::{collections::BTreeMap, fmt, str::FromStr, sync::LazyLock};
 

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -26,7 +26,7 @@ use foundry_evm::{
 };
 use foundry_linking::{LinkOutput, Linker};
 use rayon::prelude::*;
-use revm::primitives::SpecId;
+use revm::primitives::hardfork::SpecId;
 use std::{
     borrow::Borrow,
     collections::BTreeMap,

--- a/crates/forge/tests/it/config.rs
+++ b/crates/forge/tests/it/config.rs
@@ -6,12 +6,12 @@ use forge::{
 };
 use foundry_evm::{
     decode::decode_console_logs,
-    revm::primitives::SpecId,
     traces::{decode_trace_arena, render_trace_arena, CallTraceDecoderBuilder},
 };
 use foundry_test_utils::{init_tracing, Filter};
 use futures::future::join_all;
 use itertools::Itertools;
+use revm::primitives::hardfork::SpecId;
 use std::collections::BTreeMap;
 
 /// How to execute a test run.

--- a/crates/forge/tests/it/spec.rs
+++ b/crates/forge/tests/it/spec.rs
@@ -1,8 +1,8 @@
 //! Integration tests for EVM specifications.
 
 use crate::{config::*, test_helpers::TEST_DATA_PARIS};
-use foundry_evm::revm::primitives::SpecId;
 use foundry_test_utils::Filter;
+use revm::primitives::hardfork::SpecId;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_shanghai_compat() {

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -2,7 +2,7 @@
 
 use alloy_chains::NamedChain;
 use alloy_primitives::U256;
-use forge::{revm::primitives::SpecId, MultiContractRunner, MultiContractRunnerBuilder};
+use forge::{MultiContractRunner, MultiContractRunnerBuilder};
 use foundry_compilers::{
     artifacts::{EvmVersion, Libraries, Settings},
     compilers::multi::MultiCompiler,
@@ -18,6 +18,7 @@ use foundry_test_utils::{
     fd_lock, init_tracing,
     rpc::{next_http_archive_rpc_url, next_rpc_endpoint},
 };
+use revm::primitives::harfork::SpecId;
 use std::{
     env, fmt,
     io::Write,

--- a/crates/verify/Cargo.toml
+++ b/crates/verify/Cargo.toml
@@ -23,7 +23,6 @@ alloy-json-abi.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types.workspace = true
 alloy-dyn-abi.workspace = true
-revm-primitives.workspace = true
 serde.workspace = true
 eyre.workspace = true
 alloy-provider.workspace = true

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     verify::VerifierArgs,
 };
-use alloy_primitives::{hex, Address, Bytes, U256};
+use alloy_primitives::{hex, Address, Bytes, TxKind, U256};
 use alloy_provider::{
     network::{AnyTxEnvelope, TransactionBuilder},
     Provider,
@@ -23,7 +23,7 @@ use foundry_common::shell;
 use foundry_compilers::{artifacts::EvmVersion, info::ContractInfo};
 use foundry_config::{figment, impl_figment_convert, Config};
 use foundry_evm::{constants::DEFAULT_CREATE2_DEPLOYER, utils::configure_tx_req_env};
-use revm::{context::TxKind, state::AccountInfo};
+use revm::state::AccountInfo;
 use std::path::PathBuf;
 
 impl_figment_convert!(VerifyBytecodeArgs);

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -23,7 +23,7 @@ use foundry_common::shell;
 use foundry_compilers::{artifacts::EvmVersion, info::ContractInfo};
 use foundry_config::{figment, impl_figment_convert, Config};
 use foundry_evm::{constants::DEFAULT_CREATE2_DEPLOYER, utils::configure_tx_req_env};
-use revm_primitives::{AccountInfo, TxKind};
+use revm::{context::TxKind, state::AccountInfo};
 use std::path::PathBuf;
 
 impl_figment_convert!(VerifyBytecodeArgs);

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::{bytecode::VerifyBytecodeArgs, types::VerificationType};
 use alloy_dyn_abi::DynSolValue;
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_provider::{network::AnyRpcBlock, Provider};
 use alloy_rpc_types::BlockId;
 use clap::ValueEnum;
@@ -18,9 +18,11 @@ use foundry_evm::{
 };
 use reqwest::Url;
 use revm_primitives::{
-    db::Database,
+    bytecode::Bytecode,
+    database::Database,
     env::{EnvWithHandlerCfg, HandlerCfg},
-    Bytecode, Env, SpecId, TxKind,
+    hardfork::SpecId,
+    Env,
 };
 use semver::Version;
 use serde::{Deserialize, Serialize};

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -19,7 +19,7 @@ use foundry_compilers::{artifacts::EvmVersion, compilers::solc::Solc, info::Cont
 use foundry_config::{figment, impl_figment_convert, impl_figment_convert_cast, Config, SolcReq};
 use itertools::Itertools;
 use reqwest::Url;
-use revm_primitives::HashSet;
+use revm::primitives::HashSet;
 use semver::BuildMetadata;
 use std::path::PathBuf;
 

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -6,7 +6,7 @@ use crate::{
     utils::is_host_only,
     RetryArgs,
 };
-use alloy_primitives::Address;
+use alloy_primitives::{map::HashSet, Address};
 use alloy_provider::Provider;
 use clap::{Parser, ValueHint};
 use eyre::Result;
@@ -19,7 +19,6 @@ use foundry_compilers::{artifacts::EvmVersion, compilers::solc::Solc, info::Cont
 use foundry_config::{figment, impl_figment_convert, impl_figment_convert_cast, Config, SolcReq};
 use itertools::Itertools;
 use reqwest::Url;
-use revm::primitives::HashSet;
 use semver::BuildMetadata;
 use std::path::PathBuf;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/10116

Opening for visibility / easier collaboration

Restructured commit history so it is easier to revert to known good changes whilst iteratively implementing the complex changes (handler, journal)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Related PR: 

- https://github.com/foundry-rs/foundry/pull/10051 

Depends on:

- [x] https://github.com/alloy-rs/evm
- [ ] https://github.com/foundry-rs/foundry-fork-db/pull/44
- [x] https://github.com/paradigmxyz/revm-inspectors/pull/246

Next steps:

- Selectively extract changes
- Continue migrating `foundry-evm-core` crate, preferring internal mapping types rather than direct replacement - similar to Ethers > Alloy migration process
- Refactor / reimplement handlers:
  - Odyssey
  - CREATE2
- Refactor JournaledState using JournalInner
- Clarify how TxEnv + OptimismFields would work

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes