### PR TITLE
Fix typos and grammar in Solidity test comments

### DIFF
--- a/testdata/default/cheats/Broadcast.t.sol
+++ b/testdata/default/cheats/Broadcast.t.sol
@@ -45,7 +45,7 @@ contract BroadcastTest is DSTest {
         vm.broadcast(ACCOUNT_A);
         Test test = new Test();
 
-        // this wont generate tx to sign
+        // this won't generate tx to sign
         uint256 b = test.t(4);
 
         // this will
@@ -134,7 +134,7 @@ contract BroadcastTest is DSTest {
         vm.broadcast(address(0x1337));
         Test test = new Test();
 
-        // This panics because this would cause an additional relinking that isnt conceptually correct
+        // This panics because this would cause an additional relinking that isn't conceptually correct
         // from a solidity standpoint. Basically, this contract `BroadcastTest`, injects the code of
         // `Test` *into* its code. So it isn't reasonable to break solidity to our will of having *two*
         // versions of `Test` based on the sender/linker.

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -159,7 +159,7 @@ contract ExpectRevertTest is DSTest {
 
         Dummy dummy = new Dummy();
         vm.expectRevert();
-        reverter.callThenRevert(dummy, "revert message 4 i ran out of synonims for also");
+        reverter.callThenRevert(dummy, "revert message 4 i ran out of synonyms for also");
 
         vm.expectRevert();
         reverter.revertWithoutReason();

--- a/testdata/default/cheats/RecordDebugTrace.t.sol
+++ b/testdata/default/cheats/RecordDebugTrace.t.sol
@@ -68,7 +68,7 @@ contract RecordDebugTraceTest is DSTest {
     Vm constant cheats = Vm(HEVM_ADDRESS);
     /**
      * The goal of this test is to ensure the debug steps provide the correct OPCODE with its stack
-     * and memory input used. The test checke MSTORE and MLOAD and ensure it records the expected
+     * and memory input used. The test checks MSTORE and MLOAD and ensure it records the expected
      * stack and memory inputs.
      */
 


### PR DESCRIPTION


### Description
- **Summary**: Corrects minor typos and grammar in test comments to improve clarity.
- **What changed**
  - `wont` → `won’t`; `isnt` → `isn’t`
  - `synonims` → `synonyms`
  - `checke` → `checks`
- **Affected files**
  - `testdata/default/cheats/Broadcast.t.sol`
  - `testdata/default/cheats/ExpectRevert.t.sol`
  - `testdata/default/cheats/RecordDebugTrace.t.sol`

