### PR TITLE
fix(common): use proper ESC in spinner erase-line sequence

### DIFF
--- a/crates/common/src/term.rs
+++ b/crates/common/src/term.rs
@@ -75,7 +75,7 @@ impl Spinner {
 
         let indicator = self.indicator[self.idx % self.indicator.len()].green();
         let indicator = Paint::new(format!("[{indicator}]")).bold();
-        let _ = sh_print!("\r\x33[2K\r{indicator} {}", self.message);
+        let _ = sh_print!("\r\x1B[2K\r{indicator} {}", self.message);
         io::stdout().flush().unwrap();
 
         self.idx = self.idx.wrapping_add(1);


### PR DESCRIPTION
The spinner used an invalid ANSI CSI introducer: \x33[2K (literal '3') instead of ESC \x1B[2K. As a result, terminals printed over shorter updates, leaving trailing characters from previous messages.
Correct sequence per ANSI/ECMA-48: ESC 0x1B (aka \x1B or \033), then [2K to erase the entire line.

before change: 
<img width="380" height="51" alt="image" src="https://github.com/user-attachments/assets/50f48d75-4c07-43de-ad81-82aa727b27bc" />

after: 
<img width="408" height="52" alt="image" src="https://github.com/user-attachments/assets/b7936aff-a862-4f18-92ea-c790d89e98d2" />
