### PR TITLE
fix(lint): avoid ANSI chars with JSON emitter

### DIFF
--- a/crates/lint/src/linter/mod.rs
+++ b/crates/lint/src/linter/mod.rs
@@ -54,6 +54,7 @@ pub trait Lint {
 pub struct LintContext<'s, 'c> {
     sess: &'s Session,
     with_description: bool,
+    with_json_emitter: bool,
     pub config: LinterConfig<'c>,
     active_lints: Vec<&'static str>,
 }
@@ -67,10 +68,11 @@ impl<'s, 'c> LintContext<'s, 'c> {
     pub fn new(
         sess: &'s Session,
         with_description: bool,
+        with_json_emitter: bool,
         config: LinterConfig<'c>,
         active_lints: Vec<&'static str>,
     ) -> Self {
-        Self { sess, with_description, config, active_lints }
+        Self { sess, with_description, with_json_emitter, config, active_lints }
     }
 
     pub fn session(&self) -> &'s Session {
@@ -92,13 +94,19 @@ impl<'s, 'c> LintContext<'s, 'c> {
         }
 
         let desc = if self.with_description { lint.description() } else { "" };
-        let diag: DiagBuilder<'_, ()> = self
+        let mut diag: DiagBuilder<'_, ()> = self
             .sess
             .dcx
             .diag(lint.severity().into(), desc)
             .code(DiagId::new_str(lint.id()))
-            .span(MultiSpan::from_span(span))
-            .help(lint.help());
+            .span(MultiSpan::from_span(span));
+
+        // Avoid ANSI characters when using a JSON emitter
+        if self.with_json_emitter {
+            diag = diag.help(lint.help());
+        } else {
+            diag = diag.help(self.hyperlink(lint.help()));
+        }
 
         diag.emit();
     }
@@ -131,14 +139,21 @@ impl<'s, 'c> LintContext<'s, 'c> {
         };
 
         let desc = if self.with_description { lint.description() } else { "" };
-        let diag: DiagBuilder<'_, ()> = self
+        let mut diag: DiagBuilder<'_, ()> = self
             .sess
             .dcx
             .diag(lint.severity().into(), desc)
             .code(DiagId::new_str(lint.id()))
-            .span(MultiSpan::from_span(span))
-            .highlighted_note(snippet.to_note(self))
-            .help(lint.help());
+            .span(MultiSpan::from_span(span));
+
+        // Avoid ANSI characters when using a JSON emitter
+        if self.with_json_emitter {
+            diag = diag
+                .note(snippet.to_note(self).iter().map(|l| l.0.as_str()).collect::<String>())
+                .help(lint.help());
+        } else {
+            diag = diag.highlighted_note(snippet.to_note(self)).help(self.hyperlink(lint.help()));
+        }
 
         diag.emit();
     }
@@ -163,6 +178,11 @@ impl<'s, 'c> LintContext<'s, 'c> {
         }
 
         0
+    }
+
+    /// Creates a hyperlink of the input url.
+    fn hyperlink<'a>(&self, url: &'static str) -> String {
+        format!("\x1b]8;;{}\x1b\\{}\x1b]8;;\x1b\\", url, url)
     }
 }
 

--- a/crates/lint/src/linter/mod.rs
+++ b/crates/lint/src/linter/mod.rs
@@ -105,7 +105,7 @@ impl<'s, 'c> LintContext<'s, 'c> {
         if self.with_json_emitter {
             diag = diag.help(lint.help());
         } else {
-            diag = diag.help(self.hyperlink(lint.help()));
+            diag = diag.help(hyperlink(lint.help()));
         }
 
         diag.emit();
@@ -152,7 +152,7 @@ impl<'s, 'c> LintContext<'s, 'c> {
                 .note(snippet.to_note(self).iter().map(|l| l.0.as_str()).collect::<String>())
                 .help(lint.help());
         } else {
-            diag = diag.highlighted_note(snippet.to_note(self)).help(self.hyperlink(lint.help()));
+            diag = diag.highlighted_note(snippet.to_note(self)).help(hyperlink(lint.help()));
         }
 
         diag.emit();
@@ -178,11 +178,6 @@ impl<'s, 'c> LintContext<'s, 'c> {
         }
 
         0
-    }
-
-    /// Creates a hyperlink of the input url.
-    fn hyperlink<'a>(&self, url: &'static str) -> String {
-        format!("\x1b]8;;{}\x1b\\{}\x1b]8;;\x1b\\", url, url)
     }
 }
 
@@ -272,4 +267,9 @@ impl Snippet {
 
         &s[byte_offset..]
     }
+}
+
+/// Creates a hyperlink of the input url.
+fn hyperlink(url: &'static str) -> String {
+    format!("\x1b]8;;{url}\x1b\\{url}\x1b]8;;\x1b\\")
 }

--- a/crates/lint/src/sol/macros.rs
+++ b/crates/lint/src/sol/macros.rs
@@ -1,10 +1,3 @@
-#[macro_export]
-macro_rules! link {
-    ($url:expr) => {
-        concat!("\x1b]8;;", $url, "\x1b\\", $url, "\x1b]8;;\x1b\\")
-    };
-}
-
 /// Macro for defining lints and relevant metadata for the Solidity linter.
 ///
 /// # Parameters
@@ -27,7 +20,7 @@ macro_rules! declare_forge_lint {
             id: $str_id,
             severity: $severity,
             description: $desc,
-            help: link!(concat!("https://book.getfoundry.sh/reference/forge/forge-lint#", $str_id)),
+            help: concat!("https://book.getfoundry.sh/reference/forge/forge-lint#", $str_id),
         };
     };
 

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -153,7 +153,13 @@ impl<'a> SolidityLinter<'a> {
         let inline_config = parse_inline_config(sess, &comments, InlineConfigSource::Ast(ast));
 
         // Initialize and run the early lint visitor
-        let ctx = LintContext::new(sess, self.with_description, self.config(inline_config), lints);
+        let ctx = LintContext::new(
+            sess,
+            self.with_description,
+            self.with_json_emitter,
+            self.config(inline_config),
+            lints,
+        );
         let mut early_visitor = EarlyLintVisitor::new(&ctx, &mut passes);
         _ = early_visitor.visit_source_unit(ast);
         early_visitor.post_source_unit(ast);
@@ -207,8 +213,13 @@ impl<'a> SolidityLinter<'a> {
         );
 
         // Run late lint visitor
-        let ctx =
-            LintContext::new(gcx.sess, self.with_description, self.config(inline_config), lints);
+        let ctx = LintContext::new(
+            gcx.sess,
+            self.with_description,
+            self.with_json_emitter,
+            self.config(inline_config),
+            lints,
+        );
         let mut late_visitor = LateLintVisitor::new(&ctx, &mut passes, &gcx.hir);
 
         // Visit this specific source


### PR DESCRIPTION
## Motivation
ref:
- https://github.com/foundry-rs/foundry/issues/11460

## Solution

track emitter kind in `LintContext` and avoid ANSI chars when necessary