### PR TITLE
fix: improve accuracy of vanity wallet function comments

### DIFF
--- a/crates/cast/src/cmd/wallet/vanity.rs
+++ b/crates/cast/src/cmd/wallet/vanity.rs
@@ -193,15 +193,16 @@ pub fn find_vanity_address_with_nonce<T: VanityMatcher>(
     wallet_generator().find_any(create_nonce_matcher(matcher, nonce)).map(|(key, _)| key.into())
 }
 
-/// Creates a nonce matcher function, which takes a reference to a [GeneratedWallet] and returns
+/// Creates a matcher function, which takes a reference to a [GeneratedWallet] and returns
 /// whether it found a match or not by using `matcher`.
 #[inline]
 pub fn create_matcher<T: VanityMatcher>(matcher: T) -> impl Fn(&GeneratedWallet) -> bool {
     move |(_, addr)| matcher.is_match(addr)
 }
 
-/// Creates a nonce matcher function, which takes a reference to a [GeneratedWallet] and a nonce and
-/// returns whether it found a match or not by using `matcher`.
+/// Creates a contract address matcher function that uses the specified nonce.
+/// The returned function takes a reference to a [GeneratedWallet] and returns
+/// whether the contract address created with the nonce matches using `matcher`.
 #[inline]
 pub fn create_nonce_matcher<T: VanityMatcher>(
     matcher: T,


### PR DESCRIPTION
Fix misleading comments in vanity wallet functions:

- Remove incorrect "nonce" reference from create_matcher function comment
- Clarify that create_nonce_matcher captures nonce in closure, not passed to returned function
- Make function descriptions more precise and accurate

The create_matcher function does not use nonce and checks wallet addresses directly,
while create_nonce_matcher uses nonce to check contract addresses created with
the specified nonce.