### PR TITLE
fix(script): show error traces when script execution fails with no transactions

### DIFF
--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -287,6 +287,15 @@ impl ScriptArgs {
                 .as_ref()
                 .is_none_or(|txs| txs.is_empty())
             {
+                // If the script execution failed, we should still show traces to report the error
+                if !pre_simulation.execution_result.success {
+                    if shell::is_json() {
+                        pre_simulation.show_json().await?;
+                    } else {
+                        pre_simulation.show_traces().await?;
+                    }
+                }
+                
                 if pre_simulation.args.broadcast {
                     sh_warn!("No transactions to broadcast.")?;
                 }


### PR DESCRIPTION
## Summary

This PR fixes a bug where Forge scripts fail silently when they encounter errors during execution that result in no transactions being generated.

## Problem

When a script makes an external call to a non-existent contract, it fails during execution but exits silently with only "No files changed, compilation skipped" message. The actual error is never shown to the user.

### Reproduction

```solidity
contract DeployScript is Script {
    function run() external {
        vm.startBroadcast();
        
        // External call to non-existent contract causes silent failure
        IFactory(0x1234567890123456789012345678901234567890).createUpgrader(
            address(0), msg.sender, 3
        );
        
        vm.stopBroadcast();
    }
}
```

Running this script shows:
```
No files changed, compilation skipped
```

And exits with no error message.

## Solution

The issue was in `crates/script/src/lib.rs` where the code would exit early when no transactions were generated, without checking if the execution was successful.

This fix adds a check for `execution_result.success` before the early exit. If the execution failed, it calls `show_traces()` to display the error message before exiting.

## Changes

- Added error trace display when script execution fails but produces no transactions
- Ensures users see meaningful error messages instead of silent failures

## Testing

Tested with the reproduction case above. After the fix, the script properly displays:
- The execution traces showing where the failure occurred
- The revert reason or error message

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>