### PR TITLE
anvil: return JoinHandle from `TaskManager::spawn_blocking` for proper task control

### DIFF
--- a/crates/anvil/src/tasks/mod.rs
+++ b/crates/anvil/src/tasks/mod.rs
@@ -38,12 +38,14 @@ impl TaskManager {
         self.tokio_handle.spawn(task)
     }
 
-    /// Spawns the blocking task.
-    pub fn spawn_blocking(&self, task: impl Future<Output = ()> + Send + 'static) {
+    /// Spawns the blocking task and returns a handle to it.
+    ///
+    /// Returning the `JoinHandle` allows callers to cancel the task or await its completion.
+    pub fn spawn_blocking(&self, task: impl Future<Output = ()> + Send + 'static) -> JoinHandle<()> {
         let handle = self.tokio_handle.clone();
         self.tokio_handle.spawn_blocking(move || {
             handle.block_on(task);
-        });
+        })
     }
 
     /// Spawns a new task that listens for new blocks and resets the forked provider for every new

--- a/crates/anvil/src/tasks/mod.rs
+++ b/crates/anvil/src/tasks/mod.rs
@@ -41,7 +41,10 @@ impl TaskManager {
     /// Spawns the blocking task and returns a handle to it.
     ///
     /// Returning the `JoinHandle` allows callers to cancel the task or await its completion.
-    pub fn spawn_blocking(&self, task: impl Future<Output = ()> + Send + 'static) -> JoinHandle<()> {
+    pub fn spawn_blocking(
+        &self,
+        task: impl Future<Output = ()> + Send + 'static,
+    ) -> JoinHandle<()> {
         let handle = self.tokio_handle.clone();
         self.tokio_handle.spawn_blocking(move || {
             handle.block_on(task);


### PR DESCRIPTION

- **Summary**: `TaskManager::spawn_blocking` now returns a `JoinHandle<()>`, aligning it with `spawn` and enabling callers to await, cancel, or observe task failures.
- **Rationale**: Previously the handle was dropped, making it impossible to control or inspect spawned blocking tasks, which could lead to leaks and harder shutdown/error handling.
- **Change**: Function signature updated and docs expanded. 

- **Breaking change**: Yes — call sites must handle the returned `JoinHandle`.

- **Migration**:
```rust
// Before
task_manager.spawn_blocking(async { /* work */ });

// After
let handle = task_manager.spawn_blocking(async { /* work */ });
// Optionally:
handle.abort(); // or: let _ = handle.await;
```


