### PR TITLE
fix: type mismatch in `abi_encode` comparison

### DIFF
--- a/crates/cheatcodes/src/error.rs
+++ b/crates/cheatcodes/src/error.rs
@@ -301,7 +301,7 @@ mod tests {
         assert_eq!(Error::from("hello").abi_encode(), error);
         assert_eq!(Error::encode("hello"), error);
 
-        assert_eq!(Error::from(b"hello").abi_encode(), b"hello");
+        assert_eq!(Error::from(b"hello").abi_encode().as_slice(), b"hello");
         assert_eq!(Error::encode(b"hello"), b"hello"[..]);
     }
 }


### PR DESCRIPTION
## Motivation

`abi_encode()` returns `Vec<u8>`, but `b"hello"` is a `[u8; 5]`.
**comparing them directly doesn’t work in Rust.**

## Solution

use `.as_slice()` on the `Vec<u8>` so the comparison with a byte array works.

## PR Checklist

* [ ] Added Tests
* [ ] Added Documentation
* [ ] Breaking changes
