### PR TITLE
fix(`forge bind`): add `serde` as a dependency to generated `Cargo.toml` if `Serde` is being derived in bindings

### DIFF
--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -184,6 +184,11 @@ edition = "2021"
         let alloy_dep = Self::get_alloy_dep(alloy_version, alloy_rev);
         write!(toml_contents, "{alloy_dep}")?;
 
+        if all_derives {
+            let serde_dep = r#"serde = { version = "1.0", features = ["derive"] }"#;
+            write!(toml_contents, "\n{serde_dep}")?;
+        }
+
         fs::write(cargo_toml_path, toml_contents).wrap_err("Failed to write Cargo.toml")?;
 
         let mut lib_contents = String::new();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/10321

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Noticed Alloy bindings by default would add `Serde` derives but would not add `serde` as a dependency.

If the `--skip-extra-derives` flag is passed we won't add it.

Was able to reproduce `forge bind` prior to 1.0 bump would fail to build as noted here: https://github.com/foundry-rs/foundry/issues/10321#issuecomment-2811885228

Manually confirmed `forge bind` to now run succesfully post-1.0 with this fix.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes