### PR TITLE
fix: use AssumeReject instead of TooManyRejects for single vm.assume reject

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -238,7 +238,9 @@ impl FuzzedExecutor {
                             if self.config.max_test_rejects > 0
                                 && test_data.rejects >= self.config.max_test_rejects
                             {
-                                test_data.failure = Some(err);
+                                test_data.failure = Some(TestCaseError::reject(
+                                    FuzzError::TooManyRejects(self.config.max_test_rejects),
+                                ));
                                 break 'stop;
                             }
                         }


### PR DESCRIPTION
Fix incorrect error type when vm.assume rejects a single input. 

Previously, the code returned TooManyRejects immediately, which prevented proper reject counting and limit checking. 

Now it correctly returns AssumeReject for a single reject, allowing the existing limit check logic to work as intended.