### PR TITLE
fix: correct path reference in FsPathError::Copy AsRef implementation

### DIFF
--- a/crates/common/src/errors/fs.rs
+++ b/crates/common/src/errors/fs.rs
@@ -99,7 +99,7 @@ impl AsRef<Path> for FsPathError {
             Self::Write { path, .. }
             | Self::Read { path, .. }
             | Self::ReadLink { path, .. }
-            | Self::Copy { from: path, .. }
+            | Self::Copy { to: path, .. }
             | Self::CreateDir { path, .. }
             | Self::RemoveDir { path, .. }
             | Self::CreateFile { path, .. }


### PR DESCRIPTION
The Copy variant has both 'from' and 'to' fields, but the AsRef implementation was incorrectly referencing 'from' instead of 'to'. 

This fix ensures that when converting a Copy error to a Path reference, we return the destination path ('to') rather than the source path ('from'), which is more logical for error reporting and path resolution.

- Change: `Self::Copy { from: path, .. }` -> `Self::Copy { to: path, .. }`
- File: crates/common/src/errors/fs.rs
- Line: 95