### PR TITLE
PR Title: Remove unused HashMap import from trace tests

### DIFF
--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::{
     abi::{Multicall, SimpleStorage},
     fork::fork_config,


### PR DESCRIPTION
Drop the unused std::collections::HashMap import from crates/anvil/tests/it/traces.rs keeps the test module free of compiler unused_imports warnings and reduces review noise