### PR TITLE
fix(fmt): always return formatted when source read from stdin

### DIFF
--- a/crates/forge/src/cmd/fmt.rs
+++ b/crates/forge/src/cmd/fmt.rs
@@ -127,12 +127,19 @@ impl FmtArgs {
                     let path = source_unit.file.name.as_real();
                     let original = source_unit.file.src.as_str();
                     let formatted = forge_fmt::format_ast(gcx, source_unit, fmt_config.clone())?;
+                    let from_stdin = path.is_none();
+
+                    // Return formatted code when read from stdin without check or raw switch.
+                    // <https://github.com/foundry-rs/foundry/issues/11871>
+                    if from_stdin && !self.check && !self.raw {
+                        return Some(Ok(formatted));
+                    }
 
                     if original == formatted {
                         return None;
                     }
 
-                    if self.check || path.is_none() {
+                    if self.check || from_stdin {
                         let summary = if self.raw {
                             formatted
                         } else {

--- a/crates/forge/tests/cli/fmt.rs
+++ b/crates/forge/tests/cli/fmt.rs
@@ -89,3 +89,12 @@ Diff in stdin:
 
 "#]]);
 });
+
+// Test that original is returned if read from stdin and no diff.
+// <https://github.com/foundry-rs/foundry/issues/11871>
+forgetest!(fmt_stdin_original, |_prj, cmd| {
+    cmd.args(["fmt", "-"]);
+
+    cmd.stdin(FORMATTED.as_bytes());
+    cmd.assert_success().stdout_eq(FORMATTED.as_bytes());
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #11871
- always return formatted when source read from stdin (and no other args `check` or `raw` passed)
- vscode plugin use stdin and replace content with `forge fmt` output
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
