### PR TITLE
refactor: improve variable naming in `parse_bytes32_address`

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1701,10 +1701,8 @@ impl SimpleCast {
             return Err(eyre::eyre!("Not convertible to address, there are non-zero bytes"));
         };
 
-        let lowercase_address_string = format!("0x{s}");
-        let lowercase_address = Address::from_str(&lowercase_address_string)?;
-
-        Ok(lowercase_address.to_checksum(None))
+        let address = Address::from_str(&format!("0x{s}"))?;
+        Ok(address.to_checksum(None))
     }
 
     /// Decodes abi-encoded hex input or output


### PR DESCRIPTION


## **Description:**

This PR improves variable naming in `parse_bytes32_address` method to eliminate misleading names and simplify the code.

## Changes

- Removed misleading `lowercase_address_string` and `lowercase_address` variables
- Simplified to direct `Address::from_str(&format!("0x{s}"))` call


## Rationale

The previous variable names suggested lowercase conversion, but the method actually:
- Builds an address string with `0x` prefix
- Parses it as an `Address` 
- Returns EIP-55 checksum representation (not lowercase)

The misleading names created cognitive overhead. The simplified version is clearer and more direct.

