### PR TITLE
feat(cast): print a warning on calling a contract without code

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -315,12 +315,13 @@ impl CallArgs {
             return Ok(());
         }
 
-        sh_println!(
-            "{}",
-            Cast::new(provider)
-                .call(&tx, func.as_ref(), block, state_overrides, block_overrides)
-                .await?
-        )?;
+        let response = Cast::new(provider)
+            .call(&tx, func.as_ref(), block, state_overrides, block_overrides)
+            .await?;
+        if response == "0x" {
+            sh_warn!("Contract code is empty")?;
+        }
+        sh_println!("{}", response)?;
 
         Ok(())
     }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -2838,6 +2838,26 @@ casttest!(cast_call_return_array_of_tuples, |_prj, cmd| {
 "#]]);
 });
 
+// <https://github.com/foundry-rs/foundry/issues/7541>
+casttest!(cast_call_on_contract_with_no_code_prints_warning, |_prj, cmd| {
+    let eth_rpc_url = next_http_rpc_endpoint();
+    cmd.args([
+        "call",
+        "0x0000000000000000000000000000000000000000",
+        "--rpc-url",
+        eth_rpc_url.as_str(),
+    ])
+    .assert_success()
+    .stderr_eq(str![[r#"
+Warning: Contract code is empty
+
+"#]])
+    .stdout_eq(str![[r#"
+0x
+
+"#]]);
+});
+
 // <https://github.com/foundry-rs/foundry/issues/10740>
 casttest!(tx_raw_opstack_deposit, |_prj, cmd| {
     cmd.args([


### PR DESCRIPTION
Resolves https://github.com/foundry-rs/foundry/issues/7541

This PR adds a warning on `cast call` when target contract has no code:
```sh
cast call 0x0000000000000000000000000000000000000000 --rpc-url https://eth.llamarpc.com

Warning: Contract code is empty
0x
```

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
