### PR TITLE
Reduce VerificationContext cloning in Vyper Sourcify path

### DIFF
--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -275,7 +275,7 @@ impl SourcifyVerificationProvider {
                 let sources = Source::read_all_from(path, &["vy", "vyi"])?;
                 let input = VyperInput::new(
                     sources,
-                    context.clone().compiler_settings.vyper,
+                    context.compiler_settings.vyper.clone(),
                     &context.compiler_version,
                 );
                 let std_json_input = serde_json::to_value(&input)


### PR DESCRIPTION
avoid cloning the entire VerificationContext when preparing Vyper requests, clone only the compiler_settings.vyper payload needed for VyperInput::new