### PR TITLE
fix: correct bytecode placeholder replacement length

### DIFF
--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -82,8 +82,8 @@ pub fn strip_bytecode_placeholders(bytecode: &BytecodeObject) -> Option<Bytes> {
     match &bytecode {
         BytecodeObject::Bytecode(bytes) => Some(bytes.clone()),
         BytecodeObject::Unlinked(s) => {
-            // Replace all __$xxx$__ placeholders with 32 zero bytes
-            let s = (*BYTECODE_PLACEHOLDER_RE).replace_all(s, "00".repeat(40));
+            // Replace all __$xxx$__ placeholders with 20 zero bytes (40 hex chars)
+            let s = (*BYTECODE_PLACEHOLDER_RE).replace_all(s, "00".repeat(20));
             let bytes = hex::decode(s.as_bytes());
             Some(bytes.ok()?.into())
         }


### PR DESCRIPTION
The `strip_bytecode_placeholders` function was replacing 40-character libraryplaceholders with 80 hex characters instead of 40. This doubled the expectedsize and would corrupt the bytecode structure.

Library placeholders like `__$987e73aeca5e61ce83e4cb0814d87beda9$__` are 40 chars (equivalent to a 20-byte address in hex). The replacement needs to match this length to preserve bytecode integrity.

Changed `"00".repeat(40)` to `"00".repeat(20)` which produces 40 hex chars.