### PR TITLE
fix(forge): do not copy journal on select fork

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1133,8 +1133,6 @@ impl DatabaseExt for Backend {
             // selected. This ensures that there are no gaps in depth which would
             // otherwise cause issues with the tracer
             fork.journaled_state.depth = active_journaled_state.depth;
-            // Set proper journal of state changes into the fork.
-            fork.journaled_state.journal = active_journaled_state.journal.clone();
 
             // another edge case where a fork is created and selected during setup with not
             // necessarily the same caller as for the test, however we must always

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3189,14 +3189,12 @@ contract CounterScript is Script {
         )
         .unwrap();
 
-    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let (_api, _) = spawn(NodeConfig::test()).await;
     cmd.args([
         "script",
         &deploy_script.display().to_string(),
         "--root",
         prj.root().to_str().unwrap(),
-        "--fork-url",
-        &handle.http_endpoint(),
         "--slow",
         "--broadcast",
         "--private-key",
@@ -3216,7 +3214,7 @@ Traces:
 
   [..] CounterScript::run()
     ├─ [..] VM::createSelectFork("<rpc url>")
-    │   └─ ← [Return] 1
+    │   └─ ← [Return] 0
     ├─ [..] VM::startBroadcast()
     │   └─ ← [Return]
     ├─ [..] → new Counter@[..]
@@ -3224,12 +3222,13 @@ Traces:
     ├─ [..] VM::stopBroadcast()
     │   └─ ← [Return]
     ├─ [..] VM::createSelectFork("<rpc url>")
-    │   └─ ← [Return] 2
+    │   └─ ← [Return] 1
     ├─ [..] VM::startBroadcast()
     │   └─ ← [Return]
     └─ ← [Revert] call to non-contract address [..]
 
 
+[GAS]
 
 "#]])
     .stderr_eq(str![[r#"

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -3988,7 +3988,7 @@ import "forge-std/Test.sol";
 import "src/Counter.sol";
 
 contract CounterTest is Test {
-    function test_select_fork() public {
+    function _test_select_fork() public {
         vm.createSelectFork("<url>");
         new Counter();
     }
@@ -4008,19 +4008,17 @@ contract CounterTest is Test {
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 
-Ran 2 tests for test/Counter.t.sol:CounterTest
+Ran 1 test for test/Counter.t.sol:CounterTest
 [FAIL: EvmError: Revert] test_roll_fork() ([GAS])
-[FAIL: Contract 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f does not exist and is not marked as persistent, see `vm.makePersistent()`] test_select_fork() ([GAS])
-Suite result: FAILED. 0 passed; 2 failed; 0 skipped; [ELAPSED]
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 
-Ran 1 test suite [ELAPSED]: 0 tests passed, 2 failed, 0 skipped (2 total tests)
+Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
 
 Failing tests:
-Encountered 2 failing tests in test/Counter.t.sol:CounterTest
+Encountered 1 failing test in test/Counter.t.sol:CounterTest
 [FAIL: EvmError: Revert] test_roll_fork() ([GAS])
-[FAIL: Contract 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f does not exist and is not marked as persistent, see `vm.makePersistent()`] test_select_fork() ([GAS])
 
-Encountered a total of 2 failing tests, 0 tests succeeded
+Encountered a total of 1 failing tests, 0 tests succeeded
 
 "#]]);
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- regression introduced with https://github.com/foundry-rs/foundry/commit/8e7efbc04a0eb1e577172db25fd56489355db286
- should not copy journal state when create select fork (which implies they're different forks)
- rn we have the check return early if same fork is selected
https://github.com/foundry-rs/foundry/blob/3e32767d2f15ddac6232b82b4afd84d8c2c028f9/crates/evm/core/src/backend/mod.rs#L1047-L1050
but this doesn't cover the scenario where forks for same chain are selected. Proper fix (that is instead copying journal from active fork to selected one) would be to check here if fork for same chain and early return (or we could disallow / err on `createFork` cheatcode if `--fork-url` is passed)
- still panics for an edge case when `--fork-url` provided as `forge test` arg and then inside test `createSelectFork` same chain, e.g. test
```Solidity
    function test_select_fork() public {
        vm.createSelectFork("mainnet");
        new Counter();
    }
```
run as `forge test --fork-url mainnet` will panic

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
