### PR TITLE
feat(anvil): add `/eth/v1/beacon/genesis` endpoint to Beacon API

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -202,6 +202,10 @@ pub enum EthRequest {
     #[serde(rename = "anvil_getBlobSidecarsByBlockId", with = "sequence")]
     GetBlobSidecarsByBlockId(BlockId),
 
+    /// Returns the genesis time for the chain
+    #[serde(rename = "anvil_getGenesisTime", with = "empty_params")]
+    GetGenesisTime(()),
+
     #[serde(rename = "eth_getTransactionByBlockHashAndIndex")]
     EthGetTransactionByBlockHashAndIndex(TxHash, Index),
 

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -291,6 +291,7 @@ impl EthApi {
             EthRequest::GetBlobSidecarsByBlockId(block_id) => {
                 self.anvil_get_blob_sidecars_by_block_id(block_id).to_rpc_result()
             }
+            EthRequest::GetGenesisTime(()) => self.anvil_get_genesis_time().to_rpc_result(),
             EthRequest::EthGetRawTransactionByBlockHashAndIndex(hash, index) => {
                 self.raw_transaction_by_block_hash_and_index(hash, index).await.to_rpc_result()
             }
@@ -1392,6 +1393,14 @@ impl EthApi {
     ) -> Result<Option<BlobTransactionSidecar>> {
         node_info!("anvil_getBlobSidecarsByBlockId");
         Ok(self.backend.get_blob_sidecars_by_block_id(block_id)?)
+    }
+
+    /// Returns the genesis time for the Beacon chain
+    ///
+    /// Handler for Beacon API call: `GET /eth/v1/beacon/genesis`
+    pub fn anvil_get_genesis_time(&self) -> Result<u64> {
+        node_info!("anvil_getGenesisTime");
+        Ok(self.backend.genesis_time())
     }
 
     /// Get transaction by its hash.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -730,6 +730,11 @@ impl Backend {
         self.env.write().evm_env.cfg_env.chain_id = chain_id;
     }
 
+    /// Returns the genesis data for the Beacon API.
+    pub fn genesis_time(&self) -> u64 {
+        self.genesis.timestamp
+    }
+
     /// Returns balance of the given account.
     pub async fn current_balance(&self, address: Address) -> DatabaseResult<U256> {
         Ok(self.get_account(address).await?.balance)

--- a/crates/anvil/src/eth/beacon/data.rs
+++ b/crates/anvil/src/eth/beacon/data.rs
@@ -1,0 +1,15 @@
+//! Beacon data structures for the Beacon API responses
+
+use alloy_primitives::{B256, aliases::B32};
+use serde::{Deserialize, Serialize};
+
+/// Ethereum Beacon chain genesis details
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenesisDetails {
+    /// The genesis_time configured for the beacon chain
+    pub genesis_time: u64,
+    /// The genesis validators root
+    pub genesis_validators_root: B256,
+    /// The genesis fork version, as used in the beacon chain
+    pub genesis_fork_version: B32,
+}

--- a/crates/anvil/src/eth/beacon/mod.rs
+++ b/crates/anvil/src/eth/beacon/mod.rs
@@ -3,8 +3,10 @@
 //! This module provides types and utilities for implementing Beacon API endpoints
 //! in Anvil, allowing testing of blob-based transactions with standard beacon chain APIs.
 
+pub mod data;
 pub mod error;
 pub mod response;
 
+pub use data::GenesisDetails;
 pub use error::BeaconError;
 pub use response::BeaconResponse;

--- a/crates/anvil/src/server/mod.rs
+++ b/crates/anvil/src/server/mod.rs
@@ -58,6 +58,7 @@ fn beacon_router(api: EthApi) -> Router {
             get(beacon_handler::handle_get_blob_sidecars),
         )
         .route("/eth/v1/beacon/blobs/{block_id}", get(beacon_handler::handle_get_blobs))
+        .route("/eth/v1/beacon/genesis", get(beacon_handler::handle_get_genesis))
         .with_state(api)
 }
 


### PR DESCRIPTION
## Motivation

Close #12502 

## Solution

- Introduced `anvil_getGenesisTime` request to retrieve the genesis time of the chain.
- Implemented `anvil_get_genesis_time` function in the backend to return the genesis timestamp.
- Added a new handler for the `/eth/v1/beacon/genesis` endpoint to respond with genesis details.
- Created `GenesisDetails` data struct for Beacon API response

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
