### PR TITLE
chore: rm `NodeConfig::with_celo`

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1024,17 +1024,6 @@ impl NodeConfig {
         self
     }
 
-    /// Sets whether to enable Celo support
-    #[must_use]
-    pub fn with_celo(mut self, celo: bool) -> Self {
-        self.networks.celo = celo;
-        if celo {
-            // Celo requires Optimism support
-            self.networks.optimism = true;
-        }
-        self
-    }
-
     /// Makes the node silent to not emit anything on stdout
     #[must_use]
     pub fn silent(self) -> Self {

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -23,6 +23,7 @@ use alloy_signer_local::PrivateKeySigner;
 use anvil::{EthereumHardfork, NodeConfig, NodeHandle, PrecompileFactory, eth::EthApi, spawn};
 use foundry_common::provider::get_http_provider;
 use foundry_config::Config;
+use foundry_evm_networks::NetworkConfigs;
 use foundry_test_utils::rpc::{self, next_http_rpc_endpoint, next_rpc_endpoint};
 use futures::StreamExt;
 use revm::precompile::{Precompile, PrecompileId, PrecompileOutput, PrecompileResult};
@@ -1711,7 +1712,9 @@ async fn test_config_with_cancun_hardfork() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_config_with_prague_hardfork_with_celo() {
     let (api, _handle) = spawn(
-        NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into())).with_celo(true),
+        NodeConfig::test()
+            .with_hardfork(Some(EthereumHardfork::Prague.into()))
+            .with_networks(NetworkConfigs::with_celo()),
     )
     .await;
 

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -31,6 +31,10 @@ impl NetworkConfigs {
         Self { optimism: true, ..Default::default() }
     }
 
+    pub fn with_celo() -> Self {
+        Self { celo: true, ..Default::default() }
+    }
+
     pub fn with_chain_id(mut self, chain_id: u64) -> Self {
         if let Ok(NamedChain::Celo | NamedChain::CeloSepolia) = NamedChain::try_from(chain_id) {
             self.celo = true;


### PR DESCRIPTION
## Motivation

We want to centralize as much as possible into `NetworkConfigs`

## Solution

Remove `with_celo` and use `with_networks` on `NodeConfig`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
