### PR TITLE
feat(doc): replace single-match parsing with captures_iter to process all inline links

### DIFF
--- a/crates/doc/src/preprocessor/infer_hyperlinks.rs
+++ b/crates/doc/src/preprocessor/infer_hyperlinks.rs
@@ -236,7 +236,7 @@ impl<'a> InlineLink<'a> {
     }
 
     fn captures(s: &'a str) -> impl Iterator<Item = Self> + 'a {
-        RE_INLINE_LINK.captures(s).map(Self::from_capture).into_iter().flatten()
+        RE_INLINE_LINK.captures_iter(s).filter_map(Self::from_capture)
     }
 
     /// Parses the first inline link.


### PR DESCRIPTION
Prior code used the single-match API (captures), so only the first {...} placeholder in a comment was detected and converted. This contradicted the in-code intent to “replace all links” and left subsequent placeholders untouched. Switching to captures_iter ensures every inline link in a comment is processed, fixing incomplete hyperlink generation.