### PR TITLE
fix(forge): failing tests trigger early exit without --fail-fast

### DIFF
--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1135,29 +1135,30 @@ impl FuzzTestTimer {
 #[derive(Clone, Debug)]
 pub struct EarlyExit {
     /// Shared atomic flag set to `true` when a failure occurs or ctrl-c received.
-    /// None if running without fail-fast or show-progress.
-    inner: Option<Arc<AtomicBool>>,
+    inner: Arc<AtomicBool>,
+    /// Whether to exit early on test failure (fail-fast mode).
+    fail_fast: bool,
 }
 
 impl EarlyExit {
-    pub fn new(early_exit: bool) -> Self {
-        Self { inner: early_exit.then_some(Arc::new(AtomicBool::new(false))) }
+    pub fn new(fail_fast: bool) -> Self {
+        Self { inner: Arc::new(AtomicBool::new(false)), fail_fast }
     }
 
-    /// Returns `true` if fail-fast is enabled.
-    pub fn is_enabled(&self) -> bool {
-        self.inner.is_some()
-    }
-
-    /// Sets the exit flag. Used by other tests to stop early.
-    pub fn record_exit(&self) {
-        if let Some(early_exit) = &self.inner {
-            early_exit.store(true, Ordering::Relaxed);
+    /// Records a test failure. Only triggers early exit if fail-fast mode is enabled.
+    pub fn record_failure(&self) {
+        if self.fail_fast {
+            self.inner.store(true, Ordering::Relaxed);
         }
+    }
+
+    /// Records a Ctrl-C interrupt. Always triggers early exit.
+    pub fn record_ctrl_c(&self) {
+        self.inner.store(true, Ordering::Relaxed);
     }
 
     /// Whether tests should stop and exit early.
     pub fn should_stop(&self) -> bool {
-        self.inner.as_ref().map(|flag| flag.load(Ordering::Relaxed)).unwrap_or(false)
+        self.inner.load(Ordering::Relaxed)
     }
 }

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -609,7 +609,7 @@ impl MultiContractRunnerBuilder {
                 inline_config: Arc::new(InlineConfig::new_parsed(output, &self.config)?),
                 isolation: self.isolation,
                 networks: self.networks,
-                early_exit: EarlyExit::new(self.fail_fast || self.config.show_progress),
+                early_exit: EarlyExit::new(self.fail_fast),
                 config: self.config,
             },
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -402,7 +402,7 @@ impl<'a> ContractRunner<'a> {
             let interrupt = early_exit.clone();
             self.tokio_handle.spawn(async move {
                 signal::ctrl_c().await.expect("Failed to listen for Ctrl+C");
-                interrupt.record_exit();
+                interrupt.record_ctrl_c();
             });
         }
 
@@ -442,9 +442,9 @@ impl<'a> ContractRunner<'a> {
                 );
                 res.duration = start.elapsed();
 
-                // Set fail fast flag if current test failed.
+                // Record test failure for early exit (only triggers if fail-fast is enabled).
                 if res.status.is_failure() {
-                    early_exit.record_exit();
+                    early_exit.record_failure();
                 }
 
                 Some((sig, res))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

When I encountered this I was not able to figure out why I was getting undeterministic output. Took a while before I figured it was a bug. It is unexpected to see undeterministic output without `--fail-fast`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Only `record_exit` when `--fail-fast` was provided.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
