### PR TITLE
fix(script): use CLI args and config for preflight

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -62,8 +62,8 @@ pub use endpoints::{
 };
 
 mod etherscan;
-pub use etherscan::EtherscanConfigError;
-use etherscan::{EtherscanConfigs, EtherscanEnvProvider, ResolvedEtherscanConfig};
+pub use etherscan::{EtherscanConfigError, ResolvedEtherscanConfig};
+use etherscan::{EtherscanConfigs, EtherscanEnvProvider};
 
 pub mod resolve;
 pub use resolve::UnresolvedEnvVarError;

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -262,7 +262,7 @@ impl CreateArgs {
 
         let context = verify.resolve_context().await?;
 
-        verify.verification_provider()?.preflight_verify_check(verify, context).await?;
+        verify.verification_provider(&config)?.preflight_verify_check(verify, context).await?;
         Ok(())
     }
 

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -21,7 +21,7 @@ use foundry_cli::{
 };
 use foundry_common::{abi::encode_function_args, retry::RetryError};
 use foundry_compilers::{Artifact, artifacts::BytecodeObject};
-use foundry_config::Config;
+use foundry_config::{Config, ResolvedEtherscanConfig};
 use foundry_evm::constants::DEFAULT_CREATE2_DEPLOYER;
 use regex::Regex;
 use semver::BuildMetadata;
@@ -263,9 +263,14 @@ impl EtherscanVerificationProvider {
         // API key passed.
         let is_etherscan = verifier_type.is_etherscan()
             || (verifier_type.is_sourcify() && etherscan_key.is_some());
-        let etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
+        let mut etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
+        if etherscan_config.is_none() {
+            etherscan_config = first_resolved_etherscan_config(config);
+        }
 
-        let etherscan_api_url = verifier_url.or(None).map(str::to_owned);
+        let etherscan_api_url = verifier_url
+            .map(str::to_owned)
+            .or_else(|| etherscan_config.as_ref().map(|c| c.api_url.clone()));
 
         let api_url = etherscan_api_url.as_deref();
         let base_url = etherscan_config
@@ -450,6 +455,11 @@ impl EtherscanVerificationProvider {
             eyre::bail!("Local bytecode doesn't match on-chain bytecode")
         }
     }
+}
+
+fn first_resolved_etherscan_config(config: &Config) -> Option<ResolvedEtherscanConfig> {
+    let resolved = config.etherscan.clone().resolved();
+    resolved.iter().find_map(|(_, entry)| entry.clone().ok())
 }
 
 #[cfg(test)]

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -189,6 +189,7 @@ impl VerificationProviderType {
         if self.is_etherscan() {
             if let Some(chain) = chain
                 && chain.etherscan_urls().is_none()
+                && !has_url
             {
                 eyre::bail!(EtherscanConfigError::UnknownChain(String::new(), chain))
             }


### PR DESCRIPTION
When running `forge script`, use the following methods to create the Etherscan client, in order of priority
- `--verifier-url` flag
- `foundry.toml` configuration
- `foundry_block_explorers` crate

Since the `foundry_block_explorers` appears to require that the `browser_url` be set, introduce a new user-facing configuration option to that effect.

*Use case*
Before this PR on forge version 05794498bf47257b144e2e2789a1d5bf8566be0e with https://github.com/imua-xyz/imua-contracts/commit/075d333a3603fbbe111ba3f9203c2b44539fbdbc, we get the following error.

```
source .env
forge script script/18_SimulateReceive.s.sol --rpc-url imuachain_testnet
[⠊] Compiling...
No files changed, compilation skipped
Error: Chain 233 not supported
```

With this PR included, the chain's explorer is recognized and the script is run.

```
source .env
forge script script/18_SimulateReceive.s.sol --rpc-url imuachain_testnet
[⠊] Compiling...
No files changed, compilation skipped
Traces:
  [832568] → new SimulateReceive@0x9f7cF1d1F558E57ef88a59ac3D47214eF25B6A06
    └─ ← [Return] 4048 bytes of code

  [2912] SimulateReceive::run()
    ├─ [0] VM::readFile("./scanApiResponse.json") [staticcall]
    │   └─ ← [Revert] vm.readFile: failed to open file "/home/user/Documents/Work/Exocore/exocore-contracts/scanApiResponse.json": No such file or directory (os error 2)
    └─ ← [Revert] vm.readFile: failed to open file "/home/user/Documents/Work/Exocore/exocore-contracts/scanApiResponse.json": No such file or directory (os error 2)


Error: script failed: vm.readFile: failed to open file "/home/user/Documents/Work/Exocore/exocore-contracts/scanApiResponse.json": No such file or directory (os error 2)
```

The explorer is recognized even with the following patch applied to https://github.com/imua-xyz/imua-contracts/commit/075d333a3603fbbe111ba3f9203c2b44539fbdbc

```diff
diff --git a/foundry.toml b/foundry.toml
index 1e6e91b..966c8d1 100644
--- a/foundry.toml
+++ b/foundry.toml
@@ -65,6 +65,6 @@ imuachain_testnet = "${IMUACHAIN_TESTNET_RPC}"
 mainnet = { key = "${ETHERSCAN_API_KEY}" }
 sepolia = { key = "${ETHERSCAN_API_KEY}" }
 holesky = { key = "${ETHERSCAN_API_KEY}" }
-imuachain_testnet = { key = "${ETHERSCAN_API_KEY}", chain = 233, url = "${IMUACHAIN_TESTNET_EXPLORER_API}" }
+imuachain_testnet = { key = "${ETHERSCAN_API_KEY}", url = "${IMUACHAIN_TESTNET_EXPLORER_API}" }
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
```