### PR TITLE
fix: enable different gas calculation for monad testnet

### DIFF
--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -169,6 +169,7 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
                     | NamedChain::KaruraTestnet
                     | NamedChain::Mantle
                     | NamedChain::MantleSepolia
+                    | NamedChain::MonadTestnet
                     | NamedChain::Moonbase
                     | NamedChain::Moonbeam
                     | NamedChain::MoonbeamDev


### PR DESCRIPTION
## Motivation
Monad OPCODEs are priced differently hence we should use `eth_estimateGas` RPC method instead of the local Anvil node

## Solution
Add the testnet as a different gas calculation chain

## PR Checklist
- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
