### PR TITLE
fix: replace Some(URL) with URL during installation output

### DIFF
--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -162,11 +162,11 @@ impl DependencyInstallOpts {
                 .strip_prefix(git.root)
                 .wrap_err("Library directory is not relative to the repository root")?;
             sh_println!(
-                "Installing {} in {} (url: {:?}, tag: {:?})",
+                "Installing {} in {} (url: {}, tag: {})",
                 dep.name,
                 path.display(),
-                dep.url,
-                dep.tag
+                dep.url.as_deref().unwrap_or("None"),
+                dep.tag.as_deref().unwrap_or("None")
             )?;
 
             // this tracks the actual installed tag

--- a/crates/forge/src/cmd/remove.rs
+++ b/crates/forge/src/cmd/remove.rs
@@ -44,7 +44,12 @@ impl RemoveArgs {
         for (Dependency { name, tag, .. }, path) in self.dependencies.iter().zip(&paths) {
             // Get the URL from git submodule config instead of using the parsed dependency URL
             let url = git.submodule_url(path).unwrap_or(None);
-            sh_println!("Removing '{name}' in {}, (url: {url:?}, tag: {tag:?})", path.display())?;
+            sh_println!(
+                "Removing '{name}' in {}, (url: {}, tag: {})",
+                path.display(),
+                url.as_deref().unwrap_or("None"),
+                tag.as_deref().unwrap_or("None")
+            )?;
             let _ = lockfile.remove(path);
             std::fs::remove_dir_all(git_modules.join(path))?;
         }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -304,7 +304,7 @@ forgetest!(can_init_repo_with_config, |prj, cmd| {
         .assert_success()
         .stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 
@@ -353,7 +353,7 @@ forgetest!(can_init_no_git, |prj, cmd| {
 
     cmd.arg("init").arg(prj.root()).arg("--no-git").assert_success().stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 
@@ -438,7 +438,7 @@ Run with the `--force` flag to initialize regardless.
         .assert_success()
         .stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 
@@ -478,7 +478,7 @@ Run with the `--force` flag to initialize regardless.
         .assert_success()
         .stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 
@@ -520,7 +520,7 @@ Run with the `--force` flag to initialize regardless.
         .assert_success()
         .stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 
@@ -561,7 +561,7 @@ forgetest!(can_init_using_parent_repo, |prj, cmd| {
     cmd.arg("init").arg(folder).arg("--force").arg("--use-parent-git").assert_success().stdout_eq(
         str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 
@@ -592,7 +592,7 @@ forgetest!(can_init_vscode, |prj, cmd| {
 
     cmd.arg("init").arg(prj.root()).arg("--vscode").assert_success().stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 
@@ -712,7 +712,7 @@ forgetest!(can_clone, |prj, cmd| {
     .stdout_eq(str![[r#"
 Downloading the source code of 0x044b75f554b886A065b9567891e45c79542d7357 from Etherscan...
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 Collecting the creation information of 0x044b75f554b886A065b9567891e45c79542d7357 from Etherscan...
@@ -760,7 +760,7 @@ forgetest!(can_clone_no_remappings_txt, |prj, cmd| {
     .stdout_eq(str![[r#"
 Downloading the source code of 0x33e690aEa97E4Ef25F0d140F1bf044d663091DAf from Etherscan...
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 Collecting the creation information of 0x33e690aEa97E4Ef25F0d140F1bf044d663091DAf from Etherscan...
@@ -819,7 +819,7 @@ forgetest!(can_init_project, |prj, cmd| {
 
     cmd.args(["init"]).arg(prj.root()).assert_success().stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 
@@ -847,7 +847,7 @@ forgetest!(can_init_vyper_project, |prj, cmd| {
 
     cmd.args(["init", "--vyper"]).arg(prj.root()).assert_success().stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 
@@ -889,7 +889,7 @@ forgetest!(can_clone_with_node_modules, |prj, cmd| {
     .stdout_eq(str![[r#"
 Downloading the source code of 0xA3E217869460bEf59A1CfD0637e2875F9331e823 from Etherscan...
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 Collecting the creation information of 0xA3E217869460bEf59A1CfD0637e2875F9331e823 from Etherscan...

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -458,7 +458,7 @@ forgetest_init!(can_parse_remappings_correctly, |prj, cmd| {
 
     let install = |cmd: &mut TestCommand, dep: &str| {
         cmd.forge_fuse().args(["install", dep]).assert_success().stdout_eq(str![[r#"
-Installing solmate in [..] (url: Some("https://github.com/transmissions11/solmate"), tag: None)
+Installing solmate in [..] (url: https://github.com/transmissions11/solmate, tag: None)
     Installed solmate[..]
 
 "#]]);
@@ -899,7 +899,7 @@ forgetest!(can_update_libs_section, |prj, cmd| {
     prj.update_config(|config| config.libs = vec!["node_modules".into()]);
 
     cmd.args(["install", "foundry-rs/forge-std"]).assert_success().stdout_eq(str![[r#"
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
 
 "#]]);
@@ -911,7 +911,7 @@ Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std
 
     // additional install don't edit `libs`
     cmd.forge_fuse().args(["install", "dapphub/ds-test"]).assert_success().stdout_eq(str![[r#"
-Installing ds-test in [..] (url: Some("https://github.com/dapphub/ds-test"), tag: None)
+Installing ds-test in [..] (url: https://github.com/dapphub/ds-test, tag: None)
     Installed ds-test
 
 "#]]);
@@ -926,7 +926,7 @@ forgetest!(config_emit_warnings, |prj, cmd| {
     cmd.git_init();
 
     cmd.args(["install", "foundry-rs/forge-std"]).assert_success().stdout_eq(str![[r#"
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
 
 "#]]);

--- a/crates/forge/tests/cli/debug.rs
+++ b/crates/forge/tests/cli/debug.rs
@@ -12,7 +12,7 @@ forgetest!(
             .assert_success()
             .stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -94,7 +94,7 @@ forgetest!(can_install_and_remove, |prj, cmd| {
     let install = |cmd: &mut TestCommand| {
         cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success().stdout_eq(
             str![[r#"
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
 
 "#]],
@@ -110,7 +110,7 @@ Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std
     let remove = |cmd: &mut TestCommand, target: &str| {
         cmd.forge_fuse().args(["remove", "--force", target]).assert_success().stdout_eq(str![[
             r#"
-Removing 'forge-std' in [..], (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Removing 'forge-std' in [..], (url: https://github.com/foundry-rs/forge-std, tag: None)
 
 "#
         ]]);
@@ -164,7 +164,7 @@ forgetest!(can_reinstall_after_manual_remove, |prj, cmd| {
     let install = |cmd: &mut TestCommand| {
         cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success().stdout_eq(
             str![[r#"
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std tag=[..]"#]],
         );
 
@@ -388,14 +388,13 @@ forgetest!(
         let package_mod = git_mod.join("forge-5980-test");
 
         // install main dependency
-        cmd.forge_fuse()
-            .args(["install", "evalir/forge-5980-test"])
-            .assert_success()
-            .stdout_eq(str![[r#"
-Installing forge-5980-test in [..] (url: Some("https://github.com/evalir/forge-5980-test"), tag: None)
+        cmd.forge_fuse().args(["install", "evalir/forge-5980-test"]).assert_success().stdout_eq(
+            str![[r#"
+Installing forge-5980-test in [..] (url: https://github.com/evalir/forge-5980-test, tag: None)
     Installed forge-5980-test
 
-"#]]);
+"#]],
+        );
 
         // assert paths exist
         assert!(package.exists());

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1094,7 +1094,7 @@ forgetest_async!(can_execute_script_with_arguments, |prj, cmd| {
         .assert_success()
         .stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 
@@ -1222,7 +1222,7 @@ forgetest_async!(can_execute_script_with_arguments_nested_deploy, |prj, cmd| {
         .assert_success()
         .stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 
@@ -1392,7 +1392,7 @@ forgetest_async!(assert_tx_origin_is_not_overwritten, |prj, cmd| {
         .assert_success()
         .stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 
@@ -1478,7 +1478,7 @@ forgetest_async!(assert_can_create_multiple_contracts_with_correct_nonce, |prj, 
         .assert_success()
         .stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 
@@ -1707,7 +1707,7 @@ forgetest_async!(can_decode_custom_errors, |prj, cmd| {
         .assert_success()
         .stdout_eq(str![[r#"
 Initializing [..]...
-Installing forge-std in [..] (url: Some("https://github.com/foundry-rs/forge-std"), tag: None)
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
     Initialized forge project
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

While installing instead of displaying `(url: Some("https://github.com/foundry-rs/forge-std"), tag: None)` , display `(url: "https://github.com/foundry-rs/forge-std", tag: None)` . Examples can be seen in tests


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
