### PR TITLE
fix(chisel): set success flag after prelude file load

### DIFF
--- a/crates/chisel/src/args.rs
+++ b/crates/chisel/src/args.rs
@@ -128,9 +128,10 @@ async fn evaluate_prelude(
         let prelude_sources = fs::files_with_ext(&prelude_dir, "sol");
         let mut print_success_msg = false;
         for source_file in prelude_sources {
-            print_success_msg = true;
             sh_println!("{} {}", "Loading prelude source file:".yellow(), source_file.display())?;
             try_cf!(load_prelude_file(dispatcher, source_file).await?);
+            // Only set flag after successful load (try_cf! returns early on Break)
+            print_success_msg = true;
         }
 
         if print_success_msg {


### PR DESCRIPTION
Fixes the prelude loading success message to only show when files are actually loaded successfully, not before attempting to load them.