### PR TITLE
chore(cli): remove redundant eth_rpc_url insert from EvmArgs::data

### DIFF
--- a/crates/cli/src/opts/evm.rs
+++ b/crates/cli/src/opts/evm.rs
@@ -177,10 +177,6 @@ impl Provider for EvmArgs {
             dict.insert("no_rpc_rate_limit".to_string(), self.no_rpc_rate_limit.into());
         }
 
-        if let Some(fork_url) = &self.fork_url {
-            dict.insert("eth_rpc_url".to_string(), fork_url.clone().into());
-        }
-
         Ok(Map::from([(Config::selected_profile(), dict)]))
     }
 }


### PR DESCRIPTION
Removed the manual insertion of eth_rpc_url in EvmArgs::data. The field is already serialized via serde due to the rename on fork_url, so the extra insert only caused an unnecessary clone and duplicate write without changing behavior.