### PR TITLE
test: optimize backtrace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,11 @@ rand.opt-level = 3
 rand_chacha.opt-level = 3
 ppv-lite86.opt-level = 3
 
+# Backtraces.
+addr2line.opt-level = 3
+backtrace.opt-level = 3
+gimli.opt-level = 3
+
 # Forking.
 axum.opt-level = 3
 


### PR DESCRIPTION
Capturing a backtrace for the first time takes about a full second in forge tests on my machine since it has to read debug info and whatever. Optimizing these deps brings it down to ~100ms.

This happens when any eyre error is created, even if not displayed, since it captures the backtrace at the creation place.