### PR TITLE
ci: rm cores from depot macos runner

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,4 @@
 [test-groups]
-chisel-serial = { max-threads = 1 }
 
 [profile.default]
 retries = { backoff = "exponential", count = 2, delay = "5s", jitter = true }
@@ -9,6 +8,7 @@ slow-timeout = { period = "1m", terminate-after = 3 }
 filter = "test(/ext_integration|can_test_forge_std/)"
 slow-timeout = { period = "5m", terminate-after = 4 }
 
+# Do not re-run so that `cargo cheats` is ran locally.
 [[profile.default.overrides]]
 filter = "package(foundry-cheatcodes-spec)"
 retries = 0

--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -71,7 +71,7 @@ t_linux_x86 = Target("depot-ubuntu-latest-8", "x86_64-unknown-linux-gnu", "linux
 t_linux_arm = Target(
     "depot-ubuntu-24.04-arm-8", "aarch64-unknown-linux-gnu", "linux-aarch64"
 )
-t_macos = Target("depot-macos-latest-8", "aarch64-apple-darwin", "macosx-aarch64")
+t_macos = Target("depot-macos-latest", "aarch64-apple-darwin", "macosx-aarch64")
 t_windows = Target("depot-windows-latest-8", "x86_64-pc-windows-msvc", "windows-amd64")
 targets = (
     [t_linux_x86, t_windows]


### PR DESCRIPTION
https://depot.dev/docs/github-actions/runner-types#macos-runners

There is no macos-latest-XX