### PR TITLE
chore(common): clean RuntimeTransport derive and remove dead LockError

### DIFF
--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -38,10 +38,6 @@ pub enum RuntimeTransportError {
     #[error("Internal transport error: {0} with {1}")]
     TransportError(TransportError, String),
 
-    /// Failed to lock the transport
-    #[error("Failed to lock the transport")]
-    LockError,
-
     /// Invalid URL scheme
     #[error("URL scheme is not supported: {0}")]
     BadScheme(String),
@@ -70,7 +66,7 @@ pub enum RuntimeTransportError {
 /// either an HTTP WebSocket, or IPC transport depending on the URL used.
 /// Retries for rate-limiting and timeout-related errors are handled by an external
 /// client layer (e.g., `RetryBackoffLayer`) when configured.
-#[derive(Clone, Debug, Error)]
+#[derive(Clone, Debug)]
 pub struct RuntimeTransport {
     /// The inner actual transport used.
     inner: Arc<RwLock<Option<InnerTransport>>>,


### PR DESCRIPTION
- Remove Error from #[derive(Clone, Debug, Error)] on RuntimeTransport to align semantics and avoid thiserror conflicts with manual Display.
- Delete unused RuntimeTransportError::LockError variant and its message; there are no call sites and tokio::RwLock here doesn’t produce such failures.