### PR TITLE
chore: account for auths in 7702 min estimated gas

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -94,7 +94,7 @@ use futures::{
     StreamExt,
 };
 use parking_lot::RwLock;
-use revm::primitives::Bytecode;
+use revm::primitives::{eip7702::PER_EMPTY_ACCOUNT_COST, Bytecode};
 use std::{future::Future, sync::Arc, time::Duration};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 
@@ -3208,7 +3208,10 @@ fn determine_base_gas_by_kind(request: &WithOtherFields<TransactionRequest>) -> 
                 TxKind::Call(_) => MIN_TRANSACTION_GAS,
                 TxKind::Create => MIN_CREATE_GAS,
             },
-            TypedTransactionRequest::EIP7702(_) => MIN_TRANSACTION_GAS,
+            TypedTransactionRequest::EIP7702(req) => {
+                MIN_TRANSACTION_GAS +
+                    req.authorization_list.len() as u128 * PER_EMPTY_ACCOUNT_COST as u128
+            }
             TypedTransactionRequest::EIP2930(req) => match req.to {
                 TxKind::Call(_) => MIN_TRANSACTION_GAS,
                 TxKind::Create => MIN_CREATE_GAS,


### PR DESCRIPTION
the number of auths impacts the min gas, so we should respect that when picking the lowest gas during ethestimate