### PR TITLE
fix: patch solang-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "ascii-canvas"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
 dependencies = [
  "term",
 ]
@@ -1861,27 +1861,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -2995,16 +2980,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3012,19 +2987,8 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.0",
+ "redox_users",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users 0.4.6",
- "winapi",
 ]
 
 [[package]]
@@ -3419,9 +3383,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -4225,7 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-solang-parser"
-version = "0.3.5"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e16ea915458834f91f113bb3c3b47374128263a1312ead84352da2afa6ee18"
 dependencies = [
  "itertools 0.14.0",
  "lalrpop",
@@ -5549,32 +5515,33 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.20.2"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+checksum = "7047a26de42016abf8f181b46b398aef0b77ad46711df41847f6ed869a2a1d5b"
 dependencies = [
  "ascii-canvas",
- "bit-set 0.5.3",
+ "bit-set",
  "ena",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "lalrpop-util",
  "petgraph",
  "regex",
  "regex-syntax 0.8.5",
+ "sha3",
  "string_cache",
  "term",
- "tiny-keccak",
  "unicode-xid",
  "walkdir",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.20.2"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+checksum = "e8d05b3fe34b8bd562c338db725dfa9beb9451a48f65f129ccb9538b48d2c93b"
 dependencies = [
  "regex-automata 0.4.9",
+ "rustversion",
 ]
 
 [[package]]
@@ -6517,9 +6484,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap 2.9.0",
@@ -6841,8 +6808,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
@@ -7183,17 +7150,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8763,13 +8719,12 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "0.7.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+checksum = "8a984c8d058c627faaf5e8e2ed493fa3c51771889196de1016cf9c1c6e90d750"
 dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
+ "home",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "ascii-canvas"
-version = "4.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
  "term",
 ]
@@ -1861,12 +1861,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -2980,6 +2995,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,8 +3012,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.0",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -3383,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.5.7"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -4190,8 +4226,6 @@ dependencies = [
 [[package]]
 name = "foundry-solang-parser"
 version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee55a0d108bdb9ece5edd421640430254ed2475a497a508b540d696430491f5e"
 dependencies = [
  "itertools 0.14.0",
  "lalrpop",
@@ -5515,33 +5549,32 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.22.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7047a26de42016abf8f181b46b398aef0b77ad46711df41847f6ed869a2a1d5b"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
 dependencies = [
  "ascii-canvas",
- "bit-set",
+ "bit-set 0.5.3",
  "ena",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "lalrpop-util",
  "petgraph",
  "regex",
  "regex-syntax 0.8.5",
- "sha3",
  "string_cache",
  "term",
+ "tiny-keccak",
  "unicode-xid",
  "walkdir",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.22.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d05b3fe34b8bd562c338db725dfa9beb9451a48f65f129ccb9538b48d2c93b"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
  "regex-automata 0.4.9",
- "rustversion",
 ]
 
 [[package]]
@@ -6484,9 +6517,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.9.0",
@@ -6808,8 +6841,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
@@ -7150,6 +7183,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8719,12 +8763,13 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "1.0.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a984c8d058c627faaf5e8e2ed493fa3c51771889196de1016cf9c1c6e90d750"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
- "home",
- "windows-sys 0.59.0",
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,7 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-solang-parser"
-version = "0.3.3"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7bf43fbdd567b8f65c2db85ce39a38878a14bb77f42461b4212d06ce434a228"
 dependencies = [
  "itertools 0.14.0",
  "lalrpop",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-solang-parser"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7bf43fbdd567b8f65c2db85ce39a38878a14bb77f42461b4212d06ce434a228"
+checksum = "ee55a0d108bdb9ece5edd421640430254ed2475a497a508b540d696430491f5e"
 dependencies = [
  "itertools 0.14.0",
  "lalrpop",
@@ -5070,7 +5070,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.0",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -9986,19 +9986,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
-dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
- "windows-link",
- "windows-result 0.3.2",
- "windows-strings 0.4.0",
-]
-
-[[package]]
 name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10014,17 +10001,6 @@ name = "windows-implement"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10103,15 +10079,6 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "ascii-canvas"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
 dependencies = [
  "term",
 ]
@@ -1845,7 +1845,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -1861,27 +1861,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -2180,6 +2165,7 @@ dependencies = [
  "foundry-compilers",
  "foundry-config",
  "foundry-evm",
+ "foundry-solang-parser",
  "regex",
  "reqwest",
  "revm",
@@ -2187,7 +2173,6 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "solang-parser",
  "solar-parse",
  "strum 0.27.1",
  "tikv-jemallocator",
@@ -2995,16 +2980,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3012,19 +2987,8 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.0",
+ "redox_users",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users 0.4.6",
- "winapi",
 ]
 
 [[package]]
@@ -3419,9 +3383,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -3485,6 +3449,7 @@ dependencies = [
  "foundry-debugger",
  "foundry-evm",
  "foundry-linking",
+ "foundry-solang-parser",
  "foundry-test-utils",
  "foundry-wallets",
  "futures",
@@ -3507,7 +3472,6 @@ dependencies = [
  "serde_json",
  "similar",
  "similar-asserts",
- "solang-parser",
  "solar-parse",
  "soldeer-commands",
  "strum 0.27.1",
@@ -3537,13 +3501,13 @@ dependencies = [
  "foundry-common",
  "foundry-compilers",
  "foundry-config",
+ "foundry-solang-parser",
  "itertools 0.14.0",
  "mdbook",
  "rayon",
  "regex",
  "serde",
  "serde_json",
- "solang-parser",
  "thiserror 2.0.12",
  "toml 0.8.22",
  "tracing",
@@ -3556,9 +3520,9 @@ dependencies = [
  "alloy-primitives",
  "ariadne",
  "foundry-config",
+ "foundry-solang-parser",
  "itertools 0.14.0",
  "similar-asserts",
- "solang-parser",
  "thiserror 2.0.12",
  "toml 0.8.22",
  "tracing",
@@ -4221,6 +4185,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "foundry-solang-parser"
+version = "0.3.3"
+dependencies = [
+ "itertools 0.14.0",
+ "lalrpop",
+ "lalrpop-util",
+ "phf",
+ "thiserror 2.0.12",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -5537,32 +5513,33 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.20.2"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+checksum = "7047a26de42016abf8f181b46b398aef0b77ad46711df41847f6ed869a2a1d5b"
 dependencies = [
  "ascii-canvas",
- "bit-set 0.5.3",
+ "bit-set",
  "ena",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "lalrpop-util",
  "petgraph",
  "regex",
  "regex-syntax 0.8.5",
+ "sha3",
  "string_cache",
  "term",
- "tiny-keccak",
  "unicode-xid",
  "walkdir",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.20.2"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+checksum = "e8d05b3fe34b8bd562c338db725dfa9beb9451a48f65f129ccb9538b48d2c93b"
 dependencies = [
  "regex-automata 0.4.9",
+ "rustversion",
 ]
 
 [[package]]
@@ -6505,9 +6482,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap 2.9.0",
@@ -6829,8 +6806,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
@@ -7171,17 +7148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8225,20 +8191,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solang-parser"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c425ce1c59f4b154717592f0bdf4715c3a1d55058883622d3157e1f0908a5b26"
-dependencies = [
- "itertools 0.11.0",
- "lalrpop",
- "lalrpop-util",
- "phf",
- "thiserror 1.0.69",
- "unicode-xid",
-]
-
-[[package]]
 name = "solar-ast"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8765,13 +8717,12 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "0.7.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+checksum = "8a984c8d058c627faaf5e8e2ed493fa3c51771889196de1016cf9c1c6e90d750"
 dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
+ "home",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-solang-parser"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e16ea915458834f91f113bb3c3b47374128263a1312ead84352da2afa6ee18"
+checksum = "113b7633ca67d24a96ad90715d15be108ed8ddd35e7632884126838dfc60c7c9"
 dependencies = [
  "itertools 0.14.0",
  "lalrpop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ foundry-linking = { path = "crates/linking" }
 foundry-block-explorers = { version = "0.13.3", default-features = false }
 foundry-compilers = { version = "0.14.0", default-features = false }
 foundry-fork-db = "0.12"
-solang-parser = { version = "=0.3.4", package = "foundry-solang-parser" }
+solang-parser = { version = "=0.3.5", package = "foundry-solang-parser" }
 solar-parse = { version = "=0.1.2", default-features = false }
 solar-sema = { version = "=0.1.2", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ foundry-linking = { path = "crates/linking" }
 foundry-block-explorers = { version = "0.13.3", default-features = false }
 foundry-compilers = { version = "0.14.0", default-features = false }
 foundry-fork-db = "0.12"
-solang-parser = { version = "=0.3.6", package = "foundry-solang-parser" }
+solang-parser = { version = "=0.3.7", package = "foundry-solang-parser" }
 solar-parse = { version = "=0.1.2", default-features = false }
 solar-sema = { version = "=0.1.2", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ foundry-compilers.opt-level = 3
 serde_json.opt-level = 3
 serde.opt-level = 3
 
-solang-parser.opt-level = 3
+foundry-solang-parser.opt-level = 3
 lalrpop-util.opt-level = 3
 
 solar-ast.opt-level = 3
@@ -191,7 +191,7 @@ foundry-linking = { path = "crates/linking" }
 foundry-block-explorers = { version = "0.13.3", default-features = false }
 foundry-compilers = { version = "0.14.0", default-features = false }
 foundry-fork-db = "0.12"
-solang-parser = "=0.3.3"
+solang-parser = { version = "=0.3.3", package = "foundry-solang-parser" }
 solar-parse = { version = "=0.1.2", default-features = false }
 solar-sema = { version = "=0.1.2", default-features = false }
 
@@ -324,6 +324,8 @@ jiff = "0.2"
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
+foundry-solang-parser = { path = "../../danipopes/solang/solang-parser" }
+
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
 # alloy-json-abi = { path = "../../alloy-rs/core/crates/json-abi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ foundry-linking = { path = "crates/linking" }
 foundry-block-explorers = { version = "0.13.3", default-features = false }
 foundry-compilers = { version = "0.14.0", default-features = false }
 foundry-fork-db = "0.12"
-solang-parser = { version = "=0.3.5", package = "foundry-solang-parser" }
+solang-parser = { version = "=0.3.6", package = "foundry-solang-parser" }
 solar-parse = { version = "=0.1.2", default-features = false }
 solar-sema = { version = "=0.1.2", default-features = false }
 
@@ -324,8 +324,6 @@ jiff = "0.2"
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
-foundry-solang-parser = { path = "../../danipopes/solang/solang-parser" }
-
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
 # alloy-json-abi = { path = "../../alloy-rs/core/crates/json-abi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ foundry-linking = { path = "crates/linking" }
 foundry-block-explorers = { version = "0.13.3", default-features = false }
 foundry-compilers = { version = "0.14.0", default-features = false }
 foundry-fork-db = "0.12"
-solang-parser = { version = "=0.3.3", package = "foundry-solang-parser" }
+solang-parser = { version = "=0.3.4", package = "foundry-solang-parser" }
 solar-parse = { version = "=0.1.2", default-features = false }
 solar-sema = { version = "=0.1.2", default-features = false }
 
@@ -324,8 +324,6 @@ jiff = "0.2"
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
-foundry-solang-parser = { path = "../../danipopes/solang/solang-parser" }
-
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
 # alloy-json-abi = { path = "../../alloy-rs/core/crates/json-abi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,6 +324,8 @@ jiff = "0.2"
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
+foundry-solang-parser = { path = "../../danipopes/solang/solang-parser" }
+
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
 # alloy-json-abi = { path = "../../alloy-rs/core/crates/json-abi" }

--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -2093,7 +2093,10 @@ impl<W: Write> Visitor for Formatter<'_, W> {
         &mut self,
         pragma: &mut PragmaDirective,
     ) -> std::result::Result<(), Self::Error> {
-        self.visit_source(pragma.loc())?;
+        let loc = pragma.loc();
+        return_source_if_disabled!(self, loc, ';');
+
+        self.visit_source(loc)?;
         self.write_semicolon()
     }
 

--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -2005,6 +2005,12 @@ impl<W: Write> Visitor for Formatter<'_, W> {
                 );
             }
 
+            if let Some(layout) = &mut contract.layout {
+                write_chunk!(fmt, "layout at ")?;
+                fmt.visit_expr(layout.loc(), layout)?;
+                write_chunk!(fmt, " ")?;
+            }
+
             write_chunk!(fmt, "{{")?;
 
             fmt.indented(1, |fmt| {

--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -2089,6 +2089,14 @@ impl<W: Write> Visitor for Formatter<'_, W> {
         Ok(())
     }
 
+    fn visit_pragma(
+        &mut self,
+        pragma: &mut PragmaDirective,
+    ) -> std::result::Result<(), Self::Error> {
+        self.visit_source(pragma.loc())?;
+        self.write_semicolon()
+    }
+
     #[instrument(name = "import_plain", skip_all)]
     fn visit_import_plain(&mut self, loc: Loc, import: &mut ImportPath) -> Result<()> {
         return_source_if_disabled!(self, loc, ';');

--- a/crates/fmt/src/solang_ext/ast_eq.rs
+++ b/crates/fmt/src/solang_ext/ast_eq.rs
@@ -387,6 +387,8 @@ derive_ast_eq! { (0 A, 1 B) }
 derive_ast_eq! { (0 A, 1 B, 2 C) }
 derive_ast_eq! { (0 A, 1 B, 2 C, 3 D) }
 derive_ast_eq! { (0 A, 1 B, 2 C, 3 D, 4 E) }
+derive_ast_eq! { (0 A, 1 B, 2 C, 3 D, 4 E, 5 F) }
+derive_ast_eq! { (0 A, 1 B, 2 C, 3 D, 4 E, 5 F, 6 G) }
 derive_ast_eq! { bool }
 derive_ast_eq! { u8 }
 derive_ast_eq! { u16 }
@@ -413,7 +415,7 @@ derive_ast_eq! { struct VariableDeclaration { loc, ty, storage, name } }
 derive_ast_eq! { struct Using { loc, list, ty, global } }
 derive_ast_eq! { struct UsingFunction { loc, path, oper } }
 derive_ast_eq! { struct TypeDefinition { loc, name, ty } }
-derive_ast_eq! { struct ContractDefinition { loc, ty, name, base, parts } }
+derive_ast_eq! { struct ContractDefinition { loc, ty, name, base, layout, parts } }
 derive_ast_eq! { struct EventParameter { loc, ty, indexed, name } }
 derive_ast_eq! { struct ErrorParameter { loc, ty, name } }
 derive_ast_eq! { struct EventDefinition { loc, name, fields, anonymous } }
@@ -421,6 +423,13 @@ derive_ast_eq! { struct ErrorDefinition { loc, keyword, name, fields } }
 derive_ast_eq! { struct StructDefinition { loc, name, fields } }
 derive_ast_eq! { struct EnumDefinition { loc, name, values } }
 derive_ast_eq! { struct Annotation { loc, id, value } }
+derive_ast_eq! { enum PragmaDirective {
+    _
+    Identifier(loc, id1, id2),
+    StringLiteral(loc, id, lit),
+    Version(loc, id, version),
+    _
+}}
 derive_ast_eq! { enum UsingList {
     Error,
     _
@@ -480,6 +489,7 @@ derive_ast_eq! { enum StorageLocation {
     Memory(loc),
     Storage(loc),
     Calldata(loc),
+    Transient(loc),
     _
 }}
 derive_ast_eq! { enum Type {
@@ -615,7 +625,7 @@ derive_ast_eq! { enum YulSwitchOptions {
 derive_ast_eq! { enum SourceUnitPart {
     _
     ContractDefinition(def),
-    PragmaDirective(loc, ident, string),
+    PragmaDirective(pragma),
     ImportDirective(import),
     EnumDefinition(def),
     StructDefinition(def),
@@ -679,5 +689,20 @@ derive_ast_eq! { enum VariableAttribute {
     Constant(loc),
     Immutable(loc),
     Override(loc, idents),
+    StorageType(st),
+    StorageLocation(st),
     _
 }}
+
+// Who cares
+impl AstEq for StorageType {
+    fn ast_eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl AstEq for VersionComparator {
+    fn ast_eq(&self, _other: &Self) -> bool {
+        true
+    }
+}

--- a/crates/fmt/src/solang_ext/loc.rs
+++ b/crates/fmt/src/solang_ext/loc.rs
@@ -90,6 +90,17 @@ impl CodeLocationExt for pt::ImportPath {
     }
 }
 
+impl CodeLocationExt for pt::VersionComparator {
+    fn loc(&self) -> pt::Loc {
+        match self {
+            Self::Plain { loc, .. } |
+            Self::Operator { loc, .. } |
+            Self::Or { loc, .. } |
+            Self::Range { loc, .. } => *loc,
+        }
+    }
+}
+
 macro_rules! impl_delegate {
     ($($t:ty),+ $(,)?) => {$(
         impl CodeLocationExt for $t {

--- a/crates/fmt/src/solang_ext/loc.rs
+++ b/crates/fmt/src/solang_ext/loc.rs
@@ -111,6 +111,7 @@ impl_delegate! {
     pt::ErrorParameter,
     pt::EventDefinition,
     pt::EventParameter,
+    pt::PragmaDirective,
     // pt::FunctionDefinition,
     pt::HexLiteral,
     pt::Identifier,

--- a/crates/fmt/src/solang_ext/mod.rs
+++ b/crates/fmt/src/solang_ext/mod.rs
@@ -11,11 +11,12 @@ pub mod pt {
         EnumDefinition, ErrorDefinition, ErrorParameter, EventDefinition, EventParameter,
         Expression, FunctionAttribute, FunctionDefinition, FunctionTy, HexLiteral, Identifier,
         IdentifierPath, Import, ImportPath, Loc, Mutability, NamedArgument, OptionalCodeLocation,
-        Parameter, ParameterList, SourceUnit, SourceUnitPart, Statement, StorageLocation,
-        StringLiteral, StructDefinition, Type, TypeDefinition, UserDefinedOperator, Using,
-        UsingFunction, UsingList, VariableAttribute, VariableDeclaration, VariableDefinition,
-        Visibility, YulBlock, YulExpression, YulFor, YulFunctionCall, YulFunctionDefinition,
-        YulStatement, YulSwitch, YulSwitchOptions, YulTypedIdentifier,
+        Parameter, ParameterList, PragmaDirective, SourceUnit, SourceUnitPart, Statement,
+        StorageLocation, StringLiteral, StructDefinition, Type, TypeDefinition,
+        UserDefinedOperator, Using, UsingFunction, UsingList, VariableAttribute,
+        VariableDeclaration, VariableDefinition, Visibility, YulBlock, YulExpression, YulFor,
+        YulFunctionCall, YulFunctionDefinition, YulStatement, YulSwitch, YulSwitchOptions,
+        YulTypedIdentifier,
     };
 }
 

--- a/crates/fmt/src/visit.rs
+++ b/crates/fmt/src/visit.rs
@@ -1,6 +1,6 @@
 //! Visitor helpers to traverse the [solang Solidity Parse Tree](solang_parser::pt).
 
-use crate::solang_ext::pt::*;
+use crate::solang_ext::{pt::*, CodeLocationExt};
 
 /// A trait that is invoked while traversing the Solidity Parse Tree.
 /// Each method of the [Visitor] trait is a hook that can be potentially overridden.
@@ -25,13 +25,8 @@ pub trait Visitor {
         self.visit_source(annotation.loc)
     }
 
-    fn visit_pragma(
-        &mut self,
-        loc: Loc,
-        _ident: &mut Option<Identifier>,
-        _str: &mut Option<StringLiteral>,
-    ) -> Result<(), Self::Error> {
-        self.visit_source(loc)
+    fn visit_pragma(&mut self, pragma: &mut PragmaDirective) -> Result<(), Self::Error> {
+        self.visit_source(pragma.loc())
     }
 
     fn visit_import_plain(
@@ -331,7 +326,7 @@ pub trait Visitor {
         _expr: &mut Option<&mut YulExpression>,
     ) -> Result<(), Self::Error>
     where
-        T: Visitable + CodeLocation,
+        T: Visitable + CodeLocationExt,
     {
         self.visit_source(loc)
     }
@@ -459,7 +454,7 @@ impl Visitable for SourceUnitPart {
     {
         match self {
             Self::ContractDefinition(contract) => v.visit_contract(contract),
-            Self::PragmaDirective(loc, ident, str) => v.visit_pragma(*loc, ident, str),
+            Self::PragmaDirective(pragma) => v.visit_pragma(pragma),
             Self::ImportDirective(import) => import.visit(v),
             Self::EnumDefinition(enumeration) => v.visit_enum(enumeration),
             Self::StructDefinition(structure) => v.visit_struct(structure),

--- a/crates/fmt/testdata/VariableDefinition/fmt.sol
+++ b/crates/fmt/testdata/VariableDefinition/fmt.sol
@@ -1,5 +1,5 @@
 // config: line_length = 40
-contract Contract {
+contract Contract layout at 69 {
     bytes32 transient a;
 
     bytes32 private constant BYTES;

--- a/crates/fmt/testdata/VariableDefinition/fmt.sol
+++ b/crates/fmt/testdata/VariableDefinition/fmt.sol
@@ -1,5 +1,7 @@
 // config: line_length = 40
 contract Contract {
+    bytes32 transient a;
+
     bytes32 private constant BYTES;
     bytes32
         private

--- a/crates/fmt/testdata/VariableDefinition/original.sol
+++ b/crates/fmt/testdata/VariableDefinition/original.sol
@@ -1,4 +1,6 @@
 contract Contract {
+    bytes32 transient a;
+
     bytes32 constant private BYTES;
     bytes32 private constant override (Base1) BYTES;
     bytes32 private constant override (Base1, Base2) BYTES;

--- a/crates/fmt/testdata/VariableDefinition/original.sol
+++ b/crates/fmt/testdata/VariableDefinition/original.sol
@@ -1,4 +1,4 @@
-contract Contract {
+contract Contract layout at 69 {
     bytes32 transient a;
 
     bytes32 constant private BYTES;

--- a/crates/fmt/testdata/VariableDefinition/override-spacing.fmt.sol
+++ b/crates/fmt/testdata/VariableDefinition/override-spacing.fmt.sol
@@ -1,6 +1,8 @@
 // config: line_length = 40
 // config: override_spacing = true
 contract Contract {
+    bytes32 transient a;
+
     bytes32 private constant BYTES;
     bytes32
         private

--- a/crates/fmt/testdata/VariableDefinition/override-spacing.fmt.sol
+++ b/crates/fmt/testdata/VariableDefinition/override-spacing.fmt.sol
@@ -1,6 +1,6 @@
 // config: line_length = 40
 // config: override_spacing = true
-contract Contract {
+contract Contract layout at 69 {
     bytes32 transient a;
 
     bytes32 private constant BYTES;

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -107,8 +107,14 @@ fn test_formatter(
 
     assert_eof(expected_source);
 
-    let source_parsed = parse(source).unwrap();
-    let expected_parsed = parse(expected_source).unwrap();
+    let source_parsed = match parse(source) {
+        Ok(p) => p,
+        Err(e) => panic!("{e}"),
+    };
+    let expected_parsed = match parse(expected_source) {
+        Ok(p) => p,
+        Err(e) => panic!("{e}"),
+    };
 
     if !test_config.skip_compare_ast_eq && !source_parsed.pt.ast_eq(&expected_parsed.pt) {
         similar_asserts::assert_eq!(

--- a/crates/forge/src/cmd/fmt.rs
+++ b/crates/forge/src/cmd/fmt.rs
@@ -123,7 +123,8 @@ impl FmtArgs {
             solang_parser::parse(&output, 0).map_err(|diags| {
                 eyre::eyre!(
                     "Failed to construct valid Solidity code for {name}. Leaving source unchanged.\n\
-                     Debug info: {diags:?}"
+                     Debug info: {diags:?}\n\
+                     Formatted output:\n\n{output}"
                 )
             })?;
 


### PR DESCRIPTION
Hotpatch to foundry-solang-parser maintained at https://github.com/danipopes/solang (branch new-features) ([diff](https://github.com/hyperledger-solang/solang/compare/main...DaniPopes:solang:new-features)) for the following fixes:
- fixes #9088
- fixes #10244

note that this does not support more than just number literals in "layout at" due to a bug in solang-parser / lalrpop (build script runs forever if we allow any expression in that position)
