### PR TITLE
Revert "chore: pin nextest version in ci"

### DIFF
--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -54,9 +54,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: ${{ matrix.target }}
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: nextest@0.9.98
+      - uses: taiki-e/install-action@nextest
 
       # External tests dependencies
       - name: Setup Node.js


### PR DESCRIPTION
Reverts foundry-rs/foundry#10800

https://github.com/taiki-e/install-action/issues/1005 has now been fixed