### PR TITLE
Reduce redundant RPC cloning in script runner setup

### DIFF
--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -239,7 +239,7 @@ impl PreSimulationState {
             let mut script_config = self.script_config.clone();
             script_config.evm_opts.fork_url = Some(rpc.clone());
             let runner = script_config.get_runner().await?;
-            Ok((rpc.clone(), runner))
+            Ok((rpc, runner))
         });
         try_join_all(futs).await
     }


### PR DESCRIPTION
Reuse the original RPC string when returning (rpc, runner) keep the single intentional clone for fork_url and drop the redundant one