### PR TITLE
fix(anvil): respect configured fork initial_backoff in setup_fork_db_config

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1211,7 +1211,6 @@ impl NodeConfig {
                 .initial_backoff(self.fork_retry_backoff.as_millis() as u64)
                 .compute_units_per_second(self.compute_units_per_second)
                 .max_retry(self.fork_request_retries)
-                .initial_backoff(1000)
                 .headers(self.fork_headers.clone())
                 .build()
                 .wrap_err("failed to establish provider to fork url")?,


### PR DESCRIPTION
Remove a redundant .initial_backoff(1000) that overwrote the user-configured fork_retry_backoff in NodeConfig::setup_fork_db_config().
With this change, the provider’s retry backoff now follows the configuration passed via CLI or NodeConfig, improving consistency with the rest of the codebase (EvmOpts::fork_provider_with_url, ClientForkConfig::update_url).