### PR TITLE
chore(forge): delete useless todo's

### DIFF
--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -167,7 +167,6 @@ impl TestOutcome {
         }
 
         if shell::is_quiet() || silent {
-            // TODO: Avoid process::exit
             std::process::exit(1);
         }
 
@@ -201,7 +200,6 @@ impl TestOutcome {
             test_word
         )?;
 
-        // TODO: Avoid process::exit
         std::process::exit(1);
     }
 


### PR DESCRIPTION
Did this PR https://github.com/foundry-rs/foundry/pull/12266 and as I understood there's no need to keep the todo's in the file. 