### PR TITLE
feat(forge): add flag to disable HTTPS certificate validation for RPC

### DIFF
--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -837,7 +837,7 @@ async fn test_reset_fork_on_new_blocks() {
 
     let anvil_provider = handle.http_provider();
     let endpoint = next_http_rpc_endpoint();
-    let provider = Arc::new(get_http_provider(&endpoint));
+    let provider = Arc::new(get_http_provider(&endpoint, false));
 
     let current_block = anvil_provider.get_block_number().await.unwrap();
 

--- a/crates/anvil/tests/it/utils.rs
+++ b/crates/anvil/tests/it/utils.rs
@@ -8,7 +8,7 @@ use foundry_common::provider::{
 };
 
 pub fn http_provider(http_endpoint: &str) -> RetryProvider {
-    get_http_provider(http_endpoint)
+    get_http_provider(http_endpoint, false)
 }
 
 pub fn http_provider_with_signer(

--- a/crates/cli/src/opts/evm.rs
+++ b/crates/cli/src/opts/evm.rs
@@ -40,6 +40,14 @@ use foundry_common::shell;
 #[derive(Clone, Debug, Default, Serialize, Parser)]
 #[command(next_help_heading = "EVM options", about = None, long_about = None)] // override doc
 pub struct EvmArgs {
+    /// Allow insecure RPC connections (accept invalid HTTPS certificates).
+    ///
+    /// When the provider's inner runtime transport variant is HTTP, this configures the reqwest
+    /// client to accept invalid certificates.
+    #[arg(short = 'k', long = "insecure", default_value = "false")]
+    #[serde(rename = "eth_rpc_accept_invalid_certs")]
+    pub accept_invalid_certs: bool,
+
     /// Fetch state over a remote endpoint instead of starting from an empty state.
     ///
     /// If you want to fetch state from a specific block number, see --fork-block-number.
@@ -188,6 +196,10 @@ impl Provider for EvmArgs {
 
         if let Some(fork_url) = &self.fork_url {
             dict.insert("eth_rpc_url".to_string(), fork_url.clone().into());
+        }
+
+        if self.accept_invalid_certs {
+            dict.insert("eth_rpc_accept_invalid_certs".to_string(), self.accept_invalid_certs.into());
         }
 
         Ok(Map::from([(Config::selected_profile(), dict)]))

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -70,15 +70,15 @@ pub type RetryProviderWithSigner<N = AnyNetwork> = FillProvider<
 /// ```
 #[inline]
 #[track_caller]
-pub fn get_http_provider(builder: impl AsRef<str>) -> RetryProvider {
-    try_get_http_provider(builder).unwrap()
+pub fn get_http_provider(builder: impl AsRef<str>, accept_invalid_certs: bool) -> RetryProvider {
+    try_get_http_provider(builder, accept_invalid_certs).unwrap()
 }
 
 /// Constructs a provider with a 100 millisecond interval poll if it's a localhost URL (most likely
 /// an anvil or other dev node) and with the default, or 7 second otherwise.
 #[inline]
-pub fn try_get_http_provider(builder: impl AsRef<str>) -> Result<RetryProvider> {
-    ProviderBuilder::new(builder.as_ref()).build()
+pub fn try_get_http_provider(builder: impl AsRef<str>, accept_invalid_certs: bool) -> Result<RetryProvider> {
+    ProviderBuilder::new(builder.as_ref()).accept_invalid_certs(accept_invalid_certs).build()
 }
 
 /// Helper type to construct a `RetryProvider`

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -2044,7 +2044,7 @@ mod tests {
     async fn can_read_write_cache() {
         let Some(endpoint) = ENDPOINT else { return };
 
-        let provider = get_http_provider(endpoint);
+        let provider = get_http_provider(endpoint, false);
 
         let block_num = provider.get_block_number().await.unwrap();
 

--- a/crates/evm/core/src/fork/database.rs
+++ b/crates/evm/core/src/fork/database.rs
@@ -278,7 +278,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn fork_db_insert_basic_default() {
         let rpc = foundry_test_utils::rpc::next_http_rpc_endpoint();
-        let provider = get_http_provider(rpc.clone());
+        let provider = get_http_provider(rpc.clone(), false);
         let meta = BlockchainDbMeta::new(Default::default(), rpc);
 
         let db = BlockchainDb::new(meta, None);

--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -544,6 +544,7 @@ async fn create_fork(mut fork: CreateFork) -> eyre::Result<(ForkId, CreatedFork,
             .maybe_initial_backoff(fork.evm_opts.fork_retry_backoff)
             .maybe_headers(fork.evm_opts.fork_headers.clone())
             .compute_units_per_second(fork.evm_opts.get_compute_units_per_second())
+            .accept_invalid_certs(fork.evm_opts.eth_rpc_accept_invalid_certs)
             .build()?,
     );
 

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -82,6 +82,9 @@ pub struct EvmOpts {
 
     /// The CREATE2 deployer's address.
     pub create2_deployer: Address,
+
+    /// Whether to accept invalid certificates for the rpc server.
+    pub eth_rpc_accept_invalid_certs: bool,
 }
 
 impl Default for EvmOpts {
@@ -107,6 +110,7 @@ impl Default for EvmOpts {
             enable_tx_gas_limit: false,
             networks: NetworkConfigs::default(),
             create2_deployer: DEFAULT_CREATE2_DEPLOYER,
+            eth_rpc_accept_invalid_certs: false,
         }
     }
 }
@@ -129,6 +133,7 @@ impl EvmOpts {
     pub async fn fork_evm_env(&self, fork_url: &str) -> eyre::Result<(crate::Env, AnyRpcBlock)> {
         let provider = ProviderBuilder::new(fork_url)
             .compute_units_per_second(self.get_compute_units_per_second())
+            .accept_invalid_certs(self.eth_rpc_accept_invalid_certs)
             .build()?;
         environment(
             &provider,

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -42,7 +42,7 @@ impl BuildData {
     pub async fn link(self, script_config: &ScriptConfig) -> Result<LinkedBuildData> {
         let create2_deployer = script_config.evm_opts.create2_deployer;
         let can_use_create2 = if let Some(fork_url) = &script_config.evm_opts.fork_url {
-            let provider = try_get_http_provider(fork_url)?;
+            let provider = try_get_http_provider(fork_url, script_config.config.eth_rpc_accept_invalid_certs)?;
             let deployer_code = provider.get_code_at(create2_deployer).await?;
 
             !deployer_code.is_empty()
@@ -260,7 +260,7 @@ impl CompiledState {
             None
         } else {
             let fork_url = self.script_config.evm_opts.fork_url.clone().ok_or_eyre("Missing --fork-url field, if you were trying to broadcast a multi-chain sequence, please use --multi flag")?;
-            let provider = Arc::new(try_get_http_provider(fork_url)?);
+            let provider = Arc::new(try_get_http_provider(fork_url, self.args.evm.accept_invalid_certs)?);
             Some(provider.get_chain_id().await?)
         };
 

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -234,9 +234,9 @@ impl RpcData {
     }
 
     /// Checks if all RPCs support EIP-3855. Prints a warning if not.
-    async fn check_shanghai_support(&self) -> Result<()> {
+    async fn check_shanghai_support(&self, accept_invalid_certs: bool) -> Result<()> {
         let chain_ids = self.total_rpcs.iter().map(|rpc| async move {
-            let provider = get_http_provider(rpc);
+            let provider = get_http_provider(rpc, accept_invalid_certs);
             let id = provider.get_chain_id().await.ok()?;
             NamedChain::try_from(id).ok()
         });
@@ -307,7 +307,7 @@ impl ExecutedState {
                 )
             }
         }
-        rpc_data.check_shanghai_support().await?;
+        rpc_data.check_shanghai_support(self.args.evm.accept_invalid_certs).await?;
 
         Ok(PreSimulationState {
             args: self.args,

--- a/crates/script/src/providers.rs
+++ b/crates/script/src/providers.rs
@@ -17,11 +17,12 @@ impl ProvidersManager {
         &mut self,
         rpc: &str,
         is_legacy: bool,
+        accept_invalid_certs: bool,
     ) -> Result<&ProviderInfo> {
         Ok(match self.inner.entry(rpc.to_string()) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
-                let info = ProviderInfo::new(rpc, is_legacy).await?;
+                let info = ProviderInfo::new(rpc, is_legacy, accept_invalid_certs).await?;
                 entry.insert(info)
             }
         })
@@ -52,8 +53,8 @@ pub enum GasPrice {
 }
 
 impl ProviderInfo {
-    pub async fn new(rpc: &str, mut is_legacy: bool) -> Result<Self> {
-        let provider = Arc::new(get_http_provider(rpc));
+    pub async fn new(rpc: &str, mut is_legacy: bool, accept_invalid_certs: bool) -> Result<Self> {
+        let provider = Arc::new(get_http_provider(rpc, accept_invalid_certs));
         let chain = provider.get_chain_id().await?;
 
         if let Some(chain) = Chain::from(chain).named() {

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -283,7 +283,7 @@ impl FilledTransactionsState {
 
         while let Some(mut tx) = txes_iter.next() {
             let tx_rpc = tx.rpc.to_owned();
-            let provider_info = manager.get_or_init_provider(&tx.rpc, self.args.legacy).await?;
+            let provider_info = manager.get_or_init_provider(&tx.rpc, self.args.legacy, self.args.evm.accept_invalid_certs).await?;
 
             if let Some(tx) = tx.tx_mut().as_unsigned_mut() {
                 // Handles chain specific requirements for unsigned transactions.

--- a/crates/test-utils/src/script.rs
+++ b/crates/test-utils/src/script.rs
@@ -64,7 +64,7 @@ impl ScriptTester {
 
         let mut provider = None;
         if let Some(endpoint) = endpoint {
-            provider = Some(get_http_provider(endpoint))
+            provider = Some(get_http_provider(endpoint, false))
         }
 
         Self {


### PR DESCRIPTION
## Motivation

Resolve https://github.com/foundry-rs/foundry/issues/11907#issuecomment-3358036876.

## Solution

- Add `--insecure/-k` flag to `forge script` which toggles ignoring invalid certs (e.g., self-signed)

I'm not sure this PR handles all possible codepaths as new providers are built in many different places and each needs to be configured with `.accept_invalid_certs(bool)`.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
