### PR TITLE
fix(forge): use global json arg everywhere

### DIFF
--- a/crates/forge/src/cmd/eip712.rs
+++ b/crates/forge/src/cmd/eip712.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{B256, keccak256};
 use clap::{Parser, ValueHint};
 use eyre::Result;
 use foundry_cli::{opts::BuildOpts, utils::LoadConfig};
-use foundry_common::compile::ProjectCompiler;
+use foundry_common::{compile::ProjectCompiler, shell};
 use serde::Serialize;
 use solar::sema::{
     Gcx, Hir,
@@ -24,10 +24,6 @@ pub struct Eip712Args {
     /// The path to the file from which to read struct definitions.
     #[arg(value_hint = ValueHint::FilePath, value_name = "PATH")]
     pub target_path: PathBuf,
-
-    /// Output in JSON format.
-    #[arg(long, help = "Output in JSON format")]
-    pub json: bool,
 
     #[command(flatten)]
     build: BuildOpts,
@@ -72,7 +68,7 @@ impl Eip712Args {
                 })
                 .collect::<Vec<_>>();
 
-            if self.json {
+            if shell::is_json() {
                 sh_println!("{json}", json = serde_json::to_string_pretty(&outputs)?)?;
             } else {
                 for output in &outputs {

--- a/crates/forge/src/cmd/geiger.rs
+++ b/crates/forge/src/cmd/geiger.rs
@@ -49,7 +49,6 @@ impl GeigerArgs {
             paths: self.paths,
             severity: None,
             lint: Some(vec!["unsafe-cheatcode".to_string()]),
-            json: false,
             build: self.build,
         };
         lint_args.build.deny = Some(DenyLevel::Notes);

--- a/crates/forge/src/cmd/lint.rs
+++ b/crates/forge/src/cmd/lint.rs
@@ -8,7 +8,7 @@ use foundry_cli::{
     opts::BuildOpts,
     utils::{FoundryPathExt, LoadConfig},
 };
-use foundry_common::compile::ProjectCompiler;
+use foundry_common::{compile::ProjectCompiler, shell};
 use foundry_compilers::{solc::SolcLanguage, utils::SOLC_EXTENSIONS};
 use foundry_config::{filter::expand_globs, lint::Severity};
 use std::path::PathBuf;
@@ -30,10 +30,6 @@ pub struct LintArgs {
     /// `exclude_lints` project config.
     #[arg(long = "only-lint", value_name = "LINT_ID", num_args(1..))]
     pub(crate) lint: Option<Vec<String>>,
-
-    /// Activates the linter's JSON formatter (rustc-compatible).
-    #[arg(long)]
-    pub(crate) json: bool,
 
     #[command(flatten)]
     pub(crate) build: BuildOpts,
@@ -103,7 +99,7 @@ impl LintArgs {
         }
 
         let linter = SolidityLinter::new(path_config)
-            .with_json_emitter(self.json)
+            .with_json_emitter(shell::is_json())
             .with_description(true)
             .with_lints(include)
             .without_lints(exclude)


### PR DESCRIPTION
## Motivation

Close #11840

## Solution
- removed json args shadowing global json arg for the following subcommands:
  - eip712
  - lint

- geiger subcommand (alias to lint) now complies to global json arg

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes (I don't think so...)
