### PR TITLE
Gen sig with nonce

### DIFF
--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2672,6 +2672,12 @@ interface Vm {
     #[cheatcode(group = Crypto)]
     function sign(uint256 privateKey, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
 
+    /// Signs `digest` with `privateKey` on the secp256k1 curve, using the given `nonce`
+    /// as the raw ephemeral k value in ECDSA (instead of deriving it deterministically).
+    #[cheatcode(group = Crypto)]
+    function signWithNonce(uint256 privateKey, bytes32 digest, uint256 nonce) external pure returns (uint8 v, bytes32 r, bytes32 s);
+
+
     /// Signs `digest` with `privateKey` using the secp256k1 curve.
     ///
     /// Returns a compact signature (`r`, `vs`) as per EIP-2098, where `vs` encodes both the

--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -12,9 +12,9 @@ use alloy_signer_local::{
 };
 use alloy_sol_types::SolValue;
 use k256::{
-    ecdsa::SigningKey,
-    elliptic_curve::{bigint::ArrayEncoding, sec1::ToEncodedPoint},
+    ecdsa::{hazmat, SigningKey}, elliptic_curve::{bigint::ArrayEncoding, sec1::ToEncodedPoint}, FieldBytes, Scalar
 };
+
 use p256::ecdsa::{
     Signature as P256Signature, SigningKey as P256SigningKey, signature::hazmat::PrehashSigner,
 };
@@ -47,6 +47,16 @@ impl Cheatcode for sign_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { wallet, digest } = self;
         let sig = sign(&wallet.privateKey, digest)?;
+        Ok(encode_full_sig(sig))
+    }
+}
+
+impl Cheatcode for signWithNonceCall {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let pk: U256 = self.privateKey;
+        let digest: B256 = self.digest;
+        let nonce: U256 = self.nonce;
+        let sig: alloy_primitives::Signature = sign_with_nonce(&pk, &digest, &nonce)?;
         Ok(encode_full_sig(sig))
     }
 }
@@ -241,6 +251,83 @@ fn sign(private_key: &U256, digest: &B256) -> Result<alloy_primitives::Signature
     Ok(sig)
 }
 
+// Signs `digest` on secp256k1 using a user-supplied ephemeral nonce `k` (no RFC6979).
+// - `private_key` and `nonce` must be in (0, n)
+// - `digest` is a 32-byte prehash.
+// WARNING: Use sign_with_nonce with extreme caution!
+// Reusing the same nonce (k) with the same private key in ECDSA will leak the private key.
+// Always generate `nonce` with a cryptographically secure RNG, and never reuse it across signatures.
+fn sign_with_nonce(
+    private_key: &U256,
+    digest: &B256,
+    nonce: &U256,
+) -> Result<alloy_primitives::Signature> {
+    let d_scalar: Scalar =
+        <Scalar as k256::elliptic_curve::PrimeField>::from_repr(private_key.to_be_bytes().into())
+            .into_option()
+            .ok_or_else(|| fmt_err!("invalid private key scalar"))?;
+    if bool::from(d_scalar.is_zero()) {
+        return Err(fmt_err!("private key cannot be 0"));
+    }
+
+    let k_scalar: Scalar =
+        <Scalar as k256::elliptic_curve::PrimeField>::from_repr(nonce.to_be_bytes().into())
+            .into_option()
+            .ok_or_else(|| fmt_err!("invalid nonce scalar"))?;
+    if bool::from(k_scalar.is_zero()) {
+        return Err(fmt_err!("nonce cannot be 0"));
+    }
+
+    let mut z = [0u8; 32];
+    z.copy_from_slice(digest.as_slice());
+    let z_fb: FieldBytes = FieldBytes::from(z);
+
+    // Hazmat signing using the scalar `d` (SignPrimitive is implemented for `Scalar`)
+    // Note: returns (Signature, Option<RecoveryId>)
+    let (sig_raw, recid_opt) =
+        <Scalar as hazmat::SignPrimitive<k256::Secp256k1>>
+            ::try_sign_prehashed(&d_scalar, k_scalar, &z_fb)
+            .map_err(|e| fmt_err!("sign_prehashed failed: {e}"))?;
+
+    // Enforce low-s; if mirrored, parity flips (we’ll account for it below if we use recid)
+    let (sig_low, flipped) = if let Some(norm) = sig_raw.normalize_s() {
+        (norm, true)
+    } else {
+        (sig_raw, false)
+    };
+
+    let r_u256 = U256::from_be_bytes(sig_low.r().to_bytes().into());
+    let s_u256 = U256::from_be_bytes(sig_low.s().to_bytes().into());
+
+    // Determine v parity in {0,1}
+    let v_parity = if let Some(id) = recid_opt {
+        let mut v = id.to_byte() & 1;
+        if flipped { v ^= 1; }
+        v
+    } else {
+        // Fallback: choose parity by recovery to expected address
+        let expected_addr = {
+            let sk: SigningKey = parse_private_key(private_key)?;
+            alloy_signer::utils::secret_key_to_address(&sk)
+        };
+        // Try v = 0
+        let cand0 = alloy_primitives::Signature::new(r_u256, s_u256, false);
+        if cand0.recover_address_from_prehash(digest).ok() == Some(expected_addr) {
+            return Ok(cand0);
+        }
+        // Try v = 1
+        let cand1 = alloy_primitives::Signature::new(r_u256, s_u256, true);
+        if cand1.recover_address_from_prehash(digest).ok() == Some(expected_addr) {
+            return Ok(cand1);
+        }
+        return Err(fmt_err!("failed to determine recovery id for signature"));
+    };
+
+    let y_parity = v_parity != 0;
+    Ok(alloy_primitives::Signature::new(r_u256, s_u256, y_parity))
+}
+
+
 fn sign_with_wallet(
     state: &mut Cheatcodes,
     signer: Option<Address>,
@@ -393,6 +480,7 @@ fn derive_wallets<W: Wordlist>(
 mod tests {
     use super::*;
     use alloy_primitives::{FixedBytes, hex::FromHex};
+    use k256::elliptic_curve::Curve;
     use p256::ecdsa::signature::hazmat::PrehashVerifier;
 
     #[test]
@@ -437,5 +525,66 @@ mod tests {
         .unwrap();
         let result = sign_p256(&U256::ZERO, &digest);
         assert_eq!(result.err().unwrap().to_string(), "private key cannot be 0");
+    }
+
+        #[test]
+    fn test_sign_with_nonce_varies_and_recovers() {
+        // Given a fixed private key and digest
+        let pk_u256: U256 = U256::from(1u64);
+        let digest = FixedBytes::from_hex(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ).unwrap();
+
+        // Two distinct nonces
+        let n1: U256 = U256::from(123u64);
+        let n2: U256 = U256::from(456u64);
+
+        // Sign with both nonces
+        let sig1 = sign_with_nonce(&pk_u256, &digest, &n1).expect("sig1");
+        let sig2 = sign_with_nonce(&pk_u256, &digest, &n2).expect("sig2");
+
+        // (r,s) must differ when nonce differs
+        assert!(sig1.r() != sig2.r() || sig1.s() != sig2.s(), "signatures should differ with different nonces");
+
+        // ecrecover must yield the address for both signatures
+        let sk = parse_private_key(&pk_u256).unwrap();
+        let expected = alloy_signer::utils::secret_key_to_address(&sk);
+
+        assert_eq!(sig1.recover_address_from_prehash(&digest).unwrap(), expected);
+        assert_eq!(sig2.recover_address_from_prehash(&digest).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_sign_with_nonce_zero_nonce_errors() {
+        // nonce = 0 should be rejected
+        let pk_u256: U256 = U256::from(1u64);
+        let digest = FixedBytes::from_hex(
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ).unwrap();
+        let n0: U256 = U256::ZERO;
+
+        let err = sign_with_nonce(&pk_u256, &digest, &n0).unwrap_err();
+        let msg = err.to_string();
+        // Accept either of the explicit messages (depending on which branch triggers first)
+        assert!(msg.contains("nonce cannot be 0") || msg.contains("invalid nonce scalar"),
+            "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn test_sign_with_nonce_nonce_ge_order_errors() {
+        // nonce >= n should be rejected
+        use k256::Secp256k1;
+        // Curve order n as U256
+        let n_u256 = U256::from_be_slice(&Secp256k1::ORDER.to_be_byte_array());
+
+        let pk_u256: U256 = U256::from(1u64);
+        let digest = FixedBytes::from_hex(
+            "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        ).unwrap();
+
+        // Try exactly n (>= n invalid)
+        let err = sign_with_nonce(&pk_u256, &digest, &n_u256).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid nonce scalar"), "unexpected error: {msg}");
     }
 }

--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -527,7 +527,7 @@ mod tests {
         assert_eq!(result.err().unwrap().to_string(), "private key cannot be 0");
     }
 
-        #[test]
+    #[test]
     fn test_sign_with_nonce_varies_and_recovers() {
         // Given a fixed private key and digest
         let pk_u256: U256 = U256::from(1u64);
@@ -565,8 +565,7 @@ mod tests {
 
         let err = sign_with_nonce(&pk_u256, &digest, &n0).unwrap_err();
         let msg = err.to_string();
-        // Accept either of the explicit messages (depending on which branch triggers first)
-        assert!(msg.contains("nonce cannot be 0") || msg.contains("invalid nonce scalar"),
+        assert!(msg.contains("nonce cannot be 0"),
             "unexpected error: {msg}");
     }
 

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -495,6 +495,7 @@ interface Vm {
     function sign(uint256 privateKey, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
     function sign(bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
     function sign(address signer, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
+    function signWithNonce(uint256 privateKey, bytes32 digest, uint256 nonce) external pure returns (uint8 v, bytes32 r, bytes32 s);
     function skip(bool skipTest) external;
     function skip(bool skipTest, string calldata reason) external;
     function sleep(uint256 duration) external;

--- a/testdata/default/cheats/Sign.t.sol
+++ b/testdata/default/cheats/Sign.t.sol
@@ -79,11 +79,10 @@ contract SignTest is DSTest {
     function testSignWithNonceInvalidNoncesRevert() public {
         uint256 pk = 1;
         bytes32 digest = 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
-
-        (bool ok, bytes memory data) = HEVM_ADDRESS.call(abi.encodeWithSelector(Vm.signWithNonce.selector, pk, digest, 0));
+        (bool ok, bytes memory data) =
+            HEVM_ADDRESS.call(abi.encodeWithSelector(Vm.signWithNonce.selector, pk, digest, 0));
         assertTrue(!ok, "expected revert on nonce=0");
         assertEq(_revertString(data), "vm.signWithNonce: nonce cannot be 0");
-
         uint256 n = _secp256k1Order();
         (ok, data) = HEVM_ADDRESS.call(abi.encodeWithSelector(Vm.signWithNonce.selector, pk, digest, n));
         assertTrue(!ok, "expected revert on nonce >= n");
@@ -101,5 +100,4 @@ contract SignTest is DSTest {
         }
         return abi.decode(tail, (string));
     }
-
 }


### PR DESCRIPTION
## Motivation

Security researchers and advanced test writers sometimes need to create deterministic ECDSA signatures with a chosen ephemeral nonce `k`.  

This is useful to:
- Reproduce signatures deterministically for debugging or reproducibility.
- Stress test and fuzz systems that rely on signature uniqueness.

Currently, Foundry's `vm.sign` only derives `k` internally (RFC6979) and does not allow injecting a fixed nonce.  
For security testing and deeper protocol analysis, we need a way to supply `k` manually.

Closes #11266.

## Solution

This PR introduces a new cheatcode:

```solidity
function signWithNonce(uint256 privateKey, bytes32 digest, uint256 nonce)
    external
    returns (uint8 v, bytes32 r, bytes32 s);
````

* Signs `digest` on secp256k1 using `privateKey` and a user-supplied nonce `k`.
* Requires both `privateKey` and `nonce` to be in `(0, n)` where `n` is the secp256k1 curve order.
* Performs low-s normalization and recovery id computation.
* Intended primarily for **security testing**, fuzzing, and reproducing edge cases — **not** for production signing.

Changes include:

* `crypto.rs` implementation of the fixed-nonce signing path.
* Integration in the cheatcodes `Vm.sol` interface.
* New Solidity tests in `testdata/default/cheats/Sign.t.sol` covering valid and invalid nonce cases.

## PR Checklist

* [x] Added Tests
* [ ] Added Documentation
* [ ] Breaking changes
