### PR TITLE
chore(common): remove unused Typed2718 import from constants.rs

### DIFF
--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -1,6 +1,5 @@
 //! Commonly used constants.
 
-use alloy_eips::Typed2718;
 use alloy_network::AnyTxEnvelope;
 use alloy_primitives::{Address, B256, Signature, address};
 use std::time::Duration;


### PR DESCRIPTION
Removes unused `Typed2718` import from `foundry-common/src/constants.rs` to clean up dead code and eliminate compiler warnings.