### PR TITLE
perf: optimize iterator usage in coverage test checks

### DIFF
--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1862,9 +1862,7 @@ contract AContractTest is DSTest {
 "#]]);
 
     // no artifacts are to be written
-    let files = files_with_ext(prj.artifacts(), "json").collect::<Vec<_>>();
-
-    assert!(files.is_empty());
+    assert!(files_with_ext(prj.artifacts(), "json").next().is_none());
 });
 
 // <https://github.com/foundry-rs/foundry/issues/10172>


### PR DESCRIPTION
Replace unnecessary `collect()` with direct iterator check in coverage tests.

Instead of collecting all files into Vec just to check if it's empty, use `next().is_none()` which is more efficient and idiomatic Rust. This avoids unnecessary memory allocation when we only need to know if the iterator produces any elements.