### PR TITLE
fix: remove deprecated #[expect(clippy::large_enum_variant)] attributes

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/types.rs
+++ b/crates/evm/evm/src/executors/fuzz/types.rs
@@ -36,7 +36,6 @@ pub struct CounterExampleOutcome {
 
 /// Outcome of a single fuzz
 #[derive(Debug)]
-#[expect(clippy::large_enum_variant)]
 pub enum FuzzOutcome {
     Case(CaseOutcome),
     CounterExample(CounterExampleOutcome),

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -32,7 +32,6 @@ mod inspector;
 pub use inspector::Fuzzer;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[expect(clippy::large_enum_variant)]
 pub enum CounterExample {
     /// Call used as a counter example for fuzz tests.
     Single(BaseCounterExample),


### PR DESCRIPTION
```
  --> crates/evm/fuzz/src/lib.rs:35:10
   |
35 | #[expect(clippy::large_enum_variant)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `-D unfulfilled-lint-expectations` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unfulfilled_lint_expectations)]`
```
   
```
  --> crates/evm/evm/src/executors/fuzz/types.rs:39:10  
   |
39 | #[expect(clippy::large_enum_variant)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `-D unfulfilled-lint-expectations` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unfulfilled_lint_expectations)]`
```