### PR TITLE
feat(forge): add --disable-labels for forge script and test

### DIFF
--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -186,6 +186,10 @@ pub struct TestArgs {
     #[arg(long, help_heading = "Display options", requires = "summary")]
     pub detailed: bool,
 
+    /// Disables the labels in the traces.
+    #[arg(long, help_heading = "Display options")]
+    pub disable_labels: bool,
+
     #[command(flatten)]
     filter: FilterArgs,
 
@@ -527,6 +531,7 @@ impl TestArgs {
         // Build the trace decoder.
         let mut builder = CallTraceDecoderBuilder::new()
             .with_known_contracts(&known_contracts)
+            .with_label_disabled(self.disable_labels)
             .with_verbosity(verbosity);
         // Signatures are of no value for gas reports.
         if !self.gas_report {

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -332,6 +332,7 @@ impl ExecutedState {
             .with_signature_identifier(SignaturesIdentifier::from_config(
                 &self.script_config.config,
             )?)
+            .with_label_disabled(self.args.disable_labels)
             .build();
 
         let mut identifier = TraceIdentifiers::new().with_local(known_contracts).with_etherscan(

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -182,6 +182,10 @@ pub struct ScriptArgs {
     #[arg(long)]
     pub disable_code_size_limit: bool,
 
+    /// Disables the labels in the traces.
+    #[arg(long)]
+    pub disable_labels: bool,
+
     /// The Etherscan (or equivalent) API key
     #[arg(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
     pub etherscan_api_key: Option<String>,


### PR DESCRIPTION
Similar to `cast call`, add a `--disable-labels` flag to disable fetching the labels in the output of `forge script` and `forge test`.