### PR TITLE
perf: remove `BuildArgs` from `forge config`

### DIFF
--- a/crates/forge/src/cmd/config.rs
+++ b/crates/forge/src/cmd/config.rs
@@ -1,15 +1,21 @@
-use super::build::BuildArgs;
-use clap::Parser;
+use std::path::PathBuf;
+
+use clap::{Parser, ValueHint};
 use eyre::Result;
 use foundry_cli::utils::LoadConfig;
-use foundry_common::{evm::EvmArgs, shell};
+use foundry_common::shell;
 use foundry_config::fix::fix_tomls;
-
-foundry_config::impl_figment_convert!(ConfigArgs, build, evm);
 
 /// CLI arguments for `forge config`.
 #[derive(Clone, Debug, Parser)]
 pub struct ConfigArgs {
+    /// The project's root path.
+    ///
+    /// By default root of the Git repository, if in one,
+    /// or the current working directory.
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    root: Option<PathBuf>,
+
     /// Print only a basic set of the currently set config values.
     #[arg(long)]
     basic: bool,
@@ -17,14 +23,8 @@ pub struct ConfigArgs {
     /// Attempt to fix any configuration warnings.
     #[arg(long)]
     fix: bool,
-
-    // support nested build arguments
-    #[command(flatten)]
-    build: BuildArgs,
-
-    #[command(flatten)]
-    evm: EvmArgs,
 }
+foundry_config::impl_figment_convert_basic!(ConfigArgs);
 
 impl ConfigArgs {
     pub fn run(self) -> Result<()> {

--- a/crates/forge/src/cmd/remappings.rs
+++ b/crates/forge/src/cmd/remappings.rs
@@ -13,6 +13,7 @@ pub struct RemappingArgs {
     /// or the current working directory.
     #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     root: Option<PathBuf>,
+
     /// Pretty-print the remappings, grouping each of them by context.
     #[arg(long)]
     pretty: bool,


### PR DESCRIPTION
## Motivation

Running `forge config --json` in https://github.com/ithacaxyz/account/ takes about 100-110ms per invocation. [This profile](https://share.firefox.dev/3HRZcMM) shows that most of this is due to us autodetecting remappings multiple times: 

- We end up here, which calls `_with_root` which loads remappings: https://github.com/foundry-rs/foundry/blob/91cfab48f48f60a216c814776f02393101907a74/crates/config/src/lib.rs#L1637-L1639
- We then immediately turn `Config` into a figment: https://github.com/foundry-rs/foundry/blob/91cfab48f48f60a216c814776f02393101907a74/crates/config/src/lib.rs#L2157-L2161 https://github.com/foundry-rs/foundry/blob/91cfab48f48f60a216c814776f02393101907a74/crates/config/src/lib.rs#L693 which also resolves remappings again

We probably load remappings somewhere else again.

## Solution

Removing `BuildArgs` and `EvmArgs` from `forge config` takes the time down to 25ms per invocation. This is technically a breaking change, but I don't really know if anyone actually, in the wild, ever uses `forge config <opts> > foundry.toml`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
