### PR TITLE
chore: fix flaky test, bump timeout max rejects, use http provider

### DIFF
--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -669,7 +669,7 @@ async fn can_remove_pool_transactions() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_reorg() {
     let (api, handle) = spawn(NodeConfig::test()).await;
-    let provider = handle.ws_provider();
+    let provider = handle.http_provider();
 
     let accounts = handle.dev_wallets().collect::<Vec<_>>();
 

--- a/crates/forge/tests/it/fuzz.rs
+++ b/crates/forge/tests/it/fuzz.rs
@@ -254,7 +254,7 @@ forgetest_init!(test_fuzz_timeout, |prj, cmd| {
 import {Test} from "forge-std/Test.sol";
 
 contract FuzzTimeoutTest is Test {
-    /// forge-config: default.fuzz.max-test-rejects = 10000
+    /// forge-config: default.fuzz.max-test-rejects = 50000
     /// forge-config: default.fuzz.timeout = 1
     function test_fuzz_bound(uint256 a) public pure {
         vm.assume(a == 0);

--- a/testdata/default/repros/Issue10527.t.sol
+++ b/testdata/default/repros/Issue10527.t.sol
@@ -18,6 +18,9 @@ contract A {
 }
 
 contract Issue10527Test is DSTest {
+    event Event1();
+    event Event2();
+
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     A a;
@@ -28,14 +31,14 @@ contract Issue10527Test is DSTest {
 
     function test_foo_Event1() public {
         vm.expectEmit(address(a));
-        emit A.Event1();
+        emit Event1();
 
         a.foo();
     }
 
     function test_foo_Event2() public {
         vm.expectEmit({emitter: address(a), count: 0});
-        emit A.Event2();
+        emit Event2();
 
         a.foo();
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- fix fuzz timeout test by bumping the max rejects value (test finished in 537.34ms when timeout is set to 1s) https://github.com/foundry-rs/foundry/actions/runs/15410116103/job/43360205142#step:12:704
- attempt to fix anvil reorg test by using http provider instead ws https://github.com/foundry-rs/foundry/actions/runs/15414283452/job/43373308903#step:12:207
- fix flaky 10527 repro test https://github.com/foundry-rs/foundry/actions/runs/15410116103/job/43360205150#step:12:413 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes