### PR TITLE
fix(cast): handle errors in list_local_senders()

### DIFF
--- a/crates/cast/src/cmd/wallet/list.rs
+++ b/crates/cast/src/cmd/wallet/list.rs
@@ -54,7 +54,14 @@ impl ListArgs {
             || self.all
             || (!self.ledger && !self.trezor && !self.aws && !self.gcp)
         {
-            let _ = self.list_local_senders();
+            match self.list_local_senders() {
+                Ok(()) => {}
+                Err(e) => {
+                    if !self.all {
+                        sh_err!("{}", e)?;
+                    }
+                }
+            }
         }
 
         // Create options for multi wallet - ledger, trezor and AWS


### PR DESCRIPTION
Properly handle errors when listing local keystore accounts. 

Previously, errors were silently ignored with `let _ =`, hiding issues like missing  directories or permission errors. 

Now errors are reported to users unless the --all flag is used, matching the behavior for hardware wallet errors.