### PR TITLE
fix(forge): custom verifiers should not throw on unknown etherscan chains

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -62,9 +62,8 @@ pub use endpoints::{
 };
 
 mod etherscan;
-use etherscan::{
-    EtherscanConfigError, EtherscanConfigs, EtherscanEnvProvider, ResolvedEtherscanConfig,
-};
+pub use etherscan::EtherscanConfigError;
+use etherscan::{EtherscanConfigs, EtherscanEnvProvider, ResolvedEtherscanConfig};
 
 pub mod resolve;
 pub use resolve::UnresolvedEnvVarError;
@@ -1443,15 +1442,10 @@ impl Config {
 
         // etherscan fallback via API key
         if let Some(key) = self.etherscan_api_key.as_ref() {
-            match ResolvedEtherscanConfig::create(key, chain.or(self.chain).unwrap_or_default()) {
-                Some(config) => return Ok(Some(config)),
-                None => {
-                    return Err(EtherscanConfigError::UnknownChain(
-                        String::new(),
-                        chain.unwrap_or_default(),
-                    ));
-                }
-            }
+            return Ok(ResolvedEtherscanConfig::create(
+                key,
+                chain.or(self.chain).unwrap_or_default(),
+            ));
         }
         Ok(None)
     }

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -314,3 +314,49 @@ forgetest!(can_guess_constructor_args, |prj, cmd| {
 forgetest!(can_verify_random_contract_sepolia_default_sourcify, |prj, cmd| {
     verify_on_chain(EnvExternalities::sepolia_empty_verifier(), prj, cmd);
 });
+
+// Tests that verify properly validates verifier arguments.
+// <https://github.com/foundry-rs/foundry/issues/11430>
+forgetest_init!(can_validate_verifier_settings, |prj, cmd| {
+    // No verifier URL.
+    cmd.args([
+        "verify-contract",
+        "--rpc-url",
+        "https://rpc.sepolia-api.lisk.com",
+        "--verifier",
+        "blockscout",
+        "0x19b248616E4964f43F611b5871CE1250f360E9d3",
+        "src/Counter.sol:Counter",
+    ])
+    .assert_failure()
+    .stderr_eq(str![[r#"
+Error: No verifier URL specified for verifier blockscout
+
+"#]]);
+
+    // Unknown Etherscan chain.
+    cmd.forge_fuse()
+        .args([
+            "verify-contract",
+            "--rpc-url",
+            "https://rpc.sepolia-api.lisk.com",
+            "--verifier",
+            "etherscan",
+            "0x19b248616E4964f43F611b5871CE1250f360E9d3",
+            "src/Counter.sol:Counter",
+        ])
+        .assert_failure()
+        .stderr_eq(str![[r#"
+Error: No known Etherscan API URL for chain `4202`. To fix this, please:
+1. Specify a `url` 
+2. Verify the chain `4202` is correct
+
+"#]]);
+
+    cmd.forge_fuse().args(["verify-contract", "--rpc-url", "https://rpc.sepolia-api.lisk.com", "--verifier", "blockscout", "--verifier-url", "https://sepolia-blockscout.lisk.com/api", "0x19b248616E4964f43F611b5871CE1250f360E9d3", "src/Counter.sol:Counter"]).assert_success().stdout_eq(str![[r#"
+Start verifying contract `0x19b248616E4964f43F611b5871CE1250f360E9d3` deployed on 4202
+
+Contract [src/Counter.sol:Counter] "0x19b248616E4964f43F611b5871CE1250f360E9d3" is already verified. Skipping verification.
+
+"#]]);
+});

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -189,10 +189,10 @@ impl VerificationProviderType {
             if let Some(chain) = chain
                 && chain.etherscan_urls().is_none()
             {
-                eyre::bail!(EtherscanConfigError::UnknownChain(String::new(), chain,))
+                eyre::bail!(EtherscanConfigError::UnknownChain(String::new(), chain))
             }
             if !has_key {
-                eyre::bail!("ETHERSCAN_API_KEY12 must be set to use Etherscan as a verifier")
+                eyre::bail!("ETHERSCAN_API_KEY must be set to use Etherscan as a verifier")
             }
             return Ok(Box::<EtherscanVerificationProvider>::default());
         }

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -172,6 +172,7 @@ impl VerificationProviderType {
         &self,
         key: Option<&str>,
         chain: Option<Chain>,
+        has_url: bool,
     ) -> Result<Box<dyn VerificationProvider>> {
         let has_key = key.as_ref().is_some_and(|k| !k.is_empty());
         // 1. If no verifier or `--verifier sourcify` is set and no API key provided, use Sourcify.
@@ -198,8 +199,11 @@ impl VerificationProviderType {
         }
 
         // 3. If `--verifier blockscout | oklink | custom` is explicitly set, use the chosen
-        //    verifier.
+        //    verifier and make sure an URL was specified.
         if matches!(self, Self::Blockscout | Self::Oklink | Self::Custom) {
+            if !has_url {
+                eyre::bail!("No verifier URL specified for verifier {}", self);
+            }
             return Ok(Box::<EtherscanVerificationProvider>::default());
         }
 

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -14,7 +14,7 @@ use foundry_compilers::{
     multi::{MultiCompilerParser, MultiCompilerSettings},
     solc::Solc,
 };
-use foundry_config::Config;
+use foundry_config::{Chain, Config, EtherscanConfigError};
 use semver::Version;
 use std::{fmt, path::PathBuf, str::FromStr};
 
@@ -168,7 +168,11 @@ pub enum VerificationProviderType {
 
 impl VerificationProviderType {
     /// Returns the corresponding `VerificationProvider` for the key
-    pub fn client(&self, key: Option<&str>) -> Result<Box<dyn VerificationProvider>> {
+    pub fn client(
+        &self,
+        key: Option<&str>,
+        chain: Option<Chain>,
+    ) -> Result<Box<dyn VerificationProvider>> {
         let has_key = key.as_ref().is_some_and(|k| !k.is_empty());
         // 1. If no verifier or `--verifier sourcify` is set and no API key provided, use Sourcify.
         if !has_key && self.is_sourcify() {
@@ -179,10 +183,16 @@ impl VerificationProviderType {
             return Ok(Box::<SourcifyVerificationProvider>::default());
         }
 
-        // 2. If `--verifier etherscan` is explicitly set, enforce the API key requirement.
+        // 2. If `--verifier etherscan` is explicitly set, check if chain is supported and
+        // enforce the API key requirement.
         if self.is_etherscan() {
+            if let Some(chain) = chain
+                && chain.etherscan_urls().is_none()
+            {
+                eyre::bail!(EtherscanConfigError::UnknownChain(String::new(), chain,))
+            }
             if !has_key {
-                eyre::bail!("ETHERSCAN_API_KEY must be set to use Etherscan as a verifier")
+                eyre::bail!("ETHERSCAN_API_KEY12 must be set to use Etherscan as a verifier")
             }
             return Ok(Box::<EtherscanVerificationProvider>::default());
         }

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -253,7 +253,7 @@ impl VerifyArgs {
         {
             sh_println!("Constructor args: {args}")?
         }
-        self.verifier.verifier.client(self.etherscan.key().as_deref(), self.etherscan.chain)?.verify(self, context).await.map_err(|err| {
+        self.verifier.verifier.client(self.etherscan.key().as_deref(), self.etherscan.chain, self.verifier.verifier_url.is_some())?.verify(self, context).await.map_err(|err| {
             if let Some(verifier_url) = verifier_url {
                  match Url::parse(&verifier_url) {
                     Ok(url) => {
@@ -277,7 +277,11 @@ impl VerifyArgs {
 
     /// Returns the configured verification provider
     pub fn verification_provider(&self) -> Result<Box<dyn VerificationProvider>> {
-        self.verifier.verifier.client(self.etherscan.key().as_deref(), self.etherscan.chain)
+        self.verifier.verifier.client(
+            self.etherscan.key().as_deref(),
+            self.etherscan.chain,
+            self.verifier.verifier_url.is_some(),
+        )
     }
 
     /// Resolves [VerificationContext] object either from entered contract name or by trying to
@@ -478,7 +482,11 @@ impl VerifyCheckArgs {
         )?;
         self.verifier
             .verifier
-            .client(self.etherscan.key().as_deref(), self.etherscan.chain)?
+            .client(
+                self.etherscan.key().as_deref(),
+                self.etherscan.chain,
+                self.verifier.verifier_url.is_some(),
+            )?
             .check(self)
             .await
     }

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -253,7 +253,7 @@ impl VerifyArgs {
         {
             sh_println!("Constructor args: {args}")?
         }
-        self.verifier.verifier.client(self.etherscan.key().as_deref())?.verify(self, context).await.map_err(|err| {
+        self.verifier.verifier.client(self.etherscan.key().as_deref(), self.etherscan.chain)?.verify(self, context).await.map_err(|err| {
             if let Some(verifier_url) = verifier_url {
                  match Url::parse(&verifier_url) {
                     Ok(url) => {
@@ -277,7 +277,7 @@ impl VerifyArgs {
 
     /// Returns the configured verification provider
     pub fn verification_provider(&self) -> Result<Box<dyn VerificationProvider>> {
-        self.verifier.verifier.client(self.etherscan.key().as_deref())
+        self.verifier.verifier.client(self.etherscan.key().as_deref(), self.etherscan.chain)
     }
 
     /// Resolves [VerificationContext] object either from entered contract name or by trying to
@@ -476,7 +476,11 @@ impl VerifyCheckArgs {
             "Checking verification status on {}",
             self.etherscan.chain.unwrap_or_default()
         )?;
-        self.verifier.verifier.client(self.etherscan.key().as_deref())?.check(self).await
+        self.verifier
+            .verifier
+            .client(self.etherscan.key().as_deref(), self.etherscan.chain)?
+            .check(self)
+            .await
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #11430 
- config should not throw on non etherscan verifiers when chain not known by etherscan - issue introduced in https://github.com/foundry-rs/foundry/pull/11194/files#diff-0f348074359029c2930eb72b52f482c2e0f4495dc61b95bc919f155a8d2fd82cR1437-R1444. Instead should just continue as unknown etherscan chains could be supported by other verifiers like blockscout and sourcify.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- in place fix, needs a broader refactoring to reflect same code is used by etherscan-like verifiers and more tests for non-etherscan supported verifiers 
- consider backport to v1.3.3
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
