### PR TITLE
fix: force 4844 txtype in blobhashes setter

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -8,6 +8,7 @@ use crate::{
 use alloy_consensus::TxEnvelope;
 use alloy_dyn_abi::{DynSolType, DynSolValue};
 use alloy_genesis::{Genesis, GenesisAccount};
+use alloy_network::eip2718::EIP4844_TX_TYPE_ID;
 use alloy_primitives::{Address, B256, U256, hex, map::HashMap};
 use alloy_rlp::Decodable;
 use alloy_sol_types::SolValue;
@@ -542,6 +543,8 @@ impl Cheatcode for blobhashesCall {
              see EIP-4844: https://eips.ethereum.org/EIPS/eip-4844"
         );
         ccx.ecx.tx.blob_hashes.clone_from(hashes);
+        // force this as 4844 txtype
+        ccx.ecx.tx.tx_type = EIP4844_TX_TYPE_ID;
         Ok(Default::default())
     }
 }

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -416,3 +416,6 @@ test_repro!(10586);
 
 // https://github.com/foundry-rs/foundry/issues/10957
 test_repro!(10957);
+
+// https://github.com/foundry-rs/foundry/issues/11353
+test_repro!(11353);

--- a/testdata/default/repros/Issue11353.t.sol
+++ b/testdata/default/repros/Issue11353.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract Blobhash {
+    function getIndices(uint256[] calldata blobIndices) public view returns (bytes32[] memory) {
+        bytes32[] memory blobHashes = new bytes32[](blobIndices.length);
+        for (uint256 i = 0; i < blobIndices.length; i++) {
+            uint256 blobIndex = blobIndices[i];
+            bytes32 blobHash = blobhash(blobIndex);
+            require(blobHash != 0, "blob not found");
+            blobHashes[i] = blobHash;
+        }
+        return blobHashes;
+    }
+}
+
+// https://github.com/foundry-rs/foundry/issues/11353
+contract Issue11353Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    Blobhash public blobhashContract;
+
+    function setUp() public {
+        blobhashContract = new Blobhash();
+    }
+
+    function test_blobhashes() public {
+        uint256[] memory blobIndices = new uint256[](1);
+        blobIndices[0] = 0;
+
+        bytes32[] memory blobHashes = new bytes32[](1);
+        blobHashes[0] = keccak256(abi.encode(0));
+        vm.blobhashes(blobHashes);
+
+        vm.assertEq(blobhashContract.getIndices(blobIndices), blobHashes);
+    }
+}


### PR DESCRIPTION
closes #11353

revm has a new check for txtype before returning the blobhash

this forces the tx to 4844 when we set blobhashes