### PR TITLE
chore: tweak `npm` publish & handle `nightly` releases

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -7,7 +7,6 @@ on:
         type: string
         required: false
         description: The run id of the release to publish
-        default: "latest"
   #
   # Temporarily disabled
   #
@@ -169,9 +168,9 @@ jobs:
       - name: Publish ${{ matrix.os }}-${{ matrix.arch }} Binary
         working-directory: ./npm
         env:
-          RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
-          VERSION_NAME: ${{ steps.release-version.outputs.RELEASE_VERSION }}
           PROVENANCE: true
+          VERSION_NAME: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+          RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -184,6 +183,10 @@ jobs:
           echo "Published @foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
 
   publish-meta:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
     needs: publish-arch
     runs-on: ubuntu-latest
     env:
@@ -220,8 +223,9 @@ jobs:
         working-directory: ./npm
         run: bun run ./scripts/publish.ts ./@foundry-rs/forge
         env:
-          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          PROVENANCE: true
           VERSION_NAME: ${{ env.RELEASE_VERSION }}
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
           NPM_TOKEN: ${{ env.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
           NPM_REGISTRY_URL: ${{ env.NPM_REGISTRY_URL }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -140,5 +140,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          bun ./scripts/publish.ts ./@foundry-rs/forge
-          echo "Published @foundry-rs/forge"
+          ls -la ./@foundry-rs
+          bun ./scripts/publish.ts ./@foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}
+          echo "Published @foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -2,8 +2,14 @@ name: Publish NPM
 
 on:
   workflow_dispatch:
+    inputs:
+      run_id:
+        type: string
+        required: false
+        description: The run id of the release to publish
+        default: "latest"
   #
-  # Temporarily disabled 
+  # Temporarily disabled
   #
   # workflow_run:
   #   types: [completed]
@@ -33,8 +39,6 @@ jobs:
       max-parallel: 3
       fail-fast: false
       matrix:
-        # we don't need a specific runner for any of these
-        # because they've all been built already. We're just publishing
         include:
           - os: linux
             arch: amd64
@@ -46,7 +50,7 @@ jobs:
             arch: arm64
           - os: win32
             arch: amd64
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # if: ${{ github.event_name == 'workflow_run' && github.event.workflow.conclusion == 'success' }}
     outputs:
       RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
     env:
@@ -61,10 +65,9 @@ jobs:
           merge-multiple: true
           # Download all foundry artifacts from the triggering release run
           pattern: "foundry_*"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # run-id: ${{ github.event.workflow_run.id }}
-          run-id: 17369000041
           path: foundry_artifacts
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ inputs.run_id || github.event.workflow_run.id }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@main
@@ -83,29 +86,12 @@ jobs:
         working-directory: ./npm
         run: bun install --frozen-lockfile
 
+      - name: Transpile TS -> JS
+        working-directory: ./npm
+        run: bun run build
+
       - name: Derive RELEASE_VERSION
         id: release-version
-        run: |
-          set -euo pipefail
-
-          # Derive RELEASE_VERSION from any foundry artifact we downloaded
-          # Expected names: foundry_<VERSION>_<platform>_<arch>.{tar.gz,zip}
-
-          first_file=$(ls ./foundry_artifacts/foundry_* 2>/dev/null | head -n1 || true)
-          if [[ -z "${first_file}" ]]; then
-            echo "No foundry artifacts found to publish" >&2
-            exit 1
-          fi
-
-          version_part=$(basename "$first_file")
-          version_part=${version_part#foundry_}
-
-          export RELEASE_VERSION=${version_part%%_*}
-
-          echo "Detected RELEASE_VERSION=$RELEASE_VERSION"
-          echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Publish Binaries and Meta
         working-directory: ./npm
         env:
           PROVENANCE: true
@@ -130,16 +116,112 @@ jobs:
           export RELEASE_VERSION=${version_part%%_*}
           echo "Detected RELEASE_VERSION=$RELEASE_VERSION"
 
-      - name: Publish Meta
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Stage Binary Into Package
         working-directory: ./npm
         env:
-          RELEASE_VERSION: ${{ steps.publish-arch.outputs.RELEASE_VERSION }}
+          RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+        run: |
+          set -euo pipefail
+          mkdir -p tmp
+
+          FILE_PREFIX="../foundry_artifacts/foundry_${RELEASE_VERSION}_${{ matrix.os }}_${{ matrix.arch }}"
+          if [[ -f "${FILE_PREFIX}.zip" ]]; then
+            echo "Extracting ${FILE_PREFIX}.zip"
+            if ! command -v unzip >/dev/null 2>&1; then
+              sudo apt-get update -y && sudo apt-get install -y unzip
+            fi
+            unzip -o "${FILE_PREFIX}.zip" -d ./tmp
+            BIN=./tmp/forge.exe
+          else
+            echo "Extracting ${FILE_PREFIX}.tar.gz"
+            tar -xzf "${FILE_PREFIX}.tar.gz" -C ./tmp
+            BIN=./tmp/forge
+          fi
+
+          echo "Staging binary $BIN into @foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
+          PLATFORM_NAME=${{ matrix.os }} ARCH=${{ matrix.arch }} FORGE_BIN_PATH="$BIN" bun ./scripts/prepublish.ts
+
+      - name: Sanity Check Binary
+        working-directory: ./npm
+        run: |
+          set -euo pipefail
+          PKG_DIR="./@foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
+          BIN="$PKG_DIR/bin/forge"
+          if [[ "${{ matrix.os }}" == "win32" ]]; then
+            BIN="$PKG_DIR/bin/forge.exe"
+          fi
+          echo "Verifying binary at: $BIN"
+          ls -la "$BIN"
+          if [[ ! -f "$BIN" ]]; then
+            echo "ERROR: Binary not found at $BIN" >&2
+            exit 1
+          fi
+
+          if [[ "${{ matrix.os }}" != "win32" ]]; then
+            if [[ ! -x "$BIN" ]]; then
+              echo "ERROR: Binary not marked executable" >&2
+              exit 1
+            fi
+          fi
+
+      - name: Publish ${{ matrix.os }}-${{ matrix.arch }} Binary
+        working-directory: ./npm
+        env:
+          RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+          VERSION_NAME: ${{ steps.release-version.outputs.RELEASE_VERSION }}
           PROVENANCE: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
 
-          ls -la ./@foundry-rs
+          ls -la ./@foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}
+
           bun ./scripts/publish.ts ./@foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}
+
           echo "Published @foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
+
+  publish-meta:
+    needs: publish-arch
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ needs.publish-arch.outputs.RELEASE_VERSION }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_REGISTRY_URL: "https://registry.npmjs.org"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@main
+        with:
+          bun-version: latest
+          registries: |
+            https://registry.npmjs.org
+
+      - name: Setup Node (for npm publish auth)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install Dependencies
+        working-directory: ./npm
+        run: bun install --frozen-lockfile
+
+      - name: Transpile TS -> JS
+        working-directory: ./npm
+        run: bun run build
+
+      - name: Publish Meta
+        working-directory: ./npm
+        run: bun run ./scripts/publish.ts ./@foundry-rs/forge
+        env:
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          VERSION_NAME: ${{ env.RELEASE_VERSION }}
+          NPM_TOKEN: ${{ env.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
+          NPM_REGISTRY_URL: ${{ env.NPM_REGISTRY_URL }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -7,12 +7,9 @@ on:
         type: string
         required: false
         description: The run id of the release to publish
-  #
-  # Temporarily disabled
-  #
-  # workflow_run:
-  #   types: [completed]
-  #   workflows: [release]
+  workflow_run:
+    types: [completed]
+    workflows: [release]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -49,7 +46,7 @@ jobs:
             arch: arm64
           - os: win32
             arch: amd64
-    # if: ${{ github.event_name == 'workflow_run' && github.event.workflow.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow.conclusion == 'success' }}
     outputs:
       RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
     env:
@@ -66,7 +63,7 @@ jobs:
           pattern: "foundry_*"
           path: foundry_artifacts
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ inputs.run_id || github.event.workflow_run.id }}
+          run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@main

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -58,9 +58,9 @@ jobs:
           merge-multiple: true
           # Download all foundry artifacts from the triggering release run
           pattern: "foundry_*"
-          repository: foundry-rs/foundry
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # run-id: ${{ github.event.workflow_run.id }}
+          run-id: 17369000041
           path: foundry_artifacts
 
       - name: Checkout

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -188,6 +188,7 @@ jobs:
       contents: read
       id-token: write
     needs: publish-arch
+    name: Publish Meta Package
     runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: ${{ needs.publish-arch.outputs.RELEASE_VERSION }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -63,6 +63,9 @@ jobs:
           # run-id: ${{ github.event.workflow_run.id }}
           path: foundry_artifacts
 
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@main
         with:
@@ -73,11 +76,11 @@ jobs:
       - name: Setup Node (for npm publish auth)
         uses: actions/setup-node@v4
         with:
-          node-version: lts
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install Dependencies
-        working-directory: npm
+        working-directory: ./npm
         run: bun install --frozen-lockfile
 
       - name: Derive RELEASE_VERSION
@@ -103,7 +106,7 @@ jobs:
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Publish Binaries
-        working-directory: npm
+        working-directory: ./npm
         env:
           PROVENANCE: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -134,28 +137,8 @@ jobs:
     env:
       RELEASE_VERSION: ${{ needs.publish-arch.outputs.RELEASE_VERSION }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@main
-        with:
-          bun-version: latest
-          registries: |
-            https://registry.npmjs.org
-
-      - name: Setup Node (for npm publish auth)
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install Dependencies
-        working-directory: npm
-        run: bun install --frozen-lockfile
-
       - name: Publish @foundry-rs/foundry
-        working-directory: npm
+        working-directory: ./npm
         env:
           PROVENANCE: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -52,6 +52,9 @@ jobs:
     env:
       NPM_REGISTRY_URL: "https://registry.npmjs.org"
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Download Release Assets
         uses: actions/download-artifact@v5
         with:
@@ -62,9 +65,6 @@ jobs:
           # run-id: ${{ github.event.workflow_run.id }}
           run-id: 17369000041
           path: foundry_artifacts
-
-      - name: Checkout
-        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@main
@@ -91,7 +91,7 @@ jobs:
           # Derive RELEASE_VERSION from any foundry artifact we downloaded
           # Expected names: foundry_<VERSION>_<platform>_<arch>.{tar.gz,zip}
 
-          first_file=$(ls ../foundry_artifacts/foundry_* 2>/dev/null | head -n1 || true)
+          first_file=$(ls ./foundry_artifacts/foundry_* 2>/dev/null | head -n1 || true)
           if [[ -z "${first_file}" ]]; then
             echo "No foundry artifacts found to publish" >&2
             exit 1
@@ -105,7 +105,7 @@ jobs:
           echo "Detected RELEASE_VERSION=$RELEASE_VERSION"
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Publish Binaries
+      - name: Publish Binaries and Meta
         working-directory: ./npm
         env:
           PROVENANCE: true
@@ -130,21 +130,15 @@ jobs:
           export RELEASE_VERSION=${version_part%%_*}
           echo "Detected RELEASE_VERSION=$RELEASE_VERSION"
 
-  publish-meta:
-    needs: publish-arch
-    runs-on: ubuntu-latest
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    env:
-      RELEASE_VERSION: ${{ needs.publish-arch.outputs.RELEASE_VERSION }}
-    steps:
-      - name: Publish @foundry-rs/foundry
+      - name: Publish Meta
         working-directory: ./npm
         env:
+          RELEASE_VERSION: ${{ steps.publish-arch.outputs.RELEASE_VERSION }}
           PROVENANCE: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
 
-          bun ./scripts/publish.ts ./@foundry-rs/foundry
-          echo "Published @foundry-rs/foundry"
+          bun ./scripts/publish.ts ./@foundry-rs/forge
+          echo "Published @foundry-rs/forge"

--- a/npm/@foundry-rs/forge-darwin-amd64/package.json
+++ b/npm/@foundry-rs/forge-darwin-amd64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-rs/forge-darwin-amd64",
-  "version": "1.2.3",
+  "version": "1.3.2",
   "type": "module",
   "homepage": "https://getfoundry.sh/forge",
   "description": "Fast and flexible Ethereum testing framework (macOS amd64)",

--- a/npm/@foundry-rs/forge-linux-amd64/package.json
+++ b/npm/@foundry-rs/forge-linux-amd64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-rs/forge-linux-amd64",
-  "version": "1.2.3",
+  "version": "1.3.2",
   "type": "module",
   "homepage": "https://getfoundry.sh/forge",
   "description": "Fast and flexible Ethereum testing framework (Linux amd64)",

--- a/npm/@foundry-rs/forge-linux-arm64/package.json
+++ b/npm/@foundry-rs/forge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-rs/forge-linux-arm64",
-  "version": "1.2.3",
+  "version": "1.3.2",
   "type": "module",
   "homepage": "https://getfoundry.sh/forge",
   "description": "Fast and flexible Ethereum testing framework (Linux arm64)",

--- a/npm/@foundry-rs/forge-win32-amd64/package.json
+++ b/npm/@foundry-rs/forge-win32-amd64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-rs/forge-win32-amd64",
-  "version": "1.2.3",
+  "version": "1.3.2",
   "type": "module",
   "homepage": "https://getfoundry.sh/forge",
   "description": "Fast and flexible Ethereum testing framework (Windows amd64)",

--- a/npm/scripts/publish.ts
+++ b/npm/scripts/publish.ts
@@ -17,25 +17,32 @@ async function main() {
   const npmToken = Bun.env.NPM_TOKEN
   if (!npmToken) throw new Error('NPM_TOKEN is required')
 
-  const packagePath = Bun.argv[2]
-  if (!packagePath) throw new Error('Package path is required')
+  const inputPath = Bun.argv[2]
+  if (!inputPath) throw new Error('Package path is required')
+  const packagePath = NodePath.resolve(inputPath)
   console.info(colors.green, 'Package path:', packagePath)
 
   const publishVersion = getPublishVersion()
   console.info(colors.green, 'Publish version:', publishVersion)
   if (!publishVersion) throw new Error('Publish version is required')
 
-  if (packagePath === '@foundry-rs/forge')
+  if (await isMetaPackage(packagePath))
     await updateOptionalDependencies(packagePath, publishVersion)
 
-  await setPackageVersion(packagePath, publishVersion, npmToken)
+  await setPackageVersion(packagePath, publishVersion)
   const packedFile = await packPackage(packagePath)
-  await publishPackage(packagePath, packedFile)
+  await publishPackage(packagePath, packedFile, publishVersion)
 }
 
 function getPublishVersion() {
-  if (Bun.env.VERSION_NAME) return Bun.env.VERSION_NAME.replace(/^v/, '')
-  if (Bun.env.BUMP_VERSION) return Bun.env.BUMP_VERSION
+  const maybeVersion = (Bun.env.VERSION_NAME || '').replace(/^v/, '')
+  if (maybeVersion && isValidSemver(maybeVersion)) return maybeVersion
+
+  const bump = (Bun.env.BUMP_VERSION || '').replace(/^v/, '')
+  if (bump && isValidSemver(bump)) return bump
+
+  const releaseVersion = (Bun.env.RELEASE_VERSION || '').replace(/^v/, '')
+  const isNightly = releaseVersion.toLowerCase() === 'nightly'
 
   const cargoToml = NodeFS.readFileSync(
     NodePath.join(import.meta.dirname, '..', '..', 'Cargo.toml'),
@@ -45,7 +52,22 @@ function getPublishVersion() {
   const versionMatch = cargoToml.match(/^version\s*=\s*"([^"]+)"/m)
   if (!versionMatch) throw new Error('Version not found in Cargo.toml')
 
-  return versionMatch[1]
+  const base = versionMatch[1]
+  if (!isNightly) return base
+
+  const date = new Date()
+  const y = date.getUTCFullYear()
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const d = String(date.getUTCDate()).padStart(2, '0')
+  const yyyymmdd = `${y}${m}${d}`
+  const sha = (Bun.env.GITHUB_SHA || '').slice(0, 7)
+  const suffix = sha ? `nightly.${yyyymmdd}.${sha}` : `nightly.${yyyymmdd}`
+  return `${base}-${suffix}`
+}
+
+function isValidSemver(v: string): boolean {
+  // Use Bun's semver engine: a version satisfies itself iff it is valid
+  return !!v && Bun.semver.satisfies(v, v)
 }
 
 async function updateOptionalDependencies(packagePath: string, version: string) {
@@ -61,7 +83,17 @@ async function updateOptionalDependencies(packagePath: string, version: string) 
   }
 }
 
-async function setPackageVersion(packagePath: string, version: string, npmToken: string) {
+async function isMetaPackage(packagePath: string) {
+  try {
+    const packageJsonPath = NodePath.join(packagePath, 'package.json')
+    const packageJson = JSON.parse(NodeFS.readFileSync(packageJsonPath, 'utf-8'))
+    return packageJson?.name === '@foundry-rs/forge'
+  } catch {
+    return false
+  }
+}
+
+async function setPackageVersion(packagePath: string, version: string) {
   console.info(colors.green, 'Setting package version:', version)
   const result = await Bun.$`npm version ${version} --allow-same-version --no-git-tag-version`
     .cwd(packagePath)
@@ -87,8 +119,10 @@ async function packPackage(packagePath: string) {
   return packedFile
 }
 
-async function publishPackage(packagePath: string, packedFile: string) {
-  const result = await Bun.$`npm publish ./${packedFile} --access=public --registry=${REGISTRY_URL} --provenance=${
+async function publishPackage(packagePath: string, packedFile: string, version: string) {
+  const tag = /-nightly(\.|$)/.test(version) ? 'nightly' : 'latest'
+  const result = await Bun
+    .$`npm publish ./${packedFile} --access=public --registry=${REGISTRY_URL} --tag=${tag} --provenance=${
     Bun.env.PROVENANCE || 'false'
   }`
     .cwd(packagePath)

--- a/npm/scripts/publish.ts
+++ b/npm/scripts/publish.ts
@@ -123,7 +123,7 @@ async function publishPackage(packagePath: string, packedFile: string, version: 
   const tag = /-nightly(\.|$)/.test(version) ? 'nightly' : 'latest'
   const result = await Bun
     .$`npm publish ./${packedFile} --access=public --registry=${REGISTRY_URL} --tag=${tag} --provenance=${
-    Bun.env.PROVENANCE || 'false'
+    Bun.env.PROVENANCE || 'true'
   }`
     .cwd(packagePath)
     .nothrow()

--- a/npm/scripts/publish.ts
+++ b/npm/scripts/publish.ts
@@ -65,8 +65,7 @@ function getPublishVersion() {
   return `${base}-${suffix}`
 }
 
-function isValidSemver(v: string): boolean {
-  // Use Bun's semver engine: a version satisfies itself iff it is valid
+function isValidSemver(v: string) {
   return !!v && Bun.semver.satisfies(v, v)
 }
 


### PR DESCRIPTION
closes https://github.com/foundry-rs/foundry/issues/4337

verified working published version:
https://www.npmjs.com/package/@foundry-rs/forge-linux-amd64/v/1.3.2-nightly.20250902.99514b6

test:
```sh
bun x @foundry-rs/forge@1.3.2-nightly.20250902.99514b6 --help
```

related:
- https://github.com/oven-sh/bun/pull/22332

next:
- short docs mention of this install option,
- support for `anvil`, `cast`, and `chisel`

bonus: now handles `nightly` releases too.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
