### PR TITLE
fix: ensure account is always loaded and marked as touched when pranked

### DIFF
--- a/crates/cheatcodes/src/evm/prank.rs
+++ b/crates/cheatcodes/src/evm/prank.rs
@@ -124,6 +124,9 @@ fn prank(
     single_call: bool,
     delegate_call: bool,
 ) -> Result {
+    // Ensure that we load the account of the pranked address and mark it as touched.
+    // This is necessary to ensure that account state changes (such as the account's `nonce`) are
+    // properly applied.
     let account = journaled_account(ccx.ecx, *new_caller)?;
 
     // Ensure that code exists at `msg.sender` if delegate calling.

--- a/crates/cheatcodes/src/evm/prank.rs
+++ b/crates/cheatcodes/src/evm/prank.rs
@@ -126,7 +126,7 @@ fn prank(
 ) -> Result {
     // Ensure that we load the account of the pranked address and mark it as touched.
     // This is necessary to ensure that account state changes (such as the account's `nonce`) are
-    // properly applied.
+    // properly tracked.
     let account = journaled_account(ccx.ecx, *new_caller)?;
 
     // Ensure that code exists at `msg.sender` if delegate calling.

--- a/crates/cheatcodes/src/evm/prank.rs
+++ b/crates/cheatcodes/src/evm/prank.rs
@@ -1,6 +1,6 @@
-use crate::{Cheatcode, CheatsCtxt, Result, Vm::*};
+use crate::{Cheatcode, CheatsCtxt, Result, Vm::*, evm::journaled_account};
 use alloy_primitives::Address;
-use revm::{context::JournalTr, interpreter::Host};
+use revm::context::JournalTr;
 
 /// Prank information.
 #[derive(Clone, Copy, Debug, Default)]
@@ -124,13 +124,14 @@ fn prank(
     single_call: bool,
     delegate_call: bool,
 ) -> Result {
+    let account = journaled_account(ccx.ecx, *new_caller)?;
+
     // Ensure that code exists at `msg.sender` if delegate calling.
     if delegate_call {
-        let code = ccx
-            .load_account_code(*new_caller)
-            .ok_or_else(|| eyre::eyre!("cannot `prank` delegate call from an EOA"))?;
-
-        ensure!(!code.data.is_empty(), "cannot `prank` delegate call from an EOA");
+        ensure!(
+            account.info.clone().code.is_some_and(|code| !code.is_empty()),
+            "cannot `prank` delegate call from an EOA"
+        );
     }
 
     let depth = ccx.ecx.journaled_state.depth();

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1559,26 +1559,8 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
 
             // At the target depth we set `msg.sender`
             if curr_depth == prank.depth {
-                // Load the pranked account to ensure its state is properly tracked
-                // This ensures the account exists in the journal and its nonce is tracked
-                if let Err(err) = ecx.journaled_state.load_account(prank.new_caller) {
-                    // This will only err out on a database issue.
-                    return Some(CreateOutcome {
-                        result: InterpreterResult {
-                            result: InstructionResult::Revert,
-                            output: Error::encode(err),
-                            gas,
-                        },
-                        address: None,
-                    });
-                }
-
                 input.set_caller(prank.new_caller);
                 prank_applied = true;
-
-                // IMPORTANT: Ensure the pranked account's state is committed to the journal
-                // This ensures nonce increments persist even after stopPrank is called
-                ecx.journaled_state.touch(prank.new_caller);
             }
 
             // At the target depth, or deeper, we set `tx.origin`


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes: https://github.com/foundry-rs/foundry/issues/11021

Follow up of https://github.com/foundry-rs/foundry/pull/11023

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Instead of only marking the account as touched when it `create`'s a new contract we should always mark it as `touched` when `pranked` so that account state (like `nonce`) is accurately tracked.

I don't see a realistic way `journaled_account` could error unless there is an actual issue with the underlying database / memory corruption.

The performance impact should be minimal, we already do this on many other cheatcodes and we do not load code or storage keys.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
