### PR TITLE
fix(cast): read all lines for message to hash

### DIFF
--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -626,7 +626,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
             };
         }
         CastSubcommand::HashMessage { message } => {
-            let message = stdin::unwrap_line(message)?;
+            let message = stdin::unwrap(message, false)?;
             sh_println!("{}", eip191_hash_message(message))?
         }
         CastSubcommand::SigEvent { event_string } => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
```bash
#!/usr/bin/env bash
message_raw=$(<message.txt)
hashed_message1=$(printf "%s" "$message_raw" | cast hash-message)
hashed_message2=$(cast hash-message "$message_raw")
echo $hashed_message1
echo $hashed_message2
```
where message.txt is something like
```
Welcome to OpenSea!

Click to sign in and accept the OpenSea Terms of Service (https://opensea.io/tos) and Privacy Policy (https://opensea.io/privacy).

This request will not trigger a blockchain transaction or cost any gas fees.
```
outputs different hashes
```
0xc36550d1b80343edd49ced11158a478faf57dbec05ade0b463149bc7b31d8df8
0x9ae3cff27abb1798440be7218c7c62070e7fca99d0a3b68b6ef451d64b15ba63
```
because in 1st case only first line is read

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- use `stdin::unwrap(message, false)?` to read message
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes