### PR TITLE
fix(anvil): insufficient allowance → insufficient balance

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3711,7 +3711,7 @@ impl TransactionValidator for Backend {
                             InvalidTransactionError::InsufficientFunds
                         })?;
                     if account.balance < U256::from(req_funds) {
-                        warn!(target: "backend", "[{:?}] insufficient allowance={}, required={} account={:?}", tx.hash(), account.balance, req_funds, *pending.sender());
+                        warn!(target: "backend", "[{:?}] insufficient balance={}, required={} account={:?}", tx.hash(), account.balance, req_funds, *pending.sender());
                         return Err(InvalidTransactionError::InsufficientFunds);
                     }
                 }


### PR DESCRIPTION
Updated the backend mempool validation warning to log **“insufficient balance”** instead of the misleading **“insufficient allowance”** when an account’s balance is too low to cover `gas * price + value`.