### PR TITLE
fix: replace broken JSON-RPC error code link with EIP-1474 reference

### DIFF
--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -404,7 +404,7 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                             msg = format!("{msg}: {reason}");
                         }
                         RpcError {
-                            // geth returns this error code on reverts, See <https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal>
+                            // geth returns this error code on reverts, See <https://eips.ethereum.org/EIPS/eip-1474#specification>
                             code: ErrorCode::ExecutionError,
                             message: msg.into(),
                             data: serde_json::to_value(data).ok(),


### PR DESCRIPTION
Replaced the outdated and broken link to the Ethereum wiki JSON-RPC error codes with a reference to EIP-1474, which is the current official specification for Ethereum JSON-RPC error codes. This ensures the comment points to a reliable and up-to-date source.