### PR TITLE
Use POSIX-compliant shell test in Dockerfile to fix Alpine build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add clang lld curl build-base linux-headers git \
     && chmod +x ./rustup.sh \
     && ./rustup.sh -y
 
-RUN [[ "$TARGETARCH" = "arm64" ]] && echo "export CFLAGS=-mno-outline-atomics" >> $HOME/.profile || true
+RUN [ "$TARGETARCH" = "arm64" ] && echo "export CFLAGS=-mno-outline-atomics" >> "$HOME/.profile" || true
 
 WORKDIR /opt/foundry
 COPY . .


### PR DESCRIPTION


### PR Description 
- **Summary**: Replace bash-specific `[[ ... ]]` with POSIX `[ ... ]` in the `Dockerfile` to ensure compatibility with Alpine’s `/bin/sh` (BusyBox `ash`).

- **Change**:
  - `Dockerfile`: `[[ "$TARGETARCH" = "arm64" ]]` → `[ "$TARGETARCH" = "arm64" ]`

- **Why**:
  - Alpine’s default shell doesn’t support `[[ ... ]]`, which can cause build failures



