### PR TITLE
fix(common): replace Solidity link placeholders with 20 zero bytes

### DIFF
--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -82,8 +82,8 @@ pub fn strip_bytecode_placeholders(bytecode: &BytecodeObject) -> Option<Bytes> {
     match &bytecode {
         BytecodeObject::Bytecode(bytes) => Some(bytes.clone()),
         BytecodeObject::Unlinked(s) => {
-            // Replace all __$xxx$__ placeholders with 32 zero bytes
-            let s = (*BYTECODE_PLACEHOLDER_RE).replace_all(s, "00".repeat(40));
+            // Replace all __$xxx$__ placeholders with 20 zero bytes
+            let s = (*BYTECODE_PLACEHOLDER_RE).replace_all(s, "00".repeat(20));
             let bytes = hex::decode(s.as_bytes());
             Some(bytes.ok()?.into())
         }


### PR DESCRIPTION
This change fixes the placeholder replacement to match Solidity’s library linking https://docs.soliditylang.org/en/latest/using-the-compiler.html#library-linking semantics by replacing each __$...$__ region with exactly 20 zero bytes (40 hex chars) instead of 40 bytes. The Solidity documentation specifies that the placeholder is a 40-character span replaced in place by a 20-byte address encoded as 40 hex characters; emitting 80 hex characters was inflating bytecode lengths and could desynchronize offsets used by source maps and PC/IC mappings. The adjacent comment was also corrected to reflect the intended 20-byte replacement, aligning the code, comments, and external specification.