### PR TITLE
chore(anvil): Remove stale TODO in optimism deposit test

### DIFF
--- a/crates/anvil/tests/it/optimism.rs
+++ b/crates/anvil/tests/it/optimism.rs
@@ -35,7 +35,6 @@ async fn test_deposits_not_supported_if_optimism_disabled() {
         deposit_receipt_version: None,
     };
 
-    // TODO: Test this
     let other = serde_json::to_value(op_fields).unwrap().try_into().unwrap();
 
     let tx = WithOtherFields { inner: tx, other };


### PR DESCRIPTION
The comment // TODO: Test this preceding the OP deposit error assertion was outdated. The test already validates the behavior (ensuring an informative error when Optimism support is disabled). Removing the stale TODO prevents confusion for future readers by avoiding the implication that coverage is missing when it is already present.