### PR TITLE
allowing the option of choosing between "input" and "data" field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ dependencies = [
  "foundry-evm-core",
  "foundry-test-utils",
  "futures",
- "hyper",
+ "hyper 1.7.0",
  "itertools 0.14.0",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
@@ -1482,11 +1482,63 @@ dependencies = [
 
 [[package]]
 name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term 0.7.0",
+]
+
+[[package]]
+name = "ascii-canvas"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
 dependencies = [
- "term",
+ "term 1.1.0",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1505,12 +1557,143 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.0.8",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
 name = "async-priority-channel"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acde96f444d31031f760c5c43dc786b97d3e1cb2ee49dd06898383fe9a999758"
 dependencies = [
- "event-listener",
+ "event-listener 4.0.3",
+]
+
+[[package]]
+name = "async-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix 1.0.8",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.0.8",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1534,6 +1717,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1847,7 +2036,7 @@ dependencies = [
  "aws-smithy-types",
  "h2",
  "http 1.3.1",
- "hyper",
+ "hyper 1.7.0",
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
@@ -1989,7 +2178,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -2088,6 +2277,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop 0.20.2",
+ "lalrpop-util 0.20.2",
+ "regex",
+]
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,12 +2324,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -2197,6 +2412,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -2554,6 +2782,7 @@ dependencies = [
  "foundry-test-utils",
  "foundry-wallets",
  "futures",
+ "httpmock",
  "itertools 0.14.0",
  "op-alloy-consensus",
  "op-alloy-flz",
@@ -3564,6 +3793,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3571,8 +3810,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -3857,12 +4107,39 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -3989,6 +4266,12 @@ dependencies = [
  "rustc-hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -4869,8 +5152,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9645e75b89f977423690f3b4bfd8d84825e5fdabd7803cbce6d4a2c4d54972b4"
 dependencies = [
  "itertools 0.14.0",
- "lalrpop",
- "lalrpop-util",
+ "lalrpop 0.22.2",
+ "lalrpop-util 0.22.2",
  "phf",
  "thiserror 2.0.16",
  "unicode-xid",
@@ -5018,6 +5301,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5074,7 +5370,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "hyper",
+ "hyper 1.7.0",
  "jsonwebtoken",
  "once_cell",
  "prost 0.13.5",
@@ -5167,6 +5463,18 @@ dependencies = [
  "log",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5414,6 +5722,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5443,7 +5802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -5460,7 +5819,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5480,7 +5839,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper",
+ "hyper 1.7.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -5931,6 +6290,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -6104,24 +6472,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas 3.0.0",
+ "bit-set 0.5.3",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util 0.20.2",
+ "petgraph 0.6.5",
+ "pico-args",
+ "regex",
+ "regex-syntax 0.8.5",
+ "string_cache",
+ "term 0.7.0",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
 dependencies = [
- "ascii-canvas",
- "bit-set",
+ "ascii-canvas 4.0.0",
+ "bit-set 0.8.0",
  "ena",
  "itertools 0.14.0",
- "lalrpop-util",
- "petgraph",
+ "lalrpop-util 0.22.2",
+ "petgraph 0.7.1",
  "regex",
  "regex-syntax 0.8.5",
  "sha3",
  "string_cache",
- "term",
+ "term 1.1.0",
  "unicode-xid",
  "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata 0.4.9",
 ]
 
 [[package]]
@@ -7207,6 +7615,16 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.10.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
@@ -7279,6 +7697,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7331,6 +7755,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7345,6 +7780,20 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polling"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.0.8",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "pollster"
@@ -7908,6 +8357,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -8014,7 +8474,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -8855,6 +9315,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9685,6 +10155,17 @@ dependencies = [
 
 [[package]]
 name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
+name = "term"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a43bddab41f8626c7bdaab872bbba75f8df5847b516d77c569c746e2ae5eb746"
@@ -10081,7 +10562,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7620,7 +7620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
 ]
 
 [[package]]
@@ -7629,7 +7629,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "indexmap 2.11.0",
 ]
 
@@ -7976,8 +7976,8 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.9.3",
  "lazy_static",
  "num-traits",

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -90,6 +90,7 @@ evmole.workspace = true
 anvil.workspace = true
 foundry-test-utils.workspace = true
 alloy-hardforks.workspace = true
+httpmock = "0.7.0-rc.1"
 
 [features]
 default = ["jemalloc"]

--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -41,23 +41,17 @@ pub struct AccessListArgs {
 
     #[command(flatten)]
     eth: EthereumOpts,
-
-    /// When calling an RPC with optionally an "input" or a "data" field,
-    /// by default both are populated.  Set this to populate one or the
-    /// other.
-    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
-    pub use_explicit_data_field: Option<String>,
 }
 
 impl AccessListArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { to, sig, args, tx, eth, block, use_explicit_data_field } = self;
+        let Self { to, sig, args, tx, eth, block } = self;
 
         let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
         let sender = SenderKind::from_wallet_opts(eth.wallet).await?;
 
-        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, use_explicit_data_field)
+        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, Option::None)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -41,17 +41,23 @@ pub struct AccessListArgs {
 
     #[command(flatten)]
     eth: EthereumOpts,
+
+    /// When calling an RPC with optionally an "input" or a "data" field,
+    /// by default both are populated.  Set this to populate one or the
+    /// other.
+    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
+    pub use_explicit_data_field: Option<String>,
 }
 
 impl AccessListArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { to, sig, args, tx, eth, block } = self;
+        let Self { to, sig, args, tx, eth, block, use_explicit_data_field } = self;
 
         let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
         let sender = SenderKind::from_wallet_opts(eth.wallet).await?;
 
-        let (tx, _) = CastTxBuilder::new(&provider, tx, &config)
+        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, use_explicit_data_field)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -1,6 +1,6 @@
 use crate::{
     Cast,
-    tx::{CastTxBuilder, SenderKind, TxDataField},
+    tx::{CastTxBuilder, SenderKind, TransactionInputKind},
 };
 use alloy_ens::NameOrAddress;
 use alloy_rpc_types::BlockId;
@@ -46,19 +46,19 @@ pub struct AccessListArgs {
     /// by default both are populated.  Set this to populate one or the
     /// other.  Some nodes do not allow both to exist, hardhat "fork a network"
     /// is an example.
-    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
-    pub use_explicit_data_field: Option<TxDataField>,
+    #[arg(long = "transaction-input-kind", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
+    pub transaction_input_kind: Option<TransactionInputKind>,
 }
 
 impl AccessListArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { to, sig, args, tx, eth, block, use_explicit_data_field } = self;
+        let Self { to, sig, args, tx, eth, block, transaction_input_kind } = self;
 
         let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
         let sender = SenderKind::from_wallet_opts(eth.wallet).await?;
 
-        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, use_explicit_data_field)
+        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, transaction_input_kind)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -41,17 +41,24 @@ pub struct AccessListArgs {
 
     #[command(flatten)]
     eth: EthereumOpts,
+
+    /// When calling an RPC with optionally an "input" or a "data" field,
+    /// by default both are populated.  Set this to populate one or the
+    /// other.  Some nodes do not allow both to exist, hardhat "fork a network"
+    /// is an example.
+    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
+    pub use_explicit_data_field: Option<TxDataField>,
 }
 
 impl AccessListArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { to, sig, args, tx, eth, block } = self;
+        let Self { to, sig, args, tx, eth, block, use_explicit_data_field } = self;
 
         let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
         let sender = SenderKind::from_wallet_opts(eth.wallet).await?;
 
-        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, Some(TxDataField::Both))
+        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, use_explicit_data_field)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -1,6 +1,6 @@
 use crate::{
     Cast,
-    tx::{CastTxBuilder, SenderKind},
+    tx::{CastTxBuilder, SenderKind, TxDataField},
 };
 use alloy_ens::NameOrAddress;
 use alloy_rpc_types::BlockId;
@@ -51,7 +51,7 @@ impl AccessListArgs {
         let provider = utils::get_provider(&config)?;
         let sender = SenderKind::from_wallet_opts(eth.wallet).await?;
 
-        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, Option::None)
+        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, Some(TxDataField::Both))
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -1,7 +1,7 @@
 use crate::{
     Cast,
     traces::TraceKind,
-    tx::{CastTxBuilder, SenderKind},
+    tx::{CastTxBuilder, SenderKind, TxDataField},
 };
 use alloy_ens::NameOrAddress;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
@@ -170,7 +170,7 @@ pub struct CallArgs {
     /// by default both are populated.  Set this to populate one or the
     /// other.
     #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
-    pub use_explicit_data_field: Option<String>,
+    pub use_explicit_data_field: Option<TxDataField>,
 }
 
 #[derive(Debug, Parser)]

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -1,7 +1,7 @@
 use crate::{
     Cast,
     traces::TraceKind,
-    tx::{CastTxBuilder, SenderKind, TxDataField},
+    tx::{CastTxBuilder, SenderKind, TransactionInputKind},
 };
 use alloy_ens::NameOrAddress;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
@@ -170,8 +170,8 @@ pub struct CallArgs {
     /// by default both are populated.  Set this to populate one or the
     /// other.  Some nodes do not allow both to exist, hardhat "fork a network"
     /// is an example.
-    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
-    pub use_explicit_data_field: Option<TxDataField>,
+    #[arg(long = "transaction-input-kind", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
+    pub transaction_input_kind: Option<TransactionInputKind>,
 }
 
 #[derive(Debug, Parser)]
@@ -223,7 +223,7 @@ impl CallArgs {
             data,
             with_local_artifacts,
             disable_labels,
-            use_explicit_data_field,
+            transaction_input_kind,
             ..
         } = self;
 
@@ -252,7 +252,7 @@ impl CallArgs {
             None
         };
 
-        let (tx, func) = CastTxBuilder::new(&provider, tx, &config, use_explicit_data_field)
+        let (tx, func) = CastTxBuilder::new(&provider, tx, &config, transaction_input_kind)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -168,7 +168,8 @@ pub struct CallArgs {
 
     /// When calling an RPC with optionally an "input" or a "data" field,
     /// by default both are populated.  Set this to populate one or the
-    /// other.
+    /// other.  Some nodes do not allow both to exist, hardhat "fork a network"
+    /// is an example.
     #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
     pub use_explicit_data_field: Option<TxDataField>,
 }

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -165,6 +165,12 @@ pub struct CallArgs {
     /// Override the block number.
     #[arg(long = "block.number", value_name = "NUMBER")]
     pub block_number: Option<u64>,
+
+    /// When calling an RPC with optionally an "input" or a "data" field,
+    /// by default both are populated.  Set this to populate one or the
+    /// other.
+    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
+    pub use_explicit_data_field: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -216,6 +222,7 @@ impl CallArgs {
             data,
             with_local_artifacts,
             disable_labels,
+            use_explicit_data_field,
             ..
         } = self;
 
@@ -244,7 +251,7 @@ impl CallArgs {
             None
         };
 
-        let (tx, func) = CastTxBuilder::new(&provider, tx, &config)
+        let (tx, func) = CastTxBuilder::new(&provider, tx, &config, use_explicit_data_field)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/estimate.rs
+++ b/crates/cast/src/cmd/estimate.rs
@@ -45,6 +45,12 @@ pub struct EstimateArgs {
 
     #[command(flatten)]
     eth: EthereumOpts,
+
+    /// When calling an RPC with optionally an "input" or a "data" field,
+    /// by default both are populated.  Set this to populate one or the
+    /// other.
+    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
+    pub use_explicit_data_field: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -74,7 +80,7 @@ pub enum EstimateSubcommands {
 
 impl EstimateArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { to, mut sig, mut args, mut tx, block, cost, eth, command } = self;
+        let Self { to, mut sig, mut args, mut tx, block, cost, eth, command, use_explicit_data_field } = self;
 
         let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
@@ -97,7 +103,7 @@ impl EstimateArgs {
             None
         };
 
-        let (tx, _) = CastTxBuilder::new(&provider, tx, &config)
+        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, use_explicit_data_field)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/estimate.rs
+++ b/crates/cast/src/cmd/estimate.rs
@@ -45,12 +45,6 @@ pub struct EstimateArgs {
 
     #[command(flatten)]
     eth: EthereumOpts,
-
-    /// When calling an RPC with optionally an "input" or a "data" field,
-    /// by default both are populated.  Set this to populate one or the
-    /// other.
-    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
-    pub use_explicit_data_field: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -80,7 +74,7 @@ pub enum EstimateSubcommands {
 
 impl EstimateArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { to, mut sig, mut args, mut tx, block, cost, eth, command, use_explicit_data_field } = self;
+        let Self { to, mut sig, mut args, mut tx, block, cost, eth, command } = self;
 
         let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
@@ -103,7 +97,7 @@ impl EstimateArgs {
             None
         };
 
-        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, use_explicit_data_field)
+        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, Option::None)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/estimate.rs
+++ b/crates/cast/src/cmd/estimate.rs
@@ -1,4 +1,4 @@
-use crate::tx::{CastTxBuilder, SenderKind};
+use crate::tx::{CastTxBuilder, SenderKind, TxDataField};
 use alloy_ens::NameOrAddress;
 use alloy_primitives::U256;
 use alloy_provider::Provider;
@@ -97,7 +97,7 @@ impl EstimateArgs {
             None
         };
 
-        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, Option::None)
+        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, Some(TxDataField::Both))
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/estimate.rs
+++ b/crates/cast/src/cmd/estimate.rs
@@ -1,4 +1,4 @@
-use crate::tx::{CastTxBuilder, SenderKind, TxDataField};
+use crate::tx::{CastTxBuilder, SenderKind, TransactionInputKind};
 use alloy_ens::NameOrAddress;
 use alloy_primitives::U256;
 use alloy_provider::Provider;
@@ -50,8 +50,8 @@ pub struct EstimateArgs {
     /// by default both are populated.  Set this to populate one or the
     /// other.  Some nodes do not allow both to exist, hardhat "fork a network"
     /// is an example.
-    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
-    pub use_explicit_data_field: Option<TxDataField>,
+    #[arg(long = "transaction-input-kind", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
+    pub transaction_input_kind: Option<TransactionInputKind>,
 }
 
 #[derive(Debug, Parser)]
@@ -81,7 +81,7 @@ pub enum EstimateSubcommands {
 
 impl EstimateArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { to, mut sig, mut args, mut tx, block, cost, eth, command, use_explicit_data_field } = self;
+        let Self { to, mut sig, mut args, mut tx, block, cost, eth, command, transaction_input_kind } = self;
 
         let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
@@ -104,7 +104,7 @@ impl EstimateArgs {
             None
         };
 
-        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, use_explicit_data_field)
+        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, transaction_input_kind)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/estimate.rs
+++ b/crates/cast/src/cmd/estimate.rs
@@ -45,6 +45,13 @@ pub struct EstimateArgs {
 
     #[command(flatten)]
     eth: EthereumOpts,
+
+    /// When calling an RPC with optionally an "input" or a "data" field,
+    /// by default both are populated.  Set this to populate one or the
+    /// other.  Some nodes do not allow both to exist, hardhat "fork a network"
+    /// is an example.
+    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
+    pub use_explicit_data_field: Option<TxDataField>,
 }
 
 #[derive(Debug, Parser)]
@@ -74,7 +81,7 @@ pub enum EstimateSubcommands {
 
 impl EstimateArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { to, mut sig, mut args, mut tx, block, cost, eth, command } = self;
+        let Self { to, mut sig, mut args, mut tx, block, cost, eth, command, use_explicit_data_field } = self;
 
         let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
@@ -97,7 +104,7 @@ impl EstimateArgs {
             None
         };
 
-        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, Some(TxDataField::Both))
+        let (tx, _) = CastTxBuilder::new(&provider, tx, &config, use_explicit_data_field)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -59,7 +59,8 @@ pub struct MakeTxArgs {
 
     /// When calling an RPC with optionally an "input" or a "data" field,
     /// by default both are populated.  Set this to populate one or the
-    /// other.
+    /// other.  Some nodes do not allow both to exist, hardhat "fork a network"
+    /// is an example.
     #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
     pub use_explicit_data_field: Option<TxDataField>,
 }

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -56,6 +56,12 @@ pub struct MakeTxArgs {
     /// Call `eth_signTransaction` using the `--from` argument or $ETH_FROM as sender
     #[arg(long, requires = "from", conflicts_with = "raw_unsigned")]
     ethsign: bool,
+
+    /// When calling an RPC with optionally an "input" or a "data" field,
+    /// by default both are populated.  Set this to populate one or the
+    /// other.
+    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
+    pub use_explicit_data_field: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -77,7 +83,7 @@ pub enum MakeTxSubcommands {
 
 impl MakeTxArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { to, mut sig, mut args, command, tx, path, eth, raw_unsigned, ethsign } = self;
+        let Self { to, mut sig, mut args, command, tx, path, eth, raw_unsigned, ethsign, use_explicit_data_field } = self;
 
         let blob_data = if let Some(path) = path { Some(std::fs::read(path)?) } else { None };
 
@@ -98,7 +104,7 @@ impl MakeTxArgs {
 
         let provider = get_provider(&config)?;
 
-        let tx_builder = CastTxBuilder::new(&provider, tx.clone(), &config)
+        let tx_builder = CastTxBuilder::new(&provider, tx.clone(), &config, use_explicit_data_field)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -1,4 +1,4 @@
-use crate::tx::{self, CastTxBuilder};
+use crate::tx::{self, CastTxBuilder, TxDataField};
 use alloy_ens::NameOrAddress;
 use alloy_network::{EthereumWallet, TransactionBuilder, eip2718::Encodable2718};
 use alloy_primitives::{Address, hex};
@@ -61,7 +61,7 @@ pub struct MakeTxArgs {
     /// by default both are populated.  Set this to populate one or the
     /// other.
     #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
-    pub use_explicit_data_field: Option<String>,
+    pub use_explicit_data_field: Option<TxDataField>,
 }
 
 #[derive(Debug, Parser)]

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -1,4 +1,4 @@
-use crate::tx::{self, CastTxBuilder, TxDataField};
+use crate::tx::{self, CastTxBuilder, TransactionInputKind};
 use alloy_ens::NameOrAddress;
 use alloy_network::{EthereumWallet, TransactionBuilder, eip2718::Encodable2718};
 use alloy_primitives::{Address, hex};
@@ -61,8 +61,8 @@ pub struct MakeTxArgs {
     /// by default both are populated.  Set this to populate one or the
     /// other.  Some nodes do not allow both to exist, hardhat "fork a network"
     /// is an example.
-    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
-    pub use_explicit_data_field: Option<TxDataField>,
+    #[arg(long = "transaction-input-kind", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
+    pub transaction_input_kind: Option<TransactionInputKind>,
 }
 
 #[derive(Debug, Parser)]
@@ -84,7 +84,7 @@ pub enum MakeTxSubcommands {
 
 impl MakeTxArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { to, mut sig, mut args, command, tx, path, eth, raw_unsigned, ethsign, use_explicit_data_field } = self;
+        let Self { to, mut sig, mut args, command, tx, path, eth, raw_unsigned, ethsign, transaction_input_kind } = self;
 
         let blob_data = if let Some(path) = path { Some(std::fs::read(path)?) } else { None };
 
@@ -105,7 +105,7 @@ impl MakeTxArgs {
 
         let provider = get_provider(&config)?;
 
-        let tx_builder = CastTxBuilder::new(&provider, tx.clone(), &config, use_explicit_data_field)
+        let tx_builder = CastTxBuilder::new(&provider, tx.clone(), &config, transaction_input_kind)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -70,7 +70,8 @@ pub struct SendTxArgs {
 
     /// When calling an RPC with optionally an "input" or a "data" field,
     /// by default both are populated.  Set this to populate one or the
-    /// other.
+    /// other.  Some nodes do not allow both to exist, hardhat "fork a network"
+    /// is an example.
     #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
     pub use_explicit_data_field: Option<TxDataField>,
 }

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -67,6 +67,12 @@ pub struct SendTxArgs {
         help_heading = "Transaction options"
     )]
     path: Option<PathBuf>,
+
+    /// When calling an RPC with optionally an "input" or a "data" field,
+    /// by default both are populated.  Set this to populate one or the
+    /// other.
+    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
+    pub use_explicit_data_field: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -100,6 +106,7 @@ impl SendTxArgs {
             unlocked,
             path,
             timeout,
+            use_explicit_data_field
         } = self;
 
         let blob_data = if let Some(path) = path { Some(std::fs::read(path)?) } else { None };
@@ -135,7 +142,7 @@ impl SendTxArgs {
         let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
 
-        let builder = CastTxBuilder::new(&provider, tx, &config)
+        let builder = CastTxBuilder::new(&provider, tx, &config, use_explicit_data_field)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -1,6 +1,6 @@
 use crate::{
     Cast,
-    tx::{self, CastTxBuilder, TxDataField},
+    tx::{self, CastTxBuilder, TransactionInputKind},
 };
 use alloy_ens::NameOrAddress;
 use alloy_network::{AnyNetwork, EthereumWallet};
@@ -72,8 +72,8 @@ pub struct SendTxArgs {
     /// by default both are populated.  Set this to populate one or the
     /// other.  Some nodes do not allow both to exist, hardhat "fork a network"
     /// is an example.
-    #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
-    pub use_explicit_data_field: Option<TxDataField>,
+    #[arg(long = "transaction-input-kind", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
+    pub transaction_input_kind: Option<TransactionInputKind>,
 }
 
 #[derive(Debug, Parser)]
@@ -107,7 +107,7 @@ impl SendTxArgs {
             unlocked,
             path,
             timeout,
-            use_explicit_data_field
+            transaction_input_kind
         } = self;
 
         let blob_data = if let Some(path) = path { Some(std::fs::read(path)?) } else { None };
@@ -143,7 +143,7 @@ impl SendTxArgs {
         let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
 
-        let builder = CastTxBuilder::new(&provider, tx, &config, use_explicit_data_field)
+        let builder = CastTxBuilder::new(&provider, tx, &config, transaction_input_kind)
             .await?
             .with_to(to)
             .await?

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -1,6 +1,6 @@
 use crate::{
     Cast,
-    tx::{self, CastTxBuilder},
+    tx::{self, CastTxBuilder, TxDataField},
 };
 use alloy_ens::NameOrAddress;
 use alloy_network::{AnyNetwork, EthereumWallet};
@@ -72,7 +72,7 @@ pub struct SendTxArgs {
     /// by default both are populated.  Set this to populate one or the
     /// other.
     #[arg(long = "use-explicit-data-field", help_heading = "explicitly use \"input\" or \"data\" when calling an rpc where required")]
-    pub use_explicit_data_field: Option<String>,
+    pub use_explicit_data_field: Option<TxDataField>,
 }
 
 #[derive(Debug, Parser)]

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1559,7 +1559,7 @@ casttest!(estimate_explicit_data_field_input, |_prj, cmd| {
         "estimate",
         "--rpc-url",
         server.url("/").as_str(),
-        "--use-explicit-data-field",
+        "--transaction-input-kind",
         "input",
         "--create",
         "0000",
@@ -1611,7 +1611,7 @@ casttest!(estimate_explicit_data_field_data, |_prj, cmd| {
         "estimate",
         "--rpc-url",
         server.url("/").as_str(),
-        "--use-explicit-data-field",
+        "--transaction-input-kind",
         "data",
         "--create",
         "0000",
@@ -1676,7 +1676,7 @@ casttest!(access_list_explicit_data_field_input, |_prj, cmd| {
         "-33333",
         "--rpc-url",
         server.url("/").as_str(),
-        "--use-explicit-data-field",
+        "--transaction-input-kind",
         "input"
     ]).assert_success();
 
@@ -1735,7 +1735,7 @@ casttest!(access_list_explicit_data_field_data, |_prj, cmd| {
         "-33333",
         "--rpc-url",
         server.url("/").as_str(),
-        "--use-explicit-data-field",
+        "--transaction-input-kind",
         "data"
     ]).assert_success();
 
@@ -1776,7 +1776,7 @@ casttest!(mktx_explicit_data_field_input, |_prj, cmd| {
         "--priority-gas-price",
         "1000000000",
         "0x0000000000000000000000000000000000000001",
-        "--use-explicit-data-field",
+        "--transaction-input-kind",
         "input",
         "--ethsign",
         "--from",
@@ -1822,7 +1822,7 @@ casttest!(mktx_explicit_data_field_data, |_prj, cmd| {
         "--priority-gas-price",
         "1000000000",
         "0x0000000000000000000000000000000000000001",
-        "--use-explicit-data-field",
+        "--transaction-input-kind",
         "data",
         "--ethsign",
         "--from",
@@ -1852,11 +1852,11 @@ casttest!(mktx_explicit_data_field_invalid, |_prj, cmd| {
         "--priority-gas-price",
         "1000000000",
         "0x0000000000000000000000000000000000000001",
-        "--use-explicit-data-field",
+        "--transaction-input-kind",
         "blah"
     ])
     .assert_failure().stderr_eq(str![[r#"
-error: invalid value 'blah' for '--use-explicit-data-field <USE_EXPLICIT_DATA_FIELD>'
+error: invalid value 'blah' for '--transaction-input-kind <transaction_input_kind>'
   [possible values: input, data, both]
 
 For more information, try '--help'.
@@ -2749,7 +2749,7 @@ casttest!(send_eip7702_explicit_data_field_input, async |_prj, cmd| {
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
         "--rpc-url",
         server.url("/").as_str(),
-        "--use-explicit-data-field",
+        "--transaction-input-kind",
         "input",
         "--legacy"
     ])
@@ -2841,7 +2841,7 @@ casttest!(send_eip7702_explicit_data_field_data, async |_prj, cmd| {
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
         "--rpc-url",
         server.url("/").as_str(),
-        "--use-explicit-data-field",
+        "--transaction-input-kind",
         "data",
         "--legacy"
     ])
@@ -2871,11 +2871,11 @@ casttest!(send_eip7702_explicit_data_field_invalid, async |_prj, cmd| {
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
         "--rpc-url",
         server.url("/").as_str(),
-        "--use-explicit-data-field",
+        "--transaction-input-kind",
         "blah"
     ])
     .assert_failure().stderr_eq(str![[r#"
-error: invalid value 'blah' for '--use-explicit-data-field <USE_EXPLICIT_DATA_FIELD>'
+error: invalid value 'blah' for '--transaction-input-kind <transaction_input_kind>'
   [possible values: input, data, both]
 
 For more information, try '--help'.
@@ -3997,7 +3997,7 @@ casttest!(cast_call_explicit_data_field_input, |_prj, cmd| {
         "0x0000000000000000000000000000000000000000",
         "--rpc-url",
         server.url("/").as_str(),
-        "--use-explicit-data-field",
+        "--transaction-input-kind",
         "input",
     ])
     .assert_success();
@@ -4045,7 +4045,7 @@ casttest!(cast_call_explicit_data_field_data, |_prj, cmd| {
         "0x0000000000000000000000000000000000000000",
         "--rpc-url",
         server.url("/").as_str(),
-        "--use-explicit-data-field",
+        "--transaction-input-kind",
         "data",
     ])
     .assert_success();
@@ -4069,11 +4069,11 @@ casttest!(cast_call_explicit_data_field_invalid, |_prj, cmd| {
         "0x0000000000000000000000000000000000000000",
         "--rpc-url",
         server.url("/").as_str(),
-        "--use-explicit-data-field",
+        "--transaction-input-kind",
         "blah",
     ])
     .assert_failure().stderr_eq(str![[r#"
-error: invalid value 'blah' for '--use-explicit-data-field <USE_EXPLICIT_DATA_FIELD>'
+error: invalid value 'blah' for '--transaction-input-kind <transaction_input_kind>'
   [possible values: input, data, both]
 
 For more information, try '--help'.

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1624,7 +1624,10 @@ casttest!(mktx_explicit_data_field_invalid, |_prj, cmd| {
         "blah"
     ])
     .assert_failure().stderr_eq(str![[r#"
-Error: invalid value for data field: blah
+error: invalid value 'blah' for '--use-explicit-data-field <USE_EXPLICIT_DATA_FIELD>'
+  [possible values: input, data, both]
+
+For more information, try '--help'.
 
 "#]]);
 });
@@ -2630,7 +2633,10 @@ casttest!(send_eip7702_explicit_data_field_invalid, async |_prj, cmd| {
         "blah"
     ])
     .assert_failure().stderr_eq(str![[r#"
-Error: invalid value for data field: blah
+error: invalid value 'blah' for '--use-explicit-data-field <USE_EXPLICIT_DATA_FIELD>'
+  [possible values: input, data, both]
+
+For more information, try '--help'.
 
 "#]]);
 });
@@ -3815,7 +3821,10 @@ casttest!(cast_call_explicit_data_field_invalid, |_prj, cmd| {
         "blah",
     ])
     .assert_failure().stderr_eq(str![[r#"
-Error: invalid value for data field: blah
+error: invalid value 'blah' for '--use-explicit-data-field <USE_EXPLICIT_DATA_FIELD>'
+  [possible values: input, data, both]
+
+For more information, try '--help'.
 
 "#]]);
 });

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1423,6 +1423,60 @@ access list:
 "#]]);
 });
 
+casttest!(access_list_explicit_data_field_input, |_prj, cmd| {
+    let rpc = next_http_rpc_endpoint();
+    cmd.args([
+        "access-list",
+        "0xbb2b8038a1640196fbe3e38816f3e67cba72d940",
+        "skim(address)",
+        "0xbb2b8038a1640196fbe3e38816f3e67cba72d940",
+        "--rpc-url",
+        rpc.as_str(),
+        "--gas-limit", // need to set this for alchemy.io to avoid "intrinsic gas too low" error
+        "100000",
+        "--use-explicit-data-field",
+        "input"
+    ])
+    .assert_success();
+});
+
+casttest!(access_list_explicit_data_field_data, |_prj, cmd| {
+    let rpc = next_http_rpc_endpoint();
+    cmd.args([
+        "access-list",
+        "0xbb2b8038a1640196fbe3e38816f3e67cba72d940",
+        "skim(address)",
+        "0xbb2b8038a1640196fbe3e38816f3e67cba72d940",
+        "--rpc-url",
+        rpc.as_str(),
+        "--gas-limit", // need to set this for alchemy.io to avoid "intrinsic gas too low" error
+        "100000",
+        "--use-explicit-data-field",
+        "data"
+    ])
+    .assert_success();
+});
+
+casttest!(access_list_explicit_data_field_invalid, |_prj, cmd| {
+    let rpc = next_http_rpc_endpoint();
+    cmd.args([
+        "access-list",
+        "0xbb2b8038a1640196fbe3e38816f3e67cba72d940",
+        "skim(address)",
+        "0xbb2b8038a1640196fbe3e38816f3e67cba72d940",
+        "--rpc-url",
+        rpc.as_str(),
+        "--gas-limit", // need to set this for alchemy.io to avoid "intrinsic gas too low" error
+        "100000",
+        "--use-explicit-data-field",
+        "blah"
+    ])
+    .assert_failure().stderr_eq(str![[r#"
+Error: invalid value for data field: blah
+
+"#]]);
+});
+
 casttest!(logs_topics, |_prj, cmd| {
     let rpc = next_http_archive_rpc_url();
     cmd.args([
@@ -1514,6 +1568,79 @@ casttest!(mktx, |_prj, cmd| {
         "0x0000000000000000000000000000000000000001",
     ]).assert_success().stdout_eq(str![[r#"
 0x02f86b0180843b9aca008502540be4008252089400000000000000000000000000000000000000016480c001a070d55e79ed3ac9fc8f51e78eb91fd054720d943d66633f2eb1bc960f0126b0eca052eda05a792680de3181e49bab4093541f75b49d1ecbe443077b3660c836016a
+
+"#]]);
+});
+
+casttest!(mktx_explicit_data_field_input, |_prj, cmd| {
+    cmd.args([
+        "mktx",
+        "--private-key",
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "--chain",
+        "1",
+        "--nonce",
+        "0",
+        "--value",
+        "100",
+        "--gas-limit",
+        "21000",
+        "--gas-price",
+        "10000000000",
+        "--priority-gas-price",
+        "1000000000",
+        "0x0000000000000000000000000000000000000001",
+        "--use-explicit-data-field",
+        "input"
+    ]).assert_success();
+});
+
+casttest!(mktx_explicit_data_field_data, |_prj, cmd| {
+    cmd.args([
+        "mktx",
+        "--private-key",
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "--chain",
+        "1",
+        "--nonce",
+        "0",
+        "--value",
+        "100",
+        "--gas-limit",
+        "21000",
+        "--gas-price",
+        "10000000000",
+        "--priority-gas-price",
+        "1000000000",
+        "0x0000000000000000000000000000000000000001",
+        "--use-explicit-data-field",
+        "data"
+    ]).assert_success();
+});
+
+casttest!(mktx_explicit_data_field_invalid, |_prj, cmd| {
+    cmd.args([
+        "mktx",
+        "--private-key",
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "--chain",
+        "1",
+        "--nonce",
+        "0",
+        "--value",
+        "100",
+        "--gas-limit",
+        "21000",
+        "--gas-price",
+        "10000000000",
+        "--priority-gas-price",
+        "1000000000",
+        "0x0000000000000000000000000000000000000001",
+        "--use-explicit-data-field",
+        "blah"
+    ])
+    .assert_failure().stderr_eq(str![[r#"
+Error: invalid value for data field: blah
 
 "#]]);
 });
@@ -2317,6 +2444,69 @@ casttest!(send_eip7702, async |_prj, cmd| {
         .assert_success()
         .stdout_eq(str![[r#"
 0xef010070997970c51812dc3a010c7d01b50e0d17dc79c8
+
+"#]]);
+});
+
+casttest!(send_eip7702_explicit_data_field_input, async |_prj, cmd| {
+    let (_api, handle) =
+        anvil::spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into()))).await;
+    let endpoint = handle.http_endpoint();
+
+    cmd.args([
+        "send",
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "--auth",
+        "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+        "--private-key",
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        "--rpc-url",
+        &endpoint,
+        "--use-explicit-data-field",
+        "input"
+    ])
+    .assert_success();
+});
+
+casttest!(send_eip7702_explicit_data_field_data, async |_prj, cmd| {
+    let (_api, handle) =
+        anvil::spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into()))).await;
+    let endpoint = handle.http_endpoint();
+
+    cmd.args([
+        "send",
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "--auth",
+        "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+        "--private-key",
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        "--rpc-url",
+        &endpoint,
+        "--use-explicit-data-field",
+        "data"
+    ])
+    .assert_success();
+});
+
+casttest!(send_eip7702_explicit_data_field_invalid, async |_prj, cmd| {
+    let (_api, handle) =
+        anvil::spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into()))).await;
+    let endpoint = handle.http_endpoint();
+
+    cmd.args([
+        "send",
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "--auth",
+        "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+        "--private-key",
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        "--rpc-url",
+        &endpoint,
+        "--use-explicit-data-field",
+        "blah"
+    ])
+    .assert_failure().stderr_eq(str![[r#"
+Error: invalid value for data field: blah
 
 "#]]);
 });
@@ -3395,6 +3585,48 @@ Warning: Contract code is empty
 "#]]);
 });
 
+casttest!(cast_call_explicit_data_field_input, |_prj, cmd| {
+    let eth_rpc_url = next_http_rpc_endpoint();
+    cmd.args([
+        "call",
+        "0x0000000000000000000000000000000000000000",
+        "--rpc-url",
+        eth_rpc_url.as_str(),
+        "--use-explicit-data-field",
+        "input",
+    ])
+    .assert_success();
+});
+
+casttest!(cast_call_explicit_data_field_data, |_prj, cmd| {
+    let eth_rpc_url = next_http_rpc_endpoint();
+    cmd.args([
+        "call",
+        "0x0000000000000000000000000000000000000000",
+        "--rpc-url",
+        eth_rpc_url.as_str(),
+        "--use-explicit-data-field",
+        "data",
+    ])
+    .assert_success();
+});
+
+casttest!(cast_call_explicit_data_field_invalid, |_prj, cmd| {
+    let eth_rpc_url = next_http_rpc_endpoint();
+    cmd.args([
+        "call",
+        "0x0000000000000000000000000000000000000000",
+        "--rpc-url",
+        eth_rpc_url.as_str(),
+        "--use-explicit-data-field",
+        "blah",
+    ])
+    .assert_failure().stderr_eq(str![[r#"
+Error: invalid value for data field: blah
+
+"#]]);
+});
+
 // <https://github.com/foundry-rs/foundry/issues/10740>
 casttest!(tx_raw_opstack_deposit, |_prj, cmd| {
     cmd.args([
@@ -3840,6 +4072,54 @@ casttest!(cast_estimate_negative_numbers, |_prj, cmd| {
     .assert_success();
 });
 
+casttest!(cast_estimate_explicit_data_field_input, |_prj, cmd| {
+    let rpc = next_rpc_endpoint(NamedChain::Sepolia);
+    cmd.args([
+        "estimate",
+        "0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb",
+        "rebalance(int64)",
+        "-8888",
+        "--rpc-url",
+        rpc.as_str(),
+        "--use-explicit-data-field",
+        "input"
+    ])
+    .assert_success();
+});
+
+casttest!(cast_estimate_explicit_data_field_data, |_prj, cmd| {
+    let rpc = next_rpc_endpoint(NamedChain::Sepolia);
+    cmd.args([
+        "estimate",
+        "0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb",
+        "rebalance(int64)",
+        "-8888",
+        "--rpc-url",
+        rpc.as_str(),
+        "--use-explicit-data-field",
+        "data"
+    ])
+    .assert_success();
+});
+
+casttest!(cast_estimate_explicit_data_field_invalid, |_prj, cmd| {
+    let rpc = next_rpc_endpoint(NamedChain::Sepolia);
+    cmd.args([
+        "estimate",
+        "0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb",
+        "rebalance(int64)",
+        "-8888",
+        "--rpc-url",
+        rpc.as_str(),
+        "--use-explicit-data-field",
+        "blah"
+    ])
+    .assert_failure().stderr_eq(str![[r#"
+Error: invalid value for data field: blah
+
+"#]]);
+});
+
 // Test cast mktx with negative numbers
 casttest!(cast_mktx_negative_numbers, |_prj, cmd| {
     let rpc = next_rpc_endpoint(NamedChain::Sepolia);
@@ -3871,3 +4151,4 @@ casttest!(cast_access_list_negative_numbers, |_prj, cmd| {
     ])
     .assert_success();
 });
+

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -18,6 +18,8 @@ use foundry_test_utils::{
 };
 use std::{fs, io::Write, path::Path, str::FromStr};
 
+use httpmock::prelude::*;
+
 #[macro_use]
 extern crate foundry_test_utils;
 
@@ -1423,60 +1425,6 @@ access list:
 "#]]);
 });
 
-casttest!(access_list_explicit_data_field_input, |_prj, cmd| {
-    let rpc = next_http_rpc_endpoint();
-    cmd.args([
-        "access-list",
-        "0xbb2b8038a1640196fbe3e38816f3e67cba72d940",
-        "skim(address)",
-        "0xbb2b8038a1640196fbe3e38816f3e67cba72d940",
-        "--rpc-url",
-        rpc.as_str(),
-        "--gas-limit", // need to set this for alchemy.io to avoid "intrinsic gas too low" error
-        "100000",
-        "--use-explicit-data-field",
-        "input"
-    ])
-    .assert_success();
-});
-
-casttest!(access_list_explicit_data_field_data, |_prj, cmd| {
-    let rpc = next_http_rpc_endpoint();
-    cmd.args([
-        "access-list",
-        "0xbb2b8038a1640196fbe3e38816f3e67cba72d940",
-        "skim(address)",
-        "0xbb2b8038a1640196fbe3e38816f3e67cba72d940",
-        "--rpc-url",
-        rpc.as_str(),
-        "--gas-limit", // need to set this for alchemy.io to avoid "intrinsic gas too low" error
-        "100000",
-        "--use-explicit-data-field",
-        "data"
-    ])
-    .assert_success();
-});
-
-casttest!(access_list_explicit_data_field_invalid, |_prj, cmd| {
-    let rpc = next_http_rpc_endpoint();
-    cmd.args([
-        "access-list",
-        "0xbb2b8038a1640196fbe3e38816f3e67cba72d940",
-        "skim(address)",
-        "0xbb2b8038a1640196fbe3e38816f3e67cba72d940",
-        "--rpc-url",
-        rpc.as_str(),
-        "--gas-limit", // need to set this for alchemy.io to avoid "intrinsic gas too low" error
-        "100000",
-        "--use-explicit-data-field",
-        "blah"
-    ])
-    .assert_failure().stderr_eq(str![[r#"
-Error: invalid value for data field: blah
-
-"#]]);
-});
-
 casttest!(logs_topics, |_prj, cmd| {
     let rpc = next_http_archive_rpc_url();
     cmd.args([
@@ -1573,6 +1521,17 @@ casttest!(mktx, |_prj, cmd| {
 });
 
 casttest!(mktx_explicit_data_field_input, |_prj, cmd| {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.body_contains("\"input\"");
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
     cmd.args([
         "mktx",
         "--private-key",
@@ -1591,11 +1550,29 @@ casttest!(mktx_explicit_data_field_input, |_prj, cmd| {
         "1000000000",
         "0x0000000000000000000000000000000000000001",
         "--use-explicit-data-field",
-        "input"
+        "input",
+        "--ethsign",
+        "--from",
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "--rpc-url",
+        server.url("/").as_str(),
     ]).assert_success();
+
+    mock.assert();
 });
 
 casttest!(mktx_explicit_data_field_data, |_prj, cmd| {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.body_contains("\"data\"");
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
     cmd.args([
         "mktx",
         "--private-key",
@@ -1614,8 +1591,15 @@ casttest!(mktx_explicit_data_field_data, |_prj, cmd| {
         "1000000000",
         "0x0000000000000000000000000000000000000001",
         "--use-explicit-data-field",
-        "data"
+        "data",
+        "--ethsign",
+        "--from",
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "--rpc-url",
+        server.url("/").as_str(),
     ]).assert_success();
+
+    mock.assert();
 });
 
 casttest!(mktx_explicit_data_field_invalid, |_prj, cmd| {
@@ -2449,49 +2433,189 @@ casttest!(send_eip7702, async |_prj, cmd| {
 });
 
 casttest!(send_eip7702_explicit_data_field_input, async |_prj, cmd| {
-    let (_api, handle) =
-        anvil::spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into()))).await;
-    let endpoint = handle.http_endpoint();
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.body_contains("\"input\"");
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_feeHistory"}"#);
+        then.status(200).body("
+        {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"baseFeePerGas\":[\"0xf\",\"0xf\",\"0x10\",\"0x10\",\"0x10\"],\"gasUsedRatio\":[0.25118966666666664,0.6516801944444445,0.4963136388888889,0.27054894444444444],\"baseFeePerBlobGas\":[\"0x1\",\"0x1\",\"0x1\",\"0x1\",\"0x1\"],\"blobGasUsedRatio\":[0.0,0.0,0.0,0.0],\"oldestBlock\":\"0x8fcd08\",\"reward\":[[\"0x142d\",\"0x1312d00\"],[\"0x142d\",\"0x142d\"],[\"0x2faf458\",\"0x2faf458\"],[\"0x186a0\",\"0x1312d00\"]]}}
+        ");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_sendRawTransaction"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x0000000000000000000000000000000000000000000000000000000000000000\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_getBlockByNumber"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_chainId"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_getTransactionCount"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_gasPrice"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_getTransactionReceipt"}"#);
+        then.status(200).body("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"blockNumber\":\"0xda0b2\",\"contractAddress\":null,\"cumulativeGasUsed\":\"0x51c53\",\"effectiveGasPrice\":\"0xb2d05e19\",\"from\":\"0x981504475498cddffa92afab0b1101e7154a67d8\",\"gasUsed\":\"0x51c53\",\"logs\":[{\"address\":\"0xf1815bd50389c46847f0bda824ec8da914045d14\",\"topics\":[\"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef\",\"0x000000000000000000000000981504475498cddffa92afab0b1101e7154a67d8\",\"0x0000000000000000000000002086f755a6d9254045c257ea3d382ef854849b0f\"],\"data\":\"0x000000000000000000000000000000000000000000000000000000000ba2ac8d\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x0\",\"removed\":false},{\"address\":\"0xf1815bd50389c46847f0bda824ec8da914045d14\",\"topics\":[\"0xcc16f5dbb4873280815c1ee09dbd06736cffcc184412cf7a71a0fdb75d397ca5\",\"0x0000000000000000000000002086f755a6d9254045c257ea3d382ef854849b0f\"],\"data\":\"0x000000000000000000000000000000000000000000000000000000000ba2ac8d\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x1\",\"removed\":false},{\"address\":\"0xf1815bd50389c46847f0bda824ec8da914045d14\",\"topics\":[\"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef\",\"0x0000000000000000000000002086f755a6d9254045c257ea3d382ef854849b0f\",\"0x0000000000000000000000000000000000000000000000000000000000000000\"],\"data\":\"0x000000000000000000000000000000000000000000000000000000000ba2ac8d\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x2\",\"removed\":false},{\"address\":\"0x2367325334447c5e1e0f1b3a6fb947b262f58312\",\"topics\":[\"0x61ed099e74a97a1d7f8bb0952a88ca8b7b8ebd00c126ea04671f92a81213318a\"],\"data\":\"0x00000000000000000000000041bdb4aa4a63a5b2efc531858d3118392b1a1c3d0000000000000000000000000000000000000000000000000050878007fa95f5\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x3\",\"removed\":false},{\"address\":\"0x2367325334447c5e1e0f1b3a6fb947b262f58312\",\"topics\":[\"0x07ea52d82345d6e838192107d8fd7123d9c2ec8e916cd0aad13fd2b60db24644\"],\"data\":\"0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000002000000000000000000000000a80aa110f05c9c6140018aae0c4e08a70f43350d000000000000000000000000dd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000013ec19b36f7f760000000000000000000000000000000000000000000000000013ec19b36f7f76\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x4\",\"removed\":false},{\"address\":\"0x3a73033c0b1407574c76bdbac67f126f6b4a9aa9\",\"topics\":[\"0x1ab700d4ced0c005b164c0f789fd09fcbb0156d4c2041b8a3bfbcd961cd1567f\"],\"data\":\"0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001200000000000000000000000002367325334447c5e1e0f1b3a6fb947b262f58312000000000000000000000000000000000000000000000000000000000000009c0100000000000002230000769c00000000000000000000000088853d410299bcbfe5fcc9eef93c03115e9082790000759e00000000000000000000000019cfce47ed54a88614648dc3f19a5980097007dde570ed2f827a5913fb8d84a16f1a6014d5bcd2212791b9ce0643f45ed9989a3e010001000000000000000000000000981504475498cddffa92afab0b1101e7154a67d8000000000ba0e306000000000000000000000000000000000000000000000000000000000000000000000016000301001101000000000000000000000000000249f000000000000000000000\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x5\",\"removed\":false},{\"address\":\"0x2086f755a6d9254045c257ea3d382ef854849b0f\",\"topics\":[\"0x85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a\",\"0xe570ed2f827a5913fb8d84a16f1a6014d5bcd2212791b9ce0643f45ed9989a3e\",\"0x000000000000000000000000981504475498cddffa92afab0b1101e7154a67d8\"],\"data\":\"0x000000000000000000000000000000000000000000000000000000000000759e000000000000000000000000000000000000000000000000000000000ba2ac8d000000000000000000000000000000000000000000000000000000000ba0e306\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x6\",\"removed\":false}],\"logsBloom\":\"0x00000000000000000100000000000100000000000000001000000000000000000000000000000000000000400200000000000000000000000000000000000000000002000000800000000108000000000000000000000000000000000000000000000000020200008000000000000800080010000000000800010010000000000000000000000000000000081000000000000000200000000000000000200000000000008000000000100100000000000000002000600000000440000000008080000083000000000000000080000000000000000000000000000000000020000000040001000000000000000000002000000000008000000000000000000000\",\"status\":\"0x1\",\"to\":\"0x2086f755a6d9254045c257ea3d382ef854849b0f\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"type\":\"0x2\"}}");
+    });
+
 
     cmd.args([
         "send",
         "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-        "--auth",
-        "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
         "--private-key",
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
         "--rpc-url",
-        &endpoint,
+        server.url("/").as_str(),
         "--use-explicit-data-field",
-        "input"
+        "input",
+        "--legacy"
     ])
     .assert_success();
+
+    // assert the the expected mock with the included field was called
+    mock.assert();
 });
 
 casttest!(send_eip7702_explicit_data_field_data, async |_prj, cmd| {
-    let (_api, handle) =
-        anvil::spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into()))).await;
-    let endpoint = handle.http_endpoint();
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.body_contains("\"data\"");
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_feeHistory"}"#);
+        then.status(200).body("
+        {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"baseFeePerGas\":[\"0xf\",\"0xf\",\"0x10\",\"0x10\",\"0x10\"],\"gasUsedRatio\":[0.25118966666666664,0.6516801944444445,0.4963136388888889,0.27054894444444444],\"baseFeePerBlobGas\":[\"0x1\",\"0x1\",\"0x1\",\"0x1\",\"0x1\"],\"blobGasUsedRatio\":[0.0,0.0,0.0,0.0],\"oldestBlock\":\"0x8fcd08\",\"reward\":[[\"0x142d\",\"0x1312d00\"],[\"0x142d\",\"0x142d\"],[\"0x2faf458\",\"0x2faf458\"],[\"0x186a0\",\"0x1312d00\"]]}}
+        ");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_sendRawTransaction"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x0000000000000000000000000000000000000000000000000000000000000000\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_getBlockByNumber"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_chainId"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_getTransactionCount"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_gasPrice"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_getTransactionReceipt"}"#);
+        then.status(200).body("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"blockNumber\":\"0xda0b2\",\"contractAddress\":null,\"cumulativeGasUsed\":\"0x51c53\",\"effectiveGasPrice\":\"0xb2d05e19\",\"from\":\"0x981504475498cddffa92afab0b1101e7154a67d8\",\"gasUsed\":\"0x51c53\",\"logs\":[{\"address\":\"0xf1815bd50389c46847f0bda824ec8da914045d14\",\"topics\":[\"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef\",\"0x000000000000000000000000981504475498cddffa92afab0b1101e7154a67d8\",\"0x0000000000000000000000002086f755a6d9254045c257ea3d382ef854849b0f\"],\"data\":\"0x000000000000000000000000000000000000000000000000000000000ba2ac8d\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x0\",\"removed\":false},{\"address\":\"0xf1815bd50389c46847f0bda824ec8da914045d14\",\"topics\":[\"0xcc16f5dbb4873280815c1ee09dbd06736cffcc184412cf7a71a0fdb75d397ca5\",\"0x0000000000000000000000002086f755a6d9254045c257ea3d382ef854849b0f\"],\"data\":\"0x000000000000000000000000000000000000000000000000000000000ba2ac8d\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x1\",\"removed\":false},{\"address\":\"0xf1815bd50389c46847f0bda824ec8da914045d14\",\"topics\":[\"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef\",\"0x0000000000000000000000002086f755a6d9254045c257ea3d382ef854849b0f\",\"0x0000000000000000000000000000000000000000000000000000000000000000\"],\"data\":\"0x000000000000000000000000000000000000000000000000000000000ba2ac8d\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x2\",\"removed\":false},{\"address\":\"0x2367325334447c5e1e0f1b3a6fb947b262f58312\",\"topics\":[\"0x61ed099e74a97a1d7f8bb0952a88ca8b7b8ebd00c126ea04671f92a81213318a\"],\"data\":\"0x00000000000000000000000041bdb4aa4a63a5b2efc531858d3118392b1a1c3d0000000000000000000000000000000000000000000000000050878007fa95f5\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x3\",\"removed\":false},{\"address\":\"0x2367325334447c5e1e0f1b3a6fb947b262f58312\",\"topics\":[\"0x07ea52d82345d6e838192107d8fd7123d9c2ec8e916cd0aad13fd2b60db24644\"],\"data\":\"0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000002000000000000000000000000a80aa110f05c9c6140018aae0c4e08a70f43350d000000000000000000000000dd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000013ec19b36f7f760000000000000000000000000000000000000000000000000013ec19b36f7f76\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x4\",\"removed\":false},{\"address\":\"0x3a73033c0b1407574c76bdbac67f126f6b4a9aa9\",\"topics\":[\"0x1ab700d4ced0c005b164c0f789fd09fcbb0156d4c2041b8a3bfbcd961cd1567f\"],\"data\":\"0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001200000000000000000000000002367325334447c5e1e0f1b3a6fb947b262f58312000000000000000000000000000000000000000000000000000000000000009c0100000000000002230000769c00000000000000000000000088853d410299bcbfe5fcc9eef93c03115e9082790000759e00000000000000000000000019cfce47ed54a88614648dc3f19a5980097007dde570ed2f827a5913fb8d84a16f1a6014d5bcd2212791b9ce0643f45ed9989a3e010001000000000000000000000000981504475498cddffa92afab0b1101e7154a67d8000000000ba0e306000000000000000000000000000000000000000000000000000000000000000000000016000301001101000000000000000000000000000249f000000000000000000000\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x5\",\"removed\":false},{\"address\":\"0x2086f755a6d9254045c257ea3d382ef854849b0f\",\"topics\":[\"0x85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a\",\"0xe570ed2f827a5913fb8d84a16f1a6014d5bcd2212791b9ce0643f45ed9989a3e\",\"0x000000000000000000000000981504475498cddffa92afab0b1101e7154a67d8\"],\"data\":\"0x000000000000000000000000000000000000000000000000000000000000759e000000000000000000000000000000000000000000000000000000000ba2ac8d000000000000000000000000000000000000000000000000000000000ba0e306\",\"blockNumber\":\"0xda0b2\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0x516f3ca24916ad52475807c3729bc652293b85ee1892c6bcc93358858eaa8e07\",\"logIndex\":\"0x6\",\"removed\":false}],\"logsBloom\":\"0x00000000000000000100000000000100000000000000001000000000000000000000000000000000000000400200000000000000000000000000000000000000000002000000800000000108000000000000000000000000000000000000000000000000020200008000000000000800080010000000000800010010000000000000000000000000000000081000000000000000200000000000000000200000000000008000000000100100000000000000002000600000000440000000008080000083000000000000000080000000000000000000000000000000000020000000040001000000000000000000002000000000008000000000000000000000\",\"status\":\"0x1\",\"to\":\"0x2086f755a6d9254045c257ea3d382ef854849b0f\",\"transactionHash\":\"0x1d3fd84411c6cb6d1321b0cc46553036f4b7487cf139d03b576950a5d4a19ae7\",\"transactionIndex\":\"0x0\",\"type\":\"0x2\"}}");
+    });
+
 
     cmd.args([
         "send",
         "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-        "--auth",
-        "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
         "--private-key",
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
         "--rpc-url",
-        &endpoint,
+        server.url("/").as_str(),
         "--use-explicit-data-field",
-        "data"
+        "data",
+        "--legacy"
     ])
     .assert_success();
+
+    // assert the the expected mock with the included field was called
+    mock.assert();
 });
 
 casttest!(send_eip7702_explicit_data_field_invalid, async |_prj, cmd| {
-    let (_api, handle) =
-        anvil::spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into()))).await;
-    let endpoint = handle.http_endpoint();
+    let server = MockServer::start();
+
+    server.mock(|_when, then| {
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
 
     cmd.args([
         "send",
@@ -2501,7 +2625,7 @@ casttest!(send_eip7702_explicit_data_field_invalid, async |_prj, cmd| {
         "--private-key",
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
         "--rpc-url",
-        &endpoint,
+        server.url("/").as_str(),
         "--use-explicit-data-field",
         "blah"
     ])
@@ -3586,38 +3710,107 @@ Warning: Contract code is empty
 });
 
 casttest!(cast_call_explicit_data_field_input, |_prj, cmd| {
-    let eth_rpc_url = next_http_rpc_endpoint();
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.body_contains("\"input\"").json_body_partial(r#"{"method": "eth_call"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_getCode"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+    
+    server.mock(|_when, then| {
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x1\"
+          }");
+    });
+
+
     cmd.args([
         "call",
         "0x0000000000000000000000000000000000000000",
         "--rpc-url",
-        eth_rpc_url.as_str(),
+        server.url("/").as_str(),
         "--use-explicit-data-field",
         "input",
     ])
     .assert_success();
+
+    mock.assert();
 });
 
 casttest!(cast_call_explicit_data_field_data, |_prj, cmd| {
-    let eth_rpc_url = next_http_rpc_endpoint();
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.body_contains("\"data\"").json_body_partial(r#"{"method": "eth_call"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_getCode"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+    
+    server.mock(|_when, then| {
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x1\"
+          }");
+    });
+
+
     cmd.args([
         "call",
         "0x0000000000000000000000000000000000000000",
         "--rpc-url",
-        eth_rpc_url.as_str(),
+        server.url("/").as_str(),
         "--use-explicit-data-field",
         "data",
     ])
     .assert_success();
+
+    mock.assert();
 });
 
 casttest!(cast_call_explicit_data_field_invalid, |_prj, cmd| {
-    let eth_rpc_url = next_http_rpc_endpoint();
+    let server = MockServer::start();
+
+    server.mock(|_when, then| {
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x1\"
+          }");
+    });
+
     cmd.args([
         "call",
         "0x0000000000000000000000000000000000000000",
         "--rpc-url",
-        eth_rpc_url.as_str(),
+        server.url("/").as_str(),
         "--use-explicit-data-field",
         "blah",
     ])
@@ -4070,54 +4263,6 @@ casttest!(cast_estimate_negative_numbers, |_prj, cmd| {
         rpc.as_str(),
     ])
     .assert_success();
-});
-
-casttest!(cast_estimate_explicit_data_field_input, |_prj, cmd| {
-    let rpc = next_rpc_endpoint(NamedChain::Sepolia);
-    cmd.args([
-        "estimate",
-        "0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb",
-        "rebalance(int64)",
-        "-8888",
-        "--rpc-url",
-        rpc.as_str(),
-        "--use-explicit-data-field",
-        "input"
-    ])
-    .assert_success();
-});
-
-casttest!(cast_estimate_explicit_data_field_data, |_prj, cmd| {
-    let rpc = next_rpc_endpoint(NamedChain::Sepolia);
-    cmd.args([
-        "estimate",
-        "0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb",
-        "rebalance(int64)",
-        "-8888",
-        "--rpc-url",
-        rpc.as_str(),
-        "--use-explicit-data-field",
-        "data"
-    ])
-    .assert_success();
-});
-
-casttest!(cast_estimate_explicit_data_field_invalid, |_prj, cmd| {
-    let rpc = next_rpc_endpoint(NamedChain::Sepolia);
-    cmd.args([
-        "estimate",
-        "0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb",
-        "rebalance(int64)",
-        "-8888",
-        "--rpc-url",
-        rpc.as_str(),
-        "--use-explicit-data-field",
-        "blah"
-    ])
-    .assert_failure().stderr_eq(str![[r#"
-Error: invalid value for data field: blah
-
-"#]]);
 });
 
 // Test cast mktx with negative numbers

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1520,6 +1520,208 @@ casttest!(mktx, |_prj, cmd| {
 "#]]);
 });
 
+casttest!(estimate_explicit_data_field_input, |_prj, cmd| {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.body_contains(r#""input""#).json_body_partial(r#"{"method": "eth_estimateGas"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_chainId"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x1\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_getTransactionCount"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x1\"
+          }");
+    });
+
+    cmd.args([
+        "estimate",
+        "--rpc-url",
+        server.url("/").as_str(),
+        "--use-explicit-data-field",
+        "input",
+        "--create",
+        "0000",
+        "ERC20(uint256,string,string)",
+        "100",
+        "Test",
+        "TST",
+    ]).assert_success();
+
+    mock.assert();
+});
+
+casttest!(estimate_explicit_data_field_data, |_prj, cmd| {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.body_contains(r#""data""#).json_body_partial(r#"{"method": "eth_estimateGas"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_chainId"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x1\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_getTransactionCount"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x1\"
+          }");
+    });
+
+    cmd.args([
+        "estimate",
+        "--rpc-url",
+        server.url("/").as_str(),
+        "--use-explicit-data-field",
+        "data",
+        "--create",
+        "0000",
+        "ERC20(uint256,string,string)",
+        "100",
+        "Test",
+        "TST",
+    ]).assert_success();
+
+    mock.assert();
+});
+
+casttest!(access_list_explicit_data_field_input, |_prj, cmd| {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.body_contains(r#""input""#).json_body_partial(r#"{"method": "eth_createAccessList"}"#);
+        then.status(200).body(r#"{
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": {
+              "accessList": [
+                {
+                  "address": "0xa02457e5dfd32bda5fc7e1f1b008aa5979568150",
+                  "storageKeys": [
+                    "0x0000000000000000000000000000000000000000000000000000000000000081"
+                  ]
+                }
+              ],
+              "gasUsed": "0x125f8"
+            }
+          }"#);
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_chainId"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x1\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_getTransactionCount"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x1\"
+          }");
+    });
+
+    cmd.args([
+        "access-list",
+        "0x9999999999999999999999999999999999999999",
+        "adjustPosition(int128)",
+        "-33333",
+        "--rpc-url",
+        server.url("/").as_str(),
+        "--use-explicit-data-field",
+        "input"
+    ]).assert_success();
+
+    mock.assert();
+});
+
+casttest!(access_list_explicit_data_field_data, |_prj, cmd| {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.body_contains(r#""data""#).json_body_partial(r#"{"method": "eth_createAccessList"}"#);
+        then.status(200).body(r#"{
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": {
+              "accessList": [
+                {
+                  "address": "0xa02457e5dfd32bda5fc7e1f1b008aa5979568150",
+                  "storageKeys": [
+                    "0x0000000000000000000000000000000000000000000000000000000000000081"
+                  ]
+                }
+              ],
+              "gasUsed": "0x125f8"
+            }
+          }"#);
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_chainId"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x1\"
+          }");
+    });
+
+    server.mock(|when, then| {
+        when.json_body_partial(r#"{"method": "eth_getTransactionCount"}"#);
+        then.status(200).body("{
+            \"jsonrpc\": \"2.0\",
+            \"id\": 1,
+            \"result\": \"0x1\"
+          }");
+    });
+
+    cmd.args([
+        "access-list",
+        "0x9999999999999999999999999999999999999999",
+        "adjustPosition(int128)",
+        "-33333",
+        "--rpc-url",
+        server.url("/").as_str(),
+        "--use-explicit-data-field",
+        "data"
+    ]).assert_success();
+
+    mock.assert();
+});
+
 casttest!(mktx_explicit_data_field_input, |_prj, cmd| {
     let server = MockServer::start();
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1523,6 +1523,11 @@ casttest!(mktx, |_prj, cmd| {
 casttest!(estimate_explicit_data_field_input, |_prj, cmd| {
     let server = MockServer::start();
 
+    server.mock(|when, then| {
+        when.body_contains(r#""data""#);
+        then.status(500);
+    });
+
     let mock = server.mock(|when, then| {
         when.body_contains(r#""input""#).json_body_partial(r#"{"method": "eth_estimateGas"}"#);
         then.status(200).body("{
@@ -1570,6 +1575,11 @@ casttest!(estimate_explicit_data_field_input, |_prj, cmd| {
 casttest!(estimate_explicit_data_field_data, |_prj, cmd| {
     let server = MockServer::start();
 
+    server.mock(|when, then| {
+        when.body_contains(r#""input""#);
+        then.status(500);
+    });
+
     let mock = server.mock(|when, then| {
         when.body_contains(r#""data""#).json_body_partial(r#"{"method": "eth_estimateGas"}"#);
         then.status(200).body("{
@@ -1616,6 +1626,11 @@ casttest!(estimate_explicit_data_field_data, |_prj, cmd| {
 
 casttest!(access_list_explicit_data_field_input, |_prj, cmd| {
     let server = MockServer::start();
+
+    server.mock(|when, then| {
+        when.body_contains(r#""data""#);
+        then.status(500);
+    });
 
     let mock = server.mock(|when, then| {
         when.body_contains(r#""input""#).json_body_partial(r#"{"method": "eth_createAccessList"}"#);
@@ -1671,6 +1686,11 @@ casttest!(access_list_explicit_data_field_input, |_prj, cmd| {
 casttest!(access_list_explicit_data_field_data, |_prj, cmd| {
     let server = MockServer::start();
 
+    server.mock(|when, then| {
+        when.body_contains(r#""input""#);
+        then.status(500);
+    });
+
     let mock = server.mock(|when, then| {
         when.body_contains(r#""data""#).json_body_partial(r#"{"method": "eth_createAccessList"}"#);
         then.status(200).body(r#"{
@@ -1725,6 +1745,11 @@ casttest!(access_list_explicit_data_field_data, |_prj, cmd| {
 casttest!(mktx_explicit_data_field_input, |_prj, cmd| {
     let server = MockServer::start();
 
+    server.mock(|when, then| {
+        when.body_contains(r#""data""#);
+        then.status(500);
+    });
+
     let mock = server.mock(|when, then| {
         when.body_contains(r#""input""#).json_body_partial(r#"{"method": "eth_signTransaction"}"#);
         then.status(200).body("{
@@ -1765,6 +1790,11 @@ casttest!(mktx_explicit_data_field_input, |_prj, cmd| {
 
 casttest!(mktx_explicit_data_field_data, |_prj, cmd| {
     let server = MockServer::start();
+
+    server.mock(|when, then| {
+        when.body_contains(r#""input""#);
+        then.status(500);
+    });
 
     let mock = server.mock(|when, then| {
         when.body_contains(r#""data""#).json_body_partial(r#"{"method": "eth_signTransaction"}"#);
@@ -2640,6 +2670,11 @@ casttest!(send_eip7702, async |_prj, cmd| {
 casttest!(send_eip7702_explicit_data_field_input, async |_prj, cmd| {
     let server = MockServer::start();
 
+    server.mock(|when, then| {
+        when.body_contains(r#""data""#);
+        then.status(500);
+    });
+
     let mock = server.mock(|when, then| {
         when.json_body_partial(r#"{"method": "eth_estimateGas"}"#).body_contains(r#""input""#);
         then.status(200).body("{
@@ -2726,6 +2761,11 @@ casttest!(send_eip7702_explicit_data_field_input, async |_prj, cmd| {
 
 casttest!(send_eip7702_explicit_data_field_data, async |_prj, cmd| {
     let server = MockServer::start();
+
+    server.mock(|when, then| {
+        when.body_contains(r#""input""#);
+        then.status(500);
+    });
 
     let mock = server.mock(|when, then| {
         when.json_body_partial(r#"{"method": "eth_estimateGas"}"#).body_contains(r#""data""#);
@@ -3920,6 +3960,11 @@ Warning: Contract code is empty
 casttest!(cast_call_explicit_data_field_input, |_prj, cmd| {
     let server = MockServer::start();
 
+    server.mock(|when, then| {
+        when.body_contains(r#""data""#);
+        then.status(500);
+    });
+
     let mock = server.mock(|when, then| {
         when.body_contains(r#""input""#).json_body_partial(r#"{"method": "eth_call"}"#);
         then.status(200).body("{
@@ -3962,6 +4007,11 @@ casttest!(cast_call_explicit_data_field_input, |_prj, cmd| {
 
 casttest!(cast_call_explicit_data_field_data, |_prj, cmd| {
     let server = MockServer::start();
+
+    server.mock(|when, then| {
+        when.body_contains(r#""input""#);
+        then.status(500);
+    });
 
     let mock = server.mock(|when, then| {
         when.body_contains(r#""data""#).json_body_partial(r#"{"method": "eth_call"}"#);

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1524,7 +1524,7 @@ casttest!(mktx_explicit_data_field_input, |_prj, cmd| {
     let server = MockServer::start();
 
     let mock = server.mock(|when, then| {
-        when.body_contains("\"input\"");
+        when.body_contains(r#""input""#).json_body_partial(r#"{"method": "eth_signTransaction"}"#);
         then.status(200).body("{
             \"jsonrpc\": \"2.0\",
             \"id\": 1,
@@ -1565,7 +1565,7 @@ casttest!(mktx_explicit_data_field_data, |_prj, cmd| {
     let server = MockServer::start();
 
     let mock = server.mock(|when, then| {
-        when.body_contains("\"data\"");
+        when.body_contains(r#""data""#).json_body_partial(r#"{"method": "eth_signTransaction"}"#);
         then.status(200).body("{
             \"jsonrpc\": \"2.0\",
             \"id\": 1,
@@ -2439,7 +2439,7 @@ casttest!(send_eip7702_explicit_data_field_input, async |_prj, cmd| {
     let server = MockServer::start();
 
     let mock = server.mock(|when, then| {
-        when.body_contains("\"input\"");
+        when.json_body_partial(r#"{"method": "eth_estimateGas"}"#).body_contains(r#""input""#);
         then.status(200).body("{
             \"jsonrpc\": \"2.0\",
             \"id\": 1,
@@ -2526,7 +2526,7 @@ casttest!(send_eip7702_explicit_data_field_data, async |_prj, cmd| {
     let server = MockServer::start();
 
     let mock = server.mock(|when, then| {
-        when.body_contains("\"data\"");
+        when.json_body_partial(r#"{"method": "eth_estimateGas"}"#).body_contains(r#""data""#);
         then.status(200).body("{
             \"jsonrpc\": \"2.0\",
             \"id\": 1,
@@ -3719,7 +3719,7 @@ casttest!(cast_call_explicit_data_field_input, |_prj, cmd| {
     let server = MockServer::start();
 
     let mock = server.mock(|when, then| {
-        when.body_contains("\"input\"").json_body_partial(r#"{"method": "eth_call"}"#);
+        when.body_contains(r#""input""#).json_body_partial(r#"{"method": "eth_call"}"#);
         then.status(200).body("{
             \"jsonrpc\": \"2.0\",
             \"id\": 1,
@@ -3762,7 +3762,7 @@ casttest!(cast_call_explicit_data_field_data, |_prj, cmd| {
     let server = MockServer::start();
 
     let mock = server.mock(|when, then| {
-        when.body_contains("\"data\"").json_body_partial(r#"{"method": "eth_call"}"#);
+        when.body_contains(r#""data""#).json_body_partial(r#"{"method": "eth_call"}"#);
         then.status(200).body("{
             \"jsonrpc\": \"2.0\",
             \"id\": 1,


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

When calling certain eth RPCs, they validate that "input" and "data" are not both set.  As of now, `cast` will set both fields unconditionally, leading to this error with some nodes.

this gives a way to address these, as the `--trace` flag is not always a way to "get around" the issue [as mentioned in this closed issue](https://github.com/foundry-rs/foundry/issues/9327).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add a `--use-explicit-data-field` flag to choose between "input" and "data".  If this flag is omitted, ~or the string value is not one of those two~, revert to original functionality of both fields.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests.
- [x] Added Documentation
- [ ] Breaking changes
