### PR TITLE
fix(forge): v1.3 do not throw if etherscan api key set and unknown chain

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1429,19 +1429,11 @@ impl Config {
 
         // etherscan fallback via API key
         if let Some(key) = self.etherscan_api_key.as_ref() {
-            match ResolvedEtherscanConfig::create(
+            return Ok(ResolvedEtherscanConfig::create(
                 key,
                 chain.or(self.chain).unwrap_or_default(),
                 default_api_version,
-            ) {
-                Some(config) => return Ok(Some(config)),
-                None => {
-                    return Err(EtherscanConfigError::UnknownChain(
-                        String::new(),
-                        chain.unwrap_or_default(),
-                    ));
-                }
-            }
+            ));
         }
         Ok(None)
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- ref #11430 issue in v1.3.3, needs a more elaborated fix for https://github.com/foundry-rs/foundry/issues/11186 in v1.4.0, throwing the err is just breaking other verifiers when ETHERSCAN_API_KEY set

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
