### PR TITLE
Avoid redundant format! in chisel session error handling

### DIFF
--- a/crates/chisel/src/session.rs
+++ b/crates/chisel/src/session.rs
@@ -174,7 +174,7 @@ impl ChiselSession {
             let file_name = entry.file_name();
             let file_name = file_name
                 .into_string()
-                .map_err(|e| eyre::eyre!(format!("{}", e.to_string_lossy())))?;
+                .map_err(|e| eyre::eyre!(e.to_string_lossy().into_owned()))?;
             sessions.push((
                 systemtime_strftime(modified_time, "[year]-[month]-[day] [hour]:[minute]:[second]")
                     .unwrap(),


### PR DESCRIPTION
replace format!("{}", e.to_string_lossy()) with e.to_string_lossy().into_owned() in crates/chisel/src/session.rs to remove an unnecessary formatting allocation, no behavioral changes; error message text remains the same

tests: cargo test -p chisel (integration suite partially failed—existing environment issues with missing forge binary and solc output; unit tests all pass)