### PR TITLE
chore: eliminate redundant test_fail iterator clone

### DIFF
--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -385,13 +385,14 @@ impl<'a> ContractRunner<'a> {
             load_contracts(setup.traces.iter().map(|(_, t)| &t.arena), &self.mcr.known_contracts)
         });
 
-        let test_fail_functions =
-            functions.iter().filter(|func| func.test_function_kind().is_any_test_fail());
-        if test_fail_functions.clone().next().is_some() {
+        let test_fail_functions: Vec<_> =
+            functions.iter().filter(|func| func.test_function_kind().is_any_test_fail()).collect();
+        if !test_fail_functions.is_empty() {
             let fail = || {
                 TestResult::fail("`testFail*` has been removed. Consider changing to test_Revert[If|When]_Condition and expecting a revert".to_string())
             };
-            let test_results = test_fail_functions.map(|func| (func.signature(), fail())).collect();
+            let test_results =
+                test_fail_functions.into_iter().map(|func| (func.signature(), fail())).collect();
             return SuiteResult::new(start.elapsed(), test_results, warnings);
         }
 


### PR DESCRIPTION
Precompute the test_fail functions so we reuse the same vector for the result generation, eliminating the iterator clone while keeping behaviour identical