### PR TITLE
Remove redundant hex prefix check in parse_value_fallback

### DIFF
--- a/crates/cheatcodes/src/string.rs
+++ b/crates/cheatcodes/src/string.rs
@@ -2,7 +2,7 @@
 
 use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
 use alloy_dyn_abi::{DynSolType, DynSolValue};
-use alloy_primitives::{U256, hex};
+use alloy_primitives::U256;
 use alloy_sol_types::SolValue;
 
 // address


### PR DESCRIPTION
 
This PR removes a duplicate manual check for the "0x" hex prefix in `parse_value_fallback`.  
Hex string validation and normalization are now fully centralized via utility methods, making the extra `starts_with("0x")` check unnecessary and potentially divergent.

