### PR TITLE
fix: return empty array encoding for parse_array

### DIFF
--- a/crates/cheatcodes/src/string.rs
+++ b/crates/cheatcodes/src/string.rs
@@ -161,8 +161,8 @@ where
             .map(|s| parse_value(s.as_ref(), ty))
             .collect::<Result<Vec<_>, _>>()
             .map(|vec| DynSolValue::Array(vec).abi_encode()),
-        // return the empty encoded Bytes when values is empty or the first element is empty
-        _ => Ok("".abi_encode()),
+        // return the empty encoded array when values is empty or the first element is empty
+        _ => Ok(DynSolValue::Array(Vec::new()).abi_encode()),
     }
 }
 


### PR DESCRIPTION
When parse_array receives no values, it now returns a properly typed DynSolValue::Array instead of a String. While both have identical ABI encoding, this fixes semantic correctness and makes the code match its comment and function name.