### PR TITLE
forge(fix): update persistent storage from active db

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1102,11 +1102,26 @@ impl DatabaseExt for Backend {
             // update the shared state and track
             let mut fork = self.inner.take_fork(idx);
 
-            // Make sure all persistent accounts on the newly selected fork starts from the init
-            // state (from setup).
-            for addr in &self.inner.persistent_accounts {
-                if let Some(account) = self.fork_init_journaled_state.state.get(addr) {
-                    fork.journaled_state.state.insert(*addr, account.clone());
+            // Make sure all persistent accounts on the newly selected fork reflect same state as
+            // the active db / previous fork.
+            // This can get out of sync when multiple forks are created on test `setUp`, then a
+            // fork is selected and persistent contract is changed. If first action in test is to
+            // select a different fork, then the persistent contract state won't reflect changes
+            // done in `setUp` for the other fork.
+            // See <https://github.com/foundry-rs/foundry/issues/10296> and <https://github.com/foundry-rs/foundry/issues/10552>.
+            for addr in self.inner.persistent_accounts.clone() {
+                if let Some(db) = self.active_fork_db_mut() {
+                    let Ok(db_account) = db.load_account(addr) else { continue };
+
+                    let Some(fork_account) = fork.journaled_state.state.get_mut(&addr) else {
+                        continue
+                    };
+
+                    for (key, val) in &db_account.storage {
+                        if let Some(fork_storage) = fork_account.storage.get_mut(&key) {
+                            fork_storage.present_value = *val;
+                        }
+                    }
                 }
             }
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1109,8 +1109,9 @@ impl DatabaseExt for Backend {
             // select a different fork, then the persistent contract state won't reflect changes
             // done in `setUp` for the other fork.
             // See <https://github.com/foundry-rs/foundry/issues/10296> and <https://github.com/foundry-rs/foundry/issues/10552>.
-            for addr in self.inner.persistent_accounts.clone() {
-                if let Some(db) = self.active_fork_db_mut() {
+            let persistent_accounts = self.inner.persistent_accounts.clone();
+            if let Some(db) = self.active_fork_db_mut() {
+                for addr in persistent_accounts {
                     let Ok(db_account) = db.load_account(addr) else { continue };
 
                     let Some(fork_account) = fork.journaled_state.state.get_mut(&addr) else {
@@ -1118,7 +1119,7 @@ impl DatabaseExt for Backend {
                     };
 
                     for (key, val) in &db_account.storage {
-                        if let Some(fork_storage) = fork_account.storage.get_mut(&key) {
+                        if let Some(fork_storage) = fork_account.storage.get_mut(key) {
                             fork_storage.present_value = *val;
                         }
                     }

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -3521,6 +3521,7 @@ contract InterceptInitcodeTest is DSTest {
 });
 
 // <https://github.com/foundry-rs/foundry/issues/10296>
+// <https://github.com/foundry-rs/foundry/issues/10552>
 forgetest_init!(should_preserve_fork_state_setup, |prj, cmd| {
     prj.wipe_contracts();
     prj.add_test(

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -407,3 +407,6 @@ test_repro!(10477);
 
 // https://github.com/foundry-rs/foundry/issues/10527
 test_repro!(10527);
+
+// https://github.com/foundry-rs/foundry/issues/10552
+test_repro!(10552);

--- a/testdata/default/repros/Issue10552.t.sol
+++ b/testdata/default/repros/Issue10552.t.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract Counter {
+    uint256 public number;
+    uint256 public anotherNumber;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function setAnotherNumber(uint256 newNumber) public {
+        anotherNumber = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}
+
+contract Issue10552Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    Counter public counter;
+    uint256 mainnetId;
+    uint256 opId;
+
+    function setUp() public {
+        counter = new Counter();
+        counter.setNumber(10);
+        vm.makePersistent(address(counter));
+
+        mainnetId = vm.createFork("mainnet");
+        opId = vm.createFork("optimism");
+
+        vm.selectFork(mainnetId);
+        counter.setNumber(100);
+        counter.increment();
+        assertEq(counter.number(), 101);
+
+        counter.increment();
+        assertEq(counter.number(), 102);
+    }
+
+    function test_change_fork_states() public {
+        vm.selectFork(opId);
+        counter.increment();
+        // should account state changes from mainnet fork
+        // without fix for <https://github.com/foundry-rs/foundry/issues/10552> this test was failing with 11 (initial setNumber(10) + one increment) != 103
+        assertEq(counter.number(), 103);
+        counter.setAnotherNumber(11);
+        assertEq(counter.anotherNumber(), 11);
+
+        vm.selectFork(mainnetId);
+        counter.increment();
+        assertEq(counter.number(), 104);
+        assertEq(counter.anotherNumber(), 11);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #10552 
- prev fix for https://github.com/foundry-rs/foundry/issues/10296 didn't account all changes and introduced regression due to replacing entire persistent accounts when new fork selected
- make sure all persistent accounts on the newly selected fork reflect same state as the active db. It can get out of sync when first action in test is to select a different fork than the one used in `setUp` to change the persistent contract

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes