### PR TITLE
docs: correct logging documentation accuracy in debugging.md

### DIFF
--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -6,7 +6,7 @@ This is a working document intended to outline some commands contributors can us
 
 All crates use [tracing](https://docs.rs/tracing/latest/tracing/) for logging. A console formatter is installed in each binary (`cast`, `forge`, `anvil`).
 
-By setting `RUST_LOG=<filter>` you can get a lot more info out of Forge and Cast. For example, running Forge with `RUST_LOG=forge` will emit all logs of the `cli` crate, same for Cast.
+By setting `RUST_LOG=<filter>` you can get a lot more info out of Forge and Cast. For example, running Forge with `RUST_LOG=forge` will emit all logs from the `forge` package, same for Cast with `RUST_LOG=cast`.
 
 The most basic valid filter is a log level, of which these are valid:
 
@@ -16,6 +16,6 @@ The most basic valid filter is a log level, of which these are valid:
 - `debug`
 - `trace`
 
-Filters are explained in detail in the [`env_logger` crate docs](https://docs.rs/env_logger).
+Filters are explained in detail in the [`tracing-subscriber` crate docs](https://docs.rs/tracing-subscriber).
 
 You can also use the `dbg!` macro from Rust's standard library.


### PR DESCRIPTION
Fixed inaccurate references in debugging documentation. 

Changed "cli crate" to "forge package" to match actual RUST_LOG filtering behavior and updated env_logger reference to tracing-subscriber which is the actual library used for log filtering.