### PR TITLE
Use `&str` instead of `&String` in `start_suite_progress`

### DIFF
--- a/crates/forge/src/progress.rs
+++ b/crates/forge/src/progress.rs
@@ -34,7 +34,7 @@ impl TestsProgressState {
     }
 
     /// Creates new test suite progress and add it to overall progress.
-    pub fn start_suite_progress(&mut self, suite_name: &String) {
+    pub fn start_suite_progress(&mut self, suite_name: &str) {
         let suite_progress = self.multi.add(ProgressBar::new_spinner());
         suite_progress.set_style(
             indicatif::ProgressStyle::with_template("{spinner} {wide_msg:.bold.dim}")


### PR DESCRIPTION



Changed the parameter type from `&String` to `&str` in the `start_suite_progress` method signature. This follows Rust best practices where string slice references (`&str`) are preferred over string references (`&String`) for function parameters that don't need ownership.

