### PR TITLE
feat(chisel): use immutable borrow in Debug for SolidityHelper

### DIFF
--- a/crates/chisel/src/solidity_helper.rs
+++ b/crates/chisel/src/solidity_helper.rs
@@ -51,7 +51,7 @@ impl Default for SolidityHelper {
 
 impl fmt::Debug for SolidityHelper {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let this = self.inner.borrow_mut();
+        let this = self.inner.borrow();
         f.debug_struct("SolidityHelper")
             .field("errored", &this.errored)
             .field("do_paint", &this.do_paint)


### PR DESCRIPTION
Replace RefCell::borrow_mut() with borrow() in Debug impl.
Benefits:
- Avoids unnecessary exclusive borrow during formatting.
- Eliminates potential runtime panic if a shared borrow is active.
- Matches Debug’s non-mutating intent and improves robustness with Rc<RefCell<...>>.