### PR TITLE
feat: Add anvil set erc20 allowance endpoint

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -369,7 +369,6 @@ pub enum EthRequest {
         rename = "anvil_dealERC20",
         alias = "hardhat_dealERC20",
         alias = "anvil_setERC20Balance",
-        alias = "tenderly_setErc20Balance"
     )]
     DealERC20(Address, Address, #[serde(deserialize_with = "deserialize_number")] U256),
 

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -373,6 +373,10 @@ pub enum EthRequest {
     )]
     DealERC20(Address, Address, #[serde(deserialize_with = "deserialize_number")] U256),
 
+    /// Sets the ERC20 allowance for a spender
+    #[serde(rename = "anvil_setERC20Allowance")]
+    SetERC20Allowance(Address, Address, Address, #[serde(deserialize_with = "deserialize_number")] U256),
+
     /// Sets the code of a contract
     #[serde(rename = "anvil_setCode", alias = "hardhat_setCode")]
     SetCode(Address, Bytes),

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -359,6 +359,10 @@ impl EthApi {
             EthRequest::DealERC20(addr, token_addr, val) => {
                 self.anvil_deal_erc20(addr, token_addr, val).await.to_rpc_result()
             }
+            EthRequest::SetERC20Allowance(owner, spender, token_addr, val) => self
+                .anvil_set_erc20_allowance(owner, spender, token_addr, val)
+                .await
+                .to_rpc_result(),
             EthRequest::SetCode(addr, code) => {
                 self.anvil_set_code(addr, code).await.to_rpc_result()
             }
@@ -1924,6 +1928,77 @@ impl EthApi {
 
         // unable to set the balance
         Err(BlockchainError::Message("Unable to set ERC20 balance, no slot found".to_string()))
+    }
+
+    /// Sets the ERC20 allowance for a spender
+    ///
+    /// Handler for RPC call: `anvil_set_erc20_allowance`
+    pub async fn anvil_set_erc20_allowance(
+        &self,
+        owner: Address,
+        spender: Address,
+        token_address: Address,
+        amount: U256,
+    ) -> Result<()> {
+        node_info!("anvil_setERC20Allowance");
+
+        sol! {
+            #[sol(rpc)]
+            contract IERC20 {
+                function allowance(address owner, address spender) external view returns (uint256);
+            }
+        }
+
+        let calldata = IERC20::allowanceCall { owner, spender }.abi_encode();
+        let tx = TransactionRequest::default().with_to(token_address).with_input(calldata.clone());
+
+        // first collect all the slots that are used by the allowance call
+        let access_list_result =
+            self.create_access_list(WithOtherFields::new(tx.clone()), None).await?;
+        let access_list = access_list_result.access_list;
+
+        // now we can iterate over all the accessed slots and try to find the one that contains the
+        // allowance by overriding the slot and checking the `allowanceCall` result
+        for item in access_list.0 {
+            if item.address != token_address {
+                continue;
+            };
+            for slot in &item.storage_keys {
+                let account_override = AccountOverride::default()
+                    .with_state_diff(std::iter::once((*slot, B256::from(amount.to_be_bytes()))));
+
+                let state_override = StateOverridesBuilder::default()
+                    .append(token_address, account_override)
+                    .build();
+
+                let evm_override = EvmOverrides::state(Some(state_override));
+
+                let Ok(result) =
+                    self.call(WithOtherFields::new(tx.clone()), None, evm_override).await
+                else {
+                    // overriding this slot failed
+                    continue;
+                };
+
+                let Ok(result_allowance) = U256::abi_decode(&result) else {
+                    // response returned something other than a U256
+                    continue;
+                };
+
+                if result_allowance == amount {
+                    self.anvil_set_storage_at(
+                        token_address,
+                        U256::from_be_bytes(slot.0),
+                        B256::from(amount.to_be_bytes()),
+                    )
+                    .await?;
+                    return Ok(());
+                }
+            }
+        }
+
+        // unable to set the allowance
+        Err(BlockchainError::Message("Unable to set ERC20 allowance, no slot found".to_string()))
     }
 
     /// Sets the code of a contract.

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1491,6 +1491,31 @@ async fn test_set_erc20_balance() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_set_erc20_allowance() {
+    let config: NodeConfig = fork_config();
+    let owner = config.genesis_accounts[0].address();
+    let spender = config.genesis_accounts[1].address();
+    let (api, handle) = spawn(config).await;
+
+    let provider = handle.http_provider();
+
+    alloy_sol_types::sol! {
+       #[sol(rpc)]
+       contract ERC20 {
+            function allowance(address owner, address spender) external view returns (uint256);
+       }
+    }
+    let dai = address!("0x6B175474E89094C44Da98b954EedeAC495271d0F");
+    let erc20 = ERC20::new(dai, provider);
+    let value = U256::from(500);
+
+    api.anvil_set_erc20_allowance(owner, spender, dai, value).await.unwrap();
+
+    let allowance = erc20.allowance(owner, spender).call().await.unwrap();
+    assert_eq!(allowance, value);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_reset_updates_cache_path_when_rpc_url_not_provided() {
     let config: NodeConfig = fork_config();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I love the new `anvil_dealERC20` endpoint! So why not add an endpoint to override allowances? One should not exist without the other imho, it is very useful to have both.



## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Basically copied the code from `anvil_dealERC20` and modified it to use the `allowance(owner,spender,val)` function of ERC20.

Note: I also fixed my mistake of adding `tenderly_setErc20Balance` alias, but Tenderly has different order of parameters, so it would be very confusing.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes