### PR TITLE
feat(sol-macro-gen): add `Clone` to `extra_derives`

### DIFF
--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -125,7 +125,7 @@ impl MultiSolMacroGen {
                     syn::parse_quote! {
                             #[sol(rpc, alloy_sol_types = alloy::sol_types, alloy_contract =
                     alloy::contract, all_derives = true, extra_derives(serde::Serialize,
-                    serde::Deserialize))]     }
+                    serde::Deserialize, Clone))]     }
                 } else {
                     syn::parse_quote! {
                             #[sol(rpc, alloy_sol_types = alloy::sol_types, alloy_contract =


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

When create rust bindings for solidity contracts `serde::{Serialize, Deserialize}` traits are added as `extra_derives` by `foundry` and `Debug, PartialEq, Eq, Hash` by `alloy/core`.

I need for some enums coming from generated bindings to implement the `Clone` trait and the underlying structs seem to already implement it, only the enum is missing it.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add `Clone` to the `extra_derives` list.

## PR Checklist

- [ ] Added Tests
    - I didn't find any related tests already implemented 
- [ ] Added Documentation
    - `extra_derives` list currently does not exist in the documentation afaict
- [ ] Breaking changes
    - Non-breaking change
