### PR TITLE
feat(cast): Add --skip-preverification flag to run command to allow user to bypass nonce verification etc.

### DIFF
--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -94,6 +94,10 @@ pub struct RunArgs {
     /// Use current project artifacts for trace decoding.
     #[arg(long, visible_alias = "la")]
     pub with_local_artifacts: bool,
+
+    /// Skip transaction preverification (nonce etc.)
+    #[arg(long, visible_alias = "sp")]
+    pub skip_preverification: bool,
 }
 
 impl RunArgs {
@@ -181,6 +185,7 @@ impl RunArgs {
             odyssey,
             create2_deployer,
         );
+        executor.set_skip_preverification(self.skip_preverification);
         let mut env =
             EnvWithHandlerCfg::new_with_spec_id(Box::new(env.clone()), executor.spec_id());
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

When using cast run to debug a transaction on a local fork (usually hardhat) I regularily run into issues where the preverification of the transaction fails due to "nonce too high" or "insufficient balance for transaction fee" issues. Sometimes this is due to a corrupted cache (see https://github.com/foundry-rs/foundry/issues/9968) however at other times resetting the cache does not fix the issue.
Often this happens when the local fork has been the target of test scripts that include `hardhat_setBalance` and related calls. 

In these cases I am usually not interested in verifying wether a transaction has been legally included on chain but just want to simulate the evm operations inside that transaction. In the current state I am unable to do that.

## Solution

Add an optional `--skip-preverification` flag to the `cast run` comamnd that skips all transaction preverification. (by running `evm.transact_preverified` instead of `evm.transact`).



## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes