### PR TITLE
refactor(anvil): introduce get_block_with_hash and convert_block_with_hash

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2229,7 +2229,7 @@ impl Backend {
 
     fn mined_block_by_hash(&self, hash: B256) -> Option<AnyRpcBlock> {
         let block = self.blockchain.get_block_by_hash(&hash)?;
-        Some(self.convert_block(block))
+        Some(self.convert_block_with_hash(block, Some(hash)))
     }
 
     pub(crate) async fn mined_transactions_by_block_number(
@@ -2298,7 +2298,8 @@ impl Backend {
         Ok(None)
     }
 
-    pub fn get_block(&self, id: impl Into<BlockId>) -> Option<Block> {
+    /// Returns the block and its hash for the given id
+    fn get_block_with_hash(&self, id: impl Into<BlockId>) -> Option<(Block, B256)> {
         let hash = match id.into() {
             BlockId::Hash(hash) => hash.block_hash,
             BlockId::Number(number) => {
@@ -2326,7 +2327,12 @@ impl Backend {
                 }
             }
         };
-        self.get_block_by_hash(hash)
+        let block = self.get_block_by_hash(hash)?;
+        Some((block, hash))
+    }
+
+    pub fn get_block(&self, id: impl Into<BlockId>) -> Option<Block> {
+        self.get_block_with_hash(id).map(|(block, _)| block)
     }
 
     pub fn get_block_by_hash(&self, hash: B256) -> Option<Block> {
@@ -2334,28 +2340,33 @@ impl Backend {
     }
 
     pub fn mined_block_by_number(&self, number: BlockNumber) -> Option<AnyRpcBlock> {
-        let block = self.get_block(number)?;
-        let mut block = self.convert_block(block);
+        let (block, hash) = self.get_block_with_hash(number)?;
+        let mut block = self.convert_block_with_hash(block, Some(hash));
         block.transactions.convert_to_hashes();
         Some(block)
     }
 
     pub fn get_full_block(&self, id: impl Into<BlockId>) -> Option<AnyRpcBlock> {
-        let block = self.get_block(id)?;
+        let (block, hash) = self.get_block_with_hash(id)?;
         let transactions = self.mined_transactions_in_block(&block)?;
-        let mut block = self.convert_block(block);
+        let mut block = self.convert_block_with_hash(block, Some(hash));
         block.inner.transactions = BlockTransactions::Full(transactions);
-
         Some(block)
     }
 
     /// Takes a block as it's stored internally and returns the eth api conform block format.
     pub fn convert_block(&self, block: Block) -> AnyRpcBlock {
+        self.convert_block_with_hash(block, None)
+    }
+
+    /// Takes a block as it's stored internally and returns the eth api conform block format.
+    /// If `known_hash` is provided, it will be used instead of computing `hash_slow()`.
+    pub fn convert_block_with_hash(&self, block: Block, known_hash: Option<B256>) -> AnyRpcBlock {
         let size = U256::from(alloy_rlp::encode(&block).len() as u32);
 
         let Block { header, transactions, .. } = block;
 
-        let hash = header.hash_slow();
+        let hash = known_hash.unwrap_or_else(|| header.hash_slow());
         let Header { number, withdrawals_root, .. } = header;
 
         let block = AlloyBlock {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2166,12 +2166,8 @@ impl Backend {
         }
 
         for number in from..=to {
-            let storage = self.blockchain.storage.read();
-            if let Some(&block_hash) = storage.hashes.get(&number)
-                && let Some(block) = storage.blocks.get(&block_hash).cloned()
-            {
-                drop(storage);
-                all_logs.extend(self.mined_logs_for_block(filter.clone(), block, block_hash));
+            if let Some((block, hash)) = self.get_block_with_hash(number) {
+                all_logs.extend(self.mined_logs_for_block(filter.clone(), block, hash));
             }
         }
 


### PR DESCRIPTION
Introduces `get_block_with_hash` and `convert_block_with_hash` to avoid redundant hash computation.

When fetching blocks, we already have the hash (from parameters or storage lookups), but `convert_block` calls `hash_slow()` to recompute it. The new helpers pass the hash through instead, saving a lot cycles per query.