### PR TITLE
chore: remove unused labels

### DIFF
--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -20,10 +20,6 @@ use foundry_evm_core::{
         TEST_CONTRACT_ADDRESS,
     },
     decode::RevertDecoder,
-    precompiles::{
-        BLAKE_2F, EC_ADD, EC_MUL, EC_PAIRING, EC_RECOVER, IDENTITY, MOD_EXP, POINT_EVALUATION,
-        RIPEMD_160, SHA_256,
-    },
 };
 use itertools::Itertools;
 use revm_inspectors::tracing::types::{DecodedCallLog, DecodedCallTrace};
@@ -177,16 +173,6 @@ impl CallTraceDecoder {
                 (DEFAULT_CREATE2_DEPLOYER, "Create2Deployer".to_string()),
                 (CALLER, "DefaultSender".to_string()),
                 (TEST_CONTRACT_ADDRESS, "DefaultTestContract".to_string()),
-                (EC_RECOVER, "ECRecover".to_string()),
-                (SHA_256, "SHA-256".to_string()),
-                (RIPEMD_160, "RIPEMD-160".to_string()),
-                (IDENTITY, "Identity".to_string()),
-                (MOD_EXP, "ModExp".to_string()),
-                (EC_ADD, "ECAdd".to_string()),
-                (EC_MUL, "ECMul".to_string()),
-                (EC_PAIRING, "ECPairing".to_string()),
-                (BLAKE_2F, "Blake2F".to_string()),
-                (POINT_EVALUATION, "PointEvaluation".to_string()),
             ]),
             receive_contracts: Default::default(),
             fallback_contracts: Default::default(),


### PR DESCRIPTION
These labels are unused as the address label + signature is assigned here: 

https://github.com/foundry-rs/foundry/blob/588ef2a8fbf940f9f3a6783557233a83b82f35db/crates/evm/traces/src/decoder/precompiles.rs#L57-L89

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
