### PR TITLE
fix(common): avoid panic on invalid calldata selector by propagating parse error

### DIFF
--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -217,7 +217,7 @@ impl OpenChainClient {
             )
         }
 
-        let mut sigs = self.decode_function_selector(calldata[..8].parse().unwrap()).await?;
+        let mut sigs = self.decode_function_selector(calldata[..8].parse()?).await?;
         // Retain only signatures that can be decoded.
         sigs.retain(|sig| abi_decode_calldata(sig, calldata, true, true).is_ok());
         Ok(sigs)


### PR DESCRIPTION
Replace unwrap() with error propagation in decode_calldata when parsing the first 4-byte selector from calldata. Previously, invalid hex (user-provided via CLI) could cause a process panic. Now we return an error instead, aligning with the function’s eyre::Result signature and with pretty_calldata which already uses ? for selector parsing. This prevents unexpected crashes on malformed input and improves UX while keeping behavior consistent across APIs.