### PR TITLE
ci: use gha runner for macos arm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
             svm_target_platform: macosx-amd64
             platform: darwin
             arch: amd64
-          - runner: depot-macos-latest
+          - runner: macos-latest-large
             target: aarch64-apple-darwin
             svm_target_platform: macosx-aarch64
             platform: darwin


### PR DESCRIPTION
Somehow macos is harder to get right than windows