### PR TITLE
chore: remove announcement link in `nightly` as it is unmaintained

### DIFF
--- a/crates/common/src/version.rs
+++ b/crates/common/src/version.rs
@@ -23,5 +23,4 @@ pub const IS_NIGHTLY_VERSION: bool = option_env!("FOUNDRY_IS_NIGHTLY_VERSION").i
 /// The warning message for nightly versions.
 pub const NIGHTLY_VERSION_WARNING_MESSAGE: &str =
     "This is a nightly build of Foundry. It is recommended to use the latest stable version. \
-    Visit https://book.getfoundry.sh/misc/announcements for more information. \n\
     To mute this warning set `FOUNDRY_DISABLE_NIGHTLY_WARNING` in your environment. \n";


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Removed link to `announcement` page as it is unmaintained

Users are requested to visit the releases page instead to continue staying up to date: https://github.com/foundry-rs/foundry/releases

If there is a need to make an announcement not captured in a release we plan to add a banner with the call to action in the Foundry docs.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes