### PR TITLE
fix: proper error handling for multichain broadcast parsing

### DIFF
--- a/crates/script-sequence/src/reader.rs
+++ b/crates/script-sequence/src/reader.rs
@@ -67,10 +67,13 @@ impl BroadcastReader {
                     // Parse as MultiScriptSequence
 
                     let broadcast = fs::read_json_file::<serde_json::Value>(path)?;
-                    let deployments_value = broadcast
-                        .get("deployments")
-                        .ok_or_else(|| eyre::eyre!("missing 'deployments' field in multichain broadcast file: {}", path.display()))?;
-                    
+                    let deployments_value = broadcast.get("deployments").ok_or_else(|| {
+                        eyre::eyre!(
+                            "missing 'deployments' field in multichain broadcast file: {}",
+                            path.display()
+                        )
+                    })?;
+
                     let multichain_deployments: Vec<ScriptSequence> = serde_json::from_value(deployments_value.clone())
                         .map_err(|e| eyre::eyre!("failed to parse 'deployments' field in multichain broadcast file {}: {}", path.display(), e))?;
 


### PR DESCRIPTION
Previously, parsing errors were silently ignored, causing users to receive empty results without any indication of data corruption. This change propagates errors with descriptive messages, making it consistent with regular broadcast handling. 

May be valuable because BroadcastReader is used in cheatcodes (vm.getBroadcasts, vm.getDeployments).