### PR TITLE
chore: use native alloy functions for otterscan helpers

### DIFF
--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -15,73 +15,12 @@ use alloy_rpc_types::{
             BlockDetails, ContractCreator, InternalOperation, OtsBlock, OtsBlockTransactions,
             OtsReceipt, OtsSlimBlock, OtsTransactionReceipt, TraceEntry, TransactionsWithReceipts,
         },
-        parity::{
-            Action, CallAction, CallType, CreateAction, CreateOutput, LocalizedTransactionTrace,
-            RewardAction, TraceOutput,
-        },
+        parity::{Action, CreateAction, CreateOutput, TraceOutput},
     },
     Block, BlockId, BlockNumberOrTag as BlockNumber, BlockTransactions,
 };
-use itertools::Itertools;
-
 use futures::future::join_all;
-
-pub fn mentions_address(trace: LocalizedTransactionTrace, address: Address) -> Option<B256> {
-    match (trace.trace.action, trace.trace.result) {
-        (Action::Call(CallAction { from, to, .. }), _) if from == address || to == address => {
-            trace.transaction_hash
-        }
-        (_, Some(TraceOutput::Create(CreateOutput { address: created_address, .. })))
-            if created_address == address =>
-        {
-            trace.transaction_hash
-        }
-        (Action::Create(CreateAction { from, .. }), _) if from == address => trace.transaction_hash,
-        (Action::Reward(RewardAction { author, .. }), _) if author == address => {
-            trace.transaction_hash
-        }
-        _ => None,
-    }
-}
-
-/// Converts the list of traces for a transaction into the expected Otterscan format.
-///
-/// Follows format specified in the [`ots_traceTransaction`](https://docs.otterscan.io/api-docs/ots-api#ots_tracetransaction) spec.
-pub fn batch_build_ots_traces(traces: Vec<LocalizedTransactionTrace>) -> Vec<TraceEntry> {
-    traces
-        .into_iter()
-        .filter_map(|trace| {
-            let output = trace
-                .trace
-                .result
-                .map(|r| match r {
-                    TraceOutput::Call(output) => output.output,
-                    TraceOutput::Create(output) => output.code,
-                })
-                .unwrap_or_default();
-            match trace.trace.action {
-                Action::Call(call) => Some(TraceEntry {
-                    r#type: match call.call_type {
-                        CallType::Call => "CALL",
-                        CallType::CallCode => "CALLCODE",
-                        CallType::DelegateCall => "DELEGATECALL",
-                        CallType::StaticCall => "STATICCALL",
-                        CallType::AuthCall => "AUTHCALL",
-                        CallType::None => "NONE",
-                    }
-                    .to_string(),
-                    depth: trace.trace.trace_address.len() as u32,
-                    from: call.from,
-                    to: call.to,
-                    value: Some(call.value),
-                    input: call.input,
-                    output,
-                }),
-                Action::Create(_) | Action::Selfdestruct(_) | Action::Reward(_) => None,
-            }
-        })
-        .collect()
-}
+use itertools::Itertools;
 
 impl EthApi {
     /// Otterscan currently requires this endpoint, even though it's not part of the `ots_*`.
@@ -126,10 +65,19 @@ impl EthApi {
     }
 
     /// Trace a transaction and generate a trace call tree.
+    /// Converts the list of traces for a transaction into the expected Otterscan format.
+    ///
+    /// Follows format specified in the [`ots_traceTransaction`](https://docs.otterscan.io/api-docs/ots-api#ots_tracetransaction) spec.
     pub async fn ots_trace_transaction(&self, hash: B256) -> Result<Vec<TraceEntry>> {
         node_info!("ots_traceTransaction");
-
-        Ok(batch_build_ots_traces(self.backend.trace_transaction(hash).await?))
+        let traces = self
+            .backend
+            .trace_transaction(hash)
+            .await?
+            .into_iter()
+            .filter_map(|trace| TraceEntry::from_transaction_trace(&trace.trace))
+            .collect();
+        Ok(traces)
     }
 
     /// Given a transaction hash, returns its raw revert reason.
@@ -220,7 +168,8 @@ impl EthApi {
                 let hashes = traces
                     .into_iter()
                     .rev()
-                    .filter_map(|trace| mentions_address(trace, address))
+                    .filter(|trace| trace.contains_address(address))
+                    .filter_map(|trace| trace.transaction_hash)
                     .unique();
 
                 if res.len() >= page_size {
@@ -267,7 +216,8 @@ impl EthApi {
                 let hashes = traces
                     .into_iter()
                     .rev()
-                    .filter_map(|trace| mentions_address(trace, address))
+                    .filter(|trace| trace.contains_address(address))
+                    .filter_map(|trace| trace.transaction_hash)
                     .unique();
 
                 if res.len() >= page_size {


### PR DESCRIPTION
I've upstreamed these helpers to alloy directly so we can reuse them here instead


https://github.com/alloy-rs/alloy/blob/c9438a15e3fddfdcaf0f6d30af323b83def51608/crates/rpc-types-trace/src/otterscan.rs#L100-L100

https://github.com/alloy-rs/alloy/blob/c9438a15e3fddfdcaf0f6d30af323b83def51608/crates/rpc-types-trace/src/parity.rs#L247-L257