### PR TITLE
refactor: signatures identifier, trace decoding

### DIFF
--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -20,11 +20,10 @@ use foundry_common::{
     selectors::{
         decode_calldata, decode_event_topic, decode_function_selector, decode_selectors,
         import_selectors, parse_signatures, pretty_calldata, ParsedSignatures, SelectorImportData,
-        SelectorType,
+        SelectorKind,
     },
     shell, stdin,
 };
-use foundry_config::Config;
 use std::time::Instant;
 
 /// Run the `cast` command-line interface.
@@ -209,11 +208,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
                 let data = data.strip_prefix("0x").unwrap_or(data.as_str());
                 let selector = data.get(..64).unwrap_or_default();
                 let identified_event =
-                    SignaturesIdentifier::new(Config::foundry_cache_dir(), false)?
-                        .write()
-                        .await
-                        .identify_event(&hex::decode(selector)?)
-                        .await;
+                    SignaturesIdentifier::new(false)?.identify_event(selector.parse()?).await;
                 if let Some(event) = identified_event {
                     let _ = sh_println!("{}", event.signature());
                     let data = data.get(64..).unwrap_or_default();
@@ -235,11 +230,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
                 let data = data.strip_prefix("0x").unwrap_or(data.as_str());
                 let selector = data.get(..8).unwrap_or_default();
                 let identified_error =
-                    SignaturesIdentifier::new(Config::foundry_cache_dir(), false)?
-                        .write()
-                        .await
-                        .identify_error(&hex::decode(selector)?)
-                        .await;
+                    SignaturesIdentifier::new(false)?.identify_error(selector.parse()?).await;
                 if let Some(error) = identified_error {
                     let _ = sh_println!("{}", error.signature());
                     error
@@ -385,9 +376,12 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
             let max_mutability_len = functions.iter().map(|r| r.2.len()).max().unwrap_or(0);
 
             let resolve_results = if resolve {
-                let selectors_it = functions.iter().map(|r| &r.0);
-                let ds = decode_selectors(SelectorType::Function, selectors_it).await?;
-                ds.into_iter().map(|v| v.unwrap_or_default().join("|")).collect()
+                let selectors = functions
+                    .iter()
+                    .map(|&(selector, ..)| SelectorKind::Function(selector))
+                    .collect::<Vec<_>>();
+                let ds = decode_selectors(&selectors).await?;
+                ds.into_iter().map(|v| v.join("|")).collect()
             } else {
                 vec![]
             };
@@ -501,7 +495,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
         // 4Byte
         CastSubcommand::FourByte { selector } => {
             let selector = stdin::unwrap_line(selector)?;
-            let sigs = decode_function_selector(&selector).await?;
+            let sigs = decode_function_selector(selector).await?;
             if sigs.is_empty() {
                 eyre::bail!("No matching function signatures found for selector `{selector}`");
             }
@@ -514,7 +508,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
             let calldata = stdin::unwrap_line(calldata)?;
 
             if calldata.len() == 10 {
-                let sigs = decode_function_selector(&calldata).await?;
+                let sigs = decode_function_selector(calldata.parse()?).await?;
                 if sigs.is_empty() {
                     eyre::bail!("No matching function signatures found for calldata `{calldata}`");
                 }
@@ -544,7 +538,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
 
         CastSubcommand::FourByteEvent { topic } => {
             let topic = stdin::unwrap_line(topic)?;
-            let sigs = decode_event_topic(&topic).await?;
+            let sigs = decode_event_topic(topic).await?;
             if sigs.is_empty() {
                 eyre::bail!("No matching event signatures found for topic `{topic}`");
             }

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -5,7 +5,7 @@ use crate::cmd::{
     mktx::MakeTxArgs, rpc::RpcArgs, run::RunArgs, send::SendTxArgs, storage::StorageArgs,
     txpool::TxPoolSubcommands, wallet::WalletSubcommands,
 };
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, Selector, B256, U256};
 use alloy_rpc_types::BlockId;
 use clap::{Parser, Subcommand, ValueHint};
 use eyre::Result;
@@ -646,7 +646,7 @@ pub enum CastSubcommand {
     #[command(name = "4byte", visible_aliases = &["4", "4b"])]
     FourByte {
         /// The function selector.
-        selector: Option<String>,
+        selector: Option<Selector>,
     },
 
     /// Decode ABI-encoded calldata using <https://openchain.xyz>.
@@ -661,7 +661,7 @@ pub enum CastSubcommand {
     FourByteEvent {
         /// Topic 0
         #[arg(value_name = "TOPIC_0")]
-        topic: Option<String>,
+        topic: Option<B256>,
     },
 
     /// Upload the given signatures to <https://openchain.xyz>.

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -13,7 +13,7 @@ use crate::{
 use alloy_json_abi::{InternalType, JsonAbi};
 use alloy_primitives::{hex, Address};
 use forge_fmt::FormatterConfig;
-use foundry_config::{Config, RpcEndpointUrl};
+use foundry_config::RpcEndpointUrl;
 use foundry_evm::{
     decode::decode_console_logs,
     traces::{
@@ -925,9 +925,8 @@ impl ChiselDispatcher {
     ) -> eyre::Result<CallTraceDecoder> {
         let mut decoder = CallTraceDecoderBuilder::new()
             .with_labels(result.labeled_addresses.clone())
-            .with_signature_identifier(SignaturesIdentifier::new(
-                Config::foundry_cache_dir(),
-                session_config.foundry_config.offline,
+            .with_signature_identifier(SignaturesIdentifier::from_config(
+                &session_config.foundry_config,
             )?)
             .build();
 
@@ -965,7 +964,7 @@ impl ChiselDispatcher {
         for (kind, trace) in &mut result.traces {
             // Display all Setup + Execution traces.
             if matches!(kind, TraceKind::Setup | TraceKind::Execution) {
-                decode_trace_arena(trace, decoder).await?;
+                decode_trace_arena(trace, decoder).await;
                 sh_println!("{}", render_trace_arena(trace))?;
             }
         }

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -1,7 +1,10 @@
 use alloy_json_abi::JsonAbi;
 use alloy_primitives::Address;
 use eyre::{Result, WrapErr};
-use foundry_common::{compile::ProjectCompiler, fs, shell, ContractsByArtifact, TestFunctionExt};
+use foundry_common::{
+    compile::ProjectCompiler, fs, selectors::SelectorKind, shell, ContractsByArtifact,
+    TestFunctionExt,
+};
 use foundry_compilers::{
     artifacts::{CompactBytecode, Settings},
     cache::{CacheEntry, CompilerCache},
@@ -16,7 +19,7 @@ use foundry_evm::{
     traces::{
         debug::{ContractSources, DebugTraceIdentifier},
         decode_trace_arena,
-        identifier::{CachedSignatures, SignaturesIdentifier, TraceIdentifiers},
+        identifier::{SignaturesCache, SignaturesIdentifier, TraceIdentifiers},
         render_trace_arena_inner, CallTraceDecoder, CallTraceDecoderBuilder, TraceKind, Traces,
     },
 };
@@ -364,10 +367,7 @@ pub async fn handle_traces(
 
     let mut builder = CallTraceDecoderBuilder::new()
         .with_labels(labels.chain(config_labels))
-        .with_signature_identifier(SignaturesIdentifier::new(
-            Config::foundry_cache_dir(),
-            config.offline,
-        )?);
+        .with_signature_identifier(SignaturesIdentifier::from_config(config)?);
     let mut identifier = TraceIdentifiers::new().with_etherscan(config, chain)?;
     if let Some(contracts) = &known_contracts {
         builder = builder.with_known_contracts(contracts);
@@ -416,7 +416,7 @@ pub async fn print_traces(
     }
 
     for (_, arena) in traces {
-        decode_trace_arena(arena, decoder).await?;
+        decode_trace_arena(arena, decoder).await;
         sh_println!("{}", render_trace_arena_inner(arena, verbose, state_changes))?;
     }
 
@@ -437,34 +437,21 @@ pub async fn print_traces(
 
 /// Traverse the artifacts in the project to generate local signatures and merge them into the cache
 /// file.
-pub fn cache_local_signatures(output: &ProjectCompileOutput, cache_path: PathBuf) -> Result<()> {
-    let path = cache_path.join("signatures");
-    let mut cached_signatures = CachedSignatures::load(cache_path);
-    output.artifacts().for_each(|(_, artifact)| {
+pub fn cache_local_signatures(output: &ProjectCompileOutput, cache_dir: &Path) -> Result<()> {
+    let path = cache_dir.join("signatures");
+    let mut signatures = SignaturesCache::load(&path);
+    for (_, artifact) in output.artifacts() {
         if let Some(abi) = &artifact.abi {
-            for func in abi.functions() {
-                cached_signatures.functions.insert(func.selector().to_string(), func.signature());
-            }
-            for event in abi.events() {
-                cached_signatures
-                    .events
-                    .insert(event.selector().to_string(), event.full_signature());
-            }
-            for error in abi.errors() {
-                cached_signatures.errors.insert(error.selector().to_string(), error.signature());
-            }
-            // External libraries doesn't have functions included in abi, but `methodIdentifiers`.
-            if let Some(method_identifiers) = &artifact.method_identifiers {
-                method_identifiers.iter().for_each(|(signature, selector)| {
-                    cached_signatures
-                        .functions
-                        .entry(format!("0x{selector}"))
-                        .or_insert(signature.to_string());
-                });
-            }
+            signatures.extend_from_abi(abi);
         }
-    });
 
-    fs::write_json_file(&path, &cached_signatures)?;
+        // External libraries don't have functions included in abi, but `methodIdentifiers`.
+        if let Some(method_identifiers) = &artifact.method_identifiers {
+            signatures.extend(method_identifiers.iter().filter_map(|(selector, signature)| {
+                Some((SelectorKind::Function(selector.parse().ok()?), signature.clone()))
+            }));
+        }
+    }
+    signatures.save(&path);
     Ok(())
 }

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -138,7 +138,7 @@ impl RuntimeTransport {
     /// Connects the underlying transport, depending on the URL scheme.
     pub async fn connect(&self) -> Result<InnerTransport, RuntimeTransportError> {
         match self.url.scheme() {
-            "http" | "https" => self.connect_http().await,
+            "http" | "https" => self.connect_http(),
             "ws" | "wss" => self.connect_ws().await,
             "file" => self.connect_ipc().await,
             _ => Err(RuntimeTransportError::BadScheme(self.url.scheme().to_string())),
@@ -190,7 +190,7 @@ impl RuntimeTransport {
     }
 
     /// Connects to an HTTP [alloy_transport_http::Http] transport.
-    async fn connect_http(&self) -> Result<InnerTransport, RuntimeTransportError> {
+    fn connect_http(&self) -> Result<InnerTransport, RuntimeTransportError> {
         let client = self.reqwest_client()?;
         Ok(InnerTransport::Http(Http::with_client(client, self.url.clone())))
     }
@@ -351,7 +351,7 @@ mod tests {
         let transport = RuntimeTransportBuilder::new(url.clone())
             .with_headers(vec!["User-Agent: test-agent".to_string()])
             .build();
-        let inner = transport.connect_http().await.unwrap();
+        let inner = transport.connect_http().unwrap();
 
         match inner {
             InnerTransport::Http(http) => {

--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -4,8 +4,9 @@
 
 use crate::{abi::abi_decode_calldata, provider::runtime_transport::RuntimeTransportBuilder};
 use alloy_json_abi::JsonAbi;
-use alloy_primitives::map::HashMap;
+use alloy_primitives::{map::HashMap, Selector, B256};
 use eyre::Context;
+use itertools::Itertools;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
     fmt,
@@ -25,6 +26,9 @@ const REQ_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// How many request can time out before we decide this is a spurious connection.
 const MAX_TIMEDOUT_REQ: usize = 4usize;
+
+/// List of signatures for a given [`SelectorKind`].
+pub type OpenChainSignatures = Vec<String>;
 
 /// A client that can request API data from OpenChain.
 #[derive(Clone, Debug)]
@@ -54,7 +58,7 @@ impl OpenChainClient {
         })
     }
 
-    async fn get_text(&self, url: &str) -> reqwest::Result<String> {
+    async fn get_text(&self, url: impl reqwest::IntoUrl + fmt::Display) -> reqwest::Result<String> {
         trace!(%url, "GET");
         self.inner
             .get(url)
@@ -128,29 +132,16 @@ impl OpenChainClient {
     /// Decodes the given function or event selector using OpenChain
     pub async fn decode_selector(
         &self,
-        selector: &str,
-        selector_type: SelectorType,
-    ) -> eyre::Result<Vec<String>> {
-        self.decode_selectors(selector_type, std::iter::once(selector))
-            .await?
-            .pop() // Not returning on the previous line ensures a vector with exactly 1 element
-            .unwrap()
-            .ok_or_else(|| eyre::eyre!("No signature found"))
+        selector: SelectorKind,
+    ) -> eyre::Result<OpenChainSignatures> {
+        Ok(self.decode_selectors(&[selector]).await?.pop().unwrap())
     }
 
     /// Decodes the given function, error or event selectors using OpenChain.
     pub async fn decode_selectors(
         &self,
-        selector_type: SelectorType,
-        selectors: impl IntoIterator<Item = impl Into<String>>,
-    ) -> eyre::Result<Vec<Option<Vec<String>>>> {
-        let selectors: Vec<String> = selectors
-            .into_iter()
-            .map(Into::into)
-            .map(|s| s.to_lowercase())
-            .map(|s| if s.starts_with("0x") { s } else { format!("0x{s}") })
-            .collect();
-
+        selectors: &[SelectorKind],
+    ) -> eyre::Result<Vec<OpenChainSignatures>> {
         if selectors.is_empty() {
             return Ok(vec![]);
         }
@@ -158,78 +149,62 @@ impl OpenChainClient {
         debug!(len = selectors.len(), "decoding selectors");
         trace!(?selectors, "decoding selectors");
 
-        // exit early if spurious connection
+        // Exit early if spurious connection.
         self.ensure_not_spurious()?;
 
-        let expected_len = match selector_type {
-            SelectorType::Function | SelectorType::Error => 10, // 0x + hex(4bytes)
-            SelectorType::Event => 66,                          // 0x + hex(32bytes)
-        };
-        if let Some(s) = selectors.iter().find(|s| s.len() != expected_len) {
-            eyre::bail!(
-                "Invalid selector {s}: expected {expected_len} characters (including 0x prefix)."
-            )
-        }
-
-        #[derive(Deserialize)]
-        struct Decoded {
-            name: String,
-        }
-
-        #[derive(Deserialize)]
-        struct ApiResult {
-            event: HashMap<String, Option<Vec<Decoded>>>,
-            function: HashMap<String, Option<Vec<Decoded>>>,
-        }
-
-        #[derive(Deserialize)]
-        struct ApiResponse {
-            ok: bool,
-            result: ApiResult,
-        }
-
-        let url = format!(
-            "{SELECTOR_LOOKUP_URL}?{ltype}={selectors_str}",
-            ltype = match selector_type {
-                SelectorType::Function | SelectorType::Error => "function",
-                SelectorType::Event => "event",
-            },
-            selectors_str = selectors.join(",")
-        );
-
-        let res = self.get_text(&url).await?;
-        let api_response = match serde_json::from_str::<ApiResponse>(&res) {
-            Ok(inner) => inner,
-            Err(err) => {
-                eyre::bail!("Could not decode response:\n {res}.\nError: {err}")
+        // Build the URL with the query string.
+        let mut url: url::Url = SELECTOR_LOOKUP_URL.parse().unwrap();
+        {
+            let mut query = url.query_pairs_mut();
+            let functions = selectors.iter().filter_map(SelectorKind::as_function);
+            if functions.clone().next().is_some() {
+                query.append_pair("function", &functions.format(",").to_string());
             }
-        };
-
-        if !api_response.ok {
-            eyre::bail!("Failed to decode:\n {res}")
+            let events = selectors.iter().filter_map(SelectorKind::as_event);
+            if events.clone().next().is_some() {
+                query.append_pair("event", &events.format(",").to_string());
+            }
+            let _ = query.finish();
         }
 
-        let decoded = match selector_type {
-            SelectorType::Function | SelectorType::Error => api_response.result.function,
-            SelectorType::Event => api_response.result.event,
+        let text = self.get_text(url).await?;
+        let SignatureResponse { ok, mut result } = match serde_json::from_str(&text) {
+            Ok(response) => response,
+            Err(err) => eyre::bail!("could not decode response: {err}: {text}"),
         };
+        if !ok {
+            eyre::bail!("OpenChain returned an error: {text}");
+        }
 
         Ok(selectors
-            .into_iter()
-            .map(|selector| match decoded.get(&selector) {
-                Some(Some(r)) => Some(r.iter().map(|d| d.name.clone()).collect()),
-                _ => None,
+            .iter()
+            .map(|selector| {
+                let signatures = match selector {
+                    SelectorKind::Function(selector) | SelectorKind::Error(selector) => {
+                        result.function.remove(selector)
+                    }
+                    SelectorKind::Event(hash) => result.event.remove(hash),
+                };
+                signatures
+                    .unwrap_or_default()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|sig| sig.name)
+                    .collect()
             })
             .collect())
     }
 
     /// Fetches a function signature given the selector using OpenChain
-    pub async fn decode_function_selector(&self, selector: &str) -> eyre::Result<Vec<String>> {
-        self.decode_selector(selector, SelectorType::Function).await
+    pub async fn decode_function_selector(
+        &self,
+        selector: Selector,
+    ) -> eyre::Result<OpenChainSignatures> {
+        self.decode_selector(SelectorKind::Function(selector)).await
     }
 
     /// Fetches all possible signatures and attempts to abi decode the calldata
-    pub async fn decode_calldata(&self, calldata: &str) -> eyre::Result<Vec<String>> {
+    pub async fn decode_calldata(&self, calldata: &str) -> eyre::Result<OpenChainSignatures> {
         let calldata = calldata.strip_prefix("0x").unwrap_or(calldata);
         if calldata.len() < 8 {
             eyre::bail!(
@@ -238,19 +213,15 @@ impl OpenChainClient {
             )
         }
 
-        let sigs = self.decode_function_selector(&calldata[..8]).await?;
-
-        // filter for signatures that can be decoded
-        Ok(sigs
-            .iter()
-            .filter(|sig| abi_decode_calldata(sig, calldata, true, true).is_ok())
-            .cloned()
-            .collect::<Vec<String>>())
+        let mut sigs = self.decode_function_selector(calldata[..8].parse().unwrap()).await?;
+        // Retain only signatures that can be decoded.
+        sigs.retain(|sig| abi_decode_calldata(sig, calldata, true, true).is_ok());
+        Ok(sigs)
     }
 
-    /// Fetches an event signature given the 32 byte topic using OpenChain
-    pub async fn decode_event_topic(&self, topic: &str) -> eyre::Result<Vec<String>> {
-        self.decode_selector(topic, SelectorType::Event).await
+    /// Fetches an event signature given the 32 byte topic using OpenChain.
+    pub async fn decode_event_topic(&self, topic: B256) -> eyre::Result<OpenChainSignatures> {
+        self.decode_selector(SelectorKind::Event(topic)).await
     }
 
     /// Pretty print calldata and if available, fetch possible function signatures
@@ -284,6 +255,7 @@ impl OpenChainClient {
         let sigs = if offline {
             vec![]
         } else {
+            let selector = selector.parse()?;
             self.decode_function_selector(selector).await.unwrap_or_default().into_iter().collect()
         };
         let (_, data) = calldata.split_at(8);
@@ -314,7 +286,7 @@ impl OpenChainClient {
 
         let request = match data {
             SelectorImportData::Abi(abis) => {
-                let functions_and_errors: Vec<String> = abis
+                let functions_and_errors: OpenChainSignatures = abis
                     .iter()
                     .flat_map(|abi| {
                         abi.functions()
@@ -344,12 +316,12 @@ impl OpenChainClient {
 
 pub enum SelectorOrSig {
     Selector(String),
-    Sig(Vec<String>),
+    Sig(OpenChainSignatures),
 }
 
 pub struct PossibleSigs {
     method: SelectorOrSig,
-    data: Vec<String>,
+    data: OpenChainSignatures,
 }
 
 impl PossibleSigs {
@@ -382,45 +354,59 @@ impl fmt::Display for PossibleSigs {
     }
 }
 
-/// The type of selector fetched from OpenChain.
-#[derive(Clone, Copy)]
-pub enum SelectorType {
+/// The kind of selector to fetch from OpenChain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SelectorKind {
     /// A function selector.
-    Function,
+    Function(Selector),
+    /// A custom error selector. Behaves the same as a function selector.
+    Error(Selector),
     /// An event selector.
-    Event,
-    /// An custom error selector.
-    Error,
+    Event(B256),
+}
+
+impl SelectorKind {
+    /// Returns the function selector if it is a function OR custom error.
+    pub fn as_function(&self) -> Option<Selector> {
+        match *self {
+            Self::Function(selector) | Self::Error(selector) => Some(selector),
+            _ => None,
+        }
+    }
+
+    /// Returns the event selector if it is an event.
+    pub fn as_event(&self) -> Option<B256> {
+        match *self {
+            Self::Event(hash) => Some(hash),
+            _ => None,
+        }
+    }
 }
 
 /// Decodes the given function or event selector using OpenChain.
-pub async fn decode_selector(
-    selector_type: SelectorType,
-    selector: &str,
-) -> eyre::Result<Vec<String>> {
-    OpenChainClient::new()?.decode_selector(selector, selector_type).await
+pub async fn decode_selector(selector: SelectorKind) -> eyre::Result<OpenChainSignatures> {
+    OpenChainClient::new()?.decode_selector(selector).await
 }
 
 /// Decodes the given function or event selectors using OpenChain.
 pub async fn decode_selectors(
-    selector_type: SelectorType,
-    selectors: impl IntoIterator<Item = impl Into<String>>,
-) -> eyre::Result<Vec<Option<Vec<String>>>> {
-    OpenChainClient::new()?.decode_selectors(selector_type, selectors).await
+    selectors: &[SelectorKind],
+) -> eyre::Result<Vec<OpenChainSignatures>> {
+    OpenChainClient::new()?.decode_selectors(selectors).await
 }
 
 /// Fetches a function signature given the selector using OpenChain.
-pub async fn decode_function_selector(selector: &str) -> eyre::Result<Vec<String>> {
+pub async fn decode_function_selector(selector: Selector) -> eyre::Result<OpenChainSignatures> {
     OpenChainClient::new()?.decode_function_selector(selector).await
 }
 
 /// Fetches all possible signatures and attempts to abi decode the calldata using OpenChain.
-pub async fn decode_calldata(calldata: &str) -> eyre::Result<Vec<String>> {
+pub async fn decode_calldata(calldata: &str) -> eyre::Result<OpenChainSignatures> {
     OpenChainClient::new()?.decode_calldata(calldata).await
 }
 
 /// Fetches an event signature given the 32 byte topic using OpenChain.
-pub async fn decode_event_topic(topic: &str) -> eyre::Result<Vec<String>> {
+pub async fn decode_event_topic(topic: B256) -> eyre::Result<OpenChainSignatures> {
     OpenChainClient::new()?.decode_event_topic(topic).await
 }
 
@@ -448,9 +434,9 @@ pub async fn pretty_calldata(
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize)]
 pub struct RawSelectorImportData {
-    pub function: Vec<String>,
-    pub event: Vec<String>,
-    pub error: Vec<String>,
+    pub function: OpenChainSignatures,
+    pub event: OpenChainSignatures,
+    pub error: OpenChainSignatures,
 }
 
 impl RawSelectorImportData {
@@ -468,8 +454,8 @@ pub enum SelectorImportData {
 
 #[derive(Debug, Default, Serialize)]
 struct SelectorImportRequest {
-    function: Vec<String>,
-    event: Vec<String>,
+    function: OpenChainSignatures,
+    event: OpenChainSignatures,
 }
 
 #[derive(Debug, Deserialize)]
@@ -572,6 +558,24 @@ pub fn parse_signatures(tokens: Vec<String>) -> ParsedSignatures {
     );
 
     ParsedSignatures { signatures, abis }
+}
+
+/// [`SELECTOR_LOOKUP_URL`] response.
+#[derive(Deserialize)]
+struct SignatureResponse {
+    ok: bool,
+    result: SignatureResult,
+}
+
+#[derive(Deserialize)]
+struct SignatureResult {
+    event: HashMap<B256, Option<Vec<Signature>>>,
+    function: HashMap<Selector, Option<Vec<Signature>>>,
+}
+
+#[derive(Deserialize)]
+struct Signature {
+    name: String,
 }
 
 #[cfg(test)]

--- a/crates/evm/traces/src/decoder/precompiles.rs
+++ b/crates/evm/traces/src/decoder/precompiles.rs
@@ -1,5 +1,5 @@
 use crate::{CallTrace, DecodedCallData};
-use alloy_primitives::{hex, B256, U256};
+use alloy_primitives::{hex, Address, B256, U256};
 use alloy_sol_types::{abi, sol, SolCall};
 use foundry_evm_core::precompiles::{
     BLAKE_2F, EC_ADD, EC_MUL, EC_PAIRING, EC_RECOVER, IDENTITY, MOD_EXP, POINT_EVALUATION,
@@ -46,9 +46,26 @@ macro_rules! tri {
     };
 }
 
+pub(super) fn is_known_precompile(address: Address, _chain_id: u64) -> bool {
+    address[..19].iter().all(|&x| x == 0) &&
+        matches!(
+            address,
+            EC_RECOVER |
+                SHA_256 |
+                RIPEMD_160 |
+                IDENTITY |
+                MOD_EXP |
+                EC_ADD |
+                EC_MUL |
+                EC_PAIRING |
+                BLAKE_2F |
+                POINT_EVALUATION
+        )
+}
+
 /// Tries to decode a precompile call. Returns `Some` if successful.
 pub(super) fn decode(trace: &CallTrace, _chain_id: u64) -> Option<DecodedCallTrace> {
-    if !trace.address[..19].iter().all(|&x| x == 0) {
+    if !is_known_precompile(trace.address, _chain_id) {
         return None;
     }
 

--- a/crates/evm/traces/src/identifier/signatures.rs
+++ b/crates/evm/traces/src/identifier/signatures.rs
@@ -1,176 +1,266 @@
-use alloy_json_abi::{Error, Event, Function};
-use alloy_primitives::{hex, map::HashSet};
+use alloy_json_abi::{Error, Event, Function, JsonAbi};
+use alloy_primitives::{map::HashMap, Selector, B256};
+use eyre::Result;
 use foundry_common::{
     abi::{get_error, get_event, get_func},
     fs,
-    selectors::{OpenChainClient, SelectorType},
+    selectors::{OpenChainClient, SelectorKind},
 };
+use foundry_config::Config;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tokio::sync::RwLock;
 
-pub type SingleSignaturesIdentifier = Arc<RwLock<SignaturesIdentifier>>;
-
-#[derive(Debug, Default, Serialize, Deserialize)]
-pub struct CachedSignatures {
-    pub errors: BTreeMap<String, String>,
-    pub events: BTreeMap<String, String>,
-    pub functions: BTreeMap<String, String>,
+/// Cache for function, event and error signatures. Used by [`SignaturesIdentifier`].
+#[derive(Debug, Default, Deserialize)]
+#[serde(try_from = "SignaturesDiskCache")]
+pub struct SignaturesCache {
+    signatures: HashMap<SelectorKind, Option<String>>,
 }
 
-impl CachedSignatures {
-    #[instrument(target = "evm::traces")]
-    pub fn load(cache_path: PathBuf) -> Self {
-        let path = cache_path.join("signatures");
-        if path.is_file() {
-            fs::read_json_file(&path)
-                .map_err(
-                    |err| warn!(target: "evm::traces", ?path, ?err, "failed to read cache file"),
-                )
-                .unwrap_or_default()
-        } else {
-            if let Err(err) = std::fs::create_dir_all(cache_path) {
-                warn!(target: "evm::traces", "could not create signatures cache dir: {:?}", err);
-            }
-            Self::default()
+/// Disk representation of the signatures cache.
+#[derive(Serialize, Deserialize)]
+struct SignaturesDiskCache {
+    functions: BTreeMap<Selector, String>,
+    errors: BTreeMap<Selector, String>,
+    events: BTreeMap<B256, String>,
+}
+
+impl From<SignaturesDiskCache> for SignaturesCache {
+    fn from(value: SignaturesDiskCache) -> Self {
+        let functions = value
+            .functions
+            .into_iter()
+            .map(|(selector, signature)| (SelectorKind::Function(selector), signature));
+        let errors = value
+            .errors
+            .into_iter()
+            .map(|(selector, signature)| (SelectorKind::Error(selector), signature));
+        let events = value
+            .events
+            .into_iter()
+            .map(|(selector, signature)| (SelectorKind::Event(selector), signature));
+        Self {
+            signatures: functions
+                .chain(errors)
+                .chain(events)
+                .map(|(sel, sig)| (sel, (!sig.is_empty()).then_some(sig)))
+                .collect(),
         }
     }
 }
+
+impl From<&SignaturesCache> for SignaturesDiskCache {
+    fn from(value: &SignaturesCache) -> Self {
+        let (functions, errors, events) = value.signatures.iter().fold(
+            (BTreeMap::new(), BTreeMap::new(), BTreeMap::new()),
+            |mut acc, (kind, signature)| {
+                let value = signature.clone().unwrap_or_default();
+                match *kind {
+                    SelectorKind::Function(selector) => _ = acc.0.insert(selector, value),
+                    SelectorKind::Error(selector) => _ = acc.1.insert(selector, value),
+                    SelectorKind::Event(selector) => _ = acc.2.insert(selector, value),
+                }
+                acc
+            },
+        );
+        Self { functions, errors, events }
+    }
+}
+
+impl Serialize for SignaturesCache {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        SignaturesDiskCache::from(self).serialize(serializer)
+    }
+}
+
+impl SignaturesCache {
+    /// Loads the cache from a file.
+    #[instrument(target = "evm::traces")]
+    pub fn load(path: &Path) -> Self {
+        trace!(target: "evm::traces", ?path, "reading signature cache");
+        fs::read_json_file(path)
+            .inspect_err(
+                |err| warn!(target: "evm::traces", ?path, ?err, "failed to read cache file"),
+            )
+            .unwrap_or_default()
+    }
+
+    /// Saves the cache to a file.
+    #[instrument(target = "evm::traces", skip(self))]
+    pub fn save(&self, path: &Path) {
+        if let Some(parent) = path.parent() {
+            if let Err(err) = std::fs::create_dir_all(parent) {
+                warn!(target: "evm::traces", ?parent, %err, "failed to create cache");
+            }
+        }
+        if let Err(err) = fs::write_json_file(path, self) {
+            warn!(target: "evm::traces", %err, "failed to flush signature cache");
+        } else {
+            trace!(target: "evm::traces", "flushed signature cache")
+        }
+    }
+
+    /// Updates the cache from an ABI.
+    pub fn extend_from_abi(&mut self, abi: &JsonAbi) {
+        self.extend(abi.items().filter_map(|item| match item {
+            alloy_json_abi::AbiItem::Function(f) => {
+                Some((SelectorKind::Function(f.selector()), f.signature()))
+            }
+            alloy_json_abi::AbiItem::Error(e) => {
+                Some((SelectorKind::Error(e.selector()), e.signature()))
+            }
+            alloy_json_abi::AbiItem::Event(e) => {
+                Some((SelectorKind::Event(e.selector()), e.full_signature()))
+            }
+            _ => None,
+        }));
+    }
+
+    /// Inserts a single signature into the cache.
+    pub fn insert(&mut self, key: SelectorKind, value: String) {
+        self.extend(std::iter::once((key, value)));
+    }
+
+    /// Extends the cache with multiple signatures.
+    pub fn extend(&mut self, signatures: impl IntoIterator<Item = (SelectorKind, String)>) {
+        self.signatures.extend(signatures.into_iter().map(|(k, v)| (k, Some(v))));
+    }
+
+    /// Gets a signature from the cache.
+    pub fn get(&self, key: &SelectorKind) -> Option<Option<String>> {
+        self.signatures.get(key).cloned()
+    }
+
+    /// Returns true if the cache contains a signature.
+    pub fn contains_key(&self, key: &SelectorKind) -> bool {
+        self.signatures.contains_key(key)
+    }
+}
+
 /// An identifier that tries to identify functions and events using signatures found at
 /// `https://openchain.xyz` or a local cache.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
+#[allow(clippy::new_without_default)]
 pub struct SignaturesIdentifier {
     /// Cached selectors for functions, events and custom errors.
-    cached: CachedSignatures,
-    /// Location where to save `CachedSignatures`.
-    cached_path: Option<PathBuf>,
-    /// Selectors that were unavailable during the session.
-    unavailable: HashSet<String>,
-    /// The OpenChain client to fetch signatures from.
+    cache: Arc<RwLock<SignaturesCache>>,
+    /// Location where to save the signature cache.
+    cache_path: Option<PathBuf>,
+    /// The OpenChain client to fetch signatures from. `None` if disabled on construction.
     client: Option<OpenChainClient>,
 }
 
 impl SignaturesIdentifier {
-    #[instrument(target = "evm::traces")]
-    pub fn new(
-        cache_path: Option<PathBuf>,
-        offline: bool,
-    ) -> eyre::Result<SingleSignaturesIdentifier> {
-        let client = if !offline { Some(OpenChainClient::new()?) } else { None };
-
-        let identifier = if let Some(cache_path) = cache_path {
-            let path = cache_path.join("signatures");
-            trace!(target: "evm::traces", ?path, "reading signature cache");
-            let cached = CachedSignatures::load(cache_path);
-            Self { cached, cached_path: Some(path), unavailable: HashSet::default(), client }
-        } else {
-            Self {
-                cached: Default::default(),
-                cached_path: None,
-                unavailable: HashSet::default(),
-                client,
-            }
-        };
-
-        Ok(Arc::new(RwLock::new(identifier)))
+    /// Creates a new `SignaturesIdentifier` with the default cache directory.
+    pub fn new(offline: bool) -> Result<Self> {
+        Self::new_with(Config::foundry_cache_dir().as_deref(), offline)
     }
 
-    #[instrument(target = "evm::traces", skip(self))]
+    /// Creates a new `SignaturesIdentifier` from the global configuration.
+    pub fn from_config(config: &Config) -> Result<Self> {
+        Self::new(config.offline)
+    }
+
+    /// Creates a new `SignaturesIdentifier`.
+    ///
+    /// - `cache_dir` is the cache directory to store the signatures.
+    /// - `offline` disables the OpenChain client.
+    pub fn new_with(cache_dir: Option<&Path>, offline: bool) -> Result<Self> {
+        let client = if !offline { Some(OpenChainClient::new()?) } else { None };
+        let (cache, cache_path) = if let Some(cache_dir) = cache_dir {
+            let path = cache_dir.join("signatures");
+            let cache = SignaturesCache::load(&path);
+            (cache, Some(path))
+        } else {
+            Default::default()
+        };
+        Ok(Self { cache: Arc::new(RwLock::new(cache)), cache_path, client })
+    }
+
+    /// Saves the cache to the file system.
     pub fn save(&self) {
-        if let Some(cached_path) = &self.cached_path {
-            if let Some(parent) = cached_path.parent() {
-                if let Err(err) = std::fs::create_dir_all(parent) {
-                    warn!(target: "evm::traces", ?parent, ?err, "failed to create cache");
-                }
-            }
-            if let Err(err) = fs::write_json_file(cached_path, &self.cached) {
-                warn!(target: "evm::traces", ?cached_path, ?err, "failed to flush signature cache");
-            } else {
-                trace!(target: "evm::traces", ?cached_path, "flushed signature cache")
-            }
+        if let Some(path) = &self.cache_path {
+            self.cache.blocking_read().save(path);
         }
     }
 }
 
 impl SignaturesIdentifier {
-    async fn identify<T>(
-        &mut self,
-        selector_type: SelectorType,
-        identifiers: impl IntoIterator<Item = impl AsRef<[u8]>>,
-        get_type: impl Fn(&str) -> eyre::Result<T>,
-    ) -> Vec<Option<T>> {
-        let cache = match selector_type {
-            SelectorType::Function => &mut self.cached.functions,
-            SelectorType::Event => &mut self.cached.events,
-            SelectorType::Error => &mut self.cached.errors,
-        };
+    /// Identifies `Function`s.
+    pub async fn identify_functions(
+        &self,
+        identifiers: impl IntoIterator<Item = Selector>,
+    ) -> Vec<Option<Function>> {
+        self.identify_map(identifiers.into_iter().map(SelectorKind::Function), get_func).await
+    }
 
-        let hex_identifiers: Vec<String> =
-            identifiers.into_iter().map(hex::encode_prefixed).collect();
+    /// Identifies a `Function`.
+    pub async fn identify_function(&self, identifier: Selector) -> Option<Function> {
+        self.identify_functions([identifier]).await.pop().unwrap()
+    }
 
+    /// Identifies `Event`s.
+    pub async fn identify_events(
+        &self,
+        identifiers: impl IntoIterator<Item = B256>,
+    ) -> Vec<Option<Event>> {
+        self.identify_map(identifiers.into_iter().map(SelectorKind::Event), get_event).await
+    }
+
+    /// Identifies an `Event`.
+    pub async fn identify_event(&self, identifier: B256) -> Option<Event> {
+        self.identify_events([identifier]).await.pop().unwrap()
+    }
+
+    /// Identifies `Error`s.
+    pub async fn identify_errors(
+        &self,
+        identifiers: impl IntoIterator<Item = Selector>,
+    ) -> Vec<Option<Error>> {
+        self.identify_map(identifiers.into_iter().map(SelectorKind::Error), get_error).await
+    }
+
+    /// Identifies an `Error`.
+    pub async fn identify_error(&self, identifier: Selector) -> Option<Error> {
+        self.identify_errors([identifier]).await.pop().unwrap()
+    }
+
+    /// Identifies a list of selectors.
+    pub async fn identify(&self, selectors: &[SelectorKind]) -> Vec<Option<String>> {
+        let mut cache_r = self.cache.read().await;
         if let Some(client) = &self.client {
-            let query: Vec<_> = hex_identifiers
-                .iter()
-                .filter(|v| !cache.contains_key(v.as_str()))
-                .filter(|v| !self.unavailable.contains(v.as_str()))
-                .collect();
-
-            if let Ok(res) = client.decode_selectors(selector_type, query.clone()).await {
-                for (hex_id, selector_result) in query.into_iter().zip(res.into_iter()) {
-                    let mut found = false;
-                    if let Some(decoded_results) = selector_result {
-                        if let Some(decoded_result) = decoded_results.into_iter().next() {
-                            cache.insert(hex_id.clone(), decoded_result);
-                            found = true;
-                        }
-                    }
-                    if !found {
-                        self.unavailable.insert(hex_id.clone());
+            let query =
+                selectors.iter().copied().filter(|v| !cache_r.contains_key(v)).collect::<Vec<_>>();
+            if !query.is_empty() {
+                drop(cache_r);
+                let mut cache_w = self.cache.write().await;
+                if let Ok(res) = client.decode_selectors(&query).await {
+                    for (selector, signatures) in std::iter::zip(query, res) {
+                        cache_w.signatures.insert(selector, signatures.into_iter().next());
                     }
                 }
+                drop(cache_w);
+                cache_r = self.cache.read().await;
             }
         }
-
-        hex_identifiers.iter().map(|v| cache.get(v).and_then(|v| get_type(v).ok())).collect()
+        selectors.iter().map(|selector| cache_r.get(selector).unwrap_or_default()).collect()
     }
 
-    /// Identifies `Function`s from its cache or `https://api.openchain.xyz`
-    pub async fn identify_functions(
-        &mut self,
-        identifiers: impl IntoIterator<Item = impl AsRef<[u8]>>,
-    ) -> Vec<Option<Function>> {
-        self.identify(SelectorType::Function, identifiers, get_func).await
-    }
-
-    /// Identifies `Function` from its cache or `https://api.openchain.xyz`
-    pub async fn identify_function(&mut self, identifier: &[u8]) -> Option<Function> {
-        self.identify_functions(&[identifier]).await.pop().unwrap()
-    }
-
-    /// Identifies `Event`s from its cache or `https://api.openchain.xyz`
-    pub async fn identify_events(
-        &mut self,
-        identifiers: impl IntoIterator<Item = impl AsRef<[u8]>>,
-    ) -> Vec<Option<Event>> {
-        self.identify(SelectorType::Event, identifiers, get_event).await
-    }
-
-    /// Identifies `Event` from its cache or `https://api.openchain.xyz`
-    pub async fn identify_event(&mut self, identifier: &[u8]) -> Option<Event> {
-        self.identify_events(&[identifier]).await.pop().unwrap()
-    }
-
-    /// Identifies `Error`s from its cache or `https://api.openchain.xyz`.
-    pub async fn identify_errors(
-        &mut self,
-        identifiers: impl IntoIterator<Item = impl AsRef<[u8]>>,
-    ) -> Vec<Option<Error>> {
-        self.identify(SelectorType::Error, identifiers, get_error).await
-    }
-
-    /// Identifies `Error` from its cache or `https://api.openchain.xyz`.
-    pub async fn identify_error(&mut self, identifier: &[u8]) -> Option<Error> {
-        self.identify_errors(&[identifier]).await.pop().unwrap()
+    async fn identify_map<T>(
+        &self,
+        selectors: impl IntoIterator<Item = SelectorKind>,
+        get_type: impl Fn(&str) -> Result<T>,
+    ) -> Vec<Option<T>> {
+        let results = self.identify(&Vec::from_iter(selectors)).await;
+        results.into_iter().map(|r| r.and_then(|r| get_type(&r).ok())).collect()
     }
 }
 

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -174,14 +174,9 @@ impl DerefMut for SparsedTraceArena {
 /// Decode a collection of call traces.
 ///
 /// The traces will be decoded using the given decoder, if possible.
-pub async fn decode_trace_arena(
-    arena: &mut CallTraceArena,
-    decoder: &CallTraceDecoder,
-) -> Result<(), std::fmt::Error> {
+pub async fn decode_trace_arena(arena: &mut CallTraceArena, decoder: &CallTraceDecoder) {
     decoder.prefetch_signatures(arena.nodes()).await;
     decoder.populate_traces(arena.nodes_mut()).await;
-
-    Ok(())
 }
 
 /// Render a collection of call traces to a string.
@@ -260,7 +255,7 @@ pub fn load_contracts<'a>(
     let decoder = CallTraceDecoder::new();
     let mut contracts = ContractsByAddress::new();
     for trace in traces {
-        for address in local_identifier.identify_addresses(decoder.trace_addresses(trace)) {
+        for address in local_identifier.identify_addresses(&decoder.trace_addresses(trace)) {
             if let (Some(contract), Some(abi)) = (address.contract, address.abi) {
                 contracts.insert(address.address, (contract, abi.into_owned()));
             }

--- a/crates/forge/src/cmd/selectors.rs
+++ b/crates/forge/src/cmd/selectors.rs
@@ -95,7 +95,7 @@ impl SelectorsSubcommands {
                 // compile the project to get the artifacts/abis
                 let project = build_args.project()?;
                 let outcome = ProjectCompiler::new().quiet(true).compile(&project)?;
-                cache_local_signatures(&outcome, Config::foundry_cache_dir().unwrap())?
+                cache_local_signatures(&outcome, &Config::foundry_cache_dir().unwrap())?
             }
             Self::Upload { contract, all, project_paths } => {
                 let build_args = BuildOpts {

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -368,7 +368,7 @@ impl TestArgs {
 
             // Decode traces.
             let decoder = outcome.last_run_decoder.as_ref().unwrap();
-            decode_trace_arena(arena, decoder).await?;
+            decode_trace_arena(arena, decoder).await;
             let mut fst = folded_stack_trace::build(arena);
 
             let label = if self.flamegraph { "flamegraph" } else { "flamechart" };
@@ -524,10 +524,8 @@ impl TestArgs {
             .with_verbosity(verbosity);
         // Signatures are of no value for gas reports.
         if !self.gas_report {
-            builder = builder.with_signature_identifier(SignaturesIdentifier::new(
-                Config::foundry_cache_dir(),
-                config.offline,
-            )?);
+            builder =
+                builder.with_signature_identifier(SignaturesIdentifier::from_config(&config)?);
         }
 
         if self.decode_internal {
@@ -637,7 +635,7 @@ impl TestArgs {
                     };
 
                     if should_include {
-                        decode_trace_arena(arena, &decoder).await?;
+                        decode_trace_arena(arena, &decoder).await;
                         decoded_traces.push(render_trace_arena_inner(arena, false, verbosity > 4));
                     }
                 }

--- a/crates/forge/tests/it/config.rs
+++ b/crates/forge/tests/it/config.rs
@@ -77,9 +77,7 @@ impl TestConfig {
                     let decoded_traces = join_all(result.traces.iter_mut().map(|(_, arena)| {
                         let decoder = &call_trace_decoder;
                         async move {
-                            decode_trace_arena(arena, decoder)
-                                .await
-                                .expect("Failed to decode traces");
+                            decode_trace_arena(arena, decoder).await;
                             render_trace_arena(arena)
                         }
                     }))

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -20,7 +20,7 @@ use foundry_common::{
     provider::get_http_provider,
     ContractsByArtifact,
 };
-use foundry_config::{Config, NamedChain};
+use foundry_config::NamedChain;
 use foundry_debugger::Debugger;
 use foundry_evm::{
     decode::decode_console_logs,
@@ -328,9 +328,8 @@ impl ExecutedState {
             .with_labels(self.execution_result.labeled_addresses.clone())
             .with_verbosity(self.script_config.evm_opts.verbosity)
             .with_known_contracts(known_contracts)
-            .with_signature_identifier(SignaturesIdentifier::new(
-                Config::foundry_cache_dir(),
-                self.script_config.config.offline,
+            .with_signature_identifier(SignaturesIdentifier::from_config(
+                &self.script_config.config,
             )?)
             .build();
 
@@ -428,7 +427,7 @@ impl PreSimulationState {
 
                 if should_include {
                     let mut trace = trace.clone();
-                    decode_trace_arena(&mut trace, decoder).await?;
+                    decode_trace_arena(&mut trace, decoder).await;
                     sh_println!("{}", render_trace_arena(&trace))?;
                 }
             }

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -168,7 +168,7 @@ impl PreSimulationState {
             // Transaction will be `None`, if execution didn't pass.
             if tx.is_none() || self.script_config.evm_opts.verbosity > 3 {
                 for (_, trace) in &mut traces {
-                    decode_trace_arena(trace, &self.execution_artifacts.decoder).await?;
+                    decode_trace_arena(trace, &self.execution_artifacts.decoder).await;
                     sh_println!("{}", render_trace_arena(trace))?;
                 }
             }


### PR DESCRIPTION
- allow requesting multiple kinds of selectors in the same request
- simplify API by not exposing `Arc<RwLock<>>`, making signatures use &self instead of &mut self
- decode_trace_arena doesn't fail