### PR TITLE
chore: avoid unnecessary use of `inspector_mut`, `precompiles_mut` in precompile injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0210f2d5854895b376f7fbbf78f3e33eb4f0e59abc503502cc0ed8d295a837"
+checksum = "b8c5b34c78c42525917b236e4135b1951ca183ede4004b594db0effee8bed169"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.5",
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee0165cc5f92d8866c0a21320ee6f089a7e1d0cebbf7008c37a6380a912ebe2"
+checksum = "e4fda8b1920a38a5adc607d6ff7be1e8991e16ffcf97bb12765644b87331c598"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,8 +253,8 @@ revm-inspectors = { version = "0.22.3", features = ["serde"] }
 op-revm = { version = "4.0.2", default-features = false }
 
 ## alloy-evm
-alloy-evm = "0.8.1"
-alloy-op-evm = "0.8.1"
+alloy-evm = "0.9.1"
+alloy-op-evm = "0.9.1"
 
 ## cli
 anstream = "0.6"

--- a/crates/anvil/src/evm.rs
+++ b/crates/anvil/src/evm.rs
@@ -189,13 +189,13 @@ mod tests {
         let (env, mut evm) = create_eth_evm(SpecId::default());
 
         // Check that the Prague precompile IS present when using the default spec.
-        assert!(evm.precompiles_mut().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
+        assert!(evm.precompiles().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
 
-        assert!(!evm.precompiles_mut().addresses().contains(&PRECOMPILE_ADDR));
+        assert!(!evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         inject_precompiles(&mut evm, CustomPrecompileFactory.precompiles());
 
-        assert!(evm.precompiles_mut().addresses().contains(&PRECOMPILE_ADDR));
+        assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         let result = match &mut evm {
             EitherEvm::Eth(eth_evm) => eth_evm.transact(env.tx).unwrap(),
@@ -211,13 +211,13 @@ mod tests {
         let (env, mut evm) = create_eth_evm(SpecId::LONDON);
 
         // Check that the Prague precompile IS NOT present when using the London spec.
-        assert!(!evm.precompiles_mut().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
+        assert!(!evm.precompiles().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
 
-        assert!(!evm.precompiles_mut().addresses().contains(&PRECOMPILE_ADDR));
+        assert!(!evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         inject_precompiles(&mut evm, CustomPrecompileFactory.precompiles());
 
-        assert!(evm.precompiles_mut().addresses().contains(&PRECOMPILE_ADDR));
+        assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         let result = match &mut evm {
             EitherEvm::Eth(eth_evm) => eth_evm.transact(env.tx).unwrap(),
@@ -230,19 +230,19 @@ mod tests {
 
     #[test]
     fn build_op_evm_with_extra_precompiles_default_spec() {
-        let (env, mut evm) = create_op_evm(SpecId::default(), OpSpecId::ISTHMUS);
+        let (env, mut evm) = create_op_evm(SpecId::default(), OpSpecId::default());
 
         // Check that the Isthmus precompile IS present when using the default spec.
-        assert!(evm.precompiles_mut().addresses().contains(&OP_ISTHMUS_PRECOMPILE));
+        assert!(evm.precompiles().addresses().contains(&OP_ISTHMUS_PRECOMPILE));
 
         // Check that the Prague precompile IS present when using the default spec.
-        assert!(evm.precompiles_mut().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
+        assert!(evm.precompiles().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
 
-        assert!(!evm.precompiles_mut().addresses().contains(&PRECOMPILE_ADDR));
+        assert!(!evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         inject_precompiles(&mut evm, CustomPrecompileFactory.precompiles());
 
-        assert!(evm.precompiles_mut().addresses().contains(&PRECOMPILE_ADDR));
+        assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         let result = match &mut evm {
             EitherEvm::Op(op_evm) => op_evm.transact(env.tx).unwrap(),
@@ -258,16 +258,16 @@ mod tests {
         let (env, mut evm) = create_op_evm(SpecId::default(), OpSpecId::BEDROCK);
 
         // Check that the Isthmus precompile IS NOT present when using the `OpSpecId::BEDROCK` spec.
-        assert!(!evm.precompiles_mut().addresses().contains(&OP_ISTHMUS_PRECOMPILE));
+        assert!(!evm.precompiles().addresses().contains(&OP_ISTHMUS_PRECOMPILE));
 
         // Check that the Prague precompile IS NOT present when using the `OpSpecId::BEDROCK` spec.
-        assert!(!evm.precompiles_mut().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
+        assert!(!evm.precompiles().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
 
-        assert!(!evm.precompiles_mut().addresses().contains(&PRECOMPILE_ADDR));
+        assert!(!evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         inject_precompiles(&mut evm, CustomPrecompileFactory.precompiles());
 
-        assert!(evm.precompiles_mut().addresses().contains(&PRECOMPILE_ADDR));
+        assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         let result = match &mut evm {
             EitherEvm::Op(op_evm) => op_evm.transact(env.tx).unwrap(),

--- a/crates/evm/core/src/either_evm.rs
+++ b/crates/evm/core/src/either_evm.rs
@@ -151,10 +151,24 @@ where
         }
     }
 
+    fn precompiles(&self) -> &Self::Precompiles {
+        match self {
+            Self::Eth(evm) => evm.precompiles(),
+            Self::Op(evm) => evm.precompiles(),
+        }
+    }
+
     fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
         match self {
             Self::Eth(evm) => evm.precompiles_mut(),
             Self::Op(evm) => evm.precompiles_mut(),
+        }
+    }
+
+    fn inspector(&self) -> &Self::Inspector {
+        match self {
+            Self::Eth(evm) => evm.inspector(),
+            Self::Op(evm) => evm.inspector(),
         }
     }
 

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -87,7 +87,7 @@ pub fn new_evm_with_existing_context<'a>(
 
 /// Conditionally inject additional precompiles into the EVM context.
 fn inject_precompiles(evm: &mut FoundryEvm<'_, impl InspectorExt>) {
-    if evm.inspector_mut().is_odyssey() {
+    if evm.inspector().is_odyssey() {
         evm.precompiles_mut().apply_precompile(P256VERIFY.address(), |_| {
             Some(DynPrecompile::from(P256VERIFY.precompile()))
         });
@@ -175,8 +175,16 @@ impl<'db, I: InspectorExt> Evm for FoundryEvm<'db, I> {
         self.inner.db()
     }
 
+    fn precompiles(&self) -> &Self::Precompiles {
+        &self.inner.precompiles
+    }
+
     fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
         &mut self.inner.precompiles
+    }
+
+    fn inspector(&self) -> &Self::Inspector {
+        &self.inner.inspector
     }
 
     fn inspector_mut(&mut self) -> &mut Self::Inspector {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/10562

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Bumps to `alloy-evm` and `alloy-op-evm` to 0.9.1 which includes https://github.com/alloy-rs/evm/pull/93

Applies changes, minor nit to use `OpSpecId::default` instead of hardcoding to `Isthmus` in test that asserts defaults

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes