### PR TITLE
fix: avoid reloading files to pcx

### DIFF
--- a/crates/lint/src/linter/mod.rs
+++ b/crates/lint/src/linter/mod.rs
@@ -29,6 +29,10 @@ use crate::inline_config::InlineConfig;
 /// - `init`: Creates a new solar `Session` with the appropriate linter configuration.
 /// - `early_lint`: Scans the source files (using the AST) emitting a diagnostic for lints found.
 /// - `late_lint`: Scans the source files (using the HIR) emitting a diagnostic for lints found.
+///
+/// # Note:
+///
+/// - For `early_lint` and `late_lint`, the `ParsingContext` should have the sources pre-loaded.
 pub trait Linter: Send + Sync + Clone {
     type Language: Language;
     type Lint: Lint;

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -199,7 +199,9 @@ impl Linter for SolidityLinter {
         sess
     }
 
-    /// Run AST-based lints
+    /// Run AST-based lints.
+    ///
+    /// Note: the `ParsingContext` should already have the sources loaded.
     fn early_lint<'sess>(&self, input: &[PathBuf], pcx: ParsingContext<'sess>) {
         let sess = pcx.sess;
         _ = sess.enter_parallel(|| -> Result<(), diagnostics::ErrorGuaranteed> {
@@ -220,7 +222,9 @@ impl Linter for SolidityLinter {
         });
     }
 
-    /// Run HIR-based lints
+    /// Run HIR-based lints.
+    ///
+    /// Note: the `ParsingContext` should already have the sources loaded.
     fn late_lint<'sess>(&self, input: &[PathBuf], pcx: ParsingContext<'sess>) {
         let sess = pcx.sess;
         _ = sess.enter_parallel(|| -> Result<(), diagnostics::ErrorGuaranteed> {

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -200,12 +200,9 @@ impl Linter for SolidityLinter {
     }
 
     /// Run AST-based lints
-    fn early_lint<'sess>(&self, input: &[PathBuf], mut pcx: ParsingContext<'sess>) {
+    fn early_lint<'sess>(&self, input: &[PathBuf], pcx: ParsingContext<'sess>) {
         let sess = pcx.sess;
         _ = sess.enter_parallel(|| -> Result<(), diagnostics::ErrorGuaranteed> {
-            // Load all files into the parsing ctx
-            pcx.load_files(input)?;
-
             // Parse the sources
             let ast_arena = solar_sema::thread_local::ThreadLocal::new();
             let ast_result = pcx.parse(&ast_arena);
@@ -224,12 +221,9 @@ impl Linter for SolidityLinter {
     }
 
     /// Run HIR-based lints
-    fn late_lint<'sess>(&self, input: &[PathBuf], mut pcx: ParsingContext<'sess>) {
+    fn late_lint<'sess>(&self, input: &[PathBuf], pcx: ParsingContext<'sess>) {
         let sess = pcx.sess;
         _ = sess.enter_parallel(|| -> Result<(), diagnostics::ErrorGuaranteed> {
-            // Load all files into the parsing ctx
-            pcx.load_files(input)?;
-
             // Parse and lower to HIR
             let hir_arena = solar_sema::thread_local::ThreadLocal::new();
             let hir_result = pcx.parse_and_lower(&hir_arena);


### PR DESCRIPTION
`fn solar_pcx_from_build_opts` calls `solar_pcx_from_solc_project` with `add_source_files = true`. Therefore, there is no need to load the sources, as they are already available on the pcx.

https://github.com/foundry-rs/foundry/blob/450f2c761f052d32ca2236009ef64d2e7910df93/crates/cli/src/opts/build/utils.rs#L70-L84

the fix is necessary —other than for performance reasons—, because otherwise the language and version filters done by `fn solar_pcx_from_build_opts` are useless.