### PR TITLE
fix: correct error message in Fork command

### DIFF
--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -352,7 +352,7 @@ impl ChiselDispatcher {
                 }
                 if args.len() != 1 {
                     return DispatchResult::CommandFailed(Self::make_error(
-                        "Must supply a session ID as the argument.",
+                        "Must supply a URL or RPC alias as the argument.",
                     ));
                 }
                 let arg = *args.first().unwrap();


### PR DESCRIPTION
The Fork command was displaying a misleading error message that mentioned
"session ID" when it actually expects a URL or RPC alias. This change
updates the error message to correctly indicate that the command requires
a URL or RPC alias as an argument, improving user experience and reducing
confusion.

- Fixes error message in ChiselCommand::Fork
- Changes "Must supply a session ID as the argument" to 
  "Must supply a URL or RPC alias as the argument"