### PR TITLE
fix(cast): store canonical event signatures in selector cache

### DIFF
--- a/crates/evm/traces/src/identifier/signatures.rs
+++ b/crates/evm/traces/src/identifier/signatures.rs
@@ -118,7 +118,7 @@ impl SignaturesCache {
                 Some((SelectorKind::Error(e.selector()), e.signature()))
             }
             alloy_json_abi::AbiItem::Event(e) => {
-                Some((SelectorKind::Event(e.selector()), e.full_signature()))
+                Some((SelectorKind::Event(e.selector()), e.signature()))
             }
             _ => None,
         }));


### PR DESCRIPTION
- Switch selector cache writing from Event.full_signature() to Event.signature() to ensure canonical event signatures (without parameter names) are stored.
- This makes cached entries parsable by Event::parse and aligns with how functions/errors are stored, fixing the failing test cast::cli selectors::error_event_decode_with_cache and reducing flaky decoding due to non-canonical event strings.