### PR TITLE
fix(bindings): ensure forge bind generates snake_case file names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,12 +2913,6 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
@@ -3307,7 +3301,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case 0.7.1",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -4013,9 +4007,9 @@ version = "1.2.1"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
- "convert_case 0.4.0",
  "eyre",
  "foundry-common",
+ "heck",
  "prettyplease",
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,6 +2915,12 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
@@ -3303,7 +3309,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case",
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -4009,6 +4015,7 @@ version = "1.2.1"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
+ "convert_case 0.4.0",
  "eyre",
  "foundry-common",
  "prettyplease",

--- a/crates/sol-macro-gen/Cargo.toml
+++ b/crates/sol-macro-gen/Cargo.toml
@@ -26,3 +26,5 @@ prettyplease.workspace = true
 serde_json.workspace = true
 
 eyre.workspace = true
+
+convert_case = "0.4"

--- a/crates/sol-macro-gen/Cargo.toml
+++ b/crates/sol-macro-gen/Cargo.toml
@@ -27,4 +27,4 @@ serde_json.workspace = true
 
 eyre.workspace = true
 
-convert_case = "0.4"
+heck.workspace = true

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -21,7 +21,7 @@ use std::{
     str::FromStr,
 };
 
-use convert_case::{Casing, Case};
+use heck::ToSnakeCase;
 
 pub struct SolMacroGen {
     pub path: PathBuf,
@@ -211,7 +211,7 @@ edition = "2021"
         for instance in &self.instances {
             let contents = instance.expansion.as_ref().unwrap();
 
-            let name = instance.name.to_case(Case::Snake);
+            let name = instance.name.to_snake_case();
             let path = src.join(format!("{name}.rs"));
             let file = syn::parse2(contents.clone())
                 .wrap_err_with(|| parse_error(&format!("{}:{}", path.display(), name)))?;
@@ -268,7 +268,7 @@ edition = "2021"
         .to_string();
 
         for instance in &self.instances {
-            let name = instance.name.to_case(Case::Snake);
+            let name = instance.name.to_snake_case();
             if !single_file {
                 // Module
                 write_mod_name(&mut mod_contents, &name)?;
@@ -330,7 +330,7 @@ edition = "2021"
         )?;
         if !single_file {
             for instance in &self.instances {
-                let name = instance.name.to_case(Case::Snake);
+                let name = instance.name.to_snake_case();
                 let path = if is_mod {
                     crate_path.join(format!("{name}.rs"))
                 } else {

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -21,6 +21,8 @@ use std::{
     str::FromStr,
 };
 
+use convert_case::{Casing, Case};
+
 pub struct SolMacroGen {
     pub path: PathBuf,
     pub name: String,
@@ -209,7 +211,7 @@ edition = "2021"
         for instance in &self.instances {
             let contents = instance.expansion.as_ref().unwrap();
 
-            let name = instance.name.to_lowercase();
+            let name = instance.name.to_case(Case::Snake);
             let path = src.join(format!("{name}.rs"));
             let file = syn::parse2(contents.clone())
                 .wrap_err_with(|| parse_error(&format!("{}:{}", path.display(), name)))?;
@@ -266,7 +268,7 @@ edition = "2021"
         .to_string();
 
         for instance in &self.instances {
-            let name = instance.name.to_lowercase();
+            let name = instance.name.to_case(Case::Snake);
             if !single_file {
                 // Module
                 write_mod_name(&mut mod_contents, &name)?;
@@ -328,7 +330,7 @@ edition = "2021"
         )?;
         if !single_file {
             for instance in &self.instances {
-                let name = instance.name.to_lowercase();
+                let name = instance.name.to_case(Case::Snake);
                 let path = if is_mod {
                     crate_path.join(format!("{name}.rs"))
                 } else {


### PR DESCRIPTION
## Motivation

The file names generated by `forge bind` currently use `CamelCase`/`PascalCase`, which goes against Rust’s convention of using `snake_case` for file names. Closes #10524 .

## Solution

Replaced `.to_lowercase()` with `.to_snake_case()` using the [`heck`](https://docs.rs/heck/latest/heck/) crate, so that contract names are correctly transformed to `snake_case` when generating Rust binding file names.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes