### PR TITLE
chore: profile.dev cargo warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ serde.opt-level = 3
 foundry-solang-parser.opt-level = 3
 lalrpop-util.opt-level = 3
 
-solar.opt-level = 3
+solar-compiler.opt-level = 3
 solar-ast.opt-level = 3
 solar-data-structures.opt-level = 3
 solar-interface.opt-level = 3


### PR DESCRIPTION
warning: profile package spec `solar` in profile `dev` did not match any packages