### PR TITLE
Add information about excluded contracts

### DIFF
--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -322,6 +322,19 @@ impl ProjectCompiler {
 
             sh_println!("{size_report}")?;
 
+            if report_kind() == ReportKind::Text {
+                // If we are in JSON mode, we don't need to check the size limits
+                let dev_contract_count = size_report.contracts.values()
+                    .filter(|contract| contract.is_dev_contract)
+                    .count();            
+
+                let total_contract_count = size_report.contracts.len();
+
+                if dev_contract_count > 0 {
+                    sh_println!("{dev_contract_count} development and testing contracts excluded from {total_contract_count} total contracts in the size report.")?;
+                }
+            }
+
             eyre::ensure!(
                 !size_report.exceeds_runtime_size_limit(),
                 "some contracts exceed the runtime size limit \


### PR DESCRIPTION
## Motivation

Fixes the issue of contracts hidden from the user in the `forge build --sizes` contract size report by telling the user some contracts have been hidden.

See https://github.com/foundry-rs/foundry/issues/11126

## Solution

Print out the number of dev contracts excluded from the output if some contracts were marked as dev contracts.

## PR Checklist

- As it is output change, no new tests added.