### PR TITLE
Avoid panic on uncle-only block transactions in fork backend

### DIFF
--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -320,7 +320,10 @@ impl ClientFork {
                     }
                 }
                 // TODO(evalir): Is it possible to reach this case? Should we support it
-                BlockTransactions::Uncle => panic!("Uncles not supported"),
+                // Gracefully handle unsupported uncle-only block transactions to avoid panicking.
+                BlockTransactions::Uncle => {
+                    return Ok(None);
+                }
             }
         }
         Ok(None)
@@ -344,7 +347,10 @@ impl ClientFork {
                     }
                 }
                 // TODO(evalir): Is it possible to reach this case? Should we support it
-                BlockTransactions::Uncle => panic!("Uncles not supported"),
+                // Gracefully handle unsupported uncle-only block transactions to avoid panicking.
+                BlockTransactions::Uncle => {
+                    return Ok(None);
+                }
             }
         }
         Ok(None)


### PR DESCRIPTION


### Summary
Gracefully handle the rare `BlockTransactions::Uncle` case to prevent node crashes.

### Changes
- Return `Ok(None)` instead of panicking when `BlockTransactions::Uncle` is encountered in `transaction_by_block_number_and_index` and `transaction_by_block_hash_and_index`.
- Add a brief comment explaining the choice.

