### PR TITLE
ci: add --no-fail-fast

### DIFF
--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -128,6 +128,8 @@ def main():
                     flags += " --features=isolate-by-default"
                 name += os_str
 
+                flags += " --no-fail-fast"
+
                 obj = Expanded(
                     name=name,
                     runner_label=target.runner_label,


### PR DESCRIPTION
CI is pretty fast overall so I'd prefer seeing all tests that fail rather than just the first one that happens in that run.