### PR TITLE
Remove unused import of console.sol from Prompt.t.sol

### DIFF
--- a/testdata/default/cheats/Prompt.t.sol
+++ b/testdata/default/cheats/Prompt.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.18;
 
 import "ds-test/test.sol";
 import "cheats/Vm.sol";
-import "../logs/console.sol";
 
 contract PromptTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);


### PR DESCRIPTION
Cleaned up the Prompt.t.sol test file by removing the unused import of console.sol. The console library was not referenced anywhere in the file, so this import was unnecessary. This change improves code clarity and reduces potential confusion about unused dependencies.