### PR TITLE
perf: box inspectors in InspectorStack

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -111,7 +111,7 @@ pub trait CheatcodesExecutor {
     }
 
     /// Returns a mutable reference to the tracing inspector if it is available.
-    fn tracing_inspector(&mut self) -> Option<&mut Option<TracingInspector>> {
+    fn tracing_inspector(&mut self) -> Option<&mut Option<Box<TracingInspector>>> {
         None
     }
 }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -609,8 +609,11 @@ impl<'a> InvariantExecutor<'a> {
             ));
         }
 
-        self.executor.inspector_mut().fuzzer =
-            Some(Fuzzer { call_generator, fuzz_state: fuzz_state.clone(), collect: true });
+        self.executor.inspector_mut().set_fuzzer(Fuzzer {
+            call_generator,
+            fuzz_state: fuzz_state.clone(),
+            collect: true,
+        });
 
         // Let's make sure the invariant is sound before actually starting the run:
         // We'll assert the invariant in its initial state, and if it fails, we'll

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -842,7 +842,7 @@ pub struct RawCallResult {
     /// The `revm::Env` after the call
     pub env: Env,
     /// The cheatcode states after execution
-    pub cheatcodes: Option<Cheatcodes>,
+    pub cheatcodes: Option<Box<Cheatcodes>>,
     /// The raw output of the execution
     pub out: Option<Output>,
     /// The chisel state

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -262,7 +262,7 @@ pub struct InspectorData {
     pub traces: Option<SparsedTraceArena>,
     pub line_coverage: Option<HitMaps>,
     pub edge_coverage: Option<Vec<u8>>,
-    pub cheatcodes: Option<Cheatcodes>,
+    pub cheatcodes: Option<Box<Cheatcodes>>,
     pub chisel_state: Option<(Vec<U256>, Vec<u8>, Option<InstructionResult>)>,
     pub reverter: Option<Address>,
 }
@@ -290,7 +290,7 @@ pub struct InnerContextData {
 /// collection, etc.
 #[derive(Clone, Debug, Default)]
 pub struct InspectorStack {
-    pub cheatcodes: Option<Cheatcodes>,
+    pub cheatcodes: Option<Box<Cheatcodes>>,
     pub inner: InspectorStackInner,
 }
 
@@ -300,15 +300,17 @@ pub struct InspectorStack {
 #[derive(Default, Clone, Debug)]
 pub struct InspectorStackInner {
     // Inspectors.
-    pub chisel_state: Option<ChiselState>,
-    pub edge_coverage: Option<EdgeCovInspector>,
-    pub fuzzer: Option<Fuzzer>,
-    pub line_coverage: Option<LineCoverageCollector>,
-    pub log_collector: Option<LogCollector>,
-    pub printer: Option<CustomPrintTracer>,
-    pub revert_diag: Option<RevertDiagnostic>,
-    pub script_execution_inspector: Option<ScriptExecutionInspector>,
-    pub tracer: Option<TracingInspector>,
+    // These are boxed to reduce the size of the struct and slightly improve performance of the
+    // `if let Some` checks.
+    pub chisel_state: Option<Box<ChiselState>>,
+    pub edge_coverage: Option<Box<EdgeCovInspector>>,
+    pub fuzzer: Option<Box<Fuzzer>>,
+    pub line_coverage: Option<Box<LineCoverageCollector>>,
+    pub log_collector: Option<Box<LogCollector>>,
+    pub printer: Option<Box<CustomPrintTracer>>,
+    pub revert_diag: Option<Box<RevertDiagnostic>>,
+    pub script_execution_inspector: Option<Box<ScriptExecutionInspector>>,
+    pub tracer: Option<Box<TracingInspector>>,
 
     // InspectorExt and other internal data.
     pub enable_isolation: bool,
@@ -335,7 +337,7 @@ impl CheatcodesExecutor for InspectorStackInner {
         Box::new(InspectorStackRefMut { cheatcodes: Some(cheats), inner: self })
     }
 
-    fn tracing_inspector(&mut self) -> Option<&mut Option<TracingInspector>> {
+    fn tracing_inspector(&mut self) -> Option<&mut Option<Box<TracingInspector>>> {
         Some(&mut self.tracer)
     }
 }
@@ -398,19 +400,19 @@ impl InspectorStack {
     /// Set the cheatcodes inspector.
     #[inline]
     pub fn set_cheatcodes(&mut self, cheatcodes: Cheatcodes) {
-        self.cheatcodes = Some(cheatcodes);
+        self.cheatcodes = Some(cheatcodes.into());
     }
 
     /// Set the fuzzer inspector.
     #[inline]
     pub fn set_fuzzer(&mut self, fuzzer: Fuzzer) {
-        self.fuzzer = Some(fuzzer);
+        self.fuzzer = Some(fuzzer.into());
     }
 
     /// Set the Chisel inspector.
     #[inline]
     pub fn set_chisel(&mut self, final_pc: usize) {
-        self.chisel_state = Some(ChiselState::new(final_pc));
+        self.chisel_state = Some(ChiselState::new(final_pc).into());
     }
 
     /// Set whether to enable the line coverage collector.
@@ -422,7 +424,8 @@ impl InspectorStack {
     /// Set whether to enable the edge coverage collector.
     #[inline]
     pub fn collect_edge_coverage(&mut self, yes: bool) {
-        self.edge_coverage = yes.then(EdgeCovInspector::new); // TODO configurable edge size?
+        // TODO: configurable edge size?
+        self.edge_coverage = yes.then(EdgeCovInspector::new).map(Into::into);
     }
 
     /// Set whether to enable call isolation.
@@ -459,11 +462,7 @@ impl InspectorStack {
     /// Revert diagnostic inspector is activated when `mode != TraceMode::None`
     #[inline]
     pub fn tracing(&mut self, mode: TraceMode) {
-        if mode.is_none() {
-            self.revert_diag = None;
-        } else {
-            self.revert_diag = Some(RevertDiagnostic::default());
-        }
+        self.revert_diag = (!mode.is_none()).then(RevertDiagnostic::default).map(Into::into);
 
         if let Some(config) = mode.into_config() {
             *self.tracer.get_or_insert_with(Default::default).config_mut() = config;
@@ -480,7 +479,6 @@ impl InspectorStack {
     }
 
     /// Collects all the data gathered during inspection into a single struct.
-    #[inline]
     pub fn collect(self) -> InspectorData {
         let Self {
             mut cheatcodes,
@@ -531,7 +529,7 @@ impl InspectorStack {
 
     #[inline(always)]
     fn as_mut(&mut self) -> InspectorStackRefMut<'_> {
-        InspectorStackRefMut { cheatcodes: self.cheatcodes.as_mut(), inner: &mut self.inner }
+        InspectorStackRefMut { cheatcodes: self.cheatcodes.as_deref_mut(), inner: &mut self.inner }
     }
 }
 
@@ -740,17 +738,16 @@ impl InspectorStackRefMut<'_> {
     /// it.
     fn with_stack<O>(&mut self, f: impl FnOnce(&mut InspectorStack) -> O) -> O {
         let mut stack = InspectorStack {
-            cheatcodes: self
-                .cheatcodes
-                .as_deref_mut()
-                .map(|cheats| core::mem::replace(cheats, Cheatcodes::new(cheats.config.clone()))),
+            cheatcodes: self.cheatcodes.as_deref_mut().map(|cheats| {
+                core::mem::replace(cheats, Cheatcodes::new(cheats.config.clone())).into()
+            }),
             inner: std::mem::take(self.inner),
         };
 
         let out = f(&mut stack);
 
         if let Some(cheats) = self.cheatcodes.as_deref_mut() {
-            *cheats = stack.cheatcodes.take().unwrap();
+            *cheats = *stack.cheatcodes.take().unwrap();
         }
 
         *self.inner = stack.inner;
@@ -791,6 +788,11 @@ impl InspectorStackRefMut<'_> {
         }
     }
 
+    // We take extra care in optimizing `step` and `step_end`, as they're are likely the most
+    // hot functions in all of Foundry.
+    // We want to `#[inline(always)]` these functions so that `InspectorStack` does not
+    // delegate to `InspectorStackRefMut` in this case.
+
     #[inline(always)]
     fn step_inlined(
         &mut self,
@@ -799,17 +801,18 @@ impl InspectorStackRefMut<'_> {
     ) {
         call_inspectors!(
             [
-                &mut self.fuzzer,
-                &mut self.tracer,
-                &mut self.line_coverage,
+                // These are sorted in definition order.
                 &mut self.edge_coverage,
-                &mut self.script_execution_inspector,
+                &mut self.fuzzer,
+                &mut self.line_coverage,
                 &mut self.printer,
                 &mut self.revert_diag,
+                &mut self.script_execution_inspector,
+                &mut self.tracer,
                 // Keep `cheatcodes` last to make use of the tail call.
                 &mut self.cheatcodes,
             ],
-            |inspector| (*inspector).step(interpreter, ecx),
+            |inspector| (**inspector).step(interpreter, ecx),
         );
     }
 
@@ -821,14 +824,15 @@ impl InspectorStackRefMut<'_> {
     ) {
         call_inspectors!(
             [
-                &mut self.tracer,
+                // These are sorted in definition order.
                 &mut self.chisel_state,
                 &mut self.printer,
                 &mut self.revert_diag,
+                &mut self.tracer,
                 // Keep `cheatcodes` last to make use of the tail call.
                 &mut self.cheatcodes,
             ],
-            |inspector| (*inspector).step_end(interpreter, ecx),
+            |inspector| (**inspector).step_end(interpreter, ecx),
         );
     }
 }

--- a/crates/evm/fuzz/src/inspector.rs
+++ b/crates/evm/fuzz/src/inspector.rs
@@ -9,10 +9,10 @@ use revm::{
 /// An inspector that can fuzz and collect data for that effect.
 #[derive(Clone, Debug)]
 pub struct Fuzzer {
-    /// Given a strategy, it generates a random call.
-    pub call_generator: Option<RandomCallGenerator>,
     /// If set, it collects `stack` and `memory` values for fuzzing purposes.
     pub collect: bool,
+    /// Given a strategy, it generates a random call.
+    pub call_generator: Option<RandomCallGenerator>,
     /// If `collect` is set, we store the collected values in this fuzz dictionary.
     pub fuzz_state: EvmFuzzState,
 }
@@ -21,6 +21,7 @@ impl<CTX> Inspector<CTX> for Fuzzer
 where
     CTX: ContextTr<Journal: JournalExt>,
 {
+    #[inline]
     fn step(&mut self, interp: &mut Interpreter, _context: &mut CTX) {
         // We only collect `stack` and `memory` data before and after calls.
         if self.collect {


### PR DESCRIPTION
Reduces the size of `InspectorStack` and simplifies the `if let Some` checks to be simple null pointer checks. The one time memory allocation/deallocation cost is negligible compared to the gains from these small improvements.
~5-10% improvement on `forge test`.