### PR TITLE
Improve remote wallet --help commands

### DIFF
--- a/crates/cast/src/cmd/wallet/list.rs
+++ b/crates/cast/src/cmd/wallet/list.rs
@@ -24,13 +24,15 @@ pub struct ListArgs {
 
     /// List accounts from AWS KMS.
     ///
-    /// Ensure either one of AWS_KMS_KEY_IDS (comma-separated) or AWS_KMS_KEY_ID environment variables are set.
+    /// Ensure either one of AWS_KMS_KEY_IDS (comma-separated) or AWS_KMS_KEY_ID environment
+    /// variables are set.
     #[arg(long, hide = !cfg!(feature = "aws-kms"))]
     aws: bool,
 
     /// List accounts from Google Cloud KMS.
     ///
-    /// Ensure the following environment variables are set: GCP_PROJECT_ID, GCP_LOCATION, GCP_KEY_RING, GCP_KEY_NAME, GCP_KEY_VERSION.
+    /// Ensure the following environment variables are set: GCP_PROJECT_ID, GCP_LOCATION,
+    /// GCP_KEY_RING, GCP_KEY_NAME, GCP_KEY_VERSION.
     ///
     /// See: <https://cloud.google.com/kms/docs>
     #[arg(long, hide = !cfg!(feature = "gcp-kms"))]

--- a/crates/wallets/src/multi_wallet.rs
+++ b/crates/wallets/src/multi_wallet.rs
@@ -208,13 +208,15 @@ pub struct MultiWalletOpts {
 
     /// Use AWS Key Management Service.
     ///
-    /// Ensure either one of AWS_KMS_KEY_IDS (comma-separated) or AWS_KMS_KEY_ID environment variables are set.
+    /// Ensure either one of AWS_KMS_KEY_IDS (comma-separated) or AWS_KMS_KEY_ID environment
+    /// variables are set.
     #[arg(long, help_heading = "Wallet options - remote", hide = !cfg!(feature = "aws-kms"))]
     pub aws: bool,
 
     /// Use Google Cloud Key Management Service.
     ///
-    /// Ensure the following environment variables are set: GCP_PROJECT_ID, GCP_LOCATION, GCP_KEY_RING, GCP_KEY_NAME, GCP_KEY_VERSION.
+    /// Ensure the following environment variables are set: GCP_PROJECT_ID, GCP_LOCATION,
+    /// GCP_KEY_RING, GCP_KEY_NAME, GCP_KEY_VERSION.
     ///
     /// See: <https://cloud.google.com/kms/docs>
     #[arg(long, help_heading = "Wallet options - remote", hide = !cfg!(feature = "gcp-kms"))]

--- a/crates/wallets/src/wallet.rs
+++ b/crates/wallets/src/wallet.rs
@@ -78,14 +78,15 @@ pub struct WalletOpts {
     pub trezor: bool,
 
     /// Use AWS Key Management Service.
-    /// 
+    ///
     /// Ensure the AWS_KMS_KEY_ID environment variable is set.
     #[arg(long, help_heading = "Wallet options - remote", hide = !cfg!(feature = "aws-kms"))]
     pub aws: bool,
 
     /// Use Google Cloud Key Management Service.
     ///
-    /// Ensure the following environment variables are set: GCP_PROJECT_ID, GCP_LOCATION, GCP_KEY_RING, GCP_KEY_NAME, GCP_KEY_VERSION.
+    /// Ensure the following environment variables are set: GCP_PROJECT_ID, GCP_LOCATION,
+    /// GCP_KEY_RING, GCP_KEY_NAME, GCP_KEY_VERSION.
     ///
     /// See: <https://cloud.google.com/kms/docs>
     #[arg(long, help_heading = "Wallet options - remote", hide = !cfg!(feature = "gcp-kms"))]


### PR DESCRIPTION
## Motivation
When using `--aws` or `--gcp` flags for `cast send`, it's non-trivial to figure out how to actually use it correctly just by using  `cast send --help` since it isn't very informative. Only by looking into the code can one figure out which env vars they need to set.

## Solution
Add comments to commands that use remote wallet flags so it's easy to figure out how to use these commands when using the `--help` flag.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
