### PR TITLE
fix(config): normalize test_failures_file path in canonic_at()

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -919,6 +919,7 @@ impl Config {
         self.broadcast = p(&root, &self.broadcast);
         self.cache_path = p(&root, &self.cache_path);
         self.snapshots = p(&root, &self.snapshots);
+        self.test_failures_file = p(&root, &self.test_failures_file);
 
         if let Some(build_info_path) = self.build_info_path {
             self.build_info_path = Some(p(&root, &build_info_path));


### PR DESCRIPTION
An extended fix to [this PR comment](https://github.com/foundry-rs/foundry/pull/12067#issuecomment-3396054019)
.
_Compared to the previous single-point patch, this one addresses the issue at the source._

Fixes path resolution for `test_failures_file` by adding it to the `canonic_at()` method, ensuring it's resolved relative to the project root rather than the current working directory. This makes `forge test --rerun` work correctly when invoked from subdirectories, matching the behavior of other config paths like `cache_path` and `snapshots`.