### PR TITLE
chore: update advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,8 +11,8 @@ ignore = [
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2024-0437 protobuf! Crash due to uncontrolled recursion in protobuf crate.
     "RUSTSEC-2024-0437",
-    # humantime is unmaintained
-    "RUSTSEC-2025-0014",
+    # https://rustsec.org/advisories/RUSTSEC-2025-0021 gitoxide uses SHA-1 hash implementations without any collision detection, leaving it vulnerable to hash collision attacks.
+    "RUSTSEC-2025-0021"
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
sha1 used by gitoxide, doesn't affect foundry's usage