### PR TITLE
doc: confine InlineLink test helpers to tests

### DIFF
--- a/crates/doc/src/preprocessor/infer_hyperlinks.rs
+++ b/crates/doc/src/preprocessor/infer_hyperlinks.rs
@@ -239,7 +239,7 @@ impl<'a> InlineLink<'a> {
     }
 
     /// Parses the first inline link.
-    #[allow(unused)]
+    #[cfg(test)]
     fn capture(s: &'a str) -> Option<Self> {
         let cap = RE_INLINE_LINK.captures(s)?;
         Self::from_capture(cap)
@@ -267,16 +267,6 @@ impl<'a> InlineLink<'a> {
             name = part;
         }
         name
-    }
-
-    /// Returns the name of the referenced item and its arguments, if any.
-    ///
-    /// Eg: `safeMint-address-uint256-` returns `("safeMint", ["address", "uint256"])`
-    #[expect(unused)]
-    fn ref_name_exact(&self) -> (&str, impl Iterator<Item = &str> + '_) {
-        let identifier = self.exact_identifier();
-        let mut iter = identifier.split('-');
-        (iter.next().unwrap(), iter.filter(|s| !s.is_empty()))
     }
 
     /// Returns the content of the matched link.


### PR DESCRIPTION
remove the unused InlineLink::ref_name_exact helper instead of suppressing the warning gate InlineLink::capture behind #[cfg(test)] so it is only built for the test suite keep production builds free from test-only code paths and unused allowances