### PR TITLE
refactor(anvil): simplify `effective_reward` calculation in `FeeHistoryService`

### DIFF
--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -6,13 +6,12 @@ use std::{
     task::{Context, Poll},
 };
 
-use alloy_consensus::Header;
+use alloy_consensus::{Header, Transaction};
 use alloy_eips::{
     calc_next_block_base_fee, eip1559::BaseFeeParams, eip7691::MAX_BLOBS_PER_BLOCK_ELECTRA,
     eip7840::BlobParams,
 };
 use alloy_primitives::B256;
-use anvil_core::eth::transaction::TypedTransaction;
 use futures::StreamExt;
 use parking_lot::{Mutex, RwLock};
 use revm::{context_interface::block::BlobExcessGasAndPrice, primitives::hardfork::SpecId};
@@ -252,13 +251,13 @@ impl FeeHistoryService {
         };
 
         let mut block_number: Option<u64> = None;
-        let base_fee = header.base_fee_per_gas.map(|g| g as u128).unwrap_or_default();
+        let base_fee = header.base_fee_per_gas.unwrap_or_default();
         let excess_blob_gas = header.excess_blob_gas.map(|g| g as u128);
         let blob_gas_used = header.blob_gas_used.map(|g| g as u128);
         let base_fee_per_blob_gas = header.blob_fee(self.blob_params);
 
         let mut item = FeeHistoryCacheItem {
-            base_fee,
+            base_fee: base_fee as u128,
             gas_used_ratio: 0f64,
             blob_gas_used_ratio: 0f64,
             rewards: Vec::new(),
@@ -285,31 +284,12 @@ impl FeeHistoryService {
                 .enumerate()
                 .map(|(i, receipt)| {
                     let gas_used = receipt.cumulative_gas_used();
-                    let effective_reward =
-                        match block.body.transactions.get(i).map(|tx| &tx.transaction) {
-                            Some(TypedTransaction::Legacy(t)) => {
-                                t.tx().gas_price.saturating_sub(base_fee)
-                            }
-                            Some(TypedTransaction::EIP2930(t)) => {
-                                t.tx().gas_price.saturating_sub(base_fee)
-                            }
-                            Some(TypedTransaction::EIP1559(t)) => t
-                                .tx()
-                                .max_priority_fee_per_gas
-                                .min(t.tx().max_fee_per_gas.saturating_sub(base_fee)),
-                            // TODO: This probably needs to be extended to extract 4844 info.
-                            Some(TypedTransaction::EIP4844(t)) => t
-                                .tx()
-                                .tx()
-                                .max_priority_fee_per_gas
-                                .min(t.tx().tx().max_fee_per_gas.saturating_sub(base_fee)),
-                            Some(TypedTransaction::EIP7702(t)) => t
-                                .tx()
-                                .max_priority_fee_per_gas
-                                .min(t.tx().max_fee_per_gas.saturating_sub(base_fee)),
-                            Some(TypedTransaction::Deposit(_)) => 0,
-                            None => 0,
-                        };
+                    let effective_reward = block
+                        .body
+                        .transactions
+                        .get(i)
+                        .map(|tx| tx.as_ref().effective_tip_per_gas(base_fee).unwrap_or(0))
+                        .unwrap_or(0);
 
                     (gas_used, effective_reward)
                 })
@@ -334,7 +314,7 @@ impl FeeHistoryService {
                 })
                 .collect();
         } else {
-            item.rewards = reward_percentiles.iter().map(|_| 0).collect();
+            item.rewards = vec![0; reward_percentiles.len()];
         }
         (item, block_number)
     }


### PR DESCRIPTION
## Motivation
Anvil cleanup in the same vein as #12639 + smol nits

However, I created this PR separately as I’m not entirely certain that this one isn’t breaking, so it requires a more thorough review.

Imo Alloy's helper has the same logic as anvil's custom one https://github.com/alloy-rs/alloy/blob/9770720d77000d48c9d1f9979bf393f3b09b118b/crates/eips/src/eip1559/helpers.rs#L14-L30

## Solution

- Replace custom effective reward calculation with alloy's `Transaction::effective_tip_per_gas()`
- Cleanup useless `base_fee` casts, only one is necessary u64->u128, instead of u64->u128->u64
- More elegant default rewards: `vec![]` instead of heavy `.iter().map().collect()`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes (maybe...)
