### PR TITLE
fix(runner): keep Tokio guard alive and set explicit parent span

### DIFF
--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -416,18 +416,13 @@ impl<'a> ContractRunner<'a> {
 
                 let start = Instant::now();
 
-                let _guard = self.tokio_handle.enter();
-
-                let _guard;
-                let current_span = tracing::Span::current();
-                if current_span.is_none() || current_span.id() != self.span.id() {
-                    _guard = self.span.enter();
-                }
+                let _tokio_guard = self.tokio_handle.enter();
 
                 let sig = func.signature();
                 let kind = func.test_function_kind();
 
-                let _guard = debug_span!(
+                let _test_span_guard = debug_span!(
+                    parent: &self.span,
                     "test",
                     %kind,
                     name = %if enabled!(tracing::Level::TRACE) { &sig } else { &func.name },


### PR DESCRIPTION
The per-test closure in ContractRunner::run_tests() shadowed multiple guards using the same _guard name, which immediately dropped the Handle::enter() EnterGuard and made the runtime entry effectively dead code. This also briefly entered the parent span only to shadow that guard as well, relying on fragile behavior. The change introduces uniquely named, long-lived guards: a _tokio_guard that keeps the runtime context for the whole closure and a _test_span_guard created via debug_span!(parent: &self.span, ...) to establish the correct span parent without temporary enters. This eliminates shadowing and unintended early drops, clarifies intent, and aligns the behavior with multi_runner.rs where the Tokio guard is correctly held for the closure’s lifetime.