### PR TITLE
refactor(cast): use existing `strip_0x` helper instead of duplicating logic

### DIFF
--- a/crates/cast/src/cmd/create2.rs
+++ b/crates/cast/src/cmd/create2.rs
@@ -257,10 +257,10 @@ impl Create2Args {
 }
 
 fn get_regex_hex_string(s: String) -> Result<String> {
-    let s = s.strip_prefix("0x").unwrap_or(&s);
-    let pad_width = s.len() + s.len() % 2;
-    hex::decode(format!("{s:0<pad_width$}"))?;
-    Ok(s.to_string())
+    let stripped = crate::strip_0x(&s);
+    let pad_width = stripped.len() + stripped.len() % 2;
+    hex::decode(format!("{stripped:0<pad_width$}"))?;
+    Ok(stripped.to_string())
 }
 
 #[cfg(test)]


### PR DESCRIPTION


The `get_regex_hex_string` function in `create2.rs` manually implements `0x` prefix stripping using `strip_prefix("0x").unwrap_or(&s)`, while the crate already provides a `strip_0x` helper function that performs the exact same operation. This duplication creates maintenance burden and risks inconsistent behavior if the prefix handling logic needs to change in the future.


