### PR TITLE
fix: remove misleading `$ETH_FROM` 

### DIFF
--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -132,7 +132,7 @@ pub struct ScriptArgs {
     #[arg(long, short, default_value = "130")]
     pub gas_estimate_multiplier: u64,
 
-    /// Send via `eth_sendTransaction` using the `--sender` argument or `$ETH_FROM` as sender
+    /// Send via `eth_sendTransaction` using the `--sender` argument as sender.
     #[arg(
         long,
         conflicts_with_all = &["private_key", "private_keys", "froms", "ledger", "trezor", "aws"],


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Follow up for https://github.com/foundry-rs/foundry/pull/10929#discussion_r2227930383

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Removes `$ETH_FROM`, only `--sender` is valid in this context

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
