### PR TITLE
refactor(verify): remove redundant String conversion for VerificationType

### DIFF
--- a/crates/verify/src/types.rs
+++ b/crates/verify/src/types.rs
@@ -25,15 +25,6 @@ impl FromStr for VerificationType {
     }
 }
 
-impl From<VerificationType> for String {
-    fn from(v: VerificationType) -> Self {
-        match v {
-            VerificationType::Full => "full".to_string(),
-            VerificationType::Partial => "partial".to_string(),
-        }
-    }
-}
-
 impl fmt::Display for VerificationType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
Remove impl From<VerificationType> for String as it duplicates Display and introduces unnecessary allocations. The type isn’t re-exported and no call sites rely on Into<String>, so this is a safe cleanup. clap::ValueEnum and serde behavior is unaffected.