### PR TITLE
fix(common): spurious detection off-by-one

### DIFF
--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -106,7 +106,7 @@ impl OpenChainClient {
         if is_connectivity_err(err) {
             warn!("spurious network detected for OpenChain");
             let previous = self.timedout_requests.fetch_add(1, Ordering::SeqCst);
-            if previous >= self.max_timedout_requests {
+            if previous + 1 >= self.max_timedout_requests {
                 self.set_spurious();
             }
         }
@@ -641,5 +641,22 @@ mod tests {
             result,
             ParsedSignatures { signatures: Default::default(), ..Default::default() }
         );
+    }
+
+    #[tokio::test]
+    async fn spurious_marked_on_timeout_threshold() {
+        // Use an unreachable local port to trigger a quick connect error.
+        let client = OpenChainClient::new().expect("client must build");
+        let url = "http://127.0.0.1:9"; // Discard port; typically closed and fails fast.
+
+        // After MAX_TIMEDOUT_REQ - 1 failures we should NOT be spurious.
+        for i in 0..(MAX_TIMEDOUT_REQ - 1) {
+            let _ = client.get_text(url).await; // expect an error and internal counter increment
+            assert!(!client.is_spurious(), "unexpected spurious after {} failed attempts", i + 1);
+        }
+
+        // The Nth failure (N == MAX_TIMEDOUT_REQ) should flip the spurious flag.
+        let _ = client.get_text(url).await;
+        assert!(client.is_spurious(), "expected spurious after threshold failures");
     }
 }


### PR DESCRIPTION
The spurious detection logic used the pre-increment value returned by fetch_add(1) to compare against max_timedout_requests, which delayed marking the connection as spurious until one additional failure beyond the configured threshold. This off-by-one meant the client would continue attempting network calls after the maximum allowed timeouts, degrading responsiveness and violating the intended behavior described in the code comments. The comparison was corrected to use the incremented count so the flag flips exactly on the Nth failure, and an async unit test was added to ensure the spurious state is set precisely at the threshold and not earlier.