### PR TITLE
Fix: call correct assert function in assertLeDecimal with custom error

### DIFF
--- a/testdata/lib/ds-test/src/test.sol
+++ b/testdata/lib/ds-test/src/test.sol
@@ -463,7 +463,7 @@ contract DSTest {
     function assertLeDecimal(uint256 a, uint256 b, uint256 decimals, string memory err) internal {
         if (a > b) {
             emit log_named_string("Error", err);
-            assertGeDecimal(a, b, decimals);
+            assertLeDecimal(a, b, decimals);
         }
     }
 


### PR DESCRIPTION
Fixes a logic issue in the assertLeDecimal(uint256,uint256,uint256,string) function, where it previously called assertGeDecimal on failure, resulting in misleading error messages. Now it correctly calls assertLeDecimal, ensuring error logs are consistent and accurate with the intended assertion. This change improves the clarity of test failure reports and aligns the function with the rest of the assertion helpers.