### PR TITLE
feat(forge): cheatcodes to crosschain sign and attach delegation

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -3252,7 +3252,7 @@
     },
     {
       "func": {
-        "id": "attachDelegation",
+        "id": "attachDelegation_0",
         "description": "Designate the next call as an EIP-7702 transaction",
         "declaration": "function attachDelegation(SignedDelegation calldata signedDelegation) external;",
         "visibility": "external",
@@ -3264,6 +3264,26 @@
           174,
           53,
           25
+        ]
+      },
+      "group": "scripting",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "attachDelegation_1",
+        "description": "Designate the next call as an EIP-7702 transaction, with cross chain option.",
+        "declaration": "function attachDelegation(SignedDelegation calldata signedDelegation, bool crossChain) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "attachDelegation((uint8,bytes32,bytes32,uint64,address),bool)",
+        "selector": "0xf4460d34",
+        "selectorBytes": [
+          244,
+          70,
+          13,
+          52
         ]
       },
       "group": "scripting",
@@ -9622,6 +9642,26 @@
     },
     {
       "func": {
+        "id": "signAndAttachDelegation_2",
+        "description": "Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction, with cross chain option.",
+        "declaration": "function signAndAttachDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "signAndAttachDelegation(address,uint256,bool)",
+        "selector": "0xd936e146",
+        "selectorBytes": [
+          217,
+          54,
+          225,
+          70
+        ]
+      },
+      "group": "scripting",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "signCompact_0",
         "description": "Signs data with a `Wallet`.\nReturns a compact signature (`r`, `vs`) as per EIP-2098, where `vs` encodes both the\nsignature's `s` value, and the recovery id `v` in a single bytes32.\nThis format reduces the signature size from 65 to 64 bytes.",
         "declaration": "function signCompact(Wallet calldata wallet, bytes32 digest) external returns (bytes32 r, bytes32 vs);",
@@ -9734,6 +9774,26 @@
           186,
           46,
           195
+        ]
+      },
+      "group": "scripting",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "signDelegation_2",
+        "description": "Sign an EIP-7702 authorization for delegation,  with cross chain option.",
+        "declaration": "function signDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "signDelegation(address,uint256,bool)",
+        "selector": "0xcdd7563d",
+        "selectorBytes": [
+          205,
+          215,
+          86,
+          61
         ]
       },
       "group": "scripting",

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -3273,7 +3273,7 @@
     {
       "func": {
         "id": "attachDelegation_1",
-        "description": "Designate the next call as an EIP-7702 transaction, with cross chain option.",
+        "description": "Designate the next call as an EIP-7702 transaction, with optional cross-chain validity.",
         "declaration": "function attachDelegation(SignedDelegation calldata signedDelegation, bool crossChain) external;",
         "visibility": "external",
         "mutability": "",
@@ -9643,7 +9643,7 @@
     {
       "func": {
         "id": "signAndAttachDelegation_2",
-        "description": "Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction, with cross chain option.",
+        "description": "Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction, with optional cross-chain validity.",
         "declaration": "function signAndAttachDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);",
         "visibility": "external",
         "mutability": "",
@@ -9783,7 +9783,7 @@
     {
       "func": {
         "id": "signDelegation_2",
-        "description": "Sign an EIP-7702 authorization for delegation,  with cross chain option.",
+        "description": "Sign an EIP-7702 authorization for delegation, with optional cross-chain validity.",
         "declaration": "function signDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);",
         "visibility": "external",
         "mutability": "",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2229,7 +2229,7 @@ interface Vm {
     #[cheatcode(group = Scripting)]
     function signDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);
 
-    /// Sign an EIP-7702 authorization for delegation,  with cross chain option.
+    /// Sign an EIP-7702 authorization for delegation, with optional cross-chain validity.
     #[cheatcode(group = Scripting)]
     function signDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);
 

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2237,7 +2237,7 @@ interface Vm {
     #[cheatcode(group = Scripting)]
     function attachDelegation(SignedDelegation calldata signedDelegation) external;
 
-    /// Designate the next call as an EIP-7702 transaction, with cross chain option.
+    /// Designate the next call as an EIP-7702 transaction, with optional cross-chain validity.
     #[cheatcode(group = Scripting)]
     function attachDelegation(SignedDelegation calldata signedDelegation, bool crossChain) external;
 

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2249,7 +2249,7 @@ interface Vm {
     #[cheatcode(group = Scripting)]
     function signAndAttachDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);
 
-    /// Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction, with cross chain option.
+    /// Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction, with optional cross-chain validity.
     #[cheatcode(group = Scripting)]
     function signAndAttachDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);
 

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2229,9 +2229,17 @@ interface Vm {
     #[cheatcode(group = Scripting)]
     function signDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);
 
+    /// Sign an EIP-7702 authorization for delegation,  with cross chain option.
+    #[cheatcode(group = Scripting)]
+    function signDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);
+
     /// Designate the next call as an EIP-7702 transaction
     #[cheatcode(group = Scripting)]
     function attachDelegation(SignedDelegation calldata signedDelegation) external;
+
+    /// Designate the next call as an EIP-7702 transaction, with cross chain option.
+    #[cheatcode(group = Scripting)]
+    function attachDelegation(SignedDelegation calldata signedDelegation, bool crossChain) external;
 
     /// Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction
     #[cheatcode(group = Scripting)]
@@ -2240,6 +2248,10 @@ interface Vm {
     /// Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction for specific nonce
     #[cheatcode(group = Scripting)]
     function signAndAttachDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);
+
+    /// Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction, with cross chain option.
+    #[cheatcode(group = Scripting)]
+    function signAndAttachDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);
 
     /// Attach an EIP-4844 blob to the next call
     #[cheatcode(group = Scripting)]

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -33,54 +33,81 @@ impl Cheatcode for broadcast_2Call {
     }
 }
 
-impl Cheatcode for attachDelegationCall {
+impl Cheatcode for attachDelegation_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { signedDelegation } = self;
-        let SignedDelegation { v, r, s, nonce, implementation } = signedDelegation;
+        attach_delegation(ccx, signedDelegation, false)
+    }
+}
 
-        let auth = Authorization {
-            address: *implementation,
-            nonce: *nonce,
-            chain_id: U256::from(ccx.ecx.env.cfg.chain_id),
-        };
-        let signed_auth = SignedAuthorization::new_unchecked(
-            auth,
-            *v,
-            U256::from_be_bytes(r.0),
-            U256::from_be_bytes(s.0),
-        );
-        write_delegation(ccx, signed_auth.clone())?;
-        ccx.state.active_delegation = Some(signed_auth);
-        Ok(Default::default())
+impl Cheatcode for attachDelegation_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { signedDelegation, crossChain } = self;
+        attach_delegation(ccx, signedDelegation, *crossChain)
     }
 }
 
 impl Cheatcode for signDelegation_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { implementation, privateKey } = *self;
-        sign_delegation(ccx, privateKey, implementation, None, false)
+        sign_delegation(ccx, privateKey, implementation, None, false, false)
     }
 }
 
 impl Cheatcode for signDelegation_1Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { implementation, privateKey, nonce } = *self;
-        sign_delegation(ccx, privateKey, implementation, Some(nonce), false)
+        sign_delegation(ccx, privateKey, implementation, Some(nonce), false, false)
+    }
+}
+
+impl Cheatcode for signDelegation_2Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { implementation, privateKey, crossChain } = *self;
+        sign_delegation(ccx, privateKey, implementation, None, crossChain, false)
     }
 }
 
 impl Cheatcode for signAndAttachDelegation_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { implementation, privateKey } = *self;
-        sign_delegation(ccx, privateKey, implementation, None, true)
+        sign_delegation(ccx, privateKey, implementation, None, false, true)
     }
 }
 
 impl Cheatcode for signAndAttachDelegation_1Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { implementation, privateKey, nonce } = *self;
-        sign_delegation(ccx, privateKey, implementation, Some(nonce), true)
+        sign_delegation(ccx, privateKey, implementation, Some(nonce), false, true)
     }
+}
+
+impl Cheatcode for signAndAttachDelegation_2Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { implementation, privateKey, crossChain } = *self;
+        sign_delegation(ccx, privateKey, implementation, None, crossChain, true)
+    }
+}
+
+/// Helper function to attach an EIP-7702 delegation.
+fn attach_delegation(
+    ccx: &mut CheatsCtxt,
+    delegation: &SignedDelegation,
+    cross_chain: bool,
+) -> Result {
+    let SignedDelegation { v, r, s, nonce, implementation } = delegation;
+    let chain_id = if cross_chain { U256::from(0) } else { U256::from(ccx.ecx.env.cfg.chain_id) };
+
+    let auth = Authorization { address: *implementation, nonce: *nonce, chain_id };
+    let signed_auth = SignedAuthorization::new_unchecked(
+        auth,
+        *v,
+        U256::from_be_bytes(r.0),
+        U256::from_be_bytes(s.0),
+    );
+    write_delegation(ccx, signed_auth.clone())?;
+    ccx.state.active_delegation = Some(signed_auth);
+    Ok(Default::default())
 }
 
 /// Helper function to sign and attach (if needed) an EIP-7702 delegation.
@@ -90,6 +117,7 @@ fn sign_delegation(
     private_key: Uint<256, 4>,
     implementation: Address,
     nonce: Option<u64>,
+    cross_chain: bool,
     attach: bool,
 ) -> Result<Vec<u8>> {
     let signer = PrivateKeySigner::from_bytes(&B256::from(private_key))?;
@@ -101,11 +129,9 @@ fn sign_delegation(
         // If we don't have a nonce then use next auth account nonce.
         authority_acc.data.info.nonce + 1
     };
-    let auth = Authorization {
-        address: implementation,
-        nonce,
-        chain_id: U256::from(ccx.ecx.env.cfg.chain_id),
-    };
+    let chain_id = if cross_chain { U256::from(0) } else { U256::from(ccx.ecx.env.cfg.chain_id) };
+
+    let auth = Authorization { address: implementation, nonce, chain_id };
     let sig = signer.sign_hash_sync(&auth.signature_hash())?;
     // Attach delegation.
     if attach {

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -96,6 +96,8 @@ fn attach_delegation(
     cross_chain: bool,
 ) -> Result {
     let SignedDelegation { v, r, s, nonce, implementation } = delegation;
+    // Set chain id to 0 if universal deployment is preferred.
+    // See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md#protection-from-malleability-cross-chain
     let chain_id = if cross_chain { U256::from(0) } else { U256::from(ccx.ecx.env.cfg.chain_id) };
 
     let auth = Authorization { address: *implementation, nonce: *nonce, chain_id };
@@ -159,6 +161,7 @@ fn write_delegation(ccx: &mut CheatsCtxt, auth: SignedAuthorization) -> Result<(
 
     if auth.address.is_zero() {
         // Set empty code if the delegation address of authority is 0x.
+        // See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md#behavior.
         ccx.ecx.journaled_state.set_code_with_hash(authority, Bytecode::default(), KECCAK_EMPTY);
     } else {
         let bytecode = Bytecode::new_eip7702(*auth.address());

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -157,6 +157,7 @@ interface Vm {
     function assumeNoRevert(PotentialRevert[] calldata potentialReverts) external pure;
     function attachBlob(bytes calldata blob) external;
     function attachDelegation(SignedDelegation calldata signedDelegation) external;
+    function attachDelegation(SignedDelegation calldata signedDelegation, bool crossChain) external;
     function blobBaseFee(uint256 newBlobBaseFee) external;
     function blobhashes(bytes32[] calldata hashes) external;
     function breakpoint(string calldata char) external pure;
@@ -474,12 +475,14 @@ interface Vm {
     function shuffle(uint256[] calldata array) external returns (uint256[] memory);
     function signAndAttachDelegation(address implementation, uint256 privateKey) external returns (SignedDelegation memory signedDelegation);
     function signAndAttachDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);
+    function signAndAttachDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);
     function signCompact(Wallet calldata wallet, bytes32 digest) external returns (bytes32 r, bytes32 vs);
     function signCompact(uint256 privateKey, bytes32 digest) external pure returns (bytes32 r, bytes32 vs);
     function signCompact(bytes32 digest) external pure returns (bytes32 r, bytes32 vs);
     function signCompact(address signer, bytes32 digest) external pure returns (bytes32 r, bytes32 vs);
     function signDelegation(address implementation, uint256 privateKey) external returns (SignedDelegation memory signedDelegation);
     function signDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);
+    function signDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);
     function signP256(uint256 privateKey, bytes32 digest) external pure returns (bytes32 r, bytes32 s);
     function sign(Wallet calldata wallet, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
     function sign(uint256 privateKey, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);

--- a/testdata/default/cheats/AttachDelegation.t.sol
+++ b/testdata/default/cheats/AttachDelegation.t.sol
@@ -39,6 +39,22 @@ contract AttachDelegationTest is DSTest {
         assertEq(token.balanceOf(bob), 100);
     }
 
+    function testCallSingleAttachCrossChainDelegation() public {
+        Vm.SignedDelegation memory signedDelegation = vm.signDelegation(address(implementation), alice_pk, true);
+        SimpleDelegateContract.Call[] memory calls = new SimpleDelegateContract.Call[](1);
+        bytes memory data = abi.encodeCall(ERC20.mint, (100, bob));
+        calls[0] = SimpleDelegateContract.Call({to: address(token), data: data, value: 0});
+        // executing as bob to make clear that we don't need to execute the tx as alice
+        vm.broadcast(bob_pk);
+        vm.attachDelegation(signedDelegation, true);
+
+        bytes memory code = address(alice).code;
+        require(code.length > 0, "no code written to alice");
+        SimpleDelegateContract(alice).execute(calls);
+
+        assertEq(token.balanceOf(bob), 100);
+    }
+
     /// forge-config: default.allow_internal_expect_revert = true
     function testCallSingleAttachDelegationWithNonce() public {
         Vm.SignedDelegation memory signedDelegation = vm.signDelegation(address(implementation), alice_pk, 11);
@@ -54,6 +70,26 @@ contract AttachDelegationTest is DSTest {
         Vm.SignedDelegation memory signedDelegation = vm.signDelegation(address(implementation), alice_pk);
         vm.broadcast(bob_pk);
         vm.attachDelegation(signedDelegation);
+
+        SimpleDelegateContract.Call[] memory calls = new SimpleDelegateContract.Call[](2);
+        calls[0] =
+            SimpleDelegateContract.Call({to: address(token), data: abi.encodeCall(ERC20.mint, (50, bob)), value: 0});
+        calls[1] = SimpleDelegateContract.Call({
+            to: address(token),
+            data: abi.encodeCall(ERC20.mint, (50, address(this))),
+            value: 0
+        });
+
+        SimpleDelegateContract(alice).execute(calls);
+
+        assertEq(token.balanceOf(bob), 50);
+        assertEq(token.balanceOf(address(this)), 50);
+    }
+
+    function testMultiCallAttachCrossChainDelegation() public {
+        Vm.SignedDelegation memory signedDelegation = vm.signDelegation(address(implementation), alice_pk, true);
+        vm.broadcast(bob_pk);
+        vm.attachDelegation(signedDelegation, true);
 
         SimpleDelegateContract.Call[] memory calls = new SimpleDelegateContract.Call[](2);
         calls[0] =
@@ -130,6 +166,19 @@ contract AttachDelegationTest is DSTest {
         bytes memory data = abi.encodeCall(ERC20.mint, (100, bob));
         calls[0] = SimpleDelegateContract.Call({to: address(token), data: data, value: 0});
         vm.signAndAttachDelegation(address(implementation), alice_pk);
+        bytes memory code = address(alice).code;
+        require(code.length > 0, "no code written to alice");
+        vm.broadcast(bob_pk);
+        SimpleDelegateContract(alice).execute(calls);
+
+        assertEq(token.balanceOf(bob), 100);
+    }
+
+    function testCallSingleSignAndAttachCrossChainDelegation() public {
+        SimpleDelegateContract.Call[] memory calls = new SimpleDelegateContract.Call[](1);
+        bytes memory data = abi.encodeCall(ERC20.mint, (100, bob));
+        calls[0] = SimpleDelegateContract.Call({to: address(token), data: data, value: 0});
+        vm.signAndAttachDelegation(address(implementation), alice_pk, true);
         bytes memory code = address(alice).code;
         require(code.length > 0, "no code written to alice");
         vm.broadcast(bob_pk);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #10517 
- add sigs with `crossChain` arg (sets nonce to 0)
```Solidity
function signDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);

function attachDelegation(SignedDelegation calldata signedDelegation, bool crossChain) external;

function signAndAttachDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes