### PR TITLE
fix: tracy integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,7 +4390,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.19",
  "tracing-tracy",
- "tracy-client",
  "yansi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,8 +87,7 @@ codegen-units = 16
 [profile.profiling]
 inherits = "release"
 debug = "full"
-split-debuginfo = "unpacked"
-strip = false
+strip = "none"
 
 [profile.bench]
 inherits = "profiling"
@@ -287,7 +286,6 @@ thiserror = "2"
 # allocators
 mimalloc = "0.1"
 tikv-jemallocator = "0.6"
-tracy-client = "0.18"
 
 # misc
 auto_impl = "1"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -51,12 +51,11 @@ strum = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["macros"] }
 tracing-subscriber = { workspace = true, features = ["registry", "env-filter"] }
 tracing.workspace = true
-tracy-client = { workspace = true, optional = true, features = ["demangle"] }
 yansi.workspace = true
 rustls = { workspace = true, features = ["ring"] }
 dunce.workspace = true
 
-tracing-tracy = { version = "0.11", optional = true }
+tracing-tracy = { version = "0.11", optional = true, features = ["demangle"] }
 
 [dev-dependencies]
 tempfile.workspace = true
@@ -66,6 +65,6 @@ tikv-jemallocator = { workspace = true, optional = true }
 
 [features]
 tracy = ["dep:tracing-tracy"]
-tracy-allocator = ["dep:tracy-client", "tracy"]
+tracy-allocator = ["tracy"]
 jemalloc = ["dep:tikv-jemallocator"]
 mimalloc = ["dep:mimalloc"]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -14,3 +14,6 @@ extern crate tracing;
 pub mod handler;
 pub mod opts;
 pub mod utils;
+
+#[cfg(feature = "tracy")]
+tracing_tracy::client::register_demangler!();

--- a/crates/cli/src/utils/allocator.rs
+++ b/crates/cli/src/utils/allocator.rs
@@ -20,8 +20,7 @@ cfg_if::cfg_if! {
 // Wrap the allocator if the `tracy-allocator` feature is enabled.
 cfg_if::cfg_if! {
     if #[cfg(feature = "tracy-allocator")] {
-        type AllocatorWrapper = tracy_client::ProfiledAllocator<AllocatorInner>;
-        tracy_client::register_demangler!();
+        type AllocatorWrapper = tracing_tracy::client::ProfiledAllocator<AllocatorInner>;
         const fn new_allocator_wrapper() -> AllocatorWrapper {
             AllocatorWrapper::new(AllocatorInner {}, 100)
         }


### PR DESCRIPTION
- always register demangler
- remove split debug info, tracy can't seem to find debug info
