### PR TITLE
ci: update release runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,28 +100,27 @@ jobs:
           # `target`: Rust build target triple
           # `platform` and `arch`: Used in tarball names
           # `svm`: target platform to use for the Solc binary: https://github.com/roynalnaruto/svm-rs/blob/84cbe0ac705becabdc13168bae28a45ad2299749/svm-builds/build.rs#L4-L24
-          - runner: depot-ubuntu-24.04
+          # These are pinned to the oldest runner versions to support old libc/SDK versions.
+          - runner: depot-ubuntu-22.04-16
             target: x86_64-unknown-linux-gnu
             svm_target_platform: linux-amd64
             platform: linux
             arch: amd64
-          - runner: depot-ubuntu-24.04
+          - runner: depot-ubuntu-22.04-16
             target: x86_64-unknown-linux-musl
             svm_target_platform: linux-amd64
             platform: alpine
             arch: amd64
-          - runner: depot-ubuntu-24.04
+          - runner: depot-ubuntu-22.04-arm-16
             target: aarch64-unknown-linux-gnu
             svm_target_platform: linux-aarch64
             platform: linux
             arch: arm64
-          - runner: depot-ubuntu-24.04
+          - runner: depot-ubuntu-22.04-arm-16
             target: aarch64-unknown-linux-musl
             svm_target_platform: linux-aarch64
             platform: alpine
             arch: arm64
-          # This is pinned to `macos-13-large` to support old SDK versions.
-          # If the runner is deprecated it should be pinned to the oldest available version of the runner.
           - runner: macos-13-large
             target: x86_64-apple-darwin
             svm_target_platform: macosx-amd64
@@ -132,7 +131,7 @@ jobs:
             svm_target_platform: macosx-aarch64
             platform: darwin
             arch: arm64
-          - runner: depot-windows-latest
+          - runner: depot-windows-latest-16
             target: x86_64-pc-windows-msvc
             svm_target_platform: windows-amd64
             platform: win32
@@ -154,9 +153,9 @@ jobs:
           printf 'MACOSX_DEPLOYMENT_TARGET=%s\n' "$(xcrun -sdk macosx --show-sdk-platform-version)" >> "$GITHUB_ENV"
 
       - name: cross setup
-        if: matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-gnu'
+        if: contains(matrix.target, 'musl')
         run: |
-          cargo install cross --git https://github.com/cross-rs/cross --rev baf457e
+          cargo install cross --git https://github.com/cross-rs/cross --rev baf457efc2555225af47963475bd70e8d2f5993f
 
       - name: Build binaries
         env:
@@ -178,7 +177,7 @@ jobs:
 
           [[ "$TARGET" == *windows* ]] && ext=".exe"
 
-          if [[ "$TARGET" == *-musl || "$TARGET" == "aarch64-unknown-linux-gnu" ]]; then
+          if [[ "$TARGET" == *-musl ]]; then
             cross build "${flags[@]}"
           else
             cargo build "${flags[@]}"


### PR DESCRIPTION
- use 22.04
- bump linux and windows from 2 to 16 cores