### PR TITLE
docs: clarify script default entry (run())

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,11 @@ If the answer is not there:
 
 If you want to contribute, or follow along with contributor discussion, you can use our [main telegram](https://t.me/foundry_rs) to chat with us about the development of Foundry!
 
+## Troubleshooting
+
+If your script fails to run, ensure your entry function is named `run()` and exported correctly.  
+Copy-pasting examples without the parentheses may cause unexpected failures.  
+
 ## License
 
 Licensed under either of [Apache License](./LICENSE-APACHE), Version


### PR DESCRIPTION
### What
Add a short troubleshooting note clarifying that the default script entry function is `run()`.

### Why
New users copy examples directly. Explicitly mentioning `run()` prevents confusion and failures caused by missing parentheses.

### Scope
Docs-only change. No behavior impact.