### PR TITLE
ci: tweak runners, depot 16

### DIFF
--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -67,12 +67,14 @@ class Expanded:
 
 profile = os.environ.get("PROFILE")
 is_pr = os.environ.get("EVENT_NAME") == "pull_request"
-t_linux_x86 = Target("depot-ubuntu-latest-8", "x86_64-unknown-linux-gnu", "linux-amd64")
+t_linux_x86 = Target(
+    "depot-ubuntu-latest-16", "x86_64-unknown-linux-gnu", "linux-amd64"
+)
 t_linux_arm = Target(
-    "depot-ubuntu-24.04-arm-8", "aarch64-unknown-linux-gnu", "linux-aarch64"
+    "depot-ubuntu-latest-arm-16", "aarch64-unknown-linux-gnu", "linux-aarch64"
 )
 t_macos = Target("depot-macos-latest", "aarch64-apple-darwin", "macosx-aarch64")
-t_windows = Target("depot-windows-latest-8", "x86_64-pc-windows-msvc", "windows-amd64")
+t_windows = Target("depot-windows-latest-16", "x86_64-pc-windows-msvc", "windows-amd64")
 targets = (
     [t_linux_x86, t_windows]
     if is_pr

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   run-benchmarks:
     name: Run All Benchmarks
-    runs-on: depot-ubuntu-24.04
+    runs-on: foundry-runner
     permissions:
       contents: write
     steps:
@@ -155,7 +155,7 @@ jobs:
   publish-results:
     name: Publish Results
     needs: run-benchmarks
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     name: build and push
-    runs-on: Linux-22.04
+    runs-on: depot-ubuntu-22.04-16
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   matrices:
     name: build matrices
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   prepare:
     name: Prepare release
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: write


### PR DESCRIPTION
- Revert runners in benchmarks.yml for consistent results
- use depot for docker
- don't use depot for very simple jobs, gh runners are fine
- use -16 cores instead of -8