### PR TITLE
feat(cast): Verbose signing output

### DIFF
--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -454,9 +454,29 @@ impl WalletSubcommands {
                 } else {
                     wallet.sign_message(&Self::hex_str_to_bytes(&message)?).await?
                 };
-                sh_println!("message: {}", message)?;
-                sh_println!("address: {}", wallet.address())?;
-                sh_println!("signature: 0x{}", hex::encode(sig.as_bytes()))?;
+
+                if shell::verbosity() > 0 {
+                    if shell::is_json() {
+                        sh_println!(
+                            "{}",
+                            serde_json::to_string_pretty(&json!({
+                                "message": message,
+                                "address": wallet.address(),
+                                "signature": hex::encode(sig.as_bytes()),
+                            }))?
+                        )?;
+                    } else {
+                        sh_println!(
+                            "Successfully signed!\n   Message: {}\n   Address: {}\n   Signature: 0x{}",
+                            message,
+                            wallet.address(),
+                            hex::encode(sig.as_bytes()),
+                        )?;
+                    }
+                } else {
+                    // Pipe friendly output
+                    sh_println!("0x{}", hex::encode(sig.as_bytes()))?;
+                }
             }
             Self::SignAuth { rpc, nonce, chain, wallet, address } => {
                 let wallet = wallet.signer().await?;

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -454,7 +454,9 @@ impl WalletSubcommands {
                 } else {
                     wallet.sign_message(&Self::hex_str_to_bytes(&message)?).await?
                 };
-                sh_println!("0x{}", hex::encode(sig.as_bytes()))?;
+                sh_println!("message: {}", message)?;
+                sh_println!("address: {}", wallet.address())?;
+                sh_println!("signature: 0x{}", hex::encode(sig.as_bytes()))?;
             }
             Self::SignAuth { rpc, nonce, chain, wallet, address } => {
                 let wallet = wallet.signer().await?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

closes #10424

Adds some extra logging to the signing of a transaction.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I simply added two logs at the end of signing. 

I wonder if this might be considered a breaking change? If some tools rely on the cli output to only return the signature, they would need to add extra parsing... 

We could add a verbosity flag, open to ideas


## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
