### PR TITLE
chore(common): add serde skip for compute_units_per_second in EvmArgs

### DIFF
--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -300,6 +300,26 @@ mod tests {
     use foundry_config::NamedChain;
 
     #[test]
+    fn compute_units_per_second_skips_when_none() {
+        let args = EvmArgs::default();
+        let data = args.data().expect("provider data");
+        let dict = data.get(&Config::selected_profile()).expect("profile dict");
+        assert!(
+            !dict.contains_key("compute_units_per_second"),
+            "compute_units_per_second should be skipped when None"
+        );
+    }
+
+    #[test]
+    fn compute_units_per_second_present_when_some() {
+        let args = EvmArgs { compute_units_per_second: Some(1000), ..Default::default() };
+        let data = args.data().expect("provider data");
+        let dict = data.get(&Config::selected_profile()).expect("profile dict");
+        let val = dict.get("compute_units_per_second").expect("cups present");
+        assert_eq!(val, &Value::from(1000u64));
+    }
+
+    #[test]
     fn can_parse_chain_id() {
         let args = EvmArgs {
             env: EnvArgs { chain: Some(NamedChain::Mainnet.into()), ..Default::default() },

--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -113,6 +113,7 @@ pub struct EvmArgs {
     ///
     /// See also --fork-url and <https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second>
     #[arg(long, alias = "cups", value_name = "CUPS", help_heading = "Fork config")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub compute_units_per_second: Option<u64>,
 
     /// Disables rate limiting for this node's provider.


### PR DESCRIPTION
Add #[serde(skip_serializing_if = "Option::is_none")] to EvmArgs.compute_units_per_second. Without this, the CLI provider serialized a null value into Figment, which overrides lower-precedence config values (e.g., foundry.toml or endpoint configs). This caused valid configured CUPS to be cleared and defaulted to 330 during extraction. Skipping serialization when None preserves downstream configuration precedence and aligns with how other Option fields in EvmArgs are handled.