### PR TITLE
fix: add missing poll interval capping in build_with_wallet

### DIFF
--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -328,6 +328,9 @@ impl ProviderBuilder {
             client.set_poll_interval(
                 chain
                     .average_blocktime_hint()
+                    // we cap the poll interval because if not provided, chain would default to
+                    // mainnet
+                    .map(|hint| hint.min(DEFAULT_UNKNOWN_CHAIN_BLOCK_TIME))
                     .unwrap_or(DEFAULT_UNKNOWN_CHAIN_BLOCK_TIME)
                     .mul_f32(POLL_INTERVAL_BLOCK_TIME_SCALE_FACTOR),
             );


### PR DESCRIPTION
The build_with_wallet method was missing the .map(|hint| hint.min(DEFAULT_UNKNOWN_CHAIN_BLOCK_TIME)) 
call that exists in the build method. This caused inconsistent poll interval behavior between 
the two methods, where build_with_wallet could use unlimited chain block times instead of 
capping them at 3 seconds like build() does.

Added the missing logic to ensure both methods behave identically.