### PR TITLE
perf(script): run contract verifications in parallel

### DIFF
--- a/crates/script/src/progress.rs
+++ b/crates/script/src/progress.rs
@@ -1,8 +1,7 @@
 use crate::receipts::{PendingReceiptError, TxStatus, check_tx_status, format_receipt};
 use alloy_chains::Chain;
 use alloy_primitives::{
-    Address,
-    B256,
+    Address, B256,
     map::{B256HashMap, HashMap},
 };
 use eyre::Result;
@@ -290,7 +289,8 @@ Add `--resume` to your command to try and continue broadcasting the transactions
 /// State of [ProgressBar]s displayed for contract verification.
 /// Shows progress of all contracts being verified.
 /// For each contract an individual progress bar is displayed.
-/// When a contract verification completes, their progress is removed and result summary is displayed.
+/// When a contract verification completes, their progress is removed and result summary is
+/// displayed.
 #[derive(Debug)]
 pub struct VerificationProgressState {
     /// Main [MultiProgress] instance showing progress for all verifications.
@@ -335,11 +335,7 @@ impl VerificationProgressState {
     pub fn end_contract_progress(&mut self, address: Address, success: bool, error: Option<&str>) {
         if let Some(contract_progress) = self.contracts_progress.remove(&address) {
             self.multi.suspend(|| {
-                let status = if success {
-                    "✓ Verified".green()
-                } else {
-                    "✗ Failed".red()
-                };
+                let status = if success { "✓ Verified".green() } else { "✗ Failed".red() };
                 if let Some(err) = error {
                     let _ = sh_println!("{address}\n  ↪ {status}: {err}");
                 } else {
@@ -366,8 +362,6 @@ pub struct VerificationProgress {
 
 impl VerificationProgress {
     pub fn new(contracts_len: usize) -> Self {
-        Self {
-            inner: Arc::new(RwLock::new(VerificationProgressState::new(contracts_len))),
-        }
+        Self { inner: Arc::new(RwLock::new(VerificationProgressState::new(contracts_len))) }
     }
 }

--- a/crates/script/src/progress.rs
+++ b/crates/script/src/progress.rs
@@ -372,8 +372,8 @@ impl VerificationProgressState {
     }
 
     /// Updates contract verification progress message inline (as last entry).
-    /// This can be used to show intermediate progress messages like "Submitted contract for verification"
-    /// or "Verification Job ID: ..." during the verification process.
+    /// This can be used to show intermediate progress messages like "Submitted contract for
+    /// verification" or "Verification Job ID: ..." during the verification process.
     #[allow(dead_code)]
     pub fn update_contract_progress(&mut self, address: Address, message: &str) {
         if let Some(contract_progress) = self.contracts_progress.get(&address) {

--- a/crates/script/src/progress.rs
+++ b/crates/script/src/progress.rs
@@ -326,6 +326,7 @@ impl VerificationProgressState {
 
     /// Creates new contract verification progress and add it to overall progress.
     /// Displays contract details inline.
+    #[allow(clippy::too_many_arguments)]
     pub fn start_contract_progress(
         &mut self,
         address: Address,
@@ -356,10 +357,10 @@ impl VerificationProgressState {
         if let Some(compiler) = compiler_version {
             details.push_str(&format!("   - Compiler version: {compiler}\n"));
         }
-        if let Some(args) = constructor_args {
-            if !args.is_empty() {
-                details.push_str(&format!("   - Constructor args: {args}\n"));
-            }
+        if let Some(args) = constructor_args
+            && !args.is_empty()
+        {
+            details.push_str(&format!("   - Constructor args: {args}\n"));
         }
         details.push_str(&format!("   - verifier: {verifier}"));
 
@@ -398,12 +399,10 @@ impl VerificationProgressState {
                 } else {
                     format!("{details}\n   - {status}")
                 }
+            } else if let Some(err) = error {
+                format!("{address}\n   - {status}: {err}")
             } else {
-                if let Some(err) = error {
-                    format!("{address}\n   - {status}: {err}")
-                } else {
-                    format!("{address}\n   - {status}")
-                }
+                format!("{address}\n   - {status}")
             };
             contract_progress.set_message(final_message);
             contract_progress.finish_and_clear();

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -258,10 +258,7 @@ async fn verify_contracts(
 
         // Start progress for all contracts
         for (address, contract_name, _) in &verification_tasks {
-            progress_ref
-                .inner
-                .write()
-                .start_contract_progress(*address, contract_name.as_deref());
+            progress_ref.inner.write().start_contract_progress(*address, contract_name.as_deref());
         }
 
         // Wrap each verification future to track progress
@@ -275,10 +272,11 @@ async fn verify_contracts(
                         Ok(_) => (true, None),
                         Err(err) => (false, Some(err.to_string())),
                     };
-                    progress
-                        .inner
-                        .write()
-                        .end_contract_progress(address, success, error.as_deref());
+                    progress.inner.write().end_contract_progress(
+                        address,
+                        success,
+                        error.as_deref(),
+                    );
                     result
                 }
             })

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -11,6 +11,7 @@ use foundry_cli::opts::{EtherscanOpts, ProjectPathOpts};
 use foundry_common::ContractsByArtifact;
 use foundry_compilers::{Project, artifacts::EvmVersion, info::ContractInfo};
 use foundry_config::{Chain, Config};
+use futures::future::join_all;
 use semver::Version;
 
 /// State after we have broadcasted the script.
@@ -239,10 +240,11 @@ async fn verify_contracts(
         check_unverified(sequence, unverifiable_contracts, verify);
 
         let num_verifications = future_verifications.len();
-        let mut num_of_successful_verifications = 0;
         sh_println!("##\nStart verification for ({num_verifications}) contracts")?;
-        for verification in future_verifications {
-            match verification.await {
+        let results = join_all(future_verifications).await;
+        let mut num_of_successful_verifications = 0;
+        for result in results {
+            match result {
                 Ok(_) => {
                     num_of_successful_verifications += 1;
                 }

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -223,7 +223,7 @@ async fn verify_contracts(
                 ) {
                     Some((verify_args, contract_name)) => {
                         // Extract details before moving verify_args
-                        let evm_version = verify_args.evm_version.clone();
+                        let evm_version = verify_args.evm_version;
                         let compiler_version = verify_args.compiler_version.clone();
                         let constructor_args = verify_args.constructor_args.clone();
                         let verifier_type = verify_args.verifier.verifier.clone();
@@ -250,7 +250,7 @@ async fn verify_contracts(
                 ) {
                     Some((verify_args, contract_name)) => {
                         // Extract details before moving verify_args
-                        let evm_version = verify_args.evm_version.clone();
+                        let evm_version = verify_args.evm_version;
                         let compiler_version = verify_args.compiler_version.clone();
                         let constructor_args = verify_args.constructor_args.clone();
                         let verifier_type = verify_args.verifier.verifier.clone();


### PR DESCRIPTION
Replace sequential await loop with join_all to execute all contract verifications concurrently. 
This improves performance when verifyingmultiple contracts, especially for large deployments.

The change maintains the same error handling behavior while allowing all verification futures to run in parallel instead of waiting for each one to complete before starting the next.