### PR TITLE
fix(fmt): use dos2unix FileLoader for windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9143,8 +9143,7 @@ dependencies = [
 [[package]]
 name = "solar-ast"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bacae15e3ff9a01747580d0ee9816ff6a51fa26f190cdc51b46263d555f7333b"
+source = "git+https://github.com/0xrusowsky/solar.git?branch=chore%2Fdos2unix-loader#4cf723f767d8b0d5d64e7c0c5c9e62ea1370174c"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -9160,8 +9159,7 @@ dependencies = [
 [[package]]
 name = "solar-compiler"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf8d32cb292fcb5aab4158bd3215f7e3515424acfe780e54283bd520abf395a"
+source = "git+https://github.com/0xrusowsky/solar.git?branch=chore%2Fdos2unix-loader#4cf723f767d8b0d5d64e7c0c5c9e62ea1370174c"
 dependencies = [
  "alloy-primitives",
  "solar-ast",
@@ -9176,8 +9174,7 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f0368370d4e7bc45586dfa545867f6685c1d8ec46a29843031f0563c88e4ff"
+source = "git+https://github.com/0xrusowsky/solar.git?branch=chore%2Fdos2unix-loader#4cf723f767d8b0d5d64e7c0c5c9e62ea1370174c"
 dependencies = [
  "colorchoice",
  "strum 0.27.2",
@@ -9186,8 +9183,7 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e246a9af3cc34b40e7612b600a5495f70768bdd365f9fa338d64afb33a59a96b"
+source = "git+https://github.com/0xrusowsky/solar.git?branch=chore%2Fdos2unix-loader#4cf723f767d8b0d5d64e7c0c5c9e62ea1370174c"
 dependencies = [
  "bumpalo",
  "index_vec",
@@ -9201,8 +9197,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e2e4dec38bc1940946f8d303260920f57022dc5a558a3786c3b83e121c23c6"
+source = "git+https://github.com/0xrusowsky/solar.git?branch=chore%2Fdos2unix-loader#4cf723f767d8b0d5d64e7c0c5c9e62ea1370174c"
 dependencies = [
  "annotate-snippets 0.12.4",
  "anstream",
@@ -9210,7 +9205,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "itoa",
  "normalize-path",
  "once_map",
@@ -9221,7 +9216,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.16",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.0",
 ]
@@ -9229,8 +9224,7 @@ dependencies = [
 [[package]]
 name = "solar-macros"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b3d7b35daa205064e7965584b3144b73b38acce2257c21d01e351b8f8812d7"
+source = "git+https://github.com/0xrusowsky/solar.git?branch=chore%2Fdos2unix-loader#4cf723f767d8b0d5d64e7c0c5c9e62ea1370174c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9240,13 +9234,12 @@ dependencies = [
 [[package]]
 name = "solar-parse"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54766e7b5696cdfad50c0ea325035dd106ed2377635f1eb45db3043b6d117373"
+source = "git+https://github.com/0xrusowsky/solar.git?branch=chore%2Fdos2unix-loader#4cf723f767d8b0d5d64e7c0c5c9e62ea1370174c"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.9.4",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -9262,8 +9255,7 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "979354fd20a7ee6229d66d49a3c3ca1e37be0e780b5b6aa864109c327142b529"
+source = "git+https://github.com/0xrusowsky/solar.git?branch=chore%2Fdos2unix-loader#4cf723f767d8b0d5d64e7c0c5c9e62ea1370174c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -431,7 +431,7 @@ rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6
 # foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-fork-db", rev = "eee6563" }
 
 # solar
-# solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar.git", branch = "main" }
-# solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar.git", branch = "main" }
-# solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar.git", branch = "main" }
-# solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar.git", branch = "main" }
+solar = { package = "solar-compiler", git = "https://github.com/0xrusowsky/solar.git", branch = "chore/dos2unix-loader" }
+solar-interface = { package = "solar-interface", git = "https://github.com/0xrusowsky/solar.git", branch = "chore/dos2unix-loader" }
+solar-ast = { package = "solar-ast", git = "https://github.com/0xrusowsky/solar.git", branch = "chore/dos2unix-loader" }
+solar-sema = { package = "solar-sema", git = "https://github.com/0xrusowsky/solar.git", branch = "chore/dos2unix-loader" }

--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -367,7 +367,7 @@ impl<'ast> ast::Visit<'ast> for SourceVisitor<'_> {
                     stmt.span,
                 );
             }
-            StmtKind::For { body, .. } => {
+            StmtKind::For(yul::StmtFor { body, .. }) => {
                 self.push_stmt(body.span);
             }
             StmtKind::Switch(switch) => {

--- a/crates/fmt/src/state/yul.rs
+++ b/crates/fmt/src/state/yul.rs
@@ -43,18 +43,18 @@ impl<'ast> State<'_, 'ast> {
                 self.space();
                 self.s.offset(self.ind);
                 self.ibox(0);
-                self.print_yul_expr_call(expr_call, span);
+                self.print_yul_expr(expr_call);
                 self.end();
                 self.end();
             }
-            yul::StmtKind::Expr(expr_call) => self.print_yul_expr_call(expr_call, span),
+            yul::StmtKind::Expr(expr_call) => self.print_yul_expr(expr_call),
             yul::StmtKind::If(expr, stmts) => {
                 self.word("if ");
                 self.print_yul_expr(expr);
                 self.nbsp();
                 self.print_yul_block(stmts, span, false);
             }
-            yul::StmtKind::For { init, cond, step, body } => {
+            yul::StmtKind::For(yul::StmtFor { init, cond, step, body }) => {
                 self.ibox(0);
 
                 self.word("for ");

--- a/crates/forge/src/cmd/fmt.rs
+++ b/crates/forge/src/cmd/fmt.rs
@@ -138,15 +138,15 @@ impl FmtArgs {
             Input::Stdin(_) => unreachable!(),
         };
 
-        let mut compiler = Compiler::new({
-            let source_map = SourceMap::default();
-            if cfg!(windows) {
-                source_map.set_file_loader(RealFileLoaderDos2Unix);
-            }
+        let source_map = SourceMap::default();
+        if cfg!(windows) {
+            source_map.set_file_loader(RealFileLoaderDos2Unix);
+        }
 
+        let mut compiler = Compiler::new({
             solar::interface::Session::builder()
-                .with_buffer_emitter(Default::default())
                 .source_map(Arc::new(source_map))
+                .with_buffer_emitter(Default::default())
                 .build()
         });
 

--- a/crates/forge/tests/cli/fmt_integration.rs
+++ b/crates/forge/tests/cli/fmt_integration.rs
@@ -25,5 +25,4 @@ fmt_test!(
     "e41f2b9b7ed677ca03ff7bd7221a4e2fdd55504f"
 );
 
-#[cfg(not(windows))]
 fmt_test!(fmt_0x_settler, "0xProject", "0x-settler", "a388c8251ab6c4bedce1641b31027d7b1136daef");

--- a/crates/forge/tests/it/table.rs
+++ b/crates/forge/tests/it/table.rs
@@ -200,7 +200,7 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 
 "#]]);
 
-    cmd.forge_fuse().args(["coverage"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse().args(["coverage", "--exclude-tests"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!


### PR DESCRIPTION
attempt to close by upstreaming CRLF handling to solar via a dedicated `FileLoader`:
- [ ] https://github.com/foundry-rs/foundry/issues/11841

