### PR TITLE
fix: enable IPC tests on Windows

### DIFF
--- a/crates/anvil/tests/it/ipc.rs
+++ b/crates/anvil/tests/it/ipc.rs
@@ -23,7 +23,6 @@ fn ipc_config() -> (Option<TempDir>, NodeConfig) {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(windows, ignore = "TODO")]
 async fn can_get_block_number_ipc() {
     init_tracing();
 
@@ -40,7 +39,6 @@ async fn can_get_block_number_ipc() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(windows, ignore = "TODO")]
 async fn test_sub_new_heads_ipc() {
     init_tracing();
 


### PR DESCRIPTION
Wanted to fix  `#[cfg_attr(windows, ignore = "TODO")]` but as it doesn't need any impementation then I just deleted them.

IPC functionality already works on Windows, but tests were being ignored due to outdated TODO comments. 