### PR TITLE
fix(cast call/estimate/send): omit function selector from arguments on create calls

### DIFF
--- a/crates/cli/src/utils/abi.rs
+++ b/crates/cli/src/utils/abi.rs
@@ -56,6 +56,7 @@ pub async fn parse_function_args<P: Provider<AnyNetwork>>(
     };
 
     if to.is_none() {
+        // if this is a CREATE call we must exclude the (constructor) function selector: https://github.com/foundry-rs/foundry/issues/10947
         Ok((encode_function_args_raw(&func, &args)?, Some(func)))
     } else {
         Ok((encode_function_args(&func, &args)?, Some(func)))

--- a/crates/cli/src/utils/abi.rs
+++ b/crates/cli/src/utils/abi.rs
@@ -5,7 +5,9 @@ use alloy_primitives::{Address, hex};
 use alloy_provider::{Provider, network::AnyNetwork};
 use eyre::{OptionExt, Result};
 use foundry_block_explorers::EtherscanApiVersion;
-use foundry_common::abi::{encode_function_args, get_func, get_func_etherscan};
+use foundry_common::abi::{
+    encode_function_args, encode_function_args_raw, get_func, get_func_etherscan,
+};
 use futures::future::join_all;
 
 async fn resolve_name_args<P: Provider<AnyNetwork>>(args: &[String], provider: &P) -> Vec<String> {
@@ -53,5 +55,9 @@ pub async fn parse_function_args<P: Provider<AnyNetwork>>(
         get_func_etherscan(sig, to, &args, chain, etherscan_api_key, etherscan_api_version).await?
     };
 
-    Ok((encode_function_args(&func, &args)?, Some(func)))
+    if to.is_none() {
+        Ok((encode_function_args_raw(&func, &args)?, Some(func)))
+    } else {
+        Ok((encode_function_args(&func, &args)?, Some(func)))
+    }
 }

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -21,13 +21,23 @@ where
 }
 
 /// Given a function and a vector of string arguments, it proceeds to convert the args to alloy
-/// [DynSolValue]s and then ABI encode them.
+/// [DynSolValue]s and then ABI encode them, prefixes the encoded data with the function selector.
 pub fn encode_function_args<I, S>(func: &Function, args: I) -> Result<Vec<u8>>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
     Ok(func.abi_encode_input(&encode_args(&func.inputs, args)?)?)
+}
+
+/// Given a function and a vector of string arguments, it proceeds to convert the args to alloy
+/// [DynSolValue]s and then ABI encode them. Doesn't prefix the function selector.
+pub fn encode_function_args_raw<I, S>(func: &Function, args: I) -> Result<Vec<u8>>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    Ok(func.abi_encode_input_raw(&encode_args(&func.inputs, args)?)?)
 }
 
 /// Given a function and a vector of string arguments, it proceeds to convert the args to alloy


### PR DESCRIPTION
Closes https://github.com/foundry-rs/foundry/issues/10947
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/10947. 
Issue was that the function selector was prefixed to the arguments on create calls.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Added function `encode_function_args_raw`, which encodes function args without prefixing the function selector.
This is now used in `parse_function_args` when the to field is none, indicating a create call.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist
I don't really know if tests are needed for this, but I don't mind adding one for create calls in general since the current ones aren't really sufficient.
- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

