### PR TITLE
fix(anvil): trace_filter same to and from block range is valid

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2521,12 +2521,13 @@ impl Backend {
         let start = filter.from_block.unwrap_or(0);
         let end = filter.to_block.unwrap_or(self.best_number());
 
-        let dist = end.saturating_sub(start);
-        if dist == 0 {
+        if start > end {
             return Err(BlockchainError::RpcError(RpcError::invalid_params(
                 "invalid block range, ensure that to block is greater than from block".to_string(),
             )));
         }
+
+        let dist = end - start;
         if dist > 300 {
             return Err(BlockchainError::RpcError(RpcError::invalid_params(
                 "block range too large, currently limited to 300".to_string(),

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2519,7 +2519,7 @@ impl Backend {
     ) -> Result<Vec<LocalizedTransactionTrace>, BlockchainError> {
         let matcher = filter.matcher();
         let start = filter.from_block.unwrap_or(0);
-        let end = filter.to_block.unwrap_or(self.best_number());
+        let end = filter.to_block.unwrap_or_else(|| self.best_number());
 
         if start > end {
             return Err(BlockchainError::RpcError(RpcError::invalid_params(

--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -873,6 +873,21 @@ async fn test_trace_filter() {
     let traces = api.trace_filter(tracer).await;
     assert!(traces.is_err());
 
+    // Test same from and to block is valid
+    let latest = provider.get_block_number().await.unwrap();
+    let tracer = TraceFilter {
+        from_block: Some(latest),
+        to_block: Some(latest),
+        from_address: vec![],
+        to_address: vec![],
+        mode: TraceFilterMode::Union,
+        after: None,
+        count: None,
+    };
+
+    let traces = api.trace_filter(tracer).await;
+    assert!(traces.is_ok());
+
     // Test invalid block range
     let latest = provider.get_block_number().await.unwrap();
     let tracer = TraceFilter {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`from_block` and `to_block` can be equal. That is not invalid.

## Solution

Fix the check.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
