### PR TITLE
refactor(anvil): promote anvil's envelope type to foundry-primitives crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,6 +1150,7 @@ dependencies = [
  "foundry-config",
  "foundry-evm",
  "foundry-evm-networks",
+ "foundry-primitives",
  "foundry-test-utils",
  "futures",
  "hyper",
@@ -1181,7 +1182,6 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-eip5792",
  "alloy-eips",
- "alloy-evm",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
@@ -1190,8 +1190,8 @@ dependencies = [
  "bytes",
  "foundry-common",
  "foundry-evm",
+ "foundry-primitives",
  "op-alloy-consensus",
- "op-revm",
  "rand 0.9.2",
  "revm",
  "serde",
@@ -5052,6 +5052,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
+]
+
+[[package]]
+name = "foundry-primitives"
+version = "1.5.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-evm",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "op-alloy-consensus",
+ "op-revm",
+ "revm",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,11 @@ members = [
     "crates/evm/traces/",
     "crates/fmt/",
     "crates/forge/",
-    "crates/script-sequence/",
-    "crates/macros/",
-    "crates/test-utils/",
     "crates/lint/",
+    "crates/macros/",
+    "crates/primitives/",
+    "crates/script-sequence/",
+    "crates/test-utils/",
 ]
 resolver = "2"
 
@@ -220,6 +221,7 @@ foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils" }
 foundry-wallets = { path = "crates/wallets" }
 foundry-linking = { path = "crates/linking" }
+foundry-primitives = { path = "crates/primitives" }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.22.0", default-features = false }

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -28,6 +28,7 @@ foundry-common.workspace = true
 foundry-config.workspace = true
 foundry-evm.workspace = true
 foundry-evm-networks.workspace = true
+foundry-primitives.workspace = true
 
 # alloy
 alloy-evm = { workspace = true, features = ["call-util"] }

--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -15,13 +15,13 @@ workspace = true
 [dependencies]
 foundry-common.workspace = true
 foundry-evm.workspace = true
+foundry-primitives.workspace = true
 revm = { workspace = true, default-features = false, features = [
     "std",
     "serde",
     "memory_limit",
     "c-kzg",
 ] }
-op-revm.workspace = true
 
 alloy-primitives = { workspace = true, features = ["serde", "rlp"] }
 alloy-rpc-types = { workspace = true, features = ["anvil", "trace"] }
@@ -33,7 +33,6 @@ alloy-consensus = { workspace = true, features = ["k256", "kzg"] }
 alloy-dyn-abi = { workspace = true, features = ["std", "eip712"] }
 op-alloy-consensus = { workspace = true, features = ["serde"] }
 alloy-network.workspace = true
-alloy-evm.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 bytes.workspace = true

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -1,7 +1,7 @@
 //! Transaction related types
 use alloy_consensus::{
-    Receipt, ReceiptEnvelope, ReceiptWithBloom, Signed, Transaction, TransactionEnvelope,
-    TxEip1559, TxEip2930, TxEnvelope, TxLegacy, TxReceipt, Typed2718,
+    Receipt, ReceiptEnvelope, ReceiptWithBloom, Signed, Transaction, TxEip1559, TxEip2930,
+    TxEnvelope, TxLegacy, TxReceipt, Typed2718,
     transaction::{
         Recovered, TxEip7702,
         eip4844::{TxEip4844, TxEip4844Variant, TxEip4844WithSidecar},
@@ -9,31 +9,29 @@ use alloy_consensus::{
 };
 
 use alloy_eips::eip2718::{Decodable2718, Eip2718Error, Encodable2718};
-use alloy_evm::FromRecoveredTx;
-use alloy_network::{AnyReceiptEnvelope, AnyRpcTransaction, AnyTransactionReceipt, AnyTxEnvelope};
+use alloy_network::{AnyReceiptEnvelope, AnyTransactionReceipt};
 use alloy_primitives::{Address, B256, Bloom, Bytes, TxHash, TxKind, U64, U256};
 use alloy_rlp::{Decodable, Encodable, Header};
 use alloy_rpc_types::{
-    ConversionError, Transaction as RpcTransaction, TransactionReceipt,
-    request::TransactionRequest, trace::otterscan::OtsReceipt,
+    Transaction as RpcTransaction, TransactionReceipt, request::TransactionRequest,
+    trace::otterscan::OtsReceipt,
 };
 use alloy_serde::{OtherFields, WithOtherFields};
 use bytes::BufMut;
 use foundry_evm::traces::CallTraceNode;
-
+use foundry_primitives::{FoundryTxEnvelope, FoundryTypedTx};
 use op_alloy_consensus::{
     DEPOSIT_TX_TYPE_ID, OpDepositReceipt, OpDepositReceiptWithBloom, TxDeposit,
 };
-use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
-use revm::{context::TxEnv, interpreter::InstructionResult};
+use revm::interpreter::InstructionResult;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
-/// Converts a [TransactionRequest] into a [TypedTransactionRequest].
+/// Converts a [TransactionRequest] into a [FoundryTypedTx].
 /// Should be removed once the call builder abstraction for providers is in place.
 pub fn transaction_request_to_typed(
     tx: WithOtherFields<TransactionRequest>,
-) -> Option<TypedTransactionRequest> {
+) -> Option<FoundryTypedTx> {
     let WithOtherFields::<TransactionRequest> {
         inner:
             TransactionRequest {
@@ -61,7 +59,7 @@ pub fn transaction_request_to_typed(
     if transaction_type == Some(0x7E) || has_optimism_fields(&other) {
         let mint = other.get_deserialized::<U256>("mint")?.map(|m| m.to::<u128>()).ok()?;
 
-        return Some(TypedTransactionRequest::Deposit(TxDeposit {
+        return Some(FoundryTypedTx::Deposit(TxDeposit {
             from: from.unwrap_or_default(),
             source_hash: other.get_deserialized::<B256>("sourceHash")?.ok()?,
             to: to.unwrap_or_default(),
@@ -75,7 +73,7 @@ pub fn transaction_request_to_typed(
 
     // EIP7702
     if transaction_type == Some(4) || authorization_list.is_some() {
-        return Some(TypedTransactionRequest::EIP7702(TxEip7702 {
+        return Some(FoundryTypedTx::EIP7702(TxEip7702 {
             nonce: nonce.unwrap_or_default(),
             max_fee_per_gas: max_fee_per_gas.unwrap_or_default(),
             max_priority_fee_per_gas: max_priority_fee_per_gas.unwrap_or_default(),
@@ -104,7 +102,7 @@ pub fn transaction_request_to_typed(
         // legacy transaction
         (Some(0), _, None, None, None, None, None, None, _)
         | (None, Some(_), None, None, None, None, None, None, _) => {
-            Some(TypedTransactionRequest::Legacy(TxLegacy {
+            Some(FoundryTypedTx::Legacy(TxLegacy {
                 nonce: nonce.unwrap_or_default(),
                 gas_price: gas_price.unwrap_or_default(),
                 gas_limit: gas.unwrap_or_default(),
@@ -117,7 +115,7 @@ pub fn transaction_request_to_typed(
         // EIP2930
         (Some(1), _, None, None, _, None, None, None, _)
         | (None, _, None, None, Some(_), None, None, None, _) => {
-            Some(TypedTransactionRequest::EIP2930(TxEip2930 {
+            Some(FoundryTypedTx::EIP2930(TxEip2930 {
                 nonce: nonce.unwrap_or_default(),
                 gas_price: gas_price.unwrap_or_default(),
                 gas_limit: gas.unwrap_or_default(),
@@ -134,7 +132,7 @@ pub fn transaction_request_to_typed(
         | (None, None, _, Some(_), _, _, None, None, _)
         | (None, None, None, None, None, _, None, None, _) => {
             // Empty fields fall back to the canonical transaction schema.
-            Some(TypedTransactionRequest::EIP1559(TxEip1559 {
+            Some(FoundryTypedTx::EIP1559(TxEip1559 {
                 nonce: nonce.unwrap_or_default(),
                 max_fee_per_gas: max_fee_per_gas.unwrap_or_default(),
                 max_priority_fee_per_gas: max_priority_fee_per_gas.unwrap_or_default(),
@@ -166,11 +164,11 @@ pub fn transaction_request_to_typed(
             };
 
             if let Some(sidecar) = sidecar {
-                Some(TypedTransactionRequest::EIP4844(TxEip4844Variant::TxEip4844WithSidecar(
+                Some(FoundryTypedTx::EIP4844(TxEip4844Variant::TxEip4844WithSidecar(
                     TxEip4844WithSidecar::from_tx_and_sidecar(tx, sidecar),
                 )))
             } else {
-                Some(TypedTransactionRequest::EIP4844(TxEip4844Variant::TxEip4844(tx)))
+                Some(FoundryTypedTx::EIP4844(TxEip4844Variant::TxEip4844(tx)))
             }
         }
         _ => None,
@@ -183,13 +181,13 @@ pub fn has_optimism_fields(other: &OtherFields) -> bool {
         && other.contains_key("isSystemTx")
 }
 
-/// A wrapper for [TypedTransaction] that allows impersonating accounts.
+/// A wrapper for [FoundryTxEnvelope] that allows impersonating accounts.
 ///
 /// This is a helper that carries the `impersonated` sender so that the right hash
-/// [TypedTransaction::impersonated_hash] can be created.
+/// [FoundryTxEnvelope::impersonated_hash] can be created.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MaybeImpersonatedTransaction {
-    transaction: TypedTransaction,
+    transaction: FoundryTxEnvelope,
     impersonated_sender: Option<Address>,
 }
 
@@ -201,12 +199,12 @@ impl Typed2718 for MaybeImpersonatedTransaction {
 
 impl MaybeImpersonatedTransaction {
     /// Creates a new wrapper for the given transaction
-    pub fn new(transaction: TypedTransaction) -> Self {
+    pub fn new(transaction: FoundryTxEnvelope) -> Self {
         Self { transaction, impersonated_sender: None }
     }
 
     /// Creates a new impersonated transaction wrapper using the given sender
-    pub fn impersonated(transaction: TypedTransaction, impersonated_sender: Address) -> Self {
+    pub fn impersonated(transaction: FoundryTxEnvelope, impersonated_sender: Address) -> Self {
         Self { transaction, impersonated_sender: Some(impersonated_sender) }
     }
 
@@ -288,32 +286,32 @@ impl Encodable for MaybeImpersonatedTransaction {
     }
 }
 
-impl From<MaybeImpersonatedTransaction> for TypedTransaction {
+impl From<MaybeImpersonatedTransaction> for FoundryTxEnvelope {
     fn from(value: MaybeImpersonatedTransaction) -> Self {
         value.transaction
     }
 }
 
-impl From<TypedTransaction> for MaybeImpersonatedTransaction {
-    fn from(value: TypedTransaction) -> Self {
+impl From<FoundryTxEnvelope> for MaybeImpersonatedTransaction {
+    fn from(value: FoundryTxEnvelope) -> Self {
         Self::new(value)
     }
 }
 
 impl Decodable for MaybeImpersonatedTransaction {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        TypedTransaction::decode(buf).map(Self::new)
+        FoundryTxEnvelope::decode(buf).map(Self::new)
     }
 }
 
-impl AsRef<TypedTransaction> for MaybeImpersonatedTransaction {
-    fn as_ref(&self) -> &TypedTransaction {
+impl AsRef<FoundryTxEnvelope> for MaybeImpersonatedTransaction {
+    fn as_ref(&self) -> &FoundryTxEnvelope {
         &self.transaction
     }
 }
 
 impl Deref for MaybeImpersonatedTransaction {
-    type Target = TypedTransaction;
+    type Target = FoundryTxEnvelope;
 
     fn deref(&self) -> &Self::Target {
         &self.transaction
@@ -338,13 +336,13 @@ pub struct PendingTransaction {
 }
 
 impl PendingTransaction {
-    pub fn new(transaction: TypedTransaction) -> Result<Self, alloy_primitives::SignatureError> {
+    pub fn new(transaction: FoundryTxEnvelope) -> Result<Self, alloy_primitives::SignatureError> {
         let sender = transaction.recover()?;
         let hash = transaction.hash();
         Ok(Self { transaction: MaybeImpersonatedTransaction::new(transaction), sender, hash })
     }
 
-    pub fn with_impersonated(transaction: TypedTransaction, sender: Address) -> Self {
+    pub fn with_impersonated(transaction: FoundryTxEnvelope, sender: Address) -> Self {
         let hash = transaction.impersonated_hash(sender);
         Self {
             transaction: MaybeImpersonatedTransaction::impersonated(transaction, sender),
@@ -374,140 +372,6 @@ impl PendingTransaction {
 
     pub fn sender(&self) -> &Address {
         &self.sender
-    }
-}
-
-/// Container type for signed, typed transactions.
-#[derive(Clone, Debug, TransactionEnvelope)]
-#[envelope(
-    alloy_consensus = alloy_consensus,
-    tx_type_name = TxType,
-    typed = TypedTransactionRequest,
-    serde_cfg(all()),
-)]
-pub enum TypedTransaction {
-    /// Legacy transaction type
-    #[envelope(ty = 0)]
-    Legacy(Signed<TxLegacy>),
-    /// EIP-2930 transaction
-    #[envelope(ty = 1)]
-    EIP2930(Signed<TxEip2930>),
-    /// EIP-1559 transaction
-    #[envelope(ty = 2)]
-    EIP1559(Signed<TxEip1559>),
-    /// EIP-4844 transaction
-    #[envelope(ty = 3)]
-    EIP4844(Signed<TxEip4844Variant>),
-    /// EIP-7702 transaction
-    #[envelope(ty = 4)]
-    EIP7702(Signed<TxEip7702>),
-    /// op-stack deposit transaction
-    #[envelope(ty = 126)]
-    Deposit(TxDeposit),
-}
-
-impl TryFrom<AnyRpcTransaction> for TypedTransaction {
-    type Error = ConversionError;
-
-    fn try_from(value: AnyRpcTransaction) -> Result<Self, Self::Error> {
-        let WithOtherFields { inner, .. } = value.0;
-        let from = inner.inner.signer();
-        match inner.inner.into_inner() {
-            AnyTxEnvelope::Ethereum(tx) => match tx {
-                TxEnvelope::Legacy(tx) => Ok(Self::Legacy(tx)),
-                TxEnvelope::Eip2930(tx) => Ok(Self::EIP2930(tx)),
-                TxEnvelope::Eip1559(tx) => Ok(Self::EIP1559(tx)),
-                TxEnvelope::Eip4844(tx) => Ok(Self::EIP4844(tx)),
-                TxEnvelope::Eip7702(tx) => Ok(Self::EIP7702(tx)),
-            },
-            AnyTxEnvelope::Unknown(mut tx) => {
-                // Try to convert to deposit transaction
-                if tx.ty() == DEPOSIT_TX_TYPE_ID {
-                    tx.inner.fields.insert("from".to_string(), serde_json::to_value(from).unwrap());
-                    let deposit_tx =
-                        tx.inner.fields.deserialize_into::<TxDeposit>().map_err(|e| {
-                            ConversionError::Custom(format!(
-                                "Failed to deserialize deposit tx: {e}"
-                            ))
-                        })?;
-
-                    return Ok(Self::Deposit(deposit_tx));
-                };
-
-                Err(ConversionError::Custom("UnknownTxType".to_string()))
-            }
-        }
-    }
-}
-
-impl TypedTransaction {
-    /// Converts the transaction into a [`TxEnvelope`].
-    ///
-    /// Returns an error if the transaction is a Deposit transaction, which is not part of the
-    /// standard Ethereum transaction types.
-    pub fn try_into_eth(self) -> Result<TxEnvelope, Self> {
-        match self {
-            Self::Legacy(tx) => Ok(TxEnvelope::Legacy(tx)),
-            Self::EIP2930(tx) => Ok(TxEnvelope::Eip2930(tx)),
-            Self::EIP1559(tx) => Ok(TxEnvelope::Eip1559(tx)),
-            Self::EIP4844(tx) => Ok(TxEnvelope::Eip4844(tx)),
-            Self::EIP7702(tx) => Ok(TxEnvelope::Eip7702(tx)),
-            Self::Deposit(_) => Err(self),
-        }
-    }
-
-    pub fn sidecar(&self) -> Option<&TxEip4844WithSidecar> {
-        match self {
-            Self::EIP4844(signed_variant) => match signed_variant.tx() {
-                TxEip4844Variant::TxEip4844WithSidecar(with_sidecar) => Some(with_sidecar),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    pub fn as_legacy(&self) -> Option<&Signed<TxLegacy>> {
-        match self {
-            Self::Legacy(tx) => Some(tx),
-            _ => None,
-        }
-    }
-
-    /// Returns the hash of the transaction.
-    ///
-    /// Note: If this transaction has the Impersonated signature then this returns a modified unique
-    /// hash. This allows us to treat impersonated transactions as unique.
-    pub fn hash(&self) -> B256 {
-        match self {
-            Self::Legacy(t) => *t.hash(),
-            Self::EIP2930(t) => *t.hash(),
-            Self::EIP1559(t) => *t.hash(),
-            Self::EIP4844(t) => *t.hash(),
-            Self::EIP7702(t) => *t.hash(),
-            Self::Deposit(t) => t.tx_hash(),
-        }
-    }
-
-    /// Returns the hash if the transaction is impersonated (using a fake signature)
-    ///
-    /// This appends the `address` before hashing it
-    pub fn impersonated_hash(&self, sender: Address) -> B256 {
-        let mut buffer = Vec::new();
-        Encodable::encode(self, &mut buffer);
-        buffer.extend_from_slice(sender.as_ref());
-        B256::from_slice(alloy_primitives::utils::keccak256(&buffer).as_slice())
-    }
-
-    /// Recovers the Ethereum address which was used to sign the transaction.
-    pub fn recover(&self) -> Result<Address, alloy_primitives::SignatureError> {
-        match self {
-            Self::Legacy(tx) => tx.recover_signer(),
-            Self::EIP2930(tx) => tx.recover_signer(),
-            Self::EIP1559(tx) => tx.recover_signer(),
-            Self::EIP4844(tx) => tx.recover_signer(),
-            Self::EIP7702(tx) => tx.recover_signer(),
-            Self::Deposit(tx) => Ok(tx.from),
-        }
     }
 }
 
@@ -971,43 +835,10 @@ pub fn convert_to_anvil_receipt(receipt: AnyTransactionReceipt) -> Option<Receip
     })
 }
 
-impl FromRecoveredTx<TypedTransaction> for TxEnv {
-    fn from_recovered_tx(tx: &TypedTransaction, caller: Address) -> Self {
-        match tx {
-            TypedTransaction::Legacy(signed_tx) => Self::from_recovered_tx(signed_tx.tx(), caller),
-            TypedTransaction::EIP2930(signed_tx) => Self::from_recovered_tx(signed_tx.tx(), caller),
-            TypedTransaction::EIP1559(signed_tx) => Self::from_recovered_tx(signed_tx.tx(), caller),
-            TypedTransaction::EIP4844(signed_tx) => {
-                Self::from_recovered_tx(signed_tx.tx().tx(), caller)
-            }
-            TypedTransaction::EIP7702(signed_tx) => Self::from_recovered_tx(signed_tx.tx(), caller),
-            TypedTransaction::Deposit(tx) => Self::from_recovered_tx(tx, caller),
-        }
-    }
-}
-
-impl FromRecoveredTx<TypedTransaction> for OpTransaction<TxEnv> {
-    fn from_recovered_tx(tx: &TypedTransaction, caller: Address) -> Self {
-        let base = TxEnv::from_recovered_tx(tx, caller);
-
-        let deposit = if let TypedTransaction::Deposit(deposit_tx) = tx {
-            DepositTransactionParts {
-                source_hash: deposit_tx.source_hash,
-                mint: Some(deposit_tx.mint),
-                is_system_transaction: deposit_tx.is_system_transaction,
-            }
-        } else {
-            Default::default()
-        };
-
-        Self { base, deposit, enveloped_tx: None }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{Log, LogData, Signature, b256, hex};
+    use alloy_primitives::{Log, LogData, hex};
     use std::str::FromStr;
 
     // <https://github.com/foundry-rs/foundry/issues/10852>
@@ -1016,146 +847,6 @@ mod tests {
         let s = r#"{"type":"0x4","status":"0x1","cumulativeGasUsed":"0x903fd1","logs":[{"address":"0x0000d9fcd47bf761e7287d8ee09917d7e2100000","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x0000000000000000000000000000000000000000000000000000000000000000","0x000000000000000000000000234ce51365b9c417171b6dad280f49143e1b0547"],"data":"0x00000000000000000000000000000000000000000000032139b42c3431700000","blockHash":"0xd26b59c1d8b5bfa9362d19eb0da3819dfe0b367987a71f6d30908dd45e0d7a60","blockNumber":"0x159663e","blockTimestamp":"0x68411f7b","transactionHash":"0x17a6af73d1317e69cfc3cac9221bd98261d40f24815850a44dbfbf96652ae52a","transactionIndex":"0x22","logIndex":"0x158","removed":false}],"logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000008100000000000000000000000000000000000000000000000020000200000000000000800000000800000000000000010000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000","transactionHash":"0x17a6af73d1317e69cfc3cac9221bd98261d40f24815850a44dbfbf96652ae52a","transactionIndex":"0x22","blockHash":"0xd26b59c1d8b5bfa9362d19eb0da3819dfe0b367987a71f6d30908dd45e0d7a60","blockNumber":"0x159663e","gasUsed":"0x28ee7","effectiveGasPrice":"0x4bf02090","from":"0x234ce51365b9c417171b6dad280f49143e1b0547","to":"0x234ce51365b9c417171b6dad280f49143e1b0547","contractAddress":null}"#;
         let receipt: AnyTransactionReceipt = serde_json::from_str(s).unwrap();
         let _converted = convert_to_anvil_receipt(receipt).unwrap();
-    }
-
-    #[test]
-    fn test_decode_call() {
-        let bytes_first = &mut &hex::decode("f86b02843b9aca00830186a094d3e8763675e4c425df46cc3b5c0f6cbdac39604687038d7ea4c68000802ba00eb96ca19e8a77102767a41fc85a36afd5c61ccb09911cec5d3e86e193d9c5aea03a456401896b1b6055311536bf00a718568c744d8c1f9df59879e8350220ca18").unwrap()[..];
-        let decoded = TypedTransaction::decode(&mut &bytes_first[..]).unwrap();
-
-        let tx = TxLegacy {
-            nonce: 2u64,
-            gas_price: 1000000000u128,
-            gas_limit: 100000,
-            to: TxKind::Call(Address::from_slice(
-                &hex::decode("d3e8763675e4c425df46cc3b5c0f6cbdac396046").unwrap()[..],
-            )),
-            value: U256::from(1000000000000000u64),
-            input: Bytes::default(),
-            chain_id: Some(4),
-        };
-
-        let signature = Signature::from_str("0eb96ca19e8a77102767a41fc85a36afd5c61ccb09911cec5d3e86e193d9c5ae3a456401896b1b6055311536bf00a718568c744d8c1f9df59879e8350220ca182b").unwrap();
-
-        let tx = TypedTransaction::Legacy(Signed::new_unchecked(
-            tx,
-            signature,
-            b256!("0xa517b206d2223278f860ea017d3626cacad4f52ff51030dc9a96b432f17f8d34"),
-        ));
-
-        assert_eq!(tx, decoded);
-    }
-
-    #[test]
-    fn test_decode_create_goerli() {
-        // test that an example create tx from goerli decodes properly
-        let tx_bytes =
-              hex::decode("02f901ee05228459682f008459682f11830209bf8080b90195608060405234801561001057600080fd5b50610175806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80630c49c36c14610030575b600080fd5b61003861004e565b604051610045919061011d565b60405180910390f35b60606020600052600f6020527f68656c6c6f2073746174656d696e64000000000000000000000000000000000060405260406000f35b600081519050919050565b600082825260208201905092915050565b60005b838110156100be5780820151818401526020810190506100a3565b838111156100cd576000848401525b50505050565b6000601f19601f8301169050919050565b60006100ef82610084565b6100f9818561008f565b93506101098185602086016100a0565b610112816100d3565b840191505092915050565b6000602082019050818103600083015261013781846100e4565b90509291505056fea264697066735822122051449585839a4ea5ac23cae4552ef8a96b64ff59d0668f76bfac3796b2bdbb3664736f6c63430008090033c080a0136ebffaa8fc8b9fda9124de9ccb0b1f64e90fbd44251b4c4ac2501e60b104f9a07eb2999eec6d185ef57e91ed099afb0a926c5b536f0155dd67e537c7476e1471")
-                  .unwrap();
-        let _decoded = TypedTransaction::decode(&mut &tx_bytes[..]).unwrap();
-    }
-
-    #[test]
-    fn can_recover_sender() {
-        // random mainnet tx: https://etherscan.io/tx/0x86718885c4b4218c6af87d3d0b0d83e3cc465df2a05c048aa4db9f1a6f9de91f
-        let bytes = hex::decode("02f872018307910d808507204d2cb1827d0094388c818ca8b9251b393131c08a736a67ccb19297880320d04823e2701c80c001a0cf024f4815304df2867a1a74e9d2707b6abda0337d2d54a4438d453f4160f190a07ac0e6b3bc9395b5b9c8b9e6d77204a236577a5b18467b9175c01de4faa208d9").unwrap();
-
-        let Ok(TypedTransaction::EIP1559(tx)) = TypedTransaction::decode(&mut &bytes[..]) else {
-            panic!("decoding TypedTransaction failed");
-        };
-
-        assert_eq!(
-            tx.hash(),
-            &"0x86718885c4b4218c6af87d3d0b0d83e3cc465df2a05c048aa4db9f1a6f9de91f"
-                .parse::<B256>()
-                .unwrap()
-        );
-        assert_eq!(
-            tx.recover_signer().unwrap(),
-            "0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5".parse::<Address>().unwrap()
-        );
-    }
-
-    // Test vector from https://sepolia.etherscan.io/tx/0x9a22ccb0029bc8b0ddd073be1a1d923b7ae2b2ea52100bae0db4424f9107e9c0
-    // Blobscan: https://sepolia.blobscan.com/tx/0x9a22ccb0029bc8b0ddd073be1a1d923b7ae2b2ea52100bae0db4424f9107e9c0
-    #[test]
-    fn test_decode_live_4844_tx() {
-        use alloy_primitives::{address, b256};
-
-        // https://sepolia.etherscan.io/getRawTx?tx=0x9a22ccb0029bc8b0ddd073be1a1d923b7ae2b2ea52100bae0db4424f9107e9c0
-        let raw_tx = alloy_primitives::hex::decode("0x03f9011d83aa36a7820fa28477359400852e90edd0008252089411e9ca82a3a762b4b5bd264d4173a242e7a770648080c08504a817c800f8a5a0012ec3d6f66766bedb002a190126b3549fce0047de0d4c25cffce0dc1c57921aa00152d8e24762ff22b1cfd9f8c0683786a7ca63ba49973818b3d1e9512cd2cec4a0013b98c6c83e066d5b14af2b85199e3d4fc7d1e778dd53130d180f5077e2d1c7a001148b495d6e859114e670ca54fb6e2657f0cbae5b08063605093a4b3dc9f8f1a0011ac212f13c5dff2b2c6b600a79635103d6f580a4221079951181b25c7e654901a0c8de4cced43169f9aa3d36506363b2d2c44f6c49fc1fd91ea114c86f3757077ea01e11fdd0d1934eda0492606ee0bb80a7bf8f35cc5f86ec60fe5031ba48bfd544").unwrap();
-        let res = TypedTransaction::decode(&mut raw_tx.as_slice()).unwrap();
-        assert!(res.is_type(3));
-
-        let tx = match res {
-            TypedTransaction::EIP4844(tx) => tx,
-            _ => unreachable!(),
-        };
-
-        assert_eq!(tx.tx().tx().to, address!("0x11E9CA82A3a762b4B5bd264d4173a242e7a77064"));
-
-        assert_eq!(
-            tx.tx().tx().blob_versioned_hashes,
-            vec![
-                b256!("0x012ec3d6f66766bedb002a190126b3549fce0047de0d4c25cffce0dc1c57921a"),
-                b256!("0x0152d8e24762ff22b1cfd9f8c0683786a7ca63ba49973818b3d1e9512cd2cec4"),
-                b256!("0x013b98c6c83e066d5b14af2b85199e3d4fc7d1e778dd53130d180f5077e2d1c7"),
-                b256!("0x01148b495d6e859114e670ca54fb6e2657f0cbae5b08063605093a4b3dc9f8f1"),
-                b256!("0x011ac212f13c5dff2b2c6b600a79635103d6f580a4221079951181b25c7e6549")
-            ]
-        );
-
-        let from = tx.recover_signer().unwrap();
-        assert_eq!(from, address!("0xA83C816D4f9b2783761a22BA6FADB0eB0606D7B2"));
-    }
-
-    #[test]
-    fn test_decode_encode_deposit_tx() {
-        // https://sepolia-optimism.etherscan.io/tx/0xbf8b5f08c43e4b860715cd64fc0849bbce0d0ea20a76b269e7bc8886d112fca7
-        let tx_hash: TxHash = "0xbf8b5f08c43e4b860715cd64fc0849bbce0d0ea20a76b269e7bc8886d112fca7"
-            .parse::<TxHash>()
-            .unwrap();
-
-        // https://sepolia-optimism.etherscan.io/getRawTx?tx=0xbf8b5f08c43e4b860715cd64fc0849bbce0d0ea20a76b269e7bc8886d112fca7
-        let raw_tx = alloy_primitives::hex::decode(
-            "7ef861a0dfd7ae78bf3c414cfaa77f13c0205c82eb9365e217b2daa3448c3156b69b27ac94778f2146f48179643473b82931c4cd7b8f153efd94778f2146f48179643473b82931c4cd7b8f153efd872386f26fc10000872386f26fc10000830186a08080",
-        )
-        .unwrap();
-        let dep_tx = TypedTransaction::decode(&mut raw_tx.as_slice()).unwrap();
-
-        let mut encoded = Vec::new();
-        dep_tx.encode_2718(&mut encoded);
-
-        assert_eq!(raw_tx, encoded);
-
-        assert_eq!(tx_hash, dep_tx.hash());
-    }
-
-    #[test]
-    fn can_recover_sender_not_normalized() {
-        let bytes = hex::decode("f85f800182520894095e7baea6a6c7c4c2dfeb977efac326af552d870a801ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a0efffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804").unwrap();
-
-        let Ok(TypedTransaction::Legacy(tx)) = TypedTransaction::decode(&mut &bytes[..]) else {
-            panic!("decoding TypedTransaction failed");
-        };
-
-        assert_eq!(tx.tx().input, Bytes::from(b""));
-        assert_eq!(tx.tx().gas_price, 1);
-        assert_eq!(tx.tx().gas_limit, 21000);
-        assert_eq!(tx.tx().nonce, 0);
-        if let TxKind::Call(to) = tx.tx().to {
-            assert_eq!(
-                to,
-                "0x095e7baea6a6c7c4c2dfeb977efac326af552d87".parse::<Address>().unwrap()
-            );
-        } else {
-            panic!("expected a call transaction");
-        }
-        assert_eq!(tx.tx().value, U256::from(0x0au64));
-        assert_eq!(
-            tx.recover_signer().unwrap(),
-            "0f65fe9276bc9a24ae7083ae28e2660ef72df99e".parse::<Address>().unwrap()
-        );
     }
 
     #[test]
@@ -1225,61 +916,5 @@ mod tests {
         let receipt = TypedReceipt::decode(&mut &data[..]).unwrap();
 
         assert_eq!(receipt, expected);
-    }
-
-    #[test]
-    fn deser_to_type_tx() {
-        let tx = r#"
-        {
-            "type": "0x2",
-            "chainId": "0x7a69",
-            "nonce": "0x0",
-            "gas": "0x5209",
-            "maxFeePerGas": "0x77359401",
-            "maxPriorityFeePerGas": "0x1",
-            "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-            "value": "0x0",
-            "accessList": [],
-            "input": "0x",
-            "r": "0x85c2794a580da137e24ccc823b45ae5cea99371ae23ee13860fcc6935f8305b0",
-            "s": "0x41de7fa4121dab284af4453d30928241208bafa90cdb701fe9bc7054759fe3cd",
-            "yParity": "0x0",
-            "hash": "0x8c9b68e8947ace33028dba167354fde369ed7bbe34911b772d09b3c64b861515"
-        }"#;
-
-        let _typed_tx: TypedTransaction = serde_json::from_str(tx).unwrap();
-    }
-
-    #[test]
-    fn test_from_recovered_tx_legacy() {
-        let tx = r#"
-        {
-            "type": "0x0",
-            "chainId": "0x1",
-            "nonce": "0x0",
-            "gas": "0x5208",
-            "gasPrice": "0x1",
-            "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-            "value": "0x1",
-            "input": "0x",
-            "r": "0x85c2794a580da137e24ccc823b45ae5cea99371ae23ee13860fcc6935f8305b0",
-            "s": "0x41de7fa4121dab284af4453d30928241208bafa90cdb701fe9bc7054759fe3cd",
-            "v": "0x1b",
-            "hash": "0x8c9b68e8947ace33028dba167354fde369ed7bbe34911b772d09b3c64b861515"
-        }"#;
-
-        let typed_tx: TypedTransaction = serde_json::from_str(tx).unwrap();
-        let sender = typed_tx.recover().unwrap();
-
-        // Test TxEnv conversion via FromRecoveredTx trait
-        let tx_env = TxEnv::from_recovered_tx(&typed_tx, sender);
-        assert_eq!(tx_env.caller, sender);
-        assert_eq!(tx_env.gas_limit, 0x5208);
-        assert_eq!(tx_env.gas_price, 1);
-
-        // Test OpTransaction<TxEnv> conversion via FromRecoveredTx trait
-        let op_tx = OpTransaction::<TxEnv>::from_recovered_tx(&typed_tx, sender);
-        assert_eq!(op_tx.base.caller, sender);
-        assert_eq!(op_tx.base.gas_limit, 0x5208);
     }
 }

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -11,12 +11,13 @@ use alloy_primitives::{Address, B256, Bytes, U256, keccak256, map::HashMap};
 use alloy_rpc_types::BlockId;
 use anvil_core::eth::{
     block::Block,
-    transaction::{MaybeImpersonatedTransaction, TransactionInfo, TypedReceipt, TypedTransaction},
+    transaction::{MaybeImpersonatedTransaction, TransactionInfo, TypedReceipt},
 };
 use foundry_common::errors::FsPathError;
 use foundry_evm::backend::{
     BlockchainDb, DatabaseError, DatabaseResult, MemDb, RevertStateSnapshotAction, StateSnapshot,
 };
+use foundry_primitives::FoundryTxEnvelope;
 use revm::{
     Database, DatabaseCommit,
     bytecode::Bytecode,
@@ -569,7 +570,7 @@ where
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SerializableTransactionType {
-    TypedTransaction(TypedTransaction),
+    TypedTransaction(FoundryTxEnvelope),
     MaybeImpersonatedTransaction(MaybeImpersonatedTransaction),
 }
 

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -575,7 +575,7 @@ mod tests {
     use crate::eth::backend::db::Db;
     use alloy_primitives::{Address, hex};
     use alloy_rlp::Decodable;
-    use anvil_core::eth::transaction::TypedTransaction;
+    use foundry_primitives::FoundryTxEnvelope;
     use revm::{database::DatabaseRef, state::AccountInfo};
 
     #[test]
@@ -682,7 +682,7 @@ mod tests {
         let header = Header { gas_limit: 123456, ..Default::default() };
         let bytes_first = &mut &hex::decode("f86b02843b9aca00830186a094d3e8763675e4c425df46cc3b5c0f6cbdac39604687038d7ea4c68000802ba00eb96ca19e8a77102767a41fc85a36afd5c61ccb09911cec5d3e86e193d9c5aea03a456401896b1b6055311536bf00a718568c744d8c1f9df59879e8350220ca18").unwrap()[..];
         let tx: MaybeImpersonatedTransaction =
-            TypedTransaction::decode(&mut &bytes_first[..]).unwrap().into();
+            FoundryTxEnvelope::decode(&mut &bytes_first[..]).unwrap().into();
         let block = create_block(header.clone(), vec![tx.clone()]);
         let block_hash = block.header.hash_slow();
         dump_storage.blocks.insert(block_hash, block);

--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -5,7 +5,8 @@ use alloy_primitives::{
     Address, TxHash,
     map::{HashMap, HashSet},
 };
-use anvil_core::eth::transaction::{PendingTransaction, TypedTransaction};
+use anvil_core::eth::transaction::PendingTransaction;
+use foundry_primitives::FoundryTxEnvelope;
 use parking_lot::RwLock;
 use std::{cmp::Ordering, collections::BTreeSet, fmt, str::FromStr, sync::Arc, time::Instant};
 
@@ -37,7 +38,7 @@ pub enum TransactionOrder {
 
 impl TransactionOrder {
     /// Returns the priority of the transactions
-    pub fn priority(&self, tx: &TypedTransaction) -> TransactionPriority {
+    pub fn priority(&self, tx: &FoundryTxEnvelope) -> TransactionPriority {
         match self {
             Self::Fifo => TransactionPriority::default(),
             Self::Fees => TransactionPriority(tx.max_fee_per_gas()),
@@ -121,7 +122,7 @@ impl fmt::Debug for PoolTransaction {
 impl TryFrom<AnyRpcTransaction> for PoolTransaction {
     type Error = eyre::Error;
     fn try_from(value: AnyRpcTransaction) -> Result<Self, Self::Error> {
-        let typed_transaction = TypedTransaction::try_from(value)?;
+        let typed_transaction = FoundryTxEnvelope::try_from(value)?;
         let pending_transaction = PendingTransaction::new(typed_transaction)?;
         Ok(Self {
             pending_transaction,

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "foundry-primitives"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-consensus.workspace = true
+alloy-network.workspace = true
+alloy-primitives.workspace = true
+alloy-rlp.workspace = true
+alloy-rpc-types.workspace = true
+alloy-serde.workspace = true
+alloy-evm = { workspace = true, features = ["op"] }
+op-alloy-consensus = { workspace = true, features = ["serde"] }
+op-revm.workspace = true
+revm.workspace = true
+serde_json.workspace = true

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -1,0 +1,3 @@
+//! Foundry primitives
+mod transaction;
+pub use transaction::{FoundryTxEnvelope, FoundryTxType, FoundryTypedTx};

--- a/crates/primitives/src/transaction.rs
+++ b/crates/primitives/src/transaction.rs
@@ -1,0 +1,381 @@
+use alloy_consensus::{
+    Signed, TransactionEnvelope, TxEip1559, TxEip2930, TxEnvelope, TxLegacy, Typed2718,
+    transaction::{
+        TxEip7702,
+        eip4844::{TxEip4844Variant, TxEip4844WithSidecar},
+    },
+};
+use alloy_evm::FromRecoveredTx;
+use alloy_network::{AnyRpcTransaction, AnyTxEnvelope};
+use alloy_primitives::{Address, B256};
+use alloy_rlp::Encodable;
+use alloy_rpc_types::ConversionError;
+use alloy_serde::WithOtherFields;
+
+use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, TxDeposit};
+use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
+use revm::context::TxEnv;
+
+/// Container type for signed, typed transactions.
+#[derive(Clone, Debug, TransactionEnvelope)]
+#[envelope(
+    tx_type_name = FoundryTxType,
+    typed = FoundryTypedTx,
+)]
+pub enum FoundryTxEnvelope {
+    /// Legacy transaction type
+    #[envelope(ty = 0)]
+    Legacy(Signed<TxLegacy>),
+    /// EIP-2930 transaction
+    #[envelope(ty = 1)]
+    EIP2930(Signed<TxEip2930>),
+    /// EIP-1559 transaction
+    #[envelope(ty = 2)]
+    EIP1559(Signed<TxEip1559>),
+    /// EIP-4844 transaction
+    #[envelope(ty = 3)]
+    EIP4844(Signed<TxEip4844Variant>),
+    /// EIP-7702 transaction
+    #[envelope(ty = 4)]
+    EIP7702(Signed<TxEip7702>),
+    /// op-stack deposit transaction
+    #[envelope(ty = 126)]
+    Deposit(TxDeposit),
+}
+
+impl FoundryTxEnvelope {
+    /// Converts the transaction into a [`TxEnvelope`].
+    ///
+    /// Returns an error if the transaction is a Deposit transaction, which is not part of the
+    /// standard Ethereum transaction types.
+    pub fn try_into_eth(self) -> Result<TxEnvelope, Self> {
+        match self {
+            Self::Legacy(tx) => Ok(TxEnvelope::Legacy(tx)),
+            Self::EIP2930(tx) => Ok(TxEnvelope::Eip2930(tx)),
+            Self::EIP1559(tx) => Ok(TxEnvelope::Eip1559(tx)),
+            Self::EIP4844(tx) => Ok(TxEnvelope::Eip4844(tx)),
+            Self::EIP7702(tx) => Ok(TxEnvelope::Eip7702(tx)),
+            Self::Deposit(_) => Err(self),
+        }
+    }
+
+    pub fn sidecar(&self) -> Option<&TxEip4844WithSidecar> {
+        match self {
+            Self::EIP4844(signed_variant) => match signed_variant.tx() {
+                TxEip4844Variant::TxEip4844WithSidecar(with_sidecar) => Some(with_sidecar),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Returns the hash of the transaction.
+    ///
+    /// Note: If this transaction has the Impersonated signature then this returns a modified unique
+    /// hash. This allows us to treat impersonated transactions as unique.
+    pub fn hash(&self) -> B256 {
+        match self {
+            Self::Legacy(t) => *t.hash(),
+            Self::EIP2930(t) => *t.hash(),
+            Self::EIP1559(t) => *t.hash(),
+            Self::EIP4844(t) => *t.hash(),
+            Self::EIP7702(t) => *t.hash(),
+            Self::Deposit(t) => t.tx_hash(),
+        }
+    }
+
+    /// Returns the hash if the transaction is impersonated (using a fake signature)
+    ///
+    /// This appends the `address` before hashing it
+    pub fn impersonated_hash(&self, sender: Address) -> B256 {
+        let mut buffer = Vec::new();
+        Encodable::encode(self, &mut buffer);
+        buffer.extend_from_slice(sender.as_ref());
+        B256::from_slice(alloy_primitives::utils::keccak256(&buffer).as_slice())
+    }
+
+    /// Recovers the Ethereum address which was used to sign the transaction.
+    pub fn recover(&self) -> Result<Address, alloy_primitives::SignatureError> {
+        match self {
+            Self::Legacy(tx) => tx.recover_signer(),
+            Self::EIP2930(tx) => tx.recover_signer(),
+            Self::EIP1559(tx) => tx.recover_signer(),
+            Self::EIP4844(tx) => tx.recover_signer(),
+            Self::EIP7702(tx) => tx.recover_signer(),
+            Self::Deposit(tx) => Ok(tx.from),
+        }
+    }
+}
+
+impl TryFrom<AnyRpcTransaction> for FoundryTxEnvelope {
+    type Error = ConversionError;
+
+    fn try_from(value: AnyRpcTransaction) -> Result<Self, Self::Error> {
+        let WithOtherFields { inner, .. } = value.0;
+        let from = inner.inner.signer();
+        match inner.inner.into_inner() {
+            AnyTxEnvelope::Ethereum(tx) => match tx {
+                TxEnvelope::Legacy(tx) => Ok(Self::Legacy(tx)),
+                TxEnvelope::Eip2930(tx) => Ok(Self::EIP2930(tx)),
+                TxEnvelope::Eip1559(tx) => Ok(Self::EIP1559(tx)),
+                TxEnvelope::Eip4844(tx) => Ok(Self::EIP4844(tx)),
+                TxEnvelope::Eip7702(tx) => Ok(Self::EIP7702(tx)),
+            },
+            AnyTxEnvelope::Unknown(mut tx) => {
+                // Try to convert to deposit transaction
+                if tx.ty() == DEPOSIT_TX_TYPE_ID {
+                    tx.inner.fields.insert("from".to_string(), serde_json::to_value(from).unwrap());
+                    let deposit_tx =
+                        tx.inner.fields.deserialize_into::<TxDeposit>().map_err(|e| {
+                            ConversionError::Custom(format!(
+                                "Failed to deserialize deposit tx: {e}"
+                            ))
+                        })?;
+
+                    return Ok(Self::Deposit(deposit_tx));
+                };
+
+                Err(ConversionError::Custom("UnknownTxType".to_string()))
+            }
+        }
+    }
+}
+
+impl FromRecoveredTx<FoundryTxEnvelope> for TxEnv {
+    fn from_recovered_tx(tx: &FoundryTxEnvelope, caller: Address) -> Self {
+        match tx {
+            FoundryTxEnvelope::Legacy(signed_tx) => Self::from_recovered_tx(signed_tx, caller),
+            FoundryTxEnvelope::EIP2930(signed_tx) => Self::from_recovered_tx(signed_tx, caller),
+            FoundryTxEnvelope::EIP1559(signed_tx) => Self::from_recovered_tx(signed_tx, caller),
+            FoundryTxEnvelope::EIP4844(signed_tx) => {
+                Self::from_recovered_tx(signed_tx.tx().tx(), caller)
+            }
+            FoundryTxEnvelope::EIP7702(signed_tx) => Self::from_recovered_tx(signed_tx, caller),
+            FoundryTxEnvelope::Deposit(tx) => Self::from_recovered_tx(tx, caller),
+        }
+    }
+}
+
+impl FromRecoveredTx<FoundryTxEnvelope> for OpTransaction<TxEnv> {
+    fn from_recovered_tx(tx: &FoundryTxEnvelope, caller: Address) -> Self {
+        let base = TxEnv::from_recovered_tx(tx, caller);
+
+        let deposit = if let FoundryTxEnvelope::Deposit(deposit_tx) = tx {
+            DepositTransactionParts {
+                source_hash: deposit_tx.source_hash,
+                mint: Some(deposit_tx.mint),
+                is_system_transaction: deposit_tx.is_system_transaction,
+            }
+        } else {
+            Default::default()
+        };
+
+        Self { base, deposit, enveloped_tx: None }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use alloy_primitives::{Bytes, Signature, TxHash, TxKind, U256, b256, hex};
+    use alloy_rlp::Decodable;
+
+    use super::*;
+
+    #[test]
+    fn test_decode_call() {
+        let bytes_first = &mut &hex::decode("f86b02843b9aca00830186a094d3e8763675e4c425df46cc3b5c0f6cbdac39604687038d7ea4c68000802ba00eb96ca19e8a77102767a41fc85a36afd5c61ccb09911cec5d3e86e193d9c5aea03a456401896b1b6055311536bf00a718568c744d8c1f9df59879e8350220ca18").unwrap()[..];
+        let decoded = FoundryTxEnvelope::decode(&mut &bytes_first[..]).unwrap();
+
+        let tx = TxLegacy {
+            nonce: 2u64,
+            gas_price: 1000000000u128,
+            gas_limit: 100000,
+            to: TxKind::Call(Address::from_slice(
+                &hex::decode("d3e8763675e4c425df46cc3b5c0f6cbdac396046").unwrap()[..],
+            )),
+            value: U256::from(1000000000000000u64),
+            input: Bytes::default(),
+            chain_id: Some(4),
+        };
+
+        let signature = Signature::from_str("0eb96ca19e8a77102767a41fc85a36afd5c61ccb09911cec5d3e86e193d9c5ae3a456401896b1b6055311536bf00a718568c744d8c1f9df59879e8350220ca182b").unwrap();
+
+        let tx = FoundryTxEnvelope::Legacy(Signed::new_unchecked(
+            tx,
+            signature,
+            b256!("0xa517b206d2223278f860ea017d3626cacad4f52ff51030dc9a96b432f17f8d34"),
+        ));
+
+        assert_eq!(tx, decoded);
+    }
+
+    #[test]
+    fn test_decode_create_goerli() {
+        // test that an example create tx from goerli decodes properly
+        let tx_bytes =
+              hex::decode("02f901ee05228459682f008459682f11830209bf8080b90195608060405234801561001057600080fd5b50610175806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80630c49c36c14610030575b600080fd5b61003861004e565b604051610045919061011d565b60405180910390f35b60606020600052600f6020527f68656c6c6f2073746174656d696e64000000000000000000000000000000000060405260406000f35b600081519050919050565b600082825260208201905092915050565b60005b838110156100be5780820151818401526020810190506100a3565b838111156100cd576000848401525b50505050565b6000601f19601f8301169050919050565b60006100ef82610084565b6100f9818561008f565b93506101098185602086016100a0565b610112816100d3565b840191505092915050565b6000602082019050818103600083015261013781846100e4565b90509291505056fea264697066735822122051449585839a4ea5ac23cae4552ef8a96b64ff59d0668f76bfac3796b2bdbb3664736f6c63430008090033c080a0136ebffaa8fc8b9fda9124de9ccb0b1f64e90fbd44251b4c4ac2501e60b104f9a07eb2999eec6d185ef57e91ed099afb0a926c5b536f0155dd67e537c7476e1471")
+                  .unwrap();
+        let _decoded = FoundryTxEnvelope::decode(&mut &tx_bytes[..]).unwrap();
+    }
+
+    #[test]
+    fn can_recover_sender() {
+        // random mainnet tx: https://etherscan.io/tx/0x86718885c4b4218c6af87d3d0b0d83e3cc465df2a05c048aa4db9f1a6f9de91f
+        let bytes = hex::decode("02f872018307910d808507204d2cb1827d0094388c818ca8b9251b393131c08a736a67ccb19297880320d04823e2701c80c001a0cf024f4815304df2867a1a74e9d2707b6abda0337d2d54a4438d453f4160f190a07ac0e6b3bc9395b5b9c8b9e6d77204a236577a5b18467b9175c01de4faa208d9").unwrap();
+
+        let Ok(FoundryTxEnvelope::EIP1559(tx)) = FoundryTxEnvelope::decode(&mut &bytes[..]) else {
+            panic!("decoding FoundryTxEnvelope failed");
+        };
+
+        assert_eq!(
+            tx.hash(),
+            &"0x86718885c4b4218c6af87d3d0b0d83e3cc465df2a05c048aa4db9f1a6f9de91f"
+                .parse::<B256>()
+                .unwrap()
+        );
+        assert_eq!(
+            tx.recover_signer().unwrap(),
+            "0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5".parse::<Address>().unwrap()
+        );
+    }
+
+    // Test vector from https://sepolia.etherscan.io/tx/0x9a22ccb0029bc8b0ddd073be1a1d923b7ae2b2ea52100bae0db4424f9107e9c0
+    // Blobscan: https://sepolia.blobscan.com/tx/0x9a22ccb0029bc8b0ddd073be1a1d923b7ae2b2ea52100bae0db4424f9107e9c0
+    #[test]
+    fn test_decode_live_4844_tx() {
+        use alloy_primitives::{address, b256};
+
+        // https://sepolia.etherscan.io/getRawTx?tx=0x9a22ccb0029bc8b0ddd073be1a1d923b7ae2b2ea52100bae0db4424f9107e9c0
+        let raw_tx = alloy_primitives::hex::decode("0x03f9011d83aa36a7820fa28477359400852e90edd0008252089411e9ca82a3a762b4b5bd264d4173a242e7a770648080c08504a817c800f8a5a0012ec3d6f66766bedb002a190126b3549fce0047de0d4c25cffce0dc1c57921aa00152d8e24762ff22b1cfd9f8c0683786a7ca63ba49973818b3d1e9512cd2cec4a0013b98c6c83e066d5b14af2b85199e3d4fc7d1e778dd53130d180f5077e2d1c7a001148b495d6e859114e670ca54fb6e2657f0cbae5b08063605093a4b3dc9f8f1a0011ac212f13c5dff2b2c6b600a79635103d6f580a4221079951181b25c7e654901a0c8de4cced43169f9aa3d36506363b2d2c44f6c49fc1fd91ea114c86f3757077ea01e11fdd0d1934eda0492606ee0bb80a7bf8f35cc5f86ec60fe5031ba48bfd544").unwrap();
+        let res = FoundryTxEnvelope::decode(&mut raw_tx.as_slice()).unwrap();
+        assert!(res.is_type(3));
+
+        let tx = match res {
+            FoundryTxEnvelope::EIP4844(tx) => tx,
+            _ => unreachable!(),
+        };
+
+        assert_eq!(tx.tx().tx().to, address!("0x11E9CA82A3a762b4B5bd264d4173a242e7a77064"));
+
+        assert_eq!(
+            tx.tx().tx().blob_versioned_hashes,
+            vec![
+                b256!("0x012ec3d6f66766bedb002a190126b3549fce0047de0d4c25cffce0dc1c57921a"),
+                b256!("0x0152d8e24762ff22b1cfd9f8c0683786a7ca63ba49973818b3d1e9512cd2cec4"),
+                b256!("0x013b98c6c83e066d5b14af2b85199e3d4fc7d1e778dd53130d180f5077e2d1c7"),
+                b256!("0x01148b495d6e859114e670ca54fb6e2657f0cbae5b08063605093a4b3dc9f8f1"),
+                b256!("0x011ac212f13c5dff2b2c6b600a79635103d6f580a4221079951181b25c7e6549")
+            ]
+        );
+
+        let from = tx.recover_signer().unwrap();
+        assert_eq!(from, address!("0xA83C816D4f9b2783761a22BA6FADB0eB0606D7B2"));
+    }
+
+    #[test]
+    fn test_decode_encode_deposit_tx() {
+        // https://sepolia-optimism.etherscan.io/tx/0xbf8b5f08c43e4b860715cd64fc0849bbce0d0ea20a76b269e7bc8886d112fca7
+        let tx_hash: TxHash = "0xbf8b5f08c43e4b860715cd64fc0849bbce0d0ea20a76b269e7bc8886d112fca7"
+            .parse::<TxHash>()
+            .unwrap();
+
+        // https://sepolia-optimism.etherscan.io/getRawTx?tx=0xbf8b5f08c43e4b860715cd64fc0849bbce0d0ea20a76b269e7bc8886d112fca7
+        let raw_tx = alloy_primitives::hex::decode(
+            "7ef861a0dfd7ae78bf3c414cfaa77f13c0205c82eb9365e217b2daa3448c3156b69b27ac94778f2146f48179643473b82931c4cd7b8f153efd94778f2146f48179643473b82931c4cd7b8f153efd872386f26fc10000872386f26fc10000830186a08080",
+        )
+        .unwrap();
+        let dep_tx = FoundryTxEnvelope::decode(&mut raw_tx.as_slice()).unwrap();
+
+        let mut encoded = Vec::new();
+        dep_tx.encode_2718(&mut encoded);
+
+        assert_eq!(raw_tx, encoded);
+
+        assert_eq!(tx_hash, dep_tx.hash());
+    }
+
+    #[test]
+    fn can_recover_sender_not_normalized() {
+        let bytes = hex::decode("f85f800182520894095e7baea6a6c7c4c2dfeb977efac326af552d870a801ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a0efffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804").unwrap();
+
+        let Ok(FoundryTxEnvelope::Legacy(tx)) = FoundryTxEnvelope::decode(&mut &bytes[..]) else {
+            panic!("decoding FoundryTxEnvelope failed");
+        };
+
+        assert_eq!(tx.tx().input, Bytes::from(b""));
+        assert_eq!(tx.tx().gas_price, 1);
+        assert_eq!(tx.tx().gas_limit, 21000);
+        assert_eq!(tx.tx().nonce, 0);
+        if let TxKind::Call(to) = tx.tx().to {
+            assert_eq!(
+                to,
+                "0x095e7baea6a6c7c4c2dfeb977efac326af552d87".parse::<Address>().unwrap()
+            );
+        } else {
+            panic!("expected a call transaction");
+        }
+        assert_eq!(tx.tx().value, U256::from(0x0au64));
+        assert_eq!(
+            tx.recover_signer().unwrap(),
+            "0f65fe9276bc9a24ae7083ae28e2660ef72df99e".parse::<Address>().unwrap()
+        );
+    }
+
+    #[test]
+    fn deser_to_type_tx() {
+        let tx = r#"
+        {
+            "type": "0x2",
+            "chainId": "0x7a69",
+            "nonce": "0x0",
+            "gas": "0x5209",
+            "maxFeePerGas": "0x77359401",
+            "maxPriorityFeePerGas": "0x1",
+            "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            "value": "0x0",
+            "accessList": [],
+            "input": "0x",
+            "r": "0x85c2794a580da137e24ccc823b45ae5cea99371ae23ee13860fcc6935f8305b0",
+            "s": "0x41de7fa4121dab284af4453d30928241208bafa90cdb701fe9bc7054759fe3cd",
+            "yParity": "0x0",
+            "hash": "0x8c9b68e8947ace33028dba167354fde369ed7bbe34911b772d09b3c64b861515"
+        }"#;
+
+        let _typed_tx: FoundryTxEnvelope = serde_json::from_str(tx).unwrap();
+    }
+
+    #[test]
+    fn test_from_recovered_tx_legacy() {
+        let tx = r#"
+        {
+            "type": "0x0",
+            "chainId": "0x1",
+            "nonce": "0x0",
+            "gas": "0x5208",
+            "gasPrice": "0x1",
+            "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            "value": "0x1",
+            "input": "0x",
+            "r": "0x85c2794a580da137e24ccc823b45ae5cea99371ae23ee13860fcc6935f8305b0",
+            "s": "0x41de7fa4121dab284af4453d30928241208bafa90cdb701fe9bc7054759fe3cd",
+            "v": "0x1b",
+            "hash": "0x8c9b68e8947ace33028dba167354fde369ed7bbe34911b772d09b3c64b861515"
+        }"#;
+
+        let typed_tx: FoundryTxEnvelope = serde_json::from_str(tx).unwrap();
+        let sender = typed_tx.recover().unwrap();
+
+        // Test TxEnv conversion via FromRecoveredTx trait
+        let tx_env = TxEnv::from_recovered_tx(&typed_tx, sender);
+        assert_eq!(tx_env.caller, sender);
+        assert_eq!(tx_env.gas_limit, 0x5208);
+        assert_eq!(tx_env.gas_price, 1);
+
+        // Test OpTransaction<TxEnv> conversion via FromRecoveredTx trait
+        let op_tx = OpTransaction::<TxEnv>::from_recovered_tx(&typed_tx, sender);
+        assert_eq!(op_tx.base.caller, sender);
+        assert_eq!(op_tx.base.gas_limit, 0x5208);
+    }
+}


### PR DESCRIPTION
## Motivation

Close #12677

## Solution

- Created `foundry_primitives` crate
- Moved `TypedTransaction` from `anvil_core` to `foundry_primitives` as  `FoundryTxEnvelope`
- Updated all references in anvil

## PR Checklist

- [ ] Added Tests (moved exting ones)
- [x] Added Documentation
- [ ] Breaking changes
