### PR TITLE
fix(forge doc): use relative path instead of full path (#12519)

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -3,8 +3,9 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use alloy_consensus::{Header, TxEnvelope};
+use alloy_consensus::{EthereumTxEnvelope, Header, TxEip4844Variant};
 use alloy_dyn_abi::{DynSolType, DynSolValue, FunctionExt};
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use alloy_ens::NameOrAddress;
 use alloy_json_abi::Function;
 use alloy_network::{AnyNetwork, AnyRpcTransaction};
@@ -2310,9 +2311,11 @@ impl SimpleCast {
     /// let tx = "0x02f8f582a86a82058d8459682f008508351050808303fd84948e42f2f4101563bf679975178e880fd87d3efd4e80b884659ac74b00000000000000000000000080f0c1c49891dcfdd40b6e0f960f84e6042bcb6f000000000000000000000000b97ef9ef8734c71904d8002f8b6bc66dd9c48a6e00000000000000000000000000000000000000000000000000000000007ff4e20000000000000000000000000000000000000000000000000000000000000064c001a05d429597befe2835396206781b199122f2e8297327ed4a05483339e7a8b2022aa04c23a7f70fb29dda1b4ee342fb10a625e9b8ddc6a603fb4e170d4f6f37700cb8";
     /// let tx_envelope = Cast::decode_raw_transaction(&tx)?;
     /// # Ok::<(), eyre::Report>(())
-    pub fn decode_raw_transaction(tx: &str) -> Result<TxEnvelope> {
+    pub fn decode_raw_transaction(
+        tx: &str,
+    ) -> Result<EthereumTxEnvelope<TxEip4844Variant<BlobTransactionSidecarVariant>>> {
         let tx_hex = hex::decode(tx)?;
-        let tx = TxEnvelope::decode_2718(&mut tx_hex.as_slice())?;
+        let tx = Decodable2718::decode_2718(&mut tx_hex.as_slice())?;
         Ok(tx)
     }
 }

--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -124,6 +124,7 @@ impl DocBuilder {
             .collect::<Vec<_>>();
 
         let out_dir = self.out_dir()?;
+        let out_target_dir = out_dir.clone();
         let documents = compiler.enter_mut(|compiler| -> eyre::Result<Vec<Vec<Document>>> {
             let gcx = compiler.gcx();
             let documents = combined_sources
@@ -197,7 +198,7 @@ impl DocBuilder {
                                     path.clone(),
                                     target_path,
                                     from_library,
-                                    self.config.out.clone(),
+                                    out_target_dir.clone(),
                                 )
                                 .with_content(DocumentContent::Single(item), ident))
                             })
@@ -231,7 +232,7 @@ impl DocBuilder {
                                     path.clone(),
                                     target_path,
                                     from_library,
-                                    self.config.out.clone(),
+                                    out_target_dir.clone(),
                                 )
                                 .with_content(DocumentContent::Constants(consts), identity),
                             )
@@ -250,7 +251,7 @@ impl DocBuilder {
                                         path.clone(),
                                         target_path,
                                         from_library,
-                                        self.config.out.clone(),
+                                        out_target_dir.clone(),
                                     )
                                     .with_content(
                                         DocumentContent::OverloadedFunctions(funcs),

--- a/crates/doc/src/preprocessor/contract_inheritance.rs
+++ b/crates/doc/src/preprocessor/contract_inheritance.rs
@@ -62,7 +62,7 @@ impl ContractInheritance {
                 && let ParseSource::Contract(ref contract) = item.source
                 && base == contract.name.safe_unwrap().name
             {
-                return Some(candidate.target_path.clone());
+                return Some(candidate.relative_output_path().to_path_buf());
             }
         }
         None

--- a/crates/doc/src/writer/as_doc.rs
+++ b/crates/doc/src/writer/as_doc.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use itertools::Itertools;
 use solang_parser::pt::{Base, FunctionDefinition};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// The result of [`AsDoc::as_doc`].
 pub type AsDocResult = Result<String, std::fmt::Error>;
@@ -141,9 +141,6 @@ impl AsDoc for Document {
                         if !contract.base.is_empty() {
                             writer.write_bold("Inherits:")?;
 
-                            // we need this to find the _relative_ paths
-                            let src_target_dir = self.target_src_dir();
-
                             let mut bases = vec![];
                             let linked =
                                 read_context!(self, CONTRACT_INHERITANCE_ID, ContractInheritance);
@@ -155,11 +152,11 @@ impl AsDoc for Document {
                                     .as_ref()
                                     .and_then(|link| {
                                         link.get(base_ident).map(|path| {
-                                            let path = Path::new("/").join(
-                                                path.strip_prefix(&src_target_dir)
-                                                    .ok()
-                                                    .unwrap_or(path),
-                                            );
+                                            let path = if cfg!(windows) {
+                                                Path::new("\\").join(path)
+                                            } else {
+                                                Path::new("/").join(path)
+                                            };
                                             Markdown::Link(&base_doc, &path.display().to_string())
                                                 .as_doc()
                                         })
@@ -287,11 +284,6 @@ impl AsDoc for Document {
 }
 
 impl Document {
-    /// Where all the source files are written to
-    fn target_src_dir(&self) -> PathBuf {
-        self.out_target_dir.join("src")
-    }
-
     /// Writes a function to the buffer.
     fn write_function(
         &self,

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -69,3 +69,46 @@ contract Example is IExample {
     assert!(content.contains("Process multiple addresses"));
     assert!(content.contains("Process an address with a value"));
 });
+
+// Test that hyperlinks use relative paths, not absolute paths
+// fixes <https://github.com/foundry-rs/foundry/issues/12361>
+forgetest_init!(hyperlinks_use_relative_paths, |prj, cmd| {
+    prj.add_source(
+        "IBase.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IBase {
+    function baseFunction() external;
+}
+"#,
+    );
+
+    prj.add_source(
+        "Derived.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./IBase.sol";
+
+/// @dev Inherits: {IBase}
+contract Derived is IBase {
+    function baseFunction() external override {}
+}
+"#,
+    );
+
+    cmd.args(["doc", "--build"]).assert_success();
+
+    let doc_path = prj.root().join("docs/src/src/Derived.sol/contract.Derived.md");
+    let content = std::fs::read_to_string(&doc_path).unwrap();
+
+    assert!(
+        content.contains("[IBase](/src/IBase.sol/interface.IBase.md")
+            || content.contains("[IBase](\\src\\IBase.sol\\interface.IBase.md"),
+        "Hyperlink should use relative path but found: {:?}",
+        content.lines().find(|line| line.contains("[IBase]")).unwrap_or("not found")
+    );
+});


### PR DESCRIPTION
makes cast decode support any 4844 blob variant