### PR TITLE
Fix typos in test identifiers and improve timestamp assertions

### DIFF
--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -947,11 +947,11 @@ async fn test_mine_blk_with_prev_timestamp() {
     let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
 
     let third_blk_num = block.header.number;
-    let third_blk_timestmap = block.header.timestamp;
+    let third_blk_timestamp = block.header.timestamp;
 
     assert_eq!(third_blk_num, init_number + 2);
-    assert_ne!(third_blk_timestmap, next_blk_timestamp);
-    assert!(third_blk_timestmap > next_blk_timestamp);
+    assert_ne!(third_blk_timestamp, next_blk_timestamp);
+    assert!(third_blk_timestamp > next_blk_timestamp);
 }
 
 // increase time by 0 seconds i.e next_block_timestamp = prev_block_timestamp

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2292,7 +2292,7 @@ Script ran successfully.
 "#]]);
 });
 
-forgetest_init!(can_remeber_keys, |prj, cmd| {
+forgetest_init!(can_remember_keys, |prj, cmd| {
     let script = prj
         .add_source(
             "Foo",


### PR DESCRIPTION


---


**Description:**  
- Fixed a typo in the test identifier: `can_remember_keys` (was `can_rember_keys`)


---