### PR TITLE
fix(`revm bump`): incorrect resetting of evm

### DIFF
--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -644,7 +644,7 @@ impl InspectorStackRefMut<'_> {
             // set depth to 1 to make sure traces are collected correctly
             evm.journaled_state.depth = 1;
 
-            let res = evm.transact(env.tx.clone());
+            let res = evm.transact(evm.tx.clone());
 
             // need to reset the env in case it was modified via cheatcodes during execution
             *env.cfg = evm.cfg.clone();

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -646,7 +646,7 @@ impl InspectorStackRefMut<'_> {
 
             let res = evm.transact(evm.tx.clone());
 
-            // need to reset the env in case it was modified via cheatcodes during execution
+            // apply the changes to the env
             *env.cfg = evm.cfg.clone();
             *env.block = evm.block.clone();
             *env.tx = evm.tx.clone();

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -647,9 +647,9 @@ impl InspectorStackRefMut<'_> {
             let res = evm.transact(env.tx.clone());
 
             // need to reset the env in case it was modified via cheatcodes during execution
-            ecx.cfg = cached_env.evm_env.cfg_env;
-            ecx.block = cached_env.evm_env.block_env;
-            ecx.tx = cached_env.tx;
+            *env.cfg = evm.cfg.clone();
+            *env.block = evm.block.clone();
+            *env.tx = evm.tx.clone();
 
             res
         });


### PR DESCRIPTION
In `master` we are

https://github.com/foundry-rs/foundry/blob/497b6ee597a6a8042fc91c361f77eee22aed0cb2/crates/evm/evm/src/inspectors/stack.rs#L639-L640

Previously we were applying the `cached_env` in order to, as the prior comment states, reset the env.

I think we should instead do what we are doing in `master`, which is applying the changes to the outer EVM.

**Note: this currently results in a underflow of a gas refund, investigating** 