### PR TITLE
fix: spawn fork backendhandler on current tokio runtime

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1317,11 +1317,11 @@ latest block number: {latest_block}"
 
         // This will spawn the background thread that will use the provider to fetch
         // blockchain data from the other client
-        let backend = SharedBackend::spawn_backend_thread(
+        let backend = SharedBackend::spawn_backend(
             Arc::clone(&provider),
             block_chain_db.clone(),
             Some(fork_block_number.into()),
-        );
+        ).await;
 
         let config = ClientForkConfig {
             eth_rpc_url,


### PR DESCRIPTION
this previously created a new current thread runtime, which is mainly used for forge fork test where we dont expect too much traffic and dont necessarily have an active runtime.

but here we're already in the runtime context and just spawn the backend with a regular tokio::task::spawn