### PR TITLE
feat(`anvil`): reset to in-mem

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1906,7 +1906,9 @@ impl EthApi {
             self.reset_instance_id();
             self.backend.reset_fork(forking).await
         } else {
-            Err(BlockchainError::RpcUnimplemented)
+            // Reset to a fresh in-memory state
+            self.reset_instance_id();
+            self.backend.reset_to_in_mem().await
         }
     }
 

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -1055,3 +1055,98 @@ async fn test_mine_first_block_with_interval() {
     let second_block = api.block_by_number(2.into()).await.unwrap().unwrap();
     assert_eq!(second_block.header.timestamp, init_timestamp + 120);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_reset_non_fork() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    // Get initial state
+    let init_block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    let init_accounts = api.accounts().unwrap();
+    let init_balance = provider.get_balance(init_accounts[0]).await.unwrap();
+    
+    // Store the instance id before reset
+    let instance_id_before = api.instance_id();
+
+    // Mine some blocks and make transactions
+    for _ in 0..5 {
+        api.mine_one().await;
+    }
+
+    // Send a transaction
+    let to = Address::random();
+    let val = U256::from(1337);
+    let tx = TransactionRequest::default()
+        .with_from(init_accounts[0])
+        .with_to(to)
+        .with_value(val);
+    let tx = WithOtherFields::new(tx);
+    
+    let _ = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
+    
+    // Check state has changed
+    let block_before_reset = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert!(block_before_reset.header.number > init_block.header.number);
+    
+    let balance_before_reset = provider.get_balance(init_accounts[0]).await.unwrap();
+    assert!(balance_before_reset < init_balance);
+    
+    let to_balance_before_reset = provider.get_balance(to).await.unwrap();
+    assert_eq!(to_balance_before_reset, val);
+
+    // Reset to fresh in-memory state (non-fork)
+    api.anvil_reset(None).await.unwrap();
+    
+    // Check instance id has changed
+    let instance_id_after = api.instance_id();
+    assert_ne!(instance_id_before, instance_id_after);
+    
+    // Check we're back at genesis
+    let block_after_reset = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(block_after_reset.header.number, 0);
+    
+    // Check accounts are restored to initial state
+    let balance_after_reset = provider.get_balance(init_accounts[0]).await.unwrap();
+    assert_eq!(balance_after_reset, init_balance);
+    
+    // Check the recipient's balance is zero
+    let to_balance_after_reset = provider.get_balance(to).await.unwrap();
+    assert_eq!(to_balance_after_reset, U256::ZERO);
+    
+    // Test we can continue mining after reset
+    api.mine_one().await;
+    let new_block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(new_block.header.number, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_reset_fork_to_non_fork() {
+    let (api, handle) = spawn(fork_config()).await;
+    let provider = handle.http_provider();
+    
+    // Verify we're in fork mode
+    let metadata = api.anvil_metadata().await.unwrap();
+    assert!(metadata.forked_network.is_some());
+    
+    // Mine some blocks
+    for _ in 0..3 {
+        api.mine_one().await;
+    }
+    
+    // Reset to non-fork mode
+    api.anvil_reset(None).await.unwrap();
+    
+    // Verify we're no longer in fork mode
+    let metadata_after = api.anvil_metadata().await.unwrap();
+    assert!(metadata_after.forked_network.is_none());
+    
+    // Check we're at block 0
+    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(block.header.number, 0);
+    
+    // Verify we can still mine blocks
+    api.mine_one().await;
+    let new_block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(new_block.header.number, 1);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #7472 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

-  Implements non-fork mode support for the anvil_reset RPC method. 
- Resets the node to a fresh in-memory state, clearing all blockchain data, transactions, and storage while preserving
  the genesis configuration.
- Test

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
