### PR TITLE
fix: sort blocks by number

### DIFF
--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -409,7 +409,13 @@ impl BlockchainStorage {
     }
 
     pub fn serialized_blocks(&self) -> Vec<SerializableBlock> {
-        self.blocks.values().map(|block| block.clone().into()).collect()
+        let mut blocks = self
+            .blocks
+            .values()
+            .map(|block| block.clone().into())
+            .collect::<Vec<SerializableBlock>>();
+        blocks.sort_by_key(|block| block.header.number);
+        blocks
     }
 
     pub fn serialized_transactions(&self) -> Vec<SerializableTransaction> {

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -290,16 +290,17 @@ async fn computes_next_base_fee_after_loading_state() {
 
     let provider = handle.http_provider();
 
+    let base_fee_empty_chain = api.backend.fees().base_fee();
+
     let value = Unit::ETHER.wei().saturating_mul(U256::from(1)); // 1 ether
     let tx = TransactionRequest::default().with_to(alice).with_value(value).with_from(bob);
     let tx = WithOtherFields::new(tx);
 
-    let base_fee_empty_chain = api.backend.fees().base_fee();
-    provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
+    let _receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
 
     let base_fee_after_one_tx = api.backend.fees().base_fee();
     // the test is meaningless if this does not hold
-    assert!(base_fee_empty_chain != base_fee_after_one_tx);
+    assert_ne!(base_fee_empty_chain, base_fee_after_one_tx);
 
     let ser_state = api.serialized_state(true).await.unwrap();
     foundry_common::fs::write_json_file(&state_file, &ser_state).unwrap();


### PR DESCRIPTION
ensure blocks are sorted so that last is always highest, otherwise this can be nondeterministic

ref #10488

cc @naps62 
