### PR TITLE
fix(forge): check deployed bytecode and fallback to creation code

### DIFF
--- a/crates/evm/traces/src/identifier/local.rs
+++ b/crates/evm/traces/src/identifier/local.rs
@@ -86,15 +86,15 @@ impl<'a> LocalTraceIdentifier<'a> {
         let idx = self.find_index(min_len);
         for i in idx..same_length_idx {
             let (id, _) = self.ordered_ids[i];
-            if let found @ Some(_) = check(id, true, &mut min_score) {
+            if let found @ Some(_) = check(id, false, &mut min_score) {
                 return found;
             }
         }
 
-        // Fallback to comparing deployed code if min score greater than threshold.
+        // Fallback to comparing creation code if min score greater than threshold.
         if min_score >= 0.85 {
             for (artifact, _) in &self.ordered_ids {
-                if let found @ Some(_) = check(artifact, false, &mut min_score) {
+                if let found @ Some(_) = check(artifact, true, &mut min_score) {
                     return found;
                 }
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #8465 
- change check order: check creation code, deployed code, fallback into creation code when identifying addresses to artifacts (instead check creation code, creation code, fallback to deployed code)
- manually tested with env from https://github.com/foundry-rs/foundry/issues/8465#issuecomment-2767018869 (repro big to include in unit test). Unit tests added in https://github.com/foundry-rs/foundry/pull/9050 for initial fix pass.
- breaks several unit tests like `can_execute_script_with_arguments`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes