### PR TITLE
test: use proper EVM version casing in CLI tests

### DIFF
--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -650,7 +650,7 @@ contract TransientTest is Test {
    "#,
     );
 
-    cmd.args(["test", "-vvvv", "--isolate", "--evm-version", "cancun"]).assert_success();
+    cmd.args(["test", "-vvvv", "--isolate", "--evm-version", "Cancun"]).assert_success();
 });
 
 forgetest_init!(
@@ -2787,7 +2787,7 @@ contract ScrollForkTest is Test {
    "#,
         );
 
-        cmd.args(["test", "--mt", "test_roll_scroll_fork_to_tx", "--evm-version", "cancun"])
+        cmd.args(["test", "--mt", "test_roll_scroll_fork_to_tx", "--evm-version", "Cancun"])
             .assert_success();
     }
 );


### PR DESCRIPTION
Updates test cases to use `Cancun` instead of `cancun` for EVM version.

The config system already warns about the lowercase `cancun` key being deprecated in favor of `evm_version = Cancun`, but our CLI tests were still using the old lowercase format. This creates an inconsistency where we tell users to use proper casing in config files but our own tests don't follow the same convention.