### PR TITLE
feat(cheats): json/toml --> consolidate `write` and `writeUpsert`

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -11274,26 +11274,6 @@
     },
     {
       "func": {
-        "id": "writeJsonUpsert",
-        "description": "Write a serialized JSON object to an **existing** JSON file, replacing a value with key = <value_key.>\nThis is useful to replace a specific value of a JSON file, without having to parse the entire thing.\nUnlike `writeJson`, this cheatcode will create new keys if they didn't previously exist.",
-        "declaration": "function writeJsonUpsert(string calldata json, string calldata path, string calldata valueKey) external;",
-        "visibility": "external",
-        "mutability": "",
-        "signature": "writeJsonUpsert(string,string,string)",
-        "selector": "0xd0fd45d8",
-        "selectorBytes": [
-          208,
-          253,
-          69,
-          216
-        ]
-      },
-      "group": "toml",
-      "status": "stable",
-      "safety": "safe"
-    },
-    {
-      "func": {
         "id": "writeJson_0",
         "description": "Write a serialized JSON object to a file. If the file exists, it will be overwritten.",
         "declaration": "function writeJson(string calldata json, string calldata path) external;",
@@ -11315,7 +11295,7 @@
     {
       "func": {
         "id": "writeJson_1",
-        "description": "Write a serialized JSON object to an **existing** JSON file, replacing a value with key = <value_key.>\nThis is useful to replace a specific value of a JSON file, without having to parse the entire thing.",
+        "description": "Write a serialized JSON object to an **existing** JSON file, replacing a value with key = <value_key.>\nThis is useful to replace a specific value of a JSON file, without having to parse the entire thing.\nThis cheatcode will create new keys if they didn't previously exist.",
         "declaration": "function writeJson(string calldata json, string calldata path, string calldata valueKey) external;",
         "visibility": "external",
         "mutability": "",
@@ -11354,26 +11334,6 @@
     },
     {
       "func": {
-        "id": "writeTomlUpsert",
-        "description": "Takes serialized JSON, converts to TOML and write a serialized TOML table to an **existing** TOML file, replacing a value with key = <value_key.>\nThis is useful to replace a specific value of a TOML file, without having to parse the entire thing.\nUnlike `writeToml`, this cheatcode will create new keys if they didn't previously exist.",
-        "declaration": "function writeTomlUpsert(string calldata json, string calldata path, string calldata valueKey) external;",
-        "visibility": "external",
-        "mutability": "",
-        "signature": "writeTomlUpsert(string,string,string)",
-        "selector": "0x72333682",
-        "selectorBytes": [
-          114,
-          51,
-          54,
-          130
-        ]
-      },
-      "group": "toml",
-      "status": "stable",
-      "safety": "safe"
-    },
-    {
-      "func": {
         "id": "writeToml_0",
         "description": "Takes serialized JSON, converts to TOML and write a serialized TOML to a file.",
         "declaration": "function writeToml(string calldata json, string calldata path) external;",
@@ -11395,7 +11355,7 @@
     {
       "func": {
         "id": "writeToml_1",
-        "description": "Takes serialized JSON, converts to TOML and write a serialized TOML table to an **existing** TOML file, replacing a value with key = <value_key.>\nThis is useful to replace a specific value of a TOML file, without having to parse the entire thing.",
+        "description": "Takes serialized JSON, converts to TOML and write a serialized TOML table to an **existing** TOML file, replacing a value with key = <value_key.>\nThis is useful to replace a specific value of a TOML file, without having to parse the entire thing.\nThis cheatcode will create new keys if they didn't previously exist.",
         "declaration": "function writeToml(string calldata json, string calldata path, string calldata valueKey) external;",
         "visibility": "external",
         "mutability": "",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2552,14 +2552,9 @@ interface Vm {
 
     /// Write a serialized JSON object to an **existing** JSON file, replacing a value with key = <value_key.>
     /// This is useful to replace a specific value of a JSON file, without having to parse the entire thing.
+    /// This cheatcode will create new keys if they didn't previously exist.
     #[cheatcode(group = Json)]
     function writeJson(string calldata json, string calldata path, string calldata valueKey) external;
-
-    /// Write a serialized JSON object to an **existing** JSON file, replacing a value with key = <value_key.>
-    /// This is useful to replace a specific value of a JSON file, without having to parse the entire thing.
-    /// Unlike `writeJson`, this cheatcode will create new keys if they didn't previously exist.
-    #[cheatcode(group = Toml)]
-    function writeJsonUpsert(string calldata json, string calldata path, string calldata valueKey) external;
 
     // ======== TOML Parsing and Manipulation ========
 
@@ -2663,14 +2658,9 @@ interface Vm {
 
     /// Takes serialized JSON, converts to TOML and write a serialized TOML table to an **existing** TOML file, replacing a value with key = <value_key.>
     /// This is useful to replace a specific value of a TOML file, without having to parse the entire thing.
+    /// This cheatcode will create new keys if they didn't previously exist.
     #[cheatcode(group = Toml)]
     function writeToml(string calldata json, string calldata path, string calldata valueKey) external;
-
-    /// Takes serialized JSON, converts to TOML and write a serialized TOML table to an **existing** TOML file, replacing a value with key = <value_key.>
-    /// This is useful to replace a specific value of a TOML file, without having to parse the entire thing.
-    /// Unlike `writeToml`, this cheatcode will create new keys if they didn't previously exist.
-    #[cheatcode(group = Toml)]
-    function writeTomlUpsert(string calldata json, string calldata path, string calldata valueKey) external;
 
     // ======== Cryptography ========
 

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -345,24 +345,6 @@ impl Cheatcode for writeJson_0Call {
 
 impl Cheatcode for writeJson_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
-        let Self { json, path, valueKey } = self;
-        let json = serde_json::from_str(json).unwrap_or_else(|_| Value::String(json.to_owned()));
-
-        let data_path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
-        let data_s = fs::read_to_string(data_path)?;
-        let data = serde_json::from_str(&data_s)?;
-        let value =
-            jsonpath_lib::replace_with(data, &canonicalize_json_path(valueKey), &mut |_| {
-                Some(json.clone())
-            })?;
-
-        let json_string = serde_json::to_string_pretty(&value)?;
-        super::fs::write_file(state, path.as_ref(), json_string.as_bytes())
-    }
-}
-
-impl Cheatcode for writeJsonUpsertCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json: value, path, valueKey } = self;
 
         // Read, parse, and update the JSON object

--- a/crates/cheatcodes/src/toml.rs
+++ b/crates/cheatcodes/src/toml.rs
@@ -4,8 +4,8 @@ use crate::{
     Cheatcode, Cheatcodes, Result,
     Vm::*,
     json::{
-        canonicalize_json_path, check_json_key_exists, parse_json, parse_json_coerce,
-        parse_json_keys, resolve_type, upsert_json_value,
+        check_json_key_exists, parse_json, parse_json_coerce, parse_json_keys, resolve_type,
+        upsert_json_value,
     },
 };
 use alloy_dyn_abi::DynSolType;
@@ -175,26 +175,6 @@ impl Cheatcode for writeToml_0Call {
 }
 
 impl Cheatcode for writeToml_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
-        let Self { json, path, valueKey } = self;
-        let json =
-            serde_json::from_str(json).unwrap_or_else(|_| JsonValue::String(json.to_owned()));
-
-        let data_path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
-        let toml_data = fs::read_to_string(data_path)?;
-        let json_data: JsonValue =
-            toml::from_str(&toml_data).map_err(|e| fmt_err!("failed parsing TOML: {e}"))?;
-        let value =
-            jsonpath_lib::replace_with(json_data, &canonicalize_json_path(valueKey), &mut |_| {
-                Some(json.clone())
-            })?;
-
-        let toml_string = format_json_to_toml(value)?;
-        super::fs::write_file(state, path.as_ref(), toml_string.as_bytes())
-    }
-}
-
-impl Cheatcode for writeTomlUpsertCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json: value, path, valueKey } = self;
 

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -556,11 +556,9 @@ interface Vm {
     function warp(uint256 newTimestamp) external;
     function writeFile(string calldata path, string calldata data) external;
     function writeFileBinary(string calldata path, bytes calldata data) external;
-    function writeJsonUpsert(string calldata json, string calldata path, string calldata valueKey) external;
     function writeJson(string calldata json, string calldata path) external;
     function writeJson(string calldata json, string calldata path, string calldata valueKey) external;
     function writeLine(string calldata path, string calldata data) external;
-    function writeTomlUpsert(string calldata json, string calldata path, string calldata valueKey) external;
     function writeToml(string calldata json, string calldata path) external;
     function writeToml(string calldata json, string calldata path, string calldata valueKey) external;
 }

--- a/testdata/default/cheats/Json.t.sol
+++ b/testdata/default/cheats/Json.t.sol
@@ -495,7 +495,7 @@ contract WriteJsonTest is DSTest {
     function test_writeJson_createKeys() public {
         string memory path = "fixtures/Json/write_test.json";
         string memory json = vm.readFile(path);
-        
+
         bool exists = vm.keyExistsJson(json, ".parent");
         assertTrue(!exists);
         exists = vm.keyExistsJson(json, ".parent.child");

--- a/testdata/default/cheats/Json.t.sol
+++ b/testdata/default/cheats/Json.t.sol
@@ -491,4 +491,28 @@ contract WriteJsonTest is DSTest {
         address decodedAddress = abi.decode(data, (address));
         assertEq(decodedAddress, ex);
     }
+
+    function test_writeJson_createKeys() public {
+        string memory path = "fixtures/Json/write_test.json";
+        string memory json = vm.readFile(path);
+        
+        bool exists = vm.keyExistsJson(json, ".parent");
+        assertTrue(!exists);
+        exists = vm.keyExistsJson(json, ".parent.child");
+        assertTrue(!exists);
+        exists = vm.keyExistsJson(json, ".parent.child.value");
+        assertTrue(!exists);
+
+        // Write to nested path, creating intermediate keys
+        vm.writeJson(vm.toString(uint256(42)), path, ".parent.child.value");
+
+        // Verify the value was written and intermediate keys were created
+        json = vm.readFile(path);
+        uint256 value = abi.decode(vm.parseJson(json, ".parent.child.value"), (uint256));
+        assertEq(value, 42);
+
+        // Clean up the test file by removing the parent key we added
+        vm.removeFile(path);
+        vm.writeJson("{\"a\": 123, \"b\": \"0x000000000000000000000000000000000000bEEF\"}", path);
+    }
 }

--- a/testdata/default/cheats/Toml.t.sol
+++ b/testdata/default/cheats/Toml.t.sol
@@ -424,6 +424,7 @@ contract WriteTomlTest is DSTest {
 
     function test_writeToml_createKeys() public {
         string memory path = "fixtures/Toml/write_test.toml";
+        string memory toml = vm.readFile(path);
 
         bool exists = vm.keyExistsToml(toml, ".parent");
         assertTrue(!exists);

--- a/testdata/default/cheats/Toml.t.sol
+++ b/testdata/default/cheats/Toml.t.sol
@@ -421,4 +421,27 @@ contract WriteTomlTest is DSTest {
         address decodedAddress = abi.decode(data, (address));
         assertEq(decodedAddress, ex);
     }
+
+    function test_writeToml_createKeys() public {
+        string memory path = "fixtures/Toml/write_test.toml";
+
+        bool exists = vm.keyExistsToml(toml, ".parent");
+        assertTrue(!exists);
+        exists = vm.keyExistsToml(toml, ".parent.child");
+        assertTrue(!exists);
+        exists = vm.keyExistsToml(toml, ".parent.child.value");
+        assertTrue(!exists);
+
+        // Write to nested path, creating intermediate keys
+        vm.writeToml(vm.toString(uint256(42)), path, ".parent.child.value");
+
+        // Verify the value was written and intermediate keys were created
+        string memory toml = vm.readFile(path);
+        uint256 value = abi.decode(vm.parseToml(toml, ".parent.child.value"), (uint256));
+        assertEq(value, 42);
+
+        // Clean up the test file by removing the parent key we added
+        vm.removeFile(path);
+        vm.writeToml("{\"a\": 123, \"b\": \"0x000000000000000000000000000000000000bEEF\"}", path);
+    }
 }

--- a/testdata/default/cheats/Toml.t.sol
+++ b/testdata/default/cheats/Toml.t.sol
@@ -437,7 +437,7 @@ contract WriteTomlTest is DSTest {
         vm.writeToml(vm.toString(uint256(42)), path, ".parent.child.value");
 
         // Verify the value was written and intermediate keys were created
-        string memory toml = vm.readFile(path);
+        toml = vm.readFile(path);
         uint256 value = abi.decode(vm.parseToml(toml, ".parent.child.value"), (uint256));
         assertEq(value, 42);
 


### PR DESCRIPTION
## Motivation

last week we introduced `writeJsonUpsert` and `writeTomlUpsert`, which were 2 new cheatcodes that added the ability to not only update (like the previously existing `writeJson` and `writeToml` cheats), but also to add new k-v pairs:
- https://github.com/foundry-rs/foundry/pull/11414

after internal discussion, and given the fact that there were several community members asking for that feature:
- https://github.com/foundry-rs/foundry/issues/7232

this PR consolidates both cheatcodes into one: keeps the original name, but the new implementation with upsert capabilities

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
- [ ] Breaking changes
