### PR TITLE
chore(anvil): use cfg(feature = "cmd") instead of allow(dead_code) for parse

### DIFF
--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -514,7 +514,7 @@ impl SerializableState {
     }
 
     /// This is used as the clap `value_parser` implementation
-    #[allow(dead_code)]
+    #[cfg(feature = "cmd")]
     pub(crate) fn parse(path: &str) -> Result<Self, String> {
         Self::load(path).map_err(|err| err.to_string())
     }


### PR DESCRIPTION
Replaced #[allow(dead_code)] with #[cfg(feature = "cmd")] on SerializableState::parse(). The function is only used when the "cmd" feature is enabled (for CLI argument parsing), but #[allow(dead_code)] was masking this. The proper solution is conditional compilation - the function only compiles when actually needed, eliminating the warning without hiding the function's purpose