### PR TITLE
feat(foundryup): checksum verification for installed binaries

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -36,6 +36,7 @@ main() {
       -i|--install)     shift; FOUNDRYUP_VERSION=$1;;
       -l|--list)        shift; list;;
       -u|--use)         shift; FOUNDRYUP_VERSION=$1; use;;
+      -c|--check)       shift; check_installation;;
       -p|--path)        shift; FOUNDRYUP_LOCAL_REPO=$1;;
       -P|--pr)          shift; FOUNDRYUP_PR=$1;;
       -C|--commit)      shift; FOUNDRYUP_COMMIT=$1;;
@@ -454,6 +455,7 @@ OPTIONS:
     -i, --install   Install a specific version from built binaries
     -l, --list      List versions installed from built binaries
     -u, --use       Use a specific installed version from built binaries
+    -c, --check     Check installed version status with verification
     -b, --branch    Build and install a specific branch
     -P, --pr        Build and install a specific Pull Request
     -C, --commit    Build and install a specific commit
@@ -558,6 +560,72 @@ EOF
   else
     err "version $FOUNDRYUP_VERSION not installed"
   fi
+}
+
+check_installation() {
+  if ! [ -d "$FOUNDRY_BIN_DIR" ]; then
+    err "Error: No binaries found in $FOUNDRY_BIN_DIR"
+  fi
+
+  # Capture installed checksums
+  map_bin=()
+  map_hash=()
+  map_ver=()
+
+  for b in "${BINS[@]}"; do
+    map_bin+=("$b")
+    map_hash+=("$(compute_sha256 "$FOUNDRY_BIN_DIR/$b")")
+  done
+
+  # List versions with usage status
+  if [ -d "$FOUNDRY_VERSIONS_DIR" ]; then
+    for v in $FOUNDRY_VERSIONS_DIR/*; do
+      vn="${v##*/}"
+      all=true any=false
+
+      i=0
+      for b in "${BINS[@]}"; do
+        bin_path="$v/$b"
+        if [ -f "$bin_path" ]; then
+          vh=$(compute_sha256 "$bin_path")
+          if [ "$vh" = "${map_hash[$i]}" ]; then
+            any=true
+            [ -z "${map_ver[$i]}" ] && map_ver[$i]="$vn"
+          else
+            all=false
+          fi
+        else
+          all=false
+        fi
+        i=$((i + 1))
+      done
+
+      if [ "$all" = true ]; then
+        say "$vn (in use)"
+      elif [ "$any" = true ]; then
+        say "$vn (partially used)"
+      else
+        say "$vn"
+      fi
+
+      for b in "${BINS[@]}"; do
+        say "- $(ensure "$v/$b" -V)"
+      done
+      printf "\n"
+    done
+  else
+    say "No versions directory found"
+  fi
+
+  # Show installed binaries
+  say "Currently installed binaries ($FOUNDRY_BIN_DIR):"
+  i=0
+  for b in "${map_bin[@]}"; do
+    say "  $b: ${map_hash[$i]:0:16}... (from ${map_ver[$i]:-unknown})"
+    i=$((i + 1))
+  done
+
+  exit 0
 }
 
 say() {


### PR DESCRIPTION
## Motivation

Users installing multiple Foundry versions need a way to verify which version is currently active and confirm that installed binaries haven't been corrupted or tampered with. Currently, foundryup has no built-in verification mechanism   users must manually check binaries or rely on external tools.


This feature addresses two key use cases:
1. **Installation verification:** Confirm all binaries come from the same version after upgrading with `-u`
2. **Integrity checking:** Detect mixed/partial installations where binaries come from different versions
## Solution

Added a new `check_installation()` function that:
- Computes checksums of installed binaries
- Compares them against available versions in the versions directory
- Reports installation status: "(in use)" for complete matches, "(partially used)" for mixed installations
- Shows which version each binary originates from

The feature is accessed via the `-c/--check` option and uses the existing `compute_sha256()` infrastructure for consistency. Non-breaking change with minimal code footprint (~68 lines).

Example output:
```
$ FOUNDRY_DIR=/app/foundry ./foundryup -c
foundryup: v1.3.3
foundryup: - forge 1.3.2-v1.3.3 (b0381e15d1 2025-08-29T04:00:51.921550977Z)
foundryup: - cast 1.3.2-v1.3.3 (b0381e15d1 2025-08-29T04:00:51.921550977Z)
foundryup: - anvil 1.3.2-v1.3.3 (b0381e15d1 2025-08-29T04:00:51.921550977Z)
foundryup: - chisel 1.3.2-v1.3.3 (b0381e15d1 2025-08-29T04:00:51.921550977Z)

foundryup: v1.4.4 (in use)
foundryup: - forge 1.4.4-v1.4.4 (05794498bf 2025-10-30T15:50:28.714367747Z)
foundryup: - cast 1.4.4-v1.4.4 (05794498bf 2025-10-30T15:50:28.714367747Z)
foundryup: - anvil 1.4.4-v1.4.4 (05794498bf 2025-10-30T15:50:28.714367747Z)
foundryup: - chisel 1.4.4-v1.4.4 (05794498bf 2025-10-30T15:50:28.714367747Z)

foundryup: v1.5.0
foundryup: - forge 1.5.0-v1.5.0 (1c57854462 2025-11-24T06:05:14.965520784Z)
foundryup: - cast 1.5.0-v1.5.0 (1c57854462 2025-11-24T06:05:14.965520784Z)
foundryup: - anvil 1.5.0-v1.5.0 (1c57854462 2025-11-24T06:05:14.965520784Z)
foundryup: - chisel 1.5.0-v1.5.0 (1c57854462 2025-11-24T06:05:14.965520784Z)

foundryup: Currently installed binaries (/app/foundry/bin):
foundryup:   forge: b2506b895566aef3... (from v1.4.4)
foundryup:   cast: d55f540256f0dd8b... (from v1.4.4)
foundryup:   anvil: 05ee0cf1758024ea... (from v1.4.4)
foundryup:   chisel: 41b403b2afb18b9f... (from v1.4.4)
```
```
$ cp -p /app/foundry/versions/v1.5.0/anvil /app/foundry/bin/
$ FOUNDRY_DIR=/app/foundry foundryup -c
foundryup: v1.3.3
foundryup: - forge 1.3.2-v1.3.3 (b0381e15d1 2025-08-29T04:00:51.921550977Z)
foundryup: - cast 1.3.2-v1.3.3 (b0381e15d1 2025-08-29T04:00:51.921550977Z)
foundryup: - anvil 1.3.2-v1.3.3 (b0381e15d1 2025-08-29T04:00:51.921550977Z)
foundryup: - chisel 1.3.2-v1.3.3 (b0381e15d1 2025-08-29T04:00:51.921550977Z)

foundryup: v1.4.4 (partially used)
foundryup: - forge 1.4.4-v1.4.4 (05794498bf 2025-10-30T15:50:28.714367747Z)
foundryup: - cast 1.4.4-v1.4.4 (05794498bf 2025-10-30T15:50:28.714367747Z)
foundryup: - anvil 1.4.4-v1.4.4 (05794498bf 2025-10-30T15:50:28.714367747Z)
foundryup: - chisel 1.4.4-v1.4.4 (05794498bf 2025-10-30T15:50:28.714367747Z)

foundryup: v1.5.0 (partially used)
foundryup: - forge 1.5.0-v1.5.0 (1c57854462 2025-11-24T06:05:14.965520784Z)
foundryup: - cast 1.5.0-v1.5.0 (1c57854462 2025-11-24T06:05:14.965520784Z)
foundryup: - anvil 1.5.0-v1.5.0 (1c57854462 2025-11-24T06:05:14.965520784Z)
foundryup: - chisel 1.5.0-v1.5.0 (1c57854462 2025-11-24T06:05:14.965520784Z)

foundryup: Currently installed binaries (/app/foundry/bin):
foundryup:   forge: b2506b895566aef3... (from v1.4.4)
foundryup:   cast: d55f540256f0dd8b... (from v1.4.4)
foundryup:   anvil: 9797b1e9bcdf65c9... (from v1.5.0)
foundryup:   chisel: 41b403b2afb18b9f... (from v1.4.4)

```
## PR Checklist
- [x] Non-breaking change
