### PR TITLE
fix(verify): correct get_target_metadata() error to mention metadata

### DIFF
--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -81,7 +81,7 @@ impl VerificationContext {
             .find(&self.target_path, &self.target_name)
             .ok_or_eyre("failed to find target artifact when compiling for metadata")?;
 
-        artifact.metadata.clone().ok_or_eyre("target artifact does not have an ABI")
+        artifact.metadata.clone().ok_or_eyre("target artifact does not have metadata")
     }
 
     /// Returns [Vec] containing imports of the target file.


### PR DESCRIPTION
The error message in VerificationContext::get_target_metadata() incorrectly stated that the target artifact “does not have an ABI” while the function compiles with a metadata-only output selection and returns artifact.metadata. This mismatch is a clear copy-paste oversight from the ABI accessor and can confuse users and tests when metadata is missing.