### PR TITLE
chore: more etherescan v1 cleanup

### DIFF
--- a/crates/chisel/src/cmd.rs
+++ b/crates/chisel/src/cmd.rs
@@ -45,7 +45,8 @@ pub enum ChiselCommand {
     /// Export the current REPL session source to a Script file
     Export,
     /// Fetch an interface of a verified contract on Etherscan
-    /// Takes: `<addr> <interface-name>`
+    /// Takes: `<addr> <interface-name>` and optional `<chain-id>` (defaults to `1` / mainnet if
+    /// not specified).
     Fetch,
     /// Executes a shell command
     Exec,

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -500,14 +500,15 @@ impl ChiselDispatcher {
                 }
             }
             ChiselCommand::Fetch => {
-                if args.len() != 2 {
+                if args.len() != 2 && args.len() != 3 {
                     return DispatchResult::CommandFailed(Self::make_error(
-                        "Incorrect number of arguments supplied. Expected: <address> <name>",
+                        "Incorrect number of arguments supplied. Expected: <address> <name> <chainId> (optional, defaults to 1 if not provided).",
                     ));
                 }
 
                 let request_url = format!(
-                    "https://api.etherscan.io/api?module=contract&action=getabi&address={}{}",
+                    "https://api.etherscan.io/v2/api?chainId={}&module=contract&action=getabi&address={}{}",
+                    args.get(2).unwrap_or(&"1"),
                     args[0],
                     if let Some(api_key) =
                         self.source().config.foundry_config.etherscan_api_key.as_ref()

--- a/crates/forge/tests/cli/verify_bytecode.rs
+++ b/crates/forge/tests/cli/verify_bytecode.rs
@@ -160,7 +160,7 @@ forgetest_async!(can_verify_bytecode_no_metadata, |prj, cmd| {
             ..Default::default()
         },
         "etherscan",
-        "https://api.etherscan.io/api",
+        "https://api.etherscan.io/v2/api",
         ("partial", "partial"),
     );
 });
@@ -179,7 +179,7 @@ forgetest_async!(can_verify_bytecode_with_metadata, |prj, cmd| {
             ..Default::default()
         },
         "etherscan",
-        "https://api.etherscan.io/api",
+        "https://api.etherscan.io/v2/api",
         ("partial", "partial"),
     );
 });
@@ -246,7 +246,7 @@ forgetest_async!(can_verify_bytecode_with_constructor_args, |prj, cmd| {
             ..Default::default()
         },
         "etherscan",
-        "https://api.etherscan.io/api",
+        "https://api.etherscan.io/v2/api",
         ("partial", "partial"),
     );
 });
@@ -267,7 +267,7 @@ forgetest_async!(can_ignore_creation, |prj, cmd| {
             ..Default::default()
         },
         "etherscan",
-        "https://api.etherscan.io/api",
+        "https://api.etherscan.io/v2/api",
         ("ignored", "partial"),
         "creation",
         "1",
@@ -289,7 +289,7 @@ forgetest_async!(can_ignore_runtime, |prj, cmd| {
             ..Default::default()
         },
         "etherscan",
-        "https://api.etherscan.io/api",
+        "https://api.etherscan.io/v2/api",
         ("partial", "ignored"),
         "runtime",
         "1",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- update chisel etherscan to v2, support optional chain id in fetch command so interfaces from other chains could be fetched (default to mainnet if not specified)
- use etherscan v2 API for verify bytecode tests to fix https://github.com/foundry-rs/foundry/actions/runs/16143390379/job/45555947656?pr=10871#step:12:560
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
