### PR TITLE
feat: add --file option for decode-calldata

### DIFF
--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -194,8 +194,15 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
                 sh_println!("{}", SimpleCast::abi_encode_packed(&sig, &args)?)?
             }
         }
-        CastSubcommand::DecodeCalldata { sig, calldata } => {
-            let tokens = SimpleCast::calldata_decode(&sig, &calldata, true)?;
+        CastSubcommand::DecodeCalldata { sig, calldata, file } => {
+            let raw_hex = if let Some(file_path) = file {
+                let contents = fs::read_to_string(&file_path)?;
+                contents.trim().to_string()
+            } else {
+                calldata.unwrap()
+            };
+
+            let tokens = SimpleCast::calldata_decode(&sig, &raw_hex, true)?;
             print_tokens(&tokens);
         }
         CastSubcommand::CalldataEncode { sig, args, file } => {

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -574,7 +574,12 @@ pub enum CastSubcommand {
         sig: String,
 
         /// The ABI-encoded calldata.
-        calldata: String,
+        #[arg(required_unless_present = "file", index = 2)]
+        calldata: Option<String>,
+
+        /// Load ABI-encoded calldata from a file instead.
+        #[arg(long = "file", short = 'f', conflicts_with = "calldata")]
+        file: Option<PathBuf>,
     },
 
     /// Decode ABI-encoded string.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

- Adds `--file` or `-f` option to decode using the calldata inside a file instead of the argument
- If you like this idea, I can apply it to other commands as well, just let me know 😄

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

- If the calldata is too large, then this error will occur `Error: ABI decoding failed: buffer overrun while deserializing`
  ```
  cargo run cdd "sequenceBatches((bytes,bytes32,uint64,bytes32)[],uint32,uint64,bytes32,address)" 0x1489ed10000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000216cdd0000000000000000000000000000000000000000000000000000000000216ce022d8beb00115f4adf024bce1815ae9b69922c71899d0767f786c5b06a282b6fea632cb137f36108eb3f576f04740e1fd1ce5985e21fa6332250e5c3abfbaf60d0000000000000000000000006329fe417621925c81c16f9f9a18c203c21af7ab069cb83fc0d730843fa16a9642ebd975bbb79488bbe5193241f57090550b66092d2991bcf336de0a39e1ce4d7cc207d24f37904c6713bbb9f089552da054bb890926d8e5cdaed15745426241b42635a01f9b667772d36fec8e45a4f83a447e1a04de1ceca2bdd274092e26a50b01761fdce4c661224f28d8c98d73dedfce4a48088fdbaec9e29485c3ff21d21897710e71a768165e74a63bda4b3298edbb4f0a0815b04868f89bde7234ebdc349ce79b77ddb2d0328afdfac5e3d33c90f8467813baf202e83ac421da5d5014cfa835e1c37daff7d5f3ca77f7fef024abe346dd030ea119eb01b9ad33832a91168cf5a17b390a36415f8fe5c06f47b7907849bb20ad2612cbade0b665456754983e0296a9c74eec5d0b570753a51d9738ae4fe6244fd1c1f2fbf02d0cc198a78790ee1dcd5381eb0e4fb171548b15b8bd09f52a010537c0a6547168799284abea0b488192839eb584baa220a2e79df7f89c71d92b828cc611d3f956399d7dd09cf0904bb742e583af531751d5e9d4fb68c4d38b0fafe586aed753177447293b5ff366ceee099afa632b51fcf0743d54466fceae27497a38317c1819758551c728e049f626050f7d3bb8d519952f47fc93776b3b09c4322c4c0b85295f2f02f82873e8373c97f0e3d4193ca6f888dc672d5b46de24d559d2953972e7996e88b180f96b6da93a76b084ab1e2f83a06aea54296e02301587b30c9c9eeb64ec83a4a7a2c8890f21dccea7a89deb5ade0602b82845991b1ff7bf1c5ea0fd953869d10ca5ddc4e26c3fb36c64e12fd1966b02874dad0f218c9b5d5b07bb5a42afe91ecf34c4b7e34f3b5d5865b933f28d9bafc542d74b07ad686407acd2805d5c9fa9ae571a653c91460780c083464e13cc77cb6c3605183a20d59520737396ffa147b8a792de730976868327bf8fed31f757897b26342ce99791628eeaef072b0325d324a73ee839307cc4902b520bea0f62aea43ad61ee8d3da82ac2e43757ce9c5d63cffb69f58505f2bcf0c407cf8659070feb0a60f1a4d766d0d487a92fef5dad78f51bf0bd8911a0fa314968376b22c2ea8050f
  ```
- Having a `--file` option gets around this limition

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Adds a `--file` option to get around the buffer overrun limitation when decoding large calldatas.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
