### PR TITLE
feat(cast): handle invalid JSON in recover-authority without panic

### DIFF
--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -748,7 +748,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
             }
         }
         CastSubcommand::RecoverAuthority { auth } => {
-            let auth: SignedAuthorization = serde_json::from_str(&auth).unwrap();
+            let auth: SignedAuthorization = serde_json::from_str(&auth)?;
             sh_println!("{}", auth.recover_authority()?)?;
         }
         CastSubcommand::TxPool { command } => command.run().await?,


### PR DESCRIPTION
Replace unwrap() with error propagation when parsing SignedAuthorization JSON in the RecoverAuthority subcommand. This aligns with the project’s error-handling conventions (using eyre and ?), prevents the CLI from panicking on user-provided invalid JSON, and improves UX by returning a proper error message.