### PR TITLE
deps: bump ammonia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d66cfdf265bf52c0c4a952960c854c3683c71ff2fc02c9b8c317c691fd3bc28"
+checksum = "9a74cdb5404acbbb57d50ac957983e9a8ff5dc3387dcfba5b285b51a686581b5"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -365,12 +365,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-hardforks"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2823360cd87c008df4b8b78794924948c3508e745dfed7d2b685774cb473e"
+checksum = "178a212f840ab01a07017a95ce1c51531f09496c29cd9ce25e8d94071c81a31d"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
+ "alloy-primitives",
  "auto_impl",
 ]
 
@@ -2478,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.1"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318cfa722931cb5fe0838b98d3ce5621e75f6a6408abc21721d80de9223f2e4"
+checksum = "137a2a2878ed823ef1bd73e5441e245602aae5360022113b8ad259ca4b5b8727"
 dependencies = [
  "blst",
  "cc",
@@ -4117,6 +4118,7 @@ name = "forge-doc"
 version = "1.3.6"
 dependencies = [
  "alloy-primitives",
+ "ammonia",
  "derive_more",
  "eyre",
  "forge-fmt",
@@ -6161,12 +6163,12 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -6651,9 +6653,9 @@ checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
 
 [[package]]
 name = "normpath"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c178369371fd7db523726931e50d430b560e3059665abc537ba3277e9274c9c4"
+checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
 dependencies = [
  "windows-sys 0.61.0",
 ]
@@ -8716,9 +8718,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
+checksum = "cc198e42d9b7510827939c9a15f5062a0c913f3371d765977e586d2fe6c16f4a"
 dependencies = [
  "bitflags 2.9.4",
  "core-foundation 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -362,6 +362,9 @@ snapbox = { version = "0.6", features = ["json", "regex", "term-svg"] }
 # See the `idna_adapter` README.md for more details: https://docs.rs/crate/idna_adapter/latest
 idna_adapter = "=1.1.0"
 
+# Used by mdbook but has an advisory for 4.1.1.
+ammonia = "=4.1.2"
+
 [patch.crates-io]
 # https://github.com/rust-cli/rexpect/pull/106
 rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6a85bedbae71a01cc578958fc" }

--- a/crates/doc/Cargo.toml
+++ b/crates/doc/Cargo.toml
@@ -33,3 +33,6 @@ thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
 regex.workspace = true
+
+# Pinned dependencies. See root Cargo.toml.
+ammonia.workspace = true


### PR DESCRIPTION

## Motivation

`cargo deny` denies `amoonia 4.1.1` which is a dependency of `mdbook`. It's just used to sanitize search results.

## Solution

Pin to ammonia `4.1.2`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
