### PR TITLE
fix(fmt): return formatted code when stdin and `--raw`

### DIFF
--- a/crates/forge/src/cmd/fmt.rs
+++ b/crates/forge/src/cmd/fmt.rs
@@ -129,9 +129,9 @@ impl FmtArgs {
                     let formatted = forge_fmt::format_ast(gcx, source_unit, fmt_config.clone())?;
                     let from_stdin = path.is_none();
 
-                    // Return formatted code when read from stdin without check or raw switch.
+                    // Return formatted code when read from stdin and raw enabled.
                     // <https://github.com/foundry-rs/foundry/issues/11871>
-                    if from_stdin && !self.check && !self.raw {
+                    if from_stdin && self.raw {
                         return Some(Ok(formatted));
                     }
 

--- a/crates/forge/tests/cli/fmt.rs
+++ b/crates/forge/tests/cli/fmt.rs
@@ -44,7 +44,12 @@ forgetest!(fmt_stdin, |_prj, cmd| {
     cmd.stdin(UNFORMATTED.as_bytes());
     cmd.assert_success().stdout_eq(FORMATTED);
 
+    // stdin with `--raw` returns formatted code
     cmd.stdin(FORMATTED.as_bytes());
+    cmd.assert_success().stdout_eq(FORMATTED);
+
+    // stdin with `--check` and without `--raw`returns diff
+    cmd.forge_fuse().args(["fmt", "-", "--check"]);
     cmd.assert_success().stdout_eq("");
 });
 
@@ -93,7 +98,7 @@ Diff in stdin:
 // Test that original is returned if read from stdin and no diff.
 // <https://github.com/foundry-rs/foundry/issues/11871>
 forgetest!(fmt_stdin_original, |_prj, cmd| {
-    cmd.args(["fmt", "-"]);
+    cmd.args(["fmt", "-", "--raw"]);
 
     cmd.stdin(FORMATTED.as_bytes());
     cmd.assert_success().stdout_eq(FORMATTED.as_bytes());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- fmt `--raw` should output raw formatted code in stdin modes
https://github.com/foundry-rs/foundry/blob/fe10724f648a9e034f00e67dbd96539721b44bfe/crates/forge/src/cmd/fmt.rs#L41-L43
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
