### PR TITLE
chore: make `SourceData::contract_definitions` public

### DIFF
--- a/crates/evm/traces/src/debug/sources.rs
+++ b/crates/evm/traces/src/debug/sources.rs
@@ -26,7 +26,7 @@ pub struct SourceData {
     pub path: PathBuf,
     /// Maps contract name to (start, end) of the contract definition in the source code.
     /// This is useful for determining which contract contains given function definition.
-    contract_definitions: Vec<(String, Range<usize>)>,
+    pub contract_definitions: Vec<(String, Range<usize>)>,
 }
 
 impl SourceData {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

I would like to populate `SourceData` with `MultiCompilerLanguage::Solc` without the new ast handling in `SourceData::new(...)`.

The function signature for `SourceData::new(...)` was changed with PR #11541 ([code](https://github.com/foundry-rs/foundry/pull/11541/files#diff-5560e27eb7ddb2f4e5426c130c0877ae4747d30cbe49f2dc8593326cca5fa34cR33-R39)) I was using this before [here](https://github.com/cakevm/huff-neo/pull/106/files#diff-48e2f1cc0b42400ee9f6d7bf944e9a5aca72b46c1cf96cf0c60837f995f0970dL207-L214). To avoid further hacks, I would propose to allow to init `SourceData` with custom data.


It is maybe a bit of an exotic use case, but I am using the Foundry debugger for Huff. I create a source code map that maps Huff to a Solidity source map. So I can use it for the foundry debugger:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/6b8562c0-6266-412f-a3d7-27e11b45d3c3" />


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Make `contract_definitions` public and allow to init `SourceData` with custom data.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
