### PR TITLE
docs(networks): fix doc heading

### DIFF
--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -1,6 +1,6 @@
-//! # foundry-evm-precompiles
+//! # foundry-evm-networks
 //!
-//! Foundry EVM network custom precompiles.
+//! Foundry EVM network configuration.
 
 use crate::celo::transfer::{
     CELO_TRANSFER_ADDRESS, CELO_TRANSFER_LABEL, PRECOMPILE_ID_CELO_TRANSFER,


### PR DESCRIPTION
## Motivation

There was some copied over docs code in the networkconfig crate I noticed while doing #12027 

## Solution

Correct the docs

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
