### PR TITLE
fix(anvil): set envelope for non deposit tx in debug tracers

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -42,6 +42,7 @@ use alloy_consensus::{
 };
 use alloy_eip5792::{Capabilities, DelegationCapability};
 use alloy_eips::{
+    Encodable2718,
     eip1559::BaseFeeParams,
     eip4844::{BlobTransactionSidecar, kzg_to_versioned_hash},
     eip7840::BlobParams,
@@ -2769,8 +2770,7 @@ impl Backend {
             let target_tx = PendingTransaction::from_maybe_impersonated(target_tx)?;
             let mut tx_env = target_tx.to_revm_tx_env();
             if env.networks.is_optimism() {
-                tx_env.enveloped_tx =
-                    Some(alloy_rlp::encode(target_tx.transaction.transaction).into());
+                tx_env.enveloped_tx = Some(target_tx.transaction.transaction.encoded_2718().into());
             }
 
             let mut evm = self.new_evm_with_inspector_ref(&cache_db, &env, &mut inspector);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- if optimisim then set enveloped tx when replay tx for debug tracers
- ref https://github.com/foundry-rs/foundry/pull/11709
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
