### PR TITLE
feat(forge verify-contract): update Sourcify integration to support API v2

### DIFF
--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -249,6 +249,7 @@ impl CreateArgs {
             guess_constructor_args: false,
             compilation_profile: Some(id.profile.to_string()),
             language: None,
+            creation_transaction_hash: Default::default(),
         };
 
         // Check config for Etherscan API Keys to avoid preflight check failing if no
@@ -439,6 +440,7 @@ impl CreateArgs {
             guess_constructor_args: false,
             compilation_profile: Some(id.profile.to_string()),
             language: None,
+            creation_transaction_hash: Some(receipt.transaction_hash),
         };
         sh_println!("Waiting for {} to detect contract deployment...", verify.verifier.verifier)?;
         verify.run().await

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -163,6 +163,7 @@ impl VerifyBundle {
                     guess_constructor_args: false,
                     compilation_profile: Some(artifact.profile.to_string()),
                     language: None,
+                    creation_transaction_hash: None,
                 };
 
                 return Some(verify);

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -2,6 +2,7 @@ use crate::{
     VerifierArgs,
     provider::{VerificationContext, VerificationProvider},
     retry::RETRY_CHECK_ON_VERIFY,
+    utils::ensure_solc_build_metadata,
     verify::{ContractLanguage, VerifyArgs, VerifyCheckArgs},
 };
 use alloy_json_abi::Function;
@@ -12,7 +13,6 @@ use eyre::{Context, OptionExt, Result, eyre};
 use foundry_block_explorers::{
     Client, EtherscanApiVersion,
     errors::EtherscanError,
-    utils::lookup_compiler_version,
     verify::{CodeFormat, VerifyContract},
 };
 use foundry_cli::{
@@ -24,7 +24,7 @@ use foundry_compilers::{Artifact, artifacts::BytecodeObject};
 use foundry_config::Config;
 use foundry_evm::constants::DEFAULT_CREATE2_DEPLOYER;
 use regex::Regex;
-use semver::{BuildMetadata, Version};
+use semver::BuildMetadata;
 use std::{fmt::Debug, sync::LazyLock};
 
 mod flatten;
@@ -464,24 +464,6 @@ impl EtherscanVerificationProvider {
         } else {
             eyre::bail!("Local bytecode doesn't match on-chain bytecode")
         }
-    }
-}
-
-/// Given any solc [Version] return a [Version] with build metadata
-///
-/// # Example
-///
-/// ```ignore
-/// use semver::{BuildMetadata, Version};
-/// let version = Version::new(1, 2, 3);
-/// let version = ensure_solc_build_metadata(version).await?;
-/// assert_ne!(version.build, BuildMetadata::EMPTY);
-/// ```
-async fn ensure_solc_build_metadata(version: Version) -> Result<Version> {
-    if version.build != BuildMetadata::EMPTY {
-        Ok(version)
-    } else {
-        Ok(lookup_compiler_version(&version).await?)
     }
 }
 

--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -258,7 +258,7 @@ impl SourcifyVerificationProvider {
             std_json_input,
             compiler_version,
             contract_identifier,
-            creation_transaction_hash: None, // Could be added as an option later
+            creation_transaction_hash: args.creation_transaction_hash.map(|h| h.to_string()),
         };
 
         Ok(req)

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -8,6 +8,7 @@ use eyre::{OptionExt, Result};
 use foundry_block_explorers::{
     contract::{ContractCreationData, ContractMetadata, Metadata},
     errors::EtherscanError,
+    utils::lookup_compiler_version,
 };
 use foundry_common::{
     abi::encode_args, compile::ProjectCompiler, ignore_metadata_hash, provider::RetryProvider,
@@ -21,7 +22,7 @@ use foundry_evm::{
 };
 use reqwest::Url;
 use revm::{bytecode::Bytecode, database::Database, primitives::hardfork::SpecId};
-use semver::Version;
+use semver::{BuildMetadata, Version};
 use serde::{Deserialize, Serialize};
 use yansi::Paint;
 
@@ -411,6 +412,24 @@ pub async fn get_runtime_codes(
 /// This is used to check user input url for missing /api path
 pub fn is_host_only(url: &Url) -> bool {
     matches!(url.path(), "/" | "")
+}
+
+/// Given any solc [Version] return a [Version] with build metadata
+///
+/// # Example
+///
+/// ```ignore
+/// use semver::{BuildMetadata, Version};
+/// let version = Version::new(1, 2, 3);
+/// let version = ensure_solc_build_metadata(version).await?;
+/// assert_ne!(version.build, BuildMetadata::EMPTY);
+/// ```
+pub async fn ensure_solc_build_metadata(version: Version) -> Result<Version> {
+    if version.build != BuildMetadata::EMPTY {
+        Ok(version)
+    } else {
+        Ok(lookup_compiler_version(&version).await?)
+    }
 }
 
 #[cfg(test)]

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -460,7 +460,7 @@ pub struct VerifyCheckArgs {
     ///
     /// For Etherscan - Submission GUID.
     ///
-    /// For Sourcify - Contract Address.
+    /// For Sourcify - Verification Job ID.
     pub id: String,
 
     #[command(flatten)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #11065

Sourcify API v1 is deprecated and forge should be updated to use API v2.

API v2 is based on asynchronous verification jobs similar to Etherscan. Therefore, it's necessary to return the verification job ID and check the job for a successful verification.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- `forge verify-contract` outputs the verification job id after submitting to Sourcify
- `forge verify-contract --watch` automatically polls the Sourcify API for the job status.
- `forge verify-check` takes a verification job id to follow the same pattern as Etherscan with its GUID.
- Adds support for providing the creation transaction hash to the Sourcify API via a new argument. This makes it easier to get a creation match. `forge create --verify` automatically passes the transaction hash to the verify command.
- Adds the `is_contract_verified_check` which was missing and therefore inconsistent with the Etherscan command.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
