### PR TITLE
fix(coverage): disambiguate duplicate function names

### DIFF
--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -326,7 +326,7 @@ pub enum CoverageItemKind {
     /// A function in the code.
     Function {
         /// The name of the function.
-        name: String,
+        name: Box<str>,
     },
 }
 


### PR DESCRIPTION
Add `.{index}` at the end of the function name if there are multiple with the same name in the same contract. This is easier than computing the function signature. Although we could also do that, I believe it's fine since usually it's not displayed but just an internal identifier.

Fixes https://github.com/foundry-rs/foundry/issues/11183.