### PR TITLE
fix(`cast`): unknown signatures are cached as an empty string

### DIFF
--- a/crates/cast/tests/cli/selectors.rs
+++ b/crates/cast/tests/cli/selectors.rs
@@ -1,14 +1,46 @@
+use foundry_config::Config;
 use foundry_test_utils::util::OutputExt;
 use std::path::Path;
 
+// <https://github.com/foundry-rs/foundry/issues/11125>
 casttest!(error_decode_with_openchain, |prj, cmd| {
     prj.clear_cache();
+
     cmd.args(["decode-error", "0x7a0e198500000000000000000000000000000000000000000000000000000000000000650000000000000000000000000000000000000000000000000000000000000064"]).assert_success().stdout_eq(str![[r#"
 ValueTooHigh(uint256,uint256)
 101
 100
 
 "#]]);
+
+    // Read cache to ensure the error is cached
+    let cache = Config::foundry_cache_dir().unwrap().join("signatures");
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(cache).unwrap()).unwrap();
+    let errors = json.get("errors").unwrap_or(&serde_json::Value::Null);
+    assert_eq!(
+        errors.get("0x7a0e1985"),
+        Some(&serde_json::Value::String("ValueTooHigh(uint256,uint256)".to_string())),
+        "Selector should be cached"
+    );
+});
+
+// <https://github.com/foundry-rs/foundry/issues/11125>
+// NOTE: if a user does happen to mine and submit 0x37d01491 this is expected to fail.
+casttest!(error_decode_with_openchain_nonexistent, |prj, cmd| {
+    prj.clear_cache();
+
+    cmd.args(["decode-error", "0x37d0149100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002"]).assert_failure().stderr_eq(str![[r#"
+Error: No matching error signature found for selector `37d01491`
+
+"#]]);
+
+    // Read cache to ensure the error is not cached
+    let cache = Config::foundry_cache_dir().unwrap().join("signatures");
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(cache).unwrap()).unwrap();
+    let errors = json.get("errors").unwrap_or(&serde_json::Value::Null);
+    assert_eq!(errors.get("0x37d01491"), None, "Selector should not be cached");
 });
 
 casttest!(fourbyte, |_prj, cmd| {

--- a/crates/evm/traces/src/identifier/signatures.rs
+++ b/crates/evm/traces/src/identifier/signatures.rs
@@ -250,7 +250,9 @@ impl SignaturesIdentifier {
                 let mut cache_w = self.cache.write().await;
                 if let Ok(res) = client.decode_selectors(&query).await {
                     for (selector, signatures) in std::iter::zip(query, res) {
-                        cache_w.signatures.insert(selector, signatures.into_iter().next());
+                        if !signatures.is_empty() {
+                            cache_w.signatures.insert(selector, signatures.into_iter().next());
+                        }
                     }
                 }
                 drop(cache_w);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/11125

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Make sure signatures are not returned empty, previously we were caching empty results ("") preventing refetching.

previously the query would return as follows:

```
query: [Error(0x37d01491)]
res: [[]]
len(res): 1
```

meaning `0x37d01491` got paired with `[]`, yielding empty `""` string when written to cache

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes