### PR TITLE
feat: include actual tx type in unknown transaction error

### DIFF
--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -164,9 +164,7 @@ impl TryFrom<AnyRpcTransaction> for FoundryTxEnvelope {
                 };
 
                 let tx_type = tx.ty();
-                Err(ConversionError::Custom(format!(
-                    "Unknown transaction type: 0x{tx_type:02X}"
-                )))
+                Err(ConversionError::Custom(format!("Unknown transaction type: 0x{tx_type:02X}")))
             }
         }
     }


### PR DESCRIPTION
Improve error message by including the actual transaction type value when encountering an unknown transaction type.
