### PR TITLE
fix: remove redundant exists() check in check_file_contents

### DIFF
--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -325,11 +325,7 @@ edition = "2021"
     }
 
     fn check_file_contents(&self, file_path: &Path, expected_contents: &str) -> Result<()> {
-        eyre::ensure!(
-            file_path.is_file() && file_path.exists(),
-            "{} is not a file",
-            file_path.display()
-        );
+        eyre::ensure!(file_path.is_file(), "{} is not a file", file_path.display());
         let file_contents = &fs::read_to_string(file_path).wrap_err("Failed to read file")?;
 
         // Format both


### PR DESCRIPTION
Remove redundant file_path.exists() check since is_file() already verifies file existence. 

This matches the pattern used elsewhere in the codebase (e.g., check_cargo_toml at line 361).