### PR TITLE
Gate InlineLink::capture to tests

### DIFF
--- a/crates/doc/src/preprocessor/infer_hyperlinks.rs
+++ b/crates/doc/src/preprocessor/infer_hyperlinks.rs
@@ -238,8 +238,8 @@ impl<'a> InlineLink<'a> {
         RE_INLINE_LINK.captures_iter(s).filter_map(Self::from_capture)
     }
 
-    /// Parses the first inline link.
-    #[allow(unused)]
+    /// Parses the first inline link (tests only).
+    #[cfg(test)]
     fn capture(s: &'a str) -> Option<Self> {
         let cap = RE_INLINE_LINK.captures(s)?;
         Self::from_capture(cap)
@@ -272,13 +272,6 @@ impl<'a> InlineLink<'a> {
     /// Returns the name of the referenced item and its arguments, if any.
     ///
     /// Eg: `safeMint-address-uint256-` returns `("safeMint", ["address", "uint256"])`
-    #[expect(unused)]
-    fn ref_name_exact(&self) -> (&str, impl Iterator<Item = &str> + '_) {
-        let identifier = self.exact_identifier();
-        let mut iter = identifier.split('-');
-        (iter.next().unwrap(), iter.filter(|s| !s.is_empty()))
-    }
-
     /// Returns the content of the matched link.
     fn as_str(&self) -> &str {
         self.outer.as_str()


### PR DESCRIPTION
Mark InlineLink::capture as cfg(test) since it is only used by doc preprocessor unit tests, removing dead code from production builds.