### PR TITLE
fix(anvil): get account info from db when node block > fork block

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -775,18 +775,30 @@ impl EthApi {
         node_info!("eth_getAccountInfo");
 
         if let Some(fork) = self.get_fork() {
+            let block_request = self.block_request(block_number).await?;
             // check if the number predates the fork, if in fork mode
-            if let BlockRequest::Number(number) = self.block_request(block_number).await?
-                && fork.predates_fork_inclusive(number)
-            {
-                // if this predates the fork we need to fetch balance, nonce, code individually
-                // because the provider might not support this endpoint
-                let balance = fork.get_balance(address, number).map_err(BlockchainError::from);
-                let code = fork.get_code(address, number).map_err(BlockchainError::from);
-                let nonce = self.get_transaction_count(address, Some(number.into()));
-                let (balance, code, nonce) = try_join!(balance, code, nonce)?;
+            if let BlockRequest::Number(number) = block_request {
+                trace!(target: "node", "get_account_info: fork block {}, requested block {number}", fork.block_number());
+                return if fork.predates_fork(number) {
+                    // if this predates the fork we need to fetch balance, nonce, code individually
+                    // because the provider might not support this endpoint
+                    let balance = fork.get_balance(address, number).map_err(BlockchainError::from);
+                    let code = fork.get_code(address, number).map_err(BlockchainError::from);
+                    let nonce = self.get_transaction_count(address, Some(number.into()));
+                    let (balance, code, nonce) = try_join!(balance, code, nonce)?;
 
-                return Ok(alloy_rpc_types::eth::AccountInfo { balance, nonce, code });
+                    Ok(alloy_rpc_types::eth::AccountInfo { balance, nonce, code })
+                } else {
+                    // Anvil node is at the same block or higher than the fork block,
+                    // return account info from backend to reflect current state.
+                    let account_info = self.backend.get_account(address).await?;
+                    let code = self.backend.get_code(address, Some(block_request)).await?;
+                    Ok(alloy_rpc_types::eth::AccountInfo {
+                        balance: account_info.balance,
+                        nonce: account_info.nonce,
+                        code,
+                    })
+                };
             }
         }
 

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1622,7 +1622,7 @@ async fn test_fork_get_account() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_get_account_info() {
-    let (_api, handle) = spawn(fork_config()).await;
+    let (api, handle) = spawn(fork_config()).await;
     let provider = handle.http_provider();
 
     let info = provider
@@ -1645,6 +1645,23 @@ async fn test_fork_get_account_info() {
         .get_account_info(address!("0x19e53a7397bE5AA7908fE9eA991B03710bdC74Fd"))
         // predates fork
         .number(BLOCK_NUMBER)
+        .await
+        .unwrap();
+    assert_eq!(
+        info,
+        AccountInfo {
+            balance: U256::from(14352720829244098514u64),
+            nonce: 6690,
+            code: Default::default(),
+        }
+    );
+
+    // Mine and check account info at new block number, see https://github.com/foundry-rs/foundry/issues/12148
+    api.evm_mine(None).await.unwrap();
+    let info = provider
+        .get_account_info(address!("0x19e53a7397bE5AA7908fE9eA991B03710bdC74Fd"))
+        // predates fork
+        .number(BLOCK_NUMBER + 1)
         .await
         .unwrap();
     assert_eq!(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #12148 
- return account info from db if block requested is higher than fork
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
