### PR TITLE
Complete doc comment for BlockListener struct

### DIFF
--- a/crates/anvil/src/tasks/block_listener.rs
+++ b/crates/anvil/src/tasks/block_listener.rs
@@ -7,7 +7,7 @@ use std::{
     task::{Context, Poll},
 };
 
-/// A Future that will execute a given `task` for each new block that
+/// A Future that will execute a given `task` for each new block that arrives on the stream.
 pub struct BlockListener<St, F, Fut> {
     stream: St,
     task_factory: F,


### PR DESCRIPTION
Finished the previously incomplete doc comment for the BlockListener struct. The comment now clearly states that the future executes a given task for each new block that arrives on the stream, improving code clarity and documentation quality. No logic was changed.