### PR TITLE
fix(forge): use heck to normalize identifiers in forge generate

### DIFF
--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -42,6 +42,9 @@ tracing.workspace = true
 yansi.workspace = true
 chrono.workspace = true
 
+# case conversion
+heck = "0.4"
+
 # bin
 forge-doc.workspace = true
 forge-fmt.workspace = true

--- a/crates/forge/src/cmd/generate/mod.rs
+++ b/crates/forge/src/cmd/generate/mod.rs
@@ -3,6 +3,7 @@ use eyre::Result;
 use foundry_common::fs;
 use std::path::Path;
 use yansi::Paint;
+use heck::{AsLowerCamelCase, AsPascalCase};
 
 /// CLI arguments for `forge generate`.
 #[derive(Debug, Parser)]
@@ -49,22 +50,11 @@ impl GenerateTestArgs {
     }
 }
 
-/// Utility function to convert an identifier to pascal or camel case.
+/// Utility function to convert an identifier to PascalCase or lowerCamelCase.
 fn format_identifier(input: &str, is_pascal_case: bool) -> String {
-    let mut result = String::new();
-    let mut capitalize_next = is_pascal_case;
-
-    for word in input.split_whitespace() {
-        if !word.is_empty() {
-            let (first, rest) = word.split_at(1);
-            let formatted_word = if capitalize_next {
-                format!("{}{}", first.to_uppercase(), rest)
-            } else {
-                format!("{}{}", first.to_lowercase(), rest)
-            };
-            capitalize_next = true;
-            result.push_str(&formatted_word);
-        }
+    if is_pascal_case {
+        AsPascalCase(input).to_string()
+    } else {
+        AsLowerCamelCase(input).to_string()
     }
-    result
 }


### PR DESCRIPTION
Problem: format_identifier split only on spaces and only toggled the first letter, leaving the rest of each token’s casing untouched and ignoring _/- separators. Inputs like my_contract, my-contract, or mixed-case coNtract produced incorrect PascalCase/lowerCamelCase, leading to wrong contract and instance names in the generated test.

Fix: Switch to heck::AsPascalCase and heck::AsLowerCamelCase, which robustly normalize casing and handle common separators consistently with the project’s lint expectations.