### PR TITLE
fix(cheatcodes): ensure account is touched in `etchCall` for consistency

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -611,7 +611,7 @@ impl Cheatcode for etchCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { target, newRuntimeBytecode } = self;
         ccx.ensure_not_precompile(target)?;
-        ccx.ecx.journaled_state.load_account(*target)?;
+        ensure_loaded_account(ccx.ecx, *target)?;
         let bytecode = Bytecode::new_raw_checked(newRuntimeBytecode.clone())
             .map_err(|e| fmt_err!("failed to create bytecode: {e}"))?;
         ccx.ecx.journaled_state.set_code(*target, bytecode);


### PR DESCRIPTION
Uses `ensure_loaded_account` instead of `load_account` in `etchCall` to mark the account as touched when modifying its code, aligning with other state-modifying cheatcodes like `storeCall`, `dealCall`, and `setNonceCall`.