### PR TITLE
chore(test): add hints after test failed

### DIFF
--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -192,6 +192,14 @@ impl TestOutcome {
             successes.to_string().green()
         )?;
 
+        // Show helpful next steps for failed tests
+        sh_println!("\n💡 Next steps:")?;
+        sh_println!("  • Rerun only failed tests: forge test --rerun")?;
+        sh_println!("  • Debug specific test: forge test --debug --match-test <test_name>")?;
+        sh_println!("  • Watch mode with smart rerun: forge test --watch --rerun-failed")?;
+        sh_println!("  • View detailed traces: forge test -vvv --match-test <test_name>")?;
+        sh_println!("  • Run specific test: forge test --match-test <test_name>")?;
+
         // TODO: Avoid process::exit
         std::process::exit(1);
     }


### PR DESCRIPTION
During optimized #11993, I just realized there are much more magic function to help the test, but for the lazy people who don't like to read the whole docs like me, its really hard to know this, we just wait for all the test pass 😓. These hints may give alot help.