### PR TITLE
Avoid cloning git commit when building doc URLs

### DIFF
--- a/crates/doc/src/preprocessor/git_source.rs
+++ b/crates/doc/src/preprocessor/git_source.rs
@@ -26,7 +26,7 @@ impl Preprocessor for GitSource {
     fn preprocess(&self, documents: Vec<Document>) -> Result<Vec<Document>, eyre::Error> {
         if let Some(ref repo) = self.repository {
             let repo = repo.trim_end_matches('/');
-            let commit = self.commit.clone().unwrap_or("master".to_owned());
+            let commit = self.commit.as_deref().unwrap_or("master");
             for document in &documents {
                 if document.from_library {
                     continue;


### PR DESCRIPTION
Switch the git-source preprocessor to borrow the existing commit string (or the "master" default) with as_deref(), removing an unnecessary allocation per document while keeping the generated links identical.
