### PR TITLE
perf: replace format!("{}", len) with more efficient to_string()

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -749,7 +749,7 @@ impl<P: Provider<AnyNetwork>> Cast<P> {
     pub async fn codesize(&self, who: Address, block: Option<BlockId>) -> Result<String> {
         let code =
             self.provider.get_code_at(who).block_id(block.unwrap_or_default()).await?.to_vec();
-        Ok(format!("{}", code.len()))
+        Ok(code.len().to_string())
     }
 
     /// # Example


### PR DESCRIPTION
## Motivation

Replace inefficient `format!("{}", value)` pattern with direct `to_string()` method call for simple numeric-to-string conversions. The `format!` macro has overhead from the formatting machinery that is unnecessary when converting a single value to string.

## Solution

Changed `Ok(format!("{}", code.len()))` to `Ok(code.len().to_string())` in the `codesize` method. This micro-optimization improves performance by avoiding the format string parsing and reduces memory allocations while maintaining identical behavior.

## PR Checklist

- [ ] Added Tests - N/A (identical behavior, no functional changes)
- [ ] Added Documentation - N/A (no API changes)  
- [x] Breaking changes - No