### PR TITLE
chore(gitignore): restrict bin ignore to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ CLAUDE.md
 .env
 node_modules
 dist
-bin
+/bin
 _
 *.tgz
 .zed


### PR DESCRIPTION
Limit .gitignore to ignore only root bin (/bin) to avoid hiding nested */bin/ sources; consistent with existing patterns (e.g., npm/.gitignore); does not affect tracked files or CI.