### PR TITLE
fix(npm): replace process.exit with graceful error handling in forge.ts

### DIFF
--- a/npm/src/forge.ts
+++ b/npm/src/forge.ts
@@ -22,9 +22,23 @@ function getBinaryPath() {
   console.error(colors.reset)
   console.error(colors.yellow, `Platform: ${process.platform}, Architecture: ${process.arch}`)
   console.error(colors.reset)
-  process.exit(1)
+  // Propagate error instead of terminating the process here; handled at call site
+  throw new Error(`Platform-specific package ${PLATFORM_SPECIFIC_PACKAGE_NAME} not found.`)
 }
 
-NodeChildProcess.spawn(getBinaryPath(), process.argv.slice(2), {
+let binaryPath: string
+try {
+  binaryPath = getBinaryPath()
+} catch (err) {
+  console.error(colors.red, `Platform-specific package ${PLATFORM_SPECIFIC_PACKAGE_NAME} not found.`)
+  console.error(colors.yellow, 'This usually means the installation failed or your platform is not supported.')
+  console.error(colors.reset)
+  console.error(colors.yellow, `Platform: ${process.platform}, Architecture: ${process.arch}`)
+  console.error(colors.reset)
+  // Fail gracefully: set exit code and return; do not terminate abruptly
+  process.exitCode = 1
+  return
+}
+NodeChildProcess.spawn(binaryPath, process.argv.slice(2), {
   stdio: 'inherit'
 })


### PR DESCRIPTION

## Summary
Replace abrupt `process.exit(1)` call with proper error propagation and graceful process termination in `npm/src/forge.ts`.

## Changes
- **Before**: `getBinaryPath()` calls `process.exit(1)` directly, terminating the process immediately
- **After**: Function throws error, handled at call site with `process.exitCode = 1` and early return

## Benefits
- Improves testability - `getBinaryPath()` is no longer fatal
- Better control flow - calling code can handle errors appropriately  
- Graceful shutdown - allows proper cleanup and buffered output
- Maintains same user experience - same error messages and exit code

