### PR TITLE
fix: request ABI in solar_project

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -963,7 +963,9 @@ impl Config {
         let ui_testing = std::env::var_os("FOUNDRY_LINT_UI_TESTING").is_some();
         let mut project = self.create_project(self.cache && !ui_testing, false)?;
         project.update_output_selection(|selection| {
-            *selection = OutputSelection::common_output_selection([]);
+            // We have to request something to populate `contracts` in the output and thus
+            // artifacts.
+            *selection = OutputSelection::common_output_selection(["abi".into()]);
         });
         Ok(project)
     }

--- a/crates/forge/tests/cli/eip712.rs
+++ b/crates/forge/tests/cli/eip712.rs
@@ -1,8 +1,8 @@
 use foundry_config::fs_permissions::PathPermission;
 
 forgetest!(test_eip712, |prj, cmd| {
-    let path = prj.add_source(
-        "Structs",
+    let path = prj.add_test(
+        "Structs.sol",
         r#"
 library Structs {
     struct Foo {
@@ -50,6 +50,12 @@ library Structs2 {
         Structs.Rec rec;
     }
 }
+
+contract DummyTest {
+    function testDummy() public pure {
+        revert("test");
+    }
+}
 "#,
     );
 
@@ -57,7 +63,7 @@ library Structs2 {
         str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-No files changed, compilation skipped
+Compiler run successful!
 Structs.sol > Structs > Foo:
  - type: Foo(Bar bar)Art(uint256 id)Bar(Art art)
  - hash: 0x6d9b732373bd999fde4072274c752e03f7437067dd75521eb406d8edf1d30f7d
@@ -150,6 +156,26 @@ Structs.sol > Structs2 > FooBar:
 
 "#]],
     );
+
+    // Testing `solar_project` doesn't mess up cache.
+    cmd.forge_fuse().arg("test").assert_failure().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/Structs.sol:DummyTest
+[FAIL: test] testDummy() ([GAS])
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
+
+Failing tests:
+Encountered 1 failing test in test/Structs.sol:DummyTest
+[FAIL: test] testDummy() ([GAS])
+
+Encountered a total of 1 failing tests, 0 tests succeeded
+
+"#]]);
 });
 
 forgetest!(test_eip712_free_standing_structs, |prj, cmd| {
@@ -180,7 +206,7 @@ library InsideLibrary {
         str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-No files changed, compilation skipped
+Compiler run successful!
 FreeStanding:
  - type: FreeStanding(uint256 id,string name)
  - hash: 0xfb3c934b2382873277133498bde6eb3914ab323e3bef8b373ebcd423969bf1a2


### PR DESCRIPTION
We need to request something so that we populate the artifacts in the cache in case it is the first compiler invocation. Requesting nothing at all will not return anything in the output, and so we would have no artifacts in the cache entry, resulting in incorrect "nothing to compile" results after the first run.

This is slightly slower due to extra serde but the actual work done by solc remains the same. Again ideally this doesn't call solc at all but this is a decent start.