### PR TITLE
fix: correct SerializeMap size hint in RpcEndpoint::serialize

### DIFF
--- a/crates/config/src/endpoints.rs
+++ b/crates/config/src/endpoints.rs
@@ -348,7 +348,7 @@ impl Serialize for RpcEndpoint {
             // serialize as endpoint if there's no additional config
             self.endpoint.serialize(serializer)
         } else {
-            let mut map = serializer.serialize_map(Some(4))?;
+            let mut map = serializer.serialize_map(Some(5))?;
             map.serialize_entry("endpoint", &self.endpoint)?;
             map.serialize_entry("retries", &self.config.retries)?;
             map.serialize_entry("retry_backoff", &self.config.retry_backoff)?;


### PR DESCRIPTION
The custom serializer for RpcEndpoint emitted five entries but used serialize_map(Some(4)). While JSON/TOML treat this as a hint, definite-length formats may error if the count mismatches. Updated the hint to Some(5) to align with the actual number of entries and Serde expectations.