### PR TITLE
feat(`cheats`): add `vm.getRawBlockHeader(blockNumber)`

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -6376,6 +6376,26 @@
     },
     {
       "func": {
+        "id": "getRawBlockHeader",
+        "description": "Gets the RLP encoded block header for a given block number.\nReturns the block header in the same format as `cast block <block_number> --raw`.",
+        "declaration": "function getRawBlockHeader(uint256 blockNumber) external view returns (bytes memory rlpHeader);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getRawBlockHeader(uint256)",
+        "selector": "0x2c667606",
+        "selectorBytes": [
+          44,
+          102,
+          118,
+          6
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "getRecordedLogs",
         "description": "Gets all the recorded logs.",
         "declaration": "function getRecordedLogs() external returns (Log[] memory logs);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -522,6 +522,11 @@ interface Vm {
     #[cheatcode(group = Evm, safety = Safe)]
     function getBlockTimestamp() external view returns (uint256 timestamp);
 
+    /// Gets the RLP encoded block header for a given block number.
+    /// Returns the block header in the same format as `cast block <block_number> --raw`.
+    #[cheatcode(group = Evm, safety = Safe)]
+    function getRawBlockHeader(uint256 blockNumber) external view returns (bytes memory rlpHeader);
+
     /// Sets `block.blobbasefee`
     #[cheatcode(group = Evm, safety = Unsafe)]
     function blobBaseFee(uint256 newBlobBaseFee) external;

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -276,14 +276,18 @@ impl Cheatcode for getRawBlockHeaderCall {
             .active_fork_url()
             .ok_or_else(|| fmt_err!("no active fork"))?;
         let provider = ProviderBuilder::new(&url).build()?;
-        let block_number = u64::try_from(blockNumber).map_err(|_| fmt_err!("block number must be less than 2^64"))?;
-        let block = foundry_common::block_on(async move {
-            provider.get_block(block_number.into()).await
-        })
-        .map_err(|e| fmt_err!("failed to get block: {e}"))?
-        .ok_or_else(|| fmt_err!("block {block_number} not found"))?;
-        
-        let header: alloy_consensus::Header = block.into_inner().header.inner.try_into_header()
+        let block_number = u64::try_from(blockNumber)
+            .map_err(|_| fmt_err!("block number must be less than 2^64"))?;
+        let block =
+            foundry_common::block_on(async move { provider.get_block(block_number.into()).await })
+                .map_err(|e| fmt_err!("failed to get block: {e}"))?
+                .ok_or_else(|| fmt_err!("block {block_number} not found"))?;
+
+        let header: alloy_consensus::Header = block
+            .into_inner()
+            .header
+            .inner
+            .try_into_header()
             .map_err(|e| fmt_err!("failed to convert to header: {e}"))?;
         Ok(alloy_rlp::encode(&header).abi_encode())
     }

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -266,6 +266,29 @@ impl Cheatcode for eth_getLogsCall {
     }
 }
 
+impl Cheatcode for getRawBlockHeaderCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { blockNumber } = self;
+        let url = ccx
+            .ecx
+            .journaled_state
+            .database
+            .active_fork_url()
+            .ok_or_else(|| fmt_err!("no active fork"))?;
+        let provider = ProviderBuilder::new(&url).build()?;
+        let block_number = u64::try_from(blockNumber).map_err(|_| fmt_err!("block number must be less than 2^64"))?;
+        let block = foundry_common::block_on(async move {
+            provider.get_block(block_number.into()).await
+        })
+        .map_err(|e| fmt_err!("failed to get block: {e}"))?
+        .ok_or_else(|| fmt_err!("block {block_number} not found"))?;
+        
+        let header: alloy_consensus::Header = block.into_inner().header.inner.try_into_header()
+            .map_err(|e| fmt_err!("failed to convert to header: {e}"))?;
+        Ok(alloy_rlp::encode(&header).abi_encode())
+    }
+}
+
 /// Creates and then also selects the new fork
 fn create_select_fork(ccx: &mut CheatsCtxt, url_or_alias: &str, block: Option<u64>) -> Result {
     check_broadcast(ccx.state)?;

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -312,6 +312,7 @@ interface Vm {
     function getMappingSlotAt(address target, bytes32 mappingSlot, uint256 idx) external returns (bytes32 value);
     function getNonce(address account) external view returns (uint64 nonce);
     function getNonce(Wallet calldata wallet) external returns (uint64 nonce);
+    function getRawBlockHeader(uint256 blockNumber) external view returns (bytes memory rlpHeader);
     function getRecordedLogs() external returns (Log[] memory logs);
     function getStateDiff() external view returns (string memory diff);
     function getStateDiffJson() external view returns (string memory diff);

--- a/testdata/default/cheats/GetRawBlockHeader.t.sol
+++ b/testdata/default/cheats/GetRawBlockHeader.t.sol
@@ -12,7 +12,7 @@ contract GetRawBlockHeaderTest is DSTest {
         vm.createSelectFork("https://eth.llamarpc.com");
         assertEq(
             keccak256(vm.getRawBlockHeader(22985278)), 
-            // `cast keccak256 $(cast block 22985278 --flashbots --raw)`
+            // `cast keccak256 $(cast block 22985278 --raw)`
             0x492419d85d2817f50577807a287742fbdcaae00ce89f2ea885e419ee4493b00f
         );
     }

--- a/testdata/default/cheats/GetRawBlockHeader.t.sol
+++ b/testdata/default/cheats/GetRawBlockHeader.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract GetRawBlockHeaderTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testGetRawBlockHeaderWithFork() public {
+        // TODO: Not sure how RPCs are handled in tests.
+        vm.createSelectFork("https://eth.llamarpc.com");
+        assertEq(
+            keccak256(vm.getRawBlockHeader(22985278)), 
+            // `cast keccak256 $(cast block 22985278 --flashbots --raw)`
+            0x492419d85d2817f50577807a287742fbdcaae00ce89f2ea885e419ee4493b00f
+        );
+    }
+}

--- a/testdata/default/cheats/GetRawBlockHeader.t.sol
+++ b/testdata/default/cheats/GetRawBlockHeader.t.sol
@@ -9,7 +9,7 @@ contract GetRawBlockHeaderTest is DSTest {
 
     function testGetRawBlockHeaderWithFork() public {
         // TODO: Not sure how RPCs are handled in tests.
-        vm.createSelectFork("https://eth.llamarpc.com");
+        vm.createSelectFork("mainnet");
         assertEq(
             keccak256(vm.getRawBlockHeader(22985278)), 
             // `cast keccak256 $(cast block 22985278 --raw)`

--- a/testdata/default/cheats/GetRawBlockHeader.t.sol
+++ b/testdata/default/cheats/GetRawBlockHeader.t.sol
@@ -8,10 +8,9 @@ contract GetRawBlockHeaderTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function testGetRawBlockHeaderWithFork() public {
-        // TODO: Not sure how RPCs are handled in tests.
         vm.createSelectFork("mainnet");
         assertEq(
-            keccak256(vm.getRawBlockHeader(22985278)), 
+            keccak256(vm.getRawBlockHeader(22985278)),
             // `cast keccak256 $(cast block 22985278 --raw)`
             0x492419d85d2817f50577807a287742fbdcaae00ce89f2ea885e419ee4493b00f
         );


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

A previous PR added `--raw` to `cast block` #11027. It would be even more useful if this functionality were available as a native cheatcode, eliminating the need for vm.ffi.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Added `vm.getRawBlockHeader(blockNumber)` cheatcode that returns the RLP encoded block header corresponding to `blockNumber`.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
