### PR TITLE
feat(`anvil`): op support revm 21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4380,6 +4380,7 @@ dependencies = [
  "foundry-test-utils",
  "futures",
  "itertools 0.14.0",
+ "op-revm",
  "parking_lot",
  "revm",
  "revm-inspectors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-op-evm"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "324cf0b3b08b4c3354460dee8208384a59245da8b0eaefe9e962d3942d919d58"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-op-hardforks",
+ "alloy-primitives",
+ "auto_impl",
+ "op-alloy-consensus",
+ "op-revm",
+ "revm",
+]
+
+[[package]]
+name = "alloy-op-hardforks"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217a4efe17c43df77c1f261825350be0be1d907f56eb38a4b258936e33cfd1d8"
+dependencies = [
+ "alloy-hardforks",
+ "auto_impl",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1025,7 @@ dependencies = [
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
+ "alloy-op-evm",
  "alloy-primitives",
  "alloy-provider",
  "alloy-pubsub",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,6 +245,7 @@ alloy-sol-types = "0.8.22"
 
 alloy-chains = "0.1"
 alloy-evm = "0.3.2"
+alloy-op-evm = "0.3.2"
 alloy-rlp = "0.3"
 alloy-trie = "0.7.0"
 

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -31,6 +31,7 @@ foundry-evm-core.workspace = true
 
 # alloy
 alloy-evm.workspace = true
+alloy-op-evm.workspace = true
 alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-consensus = { workspace = true, features = ["k256", "kzg"] }
 alloy-contract = { workspace = true, features = ["pubsub"] }

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::{ForkChoice, DEFAULT_MNEMONIC},
     eth::{backend::db::SerializableState, pool::transactions::TransactionOrder, EthApi},
-    AccountGenerator, EthereumHardfork, NodeConfig, CHAIN_ID,
+    AccountGenerator, EthereumHardfork, NodeConfig, OptimismHardfork, CHAIN_ID,
 };
 use alloy_genesis::Genesis;
 use alloy_primitives::{utils::Unit, B256, U256};
@@ -217,11 +217,11 @@ impl NodeArgs {
 
         let hardfork = match &self.hardfork {
             Some(hf) => {
-                // if self.evm.optimism {
-                //     Some(OptimismHardfork::from_str(hf)?.into())
-                // } else {
-                Some(EthereumHardfork::from_str(hf)?.into())
-                // }
+                if self.evm.optimism {
+                    Some(OptimismHardfork::from_str(hf)?.into())
+                } else {
+                    Some(EthereumHardfork::from_str(hf)?.into())
+                }
             }
             None => None,
         };
@@ -791,9 +791,8 @@ fn duration_from_secs_f64(s: &str) -> Result<Duration, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::EthereumHardfork;
-
     use super::*;
+    use crate::{EthereumHardfork, OptimismHardfork};
     use std::{env, net::Ipv4Addr};
 
     #[test]
@@ -833,13 +832,13 @@ mod tests {
         assert_eq!(config.hardfork, Some(EthereumHardfork::Berlin.into()));
     }
 
-    // #[test]
-    // fn can_parse_optimism_hardfork() {
-    //     let args: NodeArgs =
-    //         NodeArgs::parse_from(["anvil", "--optimism", "--hardfork", "Regolith"]);
-    //     let config = args.into_node_config().unwrap();
-    //     assert_eq!(config.hardfork, Some(OptimismHardfork::Regolith.into()));
-    // }
+    #[test]
+    fn can_parse_optimism_hardfork() {
+        let args: NodeArgs =
+            NodeArgs::parse_from(["anvil", "--optimism", "--hardfork", "Regolith"]);
+        let config = args.into_node_config().unwrap();
+        assert_eq!(config.hardfork, Some(OptimismHardfork::Regolith.into()));
+    }
 
     #[test]
     fn cant_parse_invalid_hardfork() {

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1048,6 +1048,8 @@ impl NodeConfig {
             TxEnv { chain_id: Some(self.get_chain_id()), ..Default::default() },
         );
 
+        env.is_optimism = self.enable_optimism;
+
         let fees = FeeManager::new(
             spec_id,
             self.get_base_fee(),

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     hardfork::ChainHardfork,
     mem::{self, in_memory_db::MemDb},
-    EthereumHardfork, FeeManager, PrecompileFactory,
+    EthereumHardfork, FeeManager, OptimismHardfork, PrecompileFactory,
 };
 use alloy_consensus::BlockHeader;
 use alloy_genesis::Genesis;
@@ -527,9 +527,9 @@ impl NodeConfig {
         if let Some(hardfork) = self.hardfork {
             return hardfork;
         }
-        // if self.enable_optimism {
-        //     return OptimismHardfork::default().into();
-        // }
+        if self.enable_optimism {
+            return OptimismHardfork::default().into();
+        }
         EthereumHardfork::default().into()
     }
 

--- a/crates/anvil/src/eth/backend/evm.rs
+++ b/crates/anvil/src/eth/backend/evm.rs
@@ -37,7 +37,7 @@ where
     P: PrecompileProvider<EthEvmContext<DB>, Output = InterpreterResult>
         + PrecompileProvider<OpContext<DB>, Output = InterpreterResult>,
 {
-    fn transact_deposit(
+    pub fn transact_deposit(
         &mut self,
         tx: TxEnv,
         deposit: DepositTransactionParts,
@@ -55,7 +55,7 @@ where
         }
     }
 
-    fn transact_deposit_commit(
+    pub fn transact_deposit_commit(
         &mut self,
         tx: TxEnv,
         deposit: DepositTransactionParts,

--- a/crates/anvil/src/eth/backend/evm.rs
+++ b/crates/anvil/src/eth/backend/evm.rs
@@ -1,0 +1,151 @@
+use crate::eth::error::BlockchainError;
+use alloy_evm::{eth::EthEvmContext, evm, Database, EthEvm, Evm, EvmEnv, EvmFactory};
+use alloy_op_evm::OpEvm;
+use alloy_primitives::{Address, Bytes};
+use foundry_evm::{backend::DatabaseError, Env};
+use foundry_evm_core::evm::FoundryPrecompiles;
+use op_revm::{
+    precompiles::OpPrecompiles, transaction::deposit::DepositTransactionParts, L1BlockInfo,
+    OpContext, OpHaltReason, OpSpecId, OpTransaction, OpTransactionError,
+};
+use revm::{
+    context::{
+        result::{EVMError, ExecutionResult, HaltReason, HaltReasonTr, ResultAndState},
+        BlockEnv, Cfg, CfgEnv, ContextTr, Evm as RevmEvm, TxEnv,
+    },
+    handler::{instructions::EthInstructions, PrecompileProvider},
+    interpreter::InterpreterResult,
+    primitives::hardfork::SpecId,
+    DatabaseCommit, Inspector, Journal,
+};
+
+type AnvilEvmResult<DBError> =
+    Result<ResultAndState<OpHaltReason>, EVMError<DBError, OpTransactionError>>;
+
+type AnvilExecResult<DBError> =
+    Result<ExecutionResult<OpHaltReason>, EVMError<DBError, OpTransactionError>>;
+pub enum EitherEvm<DB, I, P>
+where
+    DB: Database,
+{
+    Eth(EthEvm<DB, I, P>),
+    Op(OpEvm<DB, I, P>),
+}
+
+impl<DB, I, P> EitherEvm<DB, I, P>
+where
+    DB: Database,
+    I: Inspector<EthEvmContext<DB>> + Inspector<OpContext<DB>>,
+    P: PrecompileProvider<EthEvmContext<DB>, Output = InterpreterResult>
+        + PrecompileProvider<OpContext<DB>, Output = InterpreterResult>,
+{
+    pub fn block(&self) -> &BlockEnv {
+        match self {
+            EitherEvm::Eth(evm) => evm.block(),
+            EitherEvm::Op(evm) => evm.block(),
+        }
+    }
+
+    pub fn transact_raw(
+        &mut self,
+        tx: TxEnv,
+        deposit: Option<DepositTransactionParts>,
+    ) -> AnvilEvmResult<DB::Error> {
+        match self {
+            Self::Eth(evm) => {
+                if deposit.is_some() {
+                    return Err(EVMError::Custom(
+                        "Deposit transactions not supported via EthEvm".to_string(),
+                    ));
+                }
+                let res = evm.transact_raw(tx);
+                self.map_eth_result(res)
+            }
+            Self::Op(evm) => {
+                let op_tx = OpTransaction {
+                    base: tx,
+                    deposit: deposit.unwrap_or_default(),
+                    // Used to compute L1 gas cost
+                    enveloped_tx: None,
+                };
+                evm.transact_raw(op_tx)
+            }
+        }
+    }
+
+    pub fn transact_commit(
+        &mut self,
+        tx: TxEnv,
+        deposit: Option<DepositTransactionParts>,
+    ) -> AnvilExecResult<DB::Error>
+    where
+        DB: DatabaseCommit,
+    {
+        match self {
+            Self::Eth(evm) => {
+                if deposit.is_some() {
+                    return Err(EVMError::Custom(
+                        "Deposit transactions not supported via EthEvm".to_string(),
+                    ));
+                }
+                let res = evm.transact_commit(tx);
+                self.map_exec_result(res)
+            }
+            Self::Op(evm) => {
+                let op_tx = OpTransaction {
+                    base: tx,
+                    deposit: deposit.unwrap_or_default(),
+                    // Used to compute L1 gas cost
+                    enveloped_tx: None,
+                };
+                evm.transact_commit(op_tx)
+            }
+        }
+    }
+
+    fn map_eth_result(
+        &self,
+        result: Result<ResultAndState<HaltReason>, EVMError<DB::Error>>,
+    ) -> AnvilEvmResult<DB::Error> {
+        match result {
+            Ok(result) => {
+                // Map the halt reason
+                Ok(result.map_haltreason(|hr| OpHaltReason::Base(hr)))
+            }
+            Err(e) => {
+                // Map the TransactionError
+                match e {
+                    EVMError::Transaction(invalid_tx) => {
+                        Err(EVMError::Transaction(OpTransactionError::Base(invalid_tx)))
+                    }
+                    EVMError::Database(e) => Err(EVMError::Database(e)),
+                    EVMError::Header(e) => Err(EVMError::Header(e)),
+                    EVMError::Custom(e) => Err(EVMError::Custom(e)),
+                }
+            }
+        }
+    }
+
+    fn map_exec_result(
+        &self,
+        result: Result<ExecutionResult, EVMError<DB::Error>>,
+    ) -> AnvilExecResult<DB::Error> {
+        match result {
+            Ok(result) => {
+                // Map the halt reason
+                Ok(result.map_haltreason(|hr| OpHaltReason::Base(hr)))
+            }
+            Err(e) => {
+                // Map the TransactionError
+                match e {
+                    EVMError::Transaction(invalid_tx) => {
+                        Err(EVMError::Transaction(OpTransactionError::Base(invalid_tx)))
+                    }
+                    EVMError::Database(e) => Err(EVMError::Database(e)),
+                    EVMError::Header(e) => Err(EVMError::Header(e)),
+                    EVMError::Custom(e) => Err(EVMError::Custom(e)),
+                }
+            }
+        }
+    }
+}

--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -1,6 +1,7 @@
 //! Anvil specific [`revm::Inspector`] implementation
 
-use crate::foundry_common::ErrorExt;
+use crate::{eth::macros::node_info, foundry_common::ErrorExt};
+use alloy_evm::eth::EthEvmContext;
 use alloy_primitives::{Address, Log, U256};
 use alloy_sol_types::SolInterface;
 use foundry_evm::{
@@ -23,8 +24,6 @@ use revm::{
     },
     Database, Inspector,
 };
-
-use crate::eth::{backend::executor::AnvilEvmContext, macros::node_info};
 
 /// The [`revm::Inspector`] used when transacting in the evm
 #[derive(Clone, Debug, Default)]
@@ -196,7 +195,7 @@ where
     #[inline]
     fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {
         if let Some(tracer) = &mut self.tracer {
-            Inspector::<AnvilEvmContext<'_, D>>::selfdestruct(tracer, contract, target, value);
+            Inspector::<EthEvmContext<D>>::selfdestruct(tracer, contract, target, value);
         }
     }
 }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1,7 +1,7 @@
 //! In-memory blockchain backend.
 
 use self::state::trie_storage;
-use super::{evm::EitherEvm, executor::{evm_with_inspector_ref, new_evm_with_inspector_ref, AnvilEvm}};
+use super::{evm::EitherEvm, executor::evm_with_inspector_ref};
 use crate::{
     config::PruneStateHistoryConfig,
     eth::{

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -747,11 +747,9 @@ impl Backend {
         (self.spec_id() as u8) >= (SpecId::PRAGUE as u8)
     }
 
-    // TODO: support Optimism
     /// Returns true if op-stack deposits are active
     pub fn is_optimism(&self) -> bool {
-        // self.env.read().handler_cfg.is_optimism
-        false
+        self.env.read().is_optimism
     }
 
     /// Returns an error if EIP1559 is not active (pre Berlin)

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -40,7 +40,7 @@ use alloy_consensus::{
     transaction::Recovered, Account, BlockHeader, EnvKzgSettings, Header, Receipt, ReceiptWithBloom, Signed, Transaction as TransactionTrait, TxEnvelope
 };
 use alloy_eips::{eip1559::BaseFeeParams, eip4844::MAX_BLOBS_PER_BLOCK};
-use alloy_evm::{eth::EthEvmContext, Database};
+use alloy_evm::{eth::EthEvmContext, Database, Evm};
 use alloy_network::{
     AnyHeader, AnyRpcBlock, AnyRpcHeader, AnyRpcTransaction, AnyTxEnvelope, AnyTxType,
     EthereumWallet, UnknownTxEnvelope, UnknownTypedTransaction,
@@ -95,13 +95,13 @@ use foundry_evm::{
 use foundry_evm_core::evm::FoundryPrecompiles;
 use futures::channel::mpsc::{unbounded, UnboundedSender};
 use op_alloy_consensus::{TxDeposit, DEPOSIT_TX_TYPE_ID};
-use op_revm::OpContext;
+use op_revm::{OpContext, OpHaltReason};
 use parking_lot::{Mutex, RwLock};
 use revm::{
-    context::{Block as RevmBlock, BlockEnv, ContextTr, TxEnv}, context_interface::{
+    context::{result::HaltReason, Block as RevmBlock, BlockEnv, ContextTr, TxEnv}, context_interface::{
         block::BlobExcessGasAndPrice,
         result::{ExecutionResult, Output, ResultAndState},
-    }, database::{CacheDB, DatabaseRef, WrapDatabaseRef}, interpreter::InstructionResult, primitives::{hardfork::SpecId, KECCAK_EMPTY}, state::AccountInfo, Database, DatabaseCommit, ExecuteEvm, InspectEvm, Inspector
+    }, database::{CacheDB, DatabaseRef, WrapDatabaseRef}, interpreter::InstructionResult, primitives::{hardfork::SpecId, KECCAK_EMPTY}, state::AccountInfo, DatabaseCommit, ExecuteEvm, InspectEvm, Inspector
 };
 use revm_inspectors::transfer::TransferInspector;
 use std::{
@@ -1039,7 +1039,7 @@ impl Backend {
 
     /// Creates an EVM instance with optionally injected precompiles.
     #[expect(clippy::type_complexity)]
-    fn new_evm_with_inspector_ref<'db, DB, I>(
+    fn new_evm_with_inspector_ref<'db, I>(
         &self,
         db: &'db dyn DatabaseRef<Error = DatabaseError>,
         env: &Env,
@@ -1080,7 +1080,7 @@ impl Backend {
         let db = self.db.read().await;
         let mut inspector = self.build_inspector();
         let mut evm = self.new_evm_with_inspector_ref(db.as_dyn(), &env, &mut inspector);
-        let ResultAndState { result, state } = evm.inspect_with_tx(env.tx)?;
+        let ResultAndState { result, state } = evm.transact(env.tx)?;
         let (exit_reason, gas_used, out, logs) = match result {
             ExecutionResult::Success { reason, gas_used, logs, output, .. } => {
                 (reason.into(), gas_used, Some(output), Some(logs))
@@ -1088,7 +1088,10 @@ impl Backend {
             ExecutionResult::Revert { gas_used, output } => {
                 (InstructionResult::Revert, gas_used, Some(Output::Call(output)), None)
             }
-            ExecutionResult::Halt { reason, gas_used } => (reason.into(), gas_used, None, None),
+            ExecutionResult::Halt { reason, gas_used } => {
+                let eth_reason = op_haltreason_to_instruction_result(reason);
+                (eth_reason, gas_used, None, None)
+            },
         };
 
         drop(evm);
@@ -1573,7 +1576,7 @@ impl Backend {
 
                         
                         trace!(target: "backend", env=?env.evm_env, spec=?env.evm_env.spec_id(),"simulate evm env");
-                        evm.inspect_with_tx(env.tx)?
+                        evm.transact(env.tx)?
                     } else {
                         let mut inspector = self.build_inspector();
                         let mut evm = self.new_evm_with_inspector_ref(
@@ -1583,7 +1586,7 @@ impl Backend {
                         );
 
                         trace!(target: "backend", env=?env.evm_env, spec=?env.evm_env.spec_id(),"simulate evm env");
-                        evm.inspect_with_tx(env.tx)?
+                        evm.transact(env.tx)?
                     };
                     trace!(target: "backend", ?result, ?request, "simulate call");
 
@@ -1714,7 +1717,7 @@ impl Backend {
 
         let env = self.build_call_env(request, fee_details, block_env);
         let mut evm = self.new_evm_with_inspector_ref(state, &env, &mut inspector);
-        let ResultAndState { result, state } = evm.inspect_with_tx(env.tx)?;
+        let ResultAndState { result, state } = evm.transact(env.tx)?;
         let (exit_reason, gas_used, out) = match result {
             ExecutionResult::Success { reason, gas_used, output, .. } => {
                 (reason.into(), gas_used, Some(output))
@@ -1722,7 +1725,7 @@ impl Backend {
             ExecutionResult::Revert { gas_used, output } => {
                 (InstructionResult::Revert, gas_used, Some(Output::Call(output)))
             }
-            ExecutionResult::Halt { reason, gas_used } => (reason.into(), gas_used, None),
+            ExecutionResult::Halt { reason, gas_used } => (op_haltreason_to_instruction_result(reason), gas_used, None),
         };
         drop(evm);
         inspector.print_logs();
@@ -1773,7 +1776,7 @@ impl Backend {
                                 &env,
                                 &mut inspector,
                             );
-                            let ResultAndState { result, state: _ } = evm.inspect_with_tx(env.tx)?;
+                            let ResultAndState { result, state: _ } = evm.transact(env.tx)?;
 
                             drop(evm);
                             let tracing_inspector = inspector.tracer.expect("tracer disappeared");
@@ -1805,7 +1808,7 @@ impl Backend {
 
             let env = self.build_call_env(request, fee_details, block);
             let mut evm = self.new_evm_with_inspector_ref(state.as_dyn(), &env, &mut inspector);
-            let ResultAndState { result, state: _ } = evm.inspect_with_tx(env.tx)?;
+            let ResultAndState { result, state: _ } = evm.transact(env.tx)?;
 
             let (exit_reason, gas_used, out) = match result {
                 ExecutionResult::Success { reason, gas_used, output, .. } => {
@@ -1814,7 +1817,7 @@ impl Backend {
                 ExecutionResult::Revert { gas_used, output } => {
                     (InstructionResult::Revert, gas_used, Some(Output::Call(output)))
                 }
-                ExecutionResult::Halt { reason, gas_used } => (reason.into(), gas_used, None),
+                ExecutionResult::Halt { reason, gas_used } => (op_haltreason_to_instruction_result(reason), gas_used, None),
             };
 
             drop(evm);
@@ -1845,7 +1848,7 @@ impl Backend {
 
         let env = self.build_call_env(request, fee_details, block_env);
         let mut evm = self.new_evm_with_inspector_ref(state, &env, &mut inspector);
-        let ResultAndState { result, state: _ } = evm.inspect_with_tx(env.tx)?;
+        let ResultAndState { result, state: _ } = evm.transact(env.tx)?;
         let (exit_reason, gas_used, out) = match result {
             ExecutionResult::Success { reason, gas_used, output, .. } => {
                 (reason.into(), gas_used, Some(output))
@@ -1853,7 +1856,7 @@ impl Backend {
             ExecutionResult::Revert { gas_used, output } => {
                 (InstructionResult::Revert, gas_used, Some(Output::Call(output)))
             }
-            ExecutionResult::Halt { reason, gas_used } => (reason.into(), gas_used, None),
+            ExecutionResult::Halt { reason, gas_used } => (op_haltreason_to_instruction_result(reason), gas_used, None),
         };
         drop(evm);
         let access_list = inspector.access_list();
@@ -3312,4 +3315,11 @@ pub fn is_arbitrum(chain_id: u64) -> bool {
         return chain.is_arbitrum()
     }
     false
+}
+
+pub fn op_haltreason_to_instruction_result(op_reason: OpHaltReason) -> InstructionResult {
+    match op_reason {
+        OpHaltReason::Base(eth_h) => eth_h.into(),
+        OpHaltReason::FailedDeposit => InstructionResult::Stop,
+    }
 }

--- a/crates/anvil/src/eth/backend/mod.rs
+++ b/crates/anvil/src/eth/backend/mod.rs
@@ -8,6 +8,7 @@ pub mod mem;
 pub mod cheats;
 pub mod time;
 
+pub mod evm;
 pub mod executor;
 pub mod fork;
 pub mod genesis;

--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -98,6 +98,11 @@ impl PoolTransaction {
     pub fn gas_price(&self) -> u128 {
         self.pending_transaction.transaction.gas_price()
     }
+
+    /// Returns the type of the transaction
+    pub fn tx_type(&self) -> u8 {
+        self.pending_transaction.transaction.r#type().unwrap_or_default()
+    }
 }
 
 impl fmt::Debug for PoolTransaction {

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -48,7 +48,7 @@ pub use config::{
 };
 
 mod hardfork;
-pub use hardfork::EthereumHardfork;
+pub use hardfork::{EthereumHardfork, OptimismHardfork};
 
 /// ethereum related implementations
 pub mod eth;

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -18,7 +18,9 @@ use alloy_signer_local::PrivateKeySigner;
 use anvil::{eth::EthApi, spawn, NodeConfig, NodeHandle};
 use foundry_common::provider::get_http_provider;
 use foundry_config::Config;
-use foundry_test_utils::rpc::{self, next_http_rpc_endpoint, next_rpc_endpoint};
+use foundry_test_utils::rpc::{
+    self, next_http_archive_rpc_url, next_http_rpc_endpoint, next_rpc_endpoint,
+};
 use futures::StreamExt;
 use std::{sync::Arc, thread::sleep, time::Duration};
 
@@ -1328,6 +1330,7 @@ async fn test_immutable_fork_transaction_hash() {
     use std::str::FromStr;
 
     // Fork to a block with a specific transaction
+    // <https://explorer.immutable.com/tx/0x39d64ebf9eb3f07ede37f8681bc3b61928817276c4c4680b6ef9eac9f88b6786>
     let fork_tx_hash =
         TxHash::from_str("39d64ebf9eb3f07ede37f8681bc3b61928817276c4c4680b6ef9eac9f88b6786")
             .unwrap();

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -49,6 +49,7 @@ revm = { workspace = true, features = [
     "secp256r1",
 ] }
 revm-inspectors.workspace = true
+op-revm.workspace = true
 
 auto_impl.workspace = true
 eyre.workspace = true

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -10,6 +10,7 @@ use revm::{
 pub struct Env {
     pub evm_env: EvmEnv,
     pub tx: TxEnv,
+    pub is_optimism: bool,
 }
 
 /// Helper container type for [`EvmEnv`] and [`TxEnv`].
@@ -22,7 +23,7 @@ impl Env {
     }
 
     pub fn from(cfg: CfgEnv, block: BlockEnv, tx: TxEnv) -> Self {
-        Self { evm_env: EvmEnv { cfg_env: cfg, block_env: block }, tx }
+        Self { evm_env: EvmEnv { cfg_env: cfg, block_env: block }, tx, is_optimism: false }
     }
 
     pub fn from_with_spec_id(cfg: CfgEnv, block: BlockEnv, tx: TxEnv, spec_id: SpecId) -> Self {
@@ -46,6 +47,7 @@ impl EnvMut<'_> {
         Env {
             evm_env: EvmEnv { cfg_env: self.cfg.to_owned(), block_env: self.block.to_owned() },
             tx: self.tx.to_owned(),
+            is_optimism: false,
         }
     }
 }

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -1,4 +1,5 @@
 pub use alloy_evm::EvmEnv;
+use op_revm::OpSpecId;
 use revm::{
     context::{BlockEnv, CfgEnv, JournalInner, JournalTr, TxEnv},
     primitives::hardfork::SpecId,
@@ -11,6 +12,12 @@ pub struct Env {
     pub evm_env: EvmEnv,
     pub tx: TxEnv,
     pub is_optimism: bool,
+}
+
+// TODO: [`OpEnv`] and [`Env`] should be merged as an enum.
+pub struct OpEnv {
+    pub evm_env: EvmEnv<OpSpecId>,
+    pub tx: TxEnv,
 }
 
 /// Helper container type for [`EvmEnv`] and [`TxEnv`].

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -39,6 +39,11 @@ impl Env {
 
         Self::from(cfg, block, tx)
     }
+
+    pub fn with_deposit(mut self, deposit: DepositTransactionParts) -> Self {
+        self.deposit = Some(deposit);
+        self
+    }
 }
 
 /// Helper struct with mutable references to the block and cfg environments.

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -1,5 +1,5 @@
 pub use alloy_evm::EvmEnv;
-use op_revm::OpSpecId;
+use op_revm::transaction::deposit::DepositTransactionParts;
 use revm::{
     context::{BlockEnv, CfgEnv, JournalInner, JournalTr, TxEnv},
     primitives::hardfork::SpecId,
@@ -12,12 +12,7 @@ pub struct Env {
     pub evm_env: EvmEnv,
     pub tx: TxEnv,
     pub is_optimism: bool,
-}
-
-// TODO: [`OpEnv`] and [`Env`] should be merged as an enum.
-pub struct OpEnv {
-    pub evm_env: EvmEnv<OpSpecId>,
-    pub tx: TxEnv,
+    pub deposit: Option<DepositTransactionParts>,
 }
 
 /// Helper container type for [`EvmEnv`] and [`TxEnv`].
@@ -30,7 +25,12 @@ impl Env {
     }
 
     pub fn from(cfg: CfgEnv, block: BlockEnv, tx: TxEnv) -> Self {
-        Self { evm_env: EvmEnv { cfg_env: cfg, block_env: block }, tx, is_optimism: false }
+        Self {
+            evm_env: EvmEnv { cfg_env: cfg, block_env: block },
+            tx,
+            is_optimism: false,
+            deposit: None,
+        }
     }
 
     pub fn from_with_spec_id(cfg: CfgEnv, block: BlockEnv, tx: TxEnv, spec_id: SpecId) -> Self {
@@ -55,6 +55,8 @@ impl EnvMut<'_> {
             evm_env: EvmEnv { cfg_env: self.cfg.to_owned(), block_env: self.block.to_owned() },
             tx: self.tx.to_owned(),
             is_optimism: false,
+            // TODO: DepositTransactionParts get lost here
+            deposit: None,
         }
     }
 }

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -78,6 +78,7 @@ pub async fn environment<N: Network, P: Provider<N>>(
             ..Default::default()
         },
         is_optimism: false,
+        deposit: None,
     };
 
     apply_chain_and_block_specific_env_changes::<N>(&mut env, &block);

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -77,6 +77,7 @@ pub async fn environment<N: Network, P: Provider<N>>(
             gas_limit: block.header().gas_limit() as u64,
             ..Default::default()
         },
+        is_optimism: false,
     };
 
     apply_chain_and_block_specific_env_changes::<N>(&mut env, &block);

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -175,6 +175,7 @@ impl EvmOpts {
                 ..Default::default()
             },
             is_optimism: false,
+            deposit: None,
         }
     }
 

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -174,6 +174,7 @@ impl EvmOpts {
                 caller: self.sender,
                 ..Default::default()
             },
+            is_optimism: false,
         }
     }
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -666,6 +666,7 @@ impl Executor {
                 chain_id: Some(self.env().evm_env.cfg_env.chain_id),
                 ..self.env().tx.clone()
             },
+            is_optimism: false,
         }
     }
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -667,6 +667,7 @@ impl Executor {
                 ..self.env().tx.clone()
             },
             is_optimism: false,
+            deposit: None,
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Adds OP Support to anvil using revm 21 

To be merged into #10361 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Introduce `EitherEvm` which is an enum with EthEvm and OpEvm as its variants
- Impl `alloy_evm::Evm` for `EitherEvm` which delegates the transact request to the correct EVM depending on whether `--optimism` has been enabled
- impl `Evm` works over vanilla eth `TxEnv` but the transact results are mapped to `OpHaltReason` and `EVMError<DBError, OpTransactionError>`. Opted for OP result and error types as they are supersets of the eth types. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes