### PR TITLE
ci: use actions/* directly for deploying rustdocs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,12 +34,29 @@ jobs:
         run: cargo doc --workspace --all-features --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: --cfg docsrs -D warnings --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options
-      - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v3
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: target/doc
+          path: ./target/doc
+
+  deploy-docs:
+    if: github.ref_name == 'main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: [docs]
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    timeout-minutes: 30
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   doctest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`peaceiris/actions-gh-pages` pushes to the `gh-pages` branch, GitHub will detect changes to that branch and then trigger a deployment by uploading the branch. This is the "legacy"/"classic" way of using GitHub Pages.

Switch to the newer way of deploying from GitHub actions with the official actions/* workflows, bypassing the need to have a `gh-pages` branch at all by uploading the artifacts to GitHub Pages directly, improving `git pull` times significantly.