### PR TITLE
fix(npm): robust fallback to dist binary in forge launcher

### DIFF
--- a/npm/src/forge.ts
+++ b/npm/src/forge.ts
@@ -9,14 +9,22 @@ const require = NodeModule.createRequire(import.meta.url)
 const __dirname = NodePath.dirname(fileURLToPath(import.meta.url))
 
 function getBinaryPath() {
+  // Try to resolve the platform-specific binary path from the installed package
+  let resolvedPath: string | undefined
   try {
-    const binaryPath = require.resolve(`${PLATFORM_SPECIFIC_PACKAGE_NAME}/bin/${BINARY_NAME}`)
-    if (NodeFS.existsSync(binaryPath)) return binaryPath
-  } catch {
-    // Fall back to the binary written by postinstall into dist/
-    return NodePath.join(__dirname, '..', 'dist', BINARY_NAME)
-  }
+    resolvedPath = require.resolve(`${PLATFORM_SPECIFIC_PACKAGE_NAME}/bin/${BINARY_NAME}`)
+  } catch {}
 
+  // Fallback to the binary written by postinstall into dist/
+  const fallbackPath = NodePath.join(__dirname, '..', 'dist', BINARY_NAME)
+
+  // Prefer the resolved package binary if it exists
+  if (resolvedPath && NodeFS.existsSync(resolvedPath)) return resolvedPath
+
+  // Otherwise, use the postinstall fallback binary if present
+  if (NodeFS.existsSync(fallbackPath)) return fallbackPath
+  
+  // If neither binary exists, report a clear error and exit
   console.error(colors.red, `Platform-specific package ${PLATFORM_SPECIFIC_PACKAGE_NAME} not found.`)
   console.error(colors.yellow, 'This usually means the installation failed or your platform is not supported.')
   console.error(colors.reset)


### PR DESCRIPTION


### Summary
Ensure the CLI uses the bundled dist binary when the platform package resolves but its binary file is missing, improving reliability on partially installed or corrupted environments.

### Changes
- Refactor `getBinaryPath()` to:
  - Prefer resolved platform-specific binary only if the file exists.
  - Fallback to `dist/forge` (or `forge.exe` on Windows) when the resolved path is missing.
  - Exit with a clear error only if neither binary is available.


### Why
`require.resolve(...)` can succeed while the actual file is missing (e.g., cache/corruption). Previously, the launcher didn’t use the fallback in this case, causing unnecessary failures.

