### PR TITLE
chore: remove redundant Bytes inner conversion in otterscan backend

### DIFF
--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -87,7 +87,7 @@ impl EthApi {
         if let Some(receipt) = self.backend.mined_transaction_receipt(hash)
             && !receipt.inner.inner.as_receipt_with_bloom().receipt.status.coerce_status()
         {
-            return Ok(receipt.out.map(|b| b.0.into()).unwrap_or(Bytes::default()));
+            return Ok(receipt.out.unwrap_or_default());
         }
 
         Ok(Bytes::default())


### PR DESCRIPTION
`MinedTransactionReceipt.out` is already of type `Option<alloy_primitives::Bytes>`, which matches the return type requirement. Extracting the inner `bytes::Bytes` via `.0` and converting back via `.into()` is unnecessary and obscures intent.