### PR TITLE
fix: validate indexed arguments count in `cast logs`

### DIFF
--- a/crates/cast/src/cmd/logs.rs
+++ b/crates/cast/src/cmd/logs.rs
@@ -334,12 +334,7 @@ mod tests {
             None,
             None,
             Some(TRANSFER_SIG.to_string()),
-            vec![
-                String::new(),
-                ADDRESS.to_string(),
-                ADDRESS.to_string(),
-                ADDRESS.to_string(),
-            ],
+            vec![String::new(), ADDRESS.to_string(), ADDRESS.to_string(), ADDRESS.to_string()],
         );
         assert!(result.is_err());
     }


### PR DESCRIPTION


When using `cast logs` with an event signature and indexed arguments, extra arguments beyond the number of indexed inputs are silently ignored. This causes the filter to be broader than expected, potentially matching unintended events, which is problematic for automated scripts and monitoring tools.

The issue occurs because `build_filter_event_sig` uses `zip()` to pair event inputs with user-provided arguments, and any excess arguments are simply dropped without notification.

