### PR TITLE
Remove misleading code hash reference from impersonate method doc

### DIFF
--- a/crates/anvil/src/eth/backend/cheats.rs
+++ b/crates/anvil/src/eth/backend/cheats.rs
@@ -16,8 +16,6 @@ pub struct CheatsManager {
 impl CheatsManager {
     /// Sets the account to impersonate
     ///
-    /// This also accepts the actual code hash if the address is a contract to bypass EIP-3607
-    ///
     /// Returns `true` if the account is already impersonated
     pub fn impersonate(&self, addr: Address) -> bool {
         trace!(target: "cheats", "Start impersonating {:?}", addr);


### PR DESCRIPTION
The doc comment for the impersonate method in CheatsManager previously mentioned accepting a code hash to bypass EIP-3607, but the method does not handle code hashes or EIP-3607 logic. This reference was outdated or misleading, so it was removed to accurately reflect the method's actual behavior and avoid confusion for future maintainers.