### PR TITLE
chore(forge): avoid process::exit in results

### DIFF
--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -8,7 +8,9 @@ static ALLOC: foundry_cli::utils::Allocator = foundry_cli::utils::new_allocator(
 
 fn main() {
     if let Err(err) = run() {
-        let _ = foundry_common::sh_err!("{err:?}");
+        if !(foundry_common::shell::is_quiet() || foundry_common::shell::is_json()) {
+            let _ = foundry_common::sh_err!("{err:?}");
+        }
         std::process::exit(1);
     }
 }

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -167,8 +167,8 @@ impl TestOutcome {
         }
 
         if shell::is_quiet() || silent {
-            // TODO: Avoid process::exit
-            std::process::exit(1);
+            // Return an error instead of exiting the process; caller decides how to handle it.
+            return Err(eyre::eyre!("test failures encountered"));
         }
 
         sh_println!("\nFailing tests:")?;
@@ -192,8 +192,8 @@ impl TestOutcome {
             successes.to_string().green()
         )?;
 
-        // TODO: Avoid process::exit
-        std::process::exit(1);
+        // Return an error instead of exiting the process; caller decides how to handle it.
+        Err(eyre::eyre!("test failures encountered"))
     }
 
     /// Removes first test result, if any.


### PR DESCRIPTION
## Motivation

The TestOutcome::ensure_ok method calls std::process::exit(1), which makes the library code difficult to reuse (impossible to intercept/handle on the caller's side).

## Solution

Replaced both calls to std::process::exit(1) in ensure_ok with a return to Err(...). This matches the method signature and the general error model in the project.
To avoid “breaking” quiet modes (JUnit/JSON) with an additional error string, I corrected the high-level error printing in crates/forge/bin/main.rs. Now sh_err!(“{err:?}”) is definitely printed there before process::exit(1). It is enough to wrap the print with a condition: do not print if shell::is_quiet() or shell::is_json(), but only set the exit code to 1.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
