### PR TITLE
chore: deprecate Etherscan V1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -127,7 +127,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -159,7 +159,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -183,7 +183,7 @@ dependencies = [
  "alloy-rlp",
  "k256",
  "serde",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -217,7 +217,7 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "async-trait",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -237,7 +237,7 @@ dependencies = [
  "op-alloy-consensus",
  "op-revm",
  "revm",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -289,7 +289,7 @@ dependencies = [
  "http 1.3.1",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -316,7 +316,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -428,7 +428,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "url",
@@ -591,7 +591,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -605,7 +605,7 @@ dependencies = [
  "alloy-serde",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -645,7 +645,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -662,7 +662,7 @@ dependencies = [
  "aws-sdk-kms",
  "k256",
  "spki",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -680,7 +680,7 @@ dependencies = [
  "gcloud-sdk",
  "k256",
  "spki",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -700,7 +700,7 @@ dependencies = [
  "coins-ledger",
  "futures-util",
  "semver 1.0.26",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -720,7 +720,7 @@ dependencies = [
  "eth-keystore",
  "k256",
  "rand 0.8.5",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "zeroize",
 ]
 
@@ -736,7 +736,7 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "semver 1.0.26",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tracing",
  "trezor-client",
 ]
@@ -830,7 +830,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tower",
  "tracing",
@@ -1090,7 +1090,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.19",
@@ -1118,7 +1118,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1144,7 +1144,7 @@ dependencies = [
  "pin-project 1.1.10",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio-util",
  "tower-http",
  "tracing",
@@ -2265,7 +2265,7 @@ dependencies = [
  "static_assertions",
  "tap",
  "thin-vec",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "time",
 ]
 
@@ -2350,9 +2350,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a0c21249ad725ebcadcb1b1885f8e3d56e8e6b8924f560268aab000982d637"
+checksum = "537c317ddf588aab15c695bf92cf55dec159b93221c074180ca3e0e5a94da415"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -2360,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a660ebdea4d4d3ec7788cfc9c035b66efb66028b9b97bf6cde7023ccc8e77e28"
+checksum = "ca5abbf2d4a4c6896197c9de13d6d7cb7eff438c63dacde1dde980569cb00248"
 dependencies = [
  "darling 0.21.2",
  "ident_case",
@@ -2601,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
@@ -2787,7 +2787,7 @@ checksum = "85a8ab73a1c02b0c15597b22e09c7dc36e63b2f601f9d1e83ac0c3decd38b1ae"
 dependencies = [
  "nix 0.29.0",
  "terminfo",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "which 8.0.0",
  "windows-sys 0.59.0",
 ]
@@ -4061,7 +4061,7 @@ dependencies = [
  "strum 0.27.2",
  "svm-rs",
  "tempfile",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "toml_edit 0.23.3",
  "tower-http",
@@ -4090,7 +4090,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "toml 0.9.5",
  "tracing",
 ]
@@ -4105,7 +4105,7 @@ dependencies = [
  "foundry-solang-parser",
  "itertools 0.14.0",
  "similar-asserts",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "toml 0.9.5",
  "tracing",
  "tracing-subscriber 0.3.19",
@@ -4125,7 +4125,7 @@ dependencies = [
  "solar-interface",
  "solar-parse",
  "solar-sema",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -4241,9 +4241,9 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -4271,8 +4271,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc107bbc3b4480995fdf337ca0ddedc631728175f418d3136ead9df8f4dc465e"
+source = "git+https://github.com/foundry-rs/block-explorers.git?rev=c085873#c085873500453c40c63a2c36f0e184789b71e861"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -4282,7 +4281,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -4330,7 +4329,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "toml 0.9.5",
  "tracing",
  "walkdir",
@@ -4441,7 +4440,7 @@ dependencies = [
  "solar-parse",
  "solar-sema",
  "terminal_size",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tower",
  "tracing",
@@ -4500,7 +4499,7 @@ dependencies = [
  "svm-rs",
  "svm-rs-builds",
  "tempfile",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "winnow",
@@ -4533,7 +4532,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "walkdir",
@@ -4572,7 +4571,7 @@ dependencies = [
  "serde_json",
  "svm-rs",
  "tempfile",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "walkdir",
  "xxhash-rust",
@@ -4609,7 +4608,7 @@ dependencies = [
  "solar-parse",
  "soldeer-core",
  "tempfile",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "toml 0.9.5",
  "toml_edit 0.23.3",
  "tracing",
@@ -4661,7 +4660,7 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tracing",
  "uuid 1.18.0",
 ]
@@ -4711,7 +4710,7 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "url",
@@ -4752,7 +4751,7 @@ dependencies = [
  "rand 0.9.2",
  "revm",
  "serde",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -4802,7 +4801,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "url",
@@ -4815,7 +4814,7 @@ dependencies = [
  "alloy-primitives",
  "foundry-compilers",
  "semver 1.0.26",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -4838,7 +4837,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "phf",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "unicode-xid",
 ]
 
@@ -4893,7 +4892,7 @@ dependencies = [
  "gcloud-sdk",
  "rpassword",
  "serde",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
 ]
@@ -5060,9 +5059,9 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
+checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5137,12 +5136,12 @@ dependencies = [
 
 [[package]]
 name = "gmp-mpfr-sys"
-version = "1.6.5"
+version = "1.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66d61197a68f6323b9afa616cf83d55d69191e1bf364d4eb7d35ae18defe776"
+checksum = "a636fb6a653382a379ee1e5593dacdc628667994167024c143214cafd40c1a86"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5198,7 +5197,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -5609,9 +5608,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -6545,9 +6544,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "newtype-uuid"
-version = "1.2.4"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17d82edb1c8a6c20c238747ae7aae9181133e766bc92cd2556fdd764407d0d1"
+checksum = "980493932a63b13905b6732671f5295dd11c53d763c91dbde8a7a780611c9189"
 dependencies = [
  "uuid 1.18.0",
 ]
@@ -6878,7 +6877,7 @@ dependencies = [
  "alloy-serde",
  "derive_more 2.0.1",
  "serde",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -6903,7 +6902,7 @@ dependencies = [
  "op-alloy-consensus",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -7123,9 +7122,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -7134,7 +7133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "ucd-trie",
 ]
 
@@ -7637,7 +7636,7 @@ dependencies = [
  "newtype-uuid",
  "quick-xml 0.37.5",
  "strip-ansi-escapes",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "uuid 1.18.0",
 ]
 
@@ -7673,7 +7672,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "web-time",
@@ -7694,7 +7693,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tinyvec",
  "tracing",
  "web-time",
@@ -7880,7 +7879,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -8141,9 +8140,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a76ba086ca57a718368e46e792a81c5eb7a30366956aa6293adbcec8b1181ce"
+checksum = "9d3f54151c26870f50a3d7e8688e30a0f3578dd57bc69450caa1df11a7713906"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -8156,7 +8155,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -9042,7 +9041,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "time",
 ]
 
@@ -9186,7 +9185,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tracing",
  "unicode-width 0.2.0",
 ]
@@ -9293,7 +9292,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "toml_edit 0.22.27",
  "uuid 1.18.0",
@@ -9527,7 +9526,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "url",
  "zip",
 ]
@@ -9627,15 +9626,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9714,11 +9713,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d76d3f064b981389ecb4b6b7f45a0bf9fdac1d5b9204c7bd6714fecc302850"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.15",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -9734,9 +9733,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d29feb33e986b6ea906bd9c3559a856983f92371b3eaa5e83782a351623de0"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10290,7 +10289,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "utf-8",
 ]
 
@@ -10459,9 +10458,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ec961601b32b6f5d14ae8dabd35ff2ff2e2c6cb4c0e6641845ff105abe96d958"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -10760,7 +10759,7 @@ dependencies = [
  "miette",
  "normalize-path",
  "notify",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "watchexec-events",
@@ -10786,7 +10785,7 @@ checksum = "377729679262964c27e6a28f360a84b7aedb172b59841301c1c77922305dfd83"
 dependencies = [
  "miette",
  "nix 0.30.1",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -10900,11 +10899,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11240,7 +11239,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -11385,9 +11384,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aed4ac33e8eb078c89e6cbb1d5c4c7703ec6d299fc3e7c3695af8f8b423468b"
+checksum = "d5649b9d3f6261c498410f5a25c95c4a7b0f4b84143a403fafa4e33a66178817"
 dependencies = [
  "arbitrary",
  "crc32fast",
@@ -11404,7 +11403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fa5b9958fd0b5b685af54f2c3fa21fca05fe295ebaf3e77b6d24d96c4174037"
 dependencies = [
  "log",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -406,7 +406,7 @@ idna_adapter = "=1.1.0"
 # revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors.git", rev = "956bc98" }
 
 ## foundry
-# foundry-block-explorers = { git = "https://github.com/foundry-rs/block-explorers.git", rev = "e09cb89" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/block-explorers.git", rev = "c085873" }
 # foundry-compilers = { git = "https://github.com/foundry-rs/compilers.git", rev = "e4a9b04" }
 # foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-fork-db", rev = "50683eb" }
 

--- a/crates/cast/src/cmd/creation_code.rs
+++ b/crates/cast/src/cmd/creation_code.rs
@@ -136,9 +136,8 @@ pub async fn fetch_creation_code_from_etherscan(
 ) -> Result<Bytes> {
     let config = etherscan.load_config()?;
     let chain = config.chain.unwrap_or_default();
-    let api_version = config.get_etherscan_api_version(Some(chain));
     let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
-    let client = Client::new_with_api_version(chain, api_key, api_version)?;
+    let client = Client::new(chain, api_key)?;
     let creation_data = client.contract_creation_data(contract).await?;
     let creation_tx_hash = creation_data.transaction_hash;
     let tx_data = provider.get_transaction_by_hash(creation_tx_hash).await?;

--- a/crates/cast/src/cmd/interface.rs
+++ b/crates/cast/src/cmd/interface.rs
@@ -144,9 +144,8 @@ pub async fn fetch_abi_from_etherscan(
 ) -> Result<Vec<(JsonAbi, String)>> {
     let config = etherscan.load_config()?;
     let chain = config.chain.unwrap_or_default();
-    let api_version = config.get_etherscan_api_version(Some(chain));
     let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
-    let client = Client::new_with_api_version(chain, api_key, api_version)?;
+    let client = Client::new(chain, api_key)?;
     let source = client.contract_source_code(address).await?;
     source.items.into_iter().map(|item| Ok((item.abi()?, item.contract_name))).collect()
 }

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -365,10 +365,6 @@ impl figment::Provider for RunArgs {
             map.insert("etherscan_api_key".into(), api_key.as_str().into());
         }
 
-        if let Some(api_version) = &self.etherscan.api_version {
-            map.insert("etherscan_api_version".into(), api_version.to_string().into());
-        }
-
         if let Some(evm_version) = self.evm_version {
             map.insert("evm_version".into(), figment::value::Value::serialize(evm_version)?);
         }

--- a/crates/cast/src/cmd/storage.rs
+++ b/crates/cast/src/cmd/storage.rs
@@ -138,9 +138,8 @@ impl StorageArgs {
         }
 
         let chain = utils::get_chain(config.chain, &provider).await?;
-        let api_version = config.get_etherscan_api_version(Some(chain));
         let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
-        let client = Client::new_with_api_version(chain, api_key, api_version)?;
+        let client = Client::new(chain, api_key)?;
         let source = if let Some(proxy) = self.proxy {
             find_source(client, proxy.resolve(&provider).await?).await?
         } else {

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -14,7 +14,6 @@ use alloy_serde::WithOtherFields;
 use alloy_signer::Signer;
 use alloy_transport::TransportError;
 use eyre::Result;
-use foundry_block_explorers::EtherscanApiVersion;
 use foundry_cli::{
     opts::{CliAuthorizationList, TransactionOpts},
     utils::{self, parse_function_args},
@@ -144,7 +143,6 @@ pub struct CastTxBuilder<P, S> {
     auth: Option<CliAuthorizationList>,
     chain: Chain,
     etherscan_api_key: Option<String>,
-    etherscan_api_version: EtherscanApiVersion,
     access_list: Option<Option<AccessList>>,
     state: S,
 }
@@ -156,7 +154,6 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InitState> {
         let mut tx = WithOtherFields::<TransactionRequest>::default();
 
         let chain = utils::get_chain(config.chain, &provider).await?;
-        let etherscan_api_version = config.get_etherscan_api_version(Some(chain));
         let etherscan_api_key = config.get_etherscan_api_key(Some(chain));
         // mark it as legacy if requested or the chain is legacy and no 7702 is provided.
         let legacy = tx_opts.legacy || (chain.is_legacy() && tx_opts.auth.is_none());
@@ -196,7 +193,6 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InitState> {
             blob: tx_opts.blob,
             chain,
             etherscan_api_key,
-            etherscan_api_version,
             auth: tx_opts.auth,
             access_list: tx_opts.access_list,
             state: InitState,
@@ -213,7 +209,6 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InitState> {
             blob: self.blob,
             chain: self.chain,
             etherscan_api_key: self.etherscan_api_key,
-            etherscan_api_version: self.etherscan_api_version,
             auth: self.auth,
             access_list: self.access_list,
             state: ToState { to },
@@ -239,7 +234,6 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, ToState> {
                 self.chain,
                 &self.provider,
                 self.etherscan_api_key.as_deref(),
-                self.etherscan_api_version,
             )
             .await?
         } else {
@@ -271,7 +265,6 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, ToState> {
             blob: self.blob,
             chain: self.chain,
             etherscan_api_key: self.etherscan_api_key,
-            etherscan_api_version: self.etherscan_api_version,
             auth: self.auth,
             access_list: self.access_list,
             state: InputState { kind: self.state.to.into(), input, func },

--- a/crates/cli/src/opts/rpc.rs
+++ b/crates/cli/src/opts/rpc.rs
@@ -2,7 +2,6 @@ use crate::opts::ChainValueParser;
 use alloy_chains::ChainKind;
 use clap::Parser;
 use eyre::Result;
-use foundry_block_explorers::EtherscanApiVersion;
 use foundry_config::{
     Chain, Config, FigmentProviders,
     figment::{
@@ -132,16 +131,6 @@ pub struct EtherscanOpts {
     #[serde(rename = "etherscan_api_key", skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 
-    /// The Etherscan API version.
-    #[arg(
-        short,
-        long = "etherscan-api-version",
-        alias = "api-version",
-        env = "ETHERSCAN_API_VERSION"
-    )]
-    #[serde(rename = "etherscan_api_version", skip_serializing_if = "Option::is_none")]
-    pub api_version: Option<EtherscanApiVersion>,
-
     /// The chain name or EIP-155 chain ID.
     #[arg(
         short,
@@ -181,10 +170,6 @@ impl EtherscanOpts {
         let mut dict = Dict::new();
         if let Some(key) = self.key() {
             dict.insert("etherscan_api_key".into(), key.into());
-        }
-
-        if let Some(api_version) = &self.api_version {
-            dict.insert("etherscan_api_version".into(), api_version.to_string().into());
         }
 
         if let Some(chain) = self.chain {

--- a/crates/cli/src/utils/abi.rs
+++ b/crates/cli/src/utils/abi.rs
@@ -4,7 +4,6 @@ use alloy_json_abi::Function;
 use alloy_primitives::{Address, hex};
 use alloy_provider::{Provider, network::AnyNetwork};
 use eyre::{OptionExt, Result};
-use foundry_block_explorers::EtherscanApiVersion;
 use foundry_common::abi::{
     encode_function_args, encode_function_args_raw, get_func, get_func_etherscan,
 };
@@ -32,7 +31,6 @@ pub async fn parse_function_args<P: Provider<AnyNetwork>>(
     chain: Chain,
     provider: &P,
     etherscan_api_key: Option<&str>,
-    etherscan_api_version: EtherscanApiVersion,
 ) -> Result<(Vec<u8>, Option<Function>)> {
     if sig.trim().is_empty() {
         eyre::bail!("Function signature or calldata must be provided.")
@@ -55,7 +53,7 @@ pub async fn parse_function_args<P: Provider<AnyNetwork>>(
             "Function signature does not contain parentheses. If you wish to fetch function data from Etherscan, please provide an API key.",
         )?;
         let to = to.ok_or_eyre("A 'to' address must be provided to fetch function data.")?;
-        get_func_etherscan(sig, to, &args, chain, etherscan_api_key, etherscan_api_version).await?
+        get_func_etherscan(sig, to, &args, chain, etherscan_api_key).await?
     };
 
     if to.is_none() {

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -4,9 +4,7 @@ use alloy_dyn_abi::{DynSolType, DynSolValue, FunctionExt, JsonAbiExt};
 use alloy_json_abi::{Error, Event, Function, Param};
 use alloy_primitives::{Address, LogData, hex};
 use eyre::{Context, ContextCompat, Result};
-use foundry_block_explorers::{
-    Client, EtherscanApiVersion, contract::ContractMetadata, errors::EtherscanError,
-};
+use foundry_block_explorers::{Client, contract::ContractMetadata, errors::EtherscanError};
 use foundry_config::Chain;
 use std::pin::Pin;
 
@@ -129,9 +127,8 @@ pub async fn get_func_etherscan(
     args: &[String],
     chain: Chain,
     etherscan_api_key: &str,
-    etherscan_api_version: EtherscanApiVersion,
 ) -> Result<Function> {
-    let client = Client::new_with_api_version(chain, etherscan_api_key, etherscan_api_version)?;
+    let client = Client::new(chain, etherscan_api_key)?;
     let source = find_source(client, contract).await?;
     let metadata = source.items.first().wrap_err("etherscan returned empty metadata")?;
 

--- a/crates/config/src/etherscan.rs
+++ b/crates/config/src/etherscan.rs
@@ -9,7 +9,6 @@ use figment::{
     providers::Env,
     value::{Dict, Map},
 };
-use foundry_block_explorers::EtherscanApiVersion;
 use heck::ToKebabCase;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
@@ -88,13 +87,13 @@ impl EtherscanConfigs {
     }
 
     /// Returns all (alias -> url) pairs
-    pub fn resolved(self, default_api_version: EtherscanApiVersion) -> ResolvedEtherscanConfigs {
+    pub fn resolved(self) -> ResolvedEtherscanConfigs {
         ResolvedEtherscanConfigs {
             configs: self
                 .configs
                 .into_iter()
                 .map(|(name, e)| {
-                    let resolved = e.resolve(Some(&name), default_api_version);
+                    let resolved = e.resolve(Some(&name));
                     (name, resolved)
                 })
                 .collect(),
@@ -178,9 +177,6 @@ pub struct EtherscanConfig {
     /// Etherscan API URL
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-    /// Etherscan API Version. Defaults to v2
-    #[serde(default, alias = "api-version", skip_serializing_if = "Option::is_none")]
-    pub api_version: Option<EtherscanApiVersion>,
     /// The etherscan API KEY that's required to make requests
     pub key: EtherscanApiKey,
 }
@@ -195,11 +191,8 @@ impl EtherscanConfig {
     pub fn resolve(
         self,
         alias: Option<&str>,
-        default_api_version: EtherscanApiVersion,
     ) -> Result<ResolvedEtherscanConfig, EtherscanConfigError> {
-        let Self { chain, mut url, key, api_version } = self;
-
-        let api_version = api_version.unwrap_or(default_api_version);
+        let Self { chain, mut url, key } = self;
 
         if let Some(url) = &mut url {
             *url = interpolate(url)?;
@@ -230,23 +223,17 @@ impl EtherscanConfig {
         match (chain, url) {
             (Some(chain), Some(api_url)) => Ok(ResolvedEtherscanConfig {
                 api_url,
-                api_version,
                 browser_url: chain.etherscan_urls().map(|(_, url)| url.to_string()),
                 key,
                 chain: Some(chain),
             }),
-            (Some(chain), None) => ResolvedEtherscanConfig::create(key, chain, api_version)
-                .ok_or_else(|| {
-                    let msg = alias.map(|a| format!("for `{a}`")).unwrap_or_default();
-                    EtherscanConfigError::UnknownChain(msg, chain)
-                }),
-            (None, Some(api_url)) => Ok(ResolvedEtherscanConfig {
-                api_url,
-                browser_url: None,
-                key,
-                chain: None,
-                api_version,
+            (Some(chain), None) => ResolvedEtherscanConfig::create(key, chain).ok_or_else(|| {
+                let msg = alias.map(|a| format!("for `{a}`")).unwrap_or_default();
+                EtherscanConfigError::UnknownChain(msg, chain)
             }),
+            (None, Some(api_url)) => {
+                Ok(ResolvedEtherscanConfig { api_url, browser_url: None, key, chain: None })
+            }
             (None, None) => {
                 let msg = alias
                     .map(|a| format!(" for Etherscan config with unknown alias `{a}`"))
@@ -268,9 +255,6 @@ pub struct ResolvedEtherscanConfig {
     pub browser_url: Option<String>,
     /// The resolved API key.
     pub key: String,
-    /// Etherscan API Version.
-    #[serde(default)]
-    pub api_version: EtherscanApiVersion,
     /// The chain name or EIP-155 chain ID.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chain: Option<Chain>,
@@ -278,16 +262,11 @@ pub struct ResolvedEtherscanConfig {
 
 impl ResolvedEtherscanConfig {
     /// Creates a new instance using the api key and chain
-    pub fn create(
-        api_key: impl Into<String>,
-        chain: impl Into<Chain>,
-        api_version: EtherscanApiVersion,
-    ) -> Option<Self> {
+    pub fn create(api_key: impl Into<String>, chain: impl Into<Chain>) -> Option<Self> {
         let chain = chain.into();
         let (api_url, browser_url) = chain.etherscan_urls()?;
         Some(Self {
             api_url: api_url.to_string(),
-            api_version,
             browser_url: Some(browser_url.to_string()),
             key: api_key.into(),
             chain: Some(chain),
@@ -319,7 +298,7 @@ impl ResolvedEtherscanConfig {
         self,
     ) -> Result<foundry_block_explorers::Client, foundry_block_explorers::errors::EtherscanError>
     {
-        let Self { api_url, browser_url, key: api_key, chain, api_version } = self;
+        let Self { api_url, browser_url, key: api_key, chain } = self;
 
         let chain = chain.unwrap_or_default();
         let cache = Config::foundry_etherscan_chain_cache_dir(chain);
@@ -338,7 +317,6 @@ impl ResolvedEtherscanConfig {
             .build()?;
         let mut client_builder = foundry_block_explorers::Client::builder()
             .with_client(client)
-            .with_api_version(api_version)
             .with_api_key(api_key)
             .with_cache(cache, Duration::from_secs(24 * 60 * 60));
         if let Some(browser_url) = browser_url {
@@ -435,6 +413,7 @@ fn into_url(url: impl reqwest::IntoUrl) -> std::result::Result<reqwest::Url, req
 mod tests {
     use super::*;
     use NamedChain::Mainnet;
+    use foundry_block_explorers::ETHERSCAN_V2_API_BASE_URL;
 
     #[test]
     fn can_create_client_via_chain() {
@@ -445,36 +424,14 @@ mod tests {
                 chain: Some(Mainnet.into()),
                 url: None,
                 key: EtherscanApiKey::Key("ABCDEFG".to_string()),
-                api_version: None,
             },
         );
 
-        let mut resolved = configs.resolved(EtherscanApiVersion::V2);
+        let mut resolved = configs.resolved();
         let config = resolved.remove("mainnet").unwrap().unwrap();
-        // None version = None
-        assert_eq!(config.api_version, EtherscanApiVersion::V2);
-        let client = config.into_client().unwrap();
-        assert_eq!(*client.etherscan_api_version(), EtherscanApiVersion::V2);
-    }
 
-    #[test]
-    fn can_create_v1_client_via_chain() {
-        let mut configs = EtherscanConfigs::default();
-        configs.insert(
-            "mainnet".to_string(),
-            EtherscanConfig {
-                chain: Some(Mainnet.into()),
-                url: None,
-                api_version: Some(EtherscanApiVersion::V1),
-                key: EtherscanApiKey::Key("ABCDEG".to_string()),
-            },
-        );
-
-        let mut resolved = configs.resolved(EtherscanApiVersion::V2);
-        let config = resolved.remove("mainnet").unwrap().unwrap();
-        assert_eq!(config.api_version, EtherscanApiVersion::V1);
         let client = config.into_client().unwrap();
-        assert_eq!(*client.etherscan_api_version(), EtherscanApiVersion::V1);
+        assert_eq!(client.etherscan_api_url().as_str(), ETHERSCAN_V2_API_BASE_URL);
     }
 
     #[test]
@@ -486,11 +443,10 @@ mod tests {
                 chain: Some(Mainnet.into()),
                 url: Some("https://api.etherscan.io/api".to_string()),
                 key: EtherscanApiKey::Key("ABCDEFG".to_string()),
-                api_version: None,
             },
         );
 
-        let mut resolved = configs.resolved(EtherscanApiVersion::V2);
+        let mut resolved = configs.resolved();
         let config = resolved.remove("mainnet").unwrap().unwrap();
         let _ = config.into_client().unwrap();
     }
@@ -504,12 +460,11 @@ mod tests {
             EtherscanConfig {
                 chain: Some(Mainnet.into()),
                 url: Some("https://api.etherscan.io/api".to_string()),
-                api_version: None,
                 key: EtherscanApiKey::Env(format!("${{{env}}}")),
             },
         );
 
-        let mut resolved = configs.clone().resolved(EtherscanApiVersion::V2);
+        let mut resolved = configs.clone().resolved();
         let config = resolved.remove("mainnet").unwrap();
         assert!(config.is_err());
 
@@ -517,11 +472,11 @@ mod tests {
             std::env::set_var(env, "ABCDEFG");
         }
 
-        let mut resolved = configs.resolved(EtherscanApiVersion::V2);
+        let mut resolved = configs.resolved();
         let config = resolved.remove("mainnet").unwrap().unwrap();
         assert_eq!(config.key, "ABCDEFG");
         let client = config.into_client().unwrap();
-        assert_eq!(*client.etherscan_api_version(), EtherscanApiVersion::V2);
+        assert_eq!(client.etherscan_api_url().as_str(), ETHERSCAN_V2_API_BASE_URL);
 
         unsafe {
             std::env::remove_var(env);
@@ -537,11 +492,10 @@ mod tests {
                 chain: None,
                 url: Some("https://api.etherscan.io/api".to_string()),
                 key: EtherscanApiKey::Key("ABCDEFG".to_string()),
-                api_version: None,
             },
         );
 
-        let mut resolved = configs.clone().resolved(EtherscanApiVersion::V2);
+        let mut resolved = configs.clone().resolved();
         let config = resolved.remove("blast_sepolia").unwrap().unwrap();
         assert_eq!(config.chain, Some(Chain::blast_sepolia()));
     }
@@ -552,13 +506,11 @@ mod tests {
             chain: None,
             url: Some("https://api.etherscan.io/api".to_string()),
             key: EtherscanApiKey::Key("ABCDEFG".to_string()),
-            api_version: None,
         };
-        let resolved =
-            config.clone().resolve(Some("base_sepolia"), EtherscanApiVersion::V2).unwrap();
+        let resolved = config.clone().resolve(Some("base_sepolia")).unwrap();
         assert_eq!(resolved.chain, Some(Chain::base_sepolia()));
 
-        let resolved = config.resolve(Some("base-sepolia"), EtherscanApiVersion::V2).unwrap();
+        let resolved = config.resolve(Some("base-sepolia")).unwrap();
         assert_eq!(resolved.chain, Some(Chain::base_sepolia()));
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -103,7 +103,6 @@ pub mod fix;
 // reexport so cli types can implement `figment::Provider` to easily merge compiler arguments
 pub use alloy_chains::{Chain, NamedChain};
 pub use figment;
-use foundry_block_explorers::EtherscanApiVersion;
 
 pub mod providers;
 pub use providers::Remappings;
@@ -301,8 +300,6 @@ pub struct Config {
     pub eth_rpc_headers: Option<Vec<String>>,
     /// etherscan API key, or alias for an `EtherscanConfig` in `etherscan` table
     pub etherscan_api_key: Option<String>,
-    /// etherscan API version
-    pub etherscan_api_version: Option<EtherscanApiVersion>,
     /// Multiple etherscan api configs and their aliases
     #[serde(default, skip_serializing_if = "EtherscanConfigs::is_empty")]
     pub etherscan: EtherscanConfigs,
@@ -1413,23 +1410,17 @@ impl Config {
         &self,
         chain: Option<Chain>,
     ) -> Result<Option<ResolvedEtherscanConfig>, EtherscanConfigError> {
-        let default_api_version = self.etherscan_api_version.unwrap_or_default();
-
         if let Some(maybe_alias) = self.etherscan_api_key.as_ref().or(self.eth_rpc_url.as_ref())
             && self.etherscan.contains_key(maybe_alias)
         {
-            return self
-                .etherscan
-                .clone()
-                .resolved(default_api_version)
-                .remove(maybe_alias)
-                .transpose();
+            return self.etherscan.clone().resolved().remove(maybe_alias).transpose();
         }
 
         // try to find by comparing chain IDs after resolving
-        if let Some(res) = chain.or(self.chain).and_then(|chain| {
-            self.etherscan.clone().resolved(default_api_version).find_chain(chain)
-        }) {
+        if let Some(res) = chain
+            .or(self.chain)
+            .and_then(|chain| self.etherscan.clone().resolved().find_chain(chain))
+        {
             match (res, self.etherscan_api_key.as_ref()) {
                 (Ok(mut config), Some(key)) => {
                     // we update the key, because if an etherscan_api_key is set, it should take
@@ -1447,11 +1438,7 @@ impl Config {
 
         // etherscan fallback via API key
         if let Some(key) = self.etherscan_api_key.as_ref() {
-            match ResolvedEtherscanConfig::create(
-                key,
-                chain.or(self.chain).unwrap_or_default(),
-                default_api_version,
-            ) {
+            match ResolvedEtherscanConfig::create(key, chain.or(self.chain).unwrap_or_default()) {
                 Some(config) => return Ok(Some(config)),
                 None => {
                     return Err(EtherscanConfigError::UnknownChain(
@@ -1471,17 +1458,6 @@ impl Config {
     /// See also [Self::get_etherscan_config_with_chain]
     pub fn get_etherscan_api_key(&self, chain: Option<Chain>) -> Option<String> {
         self.get_etherscan_config_with_chain(chain).ok().flatten().map(|c| c.key)
-    }
-
-    /// Helper function to get the API version.
-    ///
-    /// See also [Self::get_etherscan_config_with_chain]
-    pub fn get_etherscan_api_version(&self, chain: Option<Chain>) -> EtherscanApiVersion {
-        self.get_etherscan_config_with_chain(chain)
-            .ok()
-            .flatten()
-            .map(|c| c.api_version)
-            .unwrap_or_default()
     }
 
     /// Returns the remapping for the project's _src_ directory
@@ -2424,7 +2400,6 @@ impl Default for Config {
             eth_rpc_timeout: None,
             eth_rpc_headers: None,
             etherscan_api_key: None,
-            etherscan_api_version: None,
             verbosity: 0,
             remappings: vec![],
             auto_detect_remappings: true,
@@ -3123,11 +3098,11 @@ mod tests {
 
             let config = Config::load().unwrap();
 
-            assert!(config.etherscan.clone().resolved(EtherscanApiVersion::V2).has_unresolved());
+            assert!(config.etherscan.clone().resolved().has_unresolved());
 
             jail.set_env("_CONFIG_ETHERSCAN_MOONBEAM", "123456789");
 
-            let configs = config.etherscan.resolved(EtherscanApiVersion::V2);
+            let configs = config.etherscan.resolved();
             assert!(!configs.has_unresolved());
 
             let mb_urls = Moonbeam.etherscan_urls().unwrap();
@@ -3141,7 +3116,6 @@ mod tests {
                             api_url: mainnet_urls.0.to_string(),
                             chain: Some(NamedChain::Mainnet.into()),
                             browser_url: Some(mainnet_urls.1.to_string()),
-                            api_version: EtherscanApiVersion::V2,
                             key: "FX42Z3BBJJEWXWGYV2X1CIPRSCN".to_string(),
                         }
                     ),
@@ -3151,7 +3125,6 @@ mod tests {
                             api_url: mb_urls.0.to_string(),
                             chain: Some(Moonbeam.into()),
                             browser_url: Some(mb_urls.1.to_string()),
-                            api_version: EtherscanApiVersion::V2,
                             key: "123456789".to_string(),
                         }
                     ),
@@ -3178,11 +3151,11 @@ mod tests {
 
             let config = Config::load().unwrap();
 
-            assert!(config.etherscan.clone().resolved(EtherscanApiVersion::V2).has_unresolved());
+            assert!(config.etherscan.clone().resolved().has_unresolved());
 
             jail.set_env("_CONFIG_ETHERSCAN_MOONBEAM", "123456789");
 
-            let configs = config.etherscan.resolved(EtherscanApiVersion::V2);
+            let configs = config.etherscan.resolved();
             assert!(!configs.has_unresolved());
 
             let mb_urls = Moonbeam.etherscan_urls().unwrap();
@@ -3196,7 +3169,6 @@ mod tests {
                             api_url: mainnet_urls.0.to_string(),
                             chain: Some(NamedChain::Mainnet.into()),
                             browser_url: Some(mainnet_urls.1.to_string()),
-                            api_version: EtherscanApiVersion::V2,
                             key: "FX42Z3BBJJEWXWGYV2X1CIPRSCN".to_string(),
                         }
                     ),
@@ -3206,7 +3178,6 @@ mod tests {
                             api_url: mb_urls.0.to_string(),
                             chain: Some(Moonbeam.into()),
                             browser_url: Some(mb_urls.1.to_string()),
-                            api_version: EtherscanApiVersion::V1,
                             key: "123456789".to_string(),
                         }
                     ),

--- a/crates/forge/src/cmd/clone.rs
+++ b/crates/forge/src/cmd/clone.rs
@@ -101,10 +101,8 @@ impl CloneArgs {
         // step 0. get the chain and api key from the config
         let config = etherscan.load_config()?;
         let chain = config.chain.unwrap_or_default();
-        let etherscan_api_version = config.get_etherscan_api_version(Some(chain));
         let etherscan_api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
-        let client =
-            Client::new_with_api_version(chain, etherscan_api_key.clone(), etherscan_api_version)?;
+        let client = Client::new(chain, etherscan_api_key.clone());
 
         // step 1. get the metadata from client
         sh_println!("Downloading the source code of {address} from Etherscan...")?;

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -231,7 +231,6 @@ impl CreateArgs {
             num_of_optimizations: None,
             etherscan: EtherscanOpts {
                 key: self.eth.etherscan.key.clone(),
-                api_version: self.eth.etherscan.api_version,
                 chain: Some(chain.into()),
             },
             rpc: Default::default(),
@@ -419,11 +418,7 @@ impl CreateArgs {
             constructor_args,
             constructor_args_path: None,
             num_of_optimizations,
-            etherscan: EtherscanOpts {
-                key: self.eth.etherscan.key(),
-                api_version: self.eth.etherscan.api_version,
-                chain: Some(chain.into()),
-            },
+            etherscan: EtherscanOpts { key: self.eth.etherscan.key(), chain: Some(chain.into()) },
             rpc: Default::default(),
             flatten: false,
             force: false,

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -16,7 +16,6 @@ use alloy_primitives::U256;
 use chrono::Utc;
 use clap::{Parser, ValueHint};
 use eyre::{Context, OptionExt, Result, bail};
-use foundry_block_explorers::EtherscanApiVersion;
 use foundry_cli::{
     opts::{BuildOpts, GlobalArgs},
     utils::{self, LoadConfig},
@@ -145,10 +144,6 @@ pub struct TestArgs {
     /// The Etherscan (or equivalent) API key.
     #[arg(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
     etherscan_api_key: Option<String>,
-
-    /// The Etherscan API version.
-    #[arg(long, env = "ETHERSCAN_API_VERSION", value_name = "VERSION")]
-    etherscan_api_version: Option<EtherscanApiVersion>,
 
     /// List tests instead of running them.
     #[arg(long, short, conflicts_with_all = ["show_progress", "decode_internal", "summary"], help_heading = "Display options")]
@@ -875,10 +870,6 @@ impl Provider for TestArgs {
             self.etherscan_api_key.as_ref().filter(|s| !s.trim().is_empty())
         {
             dict.insert("etherscan_api_key".to_string(), etherscan_api_key.to_string().into());
-        }
-
-        if let Some(api_version) = &self.etherscan_api_version {
-            dict.insert("etherscan_api_version".to_string(), api_version.to_string().into());
         }
 
         if self.show_progress {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -25,7 +25,6 @@ use dialoguer::Confirm;
 use eyre::{ContextCompat, Result};
 use forge_script_sequence::{AdditionalContract, NestedValue};
 use forge_verify::{RetryArgs, VerifierArgs};
-use foundry_block_explorers::EtherscanApiVersion;
 use foundry_cli::{
     opts::{BuildOpts, GlobalArgs},
     utils::LoadConfig,
@@ -185,10 +184,6 @@ pub struct ScriptArgs {
     /// The Etherscan (or equivalent) API key
     #[arg(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
     pub etherscan_api_key: Option<String>,
-
-    /// The Etherscan API version.
-    #[arg(long, env = "ETHERSCAN_API_VERSION", value_name = "VERSION")]
-    pub etherscan_api_version: Option<EtherscanApiVersion>,
 
     /// Verifies all the contracts found in the receipts of a script, if any.
     #[arg(long)]
@@ -503,6 +498,7 @@ impl Provider for ScriptArgs {
 
     fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
         let mut dict = Dict::default();
+
         if let Some(ref etherscan_api_key) =
             self.etherscan_api_key.as_ref().filter(|s| !s.trim().is_empty())
         {
@@ -511,12 +507,11 @@ impl Provider for ScriptArgs {
                 figment::value::Value::from(etherscan_api_key.to_string()),
             );
         }
-        if let Some(api_version) = &self.etherscan_api_version {
-            dict.insert("etherscan_api_version".to_string(), api_version.to_string().into());
-        }
+
         if let Some(timeout) = self.timeout {
             dict.insert("transaction_timeout".to_string(), timeout.into());
         }
+
         Ok(Map::from([(Config::selected_profile(), dict)]))
     }
 }

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -180,7 +180,6 @@ fn next_url(is_ws: bool, chain: NamedChain) -> String {
 mod tests {
     use super::*;
     use alloy_primitives::address;
-    use foundry_block_explorers::EtherscanApiVersion;
     use foundry_config::Chain;
 
     #[tokio::test]
@@ -223,33 +222,5 @@ mod tests {
         if !failed.is_empty() {
             panic!("failed keys: {failed:#?}");
         }
-    }
-
-    #[tokio::test]
-    #[ignore = "run manually"]
-    async fn test_etherscan_keys_compatibility() {
-        let address = address!("0x111111125421cA6dc452d289314280a0f8842A65");
-        let etherscan_key = "JQNGFHINKS1W7Y5FRXU4SPBYF43J3NYK46";
-        let client = foundry_block_explorers::Client::builder()
-            .with_api_key(etherscan_key)
-            .chain(Chain::optimism_mainnet())
-            .unwrap()
-            .build()
-            .unwrap();
-        if client.contract_abi(address).await.is_ok() {
-            panic!("v1 Optimism key should not work with v2 version")
-        }
-
-        let client = foundry_block_explorers::Client::builder()
-            .with_api_key(etherscan_key)
-            .with_api_version(EtherscanApiVersion::V1)
-            .chain(Chain::optimism_mainnet())
-            .unwrap()
-            .build()
-            .unwrap();
-        match client.contract_abi(address).await {
-            Ok(_) => {}
-            Err(_) => panic!("v1 Optimism key should work with v1 version"),
-        };
     }
 }

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -110,10 +110,6 @@ impl figment::Provider for VerifyBytecodeArgs {
             dict.insert("etherscan_api_key".into(), api_key.as_str().into());
         }
 
-        if let Some(api_version) = &self.verifier.verifier_api_version {
-            dict.insert("etherscan_api_version".into(), api_version.to_string().into());
-        }
-
         if let Some(block) = &self.block {
             dict.insert("block".into(), figment::value::Value::serialize(block)?);
         }

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -10,7 +10,7 @@ use alloy_provider::Provider;
 use alloy_rpc_types::TransactionTrait;
 use eyre::{Context, OptionExt, Result, eyre};
 use foundry_block_explorers::{
-    Client, EtherscanApiVersion,
+    Client,
     errors::EtherscanError,
     utils::lookup_compiler_version,
     verify::{CodeFormat, VerifyContract},
@@ -264,23 +264,7 @@ impl EtherscanVerificationProvider {
             || (verifier_type.is_sourcify() && etherscan_key.is_some());
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
 
-        let api_version = verifier_args.verifier_api_version.unwrap_or_else(|| {
-            if is_etherscan {
-                etherscan_config.as_ref().map(|c| c.api_version).unwrap_or_default()
-            } else {
-                EtherscanApiVersion::V1
-            }
-        });
-
-        let etherscan_api_url = verifier_url
-            .or_else(|| {
-                if api_version == EtherscanApiVersion::V2 {
-                    None
-                } else {
-                    etherscan_config.as_ref().map(|c| c.api_url.as_str())
-                }
-            })
-            .map(str::to_owned);
+        let etherscan_api_url = verifier_url.or_else(|| None).map(str::to_owned);
 
         let api_url = etherscan_api_url.as_deref();
         let base_url = etherscan_config
@@ -290,7 +274,7 @@ impl EtherscanVerificationProvider {
         let etherscan_key =
             etherscan_key.or_else(|| etherscan_config.as_ref().map(|c| c.key.clone()));
 
-        let mut builder = Client::builder().with_api_version(api_version);
+        let mut builder = Client::builder();
 
         builder = if let Some(api_url) = api_url {
             // we don't want any trailing slashes because this can cause cloudflare issues: <https://github.com/foundry-rs/foundry/pull/6079>
@@ -490,6 +474,7 @@ mod tests {
     use super::*;
     use crate::provider::VerificationProviderType;
     use clap::Parser;
+    use foundry_block_explorers::ETHERSCAN_V2_API_BASE_URL;
     use foundry_common::fs;
     use foundry_test_utils::{forgetest_async, str};
     use tempfile::tempdir;
@@ -580,7 +565,7 @@ mod tests {
 
         let client = etherscan.client(&args.etherscan, &args.verifier, &config).unwrap();
 
-        assert_eq!(client.etherscan_api_url().as_str(), "https://api.etherscan.io/v2/api");
+        assert_eq!(client.etherscan_api_url().as_str(), ETHERSCAN_V2_API_BASE_URL);
         assert!(format!("{client:?}").contains("dummykey"));
 
         let args: VerifyArgs = VerifyArgs::parse_from([
@@ -604,7 +589,6 @@ mod tests {
         let etherscan = EtherscanVerificationProvider::default();
         let client = etherscan.client(&args.etherscan, &args.verifier, &config).unwrap();
         assert_eq!(client.etherscan_api_url().as_str(), "https://verifier-url.com/");
-        assert_eq!(*client.etherscan_api_version(), EtherscanApiVersion::V2);
         assert!(format!("{client:?}").contains("dummykey"));
     }
 

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -10,7 +10,6 @@ use alloy_primitives::{Address, map::HashSet};
 use alloy_provider::Provider;
 use clap::{Parser, ValueEnum, ValueHint};
 use eyre::Result;
-use foundry_block_explorers::EtherscanApiVersion;
 use foundry_cli::{
     opts::{EtherscanOpts, RpcOpts},
     utils::{self, LoadConfig},
@@ -48,10 +47,6 @@ pub struct VerifierArgs {
     /// The verifier URL, if using a custom provider.
     #[arg(long, help_heading = "Verifier options", env = "VERIFIER_URL")]
     pub verifier_url: Option<String>,
-
-    /// The verifier API version, if using a custom provider.
-    #[arg(long, help_heading = "Verifier options", env = "VERIFIER_API_VERSION")]
-    pub verifier_api_version: Option<EtherscanApiVersion>,
 }
 
 impl Default for VerifierArgs {
@@ -60,7 +55,6 @@ impl Default for VerifierArgs {
             verifier: VerificationProviderType::Sourcify,
             verifier_api_key: None,
             verifier_url: None,
-            verifier_api_version: None,
         }
     }
 }
@@ -198,10 +192,6 @@ impl figment::Provider for VerifyArgs {
 
         if let Some(api_key) = &self.verifier.verifier_api_key {
             dict.insert("etherscan_api_key".into(), api_key.as_str().into());
-        }
-
-        if let Some(api_version) = &self.verifier.verifier_api_version {
-            dict.insert("etherscan_api_version".into(), api_version.to_string().into());
         }
 
         Ok(figment::value::Map::from([(Config::selected_profile(), dict)]))
@@ -497,10 +487,6 @@ impl figment::Provider for VerifyCheckArgs {
         let mut dict = self.etherscan.dict();
         if let Some(api_key) = &self.etherscan.key {
             dict.insert("etherscan_api_key".into(), api_key.as_str().into());
-        }
-
-        if let Some(api_version) = &self.etherscan.api_version {
-            dict.insert("etherscan_api_version".into(), api_version.to_string().into());
         }
 
         Ok(figment::value::Map::from([(Config::selected_profile(), dict)]))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/10913

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Fully deprecates Etherscan version abstraction in favor of simpler V2 implementation

Opening for visibility, want to perform more testing across other block explorers that may rely on the V1 API before finalizing PR

## Breaking changes

The `etherscan_api_version` field and setting are deprecated

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
