### PR TITLE
feat(cast keccak): add --file option for reading data

### DIFF
--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -832,6 +832,10 @@ pub enum CastSubcommand {
     Keccak {
         /// The data to hash.
         data: Option<String>,
+
+        /// Input file to read data from.
+        #[arg(long, value_hint = ValueHint::FilePath)]
+        file: Option<PathBuf>,
     },
 
     /// Hash a message according to EIP-191.


### PR DESCRIPTION
## Motivation

Closes #10659 

## Solution

Adds a `--file` option, which conflicts with the existing data input option.
If both are specified, cmd will bail, if neither the cmd will default to stdin, as per previous behaviour.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes

No prior tests existed for cast keccak