### PR TITLE
Remove unused foundry-config dependency from benches crate

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -10,7 +10,6 @@ path = "src/main.rs"
 
 [dependencies]
 foundry-test-utils.workspace = true
-foundry-config.workspace = true
 foundry-common.workspace = true
 foundry-compilers = { workspace = true, features = ["project-util"] }
 eyre.workspace = true


### PR DESCRIPTION
drop the unused foundry-config workspace dependency from benches/Cargo.toml