### PR TITLE
refactor: remove redundant intermediate variable in etherscan identifier

### DIFF
--- a/crates/evm/traces/src/identifier/etherscan.rs
+++ b/crates/evm/traces/src/identifier/etherscan.rs
@@ -108,12 +108,11 @@ impl EtherscanIdentifier {
         address: Address,
         metadata: &Metadata,
     ) -> IdentifiedAddress<'static> {
-        let label = metadata.contract_name.clone();
         let abi = metadata.abi().ok().map(Cow::Owned);
         IdentifiedAddress {
             address,
-            label: Some(label.clone()),
-            contract: Some(label),
+            label: Some(metadata.contract_name.clone()),
+            contract: Some(metadata.contract_name.clone()),
             abi,
             artifact_id: None,
         }


### PR DESCRIPTION
Remove unnecessary `label` variable in `identify_from_metadata()` function.
The variable was used only to clone `metadata.contract_name` and then clone it again, which can be simplified by directly cloning the source.
## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
