### PR TITLE
feat(`foundryup`): compare installed versus remote version of `foundryup` and inform user update of `foundryup` is available

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -437,14 +437,13 @@ version() {
 update() {
   say "updating foundryup..."
 
-  # Current version is guaranteed
   current_version="$FOUNDRYUP_INSTALLER_VERSION"
 
-  # Download the new version
+  # Download the new version.
   tmp_file="$(mktemp)"
   ensure download "$FOUNDRY_BIN_URL" "$tmp_file"
 
-  # Extract new version from downloaded file
+  # Extract new version from downloaded file.
   new_version=$(extract_installer_version "$tmp_file")
 
   # If the new version could not be determined, skip the check.
@@ -455,12 +454,15 @@ update() {
     exit 0
   fi
 
+  # If the new version is not greater than the current version, skip the update.
+  # This is to prevent downgrades or unnecessary updates.
   if ! version_gt "$new_version" "$current_version"; then
     say "foundryup is already up to date (installed: $current_version, remote: $new_version)."
     rm -f "$tmp_file"
     exit 0
   fi
 
+  # Overwrite existing foundryup
   ensure mv "$tmp_file" "$FOUNDRY_BIN_PATH"
   ensure chmod +x "$FOUNDRY_BIN_PATH"
 

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -445,7 +445,7 @@ update() {
   ensure download "$FOUNDRY_BIN_URL" "$tmp_file"
 
   # Extract new version from downloaded file
-  new_version=$(grep -Eo 'FOUNDRYUP_INSTALLER_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' "$tmp_file" | cut -d'"' -f2)
+  new_version=$(extract_installer_version "$tmp_file")
 
   # If the new version could not be determined, skip the check.
   # This is in case the new file is not available or does not contain the version.
@@ -555,7 +555,7 @@ check_installer_up_to_date() {
   tmp_file="$(mktemp)"
   ensure download "$FOUNDRY_BIN_URL" "$tmp_file"
 
-  remote_version=$(grep -Eo 'FOUNDRYUP_INSTALLER_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' "$tmp_file" | cut -d'"' -f2)
+  remote_version=$(extract_installer_version "$tmp_file")
   rm -f "$tmp_file"
 
   if [ -z "$remote_version" ]; then
@@ -563,9 +563,7 @@ check_installer_up_to_date() {
     return 0
   fi
 
-  newest=$(printf "%s\n%s\n" "$FOUNDRYUP_INSTALLER_VERSION" "$remote_version" | sort -V | tail -n1)
-
-  if [ "$newest" = "$remote_version" ] && [ "$FOUNDRYUP_INSTALLER_VERSION" != "$remote_version" ]; then
+  if version_gt "$remote_version" "$FOUNDRYUP_INSTALLER_VERSION"; then
     printf '
 Your installation of foundryup is out of date.
 
@@ -581,6 +579,41 @@ Updating is highly recommended as it gives you access to the latest features and
   else
     say "foundryup is up to date."
   fi
+}
+
+# Compares two version strings in the format "major.minor.patch".
+# Returns 0 if $1 is greater than $2, 1 if $1 is less than $2, and 1 if they are equal.
+#
+# Assumes that the version strings are well-formed and contain three numeric components separated by dots.
+#
+# Example: version_gt "1.2.3" "1.2.4"
+#          returns 1 (1.2.3 < 1.2.4)
+#          version_gt "1.2.3" "1.2.3"
+#          returns 1 (1.2.3 == 1.2.3)
+#          version_gt "1.2.4" "1.2.3"
+#          returns 0 (1.2.4 > 1.2.3)
+version_gt() {
+  [ "$1" = "$2" ] && return 1
+
+  IFS=. read -r major1 minor1 patch1 <<EOF
+$1
+EOF
+  IFS=. read -r major2 minor2 patch2 <<EOF
+$2
+EOF
+
+  [ "$major1" -gt "$major2" ] && return 0
+  [ "$major1" -lt "$major2" ] && return 1
+  [ "$minor1" -gt "$minor2" ] && return 0
+  [ "$minor1" -lt "$minor2" ] && return 1
+  [ "$patch1" -gt "$patch2" ] && return 0
+  [ "$patch1" -lt "$patch2" ] && return 1
+
+  return 1
+}
+
+extract_installer_version() {
+  grep -Eo 'FOUNDRYUP_INSTALLER_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' "$1" | cut -d'"' -f2
 }
 
 check_bins_in_use() {

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -567,7 +567,7 @@ check_installer_up_to_date() {
 
   if [ "$newest" = "$remote_version" ] && [ "$FOUNDRYUP_INSTALLER_VERSION" != "$remote_version" ]; then
     printf '
-Your foundryup is out of date.
+Your installation of foundryup is out of date.
 
 Installed: %s → Latest: %s
 
@@ -575,7 +575,7 @@ To update, run:
 
   foundryup --update
 
-Updating gives you access to the latest features and bug fixes.
+Updating is highly recommended as it gives you access to the latest features and bug fixes.
 
 ' "$FOUNDRYUP_INSTALLER_VERSION" "$remote_version" >&2
   else

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -444,7 +444,7 @@ update() {
   ensure download "$FOUNDRY_BIN_URL" "$tmp_file"
 
   # Extract new version from downloaded file.
-  new_version=$(extract_installer_version "$tmp_file")
+  new_version=$(grep -Eo 'FOUNDRYUP_INSTALLER_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' "$tmp_file" | cut -d'"' -f2)
 
   # If the new version could not be determined, skip the check.
   # This is in case the new file is not available or does not contain the version.
@@ -560,11 +560,11 @@ check_cmd() {
 check_installer_up_to_date() {
   say "checking if foundryup is up to date..."
 
-  tmp_file="$(mktemp)"
-  ensure download "$FOUNDRY_BIN_URL" "$tmp_file"
-
-  remote_version=$(extract_installer_version "$tmp_file")
-  rm -f "$tmp_file"
+  if check_cmd curl; then
+    remote_version=$(curl -fsSL "$FOUNDRY_BIN_URL" | grep -Eo 'FOUNDRYUP_INSTALLER_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' | cut -d'"' -f2)
+  else
+    remote_version=$(wget -qO- "$FOUNDRY_BIN_URL" | grep -Eo 'FOUNDRYUP_INSTALLER_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' | cut -d'"' -f2)
+  fi
 
   if [ -z "$remote_version" ]; then
     warn "Could not determine remote foundryup version. Skipping version check."
@@ -618,10 +618,6 @@ EOF
   [ "$patch1" -lt "$patch2" ] && return 1
 
   return 1
-}
-
-extract_installer_version() {
-  grep -Eo 'FOUNDRYUP_INSTALLER_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' "$1" | cut -d'"' -f2
 }
 
 check_bins_in_use() {

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -2,8 +2,7 @@
 set -eo pipefail
 
 # NOTE: if you make modifications to this script, please increment the version number.
-# Major / minor: incremented for each stable release of Foundry.
-# Patch: incremented for each change between stable releases.
+# WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
 FOUNDRYUP_INSTALLER_VERSION="1.3.0"
 
 BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
@@ -446,10 +445,10 @@ update() {
   # Extract new version from downloaded file.
   new_version=$(grep -Eo 'FOUNDRYUP_INSTALLER_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' "$tmp_file" | cut -d'"' -f2)
 
-  # If the new version could not be determined, skip the check.
-  # This is in case the new file is not available or does not contain the version.
+  # If the new version could not be determined, exit gracefully.
+  # This prevents from upgrading to an empty or invalid version.
   if [ -z "$new_version" ]; then
-    warn "Could not determine new foundryup version. Skipping version check."
+    warn "could not determine new foundryup version. Exiting."
     rm -f "$tmp_file"
     exit 0
   fi

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -451,10 +451,16 @@ update() {
   # This is in case the new file is not available or does not contain the version.
   if [ -z "$new_version" ]; then
     warn "Could not determine new foundryup version. Skipping version check."
-    return 0
+    rm -f "$tmp_file"
+    exit 0
   fi
 
-  # Overwrite existing foundryup
+  if ! version_gt "$new_version" "$current_version"; then
+    say "foundryup is already up to date (installed: $current_version, remote: $new_version)."
+    rm -f "$tmp_file"
+    exit 0
+  fi
+
   ensure mv "$tmp_file" "$FOUNDRY_BIN_PATH"
   ensure chmod +x "$FOUNDRY_BIN_PATH"
 

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -64,6 +64,9 @@ main() {
   # Print the banner after successfully parsing args
   banner
 
+  # Check if the foundryup installer is up to date, warn the user if not
+  check_installer_up_to_date
+
   if [ -n "$FOUNDRYUP_PR" ]; then
     if [ -z "$FOUNDRYUP_BRANCH" ]; then
       FOUNDRYUP_BRANCH="refs/pull/$FOUNDRYUP_PR/head"
@@ -278,7 +281,7 @@ main() {
     
     if [ "$FOUNDRYUP_IGNORE_VERIFICATION" = true ]; then
       say "skipped SHA verification for downloaded binaries due to --force flag"
-    else 
+    else
       # Verify the downloaded binaries against the attestation file.
       # If the attestation file was not found or is empty, we skip the verification.
       if $attestation_missing; then
@@ -434,15 +437,28 @@ version() {
 update() {
   say "updating foundryup..."
 
-  # Download to a temporary file first
+  # Current version is guaranteed
+  current_version="$FOUNDRYUP_INSTALLER_VERSION"
+
+  # Download the new version
   tmp_file="$(mktemp)"
   ensure download "$FOUNDRY_BIN_URL" "$tmp_file"
 
-  # Replace the current foundryup with the downloaded file
+  # Extract new version from downloaded file
+  new_version=$(grep -Eo 'FOUNDRYUP_INSTALLER_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' "$tmp_file" | cut -d'"' -f2)
+
+  # If the new version could not be determined, skip the check.
+  # This is in case the new file is not available or does not contain the version.
+  if [ -z "$new_version" ]; then
+    warn "Could not determine new foundryup version. Skipping version check."
+    return 0
+  fi
+
+  # Overwrite existing foundryup
   ensure mv "$tmp_file" "$FOUNDRY_BIN_PATH"
   ensure chmod +x "$FOUNDRY_BIN_PATH"
 
-  say "successfully updated foundryup"
+  say "successfully updated foundryup: $current_version → $new_version"
   exit 0
 }
 
@@ -533,6 +549,40 @@ check_cmd() {
   command -v "$1" &>/dev/null
 }
 
+check_installer_up_to_date() {
+  say "checking if foundryup is up to date..."
+
+  tmp_file="$(mktemp)"
+  ensure download "$FOUNDRY_BIN_URL" "$tmp_file"
+
+  remote_version=$(grep -Eo 'FOUNDRYUP_INSTALLER_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' "$tmp_file" | cut -d'"' -f2)
+  rm -f "$tmp_file"
+
+  if [ -z "$remote_version" ]; then
+    warn "Could not determine remote foundryup version. Skipping version check."
+    return 0
+  fi
+
+  newest=$(printf "%s\n%s\n" "$FOUNDRYUP_INSTALLER_VERSION" "$remote_version" | sort -V | tail -n1)
+
+  if [ "$newest" = "$remote_version" ] && [ "$FOUNDRYUP_INSTALLER_VERSION" != "$remote_version" ]; then
+    printf '
+Your foundryup is out of date.
+
+Installed: %s → Latest: %s
+
+To update, run:
+
+  foundryup --update
+
+Updating gives you access to the latest features and bug fixes.
+
+' "$FOUNDRYUP_INSTALLER_VERSION" "$remote_version" >&2
+  else
+    say "foundryup is up to date."
+  fi
+}
+
 check_bins_in_use() {
   if check_cmd pgrep; then
     for bin in "${BINS[@]}"; do
@@ -570,7 +620,7 @@ download() {
   fi
 }
 
-# Banner Function for Foundry
+# Banner prompt for Foundry
 banner() {
   printf '
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Follow up for: https://github.com/foundry-rs/foundry/pull/10902

It occurred to me last night that because we versioned `foundryup` we can inform the user their installation is out of date by matching it against the version of the current version on `master`

You can test the functionality by changing `FOUNDRYUP_INSTALLER_VERSION="1.3.0"` to `FOUNDRYUP_INSTALLER_VERSION="1.0.0"`

If the version of the installer is greater than the one on `master` we proceed without informing.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Note that this update will only inform / warn users when they run `foundryup`. It does not result in a hard error.

## To do

- [ ] Check MacOS compatibility
- [x] Check Windows compatibility 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
