### PR TITLE
refactor(cheatcodes): avoid duplicate get_contract_data calls in stat…

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1420,7 +1420,7 @@ fn get_recorded_state_diffs(ccx: &mut CheatsCtxt) -> BTreeMap<Address, AccountSt
     for address in addresses_to_lookup {
         if let Some((artifact_id, contract_data)) = get_contract_data(ccx, address) {
             contract_names.insert(address, artifact_id.identifier());
-            
+
             // Also get storage layout if available
             if let Some(storage_layout) = &contract_data.storage_layout {
                 storage_layouts.insert(address, storage_layout.clone());


### PR DESCRIPTION
Noticed while poking around the state diffs code that we query `get_contract_data` twice per address - seemed a bit redundant since the function does db access and artifact searching each time.

Combined both calls into one to grab artifact_id and storage_layout together. Builds and tests fine on my end.

Any thoughts? @grandizzy 