### PR TITLE
fix(anvil): make with_steps_tracing enable steps + mem/stack snapshots

### DIFF
--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -7,7 +7,7 @@ use foundry_evm::{
     decode::decode_console_logs,
     inspectors::{LogCollector, TracingInspector},
     traces::{
-        CallTraceDecoder, SparsedTraceArena, TracingInspectorConfig, StackSnapshotType,
+        CallTraceDecoder, SparsedTraceArena, StackSnapshotType, TracingInspectorConfig,
         render_trace_arena_inner,
     },
 };


### PR DESCRIPTION
- Align AnvilInspector::with_steps_tracing with its name and CLI/docs semantics.
- Switch from recording state diffs to enabling actual step recording and full context:
  - set_steps(true)
  - set_memory_snapshots(true)
  - set_stack_snapshots(StackSnapshotType::Full)
- Keep with_trace_printer on state diffs (unchanged).
- This matches how cheatcodes enable debug step recording and unblocks geth-style step traces.