### PR TITLE
Revert "feat: accept ETH_RPC_URL env as fork-url alias"

### DIFF
--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -47,6 +47,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrices.outputs.test-matrix) }}
     env:
+      ETH_RPC_URL: https://reth-ethereum.ithaca.xyz/rpc
       CARGO_PROFILE_DEV_DEBUG: 0
     steps:
       - uses: actions/checkout@v5

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -408,7 +408,6 @@ pub struct AnvilEvmArgs {
         long,
         short,
         visible_alias = "rpc-url",
-        env = "ETH_RPC_URL",
         value_name = "URL",
         help_heading = "Fork config"
     )]

--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -46,7 +46,7 @@ pub struct EvmArgs {
     /// Fetch state over a remote endpoint instead of starting from an empty state.
     ///
     /// If you want to fetch state from a specific block number, see --fork-block-number.
-    #[arg(long, short, visible_alias = "rpc-url", env = "ETH_RPC_URL", value_name = "URL")]
+    #[arg(long, short, visible_alias = "rpc-url", value_name = "URL")]
     #[serde(rename = "eth_rpc_url", skip_serializing_if = "Option::is_none")]
     pub fork_url: Option<String>,
 


### PR DESCRIPTION
Reverts foundry-rs/foundry#8972

This PR changed the meaning of the `ETH_RPC_URL` environment variable from just an RPC that gets used when needed, to always fork mode in anvil and tests, which is too big a breaking change.

Fixes https://github.com/foundry-rs/foundry/issues/11322.