### PR TITLE
fix(cast): correct error message for --ends-with hex parsing

### DIFF
--- a/crates/cast/src/cmd/create2.rs
+++ b/crates/cast/src/cmd/create2.rs
@@ -154,7 +154,7 @@ impl Create2Args {
         if let Some(suffix) = ends_with {
             regexs.push(format!(
                 r"{}$",
-                get_regex_hex_string(suffix).wrap_err("invalid prefix hex provided")?
+                get_regex_hex_string(suffix).wrap_err("invalid suffix hex provided")?
             ))
         }
 


### PR DESCRIPTION
The --ends-with branch used “invalid prefix hex provided” due to a copy-paste oversight. This change updates it to “invalid suffix hex provided” for accuracy and consistency with the --starts-with and --matching branches