### PR TITLE
fix(cast): validate args when sig is missing in access-list

### DIFF
--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -47,6 +47,13 @@ impl AccessListArgs {
     pub async fn run(self) -> Result<()> {
         let Self { to, sig, args, tx, eth, block } = self;
 
+        // Validate that args are not provided without a function signature
+        if sig.is_none() && !args.is_empty() {
+            eyre::bail!(
+                "Arguments provided without function signature. Provide a function signature or remove the arguments."
+            );
+        }
+
         let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
         let sender = SenderKind::from_wallet_opts(eth.wallet).await?;


### PR DESCRIPTION
Add validation to prevent silent argument ignoring when function signature is not provided. Previously, arguments were ignored without any error message if sig was None, which led to confusing behavior.

Now the command fails early with a clear error message when args are provided without a signature.