### PR TITLE
Update broken REVM memory opcodes documentation link

### DIFF
--- a/crates/evm/core/src/opcodes.rs
+++ b/crates/evm/core/src/opcodes.rs
@@ -3,7 +3,7 @@
 use revm::bytecode::opcode::OpCode;
 
 /// Returns true if the opcode modifies memory.
-/// <https://bluealloy.github.io/revm/crates/interpreter/memory.html#opcodes>
+/// <https://reth.rs/docs/reth_ethereum/evm/revm/revm/bytecode/opcode/struct.OpCode.html#method.modifies_memory>
 /// <https://github.com/crytic/evm-opcodes>
 #[inline]
 pub const fn modifies_memory(opcode: OpCode) -> bool {


### PR DESCRIPTION
Replaced the outdated and broken link to the REVM memory-modifying opcodes documentation with a new, working reference to the official Reth/REVM OpCode documentation. This ensures that the comment remains relevant and provides accurate information for future maintenance and reference.