### PR TITLE
feat: collect local abis for --print-traces

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -149,6 +149,12 @@ pub struct NodeArgs {
     #[arg(long, value_name = "PATH", conflicts_with = "init")]
     pub dump_state: Option<PathBuf>,
 
+    /// The path of the associated forge project
+    ///
+    /// This can be used together with `--print-traces` to load ABI infos.
+    #[arg(long, value_name = "PATH")]
+    pub project_path: Option<PathBuf>,
+
     /// Preserve historical state snapshots when dumping the state.
     ///
     /// This will save the in-memory states of the chain at particular block hashes.
@@ -269,6 +275,7 @@ impl NodeArgs {
             .with_steps_tracing(self.evm.steps_tracing)
             .with_print_logs(!self.evm.disable_console_log)
             .with_print_traces(self.evm.print_traces)
+            .with_project_path(self.project_path)
             .with_auto_impersonate(self.evm.auto_impersonate)
             .with_ipc(self.ipc)
             .with_code_size_limit(self.evm.code_size_limit)

--- a/crates/common/src/fs.rs
+++ b/crates/common/src/fs.rs
@@ -183,6 +183,9 @@ pub fn json_files(root: &Path) -> impl Iterator<Item = PathBuf> {
     files_with_ext(root, "json")
 }
 
+/// Returns an iterator over all decoded files.
+///
+/// This is effectively [`json_files`] with `.map(serde_json::from_str(read_to_string))`.
 pub fn read_json_files<T>(root: &Path) -> impl Iterator<Item = Result<T>>
 where
     T: DeserializeOwned,

--- a/crates/common/src/fs.rs
+++ b/crates/common/src/fs.rs
@@ -5,7 +5,8 @@ use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 use serde::{Serialize, de::DeserializeOwned};
 use std::{
     fs::{self, File},
-    io::{BufReader, BufWriter, Write},
+    io::{BufReader, BufWriter, Read, Write},
+    marker::PhantomData,
     path::{Component, Path, PathBuf},
 };
 
@@ -180,6 +181,50 @@ pub fn files_with_ext<'a>(root: &Path, ext: &'a str) -> impl Iterator<Item = Pat
 /// Returns an iterator over all JSON files under the `root` dir.
 pub fn json_files(root: &Path) -> impl Iterator<Item = PathBuf> {
     files_with_ext(root, "json")
+}
+
+pub fn read_json_files<T>(root: &Path) -> impl Iterator<Item = Result<T>>
+where
+    T: DeserializeOwned,
+{
+    JsonFileDecodeIter::new(json_files(root))
+}
+
+/// An Iterator that decodes json files.
+struct JsonFileDecodeIter<T, Iter> {
+    buf: String,
+    files: Iter,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<T, Iter> JsonFileDecodeIter<T, Iter> {
+    fn new(files: Iter) -> Self {
+        Self { buf: String::with_capacity(1024), files, _marker: Default::default() }
+    }
+
+    fn decode(&mut self, path: PathBuf) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let file = open(&path)?;
+        self.buf.clear();
+        let mut reader = BufReader::new(file);
+        reader.read_to_string(&mut self.buf).map_err(|err| FsPathError::read(err, path.clone()))?;
+
+        serde_json::from_str(&self.buf).map_err(|source| FsPathError::ReadJson { source, path })
+    }
+}
+
+impl<T, Iter> Iterator for JsonFileDecodeIter<T, Iter>
+where
+    T: DeserializeOwned,
+    Iter: Iterator<Item = PathBuf>,
+{
+    type Item = Result<T>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let file = self.files.next()?;
+        Some(self.decode(file))
+    }
 }
 
 /// Canonicalize a path, returning an error if the path does not exist.

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -52,11 +52,17 @@ impl CallTraceDecoderBuilder {
         self
     }
 
-    /// Add known errors to the decoder.
+    /// Add known ABI to the decoder.
     #[inline]
     pub fn with_abi(mut self, abi: &JsonAbi) -> Self {
-        self.decoder.collect_abi(abi, None);
+        self.collect_abi(abi);
         self
+    }
+
+    /// Add known ABI to the decoder.
+    #[inline]
+    pub fn collect_abi(&mut self, abi: &JsonAbi) {
+        self.decoder.collect_abi(abi, None);
     }
 
     /// Add known contracts to the decoder.


### PR DESCRIPTION
followup for

https://github.com/foundry-rs/foundry/pull/11070

introduces a new anvil cli arg to provide the corresponding forge project.
if --print-traces, this record all abis.

introduces a new readiterator that reuses a string buffer because we can have a few of those and these are quite large