### PR TITLE
fix(evm): guard abi_mutate in new_input for zero-arg functions to avoid panic

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -499,7 +499,9 @@ impl CorpusManager {
             self.current_mutated = Some(corpus.uuid);
             let new_seq = corpus.tx_seq.clone();
             let mut tx = new_seq.first().unwrap().clone();
-            self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
+            if !function.inputs.is_empty() {
+                self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
+            }
             tx
         } else {
             self.new_tx(test_runner)?


### PR DESCRIPTION
## Motivation

new_input unconditionally calls abi_mutate, which assumes at least one input. For zero-arg functions, abi_mutate builds round_arg_idx = vec![0] while prev_inputs is empty (decoded from calldata[4..]), leading to an index out-of-bounds panic on prev_inputs[0].

Reachability conditions (panic is achievable):
  - Coverage-guided fuzzing is enabled (FuzzCorpusConfig.corpus_dir is set).
  - in_memory_corpus is non-empty (loaded at startup or after a new coverage find).
  - The fuzzed Function has zero inputs.
  - Then new_input selects a corpus entry and calls abi_mutate without checking inputs.
  
Prior art: The MutationType::Abi path already guards with if !function.inputs.is_empty().

## Solution

In crates/evm/evm/src/executors/corpus.rs::new_input, call abi_mutate only when !function.inputs.is_empty(). This prevents the panic while preserving mutation behavior for functions with arguments.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
