### PR TITLE
chore(forge lint): unused imports

### DIFF
--- a/crates/lint/src/sol/info/mixed_case.rs
+++ b/crates/lint/src/sol/info/mixed_case.rs
@@ -33,7 +33,7 @@ declare_forge_lint!(
 impl<'ast> EarlyLintPass<'ast> for MixedCaseVariable {
     fn check_variable_definition(
         &mut self,
-        ctx: &LintContext<'_>,
+        ctx: &mut LintContext<'_>,
         var: &'ast VariableDefinition<'ast>,
     ) {
         if var.mutability.is_none() {

--- a/crates/lint/src/sol/info/mod.rs
+++ b/crates/lint/src/sol/info/mod.rs
@@ -12,9 +12,13 @@ use pascal_case::PASCAL_CASE_STRUCT;
 mod screaming_snake_case;
 use screaming_snake_case::{SCREAMING_SNAKE_CASE_CONSTANT, SCREAMING_SNAKE_CASE_IMMUTABLE};
 
+mod unused_import;
+pub use unused_import::UNUSED_IMPORT;
+
 register_lints!(
     (PascalCaseStruct, (PASCAL_CASE_STRUCT)),
     (MixedCaseVariable, (MIXED_CASE_VARIABLE)),
     (MixedCaseFunction, (MIXED_CASE_FUNCTION)),
-    (ScreamingSnakeCase, (SCREAMING_SNAKE_CASE_CONSTANT, SCREAMING_SNAKE_CASE_IMMUTABLE))
+    (ScreamingSnakeCase, (SCREAMING_SNAKE_CASE_CONSTANT, SCREAMING_SNAKE_CASE_IMMUTABLE)),
+    (UnusedImport, (UNUSED_IMPORT))
 );

--- a/crates/lint/src/sol/info/screaming_snake_case.rs
+++ b/crates/lint/src/sol/info/screaming_snake_case.rs
@@ -23,7 +23,7 @@ declare_forge_lint!(
 impl<'ast> EarlyLintPass<'ast> for ScreamingSnakeCase {
     fn check_variable_definition(
         &mut self,
-        ctx: &LintContext<'_>,
+        ctx: &mut LintContext<'_>,
         var: &'ast VariableDefinition<'ast>,
     ) {
         if let (Some(name), Some(mutability)) = (var.name, var.mutability) {

--- a/crates/lint/src/sol/info/unused_import.rs
+++ b/crates/lint/src/sol/info/unused_import.rs
@@ -1,4 +1,4 @@
-use solar_ast::{ImportItems, TypeKind, UsingList};
+use solar_ast::{ExprKind, ImportItems, TypeKind, UsingList};
 
 use super::UnusedImport;
 use crate::{
@@ -52,6 +52,12 @@ impl<'ast> EarlyLintPass<'ast> for UnusedImport {
         if let TypeKind::Custom(ty) = &var.ty.kind {
             ctx.use_import(ty.last().name.clone());
         }
+
+        if let Some(expr) = &var.initializer {
+            if let ExprKind::Ident(ident) = expr.kind {
+                ctx.use_import(ident.name.clone());
+            }
+        }
     }
 
     fn check_using_directive(
@@ -68,11 +74,4 @@ impl<'ast> EarlyLintPass<'ast> for UnusedImport {
             }
         }
     }
-}
-
-#[cfg(test)]
-mod test {
-
-    #[test]
-    fn test_unused_imports() {}
 }

--- a/crates/lint/src/sol/info/unused_import.rs
+++ b/crates/lint/src/sol/info/unused_import.rs
@@ -1,0 +1,78 @@
+use solar_ast::{ImportItems, TypeKind, UsingList};
+
+use super::UnusedImport;
+use crate::{
+    declare_forge_lint,
+    linter::{EarlyLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+
+declare_forge_lint!(
+    UNUSED_IMPORT,
+    Severity::Info,
+    "unused-import",
+    "unused imports should be removed"
+);
+
+impl<'ast> EarlyLintPass<'ast> for UnusedImport {
+    fn check_import_directive(
+        &mut self,
+        ctx: &mut LintContext<'_>,
+        import: &'ast solar_ast::ImportDirective<'ast>,
+    ) {
+        // to begin with, only check explicit imports
+        if let ImportItems::Aliases(ref items) = import.items {
+            for item in &**items {
+                let (name, span) = if let Some(ref i) = &item.1 {
+                    (&i.name, &i.span)
+                } else {
+                    (&item.0.name, &item.0.span)
+                };
+
+                ctx.add_import((name.clone(), span.clone()));
+            }
+        }
+    }
+
+    fn check_item_contract(
+        &mut self,
+        ctx: &mut LintContext<'_>,
+        contract: &'ast solar_ast::ItemContract<'ast>,
+    ) {
+        for modifier in &*contract.bases {
+            ctx.use_import(modifier.name.last().name.clone());
+        }
+    }
+
+    fn check_variable_definition(
+        &mut self,
+        ctx: &mut LintContext<'_>,
+        var: &'ast solar_ast::VariableDefinition<'ast>,
+    ) {
+        if let TypeKind::Custom(ty) = &var.ty.kind {
+            ctx.use_import(ty.last().name.clone());
+        }
+    }
+
+    fn check_using_directive(
+        &mut self,
+        ctx: &mut LintContext<'_>,
+        using: &'ast solar_ast::UsingDirective<'ast>,
+    ) {
+        match &using.list {
+            UsingList::Single(ty) => ctx.use_import(ty.last().name.clone()),
+            UsingList::Multiple(types) => {
+                for (ty, _operator) in &**types {
+                    ctx.use_import(ty.last().name.clone());
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    fn test_unused_imports() {}
+}

--- a/crates/lint/src/sol/info/unused_import.rs
+++ b/crates/lint/src/sol/info/unused_import.rs
@@ -1,4 +1,4 @@
-use solar_ast::{ExprKind, ImportItems, TypeKind, UsingList};
+use solar_ast::{Expr, ExprKind, ImportItems, PathSlice, Symbol, TypeKind, UsingList};
 
 use super::UnusedImport;
 use crate::{
@@ -15,63 +15,99 @@ declare_forge_lint!(
 );
 
 impl<'ast> EarlyLintPass<'ast> for UnusedImport {
+    /// Collects all the file imports and caches them in `LintContext`.
     fn check_import_directive(
         &mut self,
         ctx: &mut LintContext<'_>,
         import: &'ast solar_ast::ImportDirective<'ast>,
     ) {
-        // to begin with, only check explicit imports
-        if let ImportItems::Aliases(ref items) = import.items {
-            for item in &**items {
-                let (name, span) = if let Some(ref i) = &item.1 {
-                    (&i.name, &i.span)
-                } else {
-                    (&item.0.name, &item.0.span)
-                };
+        match import.items {
+            ImportItems::Aliases(ref items) => {
+                for item in &**items {
+                    let (name, span) = if let Some(ref i) = &item.1 {
+                        (&i.name, &i.span)
+                    } else {
+                        (&item.0.name, &item.0.span)
+                    };
 
-                ctx.add_import((name.clone(), span.clone()));
+                    ctx.add_import((*name, *span));
+                }
             }
+            ImportItems::Glob(ref ident) => {
+                ctx.add_import((ident.name, ident.span));
+            }
+            ImportItems::Plain(ref maybe) => match maybe {
+                Some(ident) => ctx.add_import((ident.name, ident.span)),
+                None => {
+                    let path = import.path.value.to_string();
+                    let len = path.len() - 4;
+                    ctx.add_import((Symbol::intern(&path[..len]), import.path.span));
+                }
+            },
         }
     }
 
+    /// Marks contract modifiers as used, effectively removing them from the `LintContext` cache.
     fn check_item_contract(
         &mut self,
         ctx: &mut LintContext<'_>,
         contract: &'ast solar_ast::ItemContract<'ast>,
     ) {
         for modifier in &*contract.bases {
-            ctx.use_import(modifier.name.last().name.clone());
+            use_import_type(ctx, &modifier.name);
         }
     }
 
+    /// Marks variable definitions (both, variable type and initializer name) as used,
+    /// effectively removing them from the `LintContext` cache.
     fn check_variable_definition(
         &mut self,
         ctx: &mut LintContext<'_>,
         var: &'ast solar_ast::VariableDefinition<'ast>,
     ) {
         if let TypeKind::Custom(ty) = &var.ty.kind {
-            ctx.use_import(ty.last().name.clone());
+            use_import_type(ctx, ty);
         }
 
         if let Some(expr) = &var.initializer {
-            if let ExprKind::Ident(ident) = expr.kind {
-                ctx.use_import(ident.name.clone());
-            }
+            use_import_expr(ctx, expr);
         }
     }
 
+    /// Marks the types in a using directive as used, effectively removing them from the
+    /// `LintContext` cache.
     fn check_using_directive(
         &mut self,
         ctx: &mut LintContext<'_>,
         using: &'ast solar_ast::UsingDirective<'ast>,
     ) {
         match &using.list {
-            UsingList::Single(ty) => ctx.use_import(ty.last().name.clone()),
+            UsingList::Single(ty) => use_import_type(ctx, ty),
             UsingList::Multiple(types) => {
                 for (ty, _operator) in &**types {
-                    ctx.use_import(ty.last().name.clone());
+                    use_import_type(ctx, ty);
                 }
             }
         }
+    }
+}
+
+/// Marks the type as used.
+/// If the type has more than one segment, it marks both, the first, and the last one.
+fn use_import_type(ctx: &mut LintContext<'_>, ty: &&mut PathSlice) {
+    ctx.use_import(ty.last().name);
+    if ty.segments().len() != 1 {
+        ctx.use_import(ty.first().name);
+    }
+}
+
+/// Marks the type as used.
+/// If the type has more than one segment, it marks both, the first, and the last one.
+fn use_import_expr<'ast>(ctx: &mut LintContext<'_>, expr: &&mut Expr<'ast>) {
+    match &expr.kind {
+        ExprKind::Ident(ident) => ctx.use_import(ident.name),
+        ExprKind::Member(ref expr, _) => use_import_expr(ctx, expr),
+        ExprKind::Call(ref expr, _) => use_import_expr(ctx, expr),
+        _ => (),
     }
 }

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -1,6 +1,7 @@
 use crate::linter::{EarlyLintPass, EarlyLintVisitor, Lint, LintContext, Linter};
 use foundry_compilers::solc::SolcLanguage;
 use foundry_config::lint::Severity;
+use info::UNUSED_IMPORT;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use solar_ast::{visit::Visit, Arena};
 use solar_interface::{
@@ -108,9 +109,10 @@ impl SolidityLinter {
             let ast = parser.parse_file().map_err(|e| e.emit())?;
 
             // Initialize and run the visitor
-            let ctx = LintContext::new(sess, self.with_description);
-            let mut visitor = EarlyLintVisitor { ctx: &ctx, passes: &mut passes };
+            let mut ctx = LintContext::new(sess, self.with_description);
+            let mut visitor = EarlyLintVisitor { ctx: &mut ctx, passes: &mut passes };
             _ = visitor.visit_source_unit(&ast);
+            ctx.emit_unused_imports(&UNUSED_IMPORT);
 
             Ok(())
         });

--- a/crates/lint/testdata/UnusedImport.sol
+++ b/crates/lint/testdata/UnusedImport.sol
@@ -15,6 +15,22 @@ import {
     CONSTANT_1 //~NOTE: unused imports should be removed
 } from "Constants.sol";
 
+import {
+    MyTpe,
+    MyOtherType,
+    YetAnotherType //~NOTE: unused imports should be removed
+} from "Types.sol";
+
+import "SomeFile.sol";
+import "AnotherFile.sol"; //~NOTE: unused imports should be removed
+
+import "some_file_2.sol" as SomeFile2;
+import "another_file_2.sol" as AnotherFile2; //~NOTE: unused imports should be removed
+
+import * as Utils from "utils.sol";
+import * as OtherUtils from "utils2.sol"; //~NOTE: unused imports should be removed
+
+
 contract UnusedImport is IContract {
     using mySymbol for address;
 
@@ -25,7 +41,17 @@ contract UnusedImport is IContract {
         myOtherSymbol bar;
     }
 
-    symbol4 myVar;
+    SomeFile.Baz public myStruct;
+    SomeFile2.Baz public myStruct2;
+    symbol4 public myVar;
 
-    function foo(uint256 a, symbol5 b) public view {}
+    function foo(uint256 a, symbol5 b) public view returns (uint256) {
+        uint256 c = Utils.calculate(a, b);
+        return c;
+    }
+
+    function convert(address addr) public pure returns (MyOtherType) {
+        MyType a = MyTpe.wrap(123);
+        return MyOtherType.wrap(a);
+    }
 }

--- a/crates/lint/testdata/UnusedImport.sol
+++ b/crates/lint/testdata/UnusedImport.sol
@@ -10,8 +10,15 @@ import {
     IContractNotUsed //~NOTE: unused imports should be removed
 } from "File.sol";
 
+import {
+    CONSTANT_0,
+    CONSTANT_1 //~NOTE: unused imports should be removed
+} from "Constants.sol";
+
 contract UnusedImport is IContract {
     using mySymbol for address;
+
+    uint256 constant MY_CONSTANT = CONSTANT_0;
 
     struct FooBar {
         symbol3 foo;

--- a/crates/lint/testdata/UnusedImport.sol
+++ b/crates/lint/testdata/UnusedImport.sol
@@ -1,0 +1,24 @@
+import {
+    symbol0 as mySymbol,
+    symbol1 as myOtherSymbol,
+    symbol2 as notUsed, //~NOTE: unused imports should be removed
+    symbol3,
+    symbol4,
+    symbol5,
+    symbolNotUsed, //~NOTE: unused imports should be removed
+    IContract,
+    IContractNotUsed //~NOTE: unused imports should be removed
+} from "File.sol";
+
+contract UnusedImport is IContract {
+    using mySymbol for address;
+
+    struct FooBar {
+        symbol3 foo;
+        myOtherSymbol bar;
+    }
+
+    symbol4 myVar;
+
+    function foo(uint256 a, symbol5 b) public view {}
+}

--- a/crates/lint/testdata/UnusedImport.stderr
+++ b/crates/lint/testdata/UnusedImport.stderr
@@ -22,3 +22,11 @@ note[unused-import]: unused imports should be removed
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
 
+note[unused-import]: unused imports should be removed
+  --> ROOT/testdata/UnusedImport.sol:LL:CC
+   |
+15 |     CONSTANT_1
+   |     ----------
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
+

--- a/crates/lint/testdata/UnusedImport.stderr
+++ b/crates/lint/testdata/UnusedImport.stderr
@@ -1,0 +1,24 @@
+note[unused-import]: unused imports should be removed
+ --> ROOT/testdata/UnusedImport.sol:LL:CC
+  |
+4 |     symbol2 as notUsed,
+  |                -------
+  |
+  = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
+
+note[unused-import]: unused imports should be removed
+ --> ROOT/testdata/UnusedImport.sol:LL:CC
+  |
+8 |     symbolNotUsed,
+  |     -------------
+  |
+  = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
+
+note[unused-import]: unused imports should be removed
+  --> ROOT/testdata/UnusedImport.sol:LL:CC
+   |
+10 |     IContractNotUsed
+   |     ----------------
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
+

--- a/crates/lint/testdata/UnusedImport.stderr
+++ b/crates/lint/testdata/UnusedImport.stderr
@@ -30,3 +30,35 @@ note[unused-import]: unused imports should be removed
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
 
+note[unused-import]: unused imports should be removed
+  --> ROOT/testdata/UnusedImport.sol:LL:CC
+   |
+21 |     YetAnotherType
+   |     --------------
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
+
+note[unused-import]: unused imports should be removed
+  --> ROOT/testdata/UnusedImport.sol:LL:CC
+   |
+25 | import "AnotherFile.sol";
+   |        -----------------
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
+
+note[unused-import]: unused imports should be removed
+  --> ROOT/testdata/UnusedImport.sol:LL:CC
+   |
+28 | import "another_file_2.sol" as AnotherFile2;
+   |                                ------------
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
+
+note[unused-import]: unused imports should be removed
+  --> ROOT/testdata/UnusedImport.sol:LL:CC
+   |
+31 | import * as OtherUtils from "utils2.sol";
+   |             ----------
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
+


### PR DESCRIPTION
Adds a new lint rule for unused imports.

ref:
- https://github.com/foundry-rs/foundry/issues/10633#issuecomment-2919234069