### PR TITLE
Fix infinite loop in TAR extraction when encountering invalid file sizes

### DIFF
--- a/npm/src/install.mjs
+++ b/npm/src/install.mjs
@@ -198,9 +198,13 @@ function extractFileFromTarball(tarballBuffer, filepath) {
       8
     )
 
+    const sizeInvalid = !Number.isFinite(fileSize) || Number.isNaN(fileSize) || fileSize < 0
+    if (sizeInvalid) {
+      const target = fileName === filepath ? filepath : fileName || '(unnamed entry)'
+      throw new Error(`Invalid size for ${target} in tarball`)
+    }
+
     if (fileName === filepath) {
-      if (!Number.isFinite(fileSize) || Number.isNaN(fileSize) || fileSize < 0)
-        throw new Error(`Invalid size for ${filepath} in tarball`)
       if (fileSize > MAX_BINARY_BYTES)
         throw new Error(`Binary size for ${filepath} exceeds maximum allowed threshold`)
       return tarballBuffer.subarray(offset, offset + fileSize)


### PR DESCRIPTION


The `extractFileFromTarball` function in `npm/src/install.mjs` could enter an infinite loop when processing TAR archives with corrupted or malicious headers. If `fileSize` parsing resulted in `NaN` (due to invalid octal data in the TAR header), the offset calculation `(offset + fileSize + 511) & ~511` would evaluate to `0`, causing the parser to repeatedly process the same header block without advancing.

