### PR TITLE
docs: fix broken OpenZeppelin upgradeable-contracts link

### DIFF
--- a/crates/cli/src/opts/dependency.rs
+++ b/crates/cli/src/opts/dependency.rs
@@ -300,7 +300,7 @@ mod tests {
         assert_eq!(dep.name, "contracts-upgradeable");
         assert_eq!(
             dep.url,
-            Some("https://github.com/openzeppelin/contracts-upgradeable".to_string())
+            Some("https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable".to_string())
         );
         assert_eq!(dep.tag, None);
         assert_eq!(dep.alias, None);
@@ -312,7 +312,7 @@ mod tests {
         assert_eq!(dep.name, "contracts-upgradeable");
         assert_eq!(
             dep.url,
-            Some("https://github.com/openzeppelin/contracts-upgradeable".to_string())
+            Some("https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable".to_string())
         );
         assert_eq!(dep.tag, Some("v1".to_string()));
         assert_eq!(dep.alias, None);


### PR DESCRIPTION
Replaces the obsolete URL `https://github.com/openzeppelin/contracts-upgradeable` with the correct repository `https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable`.  
This change affects documentation only; no contract logic is modified.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes