### PR TITLE
Remove redundant Vec allocations in fork tracing helpers

### DIFF
--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -372,7 +372,7 @@ impl ClientFork {
             return Ok(traces);
         }
 
-        let traces = self.provider().trace_transaction(hash).await?.into_iter().collect::<Vec<_>>();
+        let traces = self.provider().trace_transaction(hash).await?;
 
         let mut storage = self.storage_write();
         storage.transaction_traces.insert(hash, traces.clone());
@@ -410,9 +410,8 @@ impl ClientFork {
             return Ok(traces);
         }
 
-        let traces =
-            self.provider().trace_block(number.into()).await?.into_iter().collect::<Vec<_>>();
-
+        let traces = self.provider().trace_block(number.into()).await?;
+        
         let mut storage = self.storage_write();
         storage.block_traces.insert(number, traces.clone());
 


### PR DESCRIPTION
Stop re-collecting the results from provider().trace_transaction and provider().trace_block rely on the provider’s existing Vec return value, eliminating extra allocation and copy