### PR TITLE
fix(`ci`): `create-an-issue` in release workflow is pinned to incorrect hash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,7 +335,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: JasonEtco/create-an-issue@56fdd2d6f960e970fa9d5ca3cf3884b6ba5af477 # v2
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_URL: |


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Current `release` workflow does not correctly open an issue, this is because `create-an-issue` was pinned to the latest commit on `main` which does not include the `dist` directory. Instead it should refer to a commit made on a release tag that does: https://github.com/JasonEtco/create-an-issue/releases/tag/v2.9.2

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Original commit does not include dist directory, tag commit does: https://github.com/JasonEtco/create-an-issue/commit/1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5, pinned it to that commit

It may be possible that Dependabot falsely will prompt for an update, if that is the case we can consider pinning this to the tag `v2.9.2` instead

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
