### PR TITLE
fix: only save sig cache on last drop

### DIFF
--- a/crates/evm/traces/src/identifier/signatures.rs
+++ b/crates/evm/traces/src/identifier/signatures.rs
@@ -149,9 +149,12 @@ impl SignaturesCache {
 /// An identifier that tries to identify functions and events using signatures found at
 /// `https://openchain.xyz` or a local cache.
 #[derive(Clone, Debug)]
-pub struct SignaturesIdentifier {
+pub struct SignaturesIdentifier(Arc<SignaturesIdentifierInner>);
+
+#[derive(Debug)]
+struct SignaturesIdentifierInner {
     /// Cached selectors for functions, events and custom errors.
-    cache: Arc<RwLock<SignaturesCache>>,
+    cache: RwLock<SignaturesCache>,
     /// Location where to save the signature cache.
     cache_path: Option<PathBuf>,
     /// The OpenChain client to fetch signatures from. `None` if disabled on construction.
@@ -182,17 +185,16 @@ impl SignaturesIdentifier {
         } else {
             Default::default()
         };
-        Ok(Self { cache: Arc::new(RwLock::new(cache)), cache_path, client })
+        Ok(Self(Arc::new(SignaturesIdentifierInner {
+            cache: RwLock::new(cache),
+            cache_path,
+            client,
+        })))
     }
 
     /// Saves the cache to the file system.
     pub fn save(&self) {
-        if let Some(path) = &self.cache_path {
-            self.cache
-                .try_read()
-                .expect("SignaturesIdentifier cache is locked while attempting to save")
-                .save(path);
-        }
+        self.0.save();
     }
 
     /// Identifies `Function`s.
@@ -241,20 +243,20 @@ impl SignaturesIdentifier {
         }
         trace!(target: "evm::traces", ?selectors, "identifying selectors");
 
-        let mut cache_r = self.cache.read().await;
-        if let Some(client) = &self.client {
+        let mut cache_r = self.0.cache.read().await;
+        if let Some(client) = &self.0.client {
             let query =
                 selectors.iter().copied().filter(|v| !cache_r.contains_key(v)).collect::<Vec<_>>();
             if !query.is_empty() {
                 drop(cache_r);
-                let mut cache_w = self.cache.write().await;
+                let mut cache_w = self.0.cache.write().await;
                 if let Ok(res) = client.decode_selectors(&query).await {
                     for (selector, signatures) in std::iter::zip(query, res) {
                         cache_w.signatures.insert(selector, signatures.into_iter().next());
                     }
                 }
                 drop(cache_w);
-                cache_r = self.cache.read().await;
+                cache_r = self.0.cache.read().await;
             }
         }
         selectors.iter().map(|selector| cache_r.get(selector).unwrap_or_default()).collect()
@@ -270,7 +272,18 @@ impl SignaturesIdentifier {
     }
 }
 
-impl Drop for SignaturesIdentifier {
+impl SignaturesIdentifierInner {
+    fn save(&self) {
+        if let Some(path) = &self.cache_path {
+            self.cache
+                .try_read()
+                .expect("SignaturesIdentifier cache is locked while attempting to save")
+                .save(path);
+        }
+    }
+}
+
+impl Drop for SignaturesIdentifierInner {
     fn drop(&mut self) {
         self.save();
     }


### PR DESCRIPTION
By moving the Arc to only the inner cache in https://github.com/foundry-rs/foundry/pull/10282, I inadvertently made all instances of SignaturesIdentifier save the cache on drop, which results in an unnecessary fs write

With https://github.com/foundry-rs/foundry/pull/11098 this instance is now present in Cheatcodes so the drop is called on every individual Executor execution (clones Cheatcodes, which clones this struct), e.g. once for every unit tests, fuzz execution etc.

Move the drop impl to an inner struct and wrap everything in Arc