### PR TITLE
feat(forge-lint): check for unwrapped modifiers 

### DIFF
--- a/crates/lint/src/sol/gas/mod.rs
+++ b/crates/lint/src/sol/gas/mod.rs
@@ -3,4 +3,7 @@ use crate::sol::{EarlyLintPass, SolLint};
 mod keccak;
 use keccak::ASM_KECCAK256;
 
-register_lints!((AsmKeccak256, (ASM_KECCAK256)));
+mod unwrapped_modifier_logic;
+use unwrapped_modifier_logic::UNWRAPPED_MODIFIER_LOGIC;
+
+register_lints!((AsmKeccak256, (ASM_KECCAK256)), (ModifierLogic, (UNWRAPPED_MODIFIER_LOGIC)));

--- a/crates/lint/src/sol/gas/unwrapped_modifier_logic.rs
+++ b/crates/lint/src/sol/gas/unwrapped_modifier_logic.rs
@@ -1,0 +1,77 @@
+use super::ModifierLogic;
+use crate::{
+    linter::{EarlyLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar_ast::{ExprKind, FunctionKind, ItemFunction, Stmt, StmtKind};
+
+declare_forge_lint!(
+    UNWRAPPED_MODIFIER_LOGIC,
+    Severity::Gas,
+    "unwrapped-modifier-logic",
+    "modifier logic should be wrapped to avoid code duplication and reduce codesize"
+);
+
+impl<'ast> EarlyLintPass<'ast> for ModifierLogic {
+    fn check_item_function(&mut self, ctx: &LintContext<'_>, func: &'ast ItemFunction<'ast>) {
+        // Only check modifiers
+        if func.kind != FunctionKind::Modifier {
+            return;
+        }
+
+        // Skip if modifier has no body or the body is empty
+        let body = match &func.body {
+            Some(body) if !body.is_empty() => body,
+            _ => return,
+        };
+
+        // Emit lint if the modifier contains unwrapped logic
+        if contains_unwrapped_logic(body)
+            && let Some(name) = func.header.name
+        {
+            ctx.emit(&UNWRAPPED_MODIFIER_LOGIC, name.span);
+        }
+    }
+}
+
+/// Returns true if the modifier body contains any logic other than:
+/// - The placeholder `_;`
+/// - Calls to internal/private/public functions via direct identifier
+fn contains_unwrapped_logic(stmts: &[Stmt<'_>]) -> bool {
+    stmts.iter().any(|stmt| !is_permitted_statement(stmt))
+}
+
+/// Returns true if the statement is allowed in a modifier without triggering the lint
+fn is_permitted_statement(stmt: &Stmt<'_>) -> bool {
+    match &stmt.kind {
+        StmtKind::Placeholder => true,
+        StmtKind::Expr(expr) => is_permitted_expression(expr),
+        _ => false,
+    }
+}
+
+/// Returns true if the expression is a call to a function via direct identifier
+/// (i.e., not a built-in like require/assert/revert, and not a member/external call)
+fn is_permitted_expression(expr: &solar_ast::Expr<'_>) -> bool {
+    match &expr.kind {
+        // Only allow function calls.
+        ExprKind::Call(func_expr, _) => match &func_expr.kind {
+            // Allow direct calls to user-defined functions (by identifier)
+            ExprKind::Ident(ident) => {
+                // Disallow calls to built-in control flow functions like require/assert/revert
+                !matches!(ident.name.as_str(), "require" | "assert" | "revert")
+            }
+
+            // Disallow member calls (e.g., object.method()), which could be external or library
+            // calls
+            // TODO: enable library calls
+            ExprKind::Member(_, _) => false,
+
+            // Disallow all other forms of function expressions (e.g., function pointers, etc.)
+            _ => false,
+        },
+
+        // Disallow all other expression types (not a function call)
+        _ => false,
+    }
+}

--- a/crates/lint/testdata/ModifierLogic.sol
+++ b/crates/lint/testdata/ModifierLogic.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title ModifierLogicTest
+ * @notice Test cases for the unwrapped-modifier-logic lint
+ * @dev This lint helps optimize gas by preventing modifier code duplication.
+ *      Solidity inlines modifier code at each usage point instead of using jumps,
+ *      so any logic in modifiers gets duplicated, increasing deployment costs.
+ */
+contract ModifierLogicTest {
+    mapping(address => bool) public isOwner;
+
+    // Good patterns: Only call internal/private/public methods
+
+    modifier empty() {
+        _;
+    }
+
+    modifier onlyOwnerPublic() {
+        checkOwnerPublic(msg.sender);
+        _;
+    }
+
+    modifier onlyOwnerPrivate() {
+        checkOwnerPrivate(msg.sender);
+        _;
+    }
+
+    modifier onlyOwnerInternal() {
+        checkOwnerInternal(msg.sender);
+        _;
+    }
+
+    modifier ownerOwnerPublicPrivateInternal(address owner0, address owner1, address owner2) {
+        checkOwnerPublic(owner0);
+        checkOwnerPrivate(owner1);
+        checkOwnerInternal(owner2);
+        _;
+    }
+
+    modifier singleInternalWithParam(address sender) {
+        checkOwnerInternal(sender);
+        _;
+    }
+
+    modifier multipleInternalWithParam(address owner0, address owner1, address owner2) {
+        checkOwnerPublic(owner0);
+        checkOwnerPrivate(owner1);
+        checkOwnerInternal(owner2);
+        _;
+    }
+
+    function checkOwnerPublic(address sender) public view {
+        require(isOwner[sender], "Not owner");
+    }
+
+    function checkOwnerPrivate(address sender) private view {
+        require(isOwner[sender], "Not owner");
+    }
+
+    function checkOwnerInternal(address sender) internal view {
+        require(isOwner[sender], "Not owner");
+    }
+
+    // Bad patterns: Any logic that is not just a call to an internal/private/public method
+
+    // 1. require
+    modifier onlyOwnerRequire() { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        require(isOwner[msg.sender], "Not owner");
+        _;
+    }
+
+    // 2. require with param
+    modifier onlyOwnerRequireWithParam(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        require(isOwner[sender], "Not owner");
+        _;
+    }
+
+    // 3. assert
+    modifier onlyOwnerAssert() { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        assert(isOwner[msg.sender]);
+        _;
+    }
+
+    // 4. assert with param
+    modifier onlyOwnerAssertWithParam(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        assert(isOwner[sender]);
+        _;
+    }
+
+    // 5. conditional revert
+    modifier onlyOwnerConditionalRevert() { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        if (!isOwner[msg.sender]) {
+            revert("Not owner");
+        }
+        _;
+    }
+
+    // 6. conditional revert with param
+    modifier onlyOwnerConditionalRevertWithParam(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        if (!isOwner[sender]) {
+            revert("Not owner");
+        }
+        _;
+    }
+
+    // 7. assignment
+    modifier setOwner(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        isOwner[sender] = true;
+        _;
+    }
+
+    // 8. assignment with param
+    modifier setOwnerWithParam(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        isOwner[sender] = true;
+        _;
+    }
+
+    // 9. combination: require + internal call
+    modifier requireAndInternal(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        require(isOwner[sender], "Not owner");
+        checkOwnerInternal(sender);
+        _;
+    }
+
+    // 10. combination: assignment + internal call
+    modifier assignAndInternal(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        isOwner[sender] = true;
+        checkOwnerInternal(sender);
+        _;
+    }
+
+    // 11. combination: require + assignment
+    modifier requireAndAssign(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        require(isOwner[sender], "Not owner");
+        isOwner[sender] = false;
+        _;
+    }
+
+    // 12. combination: require + public call
+    modifier requireAndPublic(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        require(isOwner[sender], "Not owner");
+        checkOwnerPublic(sender);
+        _;
+    }
+
+    // 13. combination: assignment + public call
+    modifier assignAndPublic(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        isOwner[sender] = true;
+        checkOwnerPublic(sender);
+        _;
+    }
+
+    // 14. combination: require + assignment + internal call
+    modifier requireAssignInternal(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        require(isOwner[sender], "Not owner");
+        isOwner[sender] = false;
+        checkOwnerInternal(sender);
+        _;
+    }
+
+    // 15. combination: require + assignment + public call
+    modifier requireAssignPublic(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        require(isOwner[sender], "Not owner");
+        isOwner[sender] = false;
+        checkOwnerPublic(sender);
+        _;
+    }
+
+    // 16. inline assembly
+    modifier withAssembly(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        assembly {
+            let x := sender
+        }
+        _;
+    }
+
+    // 17. event emission
+    event DidSomething(address who);
+
+    modifier emitEvent(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        emit DidSomething(sender);
+        _;
+    }
+
+    // 18. inline revert string
+    modifier inlineRevert(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        if (sender == address(0)) revert("Zero address");
+        _;
+    }
+
+    // 19. combination: event + require + internal call
+    modifier eventRequireInternal(address sender) { //~NOTE: modifier logic should be wrapped to avoid code duplication and reduce codesize
+        emit DidSomething(sender);
+        require(isOwner[sender], "Not owner");
+        checkOwnerInternal(sender);
+        _;
+    }
+}

--- a/crates/lint/testdata/ModifierLogic.stderr
+++ b/crates/lint/testdata/ModifierLogic.stderr
@@ -1,0 +1,152 @@
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+  --> ROOT/testdata/ModifierLogic.sol:LL:CC
+   |
+69 |     modifier onlyOwnerRequire() {
+   |              ----------------
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+  --> ROOT/testdata/ModifierLogic.sol:LL:CC
+   |
+75 |     modifier onlyOwnerRequireWithParam(address sender) {
+   |              -------------------------
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+  --> ROOT/testdata/ModifierLogic.sol:LL:CC
+   |
+81 |     modifier onlyOwnerAssert() {
+   |              ---------------
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+  --> ROOT/testdata/ModifierLogic.sol:LL:CC
+   |
+87 |     modifier onlyOwnerAssertWithParam(address sender) {
+   |              ------------------------
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+  --> ROOT/testdata/ModifierLogic.sol:LL:CC
+   |
+93 |     modifier onlyOwnerConditionalRevert() {
+   |              --------------------------
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+101 |     modifier onlyOwnerConditionalRevertWithParam(address sender) {
+    |              -----------------------------------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+109 |     modifier setOwner(address sender) {
+    |              --------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+115 |     modifier setOwnerWithParam(address sender) {
+    |              -----------------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+121 |     modifier requireAndInternal(address sender) {
+    |              ------------------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+128 |     modifier assignAndInternal(address sender) {
+    |              -----------------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+135 |     modifier requireAndAssign(address sender) {
+    |              ----------------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+142 |     modifier requireAndPublic(address sender) {
+    |              ----------------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+149 |     modifier assignAndPublic(address sender) {
+    |              ---------------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+156 |     modifier requireAssignInternal(address sender) {
+    |              ---------------------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+164 |     modifier requireAssignPublic(address sender) {
+    |              -------------------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+172 |     modifier withAssembly(address sender) {
+    |              ------------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+182 |     modifier emitEvent(address sender) {
+    |              ---------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+188 |     modifier inlineRevert(address sender) {
+    |              ------------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+
+note[unwrapped-modifier-logic]: modifier logic should be wrapped to avoid code duplication and reduce codesize
+   --> ROOT/testdata/ModifierLogic.sol:LL:CC
+    |
+194 |     modifier eventRequireInternal(address sender) {
+    |              --------------------
+    |
+    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unwrapped-modifier-logic
+


### PR DESCRIPTION
## Motivation

*Coauthored by Claude 4 Opus Max*

Modifiers in Solidity that contain logic directly in their body can lead to code duplication when used across multiple functions. Since modifiers are inlined at compile time, any logic within them is duplicated for each function that uses the modifier. This increases the contract's `codesize`, which correlates to higher deployment costs.

A common best practice is to extract modifier logic into internal functions that can be called from within the modifier, reducing code duplication and contract size.

## Solution

This PR adds a new gas optimization lint `unwrapped-modifier-logic` that detects when modifiers contain logic directly in their body instead of using local functions.

The lint checks for modifiers that contain any statements other than:
- The placeholder `_;`
- Direct calls to internal/private/public functions (not built-ins like `require`, `assert`, `revert`)

Example of code that triggers the lint:
```solidity
modifier onlyOwner() {
    require(msg.sender == owner, "Not owner"); // Unwrapped logic
    _;
}
```

Recommended pattern:
```solidity
modifier onlyOwner() {
    _checkOwner(); // Wrapped in internal function
    _;
}

function _checkOwner() internal view {
    require(msg.sender == owner, "Not owner");
}
```

## PR Checklist

- [x] Added Tests - Created `testdata/ModifierLogic.sol` and `testdata/ModifierLogic.stderr` with comprehensive test cases
- [ ] Added Documentation - Need to add lint documentation to the Foundry book under the gas optimization section
- [ ] Breaking changes - No breaking changes, this is a new lint rule