### PR TITLE
fix(cheatcodes): avoid unnecessary clone in create_end when merging recorded account diffs

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1812,7 +1812,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
         if let Some(recorded_account_diffs_stack) = &mut self.recorded_account_diffs_stack {
             // The root call cannot be recorded.
             if curr_depth > 0
-                && let Some(last_depth) = &mut recorded_account_diffs_stack.pop()
+                && let Some(mut last_depth) = recorded_account_diffs_stack.pop()
             {
                 // Update the reverted status of all deeper calls if this call reverted, in
                 // accordance with EVM behavior
@@ -1852,9 +1852,9 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
                     // vector if higher depths were not recorded. This
                     // preserves ordering of accesses.
                     if let Some(last) = recorded_account_diffs_stack.last_mut() {
-                        last.append(last_depth);
+                        last.append(&mut last_depth);
                     } else {
-                        recorded_account_diffs_stack.push(last_depth.clone());
+                        recorded_account_diffs_stack.push(last_depth);
                     }
                 }
             }


### PR DESCRIPTION
The recorded account diffs handling in create_end used a temporary borrow of pop()’s result and fell back to cloning the popped vector to return it to the stack. This introduces needless allocations and diverges from the ownership pattern used in call_end. The code now takes ownership of the popped vector (let Some(mut last_depth) = recorded_account_diffs_stack.pop()), performs the same updates, and either appends into the previous depth via append(&mut last_depth) or pushes last_depth back without cloning. This preserves behavior and ordering semantics while eliminating an unnecessary clone and aligning the implementation with call_end for consistency and performance.