### PR TITLE
feat(cast): add checksum address with chain id

### DIFF
--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -111,9 +111,9 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
             };
             sh_println!("0x{output}")?
         }
-        CastSubcommand::ToCheckSumAddress { address } => {
+        CastSubcommand::ToCheckSumAddress { address, chain_id } => {
             let value = stdin::unwrap_line(address)?;
-            sh_println!("{}", value.to_checksum(None))?
+            sh_println!("{}", value.to_checksum(chain_id))?
         }
         CastSubcommand::ToUint256 { value } => {
             let value = stdin::unwrap_line(value)?;

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -115,6 +115,7 @@ pub enum CastSubcommand {
     ToCheckSumAddress {
         /// The address to convert.
         address: Option<Address>,
+        /// EIP-155 chain ID to encode the address using EIP-1191.
         chain_id: Option<u64>,
     },
 

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -115,6 +115,7 @@ pub enum CastSubcommand {
     ToCheckSumAddress {
         /// The address to convert.
         address: Option<Address>,
+        chain_id: Option<u64>,
     },
 
     /// Convert hex data to an ASCII string.


### PR DESCRIPTION
### Solution
Added an optional `chain_id: Option<u64>` field to the `ToCheckSumAddress` subcommand. The checksum conversion now uses the `chain_id` if provided; otherwise, it defaults to `None`, preserving current behavior. This enables support for both standard `EIP-55` and chain-aware `EIP-1191` checksum formats.