### PR TITLE
fix(cheatcodes): decode long bytes/strings in occupied slot state diffs

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1497,7 +1497,7 @@ fn get_recorded_state_diffs(ccx: &mut CheatsCtxt) -> BTreeMap<Address, AccountSt
                             });
                         let layout = storage_layouts.get(&storage_access.account);
                         // Update state diff. Do not overwrite the initial value if already set.
-                        match account_diff.state_diff.entry(storage_access.slot) {
+                        let entry = match account_diff.state_diff.entry(storage_access.slot) {
                             Entry::Vacant(slot_state_diff) => {
                                 // Get storage layout info for this slot
                                 // Include mapping slots if available for the account
@@ -1509,9 +1509,8 @@ fn get_recorded_state_diffs(ccx: &mut CheatsCtxt) -> BTreeMap<Address, AccountSt
 
                                 let slot_info = layout.and_then(|layout| {
                                     let decoder = SlotIdentifier::new(layout.clone());
-                                    decoder
-                                        .identify(&storage_access.slot, mapping_slots)
-                                        .or_else(|| {
+                                    decoder.identify(&storage_access.slot, mapping_slots).or_else(
+                                        || {
                                             // Create a map of new values for bytes/string
                                             // identification. These values are used to determine
                                             // the length of the data which helps determine how many
@@ -1524,51 +1523,31 @@ fn get_recorded_state_diffs(ccx: &mut CheatsCtxt) -> BTreeMap<Address, AccountSt
                                                 &storage_access.slot,
                                                 &current_base_slot_values,
                                             )
-                                        })
-                                        .map(|mut info| {
-                                            // Always decode values first
-                                            info.decode_values(
-                                                storage_access.previousValue,
-                                                storage_access.newValue,
-                                            );
-
-                                            // Then handle long bytes/strings if applicable
-                                            if info.is_bytes_or_string() {
-                                                info.decode_bytes_or_string_values(
-                                                    &storage_access.slot,
-                                                    &raw_changes_by_slot,
-                                                );
-                                            }
-
-                                            info
-                                        })
+                                        },
+                                    )
                                 });
 
                                 slot_state_diff.insert(SlotStateDiff {
                                     previous_value: storage_access.previousValue,
                                     new_value: storage_access.newValue,
                                     slot_info,
-                                });
+                                })
                             }
-                            Entry::Occupied(mut slot_state_diff) => {
-                                let entry = slot_state_diff.get_mut();
+                            Entry::Occupied(slot_state_diff) => {
+                                let entry = slot_state_diff.into_mut();
                                 entry.new_value = storage_access.newValue;
+                                entry
+                            }
+                        };
 
-                                // Update decoded values if we have slot info
-                                if let Some(ref mut slot_info) = entry.slot_info {
-                                    slot_info.decode_values(
-                                        entry.previous_value,
-                                        storage_access.newValue,
-                                    );
-
-                                    // Then handle long bytes/strings if applicable
-                                    if slot_info.is_bytes_or_string() {
-                                        slot_info.decode_bytes_or_string_values(
-                                            &storage_access.slot,
-                                            &raw_changes_by_slot,
-                                        );
-                                    }
-                                }
+                        // Update decoded values if we have slot info
+                        if let Some(slot_info) = &mut entry.slot_info {
+                            slot_info.decode_values(entry.previous_value, storage_access.newValue);
+                            if slot_info.is_bytes_or_string() {
+                                slot_info.decode_bytes_or_string_values(
+                                    &storage_access.slot,
+                                    &raw_changes_by_slot,
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
Found a copy-paste bug in get_recorded_state_diffs where the Entry::Occupied branch was missing a chunk of logic that Entry::Vacant had.

When you update a long string (>31 bytes) multiple times in the same slot, the first update works fine but subsequent updates only decode the first 31 bytes. This happens because long strings in Solidity span multiple storage slots, and we need to call decode_bytes_or_string_values() to collect all the pieces.

The Vacant path does this correctly - it calls decode_values() and then checks if it's a long bytes/string and calls decode_bytes_or_string_values().But the Occupied path only had the first decode_values() call and was missing the second part.

Pretty straightforward fix - just added the same is_bytes_or_string() check and decode_bytes_or_string_values() call that Vacant already has. Now both branches handle multi-slot strings the same way.

Tested by looking at existing StateDiffBytesString tests which cover this scenario. The bug would have caused incomplete decoded values in the JSON output when the same long string slot gets updated more than once.