### PR TITLE
fix(`anvil`): --chain-id takes precendence over genesis

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -223,6 +223,13 @@ impl NodeArgs {
             None => None,
         };
 
+        // --chain-id takes precedence over the genesis config
+        // if both are missing, use the default chain id
+        // <https://github.com/foundry-rs/foundry/issues/10059>
+        let chain_id = self
+            .evm
+            .chain_id
+            .map_or(self.init.as_ref().map_or(CHAIN_ID, |g| g.config.chain_id), |c| c.into());
         Ok(NodeConfig::default()
             .with_gas_limit(self.evm.gas_limit)
             .disable_block_gas_limit(self.evm.disable_block_gas_limit)
@@ -254,7 +261,7 @@ impl NodeArgs {
             .with_host(self.host)
             .set_silent(shell::is_quiet())
             .set_config_out(self.config_out)
-            .with_chain_id(self.evm.chain_id)
+            .with_chain_id(Some(chain_id))
             .with_transaction_order(self.order)
             .with_genesis(self.init)
             .with_steps_tracing(self.evm.steps_tracing)
@@ -278,7 +285,7 @@ impl NodeArgs {
     fn account_generator(&self) -> AccountGenerator {
         let mut gen = AccountGenerator::new(self.accounts as usize)
             .phrase(DEFAULT_MNEMONIC)
-            .chain_id(self.evm.chain_id.unwrap_or_else(|| CHAIN_ID.into()));
+            .chain_id(self.evm.chain_id.unwrap_or(CHAIN_ID.into()));
         if let Some(ref mnemonic) = self.mnemonic {
             gen = gen.phrase(mnemonic);
         } else if let Some(count) = self.mnemonic_random {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #10059 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- `--chain-id` takes precedence if present ahead of genesis config.
- If none are present, then use default chain id

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes