### PR TITLE
feat: use signatures identifier for --print-traces

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -24,7 +24,10 @@ use anvil_core::eth::{
         DepositReceipt, PendingTransaction, TransactionInfo, TypedReceipt, TypedTransaction,
     },
 };
-use foundry_evm::{backend::DatabaseError, traces::CallTraceNode};
+use foundry_evm::{
+    backend::DatabaseError,
+    traces::{CallTraceDecoder, CallTraceNode},
+};
 use foundry_evm_core::either_evm::EitherEvm;
 use op_revm::{L1BlockInfo, OpContext, precompiles::OpPrecompiles};
 use revm::{
@@ -119,6 +122,8 @@ pub struct TransactionExecutor<'a, Db: ?Sized, V: TransactionValidator> {
     pub optimism: bool,
     pub print_logs: bool,
     pub print_traces: bool,
+    /// Recorder used for decoding traces, used together with print_traces
+    pub call_trace_decoder: Arc<CallTraceDecoder>,
     /// Precompiles to inject to the EVM.
     pub precompile_factory: Option<Arc<dyn PrecompileFactory>>,
     pub blob_params: BlobParams,
@@ -367,7 +372,7 @@ impl<DB: Db + ?Sized, V: TransactionValidator> Iterator for &mut TransactionExec
         };
 
         if self.print_traces {
-            inspector.print_traces();
+            inspector.print_traces(self.call_trace_decoder.clone());
         }
         inspector.print_logs();
 

--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -19,6 +19,7 @@ use revm::{
         interpreter::EthInterpreter,
     },
 };
+use std::sync::Arc;
 
 /// The [`revm::Inspector`] used when transacting in the evm
 #[derive(Clone, Debug, Default)]
@@ -40,17 +41,17 @@ impl AnvilInspector {
     }
 
     /// Consumes the type and prints the traces.
-    pub fn into_print_traces(mut self) {
+    pub fn into_print_traces(mut self, decoder: Arc<CallTraceDecoder>) {
         if let Some(a) = self.tracer.take() {
-            print_traces(a)
+            print_traces(a, decoder);
         }
     }
 
     /// Called after the inspecting the evm
     /// This will log all traces
-    pub fn print_traces(&self) {
+    pub fn print_traces(&self, decoder: Arc<CallTraceDecoder>) {
         if let Some(a) = self.tracer.clone() {
-            print_traces(a)
+            print_traces(a, decoder);
         }
     }
 
@@ -60,6 +61,7 @@ impl AnvilInspector {
         self
     }
 
+    /// Configures the `TracingInspector` [`revm::Inspector`]
     pub fn with_tracing_config(mut self, config: TracingInspectorConfig) -> Self {
         self.tracer = Some(TracingInspector::new(config));
         self
@@ -91,11 +93,10 @@ impl AnvilInspector {
 /// # Panics
 ///
 /// If called outside tokio runtime
-fn print_traces(tracer: TracingInspector) {
+fn print_traces(tracer: TracingInspector, decoder: Arc<CallTraceDecoder>) {
     let arena = tokio::task::block_in_place(move || {
         tokio::runtime::Handle::current().block_on(async move {
             let mut arena = tracer.into_traces();
-            let decoder = CallTraceDecoder::new();
             decoder.populate_traces(arena.nodes_mut()).await;
             arena
         })

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -410,18 +410,18 @@ impl CallTraceDecoder {
                     None
                 };
 
-                if let Some(func) = functions.first() {
-                    return DecodedCallTrace {
+                return if let Some(func) = functions.first() {
+                    DecodedCallTrace {
                         label,
                         call_data: Some(self.decode_function_input(trace, func)),
                         return_data,
-                    };
+                    }
                 } else {
-                    return DecodedCallTrace {
+                    DecodedCallTrace {
                         label,
                         call_data: self.fallback_call_data(trace),
                         return_data,
-                    };
+                    }
                 };
             }
 


### PR DESCRIPTION
closes #11064

this uses the foundry signatures identifier cache if print-traces is enabled, we could extend this next with local ABIs.