### PR TITLE
chore: unpin `rustfmt` nightly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-03
           components: rustfmt
       - run: cargo fmt --all --check
 


### PR DESCRIPTION
## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Likely was pinned because of a bug at the time, should be unpinned now