### PR TITLE
refactor(anvil): simplify receipt conversion using map_logs

### DIFF
--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -1187,30 +1187,16 @@ impl TypedReceipt {
 fn convert_receipt_to_rpc(
     receipt: ReceiptWithBloom<Receipt<alloy_primitives::Log>>,
 ) -> ReceiptWithBloom<Receipt<alloy_rpc_types::Log>> {
-    let rpc_logs: Vec<alloy_rpc_types::Log> = receipt
-        .receipt
-        .logs
-        .into_iter()
-        .map(|log| alloy_rpc_types::Log {
-            inner: log,
-            block_hash: None,
-            block_number: None,
-            block_timestamp: None,
-            transaction_hash: None,
-            transaction_index: None,
-            log_index: None,
-            removed: false,
-        })
-        .collect();
-
-    ReceiptWithBloom {
-        receipt: Receipt {
-            status: receipt.receipt.status,
-            cumulative_gas_used: receipt.receipt.cumulative_gas_used,
-            logs: rpc_logs,
-        },
-        logs_bloom: receipt.logs_bloom,
-    }
+    receipt.map_logs(|log| alloy_rpc_types::Log {
+        inner: log,
+        block_hash: None,
+        block_number: None,
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: None,
+        removed: false,
+    })
 }
 
 impl TypedReceiptRpc {


### PR DESCRIPTION
Simplifies the `convert_receipt_to_rpc` function by using the `map_logs` helper method instead of manually reconstructing the receipt.

**Before:**
- Manually iterated through logs with `.into_iter().map().collect()`
- Manually reconstructed `ReceiptWithBloom` and `Receipt` structs
- ~24 lines of code

**After:**
- Uses `receipt.map_logs()` helper method
- Automatically handles the receipt reconstruction
- ~10 lines of code

The functionality is identical - both convert `ReceiptWithBloom<Receipt<alloy_primitives::Log>>` to `ReceiptWithBloom<Receipt<alloy_rpc_types::Log>>` by wrapping each log in the RPC type. The new implementation is cleaner and more maintainable.