### PR TITLE
feat(cheatcodes): extend usable range in `assertApproxEqRel`

### DIFF
--- a/testdata/default/cheats/Assert.t.sol
+++ b/testdata/default/cheats/Assert.t.sol
@@ -804,22 +804,18 @@ contract AssertionsTest is DSTest {
     }
 
     function testAssertApproxEqRel() public {
-        vm._expectCheatcodeRevert(bytes("assertion failed: overflow in delta calculation"));
-        vm.assertApproxEqRel(type(int256).min, type(int256).max, 0);
-
         vm._expectCheatcodeRevert(
             bytes(string.concat(errorMessage, ": 1 !~= 0 (max delta: 0.0000000000000000%, real delta: undefined)"))
         );
         vm.assertApproxEqRel(int256(1), int256(0), 0, errorMessage);
-
-        vm._expectCheatcodeRevert(bytes(string.concat(errorMessage, ": overflow in delta calculation")));
-        vm.assertApproxEqRel(uint256(0), type(uint256).max, 0, errorMessage);
 
         vm._expectCheatcodeRevert(
             bytes("assertion failed: 1 !~= 0 (max delta: 0.0000000000000000%, real delta: undefined)")
         );
         vm.assertApproxEqRel(uint256(1), uint256(0), uint256(0));
 
+        vm.assertApproxEqRel(type(int256).min, type(int256).max, 2e18);
+        vm.assertApproxEqRel(uint256(0), type(uint256).max, 1e18);
         vm.assertApproxEqRel(uint256(0), uint256(0), uint256(0));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

For large values, the current implementation of the cheatcode `assertApproxEqRel` overflows during calculation of the relative delta. However, using a larger type for this calculation allows to prevent overflows and use the full range of `uint256`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

The calculation was modified to use `U512` for the calculation and only check that the final value for the delta fits inside a `uint256` (a requirement of the error type).

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes