### PR TITLE
fix: add recursion depth limit to prevent stack overflow in collect_dependencies

### DIFF
--- a/crates/linking/src/lib.rs
+++ b/crates/linking/src/lib.rs
@@ -826,7 +826,7 @@ mod tests {
         assert!(matches!(error, LinkerError::MaxDepthExceeded { depth: 101 }));
 
         // Test error message formatting
-        let error_msg = format!("{}", error);
+        let error_msg = format!("{error}");
         assert!(error_msg.contains("maximum dependency depth exceeded"));
         assert!(error_msg.contains("101"));
     }


### PR DESCRIPTION
Adds a maximum depth limit of 100 levels to the collect_dependencies method to prevent potential stack overflow when processing deeply nested library dependencies. 

Introduces a new MaxDepthExceeded error variant and refactors the method to use depth tracking. 

This addresses a potential security and stability issue in the EVM bytecode linker.