### PR TITLE
fix(cast): do not use default overrides if no override arg

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -313,8 +313,22 @@ impl CallArgs {
 
         Ok(())
     }
-    /// Parse state overrides from command line arguments
-    pub fn get_state_overrides(&self) -> eyre::Result<StateOverride> {
+
+    /// Parse state overrides from command line arguments.
+    pub fn get_state_overrides(&self) -> eyre::Result<Option<StateOverride>> {
+        // Early return if no override set - <https://github.com/foundry-rs/foundry/issues/10705>
+        if [
+            self.balance_overrides.as_ref(),
+            self.nonce_overrides.as_ref(),
+            self.code_overrides.as_ref(),
+            self.state_overrides.as_ref(),
+        ]
+        .iter()
+        .all(Option::is_none)
+        {
+            return Ok(None);
+        }
+
         let mut state_overrides_builder = StateOverridesBuilder::default();
 
         // Parse balance overrides
@@ -352,7 +366,7 @@ impl CallArgs {
                 state_overrides_builder.with_state_diff(addr, [(slot.into(), value.into())]);
         }
 
-        Ok(state_overrides_builder.build())
+        Ok(Some(state_overrides_builder.build()))
     }
 }
 

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -137,7 +137,7 @@ impl<P: Provider<AnyNetwork>> Cast<P> {
     /// let state_override_object = StateOverridesBuilder::default().build();
     ///
     /// let cast = Cast::new(alloy_provider);
-    /// let data = cast.call(&tx, None, None, state_override_object).await?;
+    /// let data = cast.call(&tx, None, None, Some(state_override_object)).await?;
     /// println!("{}", data);
     /// # Ok(())
     /// # }
@@ -147,15 +147,14 @@ impl<P: Provider<AnyNetwork>> Cast<P> {
         req: &WithOtherFields<TransactionRequest>,
         func: Option<&Function>,
         block: Option<BlockId>,
-        state_override: StateOverride,
+        state_override: Option<StateOverride>,
     ) -> Result<String> {
-        let res = self
-            .provider
-            .call(req.clone())
-            .block(block.unwrap_or_default())
-            .overrides(state_override)
-            .await?;
+        let mut call = self.provider.call(req.clone()).block(block.unwrap_or_default());
+        if let Some(state_override) = state_override {
+            call = call.overrides(state_override)
+        }
 
+        let res = call.await?;
         let mut decoded = vec![];
 
         if let Some(func) = func {

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -2718,3 +2718,13 @@ Estimated data availability size for block 30558838 with 225 transactions: 52916
 
 "#]]);
 });
+
+// <https://github.com/foundry-rs/foundry/issues/10705>
+casttest!(cast_call_return_array_of_tuples, |_prj, cmd| {
+    cmd.args(["call", "0x198FC70Dfe05E755C81e54bd67Bff3F729344B9b", "facets() returns ((address,bytes4[])[])", "--rpc-url", "https://rpc.viction.xyz"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+[(0x9640977264aec6d4e9af381F548eee11b9e27aAe, [0x1f931c1c]), (0x395db83A04cC3d3F6C5eFc73896929Cf10D0F301, [0xcdffacc6, 0x52ef6b2c, 0xadfca15e, 0x7a0ed627, 0x01ffc9a7]), (0xC6F7b47F870024B0E2DF6DFd551E10c4A37A1cEa, [0x23452b9c, 0x7200b829, 0x8da5cb5b, 0xf2fde38b]), (0xc1f27c1f6c87e73e089Ffac23C236Fc4A9E3fccc, [0x1458d7ad, 0xd9caed12]), (0x70e272A93bc8344277a1f4390Ea6153A1D5fe450, [0x536db266, 0xfbb2d381, 0xfcd8e49e, 0x9afc19c7, 0x44e2b18c, 0x2d2506a9, 0x124f1ead, 0xc3a6a96b]), (0x662BCADB7A2CBb22367b2471d8A91E5b13FCe96B, [0x612ad9cb, 0xa4c3366e]), (0x190e03D49Ce76DDabC634a98629EDa6246aB5196, [0xa516f0f3, 0x5c2ed36a]), (0xAF69C0E3BBBf6AdE78f1466f86DfF86d64C8dA2A, [0x4630a0d8]), (0xD1317DA862AC5C145519E60D24372dc186EF7426, [0xd5bcb610, 0x5fd9ae2e, 0x2c57e884, 0x736eac0b, 0x4666fc80, 0x733214a3, 0xaf7060fd]), (0x176f558949e2a7C5217dD9C27Bf7A43c6783ee28, [0x7f99d7af, 0x103c5200, 0xc318eeda, 0xee0aa320, 0xdf1c3a5b, 0x070e81f1, 0xd53482cf, 0xf58ae2ce]), (0x531d69A3fAb6CB56A77B8402E6c217cB9cC902A9, [0xf86368ae, 0x5ad317a4, 0x0340e905, 0x2fc487ae])]
+
+"#]]);
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #10705 
- regression introduced in https://github.com/foundry-rs/foundry/pull/10255 where it makes the call with default state overrides (not None) even if no override arg passed
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes