### PR TITLE
fix(forge): populate the git submodule url from git config

### DIFF
--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -711,6 +711,18 @@ ignore them in the `.gitignore` file."
         self.cmd().stderr(self.stderr()).args(["submodule", "sync"]).exec().map(drop)
     }
 
+    /// Get the URL of a submodule from git config
+    pub fn submodule_url(self, path: impl AsRef<OsStr>) -> Result<Option<String>> {
+        self.cmd()
+            .args([
+                "config",
+                "--get",
+                &format!("submodule.{}.url", path.as_ref().to_string_lossy()),
+            ])
+            .get_stdout_lossy()
+            .map(|url| Some(url.trim().to_string()))
+    }
+
     pub fn cmd(self) -> Command {
         let mut cmd = Self::cmd_no_root();
         cmd.current_dir(self.root);

--- a/crates/forge/src/cmd/remove.rs
+++ b/crates/forge/src/cmd/remove.rs
@@ -42,7 +42,9 @@ impl RemoveArgs {
         git.rm(self.force, &paths)?;
 
         // remove all the dependencies from .git/modules
-        for (Dependency { name, url, tag, .. }, path) in self.dependencies.iter().zip(&paths) {
+        for (Dependency { name, tag, .. }, path) in self.dependencies.iter().zip(&paths) {
+            // Get the URL from git submodule config instead of using the parsed dependency URL
+            let url = git.submodule_url(path).unwrap_or(None);
             sh_println!("Removing '{name}' in {}, (url: {url:?}, tag: {tag:?})", path.display())?;
             let _ = lockfile.remove(path);
             std::fs::remove_dir_all(git_modules.join(path))?;

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1463,13 +1463,10 @@ Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std
     };
 
     let remove = |cmd: &mut TestCommand, target: &str| {
-        // TODO: flaky behavior with URL, sometimes it is None, sometimes it is Some("https://github.com/lib/forge-std")
-        cmd.forge_fuse().args(["remove", "--force", target]).assert_success().stdout_eq(str![[
-            r#"
-Removing 'forge-std' in [..], (url: [..], tag: None)
+        cmd.forge_fuse().args(["remove", "--force", target]).assert_success().stdout_eq(str![[r#"
+Removing 'forge-std' in lib/forge-std, (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
 
-"#
-        ]]);
+"#]]);
 
         assert!(!forge_std.exists());
         assert!(!forge_std_mod.exists());


### PR DESCRIPTION
The `Dependency::FromStr` implementation sets url to `None` when the input is treated as an alias-only dependency, eg `forge-std`, so we can try to get the url from the git config.