### PR TITLE
chore: remove redundant Bytes conversion in mined_transaction_receipt

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3171,7 +3171,7 @@ impl Backend {
             blob_gas_used,
         };
 
-        Some(MinedTransactionReceipt { inner, out: info.out.map(|o| o.0.into()) })
+        Some(MinedTransactionReceipt { inner, out: info.out })
     }
 
     /// Returns the blocks receipts for the given number


### PR DESCRIPTION
Removed `.map(|o| o.0.into())` in `mined_transaction_receipt` since `info.out` is already `Option<Bytes>` and matches the target field type directly.