### PR TITLE
fix: remove explicit darwin SDK from flake.nix as it's deprecated

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,6 @@
               dprint
               nodejs
             ];
-            buildInputs = lib.optionals pkgs.stdenv.isDarwin
-              [ pkgs.darwin.apple_sdk.frameworks.AppKit ];
 
             packages = with pkgs; [ rust-analyzer-unwrapped ];
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes https://github.com/foundry-rs/foundry/issues/11683

## Solution

From https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks: 
> If your derivation references them, you can delete them. The default SDK should be enough to build your package.

```console
❯ nix develop -c echo Ok
warning: Git tree '/Users/shekhirin/projects/oss/foundry' has uncommitted changes
Ok
```

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
