### PR TITLE
feat: Etherscan V2 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,8 +3697,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-block-explorers"
-version = "0.13.1"
-source = "git+https://github.com/foundry-rs/block-explorers?rev=8c03122#8c0312275fecf11b2258622fe1f7eba89e8f0a8e"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb9266295447e86b27be80b74cfe7b37a79e48cc70fd01c21812af7ab3d79b"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3698,8 +3698,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001678abc9895502532c8c4a1a225079c580655fc82a194e78b06dcf99f49b8c"
+source = "git+https://github.com/foundry-rs/block-explorers?rev=8c03122#8c0312275fecf11b2258622fe1f7eba89e8f0a8e"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3782,6 +3782,7 @@ dependencies = [
  "dotenvy",
  "eyre",
  "forge-fmt",
+ "foundry-block-explorers",
  "foundry-common",
  "foundry-compilers",
  "foundry-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3593,6 +3593,7 @@ dependencies = [
  "eyre",
  "forge-script-sequence",
  "forge-verify",
+ "foundry-block-explorers",
  "foundry-cheatcodes",
  "foundry-cli",
  "foundry-common",
@@ -3691,9 +3692,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-block-explorers"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdb9266295447e86b27be80b74cfe7b37a79e48cc70fd01c21812af7ab3d79b"
+checksum = "8025385c52416bf14e5bb28d21eb5efe2490dd6fb001a49b87f1825a626b4909"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,6 +324,7 @@ jiff = "0.2"
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
+foundry-block-explorers = { git = "https://github.com/foundry-rs/block-explorers", rev = "8c03122" }
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
 # alloy-json-abi = { path = "../../alloy-rs/core/crates/json-abi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ foundry-wallets = { path = "crates/wallets" }
 foundry-linking = { path = "crates/linking" }
 
 # solc & compilation utilities
-foundry-block-explorers = { version = "0.13.2", default-features = false }
+foundry-block-explorers = { version = "0.13.3", default-features = false }
 foundry-compilers = { version = "0.14.0", default-features = false }
 foundry-fork-db = "0.12"
 solang-parser = "=0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ foundry-wallets = { path = "crates/wallets" }
 foundry-linking = { path = "crates/linking" }
 
 # solc & compilation utilities
-foundry-block-explorers = { version = "0.13.0", default-features = false }
+foundry-block-explorers = { version = "0.13.2", default-features = false }
 foundry-compilers = { version = "0.14.0", default-features = false }
 foundry-fork-db = "0.12"
 solang-parser = "=0.3.3"
@@ -324,7 +324,6 @@ jiff = "0.2"
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
-foundry-block-explorers = { git = "https://github.com/foundry-rs/block-explorers", rev = "8c03122" }
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
 # alloy-json-abi = { path = "../../alloy-rs/core/crates/json-abi" }

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1324,6 +1324,7 @@ async fn test_fork_execution_reverted() {
 
 // <https://github.com/foundry-rs/foundry/issues/8227>
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_immutable_fork_transaction_hash() {
     use std::str::FromStr;
 

--- a/crates/cast/src/cmd/constructor_args.rs
+++ b/crates/cast/src/cmd/constructor_args.rs
@@ -1,5 +1,5 @@
 use super::{
-    creation_code::fetch_creation_code,
+    creation_code::fetch_creation_code_from_etherscan,
     interface::{fetch_abi_from_etherscan, load_abi_from_file},
 };
 use alloy_dyn_abi::DynSolType;
@@ -7,7 +7,6 @@ use alloy_primitives::{Address, Bytes};
 use alloy_provider::Provider;
 use clap::{command, Parser};
 use eyre::{eyre, OptionExt, Result};
-use foundry_block_explorers::Client;
 use foundry_cli::{
     opts::{EtherscanOpts, RpcOpts},
     utils::{self, LoadConfig},
@@ -37,12 +36,10 @@ impl ConstructorArgsArgs {
 
         let config = rpc.load_config()?;
         let provider = utils::get_provider(&config)?;
-        let api_key = etherscan.key().unwrap_or_default();
         let chain = provider.get_chain_id().await?;
         etherscan.chain = Some(chain.into());
-        let client = Client::new(chain.into(), api_key)?;
 
-        let bytecode = fetch_creation_code(contract, client, provider).await?;
+        let bytecode = fetch_creation_code_from_etherscan(contract, &etherscan, provider).await?;
 
         let args_arr = parse_constructor_args(bytecode, contract, &etherscan, abi_path).await?;
         for arg in args_arr {

--- a/crates/cast/src/cmd/creation_code.rs
+++ b/crates/cast/src/cmd/creation_code.rs
@@ -50,12 +50,10 @@ impl CreationCodeArgs {
 
         let config = rpc.load_config()?;
         let provider = utils::get_provider(&config)?;
-        let api_key = etherscan.key().unwrap_or_default();
         let chain = provider.get_chain_id().await?;
         etherscan.chain = Some(chain.into());
-        let client = Client::new(chain.into(), api_key)?;
 
-        let bytecode = fetch_creation_code(contract, client, provider).await?;
+        let bytecode = fetch_creation_code_from_etherscan(contract, &etherscan, provider).await?;
 
         let bytecode = parse_code_output(
             bytecode,
@@ -131,11 +129,16 @@ pub async fn parse_code_output(
 }
 
 /// Fetches the creation code of a contract from Etherscan and RPC.
-pub async fn fetch_creation_code(
+pub async fn fetch_creation_code_from_etherscan(
     contract: Address,
-    client: Client,
+    etherscan: &EtherscanOpts,
     provider: RetryProvider,
 ) -> Result<Bytes> {
+    let config = etherscan.load_config()?;
+    let chain = config.chain.unwrap_or_default();
+    let api_version = config.get_etherscan_api_version(Some(chain));
+    let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
+    let client = Client::new_with_api_version(chain, api_key, api_version)?;
     let creation_data = client.contract_creation_data(contract).await?;
     let creation_tx_hash = creation_data.transaction_hash;
     let tx_data = provider.get_transaction_by_hash(creation_tx_hash).await?;

--- a/crates/cast/src/cmd/interface.rs
+++ b/crates/cast/src/cmd/interface.rs
@@ -143,8 +143,9 @@ pub async fn fetch_abi_from_etherscan(
 ) -> Result<Vec<(JsonAbi, String)>> {
     let config = etherscan.load_config()?;
     let chain = config.chain.unwrap_or_default();
+    let api_version = config.get_etherscan_api_version(Some(chain));
     let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
-    let client = Client::new(chain, api_key)?;
+    let client = Client::new_with_api_version(chain, api_key, api_version)?;
     let source = client.contract_source_code(address).await?;
     source.items.into_iter().map(|item| Ok((item.abi()?, item.contract_name))).collect()
 }

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -299,6 +299,10 @@ impl figment::Provider for RunArgs {
             map.insert("etherscan_api_key".into(), api_key.as_str().into());
         }
 
+        if let Some(api_version) = &self.etherscan.api_version {
+            map.insert("etherscan_api_version".into(), api_version.as_str().into());
+        }
+
         if let Some(evm_version) = self.evm_version {
             map.insert("evm_version".into(), figment::value::Value::serialize(evm_version)?);
         }

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -300,7 +300,7 @@ impl figment::Provider for RunArgs {
         }
 
         if let Some(api_version) = &self.etherscan.api_version {
-            map.insert("etherscan_api_version".into(), api_version.as_str().into());
+            map.insert("etherscan_api_version".into(), api_version.to_string().into());
         }
 
         if let Some(evm_version) = self.evm_version {

--- a/crates/cast/src/cmd/storage.rs
+++ b/crates/cast/src/cmd/storage.rs
@@ -135,8 +135,9 @@ impl StorageArgs {
         }
 
         let chain = utils::get_chain(config.chain, &provider).await?;
+        let api_version = config.get_etherscan_api_version(Some(chain));
         let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
-        let client = Client::new(chain, api_key)?;
+        let client = Client::new_with_api_version(chain, api_key, api_version)?;
         let source = if let Some(proxy) = self.proxy {
             find_source(client, proxy.resolve(&provider).await?).await?
         } else {

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -13,6 +13,7 @@ use alloy_serde::WithOtherFields;
 use alloy_signer::Signer;
 use alloy_transport::TransportError;
 use eyre::Result;
+use foundry_block_explorers::EtherscanApiVersion;
 use foundry_cli::{
     opts::{CliAuthorizationList, TransactionOpts},
     utils::{self, parse_function_args},
@@ -141,6 +142,7 @@ pub struct CastTxBuilder<P, S> {
     auth: Option<CliAuthorizationList>,
     chain: Chain,
     etherscan_api_key: Option<String>,
+    etherscan_api_version: EtherscanApiVersion,
     access_list: Option<Option<AccessList>>,
     state: S,
 }
@@ -152,6 +154,7 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InitState> {
         let mut tx = WithOtherFields::<TransactionRequest>::default();
 
         let chain = utils::get_chain(config.chain, &provider).await?;
+        let etherscan_api_version = config.get_etherscan_api_version(Some(chain));
         let etherscan_api_key = config.get_etherscan_api_key(Some(chain));
         let legacy = tx_opts.legacy || chain.is_legacy();
 
@@ -192,6 +195,7 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InitState> {
             blob: tx_opts.blob,
             chain,
             etherscan_api_key,
+            etherscan_api_version,
             auth: tx_opts.auth,
             access_list: tx_opts.access_list,
             state: InitState,
@@ -208,6 +212,7 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InitState> {
             blob: self.blob,
             chain: self.chain,
             etherscan_api_key: self.etherscan_api_key,
+            etherscan_api_version: self.etherscan_api_version,
             auth: self.auth,
             access_list: self.access_list,
             state: ToState { to },
@@ -233,6 +238,7 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, ToState> {
                 self.chain,
                 &self.provider,
                 self.etherscan_api_key.as_deref(),
+                self.etherscan_api_version,
             )
             .await?
         } else {
@@ -264,6 +270,7 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, ToState> {
             blob: self.blob,
             chain: self.chain,
             etherscan_api_key: self.etherscan_api_key,
+            etherscan_api_version: self.etherscan_api_version,
             auth: self.auth,
             access_list: self.access_list,
             state: InputState { kind: self.state.to.into(), input, func },

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -9,7 +9,7 @@ use anvil::{EthereumHardfork, NodeConfig};
 use foundry_test_utils::{
     rpc::{
         next_etherscan_api_key, next_http_archive_rpc_url, next_http_rpc_endpoint,
-        next_mainnet_etherscan_api_key, next_rpc_endpoint, next_ws_rpc_endpoint,
+        next_rpc_endpoint, next_ws_rpc_endpoint,
     },
     str,
     util::OutputExt,
@@ -1378,7 +1378,7 @@ casttest!(storage_layout_simple, |_prj, cmd| {
         "--block",
         "21034138",
         "--etherscan-api-key",
-        next_mainnet_etherscan_api_key().as_str(),
+        next_etherscan_api_key().as_str(),
         "0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2",
     ])
     .assert_success()
@@ -1405,7 +1405,7 @@ casttest!(storage_layout_simple_json, |_prj, cmd| {
         "--block",
         "21034138",
         "--etherscan-api-key",
-        next_mainnet_etherscan_api_key().as_str(),
+        next_etherscan_api_key().as_str(),
         "0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2",
         "--json",
     ])
@@ -1422,7 +1422,7 @@ casttest!(storage_layout_complex, |_prj, cmd| {
         "--block",
         "21034138",
         "--etherscan-api-key",
-        next_mainnet_etherscan_api_key().as_str(),
+        next_etherscan_api_key().as_str(),
         "0xBA12222222228d8Ba445958a75a0704d566BF2C8",
     ])
     .assert_success()
@@ -1470,7 +1470,7 @@ casttest!(storage_layout_complex_proxy, |_prj, cmd| {
         "--block",
         "7857852",
         "--etherscan-api-key",
-        next_mainnet_etherscan_api_key().as_str(),
+        next_etherscan_api_key().as_str(),
         "0xE2588A9CAb7Ea877206E35f615a39f84a64A7A3b",
         "--proxy",
         "0x29fcb43b46531bca003ddc8fcb67ffe91900c762"
@@ -1512,7 +1512,7 @@ casttest!(storage_layout_complex_json, |_prj, cmd| {
         "--block",
         "21034138",
         "--etherscan-api-key",
-        next_mainnet_etherscan_api_key().as_str(),
+        next_etherscan_api_key().as_str(),
         "0xBA12222222228d8Ba445958a75a0704d566BF2C8",
         "--json",
     ])
@@ -1601,7 +1601,7 @@ casttest!(fetch_weth_interface_from_etherscan, |_prj, cmd| {
     cmd.args([
         "interface",
         "--etherscan-api-key",
-        &next_mainnet_etherscan_api_key(),
+        &next_etherscan_api_key(),
         "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
     ])
     .assert_success()
@@ -1880,7 +1880,7 @@ casttest!(fetch_creation_code_from_etherscan, |_prj, cmd| {
     cmd.args([
         "creation-code",
         "--etherscan-api-key",
-        &next_mainnet_etherscan_api_key(),
+        &next_etherscan_api_key(),
         "0x0923cad07f06b2d0e5e49e63b8b35738d4156b95",
         "--rpc-url",
         eth_rpc_url.as_str(),
@@ -1899,7 +1899,7 @@ casttest!(fetch_creation_code_only_args_from_etherscan, |_prj, cmd| {
     cmd.args([
         "creation-code",
         "--etherscan-api-key",
-        &next_mainnet_etherscan_api_key(),
+        &next_etherscan_api_key(),
         "0x6982508145454ce325ddbe47a25d4ec3d2311933",
         "--rpc-url",
         eth_rpc_url.as_str(),
@@ -1919,7 +1919,7 @@ casttest!(fetch_constructor_args_from_etherscan, |_prj, cmd| {
     cmd.args([
         "constructor-args",
         "--etherscan-api-key",
-        &next_mainnet_etherscan_api_key(),
+        &next_etherscan_api_key(),
         "0x6982508145454ce325ddbe47a25d4ec3d2311933",
         "--rpc-url",
         eth_rpc_url.as_str(),
@@ -1940,7 +1940,7 @@ casttest!(test_non_mainnet_traces, |prj, cmd| {
         "--rpc-url",
         next_rpc_endpoint(NamedChain::Optimism).as_str(),
         "--etherscan-api-key",
-        next_etherscan_api_key(NamedChain::Optimism).as_str(),
+        next_etherscan_api_key().as_str(),
     ])
     .assert_success()
     .stdout_eq(str![[r#"
@@ -1963,7 +1963,7 @@ casttest!(fetch_artifact_from_etherscan, |_prj, cmd| {
     cmd.args([
         "artifact",
         "--etherscan-api-key",
-        &next_mainnet_etherscan_api_key(),
+        &next_etherscan_api_key(),
         "0x0923cad07f06b2d0e5e49e63b8b35738d4156b95",
         "--rpc-url",
         eth_rpc_url.as_str(),
@@ -2444,7 +2444,7 @@ contract WETH9 {
 
 casttest!(fetch_src_default, |_prj, cmd| {
     let weth = address!("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
-    let etherscan_api_key = next_mainnet_etherscan_api_key();
+    let etherscan_api_key = next_etherscan_api_key();
 
     cmd.args(["source", &weth.to_string(), "--flatten", "--etherscan-api-key", &etherscan_api_key])
         .assert_success()

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,6 +21,7 @@ foundry-evm.workspace = true
 foundry-wallets.workspace = true
 
 foundry-compilers = { workspace = true, features = ["full"] }
+foundry-block-explorers.workspace = true
 
 alloy-eips.workspace = true
 alloy-dyn-abi.workspace = true

--- a/crates/cli/src/opts/rpc.rs
+++ b/crates/cli/src/opts/rpc.rs
@@ -115,7 +115,12 @@ pub struct EtherscanOpts {
     pub key: Option<String>,
 
     /// The Etherscan API version.
-    #[arg(short, long = "etherscan-api-version", env = "ETHERSCAN_API_VERSION")]
+    #[arg(
+        short,
+        long = "etherscan-api-version",
+        alias = "api-version",
+        env = "ETHERSCAN_API_VERSION"
+    )]
     #[serde(rename = "etherscan_api_version", skip_serializing_if = "Option::is_none")]
     pub api_version: Option<String>,
 

--- a/crates/cli/src/opts/rpc.rs
+++ b/crates/cli/src/opts/rpc.rs
@@ -2,6 +2,7 @@ use crate::opts::ChainValueParser;
 use alloy_chains::ChainKind;
 use clap::Parser;
 use eyre::Result;
+use foundry_block_explorers::EtherscanApiVersion;
 use foundry_config::{
     figment::{
         self,
@@ -122,7 +123,7 @@ pub struct EtherscanOpts {
         env = "ETHERSCAN_API_VERSION"
     )]
     #[serde(rename = "etherscan_api_version", skip_serializing_if = "Option::is_none")]
-    pub api_version: Option<String>,
+    pub api_version: Option<EtherscanApiVersion>,
 
     /// The chain name or EIP-155 chain ID.
     #[arg(

--- a/crates/cli/src/opts/rpc.rs
+++ b/crates/cli/src/opts/rpc.rs
@@ -114,6 +114,11 @@ pub struct EtherscanOpts {
     #[serde(rename = "etherscan_api_key", skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 
+    /// The Etherscan API version.
+    #[arg(short, long = "etherscan-api-version", env = "ETHERSCAN_API_VERSION")]
+    #[serde(rename = "etherscan_api_version", skip_serializing_if = "Option::is_none")]
+    pub api_version: Option<String>,
+
     /// The chain name or EIP-155 chain ID.
     #[arg(
         short,
@@ -154,6 +159,11 @@ impl EtherscanOpts {
         if let Some(key) = self.key() {
             dict.insert("etherscan_api_key".into(), key.into());
         }
+
+        if let Some(api_version) = &self.api_version {
+            dict.insert("etherscan_api_version".into(), api_version.to_string().into());
+        }
+
         if let Some(chain) = self.chain {
             if let ChainKind::Id(id) = chain.kind() {
                 dict.insert("chain_id".into(), (*id).into());

--- a/crates/cli/src/utils/abi.rs
+++ b/crates/cli/src/utils/abi.rs
@@ -3,6 +3,7 @@ use alloy_json_abi::Function;
 use alloy_primitives::{hex, Address};
 use alloy_provider::{network::AnyNetwork, Provider};
 use eyre::{OptionExt, Result};
+use foundry_block_explorers::EtherscanApiVersion;
 use foundry_common::{
     abi::{encode_function_args, get_func, get_func_etherscan},
     ens::NameOrAddress,
@@ -31,6 +32,7 @@ pub async fn parse_function_args<P: Provider<AnyNetwork>>(
     chain: Chain,
     provider: &P,
     etherscan_api_key: Option<&str>,
+    etherscan_api_version: EtherscanApiVersion,
 ) -> Result<(Vec<u8>, Option<Function>)> {
     if sig.trim().is_empty() {
         eyre::bail!("Function signature or calldata must be provided.")
@@ -50,7 +52,7 @@ pub async fn parse_function_args<P: Provider<AnyNetwork>>(
             "If you wish to fetch function data from Etherscan, please provide an Etherscan API key.",
         )?;
         let to = to.ok_or_eyre("A 'to' address must be provided to fetch function data.")?;
-        get_func_etherscan(sig, to, &args, chain, etherscan_api_key).await?
+        get_func_etherscan(sig, to, &args, chain, etherscan_api_key, etherscan_api_version).await?
     };
 
     Ok((encode_function_args(&func, &args)?, Some(func)))

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -4,7 +4,9 @@ use alloy_dyn_abi::{DynSolType, DynSolValue, FunctionExt, JsonAbiExt};
 use alloy_json_abi::{Error, Event, Function, Param};
 use alloy_primitives::{hex, Address, LogData};
 use eyre::{Context, ContextCompat, Result};
-use foundry_block_explorers::{contract::ContractMetadata, errors::EtherscanError, Client};
+use foundry_block_explorers::{
+    contract::ContractMetadata, errors::EtherscanError, Client, EtherscanApiVersion,
+};
 use foundry_config::Chain;
 use std::{future::Future, pin::Pin};
 
@@ -120,8 +122,9 @@ pub async fn get_func_etherscan(
     args: &[String],
     chain: Chain,
     etherscan_api_key: &str,
+    etherscan_api_version: EtherscanApiVersion,
 ) -> Result<Function> {
-    let client = Client::new(chain, etherscan_api_key)?;
+    let client = Client::new_with_api_version(chain, etherscan_api_key, etherscan_api_version)?;
     let source = find_source(client, contract).await?;
     let metadata = source.items.first().wrap_err("etherscan returned empty metadata")?;
 

--- a/crates/config/src/etherscan.rs
+++ b/crates/config/src/etherscan.rs
@@ -330,14 +330,16 @@ impl ResolvedEtherscanConfig {
         }
 
         let api_url = into_url(&api_url)?;
-        let parsed_api_version = EtherscanApiVersion::try_from(api_version.unwrap_or_default())?;
+        let parsed_api_version = api_version
+            .map(EtherscanApiVersion::try_from)
+            .transpose()?;
         let client = reqwest::Client::builder()
             .user_agent(ETHERSCAN_USER_AGENT)
             .tls_built_in_root_certs(api_url.scheme() == "https")
             .build()?;
         foundry_block_explorers::Client::builder()
             .with_client(client)
-            .with_api_version(parsed_api_version)
+            .with_api_version(parsed_api_version.unwrap_or_default())
             .with_api_key(api_key)
             .with_api_url(api_url)?
             // the browser url is not used/required by the client so we can simply set the

--- a/crates/config/src/etherscan.rs
+++ b/crates/config/src/etherscan.rs
@@ -58,9 +58,6 @@ pub enum EtherscanConfigError {
 
     #[error("At least one of `url` or `chain` must be present{0}")]
     MissingUrlOrChain(String),
-
-    #[error("Invalid Etherscan API version {0}")]
-    InvalidApiVersion(String),
 }
 
 /// Container type for Etherscan API keys and URLs.

--- a/crates/config/src/etherscan.rs
+++ b/crates/config/src/etherscan.rs
@@ -330,9 +330,7 @@ impl ResolvedEtherscanConfig {
         }
 
         let api_url = into_url(&api_url)?;
-        let parsed_api_version = api_version
-            .map(EtherscanApiVersion::try_from)
-            .transpose()?;
+        let parsed_api_version = api_version.map(EtherscanApiVersion::try_from).transpose()?;
         let client = reqwest::Client::builder()
             .user_agent(ETHERSCAN_USER_AGENT)
             .tls_built_in_root_certs(api_url.scheme() == "https")

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1137,9 +1137,9 @@ impl Config {
 
     /// Whether caching should be enabled for the given chain id
     pub fn enable_caching(&self, endpoint: &str, chain_id: impl Into<u64>) -> bool {
-        !self.no_storage_caching
-            && self.rpc_storage_caching.enable_for_chain_id(chain_id.into())
-            && self.rpc_storage_caching.enable_for_endpoint(endpoint)
+        !self.no_storage_caching &&
+            self.rpc_storage_caching.enable_for_chain_id(chain_id.into()) &&
+            self.rpc_storage_caching.enable_for_endpoint(endpoint)
     }
 
     /// Returns the `ProjectPathsConfig` sub set of the config.
@@ -1403,11 +1403,7 @@ impl Config {
         // etherscan fallback via API key
         if let Some(key) = self.etherscan_api_key.as_ref() {
             let chain = chain.or(self.chain).unwrap_or_default();
-            return Ok(ResolvedEtherscanConfig::create(
-                key,
-                chain,
-                None::<String>,
-            ));
+            return Ok(ResolvedEtherscanConfig::create(key, chain, None::<String>));
         }
 
         Ok(None)
@@ -2012,8 +2008,8 @@ impl Config {
             let file_name = block.file_name();
             let filepath = if file_type.is_dir() {
                 block.path().join("storage.json")
-            } else if file_type.is_file()
-                && file_name.to_string_lossy().chars().all(char::is_numeric)
+            } else if file_type.is_file() &&
+                file_name.to_string_lossy().chars().all(char::is_numeric)
             {
                 block.path()
             } else {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1438,6 +1438,17 @@ impl Config {
         self.get_etherscan_config_with_chain(chain).ok().flatten().map(|c| c.key)
     }
 
+    /// Helper function to get the API version.
+    ///
+    /// See also [Self::get_etherscan_config_with_chain]
+    pub fn get_etherscan_api_version(&self, chain: Option<Chain>) -> EtherscanApiVersion {
+        self.get_etherscan_config_with_chain(chain)
+            .ok()
+            .flatten()
+            .map(|c| c.api_version)
+            .unwrap_or(EtherscanApiVersion::V2)
+    }
+
     /// Returns the remapping for the project's _src_ directory
     ///
     /// **Note:** this will add an additional `<src>/=<src path>` remapping here so imports that

--- a/crates/forge/src/cmd/clone.rs
+++ b/crates/forge/src/cmd/clone.rs
@@ -632,7 +632,7 @@ mod tests {
     use super::*;
     use alloy_primitives::hex;
     use foundry_compilers::CompilerContract;
-    use foundry_test_utils::rpc::next_mainnet_etherscan_api_key;
+    use foundry_test_utils::rpc::next_etherscan_api_key;
     use std::collections::BTreeMap;
 
     #[expect(clippy::disallowed_macros)]
@@ -711,7 +711,7 @@ mod tests {
         // create folder if not exists
         std::fs::create_dir_all(&data_folder).unwrap();
         // create metadata.json and creation_data.json
-        let client = Client::new(Chain::mainnet(), next_mainnet_etherscan_api_key()).unwrap();
+        let client = Client::new(Chain::mainnet(), next_etherscan_api_key()).unwrap();
         let meta = client.contract_source_code(address).await.unwrap();
         // dump json
         let json = serde_json::to_string_pretty(&meta).unwrap();

--- a/crates/forge/src/cmd/clone.rs
+++ b/crates/forge/src/cmd/clone.rs
@@ -101,8 +101,10 @@ impl CloneArgs {
         // step 0. get the chain and api key from the config
         let config = etherscan.load_config()?;
         let chain = config.chain.unwrap_or_default();
+        let etherscan_api_version = config.get_etherscan_api_version(Some(chain));
         let etherscan_api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
-        let client = Client::new(chain, etherscan_api_key.clone())?;
+        let client =
+            Client::new_with_api_version(chain, etherscan_api_key.clone(), etherscan_api_version)?;
 
         // step 1. get the metadata from client
         sh_println!("Downloading the source code of {address} from Etherscan...")?;

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -228,7 +228,7 @@ impl CreateArgs {
             num_of_optimizations: None,
             etherscan: EtherscanOpts {
                 key: self.eth.etherscan.key.clone(),
-                api_version: self.eth.etherscan.api_version.clone(),
+                api_version: self.eth.etherscan.api_version,
                 chain: Some(chain.into()),
             },
             rpc: Default::default(),
@@ -419,7 +419,7 @@ impl CreateArgs {
             num_of_optimizations,
             etherscan: EtherscanOpts {
                 key: self.eth.etherscan.key(),
-                api_version: self.eth.etherscan.api_version.clone(),
+                api_version: self.eth.etherscan.api_version,
                 chain: Some(chain.into()),
             },
             rpc: Default::default(),

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -228,6 +228,7 @@ impl CreateArgs {
             num_of_optimizations: None,
             etherscan: EtherscanOpts {
                 key: self.eth.etherscan.key.clone(),
+                api_version: self.eth.etherscan.api_version.clone(),
                 chain: Some(chain.into()),
             },
             rpc: Default::default(),
@@ -416,7 +417,11 @@ impl CreateArgs {
             constructor_args,
             constructor_args_path: None,
             num_of_optimizations,
-            etherscan: EtherscanOpts { key: self.eth.etherscan.key(), chain: Some(chain.into()) },
+            etherscan: EtherscanOpts {
+                key: self.eth.etherscan.key(),
+                api_version: self.eth.etherscan.api_version.clone(),
+                chain: Some(chain.into()),
+            },
             rpc: Default::default(),
             flatten: false,
             force: false,

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -146,6 +146,10 @@ pub struct TestArgs {
     #[arg(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
     etherscan_api_key: Option<String>,
 
+    /// The Etherscan API version.
+    #[arg(long, env = "ETHERSCAN_API_VERSION", value_name = "VERSION")]
+    etherscan_api_version: Option<String>,
+
     /// List tests instead of running them.
     #[arg(long, short, conflicts_with_all = ["show_progress", "decode_internal", "summary"], help_heading = "Display options")]
     list: bool,
@@ -871,6 +875,10 @@ impl Provider for TestArgs {
             self.etherscan_api_key.as_ref().filter(|s| !s.trim().is_empty())
         {
             dict.insert("etherscan_api_key".to_string(), etherscan_api_key.to_string().into());
+        }
+
+        if let Some(api_version) = &self.etherscan_api_version {
+            dict.insert("etherscan_api_version".to_string(), api_version.to_string().into());
         }
 
         if self.show_progress {

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -16,6 +16,7 @@ use alloy_primitives::U256;
 use chrono::Utc;
 use clap::{Parser, ValueHint};
 use eyre::{bail, Context, OptionExt, Result};
+use foundry_block_explorers::EtherscanApiVersion;
 use foundry_cli::{
     opts::{BuildOpts, GlobalArgs},
     utils::{self, LoadConfig},
@@ -148,7 +149,7 @@ pub struct TestArgs {
 
     /// The Etherscan API version.
     #[arg(long, env = "ETHERSCAN_API_VERSION", value_name = "VERSION")]
-    etherscan_api_version: Option<String>,
+    etherscan_api_version: Option<EtherscanApiVersion>,
 
     /// List tests instead of running them.
     #[arg(long, short, conflicts_with_all = ["show_progress", "decode_internal", "summary"], help_heading = "Display options")]

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -7,7 +7,7 @@ use foundry_config::{
 };
 use foundry_test_utils::{
     foundry_compilers::PathStyle,
-    rpc::next_mainnet_etherscan_api_key,
+    rpc::next_etherscan_api_key,
     snapbox::IntoData,
     util::{pretty_err, read_string, OutputExt, TestCommand},
 };
@@ -619,7 +619,7 @@ forgetest!(can_clone, |prj, cmd| {
     cmd.args([
         "clone",
         "--etherscan-api-key",
-        next_mainnet_etherscan_api_key().as_str(),
+        next_etherscan_api_key().as_str(),
         "0x044b75f554b886A065b9567891e45c79542d7357",
     ])
     .arg(prj.root())
@@ -648,7 +648,7 @@ forgetest!(can_clone_quiet, |prj, cmd| {
     cmd.args([
         "clone",
         "--etherscan-api-key",
-        next_mainnet_etherscan_api_key().as_str(),
+        next_etherscan_api_key().as_str(),
         "--quiet",
         "0xDb53f47aC61FE54F456A4eb3E09832D08Dd7BEec",
     ])
@@ -666,7 +666,7 @@ forgetest!(can_clone_no_remappings_txt, |prj, cmd| {
     cmd.args([
         "clone",
         "--etherscan-api-key",
-        next_mainnet_etherscan_api_key().as_str(),
+        next_etherscan_api_key().as_str(),
         "--no-remappings-txt",
         "0x33e690aEa97E4Ef25F0d140F1bf044d663091DAf",
     ])
@@ -701,7 +701,7 @@ forgetest!(can_clone_keep_directory_structure, |prj, cmd| {
         .args([
             "clone",
             "--etherscan-api-key",
-            next_mainnet_etherscan_api_key().as_str(),
+            next_etherscan_api_key().as_str(),
             "--keep-directory-structure",
             "0x33e690aEa97E4Ef25F0d140F1bf044d663091DAf",
         ])
@@ -739,7 +739,7 @@ forgetest!(can_clone_with_node_modules, |prj, cmd| {
     cmd.args([
         "clone",
         "--etherscan-api-key",
-        next_mainnet_etherscan_api_key().as_str(),
+        next_etherscan_api_key().as_str(),
         "0xA3E217869460bEf59A1CfD0637e2875F9331e823",
     ])
     .arg(prj.root())

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -119,6 +119,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         eth_rpc_timeout: None,
         eth_rpc_headers: None,
         etherscan_api_key: None,
+        etherscan_api_version: None,
         etherscan: Default::default(),
         verbosity: 4,
         remappings: vec![Remapping::from_str("forge-std/=lib/forge-std/").unwrap().into()],
@@ -1161,6 +1162,7 @@ exclude = []
   "eth_rpc_timeout": null,
   "eth_rpc_headers": null,
   "etherscan_api_key": null,
+  "etherscan_api_version": null,
   "ignored_error_codes": [
     "license",
     "code-size",

--- a/crates/forge/tests/cli/verify_bytecode.rs
+++ b/crates/forge/tests/cli/verify_bytecode.rs
@@ -2,7 +2,7 @@ use foundry_compilers::artifacts::{BytecodeHash, EvmVersion};
 use foundry_config::Config;
 use foundry_test_utils::{
     forgetest_async,
-    rpc::{next_http_archive_rpc_url, next_mainnet_etherscan_api_key},
+    rpc::{next_etherscan_api_key, next_http_archive_rpc_url},
     util::OutputExt,
     TestCommand, TestProject,
 };
@@ -19,7 +19,7 @@ fn test_verify_bytecode(
     verifier_url: &str,
     expected_matches: (&str, &str),
 ) {
-    let etherscan_key = next_mainnet_etherscan_api_key();
+    let etherscan_key = next_etherscan_api_key();
     let rpc_url = next_http_archive_rpc_url();
 
     // fetch and flatten source code
@@ -33,7 +33,7 @@ fn test_verify_bytecode(
     prj.add_source(contract_name, &source_code).unwrap();
     prj.write_config(config);
 
-    let etherscan_key = next_mainnet_etherscan_api_key();
+    let etherscan_key = next_etherscan_api_key();
     let mut args = vec![
         "verify-bytecode",
         addr,
@@ -74,7 +74,7 @@ fn test_verify_bytecode_with_ignore(
     ignore: &str,
     chain: &str,
 ) {
-    let etherscan_key = next_mainnet_etherscan_api_key();
+    let etherscan_key = next_etherscan_api_key();
     let rpc_url = next_http_archive_rpc_url();
 
     // fetch and flatten source code

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -23,6 +23,7 @@ foundry-debugger.workspace = true
 foundry-cheatcodes.workspace = true
 foundry-wallets.workspace = true
 foundry-linking.workspace = true
+foundry-block-explorers.workspace = true
 forge-script-sequence.workspace = true
 
 serde.workspace = true

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -182,6 +182,10 @@ pub struct ScriptArgs {
     #[arg(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
     pub etherscan_api_key: Option<String>,
 
+    /// The Etherscan API version.
+    #[arg(long, env = "ETHERSCAN_API_VERSION", value_name = "VERSION")]
+    pub etherscan_api_version: Option<String>,
+
     /// Verifies all the contracts found in the receipts of a script, if any.
     #[arg(long)]
     pub verify: bool,
@@ -495,6 +499,9 @@ impl Provider for ScriptArgs {
                 "etherscan_api_key".to_string(),
                 figment::value::Value::from(etherscan_api_key.to_string()),
             );
+        }
+        if let Some(api_version) = &self.etherscan_api_version {
+            dict.insert("etherscan_api_version".to_string(), api_version.to_string().into());
         }
         if let Some(timeout) = self.timeout {
             dict.insert("transaction_timeout".to_string(), timeout.into());

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -26,6 +26,7 @@ use dialoguer::Confirm;
 use eyre::{ContextCompat, Result};
 use forge_script_sequence::{AdditionalContract, NestedValue};
 use forge_verify::{RetryArgs, VerifierArgs};
+use foundry_block_explorers::EtherscanApiVersion;
 use foundry_cli::{
     opts::{BuildOpts, GlobalArgs},
     utils::LoadConfig,
@@ -184,7 +185,7 @@ pub struct ScriptArgs {
 
     /// The Etherscan API version.
     #[arg(long, env = "ETHERSCAN_API_VERSION", value_name = "VERSION")]
-    pub etherscan_api_version: Option<String>,
+    pub etherscan_api_version: Option<EtherscanApiVersion>,
 
     /// Verifies all the contracts found in the receipts of a script, if any.
     #[arg(long)]

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -59,14 +59,6 @@ static ETHERSCAN_MAINNET_KEYS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
     ])
 });
 
-// List of etherscan keys for Optimism.
-static ETHERSCAN_OPTIMISM_KEYS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
-    shuffled(vec![
-        //
-        "JQNGFHINKS1W7Y5FRXU4SPBYF43J3NYK46",
-    ])
-});
-
 /// Returns the next index to use.
 fn next_idx() -> usize {
     static NEXT_INDEX: AtomicUsize = AtomicUsize::new(0);
@@ -145,19 +137,10 @@ fn archive_urls(is_ws: bool) -> &'static [String] {
     }
 }
 
-/// Returns the next etherscan api key
-pub fn next_mainnet_etherscan_api_key() -> String {
-    next_etherscan_api_key(NamedChain::Mainnet)
-}
-
-/// Returns the next etherscan api key for given chain.
-pub fn next_etherscan_api_key(chain: NamedChain) -> String {
-    let keys = match chain {
-        Optimism => &ETHERSCAN_OPTIMISM_KEYS,
-        _ => &ETHERSCAN_MAINNET_KEYS,
-    };
-    let key = next(keys).to_string();
-    eprintln!("--- next_etherscan_api_key(chain={chain:?}) = {key} ---");
+/// Returns the next etherscan api key.
+pub fn next_etherscan_api_key() -> String {
+    let key = next(&ETHERSCAN_MAINNET_KEYS).to_string();
+    eprintln!("--- next_etherscan_api_key() = {key} ---");
     key
 }
 

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -106,7 +106,7 @@ impl figment::Provider for VerifyBytecodeArgs {
         }
 
         if let Some(api_version) = &self.verifier.verifier_api_version {
-            dict.insert("etherscan_api_version".into(), api_version.as_str().into());
+            dict.insert("etherscan_api_version".into(), api_version.to_string().into());
         }
 
         if let Some(block) = &self.block {

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -141,6 +141,7 @@ impl VerifyBytecodeArgs {
             &self.verifier.verifier,
             self.verifier.verifier_url.as_deref(),
             self.etherscan.key().as_deref(),
+            self.verifier.verifier_api_version.as_deref(),
             &config,
         )?;
 

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -105,6 +105,10 @@ impl figment::Provider for VerifyBytecodeArgs {
             dict.insert("etherscan_api_key".into(), api_key.as_str().into());
         }
 
+        if let Some(api_version) = &self.verifier.verifier_api_version {
+            dict.insert("etherscan_api_version".into(), api_version.as_str().into());
+        }
+
         if let Some(block) = &self.block {
             dict.insert("block".into(), figment::value::Value::serialize(block)?);
         }
@@ -136,14 +140,8 @@ impl VerifyBytecodeArgs {
         self.etherscan.key = config.get_etherscan_config_with_chain(Some(chain))?.map(|c| c.key);
 
         // Etherscan client
-        let etherscan = EtherscanVerificationProvider.client(
-            self.etherscan.chain.unwrap_or_default(),
-            &self.verifier.verifier,
-            self.verifier.verifier_url.as_deref(),
-            self.etherscan.key().as_deref(),
-            self.verifier.verifier_api_version.as_deref(),
-            &config,
-        )?;
+        let etherscan =
+            EtherscanVerificationProvider.client(&self.etherscan, &self.verifier, &config)?;
 
         // Get the bytecode at the address, bailing if it doesn't exist.
         let code = provider.get_code_at(self.address).await?;

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -11,7 +11,7 @@ use eyre::{eyre, Context, OptionExt, Result};
 use foundry_block_explorers::{
     errors::EtherscanError,
     utils::lookup_compiler_version,
-    verify::{self, CodeFormat, VerifyContract},
+    verify::{CodeFormat, VerifyContract},
     Client,
 };
 use foundry_cli::utils::{get_provider, read_constructor_args_file, LoadConfig};
@@ -275,10 +275,8 @@ impl EtherscanVerificationProvider {
             .as_ref()
             .and_then(|c| c.browser_url.as_deref())
             .or_else(|| chain.etherscan_urls().map(|(_, url)| url));
-
         let etherscan_key =
             etherscan_key.or_else(|| etherscan_config.as_ref().map(|c| c.key.as_str()));
- 
         let etherscan_api_version = if verifier_type.is_etherscan_v2() {
             foundry_block_explorers::EtherscanApiVersion::V2
         } else {
@@ -593,7 +591,10 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(client.etherscan_api_url().as_str(), "https://api.etherscan.io/v2/api?chainid=80001");
+        assert_eq!(
+            client.etherscan_api_url().as_str(),
+            "https://api.etherscan.io/v2/api?chainid=80001"
+        );
         assert!(format!("{client:?}").contains("dummykey"));
 
         let args: VerifyArgs = VerifyArgs::parse_from([
@@ -611,7 +612,7 @@ mod tests {
         ]);
 
         let config = args.load_config().unwrap();
-        
+
         assert_eq!(args.verifier.verifier, VerificationProviderType::EtherscanV2);
 
         let etherscan = EtherscanVerificationProvider::default();

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -1,7 +1,8 @@
 use crate::{
-    provider::{VerificationContext, VerificationProvider, VerificationProviderType},
+    provider::{VerificationContext, VerificationProvider},
     retry::RETRY_CHECK_ON_VERIFY,
     verify::{VerifyArgs, VerifyCheckArgs},
+    VerifierArgs,
 };
 use alloy_json_abi::Function;
 use alloy_primitives::hex;
@@ -14,10 +15,13 @@ use foundry_block_explorers::{
     verify::{CodeFormat, VerifyContract},
     Client, EtherscanApiVersion,
 };
-use foundry_cli::utils::{get_provider, read_constructor_args_file, LoadConfig};
+use foundry_cli::{
+    opts::EtherscanOpts,
+    utils::{get_provider, read_constructor_args_file, LoadConfig},
+};
 use foundry_common::{abi::encode_function_args, retry::RetryError};
 use foundry_compilers::{artifacts::BytecodeObject, Artifact};
-use foundry_config::{Chain, Config};
+use foundry_config::Config;
 use foundry_evm::constants::DEFAULT_CREATE2_DEPLOYER;
 use regex::Regex;
 use semver::{BuildMetadata, Version};
@@ -150,14 +154,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
     /// Executes the command to check verification status on Etherscan
     async fn check(&self, args: VerifyCheckArgs) -> Result<()> {
         let config = args.load_config()?;
-        let etherscan = self.client(
-            args.etherscan.chain.unwrap_or_default(),
-            &args.verifier.verifier,
-            args.verifier.verifier_url.as_deref(),
-            args.etherscan.key().as_deref(),
-            args.verifier.verifier_api_version.as_deref(),
-            &config,
-        )?;
+        let etherscan = self.client(&args.etherscan, &args.verifier, &config)?;
         args.retry
             .into_retry()
             .run_async_until_break(|| async {
@@ -220,14 +217,7 @@ impl EtherscanVerificationProvider {
         context: &VerificationContext,
     ) -> Result<(Client, VerifyContract)> {
         let config = args.load_config()?;
-        let etherscan = self.client(
-            args.etherscan.chain.unwrap_or_default(),
-            &args.verifier.verifier,
-            args.verifier.verifier_url.as_deref(),
-            args.etherscan.key().as_deref(),
-            args.verifier.verifier_api_version.as_deref(),
-            &config,
-        )?;
+        let etherscan = self.client(&args.etherscan, &args.verifier, &config)?;
         let verify_args = self.create_verify_request(args, context).await?;
 
         Ok((etherscan, verify_args))
@@ -254,19 +244,26 @@ impl EtherscanVerificationProvider {
     /// Create an Etherscan client.
     pub(crate) fn client(
         &self,
-        chain: Chain,
-        verifier_type: &VerificationProviderType,
-        verifier_url: Option<&str>,
-        etherscan_key: Option<&str>,
-        verifier_api_version: Option<&str>,
+        etherscan_opts: &EtherscanOpts,
+        verifier_args: &VerifierArgs,
         config: &Config,
     ) -> Result<Client> {
+        let chain = etherscan_opts.chain.unwrap_or_default();
+        let etherscan_key = etherscan_opts.key();
+        let verifier_type = &verifier_args.verifier;
+        let verifier_api_version = verifier_args.verifier_api_version.as_deref();
+        let verifier_url = verifier_args.verifier_url.as_deref();
+
+        // Verifier is etherscan if explicitly set or if no verifier set (default sourcify) but
+        // API key passed.
+        let is_etherscan = verifier_type.is_etherscan() ||
+            (verifier_type.is_sourcify() && etherscan_key.is_some());
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
 
         let api_version = match verifier_api_version {
             Some(api_version) => EtherscanApiVersion::try_from(api_version.to_string())?,
             None => {
-                if verifier_type.is_etherscan() {
+                if is_etherscan {
                     etherscan_config
                         .as_ref()
                         .map(|c| c.api_version)
@@ -293,18 +290,13 @@ impl EtherscanVerificationProvider {
             .and_then(|c| c.browser_url.as_deref())
             .or_else(|| chain.etherscan_urls().map(|(_, url)| url));
         let etherscan_key =
-            etherscan_key.or_else(|| etherscan_config.as_ref().map(|c| c.key.as_str()));
+            etherscan_key.or_else(|| etherscan_config.as_ref().map(|c| c.key.clone()));
 
         let mut builder = Client::builder().with_api_version(api_version);
 
         builder = if let Some(api_url) = api_url {
             // we don't want any trailing slashes because this can cause cloudflare issues: <https://github.com/foundry-rs/foundry/pull/6079>
             let api_url = api_url.trim_end_matches('/');
-
-            // Verifier is etherscan if explicitly set or if no verifier set (default sourcify) but
-            // API key passed.
-            let is_etherscan = verifier_type.is_etherscan() ||
-                (verifier_type.is_sourcify() && etherscan_key.is_some());
             let base_url = if !is_etherscan {
                 // If verifier is not Etherscan then set base url as api url without /api suffix.
                 api_url.strip_prefix("/api").unwrap_or(api_url)
@@ -414,14 +406,7 @@ impl EtherscanVerificationProvider {
         context: &VerificationContext,
     ) -> Result<String> {
         let provider = get_provider(&context.config)?;
-        let client = self.client(
-            args.etherscan.chain.unwrap_or_default(),
-            &args.verifier.verifier,
-            args.verifier.verifier_url.as_deref(),
-            args.etherscan.key.as_deref(),
-            args.verifier.verifier_api_version.as_deref(),
-            &context.config,
-        )?;
+        let client = self.client(&args.etherscan, &args.verifier, &context.config)?;
 
         let creation_data = client.contract_creation_data(args.address).await?;
         let transaction = provider
@@ -488,6 +473,7 @@ async fn ensure_solc_build_metadata(version: Version) -> Result<Version> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider::VerificationProviderType;
     use clap::Parser;
     use foundry_common::fs;
     use foundry_test_utils::{forgetest_async, str};
@@ -521,16 +507,7 @@ mod tests {
         let config = args.load_config().unwrap();
 
         let etherscan = EtherscanVerificationProvider::default();
-        let client = etherscan
-            .client(
-                args.etherscan.chain.unwrap_or_default(),
-                &args.verifier.verifier,
-                args.verifier.verifier_url.as_deref(),
-                args.etherscan.key().as_deref(),
-                args.verifier.verifier_api_version.as_deref(),
-                &config,
-            )
-            .unwrap();
+        let client = etherscan.client(&args.etherscan, &args.verifier, &config).unwrap();
         assert_eq!(client.etherscan_api_url().as_str(), "https://api-testnet.polygonscan.com/");
 
         assert!(format!("{client:?}").contains("dummykey"));
@@ -550,16 +527,7 @@ mod tests {
         let config = args.load_config().unwrap();
 
         let etherscan = EtherscanVerificationProvider::default();
-        let client = etherscan
-            .client(
-                args.etherscan.chain.unwrap_or_default(),
-                &args.verifier.verifier,
-                args.verifier.verifier_url.as_deref(),
-                args.etherscan.key().as_deref(),
-                args.verifier.verifier_api_version.as_deref(),
-                &config,
-            )
-            .unwrap();
+        let client = etherscan.client(&args.etherscan, &args.verifier, &config).unwrap();
         assert_eq!(client.etherscan_api_url().as_str(), "https://verifier-url.com/");
         assert!(format!("{client:?}").contains("dummykey"));
     }
@@ -595,16 +563,7 @@ mod tests {
 
         let etherscan = EtherscanVerificationProvider::default();
 
-        let client = etherscan
-            .client(
-                args.etherscan.chain.unwrap_or_default(),
-                &args.verifier.verifier,
-                args.verifier.verifier_url.as_deref(),
-                args.etherscan.key().as_deref(),
-                args.verifier.verifier_api_version.as_deref(),
-                &config,
-            )
-            .unwrap();
+        let client = etherscan.client(&args.etherscan, &args.verifier, &config).unwrap();
 
         assert_eq!(client.etherscan_api_url().as_str(), "https://api.etherscan.io/v2/api");
         assert!(format!("{client:?}").contains("dummykey"));
@@ -628,16 +587,7 @@ mod tests {
         assert_eq!(args.verifier.verifier, VerificationProviderType::Etherscan);
 
         let etherscan = EtherscanVerificationProvider::default();
-        let client = etherscan
-            .client(
-                args.etherscan.chain.unwrap_or_default(),
-                &args.verifier.verifier,
-                args.verifier.verifier_url.as_deref(),
-                args.etherscan.key().as_deref(),
-                args.verifier.verifier_api_version.as_deref(),
-                &config,
-            )
-            .unwrap();
+        let client = etherscan.client(&args.etherscan, &args.verifier, &config).unwrap();
         assert_eq!(client.etherscan_api_url().as_str(), "https://verifier-url.com/");
         assert_eq!(*client.etherscan_api_version(), EtherscanApiVersion::V2);
         assert!(format!("{client:?}").contains("dummykey"));

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -591,10 +591,7 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(
-            client.etherscan_api_url().as_str(),
-            "https://api.etherscan.io/v2/api"
-        );
+        assert_eq!(client.etherscan_api_url().as_str(), "https://api.etherscan.io/v2/api");
         assert!(format!("{client:?}").contains("dummykey"));
 
         let args: VerifyArgs = VerifyArgs::parse_from([

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -593,7 +593,7 @@ mod tests {
 
         assert_eq!(
             client.etherscan_api_url().as_str(),
-            "https://api.etherscan.io/v2/api?chainid=80001"
+            "https://api.etherscan.io/v2/api"
         );
         assert!(format!("{client:?}").contains("dummykey"));
 

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -123,11 +123,12 @@ impl FromStr for VerificationProviderType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "e" | "etherscan" => Ok(Self::Etherscan),
-            "s" | "sourcify" => Ok(Self::Sourcify),
-            "b" | "blockscout" => Ok(Self::Blockscout),
-            "o" | "oklink" => Ok(Self::Oklink),
-            "c" | "custom" => Ok(Self::Custom),
+            "e"   | "etherscan" => Ok(Self::Etherscan),
+            "ev2" | "etherscan-v2" => Ok(Self::EtherscanV2),
+            "s"   | "sourcify" => Ok(Self::Sourcify),
+            "b"   | "blockscout" => Ok(Self::Blockscout),
+            "o"   | "oklink" => Ok(Self::Oklink),
+            "c"   | "custom" => Ok(Self::Custom),
             _ => Err(format!("Unknown provider: {s}")),
         }
     }
@@ -138,6 +139,9 @@ impl fmt::Display for VerificationProviderType {
         match self {
             Self::Etherscan => {
                 write!(f, "etherscan")?;
+            }
+            Self::EtherscanV2 => {
+                write!(f, "etherscan-v2")?;
             }
             Self::Sourcify => {
                 write!(f, "sourcify")?;
@@ -159,6 +163,7 @@ impl fmt::Display for VerificationProviderType {
 #[derive(Clone, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
 pub enum VerificationProviderType {
     Etherscan,
+    EtherscanV2,
     #[default]
     Sourcify,
     Blockscout,
@@ -208,6 +213,10 @@ impl VerificationProviderType {
     }
 
     pub fn is_etherscan(&self) -> bool {
-        matches!(self, Self::Etherscan)
+        matches!(self, Self::Etherscan) || matches!(self, Self::EtherscanV2)
+    }
+
+    pub fn is_etherscan_v2(&self) -> bool {
+        matches!(self, Self::EtherscanV2)
     }
 }

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -124,7 +124,6 @@ impl FromStr for VerificationProviderType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "e" | "etherscan" => Ok(Self::Etherscan),
-            "ev2" | "etherscan-v2" => Ok(Self::EtherscanV2),
             "s" | "sourcify" => Ok(Self::Sourcify),
             "b" | "blockscout" => Ok(Self::Blockscout),
             "o" | "oklink" => Ok(Self::Oklink),
@@ -139,9 +138,6 @@ impl fmt::Display for VerificationProviderType {
         match self {
             Self::Etherscan => {
                 write!(f, "etherscan")?;
-            }
-            Self::EtherscanV2 => {
-                write!(f, "etherscan-v2")?;
             }
             Self::Sourcify => {
                 write!(f, "sourcify")?;
@@ -163,7 +159,6 @@ impl fmt::Display for VerificationProviderType {
 #[derive(Clone, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
 pub enum VerificationProviderType {
     Etherscan,
-    EtherscanV2,
     #[default]
     Sourcify,
     Blockscout,
@@ -213,10 +208,6 @@ impl VerificationProviderType {
     }
 
     pub fn is_etherscan(&self) -> bool {
-        matches!(self, Self::Etherscan) || matches!(self, Self::EtherscanV2)
-    }
-
-    pub fn is_etherscan_v2(&self) -> bool {
-        matches!(self, Self::EtherscanV2)
+        matches!(self, Self::Etherscan)
     }
 }

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -123,12 +123,12 @@ impl FromStr for VerificationProviderType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "e"   | "etherscan" => Ok(Self::Etherscan),
+            "e" | "etherscan" => Ok(Self::Etherscan),
             "ev2" | "etherscan-v2" => Ok(Self::EtherscanV2),
-            "s"   | "sourcify" => Ok(Self::Sourcify),
-            "b"   | "blockscout" => Ok(Self::Blockscout),
-            "o"   | "oklink" => Ok(Self::Oklink),
-            "c"   | "custom" => Ok(Self::Custom),
+            "s" | "sourcify" => Ok(Self::Sourcify),
+            "b" | "blockscout" => Ok(Self::Blockscout),
+            "o" | "oklink" => Ok(Self::Oklink),
+            "c" | "custom" => Ok(Self::Custom),
             _ => Err(format!("Unknown provider: {s}")),
         }
     }

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -10,6 +10,7 @@ use alloy_primitives::Address;
 use alloy_provider::Provider;
 use clap::{Parser, ValueHint};
 use eyre::Result;
+use foundry_block_explorers::EtherscanApiVersion;
 use foundry_cli::{
     opts::{EtherscanOpts, RpcOpts},
     utils::{self, LoadConfig},
@@ -40,7 +41,7 @@ pub struct VerifierArgs {
 
     /// The verifier API version, if using a custom provider.
     #[arg(long, help_heading = "Verifier options", env = "VERIFIER_API_VERSION")]
-    pub verifier_api_version: Option<String>,
+    pub verifier_api_version: Option<EtherscanApiVersion>,
 }
 
 impl Default for VerifierArgs {
@@ -184,7 +185,7 @@ impl figment::Provider for VerifyArgs {
         }
 
         if let Some(api_version) = &self.verifier.verifier_api_version {
-            dict.insert("etherscan_api_version".into(), api_version.as_str().into());
+            dict.insert("etherscan_api_version".into(), api_version.to_string().into());
         }
 
         Ok(figment::value::Map::from([(Config::selected_profile(), dict)]))
@@ -457,7 +458,7 @@ impl figment::Provider for VerifyCheckArgs {
         }
 
         if let Some(api_version) = &self.etherscan.api_version {
-            dict.insert("etherscan_api_version".into(), api_version.as_str().into());
+            dict.insert("etherscan_api_version".into(), api_version.to_string().into());
         }
 
         Ok(figment::value::Map::from([(Config::selected_profile(), dict)]))

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -451,7 +451,16 @@ impl figment::Provider for VerifyCheckArgs {
     fn data(
         &self,
     ) -> Result<figment::value::Map<figment::Profile, figment::value::Dict>, figment::Error> {
-        self.etherscan.data()
+        let mut dict = self.etherscan.dict();
+        if let Some(api_key) = &self.etherscan.key {
+            dict.insert("etherscan_api_key".into(), api_key.as_str().into());
+        }
+
+        if let Some(api_version) = &self.etherscan.api_version {
+            dict.insert("etherscan_api_version".into(), api_version.as_str().into());
+        }
+
+        Ok(figment::value::Map::from([(Config::selected_profile(), dict)]))
     }
 }
 

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -183,6 +183,10 @@ impl figment::Provider for VerifyArgs {
             dict.insert("etherscan_api_key".into(), api_key.as_str().into());
         }
 
+        if let Some(api_version) = &self.verifier.verifier_api_version {
+            dict.insert("etherscan_api_version".into(), api_version.as_str().into());
+        }
+
         Ok(figment::value::Map::from([(Config::selected_profile(), dict)]))
     }
 }

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     etherscan::EtherscanVerificationProvider,
-    provider::{VerificationProvider, VerificationProviderType},
+    provider::{VerificationContext, VerificationProvider, VerificationProviderType},
     utils::is_host_only,
     RetryArgs,
 };
@@ -23,8 +23,6 @@ use revm_primitives::HashSet;
 use semver::BuildMetadata;
 use std::path::PathBuf;
 
-use crate::provider::VerificationContext;
-
 /// Verification provider arguments
 #[derive(Clone, Debug, Parser)]
 pub struct VerifierArgs {
@@ -39,6 +37,10 @@ pub struct VerifierArgs {
     /// The verifier URL, if using a custom provider.
     #[arg(long, help_heading = "Verifier options", env = "VERIFIER_URL")]
     pub verifier_url: Option<String>,
+
+    /// The verifier API version, if using a custom provider.
+    #[arg(long, help_heading = "Verifier options", env = "VERIFIER_API_VERSION")]
+    pub verifier_api_version: Option<String>,
 }
 
 impl Default for VerifierArgs {
@@ -47,6 +49,7 @@ impl Default for VerifierArgs {
             verifier: VerificationProviderType::Sourcify,
             verifier_api_key: None,
             verifier_url: None,
+            verifier_api_version: None,
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #9196
- builds on top of https://github.com/foundry-rs/foundry/pull/10298
- single `Etherscan` provider, default to V2; custom verifier providers use V1
- `foundry.toml` config as
```toml
[etherscan]
sepolia = { key = "$KEY"}
optimisim = { key = "$KEY" }
base-sepolia = { key = "$KEY_V1", api-version="v1" }
```
or `etherscan_api_version = "v2"` in top level foundry.toml

- new `--etherscan-api-version` to forge and cast commands (added for v1 compatibility), defaults to v2
- chisel supports v2 only (for fetch commands)
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes