### PR TITLE
ipc: call to_name with Path::new(&path).as_os_str() for clarity

### DIFF
--- a/crates/anvil/server/src/ipc.rs
+++ b/crates/anvil/server/src/ipc.rs
@@ -44,7 +44,7 @@ impl<Handler: PubSubRpcHandler> IpcEndpoint<Handler> {
             }
         }
 
-        let name = to_name(path.as_ref())?;
+        let name = to_name(std::path::Path::new(&path).as_os_str())?;
         let listener = ls::ListenerOptions::new().name(name).create_tokio()?;
         let connections = futures::stream::unfold(listener, |listener| async move {
             let conn = listener.accept().await;


### PR DESCRIPTION
Make the &OsStr intent explicit when constructing the IPC socket name
Avoid implicit conversions via String::as_ref() to &str