### PR TITLE
Fix significant typos in variable name for Etherscan API key

### DIFF
--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -238,9 +238,9 @@ mod tests {
     #[ignore = "run manually"]
     async fn test_etherscan_keys_compatibility() {
         let address = address!("0x111111125421cA6dc452d289314280a0f8842A65");
-        let ehterscan_key = "JQNGFHINKS1W7Y5FRXU4SPBYF43J3NYK46";
+        let etherscan_key = "JQNGFHINKS1W7Y5FRXU4SPBYF43J3NYK46";
         let client = foundry_block_explorers::Client::builder()
-            .with_api_key(ehterscan_key)
+            .with_api_key(etherscan_key)
             .chain(Chain::optimism_mainnet())
             .unwrap()
             .build()
@@ -250,7 +250,7 @@ mod tests {
         }
 
         let client = foundry_block_explorers::Client::builder()
-            .with_api_key(ehterscan_key)
+            .with_api_key(etherscan_key)
             .with_api_version(EtherscanApiVersion::V1)
             .chain(Chain::optimism_mainnet())
             .unwrap()


### PR DESCRIPTION
Corrected significant typos in the test function test_etherscan_keys_compatibility:

- Renamed ehterscan_key to etherscan_key in both declaration and usage.

These typos affected the accuracy and readability of code interacting with the Etherscan API and could lead to confusion or bugs if used in logic beyond the test scope.