### PR TITLE
chore: remove unused str import from forge install command

### DIFF
--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -13,7 +13,6 @@ use soldeer_commands::{Command, Verbosity, commands::install::Install};
 use std::{
     io::IsTerminal,
     path::{Path, PathBuf},
-    str,
     sync::LazyLock,
 };
 use yansi::Paint;


### PR DESCRIPTION
Remove the unused std::str import in crates/forge/src/cmd/install.rs. Keep the module’s import section lint-clean and focused on the types it actually uses.