### PR TITLE
fix(coverage): contracts by artifact from linked contracts

### DIFF
--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -7,7 +7,10 @@ use crate::{
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Bytes, U256};
 use eyre::Result;
-use foundry_common::{ContractsByArtifact, TestFunctionExt, get_contract_name, shell::verbosity};
+use foundry_common::{
+    ContractsByArtifact, ContractsByArtifactBuilder, TestFunctionExt, get_contract_name,
+    shell::verbosity,
+};
 use foundry_compilers::{
     Artifact, ArtifactId, ProjectCompileOutput,
     artifacts::{Contract, Libraries},
@@ -531,10 +534,10 @@ impl MultiContractRunnerBuilder {
             }
         }
 
-        // Create known contracts with storage layout information
-        let known_contracts = ContractsByArtifact::with_storage_layout(
-            output.clone().with_stripped_file_prefixes(root),
-        );
+        // Create known contracts from linked contracts and storage layout information (if any).
+        let known_contracts = ContractsByArtifactBuilder::new(linked_contracts)
+            .with_storage_layouts(output.clone().with_stripped_file_prefixes(root))
+            .build();
 
         Ok(MultiContractRunner {
             contracts: deployable_contracts,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #11432 
- regression introduced https://github.com/foundry-rs/foundry/pull/11204/files#diff-7cf15eff5ea54b62e8810f2f11d2285a2783dc88ceb867ca0618a73487f1df60R522-R525 we need to create contracts by artifact from linked contracts
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- introduce builder to create `ContractsByArtifact` from contracts iter and enrich with storage layouts (if available)
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
