### PR TITLE
Remove unused FutureExt import from Anvil CLI

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -13,7 +13,6 @@ use core::fmt;
 use foundry_common::shell;
 use foundry_config::{Chain, Config, FigmentProviders};
 use foundry_evm_networks::NetworkConfigs;
-use futures::FutureExt;
 use rand_08::{SeedableRng, rngs::StdRng};
 use std::{
     net::IpAddr,


### PR DESCRIPTION
clean up foundry/crates/anvil/src/cmd.rs by deleting the unused FutureExt import keep the module free of dead dependencies and silence the compiler’s unused import warning