### PR TITLE
fix: infer addresses in unknown fields in UIfmt

### DIFF
--- a/crates/common/fmt/src/ui.rs
+++ b/crates/common/fmt/src/ui.rs
@@ -783,6 +783,7 @@ impl<T: UIfmt> UIfmt for WithOtherFields<T> {
 #[expect(missing_docs)]
 pub enum EthValue {
     U64(U64),
+    Address(Address),
     U256(U256),
     U64Array(Vec<U64>),
     U256Array(Vec<U256>),
@@ -800,6 +801,7 @@ impl UIfmt for EthValue {
         match self {
             Self::U64(num) => num.pretty(),
             Self::U256(num) => num.pretty(),
+            Self::Address(addr) => addr.pretty(),
             Self::U64Array(arr) => arr.pretty(),
             Self::U256Array(arr) => arr.pretty(),
             Self::Other(val) => val.to_string().trim_matches('"').to_string(),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Changes `cast tx`/`cast receipt`/`cast block` to properly format `OtherFields` entries that look like an address

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
