### PR TITLE
fix(`ci`): ignore `number_prefix` is unmaintained in `cargo deny`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,8 @@ ignore = [
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2024-0437 protobuf! Crash due to uncontrolled recursion in protobuf crate.
     "RUSTSEC-2024-0437",
+    # https://rustsec.org/advisories/RUSTSEC-2025-0119 number_prefix! is unmaintained
+    "RUSTSEC-2025-0119",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

No direct action required, imo prefer keeping the old crate versus introducing a new recommended: https://crates.io/crates/unit-prefix considering we have a number of dependencies that still rely on `number_prefix`, some of them being `soldeer` / `cliclack` and `ui_test` (https://github.com/oli-obk/ui_test/blob/67eccdb99d9956af7b0a6620fee75dd61a9a5794/Cargo.toml#L26)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
