### PR TITLE
Return error instead of terminating process in forge test result

### DIFF
--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -167,8 +167,8 @@ impl TestOutcome {
         }
 
         if shell::is_quiet() || silent {
-            // TODO: Avoid process::exit
-            std::process::exit(1);
+            // Avoid terminating the process from library code; propagate an error instead.
+            return Err(eyre::eyre!("tests failed"));
         }
 
         sh_println!("\nFailing tests:")?;
@@ -192,8 +192,8 @@ impl TestOutcome {
             successes.to_string().green()
         )?;
 
-        // TODO: Avoid process::exit
-        std::process::exit(1);
+        // Avoid terminating the process from library code; propagate an error instead.
+        Err(eyre::eyre!("tests failed"))
     }
 
     /// Removes first test result, if any.


### PR DESCRIPTION

## Summary
Replace process termination in `forge` test outcome handling with error propagation. Library code no longer calls `std::process::exit(1)`; callers can decide how to handle failures.

## Rationale
- Library code should not terminate the entire process.
- Improves composability, testability, and integration with tooling/IDE.
- Keeps CLI behavior consistent while avoiding hidden exits in lower layers.

## Changes
- `crates/forge/src/result.rs`: in `TestOutcome::ensure_ok`, replace two `std::process::exit(1)` calls with `Err(eyre::eyre!("tests failed"))`.

