### PR TITLE
Fix OpenZeppelin repository links in tests

### DIFF
--- a/crates/cli/src/opts/dependency.rs
+++ b/crates/cli/src/opts/dependency.rs
@@ -296,11 +296,11 @@ mod tests {
 
     #[test]
     fn can_parse_oz_dep() {
-        let dep = Dependency::from_str("@openzeppelin/contracts-upgradeable").unwrap();
-        assert_eq!(dep.name, "contracts-upgradeable");
+        let dep = Dependency::from_str("@openzeppelin/openzeppelin-foundry-upgrades").unwrap();
+        assert_eq!(dep.name, "openzeppelin-foundry-upgrades");
         assert_eq!(
             dep.url,
-            Some("https://github.com/openzeppelin/contracts-upgradeable".to_string())
+            Some("https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades".to_string())
         );
         assert_eq!(dep.tag, None);
         assert_eq!(dep.alias, None);
@@ -308,11 +308,11 @@ mod tests {
 
     #[test]
     fn can_parse_oz_dep_tag() {
-        let dep = Dependency::from_str("@openzeppelin/contracts-upgradeable@v1").unwrap();
-        assert_eq!(dep.name, "contracts-upgradeable");
+        let dep = Dependency::from_str("@openzeppelin/openzeppelin-foundry-upgrades@v1").unwrap();
+        assert_eq!(dep.name, "openzeppelin-foundry-upgrades");
         assert_eq!(
             dep.url,
-            Some("https://github.com/openzeppelin/contracts-upgradeable".to_string())
+            Some("https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades".to_string())
         );
         assert_eq!(dep.tag, Some("v1".to_string()));
         assert_eq!(dep.alias, None);


### PR DESCRIPTION
The old OpenZeppelin repo contracts-upgradeable was moved to a new location openzeppelin-foundry-upgrades. Updated the test URLs and package names to point to the new repository. All tests are passing now.
