### PR TITLE
chore: remove HexDisplay util

### DIFF
--- a/crates/anvil/src/eth/util.rs
+++ b/crates/anvil/src/eth/util.rs
@@ -1,58 +1,20 @@
-use alloy_primitives::Address;
+use alloy_primitives::{hex, Address};
+use itertools::Itertools;
 use revm::{
     precompile::{PrecompileSpecId, Precompiles},
     primitives::hardfork::SpecId,
 };
-use std::fmt;
 
 pub fn get_precompiles_for(spec_id: SpecId) -> Vec<Address> {
     Precompiles::new(PrecompileSpecId::from_spec_id(spec_id)).addresses().copied().collect()
 }
 
-/// wrapper type that displays byte as hex
-pub struct HexDisplay<'a>(&'a [u8]);
-
+/// Formats values as hex strings, separated by commas.
 pub fn hex_fmt_many<I, T>(i: I) -> String
 where
     I: IntoIterator<Item = T>,
     T: AsRef<[u8]>,
 {
-    i.into_iter()
-        .map(|item| HexDisplay::from(item.as_ref()).to_string())
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
-impl<'a> HexDisplay<'a> {
-    pub fn from(b: &'a [u8]) -> Self {
-        HexDisplay(b)
-    }
-}
-
-impl fmt::Display for HexDisplay<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.0.len() < 1027 {
-            for byte in self.0 {
-                f.write_fmt(format_args!("{byte:02x}"))?;
-            }
-        } else {
-            for byte in &self.0[0..512] {
-                f.write_fmt(format_args!("{byte:02x}"))?;
-            }
-            f.write_str("...")?;
-            for byte in &self.0[self.0.len() - 512..] {
-                f.write_fmt(format_args!("{byte:02x}"))?;
-            }
-        }
-        Ok(())
-    }
-}
-
-impl fmt::Debug for HexDisplay<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for byte in self.0 {
-            f.write_fmt(format_args!("{byte:02x}"))?;
-        }
-        Ok(())
-    }
+    let items = i.into_iter().map(|item| hex::encode(item.as_ref())).format(", ");
+    format!("{items}")
 }


### PR DESCRIPTION
this can just be a oneliner and we don't need the specialized size logic because this really is just used by some debug impls in pool types


<img width="690" alt="image" src="https://github.com/user-attachments/assets/e83157ec-74de-41ba-81ff-c2c45cb64a30" />
