### PR TITLE
fix: make manpage download truly optional in foundryup installer

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -273,7 +273,9 @@ main() {
     if check_cmd tar; then
       say "downloading manpages"
       mkdir -p "$FOUNDRY_MAN_DIR"
-      download "$MAN_TARBALL_URL" | tar -xzC "$FOUNDRY_MAN_DIR"
+      if ! download "$MAN_TARBALL_URL" | tar -xzC "$FOUNDRY_MAN_DIR"; then
+        warn "skipping manpage download: unavailable or invalid archive"
+      fi
     else
       say 'skipping manpage download: missing "tar"'
     fi


### PR DESCRIPTION
## Problem
The manpage download step in `foundryup` installer was marked as "optional" but could actually crash the entire installation process due to `set -e -o pipefail` behavior. If the manpage archive was unavailable or corrupted, the `download | tar` pipeline would fail and terminate the script, even though binaries were already successfully installed.

## Solution
Wrap the manpage download pipeline in an error check to make it truly optional:
- Add `if ! ...; then warn ...; fi` around the download/extract command
- Log a warning instead of crashing when manpage archive is unavailable
- Allow installation to complete successfully even if manpages fail

