### PR TITLE
fix: populate missing fields for eth simulate

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1774,8 +1774,8 @@ impl Backend {
                 }
 
                 for res in &mut call_res {
-                    res.logs.iter_mut().for_each(| log| {
-                    log.block_hash = Some(block.header.hash);
+                    res.logs.iter_mut().for_each(|log| {
+                        log.block_hash = Some(block.header.hash);
                     });
                 }
 


### PR DESCRIPTION
we didn't populate the txhash and blockhash fields for the logs in the simulated block response