### PR TITLE
refactor!: remove `--odyssey`

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -681,12 +681,6 @@ pub enum EthRequest {
     WalletGetCapabilities(()),
 
     /// Wallet send_tx
-    #[serde(
-        rename = "wallet_sendTransaction",
-        alias = "odyssey_sendTransaction",
-        with = "sequence"
-    )]
-    WalletSendTransaction(Box<WithOtherFields<TransactionRequest>>),
 
     /// Add an address to the delegation capability of the wallet
     #[serde(rename = "anvil_addCapability", with = "sequence")]

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -193,7 +193,7 @@ pub struct NodeArgs {
     #[command(flatten)]
     pub server_config: ServerConfig,
 
-    /// Path to the cache directory where states are stored.    
+    /// Path to the cache directory where states are stored.
     #[arg(long, value_name = "PATH")]
     pub cache_path: Option<PathBuf>,
 }
@@ -278,7 +278,6 @@ impl NodeArgs {
             .with_transaction_block_keeper(self.transaction_block_keeper)
             .with_max_persisted_states(self.max_persisted_states)
             .with_optimism(self.evm.optimism)
-            .with_odyssey(self.evm.odyssey)
             .with_celo(self.evm.celo)
             .with_disable_default_create2_deployer(self.evm.disable_default_create2_deployer)
             .with_disable_pool_balance_checks(self.evm.disable_pool_balance_checks)
@@ -608,10 +607,6 @@ pub struct AnvilEvmArgs {
     /// The memory limit per EVM execution in bytes.
     #[arg(long)]
     pub memory_limit: Option<u64>,
-
-    /// Enable Odyssey features
-    #[arg(long, alias = "alphanet")]
-    pub odyssey: bool,
 
     /// Run a Celo chain
     #[arg(long)]

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -196,8 +196,6 @@ pub struct NodeConfig {
     pub memory_limit: Option<u64>,
     /// Factory used by `anvil` to extend the EVM's precompiles.
     pub precompile_factory: Option<Arc<dyn PrecompileFactory>>,
-    /// Enable Odyssey features.
-    pub odyssey: bool,
     /// Enable Celo features.
     pub celo: bool,
     /// Do not print log messages.
@@ -495,7 +493,6 @@ impl Default for NodeConfig {
             slots_in_an_epoch: 32,
             memory_limit: None,
             precompile_factory: None,
-            odyssey: false,
             celo: false,
             silent: false,
             cache_path: None,
@@ -540,9 +537,6 @@ impl NodeConfig {
 
     /// Returns the hardfork to use
     pub fn get_hardfork(&self) -> ChainHardfork {
-        if self.odyssey {
-            return ChainHardfork::Ethereum(EthereumHardfork::default());
-        }
         if let Some(hardfork) = self.hardfork {
             return hardfork;
         }
@@ -1024,13 +1018,6 @@ impl NodeConfig {
         self
     }
 
-    /// Sets whether to enable Odyssey support
-    #[must_use]
-    pub fn with_odyssey(mut self, odyssey: bool) -> Self {
-        self.odyssey = odyssey;
-        self
-    }
-
     /// Sets whether to enable Celo support
     #[must_use]
     pub fn with_celo(mut self, celo: bool) -> Self {
@@ -1163,7 +1150,6 @@ impl NodeConfig {
             self.print_logs,
             self.print_traces,
             Arc::new(decoder_builder.build()),
-            self.odyssey,
             self.prune_history,
             self.max_persisted_states,
             self.transaction_block_keeper,

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -509,9 +509,6 @@ impl EthApi {
             }
             EthRequest::Rollback(depth) => self.anvil_rollback(depth).await.to_rpc_result(),
             EthRequest::WalletGetCapabilities(()) => self.get_capabilities().to_rpc_result(),
-            EthRequest::WalletSendTransaction(tx) => {
-                self.wallet_send_transaction(*tx).await.to_rpc_result()
-            }
             EthRequest::AnvilAddCapability(addr) => self.anvil_add_capability(addr).to_rpc_result(),
             EthRequest::AnvilSetExecutor(executor_pk) => {
                 self.anvil_set_executor(executor_pk).to_rpc_result()
@@ -2819,111 +2816,6 @@ impl EthApi {
     pub fn get_capabilities(&self) -> Result<WalletCapabilities> {
         node_info!("wallet_getCapabilities");
         Ok(self.backend.get_capabilities())
-    }
-
-    pub async fn wallet_send_transaction(
-        &self,
-        mut request: WithOtherFields<TransactionRequest>,
-    ) -> Result<TxHash> {
-        node_info!("wallet_sendTransaction");
-
-        // Validate the request
-        // reject transactions that have a non-zero value to prevent draining the executor.
-        if request.value.is_some_and(|val| val > U256::ZERO) {
-            return Err(WalletError::ValueNotZero.into());
-        }
-
-        // reject transactions that have from set, as this will be the executor.
-        if request.from.is_some() {
-            return Err(WalletError::FromSet.into());
-        }
-
-        // reject transaction requests that have nonce set, as this is managed by the executor.
-        if request.nonce.is_some() {
-            return Err(WalletError::NonceSet.into());
-        }
-
-        let capabilities = self.backend.get_capabilities();
-        let valid_delegations: &[Address] = capabilities
-            .get(self.chain_id())
-            .map(|caps| caps.delegation.addresses.as_ref())
-            .unwrap_or_default();
-
-        if let Some(authorizations) = &request.authorization_list
-            && authorizations.iter().any(|auth| !valid_delegations.contains(&auth.address))
-        {
-            return Err(WalletError::InvalidAuthorization.into());
-        }
-
-        // validate the destination address
-        match (request.authorization_list.is_some(), request.to) {
-            // if this is an eip-1559 tx, ensure that it is an account that delegates to a
-            // whitelisted address
-            (false, Some(TxKind::Call(addr))) => {
-                let acc = self.backend.get_account(addr).await?;
-
-                let delegated_address = acc
-                    .code
-                    .map(|code| match code {
-                        Bytecode::Eip7702(c) => c.address(),
-                        _ => Address::ZERO,
-                    })
-                    .unwrap_or_default();
-
-                // not a whitelisted address, or not an eip-7702 bytecode
-                if delegated_address == Address::ZERO
-                    || !valid_delegations.contains(&delegated_address)
-                {
-                    return Err(WalletError::IllegalDestination.into());
-                }
-            }
-            // if it's an eip-7702 tx, let it through
-            (true, _) => (),
-            // create tx's disallowed
-            _ => return Err(WalletError::IllegalDestination.into()),
-        }
-
-        let wallet = self.backend.executor_wallet().ok_or(WalletError::InternalError)?;
-
-        let from = NetworkWallet::<Ethereum>::default_signer_address(&wallet);
-
-        let nonce = self.get_transaction_count(from, Some(BlockId::latest())).await?;
-
-        request.nonce = Some(nonce);
-
-        let chain_id = self.chain_id();
-
-        request.chain_id = Some(chain_id);
-
-        request.from = Some(from);
-
-        let gas_limit_fut =
-            self.estimate_gas(request.clone(), Some(BlockId::latest()), EvmOverrides::default());
-
-        let fees_fut = self.fee_history(
-            U256::from(EIP1559_FEE_ESTIMATION_PAST_BLOCKS),
-            BlockNumber::Latest,
-            vec![EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE],
-        );
-
-        let (gas_limit, fees) = tokio::join!(gas_limit_fut, fees_fut);
-
-        let gas_limit = gas_limit?;
-        let fees = fees?;
-
-        request.gas = Some(gas_limit.to());
-
-        let base_fee = fees.latest_block_base_fee().unwrap_or_default();
-
-        let estimation = eip1559_default_estimator(base_fee, &fees.reward.unwrap_or_default());
-
-        request.max_fee_per_gas = Some(estimation.max_fee_per_gas);
-        request.max_priority_fee_per_gas = Some(estimation.max_priority_fee_per_gas);
-        request.gas_price = None;
-
-        let envelope = request.build(&wallet).await.map_err(|_| WalletError::InternalError)?;
-
-        self.send_raw_transaction(envelope.encoded_2718().into()).await
     }
 
     /// Add an address to the delegation capability of wallet.

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -45,10 +45,7 @@ use revm::{
     database::WrapDatabaseRef,
     handler::{EthPrecompiles, instructions::EthInstructions},
     interpreter::InstructionResult,
-    precompile::{
-        PrecompileSpecId, Precompiles,
-        secp256r1::{P256VERIFY, P256VERIFY_BASE_GAS_FEE},
-    },
+    precompile::{PrecompileSpecId, Precompiles},
     primitives::hardfork::SpecId,
 };
 use std::{fmt::Debug, sync::Arc};
@@ -126,7 +123,6 @@ pub struct TransactionExecutor<'a, Db: ?Sized, V: TransactionValidator> {
     /// Cumulative blob gas used by all executed transactions
     pub blob_gas_used: u64,
     pub enable_steps_tracing: bool,
-    pub odyssey: bool,
     pub optimism: bool,
     pub celo: bool,
     pub print_logs: bool,
@@ -361,10 +357,6 @@ impl<DB: Db + ?Sized, V: TransactionValidator> Iterator for &mut TransactionExec
         let exec_result = {
             let mut evm = new_evm_with_inspector(&mut *self.db, &env, &mut inspector);
 
-            if self.odyssey {
-                inject_precompiles(&mut evm, vec![(P256VERIFY, P256VERIFY_BASE_GAS_FEE)]);
-            }
-
             if self.celo {
                 evm.precompiles_mut()
                     .apply_precompile(&celo_precompile::CELO_TRANSFER_ADDRESS, move |_| {
@@ -472,7 +464,7 @@ fn build_logs_bloom(logs: Vec<Log>, bloom: &mut Bloom) {
     }
 }
 
-/// Creates a database with given database and inspector, optionally enabling odyssey features.
+/// Creates a database with given database and inspector.
 pub fn new_evm_with_inspector<DB, I>(
     db: DB,
     env: &Env,

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -6,10 +6,9 @@ use crate::{
     utils::http_provider_with_signer,
 };
 use alloy_consensus::{SignableTransaction, TxEip1559};
-use alloy_eip5792::{Capabilities, DelegationCapability};
 use alloy_hardforks::EthereumHardfork;
 use alloy_network::{EthereumWallet, TransactionBuilder, TxSignerSync};
-use alloy_primitives::{Address, Bytes, TxKind, U256, address, fixed_bytes, utils::Unit};
+use alloy_primitives::{Address, Bytes, TxKind, U256, address, fixed_bytes};
 use alloy_provider::{Provider, ext::TxPoolApi};
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, TransactionRequest,
@@ -18,16 +17,9 @@ use alloy_rpc_types::{
     },
 };
 use alloy_serde::WithOtherFields;
-use anvil::{
-    NodeConfig,
-    eth::{
-        api::CLIENT_VERSION,
-        backend::mem::{EXECUTOR, P256_DELEGATION_CONTRACT, P256_DELEGATION_RUNTIME_CODE},
-    },
-    spawn,
-};
+use anvil::{NodeConfig, eth::api::CLIENT_VERSION, spawn};
 use anvil_core::{
-    eth::{EthRequest, wallet::WalletCapabilities},
+    eth::EthRequest,
     types::{ReorgOptions, TransactionData},
 };
 
@@ -828,73 +820,6 @@ async fn test_rollback() {
 }
 
 // === wallet endpoints === //
-#[tokio::test(flavor = "multi_thread")]
-async fn can_get_wallet_capabilities() {
-    let (api, handle) = spawn(NodeConfig::test().with_odyssey(true)).await;
-
-    let provider = handle.http_provider();
-
-    let init_sponsor_bal = provider.get_balance(EXECUTOR).await.unwrap();
-
-    let expected_bal = Unit::ETHER.wei().saturating_mul(U256::from(10_000));
-    assert_eq!(init_sponsor_bal, expected_bal);
-
-    let p256_code = provider.get_code_at(P256_DELEGATION_CONTRACT).await.unwrap();
-
-    assert_eq!(p256_code, Bytes::from_static(P256_DELEGATION_RUNTIME_CODE));
-
-    let capabilities = api.get_capabilities().unwrap();
-
-    let mut expect_caps = WalletCapabilities(Default::default());
-    let cap: Capabilities = Capabilities {
-        delegation: DelegationCapability { addresses: vec![P256_DELEGATION_CONTRACT] },
-    };
-    expect_caps.0.insert(api.chain_id(), cap);
-
-    assert_eq!(capabilities, expect_caps);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn can_add_capability() {
-    let (api, _handle) = spawn(NodeConfig::test().with_odyssey(true)).await;
-
-    let init_capabilities = api.get_capabilities().unwrap();
-
-    let mut expect_caps = WalletCapabilities(Default::default());
-    let cap: Capabilities = Capabilities {
-        delegation: DelegationCapability { addresses: vec![P256_DELEGATION_CONTRACT] },
-    };
-    expect_caps.0.insert(api.chain_id(), cap);
-
-    assert_eq!(init_capabilities, expect_caps);
-
-    let new_cap_addr = Address::with_last_byte(1);
-
-    api.anvil_add_capability(new_cap_addr).unwrap();
-
-    let capabilities = api.get_capabilities().unwrap();
-
-    let cap: Capabilities = Capabilities {
-        delegation: DelegationCapability {
-            addresses: vec![P256_DELEGATION_CONTRACT, new_cap_addr],
-        },
-    };
-    expect_caps.0.insert(api.chain_id(), cap);
-
-    assert_eq!(capabilities, expect_caps);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn can_set_executor() {
-    let (api, _handle) = spawn(NodeConfig::test().with_odyssey(true)).await;
-
-    let expected_addr = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    let pk = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string();
-
-    let executor = api.anvil_set_executor(pk).unwrap();
-
-    assert_eq!(executor, expected_addr);
-}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_arb_get_block() {

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -115,10 +115,6 @@ pub struct CallArgs {
     #[arg(long, short)]
     block: Option<BlockId>,
 
-    /// Enable Odyssey features.
-    #[arg(long, alias = "alphanet")]
-    pub odyssey: bool,
-
     #[command(subcommand)]
     command: Option<CallSubcommands>,
 
@@ -259,7 +255,7 @@ impl CallArgs {
             }
 
             let create2_deployer = evm_opts.create2_deployer;
-            let (mut env, fork, chain, odyssey) =
+            let (mut env, fork, chain) =
                 TracingExecutor::get_fork_material(&config, evm_opts).await?;
 
             // modify settings that usually set in eth_call
@@ -290,7 +286,6 @@ impl CallArgs {
                 fork,
                 evm_version,
                 trace_mode,
-                odyssey,
                 create2_deployer,
                 state_overrides,
             )?;
@@ -450,10 +445,6 @@ impl figment::Provider for CallArgs {
 
     fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
         let mut map = Map::new();
-
-        if self.odyssey {
-            map.insert("odyssey".into(), self.odyssey.into());
-        }
 
         if let Some(evm_version) = self.evm_version {
             map.insert("evm_version".into(), figment::value::Value::serialize(evm_version)?);

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -94,10 +94,6 @@ pub struct RunArgs {
     #[arg(long, value_name = "NO_RATE_LIMITS", visible_alias = "no-rpc-rate-limit")]
     pub no_rate_limit: bool,
 
-    /// Enables Odyssey features.
-    #[arg(long, alias = "alphanet")]
-    pub odyssey: bool,
-
     /// Use current project artifacts for trace decoding.
     #[arg(long, visible_alias = "la")]
     pub with_local_artifacts: bool,
@@ -161,8 +157,7 @@ impl RunArgs {
         config.fork_block_number = Some(tx_block_number - 1);
 
         let create2_deployer = evm_opts.create2_deployer;
-        let (mut env, fork, chain, odyssey) =
-            TracingExecutor::get_fork_material(&config, evm_opts).await?;
+        let (mut env, fork, chain) = TracingExecutor::get_fork_material(&config, evm_opts).await?;
         let mut evm_version = self.evm_version;
 
         env.evm_env.cfg_env.disable_block_gas_limit = self.disable_block_gas_limit;
@@ -208,7 +203,6 @@ impl RunArgs {
             fork,
             evm_version,
             trace_mode,
-            odyssey,
             create2_deployer,
             None,
         )?;
@@ -368,10 +362,6 @@ impl figment::Provider for RunArgs {
 
     fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
         let mut map = Map::new();
-
-        if self.odyssey {
-            map.insert("odyssey".into(), self.odyssey.into());
-        }
 
         if let Some(api_key) = &self.etherscan.key {
             map.insert("etherscan_api_key".into(), api_key.as_str().into());

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -56,7 +56,7 @@ Options:
 
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of logical cores
-          
+
           [aliases: --jobs]
 
   -V, --version
@@ -82,11 +82,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.
@@ -1325,20 +1325,20 @@ casttest!(receipt_revert_reason, |_prj, cmd| {
 
 blockHash            0x2cfe65be49863676b6dbc04d58176a14f39b123f1e2f4fea0383a2d82c2c50d0
 blockNumber          16239315
-contractAddress      
+contractAddress
 cumulativeGasUsed    10743428
 effectiveGasPrice    10539984136
 from                 0x199D5ED7F45F4eE35960cF22EAde2076e95B253F
 gasUsed              21000
 logs                 []
 logsBloom            0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-root                 
+root
 status               1 (success)
 transactionHash      0x44f2aaa351460c074f2cb1e5a9e28cbc7d83f33e425101d2de14331c7b7ec31e
 transactionIndex     116
 type                 0
-blobGasPrice         
-blobGasUsed          
+blobGasPrice
+blobGasUsed
 to                   0x91da5bf3F8Eb72724E6f50Ec6C3D199C6355c59c
 
 "#]]);
@@ -1358,20 +1358,20 @@ to                   0x91da5bf3F8Eb72724E6f50Ec6C3D199C6355c59c
 
 blockHash            0x883f974b17ca7b28cb970798d1c80f4d4bb427473dc6d39b2a7fe24edc02902d
 blockNumber          14839405
-contractAddress      
+contractAddress
 cumulativeGasUsed    20273649
 effectiveGasPrice    21491736378
 from                 0x3cF412d970474804623bb4e3a42dE13F9bCa5436
 gasUsed              24952
 logs                 []
 logsBloom            0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-root                 
+root
 status               0 (failed)
 transactionHash      0x0e07d8b53ed3d91314c80e53cf25bcde02084939395845cbb625b029d568135c
 transactionIndex     173
 type                 2
-blobGasPrice         
-blobGasUsed          
+blobGasPrice
+blobGasUsed
 to                   0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45
 revertReason         [..]Transaction too old, data: "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000135472616e73616374696f6e20746f6f206f6c6400000000000000000000000000"
 
@@ -1393,20 +1393,20 @@ casttest!(revert_reason_from, |_prj, cmd| {
 
 blockHash            0x32663d7730c9ea8e1de6d99854483e25fcc05bb56c91c0cc82f9f04944fbffc1
 blockNumber          7823353
-contractAddress      
+contractAddress
 cumulativeGasUsed    7500797
 effectiveGasPrice    14296851013
 from                 0x3583fF95f96b356d716881C871aF7Eb55ea34a93
 gasUsed              25815
 logs                 []
 logsBloom            0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-root                 
+root
 status               0 (failed)
 transactionHash      0x10ee70cf9f5ced5c515e8d53bfab5ea9f5c72cd61b25fba455c8355ee286c4e4
 transactionIndex     96
 type                 0
-blobGasPrice         
-blobGasUsed          
+blobGasPrice
+blobGasUsed
 to                   0x91b5d4111a4C038153b24e31F75ccdC47123595d
 revertReason         Counter is too large, data: "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000014436f756e74657220697320746f6f206c61726765000000000000000000000000"
 
@@ -1688,7 +1688,7 @@ casttest!(mktx_raw_unsigned_no_from_missing_nonce, |_prj, cmd| {
         "--chain",
         "1",
         "--gas-limit",
-        "21000", 
+        "21000",
         "--gas-price",
         "20000000000",
         "0x742d35Cc6634C0532925a3b8D6Ac6F67C9c2b7FD",
@@ -3299,14 +3299,15 @@ contract WETH9 {
 
 // <https://github.com/foundry-rs/foundry/issues/10553>
 // <https://basescan.org/tx/0x17b2de59ebd7dfd2452a3638a16737b6b65ae816c1c5571631dc0d80b63c41de>
-casttest!(odyssey_can_run_p256_precompile, |_prj, cmd| {
+casttest!(osaka_can_run_p256_precompile, |_prj, cmd| {
     cmd.args([
         "run",
         "0x17b2de59ebd7dfd2452a3638a16737b6b65ae816c1c5571631dc0d80b63c41de",
         "--rpc-url",
         next_rpc_endpoint(NamedChain::Base).as_str(),
         "--quick",
-        "--odyssey",
+        "--evm-version",
+        "osaka",
     ])
     .assert_success()
     .stdout_eq(str![[r#"
@@ -3520,12 +3521,12 @@ forgetest_async!(cast_send_create_with_constructor_args, |prj, cmd| {
 contract ConstructorContract {
     uint256 public value;
     string public name;
-    
+
     constructor(uint256 _value, string memory _name) {
         value = _value;
         name = _name;
     }
-    
+
     function getValue() public view returns (uint256) {
         return value;
     }
@@ -3599,7 +3600,7 @@ casttest!(cast_estimate_create_with_constructor_args, |prj, cmd| {
 contract EstimateContract {
     uint256 public value;
     string public name;
-    
+
     constructor(uint256 _value, string memory _name) {
         value = _value;
         name = _name;
@@ -3701,13 +3702,13 @@ contract ComplexContract {
     address public owner;
     uint256[] public values;
     bool public active;
-    
+
     constructor(address _owner, uint256[] memory _values, bool _active) {
         owner = _owner;
         values = _values;
         active = _active;
     }
-    
+
     function getValuesLength() public view returns (uint256) {
         return values.length;
     }

--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -139,11 +139,6 @@ pub struct EvmArgs {
     #[arg(long)]
     #[serde(skip)]
     pub isolate: bool,
-
-    /// Whether to enable Odyssey features.
-    #[arg(long, alias = "alphanet")]
-    #[serde(skip)]
-    pub odyssey: bool,
 }
 
 // Make this set of options a `figment::Provider` so that it can be merged into the `Config`
@@ -168,10 +163,6 @@ impl Provider for EvmArgs {
 
         if self.isolate {
             dict.insert("isolate".to_string(), self.isolate.into());
-        }
-
-        if self.odyssey {
-            dict.insert("odyssey".to_string(), self.odyssey.into());
         }
 
         if self.always_use_create_2_factory {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -527,10 +527,6 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extra_args: Vec<String>,
 
-    /// Whether to enable Odyssey features.
-    #[serde(alias = "alphanet")]
-    pub odyssey: bool,
-
     /// Timeout for transactions in seconds.
     pub transaction_timeout: u64,
 
@@ -1139,7 +1135,7 @@ impl Config {
 
     /// Returns the [SpecId] derived from the configured [EvmVersion]
     pub fn evm_spec_id(&self) -> SpecId {
-        evm_spec_id(self.evm_version, self.odyssey)
+        evm_spec_id(self.evm_version)
     }
 
     /// Returns whether the compiler version should be auto-detected
@@ -2460,7 +2456,6 @@ impl Default for Config {
             legacy_assertions: false,
             warnings: vec![],
             extra_args: vec![],
-            odyssey: false,
             transaction_timeout: 120,
             additional_compiler_profiles: Default::default(),
             compilation_restrictions: Default::default(),

--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -283,10 +283,7 @@ impl FromStr for Numeric {
 }
 
 /// Returns the [SpecId] derived from [EvmVersion]
-pub fn evm_spec_id(evm_version: EvmVersion, odyssey: bool) -> SpecId {
-    if odyssey {
-        return SpecId::OSAKA;
-    }
+pub fn evm_spec_id(evm_version: EvmVersion) -> SpecId {
     match evm_version {
         EvmVersion::Homestead => SpecId::HOMESTEAD,
         EvmVersion::TangerineWhistle => SpecId::TANGERINE,

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -7,11 +7,7 @@ use crate::{
     Env, InspectorExt, backend::DatabaseExt, constants::DEFAULT_CREATE2_DEPLOYER_CODEHASH,
 };
 use alloy_consensus::constants::KECCAK_EMPTY;
-use alloy_evm::{
-    Evm, EvmEnv,
-    eth::EthEvmContext,
-    precompiles::{DynPrecompile, PrecompileInput, PrecompilesMap},
-};
+use alloy_evm::{Evm, EvmEnv, eth::EthEvmContext, precompiles::PrecompilesMap};
 use alloy_primitives::{Address, Bytes, U256};
 use foundry_fork_db::DatabaseError;
 use revm::{
@@ -31,10 +27,7 @@ use revm::{
         FrameInput, Gas, InstructionResult, InterpreterResult, SharedMemory,
         interpreter::EthInterpreter, interpreter_action::FrameInit, return_ok,
     },
-    precompile::{
-        PrecompileSpecId, Precompiles,
-        secp256r1::{P256VERIFY, P256VERIFY_BASE_GAS_FEE},
-    },
+    precompile::{PrecompileSpecId, Precompiles},
     primitives::hardfork::SpecId,
 };
 
@@ -95,15 +88,7 @@ pub fn new_evm_with_existing_context<'a>(
 
 /// Conditionally inject additional precompiles into the EVM context.
 fn inject_precompiles(evm: &mut FoundryEvm<'_, impl InspectorExt>) {
-    if evm.inspector().is_odyssey() {
-        evm.precompiles_mut().apply_precompile(P256VERIFY.address(), |_| {
-            // Create a wrapper function that adapts the new API
-            let precompile_fn = |input: PrecompileInput<'_>| -> Result<_, _> {
-                P256VERIFY.precompile()(input.data, P256VERIFY_BASE_GAS_FEE)
-            };
-            Some(DynPrecompile::from(precompile_fn))
-        });
-    }
+    let _ = evm;
 }
 
 /// Get the precompiles for the given spec.

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -57,11 +57,6 @@ pub trait InspectorExt: for<'a> Inspector<EthEvmContext<&'a mut dyn DatabaseExt>
         let _ = msg;
     }
 
-    /// Returns `true` if the current network is Odyssey.
-    fn is_odyssey(&self) -> bool {
-        false
-    }
-
     /// Returns the CREATE2 deployer address.
     fn create2_deployer(&self) -> Address {
         DEFAULT_CREATE2_DEPLOYER

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -75,9 +75,6 @@ pub struct EvmOpts {
     /// Whether to enable tx gas limit checks as imposed by Osaka (EIP-7825).
     pub enable_tx_gas_limit: bool,
 
-    /// Whether to enable Odyssey features.
-    pub odyssey: bool,
-
     /// The CREATE2 deployer's address.
     pub create2_deployer: Address,
 }
@@ -103,7 +100,6 @@ impl Default for EvmOpts {
             isolate: false,
             disable_block_gas_limit: false,
             enable_tx_gas_limit: false,
-            odyssey: false,
             create2_deployer: DEFAULT_CREATE2_DEPLOYER,
         }
     }

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -23,7 +23,6 @@ impl TracingExecutor {
         fork: Option<CreateFork>,
         version: Option<EvmVersion>,
         trace_mode: TraceMode,
-        odyssey: bool,
         create2_deployer: Address,
         state_overrides: Option<StateOverride>,
     ) -> eyre::Result<Self> {
@@ -31,10 +30,8 @@ impl TracingExecutor {
         // configures a bare version of the evm executor: no cheatcode inspector is enabled,
         // tracing will be enabled only for the targeted transaction
         let mut executor = ExecutorBuilder::new()
-            .inspectors(|stack| {
-                stack.trace_mode(trace_mode).odyssey(odyssey).create2_deployer(create2_deployer)
-            })
-            .spec_id(evm_spec_id(version.unwrap_or_default(), odyssey))
+            .inspectors(|stack| stack.trace_mode(trace_mode).create2_deployer(create2_deployer))
+            .spec_id(evm_spec_id(version.unwrap_or_default()))
             .build(env, db);
 
         // Apply the state overrides.
@@ -78,7 +75,7 @@ impl TracingExecutor {
     pub async fn get_fork_material(
         config: &Config,
         mut evm_opts: EvmOpts,
-    ) -> eyre::Result<(Env, Option<CreateFork>, Option<Chain>, bool)> {
+    ) -> eyre::Result<(Env, Option<CreateFork>, Option<Chain>)> {
         evm_opts.fork_url = Some(config.get_rpc_url_or_localhost_http()?.into_owned());
         evm_opts.fork_block_number = config.fork_block_number;
 
@@ -86,7 +83,7 @@ impl TracingExecutor {
 
         let fork = evm_opts.get_fork(config, env.clone());
 
-        Ok((env, fork, evm_opts.get_remote_chain_id().await, evm_opts.odyssey))
+        Ok((env, fork, evm_opts.get_remote_chain_id().await))
     }
 }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -65,8 +65,6 @@ pub struct InspectorStackBuilder {
     /// In isolation mode all top-level calls are executed as a separate transaction in a separate
     /// EVM context, enabling more precise gas accounting and transaction state changes.
     pub enable_isolation: bool,
-    /// Whether to enable Odyssey features.
-    pub odyssey: bool,
     /// The wallets to set in the cheatcodes context.
     pub wallets: Option<Wallets>,
     /// The CREATE2 deployer address.
@@ -161,14 +159,6 @@ impl InspectorStackBuilder {
         self
     }
 
-    /// Set whether to enable Odyssey features.
-    /// For description of call isolation, see [`InspectorStack::enable_isolation`].
-    #[inline]
-    pub fn odyssey(mut self, yes: bool) -> Self {
-        self.odyssey = yes;
-        self
-    }
-
     #[inline]
     pub fn create2_deployer(mut self, create2_deployer: Address) -> Self {
         self.create2_deployer = create2_deployer;
@@ -188,7 +178,6 @@ impl InspectorStackBuilder {
             print,
             chisel_state,
             enable_isolation,
-            odyssey,
             wallets,
             create2_deployer,
         } = self;
@@ -216,7 +205,6 @@ impl InspectorStackBuilder {
         stack.tracing(trace_mode);
 
         stack.enable_isolation(enable_isolation);
-        stack.odyssey(odyssey);
         stack.set_create2_deployer(create2_deployer);
 
         // environment, must come after all of the inspectors
@@ -314,7 +302,6 @@ pub struct InspectorStackInner {
 
     // InspectorExt and other internal data.
     pub enable_isolation: bool,
-    pub odyssey: bool,
     pub create2_deployer: Address,
     /// Flag marking if we are in the inner EVM context.
     pub in_inner_context: bool,
@@ -432,12 +419,6 @@ impl InspectorStack {
     #[inline]
     pub fn enable_isolation(&mut self, yes: bool) {
         self.enable_isolation = yes;
-    }
-
-    /// Set whether to enable call isolation.
-    #[inline]
-    pub fn odyssey(&mut self, yes: bool) {
-        self.odyssey = yes;
     }
 
     /// Set the CREATE2 deployer address.
@@ -1084,10 +1065,6 @@ impl InspectorExt for InspectorStackRefMut<'_> {
         ));
     }
 
-    fn is_odyssey(&self) -> bool {
-        self.inner.odyssey
-    }
-
     fn create2_deployer(&self) -> Address {
         self.inner.create2_deployer
     }
@@ -1173,10 +1150,6 @@ impl InspectorExt for InspectorStack {
         inputs: &CreateInputs,
     ) -> bool {
         self.as_mut().should_use_create2_factory(ecx, inputs)
-    }
-
-    fn is_odyssey(&self) -> bool {
-        self.odyssey
     }
 
     fn create2_deployer(&self) -> Address {

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -317,7 +317,6 @@ impl TestArgs {
             .with_fork(evm_opts.get_fork(&config, env.clone()))
             .enable_isolation(evm_opts.isolate)
             .fail_fast(self.fail_fast)
-            .odyssey(evm_opts.odyssey)
             .build::<MultiCompiler>(project_root, &output, env, evm_opts)?;
 
         let libraries = runner.libraries.clone();

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -297,8 +297,6 @@ pub struct TestRunnerConfig {
     pub decode_internal: InternalTraceMode,
     /// Whether to enable call isolation.
     pub isolation: bool,
-    /// Whether to enable Odyssey features.
-    pub odyssey: bool,
     /// Whether to exit early on test failure.
     pub fail_fast: FailFast,
 }
@@ -311,7 +309,6 @@ impl TestRunnerConfig {
 
         self.spec_id = config.evm_spec_id();
         self.sender = config.sender;
-        self.odyssey = config.odyssey;
         self.isolation = config.isolate;
 
         // Specific to Forge, not present in config.
@@ -337,7 +334,6 @@ impl TestRunnerConfig {
         inspector.tracing(self.trace_mode());
         inspector.collect_line_coverage(self.line_coverage);
         inspector.enable_isolation(self.isolation);
-        inspector.odyssey(self.odyssey);
         // inspector.set_create2_deployer(self.evm_opts.create2_deployer);
 
         // executor.env_mut().clone_from(&self.env);
@@ -366,7 +362,6 @@ impl TestRunnerConfig {
                     .trace_mode(self.trace_mode())
                     .line_coverage(self.line_coverage)
                     .enable_isolation(self.isolation)
-                    .odyssey(self.odyssey)
                     .create2_deployer(self.evm_opts.create2_deployer)
             })
             .spec_id(self.spec_id)
@@ -407,8 +402,6 @@ pub struct MultiContractRunnerBuilder {
     pub decode_internal: InternalTraceMode,
     /// Whether to enable call isolation
     pub isolation: bool,
-    /// Whether to enable Odyssey features.
-    pub odyssey: bool,
     /// Whether to exit early on test failure.
     pub fail_fast: bool,
 }
@@ -425,7 +418,6 @@ impl MultiContractRunnerBuilder {
             debug: Default::default(),
             isolation: Default::default(),
             decode_internal: Default::default(),
-            odyssey: Default::default(),
             fail_fast: false,
         }
     }
@@ -472,11 +464,6 @@ impl MultiContractRunnerBuilder {
 
     pub fn enable_isolation(mut self, enable: bool) -> Self {
         self.isolation = enable;
-        self
-    }
-
-    pub fn odyssey(mut self, enable: bool) -> Self {
-        self.odyssey = enable;
         self
     }
 
@@ -558,7 +545,6 @@ impl MultiContractRunnerBuilder {
                 decode_internal: self.decode_internal,
                 inline_config: Arc::new(InlineConfig::new_parsed(output, &self.config)?),
                 isolation: self.isolation,
-                odyssey: self.odyssey,
                 config: self.config,
                 fail_fast: FailFast::new(self.fail_fast),
             },

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -171,7 +171,6 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         assertions_revert: true,
         legacy_assertions: false,
         extra_args: vec![],
-        odyssey: false,
         transaction_timeout: 120,
         additional_compiler_profiles: Default::default(),
         compilation_restrictions: Default::default(),
@@ -1047,7 +1046,6 @@ create2_library_salt = "0x000000000000000000000000000000000000000000000000000000
 create2_deployer = "0x4e59b44847b379578588920ca78fbf26c0b4956c"
 assertions_revert = true
 legacy_assertions = false
-odyssey = false
 transaction_timeout = 120
 additional_compiler_profiles = []
 compilation_restrictions = []
@@ -1347,7 +1345,6 @@ exclude = []
   "soldeer": null,
   "assertions_revert": true,
   "legacy_assertions": false,
-  "odyssey": false,
   "transaction_timeout": 120,
   "additional_compiler_profiles": [],
   "compilation_restrictions": [],

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -648,7 +648,6 @@ impl ScriptConfig {
             .inspectors(|stack| {
                 stack
                     .trace_mode(if debug { TraceMode::Debug } else { TraceMode::Call })
-                    .odyssey(self.evm_opts.odyssey)
                     .create2_deployer(self.evm_opts.create2_deployer)
             })
             .spec_id(self.config.evm_spec_id())

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -312,15 +312,13 @@ pub async fn get_tracing_executor(
     fork_config.evm_version = evm_version;
 
     let create2_deployer = evm_opts.create2_deployer;
-    let (env, fork, _chain, is_odyssey) =
-        TracingExecutor::get_fork_material(fork_config, evm_opts).await?;
+    let (env, fork, _chain) = TracingExecutor::get_fork_material(fork_config, evm_opts).await?;
 
     let executor = TracingExecutor::new(
         env.clone(),
         fork,
         Some(fork_config.evm_version),
         TraceMode::Call,
-        is_odyssey,
         create2_deployer,
         None,
     )?;


### PR DESCRIPTION
## Motivation

Removes the `--odyssey` flag since Odyssey is being sunset, and we have equivalent flags that achieve the same behavior.

If you just need EIP7701, you can use `--evm-version prague`.

If you additionally need the P256 precompiles, you can use `--evm-version osaka`.

Closes #11681 

## Solution

Removes the flag. This PR also removes `wallet_sendTransaction`, it is unclear to me that it is used; it is based on a very old version of the built-in relay endpoint that was present in some earlier versions of Odyssey.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
