### PR TITLE
feat(`revm bump`): add serialization method that serializes as `u64` if fits or `U256` if not

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -347,8 +347,8 @@ pub struct Config {
     pub initial_balance: U256,
     /// the block.number value during EVM execution
     #[serde(
-        deserialize_with = "deserialize_u64_to_u256",
-        serialize_with = "serialize_u64_or_u256"
+        deserialize_with = "crate::deserialize_u64_to_u256",
+        serialize_with = "crate::serialize_u64_or_u256"
     )]
     pub block_number: U256,
     /// pins the block number for the state fork
@@ -371,8 +371,8 @@ pub struct Config {
     pub block_coinbase: Address,
     /// The `block.timestamp` value during EVM execution.
     #[serde(
-        deserialize_with = "deserialize_u64_to_u256",
-        serialize_with = "serialize_u64_or_u256"
+        deserialize_with = "crate::deserialize_u64_to_u256",
+        serialize_with = "crate::serialize_u64_or_u256"
     )]
     pub block_timestamp: U256,
     /// The `block.difficulty` value during EVM execution.
@@ -3743,8 +3743,8 @@ mod tests {
                 block_coinbase = '0x0000000000000000000000000000000000000000'
                 block_difficulty = 0
                 block_prevrandao = '0x0000000000000000000000000000000000000000000000000000000000000000'
-                block_number = "0x1"
-                block_timestamp = "0x1"
+                block_number = 1
+                block_timestamp = 1
                 use_literal_content = false
                 bytecode_hash = 'ipfs'
                 cbor_metadata = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -346,7 +346,10 @@ pub struct Config {
     /// the initial balance of each deployed test contract
     pub initial_balance: U256,
     /// the block.number value during EVM execution
-    #[serde(deserialize_with = "crate::deser_u64_to_u256")]
+    #[serde(
+        deserialize_with = "deserialize_u64_to_u256",
+        serialize_with = "serialize_u64_or_u256"
+    )]
     pub block_number: U256,
     /// pins the block number for the state fork
     pub fork_block_number: Option<u64>,
@@ -367,7 +370,10 @@ pub struct Config {
     /// The `block.coinbase` value during EVM execution.
     pub block_coinbase: Address,
     /// The `block.timestamp` value during EVM execution.
-    #[serde(deserialize_with = "crate::deser_u64_to_u256")]
+    #[serde(
+        deserialize_with = "deserialize_u64_to_u256",
+        serialize_with = "serialize_u64_or_u256"
+    )]
     pub block_timestamp: U256,
     /// The `block.difficulty` value during EVM execution.
     pub block_difficulty: u64,

--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -231,6 +231,7 @@ where
     }
 }
 
+/// Serialize `U256` as `u64` if it fits, otherwise as a hex string.
 pub fn serialize_u64_or_u256<S>(n: &U256, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{Provider, network::AnyRpcBlock};
 use eyre::WrapErr;
 use foundry_common::{ALCHEMY_FREE_TIER_CUPS, provider::ProviderBuilder};
-use foundry_config::{Chain, Config, GasLimit, deserialize_u64_to_u256, serialize_u64_or_u256};
+use foundry_config::{Chain, Config, GasLimit};
 use revm::context::{BlockEnv, TxEnv};
 use serde::{Deserialize, Serialize};
 use std::fmt::Write;
@@ -279,15 +279,15 @@ pub struct Env {
 
     /// the block.timestamp value during EVM execution
     #[serde(
-        deserialize_with = "deserialize_u64_to_u256",
-        serialize_with = "serialize_u64_or_u256"
+        deserialize_with = "foundry_config::deserialize_u64_to_u256",
+        serialize_with = "foundry_config::serialize_u64_or_u256"
     )]
     pub block_timestamp: U256,
 
     /// the block.number value during EVM execution"
     #[serde(
-        deserialize_with = "deserialize_u64_to_u256",
-        serialize_with = "serialize_u64_or_u256"
+        deserialize_with = "foundry_config::deserialize_u64_to_u256",
+        serialize_with = "foundry_config::serialize_u64_or_u256"
     )]
     pub block_number: U256,
 

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{Provider, network::AnyRpcBlock};
 use eyre::WrapErr;
 use foundry_common::{ALCHEMY_FREE_TIER_CUPS, provider::ProviderBuilder};
-use foundry_config::{Chain, Config, GasLimit};
+use foundry_config::{Chain, Config, GasLimit, deserialize_u64_to_u256, serialize_u64_or_u256};
 use revm::context::{BlockEnv, TxEnv};
 use serde::{Deserialize, Serialize};
 use std::fmt::Write;
@@ -278,11 +278,17 @@ pub struct Env {
     pub block_coinbase: Address,
 
     /// the block.timestamp value during EVM execution
-    #[serde(deserialize_with = "foundry_config::deser_u64_to_u256")]
+    #[serde(
+        deserialize_with = "deserialize_u64_to_u256",
+        serialize_with = "serialize_u64_or_u256"
+    )]
     pub block_timestamp: U256,
 
     /// the block.number value during EVM execution"
-    #[serde(deserialize_with = "foundry_config::deser_u64_to_u256")]
+    #[serde(
+        deserialize_with = "deserialize_u64_to_u256",
+        serialize_with = "serialize_u64_or_u256"
+    )]
     pub block_number: U256,
 
     /// the block.difficulty value during EVM execution

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1016,11 +1016,11 @@ prompt_timeout = 120
 sender = "0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38"
 tx_origin = "0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38"
 initial_balance = "0xffffffffffffffffffffffff"
-block_number = "0x1"
+block_number = 1
 gas_limit = 1073741824
 block_base_fee_per_gas = 0
 block_coinbase = "0x0000000000000000000000000000000000000000"
-block_timestamp = "0x1"
+block_timestamp = 1
 block_difficulty = 0
 block_prevrandao = "0x0000000000000000000000000000000000000000000000000000000000000000"
 memory_limit = 134217728
@@ -1242,7 +1242,7 @@ exclude = []
   "sender": "0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38",
   "tx_origin": "0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38",
   "initial_balance": "0xffffffffffffffffffffffff",
-  "block_number": "0x1",
+  "block_number": 1,
   "fork_block_number": null,
   "chain_id": null,
   "gas_limit": 1073741824,
@@ -1250,7 +1250,7 @@ exclude = []
   "gas_price": null,
   "block_base_fee_per_gas": 0,
   "block_coinbase": "0x0000000000000000000000000000000000000000",
-  "block_timestamp": "0x1",
+  "block_timestamp": 1,
   "block_difficulty": 0,
   "block_prevrandao": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "block_gas_limit": null,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

We currently allow users to specify as:

```toml
block_timestamp = 100123
block_number = 12345678
```

but serialize (when running `forge config`) / work internally with:

```toml
block_number = "0xbc614e"
block_timestamp = "0x1871b"
```

which is difficult to read / not in a format users regularly encounter when looking at a block explorer

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

We have a serialization method that attempts to fit the number in a `u64`, else serializing in `U256` per suggestion by @DaniPopes in https://github.com/foundry-rs/foundry/pull/10838#discussion_r2198134471

`foundry.toml` set as:

```toml
block_number = 12345678
block_timestamp = 100123
```

serializes as:

```toml
block_number = 12345678
block_timestamp = 100123
```

`foundry.toml` set as:

```toml
block_number = "0x732143"
block_timestamp = "0x123123"
```

serializes as:

```toml
block_number = 7545155
block_timestamp = 1192227
```

`foundry.toml` set as (u64::max):

```toml
block_number = "0xffffffffffffffff"
block_timestamp = "0xffffffffffffffff"
```

serializes as:

```toml
block_number = "18446744073709551615"
block_timestamp = "18446744073709551615"
```

`foundry.toml` set as (u64::max + 1):

```toml
block_number = "0x10000000000000000"
block_timestamp = "0x10000000000000000"
```

serializes as:

```toml
block_number = "0x10000000000000000"
block_timestamp = "0x10000000000000000"
```

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
