### PR TITLE
fix: correct mermaid syntax in scripting documentation

### DIFF
--- a/docs/dev/scripting.md
+++ b/docs/dev/scripting.md
@@ -64,7 +64,7 @@ ScriptArgs::execute-- "(resume || verify) && !broadcast" -->ScriptArgs::resume_d
 ```mermaid
 graph TD;
 subgraph ScriptArgs::execute
-a[*]-->ScriptArgs::prepare_runner
+Start[Start]-->ScriptArgs::prepare_runner
 subgraph ::prepare_runner
 ScriptArgs::prepare_runner--fork_url-->Backend::spawn;
 ScriptArgs::prepare_runner-->Backend::spawn;


### PR DESCRIPTION
Replace invalid a[*] syntax with proper Start[Start] node in Mermaid flowchart. 

The [*] syntax is only valid in state diagrams, not flowcharts, causing potential rendering issues.