### PR TITLE
Title: Simplify StateSnapshots::insert_at return contract

### DIFF
--- a/crates/evm/core/src/state_snapshot.rs
+++ b/crates/evm/core/src/state_snapshot.rs
@@ -60,9 +60,8 @@ impl<T> StateSnapshots<T> {
     /// Inserts the new state snapshot at the given `id`.
     ///
     ///  Does not auto-increment the next `id`.
-    pub fn insert_at(&mut self, state_snapshot: T, id: U256) -> U256 {
+    pub fn insert_at(&mut self, state_snapshot: T, id: U256) {
         self.state_snapshots.insert(id, state_snapshot);
-        id
     }
 }
 


### PR DESCRIPTION
remove the redundant U256 return value from StateSnapshots::insert_at, keeping the API honest about its side effects
leave all snapshot call sites untouched, since they already ignored the return value