### PR TITLE
refactor: simplify RuntimeTransport::boxed bounds

### DIFF
--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -269,10 +269,7 @@ impl RuntimeTransport {
     }
 
     /// Convert this transport into a boxed trait object.
-    pub fn boxed(self) -> BoxTransport
-    where
-        Self: Sized + Clone + Send + Sync + 'static,
-    {
+    pub fn boxed(self) -> BoxTransport {
         BoxTransport::new(self)
     }
 }


### PR DESCRIPTION
Trimmed the hand-written trait bounds from RuntimeTransport::boxed so we lean on BoxTransport::new to enforce them, keeping the signature clean without changing behavior. 