### PR TITLE
refactor: use derive(Default) for Handler struct

### DIFF
--- a/crates/cli/src/handler.rs
+++ b/crates/cli/src/handler.rs
@@ -3,20 +3,15 @@ use itertools::Itertools;
 use std::{error::Error, fmt};
 
 /// A custom context type for Foundry specific error reporting via `eyre`.
+#[derive(Default)]
 pub struct Handler {
     debug_handler: Option<Box<dyn EyreHandler>>,
-}
-
-impl Default for Handler {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl Handler {
     /// Create a new instance of the `Handler`.
     pub fn new() -> Self {
-        Self { debug_handler: None }
+        Self::default()
     }
 
     /// Override the debug handler with a custom one.


### PR DESCRIPTION
While looking through the codebase, noticed that Handler has a manual Default implementation that just calls new(), which creates a struct with None.

This pattern was introduced in #9766 when adding the debug_handler field.
Using derive(Default) is more idiomatic since all fields already implement Default.

This removes the manual impl Default block and updates new() to call Self::default(). Same behavior, less code to maintain.