### PR TITLE
feat(cast): get logs in batch and count

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -18,7 +18,8 @@ use alloy_provider::{
 };
 use alloy_rlp::Decodable;
 use alloy_rpc_types::{
-    BlockId, BlockNumberOrTag, BlockOverrides, Filter, TransactionRequest, state::StateOverride,
+    BlockId, BlockNumberOrTag, BlockOverrides, Filter, Log, TransactionRequest,
+    state::StateOverride,
 };
 use alloy_serde::WithOtherFields;
 use alloy_sol_types::sol;
@@ -948,9 +949,11 @@ impl<P: Provider<AnyNetwork>> Cast<P> {
         ))
     }
 
-    pub async fn filter_logs(&self, filter: Filter) -> Result<String> {
-        let logs = self.provider.get_logs(&filter).await?;
+    pub async fn get_logs(&self, filter: Filter) -> Result<Vec<Log>> {
+        Ok(self.provider.get_logs(&filter).await?)
+    }
 
+    pub async fn format_logs(&self, logs: Vec<Log>) -> Result<String> {
         let res = if shell::is_json() {
             serde_json::to_string(&logs)?
         } else {
@@ -965,6 +968,11 @@ impl<P: Provider<AnyNetwork>> Cast<P> {
             s.join("\n")
         };
         Ok(res)
+    }
+
+    pub async fn filter_logs(&self, filter: Filter) -> Result<String> {
+        let logs = self.get_logs(filter).await?;
+        self.format_logs(logs).await
     }
 
     /// Converts a block identifier into a block number.


### PR DESCRIPTION
I found some RPC providers doesn't support to query eth_logs in a large range, eg:

Fetch the USDT Transfer logs from block 17,000,000 to 18,000,000:

```bash
cast logs --from-block 17000000 --to-block 18000000 --address 0xdac17f958d2ee523a2206206994597c13d831ec7 "Transfer(address,address,uint256)"
```

The rpc provider response with:

```
Error: server returned an error response: error code -32600: params: fromBlock and toBlock the block range with a limit of 10000 blocks.
```

So here I propose to add a `--batch` flag to split the large range into smaller batches, and fetch the logs in batch, and a `--count` flag to only output the count of the logs.