### PR TITLE
fix: use `transact` from alloy-evm

### DIFF
--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -9,6 +9,7 @@ use crate::{
     fork::{CreateFork, ForkId},
     AsEnvMut, Env, EnvMut, InspectorExt,
 };
+use alloy_evm::Evm;
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{Address, B256, U256};
 use alloy_rpc_types::TransactionRequest;
@@ -73,8 +74,7 @@ impl<'a> CowBackend<'a> {
         self.is_initialized = false;
         self.spec_id = env.evm_env.cfg_env.spec;
 
-        let mut evm =
-            crate::evm::new_evm_with_inspector(self, env.to_owned(), inspector).into_inner();
+        let mut evm = crate::evm::new_evm_with_inspector(self, env.to_owned(), inspector);
 
         let res = evm.transact(env.tx.clone()).wrap_err("EVM error")?;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

After transition to `alloy_evm::EthEvm` in https://github.com/foundry-rs/foundry/pull/10412. We should be using `transact` from the `alloy_evm::Evm` trait and not transact from `revm::ExecuteEvm`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Use `alloy_evm::Evm::transact` which calls the inspector before transacting. 

This is the reason why the panic had disappeared, it is now back.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes