### PR TITLE
fix(fmt): preserve comments in tuple LHS with uninitialized vars (DeclMulti)

### DIFF
--- a/crates/fmt/testdata/Repros/fmt.sol
+++ b/crates/fmt/testdata/Repros/fmt.sol
@@ -166,6 +166,30 @@ contract DbgFmtTest is Test {
     }
 }
 
+// https://github.com/foundry-rs/foundry/issues/11836
+contract TupleLhsComments {
+    function f() external pure {
+        (
+            /* poolIndex */, // comment in empty slot 0
+            uint256 sellAmount1,
+            uint256 buyAmount1,
+            /* poolKey1 */, /* sellToken */, /* buyToken */, /* sellTokenBalanceBefore */,
+            uint256 buyTokenBalanceBefore1,
+            /* hashMul */,
+            /* hashMod */
+        ) = _swapPre(2, TOTAL_SUPPLY / 1_000, false, zeroForOne1);
+
+        (
+            , /* poolIndex */
+            uint256 sellAmount1,
+            uint256 buyAmount1, /* poolKey1 */ /* sellToken */ /* buyToken */ /* sellTokenBalanceBefore */ /* hashMul */
+            /* hashMod */
+            ,,,,
+            uint256 buyTokenBalanceBefore1,,
+        ) = _swapPre(2, TOTAL_SUPPLY / 1_000, false, zeroForOne1);
+    }
+}
+
 // https://github.com/foundry-rs/foundry/issues/11249
 function argListRepro(address tokenIn, uint256 amountIn, bool data) {
     maverickV2SwapCallback(

--- a/crates/fmt/testdata/Repros/original.sol
+++ b/crates/fmt/testdata/Repros/original.sol
@@ -167,6 +167,30 @@ contract DbgFmtTest is Test {
     }
 }
 
+// https://github.com/foundry-rs/foundry/issues/11836
+contract TupleLhsComments {
+    function f() external pure {
+        (
+            /* poolIndex */, // comment in empty slot 0
+            uint256 sellAmount1,
+            uint256 buyAmount1,
+            /* poolKey1 */, /* sellToken */, /* buyToken */, /* sellTokenBalanceBefore */,
+            uint256 buyTokenBalanceBefore1,
+            /* hashMul */,
+            /* hashMod */
+        ) = _swapPre(2, TOTAL_SUPPLY / 1_000, false, zeroForOne1);
+
+        (
+            , /* poolIndex */
+            uint256 sellAmount1,
+            uint256 buyAmount1, /* poolKey1 */ /* sellToken */ /* buyToken */ /* sellTokenBalanceBefore */ /* hashMul */
+            /* hashMod */
+            ,,,,
+            uint256 buyTokenBalanceBefore1,,
+        ) = _swapPre(2, TOTAL_SUPPLY / 1_000, false, zeroForOne1);
+    }
+}
+
 // https://github.com/foundry-rs/foundry/issues/11249
 function argListRepro(address tokenIn, uint256 amountIn, bool data) {
     maverickV2SwapCallback(


### PR DESCRIPTION
Fix #11836 

Problem: In multi-variable declarations (DeclMulti), empty tuple slots are represented as None, so they lack span information. Without spans, the formatter cannot anchor comments between commas for uninitialized positions, causing comments to merge, drift, or be misplaced.

Solution: Compute synthetic per-slot spans for the tuple LHS by scanning the source between the ( of the declaration and the start of the initializer =. Split at top-level commas (skipping nested parens and comments) to derive a span for each slot, including empty ones. Pass these spans to the list/tuple printer so print_comments can correctly place comments even when the slot has no variable.