### PR TITLE
show native token symbol on tx broadcast

### DIFF
--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -2,7 +2,7 @@ use crate::{
     build::LinkedBuildData, progress::ScriptProgress, sequence::ScriptSequenceKind,
     verify::BroadcastedState, ScriptArgs, ScriptConfig,
 };
-use alloy_chains::Chain;
+use alloy_chains::{Chain, NamedChain};
 use alloy_consensus::TxEnvelope;
 use alloy_eips::{eip2718::Encodable2718, BlockId};
 use alloy_network::{AnyNetwork, EthereumWallet, TransactionBuilder};
@@ -421,9 +421,15 @@ impl BundledState {
             let avg_gas_price = format_units(total_gas_price / sequence.receipts.len() as u64, 9)
                 .unwrap_or_else(|_| "N/A".to_string());
 
+            // Get the native token symbol for the chain using NamedChain
+            let token_symbol = NamedChain::try_from(sequence.chain)
+                .unwrap_or_default()
+                .native_currency_symbol()
+                .unwrap_or("ETH");
             seq_progress.inner.write().set_status(&format!(
-                "Total Paid: {} ETH ({} gas * avg {} gwei)\n",
+                "Total Paid: {} {} ({} gas * avg {} gwei)\n",
                 paid.trim_end_matches('0'),
+                token_symbol,
                 total_gas,
                 avg_gas_price.trim_end_matches('0').trim_end_matches('.')
             ));

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -421,7 +421,6 @@ impl BundledState {
             let avg_gas_price = format_units(total_gas_price / sequence.receipts.len() as u64, 9)
                 .unwrap_or_else(|_| "N/A".to_string());
 
-            // Get the native token symbol for the chain using NamedChain
             let token_symbol = NamedChain::try_from(sequence.chain)
                 .unwrap_or_default()
                 .native_currency_symbol()

--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -99,7 +99,6 @@ pub fn format_receipt(chain: Chain, receipt: &AnyTransactionReceipt) -> String {
                     .unwrap_or_else(|_| "N/A".into());
                 let gas_price =
                     format_units(U256::from(gas_price), 9).unwrap_or_else(|_| "N/A".into());
-                // Get the native token symbol for the chain using NamedChain
                 let token_symbol = NamedChain::try_from(chain)
                     .unwrap_or_default()
                     .native_currency_symbol()

--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -1,4 +1,4 @@
-use alloy_chains::Chain;
+use alloy_chains::{Chain, NamedChain};
 use alloy_network::AnyTransactionReceipt;
 use alloy_primitives::{utils::format_units, TxHash, U256};
 use alloy_provider::{PendingTransactionBuilder, PendingTransactionError, Provider, WatchTxError};
@@ -99,9 +99,15 @@ pub fn format_receipt(chain: Chain, receipt: &AnyTransactionReceipt) -> String {
                     .unwrap_or_else(|_| "N/A".into());
                 let gas_price =
                     format_units(U256::from(gas_price), 9).unwrap_or_else(|_| "N/A".into());
+                // Get the native token symbol for the chain using NamedChain
+                let token_symbol = NamedChain::try_from(chain)
+                    .unwrap_or_default()
+                    .native_currency_symbol()
+                    .unwrap_or("ETH");
                 format!(
-                    "Paid: {} ETH ({gas_used} gas * {} gwei)",
+                    "Paid: {} {} ({gas_used} gas * {} gwei)",
                     paid.trim_end_matches('0'),
+                    token_symbol,
                     gas_price.trim_end_matches('0').trim_end_matches('.')
                 )
             },


### PR DESCRIPTION
## Description

This PR removes hardcoded `ETH` symbol on tx broadcast and show native token symbol from the chain. The reason is currently hardcoded symbol `ETH` is used which does reflect the correct token symbol on every chain. This PR makes it dynamic as per chain on which tx is being broadcasted., 

## Demo

```
[⠊] Compiling...
No files changed, compilation skipped
Script ran successfully.

## Setting up 1 EVM.

==========================

Chain 31

Estimated gas price: 0.004878086 gwei

Estimated total gas used for script: 217644

Estimated amount required: 0.000001061686149384 tRBTC

==========================

##### rsk-testnet
✅  [Success] Hash: 0xb1ba7f566d61a40d2edca28067215bf2e276800ea10dde294d72ab24debace86
Contract Address: 0xD888957bA1Bf2B5a99901965469430b5F8dfcA9F
Block: 6491436
Paid: 0.000000816684280034 tRBTC (167419 gas * 0.004878086 gwei)

✅ Sequence #1 on rsk-testnet | Total Paid: 0.000000816684280034 tRBTC (167419 gas * avg 0.004878086 gwei)
                                                                                                                                                                         

==========================

ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
```

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes