### PR TITLE
chore(forge): re-use project output in `forge bind-json`

### DIFF
--- a/crates/forge/src/cmd/bind_json.rs
+++ b/crates/forge/src/cmd/bind_json.rs
@@ -71,7 +71,7 @@ impl BindJsonArgs {
             .unwrap();
 
         // Step 2: Preprocess sources to handle potentially invalid bindings
-        self.preprocess_sources(&mut sources)?;
+        // self.preprocess_sources(&mut sources)?;
 
         // Insert empty bindings file.
         sources.insert(target_path.clone(), Source::new(JSON_BINDINGS_PLACEHOLDER));


### PR DESCRIPTION
Re-use existing `Compiler` from `ProjectCompileOutput` in `forge bind-json`.

Towards https://github.com/foundry-rs/foundry/issues/11456.