### PR TITLE
Force `prevrandao` on Rootstock network

### DIFF
--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -56,7 +56,7 @@ pub fn apply_chain_and_block_specific_env_changes<N: Network>(
                 env.block.prevrandao = Some(env.block.difficulty.into());
                 return;
             }
-            Moonbeam | Moonbase | Moonriver | MoonbeamDev => {
+            Moonbeam | Moonbase | Moonriver | MoonbeamDev | Rsk => {
                 if env.block.prevrandao.is_none() {
                     // <https://github.com/foundry-rs/foundry/issues/4232>
                     env.block.prevrandao = Some(B256::random());


### PR DESCRIPTION
## Description

- Includes Rootstock network in workaround due to missing `block.prevrandao` (mix_hash) field in block header
- Rootstock (Bitcoin sidechain) is EVM-compatible but operates under a different consensus mechanism due to which mix_hash / block.prerandao semantics does not apply on Rootstock

## Why 

Merging this PR will successfully fix the following error: 

```
[⠊] Compiling...
No files changed, compilation skipped
Error: Failed to deploy script:
EVM error; header validation error: `prevrandao` not set
```


Merging this PR will unblock developers to use latest foundry version with Rootstock as Rootstock supports the EVM version (cancun) which is default version in foundry with the exception of prevrandao semantics which does not apply on rootstock network. 