### PR TITLE
added MONAD_SYSTEM_ADDRESS

### DIFF
--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -57,7 +57,8 @@ pub const TYPE_BINDING_PREFIX: &str = "string constant schema_";
 ///
 /// See: [ARBITRUM_SENDER], [OPTIMISM_SYSTEM_ADDRESS], [MONAD_SYSTEM_ADDRESS] and [Address::ZERO]
 pub fn is_known_system_sender(sender: Address) -> bool {
-    [ARBITRUM_SENDER, OPTIMISM_SYSTEM_ADDRESS, MONAD_SYSTEM_ADDRESS, Address::ZERO].contains(&sender)
+    [ARBITRUM_SENDER, OPTIMISM_SYSTEM_ADDRESS, MONAD_SYSTEM_ADDRESS, Address::ZERO]
+        .contains(&sender)
 }
 
 pub fn is_impersonated_tx(tx: &AnyTxEnvelope) -> bool {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Monad introduces system transactions executed at zero gas by the protocol. 
These appear in the block as regular transactions but do not follow basefee rules.
Currently, Foundry tools (cast, --quick, etc.) treat these as normal transactions. 
This causes:
	  •	cast to fail with Error #1: transaction validation error: gas price is less than basefee
	  •	--quick to fails when multiple system transactions exist in the same block, leading to nonce-too-high errors


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Added MONAD_SYSTEM_ADDRESS and updated transaction handling to skip Monad system transactions, similar to how L2 system txs are ignored.
This prevents validation errors caused by 0-gas system transactions in cast.


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
