### PR TITLE
fix(forge): same way to flatten for all commands

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -30,10 +30,10 @@ use foundry_common::{
     TransactionReceiptWithRevertReason,
     abi::{coerce_value, encode_function_args, get_event, get_func},
     compile::etherscan_project,
+    flatten,
     fmt::*,
     fs, get_pretty_tx_receipt_attr, shell,
 };
-use foundry_compilers::flatten::Flattener;
 use foundry_config::Chain;
 use foundry_evm_core::ic::decode_instructions;
 use futures::{FutureExt, StreamExt, future::Either};
@@ -2192,7 +2192,7 @@ impl SimpleCast {
         let project = etherscan_project(metadata, tmp.path())?;
         let target_path = project.find_contract_path(&metadata.contract_name)?;
 
-        let flattened = Flattener::new(project, &target_path)?.flatten();
+        let flattened = flatten(project, &target_path)?;
 
         if let Some(path) = output_path {
             fs::create_dir_all(path.parent().unwrap())?;

--- a/crates/forge/src/cmd/flatten.rs
+++ b/crates/forge/src/cmd/flatten.rs
@@ -4,12 +4,7 @@ use foundry_cli::{
     opts::{BuildOpts, ProjectPathOpts},
     utils::LoadConfig,
 };
-use foundry_common::{compile::with_compilation_reporter, fs};
-use foundry_compilers::{
-    compilers::solc::SolcLanguage,
-    error::SolcError,
-    flatten::{Flattener, FlattenerError},
-};
+use foundry_common::{flatten, fs};
 use std::path::PathBuf;
 
 /// CLI arguments for `forge flatten`.
@@ -44,22 +39,7 @@ impl FlattenArgs {
         let project = config.ephemeral_project()?;
 
         let target_path = dunce::canonicalize(target_path)?;
-
-        let flattener = with_compilation_reporter(true, Some(project.root().to_path_buf()), || {
-            Flattener::new(project.clone(), &target_path)
-        });
-
-        let flattened = match flattener {
-            Ok(flattener) => Ok(flattener.flatten()),
-            Err(FlattenerError::Compilation(_)) => {
-                // Fallback to the old flattening implementation if we couldn't compile the target
-                // successfully. This would be the case if the target has invalid
-                // syntax. (e.g. Solang)
-                project.paths.with_language::<SolcLanguage>().flatten(&target_path)
-            }
-            Err(FlattenerError::Other(err)) => Err(err),
-        }
-        .map_err(|err: SolcError| eyre::eyre!("Failed to flatten: {err}"))?;
+        let flattened = flatten(project, &target_path)?;
 
         match output {
             Some(output) => {

--- a/crates/verify/src/etherscan/flatten.rs
+++ b/crates/verify/src/etherscan/flatten.rs
@@ -1,7 +1,8 @@
 use super::{EtherscanSourceProvider, VerifyArgs};
 use crate::provider::VerificationContext;
-use eyre::{Context, Result};
+use eyre::Result;
 use foundry_block_explorers::verify::CodeFormat;
+use foundry_common::flatten;
 use foundry_compilers::{
     AggregatedCompilerOutput,
     artifacts::{BytecodeHash, Source, Sources},
@@ -32,18 +33,15 @@ impl EtherscanSourceProvider for EtherscanFlattenedSource {
             bch,
         );
 
-        let source = context
-            .project
-            .paths
-            .clone()
-            .with_language::<SolcLanguage>()
-            .flatten(&context.target_path)
-            .wrap_err("Failed to flatten contract")?;
-
+        let flattened_source = flatten(context.project.clone(), &context.target_path)?;
         if !args.force {
             // solc dry run of flattened code
-            self.check_flattened(source.clone(), &context.compiler_version, &context.target_path)
-                .map_err(|err| {
+            self.check_flattened(
+                flattened_source.clone(),
+                &context.compiler_version,
+                &context.target_path,
+            )
+            .map_err(|err| {
                 eyre::eyre!(
                     "Failed to compile the flattened code locally: `{}`\
             To skip this solc dry, have a look at the `--force` flag of this command.",
@@ -52,7 +50,7 @@ impl EtherscanSourceProvider for EtherscanFlattenedSource {
             })?;
         }
 
-        Ok((source, context.target_name.clone(), CodeFormat::SingleFile))
+        Ok((flattened_source, context.target_name.clone(), CodeFormat::SingleFile))
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #11754 use consistent flatten for `forge flatten`, `forge verify-contract` and `cast src`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
