### PR TITLE
chore(flake): update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1760769695,
-        "narHash": "sha256-eU4HnBCVuBg+c5UninnTh65VrbkkQ8HOjCaC3NDZLYM=",
+        "lastModified": 1760856120,
+        "narHash": "sha256-yH1K/WDJpwIIw7e3wKdRgwHAZ38LXgcGE2Ecvk3I6GU=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "f4cb0863b5d772b7b378ea456ac86c359303dfa7",
+        "rev": "b435bfccee71c6591dbce2fcfabe3e17e98c09fa",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760596604,
-        "narHash": "sha256-J/i5K6AAz/y5dBePHQOuzC7MbhyTOKsd/GLezSbEFiM=",
+        "lastModified": 1760872779,
+        "narHash": "sha256-c5C907Raf9eY8f1NUXYeju9aUDlm227s/V0OptEbypA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3cbe716e2346710d6e1f7c559363d14e11c32a43",
+        "rev": "63bdb5d90fa2fa11c42f9716ad1e23565613b07c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,8 @@
 
           lib = pkgs.lib;
           toolchain = fenix.packages.${system}.stable.toolchain;
-        in {
+        in
+        {
           default = pkgs.mkShell {
             nativeBuildInputs = with pkgs; [
               pkg-config
@@ -33,6 +34,10 @@
             ];
 
             packages = with pkgs; [ rust-analyzer-unwrapped ];
+
+            # Remove the hardening added by nix to fix jmalloc compilation error.
+            # More info: https://github.com/tikv/jemallocator/issues/108
+            hardeningDisable = [ "fortify" ];
 
             # Environment variables
             RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

When trying to compile/test the project on NixOS, the build fails with a jemalloc error. This is because of the hardening enabled by nix by default.

As well as updating the flake's inputs, this PR also disables this hardening to fix the issue.

More info: https://github.com/tikv/jemallocator/issues/108

## Solution

Updated the flake and disabled the hardening.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
