### PR TITLE
fix(verify): handle lack of trailing slash in verifier url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4446,6 +4446,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "url",
  "yansi",
 ]
 

--- a/crates/verify/Cargo.toml
+++ b/crates/verify/Cargo.toml
@@ -40,6 +40,7 @@ semver.workspace = true
 regex = { workspace = true, default-features = false }
 yansi.workspace = true
 itertools.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -16,6 +16,7 @@ use futures::FutureExt;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+use url::Url;
 
 pub static SOURCIFY_URL: &str = "https://sourcify.dev/server/";
 
@@ -187,8 +188,11 @@ impl VerificationProvider for SourcifyVerificationProvider {
 }
 
 impl SourcifyVerificationProvider {
-    fn get_base_url(verifier_url: Option<&str>) -> &str {
-        verifier_url.unwrap_or(SOURCIFY_URL)
+    fn get_base_url(verifier_url: Option<&str>) -> Url {
+        // note(onbjerg): a little ugly but makes this infallible as we guarantee `SOURCIFY_URL` to
+        // be well formatted
+        Url::parse(verifier_url.unwrap_or(SOURCIFY_URL))
+            .unwrap_or_else(|_| Url::parse(SOURCIFY_URL).unwrap())
     }
 
     fn get_verify_url(


### PR DESCRIPTION
## Motivation

Not providing a trailing slash to `--verifier-url` when using Sourcify would give you odd errors, see e.g. #12802

## Solution

As a simple solution we can just parse the URL using `Url::parse` and use the `Display` impl of `Url`. This is ok but I had to do a somewhat ugly workaround to keep `get_base_url` infallible. A follow up would be to simply rewrite the Sourcify verifier to use more sane types.

Closes #12802

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
