### PR TITLE
feat: support cast logs query chunking

### DIFF
--- a/crates/cast/src/cmd/logs.rs
+++ b/crates/cast/src/cmd/logs.rs
@@ -47,7 +47,7 @@ pub struct LogsArgs {
 
     /// Number of blocks to query in each chunk when the provider has range limits.
     /// Defaults to 10000 blocks per chunk.
-    #[arg(long, default_value = "10000")]
+    #[arg(long, default_value_t = 10000)]
     query_size: u64,
 
     #[command(flatten)]

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -994,19 +994,12 @@ impl<P: Provider<AnyNetwork> + Clone + Unpin> Cast<P> {
         Ok(res)
     }
 
-    fn extract_block_range(filter: &Filter) -> Result<(Option<u64>, Option<u64>)> {
+    fn extract_block_range(filter: &Filter) -> (Option<u64>, Option<u64>) {
         let FilterBlockOption::Range { from_block, to_block } = &filter.block_option else {
-            return Ok((None, None));
+            return (None, None);
         };
 
-        let extract_number = |block: Option<BlockNumberOrTag>| {
-            block.and_then(|b| match b {
-                BlockNumberOrTag::Number(n) => Some(n),
-                _ => None,
-            })
-        };
-
-        Ok((extract_number(*from_block), extract_number(*to_block)))
+        (from_block.and_then(|b| b.as_number()), to_block.and_then(|b| b.as_number()))
     }
 
     /// Retrieves logs with automatic chunking fallback.
@@ -1038,7 +1031,7 @@ impl<P: Provider<AnyNetwork> + Clone + Unpin> Cast<P> {
     where
         P: Clone + Unpin,
     {
-        let (from_block, to_block) = Self::extract_block_range(filter)?;
+        let (from_block, to_block) = Self::extract_block_range(filter);
         let (Some(from), Some(to)) = (from_block, to_block) else {
             return self.provider.get_logs(filter).await.map_err(Into::into);
         };

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1611,6 +1611,24 @@ casttest!(logs_sig_2, |_prj, cmd| {
     .stdout_eq(file!["../fixtures/cast_logs.stdout"]);
 });
 
+casttest!(logs_chunked_large_range, |_prj, cmd| {
+    let rpc = next_http_archive_rpc_url();
+    cmd.args([
+        "logs",
+        "--rpc-url",
+        rpc.as_str(),
+        "--from-block",
+        "18000000",
+        "--to-block",
+        "18050000",
+        "--query-size",
+        "1000",
+        "Transfer(address indexed from, address indexed to, uint256 value)",
+        "0xA0b86a33E6441d02dd8C6B2b7E5D1E3eD7F73b4b",
+    ])
+    .assert_success();
+});
+
 casttest!(mktx, |_prj, cmd| {
     cmd.args([
         "mktx",


### PR DESCRIPTION
closes #12687 

tested with 
```
./target/debug/cast logs --from-block 23879634 --to-block 23889634 "Transfer(address indexed from, address indexed to, uint256 value)" --query-size 7 --rpc-url https://reth-ethereum.ithaca.xyz/rpc
```

```
./target/debug/cast logs --from-block 23879634 --to-block 23889634 "Transfer(address indexed from, address indexed to, uint256 value)" --query-size 10 --rpc-url ...
```