### PR TITLE
fix(foundryup): strip leading backslash from sha256sum

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -579,7 +579,8 @@ tolower() {
 
 compute_sha256() {
   if check_cmd sha256sum; then
-    sha256sum "$1" | cut -d' ' -f1
+    # Use sed to strip leading backslash (sha256sum on Windows/Git Bash outputs \ prefix for binary files)
+    sha256sum "$1" | cut -d' ' -f1 | sed 's/^\\//'
   else
     shasum -a 256 "$1" | awk '{print $1}'
   fi


### PR DESCRIPTION
Encountered in `foundryup` usage on Windows CI here https://github.com/foundry-rs/foundry-toolchain/pull/102 e.g.:

```
foundryup: downloading manpages
foundryup: verifying downloaded binaries against the attestation file
foundryup: forge hash verification failed:
foundryup:   expected: 746226db74383cfb78d7d7e24b0f56fa17e6beedcdab87fbdf892593145c88b0
foundryup:   actual:   \746226db74383cfb78d7d7e24b0f56fa17e6beedcdab87fbdf892593145c88b0
foundryup: cast hash verification failed:
foundryup:   expected: ab3fc82baa59dc112b214074a2d75a52641c814b73b3cb6355edd35af22b7df3
foundryup:   actual:   \ab3fc82baa59dc112b214074a2d75a52641c814b73b3cb6355edd35af22b7df3
foundryup: anvil hash verification failed:
foundryup:   expected: 54f397d9bf2bc2850d53f0d53beea3fbca285c9ef8f83c384c9d8216beabc055
foundryup:   actual:   \54f397d9bf2bc2850d53f0d53beea3fbca285c9ef8f83c384c9d8216beabc055
foundryup: chisel hash verification failed:
foundryup:   expected: 791165ca9669e9b18e7dc3831ad029d5adddf93d2402575bc08f07264d1814e5
foundryup:   actual:   \791165ca9669e9b18e7dc3831ad029d5adddf93d2402575bc08f07264d1814e5
```