### PR TITLE
anvil: remove unused BlockNumberOrTag import in hardfork tests

### DIFF
--- a/crates/anvil/src/hardfork.rs
+++ b/crates/anvil/src/hardfork.rs
@@ -95,8 +95,6 @@ pub fn ethereum_hardfork_from_block_tag(block: impl Into<BlockNumberOrTag>) -> E
 mod tests {
     use super::*;
     use alloy_hardforks::ethereum::mainnet::*;
-    #[allow(unused_imports)]
-    use alloy_rpc_types::BlockNumberOrTag;
 
     #[test]
     fn test_ethereum_spec_id_mapping() {


### PR DESCRIPTION
Remove an unused `BlockNumberOrTag` import from the `tests` module in `crates/anvil/src/hardfork.rs`. The import is not referenced and was suppressed with `#[allow(unused_imports)]`. Removing it reduces noise and avoids hiding useful warnings.
