### PR TITLE
chore: update actions/cache to v4

### DIFF
--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -75,7 +75,7 @@ jobs:
         run: pip --version && pip install vyper==0.4.0
 
       - name: Forge RPC cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.foundry/cache


### PR DESCRIPTION
Updated actions/cache from v3 to v4 according to GitHub recommendations.
GitHub Actions now requires using v4 to ensure future compatibility and avoid workflow failures after upcoming deprecations.

https://github.com/actions/cache