### PR TITLE
chore: add `TransferInspector` to anvil `Inspector`

### DIFF
--- a/crates/evm/evm/src/inspectors/mod.rs
+++ b/crates/evm/evm/src/inspectors/mod.rs
@@ -5,7 +5,7 @@ pub use foundry_evm_coverage::CoverageCollector;
 pub use foundry_evm_fuzz::Fuzzer;
 pub use foundry_evm_traces::{StackSnapshotType, TracingInspector, TracingInspectorConfig};
 
-pub use revm_inspectors::access_list::AccessListInspector;
+pub use revm_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};
 
 mod chisel_state;
 pub use chisel_state::ChiselState;


### PR DESCRIPTION
In order to use `--print-traces` with `eth_simulateV1`, we need to add `TransferInspector` to the anvil `Inspector`

blocked on https://github.com/paradigmxyz/revm-inspectors/pull/279