### PR TITLE
fix(forge): show lcov hits for do while statements

### DIFF
--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -1,6 +1,6 @@
 //! Coverage reports.
 
-use alloy_primitives::map::HashMap;
+use alloy_primitives::map::{HashMap, HashSet};
 use comfy_table::{modifiers::UTF8_ROUND_CORNERS, Attribute, Cell, Color, Row, Table};
 use evm_disassembler::disassemble_bytes;
 use foundry_common::fs;
@@ -118,6 +118,8 @@ impl CoverageReporter for LcovReporter {
             writeln!(out, "TN:")?;
             writeln!(out, "SF:{}", path.display())?;
 
+            let mut recorded_lines = HashSet::new();
+
             for item in items {
                 let line = item.loc.lines.start;
                 // `lines` is half-open, so we need to subtract 1 to get the last included line.
@@ -140,8 +142,12 @@ impl CoverageReporter for LcovReporter {
                             writeln!(out, "FNDA:{hits},{name}")?;
                         }
                     }
-                    CoverageItemKind::Line => {
-                        writeln!(out, "DA:{line},{hits}")?;
+                    // Add lines / statement hits only once.
+                    CoverageItemKind::Line | CoverageItemKind::Statement => {
+                        if !recorded_lines.contains(&line) {
+                            recorded_lines.insert(line);
+                            writeln!(out, "DA:{line},{hits}")?;
+                        }
                     }
                     CoverageItemKind::Branch { branch_id, path_id, .. } => {
                         writeln!(
@@ -150,9 +156,6 @@ impl CoverageReporter for LcovReporter {
                             if hits == 0 { "-".to_string() } else { hits.to_string() }
                         )?;
                     }
-                    // Statements are not in the LCOV format.
-                    // We don't add them in order to avoid doubling line hits.
-                    CoverageItemKind::Statement => {}
                 }
             }
 

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -144,8 +144,7 @@ impl CoverageReporter for LcovReporter {
                     }
                     // Add lines / statement hits only once.
                     CoverageItemKind::Line | CoverageItemKind::Statement => {
-                        if !recorded_lines.contains(&line) {
-                            recorded_lines.insert(line);
+                        if recorded_lines.insert(line) {
                             writeln!(out, "DA:{line},{hits}")?;
                         }
                     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #10422 
- https://github.com/foundry-rs/foundry/commit/5b8416363c7c1aab6d3cda0da6e7c65594ad8a12 fixed an issue where lcov reports were doubled due to adding them both as lines and as statements, by not accounting statement hits
- turns out this breaks do / while report for block statements
- added back the DA line from statement if it wasn't already generated as line statement - this prevents doubling it but also properly generate lcov report if only statements recorded
- added test to prevent regression
![image](https://github.com/user-attachments/assets/474ad6fa-6d76-4aaf-9965-3ae24a09688e)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes