### PR TITLE
fix(forge): correct import path for generate module in args.rs

### DIFF
--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, watch},
+    cmd::{cache::CacheSubcommands, generate, watch},
     opts::{Forge, ForgeSubcommand},
 };
 use clap::{CommandFactory, Parser};
@@ -129,7 +129,7 @@ pub fn run_command(args: Forge) -> Result<()> {
         }
         ForgeSubcommand::Selectors { command } => global.block_on(command.run()),
         ForgeSubcommand::Generate(cmd) => match cmd.sub {
-            GenerateSubcommands::Test(cmd) => cmd.run(),
+            generate::GenerateSubcommands::Test(cmd) => cmd.run(),
         },
         ForgeSubcommand::Compiler(cmd) => cmd.run(),
         ForgeSubcommand::Soldeer(cmd) => global.block_on(cmd.run()),


### PR DESCRIPTION


The `args.rs` file had an incorrect import statement for the `generate` module. The code was importing `generate::GenerateSubcommands` directly instead of importing the entire `generate` module, which caused compilation issues when trying to use the full path `generate::GenerateSubcommands::Test`.

## Solution

- Changed import from `generate::GenerateSubcommands` to `generate` module
- Updated usage from `GenerateSubcommands::Test` to `generate::GenerateSubcommands::Test`
- Maintained proper handling of the hidden `generate` command while fixing the import structure

