### PR TITLE
ci: skip flaky Arbitrum fork test that fails due to inconsistent RPC …

### DIFF
--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -193,7 +193,10 @@ test_repro!(4586);
 test_repro!(4630);
 
 // https://github.com/foundry-rs/foundry/issues/4640
-test_repro!(4640);
+test_repro!(
+    #[ignore = "flaky Arbitrum RPC - l1BlockNumber field not always returned"]
+    4640
+);
 
 // https://github.com/foundry-rs/foundry/issues/4832
 // 1.0 related


### PR DESCRIPTION
found this while  #11939 —the `repros::issue_4640` test keeps failing all 3 retry attempts in CI. 

Turns out it relies on Arbitrum RPC returning `l1BlockNumber` in the block response, but the endpoint doesn't always include it. When it's missing, we get L2 block 75219831 instead of the expected L1 block 16939475.

can't depend on that field being there. Ignoring it like `issue_3703` for flaky Polygon RPCs.