### PR TITLE
Fix CRLF line ending handling in stdin utilities

### DIFF
--- a/crates/common/src/io/stdin.rs
+++ b/crates/common/src/io/stdin.rs
@@ -103,6 +103,9 @@ pub fn read_bytes(read_line: bool) -> Result<Vec<u8>> {
         // remove the trailing newline
         if let Some(b'\n') = buf.as_bytes().last() {
             buf.pop();
+            if let Some(b'\r') = buf.as_bytes().last() {
+                buf.pop();
+            }
         }
         Ok(buf.into_bytes())
     } else {


### PR DESCRIPTION


Fixed a bug in `crates/common/src/io/stdin.rs` where reading from stdin with `read_line=true` would leave trailing `\r` characters when processing CRLF line endings (Windows-style).

**Problem:**
- `read_bytes(true)` only removed `\n` but left `\r` from CRLF sequences
- This caused parsing failures and invisible characters in parsed values
- Affected all stdin utilities that use `unwrap_line()`, `parse_line()`, etc.

**Solution:**
- Added removal of trailing `\r` after `\n` in `read_bytes(true)`
- Now properly handles both LF (`\n`) and CRLF (`\r\n`) line endings

