### PR TITLE
fix(doc): follow tab width fmt config

### DIFF
--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -156,7 +156,7 @@ impl DocBuilder {
                         };
 
                         // Visit the parse tree
-                        let mut doc = Parser::new(comments, source);
+                        let mut doc = Parser::new(comments, source, self.fmt.tab_width);
                         source_unit
                             .visit(&mut doc)
                             .map_err(|err| eyre::eyre!("Failed to parse source: {err}"))?;

--- a/crates/doc/src/parser/item.rs
+++ b/crates/doc/src/parser/item.rs
@@ -80,18 +80,21 @@ impl ParseItem {
     /// Set the source code of this [ParseItem].
     ///
     /// The parameter should be the full source file where this parse item originated from.
-    pub fn with_code(mut self, source: &str) -> Self {
+    pub fn with_code(mut self, source: &str, tab_width: usize) -> Self {
         let mut code = source[self.source.range()].to_string();
 
         // Special function case, add `;` at the end of definition.
-        if let ParseSource::Function(_) = self.source {
+        if let ParseSource::Function(_) | ParseSource::Error(_) | ParseSource::Event(_) =
+            self.source
+        {
             code.push(';');
         }
 
         // Remove extra indent from source lines.
+        let prefix = &" ".repeat(tab_width);
         self.code = code
             .lines()
-            .map(|line| line.strip_prefix("    ").unwrap_or(line))
+            .map(|line| line.strip_prefix(prefix).unwrap_or(line))
             .collect::<Vec<_>>()
             .join("\n");
         self

--- a/crates/doc/src/parser/mod.rs
+++ b/crates/doc/src/parser/mod.rs
@@ -37,6 +37,8 @@ pub struct Parser {
     items: Vec<ParseItem>,
     /// Source file.
     source: String,
+    /// Tab width used to format code.
+    tab_width: usize,
 }
 
 /// [Parser] context.
@@ -50,8 +52,8 @@ struct ParserContext {
 
 impl Parser {
     /// Create a new instance of [Parser].
-    pub fn new(comments: Vec<SolangComment>, source: String) -> Self {
-        Self { comments, source, ..Default::default() }
+    pub fn new(comments: Vec<SolangComment>, source: String, tab_width: usize) -> Self {
+        Self { comments, source, tab_width, ..Default::default() }
     }
 
     /// Return the parsed items. Consumes the parser.
@@ -93,7 +95,7 @@ impl Parser {
     /// Create new [ParseItem] with comments and formatted code.
     fn new_item(&mut self, source: ParseSource, loc_start: usize) -> ParserResult<ParseItem> {
         let docs = self.parse_docs(loc_start)?;
-        Ok(ParseItem::new(source).with_comments(docs).with_code(&self.source))
+        Ok(ParseItem::new(source).with_comments(docs).with_code(&self.source, self.tab_width))
     }
 
     /// Parse the doc comments from the current start location.
@@ -218,7 +220,7 @@ mod tests {
 
     fn parse_source(src: &str) -> Vec<ParseItem> {
         let (mut source, comments) = parse(src, 0).expect("failed to parse source");
-        let mut doc = Parser::new(comments, src.to_owned());
+        let mut doc = Parser::new(comments, src.to_owned(), 4);
         source.visit(&mut doc).expect("failed to visit source");
         doc.items()
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #12073
- follows fmt config for `tab_width`
- extra: adds `;` at the end of `Event` and `Error`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
