### PR TITLE
fix(fmt): preserve comment position in disabled lines

### DIFF
--- a/crates/fmt/testdata/Repros/fmt.sol
+++ b/crates/fmt/testdata/Repros/fmt.sol
@@ -166,13 +166,14 @@ contract DbgFmtTest is Test {
     }
 }
 
+// https://github.com/foundry-rs/foundry/issues/8557
 // https://github.com/foundry-rs/foundry/issues/11249
 function argListRepro(address tokenIn, uint256 amountIn, bool data) {
     maverickV2SwapCallback(
         tokenIn,
         amountIn, // forgefmt: disable-line
         // forgefmt: disable-next-line
-        0,/* we didn't bother loading `amountOut` because we don't use it */
+        0 /* we didn't bother loading `amountOut` because we don't use it */,
         data
     );
 }

--- a/crates/fmt/testdata/Repros/original.sol
+++ b/crates/fmt/testdata/Repros/original.sol
@@ -167,6 +167,7 @@ contract DbgFmtTest is Test {
     }
 }
 
+// https://github.com/foundry-rs/foundry/issues/8557
 // https://github.com/foundry-rs/foundry/issues/11249
 function argListRepro(address tokenIn, uint256 amountIn, bool data) {
     maverickV2SwapCallback(

--- a/crates/fmt/testdata/Repros/sorted.fmt.sol
+++ b/crates/fmt/testdata/Repros/sorted.fmt.sol
@@ -167,13 +167,14 @@ contract DbgFmtTest is Test {
     }
 }
 
+// https://github.com/foundry-rs/foundry/issues/8557
 // https://github.com/foundry-rs/foundry/issues/11249
 function argListRepro(address tokenIn, uint256 amountIn, bool data) {
     maverickV2SwapCallback(
         tokenIn,
         amountIn, // forgefmt: disable-line
         // forgefmt: disable-next-line
-        0,/* we didn't bother loading `amountOut` because we don't use it */
+        0 /* we didn't bother loading `amountOut` because we don't use it */,
         data
     );
 }

--- a/crates/fmt/testdata/Repros/tab.fmt.sol
+++ b/crates/fmt/testdata/Repros/tab.fmt.sol
@@ -167,13 +167,14 @@ contract DbgFmtTest is Test {
 	}
 }
 
+// https://github.com/foundry-rs/foundry/issues/8557
 // https://github.com/foundry-rs/foundry/issues/11249
 function argListRepro(address tokenIn, uint256 amountIn, bool data) {
 	maverickV2SwapCallback(
 		tokenIn,
 		amountIn, // forgefmt: disable-line
 		// forgefmt: disable-next-line
-		0,/* we didn't bother loading `amountOut` because we don't use it */
+		0 /* we didn't bother loading `amountOut` because we don't use it */,
 		data
 	);
 }


### PR DESCRIPTION
## Motivation

closes #8557 

## Solution

since we ended up deciding that it was better for solar to use a new `SpannedOption<T>` which only added the position of uninformed elements, rather than `Spanned<T>` that would wrap both `Some(T) + None` and inform their surrounding separators, the fix introduces a workaround that:
1. peeks at a comment before the next item
2. checks if the span from the cursor to the cmnt is disabled
3. gets the snippet from the sourcemap and checks if it has any commas

**NOTE:** i know we shouldn't rely on the sm, but imo the workaround is acceptable, as this path seems quite unlikely to be triggered frequently

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
- [ ] Breaking changes
