### PR TITLE
fix(docs): strip current directory prefix

### DIFF
--- a/crates/forge/src/cmd/doc/mod.rs
+++ b/crates/forge/src/cmd/doc/mod.rs
@@ -75,7 +75,7 @@ impl DocArgs {
 
         let mut doc_config = config.doc;
         if let Some(out) = self.out {
-            doc_config.out = out;
+            doc_config.out = out.strip_prefix("./").unwrap_or(&out).to_path_buf();
         }
         if doc_config.repository.is_none() {
             // Attempt to read repo from git

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -4,5 +4,5 @@ use foundry_test_utils::util::{RemoteProject, setup_forge_remote};
 fn can_generate_solmate_docs() {
     let (prj, _) =
         setup_forge_remote(RemoteProject::new("transmissions11/solmate").set_build(false));
-    prj.forge_command().args(["doc", "--build"]).assert_success();
+    prj.forge_command().args(["doc", "--build", "--out", "./docs"]).assert_success();
 }


### PR DESCRIPTION
Resolves https://github.com/foundry-rs/foundry/issues/4533

Right now there's an issue on generating docs which is reproducible in a default forge project:
```
// works fine
forge doc --out docs 

 // throws "Error: prefix not found"
forge doc --out ./docs
``` 

The root cause of the issue is [this](https://github.com/foundry-rs/foundry/blob/f14cee85535c919a6efd3124f069e164369704cb/crates/doc/src/builder.rs#L438) line. Somehow [Path::strip_prefix](https://doc.rust-lang.org/std/path/struct.Path.html#method.strip_prefix) strips "extra" characters in path, example:
```rust
let path_str = "/my/path/./../other1/other2";
let path = Path::new(path_str);
let prefix = "/my/path";
let result = path.strip_prefix(prefix);
println!("<Path> {:?}", result); // <Path> Ok("../other1/other2")
```

Notice that in the example above the `./` part is also stripped while it was not mentioned in the prefix. Interestingly there is also the [String::strip_prefix](https://doc.rust-lang.org/std/string/struct.String.html#method.strip_prefix) method which actually works as expected (doesn't strip "extra" characters which can be seen in [this](https://gist.github.com/rust-play/a1192209d634ca3adc1401c635693917) rust playground).

What happens [here](https://github.com/foundry-rs/foundry/blob/f14cee85535c919a6efd3124f069e164369704cb/crates/doc/src/builder.rs#L438) is (roughly) that `Path::new("/project/./../project/docs").strip_prefix("/project")` returns `../project/docs` instead of `./../project/docs` which produces the `Prefix not found` error on subsequent `strip_prefix` calls.

There're many places where `strip_prefix` is used (in the `forge-doc` crate) so I suppose the simplest solution is to remove the `./` prefix from the `out` option. 

Notes: 
- probably there's an easier way to achieve the same result via `clap` arguments
- not sure how it affects windows users

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
