### PR TITLE
fix(chisel): guard inspect() behind do_execute to avoid redundant compile/execute

### DIFF
--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -132,15 +132,16 @@ impl ChiselDispatcher {
         // Create new source with exact input appended and parse
         let (new_source, do_execute) = source.clone_with_new_line(input.to_string())?;
 
-        // TODO: Cloning / parsing the session source twice on non-inspected inputs kinda sucks.
-        // Should change up how this works.
-        let (cf, res) = source.inspect(input).await?;
-        if let Some(res) = &res {
-            let _ = sh_println!("{res}");
-        }
-        if cf.is_break() {
-            debug!(%input, ?res, "inspect success");
-            return Ok(ControlFlow::Continue(()));
+        // Only inspect when the snippet is appended to run() and will be executed.
+        if do_execute {
+            let (cf, res) = source.inspect(input).await?;
+            if let Some(res) = &res {
+                let _ = sh_println!("{res}");
+            }
+            if cf.is_break() {
+                debug!(%input, ?res, "inspect success");
+                return Ok(ControlFlow::Continue(()));
+            }
         }
 
         if do_execute {


### PR DESCRIPTION
This change removes redundant compilation and execution for non-run() inputs in Chisel’s dispatcher by guarding the inspect() call behind do_execute. clone_with_new_line already determines whether the snippet targets run(); only in that case does inspection provide value for expression introspection and flow control. Contract/global declarations now skip the inspector path and only build once, preserving behavior for run() snippets while reducing allocations and compile time for declarations.