### PR TITLE
Update documentation for transaction hash fetching

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -451,7 +451,7 @@ pub struct AnvilEvmArgs {
     )]
     pub fork_block_number: Option<i128>,
 
-    /// Fetch state from a specific transaction hash over a remote endpoint.
+    /// Fetch state from AFTER a specific transaction hash has been applied over a remote endpoint.
     ///
     /// See --fork-url.
     #[arg(


### PR DESCRIPTION
Changed the documentation to clarify which state is using in `--fork-transaction-hash`.

Here is the source: 
https://github.com/foundry-rs/foundry/blob/961241c02fb06143608d5b985a1bae793ac8f172/crates/anvil/src/config.rs#L1442C26-L1442C35

## Motivation

It really was not clear to me when reading the option whether I would get the state BEFORE or AFTER that transaction has been executed. Also ChatGPT claimed BEFORE.

## Solution

I, hopefully, clarified the docs.