### PR TITLE
chore: reduce number of shrink runs for slow test

### DIFF
--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -1239,6 +1239,7 @@ forgetest_init!(
             config.fuzz.seed = Some(U256::from(119u32));
             config.invariant.runs = 1;
             config.invariant.depth = 1000;
+            config.invariant.shrink_run_limit = 365;
         });
 
         prj.add_test(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- with https://github.com/foundry-rs/foundry/pull/12180 the purpose of `shrink_run_limit` config was changed (see https://github.com/foundry-rs/foundry/pull/12180#pullrequestreview-3355122391) that is instead serving like a hard stop of shrinking process to the number of runs to be performed for founding the minimal counterexample (e.g. even if the min is found after 100 runs we still try to find a smaller sequence until we reach the `shrink_run_limit` which defaults to 5000)
- this makes the `invariant_shrink_big_sequence` test to always run slow in CI (https://github.com/foundry-rs/foundry/actions/runs/18821592937/job/53697939008#step:14:2205) hence pining the test to number of runs that finds minimal counterexample
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
