### PR TITLE
chore(npm): remove unused ArchitecturePlatform export from const.ts

### DIFF
--- a/npm/src/const.ts
+++ b/npm/src/const.ts
@@ -16,13 +16,8 @@ export type Platform = Extract<
   'darwin' | 'linux' | 'win32'
 >
 
-/**
- * foundry doesn't ship arm64 binaries for windows
- */
-export type ArchitecturePlatform = Exclude<
-  `${Platform}-${Architecture}`,
-  'win32-arm64'
->
+// Note: we intentionally don't export a combined `Platform-Architecture` alias here,
+// since only specific pairs are supported (see `BINARY_DISTRIBUTION_PACKAGES`).
 
 export const BINARY_DISTRIBUTION_PACKAGES = {
   darwin: {

--- a/npm/src/install.ts
+++ b/npm/src/install.ts
@@ -105,7 +105,7 @@ function extractFileFromTarball(
     if (fileName === filepath)
       return tarballBuffer.subarray(offset, offset + fileSize)
 
-    // Clamp offset to the uppoer multiple of 512
+    // Clamp offset to the upper multiple of 512
     offset = (offset + fileSize + 511) & ~511
   }
   throw new Error(`File ${filepath} not found in tarball`)


### PR DESCRIPTION


### Description
- Removed an unused public type export `ArchitecturePlatform` from `npm/src/const.ts`.
- Keeps the package surface minimal and avoids implying unsupported platform-arch combos.


