### PR TITLE
fix(cast): fixes #11110

### DIFF
--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -5,7 +5,7 @@ use alloy_primitives::hex;
 use alloy_provider::Provider;
 use alloy_signer::Signer;
 use clap::Parser;
-use eyre::{OptionExt, Result};
+use eyre::Result;
 use foundry_cli::{
     opts::{EthereumOpts, TransactionOpts},
     utils::{LoadConfig, get_provider},
@@ -49,7 +49,7 @@ pub struct MakeTxArgs {
     /// Generate a raw RLP-encoded unsigned transaction.
     ///
     /// Relaxes the wallet requirement.
-    #[arg(long, requires = "from")]
+    #[arg(long)]
     raw_unsigned: bool,
 
     /// Call `eth_signTransaction` using the `--from` argument or $ETH_FROM as sender
@@ -106,8 +106,7 @@ impl MakeTxArgs {
 
         if raw_unsigned {
             // Build unsigned raw tx
-            let from = eth.wallet.from.ok_or_eyre("missing `--from` address")?;
-            let raw_tx = tx_builder.build_unsigned_raw(from).await?;
+            let raw_tx = tx_builder.build_unsigned_raw(eth.wallet.from).await?;
 
             sh_println!("{raw_tx}")?;
             return Ok(());

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1603,6 +1603,52 @@ casttest!(mktx_raw_unsigned, |_prj, cmd| {
     ]]);
 });
 
+casttest!(mktx_raw_unsigned_no_from, |_prj, cmd| {
+    cmd.args([
+        "mktx",
+        "--chain",
+        "1",
+        "--nonce",
+        "0",
+        "--gas-limit",
+        "21000",
+        "--gas-price",
+        "10000000000",
+        "--priority-gas-price",
+        "1000000000",
+        "0x0000000000000000000000000000000000000001",
+        "--raw-unsigned",
+    ])
+    .assert_success()
+    .stdout_eq(str![[
+        r#"0x02e80180843b9aca008502540be4008252089400000000000000000000000000000000000000018080c0
+
+"#
+    ]]);
+});
+
+casttest!(mktx_raw_unsigned_use_default_nonce, |_prj, cmd| {
+    cmd.args([
+        "mktx",
+        "--chain",
+        "1",
+        "--gas-limit",
+        "21000",
+        "--gas-price",
+        "10000000000",
+        "--priority-gas-price",
+        "1000000000",
+        "0x0000000000000000000000000000000000000001",
+        "--raw-unsigned",
+    ])
+    .assert_success()
+    .stdout_eq(str![[
+        r#"0x02e80180843b9aca008502540be4008252089400000000000000000000000000000000000000018080c0
+
+"#
+    ]]);
+});
+
 casttest!(mktx_ethsign, async |_prj, cmd| {
     let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
     let rpc = handle.http_endpoint();


### PR DESCRIPTION
## Motivation

Fixes #11110 

## Solution

When using `cast mktx`, the `--from` parameter is now optional. In the case of an unsigned transaction, the from address parameter is only used in conjunction with the RPC provider to retrieve any missing mandatory parameters (e.g. nonce, gas price, chain ID, etc.).

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
