### PR TITLE
refactor: flatten bind_json.rs to one pass without state structs

### DIFF
--- a/crates/forge/src/cmd/bind_json.rs
+++ b/crates/forge/src/cmd/bind_json.rs
@@ -25,7 +25,7 @@ use solar_parse::{
 use solar_sema::thread_local::ThreadLocal;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
-    fmt::{self, Write},
+    fmt::Write,
     ops::ControlFlow,
     path::PathBuf,
     sync::Arc,
@@ -48,7 +48,41 @@ pub struct BindJsonArgs {
 
 impl BindJsonArgs {
     pub fn run(self) -> Result<()> {
-        self.preprocess()?.find_structs()?.resolve_imports_and_aliases().write()?;
+        let config = self.load_config()?;
+        let project = config.ephemeral_project()?;
+        let target_path = config.root.join(self.out.as_ref().unwrap_or(&config.bind_json.out));
+
+        // Step 1: Read and preprocess sources
+        let sources = project.paths.read_input_files()?;
+        let graph = Graph::<MultiCompilerParsedSource>::resolve_sources(&project.paths, sources)?;
+
+        // We only generate bindings for a single Solidity version to avoid conflicts.
+        let (version, mut sources, _) = graph
+            // resolve graph into mapping language -> version -> sources
+            .into_sources_by_version(&project)?
+            .sources
+            .into_iter()
+            // we are only interested in Solidity sources
+            .find(|(lang, _)| *lang == MultiCompilerLanguage::Solc(SolcLanguage::Solidity))
+            .ok_or_else(|| eyre::eyre!("no Solidity sources"))?
+            .1
+            .into_iter()
+            // For now, we are always picking the latest version.
+            .max_by(|(v1, _, _), (v2, _, _)| v1.cmp(v2))
+            .unwrap();
+
+        // Step 2: Preprocess sources to handle potentially invalid bindings
+        self.preprocess_sources(&mut sources)?;
+
+        // Insert empty bindings file.
+        sources.insert(target_path.clone(), Source::new(JSON_BINDINGS_PLACEHOLDER));
+
+        // Step 3: Find structs and generate bindings
+        let structs_to_write =
+            self.find_and_resolve_structs(&config, &project, version, sources, &target_path)?;
+
+        // Step 4: Write bindings
+        self.write_bindings(&structs_to_write, &target_path)?;
 
         Ok(())
     }
@@ -68,30 +102,7 @@ impl BindJsonArgs {
     ///
     /// After that we'll still have enough information for bindings but compilation should succeed
     /// in most of the cases.
-    fn preprocess(self) -> Result<PreprocessedState> {
-        let config = self.load_config()?;
-        let project = config.ephemeral_project()?;
-
-        let target_path = config.root.join(self.out.as_ref().unwrap_or(&config.bind_json.out));
-
-        let sources = project.paths.read_input_files()?;
-        let graph = Graph::<MultiCompilerParsedSource>::resolve_sources(&project.paths, sources)?;
-
-        // We only generate bindings for a single Solidity version to avoid conflicts.
-        let (version, mut sources, _) = graph
-            // resolve graph into mapping language -> version -> sources
-            .into_sources_by_version(&project)?
-            .sources
-            .into_iter()
-            // we are only interested in Solidity sources
-            .find(|(lang, _)| *lang == MultiCompilerLanguage::Solc(SolcLanguage::Solidity))
-            .ok_or_else(|| eyre::eyre!("no Solidity sources"))?
-            .1
-            .into_iter()
-            // For now, we are always picking the latest version.
-            .max_by(|(v1, _, _), (v2, _, _)| v1.cmp(v2))
-            .unwrap();
-
+    fn preprocess_sources(&self, sources: &mut Sources) -> Result<()> {
         let sess = Session::builder().with_stderr_emitter().build();
         let result = sess.enter_parallel(|| -> solar_parse::interface::Result<()> {
             sources.0.par_iter_mut().try_for_each(|(path, source)| {
@@ -115,11 +126,270 @@ impl BindJsonArgs {
             })
         });
         eyre::ensure!(result.is_ok(), "failed parsing");
+        Ok(())
+    }
 
-        // Insert empty bindings file.
-        sources.insert(target_path.clone(), Source::new(JSON_BINDINGS_PLACEHOLDER));
+    /// Find structs, resolve conflicts, and prepare them for writing
+    fn find_and_resolve_structs(
+        &self,
+        config: &Config,
+        project: &Project,
+        version: Version,
+        sources: Sources,
+        _target_path: &PathBuf,
+    ) -> Result<Vec<StructToWrite>> {
+        let settings = config.solc_settings()?;
+        let include = &config.bind_json.include;
+        let exclude = &config.bind_json.exclude;
+        let root = &config.root;
 
-        Ok(PreprocessedState { version, sources, target_path, project, config })
+        let input = SolcVersionedInput::build(sources, settings, SolcLanguage::Solidity, version);
+
+        let mut sess = Session::builder().with_stderr_emitter().build();
+        sess.dcx = sess.dcx.set_flags(|flags| flags.track_diagnostics = false);
+
+        let mut structs_to_write = Vec::new();
+
+        sess.enter_parallel(|| -> Result<()> {
+            // Set up the parsing context with the project paths, without adding the source files
+            let mut parsing_context = solar_pcx_from_solc_project(&sess, &project, &input, false);
+
+            let mut target_files = HashSet::new();
+            for (path, source) in &input.input.sources {
+                if !include.is_empty() {
+                    if !include.iter().any(|matcher| matcher.is_match(path)) {
+                        continue;
+                    }
+                } else {
+                    // Exclude library files by default
+                    if project.paths.has_library_ancestor(path) {
+                        continue;
+                    }
+                }
+
+                if exclude.iter().any(|matcher| matcher.is_match(path)) {
+                    continue;
+                }
+
+                if let Ok(src_file) =
+                    sess.source_map().new_source_file(path.clone(), source.content.as_str())
+                {
+                    target_files.insert(src_file.stable_id);
+                    parsing_context.add_file(src_file);
+                }
+            }
+
+            // Parse and resolve
+            let hir_arena = ThreadLocal::new();
+            if let Ok(Some(gcx)) = parsing_context.parse_and_lower(&hir_arena) {
+                let hir = &gcx.get().hir;
+                let resolver = Resolver::new(gcx);
+                for id in resolver.struct_ids() {
+                    if let Some(schema) = resolver.resolve_struct_eip712(id) {
+                        let def = hir.strukt(id);
+                        let source = hir.source(def.source);
+
+                        if !target_files.contains(&source.file.stable_id) {
+                            continue;
+                        }
+
+                        if let FileName::Real(ref path) = source.file.name {
+                            structs_to_write.push(StructToWrite {
+                                name: def.name.as_str().into(),
+                                contract_name: def
+                                    .contract
+                                    .map(|id| hir.contract(id).name.as_str().into()),
+                                path: path
+                                    .strip_prefix(&root)
+                                    .unwrap_or_else(|_| path)
+                                    .to_path_buf(),
+                                schema,
+                                // will be filled later
+                                import_alias: None,
+                                name_in_fns: String::new(),
+                            });
+                        }
+                    }
+                }
+            }
+            Ok(())
+        })?;
+
+        eyre::ensure!(sess.dcx.has_errors().is_ok(), "errors occurred");
+
+        // Resolve import aliases and function names
+        self.resolve_conflicts(&mut structs_to_write);
+
+        Ok(structs_to_write)
+    }
+
+    /// We manage 2 namespaces for JSON bindings:
+    ///   - Namespace of imported items. This includes imports of contracts containing structs and
+    ///     structs defined at the file level.
+    ///   - Namespace of struct names used in function names and schema_* variables.
+    ///
+    /// Both of those might contain conflicts, so we need to resolve them.
+    fn resolve_conflicts(&self, structs_to_write: &mut Vec<StructToWrite>) {
+        // firstly, we resolve imported names conflicts
+        // construct mapping name -> paths from which items with such name are imported
+        let mut names_to_paths = BTreeMap::new();
+
+        for s in structs_to_write.iter() {
+            names_to_paths
+                .entry(s.struct_or_contract_name())
+                .or_insert_with(BTreeSet::new)
+                .insert(s.path.as_path());
+        }
+
+        // now resolve aliases for names which need them and construct mapping (name, file) -> alias
+        let mut aliases = BTreeMap::new();
+
+        for (name, paths) in names_to_paths {
+            if paths.len() <= 1 {
+                continue; // no alias needed
+            }
+
+            for (i, path) in paths.into_iter().enumerate() {
+                aliases
+                    .entry(name.to_string())
+                    .or_insert_with(BTreeMap::new)
+                    .insert(path.to_path_buf(), format!("{name}_{i}"));
+            }
+        }
+
+        for s in structs_to_write.iter_mut() {
+            let name = s.struct_or_contract_name();
+            if aliases.contains_key(name) {
+                s.import_alias = Some(aliases[name][&s.path].clone());
+            }
+        }
+
+        // Each struct needs a name by which we are referencing it in function names (e.g.
+        // deserializeFoo) Those might also have conflicts, so we manage a separate
+        // namespace for them
+        let mut name_to_structs_indexes = BTreeMap::new();
+
+        for (idx, s) in structs_to_write.iter().enumerate() {
+            name_to_structs_indexes.entry(&s.name).or_insert_with(Vec::new).push(idx);
+        }
+
+        // Keeps `Some` for structs that will be referenced by name other than their definition
+        // name.
+        let mut fn_names = vec![None; structs_to_write.len()];
+
+        for (name, indexes) in name_to_structs_indexes {
+            if indexes.len() > 1 {
+                for (i, idx) in indexes.into_iter().enumerate() {
+                    fn_names[idx] = Some(format!("{name}_{i}"));
+                }
+            }
+        }
+
+        for (s, fn_name) in structs_to_write.iter_mut().zip(fn_names.into_iter()) {
+            s.name_in_fns = fn_name.unwrap_or(s.name.clone());
+        }
+    }
+
+    /// Write the final bindings file
+    fn write_bindings(
+        &self,
+        structs_to_write: &[StructToWrite],
+        target_path: &PathBuf,
+    ) -> Result<()> {
+        let mut result = String::new();
+
+        // Write imports
+        let mut grouped_imports = BTreeMap::new();
+        for struct_to_write in structs_to_write {
+            let item = struct_to_write.import_item();
+            grouped_imports
+                .entry(struct_to_write.path.as_path())
+                .or_insert_with(BTreeSet::new)
+                .insert(item);
+        }
+
+        result.push_str("// Automatically generated by forge bind-json.\n\npragma solidity >=0.6.2 <0.9.0;\npragma experimental ABIEncoderV2;\n\n");
+
+        for (path, names) in grouped_imports {
+            writeln!(
+                &mut result,
+                "import {{{}}} from \"{}\";",
+                names.iter().join(", "),
+                path.to_slash_lossy()
+            )?;
+        }
+
+        // Write VM interface
+        // Writes minimal VM interface to not depend on forge-std version
+        result.push_str(r#"
+interface Vm {
+    function parseJsonTypeArray(string calldata json, string calldata key, string calldata typeDescription) external pure returns (bytes memory);
+    function parseJsonType(string calldata json, string calldata typeDescription) external pure returns (bytes memory);
+    function parseJsonType(string calldata json, string calldata key, string calldata typeDescription) external pure returns (bytes memory);
+    function serializeJsonType(string calldata typeDescription, bytes memory value) external pure returns (string memory json);
+    function serializeJsonType(string calldata objectKey, string calldata valueKey, string calldata typeDescription, bytes memory value) external returns (string memory json);
+}
+        "#);
+
+        // Write library
+        result.push_str(
+            r#"
+library JsonBindings {
+    Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+"#,
+        );
+
+        // write schema constants
+        for struct_to_write in structs_to_write {
+            writeln!(
+                &mut result,
+                "    {}{} = \"{}\";",
+                TYPE_BINDING_PREFIX, struct_to_write.name_in_fns, struct_to_write.schema
+            )?;
+        }
+
+        // write serialization functions
+        for struct_to_write in structs_to_write {
+            write!(
+                &mut result,
+                r#"
+    function serialize({path} memory value) internal pure returns (string memory) {{
+        return vm.serializeJsonType(schema_{name_in_fns}, abi.encode(value));
+    }}
+
+    function serialize({path} memory value, string memory objectKey, string memory valueKey) internal returns (string memory) {{
+        return vm.serializeJsonType(objectKey, valueKey, schema_{name_in_fns}, abi.encode(value));
+    }}
+
+    function deserialize{name_in_fns}(string memory json) public pure returns ({path} memory) {{
+        return abi.decode(vm.parseJsonType(json, schema_{name_in_fns}), ({path}));
+    }}
+
+    function deserialize{name_in_fns}(string memory json, string memory path) public pure returns ({path} memory) {{
+        return abi.decode(vm.parseJsonType(json, path, schema_{name_in_fns}), ({path}));
+    }}
+
+    function deserialize{name_in_fns}Array(string memory json, string memory path) public pure returns ({path}[] memory) {{
+        return abi.decode(vm.parseJsonTypeArray(json, path, schema_{name_in_fns}), ({path}[]));
+    }}
+"#,
+                name_in_fns = struct_to_write.name_in_fns,
+                path = struct_to_write.full_path()
+            )?;
+        }
+
+        result.push_str("}\n");
+
+        // Write to file
+        if let Some(parent) = target_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(target_path, &result)?;
+
+        sh_println!("Bindings written to {}", target_path.display())?;
+
+        Ok(())
     }
 }
 
@@ -237,293 +507,5 @@ impl StructToWrite {
         } else {
             self.struct_or_contract_name().to_string()
         }
-    }
-}
-
-struct PreprocessedState {
-    version: Version,
-    sources: Sources,
-    target_path: PathBuf,
-    project: Project,
-    config: Config,
-}
-
-impl PreprocessedState {
-    fn find_structs(self) -> Result<StructsState> {
-        let mut structs_to_write = Vec::new();
-        let Self { version, sources, target_path, config, project } = self;
-
-        let settings = config.solc_settings()?;
-        let include = config.bind_json.include;
-        let exclude = config.bind_json.exclude;
-        let root = config.root;
-
-        let input = SolcVersionedInput::build(sources, settings, SolcLanguage::Solidity, version);
-
-        let mut sess = Session::builder().with_stderr_emitter().build();
-        sess.dcx = sess.dcx.set_flags(|flags| flags.track_diagnostics = false);
-
-        sess.enter_parallel(|| -> Result<()> {
-            // Set up the parsing context with the project paths, without adding the source files
-            let mut parsing_context = solar_pcx_from_solc_project(&sess, &project, &input, false);
-
-            let mut target_files = HashSet::new();
-            for (path, source) in &input.input.sources {
-                if !include.is_empty() {
-                    if !include.iter().any(|matcher| matcher.is_match(path)) {
-                        continue;
-                    }
-                } else {
-                    // Exclude library files by default
-                    if project.paths.has_library_ancestor(path) {
-                        continue;
-                    }
-                }
-
-                if exclude.iter().any(|matcher| matcher.is_match(path)) {
-                    continue;
-                }
-
-                if let Ok(src_file) =
-                    sess.source_map().new_source_file(path.clone(), source.content.as_str())
-                {
-                    target_files.insert(src_file.stable_id);
-                    parsing_context.add_file(src_file);
-                }
-            }
-
-            // Parse and resolve
-            let hir_arena = ThreadLocal::new();
-            if let Ok(Some(gcx)) = parsing_context.parse_and_lower(&hir_arena) {
-                let hir = &gcx.get().hir;
-                let resolver = Resolver::new(gcx);
-                for id in resolver.struct_ids() {
-                    if let Some(schema) = resolver.resolve_struct_eip712(id) {
-                        let def = hir.strukt(id);
-                        let source = hir.source(def.source);
-
-                        if !target_files.contains(&source.file.stable_id) {
-                            continue;
-                        }
-
-                        if let FileName::Real(ref path) = source.file.name {
-                            structs_to_write.push(StructToWrite {
-                                name: def.name.as_str().into(),
-                                contract_name: def
-                                    .contract
-                                    .map(|id| hir.contract(id).name.as_str().into()),
-                                path: path
-                                    .strip_prefix(&root)
-                                    .unwrap_or_else(|_| path)
-                                    .to_path_buf(),
-                                schema,
-
-                                // will be filled later
-                                import_alias: None,
-                                name_in_fns: String::new(),
-                            });
-                        }
-                    }
-                }
-            }
-            Ok(())
-        })?;
-
-        eyre::ensure!(sess.dcx.has_errors().is_ok(), "errors occurred");
-
-        Ok(StructsState { structs_to_write, target_path })
-    }
-}
-
-#[derive(Debug)]
-struct StructsState {
-    structs_to_write: Vec<StructToWrite>,
-    target_path: PathBuf,
-}
-
-impl StructsState {
-    /// We manage 2 namespsaces for JSON bindings:
-    ///   - Namespace of imported items. This includes imports of contracts containing structs and
-    ///     structs defined at the file level.
-    ///   - Namespace of struct names used in function names and schema_* variables.
-    ///
-    /// Both of those might contain conflicts, so we need to resolve them.
-    fn resolve_imports_and_aliases(self) -> ResolvedState {
-        let Self { mut structs_to_write, target_path } = self;
-
-        // firstly, we resolve imported names conflicts
-        // construct mapping name -> paths from which items with such name are imported
-        let mut names_to_paths = BTreeMap::new();
-
-        for s in &structs_to_write {
-            names_to_paths
-                .entry(s.struct_or_contract_name())
-                .or_insert_with(BTreeSet::new)
-                .insert(s.path.as_path());
-        }
-
-        // now resolve aliases for names which need them and construct mapping (name, file) -> alias
-        let mut aliases = BTreeMap::new();
-
-        for (name, paths) in names_to_paths {
-            if paths.len() <= 1 {
-                // no alias needed
-                continue
-            }
-
-            for (i, path) in paths.into_iter().enumerate() {
-                aliases
-                    .entry(name.to_string())
-                    .or_insert_with(BTreeMap::new)
-                    .insert(path.to_path_buf(), format!("{name}_{i}"));
-            }
-        }
-
-        for s in &mut structs_to_write {
-            let name = s.struct_or_contract_name();
-            if aliases.contains_key(name) {
-                s.import_alias = Some(aliases[name][&s.path].clone());
-            }
-        }
-
-        // Each struct needs a name by which we are referencing it in function names (e.g.
-        // deserializeFoo) Those might also have conflicts, so we manage a separate
-        // namespace for them
-        let mut name_to_structs_indexes = BTreeMap::new();
-
-        for (idx, s) in structs_to_write.iter().enumerate() {
-            name_to_structs_indexes.entry(&s.name).or_insert_with(Vec::new).push(idx);
-        }
-
-        // Keeps `Some` for structs that will be referenced by name other than their definition
-        // name.
-        let mut fn_names = vec![None; structs_to_write.len()];
-
-        for (name, indexes) in name_to_structs_indexes {
-            if indexes.len() > 1 {
-                for (i, idx) in indexes.into_iter().enumerate() {
-                    fn_names[idx] = Some(format!("{name}_{i}"));
-                }
-            }
-        }
-
-        for (s, fn_name) in structs_to_write.iter_mut().zip(fn_names.into_iter()) {
-            s.name_in_fns = fn_name.unwrap_or(s.name.clone());
-        }
-
-        ResolvedState { structs_to_write, target_path }
-    }
-}
-
-struct ResolvedState {
-    structs_to_write: Vec<StructToWrite>,
-    target_path: PathBuf,
-}
-
-impl ResolvedState {
-    fn write(self) -> Result<String> {
-        let mut result = String::new();
-        self.write_imports(&mut result)?;
-        self.write_vm(&mut result);
-        self.write_library(&mut result)?;
-
-        if let Some(parent) = self.target_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(&self.target_path, &result)?;
-
-        sh_println!("Bindings written to {}", self.target_path.display())?;
-
-        Ok(result)
-    }
-
-    fn write_imports(&self, result: &mut String) -> fmt::Result {
-        let mut grouped_imports = BTreeMap::new();
-
-        for struct_to_write in &self.structs_to_write {
-            let item = struct_to_write.import_item();
-            grouped_imports
-                .entry(struct_to_write.path.as_path())
-                .or_insert_with(BTreeSet::new)
-                .insert(item);
-        }
-
-        result.push_str("// Automatically generated by forge bind-json.\n\npragma solidity >=0.6.2 <0.9.0;\npragma experimental ABIEncoderV2;\n\n");
-
-        for (path, names) in grouped_imports {
-            writeln!(
-                result,
-                "import {{{}}} from \"{}\";",
-                names.iter().join(", "),
-                path.to_slash_lossy()
-            )?;
-        }
-
-        Ok(())
-    }
-
-    /// Writes minimal VM interface to not depend on forge-std version
-    fn write_vm(&self, result: &mut String) {
-        result.push_str(r#"
-interface Vm {
-    function parseJsonTypeArray(string calldata json, string calldata key, string calldata typeDescription) external pure returns (bytes memory);
-    function parseJsonType(string calldata json, string calldata typeDescription) external pure returns (bytes memory);
-    function parseJsonType(string calldata json, string calldata key, string calldata typeDescription) external pure returns (bytes memory);
-    function serializeJsonType(string calldata typeDescription, bytes memory value) external pure returns (string memory json);
-    function serializeJsonType(string calldata objectKey, string calldata valueKey, string calldata typeDescription, bytes memory value) external returns (string memory json);
-}
-        "#);
-    }
-
-    fn write_library(&self, result: &mut String) -> fmt::Result {
-        result.push_str(
-            r#"
-library JsonBindings {
-    Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
-
-"#,
-        );
-        // write schema constants
-        for struct_to_write in &self.structs_to_write {
-            writeln!(
-                result,
-                "    {}{} = \"{}\";",
-                TYPE_BINDING_PREFIX, struct_to_write.name_in_fns, struct_to_write.schema
-            )?;
-        }
-
-        // write serialization functions
-        for struct_to_write in &self.structs_to_write {
-            write!(
-                result,
-                r#"
-    function serialize({path} memory value) internal pure returns (string memory) {{
-        return vm.serializeJsonType(schema_{name_in_fns}, abi.encode(value));
-    }}
-
-    function serialize({path} memory value, string memory objectKey, string memory valueKey) internal returns (string memory) {{
-        return vm.serializeJsonType(objectKey, valueKey, schema_{name_in_fns}, abi.encode(value));
-    }}
-
-    function deserialize{name_in_fns}(string memory json) public pure returns ({path} memory) {{
-        return abi.decode(vm.parseJsonType(json, schema_{name_in_fns}), ({path}));
-    }}
-
-    function deserialize{name_in_fns}(string memory json, string memory path) public pure returns ({path} memory) {{
-        return abi.decode(vm.parseJsonType(json, path, schema_{name_in_fns}), ({path}));
-    }}
-
-    function deserialize{name_in_fns}Array(string memory json, string memory path) public pure returns ({path}[] memory) {{
-        return abi.decode(vm.parseJsonTypeArray(json, path, schema_{name_in_fns}), ({path}[]));
-    }}
-"#,
-                name_in_fns = struct_to_write.name_in_fns,
-                path = struct_to_write.full_path()
-            )?;
-        }
-
-        result.push_str("}\n");
-
-        Ok(())
     }
 }


### PR DESCRIPTION
Refactored the bind_json implementation to eliminate the intermediate state structs and flatten the logic into a single pass through the workflow.

Previously the implementation used three state structs (`PreprocessedState`, `StructsState`, `ResolvedState`) that were passed sequentially through the workflow. This change consolidates all logic into methods on `BindJsonArgs`, making the code more straightforward while preserving the same functionality.

The main `run()` method now clearly shows the 4 steps:
1. Read and preprocess sources
2. Handle potentially invalid bindings
3. Find structs and resolve conflicts
4. Write bindings

All the original logic for preprocessing, finding structs, resolving conflicts, and writing bindings remains intact.