### PR TITLE
CI: migrate workflows to cache v4

### DIFF
--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -75,7 +75,7 @@ jobs:
         run: pip --version && pip install vyper==0.4.0
 
       - name: Forge RPC cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.foundry/cache


### PR DESCRIPTION
Maintenance bump to actions/cache@v4 to align with the current runner stack; nothing else modified.