### PR TITLE
fix(evm): avoid duplicate cache checks

### DIFF
--- a/crates/evm/core/src/fork/database.rs
+++ b/crates/evm/core/src/fork/database.rs
@@ -210,12 +210,7 @@ pub struct ForkDbStateSnapshot {
 
 impl ForkDbStateSnapshot {
     fn get_storage(&self, address: Address, index: U256) -> Option<U256> {
-        self.local
-            .cache
-            .accounts
-            .get(&address)
-            .and_then(|account| account.storage.get(&index))
-            .copied()
+        self.state_snapshot.storage.get(&address).and_then(|slots| slots.get(&index)).copied()
     }
 }
 


### PR DESCRIPTION
Adjust ForkDbStateSnapshot::get_storage to read from state_snapshot.storage instead of the local cache. This removes a redundant cache lookup in storage_ref, ensures the snapshot is honored before falling back to the backend, and aligns storage precedence with basic_ref and block_hash_ref as documented.