### PR TITLE
fix(`forge script`): repeated `vm.createSelectFork` with same RPC causes segfault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6916,8 +6916,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce1dc7533f4e5716c55cd3d62488c6200cb4dfda96e0c75a7e484652464343b"
+source = "git+https://github.com/bluealloy/revm.git?rev=d9cda3a#d9cda3ad8ce75ed772072bc3b55cdf3e959e18cf"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -7990,8 +7989,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "27.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6bf82101a1ad8a2b637363a37aef27f88b4efc8a6e24c72bf5f64923dc5532"
+source = "git+https://github.com/bluealloy/revm.git?rev=d9cda3a#d9cda3ad8ce75ed772072bc3b55cdf3e959e18cf"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -8009,8 +8007,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6922f7f4fbc15ca61ea459711ff75281cc875648c797088c34e4e064de8b8a7c"
+source = "git+https://github.com/bluealloy/revm.git?rev=d9cda3a#d9cda3ad8ce75ed772072bc3b55cdf3e959e18cf"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -8022,8 +8019,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "8.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd508416a35a4d8a9feaf5ccd06ac6d6661cd31ee2dc0252f9f7316455d71f9"
+source = "git+https://github.com/bluealloy/revm.git?rev=d9cda3a#d9cda3ad8ce75ed772072bc3b55cdf3e959e18cf"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -8038,8 +8034,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc90302642d21c8f93e0876e201f3c5f7913c4fcb66fb465b0fd7b707dfe1c79"
+source = "git+https://github.com/bluealloy/revm.git?rev=d9cda3a#d9cda3ad8ce75ed772072bc3b55cdf3e959e18cf"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -8054,8 +8049,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61495e01f01c343dd90e5cb41f406c7081a360e3506acf1be0fc7880bfb04eb"
+source = "git+https://github.com/bluealloy/revm.git?rev=d9cda3a#d9cda3ad8ce75ed772072bc3b55cdf3e959e18cf"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -8068,8 +8062,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20628d6cd62961a05f981230746c16854f903762d01937f13244716530bf98f"
+source = "git+https://github.com/bluealloy/revm.git?rev=d9cda3a#d9cda3ad8ce75ed772072bc3b55cdf3e959e18cf"
 dependencies = [
  "auto_impl",
  "either",
@@ -8081,8 +8074,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1529c8050e663be64010e80ec92bf480315d21b1f2dbf65540028653a621b27d"
+source = "git+https://github.com/bluealloy/revm.git?rev=d9cda3a#d9cda3ad8ce75ed772072bc3b55cdf3e959e18cf"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -8100,8 +8092,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78db140e332489094ef314eaeb0bd1849d6d01172c113ab0eb6ea8ab9372926"
+source = "git+https://github.com/bluealloy/revm.git?rev=d9cda3a#d9cda3ad8ce75ed772072bc3b55cdf3e959e18cf"
 dependencies = [
  "auto_impl",
  "either",
@@ -8138,8 +8129,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff9d7d9d71e8a33740b277b602165b6e3d25fff091ba3d7b5a8d373bf55f28a7"
+source = "git+https://github.com/bluealloy/revm.git?rev=d9cda3a#d9cda3ad8ce75ed772072bc3b55cdf3e959e18cf"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -8150,8 +8140,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "25.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cee3f336b83621294b4cfe84d817e3eef6f3d0fce00951973364cc7f860424d"
+source = "git+https://github.com/bluealloy/revm.git?rev=d9cda3a#d9cda3ad8ce75ed772072bc3b55cdf3e959e18cf"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -8177,8 +8166,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66145d3dc61c0d6403f27fc0d18e0363bb3b7787e67970a05c71070092896599"
+source = "git+https://github.com/bluealloy/revm.git?rev=d9cda3a#d9cda3ad8ce75ed772072bc3b55cdf3e959e18cf"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -8188,8 +8176,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc830a0fd2600b91e371598e3d123480cd7bb473dd6def425a51213aa6c6d57"
+source = "git+https://github.com/bluealloy/revm.git?rev=d9cda3a#d9cda3ad8ce75ed772072bc3b55cdf3e959e18cf"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,8 +401,8 @@ idna_adapter = "=1.1.0"
 # alloy-op-evm = { git = "https://github.com/alloy-rs/evm.git", rev = "7762adc" }
 
 ## revm
-# revm = { git = "https://github.com/bluealloy/revm.git", rev = "b5808253" }
-# op-revm = { git = "https://github.com/bluealloy/revm.git", rev = "b5808253" }
+revm = { git = "https://github.com/bluealloy/revm.git", rev = "d9cda3a" }
+op-revm = { git = "https://github.com/bluealloy/revm.git", rev = "d9cda3a" }
 # revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors.git", rev = "956bc98" }
 
 ## foundry

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3101,3 +3101,93 @@ contract FactoryScript is Script {
         .expect("no Counter contract");
     assert_eq!(counter_contract.contract_name, Some("Counter".to_string()));
 });
+
+// <https://github.com/foundry-rs/foundry/issues/11213>
+forgetest_async!(call_to_non_contract_address_does_not_panic, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+
+    let endpoint = rpc::next_http_archive_rpc_url();
+
+    prj.add_source(
+        "Counter.sol",
+        r#"
+contract Counter {
+    uint256 public number;
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+    function increment() public {
+        number++;
+    }
+}
+   "#,
+    )
+    .unwrap();
+
+    let deploy_script = prj
+        .add_script(
+            "Counter.s.sol",
+            &r#"
+import "forge-std/Script.sol";
+import {Counter} from "../src/Counter.sol";
+contract CounterScript is Script {
+    Counter public counter;
+    function setUp() public {}
+    function run() public {
+        vm.createSelectFork("<url>");
+        vm.startBroadcast();
+        counter = new Counter();
+        vm.stopBroadcast();
+        vm.createSelectFork("<url>");
+        vm.startBroadcast();
+        counter.increment();
+        vm.stopBroadcast();
+    }
+}
+   "#
+            .replace("<url>", &endpoint),
+        )
+        .unwrap();
+
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    cmd.args([
+        "script",
+        &deploy_script.display().to_string(),
+        "--root",
+        prj.root().to_str().unwrap(),
+        "--fork-url",
+        &handle.http_endpoint(),
+        "--slow",
+        "--broadcast",
+        "--private-key",
+        "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+    ])
+    .assert_failure()
+    .stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+Traces:
+  [462955] → new CounterScript@0x5b73C5498c1E3b4dbA84de0F1833c4a029d90519
+    └─ ← [Return] 2200 bytes of code
+  [121] CounterScript::setUp()
+    └─ ← [Stop]
+  [141727] CounterScript::run()
+    ├─ [0] VM::createSelectFork("<rpc url>")
+    │   └─ ← [Return] 1
+    ├─ [0] VM::startBroadcast()
+    │   └─ ← [Return]
+    ├─ [96345] → new Counter@0xB6888174e4BD6f052115c0428524da1DA8B6bE00
+    │   └─ ← [Return] 481 bytes of code
+    ├─ [0] VM::stopBroadcast()
+    │   └─ ← [Return]
+    ├─ [0] VM::createSelectFork("<rpc url>")
+    │   └─ ← [Return] 2
+    ├─ [0] VM::startBroadcast()
+    │   └─ ← [Return]
+    └─ ← [Revert] call to non-contract address 0xB6888174e4BD6f052115c0428524da1DA8B6bE00
+"#]])
+    .stderr_eq(str![[r#"
+Error: script failed: call to non-contract address 0xB6888174e4BD6f052115c0428524da1DA8B6bE00
+"#]]);
+});

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3168,16 +3168,16 @@ contract CounterScript is Script {
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 Traces:
-  [462955] → new CounterScript@0x5b73C5498c1E3b4dbA84de0F1833c4a029d90519
+  [..] → new CounterScript@[..]
     └─ ← [Return] 2200 bytes of code
-  [121] CounterScript::setUp()
+  [..] CounterScript::setUp()
     └─ ← [Stop]
-  [141727] CounterScript::run()
+  [..] CounterScript::run()
     ├─ [0] VM::createSelectFork("<rpc url>")
     │   └─ ← [Return] 1
     ├─ [0] VM::startBroadcast()
     │   └─ ← [Return]
-    ├─ [96345] → new Counter@0xB6888174e4BD6f052115c0428524da1DA8B6bE00
+    ├─ [..] → new Counter@[..]
     │   └─ ← [Return] 481 bytes of code
     ├─ [0] VM::stopBroadcast()
     │   └─ ← [Return]
@@ -3185,9 +3185,9 @@ Traces:
     │   └─ ← [Return] 2
     ├─ [0] VM::startBroadcast()
     │   └─ ← [Return]
-    └─ ← [Revert] call to non-contract address 0xB6888174e4BD6f052115c0428524da1DA8B6bE00
+    └─ ← [Revert] call to non-contract address [..]
 "#]])
     .stderr_eq(str![[r#"
-Error: script failed: call to non-contract address 0xB6888174e4BD6f052115c0428524da1DA8B6bE00
+Error: script failed: call to non-contract address [..]
 "#]]);
 });

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3170,22 +3170,27 @@ Compiler run successful!
 Traces:
   [..] → new CounterScript@[..]
     └─ ← [Return] 2200 bytes of code
+
   [..] CounterScript::setUp()
     └─ ← [Stop]
+
   [..] CounterScript::run()
-    ├─ [0] VM::createSelectFork("<rpc url>")
+    ├─ [..] VM::createSelectFork("<rpc url>")
     │   └─ ← [Return] 1
-    ├─ [0] VM::startBroadcast()
+    ├─ [..] VM::startBroadcast()
     │   └─ ← [Return]
     ├─ [..] → new Counter@[..]
     │   └─ ← [Return] 481 bytes of code
-    ├─ [0] VM::stopBroadcast()
+    ├─ [..] VM::stopBroadcast()
     │   └─ ← [Return]
-    ├─ [0] VM::createSelectFork("<rpc url>")
+    ├─ [..] VM::createSelectFork("<rpc url>")
     │   └─ ← [Return] 2
-    ├─ [0] VM::startBroadcast()
+    ├─ [..] VM::startBroadcast()
     │   └─ ← [Return]
     └─ ← [Revert] call to non-contract address [..]
+
+
+
 "#]])
     .stderr_eq(str![[r#"
 Error: script failed: call to non-contract address [..]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes https://github.com/foundry-rs/foundry/issues/11213

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Pins revm to https://github.com/bluealloy/revm/tree/interpreter-is-end-flag which includes a fix for code that previously segfaulted

Bumping to revm 28 requires more work due to boxing changes in revm-inspectors, ref: https://github.com/foundry-rs/foundry/pull/11217

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes