### PR TITLE
chore(meta): fix method resolution in async tests

### DIFF
--- a/crates/test-utils/src/macros.rs
+++ b/crates/test-utils/src/macros.rs
@@ -58,7 +58,8 @@ macro_rules! forgetest_async {
         $(#[$attr])*
         async fn $test() {
             let (mut $prj, mut $cmd) = $crate::util::setup_forge(stringify!($test), $style);
-            $e
+            $e;
+            return (); // Works around weird method resolution in `$e` due to `#[tokio::test]`.
         }
     };
 }
@@ -83,7 +84,8 @@ macro_rules! casttest {
         $(#[$attr])*
         async fn $test() {
             let (mut $prj, mut $cmd) = $crate::util::setup_cast(stringify!($test), $style);
-            $e
+            $e;
+            return (); // Works around weird method resolution in `$e` due to `#[tokio::test]`.
         }
     };
 }


### PR DESCRIPTION
Currently trying to "go to definition" on any method inside a `forgetest_async` results in multiple unrelated matches in tokio.

<img width="1544" height="449" alt="image" src="https://github.com/user-attachments/assets/355c3d12-fc7c-4caf-868c-01ca4c7dd6b0" />

This is because of weird interactions with `#[tokio::test]` and Rust Analyzer.