### PR TITLE
chore(chisel): remove unused Debug import from executor.rs

### DIFF
--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -8,7 +8,6 @@ use crate::prelude::{
 use alloy_dyn_abi::{DynSolType, DynSolValue};
 use alloy_json_abi::EventParam;
 use alloy_primitives::{Address, B256, U256, hex};
-use core::fmt::Debug;
 use eyre::{Result, WrapErr};
 use foundry_compilers::Artifact;
 use foundry_evm::{


### PR DESCRIPTION
- Remove use core::fmt::Debug; from crates/chisel/src/executor.rs as it’s unused; #[derive(Debug)] doesn’t require a manual import.
- Verified with cargo check -p chisel; no functional changes.