### PR TITLE
fix(fmt): rustfmt-like blank lines in stmt blocks

### DIFF
--- a/crates/fmt/testdata/Repros/fmt.sol
+++ b/crates/fmt/testdata/Repros/fmt.sol
@@ -182,6 +182,15 @@ function noBlanksLinesBeforeIdentifiers() public {
     timelockController.grantRole(keccak256("EXECUTOR_ROLE"), address(0));
 }
 
+// https://github.com/foundry-rs/foundry/issues/11913
+function rustfmtBlankLinesInStmtBlocks() public {
+    if (someCondition) {
+        bar = true;
+
+        emit Foo(bar);
+    }
+}
+
 contract NestedCallsTest is Test {
     string constant errMsg = "User provided message";
     uint256 constant maxDecimals = 77;

--- a/crates/fmt/testdata/Repros/original.sol
+++ b/crates/fmt/testdata/Repros/original.sol
@@ -187,6 +187,22 @@ function noBlanksLinesBeforeIdentifiers() public {
         .grantRole(keccak256("EXECUTOR_ROLE"), address(0));
 }
 
+// https://github.com/foundry-rs/foundry/issues/11913
+function rustfmtBlankLinesInStmtBlocks() public {
+        if (someCondition) {
+
+
+
+    bar = true;
+
+
+
+            emit Foo(bar);
+
+
+            }
+}
+
 contract NestedCallsTest is Test {
     string constant errMsg = "User provided message";
     uint256 constant maxDecimals = 77;

--- a/crates/fmt/testdata/Repros/sorted.fmt.sol
+++ b/crates/fmt/testdata/Repros/sorted.fmt.sol
@@ -183,6 +183,15 @@ function noBlanksLinesBeforeIdentifiers() public {
     timelockController.grantRole(keccak256("EXECUTOR_ROLE"), address(0));
 }
 
+// https://github.com/foundry-rs/foundry/issues/11913
+function rustfmtBlankLinesInStmtBlocks() public {
+    if (someCondition) {
+        bar = true;
+
+        emit Foo(bar);
+    }
+}
+
 contract NestedCallsTest is Test {
     string constant errMsg = "User provided message";
     uint256 constant maxDecimals = 77;

--- a/crates/fmt/testdata/Repros/tab.fmt.sol
+++ b/crates/fmt/testdata/Repros/tab.fmt.sol
@@ -183,6 +183,15 @@ function noBlanksLinesBeforeIdentifiers() public {
 	timelockController.grantRole(keccak256("EXECUTOR_ROLE"), address(0));
 }
 
+// https://github.com/foundry-rs/foundry/issues/11913
+function rustfmtBlankLinesInStmtBlocks() public {
+	if (someCondition) {
+		bar = true;
+
+		emit Foo(bar);
+	}
+}
+
 contract NestedCallsTest is Test {
 	string constant errMsg = "User provided message";
 	uint256 constant maxDecimals = 77;


### PR DESCRIPTION
## Motivation

closes #11913 

## Solution

skip blank lines when opening a block

## PR Checklist

- [X] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
