### PR TITLE
Remove unused imports from transaction module

### DIFF
--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -709,7 +709,7 @@ impl TypedTransaction {
                 self.blob_gas()
                     .map(|g| g as u128)
                     .unwrap_or(0)
-                    .mul(self.max_fee_per_blob_gas().unwrap_or(0)),
+                    * self.max_fee_per_blob_gas().unwrap_or(0),
             )
         }
 


### PR DESCRIPTION
Cleaned up the crates/anvil/core/src/eth/transaction/mod.rs file by removing unused imports (Mul from std::ops and LogData from test module). This helps reduce compiler warnings and keeps the codebase tidy. No functional changes were made. All public and test symbols remain untouched.