### PR TITLE
fix(chisel): Regex to Handle Edge Cases with Address Matching

### DIFF
--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -55,7 +55,7 @@ static COMMENT_RE: LazyLock<Regex> =
 
 /// Matches Ethereum addresses that are not strings
 static ADDRESS_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?m)(([^"']\s*)|^)(?P<address>0x[a-fA-F0-9]{40})((\s*[^"'\w])|$)"#).unwrap()
+    Regex::new(r#"(?<!\w)(?P<address>0x[a-fA-F0-9]{40})(?!\w)"#).unwrap()
 });
 
 /// Chisel input dispatcher


### PR DESCRIPTION
## Motivation

The current regular expression has issues where it misses edge cases, such as when an address appears at the beginning or end of a line without proper spacing. This leads to false positives.

## Solution

I simplified the regular expression to handle these edge cases more reliably. The new regex ensures that the address is properly isolated, not preceded or followed by alphanumeric characters. The solution uses negative lookbehind `(?<!\w)` and negative lookahead `(?!\w)` to avoid complex conditions for line start and end.

### Old regex:
```rust
Regex::new(r#"(?m)(([^"']\s*)|^)(?P<address>0x[a-fA-F0-9]{40})((\s*[^"'\w])|$)"#)
```

### New regex:
```rust
Regex::new(r#"(?<!\w)(?P<address>0x[a-fA-F0-9]{40})(?!\w)"#).unwrap()
```

This update ensures the address is only matched when it stands alone, preventing false matches.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes