### PR TITLE
fix: Prevent panic on pending transaction block number

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1446,7 +1446,9 @@ async fn derive_block_and_transactions(
                 .get_transaction_by_hash(transaction_hash.0.into())
                 .await?
                 .ok_or_else(|| eyre::eyre!("failed to get fork transaction by hash"))?;
-            let transaction_block_number = transaction.block_number.unwrap();
+            let transaction_block_number = transaction
+                .block_number
+                .ok_or_else(|| eyre::eyre!("fork transaction is not mined yet (no block number)"))?;
 
             // Get the block pertaining to the fork transaction
             let transaction_block = provider


### PR DESCRIPTION


This PR addresses a potential panic in `crates/anvil/src/config.rs` by improving error handling for transaction block numbers.

**Problem:**
Previously, the `derive_block_and_transactions` function used an unconditional `unwrap()` on `transaction.block_number`. This could lead to a node panic if a user attempted to fork from a pending transaction, as `block_number` would be `None`.

**Solution:**
Replaced the `unwrap()` with `ok_or_else()`, providing a clear error message if the transaction's block number is not available (i.e., the transaction is not yet mined). This ensures graceful error handling instead of a crash.

**Impact:**
Enhances the robustness and stability of the application by preventing unexpected panics due to unmined transactions.