### PR TITLE
fix(cast): treat threads=0 as logical cores

### DIFF
--- a/crates/cast/src/cmd/create2.rs
+++ b/crates/cast/src/cmd/create2.rs
@@ -165,9 +165,9 @@ impl Create2Args {
 
         let regex = RegexSetBuilder::new(regexs).case_insensitive(!case_sensitive).build()?;
 
-        let mut n_threads = std::thread::available_parallelism().map_or(1, |n| n.get());
-        if let Some(threads) = threads && threads > 0 {
-            n_threads = n_threads.min(threads);
+        let mut n_threads = threads.unwrap_or(0);
+        if n_threads == 0 {
+            n_threads = std::thread::available_parallelism().map_or(1, |n| n.get());
         }
         if cfg!(test) {
             n_threads = n_threads.min(2);


### PR DESCRIPTION
The create2 subcommand documented -j0/--threads=0 as defaulting to the number of logical cores, but the implementation passed 0 through and ended up with n_threads = 0, spawning no workers and panicking when unwrapping the first result.
This change keeps the existing default of available_parallelism() and only applies the user-specified limit when threads > 0. As a result, -j0 now behaves as documented, while positive values still cap the number of worker threads without changing any other behavior.`