### PR TITLE
chore: update hardfork mappings

### DIFF
--- a/crates/anvil/src/hardfork.rs
+++ b/crates/anvil/src/hardfork.rs
@@ -54,11 +54,10 @@ pub fn spec_id_from_ethereum_hardfork(hardfork: EthereumHardfork) -> SpecId {
         EthereumHardfork::Cancun => SpecId::CANCUN,
         EthereumHardfork::Prague => SpecId::PRAGUE,
         EthereumHardfork::Osaka => SpecId::OSAKA,
-        EthereumHardfork::Bpo1
-        | EthereumHardfork::Bpo2 => SpecId::OSAKA,
-        | EthereumHardfork::Bpo3
-        | EthereumHardfork::Bpo4
-        | EthereumHardfork::Bpo5 => unimplemented!(),
+        EthereumHardfork::Bpo1 | EthereumHardfork::Bpo2 => SpecId::OSAKA,
+        EthereumHardfork::Bpo3 | EthereumHardfork::Bpo4 | EthereumHardfork::Bpo5 => {
+            unimplemented!()
+        }
         f => unreachable!("unimplemented {}", f),
     }
 }


### PR DESCRIPTION
bpo1-2 are scheduled right after osaka

jovian impl exists now