### PR TITLE
Add standard-json as inspect output field

### DIFF
--- a/crates/forge/src/cmd/inspect.rs
+++ b/crates/forge/src/cmd/inspect.rs
@@ -62,7 +62,7 @@ impl InspectArgs {
         };
 
         // Get the solc version if specified
-        let solc_version = build.use_solc.as_ref().cloned();
+        let solc_version = build.use_solc.clone();
 
         // Build modified Args
         let modified_build_args = BuildOpts {

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3635,6 +3635,53 @@ forgetest!(inspect_custom_counter_method_identifiers, |prj, cmd| {
 "#]]);
 });
 
+forgetest_init!(can_inspect_standard_json, |prj, cmd| {
+    cmd.args(["inspect", "src/Counter.sol:Counter", "standard-json"]).assert_success().stdout_eq(str![[r#"
+{
+  "language": "Solidity",
+  "sources": {
+    "src/Counter.sol": {
+      "content": "// SPDX-License-Identifier: UNLICENSED/npragma solidity ^0.8.13;/n/ncontract Counter {/n    uint256 public number;/n/n    function setNumber(uint256 newNumber) public {/n        number = newNumber;/n    }/n/n    function increment() public {/n        number++;/n    }/n}/n"
+    }
+  },
+  "settings": {
+    "remappings": [
+      "forge-std/=lib/forge-std/src/"
+    ],
+    "optimizer": {
+      "enabled": false,
+      "runs": 200
+    },
+    "metadata": {
+      "useLiteralContent": false,
+      "bytecodeHash": "ipfs",
+      "appendCBOR": true
+    },
+    "outputSelection": {
+      "*": {
+        "*": [
+          "abi",
+          "evm.bytecode.object",
+          "evm.bytecode.sourceMap",
+          "evm.bytecode.linkReferences",
+          "evm.deployedBytecode.object",
+          "evm.deployedBytecode.sourceMap",
+          "evm.deployedBytecode.linkReferences",
+          "evm.deployedBytecode.immutableReferences",
+          "evm.methodIdentifiers",
+          "metadata"
+        ]
+      }
+    },
+    "evmVersion": "cancun",
+    "viaIR": false,
+    "libraries": {}
+  }
+}
+
+"#]]);
+});
+
 // checks that `clean` also works with the "out" value set in Config
 forgetest_init!(gas_report_include_tests, |prj, cmd| {
     prj.update_config(|config| {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

We need a stable way of getting the standard JSON input from a foundry project. There is also an existing related issue for this https://github.com/foundry-rs/book/issues/1350.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add a new field option to `forge inspect` command to allow it to output the standard JSON input retrieved from the project.

## PR Checklist

- [X] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes