### PR TITLE
chore: fix foundry-macros warnings

### DIFF
--- a/crates/macros/src/cheatcodes.rs
+++ b/crates/macros/src/cheatcodes.rs
@@ -2,6 +2,14 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{Attribute, Data, DataStruct, DeriveInput, Error, Result};
 
+// TODO: `proc_macro_error2` only emits warnings when feature "nightly" is enabled, which we can't
+// practically enable.
+macro_rules! emit_warning {
+    ($($t:tt)*) => {
+        proc_macro_error2::emit_error! { $($t)* }
+    };
+}
+
 pub fn derive_cheatcode(input: &DeriveInput) -> Result<TokenStream> {
     let name = &input.ident;
     let name_s = name.to_string();


### PR DESCRIPTION
`proc_macro_error2` only emits warnings when feature "nightly" is enabled, which we can't practically enable. This wasn't the case with `proc_macro_error`, which enabled it based on a build.rs that detected nightly version automatically.

Upgrade them to errors so they are actually shown.