### PR TITLE
fix: typo in function

### DIFF
--- a/testdata/default/cheats/RecordLogs.t.sol
+++ b/testdata/default/cheats/RecordLogs.t.sol
@@ -190,7 +190,7 @@ contract RecordLogsTest is DSTest {
         assertEq(entries[2].emitter, emitter2.getEmitterAddr());
     }
 
-    function testRecordsConsumednAsRead() public {
+    function testRecordsConsumedAsRead() public {
         Vm.Log[] memory entries;
 
         emitter.emitEvent(1, generateTestData(16));


### PR DESCRIPTION
nothing fancy just fixed a small typo in function name