### PR TITLE
feat(forge): deprecate `generate`

### DIFF
--- a/crates/forge/src/cmd/generate/mod.rs
+++ b/crates/forge/src/cmd/generate/mod.rs
@@ -26,6 +26,8 @@ pub struct GenerateTestArgs {
 
 impl GenerateTestArgs {
     pub fn run(self) -> Result<()> {
+        sh_warn!("`forge generate` is deprecated and will be removed in a future version")?;
+
         let contract_name = format_identifier(&self.contract_name, true);
         let instance_name = format_identifier(&self.contract_name, false);
 

--- a/crates/forge/src/opts.rs
+++ b/crates/forge/src/opts.rs
@@ -160,6 +160,7 @@ pub enum ForgeSubcommand {
     },
 
     /// Generate scaffold files.
+    #[command(hide = true)]
     Generate(generate::GenerateArgs),
 
     /// Compiler utilities.


### PR DESCRIPTION
This command is very simplistic and does not achieve much other than a simple template replacement. This can easily be implemented in your editor or extension of choice as a macro, fitting your stylistic needs.
