### PR TITLE
fix(cheatcodes): use make_acc_non_empty in mockCalls_1Call for consistency

### DIFF
--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -111,7 +111,7 @@ impl Cheatcode for mockCalls_0Call {
 impl Cheatcode for mockCalls_1Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { callee, msgValue, data, returnData } = self;
-        ccx.ecx.journaled_state.load_account(*callee)?;
+        let _ = make_acc_non_empty(callee, ccx)?;
         mock_calls(ccx.state, callee, data, Some(msgValue), returnData, InstructionResult::Return);
         Ok(Default::default())
     }


### PR DESCRIPTION
All other mock functions use `make_acc_non_empty` to etch a single byte onto empty accounts, which prevents Solidity's `extcodesize` check from failing when mocking calls to addresses without existing bytecode.

Makes `mockCalls_1Call` consistent with the other mock cheatcodes and ensures mocked calls work correctly in all scenarios.