### PR TITLE
docs(cast): add description for `cast rpc --decode-internal`

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -97,6 +97,12 @@ pub struct CallArgs {
     #[arg(long, requires = "trace")]
     debug: bool,
 
+    /// Identify internal functions in traces.
+    ///
+    /// This will trace internal functions and decode stack parameters.
+    ///
+    /// Parameters stored in memory (such as bytes or arrays) are currently decoded only when a
+    /// single function is matched, similarly to `--debug`, for performance reasons.
     #[arg(long, requires = "trace")]
     decode_internal: bool,
 


### PR DESCRIPTION
Add argument description for `cast rpc --decode-internal` command.

Currently it is not clear what the argument does from `cast rpc --help`.

```
Usage: cast call [OPTIONS] [TO] [SIG] [ARGS]... [COMMAND]

Commands:
  --create  ignores the address field and simulates creating a contract
  help      Print this message or the help of the given subcommand(s)

Arguments:
  [TO]
          The destination of the transaction

  [SIG]
          The signature of the function to call

  [ARGS]...
          The arguments of the function to call

Options:
...

      --debug
          Opens an interactive debugger. Can only be used with `--trace`

      --decode-internal


      --labels <LABELS>
          Labels to apply to the traces; format: `address:label`. Can only be used with `--trace`

...
```