### PR TITLE
fix: canonicalize paths in `forge doc`

### DIFF
--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -96,6 +96,9 @@ impl DocBuilder {
 
     /// Parse the sources and build the documentation.
     pub fn build(self) -> eyre::Result<()> {
+        fs::create_dir_all(self.root.join(&self.config.out))
+            .wrap_err("failed to create output directory")?;
+
         // Expand ignore globs
         let ignored = expand_globs(&self.root, self.config.ignore.iter())?;
 


### PR DESCRIPTION
## Motivation

See https://github.com/foundry-rs/foundry/pull/10955

Closes https://github.com/foundry-rs/foundry/issues/4533

TL;DR: `forge doc --out ./docs` does not work, `forge doc --out docs` does work.

## Solution

Ensure all paths are canonicalized & absolute, and then make them relative where needed.

Drive-by of making some unnecessarily pub fields private :+1: 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
