### PR TITLE
fix(forge): avoid preprocessor constructor args struct name conflict

### DIFF
--- a/crates/common/src/preprocessor/data.rs
+++ b/crates/common/src/preprocessor/data.rs
@@ -141,13 +141,13 @@ impl ContractData {
     /// import "lib/openzeppelin-contracts/contracts/token/ERC20.sol";
     ///
     /// abstract contract DeployHelper335 is ERC20 {
-    ///     struct ConstructorArgs {
+    ///     struct FoundryPpConstructorArgs {
     ///         string name;
     ///         string symbol;
     ///     }
     /// }
     ///
-    /// function encodeArgs335(DeployHelper335.ConstructorArgs memory args) pure returns (bytes memory) {
+    /// function encodeArgs335(DeployHelper335.FoundryPpConstructorArgs memory args) pure returns (bytes memory) {
     ///     return abi.encode(args.name, args.symbol);
     /// }
     /// ```
@@ -158,7 +158,7 @@ impl ContractData {
     /// ```
     /// becomes
     /// ```solidity
-    /// vm.deployCode("artifact path", encodeArgs335(DeployHelper335.ConstructorArgs(name, symbol)))
+    /// vm.deployCode("artifact path", encodeArgs335(DeployHelper335.FoundryPpConstructorArgs(name, symbol)))
     /// ```
     /// With named arguments:
     /// ```solidity
@@ -166,7 +166,7 @@ impl ContractData {
     /// ```
     /// becomes
     /// ```solidity
-    /// vm.deployCode("artifact path", encodeArgs335(DeployHelper335.ConstructorArgs({name: name, symbol: symbol})))
+    /// vm.deployCode("artifact path", encodeArgs335(DeployHelper335.FoundryPpConstructorArgs({name: name, symbol: symbol})))
     /// ```
     pub fn build_helper(&self) -> Option<String> {
         let Self { contract_id, path, name, constructor_data, artifact: _ } = self;
@@ -183,12 +183,12 @@ pragma solidity >=0.4.0;
 import "{path}";
 
 abstract contract DeployHelper{contract_id} is {name} {{
-    struct ConstructorArgs {{
+    struct FoundryPpConstructorArgs {{
         {struct_fields};
     }}
 }}
 
-function encodeArgs{contract_id}(DeployHelper{contract_id}.ConstructorArgs memory args) pure returns (bytes memory) {{
+function encodeArgs{contract_id}(DeployHelper{contract_id}.FoundryPpConstructorArgs memory args) pure returns (bytes memory) {{
     return abi.encode({abi_encode_args});
 }}
         "#,

--- a/crates/common/src/preprocessor/deps.rs
+++ b/crates/common/src/preprocessor/deps.rs
@@ -320,7 +320,7 @@ pub(crate) fn remove_bytecode_dependencies(
 
                         update.push_str(", ");
                         update.push_str(&format!(
-                            "_args: encodeArgs{id}(DeployHelper{id}.ConstructorArgs",
+                            "_args: encodeArgs{id}(DeployHelper{id}.FoundryPpConstructorArgs",
                             id = dep.referenced_contract.get()
                         ));
                         if *call_args_offset > 0 {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #10312 
- current `ConstructorArgs` struct could conflict, change to `FoundryPpConstructorArgs` struct
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes