### PR TITLE
chore(sol_macro_gen): remove unlinked bytecode workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4224,7 +4224,6 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "serde_json",
  "syn 2.0.106",
 ]
 

--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -1,0 +1,27 @@
+// <https://github.com/foundry-rs/foundry/issues/9482>
+forgetest_init!(bind_unlinked_bytecode, |prj, cmd| {
+    prj.wipe();
+    prj.add_source(
+        "SomeLibContract.sol",
+        r#"
+library SomeLib {
+    function add(uint256 a, uint256 b) external pure returns (uint256) {
+        return a + b;
+    }
+}
+
+contract SomeLibContract {
+    function add(uint256 a, uint256 b) public pure returns (uint256) {
+        return SomeLib.add(a, b);
+    }
+}
+   "#,
+    );
+    cmd.args(["bind", "--select", "SomeLibContract"]).assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+Generating bindings for 1 contracts
+Bindings have been generated to [..]
+"#]]);
+});

--- a/crates/forge/tests/cli/main.rs
+++ b/crates/forge/tests/cli/main.rs
@@ -4,6 +4,7 @@ extern crate foundry_test_utils;
 pub mod constants;
 pub mod utils;
 
+mod bind;
 mod bind_json;
 mod build;
 mod cache;

--- a/crates/sol-macro-gen/Cargo.toml
+++ b/crates/sol-macro-gen/Cargo.toml
@@ -23,7 +23,6 @@ proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
 prettyplease.workspace = true
-serde_json.workspace = true
 
 eyre.workspace = true
 


### PR DESCRIPTION
## Motivation

Closes #9482

Related to #10291 and https://github.com/alloy-rs/core/pull/935

## Solution

As Alloy provides now `#[sol(ignore_unlinked)` attribute, it's possible to ignore unlinked bytecode while parsing sol input.

- Removed previous workaround
- Added `#[sol(ignore_unlinked)` attribute to token stream in `get_sol_input`
- Added a test to validate there is no error in presence of unlinked bytecode

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes (I don't think so...)
