### PR TITLE
fix(common): incorrect error message in get_error

### DIFF
--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -110,7 +110,7 @@ pub fn get_event(sig: &str) -> Result<Event> {
 
 /// Given an error signature string, it tries to parse it as a `Error`
 pub fn get_error(sig: &str) -> Result<Error> {
-    Error::parse(sig).wrap_err("could not parse event signature")
+    Error::parse(sig).wrap_err("could not parse error signature")
 }
 
 /// Given an event without indexed parameters and a rawlog, it tries to return the event with the


### PR DESCRIPTION
The helper get_error wrapped parsing failures with the text "could not parse event signature", which is a copy-paste mistake and inconsistent with get_func and get_event. Updating it to "could not parse error signature" improves accuracy and consistency, and avoids misleading diagnostics for users when parsing custom error signatures.