### PR TITLE
fix: resolve clippy warnings

### DIFF
--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -25,7 +25,7 @@ use serde_json::value::RawValue;
 use std::fmt::Write;
 
 /// Different sender kinds used by [`CastTxBuilder`].
-#[expect(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant)]
 pub enum SenderKind<'a> {
     /// An address without signer. Used for read-only calls and transactions sent through unlocked
     /// accounts.


### PR DESCRIPTION
fix: resolve clippy large_enum_variant warning

- Replace #[expect(clippy::large_enum_variant)] with #[allow(clippy::large_enum_variant)] in SenderKind enum
- All clippy warnings are now resolved
Thank you !