### PR TITLE
feat(anvil): extend Content-Type support on Beacon API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ dependencies = [
  "c-kzg",
  "derive_more",
  "either",
- "ethereum_ssz",
+ "ethereum_ssz 0.9.1",
  "ethereum_ssz_derive",
  "serde",
  "serde_with",
@@ -618,7 +618,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "derive_more",
- "ethereum_ssz",
+ "ethereum_ssz 0.9.1",
  "ethereum_ssz_derive",
  "jsonwebtoken",
  "rand 0.8.5",
@@ -1140,6 +1140,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "ctrlc",
+ "ethereum_ssz 0.10.0",
  "eyre",
  "fdlimit",
  "flate2",
@@ -4020,6 +4021,21 @@ name = "ethereum_ssz"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
+dependencies = [
+ "alloy-primitives",
+ "ethereum_serde_utils",
+ "itertools 0.13.0",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "typenum",
+]
+
+[[package]]
+name = "ethereum_ssz"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8cd8c4f47dfb947dbfe3cdf2945ae1da808dbedc592668658e827a12659ba1"
 dependencies = [
  "alloy-primitives",
  "ethereum_serde_utils",
@@ -7215,7 +7231,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-serde",
  "derive_more",
- "ethereum_ssz",
+ "ethereum_ssz 0.9.1",
  "ethereum_ssz_derive",
  "op-alloy-consensus",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -382,6 +382,7 @@ jiff = { version = "0.2", default-features = false, features = [
 heck = "0.5"
 uuid = "1.18.1"
 flate2 = "1.1"
+ethereum_ssz = "0.10"
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -95,6 +95,7 @@ tempfile.workspace = true
 itertools.workspace = true
 rand_08.workspace = true
 eyre.workspace = true
+ethereum_ssz.workspace = true
 
 # cli
 clap = { version = "4", features = [

--- a/crates/anvil/src/server/beacon_handler.rs
+++ b/crates/anvil/src/server/beacon_handler.rs
@@ -9,10 +9,49 @@ use alloy_rpc_types_beacon::{
 use axum::{
     Json,
     extract::{Path, Query, State},
+    http::HeaderMap,
     response::{IntoResponse, Response},
 };
-use hyper::StatusCode;
+use ssz::Encode;
 use std::{collections::HashMap, str::FromStr as _};
+
+/// Helper function to determine if the Accept header indicates a preference for SSZ (octet-stream)
+/// over JSON.
+pub fn must_be_ssz(headers: &HeaderMap) -> bool {
+    headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .map(|accept_str| {
+            let mut octet_stream_q = 0.0;
+            let mut json_q = 0.0;
+
+            // Parse each media type in the Accept header
+            for media_type in accept_str.split(',') {
+                let media_type = media_type.trim();
+                let quality = media_type
+                    .split(';')
+                    .find_map(|param| {
+                        let param = param.trim();
+                        if let Some(q) = param.strip_prefix("q=") {
+                            q.parse::<f32>().ok()
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(1.0); // Default quality factor is 1.0
+
+                if media_type.starts_with("application/octet-stream") {
+                    octet_stream_q = quality;
+                } else if media_type.starts_with("application/json") {
+                    json_q = quality;
+                }
+            }
+
+            // Prefer octet-stream if it has higher quality factor
+            octet_stream_q > json_q
+        })
+        .unwrap_or(false)
+}
 
 /// Handles incoming Beacon API requests for blob sidecars
 ///
@@ -32,6 +71,7 @@ pub async fn handle_get_blob_sidecars(
 ///
 /// GET /eth/v1/beacon/blobs/{block_id}
 pub async fn handle_get_blobs(
+    headers: HeaderMap,
     State(api): State<EthApi>,
     Path(block_id): Path<String>,
     Query(versioned_hashes): Query<HashMap<String, String>>,
@@ -50,11 +90,18 @@ pub async fn handle_get_blobs(
 
     // Get the blob sidecars using existing EthApi logic
     match api.anvil_get_blobs_by_block_id(block_id, versioned_hashes) {
-        Ok(Some(blobs)) => (
-            StatusCode::OK,
-            Json(GetBlobsResponse { execution_optimistic: false, finalized: false, data: blobs }),
-        )
-            .into_response(),
+        Ok(Some(blobs)) => {
+            if must_be_ssz(&headers) {
+                blobs.as_ssz_bytes().into_response()
+            } else {
+                Json(GetBlobsResponse {
+                    execution_optimistic: false,
+                    finalized: false,
+                    data: blobs,
+                })
+                .into_response()
+            }
+        }
         Ok(None) => BeaconError::block_not_found().into_response(),
         Err(_) => BeaconError::internal_error().into_response(),
     }
@@ -67,17 +114,67 @@ pub async fn handle_get_blobs(
 /// GET /eth/v1/beacon/genesis
 pub async fn handle_get_genesis(State(api): State<EthApi>) -> Response {
     match api.anvil_get_genesis_time() {
-        Ok(genesis_time) => (
-            StatusCode::OK,
-            Json(GenesisResponse {
-                data: GenesisData {
-                    genesis_time,
-                    genesis_validators_root: B256::ZERO,
-                    genesis_fork_version: B32::ZERO,
-                },
-            }),
-        )
-            .into_response(),
+        Ok(genesis_time) => Json(GenesisResponse {
+            data: GenesisData {
+                genesis_time,
+                genesis_validators_root: B256::ZERO,
+                genesis_fork_version: B32::ZERO,
+            },
+        })
+        .into_response(),
         Err(_) => BeaconError::internal_error().into_response(),
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn header_map_with_accept(accept: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(axum::http::header::ACCEPT, HeaderValue::from_str(accept).unwrap());
+        headers
+    }
+
+    #[test]
+    fn test_must_be_ssz() {
+        let test_cases = vec![
+            (None, false, "no Accept header"),
+            (Some("application/json"), false, "JSON only"),
+            (Some("application/octet-stream"), true, "octet-stream only"),
+            (Some("application/octet-stream;q=1.0,application/json;q=0.9"), true, "SSZ preferred"),
+            (
+                Some("application/json;q=1.0,application/octet-stream;q=0.9"),
+                false,
+                "JSON preferred",
+            ),
+            (Some("application/octet-stream;q=0.5,application/json;q=0.5"), false, "equal quality"),
+            (
+                Some("text/html;q=0.9, application/octet-stream;q=1.0, application/json;q=0.8"),
+                true,
+                "multiple types",
+            ),
+            (
+                Some("application/octet-stream ; q=1.0 , application/json ; q=0.9"),
+                true,
+                "whitespace handling",
+            ),
+            (Some("application/octet-stream, application/json;q=0.9"), true, "default quality"),
+        ];
+
+        for (accept_header, expected, description) in test_cases {
+            let headers = match accept_header {
+                None => HeaderMap::new(),
+                Some(header) => header_map_with_accept(header),
+            };
+            assert_eq!(
+                must_be_ssz(&headers),
+                expected,
+                "Test case '{}' failed: expected {}, got {}",
+                description,
+                expected,
+                !expected
+            );
+        }
     }
 }


### PR DESCRIPTION
## Motivation

Close #12610

## Solution

- Support "application/octet-stream" and "application/json" content types
- Implemented `must_be_ssz` helper to determine if the Accept header prefers SSZ encoding.
- Updated `handle_get_blobs` to return SSZ-encoded blobs when requested.
- Enhanced tests to verify both JSON and SSZ responses for blob sidecars.
- Added accept header assertions in tests to ensure correct content type selection.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
