### PR TITLE
chore(deps): update to soldeer 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9626,9 +9626,9 @@ dependencies = [
 
 [[package]]
 name = "soldeer-commands"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a1bc149a9ed3d12d652161f3391135858f3205add0dcc59d00966fa0368810"
+checksum = "dfd18a52d398ab7defa85ea5a3f94ca335e8ae0b40c76e8f7d5cc1ea0924e356"
 dependencies = [
  "bon",
  "clap",
@@ -9645,9 +9645,9 @@ dependencies = [
 
 [[package]]
 name = "soldeer-core"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3cc77f4a8e3c18148e5907b1fbd5de20c05669a3f0497fe37e1ef72b887fd2"
+checksum = "295509f269318c6e3f11ea3bd09b29c974d00403bdf5291577c0bc6adaa9c2fd"
 dependencies = [
  "bon",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -363,8 +363,8 @@ semver = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 similar-asserts = "1.7"
-soldeer-commands = "=0.9.0"
-soldeer-core = { version = "=0.9.0", features = ["serde"] }
+soldeer-commands = "=0.10.0"
+soldeer-core = { version = "=0.10.0", features = ["serde"] }
 strum = "0.27"
 tempfile = "3.23"
 tokio = "1"

--- a/crates/config/src/soldeer.rs
+++ b/crates/config/src/soldeer.rs
@@ -28,6 +28,10 @@ pub struct MapDependency {
     /// The git tag in case git is used as dependency source
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tag: Option<String>,
+
+    /// An optional relative path to the project's root within the repository
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_root: Option<String>,
 }
 
 /// Type for Soldeer configs, under dependencies tag in the foundry.toml


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

There was a new soldeer release: https://github.com/mario-eth/soldeer/releases/tag/v0.10.0

This release adds a new config option `project_root` for dependencies, which allows to specify where the project root lies inside of a dependency's file structure. This is required for recursive deps installation if the `foundry.toml` or `soldeer.toml` file is not at the root of the dependency's git repo or zip file. It enables the use of monorepo-style dependencies where the foundry project might not be the only project in there.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Update dependencies and add new config option to the schema.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
