### PR TITLE
feat(debugger): remove dead tick polling; use blocking read and forward

### DIFF
--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -15,7 +15,6 @@ use std::{
     ops::ControlFlow,
     sync::{Arc, mpsc},
     thread,
-    time::{Duration, Instant},
 };
 
 mod context;
@@ -76,24 +75,10 @@ impl<'a> TUI<'a> {
     }
 
     fn event_listener(tx: mpsc::Sender<Event>) {
-        // This is the recommend tick rate from `ratatui`, based on their examples
-        let tick_rate = Duration::from_millis(200);
-
-        let mut last_tick = Instant::now();
         loop {
-            // Poll events since last tick - if last tick is greater than tick_rate, we
-            // demand immediate availability of the event. This may affect interactivity,
-            // but I'm not sure as it is hard to test.
-            if event::poll(tick_rate.saturating_sub(last_tick.elapsed())).unwrap() {
-                let event = event::read().unwrap();
-                if tx.send(event).is_err() {
-                    return;
-                }
-            }
-
-            // Force update if time has passed
-            if last_tick.elapsed() > tick_rate {
-                last_tick = Instant::now();
+            let event = event::read().unwrap();
+            if tx.send(event).is_err() {
+                return;
             }
         }
     }


### PR DESCRIPTION
- Remove unused tick_rate/last_tick and “Force update” code from event_listener.
- Switch to blocking event::read() and forward events via channel.
- This change eliminates dead/incomplete tick logic that never sent tick events, which could confuse maintainers and suggests behavior that doesn’t exist. Since the UI updates only on user input and doesn’t require periodic redraws, blocking read is the correct, simpler model. This reduces complexity and prevents misleading comments from implying periodic ticks.