### PR TITLE
feat(config): warn on unknown config keys in foundry.toml

### DIFF
--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+serde_ignored = "0.1"
 foundry-block-explorers = { workspace = true, features = ["foundry-compilers"] }
 foundry-compilers = { workspace = true, features = ["svm-solc"] }
 


### PR DESCRIPTION
## Motivation

Right now, if a user makes a typo or adds a deprecated field in their local `foundry.toml`, Figment/Serde simply ignores it and the user never knows something went unused. That can lead to confusion or misconfiguration.

## Solution

Before Figment does `.extract()` into the `Config` struct, we read `foundry.toml` as raw TOML, run it through [`serde_ignored`] to collect any unused/unknown keys, and if any are found we log a `warn!` listing them. This is non-breaking (we still load all the valid settings) and only affects root keys for now.

About #10550 . For now, could I have some feedback on the implementation?

## PR Checklist

- [ ] Added Tests  
- [ ] Added Documentation  
- [ ] Breaking changes  