### PR TITLE
Remove redundant clone when parsing CLI repos

### DIFF
--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -82,8 +82,11 @@ fn main() -> Result<()> {
     };
 
     // Get repo configurations
-    let repos = if let Some(repo_specs) = cli.repos.clone() {
-        repo_specs.iter().map(|spec| spec.parse::<RepoConfig>()).collect::<Result<Vec<_>>>()?
+    let repos = if let Some(repo_specs) = &cli.repos {
+        repo_specs
+            .iter()
+            .map(|spec| spec.parse::<RepoConfig>())
+            .collect::<Result<Vec<_>>>()?
     } else {
         BENCHMARK_REPOS.clone()
     };


### PR DESCRIPTION
iterate over cli.repos by reference instead of calling clone() so we avoid allocating a temporary Vec<String>
behavior stays the same, but we drop unnecessary copying and memory usage