### PR TITLE
chore: avoid cloning bytecode in prank delegate check

### DIFF
--- a/crates/cheatcodes/src/evm/prank.rs
+++ b/crates/cheatcodes/src/evm/prank.rs
@@ -132,7 +132,7 @@ fn prank(
     // Ensure that code exists at `msg.sender` if delegate calling.
     if delegate_call {
         ensure!(
-            account.info.clone().code.is_some_and(|code| !code.is_empty()),
+            account.info.code.as_ref().is_some_and(|code| !code.is_empty()),
             "cannot `prank` delegate call from an EOA"
         );
     }


### PR DESCRIPTION
Remove redundant clone() when checking if account has code for delegate calls.

The current code clones the entire AccountInfo (including bytecode) just to check if code exists. This is unnecessary since we only need to read the code field.

This pattern is already used correctly in other parts of the codebase:
- mock.rs:219 uses acc.info.code.as_ref()
- invariant/mod.rs:987 uses account.info.code.as_ref()

