### PR TITLE
fix(config): canonicalize ignored_file_paths in canonic_at

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -5453,40 +5453,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ignored_file_paths_normalization() {
-        // Test that "./" prefixes are stripped from ignored_warnings_from paths
-        figment::Jail::expect_with(|jail| {
-            jail.create_file(
-                "foundry.toml",
-                r#"
-                [profile.default]
-                ignored_warnings_from = ["src/ignored.sol", "./test/ignored.sol"]
-                "#,
-            )?;
-
-            let config = Config::load().unwrap();
-
-            // Simulate the normalization in create_project
-            let normalized: Vec<PathBuf> = config
-                .ignored_file_paths
-                .iter()
-                .map(|path| path.strip_prefix("./").unwrap_or(path).to_path_buf())
-                .collect();
-
-            // Both paths should work the same way (with or without ./ prefix)
-            assert_eq!(
-                normalized,
-                vec![
-                    PathBuf::from("src/ignored.sol"),
-                    PathBuf::from("test/ignored.sol"), // ./ prefix removed
-                ]
-            );
-
-            Ok(())
-        });
-    }
-
-    #[test]
     fn test_inheritance_with_different_profiles() {
         figment::Jail::expect_with(|jail| {
             // Create base config with multiple profiles

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1972,3 +1972,58 @@ Warning: Found unknown `foo` config for profile `default` defined in foundry.tom
 
 "#]]);
 });
+
+forgetest_init!(test_ignored_file_paths_normalization, |prj, cmd| {
+    fn gen_contract(name: &str) -> String {
+        let fn_name = name.chars().next().unwrap().to_lowercase().to_string() + &name[1..];
+        format!(
+            r#"
+contract {name} {{
+    function {fn_name}() public returns (bool) {{ return true; }}
+}}
+"#
+        )
+    }
+
+    // Update config to ignore warnings from specific files with various path formats
+    prj.update_config(|config| {
+        config.ignored_file_paths = vec![
+            PathBuf::from("./test/IgnoredWithPrefix.sol"), // With "./" prefix
+            PathBuf::from("src/IgnoredNoPrefix.sol"),      // Without "./" prefix
+            PathBuf::from("./src/nested/IgnoredNested.sol"), // Nested path with prefix
+        ];
+    });
+
+    // Create contracts that will generate warnings
+    prj.add_source("IgnoredNoPrefix.sol", &gen_contract("IgnoredNoPrefix"));
+    prj.add_test("IgnoredWithPrefix.sol", &gen_contract("IgnoredWithPrefix"));
+
+    fs::create_dir_all(prj.root().join("src/nested")).unwrap();
+    fs::write(prj.root().join("src/nested/IgnoredNested.sol"), gen_contract("IgnoredNested"))
+        .unwrap();
+
+    prj.add_source("NotIgnored.sol", &gen_contract("NotIgnored"));
+
+    // Verify the config loads paths as specified (before normalization)
+    let config = cmd.config();
+    let raw_paths = vec![
+        PathBuf::from("./test/IgnoredWithPrefix.sol"),
+        PathBuf::from("src/IgnoredNoPrefix.sol"),
+        PathBuf::from("./src/nested/IgnoredNested.sol"),
+    ];
+    assert_eq!(config.ignored_file_paths, raw_paths);
+
+    // Build and verify compilation succeeds with just 1 warning:
+    cmd.forge_fuse().args(["build"]).assert_success().stdout_eq(
+        r#"[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful with warnings:
+Warning (2018): Function state mutability can be restricted to pure
+ [FILE]:5:5:
+  |
+5 |     function notIgnored() public returns (bool) { return true; }
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+"#,
+    );
+});


### PR DESCRIPTION
While using `ignored_warnings_from` with relative paths in my config, I noticed the warnings weren't being filtered properly. Turns out `ignored_file_paths` wasn't being canonicalized with the project root in `Config::canonic_at`, so the relative paths couldn't match correctly.