### PR TITLE
fix: use correct mix hash for header

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -135,6 +135,7 @@ impl<DB: Db + ?Sized, V: TransactionValidator> TransactionExecutor<'_, DB, V> {
         let parent_hash = self.parent_hash;
         let block_number = self.block_env.number;
         let difficulty = self.block_env.difficulty;
+        let mix_hash = self.block_env.prevrandao;
         let beneficiary = self.block_env.beneficiary;
         let timestamp = self.block_env.timestamp;
         let base_fee = if self.cfg_env.spec.is_enabled_in(SpecId::LONDON) {
@@ -233,7 +234,7 @@ impl<DB: Db + ?Sized, V: TransactionValidator> TransactionExecutor<'_, DB, V> {
             gas_used: cumulative_gas_used,
             timestamp,
             extra_data: Default::default(),
-            mix_hash: Default::default(),
+            mix_hash: mix_hash.unwrap_or_default(),
             nonce: Default::default(),
             base_fee,
             parent_beacon_block_root: is_cancun.then_some(Default::default()),


### PR DESCRIPTION
closes #10949
closes #10935

we didn't set mixhash to what we used as prevrandao during execution