### PR TITLE
fix(anvil): correct evm_set_time units to seconds

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -466,7 +466,7 @@ pub enum EthRequest {
     SetNextBlockBaseFeePerGas(U256),
 
     /// Sets the specific timestamp
-    /// Accepts timestamp (Unix epoch) with millisecond precision and returns the number of seconds
+    /// Accepts timestamp (Unix epoch, in seconds) and returns the number of seconds
     /// between the given timestamp and the current time.
     #[serde(
         rename = "anvil_setTime",

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2545,7 +2545,7 @@ impl EthApi {
 
         // number of seconds between the given timestamp and the current time.
         let offset = timestamp.saturating_sub(now);
-        Ok(Duration::from_millis(offset).as_secs())
+        Ok(Duration::from_secs(offset).as_secs())
     }
 
     /// Set the next block gas limit


### PR DESCRIPTION
- Replace Duration::from_millis(offset) with Duration::from_secs(offset) since current_call_timestamp() and timestamp are in seconds; previous code divided by 1000, returning an incorrect value.
- Update EvmSetTime RPC docs to state the input is Unix seconds and the return value is seconds delta.
- This fixes incorrect time handling and aligns implementation, tests, and documentation.