### PR TITLE
fix: use empty 7702 auths

### DIFF
--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -81,7 +81,7 @@ pub fn transaction_request_to_typed(
             to: to?.into_to()?,
             chain_id: 0,
             access_list: access_list.unwrap_or_default(),
-            authorization_list: authorization_list.unwrap(),
+            authorization_list: authorization_list.unwrap_or_default(),
         }));
     }
 


### PR DESCRIPTION
closes #11169

this should be okay, because this will get enforced by the evm and then bubbles up the appropriate error