### PR TITLE
perf: optimize comment iterator chains

### DIFF
--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -936,24 +936,21 @@ impl<'sess> State<'sess, '_> {
     where
         'sess: 'b,
     {
-        self.comments.iter().take_while(|c| c.pos() < pos).find(|c| !c.style.is_blank())
+        self.comments.iter().find(|c| c.pos() < pos && !c.style.is_blank())
     }
 
-    fn has_comment_before_with<F>(&self, pos: BytePos, f: F) -> bool
+    fn has_comment_before_with<F>(&self, pos: BytePos, mut f: F) -> bool
     where
         F: FnMut(&Comment) -> bool,
     {
-        self.comments.iter().take_while(|c| c.pos() < pos).any(f)
+        self.comments.iter().any(|c| c.pos() < pos && f(c))
     }
 
     fn peek_comment_between<'b>(&'b self, pos_lo: BytePos, pos_hi: BytePos) -> Option<&'b Comment>
     where
         'sess: 'b,
     {
-        self.comments
-            .iter()
-            .take_while(|c| pos_lo < c.pos() && c.pos() < pos_hi)
-            .find(|c| !c.style.is_blank())
+        self.comments.iter().find(|c| pos_lo < c.pos() && c.pos() < pos_hi && !c.style.is_blank())
     }
 
     fn has_comment_between(&self, start_pos: BytePos, end_pos: BytePos) -> bool {


### PR DESCRIPTION
Replace take_while().find() and take_while().any() chains with single find()/any() calls that combine the conditions. 

Since comments are sorted by position, we can safely merge the predicates without changing behavior.

This reduces iterator overhead and improves readability.