### PR TITLE
fix(invariant): ensure strategy always generates valid sender

### DIFF
--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -99,7 +99,10 @@ fn select_random_sender(
         ]
         .prop_map(move |addr| {
             let mut addr = addr.as_address().unwrap();
-            // Make sure the selected address is not in list of excluded senders.
+            // Make sure the selected address is not in the list of excluded senders.
+            // We don't use proptest's filter to avoid reaching the `PROPTEST_MAX_LOCAL_REJECTS`
+            // max rejects and exiting test before all runs completes.
+            // See <https://github.com/foundry-rs/foundry/issues/11369>.
             loop {
                 if !senders.excluded.contains(&addr) {
                     break;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes https://github.com/foundry-rs/foundry/issues/11369 
- in v1.2.3 (with proptest runner), the test just stops if `PROPTEST_MAX_LOCAL_REJECTS` is  reached and is not considered a failure - this doesn't perform all expected runs. In v1.3.0 proptest strategy will stop generate new values and it is reported as a failure
- ensure sender address generated by strategy is always valid, so `PROPTEST_MAX_LOCAL_REJECTS` is never reached and all runs performed as expected
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
