### PR TITLE
fix: force install default crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3789,6 +3789,7 @@ dependencies = [
  "itertools 0.14.0",
  "rayon",
  "regex",
+ "rustls",
  "serde",
  "serde_json",
  "strsim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,6 +259,8 @@ thiserror = "2"
 
 # misc
 auto_impl = "1"
+aws-config = { version = "1", default-features = true }
+aws-sdk-kms = { version = "1", default-features = false }
 bytes = "1.8"
 walkdir = "2"
 prettyplease = "0.2"
@@ -293,6 +295,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
     "rustls-tls-native-roots",
 ] }
+rustls = "0.23"
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }

--- a/crates/anvil/src/args.rs
+++ b/crates/anvil/src/args.rs
@@ -16,6 +16,7 @@ pub fn run() -> Result<()> {
 
 /// Setup the exception handler and other utilities.
 pub fn setup() -> Result<()> {
+    utils::install_crypto_provider();
     handler::install();
     utils::load_dotenv();
     utils::enable_paint();

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -61,7 +61,7 @@ serde_json.workspace = true
 serde.workspace = true
 
 # aws-kms
-aws-sdk-kms = { version = "1", default-features = false, optional = true }
+aws-sdk-kms = { workspace = true, default-features = false, optional = true }
 
 # bin
 foundry-cli.workspace = true

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -38,6 +38,7 @@ pub fn run() -> Result<()> {
 
 /// Setup the global logger and other utilities.
 pub fn setup() -> Result<()> {
+    utils::install_crypto_provider();
     handler::install();
     utils::load_dotenv();
     utils::subscriber();

--- a/crates/chisel/src/args.rs
+++ b/crates/chisel/src/args.rs
@@ -35,6 +35,7 @@ pub fn run() -> Result<()> {
 
 /// Setup the global logger and other utilities.
 pub fn setup() -> Result<()> {
+    utils::install_crypto_provider();
     handler::install();
     utils::subscriber();
     utils::load_dotenv();

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -47,6 +47,7 @@ tokio = { workspace = true, features = ["macros"] }
 tracing-subscriber = { workspace = true, features = ["registry", "env-filter"] }
 tracing.workspace = true
 yansi.workspace = true
+rustls = { workspace = true, features = ["ring"] }
 
 tracing-tracy = { version = "0.11", optional = true }
 

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -205,6 +205,23 @@ pub fn enable_paint() {
     yansi::whenever(yansi::Condition::cached(enable));
 }
 
+/// This force installs the default crypto provider.
+///
+/// This is necessary in case there are more than one available backends enabled in rustls (ring,
+/// aws-lc-rs).
+///
+/// This should be called high in the main fn.
+///
+/// See also:
+///   <https://github.com/snapview/tokio-tungstenite/issues/353#issuecomment-2455100010>
+///   <https://github.com/awslabs/aws-sdk-rust/discussions/1257>
+pub fn install_crypto_provider() {
+    // https://github.com/snapview/tokio-tungstenite/issues/353
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install default rustls crypto provider");
+}
+
 /// Useful extensions to [`std::process::Command`].
 pub trait CommandUtils {
     /// Returns the command's output if execution is successful, otherwise, throws an error.

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -21,6 +21,7 @@ pub fn run() -> Result<()> {
 
 /// Setup the global logger and other utilities.
 pub fn setup() -> Result<()> {
+    utils::install_crypto_provider();
     handler::install();
     utils::load_dotenv();
     utils::subscriber();

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -3,6 +3,7 @@
 use alloy_chains::NamedChain;
 use alloy_primitives::U256;
 use forge::{revm::primitives::SpecId, MultiContractRunner, MultiContractRunnerBuilder};
+use foundry_cli::utils::install_crypto_provider;
 use foundry_compilers::{
     artifacts::{EvmVersion, Libraries, Settings},
     compilers::multi::MultiCompiler,
@@ -172,6 +173,7 @@ impl ForgeTestData {
     ///
     /// Uses [get_compiled] to lazily compile the project.
     pub fn new(profile: ForgeTestProfile) -> Self {
+        install_crypto_provider();
         init_tracing();
         let config = Arc::new(profile.config());
         let mut project = config.project().unwrap();

--- a/crates/wallets/Cargo.toml
+++ b/crates/wallets/Cargo.toml
@@ -27,8 +27,8 @@ alloy-dyn-abi.workspace = true
 
 # aws-kms
 alloy-signer-aws = { workspace = true, features = ["eip712"], optional = true }
-aws-config = { version = "1", default-features = true, optional = true }
-aws-sdk-kms = { version = "1", default-features = false, optional = true }
+aws-config = { workspace = true, default-features = true, optional = true }
+aws-sdk-kms = { workspace = true, default-features = false, optional = true }
 
 # gcp-kms
 alloy-signer-gcp = { workspace = true, features = ["eip712"], optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -56,6 +56,7 @@ allow = [
     "MPL-2.0",
     "CDDL-1.0",
     "Zlib",
+    "OpenSSL",
 ]
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses


### PR DESCRIPTION
closes #10326 

https://github.com/foundry-rs/foundry/pull/10158 introduced aws-lc-rs which broke this default:

ref https://github.com/snapview/tokio-tungstenite/issues/353#issuecomment-2455100010

> if exactly one of the two providers is available (that is, your application and all its dependencies only select either via features), it will be the default one.


the proper way of doing this is installing the default crypto provider manually.