### PR TITLE
revert evm version incompat warning

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2218,44 +2218,18 @@ impl Config {
     /// This normalizes the default `evm_version` if a `solc` was provided in the config.
     ///
     /// See also <https://github.com/foundry-rs/foundry/issues/7014>
-    #[expect(clippy::disallowed_macros)]
     fn normalize_defaults(&self, mut figment: Figment) -> Figment {
-        let evm_version = figment.extract_inner::<EvmVersion>("evm_version").ok().or_else(|| {
-            figment
-                .extract_inner::<String>("evm_version")
-                .ok()
-                .and_then(|s| s.parse::<EvmVersion>().ok())
-        });
-
-        let solc_version = figment
-            .extract_inner::<SolcReq>("solc")
-            .ok()
-            .and_then(|solc| solc.try_version().ok())
-            .and_then(|v| self.evm_version.normalize_version_solc(&v));
-
         if figment.contains("evm_version") {
-            // Check compatibility if both evm_version and solc are provided
-            // First try to extract as EvmVersion directly, then fallback to string parsing for
-            // case-insensitive support
-            if let Some(evm_version) = evm_version {
-                figment = figment.merge(("evm_version", evm_version));
-
-                if let Some(solc_version) = solc_version
-                    && solc_version != evm_version
-                {
-                    eprintln!(
-                        "{}",
-                        yansi::Paint::yellow(&format!(
-                            "Warning: evm_version '{evm_version}' may be incompatible with solc version. Consider using '{solc_version}'"
-                        ))
-                    );
-                }
-            }
             return figment;
         }
 
         // Normalize `evm_version` based on the provided solc version.
-        if let Some(version) = solc_version {
+        if let Ok(solc) = figment.extract_inner::<SolcReq>("solc")
+            && let Some(version) = solc
+                .try_version()
+                .ok()
+                .and_then(|version| self.evm_version.normalize_version_solc(&version))
+        {
             figment = figment.merge(("evm_version", version));
         }
 
@@ -6342,25 +6316,6 @@ mod tests {
 
             // Assert that the deprecated flag is correctly interpreted
             assert_eq!(config.deny, DenyLevel::Warnings);
-            Ok(())
-        });
-    }
-
-    #[test]
-    fn test_evm_version_solc_compatibility_warning() {
-        figment::Jail::expect_with(|jail| {
-            // Create a config with incompatible evm_version and solc version
-            // Using Cancun with an older solc version (Berlin) that doesn't support it
-            jail.create_file(
-                "foundry.toml",
-                r#"
-            [profile.default]
-            evm_version = "Cancun"
-            solc = "0.8.5"
-        "#,
-            )?;
-
-            let _config = Config::load().unwrap();
             Ok(())
         });
     }

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1924,31 +1924,3 @@ Warning: Key `deny_warnings` is being deprecated in favor of `deny = warnings`. 
 
 "#]]);
 });
-
-// Test that EVM version configuration works and the incompatibility check is available
-forgetest_init!(evm_version_incompatibility_check, |prj, cmd| {
-    // Clear default contracts
-    prj.wipe_contracts();
-
-    // Add a simple contract
-    prj.add_source(
-        "Simple.sol",
-        r#"
-pragma solidity ^0.8.5;
-
-contract Simple {
-    uint public value = 42;
-}
-"#,
-    );
-
-    prj.update_config(|config| {
-        config.evm_version = EvmVersion::Cancun;
-        config.solc = Some(SolcReq::Version("0.8.5".parse().unwrap()));
-    });
-
-    let result = cmd.args(["build"]).assert_success();
-    let output = result.get_output();
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("Warning: evm_version 'cancun' may be incompatible with solc version. Consider using 'berlin'"));
-});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- reverts changes added in https://github.com/foundry-rs/foundry/commit/d22355229fb23e8bf7a32b4785856e93c5331cf9

There are two issues with the approach:
- warning appears in all commands involving project config (forge clean, etc.)
- warning appears multiple times and wrong 

E.g.
on https://github.com/pcaversaccio/createx
```
> forge clean

Warning: evm_version 'paris' may be incompatible with solc version. Consider using 'prague'
Warning: evm_version 'paris' may be incompatible with solc version. Consider using 'shanghai'
```

on https://github.com/ithacaxyz/account
```
> forge clean

Warning: evm_version 'paris' may be incompatible with solc version. Consider using 'prague'
```
even if `evm_version = "prague"` set

Suggest this to be implemented as part of `WarningProviders` https://github.com/foundry-rs/foundry/blob/954accf6d7dcecd69ac62754d5f1911281a9ae15/crates/config/src/providers/warnings.rs#L9 and make sure all cases are covered
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
