### PR TITLE
fix(npm): kill child process when SIGTERM or SIGINT is received

### DIFF
--- a/npm/src/bin.mjs
+++ b/npm/src/bin.mjs
@@ -28,7 +28,14 @@ if (!platformPackage) {
   process.exit(1)
 }
 
-NodeChildProcess.spawn(selectBinaryPath(), process.argv.slice(2), { stdio: 'inherit' })
+const child = NodeChildProcess.spawn(
+    selectBinaryPath(),
+    process.argv.slice(2),
+    { stdio: 'inherit' }
+)
+
+process.on('SIGINT', killChild)
+process.on('SIGTERM', killChild)
 
 /**
  * Determines which tool wrapper is executing.
@@ -116,4 +123,11 @@ function selectBinaryPath() {
   }
 
   return NodePath.join(__dirname, '..', 'dist', binaryName)
+}
+
+/**
+ * Kills the child process.
+ */
+function killChild() {
+    child.kill()
 }


### PR DESCRIPTION
## Motivation

See #12408 for context and motivation.

## Solution

Adding handlers for `SIGTERM` and `SIGINT` signals that kill the child process.
I have tested this locally both on Linux and Windows, but not on macOS.
I would appreciate some guidance on how to add tests for this bugfix.
Do I need to add documentation for this? If so, where?
I am not sure this PR introduces any breaking changes.