### PR TITLE
fix(verify): handle missing optimizer_runs mismatch message

### DIFF
--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -229,7 +229,7 @@ fn find_mismatch_in_settings(
     {
         let str = format!(
             "Optimizer runs mismatch: local={}, onchain={}",
-            local_settings.optimizer_runs.unwrap(),
+            local_settings.optimizer_runs.map_or("unknown".to_string(), |runs| runs.to_string()),
             etherscan_settings.runs
         );
         mismatches.push(str);


### PR DESCRIPTION
- avoid unwrap panic when optimizer_runs is unset during verification mismatch reporting
- display “unknown” for missing local optimizer runs so error output stays informative without changing matching logic