### PR TITLE
feat: add cast da-estimate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,6 +2386,8 @@ dependencies = [
  "futures",
  "gcloud-sdk",
  "itertools 0.14.0",
+ "op-alloy-consensus",
+ "op-alloy-flz",
  "rand 0.8.5",
  "rand 0.9.1",
  "rayon",
@@ -6407,13 +6409,21 @@ checksum = "6f318b09e24148f07392c5e011bae047a0043851f9041145df5f3b01e4fedd1e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.5",
+ "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-eth",
  "alloy-serde 1.0.5",
  "derive_more 2.0.1",
  "serde",
  "thiserror 2.0.12",
 ]
+
+[[package]]
+name = "op-alloy-flz"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ef71f23a8caf6f2a2d5cafbdc44956d44e6014dcb9aa58abf7e4e6481c6ec34"
 
 [[package]]
 name = "op-alloy-rpc-types"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,6 +247,7 @@ alloy-trie = "0.8.1"
 ## op-alloy
 op-alloy-consensus = "0.16.0"
 op-alloy-rpc-types = "0.16.0"
+op-alloy-flz = "0.13.0"
 
 ## revm
 revm = { version = "23.1.0", default-features = false }

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -54,6 +54,9 @@ alloy-sol-types.workspace = true
 alloy-transport.workspace = true
 alloy-ens = { workspace = true, features = ["provider"] }
 
+op-alloy-flz.workspace = true
+op-alloy-consensus = { workspace = true, features = ["alloy-compat"] }
+
 chrono.workspace = true
 eyre.workspace = true
 futures.workspace = true

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -715,6 +715,9 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
             }
         }
         CastSubcommand::TxPool { command } => command.run().await?,
+        CastSubcommand::DAEstimate(cmd) => {
+            cmd.run().await?;
+        }
     };
 
     /// Prints slice of tokens using [`format_tokens`] or [`format_tokens_raw`] depending whether

--- a/crates/cast/src/cmd/da_estimate.rs
+++ b/crates/cast/src/cmd/da_estimate.rs
@@ -1,0 +1,48 @@
+//! Estimates the data availability size of a block for opstack.
+
+use alloy_consensus::BlockHeader;
+use alloy_network::eip2718::Encodable2718;
+use alloy_provider::Provider;
+use alloy_rpc_types::BlockId;
+use clap::Parser;
+use foundry_cli::{
+    opts::RpcOpts,
+    utils::{self, LoadConfig},
+};
+use op_alloy_consensus::OpTxEnvelope;
+
+/// CLI arguments for `cast da-estimate`.
+#[derive(Debug, Parser)]
+pub struct DAEstimateArgs {
+    /// The block to estimate the data availability size for.
+    pub block: BlockId,
+    #[command(flatten)]
+    pub rpc: RpcOpts,
+}
+
+impl DAEstimateArgs {
+    /// Load the RPC URL from the config file.
+    pub async fn run(self) -> eyre::Result<()> {
+        let Self { block, rpc } = self;
+        let config = rpc.load_config()?;
+        let provider = utils::get_provider(&config)?;
+        let block = provider
+            .get_block(block)
+            .full()
+            .await?
+            .ok_or_else(|| eyre::eyre!("Block not found"))?;
+
+        let block_number = block.header.number();
+        let tx_count = block.transactions.len();
+        let mut da_estimate = 0;
+        for tx in block.into_transactions_iter() {
+            // try to convert into opstack transaction
+            let tx = OpTxEnvelope::try_from(tx)?;
+            da_estimate += op_alloy_flz::tx_estimated_size_fjord(&tx.encoded_2718());
+        }
+
+        println!("Estimated data availability size for block {block_number} with {tx_count} transactions: {da_estimate}");
+
+        Ok(())
+    }
+}

--- a/crates/cast/src/cmd/da_estimate.rs
+++ b/crates/cast/src/cmd/da_estimate.rs
@@ -41,7 +41,7 @@ impl DAEstimateArgs {
             da_estimate += op_alloy_flz::tx_estimated_size_fjord(&tx.encoded_2718());
         }
 
-        println!("Estimated data availability size for block {block_number} with {tx_count} transactions: {da_estimate}");
+        sh_println!("Estimated data availability size for block {block_number} with {tx_count} transactions: {da_estimate}")?;
 
         Ok(())
     }

--- a/crates/cast/src/cmd/mod.rs
+++ b/crates/cast/src/cmd/mod.rs
@@ -12,6 +12,7 @@ pub mod call;
 pub mod constructor_args;
 pub mod create2;
 pub mod creation_code;
+pub mod da_estimate;
 pub mod estimate;
 pub mod find_block;
 pub mod interface;

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -1,9 +1,9 @@
 use crate::cmd::{
     access_list::AccessListArgs, artifact::ArtifactArgs, bind::BindArgs, call::CallArgs,
     constructor_args::ConstructorArgsArgs, create2::Create2Args, creation_code::CreationCodeArgs,
-    estimate::EstimateArgs, find_block::FindBlockArgs, interface::InterfaceArgs, logs::LogsArgs,
-    mktx::MakeTxArgs, rpc::RpcArgs, run::RunArgs, send::SendTxArgs, storage::StorageArgs,
-    txpool::TxPoolSubcommands, wallet::WalletSubcommands,
+    da_estimate::DAEstimateArgs, estimate::EstimateArgs, find_block::FindBlockArgs,
+    interface::InterfaceArgs, logs::LogsArgs, mktx::MakeTxArgs, rpc::RpcArgs, run::RunArgs,
+    send::SendTxArgs, storage::StorageArgs, txpool::TxPoolSubcommands, wallet::WalletSubcommands,
 };
 use alloy_ens::NameOrAddress;
 use alloy_primitives::{Address, Selector, B256, U256};
@@ -1065,6 +1065,9 @@ pub enum CastSubcommand {
         #[command(subcommand)]
         command: TxPoolSubcommands,
     },
+    /// Estimates the data availability size of a given opstack block.
+    #[command(name = "da-estimate")]
+    DAEstimate(DAEstimateArgs),
 }
 
 /// CLI arguments for `cast --to-base`.

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -2616,3 +2616,13 @@ Error: Failed to estimate gas: server returned an error response: error code 3: 
 
 "#]]);
 });
+
+// <https://basescan.org/block/30558838>
+casttest!(estimate_base_da, |_prj, cmd| {
+    cmd.args(["da-estimate", "30558838", "-r", "https://mainnet.base.org/"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Estimated data availability size for block 30558838 with 225 transactions: 52916546100
+
+"#]]);
+});


### PR DESCRIPTION
on opstack the sequencer may enforce a DA limit per block, this new command displays the total estimated size of a da block
adds a new cast subcommand that estimates the DA size of an opstack block
