### PR TITLE
feat: make `find_by_deployed_code_exact` smarter

### DIFF
--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -325,7 +325,7 @@ impl ContractsByArtifact {
                     left = right + offset.length as usize;
                 }
 
-                let partal_match = if left < code.len() {
+                let is_partial = if left < code.len() {
                     match deployed_code {
                         BytecodeObject::Bytecode(bytes) => bytes[left..] == code[left..],
                         BytecodeObject::Unlinked(bytes) => {
@@ -340,7 +340,7 @@ impl ContractsByArtifact {
                     true
                 };
 
-                if !partal_match {
+                if !is_partial {
                     return false;
                 }
 

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -358,10 +358,10 @@ impl ContractsByArtifact {
                 };
 
                 if exact_match {
-                    return true;
+                    true
                 } else {
                     partial_match = Some((*id, *contract));
-                    return false;
+                    false
                 }
             })
             .or(partial_match)

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -241,101 +241,130 @@ impl ContractsByArtifact {
             return None;
         }
 
-        self.iter().find(|(_, contract)| {
-            let Some(deployed_bytecode) = &contract.deployed_bytecode else {
-                return false;
-            };
-            let Some(deployed_code) = &deployed_bytecode.object else {
-                return false;
-            };
+        let mut partial_match = None;
+        self.iter()
+            .find(|(id, contract)| {
+                let Some(deployed_bytecode) = &contract.deployed_bytecode else {
+                    return false;
+                };
+                let Some(deployed_code) = &deployed_bytecode.object else {
+                    return false;
+                };
 
-            let len = match deployed_code {
-                BytecodeObject::Bytecode(bytes) => bytes.len(),
-                BytecodeObject::Unlinked(bytes) => bytes.len() / 2,
-            };
+                let len = match deployed_code {
+                    BytecodeObject::Bytecode(bytes) => bytes.len(),
+                    BytecodeObject::Unlinked(bytes) => bytes.len() / 2,
+                };
 
-            if len != code.len() {
-                return false;
-            }
-
-            // Collect ignored offsets by chaining link and immutable references.
-            let mut ignored = deployed_bytecode
-                .immutable_references
-                .values()
-                .chain(deployed_bytecode.link_references.values().flat_map(|v| v.values()))
-                .flatten()
-                .cloned()
-                .collect::<Vec<_>>();
-
-            // For libraries solidity adds a call protection prefix to the bytecode. We need to
-            // ignore it as it includes library address determined at runtime.
-            // See https://docs.soliditylang.org/en/latest/contracts.html#call-protection-for-libraries and
-            // https://github.com/NomicFoundation/hardhat/blob/af7807cf38842a4f56e7f4b966b806e39631568a/packages/hardhat-verify/src/internal/solc/bytecode.ts#L172
-            let has_call_protection = match deployed_code {
-                BytecodeObject::Bytecode(bytes) => {
-                    bytes.starts_with(&CALL_PROTECTION_BYTECODE_PREFIX)
+                if len != code.len() {
+                    return false;
                 }
-                BytecodeObject::Unlinked(bytes) => {
-                    if let Ok(bytes) =
-                        Bytes::from_str(&bytes[..CALL_PROTECTION_BYTECODE_PREFIX.len() * 2])
-                    {
+
+                // Collect ignored offsets by chaining link and immutable references.
+                let mut ignored = deployed_bytecode
+                    .immutable_references
+                    .values()
+                    .chain(deployed_bytecode.link_references.values().flat_map(|v| v.values()))
+                    .flatten()
+                    .cloned()
+                    .collect::<Vec<_>>();
+
+                // For libraries solidity adds a call protection prefix to the bytecode. We need to
+                // ignore it as it includes library address determined at runtime.
+                // See https://docs.soliditylang.org/en/latest/contracts.html#call-protection-for-libraries and
+                // https://github.com/NomicFoundation/hardhat/blob/af7807cf38842a4f56e7f4b966b806e39631568a/packages/hardhat-verify/src/internal/solc/bytecode.ts#L172
+                let has_call_protection = match deployed_code {
+                    BytecodeObject::Bytecode(bytes) => {
                         bytes.starts_with(&CALL_PROTECTION_BYTECODE_PREFIX)
-                    } else {
-                        false
                     }
-                }
-            };
-
-            if has_call_protection {
-                ignored.push(Offsets { start: 1, length: 20 });
-            }
-
-            if let Some(metadata) = find_metadata_start(code) {
-                ignored.push(Offsets {
-                    start: metadata as u32,
-                    length: (code.len() - metadata) as u32,
-                });
-            }
-
-            ignored.sort_by_key(|o| o.start);
-
-            let mut left = 0;
-            for offset in ignored {
-                let right = offset.start as usize;
-
-                let matched = match deployed_code {
-                    BytecodeObject::Bytecode(bytes) => bytes[left..right] == code[left..right],
                     BytecodeObject::Unlinked(bytes) => {
-                        if let Ok(bytes) = Bytes::from_str(&bytes[left * 2..right * 2]) {
-                            bytes == code[left..right]
+                        if let Ok(bytes) =
+                            Bytes::from_str(&bytes[..CALL_PROTECTION_BYTECODE_PREFIX.len() * 2])
+                        {
+                            bytes.starts_with(&CALL_PROTECTION_BYTECODE_PREFIX)
                         } else {
                             false
                         }
                     }
                 };
 
-                if !matched {
+                if has_call_protection {
+                    ignored.push(Offsets { start: 1, length: 20 });
+                }
+
+                let metadata_start = find_metadata_start(code);
+
+                if let Some(metadata) = metadata_start {
+                    ignored.push(Offsets {
+                        start: metadata as u32,
+                        length: (code.len() - metadata) as u32,
+                    });
+                }
+
+                ignored.sort_by_key(|o| o.start);
+
+                let mut left = 0;
+                for offset in ignored {
+                    let right = offset.start as usize;
+
+                    let matched = match deployed_code {
+                        BytecodeObject::Bytecode(bytes) => bytes[left..right] == code[left..right],
+                        BytecodeObject::Unlinked(bytes) => {
+                            if let Ok(bytes) = Bytes::from_str(&bytes[left * 2..right * 2]) {
+                                bytes == code[left..right]
+                            } else {
+                                false
+                            }
+                        }
+                    };
+
+                    if !matched {
+                        return false;
+                    }
+
+                    left = right + offset.length as usize;
+                }
+
+                let partal_match = if left < code.len() {
+                    match deployed_code {
+                        BytecodeObject::Bytecode(bytes) => bytes[left..] == code[left..],
+                        BytecodeObject::Unlinked(bytes) => {
+                            if let Ok(bytes) = Bytes::from_str(&bytes[left * 2..]) {
+                                bytes == code[left..]
+                            } else {
+                                false
+                            }
+                        }
+                    }
+                } else {
+                    true
+                };
+
+                if !partal_match {
                     return false;
                 }
 
-                left = right + offset.length as usize;
-            }
+                let Some(metadata) = metadata_start else { return true };
 
-            if left < code.len() {
-                match deployed_code {
-                    BytecodeObject::Bytecode(bytes) => bytes[left..] == code[left..],
+                let exact_match = match deployed_code {
+                    BytecodeObject::Bytecode(bytes) => bytes[metadata..] == code[metadata..],
                     BytecodeObject::Unlinked(bytes) => {
-                        if let Ok(bytes) = Bytes::from_str(&bytes[left * 2..]) {
-                            bytes == code[left..]
+                        if let Ok(bytes) = Bytes::from_str(&bytes[metadata * 2..]) {
+                            bytes == code[metadata..]
                         } else {
                             false
                         }
                     }
+                };
+
+                if exact_match {
+                    return true;
+                } else {
+                    partial_match = Some((*id, *contract));
+                    return false;
                 }
-            } else {
-                true
-            }
-        })
+            })
+            .or(partial_match)
     }
 
     /// Finds a contract which has the same contract name or identifier as `id`. If more than one is

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -1,6 +1,6 @@
 //! Commonly used contract types and functions.
 
-use crate::{compile::PathOrContractInfo, strip_bytecode_placeholders};
+use crate::{compile::PathOrContractInfo, find_metadata_start, strip_bytecode_placeholders};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::{Event, Function, JsonAbi};
 use alloy_primitives::{Address, B256, Bytes, Selector, hex};
@@ -288,6 +288,13 @@ impl ContractsByArtifact {
 
             if has_call_protection {
                 ignored.push(Offsets { start: 1, length: 20 });
+            }
+
+            if let Some(metadata) = find_metadata_start(code) {
+                ignored.push(Offsets {
+                    start: metadata as u32,
+                    length: (code.len() - metadata) as u32,
+                });
             }
 
             ignored.sort_by_key(|o| o.start);

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -49,7 +49,7 @@ pub fn erc7201(id: &str) -> B256 {
 /// This assumes that the metadata is at the end of the bytecode.
 pub fn find_metadata_start(bytecode: &[u8]) -> Option<usize> {
     // Get the last two bytes of the bytecode to find the length of CBOR metadata.
-    let Some((rest, metadata_len_bytes)) = bytecode.split_last_chunk() else { return None };
+    let (rest, metadata_len_bytes) = bytecode.split_last_chunk()?;
     let metadata_len = u16::from_be_bytes(*metadata_len_bytes) as usize;
     if metadata_len > rest.len() {
         return None;

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -45,17 +45,28 @@ pub fn erc7201(id: &str) -> B256 {
     keccak256(x.to_be_bytes::<32>()) & B256::from(!U256::from(0xff))
 }
 
+/// Utility function to find the start of the metadata in the bytecode.
+/// This assumes that the metadata is at the end of the bytecode.
+pub fn find_metadata_start(bytecode: &[u8]) -> Option<usize> {
+    // Get the last two bytes of the bytecode to find the length of CBOR metadata.
+    let Some((rest, metadata_len_bytes)) = bytecode.split_last_chunk() else { return None };
+    let metadata_len = u16::from_be_bytes(*metadata_len_bytes) as usize;
+    if metadata_len > rest.len() {
+        return None;
+    }
+    ciborium::from_reader::<ciborium::Value, _>(&rest[rest.len() - metadata_len..])
+        .is_ok()
+        .then(|| rest.len() - metadata_len)
+}
+
 /// Utility function to ignore metadata hash of the given bytecode.
 /// This assumes that the metadata is at the end of the bytecode.
 pub fn ignore_metadata_hash(bytecode: &[u8]) -> &[u8] {
-    // Get the last two bytes of the bytecode to find the length of CBOR metadata.
-    let Some((rest, metadata_len_bytes)) = bytecode.split_last_chunk() else { return bytecode };
-    let metadata_len = u16::from_be_bytes(*metadata_len_bytes) as usize;
-    if metadata_len > rest.len() {
-        return bytecode;
+    if let Some(metadata) = find_metadata_start(bytecode) {
+        &bytecode[..metadata]
+    } else {
+        bytecode
     }
-    let (rest, metadata) = rest.split_at(rest.len() - metadata_len);
-    if ciborium::from_reader::<ciborium::Value, _>(metadata).is_ok() { rest } else { bytecode }
 }
 
 /// Strips all __$xxx$__ placeholders from the bytecode if it's an unlinked bytecode.

--- a/testdata/default/cheats/RecordAccountAccesses.t.sol
+++ b/testdata/default/cheats/RecordAccountAccesses.t.sol
@@ -348,7 +348,7 @@ contract RecordAccountAccessesTest is DSTest {
             "0x000000000000000000000000000000000000162e\n- balance diff: 0 \xE2\x86\x92 1000000000000000000\n\n";
         expectedStateDiff = string.concat(expectedStateDiff, callerAddress);
         expectedStateDiff =
-            string.concat(expectedStateDiff, "\ncontract: default/cheats/RecordAccountAccesses.t.sol:SelfCaller");
+            string.concat(expectedStateDiff, "\ncontract: default/cheats/RecordAccountAccesses.t.sol:SelfCaller");  
         expectedStateDiff = string.concat(
             expectedStateDiff,
             "\n- balance diff: 0 \xE2\x86\x92 2000000000000000000\n- nonce diff: 0 \xE2\x86\x92 1\n\n"

--- a/testdata/default/cheats/RecordAccountAccesses.t.sol
+++ b/testdata/default/cheats/RecordAccountAccesses.t.sol
@@ -348,7 +348,7 @@ contract RecordAccountAccessesTest is DSTest {
             "0x000000000000000000000000000000000000162e\n- balance diff: 0 \xE2\x86\x92 1000000000000000000\n\n";
         expectedStateDiff = string.concat(expectedStateDiff, callerAddress);
         expectedStateDiff =
-            string.concat(expectedStateDiff, "\ncontract: default/cheats/RecordAccountAccesses.t.sol:SelfCaller");  
+            string.concat(expectedStateDiff, "\ncontract: default/cheats/RecordAccountAccesses.t.sol:SelfCaller");
         expectedStateDiff = string.concat(
             expectedStateDiff,
             "\n- balance diff: 0 \xE2\x86\x92 2000000000000000000\n- nonce diff: 0 \xE2\x86\x92 1\n\n"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Changes `find_by_deployed_code_exact` to also ignore the metadata hash at the end of bytecode. Review with "Hide whitespace"

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
