### PR TITLE
docs: clarify gas reporting behavior in multi-contract forge tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+> Note: In multi-contract test setups, forge aggregates gas usage per call context. Developers may observe higher totals when factory patterns or nested calls are involved.
 <div align="center">
   <img src=".github/assets/banner.png" alt="Foundry banner" />
 


### PR DESCRIPTION
Forge’s gas reports can be confusing in multi-contract test scenarios,
especially when factory patterns or nested calls are involved. Developers
often expect per-function gas usage, but forge aggregates gas usage per
call context, which leads to higher totals in more complex test setups.

Clarifying this behavior in the documentation will help contributors and
users interpret gas reports more accurately.



This PR adds a brief note to the documentation explaining how forge
aggregates gas usage in multi-contract test flows. The clarification
helps set expectations when analyzing gas profiles for tests that involve
multiple contracts or nested call structures.

This change is documentation-only and does not modify any code or logic.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
