### PR TITLE
feat(forge-inspect): add ability to inspect libraries

### DIFF
--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3767,6 +3767,41 @@ forgetest_init!(can_inspect_standard_json, |prj, cmd| {
 "#]]);
 });
 
+forgetest_init!(can_inspect_libraries, |prj, cmd| {
+    prj.add_source(
+        "Source.sol",
+        r#"
+    import "./Lib.sol";
+
+    library Lib2 {
+        function foo() public {}
+    }
+
+    contract Source {
+        function foo() public {
+            Lib.foo();
+            Lib2.foo();
+        }
+    }"#,
+    );
+
+    prj.add_source(
+        "Lib.sol",
+        r#"
+    library Lib {
+        function foo() public {}
+    }
+    "#,
+    );
+
+    cmd.args(["inspect", "Source", "libraries"]).assert_success().stdout_eq(str![[r#"
+Dynamically linked libraries:
+  src/Lib.sol:Lib
+  src/Source.sol:Lib2
+
+"#]]);
+});
+
 // checks that `clean` also works with the "out" value set in Config
 forgetest_init!(gas_report_include_tests, |prj, cmd| {
     prj.update_config(|config| {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Its useful to be able to inspect which libraries a contract needs to dynamically link to.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Uses the `link_references` mapping already available on the artifact.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
