### PR TITLE
fix: forge doc panic

### DIFF
--- a/crates/forge/src/cmd/doc/server.rs
+++ b/crates/forge/src/cmd/doc/server.rs
@@ -94,7 +94,7 @@ impl Server {
 async fn serve(build_dir: PathBuf, address: SocketAddr, file_404: &str) -> io::Result<()> {
     let file_404 = build_dir.join(file_404);
     let svc = ServeDir::new(build_dir).not_found_service(ServeFile::new(file_404));
-    let app = Router::new().nest_service("/", get_service(svc));
+    let app = Router::new().fallback_service(get_service(svc));
     let tcp_listener = tokio::net::TcpListener::bind(address).await?;
     axum::serve(tcp_listener, app.into_make_service()).await
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/10850

Confirming https://github.com/foundry-rs/foundry/issues/9931 has been fixed.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Panic was due to a breaking change in Axum, not allowing nesting services at the root. For our simple usecase of serving files from the root `/` we can use the fallback_service instead.

Manually tested in combination w/ #9931 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
