### PR TITLE
fix(anvil): guard against the blockchain advancing while checking latest block

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2290,7 +2290,7 @@ impl Backend {
                         .number
                 }
                 BlockId::Number(num) => match num {
-                    BlockNumber::Latest | BlockNumber::Pending => self.best_number(),
+                    BlockNumber::Latest | BlockNumber::Pending => current,
                     BlockNumber::Earliest => U64::ZERO.to::<u64>(),
                     BlockNumber::Number(num) => num,
                     BlockNumber::Safe => current.saturating_sub(self.slots_in_an_epoch),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Our tests sometimes flake with a `BlockRangeOutOfRangeError` when calling `eth_call` with the `latest` block tag. IIUC, this should not be possible.

I had a look at the code in order to see if a newer version of Anvil would fix the flake. I think there is a race condition in this code if the call is made right as a block was being produced:

```
  pub async fn ensure_block_number<T: Into<BlockId>>(More actions
        &self,
        block_id: Option<T>,
    ) -> Result<u64, BlockchainError> {
        let current = self.best_number(); // <- returns 20
        let requested =
            match block_id.map(Into::into).unwrap_or(BlockId::Number(BlockNumber::Latest)) {
                // ...
                BlockId::Number(num) => match num {
                    BlockNumber::Latest | BlockNumber::Pending => self.best_number(), // <- returns 21
                    // ...
                },
            };

        if requested > current { // if 21 > 20
            Err(BlockchainError::BlockOutOfRange(current, requested))
        } else {
            Ok(requested)
        }
  }
```

See issue #10709 for context

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Instead of calling `self.best_number()` twice, which could return different values if a block is built at the same time, the code now uses the pinned block at the beginning of the function.

I'm not sure how best to test this fix since this is code is heavily dependent on async operations. I'd appreciate some help here :)

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

Fix #10709