### PR TITLE
feat(cast): add disable-labels for cast run

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -330,7 +330,7 @@ impl CallArgs {
                 with_local_artifacts,
                 debug,
                 decode_internal,
-                Some(disable_labels),
+                disable_labels,
             )
             .await?;
 

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -56,6 +56,10 @@ pub struct RunArgs {
     #[arg(long)]
     quick: bool,
 
+    /// Disables the labels in the traces.
+    #[arg(long, default_value_t = false)]
+    disable_labels: bool,
+
     /// Label addresses in the trace.
     ///
     /// Example: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth
@@ -286,7 +290,7 @@ impl RunArgs {
             self.with_local_artifacts,
             self.debug,
             self.decode_internal,
-            None,
+            self.disable_labels,
         )
         .await?;
 

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -343,7 +343,7 @@ pub async fn handle_traces(
     with_local_artifacts: bool,
     debug: bool,
     decode_internal: bool,
-    disable_label: Option<bool>,
+    disable_label: bool,
 ) -> Result<()> {
     let (known_contracts, mut sources) = if with_local_artifacts {
         let _ = sh_println!("Compiling project to generate artifacts");
@@ -375,7 +375,7 @@ pub async fn handle_traces(
     let mut builder = CallTraceDecoderBuilder::new()
         .with_labels(labels.chain(config_labels))
         .with_signature_identifier(SignaturesIdentifier::from_config(config)?)
-        .with_label_disabled(disable_label.unwrap_or_default());
+        .with_label_disabled(disable_label);
     let mut identifier = TraceIdentifiers::new().with_etherscan(config, chain)?;
     if let Some(contracts) = &known_contracts {
         builder = builder.with_known_contracts(contracts);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- https://github.com/foundry-rs/foundry/pull/10924 added the `--disable-labels` switch for `cast call`
- good to have for `cast run` too, for example when comparing `cast run` output with raw trace details as https://www.hyperscan.com/tx/0x84a03169ac02688b0af28ca81fb0ccc1d4fea0ff10d024cd65a910ba04df480a?tab=raw_trace
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
