### PR TITLE
upgrade to Node.js 24

### DIFF
--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -61,7 +61,7 @@ jobs:
         if: contains(matrix.name, 'external')
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Install Bun
         if: contains(matrix.name, 'external') && !contains(matrix.runner_label, 'windows')
         uses: oven-sh/setup-bun@v1


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use Node.js 24 instead of 20.

Node.js 24 includes updated V8, npm 11, and other performance and compatibility improvements.
No other changes were required. CI and lint checks run successfully under the new version.

Reference: [Node.js 24.4.1 release notes](https://github.com/nodejs/node/releases/tag/v24.4.1)
