### PR TITLE
fix(fmt): 'at' is not a keyword

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4696,9 +4696,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-solang-parser"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b7633ca67d24a96ad90715d15be108ed8ddd35e7632884126838dfc60c7c9"
+checksum = "33c5fc5210af6b311ab9c6bce41d651d1cd0ab62ea5e0e7fde9635697fb19180"
 dependencies = [
  "itertools 0.14.0",
  "lalrpop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ foundry-linking = { path = "crates/linking" }
 foundry-block-explorers = { version = "0.17.0", default-features = false }
 foundry-compilers = { version = "0.16.1", default-features = false }
 foundry-fork-db = "0.14"
-solang-parser = { version = "=0.3.7", package = "foundry-solang-parser" }
+solang-parser = { version = "=0.3.8", package = "foundry-solang-parser" }
 solar-parse = { version = "=0.1.3", default-features = false }
 solar-sema = { version = "=0.1.3", default-features = false }
 

--- a/crates/fmt/testdata/NonKeywords/fmt.sol
+++ b/crates/fmt/testdata/NonKeywords/fmt.sol
@@ -1,0 +1,42 @@
+struct S {
+    uint256 error;
+    // uint256 layout;
+    uint256 at;
+}
+// uint256 transient;
+
+function f() {
+    uint256 error = 0;
+    // uint256 layout = 0;
+    uint256 at = 0;
+    // uint256 transient = 0;
+
+    error = 0;
+    // layout = 0;
+    at = 0;
+    // transient = 0;
+
+    S memory x = S({
+        error: 0,
+        // layout: 0,
+        at: 0
+    });
+    // transient: 0
+
+    x.error = 0;
+    // x.layout = 0;
+    x.at = 0;
+    // x.transient = 0;
+
+    assembly {
+        let error := 0
+        // let layout := 0
+        let at := 0
+        // let transient := 0
+
+        error := 0
+        // layout := 0
+        at := 0
+        // transient := 0
+    }
+}

--- a/crates/fmt/testdata/NonKeywords/original.sol
+++ b/crates/fmt/testdata/NonKeywords/original.sol
@@ -1,0 +1,42 @@
+struct S {
+    uint256 error;
+    // uint256 layout;
+    uint256 at;
+    // uint256 transient;
+}
+
+function f() {
+    uint256 error = 0;
+    // uint256 layout = 0;
+    uint256 at = 0;
+    // uint256 transient = 0;
+
+    error = 0;
+    // layout = 0;
+    at = 0;
+    // transient = 0;
+
+    S memory x = S({
+        error: 0,
+        // layout: 0,
+        at: 0
+        // transient: 0
+    });
+
+    x.error = 0;
+    // x.layout = 0;
+    x.at = 0;
+    // x.transient = 0;
+
+    assembly {
+        let error := 0
+        // let layout := 0
+        let at := 0
+        // let transient := 0
+
+        error := 0
+        // layout := 0
+        at := 0
+        // transient := 0
+    }
+}

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -217,6 +217,7 @@ test_directories! {
     TryStatement,
     ConditionalOperatorExpression,
     NamedFunctionCallExpression,
+    NonKeywords,
     ArrayExpressions,
     UnitExpression,
     ThisExpression,


### PR DESCRIPTION
Unfortunately it looks like it's the only one we can special case without blowing up the solang-parser build script, same limitation as in only allowing number literals in "layout at" specifiers.

Fixes https://github.com/foundry-rs/foundry/issues/10554.