### PR TITLE
fix(forge): apply evm version set in setup and test constructor

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1108,10 +1108,11 @@ impl Cheatcode for stopAndReturnDebugTraceRecordingCall {
 impl Cheatcode for setEvmVersionCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { evm } = self;
-        ccx.ecx.cfg.spec = evm_spec_id(
+        let spec_id = evm_spec_id(
             EvmVersion::from_str(evm)
                 .map_err(|_| Error::from(format!("invalid evm version {evm}")))?,
         );
+        ccx.state.execution_evm_version = Some(spec_id);
         Ok(Default::default())
     }
 }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -61,6 +61,7 @@ use revm::{
         InstructionResult, Interpreter, InterpreterAction, InterpreterResult,
         interpreter_types::{Jumps, LoopControl, MemoryTr},
     },
+    primitives::hardfork::SpecId,
     state::EvmStorageSlot,
 };
 use serde_json::Value;
@@ -509,6 +510,8 @@ pub struct Cheatcodes {
     /// If GAS opcode is followed by CALL opcode then both flags are marked true and call
     /// has non-fixed gas limit, otherwise the call is considered to have fixed gas limit.
     pub dynamic_gas_limit_sequence: Option<(bool, bool)>,
+    // Custom execution evm version.
+    pub execution_evm_version: Option<SpecId>,
 }
 
 // This is not derived because calling this in `fn new` with `..Default::default()` creates a second
@@ -566,6 +569,7 @@ impl Cheatcodes {
             wallets: Default::default(),
             signatures_identifier: Default::default(),
             dynamic_gas_limit_sequence: Default::default(),
+            execution_evm_version: None,
         }
     }
 
@@ -695,6 +699,11 @@ impl Cheatcodes {
         call: &mut CallInputs,
         executor: &mut dyn CheatcodesExecutor,
     ) -> Option<CallOutcome> {
+        // Apply custom execution evm version.
+        if let Some(spec_id) = self.execution_evm_version {
+            ecx.cfg.spec = spec_id;
+        }
+
         let gas = Gas::new(call.gas_limit);
         let curr_depth = ecx.journaled_state.depth();
 
@@ -1596,6 +1605,11 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
     }
 
     fn create(&mut self, ecx: Ecx, mut input: &mut CreateInputs) -> Option<CreateOutcome> {
+        // Apply custom execution evm version.
+        if let Some(spec_id) = self.execution_evm_version {
+            ecx.cfg.spec = spec_id;
+        }
+
         let gas = Gas::new(input.gas_limit());
         // Check if we should intercept this create
         if self.intercept_next_create_call {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- follow up for https://github.com/foundry-rs/foundry/pull/12014
- apply evm version set through cheatcode in test constructor / setUp
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
