### PR TITLE
chore: avoid leaking Anvil specific optimism fields into evm/core

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1293,7 +1293,7 @@ latest block number: {latest_block}"
             // need to update the dev signers and env with the chain id
             self.set_chain_id(Some(chain_id));
             env.evm_env.cfg_env.chain_id = chain_id;
-            env.tx.chain_id = chain_id.into();
+            env.tx.base.chain_id = chain_id.into();
             chain_id
         };
         let override_chain_id = self.chain_id;

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -39,6 +39,7 @@ use foundry_evm::{
     constants::DEFAULT_CREATE2_DEPLOYER,
     utils::apply_chain_and_block_specific_env_changes,
 };
+use foundry_evm_core::AsEnvMut;
 use itertools::Itertools;
 use op_revm::OpTransaction;
 use parking_lot::RwLock;
@@ -1298,7 +1299,7 @@ latest block number: {latest_block}"
         };
         let override_chain_id = self.chain_id;
         // apply changes such as difficulty -> prevrandao and chain specifics for current chain id
-        apply_chain_and_block_specific_env_changes::<AnyNetwork>(env, &block);
+        apply_chain_and_block_specific_env_changes::<AnyNetwork>(&mut env.as_env_mut(), &block);
 
         let meta = BlockchainDbMeta::new(env.evm_env.block_env.clone(), eth_rpc_url.clone());
         let block_chain_db = if self.fork_chain_id.is_some() {

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -2,6 +2,7 @@ use crate::{
     eth::{
         backend::{
             db::{Db, SerializableState},
+            env::Env,
             fork::{ClientFork, ClientForkConfig},
             genesis::GenesisConfig,
             mem::fork_db::ForkedDatabase,
@@ -37,9 +38,9 @@ use foundry_evm::{
     backend::{BlockchainDb, BlockchainDbMeta, SharedBackend},
     constants::DEFAULT_CREATE2_DEPLOYER,
     utils::apply_chain_and_block_specific_env_changes,
-    Env,
 };
 use itertools::Itertools;
+use op_revm::OpTransaction;
 use parking_lot::RwLock;
 use rand::thread_rng;
 use revm::{
@@ -1044,10 +1045,11 @@ impl NodeConfig {
                 basefee: self.get_base_fee(),
                 ..Default::default()
             },
-            TxEnv { chain_id: Some(self.get_chain_id()), ..Default::default() },
+            OpTransaction {
+                base: TxEnv { chain_id: Some(self.get_chain_id()), ..Default::default() },
+                ..Default::default()
+            },
         );
-
-        env.is_optimism = self.enable_optimism;
 
         let fees = FeeManager::new(
             spec_id,

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1299,7 +1299,7 @@ latest block number: {latest_block}"
         };
         let override_chain_id = self.chain_id;
         // apply changes such as difficulty -> prevrandao and chain specifics for current chain id
-        apply_chain_and_block_specific_env_changes::<AnyNetwork>(&mut env.as_env_mut(), &block);
+        apply_chain_and_block_specific_env_changes::<AnyNetwork>(env.as_env_mut(), &block);
 
         let meta = BlockchainDbMeta::new(env.evm_env.block_env.clone(), eth_rpc_url.clone());
         let block_chain_db = if self.fork_chain_id.is_some() {

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1052,6 +1052,8 @@ impl NodeConfig {
             },
         );
 
+        env.is_optimism = self.enable_optimism;
+
         let fees = FeeManager::new(
             spec_id,
             self.get_base_fee(),

--- a/crates/anvil/src/eth/backend/env.rs
+++ b/crates/anvil/src/eth/backend/env.rs
@@ -1,0 +1,39 @@
+use alloy_evm::EvmEnv;
+use op_revm::OpTransaction;
+use revm::{
+    context::{BlockEnv, CfgEnv, TxEnv},
+    primitives::hardfork::SpecId,
+};
+
+/// Helper container type for [`EvmEnv`] and [`OpTransaction<TxEnd>`].
+#[derive(Clone, Debug, Default)]
+pub struct Env {
+    pub evm_env: EvmEnv,
+    pub tx: OpTransaction<TxEnv>,
+}
+
+/// Helper container type for [`EvmEnv`] and [`TxEnv`].
+impl Env {
+    pub fn default_with_spec_id(spec_id: SpecId) -> Self {
+        let mut cfg = CfgEnv::default();
+        cfg.spec = spec_id;
+
+        Self::from(cfg, BlockEnv::default(), OpTransaction::default())
+    }
+
+    pub fn from(cfg: CfgEnv, block: BlockEnv, tx: OpTransaction<TxEnv>) -> Self {
+        Self { evm_env: EvmEnv { cfg_env: cfg, block_env: block }, tx }
+    }
+
+    pub fn new_with_spec_id(
+        cfg: CfgEnv,
+        block: BlockEnv,
+        tx: OpTransaction<TxEnv>,
+        spec_id: SpecId,
+    ) -> Self {
+        let mut cfg = cfg;
+        cfg.spec = spec_id;
+
+        Self::from(cfg, block, tx)
+    }
+}

--- a/crates/anvil/src/eth/backend/env.rs
+++ b/crates/anvil/src/eth/backend/env.rs
@@ -1,5 +1,5 @@
 use alloy_evm::EvmEnv;
-use op_revm::OpTransaction;
+use op_revm::{transaction::deposit::DepositTransactionParts, OpTransaction};
 use revm::{
     context::{BlockEnv, CfgEnv, TxEnv},
     primitives::hardfork::SpecId,
@@ -35,5 +35,10 @@ impl Env {
         cfg.spec = spec_id;
 
         Self::from(cfg, block, tx)
+    }
+
+    pub fn with_deposit(mut self, deposit: DepositTransactionParts) -> Self {
+        self.tx.deposit = deposit;
+        self
     }
 }

--- a/crates/anvil/src/eth/backend/env.rs
+++ b/crates/anvil/src/eth/backend/env.rs
@@ -1,5 +1,6 @@
 use alloy_evm::EvmEnv;
-use foundry_evm::Env as FoundryEnv;
+use foundry_evm::EnvMut;
+use foundry_evm_core::AsEnvMut;
 use op_revm::{transaction::deposit::DepositTransactionParts, OpTransaction};
 use revm::{
     context::{BlockEnv, CfgEnv, TxEnv},
@@ -42,5 +43,15 @@ impl Env {
     pub fn with_deposit(mut self, deposit: DepositTransactionParts) -> Self {
         self.tx.deposit = deposit;
         self
+    }
+}
+
+impl AsEnvMut for Env {
+    fn as_env_mut(&mut self) -> EnvMut<'_> {
+        EnvMut {
+            block: &mut self.evm_env.block_env,
+            cfg: &mut self.evm_env.cfg_env,
+            tx: &mut self.tx.base,
+        }
     }
 }

--- a/crates/anvil/src/eth/backend/env.rs
+++ b/crates/anvil/src/eth/backend/env.rs
@@ -1,4 +1,5 @@
 use alloy_evm::EvmEnv;
+use foundry_evm::Env as FoundryEnv;
 use op_revm::{transaction::deposit::DepositTransactionParts, OpTransaction};
 use revm::{
     context::{BlockEnv, CfgEnv, TxEnv},
@@ -10,6 +11,7 @@ use revm::{
 pub struct Env {
     pub evm_env: EvmEnv,
     pub tx: OpTransaction<TxEnv>,
+    pub is_optimism: bool,
 }
 
 /// Helper container type for [`EvmEnv`] and [`TxEnv`].
@@ -22,7 +24,7 @@ impl Env {
     }
 
     pub fn from(cfg: CfgEnv, block: BlockEnv, tx: OpTransaction<TxEnv>) -> Self {
-        Self { evm_env: EvmEnv { cfg_env: cfg, block_env: block }, tx }
+        Self { evm_env: EvmEnv { cfg_env: cfg, block_env: block }, tx, is_optimism: false }
     }
 
     pub fn new_with_spec_id(

--- a/crates/anvil/src/eth/backend/env.rs
+++ b/crates/anvil/src/eth/backend/env.rs
@@ -15,7 +15,7 @@ pub struct Env {
     pub is_optimism: bool,
 }
 
-/// Helper container type for [`EvmEnv`] and [`TxEnv`].
+/// Helper container type for [`EvmEnv`] and [`OpTransaction<TxEnv>`].
 impl Env {
     pub fn default_with_spec_id(spec_id: SpecId) -> Self {
         let mut cfg = CfgEnv::default();

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -1,7 +1,8 @@
 use crate::{
     eth::{
         backend::{
-            db::Db, mem::op_haltreason_to_instruction_result, validate::TransactionValidator,
+            db::Db, env::Env, mem::op_haltreason_to_instruction_result,
+            validate::TransactionValidator,
         },
         error::InvalidTransactionError,
         pool::transactions::PoolTransaction,
@@ -22,7 +23,7 @@ use anvil_core::eth::{
     },
     trie,
 };
-use foundry_evm::{backend::DatabaseError, traces::CallTraceNode, Env};
+use foundry_evm::{backend::DatabaseError, traces::CallTraceNode};
 use foundry_evm_core::{either_evm::EitherEvm, evm::FoundryPrecompiles};
 use op_revm::{
     transaction::deposit::DEPOSIT_TRANSACTION_TYPE, L1BlockInfo, OpContext, OpTransaction,

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -26,8 +26,7 @@ use anvil_core::eth::{
 use foundry_evm::{backend::DatabaseError, traces::CallTraceNode};
 use foundry_evm_core::{either_evm::EitherEvm, evm::FoundryPrecompiles};
 use op_revm::{
-    transaction::deposit::DEPOSIT_TRANSACTION_TYPE, L1BlockInfo, OpContext, OpTransaction,
-    OpTransactionError,
+    transaction::deposit::DEPOSIT_TRANSACTION_TYPE, L1BlockInfo, OpContext, OpTransactionError,
 };
 use revm::{
     context::{Block as RevmBlock, BlockEnv, CfgEnv, Evm as RevmEvm, JournalTr},
@@ -331,10 +330,8 @@ impl<DB: Db + ?Sized, V: TransactionValidator> Iterator for &mut TransactionExec
             &mut inspector,
             transaction.tx_type() == DEPOSIT_TRANSACTION_TYPE,
         );
-
-        let tx = OpTransaction { base: env.tx.base, deposit: env.tx.deposit, enveloped_tx: None };
         trace!(target: "backend", "[{:?}] executing", transaction.hash());
-        let exec_result = match evm.transact_commit(tx) {
+        let exec_result = match evm.transact_commit(env.tx) {
             Ok(exec_result) => exec_result,
             Err(err) => {
                 warn!(target: "backend", "[{:?}] failed to execute: {:?}", transaction.hash(), err);
@@ -436,11 +433,7 @@ where
             },
             block: env.evm_env.block_env.clone(),
             cfg: env.evm_env.cfg_env.clone().with_spec(op_revm::OpSpecId::BEDROCK),
-            tx: OpTransaction {
-                base: env.tx.base.clone(),
-                deposit: env.tx.deposit.clone(),
-                enveloped_tx: None,
-            },
+            tx: env.tx.clone(),
             chain: L1BlockInfo::default(),
             error: Ok(()),
         };

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1090,7 +1090,7 @@ impl Backend {
         let db = self.db.read().await;
         let mut inspector = self.build_inspector();
         let mut evm = self.new_evm_with_inspector_ref(db.as_dyn(), &env, &mut inspector);
-        let ResultAndState { result, state } = evm.transact(op_tx)?;
+        let ResultAndState { result, state } = evm.transact(env.tx)?;
         let (exit_reason, gas_used, out, logs) = match result {
             ExecutionResult::Success { reason, gas_used, logs, output, .. } => {
                 (reason.into(), gas_used, Some(output), Some(logs))

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1087,6 +1087,11 @@ impl Backend {
         let mut env = self.next_env();
         env.tx = tx.pending_transaction.to_revm_tx_env();
 
+        if env.is_optimism {
+            env.tx.enveloped_tx =
+                Some(alloy_rlp::encode(&tx.pending_transaction.transaction.transaction).into());
+        }
+
         let db = self.db.read().await;
         let mut inspector = self.build_inspector();
         let mut evm = self.new_evm_with_inspector_ref(db.as_dyn(), &env, &mut inspector);

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -8,6 +8,7 @@ use crate::{
         backend::{
             cheats::CheatsManager,
             db::{Db, MaybeFullDatabase, SerializableState},
+            env::Env,
             executor::{ExecutedTransactions, TransactionExecutor},
             fork::ClientFork,
             genesis::GenesisConfig,
@@ -91,7 +92,6 @@ use foundry_evm::{
     decode::RevertDecoder,
     inspectors::AccessListInspector,
     traces::TracingInspectorConfig,
-    Env,
 };
 use foundry_evm_core::{either_evm::EitherEvm, evm::FoundryPrecompiles};
 use futures::channel::mpsc::{unbounded, UnboundedSender};

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -5,6 +5,7 @@ use crate::eth::{
             MaybeFullDatabase, SerializableBlock, SerializableHistoricalStates,
             SerializableTransaction, StateDb,
         },
+        env::Env,
         mem::cache::DiskStateCache,
     },
     error::BlockchainError,
@@ -37,7 +38,6 @@ use foundry_evm::{
     traces::{
         CallKind, FourByteInspector, GethTraceBuilder, ParityTraceBuilder, TracingInspectorConfig,
     },
-    Env,
 };
 use parking_lot::RwLock;
 use revm::{context::Block as RevmBlock, primitives::hardfork::SpecId};

--- a/crates/anvil/src/eth/backend/mod.rs
+++ b/crates/anvil/src/eth/backend/mod.rs
@@ -8,6 +8,7 @@ pub mod mem;
 pub mod cheats;
 pub mod time;
 
+pub mod env;
 pub mod executor;
 pub mod fork;
 pub mod genesis;

--- a/crates/anvil/src/eth/backend/validate.rs
+++ b/crates/anvil/src/eth/backend/validate.rs
@@ -1,8 +1,10 @@
 //! Support for validating transactions at certain stages
 
-use crate::eth::error::{BlockchainError, InvalidTransactionError};
+use crate::eth::{
+    backend::env::Env,
+    error::{BlockchainError, InvalidTransactionError},
+};
 use anvil_core::eth::transaction::PendingTransaction;
-use foundry_evm::Env;
 use revm::state::AccountInfo;
 
 /// A trait for validating transactions

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -168,7 +168,7 @@ impl RunArgs {
                     evm_version = Some(EvmVersion::Cancun);
                 }
             }
-            apply_chain_and_block_specific_env_changes::<AnyNetwork>(&mut env.as_env_mut(), block);
+            apply_chain_and_block_specific_env_changes::<AnyNetwork>(env.as_env_mut(), block);
         }
 
         let trace_mode = TraceMode::Call

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -168,7 +168,7 @@ impl RunArgs {
                     evm_version = Some(EvmVersion::Cancun);
                 }
             }
-            apply_chain_and_block_specific_env_changes::<AnyNetwork>(&mut env, block);
+            apply_chain_and_block_specific_env_changes::<AnyNetwork>(&mut env.as_env_mut(), block);
         }
 
         let trace_mode = TraceMode::Call

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -1,5 +1,4 @@
 pub use alloy_evm::EvmEnv;
-use op_revm::transaction::deposit::DepositTransactionParts;
 use revm::{
     context::{BlockEnv, CfgEnv, JournalInner, JournalTr, TxEnv},
     primitives::hardfork::SpecId,
@@ -11,8 +10,6 @@ use revm::{
 pub struct Env {
     pub evm_env: EvmEnv,
     pub tx: TxEnv,
-    pub is_optimism: bool,
-    pub deposit: Option<DepositTransactionParts>,
 }
 
 /// Helper container type for [`EvmEnv`] and [`TxEnv`].
@@ -25,12 +22,7 @@ impl Env {
     }
 
     pub fn from(cfg: CfgEnv, block: BlockEnv, tx: TxEnv) -> Self {
-        Self {
-            evm_env: EvmEnv { cfg_env: cfg, block_env: block },
-            tx,
-            is_optimism: false,
-            deposit: None,
-        }
+        Self { evm_env: EvmEnv { cfg_env: cfg, block_env: block }, tx }
     }
 
     pub fn new_with_spec_id(cfg: CfgEnv, block: BlockEnv, tx: TxEnv, spec_id: SpecId) -> Self {
@@ -38,11 +30,6 @@ impl Env {
         cfg.spec = spec_id;
 
         Self::from(cfg, block, tx)
-    }
-
-    pub fn with_deposit(mut self, deposit: DepositTransactionParts) -> Self {
-        self.deposit = Some(deposit);
-        self
     }
 }
 
@@ -59,8 +46,6 @@ impl EnvMut<'_> {
         Env {
             evm_env: EvmEnv { cfg_env: self.cfg.to_owned(), block_env: self.block.to_owned() },
             tx: self.tx.to_owned(),
-            is_optimism: false,
-            deposit: None,
         }
     }
 }

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -1,4 +1,4 @@
-use crate::{utils::apply_chain_and_block_specific_env_changes, Env, EvmEnv};
+use crate::{utils::apply_chain_and_block_specific_env_changes, AsEnvMut, Env, EvmEnv};
 use alloy_consensus::BlockHeader;
 use alloy_primitives::Address;
 use alloy_provider::{network::BlockResponse, Network, Provider};
@@ -80,7 +80,7 @@ pub async fn environment<N: Network, P: Provider<N>>(
         },
     };
 
-    apply_chain_and_block_specific_env_changes::<N>(&mut env, &block);
+    apply_chain_and_block_specific_env_changes::<N>(&mut env.as_env_mut(), &block);
 
     Ok((env, block))
 }

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -80,7 +80,7 @@ pub async fn environment<N: Network, P: Provider<N>>(
         },
     };
 
-    apply_chain_and_block_specific_env_changes::<N>(&mut env.as_env_mut(), &block);
+    apply_chain_and_block_specific_env_changes::<N>(env.as_env_mut(), &block);
 
     Ok((env, block))
 }

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -78,8 +78,6 @@ pub async fn environment<N: Network, P: Provider<N>>(
             gas_limit: block.header().gas_limit() as u64,
             ..Default::default()
         },
-        is_optimism: false,
-        deposit: None,
     };
 
     apply_chain_and_block_specific_env_changes::<N>(&mut env, &block);

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -174,8 +174,6 @@ impl EvmOpts {
                 caller: self.sender,
                 ..Default::default()
             },
-            is_optimism: false,
-            deposit: None,
         }
     }
 

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -9,7 +9,7 @@ use foundry_config::NamedChain;
 use revm::primitives::hardfork::SpecId;
 pub use revm::state::EvmState as StateChangeset;
 
-use crate::{Env, EnvMut};
+use crate::{AsEnvMut, EnvMut};
 
 /// Depending on the configured chain id and block number this should apply any specific changes
 ///
@@ -18,19 +18,21 @@ use crate::{Env, EnvMut};
 ///
 /// Should be called with proper chain id (retrieved from provider if not provided).
 pub fn apply_chain_and_block_specific_env_changes<N: Network>(
-    env: &mut Env,
+    env: &mut EnvMut<'_>,
     block: &N::BlockResponse,
 ) {
     use NamedChain::*;
-    if let Ok(chain) = NamedChain::try_from(env.evm_env.cfg_env.chain_id) {
+
+    let env = env.as_env_mut();
+
+    if let Ok(chain) = NamedChain::try_from(env.cfg.chain_id) {
         let block_number = block.header().number();
 
         match chain {
             Mainnet => {
                 // after merge difficulty is supplanted with prevrandao EIP-4399
                 if block_number >= 15_537_351u64 {
-                    env.evm_env.block_env.difficulty =
-                        env.evm_env.block_env.prevrandao.unwrap_or_default().into();
+                    env.block.difficulty = env.block.prevrandao.unwrap_or_default().into();
                 }
 
                 return;
@@ -42,13 +44,13 @@ pub fn apply_chain_and_block_specific_env_changes<N: Network>(
                 // (`mixHash`) is always zero, even though bsc adopts the newer EVM
                 // specification. This will confuse revm and causes emulation
                 // failure.
-                env.evm_env.block_env.prevrandao = Some(env.evm_env.block_env.difficulty.into());
+                env.block.prevrandao = Some(env.block.difficulty.into());
                 return;
             }
             Moonbeam | Moonbase | Moonriver | MoonbeamDev | Rsk => {
-                if env.evm_env.block_env.prevrandao.is_none() {
+                if env.block.prevrandao.is_none() {
                     // <https://github.com/foundry-rs/foundry/issues/4232>
-                    env.evm_env.block_env.prevrandao = Some(B256::random());
+                    env.block.prevrandao = Some(B256::random());
                 }
             }
             c if c.is_arbitrum() => {
@@ -61,7 +63,7 @@ pub fn apply_chain_and_block_specific_env_changes<N: Network>(
                         serde_json::from_value::<U256>(l1_block_number).ok()
                     })
                 {
-                    env.evm_env.block_env.number = l1_block_number.to();
+                    env.block.number = l1_block_number.to();
                 }
             }
             _ => {}
@@ -70,8 +72,7 @@ pub fn apply_chain_and_block_specific_env_changes<N: Network>(
 
     // if difficulty is `0` we assume it's past merge
     if block.header().difficulty().is_zero() {
-        env.evm_env.block_env.difficulty =
-            env.evm_env.block_env.prevrandao.unwrap_or_default().into();
+        env.block.difficulty = env.block.prevrandao.unwrap_or_default().into();
     }
 }
 

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -9,7 +9,7 @@ use foundry_config::NamedChain;
 use revm::primitives::hardfork::SpecId;
 pub use revm::state::EvmState as StateChangeset;
 
-use crate::{AsEnvMut, EnvMut};
+use crate::EnvMut;
 
 /// Depending on the configured chain id and block number this should apply any specific changes
 ///
@@ -18,12 +18,10 @@ use crate::{AsEnvMut, EnvMut};
 ///
 /// Should be called with proper chain id (retrieved from provider if not provided).
 pub fn apply_chain_and_block_specific_env_changes<N: Network>(
-    env: &mut EnvMut<'_>,
+    env: EnvMut<'_>,
     block: &N::BlockResponse,
 ) {
     use NamedChain::*;
-
-    let env = env.as_env_mut();
 
     if let Ok(chain) = NamedChain::try_from(env.cfg.chain_id) {
         let block_number = block.header().number();

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -672,8 +672,6 @@ impl Executor {
                 chain_id: Some(self.env().evm_env.cfg_env.chain_id),
                 ..self.env().tx.clone()
             },
-            is_optimism: false,
-            deposit: None,
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

Related: https://github.com/foundry-rs/foundry/pull/10183

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

>we should keep the logic for setting enveloped_tx

https://github.com/foundry-rs/foundry/pull/10183#discussion_r2079573383

>could we introduce a separate type for anvil that would store OpTransaction instead of TxEnv here to fix it?

https://github.com/foundry-rs/foundry/pull/10183#discussion_r2079585533

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Adds separate Anvil specific `Env` with an `OpTransaction` field, implements `AsEnvMut` to convert to Foundry's `Env`
- Adds back `enveloped_tx` setting

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes