### PR TITLE
fix(forge): remove `strategy` section from workflow template to simplify

### DIFF
--- a/crates/forge/assets/workflowTemplate.yml
+++ b/crates/forge/assets/workflowTemplate.yml
@@ -10,9 +10,6 @@ env:
 
 jobs:
   check:
-    strategy:
-      fail-fast: true
-
     name: Foundry project
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Motivation
According to the [JSON Schema for GitHub Actions workflows](https://json.schemastore.org/github-workflow.json) (maintained by SchemaStore), the `matrix` field is required when using the `strategy` section. However, this template typically doesn't need this level of complexity that matrix configurations provide.

## Solution
This PR removes the `strategy` section from the workflow template.