### PR TITLE
fix(cheatcodes): enforce exit code check for `ffiCall`

### DIFF
--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -532,7 +532,17 @@ impl Cheatcode for ffiCall {
         let Self { commandInput: input } = self;
 
         let output = ffi(state, input)?;
-        // TODO: check exit code?
+
+        if output.exitCode != 0 {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(fmt_err!(
+                "FFI command {:?} failed with exit code {}: {}",
+                input,
+                output.exitCode,
+                stderr
+            ));
+        }
+
         if !output.stderr.is_empty() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             error!(target: "cheatcodes", ?input, ?stderr, "non-empty stderr");


### PR DESCRIPTION
- Added a check for `output.exitCode != 0` in `ffiCall`.
- If the exit code is non-zero, the error is returned with the stderr content.
- The existing behavior for `tryFfiCall` remains unchanged (no exit code enforcement).

This makes `ffiCall` behavior safer and better aligned with expected shell semantics.