### PR TITLE
fix(npm/prepublish): stage binary into packagePath/bin and handle forge.exe on Windows

### DIFF
--- a/npm/scripts/prepublish.ts
+++ b/npm/scripts/prepublish.ts
@@ -73,12 +73,13 @@ function getPlatformInfo() {
 
 function findForgeBinary(arch: string, platform: string, profile: string) {
   const targetDir = TARGET_MAP[`${arch}-${platform}` as keyof typeof TARGET_MAP]
-  const targetPath = NodePath.join(process.cwd(), '..', 'target', targetDir, profile, 'forge')
+  const binaryName = platform === 'win32' ? 'forge.exe' : 'forge'
+  const targetPath = NodePath.join(process.cwd(), '..', 'target', targetDir, profile, binaryName)
 
   if (NodeFS.existsSync(targetPath))
     return targetPath
 
-  return NodePath.join(process.cwd(), '..', 'target', 'release', 'forge')
+  return NodePath.join(process.cwd(), '..', 'target', 'release', binaryName)
 }
 
 async function cleanPackageDirectory(packagePath: string) {
@@ -112,7 +113,8 @@ async function copyBinary(forgeBinPath: string, packagePath: string, platform: s
     throw new Error(`Source binary not found at ${forgeBinPath}`)
 
   const binaryName = platform === 'win32' ? 'forge.exe' : 'forge'
-  const targetDir = NodePath.join('@foundry-rs', NodePath.basename(packagePath), 'bin')
+  // Ensure we write inside the prepared package directory
+  const targetDir = NodePath.join(packagePath, 'bin')
 
   NodeFS.mkdirSync(targetDir, { recursive: true })
 


### PR DESCRIPTION
This PR fixes two issues in the prepublish script: (1) the binary was being staged to a relative path @foundry-rs/.../bin instead of the prepared packagePath/bin, which could place it outside the package directory and break published artifacts; (2) findForgeBinary() hardcoded 'forge' and would fail to locate forge.exe on Windows. The changes ensure the binary is correctly placed inside the package directory and use the proper executable name based on platform (forge.exe for Windows, forge otherwise). This improves cross-platform reliability of the npm packaging process without breaking existing functionality.