### PR TITLE
fix(fmt): simplify boolean expression in Solidity formatter

### DIFF
--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -565,7 +565,6 @@ impl<'ast> State<'_, 'ast> {
         if !skip_returns
             && let Some(ret) = returns
             && !ret.is_empty()
-            && let Some(ret) = returns
         {
             if !self.handle_span(self.cursor.span(ret.span.lo()), false) {
                 if !self.is_bol_or_only_ind() && !self.last_token_is_space() {


### PR DESCRIPTION
Simplify the chained if-condition in print_function() to bind `ret` once and
remove the duplicated `let Some(ret) = returns`.

This resolves the clippy::nonminimal_bool warning by eliminating redundant
pattern matches while preserving behavior. The change makes the condition
clearer and keeps the code compliant with Clippy defaults.

