### PR TITLE
perf(anvil): avoid unnecessary transaction vector cloning in Block::new

### DIFF
--- a/crates/anvil/core/src/eth/block.rs
+++ b/crates/anvil/core/src/eth/block.rs
@@ -32,9 +32,7 @@ impl Block {
         T: Into<Transaction>,
     {
         let transactions: Vec<_> = transactions.into_iter().map(Into::into).collect();
-        let transactions_for_root: Vec<_> =
-            transactions.iter().map(|t| t.transaction.clone()).collect();
-        let transactions_root = calculate_transaction_root(&transactions_for_root);
+        let transactions_root = calculate_transaction_root(&transactions);
 
         Self {
             header: Header {

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -206,6 +206,12 @@ pub struct MaybeImpersonatedTransaction {
     pub impersonated_sender: Option<Address>,
 }
 
+impl Typed2718 for MaybeImpersonatedTransaction {
+    fn ty(&self) -> u8 {
+        self.transaction.ty()
+    }
+}
+
 impl MaybeImpersonatedTransaction {
     /// Creates a new wrapper for the given transaction
     pub fn new(transaction: TypedTransaction) -> Self {
@@ -276,6 +282,16 @@ impl MaybeImpersonatedTransaction {
             effective_gas_price: None,
             inner: Recovered::new_unchecked(inner_envelope, from),
         }
+    }
+}
+
+impl Encodable2718 for MaybeImpersonatedTransaction {
+    fn encode_2718_len(&self) -> usize {
+        self.transaction.encode_2718_len()
+    }
+
+    fn encode_2718(&self, out: &mut dyn BufMut) {
+        self.transaction.encode_2718(out)
     }
 }
 


### PR DESCRIPTION
Replace vector clone with direct field access when calculating transaction root.

Instead of cloning the entire Vec<MaybeImpersonatedTransaction>, we now iterate over references and clone only the inner TypedTransaction field. 

This reduces memory usage, especially for blocks with many transactions.