### PR TITLE
fix(forge): do not warn on backward compatible `solc_version` config

### DIFF
--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -110,8 +110,13 @@ impl<P: Provider> WarningsProvider<P> {
                         let is_not_allowed = !allowed_keys.contains(key)
                             && !allowed_keys.contains(&key.to_snake_case());
                         let is_not_reserved = key != "extends" && key != Self::WARNINGS_KEY;
+                        let is_not_backward_compatible = key != "solc_version";
 
-                        if is_not_deprecated && is_not_allowed && is_not_reserved {
+                        if is_not_deprecated
+                            && is_not_allowed
+                            && is_not_reserved
+                            && is_not_backward_compatible
+                        {
                             out.push(Warning::UnknownKey {
                                 key: key.clone(),
                                 profile: profile.clone(),

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1953,6 +1953,7 @@ forgetest!(config_warnings_on_unknown_keys, |prj, cmd| {
     let faulty_toml = r"[profile.default]
     src = 'src'
     out = 'out'
+    solc_version = '0.8.18'
     foo = 'unknown'
 
     [profile.another]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- `solc_version` is a backward compatible config (replaced by `solc`) and removed from dict, should not warn if in config
https://github.com/foundry-rs/foundry/blob/4d07808d1615421746a32a7d2ab8f4a9983a4bc3/crates/config/src/providers/ext.rs#L299-L303 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
