### PR TITLE
fix(`evm`): remove Handler impl for `FoundryHandler`

### DIFF
--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -281,7 +281,8 @@ impl<'db, I: InspectorExt> Handler for FoundryHandler<'db, I> {
 }
 
 impl<'db, I: InspectorExt> FoundryHandler<'db, I> {
-    /// Handles CREATE2 frame initialization, potentially transforming it to use the CREATE2 factory.
+    /// Handles CREATE2 frame initialization, potentially transforming it to use the CREATE2
+    /// factory.
     fn handle_create_frame(
         &mut self,
         evm: &mut <Self as Handler>::Evm,
@@ -299,23 +300,19 @@ impl<'db, I: InspectorExt> FoundryHandler<'db, I> {
                 let create2_deployer = evm.inspector().create2_deployer();
 
                 // Generate call inputs for CREATE2 factory.
-                let call_inputs =
-                    get_create2_factory_call_inputs(salt, inputs, create2_deployer);
+                let call_inputs = get_create2_factory_call_inputs(salt, inputs, create2_deployer);
 
                 // Push data about current override to the stack.
-                self.create2_overrides
-                    .push((evm.journal().depth(), call_inputs.clone()));
+                self.create2_overrides.push((evm.journal().depth(), call_inputs.clone()));
 
                 // Sanity check that CREATE2 deployer exists.
-                let code_hash =
-                    evm.journal_mut().load_account(create2_deployer)?.info.code_hash;
+                let code_hash = evm.journal_mut().load_account(create2_deployer)?.info.code_hash;
                 if code_hash == KECCAK_EMPTY {
                     return Ok(Some(FrameResult::Call(CallOutcome {
                         result: InterpreterResult {
                             result: InstructionResult::Revert,
                             output: Bytes::copy_from_slice(
-                                format!("missing CREATE2 deployer: {create2_deployer}")
-                                    .as_bytes(),
+                                format!("missing CREATE2 deployer: {create2_deployer}").as_bytes(),
                             ),
                             gas: Gas::new(gas_limit),
                         },
@@ -345,11 +342,7 @@ impl<'db, I: InspectorExt> FoundryHandler<'db, I> {
         evm: &mut <Self as Handler>::Evm,
         result: FrameResult,
     ) -> FrameResult {
-        if self
-            .create2_overrides
-            .last()
-            .is_some_and(|(depth, _)| *depth == evm.journal().depth())
-        {
+        if self.create2_overrides.last().is_some_and(|(depth, _)| *depth == evm.journal().depth()) {
             let (_, call_inputs) = self.create2_overrides.pop().unwrap();
             let FrameResult::Call(mut call) = result else {
                 unreachable!("create2 override should be a call frame");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Revm 27 introduces the `InspectorHandler` which overrides the `Handler` implementation. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Since foundry is always inspecting we can remove the vanilla `Handler` impl and only keep the `InspectorHandler`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
