### PR TITLE
chore: bsc testnet rpc url

### DIFF
--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -159,6 +159,10 @@ fn next_url(is_ws: bool, chain: NamedChain) -> String {
         return "https://mainnet.base.org".to_string();
     }
 
+    if matches!(chain, BinanceSmartChainTestnet) {
+        return "https://bsc-testnet-rpc.publicnode.com".to_string();
+    }
+
     let domain = if matches!(chain, Mainnet) {
         // For Mainnet pick one of Reth nodes.
         let idx = next_idx() % RETH_HOSTS.len();
@@ -178,7 +182,6 @@ fn next_url(is_ws: bool, chain: NamedChain) -> String {
             Arbitrum => "arbitrum",
             Polygon => "polygon",
             Sepolia => "sepolia",
-            BinanceSmartChainTestnet => "bsc-testnet",
             _ => "",
         };
         format!("lb.drpc.org/ogrpc?network={network}&dkey={key}")


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- drpc chose from public nodes and lately seen many timeouts for bsc testnet test
- hardcode bsc testnet rpc url to https://bsc-testnet-rpc.publicnode.com/ to avoid picking other nodes that could timeout
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes