### PR TITLE
fix(`anvil`): inject the P256 precompile for `--odyssey` upon EVM construction and fix `NotActivated` for `--optimism`

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -431,9 +431,7 @@ where
     I: Inspector<EthEvmContext<DB>> + Inspector<OpContext<DB>>,
 {
     if env.is_optimism {
-        // TODO: we currently pin to `OpSpecId::BEDROCK` as it is primarily used in the context of
-        // testing deposit transactions. We should make this configurable in the future.
-        let op_cfg = env.evm_env.cfg_env.clone().with_spec(op_revm::OpSpecId::BEDROCK);
+        let op_cfg = env.evm_env.cfg_env.clone().with_spec(op_revm::OpSpecId::ISTHMUS);
         let op_context = OpContext {
             journaled_state: {
                 let mut journal = Journal::new(db);

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -33,7 +33,7 @@ use revm::{
     database::WrapDatabaseRef,
     handler::{instructions::EthInstructions, EthPrecompiles},
     interpreter::InstructionResult,
-    precompile::{PrecompileSpecId, Precompiles},
+    precompile::{secp256r1::P256VERIFY, PrecompileSpecId, Precompiles},
     primitives::hardfork::SpecId,
     Database, DatabaseRef, Inspector, Journal,
 };
@@ -326,6 +326,11 @@ impl<DB: Db + ?Sized, V: TransactionValidator> Iterator for &mut TransactionExec
 
         let exec_result = {
             let mut evm = new_evm_with_inspector(&mut *self.db, &env, &mut inspector);
+
+            if self.odyssey {
+                inject_precompiles(&mut evm, vec![P256VERIFY]);
+            }
+
             if let Some(factory) = &self.precompile_factory {
                 inject_precompiles(&mut evm, factory.precompiles());
             }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -114,6 +114,7 @@ use revm::{
     },
     database::{CacheDB, DatabaseRef, WrapDatabaseRef},
     interpreter::InstructionResult,
+    precompile::secp256r1::P256VERIFY,
     primitives::{hardfork::SpecId, KECCAK_EMPTY},
     state::AccountInfo,
     DatabaseCommit, Inspector,
@@ -1107,6 +1108,10 @@ impl Backend {
             Database<Error = DatabaseError>,
     {
         let mut evm = new_evm_with_inspector_ref(db, env, inspector);
+
+        if self.odyssey {
+            inject_precompiles(&mut evm, vec![P256VERIFY]);
+        }
 
         if let Some(factory) = &self.precompile_factory {
             inject_precompiles(&mut evm, factory.precompiles());

--- a/crates/anvil/src/evm.rs
+++ b/crates/anvil/src/evm.rs
@@ -36,7 +36,7 @@ mod tests {
 
     use alloy_evm::{eth::EthEvmContext, precompiles::PrecompilesMap, EthEvm, Evm, EvmEnv};
     use alloy_op_evm::OpEvm;
-    use alloy_primitives::{address, Address, Bytes, TxKind};
+    use alloy_primitives::{address, Address, Bytes, TxKind, U256};
     use foundry_evm_core::either_evm::EitherEvm;
     use itertools::Itertools;
     use op_revm::{precompiles::OpPrecompiles, L1BlockInfo, OpContext, OpSpecId, OpTransaction};
@@ -59,8 +59,8 @@ mod tests {
     // A precompile activated in the `Prague` spec.
     const ETH_PRAGUE_PRECOMPILE: Address = address!("0x0000000000000000000000000000000000000011");
 
-    // A precompile activated in the `Fjord` spec.
-    const OP_FROJD_PRECOMPILE: Address = address!("0x0000000000000000000000000000000000000100");
+    // A precompile activated in the `Isthmus` spec.
+    const OP_ISTHMUS_PRECOMPILE: Address = address!("0x0000000000000000000000000000000000000100");
 
     // A custom precompile address and payload for testing.
     const PRECOMPILE_ADDR: Address = address!("0x0000000000000000000000000000000000000071");
@@ -147,6 +147,13 @@ mod tests {
             is_optimism: true,
         };
 
+        let mut chain = L1BlockInfo::default();
+
+        if op_spec == OpSpecId::ISTHMUS {
+            chain.operator_fee_constant = Some(U256::from(0));
+            chain.operator_fee_scalar = Some(U256::from(0));
+        }
+
         let op_cfg = op_env.evm_env.cfg_env.clone().with_spec(op_spec);
         let op_evm_context = OpContext {
             journaled_state: {
@@ -158,7 +165,7 @@ mod tests {
             block: op_env.evm_env.block_env.clone(),
             cfg: op_cfg.clone(),
             tx: op_env.tx.clone(),
-            chain: L1BlockInfo::default(),
+            chain,
             local: LocalContext::default(),
             error: Ok(()),
         };
@@ -223,18 +230,13 @@ mod tests {
 
     #[test]
     fn build_op_evm_with_extra_precompiles_default_spec() {
-        let (env, mut evm) = create_op_evm(
-            SpecId::default(),
-            // TODO: OpSpecId::ISTHMUS is not yet supported, fails with: `Missing operator fee
-            // scalar for isthmus L1 Block`.
-            OpSpecId::HOLOCENE,
-        );
+        let (env, mut evm) = create_op_evm(SpecId::default(), OpSpecId::ISTHMUS);
 
-        // Check that the Fjord precompile IS present when using the default spec.
-        assert!(evm.precompiles_mut().addresses().contains(&OP_FROJD_PRECOMPILE));
+        // Check that the Isthmus precompile IS present when using the default spec.
+        assert!(evm.precompiles_mut().addresses().contains(&OP_ISTHMUS_PRECOMPILE));
 
-        // Check that the Prague precompile is NOT present when using the default spec.
-        assert!(!evm.precompiles_mut().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
+        // Check that the Prague precompile IS present when using the default spec.
+        assert!(evm.precompiles_mut().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
 
         assert!(!evm.precompiles_mut().addresses().contains(&PRECOMPILE_ADDR));
 
@@ -255,8 +257,8 @@ mod tests {
     fn build_op_evm_with_extra_precompiles_bedrock_spec() {
         let (env, mut evm) = create_op_evm(SpecId::default(), OpSpecId::BEDROCK);
 
-        // Check that the Fjord precompile IS NOT present when using the `OpSpecId::BEDROCK` spec.
-        assert!(!evm.precompiles_mut().addresses().contains(&OP_FROJD_PRECOMPILE));
+        // Check that the Isthmus precompile IS NOT present when using the `OpSpecId::BEDROCK` spec.
+        assert!(!evm.precompiles_mut().addresses().contains(&OP_ISTHMUS_PRECOMPILE));
 
         // Check that the Prague precompile IS NOT present when using the `OpSpecId::BEDROCK` spec.
         assert!(!evm.precompiles_mut().addresses().contains(&ETH_PRAGUE_PRECOMPILE));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/10566

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Injects the P256 precompile if `--odyssey` is passed.

Adds support for Isthmus OP hardfork as defaulting to OP Bedrock raised `NotActivated`.

The Isthmus hardfork requires two fields to be set but can fortunately be mocked by `Some(0)`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes