### PR TITLE
fix(script): correct debug log field name from `bytecode` to `creation_code`

### DIFF
--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -135,7 +135,7 @@ impl ScriptTransactionBuilder {
                     constructor_args=%hex::encode(constructor_args),
                     "Failed to decode constructor arguments",
                 );
-                debug!(full_data=%hex::encode(data), bytecode=%hex::encode(creation_code));
+                debug!(full_data=%hex::encode(data), creation_code=%hex::encode(creation_code));
             })?;
         self.transaction.arguments = Some(values.iter().map(format_token_raw).collect());
 


### PR DESCRIPTION


The debug log in `transaction.rs` incorrectly labeled the logged field as `bytecode` when it actually contains `creation_code` (bytecode + constructor arguments). This misleading label makes debugging constructor argument decoding failures more difficult, as developers expect to see the actual contract bytecode but instead see the full creation code.

