### PR TITLE
Prevent panic in find_mismatch_in_settings when optimizer_runs is unset

### DIFF
--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -226,9 +226,12 @@ fn find_mismatch_in_settings(
     if local_settings.optimizer_runs.is_some_and(|runs| etherscan_settings.runs != runs as u64)
         || (local_settings.optimizer_runs.is_none() && etherscan_settings.runs > 0)
     {
+        let local_runs = local_settings.optimizer_runs
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "None".to_string());
         let str = format!(
             "Optimizer runs mismatch: local={}, onchain={}",
-            local_settings.optimizer_runs.unwrap(),
+            local_runs,
             etherscan_settings.runs
         );
         mismatches.push(str);


### PR DESCRIPTION
Previously, the function find_mismatch_in_settings used unwrap() on the local_settings.optimizer_runs option when reporting an optimizer runs mismatch. This could cause a panic if the local configuration did not specify the optimizer_runs value (i.e., if it was None), even though this is a valid and possible scenario for users who do not explicitly set this parameter.

This commit replaces the unwrap() with a safer approach: if optimizer_runs is None, the message now displays "None" for the local value. This change ensures that the CLI does not crash unexpectedly and instead provides a clear, user-friendly message indicating that the local configuration is missing the optimizer runs setting, while still reporting the on-chain value for comparison.

Rationale:
- Users may omit optimizer_runs in their configuration, either intentionally or by mistake. In such cases, a panic is not helpful and does not guide the user toward resolving the mismatch.
- By handling the None case gracefully, we improve the robustness and user experience of the verification tool, making it more resilient to incomplete or missing configuration.
- The new behavior makes it clear to the user what value is missing, helping them to diagnose and fix configuration issues without encountering a cryptic panic or stack trace.
- This approach is more appropriate for CLI tools, where user input can be unpredictable and should be handled gracefully whenever possible.

In summary, this change prevents unnecessary panics, improves error reporting, and makes the tool more user-friendly and reliable.