### PR TITLE
feat: add 7702 support to eth-sendtransaction

### DIFF
--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -54,7 +54,8 @@ pub fn transaction_request_to_typed(
                 access_list,
                 sidecar,
                 transaction_type,
-                ..
+                authorization_list,
+                chain_id: _,
             },
         other,
     } = tx;
@@ -72,6 +73,23 @@ pub fn transaction_request_to_typed(
             gas_limit: gas.unwrap_or_default(),
             is_system_transaction: other.get_deserialized::<bool>("isSystemTx")?.ok()?,
             input: input.into_input().unwrap_or_default(),
+        }));
+    }
+
+    // EIP7702
+    if transaction_type == Some(4) || authorization_list.is_some() {
+        return Some(TypedTransactionRequest::EIP7702(TxEip7702 {
+            nonce: nonce.unwrap_or_default(),
+            max_fee_per_gas: max_fee_per_gas.unwrap_or_default(),
+            max_priority_fee_per_gas: max_priority_fee_per_gas.unwrap_or_default(),
+            gas_limit: gas.unwrap_or_default(),
+            value: value.unwrap_or(U256::ZERO),
+            input: input.into_input().unwrap_or_default(),
+            // requires to
+            to: to?.into_to()?,
+            chain_id: 0,
+            access_list: access_list.unwrap_or_default(),
+            authorization_list: authorization_list.unwrap(),
         }));
     }
 
@@ -173,6 +191,7 @@ pub enum TypedTransactionRequest {
     Legacy(TxLegacy),
     EIP2930(TxEip2930),
     EIP1559(TxEip1559),
+    EIP7702(TxEip7702),
     EIP4844(TxEip4844Variant),
     Deposit(TxDeposit),
 }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3008,6 +3008,15 @@ impl EthApi {
                 }
                 TypedTransactionRequest::EIP1559(m)
             }
+            Some(TypedTransactionRequest::EIP7702(mut m)) => {
+                m.nonce = nonce;
+                m.chain_id = chain_id;
+                m.gas_limit = gas_limit;
+                if max_fee_per_gas.is_none() {
+                    m.max_fee_per_gas = self.gas_price();
+                }
+                TypedTransactionRequest::EIP7702(m)
+            }
             Some(TypedTransactionRequest::EIP4844(m)) => {
                 TypedTransactionRequest::EIP4844(match m {
                     // We only accept the TxEip4844 variant which has the sidecar.
@@ -3075,6 +3084,7 @@ impl EthApi {
             ),
             TypedTransactionRequest::EIP2930(_) |
             TypedTransactionRequest::EIP1559(_) |
+            TypedTransactionRequest::EIP7702(_) |
             TypedTransactionRequest::EIP4844(_) |
             TypedTransactionRequest::Deposit(_) => Signature::from_scalars_and_parity(
                 B256::with_last_byte(1),
@@ -3198,6 +3208,7 @@ fn determine_base_gas_by_kind(request: &WithOtherFields<TransactionRequest>) -> 
                 TxKind::Call(_) => MIN_TRANSACTION_GAS,
                 TxKind::Create => MIN_CREATE_GAS,
             },
+            TypedTransactionRequest::EIP7702(_) => MIN_TRANSACTION_GAS,
             TypedTransactionRequest::EIP2930(req) => match req.to {
                 TxKind::Call(_) => MIN_TRANSACTION_GAS,
                 TxKind::Create => MIN_CREATE_GAS,

--- a/crates/anvil/src/eth/sign.rs
+++ b/crates/anvil/src/eth/sign.rs
@@ -104,6 +104,7 @@ impl Signer for DevSigner {
             TypedTransactionRequest::Legacy(mut tx) => Ok(signer.sign_transaction_sync(&mut tx)?),
             TypedTransactionRequest::EIP2930(mut tx) => Ok(signer.sign_transaction_sync(&mut tx)?),
             TypedTransactionRequest::EIP1559(mut tx) => Ok(signer.sign_transaction_sync(&mut tx)?),
+            TypedTransactionRequest::EIP7702(mut tx) => Ok(signer.sign_transaction_sync(&mut tx)?),
             TypedTransactionRequest::EIP4844(mut tx) => Ok(signer.sign_transaction_sync(&mut tx)?),
             TypedTransactionRequest::Deposit(_) => {
                 unreachable!("op deposit txs should not be signed")
@@ -128,6 +129,9 @@ pub fn build_typed_transaction(
         }
         TypedTransactionRequest::EIP1559(tx) => {
             TypedTransaction::EIP1559(tx.into_signed(signature))
+        }
+        TypedTransactionRequest::EIP7702(tx) => {
+            TypedTransaction::EIP7702(tx.into_signed(signature))
         }
         TypedTransactionRequest::EIP4844(tx) => {
             TypedTransaction::EIP4844(tx.into_signed(signature))

--- a/crates/anvil/tests/it/eip7702.rs
+++ b/crates/anvil/tests/it/eip7702.rs
@@ -2,7 +2,7 @@ use crate::utils::http_provider;
 use alloy_consensus::{transaction::TxEip7702, SignableTransaction};
 use alloy_network::{ReceiptResponse, TransactionBuilder, TxSignerSync};
 use alloy_primitives::{bytes, U256};
-use alloy_provider::Provider;
+use alloy_provider::{PendingTransactionConfig, Provider};
 use alloy_rpc_types::{Authorization, TransactionRequest};
 use alloy_serde::WithOtherFields;
 use alloy_signer::SignerSync;
@@ -70,6 +70,82 @@ async fn can_send_eip7702_tx() {
 
     let receipt =
         provider.send_raw_transaction(&encoded).await.unwrap().get_receipt().await.unwrap();
+    let log = &receipt.inner.inner.logs()[0];
+    // assert that log was from EOA which signed authorization
+    assert_eq!(log.address(), from);
+    assert_eq!(log.topics().len(), 0);
+    assert_eq!(log.data().data, log_data);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_send_eip7702_request() {
+    let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into()));
+    let (api, handle) = spawn(node_config).await;
+    let provider = http_provider(&handle.http_endpoint());
+
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+
+    // deploy simple contract forwarding calldata to LOG0
+    // PUSH7(CALLDATASIZE PUSH0 PUSH0 CALLDATACOPY CALLDATASIZE PUSH0 LOG0) PUSH0 MSTORE PUSH1(7)
+    // PUSH1(25) RETURN
+    let logger_bytecode = bytes!("66365f5f37365fa05f5260076019f3");
+
+    let eip1559_est = provider.estimate_eip1559_fees().await.unwrap();
+
+    let from = wallets[0].address();
+    let tx = TransactionRequest::default()
+        .with_from(from)
+        .into_create()
+        .with_nonce(0)
+        .with_max_fee_per_gas(eip1559_est.max_fee_per_gas)
+        .with_max_priority_fee_per_gas(eip1559_est.max_priority_fee_per_gas)
+        .with_input(logger_bytecode);
+
+    let receipt = provider
+        .send_transaction(WithOtherFields::new(tx))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+
+    assert!(receipt.status());
+
+    let contract = receipt.contract_address.unwrap();
+    let authorization = Authorization {
+        chain_id: U256::from(31337u64),
+        address: contract,
+        nonce: provider.get_transaction_count(from).await.unwrap(),
+    };
+    let signature = wallets[0].sign_hash_sync(&authorization.signature_hash()).unwrap();
+    let authorization = authorization.into_signed(signature);
+
+    let log_data = bytes!("11112222");
+    let tx = TxEip7702 {
+        max_fee_per_gas: eip1559_est.max_fee_per_gas,
+        max_priority_fee_per_gas: eip1559_est.max_priority_fee_per_gas,
+        gas_limit: 100000,
+        chain_id: 31337,
+        to: from,
+        input: bytes!("11112222"),
+        authorization_list: vec![authorization],
+        ..Default::default()
+    };
+
+    let sender = wallets[1].address();
+    let request = TransactionRequest::from_transaction(tx).with_from(sender);
+
+    api.anvil_impersonate_account(sender).await.unwrap();
+    let txhash = api.send_transaction(WithOtherFields::new(request)).await.unwrap();
+
+    let txhash = provider
+        .watch_pending_transaction(PendingTransactionConfig::new(txhash))
+        .await
+        .unwrap()
+        .await
+        .unwrap();
+
+    let receipt = provider.get_transaction_receipt(txhash).await.unwrap().unwrap();
     let log = &receipt.inner.inner.logs()[0];
     // assert that log was from EOA which signed authorization
     assert_eq!(log.address(), from);


### PR DESCRIPTION
we were missing 7702 variant for the ethsendtransaction endpoint