### PR TITLE
docs(Makefile): Precise nextest filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,15 +83,16 @@ docker-build-prepare: ## Prepare the Docker build environment.
 ## Run unit/doc tests and generate html coverage report in `target/llvm-cov/html` folder.
 ## Notice that `llvm-cov` supports doc tests only in nightly builds because the `--doc` flag 
 ## is unstable (https://github.com/taiki-e/cargo-llvm-cov/issues/2).
+.
 .PHONY: test-coverage
 test-coverage: 
-	cargo +nightly llvm-cov --no-report nextest -E 'kind(test) & !test(/\b(issue|ext_integration)/)' && \
+    cargo +nightly llvm-cov --no-report nextest -E 'kind(test) & !test(/^.*repros::issue_/) & !test(/^ext_integration(::|$)/)' && \
 	cargo +nightly llvm-cov --no-report --doc && \
 	cargo +nightly llvm-cov report --doctests --open
 
 .PHONY: test-unit
 test-unit: ## Run unit tests.
-	cargo nextest run -E 'kind(test) & !test(/\b(issue|ext_integration)/)'
+    cargo nextest run -E 'kind(test) & !test(/^.*repros::issue_/) & !test(/^ext_integration(::|$)/)'
 
 .PHONY: test-doc
 test-doc: ## Run doc tests.


### PR DESCRIPTION
## Description

Refine nextest filters to avoid over-excluding tests:
- Previous filter: !test(/\b(issue|ext_integration)/) excluded any test name containing “issue”, not just repros. This risks silently skipping unrelated tests.
- Repros are generated under module path “repros::issue_…”, and ext integration tests are under the “ext_integration” binary.
