### PR TITLE
Remove redundant double .into() conversion in RPC error methods

### DIFF
--- a/crates/anvil/rpc/src/error.rs
+++ b/crates/anvil/rpc/src/error.rs
@@ -42,25 +42,25 @@ impl RpcError {
     /// Creates a new `InvalidParams` error.
     pub fn invalid_params<M>(message: M) -> Self
     where
-        M: Into<String>,
+        M: Into<Cow<'static, str>>,
     {
-        Self { code: ErrorCode::InvalidParams, message: message.into().into(), data: None }
+        Self { code: ErrorCode::InvalidParams, message: message.into(), data: None }
     }
 
     /// Creates a new `InternalError` error with a message.
     pub fn internal_error_with<M>(message: M) -> Self
     where
-        M: Into<String>,
+        M: Into<Cow<'static, str>>,
     {
-        Self { code: ErrorCode::InternalError, message: message.into().into(), data: None }
+        Self { code: ErrorCode::InternalError, message: message.into(), data: None }
     }
 
     /// Creates a new RPC error for when a transaction was rejected.
     pub fn transaction_rejected<M>(message: M) -> Self
     where
-        M: Into<String>,
+        M: Into<Cow<'static, str>>,
     {
-        Self { code: ErrorCode::TransactionRejected, message: message.into().into(), data: None }
+        Self { code: ErrorCode::TransactionRejected, message: message.into(), data: None }
     }
 }
 


### PR DESCRIPTION
Changes the generic constraint from `Into<String>` to `Into<Cow<'static, str>>` and removes the double `.into()` conversion in three RPC error methods. Both `String` and `&str` implement `Into<Cow<'static, str>>` directly, so the intermediate conversion through `String` is unnecessary.