### PR TITLE
chore: cheat eip712 struct hash

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -4296,6 +4296,46 @@
     },
     {
       "func": {
+        "id": "eip712HashStruct_0",
+        "description": "",
+        "declaration": "function eip712HashStruct(string calldata typeNameOrDefinition, string calldata jsonData) external pure returns (bytes32 typeHash);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "eip712HashStruct(string,string)",
+        "selector": "0x686230fc",
+        "selectorBytes": [
+          104,
+          98,
+          48,
+          252
+        ]
+      },
+      "group": "utilities",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "eip712HashStruct_1",
+        "description": "",
+        "declaration": "function eip712HashStruct(string calldata bindingsPath, string calldata typeName, string calldata jsonData) external pure returns (bytes32 typeHash);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "eip712HashStruct(string,string,string)",
+        "selector": "0x0e7d8d44",
+        "selectorBytes": [
+          14,
+          125,
+          141,
+          68
+        ]
+      },
+      "group": "utilities",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "eip712HashType_0",
         "description": "Generates the hash of the canonical EIP-712 type representation.\nSupports 2 different inputs:\n 1. Name of the type (i.e. \"Transaction\"):\n    * requires previous binding generation with `forge bind-json`.\n    * bindings will be retrieved from the path configured in `foundry.toml`.\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will output the canonical type even if the input is malformated\n            with the wrong order of elements or with extra whitespaces.",
         "declaration": "function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2910,6 +2910,12 @@ interface Vm {
     ///  * `typeName`: Name of the type (i.e. "Transaction").
     #[cheatcode(group = Utilities)]
     function eip712HashType(string calldata bindingsPath, string calldata typeName) external pure returns (bytes32 typeHash);
+
+    #[cheatcode(group = Utilities)]
+    function eip712HashStruct(string calldata typeNameOrDefinition, string calldata jsonData) external pure returns (bytes32 typeHash);
+
+    #[cheatcode(group = Utilities)]
+    function eip712HashStruct(string calldata bindingsPath, string calldata typeName, string calldata jsonData) external pure returns (bytes32 typeHash);
 }
 }
 

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -208,6 +208,8 @@ interface Vm {
     function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index, string calldata language) external pure returns (uint256 privateKey);
     function difficulty(uint256 newDifficulty) external;
     function dumpState(string calldata pathToStateJson) external;
+    function eip712HashStruct(string calldata typeNameOrDefinition, string calldata jsonData) external pure returns (bytes32 typeHash);
+    function eip712HashStruct(string calldata bindingsPath, string calldata typeName, string calldata jsonData) external pure returns (bytes32 typeHash);
     function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);
     function eip712HashType(string calldata bindingsPath, string calldata typeName) external pure returns (bytes32 typeHash);
     function ensNamehash(string calldata name) external pure returns (bytes32);


### PR DESCRIPTION
Adds a new cheatcode to safely generate struct hashes following the EIP-712 spec, further enhancing Foundry's support.
Complementary of:
- https://github.com/foundry-rs/foundry/pull/10570

## implementation details

ref https://github.com/foundry-rs/foundry/issues/4818

the cheatcode accepts two primary arguments:
1. primary type identifier:
   -   the type name, which will we will attempt to retrieve from the bindings generated by `forge bind-json` (recommended)
   -   the full string representation of the type definition. In this case, we leverage alloy's eip712 support to generate the canonical representation of the type even if users pass malformed  types (unsorted or with extra whitespaces).
2. JSON string of the EIP-712 struct data.

internally, the cheatcode implementation leverages ⁠alloy to encode the data.

## context

while ⁠`vm.eip712HashType` offers a reliable method for obtaining the type hash, developers also need to compute the ⁠`hashStruct(message)` to prepare data for signing or to verify signatures. Manually implementing the ⁠data encoding logic in Solidity is a significant source of errors.

`vm.eip712HashStruct` abstracts this complexity. It provides a dependable way to obtain the correct struct hash for any given EIP-712 compliant data directly within Foundry.

this new cheatcode aims to provide robustness to the codebases, and peace of mind for developers, giving them guarantees that the encoding scheme that they used is correct.

## example usage

```solidity
function testHashPermitSingle() public {
        PermitDetails memory details = PermitDetails({
            token: 0x1111111111111111111111111111111111111111,
            amount: 1000 ether,
            expiration: 12345,
            nonce: 1
        });

        PermitSingle memory permit = PermitSingle({
            details: details,
            spender: 0x2222222222222222222222222222222222222222,
            sigDeadline: 12345
        });

        // user-computed permit (using uniswap hash library)
        bytes32 userStructHash = PermitHash.hash(permit);

        // cheatcode-computed permit (previously serializing to JSON)
        string memory jsonData = permit.serialize();

        console.log("JSON data for PermitSingle:");
        console.log(jsonData);

        bytes32 cheatStructHash = vm.eip712HashStruct("PermitSingle", jsonData);
        console.log("PermitSingle struct hash from cheatcode:");
        console.logBytes32(cheatStructHash);

        assertEq(cheatStructHash, userStructHash, "permit struct hash mismatch");
    }
```

## important note

**Recommendation:** use ⁠forge `bind-json` to generate bindings for your Solidity structs and then use the `⁠.serialize()` method from these bindings (as shown in the example) to easily create the JSON data string. This greatly reduces the risk of manual JSON formatting errors.