### PR TITLE
fix(cli): correct deprecation note to ProjectPathOpts::get_remappings

### DIFF
--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -174,7 +174,7 @@ impl BuildOpts {
     }
 
     /// Returns the remappings to add to the config
-    #[deprecated(note = "Use ProjectPathsArgs::get_remappings() instead")]
+    #[deprecated(note = "Use ProjectPathOpts::get_remappings() instead")]
     pub fn get_remappings(&self) -> Vec<Remapping> {
         self.project_paths.get_remappings()
     }


### PR DESCRIPTION
The deprecation note on BuildOpts::get_remappings() referenced a non-existent type ProjectPathsArgs, which is misleading and breaks discoverability of the intended replacement. The correct, existing type is ProjectPathOpts, re-exported in 
crates/cli/src/opts/build/mod.rs, and it provides the get_remappings() method used throughout the codebase. No occurrences of ProjectPathsArgs exist elsewhere, indicating this was a typo rather than an intentional alias.