### PR TITLE
chore: add missing error mapping

### DIFF
--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -255,6 +255,7 @@ impl From<u64> for SolidityErrorCode {
             5740 => Self::Unreachable,
             3420 => Self::PragmaSolidity,
             2394 => Self::TransientStorageUsed,
+            4591 => Self::TooManyWarnings,
             other => Self::Other(other),
         }
     }


### PR DESCRIPTION
Added a missing mapping for the `TooManyWarnings` error.
Mapping fetched from [here](https://github.com/foundry-rs/foundry/blob/master/crates/config/src/error.rs#L195)
