### PR TITLE
fix: own creation initcode to avoid borrowing temporary in trace branch

### DIFF
--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -383,9 +383,8 @@ impl VerifyBytecodeArgs {
             trace!("mismatch of constructor args with etherscan");
             // If local bytecode is longer than on-chain one, this is probably not a match.
             if maybe_creation_code.as_ref().len() >= local_bytecode.len() {
-                constructor_args = Bytes::copy_from_slice(
-                    &maybe_creation_code.as_ref()[local_bytecode.len()..],
-                );
+                constructor_args =
+                    Bytes::copy_from_slice(&maybe_creation_code.as_ref()[local_bytecode.len()..]);
                 trace!(
                     target: "forge::verify",
                     "setting constructor args to latest {} bytes of bytecode",


### PR DESCRIPTION
Ensure maybe_creation_code is Bytes across branches (standard, CREATE2, trace). Replace borrowed temporary with owned value; adjust comparisons and slicing to use as_ref(). Removes a potential lifetime error and aligns with the approach used in cast creation-code.