### PR TITLE
fix: add workaround for unlinked artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3638,6 +3638,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn 2.0.100",
 ]
 

--- a/crates/sol-macro-gen/Cargo.toml
+++ b/crates/sol-macro-gen/Cargo.toml
@@ -23,5 +23,6 @@ proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
 prettyplease.workspace = true
+serde_json.workspace = true
 
 eyre.workspace = true

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -110,7 +110,7 @@ impl MultiSolMacroGen {
                     std::mem::swap(&mut tmp_file, &mut instance.path);
                     input.normalize_json()?
                 } else {
-                    return Err(error.into())
+                    return Err(error)
                 }
             }
         };

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -15,6 +15,7 @@ use eyre::{Context, OptionExt, Result};
 use foundry_common::fs;
 use proc_macro2::{Span, TokenStream};
 use std::{
+    env::temp_dir,
     fmt::Write,
     path::{Path, PathBuf},
     str::FromStr,
@@ -82,7 +83,37 @@ impl MultiSolMacroGen {
     }
 
     fn generate_binding(instance: &mut SolMacroGen, all_derives: bool) -> Result<()> {
-        let input = instance.get_sol_input()?.normalize_json()?;
+        // TODO: in `get_sol_input` we currently can't handle unlinked bytecode: <https://github.com/alloy-rs/core/issues/926>
+        let input = match instance.get_sol_input() {
+            Ok(input) => input.normalize_json()?,
+            Err(error) => {
+                // TODO(mattsse): remove after <https://github.com/alloy-rs/core/issues/926>
+                if error.to_string().contains("expected bytecode, found unlinked bytecode") {
+                    // we attempt to do a little hack here until we have this properly supported by
+                    // removing the bytecode objects from the json file and using a tmpfile (very
+                    // hacky)
+                    let content = std::fs::read_to_string(&instance.path)?;
+                    let mut value = serde_json::from_str::<serde_json::Value>(&content)?;
+                    let obj = value.as_object_mut().expect("valid abi");
+
+                    // clear unlinked bytecode
+                    obj.remove("bytecode");
+                    obj.remove("deployedBytecode");
+
+                    let tmpdir = temp_dir();
+                    let mut tmp_file = tmpdir.join(instance.path.file_name().unwrap());
+                    std::fs::write(&tmp_file, serde_json::to_string(&value)?)?;
+
+                    // try again
+                    std::mem::swap(&mut tmp_file, &mut instance.path);
+                    let input = instance.get_sol_input()?.normalize_json()?;
+                    std::mem::swap(&mut tmp_file, &mut instance.path);
+                    input.normalize_json()?
+                } else {
+                    return Err(error.into())
+                }
+            }
+        };
 
         let SolInput { attrs: _, path: _, kind } = input;
 


### PR DESCRIPTION
closes #9482 ?

This adds a very! hacky workaround until we have this natively in SolInput, but since this is currently broken for unlinked artifacts this should work.

tested with this workaround 

https://github.com/foundry-rs/foundry/issues/9482#issuecomment-2794365323

```
 ~/git/rust/foundry/target/debug/forge bind --alloy --bindings-path crates/utils/src/slashing/middleware --overwrite --root ./crates/operator_sets_contracts/lib/eigenlayer-middleware --module --select RegistryCoordinator --libraries ./crates/operator_sets_contracts/lib/eigenlayer-middleware/src/libraries/QuorumBitmapHistoryLib.sol:QuorumBitmapHistoryLib:0x0000000000000000000000000000000000000001 --libraries ./crates/operator_sets_contracts/lib/eigenlayer-middleware/src/libraries/SignatureCheckerLib.sol:SignatureCheckerLib:0x0000000000000000000000000000000000000002
[⠢] Compiling...
No files changed, compilation skipped
Generating bindings for 39 contracts
Bindings have been generated to crates/utils/src/slashing/middleware
```

this can be done more efficiently but since this is expected to be tmp it should be okay.


@supernovahs and @sveitser mind giving this a try?