### PR TITLE
fix(chisel): disable compiler optimizations

### DIFF
--- a/crates/chisel/src/args.rs
+++ b/crates/chisel/src/args.rs
@@ -51,6 +51,7 @@ pub async fn run_command(args: Chisel) -> Result<()> {
         evm_opts,
         backend: None,
         calldata: None,
+        ir_minimum: args.ir_minimum,
     })?;
 
     // Execute prelude Solidity source files

--- a/crates/chisel/src/opts.rs
+++ b/crates/chisel/src/opts.rs
@@ -31,6 +31,13 @@ pub struct Chisel {
     ))]
     pub no_vm: bool,
 
+    /// Enable viaIR with minimum optimization
+    ///
+    /// This can fix most of the "stack too deep" errors while resulting a
+    /// relatively accurate source map.
+    #[arg(long, help_heading = "REPL options")]
+    pub ir_minimum: bool,
+
     #[command(flatten)]
     pub build: BuildOpts,
 

--- a/crates/chisel/src/source.rs
+++ b/crates/chisel/src/source.rs
@@ -382,6 +382,11 @@ pub struct SessionSourceConfig {
     pub traces: bool,
     /// Optionally set calldata for the REPL contract execution
     pub calldata: Option<Vec<u8>>,
+    /// Enable viaIR with minimum optimization
+    ///
+    /// This can fix most of the "stack too deep" errors while resulting a
+    /// relatively accurate source map.
+    pub ir_minimum: bool,
 }
 
 impl SessionSourceConfig {
@@ -603,7 +608,8 @@ impl SessionSource {
     fn compile(&self) -> Result<ProjectCompileOutput> {
         let sources = self.get_sources();
 
-        let project = self.config.foundry_config.ephemeral_project()?;
+        let mut project = self.config.foundry_config.ephemeral_project()?;
+        self.config.foundry_config.disable_optimizations(&mut project, self.config.ir_minimum);
         let mut output = ProjectCompiler::with_sources(&project, sources)?.compile()?;
 
         if output.has_compiler_errors() {

--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -12,7 +12,7 @@ use foundry_cli::utils::{LoadConfig, STATIC_FUZZ_SEED};
 use foundry_common::{compile::ProjectCompiler, errors::convert_solar_errors};
 use foundry_compilers::{
     Artifact, ArtifactId, Project, ProjectCompileOutput, ProjectPathsConfig, VYPER_EXTENSIONS,
-    artifacts::{CompactBytecode, CompactDeployedBytecode, SolcLanguage, sourcemap::SourceMap},
+    artifacts::{CompactBytecode, CompactDeployedBytecode, sourcemap::SourceMap},
 };
 use foundry_config::Config;
 use foundry_evm::{core::ic::IcPcMap, opts::EvmOpts};
@@ -131,7 +131,6 @@ impl CoverageArgs {
         let mut project = config.ephemeral_project()?;
 
         if self.ir_minimum {
-            // print warning message
             sh_warn!(
                 "`--ir-minimum` enables `viaIR` with minimum optimization, \
                  which can result in inaccurate source mappings.\n\
@@ -139,30 +138,15 @@ impl CoverageArgs {
                  Note that `viaIR` is production ready since Solidity 0.8.13 and above.\n\
                  See more: https://github.com/foundry-rs/foundry/issues/3357"
             )?;
-
-            // Enable viaIR with minimum optimization: https://github.com/ethereum/solidity/issues/12533#issuecomment-1013073350
-            // And also in new releases of Solidity: https://github.com/ethereum/solidity/issues/13972#issuecomment-1628632202
-            project.settings.solc.settings =
-                project.settings.solc.settings.with_via_ir_minimum_optimization();
-
-            // Sanitize settings for solc 0.8.4 if version cannot be detected: https://github.com/foundry-rs/foundry/issues/9322
-            // But keep the EVM version: https://github.com/ethereum/solidity/issues/15775
-            let evm_version = project.settings.solc.evm_version;
-            let version = config.solc_version().unwrap_or_else(|| Version::new(0, 8, 4));
-            project.settings.solc.settings.sanitize(&version, SolcLanguage::Solidity);
-            project.settings.solc.evm_version = evm_version;
         } else {
             sh_warn!(
                 "optimizer settings and `viaIR` have been disabled for accurate coverage reports.\n\
                  If you encounter \"stack too deep\" errors, consider using `--ir-minimum` which \
                  enables `viaIR` with minimum optimization resolving most of the errors"
             )?;
-
-            project.settings.solc.optimizer.disable();
-            project.settings.solc.optimizer.runs = None;
-            project.settings.solc.optimizer.details = None;
-            project.settings.solc.via_ir = None;
         }
+
+        config.disable_optimizations(&mut project, self.ir_minimum);
 
         let output = ProjectCompiler::default()
             .compile(&project)?


### PR DESCRIPTION
Add --ir-minimum like in `forge coverage`, and disable optimizations since we rely on source maps to inspect expressions.

Fixes #11981.