### PR TITLE
fix(anvil): eth_getAccountInfo check if predates fork inclusive

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -777,7 +777,7 @@ impl EthApi {
         if let Some(fork) = self.get_fork() {
             // check if the number predates the fork, if in fork mode
             if let BlockRequest::Number(number) = self.block_request(block_number).await?
-                && fork.predates_fork(number)
+                && fork.predates_fork_inclusive(number)
             {
                 // if this predates the fork we need to fetch balance, nonce, code individually
                 // because the provider might not support this endpoint

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1639,6 +1639,22 @@ async fn test_fork_get_account_info() {
             code: Default::default(),
         }
     );
+
+    // Check account info at block number, see https://github.com/foundry-rs/foundry/issues/12072
+    let info = provider
+        .get_account_info(address!("0x19e53a7397bE5AA7908fE9eA991B03710bdC74Fd"))
+        // predates fork
+        .number(BLOCK_NUMBER)
+        .await
+        .unwrap();
+    assert_eq!(
+        info,
+        AccountInfo {
+            balance: U256::from(14352720829244098514u64),
+            nonce: 6690,
+            code: Default::default(),
+        }
+    );
 }
 
 fn assert_hardfork_config(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #12072 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- updated `eth_getAccountInfo` in fork mode to fetch balance, code and nonce from provider if predates fork including current block
- updated test to ensure proper nonce and balance at forked block number (fails if `predates_fork`)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
