### PR TITLE
Prevent secret leakage by not logging first positional CLI argument

### DIFF
--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -286,15 +286,7 @@ impl CommandUtils for Command {
                 format!("stdout:\n{stdout}\n\nstderr:\n{stderr}")
             };
 
-            let mut name = self.get_program().to_string_lossy();
-            if let Some(arg) = self.get_args().next() {
-                let arg = arg.to_string_lossy();
-                if !arg.starts_with('-') {
-                    let name = name.to_mut();
-                    name.push(' ');
-                    name.push_str(&arg);
-                }
-            }
+            let name = self.get_program().to_string_lossy();
 
             let mut err = match output.status.code() {
                 Some(code) => format!("{name} exited with code {code}"),


### PR DESCRIPTION


Description
- What: Remove inclusion of the first positional argument from error messages in CommandUtils::exec.
- Why: Positional args may contain secrets (e.g., keys, tokens, mnemonics, credentials in URLs). Logging them risks secret exposure.
- Scope: crates/cli/src/utils/mod.rs only; no functional behavior change.

Security
- Reduces risk of “secrets-in-logs” leakage in error paths.
- No change to stdout/stderr content; only the synthesized error header is safer.

