### PR TITLE
fix: add missing semicolon in typos error message in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ lint-clippy: ## Run clippy on the codebase.
 .PHONY: lint-typos
 lint-typos: ## Run typos on the codebase.
 	@command -v typos >/dev/null || { \
-		echo "typos not found. Please install it by running the command `cargo install typos-cli` or refer to the following link for more information: https://github.com/crate-ci/typos" \
+		echo "typos not found. Please install it by running the command `cargo install typos-cli` or refer to the following link for more information: https://github.com/crate-ci/typos"; \
 		exit 1; \
 	}
 	typos


### PR DESCRIPTION

Add missing semicolon after the echo command in the lint-typos target to ensure proper shell syntax compatibility across different environments. This prevents potential build failures when the typos command is not found

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
