### PR TITLE
perf: find latest block for next-base-fee. replaces #10505

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1006,8 +1006,8 @@ impl Backend {
             }
         }
 
-        if let Some(block) = state.blocks.last() {
-            let header = &block.header;
+        if let Some(latest) = state.blocks.iter().max_by_key(|b|b.header.number) {
+            let header = &latest.header;
             let next_block_base_fee = self.fees.get_next_block_base_fee_per_gas(
                 header.gas_used as u128,
                 header.gas_limit as u128,

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1006,7 +1006,7 @@ impl Backend {
             }
         }
 
-        if let Some(latest) = state.blocks.iter().max_by_key(|b|b.header.number) {
+        if let Some(latest) = state.blocks.iter().max_by_key(|b| b.header.number) {
             let header = &latest.header;
             let next_block_base_fee = self.fees.get_next_block_base_fee_per_gas(
                 header.gas_used as u128,

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -409,13 +409,7 @@ impl BlockchainStorage {
     }
 
     pub fn serialized_blocks(&self) -> Vec<SerializableBlock> {
-        let mut blocks = self
-            .blocks
-            .values()
-            .map(|block| block.clone().into())
-            .collect::<Vec<SerializableBlock>>();
-        blocks.sort_by_key(|block| block.header.number);
-        blocks
+        self.blocks.values().map(|block|block.clone().into()).collect()
     }
 
     pub fn serialized_transactions(&self) -> Vec<SerializableTransaction> {

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -409,7 +409,7 @@ impl BlockchainStorage {
     }
 
     pub fn serialized_blocks(&self) -> Vec<SerializableBlock> {
-        self.blocks.values().map(|block|block.clone().into()).collect()
+        self.blocks.values().map(|block| block.clone().into()).collect()
     }
 
     pub fn serialized_transactions(&self) -> Vec<SerializableTransaction> {


### PR DESCRIPTION
Alternative fix to #10505 , which is itself a fix for https://github.com/foundry-rs/foundry/pull/10488

this works by finding the latest block when loading state, instead of performing a full block sort when saving, which adds unnecessary overhead

cc/ @mattsse @grandizzy 