### PR TITLE
chore(meta): configure issue types in issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -1,58 +1,59 @@
 name: Bug report
 description: File a bug report
+type: Bug
 labels: ["T-bug", "T-needs-triage"]
 body:
-    - type: markdown
-      attributes:
-          value: |
-              Please ensure that the bug has not already been filed in the issue tracker.
+  - type: markdown
+    attributes:
+      value: |
+        Please ensure that the bug has not already been filed in the issue tracker.
 
-              Thanks for taking the time to report this bug!
-    - type: dropdown
-      attributes:
-          label: Component
-          description: What component is the bug in?
-          multiple: true
-          options:
-              - Forge
-              - Cast
-              - Anvil
-              - Foundryup
-              - Chisel
-              - Other (please describe)
-      validations:
-          required: true
-    - type: checkboxes
-      attributes:
-          label: Have you ensured that all of these are up to date?
-          options:
-              - label: Foundry
-              - label: Foundryup
-    - type: input
-      attributes:
-          label: What version of Foundry are you on?
-          placeholder: "Run forge --version and paste the output here"
-    - type: input
-      attributes:
-          label: What version of Foundryup are you on?
-          placeholder: "Run foundryup --version and paste the output here"
-    - type: input
-      attributes:
-          label: What command(s) is the bug in?
-          description: Leave empty if not relevant
-          placeholder: "For example: forge test"
-    - type: dropdown
-      attributes:
-          label: Operating System
-          description: What operating system are you on?
-          options:
-              - Windows
-              - macOS (Intel)
-              - macOS (Apple Silicon)
-              - Linux
-    - type: textarea
-      attributes:
-          label: Describe the bug
-          description: Please include relevant Solidity snippets as well if relevant.
-      validations:
-          required: true
+        Thanks for taking the time to report this bug!
+  - type: dropdown
+    attributes:
+      label: Component
+      description: What component is the bug in?
+      multiple: true
+      options:
+        - Forge
+        - Cast
+        - Anvil
+        - Foundryup
+        - Chisel
+        - Other (please describe)
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Have you ensured that all of these are up to date?
+      options:
+        - label: Foundry
+        - label: Foundryup
+  - type: input
+    attributes:
+      label: What version of Foundry are you on?
+      placeholder: "Run forge --version and paste the output here"
+  - type: input
+    attributes:
+      label: What version of Foundryup are you on?
+      placeholder: "Run foundryup --version and paste the output here"
+  - type: input
+    attributes:
+      label: What command(s) is the bug in?
+      description: Leave empty if not relevant
+      placeholder: "For example: forge test"
+  - type: dropdown
+    attributes:
+      label: Operating System
+      description: What operating system are you on?
+      options:
+        - Windows
+        - macOS (Intel)
+        - macOS (Apple Silicon)
+        - Linux
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: Please include relevant Solidity snippets as well if relevant.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
@@ -1,34 +1,35 @@
 name: Feature request
 description: Suggest a feature
+type: Feature
 labels: ["T-feature", "T-needs-triage"]
 body:
-    - type: markdown
-      attributes:
-          value: |
-              Please ensure that the feature has not already been requested in the issue tracker.
+  - type: markdown
+    attributes:
+      value: |
+        Please ensure that the feature has not already been requested in the issue tracker.
 
-              Thanks for helping us improve Foundry!
-    - type: dropdown
-      attributes:
-          label: Component
-          description: What component is the feature for?
-          multiple: true
-          options:
-              - Forge
-              - Cast
-              - Anvil
-              - Foundryup
-              - Chisel
-              - Other (please describe)
-      validations:
-          required: true
-    - type: textarea
-      attributes:
-          label: Describe the feature you would like
-          description: Please also describe what the feature is aiming to solve, if relevant.
-      validations:
-          required: true
-    - type: textarea
-      attributes:
-          label: Additional context
-          description: Add any other context to the feature (like screenshots, resources)
+        Thanks for helping us improve Foundry!
+  - type: dropdown
+    attributes:
+      label: Component
+      description: What component is the feature for?
+      multiple: true
+      options:
+        - Forge
+        - Cast
+        - Anvil
+        - Foundryup
+        - Chisel
+        - Other (please describe)
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the feature you would like
+      description: Please also describe what the feature is aiming to solve, if relevant.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context to the feature (like screenshots, resources)


### PR DESCRIPTION
## Motivation

Long term we should consider deprecating the labels T-feature and T-bug in favor of using issue types.

## Solution

Add issue types to the issue forms.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
