### PR TITLE
test: re-enable external tests with fork block

### DIFF
--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -218,12 +218,6 @@ impl ExtTester {
 
     /// Runs the test.
     pub fn run(&self) {
-        // Skip fork tests if the RPC url is not set.
-        if self.fork_block.is_some() && std::env::var_os("ETH_RPC_URL").is_none() {
-            eprintln!("ETH_RPC_URL is not set; skipping");
-            return;
-        }
-
         let (prj, mut test_cmd) = self.setup_forge_prj(true);
 
         // Run installation command.


### PR DESCRIPTION
ETH_RPC_URL is not set anymore.

You can see here they don't run in CI: https://github.com/foundry-rs/foundry/actions/runs/18576051740/job/52973509592?pr=12049#step:13:1606