### PR TITLE
Remove unused InlineLink::ref_name_exact helper

### DIFF
--- a/crates/doc/src/preprocessor/infer_hyperlinks.rs
+++ b/crates/doc/src/preprocessor/infer_hyperlinks.rs
@@ -269,16 +269,6 @@ impl<'a> InlineLink<'a> {
         name
     }
 
-    /// Returns the name of the referenced item and its arguments, if any.
-    ///
-    /// Eg: `safeMint-address-uint256-` returns `("safeMint", ["address", "uint256"])`
-    #[expect(unused)]
-    fn ref_name_exact(&self) -> (&str, impl Iterator<Item = &str> + '_) {
-        let identifier = self.exact_identifier();
-        let mut iter = identifier.split('-');
-        (iter.next().unwrap(), iter.filter(|s| !s.is_empty()))
-    }
-
     /// Returns the content of the matched link.
     fn as_str(&self) -> &str {
         self.outer.as_str()


### PR DESCRIPTION
drop the unused InlineLink::ref_name_exact helper from infer_hyperlinks.rs, remove the #[expect(unused)] suppression now that the dead code is gone