### PR TITLE
feat(anvil): add block context overrides for eth_call and eth_estimateGas

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -10,7 +10,7 @@ use alloy_rpc_types::{
         filter::TraceFilter,
         geth::{GethDebugTracingCallOptions, GethDebugTracingOptions},
     },
-    BlockId, BlockNumberOrTag as BlockNumber, Filter, Index,
+    BlockId, BlockNumberOrTag as BlockNumber, BlockOverrides, Filter, Index,
 };
 use alloy_serde::WithOtherFields;
 use foundry_common::serde_helpers::{
@@ -151,6 +151,7 @@ pub enum EthRequest {
         WithOtherFields<TransactionRequest>,
         #[serde(default)] Option<BlockId>,
         #[serde(default)] Option<StateOverride>,
+        #[serde(default)] Option<BlockOverrides>,
     ),
 
     #[serde(rename = "eth_simulateV1")]
@@ -164,6 +165,7 @@ pub enum EthRequest {
         WithOtherFields<TransactionRequest>,
         #[serde(default)] Option<BlockId>,
         #[serde(default)] Option<StateOverride>,
+        #[serde(default)] Option<BlockOverrides>,
     ),
 
     #[serde(rename = "eth_getTransactionByHash", with = "sequence")]

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1,5 +1,8 @@
 use super::{
-    backend::mem::{state, BlockRequest, State},
+    backend::{
+        db::MaybeFullDatabase,
+        mem::{apply_block_overrides, state, BlockRequest, State},
+    },
     sign::build_typed_transaction,
 };
 use crate::{
@@ -61,8 +64,8 @@ use alloy_rpc_types::{
         parity::LocalizedTransactionTrace,
     },
     txpool::{TxpoolContent, TxpoolInspect, TxpoolInspectSummary, TxpoolStatus},
-    AccessList, AccessListResult, BlockId, BlockNumberOrTag as BlockNumber, BlockTransactions,
-    EIP1186AccountProofResponse, FeeHistory, Filter, FilteredParams, Index, Log,
+    AccessList, AccessListResult, BlockId, BlockNumberOrTag as BlockNumber, BlockOverrides,
+    BlockTransactions, EIP1186AccountProofResponse, FeeHistory, Filter, FilteredParams, Index, Log,
 };
 use alloy_serde::WithOtherFields;
 use alloy_transport::TransportErrorKind;
@@ -84,7 +87,7 @@ use foundry_evm::{
     backend::DatabaseError,
     decode::RevertDecoder,
     revm::{
-        db::DatabaseRef,
+        db::{CacheDB, DatabaseRef},
         interpreter::{return_ok, return_revert, InstructionResult},
         primitives::BlockEnv,
     },
@@ -247,8 +250,8 @@ impl EthApi {
             EthRequest::EthSendRawTransaction(tx) => {
                 self.send_raw_transaction(tx).await.to_rpc_result()
             }
-            EthRequest::EthCall(call, block, overrides) => {
-                self.call(call, block, overrides).await.to_rpc_result()
+            EthRequest::EthCall(call, block, state_override, block_overrides) => {
+                self.call(call, block, state_override, block_overrides).await.to_rpc_result()
             }
             EthRequest::EthSimulateV1(simulation, block) => {
                 self.simulate_v1(simulation, block).await.to_rpc_result()
@@ -256,9 +259,10 @@ impl EthApi {
             EthRequest::EthCreateAccessList(call, block) => {
                 self.create_access_list(call, block).await.to_rpc_result()
             }
-            EthRequest::EthEstimateGas(call, block, overrides) => {
-                self.estimate_gas(call, block, overrides).await.to_rpc_result()
-            }
+            EthRequest::EthEstimateGas(call, block, state_override, block_overrides) => self
+                .estimate_gas(call, block, state_override, block_overrides)
+                .await
+                .to_rpc_result(),
             EthRequest::EthGetRawTransactionByHash(hash) => {
                 self.raw_transaction(hash).await.to_rpc_result()
             }
@@ -969,7 +973,7 @@ impl EthApi {
 
         if request.gas.is_none() {
             // estimate if not provided
-            if let Ok(gas) = self.estimate_gas(request.clone(), None, None).await {
+            if let Ok(gas) = self.estimate_gas(request.clone(), None, None, None).await {
                 request.gas = Some(gas.to());
             }
         }
@@ -996,7 +1000,7 @@ impl EthApi {
 
         if request.gas.is_none() {
             // estimate if not provided
-            if let Ok(gas) = self.estimate_gas(request.clone(), None, None).await {
+            if let Ok(gas) = self.estimate_gas(request.clone(), None, None, None).await {
                 request.gas = Some(gas.to());
             }
         }
@@ -1070,7 +1074,8 @@ impl EthApi {
         &self,
         request: WithOtherFields<TransactionRequest>,
         block_number: Option<BlockId>,
-        overrides: Option<StateOverride>,
+        state_override: Option<StateOverride>,
+        block_overrides: Option<BlockOverrides>,
     ) -> Result<Bytes> {
         node_info!("eth_call");
         let block_request = self.block_request(block_number).await?;
@@ -1078,8 +1083,8 @@ impl EthApi {
         if let BlockRequest::Number(number) = block_request {
             if let Some(fork) = self.get_fork() {
                 if fork.predates_fork(number) {
-                    if overrides.is_some() {
-                        return Err(BlockchainError::StateOverrideError(
+                    if state_override.is_some() || block_overrides.is_some() {
+                        return Err(BlockchainError::EvmOverrideError(
                             "not available on past forked blocks".to_string(),
                         ));
                     }
@@ -1098,8 +1103,10 @@ impl EthApi {
         // this can be blocking for a bit, especially in forking mode
         // <https://github.com/foundry-rs/foundry/issues/6036>
         self.on_blocking_task(|this| async move {
-            let (exit, out, gas, _) =
-                this.backend.call(request, fees, Some(block_request), overrides).await?;
+            let (exit, out, gas, _) = this
+                .backend
+                .call(request, fees, Some(block_request), state_override, block_overrides)
+                .await?;
             trace!(target : "node", "Call status {:?}, gas {}", exit, gas);
 
             ensure_return_ok(exit, &out)
@@ -1201,13 +1208,15 @@ impl EthApi {
         &self,
         request: WithOtherFields<TransactionRequest>,
         block_number: Option<BlockId>,
-        overrides: Option<StateOverride>,
+        state_override: Option<StateOverride>,
+        block_overrides: Option<BlockOverrides>,
     ) -> Result<U256> {
         node_info!("eth_estimateGas");
         self.do_estimate_gas(
             request,
             block_number.or_else(|| Some(BlockNumber::Pending.into())),
-            overrides,
+            state_override,
+            block_overrides,
         )
         .await
         .map(U256::from)
@@ -2082,7 +2091,7 @@ impl EthApi {
 
                 // Estimate gas
                 if tx_req.gas.is_none() {
-                    if let Ok(gas) = self.estimate_gas(tx_req.clone(), None, None).await {
+                    if let Ok(gas) = self.estimate_gas(tx_req.clone(), None, None, None).await {
                         tx_req.gas = Some(gas.to());
                     }
                 }
@@ -2550,7 +2559,7 @@ impl EthApi {
 
         request.from = Some(from);
 
-        let gas_limit_fut = self.estimate_gas(request.clone(), Some(BlockId::latest()), None);
+        let gas_limit_fut = self.estimate_gas(request.clone(), Some(BlockId::latest()), None, None);
 
         let fees_fut = self.fee_history(
             U256::from(EIP1559_FEE_ESTIMATION_PAST_BLOCKS),
@@ -2651,15 +2660,16 @@ impl EthApi {
         &self,
         request: WithOtherFields<TransactionRequest>,
         block_number: Option<BlockId>,
-        overrides: Option<StateOverride>,
+        state_overrides: Option<StateOverride>,
+        block_overrides: Option<BlockOverrides>,
     ) -> Result<u128> {
         let block_request = self.block_request(block_number).await?;
         // check if the number predates the fork, if in fork mode
         if let BlockRequest::Number(number) = block_request {
             if let Some(fork) = self.get_fork() {
                 if fork.predates_fork(number) {
-                    if overrides.is_some() {
-                        return Err(BlockchainError::StateOverrideError(
+                    if state_overrides.is_some() || block_overrides.is_some() {
+                        return Err(BlockchainError::EvmOverrideError(
                             "not available on past forked blocks".to_string(),
                         ));
                     }
@@ -2672,14 +2682,18 @@ impl EthApi {
         // <https://github.com/foundry-rs/foundry/issues/6036>
         self.on_blocking_task(|this| async move {
             this.backend
-                .with_database_at(Some(block_request), |mut state, block| {
-                    if let Some(overrides) = overrides {
-                        state = Box::new(state::apply_state_override(
-                            overrides.into_iter().collect(),
-                            state,
-                        )?);
+                .with_database_at(Some(block_request), |state, mut block| {
+                    let mut cache_db = CacheDB::new(state);
+                    if let Some(state_overrides) = state_overrides {
+                        state::apply_state_overrides(
+                            state_overrides.into_iter().collect(),
+                            &mut cache_db,
+                        )?;
                     }
-                    this.do_estimate_gas_with_state(request, &state, block)
+                    if let Some(block_overrides) = block_overrides {
+                        apply_block_overrides(block_overrides, &mut cache_db, &mut block);
+                    }
+                    this.do_estimate_gas_with_state(request, cache_db.as_dyn(), block)
                 })
                 .await?
         })

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -61,9 +61,10 @@ use alloy_rpc_types::{
         },
         parity::LocalizedTransactionTrace,
     },
-    AccessList, Block as AlloyBlock, BlockId, BlockNumberOrTag as BlockNumber, BlockTransactions,
-    EIP1186AccountProofResponse as AccountProof, EIP1186StorageProof as StorageProof, Filter,
-    FilteredParams, Header as AlloyHeader, Index, Log, Transaction, TransactionReceipt,
+    AccessList, Block as AlloyBlock, BlockId, BlockNumberOrTag as BlockNumber, BlockOverrides,
+    BlockTransactions, EIP1186AccountProofResponse as AccountProof,
+    EIP1186StorageProof as StorageProof, Filter, FilteredParams, Header as AlloyHeader, Index, Log,
+    Transaction, TransactionReceipt,
 };
 use alloy_serde::{OtherFields, WithOtherFields};
 use alloy_signer::Signature;
@@ -1359,16 +1360,20 @@ impl Backend {
         request: WithOtherFields<TransactionRequest>,
         fee_details: FeeDetails,
         block_request: Option<BlockRequest>,
-        overrides: Option<StateOverride>,
+        state_overrides: Option<StateOverride>,
+        block_overrides: Option<BlockOverrides>,
     ) -> Result<(InstructionResult, Option<Output>, u128, State), BlockchainError> {
-        self.with_database_at(block_request, |state, block| {
+        self.with_database_at(block_request, |state, mut block| {
             let block_number = block.number.to::<u64>();
-            let (exit, out, gas, state) = match overrides {
-                None => self.call_with_state(state.as_dyn(), request, fee_details, block),
-                Some(overrides) => {
-                    let state = state::apply_state_override(overrides.into_iter().collect(), state)?;
-                    self.call_with_state(state.as_dyn(), request, fee_details, block)
-                },
+            let (exit, out, gas, state) = {
+                let mut cache_db = CacheDB::new(state);
+                if let Some(state_overrides) = state_overrides {
+                    state::apply_state_overrides(state_overrides.into_iter().collect(), &mut cache_db)?;
+                }
+                if let Some(block_overrides) = block_overrides {
+                    apply_block_overrides(block_overrides, &mut cache_db, &mut block);
+                }
+                self.call_with_state(cache_db.as_dyn(), request, fee_details, block)
             }?;
             trace!(target: "backend", "call return {:?} out: {:?} gas {} on block {}", exit, out, gas, block_number);
             Ok((exit, out, gas, state))
@@ -1512,34 +1517,12 @@ impl Backend {
                 let mut log_index = 0;
                 let mut gas_used = 0;
                 let mut transactions = Vec::with_capacity(calls.len());
-                // apply state overrides before executing the transactions
+                // apply state and block overrides before executing the transactions
                 if let Some(state_overrides) = state_overrides {
-                    state::apply_cached_db_state_override(state_overrides, &mut cache_db)?;
+                    state::apply_state_overrides(state_overrides, &mut cache_db)?;
                 }
-
-                // apply block overrides
-                if let Some(overrides) = block_overrides {
-                    if let Some(number) = overrides.number {
-                        block_env.number = number.saturating_to();
-                    }
-                    if let Some(difficulty) = overrides.difficulty {
-                        block_env.difficulty = difficulty;
-                    }
-                    if let Some(time) = overrides.time {
-                        block_env.timestamp = U256::from(time);
-                    }
-                    if let Some(gas_limit) = overrides.gas_limit {
-                        block_env.gas_limit = U256::from(gas_limit);
-                    }
-                    if let Some(coinbase) = overrides.coinbase {
-                        block_env.coinbase = coinbase;
-                    }
-                    if let Some(random) = overrides.random {
-                        block_env.prevrandao = Some(random);
-                    }
-                    if let Some(base_fee) = overrides.base_fee {
-                        block_env.basefee = base_fee.saturating_to();
-                    }
+                if let Some(block_overrides) = block_overrides {
+                    apply_block_overrides(block_overrides, &mut cache_db, &mut block_env);
                 }
 
                 // execute all calls in that block
@@ -1740,19 +1723,20 @@ impl Backend {
         block_request: Option<BlockRequest>,
         opts: GethDebugTracingCallOptions,
     ) -> Result<GethTrace, BlockchainError> {
-        let GethDebugTracingCallOptions { tracing_options, block_overrides: _, state_overrides } =
+        let GethDebugTracingCallOptions { tracing_options, block_overrides, state_overrides } =
             opts;
         let GethDebugTracingOptions { config, tracer, tracer_config, .. } = tracing_options;
 
-        self.with_database_at(block_request, |state, block| {
+        self.with_database_at(block_request, |state, mut block| {
             let block_number = block.number;
 
-            let state = if let Some(overrides) = state_overrides {
-                Box::new(state::apply_state_override(overrides, state)?)
-                    as Box<dyn MaybeFullDatabase>
-            } else {
-                state
-            };
+            let mut cache_db = CacheDB::new(state);
+            if let Some(state_overrides) = state_overrides {
+                state::apply_state_overrides(state_overrides, &mut cache_db)?;
+            }
+            if let Some(block_overrides) = block_overrides {
+                apply_block_overrides(block_overrides, &mut cache_db, &mut block);
+            }
 
             if let Some(tracer) = tracer {
                 return match tracer {
@@ -1768,7 +1752,7 @@ impl Backend {
 
                             let env = self.build_call_env(request, fee_details, block);
                             let mut evm = self.new_evm_with_inspector_ref(
-                                state.as_dyn(),
+                                cache_db.as_dyn(),
                                 env,
                                 &mut inspector,
                             );
@@ -1803,7 +1787,7 @@ impl Backend {
                 .with_tracing_config(TracingInspectorConfig::from_geth_config(&config));
 
             let env = self.build_call_env(request, fee_details, block);
-            let mut evm = self.new_evm_with_inspector_ref(state.as_dyn(), env, &mut inspector);
+            let mut evm = self.new_evm_with_inspector_ref(cache_db.as_dyn(), env, &mut inspector);
             let ResultAndState { result, state: _ } = evm.transact()?;
 
             let (exit_reason, gas_used, out) = match result {
@@ -3312,4 +3296,51 @@ pub fn is_arbitrum(chain_id: u64) -> bool {
         return chain.is_arbitrum()
     }
     false
+}
+
+/// Applies the given block overrides to the env and updates overridden block hashes in the db.
+pub fn apply_block_overrides<DB>(
+    overrides: BlockOverrides,
+    cache_db: &mut CacheDB<DB>,
+    env: &mut BlockEnv,
+) {
+    let BlockOverrides {
+        number,
+        difficulty,
+        time,
+        gas_limit,
+        coinbase,
+        random,
+        base_fee,
+        block_hash,
+    } = overrides;
+
+    if let Some(block_hashes) = block_hash {
+        // override block hashes
+        cache_db
+            .block_hashes
+            .extend(block_hashes.into_iter().map(|(num, hash)| (U256::from(num), hash)))
+    }
+
+    if let Some(number) = number {
+        env.number = number;
+    }
+    if let Some(difficulty) = difficulty {
+        env.difficulty = difficulty;
+    }
+    if let Some(time) = time {
+        env.timestamp = U256::from(time);
+    }
+    if let Some(gas_limit) = gas_limit {
+        env.gas_limit = U256::from(gas_limit);
+    }
+    if let Some(coinbase) = coinbase {
+        env.coinbase = coinbase;
+    }
+    if let Some(random) = random {
+        env.prevrandao = Some(random);
+    }
+    if let Some(base_fee) = base_fee {
+        env.basefee = base_fee;
+    }
 }

--- a/crates/anvil/src/eth/backend/mem/state.rs
+++ b/crates/anvil/src/eth/backend/mem/state.rs
@@ -70,21 +70,8 @@ pub fn trie_account_rlp(info: &AccountInfo, storage: &HashMap<U256, U256>) -> Ve
     out
 }
 
-/// Applies the given state overrides to the state, returning a new CacheDB state
-pub fn apply_state_override<D>(
-    overrides: StateOverride,
-    state: D,
-) -> Result<CacheDB<D>, BlockchainError>
-where
-    D: DatabaseRef<Error = DatabaseError>,
-{
-    let mut cache_db = CacheDB::new(state);
-    apply_cached_db_state_override(overrides, &mut cache_db)?;
-    Ok(cache_db)
-}
-
 /// Applies the given state overrides to the given CacheDB
-pub fn apply_cached_db_state_override<D>(
+pub fn apply_state_overrides<D>(
     overrides: StateOverride,
     cache_db: &mut CacheDB<D>,
 ) -> Result<(), BlockchainError>

--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -60,6 +60,8 @@ pub enum BlockchainError {
     AlloyForkProvider(#[from] TransportError),
     #[error("EVM error {0:?}")]
     EvmError(InstructionResult),
+    #[error("Evm override error: {0}")]
+    EvmOverrideError(String),
     #[error("Invalid url {0:?}")]
     InvalidUrl(String),
     #[error("Internal error: {0:?}")]
@@ -427,6 +429,9 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                 }
                 err @ BlockchainError::EvmError(_) => {
                     RpcError::internal_error_with(err.to_string())
+                }
+                err @ BlockchainError::EvmOverrideError(_) => {
+                    RpcError::invalid_params(err.to_string())
                 }
                 err @ BlockchainError::InvalidUrl(_) => RpcError::invalid_params(err.to_string()),
                 BlockchainError::Internal(err) => RpcError::internal_error_with(err),

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -871,6 +871,7 @@ async fn test_fork_call() {
             }),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1313,6 +1314,7 @@ async fn test_fork_execution_reverted() {
                 ..Default::default()
             }),
             Some(target.into()),
+            None,
             None,
         )
         .await;

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -1090,7 +1090,7 @@ async fn estimates_gas_on_pending_by_default() {
         .to(sender)
         .value(U256::from(1e10))
         .input(Bytes::from(vec![0x42]).into());
-    api.estimate_gas(WithOtherFields::new(tx), None, None).await.unwrap();
+    api.estimate_gas(WithOtherFields::new(tx), None, None, None).await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1107,7 +1107,7 @@ async fn test_estimate_gas() {
         .value(U256::from(1e10))
         .input(Bytes::from(vec![0x42]).into());
     // Expect the gas estimation to fail due to insufficient funds.
-    let error_result = api.estimate_gas(WithOtherFields::new(tx.clone()), None, None).await;
+    let error_result = api.estimate_gas(WithOtherFields::new(tx.clone()), None, None, None).await;
 
     assert!(error_result.is_err(), "Expected an error due to insufficient funds");
     let error_message = error_result.unwrap_err().to_string();
@@ -1125,7 +1125,7 @@ async fn test_estimate_gas() {
 
     // Estimate gas with state override implying sufficient funds.
     let gas_estimate = api
-        .estimate_gas(WithOtherFields::new(tx), None, Some(state_override))
+        .estimate_gas(WithOtherFields::new(tx), None, Some(state_override), None)
         .await
         .expect("Failed to estimate gas with state override");
 
@@ -1242,5 +1242,5 @@ async fn estimates_gas_prague() {
         .with_input(hex!("0xcafebabe"))
         .with_from(address!("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"))
         .with_to(address!("0x70997970c51812dc3a010c7d01b50e0d17dc79c8"));
-    api.estimate_gas(WithOtherFields::new(req), None, None).await.unwrap();
+    api.estimate_gas(WithOtherFields::new(req), None, None, None).await.unwrap();
 }


### PR DESCRIPTION
## Motivation

Resolve #10458 by implementing block context overrides for `eth_call` and `eth_estimateGas` RPC methods, allowing users to specify block parameters like timestamp, number, difficulty, etc. for call execution context.

## Solution

Key changes:
- BlockOverrides added to EthRequest enum variants for eth_call and eth_estimateGas
- Block override handling implemented in `anvil::eth::backend::mem` as `apply_block_overrides()` function (ported from reth)
- Add new error type EvmOverrideError to group state and block override related errors (due to fork mode)
- State override handling refactored s
  - Rename `apply_cached_db_state_override()` to `apply_state_overrides()`
  - Modify to take mutable `CacheDB` reference instead of creating new instance
  - Consistent pattern for `apply_state_overrides()` and `apply_block_overrides()`
- Added appropriate error handling for block override operations

## Note
Attempted to use EvmOverrides to bundle state and block overrides in EthRequest enum variants but reverted because it is declared as serializable in `alloy-rpc-types-eth`. Current implementation maintains separate override types resulting in lint expectation unfulfilled.

Would it be appropriate to open an issue on this subject on the Alloy project?

## PR Checklist
- [ ] Fix EthRequest unfulfilled lint expectation
- [ ] Add Tests with State and Block overrides for `eth_call` and `eth_estimateGas` 
