### PR TITLE
feat(`anvil`): add `eth_config` rpc endpoint

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -264,6 +264,9 @@ pub enum EthRequest {
     #[serde(rename = "eth_syncing", with = "empty_params")]
     EthSyncing(()),
 
+    #[serde(rename = "eth_config", with = "empty_params")]
+    EthConfig(()),
+
     /// geth's `debug_getRawTransaction`  endpoint
     #[serde(rename = "debug_getRawTransaction", with = "sequence")]
     DebugGetRawTransaction(TxHash),

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1477,15 +1477,23 @@ impl EthApi {
         Ok(false)
     }
 
+    /// Returns the current configuration of the chain.
+    ///
+    /// Note: the activation timestamp is always 0 as the configuration is set at genesis.
+    /// Note: the `fork_id` is always `0x00000000` as this node does not participate in any forking
+    /// on the network.
+    /// Note: the `next` and `last` fields are always `null` as this node does not participate in
+    /// any forking on the network.
+    ///
+    /// Handler for ETH RPC call: `eth_config`
     pub fn config(&self) -> Result<EthConfig> {
         node_info!("eth_config");
-
         Ok(EthConfig {
             current: EthForkConfig {
                 activation_time: 0,
                 blob_schedule: self.backend.blob_params(),
                 chain_id: self.backend.env().read().evm_env.cfg_env.chain_id,
-                fork_id: Bytes::from_static(b"0x"),
+                fork_id: Bytes::from_static(b"0x00000000"),
                 precompiles: self.backend.precompiles(),
                 system_contracts: self.backend.system_contracts(),
             },

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1477,7 +1477,7 @@ impl EthApi {
         Ok(false)
     }
 
-    /// Returns the current configuration of the chain.
+    /// Returns the current configuration of the chain. This is useful to
     ///
     /// Note: the activation timestamp is always 0 as the configuration is set at genesis.
     /// Note: the `fork_id` is always `0x00000000` as this node does not participate in any forking
@@ -1493,7 +1493,7 @@ impl EthApi {
                 activation_time: 0,
                 blob_schedule: self.backend.blob_params(),
                 chain_id: self.backend.env().read().evm_env.cfg_env.chain_id,
-                fork_id: Bytes::from_static(b"0x00000000"),
+                fork_id: Bytes::from_static(&[0; 4]),
                 precompiles: self.backend.precompiles(),
                 system_contracts: self.backend.system_contracts(),
             },

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -27,7 +27,7 @@ use crate::{
         pool::transactions::PoolTransaction,
         sign::build_typed_transaction,
     },
-    evm::celo_precompile,
+    evm::celo_precompile::{self, CELO_TRANSFER_ADDRESS},
     inject_precompiles,
     mem::{
         inspector::AnvilInspector,
@@ -41,7 +41,10 @@ use alloy_consensus::{
     proofs::{calculate_receipt_root, calculate_transaction_root},
     transaction::Recovered,
 };
-use alloy_eips::{eip1559::BaseFeeParams, eip4844::kzg_to_versioned_hash, eip7840::BlobParams};
+use alloy_eips::{
+    eip1559::BaseFeeParams, eip4844::kzg_to_versioned_hash, eip7840::BlobParams,
+    eip7910::SystemContract,
+};
 use alloy_evm::{
     Database, Evm,
     eth::EthEvmContext,
@@ -114,8 +117,13 @@ use revm::{
         result::{ExecutionResult, Output, ResultAndState},
     },
     database::{CacheDB, WrapDatabaseRef},
+    handler::EthPrecompiles,
     interpreter::InstructionResult,
-    precompile::secp256r1::{P256VERIFY, P256VERIFY_BASE_GAS_FEE},
+    precompile::{
+        PrecompileId, PrecompileSpecId, Precompiles,
+        secp256r1::{P256VERIFY, P256VERIFY_ADDRESS, P256VERIFY_BASE_GAS_FEE},
+        u64_to_address,
+    },
     primitives::{KECCAK_EMPTY, hardfork::SpecId},
     state::AccountInfo,
 };
@@ -841,6 +849,56 @@ impl Backend {
     /// Returns true if Celo features are active
     pub fn is_celo(&self) -> bool {
         self.env.read().is_celo
+    }
+
+    /// Returns the precompiles for the current spec.
+    pub fn precompiles(&self) -> BTreeMap<String, Address> {
+        let spec_id = self.env.read().evm_env.cfg_env.spec;
+        let precompiles = Precompiles::new(PrecompileSpecId::from_spec_id(spec_id));
+
+        let mut precompiles_map = BTreeMap::<String, Address>::default();
+        for (address, precompile) in precompiles.inner() {
+            precompiles_map.insert(precompile.id().name().to_string(), *address);
+        }
+
+        if self.odyssey {
+            precompiles_map.insert(
+                PrecompileId::P256Verify.name().to_string(),
+                u64_to_address(P256VERIFY_ADDRESS),
+            );
+        }
+
+        if self.is_celo() {
+            precompiles_map.insert(
+                celo_precompile::PRECOMPILE_ID_CELO_TRANSFER.clone().name().to_string(),
+                CELO_TRANSFER_ADDRESS,
+            );
+        }
+
+        if let Some(factory) = &self.precompile_factory {
+            for (precompile, _) in &factory.precompiles() {
+                precompiles_map.insert(precompile.id().name().to_string(), *precompile.address());
+            }
+        }
+
+        precompiles_map
+    }
+
+    /// Returns the system contracts for the current spec.
+    pub fn system_contracts(&self) -> BTreeMap<SystemContract, Address> {
+        let mut system_contracts = BTreeMap::<SystemContract, Address>::default();
+
+        let spec_id = self.env.read().evm_env.cfg_env.spec;
+
+        if spec_id >= SpecId::CANCUN {
+            system_contracts.extend(SystemContract::cancun());
+        }
+
+        if spec_id >= SpecId::PRAGUE {
+            system_contracts.extend(SystemContract::prague(None));
+        }
+
+        system_contracts
     }
 
     /// Returns [`BlobParams`] corresponding to the current spec.

--- a/crates/anvil/src/evm/celo_precompile.rs
+++ b/crates/anvil/src/evm/celo_precompile.rs
@@ -11,18 +11,24 @@
 //! - to address (32 bytes, left-padded)
 //! - value (32 bytes, big-endian U256)
 
+use std::borrow::Cow;
+
 use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
 use alloy_primitives::{Address, U256, address};
 use revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
 
 pub const CELO_TRANSFER_ADDRESS: Address = address!("0x00000000000000000000000000000000000000fd");
 
+/// ID for the [`CheatEcrecover::precompile_id`] precompile.
+pub static PRECOMPILE_ID_CELO_TRANSFER: PrecompileId =
+    PrecompileId::Custom(Cow::Borrowed("celo transfer"));
+
 /// Gas cost for Celo transfer precompile
 const CELO_TRANSFER_GAS_COST: u64 = 9000;
 
 /// Returns the celo native transfer
 pub fn precompile() -> DynPrecompile {
-    DynPrecompile::new_stateful(PrecompileId::custom("celo transfer"), celo_transfer_precompile)
+    DynPrecompile::new_stateful(PRECOMPILE_ID_CELO_TRANSFER.clone(), celo_transfer_precompile)
 }
 
 /// Celo transfer precompile implementation.

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -5,6 +5,10 @@ use crate::{
     utils::{http_provider, http_provider_with_signer},
 };
 use alloy_chains::NamedChain;
+use alloy_eips::{
+    eip7840::BlobParams,
+    eip7910::{EthConfig, SystemContract},
+};
 use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder, TransactionResponse};
 use alloy_primitives::{Address, Bytes, TxHash, TxKind, U64, U256, address, b256, bytes, uint};
 use alloy_provider::Provider;
@@ -16,12 +20,19 @@ use alloy_rpc_types::{
 };
 use alloy_serde::WithOtherFields;
 use alloy_signer_local::PrivateKeySigner;
-use anvil::{NodeConfig, NodeHandle, eth::EthApi, spawn};
+use anvil::{EthereumHardfork, NodeConfig, NodeHandle, PrecompileFactory, eth::EthApi, spawn};
 use foundry_common::provider::get_http_provider;
 use foundry_config::Config;
 use foundry_test_utils::rpc::{self, next_http_rpc_endpoint, next_rpc_endpoint};
 use futures::StreamExt;
-use std::{sync::Arc, thread::sleep, time::Duration};
+use revm::precompile::{Precompile, PrecompileId, PrecompileOutput, PrecompileResult};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+    thread::sleep,
+    time::Duration,
+};
 
 const BLOCK_NUMBER: u64 = 14_608_400u64;
 const DEAD_BALANCE_AT_BLOCK_NUMBER: u128 = 12_556_069_338_441_120_059_867u128;
@@ -1606,4 +1617,274 @@ async fn test_fork_get_account() {
     let alice_acc_prev_block = provider.get_account(alice).number(init_block).await.unwrap();
 
     assert_eq!(alice_acc_init, alice_acc_prev_block);
+}
+
+fn assert_hardfork_config(
+    config: &EthConfig,
+    expected_blob_params: &BlobParams,
+    expected_precompiles: &[Address],
+    expected_system_contracts: &BTreeMap<SystemContract, Address>,
+) {
+    assert!(config.next.is_none());
+    assert!(config.last.is_none());
+
+    let current = &config.current;
+
+    assert_eq!(current.activation_time, 0);
+    assert_eq!(current.chain_id, 31337);
+    assert_eq!(current.fork_id, Bytes::from(vec![0, 0, 0, 0]));
+
+    assert_eq!(&current.blob_schedule, expected_blob_params);
+
+    assert_eq!(
+        current.precompiles.values().copied().collect::<BTreeSet<_>>(),
+        expected_precompiles.iter().copied().collect::<BTreeSet<_>>(),
+    );
+
+    assert_eq!(current.system_contracts, *expected_system_contracts);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_config_with_cancun_hardfork() {
+    let (api, _handle) =
+        spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()))).await;
+
+    let config = api.config().unwrap();
+
+    let expected_blob_params = BlobParams {
+        target_blob_count: 3,
+        max_blob_count: 6,
+        update_fraction: 3338477,
+        min_blob_fee: 1,
+        max_blobs_per_tx: 6,
+        blob_base_cost: 0,
+    };
+
+    let expected_precompiles = [
+        address!("0000000000000000000000000000000000000001"),
+        address!("0000000000000000000000000000000000000002"),
+        address!("0000000000000000000000000000000000000003"),
+        address!("0000000000000000000000000000000000000004"),
+        address!("0000000000000000000000000000000000000005"),
+        address!("0000000000000000000000000000000000000006"),
+        address!("0000000000000000000000000000000000000007"),
+        address!("0000000000000000000000000000000000000008"),
+        address!("0000000000000000000000000000000000000009"),
+        address!("000000000000000000000000000000000000000a"),
+    ];
+
+    let expected_system_contracts = BTreeMap::from([(
+        SystemContract::BeaconRoots,
+        address!("000f3df6d732807ef1319fb7b8bb8522d0beac02"),
+    )]);
+
+    assert_hardfork_config(
+        &config,
+        &expected_blob_params,
+        &expected_precompiles,
+        &expected_system_contracts,
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_config_with_prague_hardfork_with_celo() {
+    let (api, _handle) = spawn(
+        NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into())).with_celo(true),
+    )
+    .await;
+
+    let config = api.config().unwrap();
+
+    let expected_blob_params = BlobParams {
+        target_blob_count: 6,
+        max_blob_count: 9,
+        update_fraction: 5007716,
+        min_blob_fee: 1,
+        max_blobs_per_tx: 9,
+        blob_base_cost: 0,
+    };
+
+    let expected_precompiles = [
+        address!("0000000000000000000000000000000000000001"),
+        address!("0000000000000000000000000000000000000002"),
+        address!("0000000000000000000000000000000000000003"),
+        address!("0000000000000000000000000000000000000004"),
+        address!("0000000000000000000000000000000000000005"),
+        address!("0000000000000000000000000000000000000006"),
+        address!("0000000000000000000000000000000000000007"),
+        address!("0000000000000000000000000000000000000008"),
+        address!("0000000000000000000000000000000000000009"),
+        address!("000000000000000000000000000000000000000a"),
+        address!("000000000000000000000000000000000000000b"),
+        address!("000000000000000000000000000000000000000c"),
+        address!("000000000000000000000000000000000000000d"),
+        address!("000000000000000000000000000000000000000e"),
+        address!("000000000000000000000000000000000000000f"),
+        address!("0000000000000000000000000000000000000010"),
+        address!("0000000000000000000000000000000000000011"),
+        address!("00000000000000000000000000000000000000fd"), // `celo transfer`
+    ];
+
+    let expected_system_contracts = BTreeMap::from([
+        (SystemContract::BeaconRoots, address!("000f3df6d732807ef1319fb7b8bb8522d0beac02")),
+        (
+            SystemContract::ConsolidationRequestPredeploy,
+            address!("0000bbddc7ce488642fb579f8b00f3a590007251"),
+        ),
+        (SystemContract::DepositContract, address!("00000000219ab540356cbb839cbe05303d7705fa")),
+        (SystemContract::HistoryStorage, address!("0000f90827f1c53a10cb7a02335b175320002935")),
+        (
+            SystemContract::WithdrawalRequestPredeploy,
+            address!("00000961ef480eb55e80d19ad83579a64c007002"),
+        ),
+    ]);
+
+    assert_hardfork_config(
+        &config,
+        &expected_blob_params,
+        &expected_precompiles,
+        &expected_system_contracts,
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_config_with_osaka_hardfork() {
+    let (api, _handle) =
+        spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Osaka.into()))).await;
+
+    let config = api.config().unwrap();
+
+    let expected_blob_params = BlobParams {
+        target_blob_count: 6,
+        max_blob_count: 9,
+        update_fraction: 5007716,
+        min_blob_fee: 1,
+        max_blobs_per_tx: 6,
+        blob_base_cost: 8192,
+    };
+
+    let expected_precompiles = [
+        address!("0000000000000000000000000000000000000001"),
+        address!("0000000000000000000000000000000000000002"),
+        address!("0000000000000000000000000000000000000003"),
+        address!("0000000000000000000000000000000000000004"),
+        address!("0000000000000000000000000000000000000005"),
+        address!("0000000000000000000000000000000000000006"),
+        address!("0000000000000000000000000000000000000007"),
+        address!("0000000000000000000000000000000000000008"),
+        address!("0000000000000000000000000000000000000009"),
+        address!("000000000000000000000000000000000000000a"),
+        address!("000000000000000000000000000000000000000b"),
+        address!("000000000000000000000000000000000000000c"),
+        address!("000000000000000000000000000000000000000d"),
+        address!("000000000000000000000000000000000000000e"),
+        address!("000000000000000000000000000000000000000f"),
+        address!("0000000000000000000000000000000000000010"),
+        address!("0000000000000000000000000000000000000011"),
+        address!("0000000000000000000000000000000000000100"),
+    ];
+
+    let expected_system_contracts = BTreeMap::from([
+        (SystemContract::BeaconRoots, address!("000f3df6d732807ef1319fb7b8bb8522d0beac02")),
+        (
+            SystemContract::ConsolidationRequestPredeploy,
+            address!("0000bbddc7ce488642fb579f8b00f3a590007251"),
+        ),
+        (SystemContract::DepositContract, address!("00000000219ab540356cbb839cbe05303d7705fa")),
+        (SystemContract::HistoryStorage, address!("0000f90827f1c53a10cb7a02335b175320002935")),
+        (
+            SystemContract::WithdrawalRequestPredeploy,
+            address!("00000961ef480eb55e80d19ad83579a64c007002"),
+        ),
+    ]);
+
+    assert_hardfork_config(
+        &config,
+        &expected_blob_params,
+        &expected_precompiles,
+        &expected_system_contracts,
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_config_with_osaka_hardfork_with_precompile_factory() {
+    fn custom_echo_precompile(input: &[u8], _gas_limit: u64) -> PrecompileResult {
+        Ok(PrecompileOutput { bytes: Bytes::copy_from_slice(input), gas_used: 0, reverted: false })
+    }
+
+    #[derive(Debug)]
+    struct CustomPrecompileFactory;
+
+    impl PrecompileFactory for CustomPrecompileFactory {
+        fn precompiles(&self) -> Vec<(Precompile, u64)> {
+            vec![(
+                Precompile::from((
+                    PrecompileId::Custom(Cow::Borrowed("custom_echo")),
+                    address!("0x0000000000000000000000000000000000000071"),
+                    custom_echo_precompile as fn(&[u8], u64) -> PrecompileResult,
+                )),
+                1000,
+            )]
+        }
+    }
+
+    let (api, _handle) = spawn(
+        NodeConfig::test()
+            .with_hardfork(Some(EthereumHardfork::Osaka.into()))
+            .with_precompile_factory(CustomPrecompileFactory),
+    )
+    .await;
+
+    let config = api.config().unwrap();
+
+    let expected_blob_params = BlobParams {
+        target_blob_count: 6,
+        max_blob_count: 9,
+        update_fraction: 5007716,
+        min_blob_fee: 1,
+        max_blobs_per_tx: 6,
+        blob_base_cost: 8192,
+    };
+
+    let expected_precompiles = [
+        address!("0000000000000000000000000000000000000001"),
+        address!("0000000000000000000000000000000000000002"),
+        address!("0000000000000000000000000000000000000003"),
+        address!("0000000000000000000000000000000000000004"),
+        address!("0000000000000000000000000000000000000005"),
+        address!("0000000000000000000000000000000000000006"),
+        address!("0000000000000000000000000000000000000007"),
+        address!("0000000000000000000000000000000000000008"),
+        address!("0000000000000000000000000000000000000009"),
+        address!("000000000000000000000000000000000000000a"),
+        address!("000000000000000000000000000000000000000b"),
+        address!("000000000000000000000000000000000000000c"),
+        address!("000000000000000000000000000000000000000d"),
+        address!("000000000000000000000000000000000000000e"),
+        address!("000000000000000000000000000000000000000f"),
+        address!("0000000000000000000000000000000000000010"),
+        address!("0000000000000000000000000000000000000011"),
+        address!("0000000000000000000000000000000000000071"), // `custom_echo`
+        address!("0000000000000000000000000000000000000100"),
+    ];
+    let expected_system_contracts = BTreeMap::from([
+        (SystemContract::BeaconRoots, address!("000f3df6d732807ef1319fb7b8bb8522d0beac02")),
+        (
+            SystemContract::ConsolidationRequestPredeploy,
+            address!("0000bbddc7ce488642fb579f8b00f3a590007251"),
+        ),
+        (SystemContract::DepositContract, address!("00000000219ab540356cbb839cbe05303d7705fa")),
+        (SystemContract::HistoryStorage, address!("0000f90827f1c53a10cb7a02335b175320002935")),
+        (
+            SystemContract::WithdrawalRequestPredeploy,
+            address!("00000961ef480eb55e80d19ad83579a64c007002"),
+        ),
+    ]);
+
+    assert_hardfork_config(
+        &config,
+        &expected_blob_params,
+        &expected_precompiles,
+        &expected_system_contracts,
+    );
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

In order to make it easier to figure out the supported precompiles and system contracts as a user I think it makes sense to add an `eth_config`-like RPC method: https://eips.ethereum.org/EIPS/eip-7910

Closes: https://github.com/foundry-rs/foundry/issues/11433

This completes the work required to make Foundry ready for Osaka.

Closes: https://github.com/foundry-rs/foundry/issues/11428

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds `eth_config`-like endpoint inspired by the actual `eth_config` specification with notable exceptions:

- Note: the activation timestamp is always 0 as the configuration is set at genesis (spec compliant).
- Note: the `next` and `last` fields are always `null` as this node does not participate in any forking on the network (spec compliant).

Not spec compliant:

The `fork_id` is always `0x00000000` as this node does not participate in any forking on the network. For all intended purposes you can consider this unused by Anvil.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
