### PR TITLE
chore(meta): remove MSRV from clippy.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ resolver = "2"
 [workspace.package]
 version = "1.4.4"
 edition = "2024"
-# Remember to update clippy.toml as well
 rust-version = "1.89"
 authors = ["Foundry Contributors"]
 license = "MIT OR Apache-2.0"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,3 @@
-msrv = "1.89"
-
 # `bytes::Bytes` is included by default and `alloy_primitives::Bytes` is a wrapper around it,
 # so it is safe to ignore it as well.
 ignore-interior-mutability = ["bytes::Bytes", "alloy_primitives::Bytes"]


### PR DESCRIPTION
It is inferred from package.rust-version.