### PR TITLE
ci: use depot

### DIFF
--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -67,10 +67,10 @@ class Expanded:
 
 profile = os.environ.get("PROFILE")
 is_pr = os.environ.get("EVENT_NAME") == "pull_request"
-t_linux_x86 = Target("ubuntu-latest", "x86_64-unknown-linux-gnu", "linux-amd64")
-t_linux_arm = Target("ubuntu-24.04-arm", "aarch64-unknown-linux-gnu", "linux-aarch64")
-t_macos = Target("macos-latest", "aarch64-apple-darwin", "macosx-aarch64")
-t_windows = Target("windows-latest", "x86_64-pc-windows-msvc", "windows-amd64")
+t_linux_x86 = Target("depot-ubuntu-latest-4", "x86_64-unknown-linux-gnu", "linux-amd64")
+t_linux_arm = Target("depot-ubuntu-24.04-arm-4", "aarch64-unknown-linux-gnu", "linux-aarch64")
+t_macos = Target("depot-macos-latest-4", "aarch64-apple-darwin", "macosx-aarch64")
+t_windows = Target("depot-windows-latest-4", "x86_64-pc-windows-msvc", "windows-amd64")
 targets = (
     [t_linux_x86, t_windows]
     if is_pr

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,11 +24,12 @@ env:
   ITHACAXYZ_ACCOUNT: "ithacaxyz/account:v0.3.2"
   VECTORIZED_SOLADY: "Vectorized/solady:v0.1.22"
   DEFAULT_REPOS: "ithacaxyz/account:v0.3.2,Vectorized/solady:v0.1.22"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   run-benchmarks:
     name: Run All Benchmarks
-    runs-on: foundry-runner
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -49,11 +50,8 @@ jobs:
 
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2
-        with:
-          workspaces: |
-            ./
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: Setup Foundry
         env:
@@ -157,7 +155,7 @@ jobs:
   publish-results:
     name: Publish Results
     needs: run-benchmarks
-    runs-on: foundry-runner
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -18,11 +18,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   matrices:
     name: build matrices
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     permissions:
       contents: read
     outputs:
@@ -96,9 +97,8 @@ jobs:
             ~/.foundry/cache
             ~/.config/.foundry/cache
           key: rpc-cache-${{ hashFiles('crates/forge/tests/rpc-cache-keyfile') }}
-      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2
-        with:
-          cache-on-failure: true
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Setup Git config
         run: |
           git config --global user.name "GitHub Actions Bot"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   prepare:
     name: Prepare release
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: write
@@ -100,22 +100,22 @@ jobs:
           # `target`: Rust build target triple
           # `platform` and `arch`: Used in tarball names
           # `svm`: target platform to use for the Solc binary: https://github.com/roynalnaruto/svm-rs/blob/84cbe0ac705becabdc13168bae28a45ad2299749/svm-builds/build.rs#L4-L24
-          - runner: Linux-22.04
+          - runner: depot-ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             svm_target_platform: linux-amd64
             platform: linux
             arch: amd64
-          - runner: Linux-22.04
+          - runner: depot-ubuntu-24.04
             target: x86_64-unknown-linux-musl
             svm_target_platform: linux-amd64
             platform: alpine
             arch: amd64
-          - runner: Linux-22.04
+          - runner: depot-ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             svm_target_platform: linux-aarch64
             platform: linux
             arch: arm64
-          - runner: Linux-22.04
+          - runner: depot-ubuntu-24.04
             target: aarch64-unknown-linux-musl
             svm_target_platform: linux-aarch64
             platform: alpine
@@ -127,12 +127,12 @@ jobs:
             svm_target_platform: macosx-amd64
             platform: darwin
             arch: amd64
-          - runner: macos-latest-large
+          - runner: depot-macos-latest
             target: aarch64-apple-darwin
             svm_target_platform: macosx-aarch64
             platform: darwin
             arch: arm64
-          - runner: Windows
+          - runner: depot-windows-latest
             target: x86_64-pc-windows-msvc
             svm_target_platform: windows-amd64
             platform: win32

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   nextest:
@@ -26,7 +27,7 @@ jobs:
     secrets: inherit
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
@@ -38,9 +39,8 @@ jobs:
         with:
           toolchain: nightly
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2
-        with:
-          cache-on-failure: true
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Build documentation
         run: cargo doc --workspace --all-features --no-deps --document-private-items
         env:
@@ -55,7 +55,7 @@ jobs:
   deploy-docs:
     if: github.ref_name == 'master' && github.event_name == 'push'
     needs: [docs]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       pages: write
@@ -69,7 +69,7 @@ jobs:
         uses: actions/deploy-pages@v4
 
   doctest:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
@@ -81,13 +81,12 @@ jobs:
         with:
           toolchain: stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2
-        with:
-          cache-on-failure: true
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - run: cargo test --workspace --doc
 
   typos:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
@@ -98,7 +97,7 @@ jobs:
       - uses: crate-ci/typos@85f62a8a84f939ae994ab3763f01a0296d61a7ee # v1
 
   clippy:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
@@ -111,15 +110,14 @@ jobs:
           toolchain: nightly
           components: clippy
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2
-        with:
-          cache-on-failure: true
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - run: cargo clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -Dwarnings
 
   rustfmt:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
@@ -134,7 +132,7 @@ jobs:
       - run: cargo fmt --all --check
 
   forge-fmt:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
@@ -146,15 +144,14 @@ jobs:
         with:
           toolchain: stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2
-        with:
-          cache-on-failure: true
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: forge fmt
         shell: bash
         run: ./.github/scripts/format.sh --check
 
   crate-checks:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
@@ -169,9 +166,8 @@ jobs:
       - uses: taiki-e/install-action@cd39cb0572834c149bf3533a143f05e09def0f3c # v2
         with:
           tool: cargo-hack
-      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2
-        with:
-          cache-on-failure: true
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - run: cargo hack check
 
   deny:

--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ shall be dual licensed as above, without any additional terms or conditions.
 - [Matthias Seitz](https://twitter.com/mattsse_): Created [ethers-solc] (now [foundry-compilers]) which is the backbone of our compilation pipeline, as well as countless contributions to ethers, in particular the `abigen` macros.
 - [Rohit Narurkar](https://twitter.com/rohitnarurkar): Created the Rust Solidity version manager [svm-rs](https://github.com/roynalnaruto/svm-rs) which we use to auto-detect and manage multiple Solidity versions.
 - [Brock Elmore](https://twitter.com/brockjelmore): For extending the VM's cheatcodes and implementing [structured call tracing](https://github.com/foundry-rs/foundry/pull/192), a critical feature for debugging smart contract calls.
+- Thank you to [Depot](https://depot.dev) for sponsoring us with their fast GitHub runners and sccache, which we use in CI to reduce build and test times significantly.
 - All the other [contributors](https://github.com/foundry-rs/foundry/graphs/contributors) to the [ethers-rs](https://github.com/gakonst/ethers-rs), [alloy][alloy] & [foundry](https://github.com/foundry-rs/foundry) repositories and chatrooms.
 
 [solidity]: https://soliditylang.org/

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -53,7 +53,7 @@ pub struct ProjectCompiler {
     /// Whether to ignore the contract initcode size limit introduced by EIP-3860.
     ignore_eip_3860: bool,
 
-    /// Extra files to include, that are not necessarily in the project's source dir.
+    /// Extra files to include, that are not necessarily in the project's source directory.
     files: Vec<PathBuf>,
 
     /// Whether to compile with dynamic linking tests and scripts.

--- a/crates/debugger/src/builder.rs
+++ b/crates/debugger/src/builder.rs
@@ -4,6 +4,7 @@ use crate::{DebugNode, Debugger, node::flatten_call_trace};
 use alloy_primitives::{Address, map::AddressHashMap};
 use foundry_common::{evm::Breakpoints, get_contract_name};
 use foundry_evm_traces::{CallTraceArena, CallTraceDecoder, Traces, debug::ContractSources};
+
 /// Debugger builder.
 #[derive(Debug, Default)]
 #[must_use = "builders do nothing unless you call `build` on them"]


### PR DESCRIPTION
## Motivation

CI speed is slow and we have a lot of dependencies.

## Solution

Use depot runners and their sccache.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
