### PR TITLE
Remove redundant boolean comparison in invariant test fixture

### DIFF
--- a/crates/forge/tests/cli/test_cmd/invariant/target.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/target.rs
@@ -36,7 +36,7 @@ contract ExcludeContracts is Test {
     }
 
     function invariantTrueWorld() public {
-        require(hello.world() == true, "false world");
+        require(hello.world(), "false world");
     }
 }
 "#,


### PR DESCRIPTION
replace require(hello.world() == true, "false world"); with require(hello.world(), "false world"); in the CLI invariant target to remove dead code while preserving behaviour keeps the test string clearer and aligns with Solidity style