### PR TITLE
Remove unused import of console.sol from Base64.t.sol

### DIFF
--- a/testdata/default/cheats/Base64.t.sol
+++ b/testdata/default/cheats/Base64.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.18;
 
 import "ds-test/test.sol";
 import "cheats/Vm.sol";
-import "../logs/console.sol";
 
 contract Base64Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);


### PR DESCRIPTION
Cleaned up the Base64.t.sol test file by removing the unused import of console.sol. This reduces unnecessary dependencies and improves code clarity. No functional changes were made.