### PR TITLE
perf(doc): avoid extra allocation in ParseItem::with_code

### DIFF
--- a/crates/doc/src/parser/item.rs
+++ b/crates/doc/src/parser/item.rs
@@ -81,7 +81,15 @@ impl ParseItem {
     ///
     /// The parameter should be the full source file where this parse item originated from.
     pub fn with_code(mut self, source: &str, tab_width: usize) -> Self {
-        let mut code = source[self.source.range()].to_string();
+        // Remove extra indent from source lines first, working directly on the source slice.
+        let prefix = &" ".repeat(tab_width);
+        let code_slice = &source[self.source.range()];
+
+        let mut code = code_slice
+            .lines()
+            .map(|line| line.strip_prefix(prefix).unwrap_or(line))
+            .collect::<Vec<_>>()
+            .join("\n");
 
         // Special function case, add `;` at the end of definition.
         if let ParseSource::Function(_) | ParseSource::Error(_) | ParseSource::Event(_) =
@@ -90,13 +98,7 @@ impl ParseItem {
             code.push(';');
         }
 
-        // Remove extra indent from source lines.
-        let prefix = &" ".repeat(tab_width);
-        self.code = code
-            .lines()
-            .map(|line| line.strip_prefix(prefix).unwrap_or(line))
-            .collect::<Vec<_>>()
-            .join("\n");
+        self.code = code;
         self
     }
 


### PR DESCRIPTION
Optimize ParseItem::with_code by building the formatted code string directly from the source slice instead of first copying it into an intermediate String. This removes one full allocation and copy of the item’s source while preserving existing behavior, including indentation stripping, newline normalization, and appending ; for functions, events, and errors.