### PR TITLE
fix(prevrandao not set): support gnosis network

### DIFF
--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -55,7 +55,7 @@ pub fn apply_chain_and_block_specific_env_changes<N: Network>(
                 env.block.prevrandao = Some(env.block.difficulty.into());
                 return;
             }
-            Moonbeam | Moonbase | Moonriver | MoonbeamDev | Rsk | RskTestnet | Quicknode => {
+            Moonbeam | Moonbase | Moonriver | MoonbeamDev | Rsk | RskTestnet | Gnosis => {
                 if env.block.prevrandao.is_none() {
                     // <https://github.com/foundry-rs/foundry/issues/4232>
                     env.block.prevrandao = Some(B256::random());

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -55,7 +55,7 @@ pub fn apply_chain_and_block_specific_env_changes<N: Network>(
                 env.block.prevrandao = Some(env.block.difficulty.into());
                 return;
             }
-            Moonbeam | Moonbase | Moonriver | MoonbeamDev | Rsk | RskTestnet => {
+            Moonbeam | Moonbase | Moonriver | MoonbeamDev | Rsk | RskTestnet | Quicknode => {
                 if env.block.prevrandao.is_none() {
                     // <https://github.com/foundry-rs/foundry/issues/4232>
                     env.block.prevrandao = Some(B256::random());

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -55,7 +55,7 @@ pub fn apply_chain_and_block_specific_env_changes<N: Network>(
                 env.block.prevrandao = Some(env.block.difficulty.into());
                 return;
             }
-            Moonbeam | Moonbase | Moonriver | MoonbeamDev | Rsk | RskTestnet | Gnosis => {
+            Moonbeam | Moonbase | Moonriver | MoonbeamDev | Rsk | RskTestnet | Gnosis | GnosisTestnet | GnosisChiado => {
                 if env.block.prevrandao.is_none() {
                     // <https://github.com/foundry-rs/foundry/issues/4232>
                     env.block.prevrandao = Some(B256::random());

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -55,7 +55,7 @@ pub fn apply_chain_and_block_specific_env_changes<N: Network>(
                 env.block.prevrandao = Some(env.block.difficulty.into());
                 return;
             }
-            Moonbeam | Moonbase | Moonriver | MoonbeamDev | Rsk | RskTestnet | Gnosis | GnosisTestnet | GnosisChiado => {
+            Moonbeam | Moonbase | Moonriver | MoonbeamDev | Rsk | RskTestnet | Gnosis | Chiado => {
                 if env.block.prevrandao.is_none() {
                     // <https://github.com/foundry-rs/foundry/issues/4232>
                     env.block.prevrandao = Some(B256::random());


### PR DESCRIPTION
## Motivation

I make some tests in Gnosis network:
```solidity
    function setUp() public {
        string memory RPC_URL = vm.envString("GNOSIS_MAINNET_RPC");
        vm.createSelectFork(RPC_URL, 21_120_284 - 1);
```
Then I get that error:
```bash
[FAIL: EVM error; header validation error: `prevrandao` not set]
```
I find the relevant issues: https://github.com/foundry-rs/foundry/issues/4232

Here is the provider I use:
```bash
https://weathered-silent-panorama.xdai.quiknode.pro/xxxxxxxxxxxx
```

## Solution

Just add `Gnosis`

## PR Checklist

btw I am not sure how to run the test. Could u kindly provide a demo so that I could test it in my side? And then I could add a test case in this PR.

<img width="1089" height="170" alt="image" src="https://github.com/user-attachments/assets/43ec3a39-99d3-44e0-8dc2-0bd28a1da59d" />


- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
