### PR TITLE
chore(forge): filter out old solidity versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9214,8 +9214,7 @@ dependencies = [
 [[package]]
 name = "solar-ast"
 version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6aaf98d032ba3be85dca5f969895ade113a9137bb5956f80c5faf14689de59"
+source = "git+https://github.com/paradigmxyz/solar.git?branch=main#a264ef3c9f93388ed0ff84d07ae383e0676ee2d4"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -9231,8 +9230,7 @@ dependencies = [
 [[package]]
 name = "solar-compiler"
 version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e792060bcbb007a6b9b060292945fb34ff854c7d93a9628f81b6c809eb4360"
+source = "git+https://github.com/paradigmxyz/solar.git?branch=main#a264ef3c9f93388ed0ff84d07ae383e0676ee2d4"
 dependencies = [
  "alloy-primitives",
  "solar-ast",
@@ -9247,8 +9245,7 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff16d692734c757edd339f5db142ba91b42772f8cbe1db1ce3c747f1e777185f"
+source = "git+https://github.com/paradigmxyz/solar.git?branch=main#a264ef3c9f93388ed0ff84d07ae383e0676ee2d4"
 dependencies = [
  "colorchoice",
  "strum 0.27.2",
@@ -9257,8 +9254,7 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dea34e58332c7d6a8cde1f1740186d31682b7be46e098b8cc16fcb7ffd98bf5"
+source = "git+https://github.com/paradigmxyz/solar.git?branch=main#a264ef3c9f93388ed0ff84d07ae383e0676ee2d4"
 dependencies = [
  "bumpalo",
  "index_vec",
@@ -9272,8 +9268,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6163af2e773f4d455212fa9ba2c0664506029dd26232eb406f5046092ac311"
+source = "git+https://github.com/paradigmxyz/solar.git?branch=main#a264ef3c9f93388ed0ff84d07ae383e0676ee2d4"
 dependencies = [
  "annotate-snippets 0.12.4",
  "anstream",
@@ -9281,7 +9276,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "itoa",
  "normalize-path",
  "once_map",
@@ -9292,7 +9287,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.17",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.0",
 ]
@@ -9300,8 +9295,7 @@ dependencies = [
 [[package]]
 name = "solar-macros"
 version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a98045888d75d17f52e7b76f6098844b76078b5742a450c3ebcdbdb02da124"
+source = "git+https://github.com/paradigmxyz/solar.git?branch=main#a264ef3c9f93388ed0ff84d07ae383e0676ee2d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9311,13 +9305,12 @@ dependencies = [
 [[package]]
 name = "solar-parse"
 version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b77a9cbb07948e4586cdcf64f0a483424197308816ebd57a4cf06130b68562"
+source = "git+https://github.com/paradigmxyz/solar.git?branch=main#a264ef3c9f93388ed0ff84d07ae383e0676ee2d4"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.9.4",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -9333,8 +9326,7 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd033af43a38da316a04b25bbd20b121ce5d728b61e6988fd8fd6e2f1e68d0a1"
+source = "git+https://github.com/paradigmxyz/solar.git?branch=main#a264ef3c9f93388ed0ff84d07ae383e0676ee2d4"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -444,7 +444,7 @@ rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6
 # foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-fork-db", rev = "eee6563" }
 
 # solar
-# solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar.git", branch = "main" }
-# solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar.git", branch = "main" }
-# solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar.git", branch = "main" }
-# solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar.git", branch = "main" }
+solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar.git", branch = "main" }
+solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar.git", branch = "main" }
+solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar.git", branch = "main" }
+solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar.git", branch = "main" }

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -572,10 +572,7 @@ impl MultiContractRunnerBuilder {
                 if files.is_empty() { None } else { Some(&files) },
             )?;
             pcx.parse();
-            // Check if any sources exist, to avoid logging `error: no files found`
-            if !compiler.sess().source_map().is_empty() {
-                let _ = compiler.lower_asts();
-            }
+            let _ = compiler.lower_asts();
             Ok(())
         })?;
 


### PR DESCRIPTION
## Motivation

closes https://github.com/foundry-rs/foundry/issues/12008

## Solution

- filter out old solidity versions when setting up the solar compiler sources
- issue a warning when not relying on a previous compiler output

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
