### PR TITLE
feat(forge): add --empty to forge init

### DIFF
--- a/crates/forge/src/cmd/clone.rs
+++ b/crates/forge/src/cmd/clone.rs
@@ -161,9 +161,9 @@ impl CloneArgs {
     /// * `enable_git` - whether to enable git for the project.
     /// * `quiet` - whether to print messages.
     pub(crate) fn init_an_empty_project(root: &Path, install: DependencyInstallOpts) -> Result<()> {
-        // Initialize the project with no_example set to true to avoid creating example contracts
+        // Initialize the project with empty set to true to avoid creating example contracts
         let init_args =
-            InitArgs { root: root.to_path_buf(), install, no_example: true, ..Default::default() };
+            InitArgs { root: root.to_path_buf(), install, empty: true, ..Default::default() };
         init_args.run().map_err(|e| eyre::eyre!("Project init error: {:?}", e))?;
 
         Ok(())

--- a/crates/forge/src/cmd/init.rs
+++ b/crates/forge/src/cmd/init.rs
@@ -48,7 +48,7 @@ pub struct InitArgs {
 
     /// Do not create example contracts (Counter.sol, Counter.t.sol, Counter.s.sol).
     #[arg(long, conflicts_with = "template")]
-    pub no_example: bool,
+    pub empty: bool,
 
     #[command(flatten)]
     pub install: DependencyInstallOpts,
@@ -66,7 +66,7 @@ impl InitArgs {
             vscode,
             use_parent_git,
             vyper,
-            no_example,
+            empty,
         } = self;
         let DependencyInstallOpts { shallow, no_git, commit } = install;
 
@@ -143,7 +143,7 @@ impl InitArgs {
             fs::create_dir_all(&script)?;
 
             // Only create example contracts if not disabled
-            if !no_example {
+            if !empty {
                 if vyper {
                     // write the contract file
                     let contract_path = src.join("Counter.vy");


### PR DESCRIPTION
Replaces the temporary file deletion workaround in `init_an_empty_project` with a proper `--no-example` flag for `forge init`.

Fixes the TODO mentioned in `clone.rs:171-172`.