### PR TITLE
fix: make sign and verify symmetrical

### DIFF
--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -147,6 +147,9 @@ pub enum WalletSubcommands {
     #[command(visible_alias = "v")]
     Verify {
         /// The original message.
+        ///
+        /// Treats 0x-prefixed strings as hex encoded bytes.
+        /// Non 0x-prefixed strings are treated as raw input message.
         message: String,
 
         /// The signature to verify.
@@ -759,11 +762,17 @@ flag to set your key via:
         Ok(())
     }
 
-    /// Recovers an address from the specified message and signature
+    /// Recovers an address from the specified message and signature.
+    ///
+    /// Note: This attempts to decode the message as hex if it starts with 0x.
     fn recover_address_from_message(message: &str, signature: &Signature) -> Result<Address> {
+        let message = Self::hex_str_to_bytes(message)?;
         Ok(signature.recover_address_from_msg(message)?)
     }
 
+    /// Strips the 0x prefix from a hex string and decodes it to bytes.
+    ///
+    /// Treats the string as raw bytes if it doesn't start with 0x.
     fn hex_str_to_bytes(s: &str) -> Result<Vec<u8>> {
         Ok(match s.strip_prefix("0x") {
             Some(data) => hex::decode(data).wrap_err("Could not decode 0x-prefixed string.")?,

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -290,6 +290,66 @@ casttest!(wallet_sign_message_hex_data, |_prj, cmd| {
 "#]]);
 });
 
+// <https://github.com/foundry-rs/foundry/issues/10613>
+// tests that `cast wallet sign` and `cast wallet verify` work with the same message as input
+casttest!(wallet_sign_and_verify_message_hex_data, |_prj, cmd| {
+    //     message="$1"
+    //     mnemonic="test test test test test test test test test test test junk"
+    //     key=$(cast wallet private-key --mnemonic "$mnemonic")
+    //     address=$(cast wallet address --mnemonic "$mnemonic")
+    //     signature=$(cast wallet sign --private-key "$key" "$message")
+    //     cast wallet verify --address "$address" "$message" "$signature"
+    let mnemonic = "test test test test test test test test test test test junk";
+    let key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    let address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+    cmd.args(["wallet", "private-key", "--mnemonic", mnemonic]).assert_success().stdout_eq(str![[
+        r#"
+0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+"#
+    ]]);
+    cmd.cast_fuse().args(["wallet", "address", "--mnemonic", mnemonic]).assert_success().stdout_eq(
+        str![[r#"
+0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+
+"#]],
+    );
+
+    let msg_hex = "0x0000000000000000000000000000000000000000000000000000000000000001";
+    let signature_hex = "0xed769da87f78d0166b30aebf2767ceed5a3867da21b2fba8c6527af256bbcebe24a1e758ec8ad1ffc29cfefa540ea7ba7966c0edf6907af82348f894ba4f40fa1b";
+    cmd.cast_fuse().args([
+        "wallet", "sign", "--private-key",key, msg_hex
+    ]).assert_success().stdout_eq(str![[r#"
+0xed769da87f78d0166b30aebf2767ceed5a3867da21b2fba8c6527af256bbcebe24a1e758ec8ad1ffc29cfefa540ea7ba7966c0edf6907af82348f894ba4f40fa1b
+
+"#]]);
+
+    cmd.cast_fuse()
+        .args(["wallet", "verify", "--address", address, msg_hex, signature_hex])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Validation succeeded. Address 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 signed this message.
+
+"#]]);
+
+    let msg_raw = "0000000000000000000000000000000000000000000000000000000000000001";
+    let signature_raw = "0x27a97b378477d9d004bd19cbd838d59bbb9847074ae4cc5b5975cc5566065eea76ee5b752fcdd483073e1baba548d82d9accc8603b3781bcc9abf195614cd3411c";
+    cmd.cast_fuse().args([
+        "wallet", "sign", "--private-key",key, msg_raw
+    ]).assert_success().stdout_eq(str![[r#"
+0x27a97b378477d9d004bd19cbd838d59bbb9847074ae4cc5b5975cc5566065eea76ee5b752fcdd483073e1baba548d82d9accc8603b3781bcc9abf195614cd3411c
+
+"#]]);
+
+    cmd.cast_fuse()
+        .args(["wallet", "verify", "--address", address, msg_raw, signature_raw])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Validation succeeded. Address 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 signed this message.
+
+"#]]);
+});
+
 // tests that `cast wallet sign typed-data` outputs the expected signature, given a JSON string
 casttest!(wallet_sign_typed_data_string, |_prj, cmd| {
     cmd.args([


### PR DESCRIPTION
closes #10613

sign does this:

https://github.com/foundry-rs/foundry/blob/17db1eacd422c3023b74c17a6a34ecc85ec41d0c/crates/cast/src/cmd/wallet/mod.rs#L458-L458

while verify didn't

this adds the same call to verify, although I'm not 100% sure we can do this without causing side-effects