### PR TITLE
fix(`cheatcodes`): identify common proxies in state diffs

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1346,8 +1346,8 @@ fn get_recorded_state_diffs(ccx: &mut CheatsCtxt) -> BTreeMap<Address, AccountSt
     let mut contract_names = HashMap::new();
     let mut storage_layouts = HashMap::new();
     for address in addresses_to_lookup {
-        if let Some(name) = get_contract_name(ccx, address) {
-            contract_names.insert(address, name);
+        if let Some((artifact_id, _)) = get_contract_data(ccx, address) {
+            contract_names.insert(address, artifact_id.identifier());
         }
 
         // Also get storage layout if available
@@ -1478,49 +1478,6 @@ const EIP1967_IMPL_SLOT: &str = "360894a13ba1a3210667c828492db98dca3e2076cc3735a
 const EIP1822_PROXIABLE_SLOT: &str =
     "c5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7";
 
-/// Helper function to get the contract name from the deployed code.
-fn get_contract_name(ccx: &mut CheatsCtxt, address: Address) -> Option<String> {
-    // Check if we have available artifacts to match against
-    let artifacts = ccx.state.config.available_artifacts.as_ref()?;
-    // Try to load the account and get its code
-    let account = ccx.ecx.journaled_state.load_account(address).ok()?;
-    let code = account.info.code.as_ref()?;
-
-    // Skip if code is empty
-    if code.is_empty() {
-        return None;
-    }
-
-    // Try to find the artifact by deployed code
-    let code_bytes = code.original_bytes();
-
-    // Check if this is a proxy contract by looking for proxy storage slot patterns
-    let hex_str = hex::encode(&code_bytes);
-
-    let find_by_suffix = |suffix: &str| {
-        artifacts.iter().find_map(|(a, _)| a.identifier().ends_with(suffix).then(|| a.identifier()))
-    };
-
-    // Simple proxy detection based on storage slot patterns
-    if hex_str.contains(EIP1967_IMPL_SLOT) {
-        return find_by_suffix(":TransparentUpgradeableProxy");
-    } else if hex_str.contains(EIP1822_PROXIABLE_SLOT) {
-        return find_by_suffix(":UUPSUpgradeable");
-    }
-
-    // Try exact match
-    if let Some((artifact_id, _)) = artifacts.find_by_deployed_code_exact(&code_bytes) {
-        return Some(artifact_id.identifier());
-    }
-
-    // Try fuzzy matching
-    if let Some((artifact_id, _)) = artifacts.find_by_deployed_code(&code_bytes) {
-        return Some(artifact_id.identifier());
-    }
-
-    None
-}
-
 /// Helper function to get the contract data from the deployed code at an address.
 fn get_contract_data<'a>(
     ccx: &'a mut CheatsCtxt,
@@ -1540,7 +1497,22 @@ fn get_contract_data<'a>(
 
     // Try to find the artifact by deployed code
     let code_bytes = code.original_bytes();
+    // First check for proxy patterns
+    let hex_str = hex::encode(&code_bytes);
+    let find_by_suffix =
+        |suffix: &str| artifacts.iter().find(|(a, _)| a.identifier().ends_with(suffix));
+    // Simple proxy detection based on storage slot patterns
+    if hex_str.contains(EIP1967_IMPL_SLOT) {
+        if let Some(result) = find_by_suffix(":TransparentUpgradeableProxy") {
+            return Some(result);
+        }
+    } else if hex_str.contains(EIP1822_PROXIABLE_SLOT) {
+        if let Some(result) = find_by_suffix(":UUPSUpgradeable") {
+            return Some(result);
+        }
+    }
 
+    // Try exact match
     if let Some(result) = artifacts.find_by_deployed_code_exact(&code_bytes) {
         return Some(result);
     }

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1502,14 +1502,14 @@ fn get_contract_data<'a>(
     let find_by_suffix =
         |suffix: &str| artifacts.iter().find(|(a, _)| a.identifier().ends_with(suffix));
     // Simple proxy detection based on storage slot patterns
-    if hex_str.contains(EIP1967_IMPL_SLOT) {
-        if let Some(result) = find_by_suffix(":TransparentUpgradeableProxy") {
-            return Some(result);
-        }
-    } else if hex_str.contains(EIP1822_PROXIABLE_SLOT) {
-        if let Some(result) = find_by_suffix(":UUPSUpgradeable") {
-            return Some(result);
-        }
+    if hex_str.contains(EIP1967_IMPL_SLOT)
+        && let Some(result) = find_by_suffix(":TransparentUpgradeableProxy")
+    {
+        return Some(result);
+    } else if hex_str.contains(EIP1822_PROXIABLE_SLOT)
+        && let Some(result) = find_by_suffix(":UUPSUpgradeable")
+    {
+        return Some(result);
     }
 
     // Try exact match


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Ref: https://github.com/foundry-rs/foundry/pull/11276#issuecomment-3205034758

The current approach would not identify storage changes on proxy contracts. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Identify whether the account being accessed is a proxy or not.
- We can do this by checking whether the bytecode contains one of the two `EIP1967_IMPL_SLOT` or `EIP1822_PROXIABLE_SLOT`
- Find the artifact accordingly
- Unify `get_contract_name` into `get_contract_data` since they do the same thing

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
