### PR TITLE
ci: drop force_orphan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: target/doc
-          force_orphan: true
 
   doctest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`force_orphan` makes it so that the branch always gets reset.

This job runs on-push, so every `git pull` on the repository will reset the `gh-pages` branch and pull everything from the remote, currently about ~20,000 files and ~20MiB, which is slow and useless. Let's try removing this option to see if it fixes this problem.