### PR TITLE
fix: find_git_root allows any .git

### DIFF
--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -35,7 +35,7 @@ pub fn load_config_with_root(root: Option<&Path>) -> eyre::Result<Config> {
 pub fn find_git_root(relative_to: &Path) -> io::Result<Option<PathBuf>> {
     let root =
         if relative_to.is_absolute() { relative_to } else { &dunce::canonicalize(relative_to)? };
-    Ok(root.ancestors().find(|p| p.join(".git").is_dir()).map(Path::to_path_buf))
+    Ok(root.ancestors().find(|p| p.join(".git").exists()).map(Path::to_path_buf))
 }
 
 /// Returns the root path to set for the project root.


### PR DESCRIPTION
Not just directories. `.git` can be a file when it's a git-worktree.
