### PR TITLE
fix: remove redundant logs clone in fuzz counterexample

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -215,11 +215,11 @@ impl FuzzedExecutor {
                     }
                     FuzzOutcome::CounterExample(CounterExampleOutcome {
                         exit_reason: status,
-                        counterexample: outcome,
+                        counterexample: mut outcome,
                         ..
                     }) => {
                         let reason = rd.maybe_decode(&outcome.1.result, status);
-                        test_data.logs.extend(outcome.1.logs.clone());
+                        test_data.logs.extend(std::mem::take(&mut outcome.1.logs));
                         test_data.counterexample = outcome;
                         test_data.failure = Some(TestCaseError::fail(reason.unwrap_or_default()));
                         break 'stop;


### PR DESCRIPTION
## Motivation

The fuzz executor was cloning logs from counterexample outcomes before moving them into `test_data.logs`, even though the logs are never accessed from the counterexample afterwards. This unnecessary clone adds overhead, especially when processing many failed fuzz cases.

## Solution

Replace `logs.clone()` with `std::mem::take()` to move logs instead of cloning them. This matches the pattern already used in successful fuzz cases and eliminates the redundant allocation.