### PR TITLE
feat: add new cheatcode `attachBlob` to send EIP-4844 transaction

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -3232,6 +3232,26 @@
     },
     {
       "func": {
+        "id": "attachBlob",
+        "description": "Attach an EIP-4844 blob to the next call",
+        "declaration": "function attachBlob(bytes calldata blob) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "attachBlob(bytes)",
+        "selector": "0x10cb385c",
+        "selectorBytes": [
+          16,
+          203,
+          56,
+          92
+        ]
+      },
+      "group": "scripting",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "attachDelegation",
         "description": "Designate the next call as an EIP-7702 transaction",
         "declaration": "function attachDelegation(SignedDelegation calldata signedDelegation) external;",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2236,6 +2236,10 @@ interface Vm {
     #[cheatcode(group = Scripting)]
     function signAndAttachDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);
 
+    /// Attach an EIP-4844 blob to the next call
+    #[cheatcode(group = Scripting)]
+    function attachBlob(bytes calldata blob) external;
+
     /// Returns addresses of available unlocked wallets in the script environment.
     #[cheatcode(group = Scripting)]
     function getWallets() external returns (address[] memory wallets);

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -21,6 +21,8 @@ use crate::{
     CheatsConfig, CheatsCtxt, DynCheatcode, Error, Result,
     Vm::{self, AccountAccess},
 };
+use alloy_consensus::BlobTransactionSidecar;
+use alloy_network::TransactionBuilder4844;
 use alloy_primitives::{
     hex,
     map::{AddressHashMap, HashMap, HashSet},
@@ -393,6 +395,9 @@ pub struct Cheatcodes {
     /// transaction construction.
     pub active_delegation: Option<SignedAuthorization>,
 
+    /// The active EIP-4844 blob that will be attached to the next call.
+    pub active_blob_sidecar: Option<BlobTransactionSidecar>,
+
     /// The gas price.
     ///
     /// Used in the cheatcode handler to overwrite the gas price separately from the gas price
@@ -526,6 +531,7 @@ impl Cheatcodes {
             config,
             block: Default::default(),
             active_delegation: Default::default(),
+            active_blob_sidecar: Default::default(),
             gas_price: Default::default(),
             pranks: Default::default(),
             expected_revert: Default::default(),
@@ -1127,10 +1133,30 @@ where {
                         ..Default::default()
                     };
 
-                    if let Some(auth_list) = self.active_delegation.take() {
-                        tx_req.authorization_list = Some(vec![auth_list]);
-                    } else {
-                        tx_req.authorization_list = None;
+                    match (self.active_delegation.take(), self.active_blob_sidecar.take()) {
+                        (Some(_), Some(_)) => {
+                            let msg = "both delegation and blob are active; `attachBlob` and `attachDelegation` are not compatible";
+                            return Some(CallOutcome {
+                                result: InterpreterResult {
+                                    result: InstructionResult::Revert,
+                                    output: Error::encode(msg),
+                                    gas,
+                                },
+                                memory_offset: call.return_memory_offset.clone(),
+                            });
+                        }
+                        (Some(auth_list), None) => {
+                            tx_req.authorization_list = Some(vec![auth_list]);
+                            tx_req.sidecar = None;
+                        }
+                        (None, Some(blob_sidecar)) => {
+                            tx_req.set_blob_sidecar(blob_sidecar);
+                            tx_req.authorization_list = None;
+                        }
+                        (None, None) => {
+                            tx_req.sidecar = None;
+                            tx_req.authorization_list = None;
+                        }
                     }
 
                     self.broadcastable_transactions.push_back(BroadcastableTransaction {

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -1,6 +1,7 @@
 //! Implementations of [`Scripting`](spec::Group::Scripting) cheatcodes.
 
 use crate::{Cheatcode, CheatsCtxt, Result, Vm::*};
+use alloy_consensus::{SidecarBuilder, SimpleCoder};
 use alloy_primitives::{Address, Uint, B256, U256};
 use alloy_rpc_types::Authorization;
 use alloy_signer::SignerSync;
@@ -8,7 +9,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolValue;
 use foundry_wallets::{multi_wallet::MultiWallet, WalletSigner};
 use parking_lot::Mutex;
-use revm::primitives::{Bytecode, SignedAuthorization};
+use revm::primitives::{Bytecode, SignedAuthorization, SpecId};
 use std::sync::Arc;
 
 impl Cheatcode for broadcast_0Call {
@@ -131,6 +132,21 @@ fn write_delegation(ccx: &mut CheatsCtxt, auth: SignedAuthorization) -> Result<(
     let bytecode = Bytecode::new_eip7702(*auth.address());
     ccx.ecx.journaled_state.set_code(authority, bytecode);
     Ok(())
+}
+
+impl Cheatcode for attachBlobCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { blob } = self;
+        ensure!(
+            ccx.ecx.spec_id() >= SpecId::CANCUN,
+            "`attachBlob` is not supported before the Cancun hard fork; \
+             see EIP-4844: https://eips.ethereum.org/EIPS/eip-4844"
+        );
+        let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(blob);
+        let sidecar = sidecar.build().map_err(|e| format!("{e}"))?;
+        ccx.state.active_blob_sidecar = Some(sidecar);
+        Ok(Default::default())
+    }
 }
 
 impl Cheatcode for startBroadcast_0Call {

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -155,6 +155,7 @@ interface Vm {
     function assumeNoRevert() external pure;
     function assumeNoRevert(PotentialRevert calldata potentialRevert) external pure;
     function assumeNoRevert(PotentialRevert[] calldata potentialReverts) external pure;
+    function attachBlob(bytes calldata blob) external;
     function attachDelegation(SignedDelegation calldata signedDelegation) external;
     function blobBaseFee(uint256 newBlobBaseFee) external;
     function blobhashes(bytes32[] calldata hashes) external;

--- a/testdata/default/cheats/AttachBlob.t.sol
+++ b/testdata/default/cheats/AttachBlob.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.25;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract Counter {
+    uint256 public counter;
+
+    function increment() public {
+        counter++;
+    }
+}
+
+contract AttachBlobTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    uint256 bobPk =
+        0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d;
+    address bob = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
+
+    Counter public counter;
+
+    function setUp() public {
+        counter = new Counter();
+    }
+
+    function testAttachBlob() public {
+        bytes memory blob = abi.encode("Blob the Builder");
+        vm.attachBlob(blob);
+
+        vm.broadcast(bobPk);
+        counter.increment();
+    }
+
+    function testAttachBlobWithCreateTx() public {
+        bytes memory blob = abi.encode("Blob the Builder");
+        vm.attachBlob(blob);
+
+        vm.broadcast(bobPk);
+        new Counter();
+
+        // blob is attached with this tx instead
+        vm.broadcast(bobPk);
+        counter.increment();
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testRevertAttachBlobWithDelegation() public {
+        bytes memory blob = abi.encode("Blob the Builder");
+        vm.attachBlob(blob);
+        vm.signAndAttachDelegation(address(0), bobPk);
+
+        vm.broadcast(bobPk);
+        vm.expectRevert(
+            "both delegation and blob are active; `attachBlob` and `attachDelegation` are not compatible"
+        );
+        counter.increment();
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Add new cheatcode `vm.attachBlob(bytes)` that will add a blob sidecar to the next transaction.
  - Will revert if `vm.attachBlob` and `vm.attachDelegation` is being used on the same transaction since both are not compatible.
  - If next call is contract creation, blob will be attached to the call after contract creation call.

Resolves #10290 

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes