### PR TITLE
cast: Improve debugger when tracing on-chain transactions/calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,6 +4152,7 @@ dependencies = [
  "jiff",
  "num-format",
  "path-slash",
+ "regex",
  "reqwest",
  "semver 1.0.26",
  "serde",

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -34,6 +34,8 @@ use regex::Regex;
 use revm::context::TransactionType;
 use std::{str::FromStr, sync::LazyLock};
 
+use super::run::fetch_contracts_bytecode_from_trace;
+
 // matches override pattern <address>:<slot>:<value>
 // e.g. 0x123:0x1:0x1234
 static OVERRIDE_PATTERN: LazyLock<Regex> =
@@ -292,10 +294,12 @@ impl CallArgs {
                 ),
             };
 
+            let contracts_bytecode = fetch_contracts_bytecode_from_trace(&provider, &trace).await?;
             handle_traces(
                 trace,
                 &config,
                 chain,
+                &contracts_bytecode,
                 labels,
                 with_local_artifacts,
                 debug,

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -1,5 +1,5 @@
 use alloy_json_abi::JsonAbi;
-use alloy_primitives::Address;
+use alloy_primitives::{map::HashMap, Address, Bytes};
 use eyre::{Result, WrapErr};
 use foundry_common::{
     compile::ProjectCompiler, fs, selectors::SelectorKind, shell, ContractsByArtifact,
@@ -25,6 +25,7 @@ use foundry_evm::{
 };
 use std::{
     fmt::Write,
+    hash::RandomState,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -332,10 +333,12 @@ impl TryFrom<Result<RawCallResult>> for TraceResult {
 }
 
 /// labels the traces, conditionally prints them or opens the debugger
+#[expect(clippy::too_many_arguments)]
 pub async fn handle_traces(
     mut result: TraceResult,
     config: &Config,
     chain: Option<Chain>,
+    contracts_bytecode: &HashMap<Address, Bytes, RandomState>,
     labels: Vec<String>,
     with_local_artifacts: bool,
     debug: bool,
@@ -374,7 +377,7 @@ pub async fn handle_traces(
     let mut identifier = TraceIdentifiers::new().with_etherscan(config, chain)?;
     if let Some(contracts) = &known_contracts {
         builder = builder.with_known_contracts(contracts);
-        identifier = identifier.with_local(contracts);
+        identifier = identifier.with_local_and_bytecodes(contracts, contracts_bytecode);
     }
 
     let mut decoder = builder.build();

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -57,6 +57,7 @@ itertools.workspace = true
 jiff.workspace = true
 num-format.workspace = true
 path-slash.workspace = true
+regex.workspace = true
 reqwest.workspace = true
 semver.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -1,6 +1,6 @@
 //! Commonly used contract types and functions.
 
-use crate::compile::PathOrContractInfo;
+use crate::{compile::PathOrContractInfo, strip_bytecode_placeholders};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::{Event, Function, JsonAbi};
 use alloy_primitives::{hex, Address, Bytes, Selector, B256};
@@ -86,6 +86,16 @@ impl ContractData {
     /// Returns reference to bytes of contract deployed code, if present.
     pub fn deployed_bytecode(&self) -> Option<&Bytes> {
         self.deployed_bytecode.as_ref()?.bytes().filter(|b| !b.is_empty())
+    }
+
+    /// Returns the bytecode without placeholders, if present.
+    pub fn bytecode_without_placeholders(&self) -> Option<Bytes> {
+        strip_bytecode_placeholders(self.bytecode.as_ref()?.object.as_ref()?)
+    }
+
+    /// Returns the deployed bytecode without placeholders, if present.
+    pub fn deployed_bytecode_without_placeholders(&self) -> Option<Bytes> {
+        strip_bytecode_placeholders(self.deployed_bytecode.as_ref()?.object.as_ref()?)
     }
 }
 

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -1,6 +1,8 @@
 //! Uncategorised utilities.
 
-use alloy_primitives::{keccak256, B256, U256};
+use alloy_primitives::{hex, keccak256, Bytes, B256, U256};
+use foundry_compilers::artifacts::BytecodeObject;
+use regex::Regex;
 /// Block on a future using the current tokio runtime on the current thread.
 pub fn block_on<F: std::future::Future>(future: F) -> F::Output {
     block_on_handle(&tokio::runtime::Handle::current(), future)
@@ -52,5 +54,22 @@ pub fn ignore_metadata_hash(bytecode: &[u8]) -> &[u8] {
         rest
     } else {
         bytecode
+    }
+}
+
+/// Strips all __$xxx$__ placeholders from the bytecode if it's an unlinked bytecode.
+/// by replacing them with 20 zero bytes.
+/// This is useful for matching bytecodes to a contract source, and for the source map,
+/// in which the actual address of the placeholder isn't important.
+pub fn strip_bytecode_placeholders(bytecode: &BytecodeObject) -> Option<Bytes> {
+    match &bytecode {
+        BytecodeObject::Bytecode(bytes) => Some(bytes.clone()),
+        BytecodeObject::Unlinked(s) => {
+            // Replace all __$xxx$__ placeholders with 32 zero bytes
+            let re = Regex::new(r"__\$.{34}\$__").expect("invalid regex");
+            let s = re.replace_all(s, "00".repeat(40));
+            let bytes = hex::decode(s.as_bytes());
+            Some(bytes.ok()?.into())
+        }
     }
 }

--- a/crates/evm/traces/src/debug/sources.rs
+++ b/crates/evm/traces/src/debug/sources.rs
@@ -1,5 +1,5 @@
 use eyre::{Context, Result};
-use foundry_common::compact_to_contract;
+use foundry_common::{compact_to_contract, strip_bytecode_placeholders};
 use foundry_compilers::{
     artifacts::{
         sourcemap::{SourceElement, SourceMap},
@@ -94,9 +94,9 @@ impl ArtifactData {
                 })
             };
 
-            // Only parse bytecode if it's not empty.
-            let pc_ic_map = if let Some(bytes) = b.bytes() {
-                (!bytes.is_empty()).then(|| PcIcMap::new(bytes))
+            // Only parse bytecode if it's not empty, stripping placeholders if necessary.
+            let pc_ic_map = if let Some(bytes) = strip_bytecode_placeholders(&b.object) {
+                (!bytes.is_empty()).then(|| PcIcMap::new(bytes.as_ref()))
             } else {
                 None
             };

--- a/crates/evm/traces/src/identifier/local.rs
+++ b/crates/evm/traces/src/identifier/local.rs
@@ -1,10 +1,11 @@
 use super::{IdentifiedAddress, TraceIdentifier};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::JsonAbi;
+use alloy_primitives::{map::HashMap, Address, Bytes};
 use foundry_common::contracts::{bytecode_diff_score, ContractsByArtifact};
 use foundry_compilers::ArtifactId;
 use revm_inspectors::tracing::types::CallTraceNode;
-use std::borrow::Cow;
+use std::{borrow::Cow, hash::RandomState};
 
 /// A trace identifier that tries to identify addresses using local contracts.
 pub struct LocalTraceIdentifier<'a> {
@@ -12,6 +13,8 @@ pub struct LocalTraceIdentifier<'a> {
     known_contracts: &'a ContractsByArtifact,
     /// Vector of pairs of artifact ID and the runtime code length of the given artifact.
     ordered_ids: Vec<(&'a ArtifactId, usize)>,
+    /// The contracts bytecode.
+    contracts_bytecode: Option<&'a HashMap<Address, Bytes, RandomState>>,
 }
 
 impl<'a> LocalTraceIdentifier<'a> {
@@ -24,7 +27,15 @@ impl<'a> LocalTraceIdentifier<'a> {
             .map(|(id, bytecode)| (id, bytecode.len()))
             .collect::<Vec<_>>();
         ordered_ids.sort_by_key(|(_, len)| *len);
-        Self { known_contracts, ordered_ids }
+        Self { known_contracts, ordered_ids, contracts_bytecode: None }
+    }
+
+    pub fn with_bytecodes(
+        mut self,
+        contracts_bytecode: &'a HashMap<Address, Bytes, RandomState>,
+    ) -> Self {
+        self.contracts_bytecode = Some(contracts_bytecode);
+        self
     }
 
     /// Returns the known contracts.
@@ -161,7 +172,18 @@ impl TraceIdentifier for LocalTraceIdentifier<'_> {
                 let _span =
                     trace_span!(target: "evm::traces::local", "identify", %address).entered();
 
-                let (id, abi) = self.identify_code(runtime_code?, creation_code?)?;
+                // In order to identify the addresses, we need at least the runtime code. It can be
+                // obtained from the trace itself (if it's a CREATE* call), or from the fetched
+                // bytecodes.
+                let (runtime_code, creation_code) = match (runtime_code, creation_code) {
+                    (Some(runtime_code), Some(creation_code)) => (runtime_code, creation_code),
+                    (Some(runtime_code), _) => (runtime_code, &[] as &[u8]),
+                    _ => {
+                        let code = self.contracts_bytecode?.get(&address)?;
+                        (code.as_ref(), &[] as &[u8])
+                    }
+                };
+                let (id, abi) = self.identify_code(runtime_code, creation_code)?;
                 trace!(target: "evm::traces::local", id=%id.identifier(), "identified");
 
                 Some(IdentifiedAddress {

--- a/crates/evm/traces/src/identifier/local.rs
+++ b/crates/evm/traces/src/identifier/local.rs
@@ -59,9 +59,9 @@ impl<'a> LocalTraceIdentifier<'a> {
             let contract = self.known_contracts.get(id)?;
             // Select bytecodes to compare based on `is_creation` flag.
             let (contract_bytecode, current_bytecode) = if is_creation {
-                (contract.bytecode(), creation_code)
+                (contract.bytecode_without_placeholders(), creation_code)
             } else {
-                (contract.deployed_bytecode(), runtime_code)
+                (contract.deployed_bytecode_without_placeholders(), runtime_code)
             };
 
             if let Some(bytecode) = contract_bytecode {
@@ -78,7 +78,7 @@ impl<'a> LocalTraceIdentifier<'a> {
                     }
                 }
 
-                let score = bytecode_diff_score(bytecode, current_bytecode);
+                let score = bytecode_diff_score(&bytecode, current_bytecode);
                 if score == 0.0 {
                     trace!(target: "evm::traces::local", "found exact match");
                     return Some((id, &contract.abi));

--- a/crates/evm/traces/src/identifier/mod.rs
+++ b/crates/evm/traces/src/identifier/mod.rs
@@ -1,10 +1,10 @@
 use alloy_json_abi::JsonAbi;
-use alloy_primitives::Address;
+use alloy_primitives::{map::HashMap, Address, Bytes};
 use foundry_common::ContractsByArtifact;
 use foundry_compilers::ArtifactId;
 use foundry_config::{Chain, Config};
 use revm_inspectors::tracing::types::CallTraceNode;
-use std::borrow::Cow;
+use std::{borrow::Cow, hash::RandomState};
 
 mod local;
 pub use local::LocalTraceIdentifier;
@@ -43,6 +43,8 @@ pub struct TraceIdentifiers<'a> {
     pub local: Option<LocalTraceIdentifier<'a>>,
     /// The optional Etherscan trace identifier.
     pub etherscan: Option<EtherscanIdentifier>,
+    /// The contracts bytecode.
+    pub contracts_bytecode: Option<&'a HashMap<Address, Bytes, RandomState>>,
 }
 
 impl Default for TraceIdentifiers<'_> {
@@ -70,12 +72,23 @@ impl TraceIdentifier for TraceIdentifiers<'_> {
 impl<'a> TraceIdentifiers<'a> {
     /// Creates a new, empty instance.
     pub const fn new() -> Self {
-        Self { local: None, etherscan: None }
+        Self { local: None, etherscan: None, contracts_bytecode: None }
     }
 
     /// Sets the local identifier.
     pub fn with_local(mut self, known_contracts: &'a ContractsByArtifact) -> Self {
         self.local = Some(LocalTraceIdentifier::new(known_contracts));
+        self
+    }
+
+    /// Sets the local identifier.
+    pub fn with_local_and_bytecodes(
+        mut self,
+        known_contracts: &'a ContractsByArtifact,
+        contracts_bytecode: &'a HashMap<Address, Bytes, RandomState>,
+    ) -> Self {
+        self.local =
+            Some(LocalTraceIdentifier::new(known_contracts).with_bytecodes(contracts_bytecode));
         self
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The current debugger provided in `cast` is great, but it currently cannot show the source file of local contracts in `cast run` (for example).

It seems that it can only match contracts to source code, whether from Etherscan (but this requires both an API key, and a verified contract), or locally via `--with-local-artifacts`. However, w/ `--with-local-artifacts`, it only matches the contracts for which the deployment is within the same transaction, to get both the deployment bytecode, as well as the runtime one.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

A simple solution to this problem (first commit), is to actually fetch the bytecode of all addresses involved in a trace, to pass it along to the local identifier. This is done for both `cast run` (which I guess already has all bytecodes available, since it re-executes the tx), as well as `cast call`, for which I'm unsure if it's a good default, or should it be behind a flag?

Another issue arose, for contracts using libraries. For those, the bytecode isn't convertible to `bytes`, as it has placeholders. A simple solution is to replace all those placeholders w/ the `0x00.00` address, which should still yield some good matching score. It's also used in the sourcemap generation, in which the actual value of the library's address isn't needed anyway.

## Reproduction

Clone the morpho-blue repo: https://github.com/morpho-org/morpho-blue and
```bash
cast run --with-local-artifacts -r "<NODE_URL>" --debug 0x32fbce9a55b5b13d65fc5a359d40d742812d409df6c4a7483db3a18f0b8e3d22
```
and go through the calls until the first call to `0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb`

The tx https://etherscan.io/tx/0x32fbce9a55b5b13d65fc5a359d40d742812d409df6c4a7483db3a18f0b8e3d22 calls the Morpho Blue contract in the 5th call, which shows no matching contract on `master`, but properly shows the contract source code on this branch.

Same with
```bash
cast call --with-local-artifacts --trace --debug -r "http://rpc.eth.moonce.vpn" 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb "feeRecipient()"
```

## PR Checklist

I haven't added any tests yet, as I wanted to hear from maintainers first on the PR's logic/structure.

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes