### PR TITLE
refactor(script): remove unreachable ENS error branch in simulate()

### DIFF
--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -250,7 +250,7 @@ impl ScriptRunner {
                 authorization_list,
                 true,
             )
-        } else if to.is_none() {
+        } else {
             let res = self.executor.deploy(
                 from,
                 calldata.expect("No data for create transaction"),
@@ -279,8 +279,6 @@ impl ScriptRunner {
                 address: Some(address),
                 ..Default::default()
             })
-        } else {
-            eyre::bail!("ENS not supported.");
         }
     }
 


### PR DESCRIPTION
The to parameter is Option<Address>, so the combination of if let Some(to) and else if to.is_none() already covers all cases. The final else with “ENS not supported.” was unreachable and misleading. Simplified the branching to if Some(..) { call } else { create }, removing dead code and improving readability without changing behavior. This matches how simulate is called from simulate_and_fill, where to is always derived as Option<Address> from TxKind.