### PR TITLE
fix: always update auth txenv var

### DIFF
--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -167,9 +167,7 @@ pub fn configure_tx_req_env(
     env.tx.max_fee_per_blob_gas = max_fee_per_blob_gas.unwrap_or_default();
 
     // Type 4, EIP-7702
-    if let Some(authorization_list) = authorization_list {
-        env.tx.set_signed_authorization(authorization_list.clone());
-    }
+    env.tx.set_signed_authorization(authorization_list.clone().unwrap_or_default());
 
     Ok(())
 }


### PR DESCRIPTION
closes #10706

this is a legacy revm style bug where the txenv isn't fully updated

we should consider adapting more alloy-evm style oneshot `tx -> txenv` conversion patterns for this