### PR TITLE
perf: spawn mining on blocking

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1748,7 +1748,8 @@ impl EthApi {
                 this.mine_one().await;
             }
             Ok(())
-        }).await?;
+        })
+        .await?;
 
         Ok(())
     }
@@ -2640,7 +2641,8 @@ impl EthApi {
                 this.mine_one().await;
             }
             Ok(())
-        }).await?;
+        })
+        .await?;
 
         Ok(blocks_to_mine)
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1738,15 +1738,17 @@ impl EthApi {
             return Ok(());
         }
 
-        // mine all the blocks
-        for _ in 0..blocks.to::<u64>() {
-            // If we have an interval, jump forwards in time to the "next" timestamp
-            if let Some(interval) = interval {
-                self.backend.time().increase_time(interval);
+        self.on_blocking_task(|this| async move {
+            // mine all the blocks
+            for _ in 0..blocks.to::<u64>() {
+                // If we have an interval, jump forwards in time to the "next" timestamp
+                if let Some(interval) = interval {
+                    this.backend.time().increase_time(interval);
+                }
+                this.mine_one().await;
             }
-
-            self.mine_one().await;
-        }
+            Ok(())
+        }).await?;
 
         Ok(())
     }
@@ -2630,10 +2632,15 @@ impl EthApi {
             }
         }
 
-        // mine all the blocks
-        for _ in 0..blocks_to_mine {
-            self.mine_one().await;
-        }
+        // this can be blocking for a bit, especially in forking mode
+        // <https://github.com/foundry-rs/foundry/issues/6036>
+        self.on_blocking_task(|this| async move {
+            // mine all the blocks
+            for _ in 0..blocks_to_mine {
+                this.mine_one().await;
+            }
+            Ok(())
+        }).await?;
 
         Ok(blocks_to_mine)
     }


### PR DESCRIPTION
ref #10452

mining a block is a blocking operation as far as tokio is concerned, because this can take a relatively long time even in non-forking mode and in forking mode this can be significantly worse due to all the db lookups=rpc requests.

hence we should spawn these request handlers as blocking tasks.

it's possible that recent db change handling made this process a bit more expensive which could have caused #10452