### PR TITLE
docs: Clarify comments in ChiselRunner: fix incomplete and misleading docstrings

### DIFF
--- a/crates/chisel/src/runner.rs
+++ b/crates/chisel/src/runner.rs
@@ -3,13 +3,13 @@
 //! This module contains the `ChiselRunner` struct, which assists with deploying
 //! and calling the REPL contract on a in-memory REVM instance.
 
-use alloy_primitives::{map::AddressHashMap, Address, Bytes, Log, U256};
+use alloy_primitives::{Address, Bytes, Log, U256, map::AddressHashMap};
 use eyre::Result;
 use foundry_evm::{
     executors::{DeployResult, Executor, RawCallResult},
     traces::{TraceKind, Traces},
 };
-use revm::interpreter::{return_ok, InstructionResult};
+use revm::interpreter::{InstructionResult, return_ok};
 
 /// The function selector of the REPL contract's entrypoint, the `run()` function.
 static RUN_SELECTOR: [u8; 4] = [0xc0, 0x40, 0x62, 0x26];
@@ -151,9 +151,9 @@ impl ChiselRunner {
                 self.executor.env_mut().tx.gas_limit = mid_gas_limit;
                 let res = self.executor.call_raw(from, to, calldata.clone(), value)?;
                 match res.exit_reason {
-                    InstructionResult::Revert |
-                    InstructionResult::OutOfGas |
-                    InstructionResult::OutOfFunds => {
+                    InstructionResult::Revert
+                    | InstructionResult::OutOfGas
+                    | InstructionResult::OutOfFunds => {
                         lowest_gas_limit = mid_gas_limit;
                     }
                     _ => {
@@ -161,9 +161,9 @@ impl ChiselRunner {
                         // if last two successful estimations only vary by 10%, we consider this to
                         // sufficiently accurate
                         const ACCURACY: u64 = 10;
-                        if (last_highest_gas_limit - highest_gas_limit) * ACCURACY /
-                            last_highest_gas_limit <
-                            1
+                        if (last_highest_gas_limit - highest_gas_limit) * ACCURACY
+                            / last_highest_gas_limit
+                            < 1
                         {
                             // update the gas
                             gas_used = highest_gas_limit;

--- a/crates/chisel/src/runner.rs
+++ b/crates/chisel/src/runner.rs
@@ -3,13 +3,13 @@
 //! This module contains the `ChiselRunner` struct, which assists with deploying
 //! and calling the REPL contract on a in-memory REVM instance.
 
-use alloy_primitives::{Address, Bytes, Log, U256, map::AddressHashMap};
+use alloy_primitives::{map::AddressHashMap, Address, Bytes, Log, U256};
 use eyre::Result;
 use foundry_evm::{
     executors::{DeployResult, Executor, RawCallResult},
     traces::{TraceKind, Traces},
 };
-use revm::interpreter::{InstructionResult, return_ok};
+use revm::interpreter::{return_ok, InstructionResult};
 
 /// The function selector of the REPL contract's entrypoint, the `run()` function.
 static RUN_SELECTOR: [u8; 4] = [0xc0, 0x40, 0x62, 0x26];
@@ -79,7 +79,7 @@ impl ChiselRunner {
     ///
     /// ### Returns
     ///
-    /// Optionally, a tuple containing the deployed address of the bytecode as well as a
+    /// A tuple containing the deployed address of the bytecode as well as a
     /// [ChiselResult] containing information about the result of the call to the deployed REPL
     /// contract.
     pub fn run(&mut self, bytecode: Bytes) -> Result<(Address, ChiselResult)> {
@@ -151,9 +151,9 @@ impl ChiselRunner {
                 self.executor.env_mut().tx.gas_limit = mid_gas_limit;
                 let res = self.executor.call_raw(from, to, calldata.clone(), value)?;
                 match res.exit_reason {
-                    InstructionResult::Revert
-                    | InstructionResult::OutOfGas
-                    | InstructionResult::OutOfFunds => {
+                    InstructionResult::Revert |
+                    InstructionResult::OutOfGas |
+                    InstructionResult::OutOfFunds => {
                         lowest_gas_limit = mid_gas_limit;
                     }
                     _ => {
@@ -161,9 +161,9 @@ impl ChiselRunner {
                         // if last two successful estimations only vary by 10%, we consider this to
                         // sufficiently accurate
                         const ACCURACY: u64 = 10;
-                        if (last_highest_gas_limit - highest_gas_limit) * ACCURACY
-                            / last_highest_gas_limit
-                            < 1
+                        if (last_highest_gas_limit - highest_gas_limit) * ACCURACY /
+                            last_highest_gas_limit <
+                            1
                         {
                             // update the gas
                             gas_used = highest_gas_limit;
@@ -173,7 +173,7 @@ impl ChiselRunner {
                     }
                 }
             }
-            // reset gas limit in the
+            // reset gas limit in the executor environment to its original value
             self.executor.env_mut().tx.gas_limit = init_gas_limit;
         }
 


### PR DESCRIPTION
- Completed an unfinished inline comment explaining the gas limit reset logic in the executor environment.
- Updated the docstring for the run function to remove the misleading word "Optionally," reflecting that the function always returns a tuple on success.
- These changes improve code clarity and ensure documentation accurately describes the function's behavior.