### PR TITLE
refactor(cast): simplify Unit parsing in from_fixed_point

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1248,12 +1248,7 @@ impl SimpleCast {
     /// # Ok::<_, eyre::Report>(())
     /// ```
     pub fn from_fixed_point(value: &str, decimals: &str) -> Result<String> {
-        // TODO: https://github.com/alloy-rs/core/pull/461
-        let units: Unit = if let Ok(x) = decimals.parse() {
-            Unit::new(x).ok_or_else(|| eyre::eyre!("invalid unit"))?
-        } else {
-            decimals.parse()?
-        };
+        let units: Unit = Unit::from_str(decimals)?;
         let n = ParseUnits::parse_units(value, units)?;
         Ok(n.to_string())
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Simplify the logic for parsing `decimals` in `from_fixed_point`. The original implementation had a TODO due to alloy limitations.

## Solution

Replaced the conditional parsing and manual `Unit::new` construction with a single call to `Unit::from_str`. This relies on the updated behavior introduced in https://github.com/alloy-rs/core/pull/461.