### PR TITLE
feat(anvil): wire eth_protocolVersion, eth_hashrate, eth_coinbase RPCs

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -43,6 +43,10 @@ pub enum EthRequest {
     #[serde(rename = "web3_sha3", with = "sequence")]
     Web3Sha3(Bytes),
 
+    /// Returns the current Ethereum protocol version.
+    #[serde(rename = "eth_protocolVersion", with = "empty_params")]
+    EthProtocolVersion(()),
+
     #[serde(rename = "eth_chainId", with = "empty_params")]
     EthChainId(()),
 
@@ -51,6 +55,10 @@ pub enum EthRequest {
 
     #[serde(rename = "net_listening", with = "empty_params")]
     NetListening(()),
+
+    /// Returns the number of hashes per second with which the node is mining.
+    #[serde(rename = "eth_hashrate", with = "empty_params")]
+    EthHashrate(()),
 
     #[serde(rename = "eth_gasPrice", with = "empty_params")]
     EthGasPrice(()),
@@ -66,6 +74,10 @@ pub enum EthRequest {
 
     #[serde(rename = "eth_blockNumber", with = "empty_params")]
     EthBlockNumber(()),
+
+    /// Returns the client coinbase address.
+    #[serde(rename = "eth_coinbase", with = "empty_params")]
+    EthCoinbase(()),
 
     #[serde(rename = "eth_getBalance")]
     EthGetBalance(Address, Option<BlockId>),

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -172,6 +172,7 @@ impl EthApi {
     pub async fn execute(&self, request: EthRequest) -> ResponseResult {
         trace!(target: "rpc::api", "executing eth request");
         let response = match request.clone() {
+            EthRequest::EthProtocolVersion(()) => self.protocol_version().to_rpc_result(),
             EthRequest::Web3ClientVersion(()) => self.client_version().to_rpc_result(),
             EthRequest::Web3Sha3(content) => self.sha3(content).to_rpc_result(),
             EthRequest::EthGetAccount(addr, block) => {
@@ -195,6 +196,7 @@ impl EthApi {
             EthRequest::EthChainId(_) => self.eth_chain_id().to_rpc_result(),
             EthRequest::EthNetworkId(_) => self.network_id().to_rpc_result(),
             EthRequest::NetListening(_) => self.net_listening().to_rpc_result(),
+            EthRequest::EthHashrate(()) => self.hashrate().to_rpc_result(),
             EthRequest::EthGasPrice(_) => self.eth_gas_price().to_rpc_result(),
             EthRequest::EthMaxPriorityFeePerGas(_) => {
                 self.gas_max_priority_fee_per_gas().to_rpc_result()
@@ -202,6 +204,7 @@ impl EthApi {
             EthRequest::EthBlobBaseFee(_) => self.blob_base_fee().to_rpc_result(),
             EthRequest::EthAccounts(_) => self.accounts().to_rpc_result(),
             EthRequest::EthBlockNumber(_) => self.block_number().to_rpc_result(),
+            EthRequest::EthCoinbase(()) => self.author().to_rpc_result(),
             EthRequest::EthGetStorageAt(addr, slot, block) => {
                 self.storage_at(addr, slot, block).await.to_rpc_result()
             }


### PR DESCRIPTION
## Motivation

The codebase had three RPC handler methods (protocol_version, hashrate, author) that were implemented in EthApi but were effectively dead code because they were not exposed through the JSON-RPC interface. These methods existed with proper documentation indicating they were handlers for standard Ethereum RPC calls (eth_protocolVersion, eth_hashrate, eth_coinbase), but they were never wired up in the EthRequest enum or the execute() dispatcher. This meant clients expecting these standard RPC endpoints would receive "method not found" errors, reducing Anvil's compatibility with Ethereum tooling and clients.

## Solution

1. Adding missing EthRequest variants in crates/anvil/core/src/eth/mod.rs:
- EthProtocolVersion(()) for eth_protocolVersion
- EthHashrate(()) for eth_hashrate
- EthCoinbase(()) for eth_coinbase

2. Wiring the handlers in EthApi::execute() in crates/anvil/src/eth/api.rs:
- EthProtocolVersion(_) => self.protocol_version().to_rpc_result()
- EthHashrate(_) => self.hashrate().to_rpc_result()
- EthCoinbase(_) => self.author().to_rpc_result()

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
