### PR TITLE
chore: align error messages with boundary conditions

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -442,7 +442,10 @@ impl Cheatcode for getChainIdCall {
 impl Cheatcode for chainIdCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { newChainId } = self;
-        ensure!(*newChainId <= U256::from(u64::MAX), "chain ID must be less than 2^64");
+        ensure!(
+            *newChainId <= U256::from(u64::MAX),
+            "chain ID must be less than or equal to 2^64 - 1"
+        );
         ccx.ecx.cfg.chain_id = newChainId.to();
         Ok(Default::default())
     }
@@ -472,7 +475,10 @@ impl Cheatcode for difficultyCall {
 impl Cheatcode for feeCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { newBasefee } = self;
-        ensure!(*newBasefee <= U256::from(u64::MAX), "base fee must be less than 2^64");
+        ensure!(
+            *newBasefee <= U256::from(u64::MAX),
+            "base fee must be less than or equal to 2^64 - 1"
+        );
         ccx.ecx.block.basefee = newBasefee.saturating_to();
         Ok(Default::default())
     }
@@ -549,7 +555,10 @@ impl Cheatcode for getBlockNumberCall {
 impl Cheatcode for txGasPriceCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { newGasPrice } = self;
-        ensure!(*newGasPrice <= U256::from(u64::MAX), "gas price must be less than 2^64");
+        ensure!(
+            *newGasPrice <= U256::from(u64::MAX),
+            "gas price must be less than or equal to 2^64 - 1"
+        );
         ccx.ecx.tx.gas_price = newGasPrice.saturating_to();
         Ok(Default::default())
     }
@@ -1030,7 +1039,10 @@ impl Cheatcode for broadcastRawTransactionCall {
 impl Cheatcode for setBlockhashCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { blockNumber, blockHash } = *self;
-        ensure!(blockNumber <= U256::from(u64::MAX), "blockNumber must be less than 2^64");
+        ensure!(
+            blockNumber <= U256::from(u64::MAX),
+            "blockNumber must be less than or equal to 2^64 - 1"
+        );
         ensure!(
             blockNumber <= U256::from(ccx.ecx.block.number),
             "block number must be less than or equal to the current block number"

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -225,7 +225,7 @@ impl Cheatcode for eth_getLogsCall {
         let Self { fromBlock, toBlock, target, topics } = self;
         let (Ok(from_block), Ok(to_block)) = (u64::try_from(fromBlock), u64::try_from(toBlock))
         else {
-            bail!("blocks in block range must be less than 2^64")
+            bail!("blocks in block range must be less than or equal to 2^64 - 1")
         };
 
         if topics.len() > 4 {
@@ -277,7 +277,7 @@ impl Cheatcode for getRawBlockHeaderCall {
             .ok_or_else(|| fmt_err!("no active fork"))?;
         let provider = ProviderBuilder::new(&url).build()?;
         let block_number = u64::try_from(blockNumber)
-            .map_err(|_| fmt_err!("block number must be less than 2^64"))?;
+            .map_err(|_| fmt_err!("block number must be less than or equal to 2^64 - 1"))?;
         let block =
             foundry_common::block_on(async move { provider.get_block(block_number.into()).await })
                 .map_err(|e| fmt_err!("failed to get block: {e}"))?

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -49,7 +49,10 @@ impl Cheatcode for getLabelCall {
 impl Cheatcode for computeCreateAddressCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { nonce, deployer } = self;
-        ensure!(*nonce <= U256::from(u64::MAX), "nonce must be less than 2^64");
+        ensure!(
+            *nonce <= U256::from(u64::MAX),
+            "nonce must be less than or equal to 2^64 - 1"
+        );
         Ok(deployer.create(nonce.to()).abi_encode())
     }
 }

--- a/crates/forge/src/cmd/clone.rs
+++ b/crates/forge/src/cmd/clone.rs
@@ -455,8 +455,8 @@ fn dump_sources(meta: &Metadata, root: &PathBuf, no_reorg: bool) -> Result<Vec<R
         });
 
     // ensure `src` and `lib` directories exist
-    eyre::ensure!(Path::exists(&root.join(src_dir)), "`src` directory must exists");
-    eyre::ensure!(Path::exists(&root.join(lib_dir)), "`lib` directory must exists");
+    eyre::ensure!(Path::exists(&root.join(src_dir)), "`src` directory must exist");
+    eyre::ensure!(Path::exists(&root.join(lib_dir)), "`lib` directory must exist");
 
     // move source files
     for entry in std::fs::read_dir(tmp_dump_dir.join(contract_name))? {


### PR DESCRIPTION
Standardize error messages to match conditions and fix a minor grammar error.
