### PR TITLE
chore(anvil): fixed broken link

### DIFF
--- a/crates/anvil/rpc/src/error.rs
+++ b/crates/anvil/rpc/src/error.rs
@@ -84,7 +84,7 @@ pub enum ErrorCode {
     InvalidParams,
     /// internal call error
     InternalError,
-    /// Failed to send transaction, See also <https://github.com/MetaMask/eth-rpc-errors/blob/main/src/error-constants.ts>
+    /// Failed to send transaction, See also <https://github.com/MetaMask/rpc-errors/blob/main/src/error-constants.ts>
     TransactionRejected,
     /// Custom geth error code, <https://github.com/vapory-legacy/wiki/blob/master/JSON-RPC-Error-Codes-Improvement-Proposal.md>
     ExecutionError,


### PR DESCRIPTION
Hi! I found dead link in code and fixed their.
https://github.com/MetaMask/eth-rpc-errors/blob/main/src/error-constants.ts
<img width="535" height="211" alt="image" src="https://github.com/user-attachments/assets/0f114644-a0a0-4e11-bd8c-e41525f63c1d" />
