### PR TITLE
feat(forge-selectors-list): add --no-group option

### DIFF
--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -3411,6 +3411,106 @@ Selectors successfully uploaded to OpenChain
 "#]]);
 });
 
+forgetest_init!(selectors_list_cmd, |prj, cmd| {
+    prj.add_source(
+        "Counter.sol",
+        r"
+contract Counter {
+    uint256 public number;
+    event Incremented(uint256 newNumber);
+    error IncrementError();
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}
+   ",
+    )
+    .unwrap();
+
+    prj.add_source(
+        "CounterV2.sol",
+        r"
+contract CounterV2 {
+    uint256 public number;
+
+    function setNumberV2(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function incrementV2() public {
+        number++;
+    }
+}
+   ",
+    )
+    .unwrap();
+
+    cmd.args(["selectors", "list"]).assert_success().stdout_eq(str![[r#"
+Listing selectors for contracts in the project...
+Counter
+
+╭----------+----------------------+--------------------------------------------------------------------╮
+| Type     | Signature            | Selector                                                           |
++======================================================================================================+
+| Function | increment()          | 0xd09de08a                                                         |
+|----------+----------------------+--------------------------------------------------------------------|
+| Function | number()             | 0x8381f58a                                                         |
+|----------+----------------------+--------------------------------------------------------------------|
+| Function | setNumber(uint256)   | 0x3fb5c1cb                                                         |
+|----------+----------------------+--------------------------------------------------------------------|
+| Event    | Incremented(uint256) | 0x20d8a6f5a693f9d1d627a598e8820f7a55ee74c183aa8f1a30e8d4e8dd9a8d84 |
+|----------+----------------------+--------------------------------------------------------------------|
+| Error    | IncrementError()     | 0x46544c04                                                         |
+╰----------+----------------------+--------------------------------------------------------------------╯
+
+CounterV2
+
+╭----------+----------------------+------------╮
+| Type     | Signature            | Selector   |
++==============================================+
+| Function | incrementV2()        | 0x49365a69 |
+|----------+----------------------+------------|
+| Function | number()             | 0x8381f58a |
+|----------+----------------------+------------|
+| Function | setNumberV2(uint256) | 0xb525b68c |
+╰----------+----------------------+------------╯
+
+"#]]);
+
+    cmd.forge_fuse()
+        .args(["selectors", "list", "--no-group"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Listing selectors for contracts in the project...
+
+╭----------+----------------------+--------------------------------------------------------------------+-----------╮
+| Type     | Signature            | Selector                                                           | Contract  |
++==================================================================================================================+
+| Function | increment()          | 0xd09de08a                                                         | Counter   |
+|----------+----------------------+--------------------------------------------------------------------+-----------|
+| Function | number()             | 0x8381f58a                                                         | Counter   |
+|----------+----------------------+--------------------------------------------------------------------+-----------|
+| Function | setNumber(uint256)   | 0x3fb5c1cb                                                         | Counter   |
+|----------+----------------------+--------------------------------------------------------------------+-----------|
+| Event    | Incremented(uint256) | 0x20d8a6f5a693f9d1d627a598e8820f7a55ee74c183aa8f1a30e8d4e8dd9a8d84 | Counter   |
+|----------+----------------------+--------------------------------------------------------------------+-----------|
+| Error    | IncrementError()     | 0x46544c04                                                         | Counter   |
+|----------+----------------------+--------------------------------------------------------------------+-----------|
+| Function | incrementV2()        | 0x49365a69                                                         | CounterV2 |
+|----------+----------------------+--------------------------------------------------------------------+-----------|
+| Function | number()             | 0x8381f58a                                                         | CounterV2 |
+|----------+----------------------+--------------------------------------------------------------------+-----------|
+| Function | setNumberV2(uint256) | 0xb525b68c                                                         | CounterV2 |
+╰----------+----------------------+--------------------------------------------------------------------+-----------╯
+
+"#]]);
+});
+
 // tests `interceptInitcode` function
 forgetest_init!(intercept_initcode, |prj, cmd| {
     prj.wipe_contracts();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Currently `forge selectors list` shows one table of selectors per contract and that is fine. But the output is not greppable because if I wanted to see which contract had a particular selector, the contract name would be appearing before the table is printed.

## Solution

`--no-group` option only prints one table and adds a `contract` field to each row which makes it greppable. And since it is a new option, the current behavior stays the same for everyone.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
