### PR TITLE
fix(`common`): find target by path if present

### DIFF
--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -454,6 +454,29 @@ pub fn find_target_path(project: &Project, identifier: &PathOrContractInfo) -> R
     match identifier {
         PathOrContractInfo::Path(path) => Ok(canonicalized(project.root().join(path))),
         PathOrContractInfo::ContractInfo(info) => {
+            if let Some(path) = info.path.as_ref() {
+                let path = canonicalized(project.root().join(path));
+                let sources = project.sources()?;
+                let contract_path = sources
+                    .iter()
+                    .find_map(|(src_path, _)| {
+                        if **src_path == path {
+                            return Some(src_path.clone());
+                        }
+                        None
+                    })
+                    .ok_or_else(|| {
+                        eyre::eyre!(
+                            "Could not find source file for contract `{}` at {}",
+                            info.name,
+                            path.strip_prefix(project.root()).unwrap().display()
+                        )
+                    })?;
+                return Ok(contract_path)
+            }
+            // If ContractInfo.path hasn't been provided we try to find the contract using the name.
+            // This will fail if projects have multiple contracts with the same name. In that case,
+            // path must be specified.
             let path = project.find_contract_path(&info.name)?;
             Ok(path)
         }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3572,6 +3572,42 @@ forgetest!(test_inspect_contract_with_same_name, |prj, cmd| {
 "#]]);
 });
 
+// <https://github.com/foundry-rs/foundry/issues/10531>
+forgetest!(inspect_multiple_contracts_with_different_paths, |prj, cmd| {
+    prj.add_source(
+        "Source.sol",
+        r#"
+    contract Source {
+        function foo() public {}
+    }   
+    "#,
+    )
+    .unwrap();
+
+    prj.add_source(
+        "another/Source.sol",
+        r#"
+    contract Source {
+        function bar() public {}
+    }
+    "#,
+    )
+    .unwrap();
+
+    cmd.args(["inspect", "src/another/Source.sol:Source", "methodIdentifiers"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+
+╭--------+------------╮
+| Method | Identifier |
++=====================+
+| bar()  | febb0f7e   |
+╰--------+------------╯
+
+
+"#]]);
+});
+
 forgetest!(inspect_custom_counter_method_identifiers, |prj, cmd| {
     prj.add_source("Counter.sol", CUSTOM_COUNTER).unwrap();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #10531 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- There maybe multiple contracts with the same name in a project. 
- `find_contract_path` from compilers: https://github.com/foundry-rs/compilers/blob/b1b9e58d276b8b2635149ede841dce96b10b79f4/crates/compilers/src/lib.rs#L409 would fail in this case as it is geared towards finding a path using only the contract name.
- Try to find the target using the path if present, fallback to `find_contract_path` 



<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes