### PR TITLE
fix(ci): ignore clippy error:  `.exactly_one()` may be added to the standard library in the future on `rustc 1.93.0-nightly`

### DIFF
--- a/crates/fmt/src/state/common.rs
+++ b/crates/fmt/src/state/common.rs
@@ -176,6 +176,7 @@ impl<'ast> State<'_, 'ast> {
         let mut s = format!("{prefix}{quote}{s}{quote}");
 
         // If the output is not a single token then revert to the original quote.
+        #[allow(unstable_name_collisions)]
         if Cursor::new(&s).exactly_one().is_err() {
             let other_quote = if quote == '\"' { '\'' } else { '\"' };
             {


### PR DESCRIPTION
```
error: a method with this name may be added to the standard library in the future
   --> crates/fmt/src/state/common.rs:179:28
    |
179 |         if Cursor::new(&s).exactly_one().is_err() {
    |                            ^^^^^^^^^^^
    |
    = warning: once this associated item is added to the standard library, the ambiguity may cause an error or change in behavior!
    = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
    = help: call with fully qualified syntax `itertools::Itertools::exactly_one(...)` to keep using the current method
    = note: `-D unstable-name-collisions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unstable_name_collisions)]`
help: add `#![feature(exact_length_collection)]` to the crate attributes to enable `std::iter::Iterator::exactly_one`
   --> crates/fmt/src/lib.rs:5:1
    |
  5 + #![feature(exact_length_collection)]
    |

error: a method with this name may be added to the standard library in the future
   --> crates/fmt/src/state/common.rs:186:43
    |
186 |             debug_assert!(Cursor::new(&s).exactly_one().map(|_| true).unwrap());
    |                                           ^^^^^^^^^^^
    |
    = warning: once this associated item is added to the standard library, the ambiguity may cause an error or change in behavior!
    = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
    = help: call with fully qualified syntax `itertools::Itertools::exactly_one(...)` to keep using the current method
help: add `#![feature(exact_length_collection)]` to the crate attributes to enable `std::iter::Iterator::exactly_one`
   --> crates/fmt/src/lib.rs:5:1
    |
  5 + #![feature(exact_length_collection)]
    |

error: could not compile `forge-fmt` (lib) due to 2 previous errors
```

To be resolved by: https://github.com/paradigmxyz/solar/issues/606 upstream