### PR TITLE
chore(benches): drop unused tokio dependency

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -18,7 +18,6 @@ color-eyre.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["full"] }
 chrono = { version = "0.4", features = ["serde"] }
 rayon.workspace = true
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
Removed the unused `tokio` dependency from `benches/Cargo.toml`, keeping the bench crate dependency set leaner. Verified the change with `cargo check -p foundry-bench`.
