### PR TITLE
chore: pass project root to spinner

### DIFF
--- a/crates/common/src/term.rs
+++ b/crates/common/src/term.rs
@@ -3,7 +3,6 @@ use foundry_compilers::{
     artifacts::remappings::Remapping,
     report::{self, BasicStdoutReporter, Reporter},
 };
-use foundry_config::find_project_root;
 use itertools::Itertools;
 use semver::Version;
 use std::{
@@ -94,6 +93,8 @@ impl Spinner {
 pub struct SpinnerReporter {
     /// The sender to the spinner thread.
     sender: mpsc::Sender<SpinnerMsg>,
+    /// The project root path for trimming file paths in verbose output.
+    project_root: Option<PathBuf>,
 }
 
 impl SpinnerReporter {
@@ -102,7 +103,7 @@ impl SpinnerReporter {
     /// The spinner's message will be updated via the `reporter` events
     ///
     /// On drop the channel will disconnect and the thread will terminate
-    pub fn spawn() -> Self {
+    pub fn spawn(project_root: Option<PathBuf>) -> Self {
         let (sender, rx) = mpsc::channel::<SpinnerMsg>();
 
         std::thread::Builder::new()
@@ -130,7 +131,7 @@ impl SpinnerReporter {
             })
             .expect("failed to spawn thread");
 
-        Self { sender }
+        Self { sender, project_root }
     }
 
     fn send_msg(&self, msg: impl Into<String>) {
@@ -157,14 +158,12 @@ impl Reporter for SpinnerReporter {
         // Verbose message with dirty files displays first to avoid being overlapped
         // by the spinner in .tick() which prints repeatedly over the same line.
         if shell::verbosity() >= 5 {
-            let project_root = find_project_root(None);
-
             self.send_msg(format!(
                 "Files to compile:\n{}",
                 dirty_files
                     .iter()
                     .map(|path| {
-                        let trimmed_path = if let Ok(project_root) = &project_root {
+                        let trimmed_path = if let Some(project_root) = &self.project_root {
                             path.strip_prefix(project_root).unwrap_or(path)
                         } else {
                             path
@@ -214,9 +213,9 @@ impl Reporter for SpinnerReporter {
 /// spinning cursor to display solc progress.
 ///
 /// If no terminal is available this falls back to common `println!` in [`BasicStdoutReporter`].
-pub fn with_spinner_reporter<T>(f: impl FnOnce() -> T) -> T {
+pub fn with_spinner_reporter<T>(project_root: Option<PathBuf>, f: impl FnOnce() -> T) -> T {
     let reporter = if TERM_SETTINGS.indicate_progress {
-        report::Report::new(SpinnerReporter::spawn())
+        report::Report::new(SpinnerReporter::spawn(project_root))
     } else {
         report::Report::new(BasicStdoutReporter::default())
     };
@@ -240,7 +239,7 @@ mod tests {
 
     #[test]
     fn can_format_properly() {
-        let r = SpinnerReporter::spawn();
+        let r = SpinnerReporter::spawn(None);
         let remappings: Vec<Remapping> = vec![
             "library/=library/src/".parse().unwrap(),
             "weird-erc20/=lib/weird-erc20/src/".parse().unwrap(),

--- a/crates/forge/src/cmd/flatten.rs
+++ b/crates/forge/src/cmd/flatten.rs
@@ -45,8 +45,9 @@ impl FlattenArgs {
 
         let target_path = dunce::canonicalize(target_path)?;
 
-        let flattener =
-            with_compilation_reporter(true, || Flattener::new(project.clone(), &target_path));
+        let flattener = with_compilation_reporter(true, Some(project.root().to_path_buf()), || {
+            Flattener::new(project.clone(), &target_path)
+        });
 
         let flattened = match flattener {
             Ok(flattener) => Ok(flattener.flatten()),


### PR DESCRIPTION

## Motivation

fixes #11738

## Solution
Added project_root argument in `SpinnerReported::spawn` to avoid computing project_root on every call

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
