### PR TITLE
fix(anvil): enforce inclusive on-disk state limit in InMemoryBlockStates

### DIFF
--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -156,7 +156,7 @@ impl InMemoryBlockStates {
         }
 
         // enforce on disk limit and purge the oldest state cached on disk
-        while !self.is_memory_only() && self.oldest_on_disk.len() >= self.max_on_disk_limit {
+        while !self.is_memory_only() && self.oldest_on_disk.len() > self.max_on_disk_limit {
             // evict the oldest block
             if let Some(hash) = self.oldest_on_disk.pop_front() {
                 self.on_disk_states.remove(&hash);


### PR DESCRIPTION
This change fixes an off-by-one error in the on-disk state eviction logic. Previously, the enforcement loop used a >= comparison which caused the number of persisted states to be strictly less than the configured max_persisted_states. This contradicted the semantics implied by the configuration and comments (e.g., MAX_ON_DISK_HISTORY_LIMIT representing one hour at 1s intervals), effectively reducing retention by one. By changing the comparison to > we ensure the on-disk cache allows up to the configured maximum inclusively, aligning behavior with the documented intent.