### PR TITLE
fix(`anvil`): v1.2 state load compatibility

### DIFF
--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -385,7 +385,7 @@ impl MaybeFullDatabase for StateDb {
     }
 }
 
-/// Custom deserializer for BlockEnv that handles both old and new formats
+/// Custom deserializer for `BlockEnv` that handles both v1.2 and v1.3+ formats.
 fn deserialize_block_env_compat<'de, D>(deserializer: D) -> Result<Option<BlockEnv>, D::Error>
 where
     D: Deserializer<'de>,
@@ -481,8 +481,8 @@ where
     }
 }
 
-/// Custom deserializer for best_block_number that handles both hex string and number formats
-fn deserialize_best_block_number<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+/// Custom deserializer for `best_block_number` that handles both v1.2 and v1.3+ formats.
+fn deserialize_best_block_number_compat<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -517,7 +517,7 @@ pub struct SerializableState {
     pub block: Option<BlockEnv>,
     pub accounts: BTreeMap<Address, SerializableAccountRecord>,
     /// The best block number of the state, can be different from block number (Arbitrum chain).
-    #[serde(deserialize_with = "deserialize_best_block_number")]
+    #[serde(deserialize_with = "deserialize_best_block_number_compat")]
     pub best_block_number: Option<u64>,
     #[serde(default)]
     pub blocks: Vec<SerializableBlock>,

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -8,6 +8,10 @@ use alloy_rpc_types::{BlockId, TransactionRequest};
 use alloy_serde::WithOtherFields;
 use anvil::{NodeConfig, eth::backend::db::SerializableState, spawn};
 use foundry_test_utils::rpc::next_http_archive_rpc_url;
+use revm::{
+    context_interface::block::BlobExcessGasAndPrice,
+    primitives::eip4844::BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE,
+};
 use serde_json::json;
 use std::str::FromStr;
 
@@ -446,7 +450,10 @@ async fn test_backward_compatibility_optional_fields_deserialization_v1_2() {
         block_env.prevrandao.unwrap(),
         b256!("ecc5f0af8ff6b65c14bfdac55ba9db870d89482eb2b87200c6d7e7cd3a3a5ad5")
     );
-    assert!(block_env.blob_excess_gas_and_price.is_none());
+    assert_eq!(
+        block_env.blob_excess_gas_and_price,
+        Some(BlobExcessGasAndPrice::new(0, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE))
+    );
 
     assert_eq!(state.best_block_number, Some(1));
     assert!(state.blocks.is_empty());

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -434,12 +434,10 @@ async fn test_backward_compatibility_optional_fields_deserialization_v1_2() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_backward_compatibility_state_dump_deserialization_v1_2() {
-    // Test with the actual old state dump provided by the user
     let tmp = tempfile::tempdir().unwrap();
-    let old_state_file = tmp.path().join("real_old_state.json");
+    let old_state_file = tmp.path().join("old_state.json");
 
-    // This is the exact old format state dump that was provided
-    let real_old_state_json = json!({
+    let old_state_json = json!({
       "block": {
         "number": "0x1",
         "coinbase": "0x0000000000000000000000000000000000000001",
@@ -670,11 +668,10 @@ async fn test_backward_compatibility_state_dump_deserialization_v1_2() {
     });
 
     // Write the old state to file.
-    foundry_common::fs::write_json_file(&old_state_file, &real_old_state_json).unwrap();
+    foundry_common::fs::write_json_file(&old_state_file, &old_state_json).unwrap();
 
     // Test deserializing the old state dump directly.
-    let deserialized_state: SerializableState =
-        serde_json::from_value(real_old_state_json).unwrap();
+    let deserialized_state: SerializableState = serde_json::from_value(old_state_json).unwrap();
 
     // Verify the old state was loaded correctly with `coinbase` to `beneficiary` conversion.
     let block_env = deserialized_state.block.unwrap();

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -6,8 +6,10 @@ use alloy_primitives::{Bytes, U256, Uint, address, utils::Unit};
 use alloy_provider::Provider;
 use alloy_rpc_types::{BlockId, TransactionRequest};
 use alloy_serde::WithOtherFields;
-use anvil::{NodeConfig, spawn};
+use anvil::{NodeConfig, eth::backend::db::SerializableState, spawn};
 use foundry_test_utils::rpc::next_http_archive_rpc_url;
+use serde_json::json;
+use std::str::FromStr;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_load_state() {
@@ -308,4 +310,418 @@ async fn computes_next_base_fee_after_loading_state() {
     let (api, _handle) = spawn(NodeConfig::test().with_init_state_path(state_file)).await;
     let base_fee_after_reload = api.backend.fees().base_fee();
     assert_eq!(base_fee_after_reload, base_fee_after_one_tx);
+}
+
+// <https://github.com/foundry-rs/foundry/issues/11176>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_backward_compatibility_deserialization_v1_2() {
+    let old_format_json = r#"{
+        "block": {
+            "number": "0x5",
+            "coinbase": "0x1234567890123456789012345678901234567890",
+            "timestamp": "0x688c83b5",
+            "gas_limit": "0x1c9c380",
+            "basefee": "0x3b9aca00",  
+            "difficulty": "0x0",
+            "prevrandao": "0xecc5f0af8ff6b65c14bfdac55ba9db870d89482eb2b87200c6d7e7cd3a3a5ad5",
+            "blob_excess_gas_and_price": {
+                "excess_blob_gas": 0,
+                "blob_gasprice": 1
+            }
+        },
+        "accounts": {},
+        "best_block_number": "0x5",
+        "blocks": [],
+        "transactions": []
+    }"#;
+
+    let state: SerializableState = serde_json::from_str(old_format_json).unwrap();
+    assert!(state.block.is_some());
+    let block_env = state.block.unwrap();
+    assert_eq!(block_env.number, U256::from(5));
+    // Verify coinbase was converted to beneficiary
+    assert_eq!(block_env.beneficiary, address!("0x1234567890123456789012345678901234567890"));
+
+    // New format with beneficiary and numeric values
+    let new_format_json = r#"{
+        "block": {
+            "number": 6,
+            "beneficiary": "0x1234567890123456789012345678901234567891",
+            "timestamp": 1751619509,
+            "gas_limit": 30000000,
+            "basefee": 1000000000,
+            "difficulty": "0x0",
+            "prevrandao": "0xecc5f0af8ff6b65c14bfdac55ba9db870d89482eb2b87200c6d7e7cd3a3a5ad5",
+            "blob_excess_gas_and_price": {
+                "excess_blob_gas": 0,
+                "blob_gasprice": 1
+            }
+        },
+        "accounts": {},
+        "best_block_number": 6,
+        "blocks": [],
+        "transactions": []
+    }"#;
+
+    let state: SerializableState = serde_json::from_str(new_format_json).unwrap();
+    assert!(state.block.is_some());
+    let block_env = state.block.unwrap();
+    assert_eq!(block_env.number, U256::from(6));
+    assert_eq!(block_env.beneficiary, address!("0x1234567890123456789012345678901234567891"));
+}
+
+// <https://github.com/foundry-rs/foundry/issues/11176>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_backward_compatibility_mixed_formats_deserialization_v1_2() {
+    let mixed_format = json!({
+        "block": {
+            "number": "0x3",
+            "coinbase": "0x1111111111111111111111111111111111111111",
+            "timestamp": 1751619509,
+            "gas_limit": "0x1c9c380",
+            "basefee": 1000000000,
+            "difficulty": "0x0",
+            "prevrandao": "0xecc5f0af8ff6b65c14bfdac55ba9db870d89482eb2b87200c6d7e7cd3a3a5ad5",
+            "blob_excess_gas_and_price": {
+                "excess_blob_gas": 0,
+                "blob_gasprice": 1
+            }
+        },
+        "accounts": {},
+        "best_block_number": 3, // numeric instead of hex
+        "blocks": [],
+        "transactions": []
+    });
+
+    let state: SerializableState = serde_json::from_str(&mixed_format.to_string()).unwrap();
+    let block_env = state.block.unwrap();
+    assert_eq!(block_env.number, U256::from(3));
+    assert_eq!(block_env.beneficiary, address!("0x1111111111111111111111111111111111111111"));
+    assert_eq!(block_env.timestamp, U256::from(1751619509));
+    assert_eq!(block_env.gas_limit, 30000000);
+    assert_eq!(block_env.basefee, 1000000000);
+    assert_eq!(state.best_block_number, Some(3));
+}
+
+// <https://github.com/foundry-rs/foundry/issues/11176>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_backward_compatibility_optional_fields_deserialization_v1_2() {
+    // Test with missing optional fields from old format
+    let minimal_old_format = json!({
+        "block": {
+            "number": "0x1",
+            "coinbase": "0x0000000000000000000000000000000000000000",
+            "timestamp": "0x688c83b5",
+            "gas_limit": "0x1c9c380",
+            "basefee": "0x3b9aca00",
+            "difficulty": "0x0",
+            "prevrandao": "0xecc5f0af8ff6b65c14bfdac55ba9db870d89482eb2b87200c6d7e7cd3a3a5ad5"
+            // Missing blob_excess_gas_and_price - should be None
+        },
+        "accounts": {},
+        "best_block_number": "0x1"
+        // Missing blocks and transactions arrays - should default to empty
+    });
+
+    let state: SerializableState = serde_json::from_str(&minimal_old_format.to_string()).unwrap();
+    assert!(state.block.is_some());
+    let block_env = state.block.unwrap();
+    assert_eq!(block_env.number, U256::from(1));
+    assert!(block_env.blob_excess_gas_and_price.is_none());
+    assert!(state.blocks.is_empty());
+    assert!(state.transactions.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_backward_compatibility_state_dump_deserialization_v1_2() {
+    // Test with the actual old state dump provided by the user
+    let tmp = tempfile::tempdir().unwrap();
+    let old_state_file = tmp.path().join("real_old_state.json");
+
+    // This is the exact old format state dump that was provided
+    let real_old_state_json = json!({
+      "block": {
+        "number": "0x1",
+        "coinbase": "0x0000000000000000000000000000000000000001",
+        "timestamp": "0x688c83b5",
+        "gas_limit": "0x1c9c380",
+        "basefee": "0x3b9aca00",
+        "difficulty": "0x0",
+        "prevrandao": "0xecc5f0af8ff6b65c14bfdac55ba9db870d89482eb2b87200c6d7e7cd3a3a5ad5",
+        "blob_excess_gas_and_price": {
+          "excess_blob_gas": 0,
+          "blob_gasprice": 1
+        }
+      },
+      "accounts": {
+        "0x0000000000000000000000000000000000000000": {
+          "nonce": 0,
+          "balance": "0x26481",
+          "code": "0x",
+          "storage": {}
+        },
+        "0x14dc79964da2c08b23698b3d3cc7ca32193d9955": {
+          "nonce": 0,
+          "balance": "0x21e19e0c9bab2400000",
+          "code": "0x",
+          "storage": {}
+        },
+        "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65": {
+          "nonce": 0,
+          "balance": "0x21e19e0c9bab2400000",
+          "code": "0x",
+          "storage": {}
+        },
+        "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f": {
+          "nonce": 0,
+          "balance": "0x21e19e0c9bab2400000",
+          "code": "0x",
+          "storage": {}
+        },
+        "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc": {
+          "nonce": 0,
+          "balance": "0x21e19e0c9bab2400000",
+          "code": "0x",
+          "storage": {}
+        },
+        "0x4e59b44847b379578588920ca78fbf26c0b4956c": {
+          "nonce": 0,
+          "balance": "0x0",
+          "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3",
+          "storage": {}
+        },
+        "0x5fbdb2315678afecb367f032d93f642f64180aa3": {
+          "nonce": 1,
+          "balance": "0x0",
+          "code": "0x608060405234801561000f575f5ffd5b506004361061003f575f3560e01c80633fb5c1cb146100435780638381f58a1461005f578063d09de08a1461007d575b5f5ffd5b61005d600480360381019061005891906100e4565b610087565b005b610067610090565b604051610074919061011e565b60405180910390f35b610085610095565b005b805f8190555050565b5f5481565b5f5f8154809291906100a690610164565b9190505550565b5f5ffd5b5f819050919050565b6100c3816100b1565b81146100cd575f5ffd5b50565b5f813590506100de816100ba565b92915050565b5f602082840312156100f9576100f86100ad565b5b5f610106848285016100d0565b91505092915050565b610118816100b1565b82525050565b5f6020820190506101315f83018461010f565b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f61016e826100b1565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff82036101a05761019f610137565b5b60018201905091905056fea264697066735822122040b6a3cd3ec8f890002f39a8719ebee029ba9bac3d7fa9d581d4712cfe9ffec264736f6c634300081e0033",
+          "storage": {}
+        },
+        "0x70997970c51812dc3a010c7d01b50e0d17dc79c8": {
+          "nonce": 0,
+          "balance": "0x21e19e0c9bab2400000",
+          "code": "0x",
+          "storage": {}
+        },
+        "0x90f79bf6eb2c4f870365e785982e1f101e93b906": {
+          "nonce": 0,
+          "balance": "0x21e19e0c9bab2400000",
+          "code": "0x",
+          "storage": {}
+        },
+        "0x976ea74026e726554db657fa54763abd0c3a0aa9": {
+          "nonce": 0,
+          "balance": "0x21e19e0c9bab2400000",
+          "code": "0x",
+          "storage": {}
+        },
+        "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc": {
+          "nonce": 0,
+          "balance": "0x21e19e0c9bab2400000",
+          "code": "0x",
+          "storage": {}
+        },
+        "0xa0ee7a142d267c1f36714e4a8f75612f20a79720": {
+          "nonce": 0,
+          "balance": "0x21e19e0c9bab2400000",
+          "code": "0x",
+          "storage": {}
+        },
+        "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266": {
+          "nonce": 1,
+          "balance": "0x21e19e03b1e9e55d17f",
+          "code": "0x",
+          "storage": {}
+        }
+      },
+      "best_block_number": "0x1",
+      "blocks": [
+        {
+          "header": {
+            "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+            "miner": "0x0000000000000000000000000000000000000000",
+            "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "receiptsRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "difficulty": "0x0",
+            "number": "0x0",
+            "gasLimit": "0x1c9c380",
+            "gasUsed": "0x0",
+            "timestamp": "0x688c83b0",
+            "extraData": "0x",
+            "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "nonce": "0x0000000000000000",
+            "baseFeePerGas": "0x3b9aca00",
+            "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "blobGasUsed": "0x0",
+            "excessBlobGas": "0x0",
+            "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000"
+          },
+          "transactions": [],
+          "ommers": []
+        },
+        {
+          "header": {
+            "parentHash": "0x25097583380d90c4ac42b454ed7d2f59450ed3a16fdcf7f7bd93295aa126a901",
+            "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+            "miner": "0x0000000000000000000000000000000000000000",
+            "stateRoot": "0x6e005b459ac9acefa5f47fd2d7ff8ca81a91794fdc5f7fbc3e2faeeaefe5d516",
+            "transactionsRoot": "0x59f0457ec18e2181c186f49d9ac911b33b5f4f55db5c494022147346bcfc9837",
+            "receiptsRoot": "0x88ac48b910f796aab7407814203b3a15a04a812f387e92efeccc92a2ecf809da",
+            "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "difficulty": "0x0",
+            "number": "0x1",
+            "gasLimit": "0x1c9c380",
+            "gasUsed": "0x26481",
+            "timestamp": "0x688c83b5",
+            "extraData": "0x",
+            "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "nonce": "0x0000000000000000",
+            "baseFeePerGas": "0x3b9aca00",
+            "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "blobGasUsed": "0x0",
+            "excessBlobGas": "0x0",
+            "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000"
+          },
+          "transactions": [
+            {
+              "transaction": {
+                "EIP1559": {
+                  "chainId": "0x7a69",
+                  "nonce": "0x0",
+                  "gas": "0x31c41",
+                  "maxFeePerGas": "0x77359401",
+                  "maxPriorityFeePerGas": "0x1",
+                  "to": null,
+                  "value": "0x0",
+                  "accessList": [],
+                  "input": "0x6080604052348015600e575f5ffd5b506101e18061001c5f395ff3fe608060405234801561000f575f5ffd5b506004361061003f575f3560e01c80633fb5c1cb146100435780638381f58a1461005f578063d09de08a1461007d575b5f5ffd5b61005d600480360381019061005891906100e4565b610087565b005b610067610090565b604051610074919061011e565b60405180910390f35b610085610095565b005b805f8190555050565b5f5481565b5f5f8154809291906100a690610164565b9190505550565b5f5ffd5b5f819050919050565b6100c3816100b1565b81146100cd575f5ffd5b50565b5f813590506100de816100ba565b92915050565b5f602082840312156100f9576100f86100ad565b5b5f610106848285016100d0565b91505092915050565b610118816100b1565b82525050565b5f6020820190506101315f83018461010f565b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f61016e826100b1565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff82036101a05761019f610137565b5b60018201905091905056fea264697066735822122040b6a3cd3ec8f890002f39a8719ebee029ba9bac3d7fa9d581d4712cfe9ffec264736f6c634300081e0033",
+                  "r": "0xa7398e28ca9a56b423cab87aeb3612378bac9c5684aaf778a78943f2637fd731",
+                  "s": "0x583511da658f564253c8c0f9ee1820ef370f23556be504b304ac1292f869d9a0",
+                  "yParity": "0x0",
+                  "v": "0x0",
+                  "hash": "0x9e4846328caa09cbe8086d11b7e115adf70390e79ff203d8e5f37785c2a890be"
+                }
+              },
+              "impersonated_sender": null
+            }
+          ],
+          "ommers": []
+        }
+      ],
+      "transactions": [
+        {
+          "info": {
+            "transaction_hash": "0x9e4846328caa09cbe8086d11b7e115adf70390e79ff203d8e5f37785c2a890be",
+            "transaction_index": 0,
+            "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            "to": null,
+            "contract_address": "0x5fbdb2315678afecb367f032d93f642f64180aa3",
+            "traces": [
+              {
+                "parent": null,
+                "children": [],
+                "idx": 0,
+                "trace": {
+                  "depth": 0,
+                  "success": true,
+                  "caller": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "address": "0x5fbdb2315678afecb367f032d93f642f64180aa3",
+                  "maybe_precompile": false,
+                  "selfdestruct_address": null,
+                  "selfdestruct_refund_target": null,
+                  "selfdestruct_transferred_value": null,
+                  "kind": "CREATE",
+                  "value": "0x0",
+                  "data": "0x6080604052348015600e575f5ffd5b506101e18061001c5f395ff3fe608060405234801561000f575f5ffd5b506004361061003f575f3560e01c80633fb5c1cb146100435780638381f58a1461005f578063d09de08a1461007d575b5f5ffd5b61005d600480360381019061005891906100e4565b610087565b005b610067610090565b604051610074919061011e565b60405180910390f35b610085610095565b005b805f8190555050565b5f5481565b5f5f8154809291906100a690610164565b9190505550565b5f5ffd5b5f819050919050565b6100c3816100b1565b81146100cd575f5ffd5b50565b5f813590506100de816100ba565b92915050565b5f602082840312156100f9576100f86100ad565b5b5f610106848285016100d0565b91505092915050565b610118816100b1565b82525050565b5f6020820190506101315f83018461010f565b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f61016e826100b1565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff82036101a05761019f610137565b5b60018201905091905056fea264697066735822122040b6a3cd3ec8f890002f39a8719ebee029ba9bac3d7fa9d581d4712cfe9ffec264736f6c634300081e0033",
+                  "output": "0x608060405234801561000f575f5ffd5b506004361061003f575f3560e01c80633fb5c1cb146100435780638381f58a1461005f578063d09de08a1461007d575b5f5ffd5b61005d600480360381019061005891906100e4565b610087565b005b610067610090565b604051610074919061011e565b60405180910390f35b610085610095565b005b805f8190555050565b5f5481565b5f5f8154809291906100a690610164565b9190505550565b5f5ffd5b5f819050919050565b6100c3816100b1565b81146100cd575f5ffd5b50565b5f813590506100de816100ba565b92915050565b5f602082840312156100f9576100f86100ad565b5b5f610106848285016100d0565b91505092915050565b610118816100b1565b82525050565b5f6020820190506101315f83018461010f565b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f61016e826100b1565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff82036101a05761019f610137565b5b60018201905091905056fea264697066735822122040b6a3cd3ec8f890002f39a8719ebee029ba9bac3d7fa9d581d4712cfe9ffec264736f6c634300081e0033",
+                  "gas_used": 96345,
+                  "gas_limit": 143385,
+                  "status": "Return",
+                  "steps": [],
+                  "decoded": {
+                    "label": null,
+                    "return_data": null,
+                    "call_data": null
+                  }
+                },
+                "logs": [],
+                "ordering": []
+              }
+            ],
+            "exit": "Return",
+            "out": "0x608060405234801561000f575f5ffd5b506004361061003f575f3560e01c80633fb5c1cb146100435780638381f58a1461005f578063d09de08a1461007d575b5f5ffd5b61005d600480360381019061005891906100e4565b610087565b005b610067610090565b604051610074919061011e565b60405180910390f35b610085610095565b005b805f8190555050565b5f5481565b5f5f8154809291906100a690610164565b9190505550565b5f5ffd5b5f819050919050565b6100c3816100b1565b81146100cd575f5ffd5b50565b5f813590506100de816100ba565b92915050565b5f602082840312156100f9576100f86100ad565b5b5f610106848285016100d0565b91505092915050565b610118816100b1565b82525050565b5f6020820190506101315f83018461010f565b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f61016e826100b1565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff82036101a05761019f610137565b5b60018201905091905056fea264697066735822122040b6a3cd3ec8f890002f39a8719ebee029ba9bac3d7fa9d581d4712cfe9ffec264736f6c634300081e0033",
+            "nonce": 0,
+            "gas_used": 156801
+          },
+          "receipt": {
+            "type": "0x2",
+            "status": "0x1",
+            "cumulativeGasUsed": "0x26481",
+            "logs": [],
+            "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+          },
+          "block_hash": "0x313ea0d32d662434a55a20d7c58544e6baaea421b6eccf4b68392dec2a76d771",
+          "block_number": 1
+        }
+      ],
+      "historical_states": null
+    });
+
+    // Write the old state to file.
+    foundry_common::fs::write_json_file(&old_state_file, &real_old_state_json).unwrap();
+
+    // Test deserializing the old state dump directly.
+    let deserialized_state: SerializableState =
+        serde_json::from_value(real_old_state_json).unwrap();
+
+    // Verify the old state was loaded correctly with `coinbase` to `beneficiary` conversion.
+    let block_env = deserialized_state.block.unwrap();
+    assert_eq!(block_env.number, U256::from(1));
+    assert_eq!(block_env.beneficiary, address!("0000000000000000000000000000000000000001"));
+    assert_eq!(block_env.gas_limit, 0x1c9c380);
+    assert_eq!(block_env.basefee, 0x3b9aca00);
+
+    // Verify best_block_number hex string parsing.
+    assert_eq!(deserialized_state.best_block_number, Some(1));
+
+    // Verify account data was preserved.
+    assert_eq!(deserialized_state.accounts.len(), 13);
+
+    // Test specific accounts from the old dump.
+    let deployer_addr = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266".parse().unwrap();
+    let deployer_account = deserialized_state.accounts.get(&deployer_addr).unwrap();
+    assert_eq!(deployer_account.nonce, 1);
+    assert_eq!(deployer_account.balance, U256::from_str("0x21e19e03b1e9e55d17f").unwrap());
+
+    // Test contract account.
+    let contract_addr = "0x5fbdb2315678afecb367f032d93f642f64180aa3".parse().unwrap();
+    let contract_account = deserialized_state.accounts.get(&contract_addr).unwrap();
+    assert_eq!(contract_account.nonce, 1);
+    assert_eq!(contract_account.balance, U256::ZERO);
+    assert!(!contract_account.code.is_empty()); // Has contract code
+
+    // Verify blocks and transactions are preserved.
+    assert_eq!(deserialized_state.blocks.len(), 2);
+    assert_eq!(deserialized_state.transactions.len(), 1);
+
+    // Test that Anvil can actually load this old state dump.
+    let (api, _handle) = spawn(NodeConfig::test().with_init_state_path(&old_state_file)).await;
+
+    // Verify the state was loaded correctly by Anvil.
+    let block_number = api.block_number().unwrap();
+    assert_eq!(block_number, U256::from(1));
+
+    // Verify account balances are preserved.
+    let provider = _handle.http_provider();
+    let deployer_balance = provider.get_balance(deployer_addr).await.unwrap();
+    assert_eq!(deployer_balance, U256::from_str("0x21e19e03b1e9e55d17f").unwrap());
+
+    let contract_balance = provider.get_balance(contract_addr).await.unwrap();
+    assert_eq!(contract_balance, U256::ZERO);
+
+    // Verify contract code is preserved.
+    let contract_code = provider.get_code_at(contract_addr).await.unwrap();
+    assert!(!contract_code.is_empty());
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Optimistically closes: https://github.com/foundry-rs/foundry/issues/11176

Implements backwards compatibility for loading Anvil state dumps generated with v1.2

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Previously:

```
error: invalid value '<old state file>' for '--load-state <PATH>': failed to parse json file: "<old state file>": invalid type: string "0x1c9c380", expected u64 at line 1 column 129
```

now succeeds loading

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
