### PR TITLE
chore: check compatibility of evm_version and solc

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2140,7 +2140,6 @@ impl Config {
     /// This normalizes the default `evm_version` if a `solc` was provided in the config.
     ///
     /// See also <https://github.com/foundry-rs/foundry/issues/7014>
-    #[expect(clippy::disallowed_macros)]
     fn normalize_defaults(&self, mut figment: Figment) -> Figment {
         if figment.contains("evm_version") {
             // Check compatibility if both evm_version and solc are provided

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2140,29 +2140,44 @@ impl Config {
     /// This normalizes the default `evm_version` if a `solc` was provided in the config.
     ///
     /// See also <https://github.com/foundry-rs/foundry/issues/7014>
+    #[expect(clippy::disallowed_macros)]
     fn normalize_defaults(&self, mut figment: Figment) -> Figment {
+        let evm_version = figment.extract_inner::<EvmVersion>("evm_version").ok().or_else(|| {
+            figment
+                .extract_inner::<String>("evm_version")
+                .ok()
+                .and_then(|s| s.parse::<EvmVersion>().ok())
+        });
+
+        let solc_version = figment
+            .extract_inner::<SolcReq>("solc")
+            .ok()
+            .and_then(|solc| solc.try_version().ok())
+            .and_then(|v| self.evm_version.normalize_version_solc(&v));
+
         if figment.contains("evm_version") {
             // Check compatibility if both evm_version and solc are provided
-            if let Ok(evm_version) = figment.extract_inner::<EvmVersion>("evm_version")
-                && let Ok(solc) = figment.extract_inner::<SolcReq>("solc")
-                && let Ok(solc_version) = solc.try_version()
-                && let Some(normalized) = self.evm_version.normalize_version_solc(&solc_version)
-                && normalized != evm_version
-            {
-                warn!(
-                    "evm_version '{evm_version}' may be incompatible with solc version '{solc_version}'. Consider using '{normalized}'"
-                );
+            // First try to extract as EvmVersion directly, then fallback to string parsing for
+            // case-insensitive support
+            if let Some(evm_version) = evm_version {
+                figment = figment.merge(("evm_version", evm_version));
+
+                if let Some(solc_version) = solc_version
+                    && solc_version != evm_version
+                {
+                    eprintln!(
+                        "{}",
+                        yansi::Paint::yellow(&format!(
+                            "Warning: evm_version '{evm_version}' may be incompatible with solc version. Consider using '{solc_version}'"
+                        ))
+                    );
+                }
             }
             return figment;
         }
 
         // Normalize `evm_version` based on the provided solc version.
-        if let Ok(solc) = figment.extract_inner::<SolcReq>("solc")
-            && let Some(version) = solc
-                .try_version()
-                .ok()
-                .and_then(|version| self.evm_version.normalize_version_solc(&version))
-        {
+        if let Some(version) = solc_version {
             figment = figment.merge(("evm_version", version));
         }
 
@@ -6240,7 +6255,7 @@ mod tests {
     fn test_evm_version_solc_compatibility_warning() {
         figment::Jail::expect_with(|jail| {
             // Create a config with incompatible evm_version and solc version
-            // Using Cancun (latest) with an older solc version (Berlin) that doesn't support it
+            // Using Cancun with an older solc version (Berlin) that doesn't support it
             jail.create_file(
                 "foundry.toml",
                 r#"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2150,8 +2150,8 @@ impl Config {
                 && let Some(normalized) = self.evm_version.normalize_version_solc(&solc_version)
                 && normalized != evm_version
             {
-                eprintln!(
-                    "Warning: evm_version '{evm_version}' may be incompatible with solc version '{solc_version}'. Consider using '{normalized}'"
+                warn!(
+                    "evm_version '{evm_version}' may be incompatible with solc version '{solc_version}'. Consider using '{normalized}'"
                 );
             }
             return figment;

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6235,4 +6235,31 @@ mod tests {
             Ok(())
         });
     }
+
+    #[test]
+    fn test_evm_version_solc_compatibility_warning() {
+        figment::Jail::expect_with(|jail| {
+            // Create a config with incompatible evm_version and solc version
+            // Using Cancun (latest) with an older solc version that doesn't support it
+            jail.create_file(
+                "foundry.toml",
+                r"
+                [default]
+                evm_version = 'cancun'
+                solc = '0.8.20'
+            ",
+            )?;
+
+            // Load the config - this should trigger the compatibility check
+            let config = Config::load().unwrap().sanitized();
+            
+            // Verify that the config loaded successfully
+            // The actual normalized version depends on the implementation
+            // Let's just verify that the config loads without panicking
+            // and that we have a valid EVM version
+            assert!(matches!(config.evm_version, EvmVersion::Cancun | EvmVersion::Shanghai | EvmVersion::London));
+            
+            Ok(())
+        });
+    }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6240,25 +6240,17 @@ mod tests {
     fn test_evm_version_solc_compatibility_warning() {
         figment::Jail::expect_with(|jail| {
             // Create a config with incompatible evm_version and solc version
-            // Using Cancun (latest) with an older solc version that doesn't support it
+            // Using Cancun (latest) with an older solc version (Berlin) that doesn't support it
             jail.create_file(
                 "foundry.toml",
-                r"
-                [default]
-                evm_version = 'cancun'
-                solc = '0.8.20'
-            ",
+                r#"
+            [profile.default]
+            evm_version = "Cancun"
+            solc = "0.8.5"
+        "#,
             )?;
 
-            // Load the config - this should trigger the compatibility check
-            let config = Config::load().unwrap().sanitized();
-            
-            // Verify that the config loaded successfully
-            // The actual normalized version depends on the implementation
-            // Let's just verify that the config loads without panicking
-            // and that we have a valid EVM version
-            assert!(matches!(config.evm_version, EvmVersion::Cancun | EvmVersion::Shanghai | EvmVersion::London));
-            
+            let _config = Config::load().unwrap();
             Ok(())
         });
     }


### PR DESCRIPTION
Add a log if `evm_version` is not compatible with the `solc` version, to avoid the confusion of the user.