### PR TITLE
fix: strip 0x/0X before U256::from_str_radix to prevent hex parsing errors

### DIFF
--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -149,8 +149,8 @@ where
 /// If the string represents an untagged amount (e.g. "100") then
 /// it is interpreted as wei.
 pub fn parse_ether_value(value: &str) -> Result<U256> {
-    Ok(if value.starts_with("0x") {
-        U256::from_str_radix(value, 16)?
+    Ok(if let Some(hex) = value.strip_prefix("0x").or_else(|| value.strip_prefix("0X")) {
+        U256::from_str_radix(hex, 16)?
     } else {
         alloy_dyn_abi::DynSolType::coerce_str(&alloy_dyn_abi::DynSolType::Uint(256), value)?
             .as_uint()

--- a/crates/common/src/serde_helpers.rs
+++ b/crates/common/src/serde_helpers.rs
@@ -29,8 +29,8 @@ impl FromStr for Numeric {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Ok(val) = s.parse::<u128>() {
             Ok(Self::U256(U256::from(val)))
-        } else if s.starts_with("0x") {
-            U256::from_str_radix(s, 16).map(Numeric::U256).map_err(|err| err.to_string())
+        } else if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+            U256::from_str_radix(hex, 16).map(Numeric::U256).map_err(|err| err.to_string())
         } else {
             U256::from_str(s).map(Numeric::U256).map_err(|err| err.to_string())
         }

--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -274,8 +274,8 @@ impl FromStr for Numeric {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.starts_with("0x") {
-            U256::from_str_radix(s, 16).map(Numeric::U256).map_err(|err| err.to_string())
+        if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+            U256::from_str_radix(hex, 16).map(Numeric::U256).map_err(|err| err.to_string())
         } else {
             U256::from_str(s).map(Numeric::U256).map_err(|err| err.to_string())
         }


### PR DESCRIPTION
Problem: Calls to U256::from_str_radix(..., 16) were made with “0x…” inputs, but from_str_radix expects strings without base prefixes. This caused parsing failures on otherwise valid hex inputs (e.g., from JSON-RPC/CLI).

Inconsistency: Other parts of the codebase (e.g., cast, anvil) already strip the prefix before calling from_str_radix, leading to divergent behavior and unexpected errors.

Why necessary: Without stripping the prefix, valid hex values could fail to parse, breaking user-facing flows and JSON-RPC handling.

How fixed: Strip 0x/0X before from_str_radix in:
- crates/common/src/serde_helpers.rs (Numeric::from_str)
- crates/config/src/utils.rs (Numeric::from_str)
- crates/cli/src/utils/mod.rs (parse_ether_value)