### PR TITLE
fix: prevent panic in format_help when categories is empty

### DIFF
--- a/crates/chisel/src/cmd.rs
+++ b/crates/chisel/src/cmd.rs
@@ -130,6 +130,10 @@ impl ChiselCommand {
                 cat = Some(cat_);
                 categories.push((cat_, vec![]));
             }
+            // Ensure we have at least one category before accessing last_mut()
+            if categories.is_empty() {
+                categories.push(("General", vec![]));
+            }
             categories.last_mut().unwrap().1.push(sub);
         }
         format!(


### PR DESCRIPTION
Added safety check to prevent panic when accessing empty categories vector in format_help function. 

Commands without help headings now get grouped under a default "General" category instead of causing a crash.