### PR TITLE
docs: explicitly mark `forge geiger` deprecated

### DIFF
--- a/crates/forge/src/cmd/geiger.rs
+++ b/crates/forge/src/cmd/geiger.rs
@@ -41,7 +41,7 @@ impl GeigerArgs {
         }
 
         sh_warn!(
-            "`forge geiger` is just an alias for `forge lint --only-lint unsafe-cheatcode`\n"
+            "`forge geiger` is deprecated, as it is just an alias for `forge lint --only-lint unsafe-cheatcode`\n"
         )?;
 
         // Convert geiger command to lint command with specific lint filter

--- a/crates/forge/src/opts.rs
+++ b/crates/forge/src/opts.rs
@@ -140,7 +140,7 @@ pub enum ForgeSubcommand {
     #[command(visible_alias = "tr")]
     Tree(tree::TreeArgs),
 
-    /// Detects usage of unsafe cheat codes in a project and its dependencies.
+    /// DEPRECATED: Detects usage of unsafe cheat codes in a project and its dependencies.
     ///
     /// This is an alias for `forge lint --only-lint unsafe-cheatcode`.
     Geiger(geiger::GeigerArgs),


### PR DESCRIPTION
## Motivation

`forge geiger` is just a `forge lint` alias.

## Solution

Make it very clear that `forge geiger` might be removed in the future.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
