### PR TITLE
fix(fmt): 'layout' is not a keyword

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4586,9 +4586,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-solang-parser"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c5fc5210af6b311ab9c6bce41d651d1cd0ab62ea5e0e7fde9635697fb19180"
+checksum = "9645e75b89f977423690f3b4bfd8d84825e5fdabd7803cbce6d4a2c4d54972b4"
 dependencies = [
  "itertools 0.14.0",
  "lalrpop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ foundry-linking = { path = "crates/linking" }
 foundry-block-explorers = { version = "0.17.0", default-features = false }
 foundry-compilers = { version = "0.16.1", default-features = false }
 foundry-fork-db = "0.15"
-solang-parser = { version = "=0.3.8", package = "foundry-solang-parser" }
+solang-parser = { version = "=0.3.9", package = "foundry-solang-parser" }
 solar-ast = { version = "=0.1.3", default-features = false }
 solar-parse = { version = "=0.1.3", default-features = false }
 solar-interface = { version = "=0.1.3", default-features = false }

--- a/crates/fmt/testdata/NonKeywords/fmt.sol
+++ b/crates/fmt/testdata/NonKeywords/fmt.sol
@@ -1,13 +1,13 @@
 struct S {
     uint256 error;
-    // uint256 layout;
+    uint256 layout;
     uint256 at;
 }
 // uint256 transient;
 
 function f() {
     uint256 error = 0;
-    // uint256 layout = 0;
+    uint256 layout = 0;
     uint256 at = 0;
     // uint256 transient = 0;
 
@@ -17,25 +17,26 @@ function f() {
     // transient = 0;
 
     S memory x = S({
+        // format
         error: 0,
-        // layout: 0,
+        layout: 0,
         at: 0
     });
     // transient: 0
 
     x.error = 0;
-    // x.layout = 0;
+    x.layout = 0;
     x.at = 0;
     // x.transient = 0;
 
     assembly {
         let error := 0
-        // let layout := 0
+        let layout := 0
         let at := 0
         // let transient := 0
 
         error := 0
-        // layout := 0
+        layout := 0
         at := 0
         // transient := 0
     }

--- a/crates/fmt/testdata/NonKeywords/original.sol
+++ b/crates/fmt/testdata/NonKeywords/original.sol
@@ -1,13 +1,13 @@
 struct S {
     uint256 error;
-    // uint256 layout;
+    uint256 layout;
     uint256 at;
     // uint256 transient;
 }
 
 function f() {
     uint256 error = 0;
-    // uint256 layout = 0;
+    uint256 layout = 0;
     uint256 at = 0;
     // uint256 transient = 0;
 
@@ -17,25 +17,26 @@ function f() {
     // transient = 0;
 
     S memory x = S({
+        // format
         error: 0,
-        // layout: 0,
+        layout: 0,
         at: 0
         // transient: 0
     });
 
     x.error = 0;
-    // x.layout = 0;
+    x.layout = 0;
     x.at = 0;
     // x.transient = 0;
 
     assembly {
         let error := 0
-        // let layout := 0
+        let layout := 0
         let at := 0
         // let transient := 0
 
         error := 0
-        // layout := 0
+        layout := 0
         at := 0
         // transient := 0
     }

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -217,7 +217,6 @@ test_directories! {
     TryStatement,
     ConditionalOperatorExpression,
     NamedFunctionCallExpression,
-    NonKeywords,
     ArrayExpressions,
     UnitExpression,
     ThisExpression,
@@ -242,3 +241,4 @@ test_directories! {
 }
 
 test_dir!(SortedImports, TestConfig::skip_compare_ast_eq());
+test_dir!(NonKeywords, TestConfig::skip_compare_ast_eq());


### PR DESCRIPTION
Same as https://github.com/foundry-rs/foundry/pull/10556, but still doesn't allow `layout` everywhere due to limitations described in previous PRs (only `layout = x;` is not allowed, but `uint layout = x;` and everywhere else is).
With this PR, this is the most we can allow of the new not-actually-keyword keywords.

Fixes https://github.com/foundry-rs/foundry/issues/10654.