### PR TITLE
fix(forge): decrement runs when fuzz input rejected

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -221,7 +221,8 @@ impl FuzzedExecutor {
                             break 'stop;
                         }
                         TestCaseError::Reject(_) => {
-                            // Apply max rejects only if configured, otherwise silently discard run.
+                            // Discard run and apply max rejects if configured.
+                            test_data.runs -= 1;
                             if self.config.max_test_rejects > 0 {
                                 test_data.rejects += 1;
                                 if test_data.rejects >= self.config.max_test_rejects {

--- a/crates/forge/tests/it/fuzz.rs
+++ b/crates/forge/tests/it/fuzz.rs
@@ -360,3 +360,34 @@ Suite result: FAILED. 0 passed; 2 failed; 0 skipped; [ELAPSED]
 
 "#]]);
 });
+
+// Test 256 runs regardless number of test rejects.
+// <https://github.com/foundry-rs/foundry/issues/9054>
+forgetest_init!(test_fuzz_runs_with_rejects, |prj, cmd| {
+    prj.add_test(
+        "FuzzWithRejectsTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract FuzzWithRejectsTest is Test {
+    function testFuzzWithRejects(uint256 x) public pure {
+        vm.assume(x < 1_000_000);
+    }
+}
+   "#,
+    );
+
+    // Tests should not fail as revert happens in Counter contract.
+    cmd.args(["test", "--mc", "FuzzWithRejectsTest"]).assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/FuzzWithRejectsTest.t.sol:FuzzWithRejectsTest
+[PASS] testFuzzWithRejects(uint256) (runs: 256, [AVG_GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]);
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #11787 
- decrement test runs when assume rejects run
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
