### PR TITLE
Allow PubSubRpcHandler Implementations To Be !Unpin

### DIFF
--- a/crates/anvil/server/src/pubsub.rs
+++ b/crates/anvil/server/src/pubsub.rs
@@ -19,7 +19,7 @@ use std::{
 
 /// The general purpose trait for handling RPC requests and subscriptions
 #[async_trait::async_trait]
-pub trait PubSubRpcHandler: Clone + Send + Sync + Unpin + 'static {
+pub trait PubSubRpcHandler: Clone + Send + Sync + 'static {
     /// The request type to expect
     type Request: DeserializeOwned + Send + Sync + fmt::Debug;
     /// The identifier to use for subscriptions


### PR DESCRIPTION
drop the Unpin bound from PubSubRpcHandler so implementors aren’t forced to be Unpin, highlight that PubSubConnection::poll still relies on Unpin; follow-up work must ensure the struct remains safely pinned or adjusted