### PR TITLE
fix: include transaction index in simulation failure error messages

### DIFF
--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -221,10 +221,7 @@ impl PreSimulationState {
         }
 
         if !failed_transactions.is_empty() {
-            eyre::bail!(
-                "Simulated execution failed for: {}",
-                failed_transactions.join("; ")
-            );
+            eyre::bail!("Simulated execution failed for: {}", failed_transactions.join("; "));
         }
 
         Ok(final_txs)


### PR DESCRIPTION
When simulating multiple transactions, if any transaction fails, the error message only shows "Simulated execution failed." without indicating which transaction caused the failure. Makes debugging scripts with many transactions difficult.

Old:
```
Error: Simulated execution failed.
```

Now:
```
Error: Simulated execution failed for: Transaction #3, contract: MyToken, function: transfer
```

For multiple failures:
```
Error: Simulated execution failed for: Transaction #2, contract: MyToken, function: mint; Transaction #5, contract: Staking, function: stake
```