### PR TITLE
Remove redundant allocation when resolving script functions

### DIFF
--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -377,12 +377,11 @@ impl ScriptArgs {
                 .find(|&abi_func| abi_func.selector() == func.selector())
                 .wrap_err(format!("Function `{}` is not implemented in your script.", self.sig))?
         } else {
-            let matching_functions =
-                abi.functions().filter(|func| func.name == self.sig).collect::<Vec<_>>();
-            match matching_functions.len() {
-                0 => eyre::bail!("Function `{}` not found in the ABI", self.sig),
-                1 => matching_functions[0],
-                2.. => eyre::bail!(
+            let mut matching_functions = abi.functions().filter(|func| func.name == self.sig);
+            match (matching_functions.next(), matching_functions.next()) {
+                (None, _) => eyre::bail!("Function `{}` not found in the ABI", self.sig),
+                (Some(func), None) => func,
+                (Some(_), Some(_)) => eyre::bail!(
                     "Multiple functions with the same name `{}` found in the ABI",
                     self.sig
                 ),


### PR DESCRIPTION
replace the temporary Vec allocation in get_method_and_calldata with streaming next calls, stop scanning the ABI once a duplicate function name is detected, preserving existing error messages