### PR TITLE
refactor(cast): rename misleading variable names in parse_bytes32_address

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1755,10 +1755,10 @@ impl SimpleCast {
             return Err(eyre::eyre!("Not convertible to address, there are non-zero bytes"));
         };
 
-        let lowercase_address_string = format!("0x{s}");
-        let lowercase_address = Address::from_str(&lowercase_address_string)?;
+        let address_string = format!("0x{s}");
+        let address = Address::from_str(&address_string)?;
 
-        Ok(lowercase_address.to_checksum(None))
+        Ok(address.to_checksum(None))
     }
 
     /// Decodes abi-encoded hex input or output


### PR DESCRIPTION

Renames misleading variable names in `parse_bytes32_address` function to improve code clarity.
The original variable names suggested a lowercase transformation that was not performed, potentially causing confusion for readers. The new names accurately reflect the variables' actual purpose without implying any case conversion.

