### PR TITLE
feat(forge): add vm.setArbitraryStorage with overwrites

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -9336,7 +9336,7 @@
     },
     {
       "func": {
-        "id": "setArbitraryStorage",
+        "id": "setArbitraryStorage_0",
         "description": "Utility cheatcode to set arbitrary storage for given target address.",
         "declaration": "function setArbitraryStorage(address target) external;",
         "visibility": "external",
@@ -9348,6 +9348,26 @@
           99,
           24,
           55
+        ]
+      },
+      "group": "utilities",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "setArbitraryStorage_1",
+        "description": "Utility cheatcode to set arbitrary storage for given target address and overwrite\nany storage slots that have been previously set.",
+        "declaration": "function setArbitraryStorage(address target, bool overwrite) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "setArbitraryStorage(address,bool)",
+        "selector": "0xd3ec2a0b",
+        "selectorBytes": [
+          211,
+          236,
+          42,
+          11
         ]
       },
       "group": "utilities",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2826,6 +2826,11 @@ interface Vm {
     #[cheatcode(group = Utilities)]
     function setArbitraryStorage(address target) external;
 
+    /// Utility cheatcode to set arbitrary storage for given target address and overwrite
+    /// any storage slots that have been previously set.
+    #[cheatcode(group = Utilities)]
+    function setArbitraryStorage(address target, bool overwrite) external;
+
     /// Sorts an array in ascending order.
     #[cheatcode(group = Utilities)]
     function sort(uint256[] calldata array) external returns (uint256[] memory);

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -193,10 +193,19 @@ impl Cheatcode for resumeTracingCall {
     }
 }
 
-impl Cheatcode for setArbitraryStorageCall {
+impl Cheatcode for setArbitraryStorage_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { target } = self;
-        ccx.state.arbitrary_storage().mark_arbitrary(target);
+        ccx.state.arbitrary_storage().mark_arbitrary(target, false);
+
+        Ok(Default::default())
+    }
+}
+
+impl Cheatcode for setArbitraryStorage_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { target, overwrite } = self;
+        ccx.state.arbitrary_storage().mark_arbitrary(target, *overwrite);
 
         Ok(Default::default())
     }

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -461,6 +461,7 @@ interface Vm {
     function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value) external returns (string memory json);
     function serializeUint(string calldata objectKey, string calldata valueKey, uint256[] calldata values) external returns (string memory json);
     function setArbitraryStorage(address target) external;
+    function setArbitraryStorage(address target, bool overwrite) external;
     function setBlockhash(uint256 blockNumber, bytes32 blockHash) external;
     function setEnv(string calldata name, string calldata value) external;
     function setNonce(address account, uint64 newNonce) external;

--- a/testdata/default/cheats/ArbitraryStorage.t.sol
+++ b/testdata/default/cheats/ArbitraryStorage.t.sol
@@ -123,3 +123,33 @@ contract SymbolicStorageWithSeedTest is DSTest {
         assertEq(uint256(storage_value), 0);
     }
 }
+
+// <https://github.com/foundry-rs/foundry/issues/10084>
+contract ArbitraryStorageOverwriteWithSeedTest is DSTest {
+    Vm vm = Vm(HEVM_ADDRESS);
+    uint256 _value;
+
+    function testArbitraryStorageFalse(uint256 value) public {
+        _value = value;
+        vm.setArbitraryStorage(address(this), false);
+        assertEq(_value, value);
+    }
+
+    function testArbitraryStorageTrue(uint256 value) public {
+        _value = value;
+        vm.setArbitraryStorage(address(this), true);
+        assertTrue(_value != value);
+    }
+
+    function testArbitraryStorageFalse_setAfter(uint256 value) public {
+        vm.setArbitraryStorage(address(this), false);
+        _value = value;
+        assertEq(_value, value);
+    }
+
+    function testArbitraryStorageTrue_setAfter(uint256 value) public {
+        vm.setArbitraryStorage(address(this), true);
+        _value = value;
+        assertEq(_value, value);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #10084 
- adds cheatcode
```Solidity
    /// Utility cheatcode to set arbitrary storage for given target address and overwrite
    /// any storage slots that have been previously set.
    function setArbitraryStorage(address target, bool overwrite) external;
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes