### PR TITLE
Clean up dead code in ChiselSession REPL helper

### DIFF
--- a/crates/chisel/tests/it/repl/session.rs
+++ b/crates/chisel/tests/it/repl/session.rs
@@ -8,7 +8,7 @@ const PROMPT: &str = "➜ ";
 /// Testing session for Chisel.
 pub struct ChiselSession {
     session: Box<PtySession>,
-    project: Box<TestProject>,
+    _project: Box<TestProject>,
     is_repl: bool,
 }
 
@@ -19,7 +19,6 @@ fn is_repl(args: &[String]) -> bool {
         || !SUBCOMMANDS.iter().any(|subcommand| args.iter().any(|arg| arg == subcommand))
 }
 
-#[allow(dead_code)]
 impl ChiselSession {
     pub fn new(name: &str, flags: &str, init: bool) -> Self {
         let project = foundry_test_utils::TestProject::new(name, PathStyle::Dapptools);


### PR DESCRIPTION
drop the unused ChiselSession::project accessor and the blanket #[allow(dead_code)]
rename the stored TestProject handle to _project so the temporary project stays alive without triggering warnings