### PR TITLE
fix: add assertion on existence of `tempo-std` in template test

### DIFF
--- a/crates/forge/assets/tempo/workflowTemplate.yml
+++ b/crates/forge/assets/tempo/workflowTemplate.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-
     steps:
       - uses: actions/checkout@v6
         with:

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -889,6 +889,7 @@ Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: N
 
     assert!(prj.root().join("foundry.toml").exists());
     assert!(prj.root().join("lib/forge-std").exists());
+    assert!(prj.root().join("lib/tempo-std").exists());
 
     assert!(prj.root().join("src").exists());
     assert!(prj.root().join("src").join("Mail.sol").exists());


### PR DESCRIPTION
Was missed during migration + fix additional spacing in workflow template