### PR TITLE
chore: mv EitherEvm to foundry_evm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4409,6 +4409,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-json-abi",
  "alloy-network",
+ "alloy-op-evm",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -1,4 +1,3 @@
-use crate::eth::backend::evm::EitherEvm;
 use crate::{
     eth::{
         backend::{
@@ -24,7 +23,7 @@ use anvil_core::eth::{
     trie,
 };
 use foundry_evm::{backend::DatabaseError, traces::CallTraceNode, Env};
-use foundry_evm_core::evm::FoundryPrecompiles;
+use foundry_evm_core::{either_evm::EitherEvm, evm::FoundryPrecompiles};
 use op_revm::{
     transaction::deposit::DEPOSIT_TRANSACTION_TYPE, L1BlockInfo, OpContext, OpTransaction,
     OpTransactionError,

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1,7 +1,7 @@
 //! In-memory blockchain backend.
 
 use self::state::trie_storage;
-use super::{evm::EitherEvm, executor::evm_with_inspector_ref};
+use super::executor::evm_with_inspector_ref;
 use crate::{
     config::PruneStateHistoryConfig,
     eth::{
@@ -93,7 +93,7 @@ use foundry_evm::{
     traces::TracingInspectorConfig,
     Env,
 };
-use foundry_evm_core::evm::FoundryPrecompiles;
+use foundry_evm_core::{either_evm::EitherEvm, evm::FoundryPrecompiles};
 use futures::channel::mpsc::{unbounded, UnboundedSender};
 use op_alloy_consensus::{TxDeposit, DEPOSIT_TX_TYPE_ID};
 use op_revm::{OpContext, OpHaltReason};
@@ -1143,7 +1143,7 @@ impl Backend {
             validator: self,
             pending: pool_transactions.into_iter(),
             block_env: env.evm_env.block_env.clone(),
-            cfg_env: env.evm_env.cfg_env.clone(),
+            cfg_env: env.evm_env.cfg_env,
             parent_hash: storage.best_hash,
             gas_used: 0,
             blob_gas_used: 0,

--- a/crates/anvil/src/eth/backend/mod.rs
+++ b/crates/anvil/src/eth/backend/mod.rs
@@ -8,7 +8,6 @@ pub mod mem;
 pub mod cheats;
 pub mod time;
 
-pub mod evm;
 pub mod executor;
 pub mod fork;
 pub mod genesis;

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -50,6 +50,7 @@ revm = { workspace = true, features = [
 ] }
 revm-inspectors.workspace = true
 op-revm.workspace = true
+alloy-op-evm.workspace = true
 
 auto_impl.workspace = true
 eyre.workspace = true

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod backend;
 pub mod buffer;
 pub mod constants;
 pub mod decode;
+pub mod either_evm;
 pub mod evm;
 pub mod fork;
 pub mod ic;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Move `EitherEvm` to `foundry_evm_core` from anvil

Prep for adding OP support to forge

Next steps:
1. EitherEvm integration into the Cow Backend and InspectorStack

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Move `EitherEvm` 
- Rename type Aliases

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes