### PR TITLE
chore: mark `NetworkConfigs` non-exhaustive

### DIFF
--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -15,6 +15,7 @@ use std::collections::BTreeMap;
 pub mod celo;
 
 #[derive(Clone, Debug, Default, Parser, Copy, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct NetworkConfigs {
     /// Enable Optimism network features.
     #[arg(help_heading = "Networks", long, visible_alias = "optimism", conflicts_with = "celo")]


### PR DESCRIPTION
## Motivation

Ideally `NetworkConfigs` is an enum, but for now we're stuck with the `--<network>` flag paradigm. Ideally, it would be something like `--flavor <network>` or `--network <network>`, because it is a logic error to have multiple networks enabled at the same time.

## Solution

Given we're stuck with `--<network>`, we should mark `NetworkConfigs` non-exhaustive to prevent constructing the struct directly, and to prevent destructuring it without handling future networks.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
