### PR TITLE
fix(fmt): don't break var assignments when callee fits

### DIFF
--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -846,7 +846,13 @@ impl<'ast> State<'_, 'ast> {
                         && get_callee_head_size(lhs) + lhs_size <= space_left
                     {
                         // Keep complex exprs (where callee fits) inline, as they will have breaks
-                        print_inline(self);
+                        if matches!(lhs.kind, ast::ExprKind::Call(..)) {
+                            self.s.ibox(-self.ind);
+                            print_inline(self);
+                            self.end();
+                        } else {
+                            print_inline(self);
+                        }
                     } else {
                         print_with_break(self, false);
                     }

--- a/crates/fmt/testdata/VariableAssignment/bracket-spacing.fmt.sol
+++ b/crates/fmt/testdata/VariableAssignment/bracket-spacing.fmt.sol
@@ -59,8 +59,14 @@ contract TestContract {
     // https://github.com/foundry-rs/foundry/issues/12322
     function test_longComplexBinExpr() {
         vars.previousTotalDebt = getDescaledAmount(
-                flow.getSnapshotDebtScaled(streamId),
-                flow.getTokenDecimals(streamId)
-            ) + vars.previousOngoingDebtScaled;
+            flow.getSnapshotDebtScaled(streamId),
+            flow.getTokenDecimals(streamId)
+        ) + vars.previousOngoingDebtScaled;
+
+        vars.previousTotalDebt = vars.reallyLongVarThatCausesALineBreak
+            + vars.previousOngoingDebtScaled;
+
+        vars.previousTotalDebt = vars.reallyLongVarThatCausesALineBreak()
+            .previousOngoingDebtScaled();
     }
 }

--- a/crates/fmt/testdata/VariableAssignment/fmt.sol
+++ b/crates/fmt/testdata/VariableAssignment/fmt.sol
@@ -58,8 +58,14 @@ contract TestContract {
     // https://github.com/foundry-rs/foundry/issues/12322
     function test_longComplexBinExpr() {
         vars.previousTotalDebt = getDescaledAmount(
-                flow.getSnapshotDebtScaled(streamId),
-                flow.getTokenDecimals(streamId)
-            ) + vars.previousOngoingDebtScaled;
+            flow.getSnapshotDebtScaled(streamId),
+            flow.getTokenDecimals(streamId)
+        ) + vars.previousOngoingDebtScaled;
+
+        vars.previousTotalDebt = vars.reallyLongVarThatCausesALineBreak
+            + vars.previousOngoingDebtScaled;
+
+        vars.previousTotalDebt = vars.reallyLongVarThatCausesALineBreak()
+            .previousOngoingDebtScaled();
     }
 }

--- a/crates/fmt/testdata/VariableAssignment/original.sol
+++ b/crates/fmt/testdata/VariableAssignment/original.sol
@@ -46,8 +46,10 @@ contract TestContract {
 
     // https://github.com/foundry-rs/foundry/issues/12322
     function test_longComplexBinExpr() {
-        vars.previousTotalDebt =
-            getDescaledAmount(flow.getSnapshotDebtScaled(streamId), flow.getTokenDecimals(streamId))
-                + vars.previousOngoingDebtScaled;
+        vars.previousTotalDebt = getDescaledAmount(flow.getSnapshotDebtScaled(streamId), flow.getTokenDecimals(streamId)) + vars.previousOngoingDebtScaled;
+
+        vars.previousTotalDebt = vars.reallyLongVarThatCausesALineBreak + vars.previousOngoingDebtScaled;
+
+        vars.previousTotalDebt = vars.reallyLongVarThatCausesALineBreak() .previousOngoingDebtScaled();
     }
 }


### PR DESCRIPTION
## Motivation

closes #12322 

## Solution

add new check on for binary exprs, to see if lhs callee fits in the same line

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
- [ ] Breaking changes
