### PR TITLE
fix(`cast`): include zero address as known system sender in cast run

### DIFF
--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -52,7 +52,7 @@ pub const DEFAULT_USER_AGENT: &str = concat!("foundry/", env!("CARGO_PKG_VERSION
 /// See: [ARBITRUM_SENDER], [OPTIMISM_SYSTEM_ADDRESS]
 #[inline]
 pub fn is_known_system_sender(sender: Address) -> bool {
-    [ARBITRUM_SENDER, OPTIMISM_SYSTEM_ADDRESS].contains(&sender)
+    [ARBITRUM_SENDER, OPTIMISM_SYSTEM_ADDRESS, Address::ZERO].contains(&sender)
 }
 
 pub fn is_impersonated_tx(tx: &AnyTxEnvelope) -> bool {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #10606 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add the `Address::ZERO` as system tx address. 
We already ignore system transactions from Arb and Optimism here: https://github.com/foundry-rs/foundry/blob/12c11781a61c3f81c8f891bb13ac1d14844bfe82/crates/cast/src/cmd/run.rs#L215 

Might as well extend it with the zero address to cover most chains

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes