### PR TITLE
fix: use to_snake_case in populate_expansion to match generated file names

### DIFF
--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -60,7 +60,7 @@ impl MultiSolMacroGen {
 
     pub fn populate_expansion(&mut self, bindings_path: &Path) -> Result<()> {
         for instance in &mut self.instances {
-            let path = bindings_path.join(format!("{}.rs", instance.name.to_lowercase()));
+            let path = bindings_path.join(format!("{}.rs", instance.name.to_snake_case()));
             let expansion = fs::read_to_string(path).wrap_err("Failed to read file")?;
 
             let tokens = TokenStream::from_str(&expansion)


### PR DESCRIPTION
Reason: generated bindings are written using to_snake_case (e.g., MyToken -> my_token.rs), but populate_expansion searched using to_lowercase (mytoken.rs), causing lookup mismatches.

Goal: align file lookup with the generation logic so populate_expansion can reliably load the generated bindings.

cargo check -p forge-sol-macro-gen    passed sucessfully