### PR TITLE
chore(common): drop unused fs import and fix doc links

### DIFF
--- a/crates/common/src/errors/fs.rs
+++ b/crates/common/src/errors/fs.rs
@@ -3,39 +3,36 @@ use std::{
     path::{Path, PathBuf},
 };
 
-#[expect(unused_imports)]
-use std::fs::{self, File};
-
 /// Various error variants for `fs` operations that serve as an addition to the io::Error which
 /// does not provide any information about the path.
 #[derive(Debug, thiserror::Error)]
 #[expect(missing_docs)]
 pub enum FsPathError {
-    /// Provides additional path context for [`fs::write`].
+    /// Provides additional path context for [`std::fs::write`].
     #[error("failed to write to {path:?}: {source}")]
     Write { source: io::Error, path: PathBuf },
-    /// Provides additional path context for [`fs::read`].
+    /// Provides additional path context for [`std::fs::read`].
     #[error("failed to read from {path:?}: {source}")]
     Read { source: io::Error, path: PathBuf },
-    /// Provides additional path context for [`fs::copy`].
+    /// Provides additional path context for [`std::fs::copy`].
     #[error("failed to copy from {from:?} to {to:?}: {source}")]
     Copy { source: io::Error, from: PathBuf, to: PathBuf },
-    /// Provides additional path context for [`fs::read_link`].
+    /// Provides additional path context for [`std::fs::read_link`].
     #[error("failed to read from {path:?}: {source}")]
     ReadLink { source: io::Error, path: PathBuf },
-    /// Provides additional path context for [`File::create`].
+    /// Provides additional path context for [`std::fs::File::create`].
     #[error("failed to create file {path:?}: {source}")]
     CreateFile { source: io::Error, path: PathBuf },
-    /// Provides additional path context for [`fs::remove_file`].
+    /// Provides additional path context for [`std::fs::remove_file`].
     #[error("failed to remove file {path:?}: {source}")]
     RemoveFile { source: io::Error, path: PathBuf },
-    /// Provides additional path context for [`fs::create_dir`].
+    /// Provides additional path context for [`std::fs::create_dir`].
     #[error("failed to create dir {path:?}: {source}")]
     CreateDir { source: io::Error, path: PathBuf },
-    /// Provides additional path context for [`fs::remove_dir`].
+    /// Provides additional path context for [`std::fs::remove_dir`].
     #[error("failed to remove dir {path:?}: {source}")]
     RemoveDir { source: io::Error, path: PathBuf },
-    /// Provides additional path context for [`File::open`].
+    /// Provides additional path context for [`std::fs::File::open`].
     #[error("failed to open file {path:?}: {source}")]
     Open { source: io::Error, path: PathBuf },
     #[error("failed to lock file {path:?}: {source}")]
@@ -51,57 +48,57 @@ pub enum FsPathError {
 }
 
 impl FsPathError {
-    /// Returns the complementary error variant for [`fs::write`].
+    /// Returns the complementary error variant for [`std::fs::write`].
     pub fn write(source: io::Error, path: impl Into<PathBuf>) -> Self {
         Self::Write { source, path: path.into() }
     }
 
-    /// Returns the complementary error variant for [`fs::read`].
+    /// Returns the complementary error variant for [`std::fs::read`].
     pub fn read(source: io::Error, path: impl Into<PathBuf>) -> Self {
         Self::Read { source, path: path.into() }
     }
 
-    /// Returns the complementary error variant for [`fs::copy`].
+    /// Returns the complementary error variant for [`std::fs::copy`].
     pub fn copy(source: io::Error, from: impl Into<PathBuf>, to: impl Into<PathBuf>) -> Self {
         Self::Copy { source, from: from.into(), to: to.into() }
     }
 
-    /// Returns the complementary error variant for [`fs::read_link`].
+    /// Returns the complementary error variant for [`std::fs::read_link`].
     pub fn read_link(source: io::Error, path: impl Into<PathBuf>) -> Self {
         Self::ReadLink { source, path: path.into() }
     }
 
-    /// Returns the complementary error variant for [`File::create`].
+    /// Returns the complementary error variant for [`std::fs::File::create`].
     pub fn create_file(source: io::Error, path: impl Into<PathBuf>) -> Self {
         Self::CreateFile { source, path: path.into() }
     }
 
-    /// Returns the complementary error variant for [`fs::remove_file`].
+    /// Returns the complementary error variant for [`std::fs::remove_file`].
     pub fn remove_file(source: io::Error, path: impl Into<PathBuf>) -> Self {
         Self::RemoveFile { source, path: path.into() }
     }
 
-    /// Returns the complementary error variant for [`fs::create_dir`].
+    /// Returns the complementary error variant for [`std::fs::create_dir`].
     pub fn create_dir(source: io::Error, path: impl Into<PathBuf>) -> Self {
         Self::CreateDir { source, path: path.into() }
     }
 
-    /// Returns the complementary error variant for [`fs::remove_dir`].
+    /// Returns the complementary error variant for [`std::fs::remove_dir`].
     pub fn remove_dir(source: io::Error, path: impl Into<PathBuf>) -> Self {
         Self::RemoveDir { source, path: path.into() }
     }
 
-    /// Returns the complementary error variant for [`File::open`].
+    /// Returns the complementary error variant for [`std::fs::File::open`].
     pub fn open(source: io::Error, path: impl Into<PathBuf>) -> Self {
         Self::Open { source, path: path.into() }
     }
 
-    /// Returns the complementary error variant for [`File::lock`].
+    /// Returns the complementary error variant when locking a file.
     pub fn lock(source: io::Error, path: impl Into<PathBuf>) -> Self {
         Self::Lock { source, path: path.into() }
     }
 
-    /// Returns the complementary error variant for [`File::unlock`].
+    /// Returns the complementary error variant when unlocking a file.
     pub fn unlock(source: io::Error, path: impl Into<PathBuf>) -> Self {
         Self::Unlock { source, path: path.into() }
     }


### PR DESCRIPTION
remove the suppressed std::fs import from FsPathError point every intra-doc link at fully qualified std::fs items and clarify lock/unlock docs keep error variants unchanged so external usage is unaffected