### PR TITLE
fix(`Makefile`): update `lint-foundry` target to explicitly use nightly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ fmt: ## Run all formatters.
 	./.github/scripts/format.sh --check
 
 lint-foundry:
-	RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets --all-features
+	RUSTFLAGS="-Dwarnings" cargo +nightly clippy --workspace --all-targets --all-features
 
 lint-codespell: ensure-codespell
 	codespell --skip "*.json"


### PR DESCRIPTION
## Motivation

Fix #10525

## Solution

use explicitly `nightly` toolchain in Makefile `lint-foundry` target.