### PR TITLE
chisel/runner: skip redundant call_raw when commit=true

### DIFF
--- a/crates/chisel/src/runner.rs
+++ b/crates/chisel/src/runner.rs
@@ -184,7 +184,9 @@ impl ChiselRunner {
                 cheatcodes.fs_commit = !cheatcodes.fs_commit;
             }
 
-            res = self.executor.call_raw(from, to, calldata.clone(), value)?;
+            if !commit {
+                res = self.executor.call_raw(from, to, calldata.clone(), value)?;
+            }
         }
 
         if commit {


### PR DESCRIPTION
Avoid an unnecessary call_raw when fs_commit is restored and commit == true; we directly proceed to transact_raw.
No functional changes; micro-optimization that removes one extra EVM call on the commit path.