### PR TITLE
fix(forge lint): do not flag `fn test*` and `fn invariant*`

### DIFF
--- a/crates/lint/src/sol/info/mixed_case.rs
+++ b/crates/lint/src/sol/info/mixed_case.rs
@@ -19,7 +19,7 @@ impl<'ast> EarlyLintPass<'ast> for MixedCaseFunction {
     fn check_item_function(&mut self, ctx: &LintContext<'_>, func: &'ast ItemFunction<'ast>) {
         if let Some(name) = func.header.name {
             let name = name.as_str();
-            if !is_mixed_case(name) && name.len() > 1 {
+            if !is_mixed_case(name, true) {
                 ctx.emit(&MIXED_CASE_FUNCTION, func.body_span);
             }
         }
@@ -42,7 +42,7 @@ impl<'ast> EarlyLintPass<'ast> for MixedCaseVariable {
         if var.mutability.is_none() {
             if let Some(name) = var.name {
                 let name = name.as_str();
-                if !is_mixed_case(name) {
+                if !is_mixed_case(name, false) {
                     ctx.emit(&MIXED_CASE_VARIABLE, var.span);
                 }
             }
@@ -54,11 +54,17 @@ impl<'ast> EarlyLintPass<'ast> for MixedCaseVariable {
 ///
 /// To avoid false positives like `fn increment()` or `uint256 counter`,
 /// lowercase strings are treated as mixedCase.
-pub fn is_mixed_case(s: &str) -> bool {
+pub fn is_mixed_case(s: &str, is_fn: bool) -> bool {
     if s.len() <= 1 {
         return true;
     }
 
     // Remove leading/trailing underscores like `heck` does
-    s.trim_matches('_') == format!("{}", heck::AsLowerCamelCase(s)).as_str()
+    if s.trim_matches('_') == format!("{}", heck::AsLowerCamelCase(s)).as_str() {
+        return true
+    }
+
+    // Ignore `fn test*` and `fn invariant*` patterns, as they usually contain (allowed)
+    // underscores.
+    is_fn && (s.starts_with("test") || s.starts_with("invariant"))
 }

--- a/crates/lint/src/sol/info/mixed_case.rs
+++ b/crates/lint/src/sol/info/mixed_case.rs
@@ -64,7 +64,7 @@ pub fn is_mixed_case(s: &str, is_fn: bool) -> bool {
         return true
     }
 
-    // Ignore `fn test*`, `fn invariant*`, and `fn statefulFuzz` patterns, as they usually contain
+    // Ignore `fn test*`, `fn invariant_*`, and `fn statefulFuzz*` patterns, as they usually contain
     // (allowed) underscores.
-    is_fn && (s.starts_with("test") || s.starts_with("invariant") || s.starts_with("statefulFuzz"))
+    is_fn && (s.starts_with("test") || s.starts_with("invariant_") || s.starts_with("statefulFuzz"))
 }

--- a/crates/lint/src/sol/info/mixed_case.rs
+++ b/crates/lint/src/sol/info/mixed_case.rs
@@ -64,7 +64,7 @@ pub fn is_mixed_case(s: &str, is_fn: bool) -> bool {
         return true
     }
 
-    // Ignore `fn test*` and `fn invariant*` patterns, as they usually contain (allowed)
-    // underscores.
-    is_fn && (s.starts_with("test") || s.starts_with("invariant"))
+    // Ignore `fn test*`, `fn invariant*`, and `fn statefulFuzz` patterns, as they usually contain
+    // (allowed) underscores.
+    is_fn && (s.starts_with("test") || s.starts_with("invariant") || s.starts_with("statefulFuzz"))
 }

--- a/crates/lint/testdata/MixedCase.sol
+++ b/crates/lint/testdata/MixedCase.sol
@@ -29,32 +29,32 @@ contract MixedCaseTest {
     function function_mixed_case() public {} //~NOTE: function names should use mixedCase
 
     // mixedCase checks are disabled for functions that starting with:
-    // `test`, `invariant`, and `statefulFuzz`
+    // `test`, `invariant_`, and `statefulFuzz`
     function test_MixedCase_Disabled() public {}
     function test_mixedcase_disabled() public {}
     function testMixedCaseDisabled() public {}
     function testmixedcasedisabled() public {}
-    
+
     function testFuzz_MixedCase_Disabled() public {}
     function testFuzz_mixedcase_disabled() public {}
     function testFuzzMixedCaseDisabled() public {}
     function testfuzzmixedcasedisabled() public {}
-    
+
     function testRevert_MixedCase_Disabled() public {}
     function testRevert_mixedcase_disabled() public {}
     function testRevertMixedCaseDisabled() public {}
     function testrevertmixedcasedisabled() public {}
-    
+
     function invariant_MixedCase_Disabled() public {}
     function invariant_mixedcase_disabled() public {}
-    function invariantMixedCaseDisabled() public {}
-    function invariantmixedcasedisabled() public {}
-    
-    function invariantBalance_MixedCase_Disabled() public {}
-    function invariantbalance_mixedcase_disabled() public {}
-    function invariantBalanceMixedCaseDisabled() public {}
-    function invariantbalancemixedcasedisabled() public {}
-    
+    function invariant_MixedCaseDisabled() public {}
+    function invariant_mixedcasedisabled() public {}
+
+    function invariantBalance_MixedCase_Enabled() public {} //~NOTE: function names should use mixedCase
+    function invariantbalance_mixedcase_enabled() public {} //~NOTE: function names should use mixedCase
+    function invariantBalanceMixedCaseEnabled() public {}
+    function invariantbalancemixedcaseenabled() public {}
+
     function statefulFuzz_MixedCase_Disabled() public {}
     function statefulFuzz_mixedcase_disabled() public {}
     function statefulFuzzMixedCaseDisabled() public {}

--- a/crates/lint/testdata/MixedCase.sol
+++ b/crates/lint/testdata/MixedCase.sol
@@ -31,9 +31,32 @@ contract MixedCaseTest {
     // mixedCase checks are disabled for functions that starting with:
     // `test`, `invariant`, and `statefulFuzz`
     function test_MixedCase_Disabled() public {}
+    function test_mixedcase_disabled() public {}
+    function testMixedCaseDisabled() public {}
+    function testmixedcasedisabled() public {}
+    
     function testFuzz_MixedCase_Disabled() public {}
+    function testFuzz_mixedcase_disabled() public {}
+    function testFuzzMixedCaseDisabled() public {}
+    function testfuzzmixedcasedisabled() public {}
+    
     function testRevert_MixedCase_Disabled() public {}
+    function testRevert_mixedcase_disabled() public {}
+    function testRevertMixedCaseDisabled() public {}
+    function testrevertmixedcasedisabled() public {}
+    
     function invariant_MixedCase_Disabled() public {}
+    function invariant_mixedcase_disabled() public {}
+    function invariantMixedCaseDisabled() public {}
+    function invariantmixedcasedisabled() public {}
+    
     function invariantBalance_MixedCase_Disabled() public {}
+    function invariantbalance_mixedcase_disabled() public {}
+    function invariantBalanceMixedCaseDisabled() public {}
+    function invariantbalancemixedcasedisabled() public {}
+    
     function statefulFuzz_MixedCase_Disabled() public {}
+    function statefulFuzz_mixedcase_disabled() public {}
+    function statefulFuzzMixedCaseDisabled() public {}
+    function statefulFuzzmixedcasedisabled() public {}
 }

--- a/crates/lint/testdata/MixedCase.sol
+++ b/crates/lint/testdata/MixedCase.sol
@@ -32,4 +32,5 @@ contract MixedCaseTest {
     function testFuzz_CanHaveUnderscores() public {}
     function testRevert_CanHaveUnderscores() public {}
     function invariant_CanHaveUnderscores() public {}
+    function statefulFuzz_CanHaveUnderscores() public {}
 }

--- a/crates/lint/testdata/MixedCase.sol
+++ b/crates/lint/testdata/MixedCase.sol
@@ -28,9 +28,12 @@ contract MixedCaseTest {
     function FunctionMixedCase() public {} //~NOTE: function names should use mixedCase
     function function_mixed_case() public {} //~NOTE: function names should use mixedCase
 
-    function test_CanHaveUnderscores() public {}
-    function testFuzz_CanHaveUnderscores() public {}
-    function testRevert_CanHaveUnderscores() public {}
-    function invariant_CanHaveUnderscores() public {}
-    function statefulFuzz_CanHaveUnderscores() public {}
+    // mixedCase checks are disabled for functions that starting with:
+    // `test`, `invariant`, and `statefulFuzz`
+    function test_MixedCase_Disabled() public {}
+    function testFuzz_MixedCase_Disabled() public {}
+    function testRevert_MixedCase_Disabled() public {}
+    function invariant_MixedCase_Disabled() public {}
+    function invariantBalance_MixedCase_Disabled() public {}
+    function statefulFuzz_MixedCase_Disabled() public {}
 }

--- a/crates/lint/testdata/MixedCase.sol
+++ b/crates/lint/testdata/MixedCase.sol
@@ -26,4 +26,10 @@ contract MixedCaseTest {
     function Functionmixedcase() public {} //~NOTE: function names should use mixedCase
     function FUNCTION_MIXED_CASE() public {} //~NOTE: function names should use mixedCase
     function FunctionMixedCase() public {} //~NOTE: function names should use mixedCase
+    function function_mixed_case() public {} //~NOTE: function names should use mixedCase
+
+    function test_CanHaveUnderscores() public {}
+    function testFuzz_CanHaveUnderscores() public {}
+    function testRevert_CanHaveUnderscores() public {}
+    function invariant_CanHaveUnderscores() public {}
 }

--- a/crates/lint/testdata/MixedCase.stderr
+++ b/crates/lint/testdata/MixedCase.stderr
@@ -64,3 +64,11 @@ note[mixed-case-function]: function names should use mixedCase
    |
    = help: https://docs.soliditylang.org/en/latest/style-guide.html#function-names
 
+note[mixed-case-function]: function names should use mixedCase
+  --> ROOT/testdata/MixedCase.sol:LL:CC
+   |
+29 |     function function_mixed_case() public {}
+   |                                           --
+   |
+   = help: https://docs.soliditylang.org/en/latest/style-guide.html#function-names
+

--- a/crates/lint/testdata/MixedCase.stderr
+++ b/crates/lint/testdata/MixedCase.stderr
@@ -72,3 +72,19 @@ note[mixed-case-function]: function names should use mixedCase
    |
    = help: https://docs.soliditylang.org/en/latest/style-guide.html#function-names
 
+note[mixed-case-function]: function names should use mixedCase
+  --> ROOT/testdata/MixedCase.sol:LL:CC
+   |
+53 |     function invariantBalance_MixedCase_Enabled() public {}
+   |                                                          --
+   |
+   = help: https://docs.soliditylang.org/en/latest/style-guide.html#function-names
+
+note[mixed-case-function]: function names should use mixedCase
+  --> ROOT/testdata/MixedCase.sol:LL:CC
+   |
+54 |     function invariantbalance_mixedcase_enabled() public {}
+   |                                                          --
+   |
+   = help: https://docs.soliditylang.org/en/latest/style-guide.html#function-names
+


### PR DESCRIPTION
## Motivation and Solution

as raised on:
- https://github.com/foundry-rs/foundry/issues/10599

`forge lint` currently flags any functions which do not stick to mixedCase. This PR modifies `fn is_mixed_case()` to disable warnings on function names that start with `test*`, `invariant*`, and `statefulFuzz*`.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation