### PR TITLE
Collapse redundant Windows pipe path check in provider

### DIFF
--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -356,10 +356,10 @@ fn resolve_path(path: &Path) -> Result<PathBuf, ()> {
 
 #[cfg(windows)]
 fn resolve_path(path: &Path) -> Result<PathBuf, ()> {
-    if let Some(s) = path.to_str() {
-        if s.starts_with(r"\\.\pipe\") {
-            return Ok(path.to_path_buf());
-        }
+    if let Some(s) = path.to_str()
+        && s.starts_with(r"\\.\pipe\")
+    {
+        return Ok(path.to_path_buf());
     }
     Err(())
 }


### PR DESCRIPTION
merge the nested if let/if in resolve_path into a single condition, keep the Windows named-pipe fast path while removing the clippy::collapsible_if warning