### PR TITLE
Fix missing Artifact trait import in linker

### DIFF
--- a/crates/linking/src/lib.rs
+++ b/crates/linking/src/lib.rs
@@ -6,8 +6,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 use alloy_primitives::{Address, B256, Bytes};
-use foundry_compilers::{
-    Artifact, ArtifactId,
+use foundry_compilers::{ Artifact, ArtifactId,
     artifacts::{CompactBytecode, CompactContractBytecodeCow, Libraries},
     contracts::ArtifactContracts,
 };


### PR DESCRIPTION
keep the Artifact trait in the foundry_compilers import list so the linker can call get_bytecode_bytes
avoid build failures introduced when the trait drops out of scope