### PR TITLE
feat(cast mktx): add support for "--ethsign" option

### DIFF
--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -2,6 +2,7 @@ use crate::tx::{self, CastTxBuilder};
 use alloy_ens::NameOrAddress;
 use alloy_network::{eip2718::Encodable2718, EthereumWallet, TransactionBuilder};
 use alloy_primitives::hex;
+use alloy_provider::Provider;
 use alloy_signer::Signer;
 use clap::Parser;
 use eyre::{OptionExt, Result};
@@ -50,6 +51,10 @@ pub struct MakeTxArgs {
     /// Relaxes the wallet requirement.
     #[arg(long, requires = "from")]
     raw_unsigned: bool,
+
+    /// Call `eth_signTransaction` using the `--from` argument or $ETH_FROM as sender
+    #[arg(long, requires = "from", conflicts_with = "raw_unsigned")]
+    ethsign: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -70,7 +75,7 @@ pub enum MakeTxSubcommands {
 
 impl MakeTxArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { to, mut sig, mut args, command, tx, path, eth, raw_unsigned } = self;
+        let Self { to, mut sig, mut args, command, tx, path, eth, raw_unsigned, ethsign } = self;
 
         let blob_data = if let Some(path) = path { Some(std::fs::read(path)?) } else { None };
 
@@ -91,7 +96,7 @@ impl MakeTxArgs {
 
         let provider = get_provider(&config)?;
 
-        let tx_builder = CastTxBuilder::new(provider, tx, &config)
+        let tx_builder = CastTxBuilder::new(&provider, tx, &config)
             .await?
             .with_to(to)
             .await?
@@ -108,7 +113,18 @@ impl MakeTxArgs {
             return Ok(());
         }
 
-        // Retrieve the signer, and bail if it can't be constructed.
+        if ethsign {
+            // Use "eth_signTransaction" to sign the transaction only works if the node/RPC has
+            // unlocked accounts.
+            let (tx, _) = tx_builder.build(config.sender).await?;
+            let signed_tx = provider.sign_transaction(tx).await?;
+
+            sh_println!("{signed_tx}")?;
+            return Ok(());
+        }
+
+        // Default to using the local signer.
+        // Get the signer from the wallet, and fail if it can't be constructed.
         let signer = eth.wallet.signer().await?;
         let from = signer.address();
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1296,6 +1296,37 @@ casttest!(mktx_raw_unsigned, |_prj, cmd| {
     ]]);
 });
 
+casttest!(mktx_ethsign, async |_prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+    cmd.args([
+        "mktx",
+        "--from",
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "--chain",
+        "31337",
+        "--nonce",
+        "0",
+        "--gas-limit",
+        "21000",
+        "--gas-price",
+        "10000000000",
+        "--priority-gas-price",
+        "1000000000",
+        "0x0000000000000000000000000000000000000001",
+        "--ethsign",
+        "--rpc-url",
+        rpc.as_str(),
+    ])
+    .assert_success()
+    .stdout_eq(str![[
+        r#"
+0x02f86d827a6980843b9aca008502540be4008252089400000000000000000000000000000000000000018080c001a0b8eeb1ded87b085859c510c5692bed231e3ee8b068ccf71142bbf28da0e95987a07813b676a248ae8055f28495021d78dee6695479d339a6ad9d260d9eaf20674c
+
+"#
+    ]]);
+});
+
 // tests that the raw encoded transaction is returned
 casttest!(tx_raw, |_prj, cmd| {
     let rpc = next_http_rpc_endpoint();


### PR DESCRIPTION
## Motivation
Resolve #10629 by adding "--ethsign" option to `cast mktx` command.

## Solution
- Sign transactions using "eth_signTransaction" on local node with unlocked accounts.
- Same TX building logic as in "cast send --unlocked".
- Added a test case to validate the new functionality.

## Remarks
This new "--ethsign" option conflicts with "--raw-unsigned", this is properly declared in the Clap macro.

## PR Checklist
- [x] Added Tests
- [x] ~Added Documentation~
- [x] Breaking changes