### PR TITLE
chore(cli): remove useless clap visible aliases

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -100,7 +100,7 @@ pub struct NodeArgs {
     #[arg(long, visible_alias = "no-mine", conflicts_with = "block_time")]
     pub no_mining: bool,
 
-    #[arg(long, visible_alias = "mixed-mining", requires = "block_time")]
+    #[arg(long, requires = "block_time")]
     pub mixed_mining: bool,
 
     /// The hosts the server will listen on.

--- a/crates/cli/src/opts/evm.rs
+++ b/crates/cli/src/opts/evm.rs
@@ -237,7 +237,7 @@ pub struct EnvArgs {
     pub block_prevrandao: Option<B256>,
 
     /// The block gas limit.
-    #[arg(long, visible_aliases = &["block-gas-limit", "gas-limit"], value_name = "BLOCK_GAS_LIMIT")]
+    #[arg(long, visible_alias = "gas-limit", value_name = "BLOCK_GAS_LIMIT")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_gas_limit: Option<u64>,
 

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -20,7 +20,7 @@ pub mod celo;
 #[derive(Clone, Debug, Default, Parser, Copy, Serialize, Deserialize, PartialEq)]
 pub struct NetworkConfigs {
     /// Enable Optimism network features.
-    #[arg(help_heading = "Networks", long, visible_alias = "optimism", conflicts_with = "celo")]
+    #[arg(help_heading = "Networks", long, conflicts_with = "celo")]
     // Skipped from configs (forge) as there is no feature to be added yet.
     #[serde(skip)]
     optimism: bool,


### PR DESCRIPTION
## Motivation

Smol clean-up found while working on another issue.

There are some duplicate Clap arg aliases, like here for `optimism` :
```
Networks:
      --celo       Enable Celo network features
      --optimism   Enable Optimism network features [aliases: --optimism]
```

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes (only removed duplicates)
