### PR TITLE
fix: doc comment for set_code method in Db trait

### DIFF
--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -119,7 +119,7 @@ pub trait Db:
         Ok(())
     }
 
-    /// Sets the balance of the given address
+    /// Sets the code of the given address
     fn set_code(&mut self, address: Address, code: Bytes) -> DatabaseResult<()> {
         let mut info = self.basic(address)?.unwrap_or_default();
         let code_hash = if code.as_ref().is_empty() {
@@ -133,7 +133,7 @@ pub trait Db:
         Ok(())
     }
 
-    /// Sets the balance of the given address
+    /// Sets the storage value at the given slot for the address
     fn set_storage_at(&mut self, address: Address, slot: B256, val: B256) -> DatabaseResult<()>;
 
     /// inserts a blockhash for the given number


### PR DESCRIPTION
Corrected the doc comment for the set_code method in the Db trait to accurately describe its functionality. The method sets the code of the given address, not the balance. No logic was changed; only the documentation was updated for clarity and accuracy.