### PR TITLE
Fix panic on NaN/Inf values in TOML to JSON conversion

### DIFF
--- a/crates/cheatcodes/src/toml.rs
+++ b/crates/cheatcodes/src/toml.rs
@@ -234,7 +234,10 @@ pub(super) fn toml_to_json_value(toml: TomlValue) -> JsonValue {
             _ => JsonValue::String(s),
         },
         TomlValue::Integer(i) => JsonValue::Number(i.into()),
-        TomlValue::Float(f) => JsonValue::Number(serde_json::Number::from_f64(f).unwrap()),
+        TomlValue::Float(f) => match serde_json::Number::from_f64(f) {
+            Some(n) => JsonValue::Number(n),
+            None => JsonValue::String(f.to_string()),
+        },
         TomlValue::Boolean(b) => JsonValue::Bool(b),
         TomlValue::Array(a) => JsonValue::Array(a.into_iter().map(toml_to_json_value).collect()),
         TomlValue::Table(t) => {

--- a/testdata/default/cheats/Toml.t.sol
+++ b/testdata/default/cheats/Toml.t.sol
@@ -329,6 +329,24 @@ contract ParseTomlTest is DSTest {
 
         assertEq(keccak256(abi.encode(members)), keccak256(abi.encode(data.members)));
     }
+    
+    function test_floatNaN() public {
+        bytes memory data = vm.parseToml(toml, ".nanFloat");
+        string memory decodedData = abi.decode(data, (string));
+        assertEq("NaN", decodedData);
+    }
+
+    function test_floatInf() public {
+        bytes memory data = vm.parseToml(toml, ".infFloat");
+        string memory decodedData = abi.decode(data, (string));
+        assertEq("inf", decodedData);
+    }
+
+    function test_floatNegInf() public {
+        bytes memory data = vm.parseToml(toml, ".neginfFloat");
+        string memory decodedData = abi.decode(data, (string));
+        assertEq("-inf", decodedData);
+    }
 }
 
 contract WriteTomlTest is DSTest {

--- a/testdata/default/cheats/Toml.t.sol
+++ b/testdata/default/cheats/Toml.t.sol
@@ -329,7 +329,7 @@ contract ParseTomlTest is DSTest {
 
         assertEq(keccak256(abi.encode(members)), keccak256(abi.encode(data.members)));
     }
-    
+
     function test_floatNaN() public {
         bytes memory data = vm.parseToml(toml, ".nanFloat");
         string memory decodedData = abi.decode(data, (string));

--- a/testdata/fixtures/Toml/test.toml
+++ b/testdata/fixtures/Toml/test.toml
@@ -1,3 +1,7 @@
+nanFloat = nan
+infFloat = +inf
+neginfFloat = -inf
+
 basicString = "hai"
 nullString = "null"
 multilineString = """
@@ -49,8 +53,4 @@ id = 1
 [[advancedTomlPath]]
 id = 2
 
-# Floating special values for tests
-nanFloat = nan
-infFloat = +inf
-neginfFloat = -inf
 

--- a/testdata/fixtures/Toml/test.toml
+++ b/testdata/fixtures/Toml/test.toml
@@ -48,3 +48,9 @@ id = 1
 
 [[advancedTomlPath]]
 id = 2
+
+# Floating special values for tests
+nanFloat = nan
+infFloat = +inf
+neginfFloat = -inf
+


### PR DESCRIPTION


Fixes a potential panic when converting TOML float values containing `NaN`, `+inf`, or `-inf` to JSON format.

**Problem:**
- `serde_json::Number::from_f64()` returns `None` for non-finite values
- The code used `.unwrap()` which would panic on valid TOML input
- TOML spec allows these values, but JSON doesn't support them

**Solution:**
- Replace `unwrap()` with safe pattern matching
- Convert non-finite floats to string representation (`"NaN"`, `"inf"`, `"-inf"`)
- Maintains type safety and prevents unexpected crashes

