### PR TITLE
feat: refactor precompiles decoding, show output

### DIFF
--- a/crates/evm/traces/src/decoder/precompiles.rs
+++ b/crates/evm/traces/src/decoder/precompiles.rs
@@ -147,6 +147,11 @@ impl Precompile for Sha256 {
     fn signature(&self) -> &'static str {
         sha256Call::SIGNATURE
     }
+
+    fn decode_return(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let ret = sha256Call::abi_decode_returns(data)?;
+        Ok(vec![ret.to_string()])
+    }
 }
 
 struct Ripemd160;
@@ -157,6 +162,11 @@ impl Precompile for Ripemd160 {
 
     fn signature(&self) -> &'static str {
         ripemdCall::SIGNATURE
+    }
+
+    fn decode_return(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let ret = ripemdCall::abi_decode_returns(data)?;
+        Ok(vec![ret.to_string()])
     }
 }
 


### PR DESCRIPTION
Refactor to have a dynamic list of precompiles with some data and decoding functions.

Closes https://github.com/foundry-rs/foundry/pull/11289.

For example, before:
```
├─ [3000] PRECOMPILES::ecrecover(0x92f43d8eb366388530b32d33c38016283ae5afdde3d519e88151b4ec86d6aa27, 27, 61338666317017115141987911171165186413379531469970292499717929358861286761030, 15249423654515047357429213923532324914321294959112720042411341249220520895962) [staticcall]
    │   └─ ← [Return] 0x00000000000000000000000036da43e1659ee3f43ec77911ca20e8c7871ff1ae
```

After:
```
├─ [3000] PRECOMPILES::ecrecover(0x92f43d8eb366388530b32d33c38016283ae5afdde3d519e88151b4ec86d6aa27, 27, 61338666317017115141987911171165186413379531469970292499717929358861286761030, 15249423654515047357429213923532324914321294959112720042411341249220520895962) [staticcall]
    │   └─ ← [Return] 0x36da43E1659EE3F43ec77911Ca20E8c7871ff1AE
```