### PR TITLE
feat/fix(anvil): add genesis number CLI option, fix genesis block construction

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -658,7 +658,7 @@ impl Future for PeriodicStateDumper {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         if this.dump_state.is_none() {
-            return Poll::Pending;
+            return Poll::Pending
         }
 
         loop {
@@ -669,7 +669,7 @@ impl Future for PeriodicStateDumper {
                     }
                     Poll::Pending => {
                         this.in_progress_dump = Some(flush);
-                        return Poll::Pending;
+                        return Poll::Pending
                     }
                 }
             }
@@ -680,7 +680,7 @@ impl Future for PeriodicStateDumper {
                 this.in_progress_dump =
                     Some(Box::pin(Self::dump_state(api, path, this.preserve_historical_states)));
             } else {
-                break;
+                break
             }
         }
 
@@ -710,7 +710,7 @@ impl StateFile {
         }
         let mut state = Self { path, state: None };
         if !state.path.exists() {
-            return Ok(state);
+            return Ok(state)
         }
 
         state.state = Some(SerializableState::load(&state.path).map_err(|err| err.to_string())?);
@@ -745,14 +745,14 @@ impl FromStr for ForkUrl {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some((url, block)) = s.rsplit_once('@') {
             if block == "latest" {
-                return Ok(Self { url: url.to_string(), block: None });
+                return Ok(Self { url: url.to_string(), block: None })
             }
             // this will prevent false positives for auths `user:password@example.com`
             if !block.is_empty() && !block.contains(':') && !block.contains('.') {
                 let block: u64 = block
                     .parse()
                     .map_err(|_| format!("Failed to parse block number: `{block}`"))?;
-                return Ok(Self { url: url.to_string(), block: Some(block) });
+                return Ok(Self { url: url.to_string(), block: Some(block) })
             }
         }
         Ok(Self { url: s.to_string(), block: None })

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -105,6 +105,8 @@ pub struct NodeConfig {
     pub genesis_balance: U256,
     /// Genesis block timestamp
     pub genesis_timestamp: Option<u64>,
+    /// Genesis block number
+    pub genesis_block_number: Option<u64>,
     /// Signer accounts that can sign messages/transactions from the EVM node
     pub signer_accounts: Vec<PrivateKeySigner>,
     /// Configured block time for the EVM chain. Use `None` to mine a new block for every tx
@@ -428,6 +430,7 @@ impl Default for NodeConfig {
             hardfork: None,
             signer_accounts: genesis_accounts.clone(),
             genesis_timestamp: None,
+            genesis_block_number: None,
             genesis_accounts,
             // 100ETH default balance
             genesis_balance: Unit::ETHER.wei().saturating_mul(U256::from(100u64)),
@@ -666,9 +669,20 @@ impl NodeConfig {
         self
     }
 
+    /// Sets the genesis number
+    #[must_use]
+    pub fn with_genesis_block_number<U: Into<u64>>(mut self, number: Option<U>) -> Self {
+        if let Some(number) = number {
+            self.genesis_block_number = Some(number.into());
+        }
+        self
+    }
+
     /// Returns the genesis number
     pub fn get_genesis_number(&self) -> u64 {
-        self.genesis.as_ref().and_then(|g| g.number).unwrap_or(0)
+        self.genesis_block_number
+            .or_else(|| self.genesis.as_ref().and_then(|g| g.number))
+            .unwrap_or_else(|| 0)
     }
 
     /// Sets the hardfork

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -682,7 +682,7 @@ impl NodeConfig {
     pub fn get_genesis_number(&self) -> u64 {
         self.genesis_block_number
             .or_else(|| self.genesis.as_ref().and_then(|g| g.number))
-            .unwrap_or_else(|| 0)
+            .unwrap_or(0)
     }
 
     /// Sets the hardfork

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -291,7 +291,7 @@ impl BlockchainStorage {
             difficulty: env.block.difficulty,
             blob_gas_used: env.block.blob_excess_gas_and_price.as_ref().map(|_| 0),
             excess_blob_gas: env.block.get_blob_excess_gas(),
-
+            number: genesis_number,
             parent_beacon_block_root: is_cancun.then_some(Default::default()),
             withdrawals_root: is_shanghai.then_some(EMPTY_WITHDRAWALS),
             requests_hash: is_prague.then_some(EMPTY_REQUESTS_HASH),

--- a/crates/anvil/tests/it/anvil.rs
+++ b/crates/anvil/tests/it/anvil.rs
@@ -121,8 +121,6 @@ async fn test_can_set_genesis_block_number() {
     let (_api, handle) = spawn(NodeConfig::test().with_genesis_block_number(Some(1337u64))).await;
     let provider = handle.http_provider();
 
-    println!("block: {:?}", provider.get_block(1337.into()).await.unwrap());
-
     let block_number = provider.get_block_number().await.unwrap();
     assert_eq!(block_number, 1337u64);
 

--- a/crates/anvil/tests/it/anvil.rs
+++ b/crates/anvil/tests/it/anvil.rs
@@ -115,3 +115,24 @@ async fn test_cancun_fields() {
     assert!(block.header.blob_gas_used.is_some());
     assert!(block.header.excess_blob_gas.is_some());
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_can_set_genesis_block_number() {
+    let (_api, handle) = spawn(NodeConfig::test().with_genesis_block_number(Some(1337u64))).await;
+    let provider = handle.http_provider();
+
+    println!("block: {:?}", provider.get_block(1337.into()).await.unwrap());
+
+    let block_number = provider.get_block_number().await.unwrap();
+    assert_eq!(block_number, 1337u64);
+
+    assert_eq!(1337, provider.get_block(1337.into()).await.unwrap().unwrap().header.number);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_can_use_default_genesis_block_number() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    assert_eq!(0, provider.get_block(0.into()).await.unwrap().unwrap().header.number);
+}


### PR DESCRIPTION
## Motivation

1. Iterates on https://github.com/foundry-rs/foundry/pull/10080 by adding a way of specifying the genesis block number through CLI arguments
2. Fixes the genesis block construction, previously the header was incorrectly constructed (I'm sorry)

## Solution

* Added a new field `number` to `NodeArgs` to specify the genesis block number (`crates/anvil/src/cmd.rs`).
* Updated the `NodeArgs` implementation to include the genesis block number when initializing the node (`crates/anvil/src/cmd.rs`).
* Introduced a new field `genesis_block_number` in `NodeConfig` to store the genesis block number (`crates/anvil/src/config.rs`).
* Added methods `with_genesis_block_number` and `get_genesis_number` to `NodeConfig` to set and retrieve the genesis block number (`crates/anvil/src/config.rs`).

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes