### PR TITLE
fix(forge): ensure broadcast account is touched

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -855,6 +855,8 @@ impl Cheatcodes {
                     let is_fixed_gas_limit = check_if_fixed_gas_limit(&ecx, call.gas_limit);
 
                     let input = TransactionInput::new(call.input.bytes(ecx));
+                    // Ensure account is touched.
+                    ecx.journaled_state.touch(broadcast.new_origin);
 
                     let account =
                         ecx.journaled_state.inner.state().get_mut(&broadcast.new_origin).unwrap();
@@ -1613,6 +1615,8 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
             if curr_depth == broadcast.depth {
                 input.set_caller(broadcast.new_origin);
                 let is_fixed_gas_limit = check_if_fixed_gas_limit(&ecx, input.gas_limit());
+                // Ensure account is touched.
+                ecx.journaled_state.touch(broadcast.new_origin);
 
                 let account = &ecx.journaled_state.inner.state()[&broadcast.new_origin];
                 self.broadcastable_transactions.push_back(BroadcastableTransaction {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes https://github.com/foundry-rs/foundry/issues/11633
- similar with prank fix in https://github.com/foundry-rs/foundry/pull/11025 but for broadcast (probably don't need to ensure touch on call but only on create, though harmless)
- complex test to include, manually tested fix against https://github.com/espressosystems/espresso-network
- considering backporting to v1.3.6

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
