### PR TITLE
fix(verify): avoid building standard json input for vyper

### DIFF
--- a/crates/verify/src/etherscan/standard_json.rs
+++ b/crates/verify/src/etherscan/standard_json.rs
@@ -16,12 +16,6 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
         args: &VerifyArgs,
         context: &VerificationContext,
     ) -> Result<(String, String, CodeFormat)> {
-        let mut input: StandardJsonCompilerInput = context
-            .project
-            .standard_json_input(&context.target_path)
-            .wrap_err("Failed to get standard json input")?
-            .normalize_evm_version(&context.compiler_version);
-
         let lang = args.detect_language(context);
 
         let code_format = match lang {
@@ -29,26 +23,32 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
             ContractLanguage::Vyper => CodeFormat::VyperJson,
         };
 
-        let mut settings = context.compiler_settings.solc.settings.clone();
-        settings.libraries.libs = input
-            .settings
-            .libraries
-            .libs
-            .into_iter()
-            .map(|(f, libs)| {
-                (f.strip_prefix(context.project.root()).unwrap_or(&f).to_path_buf(), libs)
-            })
-            .collect();
-
-        settings.remappings = input.settings.remappings;
-
-        // remove all incompatible settings
-        settings.sanitize(&context.compiler_version, SolcLanguage::Solidity);
-
-        input.settings = settings;
-
         let source = match lang {
             ContractLanguage::Solidity => {
+                let mut input: StandardJsonCompilerInput = context
+                    .project
+                    .standard_json_input(&context.target_path)
+                    .wrap_err("Failed to get standard json input")?
+                    .normalize_evm_version(&context.compiler_version);
+
+                let mut settings = context.compiler_settings.solc.settings.clone();
+                settings.libraries.libs = input
+                    .settings
+                    .libraries
+                    .libs
+                    .into_iter()
+                    .map(|(f, libs)| {
+                        (f.strip_prefix(context.project.root()).unwrap_or(&f).to_path_buf(), libs)
+                    })
+                    .collect();
+
+                settings.remappings = input.settings.remappings;
+
+                // remove all incompatible settings
+                settings.sanitize(&context.compiler_version, SolcLanguage::Solidity);
+
+                input.settings = settings;
+
                 serde_json::to_string(&input).wrap_err("Failed to parse standard json input")?
             }
             ContractLanguage::Vyper => {


### PR DESCRIPTION
When verifying contracts via Etherscan using the standard-json provider, always constructed a StandardJsonCompilerInput and sanitized solc settings even when the target language was Vyper. For Vyper we then ignored this input and built a separate VyperInput, which adds unnecessary work and allocations on larger projects. This change detects the contract language first and only builds and normalizes the StandardJsonCompilerInput in the Solidity branch, leaving the Vyper path to construct only the Vyper input JSON as before.