### PR TITLE
fix(anvil): traces' colors

### DIFF
--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -112,8 +112,8 @@ fn print_traces(tracer: TracingInspector, decoder: Arc<CallTraceDecoder>) {
     });
 
     let traces = SparsedTraceArena { arena, ignored: Default::default() };
-    node_info!("Traces:");
-    node_info!("{}", render_trace_arena_inner(&traces, false, true));
+    let trace = render_trace_arena_inner(&traces, false, true);
+    node_info!(Traces = %format!("\n{}", trace));
 }
 
 impl<CTX> Inspector<CTX, EthInterpreter> for AnvilInspector


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Anvil logging is done using `tracing_subscriber::fmt` which escapes ansi codes on the `message` field which makes it not render the colored traces properly, but print the trace with escape codes instead. From my couple hours of research I can't figure out a simple way to fix that, but the proposed fix is quite minimal, only change is instead of `Traces:`, it will show as `Traces=`  where `Traces` is in italic.

## Solution

Log the traces with `std::fmt::Display` with `%`.


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
