### PR TITLE
Fix: Replace unsafe mnemonic fallback with secure random generation

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -299,7 +299,8 @@ impl NodeArgs {
                 Ok(mnemonic) => mnemonic.to_phrase(),
                 Err(err) => {
                     warn!(target: "node", ?count, %err, "failed to generate mnemonic, falling back to 12-word random mnemonic");
-                    // Fallback: generate a valid 12-word random mnemonic instead of using DEFAULT_MNEMONIC
+                    // Fallback: generate a valid 12-word random mnemonic instead of using
+                    // DEFAULT_MNEMONIC
                     Mnemonic::<English>::new_with_count(&mut rng, 12)
                         .expect("valid default word count")
                         .to_phrase()

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -297,7 +297,13 @@ impl NodeArgs {
             let mut rng = rand_08::thread_rng();
             let mnemonic = match Mnemonic::<English>::new_with_count(&mut rng, count) {
                 Ok(mnemonic) => mnemonic.to_phrase(),
-                Err(_) => DEFAULT_MNEMONIC.to_string(),
+                Err(err) => {
+                    warn!(target: "node", ?count, %err, "invalid mnemonic word count, falling back to 12-word random mnemonic");
+                    // Fallback: generate a valid 12-word random mnemonic instead of using DEFAULT_MNEMONIC
+                    Mnemonic::<English>::new_with_count(&mut rng, 12)
+                        .expect("valid default word count")
+                        .to_phrase()
+                }
             };
             generator = generator.phrase(mnemonic);
         } else if let Some(seed) = self.mnemonic_seed {

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -298,7 +298,8 @@ impl NodeArgs {
             let mnemonic = match Mnemonic::<English>::new_with_count(&mut rng, count) {
                 Ok(mnemonic) => mnemonic.to_phrase(),
                 Err(err) => {
-                    warn!(target: "node", ?count, %err, "invalid mnemonic word count, falling back to 12-word random mnemonic");
+                    warn!(target: "node", ?count, %err, "failed to generate mnemonic, falling back to 12-word random mnemonic");
+                    // Fallback: generate a valid 12-word random mnemonic instead of using DEFAULT_MNEMONIC
                     Mnemonic::<English>::new_with_count(&mut rng, 12)
                         .expect("valid default word count")
                         .to_phrase()

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -299,7 +299,6 @@ impl NodeArgs {
                 Ok(mnemonic) => mnemonic.to_phrase(),
                 Err(err) => {
                     warn!(target: "node", ?count, %err, "invalid mnemonic word count, falling back to 12-word random mnemonic");
-                    // Fallback: generate a valid 12-word random mnemonic instead of using DEFAULT_MNEMONIC
                     Mnemonic::<English>::new_with_count(&mut rng, 12)
                         .expect("valid default word count")
                         .to_phrase()


### PR DESCRIPTION


## Description

**Security Issue Fixed**: Removed silent fallback to the well-known test mnemonic `"test test test test test test test test test test test junk"` when invalid word count is provided to `--mnemonic-random`.

### **Problem**
When users specified an invalid word count (e.g., `anvil --mnemonic-random 13`), the code would silently fall back to `DEFAULT_MNEMONIC`, which is a publicly known test phrase. This created a security risk where users might unknowingly use predictable, insecure accounts.

### **Solution**
- **Added warning logging** when invalid word count is detected
- **Generate secure random 12-word mnemonic** as fallback instead of using the test phrase
- **Preserve user intent** of having a random mnemonic while ensuring security

