### PR TITLE
fix(wallets): prevent duplicate Trezor wallets when using --hd-paths

### DIFF
--- a/crates/wallets/src/multi_wallet.rs
+++ b/crates/wallets/src/multi_wallet.rs
@@ -380,7 +380,13 @@ impl MultiWalletOpts {
 
     pub async fn trezors(&self) -> Result<Option<Vec<WalletSigner>>> {
         if self.trezor {
-            create_hw_wallets!(self, utils::create_trezor_signer, wallets);
+            let mut args = self.clone();
+
+            if args.hd_paths.is_some() {
+                args.mnemonic_indexes = None;
+            }
+
+            create_hw_wallets!(args, utils::create_trezor_signer, wallets);
             return Ok(Some(wallets));
         }
         Ok(None)


### PR DESCRIPTION
Clear mnemonic_indexes for Trezor when hd_paths are specified, mirroring Ledger behavior. This avoids creating both a path-derived wallet and an index 0 wallet due to the default_value on --mnemonic-indexes. Root cause: with default indexes present, the macro created wallets from both hd_paths and indexes, producing duplicates for Trezor.