### PR TITLE
feat(forge): add `--show-last-run` to display failed test list

### DIFF
--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -898,24 +898,9 @@ impl TestArgs {
                 for test in &tests {
                     sh_println!("  • {}", test)?;
                 }
-                sh_println!()?;
-                sh_println!(
-                    "Run `forge test --rerun` to retry {} test{}",
-                    tests.len(),
-                    if tests.len() == 1 { "" } else { "s" }
-                )?;
-                sh_println!(
-                    "Or use `forge test --match-test \"{}\"` to run with filters",
-                    tests.join("|")
-                )?;
             }
             None => {
                 sh_println!("No test failures recorded from last run")?;
-                sh_println!()?;
-                sh_println!(
-                    "Failure records are saved to: {}",
-                    config.test_failures_file.display()
-                )?;
             }
         }
         Ok(TestOutcome::empty(None, false))


### PR DESCRIPTION
Working on a codebase with 100+ tests and kept running into this annoyance - when tests fail, there's no easy way to see which ones broke without scrolling back through terminal output or catting `cache/test-failures` to read pipe-delimited regex.

Added `forge test --show-last-run` to solve this. It reads the failures file and displays them in a clean list.

**Before:**
```bash
$ cat cache/test-failures
testBurn|testWithdraw|testEmergencyExit

# Not exactly readable, and you still need to manually construct the match-test pattern
```

**After:**
```bash
$ forge test --show-last-run

Last test run failures (3 tests):

  • testBurn
  • testWithdraw
  • testEmergencyExit
```

Also fixed path resolution in `last_run_failures()` and `persist_run_failures()` - they were using relative paths which could break when running forge from different working directories. Now properly using `config.root.join()` for robust path handling.