### PR TITLE
fix(fmt): underscore for hex literals

### DIFF
--- a/crates/fmt/src/state/common.rs
+++ b/crates/fmt/src/state/common.rs
@@ -65,9 +65,10 @@ impl<'ast> State<'_, 'ast> {
             out: &mut String,
             config: config::NumberUnderscore,
             string: &str,
+            is_dec: bool,
             reversed: bool,
         ) {
-            if !config.is_thousands() || string.len() < 5 {
+            if !config.is_thousands() || !is_dec || string.len() < 5 {
                 out.push_str(string);
                 return;
             }
@@ -114,12 +115,12 @@ impl<'ast> State<'_, 'ast> {
         if val.is_empty() {
             out.push('0');
         } else {
-            add_underscores(&mut out, config, val, false);
+            add_underscores(&mut out, config, val, is_dec, false);
         }
         if source.contains('.') {
             out.push('.');
             if !fract.is_empty() {
-                add_underscores(&mut out, config, fract, true);
+                add_underscores(&mut out, config, fract, is_dec, true);
             } else {
                 out.push('0');
             }
@@ -127,7 +128,7 @@ impl<'ast> State<'_, 'ast> {
         if !exp.is_empty() {
             out.push('e');
             out.push_str(exp_sign);
-            add_underscores(&mut out, config, exp, false);
+            add_underscores(&mut out, config, exp, is_dec, false);
         }
 
         self.word(out);

--- a/crates/fmt/testdata/NumberLiteralUnderscore/fmt.sol
+++ b/crates/fmt/testdata/NumberLiteralUnderscore/fmt.sol
@@ -1,4 +1,6 @@
 contract NumberLiteral {
+    bytes4 internal constant HEX_NUM = 0x01ffc9a7;
+
     function test() external {
         1;
         123_000;

--- a/crates/fmt/testdata/NumberLiteralUnderscore/original.sol
+++ b/crates/fmt/testdata/NumberLiteralUnderscore/original.sol
@@ -1,4 +1,6 @@
 contract NumberLiteral {
+    bytes4 internal constant HEX_NUM = 0x01ffc9a7;
+
     function test() external {
         1;
         123_000;

--- a/crates/fmt/testdata/NumberLiteralUnderscore/preserve.fmt.sol
+++ b/crates/fmt/testdata/NumberLiteralUnderscore/preserve.fmt.sol
@@ -1,5 +1,7 @@
 // config: number_underscore = "preserve"
 contract NumberLiteral {
+    bytes4 internal constant HEX_NUM = 0x01ffc9a7;
+
     function test() external {
         1;
         123_000;

--- a/crates/fmt/testdata/NumberLiteralUnderscore/remove.fmt.sol
+++ b/crates/fmt/testdata/NumberLiteralUnderscore/remove.fmt.sol
@@ -1,5 +1,7 @@
 // config: number_underscore = "remove"
 contract NumberLiteral {
+    bytes4 internal constant HEX_NUM = 0x01ffc9a7;
+
     function test() external {
         1;
         123000;

--- a/crates/fmt/testdata/NumberLiteralUnderscore/thousands.fmt.sol
+++ b/crates/fmt/testdata/NumberLiteralUnderscore/thousands.fmt.sol
@@ -1,5 +1,7 @@
 // config: number_underscore = "thousands"
 contract NumberLiteral {
+    bytes4 internal constant HEX_NUM = 0x01ffc9a7;
+
     function test() external {
         1;
         123_000;


### PR DESCRIPTION
## Motivation

ref:
- https://github.com/foundry-rs/foundry/issues/11820

## Solution

only underscore decimal literals

## PR Checklist

- [X] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
