### PR TITLE
feat(cheatcodes): add config state management with exists check

### DIFF
--- a/crates/cheatcodes/spec/src/cheatcode.rs
+++ b/crates/cheatcodes/spec/src/cheatcode.rs
@@ -116,6 +116,12 @@ pub enum Group {
     ///
     /// Safety: safe.
     Toml,
+    /// Cheatcodes that manage runtime configuration state.
+    ///
+    /// Examples: `getConfig`, `setConfig`, `configExists`.
+    ///
+    /// Safety: safe.
+    Config,
     /// Cryptography-related cheatcodes.
     ///
     /// Examples: `sign*`.
@@ -144,6 +150,7 @@ impl Group {
             | Self::String
             | Self::Json
             | Self::Toml
+            | Self::Config
             | Self::Crypto
             | Self::Utilities => Some(Safety::Safe),
         }
@@ -160,6 +167,7 @@ impl Group {
             Self::String => "string",
             Self::Json => "json",
             Self::Toml => "toml",
+            Self::Config => "config",
             Self::Crypto => "crypto",
             Self::Utilities => "utilities",
         }

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2686,6 +2686,22 @@ interface Vm {
     #[cheatcode(group = Toml)]
     function writeToml(string calldata json, string calldata path, string calldata valueKey) external;
 
+    // ======== Configuration State Management ========
+
+    /// Checks if a configuration key exists in the runtime configuration storage.
+    /// Returns true if the key exists, false otherwise.
+    #[cheatcode(group = Config, safety = Safe)]
+    function configExists(string calldata key) external view returns (bool);
+
+    /// Gets a configuration value from the runtime configuration storage.
+    /// Reverts with NotInitialized if the key does not exist.
+    #[cheatcode(group = Config, safety = Safe)]
+    function getConfig(string calldata key) external view returns (string memory value);
+
+    /// Sets a configuration value in the runtime configuration storage.
+    #[cheatcode(group = Config, safety = Safe)]
+    function setConfig(string calldata key, string calldata value) external;
+
     // ======== Cryptography ========
 
     // -------- Key Management --------

--- a/crates/cheatcodes/src/config_state.rs
+++ b/crates/cheatcodes/src/config_state.rs
@@ -1,0 +1,30 @@
+//! Implementations of [`Config`](spec::Group::Config) cheatcodes.
+
+use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
+use alloy_sol_types::SolValue;
+
+impl Cheatcode for configExistsCall {
+    fn apply(&self, state: &mut Cheatcodes) -> Result {
+        let Self { key } = self;
+        let exists = state.config_storage.contains_key(key);
+        Ok(exists.abi_encode())
+    }
+}
+
+impl Cheatcode for getConfigCall {
+    fn apply(&self, state: &mut Cheatcodes) -> Result {
+        let Self { key } = self;
+        match state.config_storage.get(key) {
+            Some(value) => Ok(value.abi_encode()),
+            None => Err(fmt_err!("NotInitialized: config key '{}' does not exist", key)),
+        }
+    }
+}
+
+impl Cheatcode for setConfigCall {
+    fn apply(&self, state: &mut Cheatcodes) -> Result {
+        let Self { key, value } = self;
+        state.config_storage.insert(key.clone(), value.clone());
+        Ok(Default::default())
+    }
+}

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -474,6 +474,10 @@ pub struct Cheatcodes {
     // **Note**: both must a BTreeMap to ensure the order of the keys is deterministic.
     pub serialized_jsons: BTreeMap<String, BTreeMap<String, Value>>,
 
+    /// Runtime configuration storage.
+    // **Note**: must be a BTreeMap to ensure the order of the keys is deterministic.
+    pub config_storage: BTreeMap<String, String>,
+
     /// All recorded ETH `deal`s.
     pub eth_deals: Vec<DealRecord>,
 
@@ -559,6 +563,7 @@ impl Cheatcodes {
             access_list: Default::default(),
             test_context: Default::default(),
             serialized_jsons: Default::default(),
+            config_storage: Default::default(),
             eth_deals: Default::default(),
             gas_metering: Default::default(),
             gas_snapshots: Default::default(),

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -35,6 +35,8 @@ mod base64;
 
 mod config;
 
+mod config_state;
+
 mod crypto;
 
 mod version;


### PR DESCRIPTION
foundry-rs/forge-std#773 - Adds vm.configExists/getConfig/setConfig for safe runtime config operations