### PR TITLE
CI: remove workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
       - "v*.*.*"
   schedule:
     - cron: "0 6 * * *"
-  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The branches/tag filter actually is not supported for workflow_dispatch
