### PR TITLE
chore(script-sequence): remove unused ContextCompat import

### DIFF
--- a/crates/script-sequence/src/sequence.rs
+++ b/crates/script-sequence/src/sequence.rs
@@ -1,7 +1,7 @@
 use crate::transaction::TransactionWithMetadata;
 use alloy_network::AnyTransactionReceipt;
 use alloy_primitives::{TxHash, hex, map::HashMap};
-use eyre::{ContextCompat, Result, WrapErr};
+use eyre::{Result, WrapErr};
 use foundry_common::{SELECTOR_LEN, TransactionMaybeSigned, fs, shell};
 use foundry_compilers::ArtifactId;
 use foundry_config::Config;


### PR DESCRIPTION
Remove unused `ContextCompat` import from `sequence.rs`. The file only uses `.wrap_err()` which requires the `WrapErr` trait, not `ContextCompat`.