### PR TITLE
fix(forge-lint): [unused-imports] manually walk override paths

### DIFF
--- a/crates/lint/src/sol/info/imports.rs
+++ b/crates/lint/src/sol/info/imports.rs
@@ -124,6 +124,20 @@ impl<'ast> Visit<'ast> for UnusedChecker<'ast> {
         self.walk_using_directive(using)
     }
 
+    fn visit_function_header(
+        &mut self,
+        header: &'ast solar_ast::FunctionHeader<'ast>,
+    ) -> ControlFlow<Self::BreakValue> {
+        // temporary workaround until solar also visits `override` and its paths <https://github.com/paradigmxyz/solar/pull/383>.
+        if let Some(ref override_) = header.override_ {
+            for path in override_.paths.iter() {
+                _ = self.visit_path(path);
+            }
+        }
+
+        self.walk_function_header(header)
+    }
+
     fn visit_modifier(
         &mut self,
         modifier: &'ast ast::Modifier<'ast>,

--- a/crates/lint/testdata/Imports.sol
+++ b/crates/lint/testdata/Imports.sol
@@ -9,6 +9,7 @@ import {
     docSymbol2,
     docSymbolWrongTag, //~NOTE: unused imports should be removed
     eventSymbol,
+    overrideSymbol,
     symbolNotUsed, //~NOTE: unused imports should be removed
     IContract,
     IContractNotUsed //~NOTE: unused imports should be removed
@@ -54,7 +55,7 @@ contract UnusedImport is IContract {
     SomeFile2.Baz public myStruct2;
     symbol4 public myVar;
 
-    function foo(uint256 a, symbol5 b) public view returns (uint256) {
+    function foo(uint256 a, symbol5 b) public view override(overrideSymbol) returns (uint256) {
         emit eventSymbol.foo(c);
         uint256 c = Utils.calculate(a, b);
         return c;

--- a/crates/lint/testdata/Imports.stderr
+++ b/crates/lint/testdata/Imports.stderr
@@ -1,7 +1,7 @@
 note[unaliased-plain-import]: use named imports '{A, B}' or alias 'import ".." as X'
   --> ROOT/testdata/Imports.sol:LL:CC
    |
-28 | import "SomeFile.sol";
+29 | import "SomeFile.sol";
    |        --------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unaliased-plain-import
@@ -9,7 +9,7 @@ note[unaliased-plain-import]: use named imports '{A, B}' or alias 'import ".." a
 note[unaliased-plain-import]: use named imports '{A, B}' or alias 'import ".." as X'
   --> ROOT/testdata/Imports.sol:LL:CC
    |
-29 | import "AnotherFile.sol";
+30 | import "AnotherFile.sol";
    |        -----------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unaliased-plain-import
@@ -33,7 +33,7 @@ note[unused-import]: unused imports should be removed
 note[unused-import]: unused imports should be removed
   --> ROOT/testdata/Imports.sol:LL:CC
    |
-12 |     symbolNotUsed,
+13 |     symbolNotUsed,
    |     -------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
@@ -41,7 +41,7 @@ note[unused-import]: unused imports should be removed
 note[unused-import]: unused imports should be removed
   --> ROOT/testdata/Imports.sol:LL:CC
    |
-14 |     IContractNotUsed
+15 |     IContractNotUsed
    |     ----------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
@@ -49,7 +49,7 @@ note[unused-import]: unused imports should be removed
 note[unused-import]: unused imports should be removed
   --> ROOT/testdata/Imports.sol:LL:CC
    |
-19 |     CONSTANT_1
+20 |     CONSTANT_1
    |     ----------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
@@ -57,7 +57,7 @@ note[unused-import]: unused imports should be removed
 note[unused-import]: unused imports should be removed
   --> ROOT/testdata/Imports.sol:LL:CC
    |
-25 |     YetAnotherType
+26 |     YetAnotherType
    |     --------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
@@ -65,7 +65,7 @@ note[unused-import]: unused imports should be removed
 note[unused-import]: unused imports should be removed
   --> ROOT/testdata/Imports.sol:LL:CC
    |
-32 | import "another_file_2.sol" as AnotherFile2;
+33 | import "another_file_2.sol" as AnotherFile2;
    | --------------------------------------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import
@@ -73,7 +73,7 @@ note[unused-import]: unused imports should be removed
 note[unused-import]: unused imports should be removed
   --> ROOT/testdata/Imports.sol:LL:CC
    |
-35 | import * as OtherUtils from "utils2.sol";
+36 | import * as OtherUtils from "utils2.sol";
    | -----------------------------------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import


### PR DESCRIPTION
Temporary walk the `override` paths manually, until it is done by default:
 - https://github.com/paradigmxyz/solar/pull/383

Once the solar PR is merged, we can remove this patch.