### PR TITLE
chore: rm dead code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4470,7 +4470,6 @@ dependencies = [
  "serde",
  "serde_json",
  "solar-compiler",
- "terminal_size",
  "thiserror 2.0.16",
  "tokio",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,7 +283,6 @@ anstyle = "1.0"
 dialoguer = { version = "0.12", default-features = false, features = [
     "password",
 ] }
-terminal_size = "0.4"
 clap_complete = "4"
 clap_complete_nushell = "4"
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -72,7 +72,6 @@ yansi.workspace = true
 
 anstream.workspace = true
 anstyle.workspace = true
-terminal_size.workspace = true
 ciborium.workspace = true
 
 flate2.workspace = true

--- a/crates/common/src/io/shell.rs
+++ b/crates/common/src/io/shell.rs
@@ -51,39 +51,6 @@ pub fn is_markdown() -> bool {
 /// The global shell instance.
 static GLOBAL_SHELL: OnceLock<Mutex<Shell>> = OnceLock::new();
 
-/// Terminal width.
-pub enum TtyWidth {
-    /// Not a terminal, or could not determine size.
-    NoTty,
-    /// A known width.
-    Known(usize),
-    /// A guess at the width.
-    Guess(usize),
-}
-
-impl TtyWidth {
-    /// Returns the width of the terminal from the environment, if known.
-    pub fn get() -> Self {
-        // use stderr
-        #[cfg(unix)]
-        let opt = terminal_size::terminal_size_of(std::io::stderr());
-        #[cfg(not(unix))]
-        let opt = terminal_size::terminal_size();
-        match opt {
-            Some((w, _)) => Self::Known(w.0 as usize),
-            None => Self::NoTty,
-        }
-    }
-
-    /// Returns the width used by progress bars for the tty.
-    pub fn progress_max_width(&self) -> Option<usize> {
-        match *self {
-            Self::NoTty => None,
-            Self::Known(width) | Self::Guess(width) => Some(width),
-        }
-    }
-}
-
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 /// The requested output mode.
 pub enum OutputMode {
@@ -294,14 +261,6 @@ impl Shell {
     /// Returns `true` if the `needs_clear` flag is unset.
     pub fn is_cleared(&self) -> bool {
         !self.needs_clear()
-    }
-
-    /// Returns the width of the terminal in spaces, if any.
-    pub fn err_width(&self) -> TtyWidth {
-        match self.output {
-            ShellOut::Stream { stderr_tty: true, .. } => TtyWidth::get(),
-            _ => TtyWidth::NoTty,
-        }
     }
 
     /// Gets the output format of the shell.


### PR DESCRIPTION
## Motivation

Reduce dep graph size

## Solution

Removes some dead code that brought in `terminal_size`, and remove `terminal_size`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
