### PR TITLE
ci(doc): document feature sync

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ env:
 
   # Keep in sync with `release.yml`.
   RUST_PROFILE: maxperf
-  RUST_FEATURES: aws-kms,gcp-kms,cli,asm-keccak,js-tracer
+  RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
 
   # Keep in sync with `docker-publish.yml`.
   RUST_PROFILE: maxperf
-  RUST_FEATURES: aws-kms,gcp-kms,cli,asm-keccak,js-tracer
+  RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer
 
   LAST_STABLE_VERSION: "v1.4.4"
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -79,6 +79,10 @@ We use [cargo-nextest][nextest] as the test runner.
 
 If `make test` passes locally, that's a good sign that CI will be green as well.
 
+## Release Features
+
+Nightly/stable release builds derive their enabled functionality from the shared `RUST_FEATURES` environment variable in `.github/workflows/release.yml` and `.github/workflows/docker-publish.yml`. Keep that list aligned with the default `FEATURES` value in the root `Makefile` so published artifacts expose the same CLI surface area (wallet backends, allocators, tracers, etc.) as local builds.
+
 [foundry-book]: https://book.getfoundry.sh
 [cargo-workspace]: https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html
 [nextest]: https://nexte.st/


### PR DESCRIPTION
## Summary

  - Add `turnkey` to the `RUST_FEATURES` env shared by `release.yml` and `docker-publish.yml` so nightly/stable tarballs and Docker images ship binaries with the new signer enabled.
  - Document in `docs/dev/README.md` that the workflow env var must stay in sync with the Makefile’s default feature list to avoid future drift.

  ## Testing

  ```sh
  cargo build --profile maxperf --no-default-features --features "aws-kms,gcp-kms,turnkey,cli,asm-
  keccak,js-tracer"

  target/maxperf/cast send --help | grep -n turnkey

  239:      --turnkey
  245:          See: <https://docs.turnkey.com/getting-started/quickstart>
```