### PR TITLE
fix(`anvil`): unwrap panic in `eth/backend/mem/mod.rs`

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1722,11 +1722,10 @@ impl Backend {
                     cache_db.commit(state);
                     gas_used += result.gas_used();
 
-                    // TODO: this is likely incomplete
                     // create the transaction from a request
                     let from = request.from.unwrap_or_default();
-                    let request =
-                        transaction_request_to_typed(WithOtherFields::new(request)).unwrap();
+                    let request = transaction_request_to_typed(WithOtherFields::new(request))
+                        .ok_or(BlockchainError::MissingRequiredFields)?;
                     let tx = build_typed_transaction(
                         request,
                         Signature::new(Default::default(), Default::default(), false),

--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -115,6 +115,8 @@ pub enum BlockchainError {
         /// Duration that was waited before timing out
         duration: Duration,
     },
+    #[error("Failed to parse transaction request: missing required fields")]
+    MissingRequiredFields,
 }
 
 impl From<eyre::Report> for BlockchainError {
@@ -561,6 +563,9 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                 }
                 err @ BlockchainError::Message(_) => RpcError::internal_error_with(err.to_string()),
                 err @ BlockchainError::UnknownTransactionType => {
+                    RpcError::invalid_params(err.to_string())
+                }
+                err @ BlockchainError::MissingRequiredFields => {
                     RpcError::invalid_params(err.to_string())
                 }
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes: https://github.com/foundry-rs/foundry/issues/11128

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Previously resulted in:

```
eth_simulateV1
The application panicked (crashed).
Message:  called `Option::unwrap()` on a `None` value
Location: crates/anvil/src/eth/backend/mem/mod.rs:1729

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 7 frames hidden ⋮                               
   8: core::panicking::panic::h4a11c031239f36a8
      at <unknown source file>:<unknown line>
   9: core::option::unwrap_failed::h62317944fa5dc382
      at <unknown source file>:<unknown line>
  10: anvil::eth::backend::mem::Backend::simulate::{{closure}}::{{closure}}::h4f7a2c0dde92fd30
      at <unknown source file>:<unknown line>
  11: tokio::runtime::task::raw::poll::h07991a65e36b9f08
      at <unknown source file>:<unknown line>
  12: std::sys::backtrace::__rust_begin_short_backtrace::h7f53d53b8358a8a1
      at <unknown source file>:<unknown line>
  13: core::ops::function::FnOnce::call_once{{vtable.shim}}::hdf48ba9eb1133995
      at <unknown source file>:<unknown line>
  14: std::sys::pal::unix::thread::Thread::new::thread_start::h1822d22fde68314f
      at <unknown source file>:<unknown line>
  15: start_thread<unknown>
      at ./nptl/pthread_create.c:447
  16: clone3<unknown>
      at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:78

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
Aborted (core dumped)
```

now yields (and no longer panics):

(user side)

``` 
{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Failed to parse transaction request: missing required fields"}}
```

(anvil side)

```
eth_simulateV1

RPC request failed:
    Request: EthSimulateV1(SimulatePayload { block_state_calls: [SimBlock { block_overrides: None, state_overrides: None, calls: [TransactionRequest { from: Some(0x26e9568a58a5fd4437e7674d857dc3b2b1d30ddd), to: Some(Call(0x88c430c91cbb608b41cdb2fce27604e12233233f)), gas_price: None, max_fee_per_gas: Some(3159), max_priority_fee_per_gas: Some(847), max_fee_per_blob_gas: None, gas: Some(300000), value: Some(0), input: TransactionInput { input: None, data: Some(0x629c6d8e04ede7b81aae6bdb1f36d1c80f85f253860527578929149cfdce8fd4cdeaa4980000000000000000000000000000000000000000000000000000000000000060a420871db2c68c3ba70219ca71c81aed7452a208eb54ab66a957aeb95dc4c7ba0000000000000000000000000000000000000000000000000000000000000030b1cc3955fd6cda4e19a15e4eb8e6e71f6cb59f98fab8e7ed087d05b1a3bf878bba289eee016bd23ccbdd3533ec98f2e000000000000000000000000000000000) }, nonce: Some(1487), chain_id: None, access_list: None, transaction_type: Some(3), blob_versioned_hashes: None, sidecar: None, authorization_list: None }] }], trace_transfers: true, validation: false, return_full_transactions: false }, Some(latest))
    Error: Invalid params: Failed to parse transaction request: missing required fields
```

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
