### PR TITLE
chore(linking): remove unused Artifact import

### DIFF
--- a/crates/linking/src/lib.rs
+++ b/crates/linking/src/lib.rs
@@ -7,10 +7,11 @@
 
 use alloy_primitives::{Address, B256, Bytes};
 use foundry_compilers::{
-    Artifact, ArtifactId,
+    ArtifactId,
     artifacts::{CompactBytecode, CompactContractBytecodeCow, Libraries},
     contracts::ArtifactContracts,
 };
+use rayon::prelude::*;
 use rayon::prelude::*;
 use semver::Version;
 use std::{


### PR DESCRIPTION
unused Artifact import from crates/linking/src/lib.rs to eliminate compiler/clippy warnings