### PR TITLE
Remove unnecessary `unsafe` block around `std::env::set_var`

### DIFF
--- a/crates/cli/src/handler.rs
+++ b/crates/cli/src/handler.rs
@@ -80,9 +80,7 @@ impl EyreHandler for Handler {
 /// Panics are always caught by the more debug-centric handler.
 pub fn install() {
     if std::env::var_os("RUST_BACKTRACE").is_none() {
-        unsafe {
-            std::env::set_var("RUST_BACKTRACE", "1");
-        }
+        std::env::set_var("RUST_BACKTRACE", "1");
     }
 
     let panic_section =


### PR DESCRIPTION


## Description

Removed the unnecessary `unsafe` block around `std::env::set_var("RUST_BACKTRACE", "1")` in the error handler installation function. The `std::env::set_var` function is safe and doesn't require an `unsafe` block.

This change eliminates an anti-pattern without affecting the functionality - the environment variable is still set correctly when needed.