### PR TITLE
fix(anvil): Fix tracing-subscriber initialization conflict in EIP4844 test

### DIFF
--- a/crates/anvil/tests/it/eip4844.rs
+++ b/crates/anvil/tests/it/eip4844.rs
@@ -300,7 +300,7 @@ async fn can_correctly_estimate_blob_gas_with_recommended_fillers_with_signer() 
 // <https://github.com/foundry-rs/foundry/issues/9924>
 #[tokio::test]
 async fn can_bypass_sidecar_requirement() {
-    tracing_subscriber::fmt::init();
+    crate::init_tracing();
     let node_config = NodeConfig::test()
         .with_hardfork(Some(EthereumHardfork::Cancun.into()))
         .with_auto_impersonate(true);


### PR DESCRIPTION


## Motivation

---- eip4844::can_bypass_sidecar_requirement stdout ----

thread 'eip4844::can_bypass_sidecar_requirement' panicked at \src\fmt\mod.rs:1244:16:
Unable to install global subscriber: SetGlobalDefaultError("a global default trace dispatcher has already been set")      


## Solution

In the can_bypass_sidecar_requirement test, tracing_subscriber::fmt::init() was called directly, 
which caused conflict with other initializations of the global trace handler.

The fix replaces the direct tracing initialization call with the use of 
of the crate::init_tracing() built-in function, which avoids the error 
"a global default trace dispatcher has already been set".

The error occurred due to an attempt to set multiple global 
trace handlers in a single application, which is not allowed by the tracing-subscriber library.


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes