### PR TITLE
test: lower timeout for normal tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,10 +2,10 @@
 
 [profile.default]
 retries = { backoff = "exponential", count = 2, delay = "5s", jitter = true }
-slow-timeout = { period = "1m", terminate-after = 3 }
+slow-timeout = { period = "30s", terminate-after = 3 }
 
 [[profile.default.overrides]]
-filter = "test(/ext_integration|can_test_forge_std/)"
+filter = "test(/ext_integration/)"
 slow-timeout = { period = "5m", terminate-after = 4 }
 
 # Do not re-run so that `cargo cheats` is ran locally.


### PR DESCRIPTION
With faster new machines we can afford to lower timeout.
It is not uncommon for tests to timeout, especially for Anvil/RPC tests and on Windows.