### PR TITLE
wip: clear delegations for anvil default accounts

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -75,7 +75,7 @@ use alloy_rpc_types::{
     EIP1186AccountProofResponse as AccountProof, EIP1186StorageProof as StorageProof, Filter,
     Header as AlloyHeader, Index, Log, Transaction, TransactionReceipt,
 };
-use alloy_serde::{OtherFields, WithOtherFields};
+use alloy_serde::{quantity::vec, OtherFields, WithOtherFields};
 use alloy_signer::Signature;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_trie::{proof::ProofRetainer, HashBuilder, Nibbles};
@@ -3384,4 +3384,9 @@ pub fn op_haltreason_to_instruction_result(op_reason: OpHaltReason) -> Instructi
         OpHaltReason::Base(eth_h) => eth_h.into(),
         OpHaltReason::FailedDeposit => InstructionResult::Stop,
     }
+}
+
+pub fn is_default_anvil_acc(address: Address) -> bool {
+    let default_accs = vec![address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")];
+    default_accs.contains(&address)
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Since the advent of 7702, anvil default accounts have been delegated to drainers such as https://etherscan.io/address/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266#authlist7702

This spoils DevX when users are running anvil in fork mode and use one of the default accounts. 

This affects RPC calls such as `eth_getCode`, `eth_call`, and any other account-related calls. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

WIP

This is encountered only when the RPC request `block_number` predates the `fork_block_number`. Hence, every time we encounter such a scenario involving one of the default accounts, we can manually reset the code wiping the delegation or apply state overrides in case of `eth_call`.

Still some cleanup to do and also apply this to other RPC methods, but opening this for feedback on the approach. 

cc @mattsse @grandizzy 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes