### PR TITLE
Remove Unused yansi::Paint Import in watch Command

### DIFF
--- a/crates/forge/src/cmd/watch.rs
+++ b/crates/forge/src/cmd/watch.rs
@@ -29,7 +29,7 @@ use watchexec_events::{
     filekind::{AccessKind, FileEventKind},
 };
 use watchexec_signals::Signal;
-use yansi::{Color, Paint};
+use yansi::Color;
 
 type SpawnHook = Arc<dyn Fn(&[Event], &mut TokioCommand) + Send + Sync + 'static>;
 


### PR DESCRIPTION
drop the unused yansi::Paint import from foundry/crates/forge/src/cmd/watch.rs, keeping only Color eliminates the unused_imports lint triggered by the workspace configuration (verification) attempted cargo check -p forge, but cargo is unavailable on the host; no further checks run