### PR TITLE
feat(`forge`): integrate `EitherEvm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4378,6 +4378,7 @@ dependencies = [
  "foundry-evm-fuzz",
  "foundry-evm-traces",
  "indicatif",
+ "op-revm",
  "parking_lot",
  "proptest",
  "revm",

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -100,6 +100,10 @@ pub trait ContextExt {
     fn as_db_env_and_journal(
         &mut self,
     ) -> (&mut Self::DB, &mut JournalInner<JournalEntry>, EnvMut<'_>);
+
+    fn cfg_env(&self) -> CfgEnv;
+    fn block_env(&self) -> BlockEnv;
+    fn tx_env(&self) -> TxEnv;
 }
 
 impl<DB: Database, C> ContextExt
@@ -115,5 +119,17 @@ impl<DB: Database, C> ContextExt
             &mut self.journaled_state.inner,
             EnvMut { block: &mut self.block, cfg: &mut self.cfg, tx: &mut self.tx },
         )
+    }
+
+    fn cfg_env(&self) -> CfgEnv {
+        self.cfg.clone()
+    }
+
+    fn block_env(&self) -> BlockEnv {
+        self.block.clone()
+    }
+
+    fn tx_env(&self) -> TxEnv {
+        self.tx.clone()
     }
 }

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -43,6 +43,7 @@ revm = { workspace = true, default-features = false, features = [
     "arbitrary",
     "c-kzg",
 ] }
+op-revm.workspace = true
 revm-inspectors.workspace = true
 
 eyre.workspace = true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Integrate `EitherEvm` into forge to add OP support.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This is non-trivial and will require the `InspectorStack`, `InspectorStackRefMut`, `InspectorExt` and most importantly the `Cheatcodes` inspector and `CheatCtxt` to be generic over `CTX`.

- Start with making the `InspectorStack` and related types generic
- Make `InspectorExt` generic
- Carry similar changes to the cheatcodes inspector


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes