### PR TITLE
perf: avoid unnecessary clone in HashSet duplicate check

### DIFF
--- a/crates/forge/src/cmd/bind.rs
+++ b/crates/forge/src/cmd/bind.rs
@@ -202,7 +202,12 @@ impl BindArgs {
             .get_json_files(artifacts)?
             .filter_map(|(name, path)| {
                 trace!(?path, "parsing SolMacroGen from file");
-                if dup.insert(name.clone()) { Some(SolMacroGen::new(path, name)) } else { None }
+                if !dup.contains(&name) {
+                    dup.insert(name.clone());
+                    Some(SolMacroGen::new(path, name))
+                } else {
+                    None
+                }
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
Check for duplicates before cloning to avoid unnecessary allocations.