### PR TITLE
security: sanitize compiler diagnostics to prevent sensitive info leakage

### DIFF
--- a/crates/common/src/errors/mod.rs
+++ b/crates/common/src/errors/mod.rs
@@ -51,6 +51,60 @@ pub fn convert_solar_errors(dcx: &solar::interface::diagnostics::DiagCtxt) -> ey
     }
 }
 
+/// Sanitizes compiler error messages by removing sensitive information.
+///
+/// This function filters out potentially sensitive information from compiler diagnostics
+/// such as absolute file paths, internal system details, and other sensitive data
+/// that could be exposed in error messages.
+///
+/// # Arguments
+///
+/// * `diagnostics` - The raw compiler diagnostics string to sanitize
+///
+/// # Returns
+///
+/// A sanitized version of the diagnostics with sensitive information removed or masked.
+pub fn sanitize_compiler_diagnostics(diagnostics: &str) -> String {
+    use regex::Regex;
+    
+    let mut sanitized = diagnostics.to_string();
+    
+    // List of regex patterns to sanitize sensitive information
+    let patterns = [
+        // Remove absolute file paths - replace with relative paths or [REDACTED_PATH]
+        (r"/[^\s\n]*\.sol", "[REDACTED_PATH].sol"),
+        (r"/[^\s\n]*\.rs", "[REDACTED_PATH].rs"),
+        (r"/[^\s\n]*\.json", "[REDACTED_PATH].json"),
+        // Remove Windows absolute paths
+        (r"[A-Za-z]:\\[^\s\n]*\.sol", "[REDACTED_PATH].sol"),
+        (r"[A-Za-z]:\\[^\s\n]*\.rs", "[REDACTED_PATH].rs"),
+        (r"[A-Za-z]:\\[^\s\n]*\.json", "[REDACTED_PATH].json"),
+        // Remove home directory paths
+        (r"~/[^\s\n]*", "[REDACTED_PATH]"),
+        (r"/home/[^/\s\n]+/[^\s\n]*", "[REDACTED_PATH]"),
+        (r"/Users/[^/\s\n]+/[^\s\n]*", "[REDACTED_PATH]"),
+        // Remove specific compiler version details that might reveal system info
+        (r"Solc( version)? \d+\.\d+\.\d+", "Solc [VERSION]"),
+        // Remove line and column information that might reveal internal structure
+        (r":\d+:\d+:", ":[LINE]:[COL]:"),
+        (r"line \d+", "line [LINE]"),
+        (r"column \d+", "column [COL]"),
+        // Remove memory addresses or internal references
+        (r"0x[0-9a-fA-F]{8,}", "[ADDRESS]"),
+        // Remove potential environment variable paths
+        (r"\$[A-Z_]+/[^\s\n]*", "[ENV_PATH]"),
+        (r"%[A-Z_]+%[^\s\n]*", "[ENV_PATH]"),
+    ];
+    
+    for (pattern, replacement) in patterns {
+        if let Ok(regex) = Regex::new(pattern) {
+            sanitized = regex.replace_all(&sanitized, replacement).to_string();
+        }
+    }
+    
+    sanitized
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -71,5 +125,53 @@ mod tests {
         assert_eq!(full, "my error: hello; hello");
         let chained = display_chain(&ee);
         assert_eq!(chained, "my error: hello");
+    }
+
+    #[test]
+    fn test_sanitize_compiler_diagnostics() {
+        let test_input = r#"
+Error: /home/user/project/contracts/MyContract.sol:123:45: DeclarationError: Identifier already declared.
+  --> /Users/developer/src/Token.sol:67:12
+  |
+67 |     function transfer(address to, uint256 amount) public returns (bool) {
+  |            ^^^^^^^^^
+  |
+  = note: Solc version 0.8.19+commit.7dd6d404
+  = help: Consider using a different name or removing the duplicate declaration.
+  
+Error: C:\Users\Admin\Documents\project\utils\Helper.sol:89:23: TypeError: Member "balance" not found.
+  --> 0x1234567890abcdef1234567890abcdef12345678
+  |
+89 |     uint256 bal = address(this).balance;
+  |                       ^^^^^^^
+"#;
+
+        let sanitized = sanitize_compiler_diagnostics(test_input);
+        
+        // Check that sensitive paths are redacted
+        assert!(!sanitized.contains("/home/user/project/"));
+        assert!(!sanitized.contains("/Users/developer/src/"));
+        assert!(!sanitized.contains("C:\\Users\\Admin\\Documents\\"));
+        assert!(sanitized.contains("[REDACTED_PATH]"));
+        
+        // Check that version info is redacted
+        assert!(!sanitized.contains("0.8.19+commit.7dd6d404"));
+        assert!(sanitized.contains("Solc [VERSION]"));
+        
+        // Check that line/column info is redacted
+        assert!(!sanitized.contains(":123:45:"));
+        assert!(!sanitized.contains(":67:12"));
+        assert!(!sanitized.contains(":89:23"));
+        assert!(sanitized.contains(":[LINE]:[COL]:"));
+        
+        // Check that addresses are redacted
+        assert!(!sanitized.contains("0x1234567890abcdef1234567890abcdef12345678"));
+        assert!(sanitized.contains("[ADDRESS]"));
+        
+        // Check that error messages are preserved
+        assert!(sanitized.contains("DeclarationError"));
+        assert!(sanitized.contains("TypeError"));
+        assert!(sanitized.contains("Identifier already declared"));
+        assert!(sanitized.contains("Member \"balance\" not found"));
     }
 }

--- a/crates/verify/src/etherscan/flatten.rs
+++ b/crates/verify/src/etherscan/flatten.rs
@@ -2,7 +2,7 @@ use super::{EtherscanSourceProvider, VerifyArgs};
 use crate::provider::VerificationContext;
 use eyre::Result;
 use foundry_block_explorers::verify::CodeFormat;
-use foundry_common::flatten;
+use foundry_common::{errors::sanitize_compiler_diagnostics, flatten};
 use foundry_compilers::{
     AggregatedCompilerOutput,
     artifacts::{BytecodeHash, Source, Sources},
@@ -96,8 +96,9 @@ impl EtherscanFlattenedSource {
 Failed to compile the flattened code locally.
 This could be a bug, please inspect the output of `forge flatten {}` and report an issue.
 To skip this solc dry, pass `--force`.
-Diagnostics: {diags}",
-                contract_path.display()
+Diagnostics: {}",
+                contract_path.display(),
+                sanitize_compiler_diagnostics(&diags.to_string())
             );
         }
 


### PR DESCRIPTION

### Problem
The `flatten.rs` module was exposing raw compiler diagnostics without filtering, potentially leaking sensitive information like absolute file paths, system details, and project structure.

### Solution
- **Added `sanitize_compiler_diagnostics()` function** in `foundry-common/src/errors/mod.rs`
- **Applied sanitization** in `verify/src/etherscan/flatten.rs` 
- **Added comprehensive test coverage**

### Security Impact
- **Before**: Raw diagnostics could expose `/home/user/project/`, `C:\Users\Admin\`, etc.
- **After**: Sensitive info masked as `[REDACTED_PATH]`, `[VERSION]`, `[ADDRESS]`

### Files Changed
- `crates/common/src/errors/mod.rs` - Added sanitization function and tests
- `crates/verify/src/etherscan/flatten.rs` - Applied sanitization to error output

### Example
```diff
- Error: /home/user/project/contracts/MyContract.sol:123:45: DeclarationError
+ Error: [REDACTED_PATH].sol:[LINE]:[COL]: DeclarationError
```
