### PR TITLE
Fix typos in Anvil module comments, docs, and test names

### DIFF
--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -361,7 +361,7 @@ pub struct PendingTransaction {
     pub transaction: MaybeImpersonatedTransaction,
     /// the recovered sender of this transaction
     sender: Address,
-    /// hash of `transaction`, so it can easily be reused with encoding and hashing agan
+    /// hash of `transaction`, so it can easily be reused with encoding and hashing again
     hash: TxHash,
 }
 

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2724,7 +2724,7 @@ impl EthApi {
     }
 }
 
-// ===== impl Wallet endppoints =====
+// ===== impl Wallet endpoints =====
 impl EthApi {
     /// Get the capabilities of the wallet.
     ///

--- a/crates/anvil/src/eth/miner.rs
+++ b/crates/anvil/src/eth/miner.rs
@@ -135,7 +135,7 @@ pub enum MiningMode {
     /// A miner that constructs a new block every `interval` tick
     FixedBlockTime(FixedBlockTimeMiner),
 
-    /// A minner that uses both Auto and FixedBlockTime
+    /// A miner that uses both Auto and FixedBlockTime
     Mixed(ReadyTransactionMiner, FixedBlockTimeMiner),
 }
 

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -1003,7 +1003,7 @@ async fn evm_mine_blk_with_same_timestamp() {
 
 // mine 4 blocks instantly.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_mine_blks_with_same_timestamp() {
+async fn test_mine_blk_with_same_timestamp() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 


### PR DESCRIPTION
Resolved several minor typos and inconsistencies across the Anvil crate:

- Changed agan to again in mod.rs
- Corrected endppoints to endpoints in api.rs
- Fixed minner to miner in miner.rs
-Renamed test function test_mine_blks_with_same_timestamp to test_mine_blk_with_same_timestamp for consistency with its purpose

These improvements enhance code readability and maintain naming clarity.