### PR TITLE
chore: fix erc20 balance test

### DIFF
--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -2199,14 +2199,14 @@ casttest!(storage_layout_complex_json, |_prj, cmd| {
 
 casttest!(balance, |_prj, cmd| {
     let rpc = next_http_rpc_endpoint();
-    let usdt = "0xdac17f958d2ee523a2206206994597c13d831ec7";
+    let dai = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 
-    let usdt_result = cmd
+    let dai_result = cmd
         .args([
             "balance",
             "0x0000000000000000000000000000000000000000",
             "--erc20",
-            usdt,
+            dai,
             "--rpc-url",
             &rpc,
         ])
@@ -2222,7 +2222,7 @@ casttest!(balance, |_prj, cmd| {
             "balance",
             "0x0000000000000000000000000000000000000000",
             "--erc721",
-            usdt,
+            dai,
             "--rpc-url",
             &rpc,
         ])
@@ -2232,8 +2232,8 @@ casttest!(balance, |_prj, cmd| {
         .trim()
         .to_string();
 
-    assert_ne!(usdt_result, "0");
-    assert_eq!(alias_result, usdt_result);
+    assert_ne!(dai_result, "0");
+    assert_eq!(alias_result, dai_result);
 });
 
 // tests that `cast interface` excludes the constructor


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- update cast balance test to use DAI address instead usdt (DAI balance of 0x cannot go back to 0)
```
cast balance 0x0000000000000000000000000000000000000000 --erc20 0xdac17f958d2ee523a2206206994597c13d831ec7 --rpc-url https://eth.llamarpc.com --block 23628085
206947319889 [2.069e11]

cast balance 0x0000000000000000000000000000000000000000 --erc20 0xdac17f958d2ee523a2206206994597c13d831ec7 --rpc-url https://eth.llamarpc.com --block 23628086
0
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
