### PR TITLE
chore: add `URI` (e.g. `tokenURI` from ERC721 / ERC6909) as exception

### DIFF
--- a/crates/config/src/lint.rs
+++ b/crates/config/src/lint.rs
@@ -28,7 +28,8 @@ pub struct LinterConfig {
 
     /// Configurable patterns that should be excluded when performing `mixedCase` lint checks.
     ///
-    /// Default's to ["ERC"] to allow common names like `rescueERC20` or `ERC721TokenReceiver`.
+    /// Default's to ["ERC", "URI"] to allow common names like `rescueERC20`, `ERC721TokenReceiver`
+    /// or `tokenURI`.
     pub mixed_case_exceptions: Vec<String>,
 }
 
@@ -39,7 +40,7 @@ impl Default for LinterConfig {
             severity: Vec::new(),
             exclude_lints: Vec::new(),
             ignore: Vec::new(),
-            mixed_case_exceptions: vec!["ERC".to_string()],
+            mixed_case_exceptions: vec!["ERC".to_string(), "URI".to_string()],
         }
     }
 }

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1081,7 +1081,7 @@ severity = []
 exclude_lints = []
 ignore = []
 lint_on_build = true
-mixed_case_exceptions = ["ERC"]
+mixed_case_exceptions = ["ERC", "URI"]
 
 [doc]
 out = "docs"
@@ -1308,7 +1308,8 @@ exclude = []
     "ignore": [],
     "lint_on_build": true,
     "mixed_case_exceptions": [
-      "ERC"
+      "ERC",
+      "URI"
     ]
   },
   "doc": {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Encountered this, required function in ERC721 / ERC6909 spec throws as a mixed case function lint:

```
    |
106 |     function tokenURI(uint256 id) public view override returns (string memory) {
    |              --------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#mixed-case-function
```

Ref: https://eips.ethereum.org/EIPS/eip-6909#content-uri-extension
Ref: https://eips.ethereum.org/EIPS/eip-721#specification

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds exception to list alongside existing `ERC` exception

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
