### PR TITLE
remove unused Artifact import

### DIFF
--- a/crates/linking/src/lib.rs
+++ b/crates/linking/src/lib.rs
@@ -7,7 +7,7 @@
 
 use alloy_primitives::{Address, B256, Bytes};
 use foundry_compilers::{
-    Artifact, ArtifactId,
+    ArtifactId,
     artifacts::{CompactBytecode, CompactContractBytecodeCow, Libraries},
     contracts::ArtifactContracts,
 };


### PR DESCRIPTION
remove the unused Artifact import from crates/linking/src/lib.rs