### PR TITLE
feat: implement add_balance endpoint

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -361,8 +361,20 @@ pub enum EthRequest {
     SetRpcUrl(String),
 
     /// Modifies the balance of an account.
-    #[serde(rename = "anvil_setBalance", alias = "hardhat_setBalance")]
+    #[serde(
+        rename = "anvil_setBalance",
+        alias = "hardhat_setBalance",
+        alias = "tenderly_setBalance"
+    )]
     SetBalance(Address, #[serde(deserialize_with = "deserialize_number")] U256),
+
+    /// Increases the balance of an account.
+    #[serde(
+        rename = "anvil_addBalance",
+        alias = "hardhat_addBalance",
+        alias = "tenderly_addBalance"
+    )]
+    AddBalance(Address, #[serde(deserialize_with = "deserialize_number")] U256),
 
     /// Modifies the ERC20 balance of an account.
     #[serde(

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -356,6 +356,9 @@ impl EthApi {
             EthRequest::SetBalance(addr, val) => {
                 self.anvil_set_balance(addr, val).await.to_rpc_result()
             }
+            EthRequest::AddBalance(addr, val) => {
+                self.anvil_add_balance(addr, val).await.to_rpc_result()
+            }
             EthRequest::DealERC20(addr, token_addr, val) => {
                 self.anvil_deal_erc20(addr, token_addr, val).await.to_rpc_result()
             }
@@ -1853,6 +1856,16 @@ impl EthApi {
     pub async fn anvil_set_balance(&self, address: Address, balance: U256) -> Result<()> {
         node_info!("anvil_setBalance");
         self.backend.set_balance(address, balance).await?;
+        Ok(())
+    }
+
+    /// Increases the balance of an account.
+    ///
+    /// Handler for RPC call: `anvil_addBalance`
+    pub async fn anvil_add_balance(&self, address: Address, balance: U256) -> Result<()> {
+        node_info!("anvil_addBalance");
+        let current_balance = self.backend.get_balance(address, None).await?;
+        self.backend.set_balance(address, current_balance + balance).await?;
         Ok(())
     }
 

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1491,6 +1491,22 @@ async fn test_set_erc20_balance() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_add_balance() {
+    let config: NodeConfig = fork_config();
+    let address = config.genesis_accounts[0].address();
+    let (api, _handle) = spawn(config).await;
+
+    let start_balance = U256::from(100_000_u64);
+    api.anvil_set_balance(address, start_balance).await.unwrap();
+
+    let balance_increase = U256::from(50_000_u64);
+    api.anvil_add_balance(address, balance_increase).await.unwrap();
+
+    let new_balance = api.balance(address, None).await.unwrap();
+    assert_eq!(new_balance, start_balance + balance_increase);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_reset_updates_cache_path_when_rpc_url_not_provided() {
     let config: NodeConfig = fork_config();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Adds an `addBalance` anvil endpoint as a convenience endpoint to bring on par with Tenderly endpoints https://docs.tenderly.co/virtual-testnets/admin-rpc#tenderly_addbalance

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Simple fetch of current balance and increase using the existing `setBalance` endpoint.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes