### PR TITLE
fix(forge): verify bytecode should replay txes

### DIFF
--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -12,8 +12,7 @@ use alloy_provider::{
     Provider,
     ext::TraceApi,
     network::{
-        AnyNetwork, AnyTxEnvelope, TransactionBuilder, TransactionResponse,
-        primitives::BlockTransactions,
+        AnyTxEnvelope, TransactionBuilder, TransactionResponse, primitives::BlockTransactions,
     },
 };
 use alloy_rpc_types::{
@@ -33,7 +32,7 @@ use foundry_evm::{
     constants::DEFAULT_CREATE2_DEPLOYER,
     core::AsEnvMut,
     executors::EvmError,
-    utils::{apply_chain_and_block_specific_env_changes, configure_tx_env, configure_tx_req_env},
+    utils::{configure_tx_env, configure_tx_req_env},
 };
 use revm::state::AccountInfo;
 use std::path::PathBuf;
@@ -485,13 +484,7 @@ impl VerifyBytecodeArgs {
             transaction.set_nonce(prev_block_nonce);
 
             if let Some(ref block) = block {
-                env.evm_env.block_env.timestamp = U256::from(block.header.timestamp);
-                env.evm_env.block_env.beneficiary = block.header.beneficiary;
-                env.evm_env.block_env.difficulty = block.header.difficulty;
-                env.evm_env.block_env.prevrandao = Some(block.header.mix_hash.unwrap_or_default());
-                env.evm_env.block_env.basefee = block.header.base_fee_per_gas.unwrap_or_default();
-                env.evm_env.block_env.gas_limit = block.header.gas_limit;
-                apply_chain_and_block_specific_env_changes::<AnyNetwork>(env.as_env_mut(), block);
+                configure_env_block(&mut env.as_env_mut(), block);
 
                 let BlockTransactions::Full(ref txs) = block.transactions else {
                     return Err(eyre::eyre!("Could not get block txs"));
@@ -535,8 +528,6 @@ impl VerifyBytecodeArgs {
                         }
                     }
                 }
-
-                configure_env_block(&mut env.as_env_mut(), block)
             }
 
             // Replace the `input` with local creation code in the creation tx.

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -1,7 +1,10 @@
 use crate::{bytecode::VerifyBytecodeArgs, types::VerificationType};
 use alloy_dyn_abi::DynSolValue;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
-use alloy_provider::{Provider, network::AnyRpcBlock};
+use alloy_provider::{
+    Provider,
+    network::{AnyNetwork, AnyRpcBlock},
+};
 use alloy_rpc_types::BlockId;
 use clap::ValueEnum;
 use eyre::{OptionExt, Result};
@@ -17,8 +20,8 @@ use foundry_common::{
 use foundry_compilers::artifacts::{BytecodeHash, CompactContractBytecode, EvmVersion};
 use foundry_config::Config;
 use foundry_evm::{
-    Env, EnvMut, constants::DEFAULT_CREATE2_DEPLOYER, executors::TracingExecutor, opts::EvmOpts,
-    traces::TraceMode,
+    Env, EnvMut, constants::DEFAULT_CREATE2_DEPLOYER, core::AsEnvMut, executors::TracingExecutor,
+    opts::EvmOpts, traces::TraceMode, utils::apply_chain_and_block_specific_env_changes,
 };
 use reqwest::Url;
 use revm::{bytecode::Bytecode, database::Database, primitives::hardfork::SpecId};
@@ -335,6 +338,7 @@ pub fn configure_env_block(env: &mut EnvMut<'_>, block: &AnyRpcBlock) {
     env.block.prevrandao = Some(block.header.mix_hash.unwrap_or_default());
     env.block.basefee = block.header.base_fee_per_gas.unwrap_or_default();
     env.block.gas_limit = block.header.gas_limit;
+    apply_chain_and_block_specific_env_changes::<AnyNetwork>(env.as_env_mut(), block);
 }
 
 pub fn deploy_contract(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #12013 
- replay all txes until the tx we want to verify / replace runtime bytecode in
- this should handle the case when 2 contracts are created in same block and one depends on the other, e.g. 
  - `StakingRewards` created in https://etherscan.io/tx/0xf81f32a6b8476569da6eff54dddfe4f7b6a333d6490308a35dc68f44273efc59 with address `0xb44c2fb4181d7cb06bdff34a46fdfe4a259b40fc`
  - the staking rewards address is used in `VestedRewards` constructor created in next tx https://etherscan.io/tx/0xb78589ca0feb923503973b659d84f41ebfc369c8e0a1b2801561829f0bf341f2
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
