### PR TITLE
fix(`evm`): enable tx_chain_id_check

### DIFF
--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -43,7 +43,7 @@ pub fn new_evm_with_inspector<'i, 'db, I: InspectorExt + ?Sized>(
     env: Env,
     inspector: &'i mut I,
 ) -> FoundryEvm<'db, &'i mut I> {
-    let ctx = EthEvmContext {
+    let mut ctx = EthEvmContext {
         journaled_state: {
             let mut journal = Journal::new(db);
             journal.set_spec_id(env.evm_env.cfg_env.spec);
@@ -56,6 +56,7 @@ pub fn new_evm_with_inspector<'i, 'db, I: InspectorExt + ?Sized>(
         local: LocalContext::default(),
         error: Ok(()),
     };
+    ctx.cfg.tx_chain_id_check = true;
     let spec = ctx.cfg.spec;
 
     let mut evm = FoundryEvm {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

- The `test_revert_wrong_chainid` was failing becuase revm introduced a chain id and transaction validation which is set to false by default.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Enable the chain-id check upon evm instantiation

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
