### PR TITLE
fix: node_info label for erigon_get_header_by_number

### DIFF
--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -32,7 +32,7 @@ impl EthApi {
         &self,
         number: BlockNumber,
     ) -> Result<Option<AnyRpcBlock>> {
-        node_info!("ots_getApiLevel");
+        node_info!("erigon_getHeaderByNumber");
 
         self.backend.block_by_number(number).await
     }


### PR DESCRIPTION
- Correct the node_info! label in erigon_get_header_by_number to erigon_getHeaderByNumber.
- This aligns logs with the actual JSON-RPC method name (EthRequest::ErigonGetHeaderByNumber) and matches the convention used across the codebase.