### PR TITLE
Adding support to etherscan-v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3698,8 +3698,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001678abc9895502532c8c4a1a225079c580655fc82a194e78b06dcf99f49b8c"
+source = "git+https://github.com/foundry-rs/block-explorers?rev=8c03122#8c0312275fecf11b2258622fe1f7eba89e8f0a8e"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,6 +324,7 @@ jiff = "0.2"
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
+foundry-block-explorers = { git = "https://github.com/foundry-rs/block-explorers", rev = "8c03122" }
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
 # alloy-json-abi = { path = "../../alloy-rs/core/crates/json-abi" }

--- a/crates/config/src/etherscan.rs
+++ b/crates/config/src/etherscan.rs
@@ -330,14 +330,16 @@ impl ResolvedEtherscanConfig {
         }
 
         let api_url = into_url(&api_url)?;
-        let parsed_api_version = EtherscanApiVersion::try_from(api_version.unwrap_or_default())?;
+        let parsed_api_version = api_version
+            .map(EtherscanApiVersion::try_from)
+            .transpose()?;
         let client = reqwest::Client::builder()
             .user_agent(ETHERSCAN_USER_AGENT)
             .tls_built_in_root_certs(api_url.scheme() == "https")
             .build()?;
         foundry_block_explorers::Client::builder()
             .with_client(client)
-            .with_api_version(parsed_api_version)
+            .with_api_version(parsed_api_version.unwrap_or_default())
             .with_api_key(api_key)
             .with_api_url(api_url)?
             // the browser url is not used/required by the client so we can simply set the

--- a/crates/config/src/etherscan.rs
+++ b/crates/config/src/etherscan.rs
@@ -330,9 +330,7 @@ impl ResolvedEtherscanConfig {
         }
 
         let api_url = into_url(&api_url)?;
-        let parsed_api_version = api_version
-            .map(EtherscanApiVersion::try_from)
-            .transpose()?;
+        let parsed_api_version = api_version.map(EtherscanApiVersion::try_from).transpose()?;
         let client = reqwest::Client::builder()
             .user_agent(ETHERSCAN_USER_AGENT)
             .tls_built_in_root_certs(api_url.scheme() == "https")

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1137,9 +1137,9 @@ impl Config {
 
     /// Whether caching should be enabled for the given chain id
     pub fn enable_caching(&self, endpoint: &str, chain_id: impl Into<u64>) -> bool {
-        !self.no_storage_caching
-            && self.rpc_storage_caching.enable_for_chain_id(chain_id.into())
-            && self.rpc_storage_caching.enable_for_endpoint(endpoint)
+        !self.no_storage_caching &&
+            self.rpc_storage_caching.enable_for_chain_id(chain_id.into()) &&
+            self.rpc_storage_caching.enable_for_endpoint(endpoint)
     }
 
     /// Returns the `ProjectPathsConfig` sub set of the config.
@@ -1403,11 +1403,7 @@ impl Config {
         // etherscan fallback via API key
         if let Some(key) = self.etherscan_api_key.as_ref() {
             let chain = chain.or(self.chain).unwrap_or_default();
-            return Ok(ResolvedEtherscanConfig::create(
-                key,
-                chain,
-                None::<String>,
-            ));
+            return Ok(ResolvedEtherscanConfig::create(key, chain, None::<String>));
         }
 
         Ok(None)
@@ -2012,8 +2008,8 @@ impl Config {
             let file_name = block.file_name();
             let filepath = if file_type.is_dir() {
                 block.path().join("storage.json")
-            } else if file_type.is_file()
-                && file_name.to_string_lossy().chars().all(char::is_numeric)
+            } else if file_type.is_file() &&
+                file_name.to_string_lossy().chars().all(char::is_numeric)
             {
                 block.path()
             } else {

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -11,7 +11,7 @@ use eyre::{eyre, Context, OptionExt, Result};
 use foundry_block_explorers::{
     errors::EtherscanError,
     utils::lookup_compiler_version,
-    verify::{self, CodeFormat, VerifyContract},
+    verify::{CodeFormat, VerifyContract},
     Client,
 };
 use foundry_cli::utils::{get_provider, read_constructor_args_file, LoadConfig};
@@ -275,10 +275,8 @@ impl EtherscanVerificationProvider {
             .as_ref()
             .and_then(|c| c.browser_url.as_deref())
             .or_else(|| chain.etherscan_urls().map(|(_, url)| url));
-
         let etherscan_key =
             etherscan_key.or_else(|| etherscan_config.as_ref().map(|c| c.key.as_str()));
- 
         let etherscan_api_version = if verifier_type.is_etherscan_v2() {
             foundry_block_explorers::EtherscanApiVersion::V2
         } else {
@@ -593,7 +591,10 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(client.etherscan_api_url().as_str(), "https://api.etherscan.io/v2/api?chainid=80001");
+        assert_eq!(
+            client.etherscan_api_url().as_str(),
+            "https://api.etherscan.io/v2/api?chainid=80001"
+        );
         assert!(format!("{client:?}").contains("dummykey"));
 
         let args: VerifyArgs = VerifyArgs::parse_from([
@@ -611,7 +612,7 @@ mod tests {
         ]);
 
         let config = args.load_config().unwrap();
-        
+
         assert_eq!(args.verifier.verifier, VerificationProviderType::EtherscanV2);
 
         let etherscan = EtherscanVerificationProvider::default();

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -591,10 +591,7 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(
-            client.etherscan_api_url().as_str(),
-            "https://api.etherscan.io/v2/api"
-        );
+        assert_eq!(client.etherscan_api_url().as_str(), "https://api.etherscan.io/v2/api");
         assert!(format!("{client:?}").contains("dummykey"));
 
         let args: VerifyArgs = VerifyArgs::parse_from([

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -593,7 +593,7 @@ mod tests {
 
         assert_eq!(
             client.etherscan_api_url().as_str(),
-            "https://api.etherscan.io/v2/api?chainid=80001"
+            "https://api.etherscan.io/v2/api"
         );
         assert!(format!("{client:?}").contains("dummykey"));
 

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -123,11 +123,12 @@ impl FromStr for VerificationProviderType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "e" | "etherscan" => Ok(Self::Etherscan),
-            "s" | "sourcify" => Ok(Self::Sourcify),
-            "b" | "blockscout" => Ok(Self::Blockscout),
-            "o" | "oklink" => Ok(Self::Oklink),
-            "c" | "custom" => Ok(Self::Custom),
+            "e"   | "etherscan" => Ok(Self::Etherscan),
+            "ev2" | "etherscan-v2" => Ok(Self::EtherscanV2),
+            "s"   | "sourcify" => Ok(Self::Sourcify),
+            "b"   | "blockscout" => Ok(Self::Blockscout),
+            "o"   | "oklink" => Ok(Self::Oklink),
+            "c"   | "custom" => Ok(Self::Custom),
             _ => Err(format!("Unknown provider: {s}")),
         }
     }
@@ -138,6 +139,9 @@ impl fmt::Display for VerificationProviderType {
         match self {
             Self::Etherscan => {
                 write!(f, "etherscan")?;
+            }
+            Self::EtherscanV2 => {
+                write!(f, "etherscan-v2")?;
             }
             Self::Sourcify => {
                 write!(f, "sourcify")?;
@@ -159,6 +163,7 @@ impl fmt::Display for VerificationProviderType {
 #[derive(Clone, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
 pub enum VerificationProviderType {
     Etherscan,
+    EtherscanV2,
     #[default]
     Sourcify,
     Blockscout,
@@ -208,6 +213,10 @@ impl VerificationProviderType {
     }
 
     pub fn is_etherscan(&self) -> bool {
-        matches!(self, Self::Etherscan)
+        matches!(self, Self::Etherscan) || matches!(self, Self::EtherscanV2)
+    }
+
+    pub fn is_etherscan_v2(&self) -> bool {
+        matches!(self, Self::EtherscanV2)
     }
 }

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -123,12 +123,12 @@ impl FromStr for VerificationProviderType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "e"   | "etherscan" => Ok(Self::Etherscan),
+            "e" | "etherscan" => Ok(Self::Etherscan),
             "ev2" | "etherscan-v2" => Ok(Self::EtherscanV2),
-            "s"   | "sourcify" => Ok(Self::Sourcify),
-            "b"   | "blockscout" => Ok(Self::Blockscout),
-            "o"   | "oklink" => Ok(Self::Oklink),
-            "c"   | "custom" => Ok(Self::Custom),
+            "s" | "sourcify" => Ok(Self::Sourcify),
+            "b" | "blockscout" => Ok(Self::Blockscout),
+            "o" | "oklink" => Ok(Self::Oklink),
+            "c" | "custom" => Ok(Self::Custom),
             _ => Err(format!("Unknown provider: {s}")),
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Fixes #9196

For tests to pass and to merge this pr, an update to `block-explorers` is first required: https://github.com/foundry-rs/block-explorers/pull/82.

## Solution

Add case statements and proper flags for `ev2` and `etherscan-v2` for verifying with etherscan v2 API which sets the /mode for the backend contracts to use different URL structures and logic for interacting with the etherscan API.

Added one test, need to add more or update existing tests to handle new logic.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes