### PR TITLE
fix(`verify`): handle `Address is not a smart-contract` with Blockscout verification

### DIFF
--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -107,6 +107,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
 
                     if resp.result.starts_with("Unable to locate ContractCode at")
                         || resp.result.starts_with("The address is not a smart contract")
+                        || resp.result.starts_with("Address is not a smart-contract")
                     {
                         warn!("{}", resp.result);
                         return Err(eyre!("Could not detect deployment: {}", resp.result));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Blockscout has updated an error in a recent version making the retry case not match on `The address is not a smart contract`

```
Error: Encountered an error verifying this contract:
Response: `Address is not a smart-contract`
Details:
                        `Address is not a smart-contract`
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds as additional case for backwards compatibility in case old explorers still return the old version.

There is probably something more clever we can do here to combine the checks but I prefer the explicitness of this solution