### PR TITLE
chore: use public Arbitrum RPC directly instead of `drpc` in CI

### DIFF
--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -151,6 +151,10 @@ fn next_url(is_ws: bool, chain: NamedChain) -> String {
         return "https://mainnet.optimism.io".to_string();
     }
 
+    if matches!(chain, Arbitrum) {
+        return "https://arb1.arbitrum.io/rpc".to_string();
+    }
+
     if matches!(chain, BinanceSmartChainTestnet) {
         return "https://bsc-testnet-rpc.publicnode.com".to_string();
     }
@@ -170,7 +174,6 @@ fn next_url(is_ws: bool, chain: NamedChain) -> String {
         let key = DRPC_KEYS[idx];
 
         let network = match chain {
-            Arbitrum => "arbitrum",
             Polygon => "polygon",
             Sepolia => "sepolia",
             _ => "",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->


<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Related failure: https://github.com/foundry-rs/foundry/actions/runs/15537036945/job/43739434869

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes