### PR TITLE
cli(paths): remove eyre::Result import to avoid Result shadowing in Provider impl

### DIFF
--- a/crates/cli/src/opts/build/paths.rs
+++ b/crates/cli/src/opts/build/paths.rs
@@ -1,5 +1,4 @@
 use clap::{Parser, ValueHint};
-use eyre::Result;
 use foundry_compilers::artifacts::remappings::Remapping;
 use foundry_config::{
     Config, figment,


### PR DESCRIPTION
Removed use eyre::Result; in crates/cli/src/opts/build/paths.rs.
Prevents shadowing of std::result::Result required by Provider::data signature (Result<T, E>).
No behavior change; improves type clarity.