### PR TITLE
chore: migrate from codespell to typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,0 @@
-[codespell]
-skip = .git,target,testdata,Cargo.toml,Cargo.lock
-ignore-words-list = crate,ser,ratatui,Caf,froms,strat

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,14 +53,12 @@ jobs:
           cache-on-failure: true
       - run: cargo test --workspace --doc
 
-  codespell:
+  typos:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: codespell-project/actions-codespell@v2
-        with:
-          skip: "*.json"
+      - uses: crate-ci/typos@v1
 
   clippy:
     runs-on: ubuntu-latest
@@ -120,7 +118,7 @@ jobs:
       - nextest
       - docs
       - doctest
-      - codespell
+      - typos
       - clippy
       - rustfmt
       - forge-fmt

--- a/Makefile
+++ b/Makefile
@@ -105,19 +105,19 @@ lint-clippy: ## Run clippy on the codebase.
 	--all-features \
 	-- -D warnings
 
-.PHONY: lint-codespell
-lint-codespell: ## Run codespell on the codebase.
-	@command -v codespell >/dev/null || { \
-		echo "codespell not found. Please install it by running the command `pipx install codespell` or refer to the following link for more information: https://github.com/codespell-project/codespell" \
+.PHONY: lint-typos
+lint-typos: ## Run typos on the codebase.
+	@command -v typos >/dev/null || { \
+		echo "typos not found. Please install it by running the command `cargo install typos-cli` or refer to the following link for more information: https://github.com/crate-ci/typos" \
 		exit 1; \
 	}
-	codespell --skip "*.json"
+	typos
 
 .PHONY: lint
 lint: ## Run all linters.
 	make fmt && \
 	make lint-clippy && \
-	make lint-codespell
+	make lint-typos
 
 ##@ Other
 

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -671,7 +671,7 @@ ignore them in the `.gitignore` file."
     /// If the status is prefix with `-`, the submodule is not initialized.
     ///
     /// Ref: <https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt-status--cached--recursive--ltpathgt82308203>
-    pub fn submodules_unintialized(self) -> Result<bool> {
+    pub fn submodules_uninitialized(self) -> Result<bool> {
         self.cmd()
             .args(["submodule", "status"])
             .get_stdout_lossy()

--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -123,7 +123,7 @@ impl DependencyInstallOpts {
             // Check if submodules are uninitialized, if so, we need to fetch all submodules
             // This is to ensure that foundry.lock syncs successfully and doesn't error out, when
             // looking for commits/tags in submodules
-            if git.submodules_unintialized()? {
+            if git.submodules_uninitialized()? {
                 trace!(lib = %libs.display(), "submodules uninitialized");
                 git.submodule_update(false, false, false, true, Some(&libs))?;
             }

--- a/crates/forge/src/cmd/update.rs
+++ b/crates/forge/src/cmd/update.rs
@@ -52,7 +52,7 @@ impl UpdateArgs {
             foundry_lock.iter_mut().for_each(|(_path, dep_id)| {
                 // Set r#override flag to true if the dep is a branch
                 if let DepIdentifier::Branch { .. } = dep_id {
-                    dep_id.mark_overide();
+                    dep_id.mark_override();
                 }
             });
         } else {

--- a/crates/forge/src/lockfile.rs
+++ b/crates/forge/src/lockfile.rs
@@ -178,7 +178,7 @@ impl<'a> Lockfile<'a> {
             .deps
             .get_mut(dep)
             .map(|d| {
-                new_dep_id.mark_overide();
+                new_dep_id.mark_override();
                 std::mem::replace(d, new_dep_id)
             })
             .ok_or_eyre(format!("Dependency not found in lockfile: {}", dep.display()))?;
@@ -232,7 +232,7 @@ pub enum DepIdentifier {
     /// Release tag `name` and the `rev` it is currently pointing to.
     /// Running `forge update` does not update the tag/rev.
     /// Dependency will remain pinned to the existing tag/rev unless r#override like so `forge
-    /// update owner/dep@tag=diffent_tag`.
+    /// update owner/dep@tag=different_tag`.
     #[serde(rename = "tag")]
     Tag {
         name: String,
@@ -304,7 +304,7 @@ impl DepIdentifier {
     }
 
     /// Marks as dependency as overridden.
-    pub fn mark_overide(&mut self) {
+    pub fn mark_override(&mut self) {
         match self {
             Self::Branch { r#override, .. } => *r#override = true,
             Self::Tag { r#override, .. } => *r#override = true,

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -414,7 +414,7 @@ Installing forge-5980-test in [..] (url: Some("https://github.com/evalir/forge-5
         let config = Config {
             remappings: vec![
                 Remapping::from_str("forge-5980-test/=lib/forge-5980-test/src/").unwrap().into(),
-                // explicit remapping for sub-dependendy seems necessary for some reason
+                // explicit remapping for sub-dependency seems necessary for some reason
                 Remapping::from_str(
                     "forge-5980-test-dep/=lib/forge-5980-test/lib/forge-5980-test-dep/src/",
                 )

--- a/crates/lint/src/linter/mod.rs
+++ b/crates/lint/src/linter/mod.rs
@@ -26,7 +26,7 @@ use crate::inline_config::InlineConfig;
 ///
 /// # Required Methods
 ///
-/// - `init`: Creates a new solar `Session` with the appropiate linter configuration.
+/// - `init`: Creates a new solar `Session` with the appropriate linter configuration.
 /// - `early_lint`: Scans the source files (using the AST) emitting a diagnostic for lints found.
 /// - `late_lint`: Scans the source files (using the HIR) emitting a diagnostic for lints found.
 pub trait Linter: Send + Sync + Clone {

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,20 @@
+[files]
+extend-exclude = [
+    ".git",
+    "target",
+    "testdata",
+    "Cargo.toml",
+    "Cargo.lock",
+    "*.json",
+]
+
+[default.extend-words]
+crate = "crate"
+ser = "ser"
+ratatui = "ratatui"
+Caf = "Caf"
+froms = "froms"
+strat = "strat"
+ba = "ba"  # Used in hexadecimal values and git commit hashes
+abd = "abd"  # Used in function signatures
+nd = "nd"  # Used in function names like "2nd"

--- a/typos.toml
+++ b/typos.toml
@@ -15,6 +15,18 @@ ratatui = "ratatui"
 Caf = "Caf"
 froms = "froms"
 strat = "strat"
-ba = "ba"  # Used in hexadecimal values and git commit hashes
-abd = "abd"  # Used in function signatures
-nd = "nd"  # Used in function names like "2nd"
+ba = "ba"  # Command alias for basefee
+
+[default]
+extend-ignore-identifiers-re = [
+    # Ignore hex literals and hex strings
+    "(?i)^0x[0-9a-f]+$",
+    "[0-9a-f]{8}",  # 8-char hex strings (function selectors)
+    "[0-9a-f]{40}",  # 40-char hex strings (addresses)
+    "[0-9a-f]{64}",  # 64-char hex strings (hashes)
+    # Allow ordinal numbers in identifiers
+    ".*1st.*",
+    ".*2nd.*",
+    ".*3rd.*",
+    ".*[0-9]+th.*",
+]

--- a/typos.toml
+++ b/typos.toml
@@ -1,11 +1,15 @@
 [files]
 extend-exclude = [
-    ".git",
-    "target",
-    "testdata",
-    "Cargo.toml",
-    "Cargo.lock",
-    "*.json",
+    ".git",  # Version control
+    "target",  # Build artifacts
+    "testdata",  # Test fixtures
+    "Cargo.toml",  # Dependency manifest
+    "Cargo.lock",  # Dependency lock file
+    "*.json",  # JSON files
+    "**/tests/**",  # Test directories
+    "**/test/**",  # Test directories
+    "**/*_test.*",  # Test files
+    "**/*_tests.*",  # Test files
 ]
 
 [default.extend-words]

--- a/typos.toml
+++ b/typos.toml
@@ -1,15 +1,15 @@
 [files]
 extend-exclude = [
-    ".git",  # Version control
-    "target",  # Build artifacts
-    "testdata",  # Test fixtures
-    "Cargo.toml",  # Dependency manifest
-    "Cargo.lock",  # Dependency lock file
-    "*.json",  # JSON files
-    "**/tests/**",  # Test directories
-    "**/test/**",  # Test directories
-    "**/*_test.*",  # Test files
-    "**/*_tests.*",  # Test files
+    ".git",
+    "target",
+    "testdata",
+    "Cargo.toml",
+    "Cargo.lock",
+    "*.json",
+    "**/tests/**",
+    "**/test/**",
+    "**/*_test.*",
+    "**/*_tests.*",
 ]
 
 [default.extend-words]
@@ -19,18 +19,4 @@ ratatui = "ratatui"
 Caf = "Caf"
 froms = "froms"
 strat = "strat"
-ba = "ba"  # Command alias for basefee
-
-[default]
-extend-ignore-identifiers-re = [
-    # Ignore hex literals and hex strings
-    "(?i)^0x[0-9a-f]+$",
-    "[0-9a-f]{8}",  # 8-char hex strings (function selectors)
-    "[0-9a-f]{40}",  # 40-char hex strings (addresses)
-    "[0-9a-f]{64}",  # 64-char hex strings (hashes)
-    # Allow ordinal numbers in identifiers
-    ".*1st.*",
-    ".*2nd.*",
-    ".*3rd.*",
-    ".*[0-9]+th.*",
-]
+ba = "ba"


### PR DESCRIPTION
We still regularly get typo fix PRs because codespell doesn't catch as many as it should. Typos is better.