### PR TITLE
fix(docker): build docker aarch64 without jemalloc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,13 @@ build-%:
 
 .PHONY: docker-build-push
 docker-build-push: docker-build-prepare ## Build and push a cross-arch Docker image tagged with DOCKER_IMAGE_NAME.
-	$(MAKE) build-x86_64-unknown-linux-gnu
+	FEATURES="jemalloc aws-kms cli asm-keccak" $(MAKE) build-x86_64-unknown-linux-gnu
 	mkdir -p $(BIN_DIR)/amd64
 	for bin in anvil cast chisel forge; do \
 		cp $(CARGO_TARGET_DIR)/x86_64-unknown-linux-gnu/$(PROFILE)/$$bin $(BIN_DIR)/amd64/; \
 	done
 
-	$(MAKE) build-aarch64-unknown-linux-gnu
+	FEATURES="aws-kms cli asm-keccak" $(MAKE) build-aarch64-unknown-linux-gnu
 	mkdir -p $(BIN_DIR)/arm64
 	for bin in anvil cast chisel forge; do \
 		cp $(CARGO_TARGET_DIR)/aarch64-unknown-linux-gnu/$(PROFILE)/$$bin $(BIN_DIR)/arm64/; \


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #10065 
- images built from branch https://github.com/foundry-rs/foundry/pkgs/container/foundry/392697416?tag=docker-aarch64
- x86_64 flags: https://github.com/foundry-rs/foundry/actions/runs/14376428844/job/40309860705#step:10:59
- aarch64 flags: https://github.com/foundry-rs/foundry/actions/runs/14376428844/job/40309860705#step:10:184
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes