### PR TITLE
fix: improve script sequence error handling and time safety

### DIFF
--- a/crates/script-sequence/src/sequence.rs
+++ b/crates/script-sequence/src/sequence.rs
@@ -101,7 +101,7 @@ impl ScriptSequence {
 
         let Some((path, sensitive_path)) = self.paths.clone() else { return Ok(()) };
 
-        self.timestamp = now().as_millis();
+        self.timestamp = now()?.as_millis();
         let ts_name = format!("run-{}.json", self.timestamp);
 
         let sensitive_script_sequence: SensitiveScriptSequence = self.clone().into();
@@ -201,9 +201,9 @@ impl ScriptSequence {
         Ok((broadcast, cache))
     }
 
-    /// Returns the first RPC URL of this sequence.
-    pub fn rpc_url(&self) -> &str {
-        self.transactions.front().expect("empty sequence").rpc.as_str()
+    /// Returns the first RPC URL of this sequence, or None if sequence is empty.
+    pub fn rpc_url(&self) -> Option<&str> {
+        self.transactions.front().map(|tx| tx.rpc.as_str())
     }
 
     /// Returns the list of the transactions without the metadata.
@@ -237,8 +237,8 @@ pub fn sig_to_file_name(sig: &str) -> String {
     sig.to_string()
 }
 
-pub fn now() -> Duration {
-    SystemTime::now().duration_since(UNIX_EPOCH).expect("time went backwards")
+pub fn now() -> Result<Duration, std::time::SystemTimeError> {
+    SystemTime::now().duration_since(UNIX_EPOCH)
 }
 
 #[cfg(test)]

--- a/crates/script/src/multi_sequence.rs
+++ b/crates/script/src/multi_sequence.rs
@@ -46,7 +46,7 @@ impl MultiChainSequence {
     ) -> Result<Self> {
         let (path, sensitive_path) = Self::get_paths(config, sig, target, dry_run)?;
 
-        Ok(Self { deployments, path, sensitive_path, timestamp: now().as_millis() })
+        Ok(Self { deployments, path, sensitive_path, timestamp: now()?.as_millis() })
     }
 
     /// Gets paths in the formats
@@ -113,7 +113,7 @@ impl MultiChainSequence {
     pub fn save(&mut self, silent: bool, save_ts: bool) -> Result<()> {
         self.deployments.iter_mut().for_each(|sequence| sequence.sort_receipts());
 
-        self.timestamp = now().as_millis();
+        self.timestamp = now()?.as_millis();
 
         let sensitive_sequence = SensitiveMultiChainSequence::from_multi_sequence(self.clone());
 

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -454,7 +454,7 @@ impl FilledTransactionsState {
             receipts: vec![],
             pending: vec![],
             paths,
-            timestamp: now().as_millis(),
+            timestamp: now()?.as_millis(),
             libraries,
             chain,
             commit,


### PR DESCRIPTION
Replaces panic-prone operations in script sequences with proper error handling, and should prevent runtime crashes when dealing with empty transaction sequences or system clock issues.

- `rpc_url()` now returns `Option<&str>` instead of panicking on empty sequences
- `now()` functions return `Result` instead of panicking on system time errors
## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
