### PR TITLE
fix(forge): show git submodule status error

### DIFF
--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -142,9 +142,8 @@ impl DependencyInstallOpts {
                     git.submodule_update(false, false, false, true, Some(&libs))?;
                     lockfile.write()?;
                 }
-
                 Err(err) => {
-                    warn!(?err, "Failed to check for submodules");
+                    sh_err!("Failed to check for submodules: {err}")?;
                 }
                 _ => {
                     // no submodules, nothing to do


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- user messed up submodules, then `forge install` silently failed
- running with `RUST_LOG=trace` revealed error when `git submodule status`
```
2025-07-17T13:48:42.028092Z TRACE foundry_cli::utils: code=Some(0) output=Output { status: ExitStatus(unix_wait_status(0)), stdout: "/Users/ffd/do/do/GA/repo\n", stderr: "" }
2025-07-17T13:48:42.029291Z TRACE foundry_cli::utils: executing command=cd "/Users/ffd/do/do/GA/repo" && "git" "submodule" "status" "/Users/ffd/do/do/GA/repo"
2025-07-17T13:48:42.147333Z TRACE foundry_cli::utils: code=Some(128) output=Output { status: ExitStatus(unix_wait_status(32768)), stdout: " ad4e51105af61eb4c1cb89585d59c02931193478 lib/common (v1.1.0-3-gad4e511)\n 77041d2ce690e692d6e03cc812b57d1ddaa4d505 lib/forge-std (v1.9.7)\n 8116ad7ed50c41d0a40d2475c93c98f3653fa8fd lib/fuzzlib (v0.3.1)\n 441b1c1c5b909498ca6206a84445ee516067e7fc lib/openzeppelin-contracts (v4.8.0-913-g441b1c1c)\n 78048ebe3be1fa256182d9c8c4f9a64587c0d6b3 lib/openzeppelin-foundry-upgrades (v0.4.0-6-g78048eb)\n", stderr: "fatal: no submodule mapping found in .gitmodules for path 'lib/permit2'\n" }
2025-07-17T13:48:42.147864Z  WARN forge::cmd::install: Failed to check for submodules err=git submodule exited with code 128:
stdout:
ad4e51105af61eb4c1cb89585d59c02931193478 lib/common (v1.1.0-3-gad4e511)
 77041d2ce690e692d6e03cc812b57d1ddaa4d505 lib/forge-std (v1.9.7)
 8116ad7ed50c41d0a40d2475c93c98f3653fa8fd lib/fuzzlib (v0.3.1)
 441b1c1c5b909498ca6206a84445ee516067e7fc lib/openzeppelin-contracts (v4.8.0-913-g441b1c1c)
 78048ebe3be1fa256182d9c8c4f9a64587c0d6b3 lib/openzeppelin-foundry-upgrades (v0.4.0-6-g78048eb)

stderr:
fatal: no submodule mapping found in .gitmodules for path 'lib/permit2'
```
- fix by `sh_err!` error to the user
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
