### PR TITLE
cheatcodes: redact FFI command args in debug logs

### DIFF
--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -641,7 +641,7 @@ fn ffi(state: &Cheatcodes, input: &[String]) -> Result<FfiResult> {
     let mut cmd = Command::new(&input[0]);
     cmd.args(&input[1..]);
 
-    debug!(target: "cheatcodes", ?cmd, "invoking ffi");
+    debug!(target: "cheatcodes", program = %input[0], args_len = input.len().saturating_sub(1), "invoking ffi");
 
     let output = cmd
         .current_dir(&state.config.root)


### PR DESCRIPTION

### Summary
- Replace debug logging of full FFI command with a safe variant that avoids printing arguments.

### Motivation
- FFI commands may include secrets (keys, tokens, passwords). Previous `?cmd` logging could leak them to debug logs.

### Changes
- Log only the program name and the number of arguments:
  - Before: logged entire `cmd` with all args
  - After: `program=<input[0]>, args_len=<len-1>`

### Impact
- No functional behavior changes.
- Reduces risk of secret leakage in logs.
- Backwards compatible; minor reduction in debug verbosity.