### PR TITLE
chore(anvil): replace `inject_custom_precompiles` with `PrecompilesMap::extend_precompiles` method

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -11,7 +11,6 @@ use crate::{
         error::InvalidTransactionError,
         pool::transactions::PoolTransaction,
     },
-    inject_custom_precompiles,
     mem::inspector::AnvilInspector,
 };
 use alloy_consensus::{
@@ -361,7 +360,7 @@ impl<DB: Db + ?Sized, V: TransactionValidator> Iterator for &mut TransactionExec
             self.networks.inject_precompiles(evm.precompiles_mut());
 
             if let Some(factory) = &self.precompile_factory {
-                inject_custom_precompiles(&mut evm, factory.precompiles());
+                evm.precompiles_mut().extend_precompiles(factory.precompiles());
             }
 
             let cheats = Arc::new(self.cheats.clone());

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -27,7 +27,6 @@ use crate::{
         pool::transactions::PoolTransaction,
         sign::build_typed_transaction,
     },
-    inject_custom_precompiles,
     mem::{
         inspector::AnvilInspector,
         storage::{BlockchainStorage, InMemoryBlockStates, MinedBlockOutcome},
@@ -1180,7 +1179,7 @@ impl Backend {
         self.env.read().networks.inject_precompiles(evm.precompiles_mut());
 
         if let Some(factory) = &self.precompile_factory {
-            inject_custom_precompiles(&mut evm, factory.precompiles());
+            evm.precompiles_mut().extend_precompiles(factory.precompiles());
         }
 
         let cheats = Arc::new(self.cheats.clone());

--- a/crates/anvil/src/evm.rs
+++ b/crates/anvil/src/evm.rs
@@ -1,12 +1,5 @@
-use alloy_evm::{
-    Database, Evm,
-    eth::EthEvmContext,
-    precompiles::{DynPrecompile, PrecompilesMap},
-};
+use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::Address;
-use foundry_evm::core::either_evm::EitherEvm;
-use op_revm::OpContext;
-use revm::Inspector;
 use std::fmt::Debug;
 
 /// Object-safe trait that enables injecting extra precompiles when using
@@ -16,24 +9,11 @@ pub trait PrecompileFactory: Send + Sync + Unpin + Debug {
     fn precompiles(&self) -> Vec<(Address, DynPrecompile)>;
 }
 
-/// Inject custom precompiles into the EVM dynamically.
-pub fn inject_custom_precompiles<DB, I>(
-    evm: &mut EitherEvm<DB, I, PrecompilesMap>,
-    precompiles: Vec<(Address, DynPrecompile)>,
-) where
-    DB: Database,
-    I: Inspector<EthEvmContext<DB>> + Inspector<OpContext<DB>>,
-{
-    for (addr, precompile) in precompiles {
-        evm.precompiles_mut().apply_precompile(&addr, move |_| Some(precompile));
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::convert::Infallible;
 
-    use crate::{PrecompileFactory, inject_custom_precompiles};
+    use crate::PrecompileFactory;
     use alloy_evm::{
         EthEvm, Evm, EvmEnv,
         eth::EthEvmContext,
@@ -194,7 +174,7 @@ mod tests {
 
         assert!(!evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
-        inject_custom_precompiles(&mut evm, CustomPrecompileFactory.precompiles());
+        evm.precompiles_mut().extend_precompiles(CustomPrecompileFactory.precompiles());
 
         assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
@@ -216,7 +196,7 @@ mod tests {
 
         assert!(!evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
-        inject_custom_precompiles(&mut evm, CustomPrecompileFactory.precompiles());
+        evm.precompiles_mut().extend_precompiles(CustomPrecompileFactory.precompiles());
 
         assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
@@ -241,7 +221,7 @@ mod tests {
 
         assert!(!evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
-        inject_custom_precompiles(&mut evm, CustomPrecompileFactory.precompiles());
+        evm.precompiles_mut().extend_precompiles(CustomPrecompileFactory.precompiles());
 
         assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
@@ -266,7 +246,7 @@ mod tests {
 
         assert!(!evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
-        inject_custom_precompiles(&mut evm, CustomPrecompileFactory.precompiles());
+        evm.precompiles_mut().extend_precompiles(CustomPrecompileFactory.precompiles());
 
         assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -55,7 +55,7 @@ pub use alloy_hardforks::EthereumHardfork;
 pub mod eth;
 /// Evm related abstractions
 mod evm;
-pub use evm::{PrecompileFactory, inject_custom_precompiles};
+pub use evm::PrecompileFactory;
 
 /// support for polling filters
 pub mod filter;


### PR DESCRIPTION
## Motivation

Replace `inject_custom_precompiles` function with `PrecompilesMap::extend_precompiles` method recently introduced in alloy-evm.

Thanks @mattsse for the idea 👍 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
