### PR TITLE
feat(primitives): `get_deposit_tx_parts` helper

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -4,4 +4,4 @@ mod request;
 
 pub use envelope::{FoundryTxEnvelope, FoundryTxType, FoundryTypedTx};
 pub use receipt::FoundryReceiptEnvelope;
-pub use request::FoundryTransactionRequest;
+pub use request::{FoundryTransactionRequest, get_deposit_tx_parts};


### PR DESCRIPTION
## Motivation

#12804 follow-up

## Solution

- Introduce `get_deposit_tx_parts` helper, that converts `OtherFields` to `DepositTransactionParts`, on failure it returns the list of missing fields

Could be moved to alloy later, and/or wrapped into `TryFrom<OtherFields>` trait impl.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
