### PR TITLE
fix: fix formating crash caused by non-breaking space in comment.

### DIFF
--- a/crates/fmt/src/buffer.rs
+++ b/crates/fmt/src/buffer.rs
@@ -181,7 +181,7 @@ impl<W: Write> FormatBuffer<W> {
                 .take(self.base_indent_len)
                 .take_while(|(_, _, ch)| ch.is_whitespace())
                 .last()
-                .map(|(state, idx, _)| (state, idx + 1))
+                .map(|(state, idx, ch)| (state, idx + ch.len_utf8()))
                 .unwrap_or((comment_state, 0));
             comment_state = new_comment_state;
             let trimmed_line = &line[line_start..];


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Fix: #10519.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Changing the `index+1` to `index+ch.len_utf8()`, Since Unicode space is not just one byte, the index should be adjusted based on UTF-8 length.
Check the implementation of the `is_whitespace` in std lib:
https://github.com/rust-lang/rust/blob/414482f6a0d4e7290f614300581a0b55442552a3/library/core/src/char/methods.rs#L891-L896
and https://en.wikipedia.org/wiki/Non-breaking_space

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes