### PR TITLE
fix(npm): handle unhandled promise rejection in binary download

### DIFF
--- a/npm/src/install.ts
+++ b/npm/src/install.ts
@@ -228,7 +228,10 @@ if (!PLATFORM_SPECIFIC_PACKAGE_NAME)
 // Skip downloading the binary if it was already installed via optionalDependencies
 if (!isPlatformSpecificPackageInstalled()) {
   console.log('Platform specific package not found. Will manually download binary.')
-  downloadBinaryFromRegistry()
+  downloadBinaryFromRegistry().catch(error => {
+    console.error(colors.red, 'Failed to download binary:', error, colors.reset)
+    process.exitCode = 1
+  })
 } else {
   console.log('Platform specific package already installed. Skipping manual download.')
 }


### PR DESCRIPTION
The `downloadBinaryFromRegistry()` function is called without awaiting or handling promise rejections, which can lead to unhandled promise rejections. This is particularly problematic in CI environments where installation failures may not be properly signaled, potentially leaving the system in an inconsistent state.


