### PR TITLE
fix(forge lint): gas lints

### DIFF
--- a/crates/forge/src/cmd/lint.rs
+++ b/crates/forge/src/cmd/lint.rs
@@ -45,6 +45,7 @@ impl LintArgs {
     pub fn run(self) -> Result<()> {
         let config = self.load_config()?;
         let project = config.project()?;
+        let path_config = config.project_paths();
 
         // Expand ignore globs and canonicalize from the get go
         let ignored = expand_globs(&config.root, config.lint.ignore.iter())?
@@ -105,7 +106,7 @@ impl LintArgs {
             return Err(eyre!("Linting not supported for this language"));
         }
 
-        let linter = SolidityLinter::new()
+        let linter = SolidityLinter::new(path_config)
             .with_json_emitter(self.json)
             .with_description(true)
             .with_lints(include)

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -73,10 +73,14 @@ impl SolidityLinter {
         let _ = sess.enter(|| -> Result<(), diagnostics::ErrorGuaranteed> {
             // Declare all available passes and lints
             let mut passes_and_lints = Vec::new();
-            passes_and_lints.extend(gas::create_lint_passes());
             passes_and_lints.extend(high::create_lint_passes());
             passes_and_lints.extend(med::create_lint_passes());
             passes_and_lints.extend(info::create_lint_passes());
+
+            // Do not apply gas-severity rules on tests and scripts
+            if !file.ends_with(".t.sol") && !file.ends_with(".s.sol") {
+                passes_and_lints.extend(gas::create_lint_passes());
+            }
 
             // Filter based on linter config
             let mut passes: Vec<Box<dyn EarlyLintPass<'_>>> = passes_and_lints

--- a/crates/lint/testdata/Keccak256.sol
+++ b/crates/lint/testdata/Keccak256.sol
@@ -1,13 +1,19 @@
 contract AsmKeccak256 {
+
+    // constants are optimized by the compiler
+    bytes32 constant HASH = keccak256("hello");
+    bytes32 constant OTHER_HASH = keccak256(1234);
+
     constructor(uint256 a, uint256 b) {
         keccak256(abi.encodePacked(a, b)); //~NOTE: hash using inline assembly to save gas
     }
 
-    function solidityHash(uint256 a, uint256 b) public view {
-        keccak256(abi.encodePacked(a, b)); //~NOTE: hash using inline assembly to save gas
+    function solidityHash(uint256 a, uint256 b) public view returns (bytes32) {
+        bytes32 hash = keccak256(a); //~NOTE: hash using inline assembly to save gas
+        return keccak256(abi.encodePacked(a, b)); //~NOTE: hash using inline assembly to save gas
     }
 
-    function assemblyHash(uint256 a, uint256 b) public view {
+    function assemblyHash(uint256 a, uint256 b) public view returns (bytes32){
         //optimized
         assembly {
             mstore(0x00, a)

--- a/crates/lint/testdata/Keccak256.stderr
+++ b/crates/lint/testdata/Keccak256.stderr
@@ -1,16 +1,24 @@
 note[asm-keccak256]: hash using inline assembly to save gas
  --> ROOT/testdata/Keccak256.sol:LL:CC
   |
-3 |         keccak256(abi.encodePacked(a, b));
+8 |         keccak256(abi.encodePacked(a, b));
   |         ---------
   |
   = help: https://book.getfoundry.sh/reference/forge/forge-lint#asm-keccak256
 
 note[asm-keccak256]: hash using inline assembly to save gas
- --> ROOT/testdata/Keccak256.sol:LL:CC
-  |
-7 |         keccak256(abi.encodePacked(a, b));
-  |         ---------
-  |
-  = help: https://book.getfoundry.sh/reference/forge/forge-lint#asm-keccak256
+  --> ROOT/testdata/Keccak256.sol:LL:CC
+   |
+12 |         bytes32 hash = keccak256(a);
+   |                        ---------
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#asm-keccak256
+
+note[asm-keccak256]: hash using inline assembly to save gas
+  --> ROOT/testdata/Keccak256.sol:LL:CC
+   |
+13 |         return keccak256(abi.encodePacked(a, b));
+   |                ---------
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#asm-keccak256
 


### PR DESCRIPTION
closes: https://github.com/foundry-rs/foundry/issues/10663

## Motivation

- disable gas-related lints for test and script files
- reduce the amount of false positives for keccak256

## Solution

previously, any time keccak256 was used, it would be flag as an unoptimized usage.

with this change, those hashes which simply hash a single literal (i.e. `keccak256("hello")` or `keccak256(1234)`) won't be flagged, as the compiler should inline its hash.