### PR TITLE
fix(fmt): estimate size + account for all blocks

### DIFF
--- a/crates/common/src/comments/mod.rs
+++ b/crates/common/src/comments/mod.rs
@@ -233,7 +233,18 @@ impl<'ast> CommentGatherer<'ast> {
                 let pos_in_file = self.start_bpos + BytePos(self.pos as u32);
                 let line_begin_in_file = line_begin_pos(self.sf, pos_in_file);
                 let line_begin_pos = (line_begin_in_file - self.start_bpos).to_usize();
-                let col = CharPos(self.text[line_begin_pos..self.pos].chars().count());
+                let mut col = CharPos(self.text[line_begin_pos..self.pos].chars().count());
+
+                // To preserve alignment in non-doc comments, normalize the block based on its
+                // least-indented line.
+                if !is_doc {
+                    col = token_text.lines().skip(1).fold(col, |min, line| {
+                        std::cmp::min(
+                            CharPos(line.chars().count() - line.trim_start().chars().count()),
+                            min,
+                        )
+                    })
+                };
 
                 let lines = self.split_block_comment_into_lines(token_text, is_doc, col);
                 self.comments.push(Comment { is_doc, kind, style, lines, span })

--- a/crates/common/src/comments/mod.rs
+++ b/crates/common/src/comments/mod.rs
@@ -239,6 +239,9 @@ impl<'ast> CommentGatherer<'ast> {
                 // least-indented line.
                 if !is_doc {
                     col = token_text.lines().skip(1).fold(col, |min, line| {
+                        if line.is_empty() {
+                            return min;
+                        }
                         std::cmp::min(
                             CharPos(line.chars().count() - line.trim_start().chars().count()),
                             min,

--- a/crates/fmt/src/state/common.rs
+++ b/crates/fmt/src/state/common.rs
@@ -516,6 +516,9 @@ impl<'ast> State<'_, 'ast> {
             return;
         }
 
+        // update block depth
+        self.block_depth += 1;
+
         // Print multiline block comments.
         let block_lo = get_block_span(&block[0]).lo();
         match block_format {
@@ -626,6 +629,9 @@ impl<'ast> State<'_, 'ast> {
         if block_format.with_braces() {
             self.print_word("}");
         }
+
+        // restore block depth
+        self.block_depth -= 1;
     }
 
     fn print_single_line_block<T: Debug>(

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -832,6 +832,13 @@ impl<'sess> State<'sess, '_> {
         self.comments.iter().take_while(|c| c.pos() < pos).find(|c| !c.style.is_blank())
     }
 
+    fn has_comment_before_with<F>(&self, pos: BytePos, f: F) -> bool
+    where
+        F: FnMut(&Comment) -> bool,
+    {
+        self.comments.iter().take_while(|c| c.pos() < pos).any(f)
+    }
+
     fn peek_comment_between<'b>(&'b self, pos_lo: BytePos, pos_hi: BytePos) -> Option<&'b Comment>
     where
         'sess: 'b,

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -377,7 +377,21 @@ impl State<'_, '_> {
                     // Previous line ended with ';' a hardbreak is required.
                     size += 1;
                 }
-                size += line.trim().len();
+
+                // trim spaces before and after mixed comments
+                let mut search = line;
+                loop {
+                    if let Some((lhs, comment)) = search.split_once(r#"/*"#) {
+                        size += lhs.trim().len() + 2;
+                        search = comment;
+                    } else if let Some((comment, rhs)) = search.split_once(r#"*/"#) {
+                        size += comment.len() + 2;
+                        search = rhs;
+                    } else {
+                        size += search.trim().len();
+                        break;
+                    }
+                }
 
                 prev_needs_space = (self.config.bracket_spacing
                     && (line.ends_with('(') || line.ends_with('{')))

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -379,8 +379,8 @@ impl State<'_, '_> {
                 }
                 size += line.trim().len();
 
-                prev_needs_space = self.config.bracket_spacing
-                    && (line.ends_with('(') || line.ends_with('{'))
+                prev_needs_space = (self.config.bracket_spacing
+                    && (line.ends_with('(') || line.ends_with('{')))
                     || line.ends_with(',')
                     || line.ends_with(';');
             }

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -822,7 +822,9 @@ impl<'ast> State<'_, 'ast> {
                 self.print_expr(init);
             } else {
                 let callee_doesnt_fit = if let ast::ExprKind::Call(call_expr, ..) = &init.kind {
-                    self.estimate_size(call_expr.span) + pre_init_size > init_space_left
+                    let calle_size = get_callee_head_size(call_expr);
+                    calle_size + pre_init_size > init_space_left
+                        && calle_size + self.config.tab_width < init_space_left
                 } else {
                     false
                 };

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1570,6 +1570,7 @@ impl<'ast> State<'_, 'ast> {
         }
 
         self.call_stack.push(CallContext::nested(callee_size));
+
         // Clear the binary expression cache before the call.
         let cache = self.binary_expr.take();
 

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -822,9 +822,9 @@ impl<'ast> State<'_, 'ast> {
                 self.print_expr(init);
             } else {
                 let callee_doesnt_fit = if let ast::ExprKind::Call(call_expr, ..) = &init.kind {
-                    let calle_size = get_callee_head_size(call_expr);
-                    calle_size + pre_init_size > init_space_left
-                        && calle_size + self.config.tab_width < init_space_left
+                    let callee_size = get_callee_head_size(call_expr);
+                    callee_size + pre_init_size > init_space_left
+                        && callee_size + self.config.tab_width < init_space_left
                 } else {
                     false
                 };

--- a/crates/fmt/testdata/ReprosCalls/110.fmt.sol
+++ b/crates/fmt/testdata/ReprosCalls/110.fmt.sol
@@ -85,3 +85,20 @@ function returnLongBinaryOp() returns (bytes32) {
         uint256(Feature.unwrap(feature)) << 128 | uint256(block.chainid) << 64 | uint256(Nonce.unwrap(nonce))
     );
 }
+
+contract Orchestrator {
+    function test() public {
+        uint256 globalBuyAmount =
+            Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
+        uint256 globalBuyAmount =
+            Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
+        uint256 globalBuyAmount =
+            Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
+
+        {
+            u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
+            u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
+            u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
+        }
+    }
+}

--- a/crates/fmt/testdata/ReprosCalls/110.fmt.sol
+++ b/crates/fmt/testdata/ReprosCalls/110.fmt.sol
@@ -104,5 +104,16 @@ contract Orchestrator {
         ISettlerBase.AllowedSlippage memory allowedSlippage = ISettlerBase.AllowedSlippage({
             recipient: payable(address(0)), buyToken: IERC20(address(0)), minAmountOut: 0
         });
+
+        ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(
+            address(fromToken()),
+            amount(),
+            0 /* nonce */
+        );
+        ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(
+            address(fromToken()),
+            amount(),
+            0 /* nonce */
+        );
     }
 }

--- a/crates/fmt/testdata/ReprosCalls/110.fmt.sol
+++ b/crates/fmt/testdata/ReprosCalls/110.fmt.sol
@@ -92,13 +92,17 @@ contract Orchestrator {
             Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
         uint256 globalBuyAmount =
             Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
-        uint256 globalBuyAmount =
-            Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
 
         {
             u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
             u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
-            u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
         }
+
+        ISettlerBase.AllowedSlippage memory allowedSlippage = ISettlerBase.AllowedSlippage({
+            recipient: payable(address(0)), buyToken: IERC20(address(0)), minAmountOut: 0
+        });
+        ISettlerBase.AllowedSlippage memory allowedSlippage = ISettlerBase.AllowedSlippage({
+            recipient: payable(address(0)), buyToken: IERC20(address(0)), minAmountOut: 0
+        });
     }
 }

--- a/crates/fmt/testdata/ReprosCalls/120.fmt.sol
+++ b/crates/fmt/testdata/ReprosCalls/120.fmt.sol
@@ -94,5 +94,16 @@ contract Orchestrator {
         ISettlerBase.AllowedSlippage memory allowedSlippage = ISettlerBase.AllowedSlippage({
             recipient: payable(address(0)), buyToken: IERC20(address(0)), minAmountOut: 0
         });
+
+        ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(
+            address(fromToken()),
+            amount(),
+            0 /* nonce */
+        );
+        ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(
+            address(fromToken()),
+            amount(),
+            0 /* nonce */
+        );
     }
 }

--- a/crates/fmt/testdata/ReprosCalls/120.fmt.sol
+++ b/crates/fmt/testdata/ReprosCalls/120.fmt.sol
@@ -77,3 +77,17 @@ function returnLongBinaryOp() returns (bytes32) {
     return
         bytes32(uint256(Feature.unwrap(feature)) << 128 | uint256(block.chainid) << 64 | uint256(Nonce.unwrap(nonce)));
 }
+
+contract Orchestrator {
+    function test() public {
+        uint256 globalBuyAmount = Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
+        uint256 globalBuyAmount = Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
+        uint256 globalBuyAmount = Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
+
+        {
+            u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
+            u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
+            u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
+        }
+    }
+}

--- a/crates/fmt/testdata/ReprosCalls/120.fmt.sol
+++ b/crates/fmt/testdata/ReprosCalls/120.fmt.sol
@@ -82,12 +82,17 @@ contract Orchestrator {
     function test() public {
         uint256 globalBuyAmount = Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
         uint256 globalBuyAmount = Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
-        uint256 globalBuyAmount = Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
 
         {
             u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
             u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
-            u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
         }
+
+        ISettlerBase.AllowedSlippage memory allowedSlippage = ISettlerBase.AllowedSlippage({
+            recipient: payable(address(0)), buyToken: IERC20(address(0)), minAmountOut: 0
+        });
+        ISettlerBase.AllowedSlippage memory allowedSlippage = ISettlerBase.AllowedSlippage({
+            recipient: payable(address(0)), buyToken: IERC20(address(0)), minAmountOut: 0
+        });
     }
 }

--- a/crates/fmt/testdata/ReprosCalls/80.fmt.sol
+++ b/crates/fmt/testdata/ReprosCalls/80.fmt.sol
@@ -118,3 +118,41 @@ function returnLongBinaryOp() returns (bytes32) {
             | uint256(Nonce.unwrap(nonce))
     );
 }
+
+contract Orchestrator {
+    function test() public {
+        uint256 globalBuyAmount = Take.take(
+            state,
+            notes,
+            uint32(IPoolManager.take.selector),
+            recipient,
+            minBuyAmount
+        );
+        uint256 globalBuyAmount = Take.take(
+            state,
+            notes,
+            uint32(IPoolManager.take.selector),
+            recipient,
+            minBuyAmount
+        );
+        uint256 globalBuyAmount = Take.take(
+            state,
+            notes,
+            uint32(IPoolManager.take.selector),
+            recipient,
+            minBuyAmount
+        );
+
+        {
+            u.executionData = _transferExecution(
+                address(paymentToken), address(0xabcd), 1 ether
+            );
+            u.executionData = _transferExecution(
+                address(paymentToken), address(0xabcd), 1 ether
+            );
+            u.executionData = _transferExecution(
+                address(paymentToken), address(0xabcd), 1 ether
+            );
+        }
+    }
+}

--- a/crates/fmt/testdata/ReprosCalls/80.fmt.sol
+++ b/crates/fmt/testdata/ReprosCalls/80.fmt.sol
@@ -135,13 +135,6 @@ contract Orchestrator {
             recipient,
             minBuyAmount
         );
-        uint256 globalBuyAmount = Take.take(
-            state,
-            notes,
-            uint32(IPoolManager.take.selector),
-            recipient,
-            minBuyAmount
-        );
 
         {
             u.executionData = _transferExecution(
@@ -150,9 +143,19 @@ contract Orchestrator {
             u.executionData = _transferExecution(
                 address(paymentToken), address(0xabcd), 1 ether
             );
-            u.executionData = _transferExecution(
-                address(paymentToken), address(0xabcd), 1 ether
-            );
         }
+
+        ISettlerBase.AllowedSlippage memory allowedSlippage =
+            ISettlerBase.AllowedSlippage({
+                recipient: payable(address(0)),
+                buyToken: IERC20(address(0)),
+                minAmountOut: 0
+            });
+        ISettlerBase.AllowedSlippage memory allowedSlippage =
+            ISettlerBase.AllowedSlippage({
+                recipient: payable(address(0)),
+                buyToken: IERC20(address(0)),
+                minAmountOut: 0
+            });
     }
 }

--- a/crates/fmt/testdata/ReprosCalls/80.fmt.sol
+++ b/crates/fmt/testdata/ReprosCalls/80.fmt.sol
@@ -157,5 +157,18 @@ contract Orchestrator {
                 buyToken: IERC20(address(0)),
                 minAmountOut: 0
             });
+
+        ISignatureTransfer.PermitTransferFrom memory permit =
+            defaultERC20PermitTransfer(
+                address(fromToken()),
+                amount(),
+                0 /* nonce */
+            );
+        ISignatureTransfer.PermitTransferFrom memory permit =
+            defaultERC20PermitTransfer(
+                address(fromToken()),
+                amount(),
+                0 /* nonce */
+            );
     }
 }

--- a/crates/fmt/testdata/ReprosCalls/original.sol
+++ b/crates/fmt/testdata/ReprosCalls/original.sol
@@ -83,7 +83,6 @@ function returnLongBinaryOp() returns (bytes32) {
 
 contract Orchestrator {
     function test() public {
-        uint256 globalBuyAmount = Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
         uint256 globalBuyAmount =
             Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
         uint256 globalBuyAmount = Take.take(
@@ -91,12 +90,20 @@ contract Orchestrator {
         );
 
         {
-            u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
             u.executionData =
                 _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
             u.executionData = _transferExecution(
                 address(paymentToken), address(0xabcd), 1 ether
             );
         }
+
+        ISettlerBase.AllowedSlippage memory allowedSlippage = ISettlerBase.AllowedSlippage({
+            recipient: payable(address(0)),
+            buyToken: IERC20(address(0)),
+            minAmountOut: 0
+        });
+        ISettlerBase.AllowedSlippage memory allowedSlippage = ISettlerBase.AllowedSlippage({
+            recipient: payable(address(0)), buyToken: IERC20(address(0)), minAmountOut: 0
+        });
     }
 }

--- a/crates/fmt/testdata/ReprosCalls/original.sol
+++ b/crates/fmt/testdata/ReprosCalls/original.sol
@@ -80,3 +80,23 @@ function returnLongBinaryOp() returns (bytes32) {
     return
         bytes32(uint256(Feature.unwrap(feature)) << 128 | uint256(block.chainid) << 64 | uint256(Nonce.unwrap(nonce)));
 }
+
+contract Orchestrator {
+    function test() public {
+        uint256 globalBuyAmount = Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
+        uint256 globalBuyAmount =
+            Take.take(state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount);
+        uint256 globalBuyAmount = Take.take(
+            state, notes, uint32(IPoolManager.take.selector), recipient, minBuyAmount
+        );
+
+        {
+            u.executionData = _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
+            u.executionData =
+                _transferExecution(address(paymentToken), address(0xabcd), 1 ether);
+            u.executionData = _transferExecution(
+                address(paymentToken), address(0xabcd), 1 ether
+            );
+        }
+    }
+}

--- a/crates/fmt/testdata/ReprosCalls/original.sol
+++ b/crates/fmt/testdata/ReprosCalls/original.sol
@@ -105,5 +105,11 @@ contract Orchestrator {
         ISettlerBase.AllowedSlippage memory allowedSlippage = ISettlerBase.AllowedSlippage({
             recipient: payable(address(0)), buyToken: IERC20(address(0)), minAmountOut: 0
         });
+
+        ISignatureTransfer.PermitTransferFrom memory permit =
+            defaultERC20PermitTransfer(address(fromToken()), amount(), 0 /* nonce */);
+        ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(
+            address(fromToken()), amount(), 0 /* nonce */
+        );
     }
 }

--- a/testdata/default/cheats/AttachDelegation.t.sol
+++ b/testdata/default/cheats/AttachDelegation.t.sol
@@ -198,9 +198,8 @@ contract AttachDelegationTest is DSTest {
         calls[0] = SimpleDelegateContract.Call({
             to: address(token), data: abi.encodeCall(ERC20.mint, (50, address(this))), value: 0
         });
-        calls[1] = SimpleDelegateContract.Call({
-            to: address(token), data: abi.encodeCall(ERC20.mint, (50, alice)), value: 0
-        });
+        calls[1] =
+            SimpleDelegateContract.Call({to: address(token), data: abi.encodeCall(ERC20.mint, (50, alice)), value: 0});
         vm.broadcast(bob_pk);
         SimpleDelegateContract(alice).execute(calls);
 

--- a/testdata/default/cheats/GetCode.t.sol
+++ b/testdata/default/cheats/GetCode.t.sol
@@ -49,27 +49,27 @@ contract GetCodeTest is DSTest {
 
     // TODO: Huff uses its own ABI.
     /*
-        function testGetCodeHuffArtifact() public {
-            string memory path = "fixtures/GetCode/HuffWorkingContract.json";
-            bytes memory bytecode = vm.getCode(path);
-            string memory expected = string(
-                bytes(
-                    hex"602d8060093d393df33d3560e01c63d1efd30d14610012573d3dfd5b6f656d6f2e6574682077757a206865726560801b3d523d6020f3"
-                )
-            );
-            assertEq(string(bytecode), expected, "code for path was incorrect");
+    function testGetCodeHuffArtifact() public {
+        string memory path = "fixtures/GetCode/HuffWorkingContract.json";
+        bytes memory bytecode = vm.getCode(path);
+        string memory expected = string(
+            bytes(
+                hex"602d8060093d393df33d3560e01c63d1efd30d14610012573d3dfd5b6f656d6f2e6574682077757a206865726560801b3d523d6020f3"
+            )
+        );
+        assertEq(string(bytecode), expected, "code for path was incorrect");
 
-            // deploy the contract from the bytecode
-            address deployed;
-            assembly {
-                deployed := create(0, add(bytecode, 0x20), mload(bytecode))
-            }
-            // get the deployed code using the cheatcode
-            bytes memory deployedCode = vm.getDeployedCode(path);
-            // compare the loaded code to the actual deployed code
-            assertEq(string(deployedCode), string(deployed.code), "deployedCode for path was incorrect");
+        // deploy the contract from the bytecode
+        address deployed;
+        assembly {
+            deployed := create(0, add(bytecode, 0x20), mload(bytecode))
         }
-        */
+        // get the deployed code using the cheatcode
+        bytes memory deployedCode = vm.getDeployedCode(path);
+        // compare the loaded code to the actual deployed code
+        assertEq(string(deployedCode), string(deployed.code), "deployedCode for path was incorrect");
+    }
+    */
 
     /// forge-config: default.allow_internal_expect_revert = true
     function testRevertIfGetUnlinked() public {

--- a/testdata/default/cheats/GetCode.t.sol
+++ b/testdata/default/cheats/GetCode.t.sol
@@ -49,27 +49,27 @@ contract GetCodeTest is DSTest {
 
     // TODO: Huff uses its own ABI.
     /*
-    function testGetCodeHuffArtifact() public {
-        string memory path = "fixtures/GetCode/HuffWorkingContract.json";
-        bytes memory bytecode = vm.getCode(path);
-        string memory expected = string(
-            bytes(
-                hex"602d8060093d393df33d3560e01c63d1efd30d14610012573d3dfd5b6f656d6f2e6574682077757a206865726560801b3d523d6020f3"
-            )
-        );
-        assertEq(string(bytecode), expected, "code for path was incorrect");
+        function testGetCodeHuffArtifact() public {
+            string memory path = "fixtures/GetCode/HuffWorkingContract.json";
+            bytes memory bytecode = vm.getCode(path);
+            string memory expected = string(
+                bytes(
+                    hex"602d8060093d393df33d3560e01c63d1efd30d14610012573d3dfd5b6f656d6f2e6574682077757a206865726560801b3d523d6020f3"
+                )
+            );
+            assertEq(string(bytecode), expected, "code for path was incorrect");
 
-        // deploy the contract from the bytecode
-        address deployed;
-        assembly {
-            deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+            // deploy the contract from the bytecode
+            address deployed;
+            assembly {
+                deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+            }
+            // get the deployed code using the cheatcode
+            bytes memory deployedCode = vm.getDeployedCode(path);
+            // compare the loaded code to the actual deployed code
+            assertEq(string(deployedCode), string(deployed.code), "deployedCode for path was incorrect");
         }
-        // get the deployed code using the cheatcode
-        bytes memory deployedCode = vm.getDeployedCode(path);
-        // compare the loaded code to the actual deployed code
-        assertEq(string(deployedCode), string(deployed.code), "deployedCode for path was incorrect");
-    }
-    */
+        */
 
     /// forge-config: default.allow_internal_expect_revert = true
     function testRevertIfGetUnlinked() public {

--- a/testdata/default/repros/Issue3703.t.sol
+++ b/testdata/default/repros/Issue3703.t.sol
@@ -9,9 +9,8 @@ contract Issue3703Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function setUp() public {
-        uint256 fork = vm.createSelectFork(
-            "polygon", bytes32(0xbed0c8c1b9ff8bf0452979d170c52893bb8954f18a904aa5bcbd0f709be050b9)
-        );
+        uint256 fork =
+            vm.createSelectFork("polygon", bytes32(0xbed0c8c1b9ff8bf0452979d170c52893bb8954f18a904aa5bcbd0f709be050b9));
     }
 
     function poolState(address poolAddr, uint256 expectedSqrtPriceX96, uint256 expectedLiquidity) private {


### PR DESCRIPTION
## Motivation

closes: 
- [x] https://github.com/foundry-rs/foundry/issues/11821

## Solution

this PR introduces 2 fixes:
- when estimating the size of a snippet, only account for line breaks that are preceeded by a line that ends with a semicolon.
- track block depth so that, when estimating the space left, we can account for all of them rather than just contracts and funcs

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
- [ ] Breaking changes
