### PR TITLE
fix: disable tx gas limit cap

### DIFF
--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -92,5 +92,7 @@ pub fn configure_env(chain_id: u64, memory_limit: u64, disable_block_gas_limit: 
     cfg.disable_eip3607 = true;
     cfg.disable_block_gas_limit = disable_block_gas_limit;
     cfg.disable_nonce_check = true;
+    // For Osaka EIP-7825
+    cfg.tx_gas_limit_cap = Some(u64::MAX);
     cfg
 }


### PR DESCRIPTION
disables EIP-7825 gas limit cap by default

osaka is upcoming so we can bypass this entirely for the time being, but ideally this is also made a setting