### PR TITLE
test: make default contracts opt-in for test initialization

### DIFF
--- a/crates/test-utils/src/macros.rs
+++ b/crates/test-utils/src/macros.rs
@@ -100,6 +100,7 @@ macro_rules! forgetest_init {
         fn $test() {
             let (mut $prj, mut $cmd) = $crate::util::setup_forge(stringify!($test), $style);
             $crate::util::initialize($prj.root());
+            $prj.initialize_default_contracts();
             $e
         }
     };
@@ -118,6 +119,7 @@ macro_rules! forgesoldeer {
         fn $test() {
             let (mut $prj, mut $cmd) = $crate::util::setup_forge(stringify!($test), $style);
             $crate::util::initialize($prj.root());
+            $prj.initialize_default_contracts();
             $e
         }
     };


### PR DESCRIPTION
## Fix test initialization performance issue

The `initialize()` function was already using `--empty` but some test macros still expected default contracts to exist, causing confusion and potential test failures.

### What changed
- `forgetest_init!` and `forgesoldeer!` now explicitly call `initialize_default_contracts()` 
- Tests that need `Counter.sol` and friends still get them
- Tests that don't need defaults get faster startup

### Why this matters
- Most tests run faster (no unnecessary file creation)
- No more need to `wipe()` unwanted template files
- Makes the "opt-in" approach actually work as intended

No breaking changes - existing tests work exactly the same.

Fixes #11625