### PR TITLE
fix: dont check pool for gettransaction receipt

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1373,10 +1373,6 @@ impl EthApi {
     /// Handler for ETH RPC call: `eth_getTransactionReceipt`
     pub async fn transaction_receipt(&self, hash: B256) -> Result<Option<ReceiptResponse>> {
         node_info!("eth_getTransactionReceipt");
-        let tx = self.pool.get_transaction(hash);
-        if tx.is_some() {
-            return Ok(None);
-        }
         self.backend.transaction_receipt(hash).await
     }
 


### PR DESCRIPTION
optimistically closes https://github.com/foundry-rs/foundry/issues/10944

there's no reason to check the pool here really, 

this is also problematic because there's a smol race condition here:

https://github.com/foundry-rs/foundry/blob/7d8842448acdb0ad787ac944b6e30aaabdc55121/crates/anvil/src/eth/api.rs#L3149-L3156

which cleans up the pool after the block was mined