### PR TITLE
perf(common): avoid double JSON logging and remove intermediate Vec in imports

### DIFF
--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -76,7 +76,7 @@ impl OpenChainClient {
         url: &str,
         body: &T,
     ) -> reqwest::Result<R> {
-        trace!(%url, body=?serde_json::to_string(body), "POST");
+        trace!(%url, body=?body, "POST");
         self.inner
             .post(url)
             .json(body)
@@ -296,7 +296,6 @@ impl OpenChainClient {
                         abi.functions()
                             .map(|func| func.signature())
                             .chain(abi.errors().map(|error| error.signature()))
-                            .collect::<Vec<_>>()
                     })
                     .collect();
 


### PR DESCRIPTION
Replaced serde_json::to_string(body) in OpenChainClient::post_json() logging with ?body to prevent unnecessary allocations and double serialization when TRACE logging is disabled. The request is still serialized once by .json(body).
In OpenChainClient::import_selectors() for SelectorImportData::Abi, removed collect::<Vec<_>>() inside flat_map when combining function and error signatures. This avoids creating a temporary vector per ABI and relies on a single final collection, matching the already optimal event path.
These changes maintain behavior while reducing overhead and improving consistency.