### PR TITLE
fix(chisel): handle Function/CustomStruct variants in format_token to prevent panics

### DIFF
--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -335,8 +335,8 @@ fn format_token(token: DynSolValue) -> String {
             out.push_str(&')'.red().to_string());
             out
         }
-        _ => {
-            unimplemented!()
+        t @ (DynSolValue::Function(_) | DynSolValue::CustomStruct { .. }) => {
+            foundry_common::fmt::format_token(&t)
         }
     }
 }


### PR DESCRIPTION
Add explicit handling for DynSolValue::Function and DynSolValue::CustomStruct by delegating to the shared formatter for consistent output.