### PR TITLE
chore(deps): replace humantime with jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3502,7 +3502,6 @@ dependencies = [
  "foundry-wallets",
  "futures",
  "globset",
- "humantime-serde",
  "indicatif",
  "inferno",
  "itertools 0.14.0",
@@ -3850,6 +3849,7 @@ dependencies = [
  "foundry-compilers",
  "foundry-config",
  "itertools 0.14.0",
+ "jiff",
  "num-format",
  "path-slash",
  "reqwest",
@@ -5016,22 +5016,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
-
-[[package]]
-name = "humantime-serde"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
-dependencies = [
- "humantime",
- "serde",
-]
 
 [[package]]
 name = "hyper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,6 +314,7 @@ url = "2"
 vergen = { version = "8", default-features = false }
 yansi = { version = "1.0", features = ["detect-tty", "detect-env"] }
 path-slash = "0.2"
+jiff = "0.2"
 
 # Use unicode-rs which has a smaller binary size than the default ICU4X as the IDNA backend, used
 # by the `url` crate.

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -56,18 +56,19 @@ comfy-table.workspace = true
 dunce.workspace = true
 eyre.workspace = true
 itertools.workspace = true
+jiff.workspace = true
 num-format.workspace = true
+path-slash.workspace = true
 reqwest.workspace = true
 semver.workspace = true
-serde_json.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 walkdir.workspace = true
 yansi.workspace = true
-path-slash.workspace = true
 
 anstream.workspace = true
 anstyle.workspace = true

--- a/crates/common/src/serde_helpers.rs
+++ b/crates/common/src/serde_helpers.rs
@@ -125,3 +125,25 @@ where
 
     Ok(num)
 }
+
+pub mod duration {
+    use serde::{Deserialize, Deserializer};
+    use std::time::Duration;
+
+    pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let d = jiff::SignedDuration::try_from(*duration).map_err(serde::ser::Error::custom)?;
+        serializer.serialize_str(&format!("{d:#}"))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let d = s.parse::<jiff::SignedDuration>().map_err(serde::de::Error::custom)?;
+        d.try_into().map_err(serde::de::Error::custom)
+    }
+}

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -35,7 +35,6 @@ rayon.workspace = true
 serde.workspace = true
 tracing.workspace = true
 yansi.workspace = true
-humantime-serde = "1.1.1"
 chrono.workspace = true
 
 # bin

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -205,7 +205,7 @@ impl TestOutcome {
 #[derive(Clone, Debug, Serialize)]
 pub struct SuiteResult {
     /// Wall clock time it took to execute all tests in this suite.
-    #[serde(with = "humantime_serde")]
+    #[serde(with = "foundry_common::serde_helpers::duration")]
     pub duration: Duration,
     /// Individual test results: `test fn signature -> TestResult`.
     pub test_results: BTreeMap<String, TestResult>,
@@ -409,6 +409,7 @@ pub struct TestResult {
     /// Labeled addresses
     pub labeled_addresses: AddressHashMap<String>,
 
+    #[serde(with = "foundry_common::serde_helpers::duration")]
     pub duration: Duration,
 
     /// pc breakpoint char map

--- a/crates/forge/tests/fixtures/SimpleContractTestNonVerbose.json
+++ b/crates/forge/tests/fixtures/SimpleContractTestNonVerbose.json
@@ -15,10 +15,7 @@
                 },
                 "traces": [],
                 "labeled_addresses": {},
-                "duration": {
-                    "secs": "{...}",
-                    "nanos": "{...}"
-                },
+                "duration": "{...}",
                 "breakpoints": {},
                 "gas_snapshots": {}
             }

--- a/crates/forge/tests/fixtures/SimpleContractTestVerbose.json
+++ b/crates/forge/tests/fixtures/SimpleContractTestVerbose.json
@@ -204,10 +204,7 @@
           ]
         ],
         "labeled_addresses": {},
-        "duration": {
-          "secs": "{...}",
-          "nanos": "{...}"
-        },
+        "duration": "{...}",
         "breakpoints": {},
         "gas_snapshots": {}
       }


### PR DESCRIPTION
The format is the same as humantime. Also add it to the inner `duration` in `TestResult`.

Before:
```json
{"test/Counter.t.sol:CounterTest":{"duration":"6ms 306us 765ns","test_results":{"testFuzz_SetNumber(uint256)":{"status":"Success","reason":null,"counterexample":null,"logs":[],"decoded_logs":[],"kind":{"Fuzz":{"first_case":{"calldata":"0x5c7f60d70000000000000000000000000000000000000000000000000000000000001477","gas":53570,"stipend":21216},"runs":256,"mean_gas":31965,"median_gas":32354}},"traces":[],"labeled_addresses":{},"duration":{"secs":0,"nanos":4319680},"breakpoints":{},"gas_snapshots":{}},"test_Increment()":{"status":"Success","reason":null,"counterexample":null,"logs":[],"decoded_logs":[],"kind":{"Unit":{"gas":31851}},"traces":[],"labeled_addresses":{},"duration":{"secs":0,"nanos":772251},"breakpoints":{},"gas_snapshots":{}}},"warnings":[]}}
```

After:
```json
{"test/Counter.t.sol:CounterTest":{"duration":"45ms 358µs 998ns","test_results":{"testFuzz_SetNumber(uint256)":{"status":"Success","reason":null,"counterexample":null,"logs":[],"decoded_logs":[],"kind":{"Fuzz":{"first_case":{"calldata":"0x5c7f60d70000000000000000000000000000000000000000000000000000000000001a4e","gas":53570,"stipend":21216},"runs":256,"mean_gas":32043,"median_gas":32354}},"traces":[],"labeled_addresses":{},"duration":"44ms 522µs 396ns","breakpoints":{},"gas_snapshots":{}},"test_Increment()":{"status":"Success","reason":null,"counterexample":null,"logs":[],"decoded_logs":[],"kind":{"Unit":{"gas":31851}},"traces":[],"labeled_addresses":{},"duration":"282µs 411ns","breakpoints":{},"gas_snapshots":{}}},"warnings":[]}}
```