### PR TITLE
fix(cast): allow negative numbers for function call arguments

### DIFF
--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -27,7 +27,7 @@ pub struct AccessListArgs {
     sig: Option<String>,
 
     /// The arguments of the function to call.
-    #[arg(value_name = "ARGS")]
+    #[arg(value_name = "ARGS", allow_negative_numbers = true)]
     args: Vec<String>,
 
     /// The block height to query at.

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -72,6 +72,7 @@ pub struct CallArgs {
     sig: Option<String>,
 
     /// The arguments of the function to call.
+    #[arg(allow_negative_numbers = true)]
     args: Vec<String>,
 
     /// Raw hex-encoded data for the transaction. Used instead of \[SIG\] and \[ARGS\].
@@ -177,6 +178,7 @@ pub enum CallSubcommands {
         sig: Option<String>,
 
         /// The arguments of the constructor.
+        #[arg(allow_negative_numbers = true)]
         args: Vec<String>,
 
         /// Ether to send in the transaction.
@@ -642,5 +644,22 @@ mod tests {
             args.state_overrides,
             Some(vec!["0x123:0x1:0x1234".to_string(), "0x456:0x2:0x5678".to_string()])
         );
+    }
+
+    #[test]
+    fn test_negative_args_with_flags() {
+        // Test that negative args work with flags
+        let args = CallArgs::parse_from([
+            "foundry-cli",
+            "--trace",
+            "0xDeaDBeeFcAfEbAbEfAcEfEeDcBaDbEeFcAfEbAbE",
+            "process(int256)",
+            "-999999",
+            "--debug",
+        ]);
+
+        assert!(args.trace);
+        assert!(args.debug);
+        assert_eq!(args.args, vec!["-999999"]);
     }
 }

--- a/crates/cast/src/cmd/estimate.rs
+++ b/crates/cast/src/cmd/estimate.rs
@@ -22,6 +22,7 @@ pub struct EstimateArgs {
     sig: Option<String>,
 
     /// The arguments of the function to call.
+    #[arg(allow_negative_numbers = true)]
     args: Vec<String>,
 
     /// The block height to query at.
@@ -58,6 +59,7 @@ pub enum EstimateSubcommands {
         sig: Option<String>,
 
         /// Constructor arguments
+        #[arg(allow_negative_numbers = true)]
         args: Vec<String>,
 
         /// Ether to send in the transaction

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -25,6 +25,7 @@ pub struct MakeTxArgs {
     sig: Option<String>,
 
     /// The arguments of the function to call.
+    #[arg(allow_negative_numbers = true)]
     args: Vec<String>,
 
     #[command(subcommand)]
@@ -69,6 +70,7 @@ pub enum MakeTxSubcommands {
         sig: Option<String>,
 
         /// The constructor arguments.
+        #[arg(allow_negative_numbers = true)]
         args: Vec<String>,
     },
 }

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -30,6 +30,7 @@ pub struct SendTxArgs {
     sig: Option<String>,
 
     /// The arguments of the function to call.
+    #[arg(allow_negative_numbers = true)]
     args: Vec<String>,
 
     /// Only print the transaction hash and exit immediately.
@@ -80,6 +81,7 @@ pub enum SendTxSubcommands {
         sig: Option<String>,
 
         /// The arguments of the function to call.
+        #[arg(allow_negative_numbers = true)]
         args: Vec<String>,
     },
 }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3741,3 +3741,132 @@ Transaction successfully executed.
 
 "#]]);
 });
+
+// Tests for negative number argument parsing
+// Ensures that negative numbers in function arguments are properly parsed
+// instead of being treated as command flags
+
+// Test that cast call accepts negative numbers as function arguments
+casttest!(cast_call_negative_numbers, |_prj, cmd| {
+    let rpc = next_rpc_endpoint(NamedChain::Sepolia);
+    // Test with negative int parameter - should not treat -456789 as a flag
+    cmd.args([
+        "call",
+        "0xAbCdEf1234567890aBcDeF1234567890aBcDeF12",
+        "processValue(int128)",
+        "-456789",
+        "--rpc-url",
+        rpc.as_str(),
+    ])
+    .assert_success();
+});
+
+// Test negative numbers with multiple parameters
+casttest!(cast_call_multiple_negative_numbers, |_prj, cmd| {
+    let rpc = next_rpc_endpoint(NamedChain::Sepolia);
+    cmd.args([
+        "call",
+        "--rpc-url",
+        rpc.as_str(),
+        "0xDeaDBeeFcAfEbAbEfAcEfEeDcBaDbEeFcAfEbAbE",
+        "calculateDelta(int64,int32,uint16)",
+        "-987654321",
+        "-42",
+        "65535",
+    ])
+    .assert_success();
+});
+
+// Test negative numbers mixed with flags
+casttest!(cast_call_negative_with_flags, |_prj, cmd| {
+    let rpc = next_rpc_endpoint(NamedChain::Sepolia);
+    cmd.args([
+        "call",
+        "--trace", // flag before
+        "0x9876543210FeDcBa9876543210FeDcBa98765432",
+        "updateBalance(int256)",
+        "-777888",
+        "--rpc-url",
+        rpc.as_str(), // flag after
+    ])
+    .assert_success();
+});
+
+// Test that actual invalid flags are still caught
+casttest!(cast_call_invalid_flag_still_caught, |_prj, cmd| {
+    cmd.args([
+        "call",
+        "--invalid-flag", // This should be caught as invalid
+        "0x5555555555555555555555555555555555555555",
+    ])
+    .assert_failure()
+    .stderr_eq(str![[r#"
+error: unexpected argument '--invalid-flag' found
+
+  tip: to pass '--invalid-flag' as a value, use '-- --invalid-flag'
+
+Usage: cast call [OPTIONS] [TO] [SIG] [ARGS]... [COMMAND]
+
+For more information, try '--help'.
+"#]]);
+});
+
+// Test cast send with negative numbers
+casttest!(cast_send_negative_numbers, |_prj, cmd| {
+    cmd.args([
+        "send",
+        "0xCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCc",
+        "withdraw(int128)",
+        "-2500"
+    ])
+    .assert_failure() // Will fail due to wallet/RPC, but parsing should work
+    .stderr_eq(str![[r#"
+Error: Could not find or load private key. Make sure you set your private key via the --private-key flag or the ETH_PRIVATE_KEY env var.
+"#]]);
+});
+
+// Test cast estimate with negative numbers
+casttest!(cast_estimate_negative_numbers, |_prj, cmd| {
+    let rpc = next_rpc_endpoint(NamedChain::Sepolia);
+    cmd.args([
+        "estimate",
+        "0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb",
+        "rebalance(int64)",
+        "-8888",
+        "--rpc-url",
+        rpc.as_str(),
+    ])
+    .assert_success();
+});
+
+// Test cast mktx with negative numbers
+casttest!(cast_mktx_negative_numbers, |_prj, cmd| {
+    let rpc = next_rpc_endpoint(NamedChain::Sepolia);
+    cmd.args([
+        "mktx",
+        "0x1111111111111111111111111111111111111111",
+        "settleDebt(int256)",
+        "-15000",
+        "--private-key",
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", // anvil wallet #0
+        "--rpc-url",
+        rpc.as_str(),
+        "--gas-limit",
+        "100000",
+    ])
+    .assert_success();
+});
+
+// Test cast access-list with negative numbers
+casttest!(cast_access_list_negative_numbers, |_prj, cmd| {
+    let rpc = next_rpc_endpoint(NamedChain::Sepolia);
+    cmd.args([
+        "access-list",
+        "0x9999999999999999999999999999999999999999",
+        "adjustPosition(int128)",
+        "-33333",
+        "--rpc-url",
+        rpc.as_str(),
+    ])
+    .assert_success();
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`cast` didn't allow negative numbers because it parsed them as unexpected options. That didn't allow you to encode -ve numbers for intX args. This fixes that.

## Solution

https://docs.rs/clap/latest/clap/struct.Arg.html#method.allow_negative_numbers

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
