### PR TITLE
Fix/template initialization empty flag

### DIFF
--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -886,6 +886,7 @@ forgetest!(can_clean_hardhat, PathStyle::HardHat, |prj, cmd| {
 // checks that `clean` also works with the "out" value set in Config
 forgetest_init!(can_clean_config, |prj, cmd| {
     prj.update_config(|config| config.out = "custom-out".into());
+    prj.initialize_default_contracts();
     cmd.arg("build").assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
@@ -907,6 +908,7 @@ forgetest_init!(can_clean_test_cache, |prj, cmd| {
         config.fuzz = FuzzConfig::new("cache/fuzz".into());
         config.invariant = InvariantConfig::new("cache/invariant".into());
     });
+    prj.initialize_default_contracts();
     // default test contract is written in custom out directory
     let fuzz_cache_dir = prj.root().join("cache/fuzz");
     let _ = fs::create_dir(fuzz_cache_dir.clone());
@@ -923,6 +925,7 @@ forgetest_init!(can_clean_test_cache, |prj, cmd| {
 
 // checks that extra output works
 forgetest_init!(can_emit_extra_output, |prj, cmd| {
+    prj.initialize_default_contracts();
     prj.clear();
 
     cmd.args(["build", "--extra-output", "metadata"]).assert_success().stdout_eq(str![[r#"
@@ -955,6 +958,7 @@ Compiler run successful!
 
 // checks that extra output works
 forgetest_init!(can_emit_multiple_extra_output, |prj, cmd| {
+    prj.initialize_default_contracts();
     cmd.args([
         "build",
         "--extra-output",

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -11,6 +11,7 @@ fn assert_lcov(cmd: &mut TestCommand, data: impl IntoData) {
 }
 
 fn basic_base(prj: TestProject, mut cmd: TestCommand) {
+    prj.initialize_default_contracts();
     cmd.args(["coverage", "--report=lcov", "--report=summary"]).assert_success().stdout_eq(str![[
         r#"
 [COMPILING_FILES] with [SOLC_VERSION]

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -283,7 +283,7 @@ pub fn initialize(target: &Path) {
             let (prj, mut cmd) = setup_forge("template", foundry_compilers::PathStyle::Dapptools);
             println!("- initializing template dir in {}", prj.root().display());
 
-            cmd.args(["init", "--force"]).assert_success();
+            cmd.args(["init", "--force", "--empty"]).assert_success();
             prj.write_config(Config {
                 solc: Some(foundry_config::SolcReq::Version(SOLC_VERSION.parse().unwrap())),
                 ..Default::default()
@@ -755,6 +755,11 @@ impl TestProject {
         rm_create(&self.paths().sources);
         rm_create(&self.paths().tests);
         rm_create(&self.paths().scripts);
+    }
+
+    pub fn initialize_default_contracts(&self) {
+        let mut cmd = self.forge_command();
+        cmd.args(["init", "--force"]).assert_success();
     }
 }
 


### PR DESCRIPTION
Closes #11625 

## Changes
- Added `--empty` flag to the `forge init` command on line 286 in the `initialize()` function
- This ensures the template directory is initialized without any default contract files
- Added `fn initialize_default_contracts` to `TestProject`


## Tests
- exploratory analysis ins progress to reach all tests that might fail after changes above (WIP).