### PR TITLE
fix: check for auth when deriving legacy

### DIFF
--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -243,7 +243,7 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, ToState> {
                 self.etherscan_api_key.as_deref(),
                 self.etherscan_api_version,
             )
-                .await?
+            .await?
         } else {
             (Vec::new(), None)
         };


### PR DESCRIPTION
closes #10204

this was caused by outdated legacy match in chains which incorrectly determined that bsc only supports legacy txs, updated here: https://github.com/alloy-rs/chains/pull/165

this fix in this pr works independently because this now also checks the auth field together with `is_legacy`