### PR TITLE
fix(anvil): fix variable shadowing bug in txpool remove_with_markers

### DIFF
--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -653,11 +653,11 @@ impl ReadyTransactions {
 
                 // remove from unlocks
                 for mark in &tx.transaction.transaction.requires {
-                    if let Some(hash) = self.provided_markers.get(mark)
-                        && let Some(tx) = ready.get_mut(hash)
-                        && let Some(idx) = tx.unlocks.iter().position(|i| i == hash)
+                    if let Some(provider_hash) = self.provided_markers.get(mark)
+                        && let Some(provider_tx) = ready.get_mut(provider_hash)
+                        && let Some(idx) = provider_tx.unlocks.iter().position(|i| i == &hash)
                     {
-                        tx.unlocks.swap_remove(idx);
+                        provider_tx.unlocks.swap_remove(idx);
                     }
                 }
 


### PR DESCRIPTION
Fixed a bug where the `hash` variable was shadowed inside the loop, causing the wrong hash to be searched in `unlocks`. The code was comparing provider's hash against itself instead of the removed transaction's hash. This meant transactions were never actually removed from `unlocks`, breaking dependency tracking.

The fix follows the same pattern already used in `prune_tags` in the same file.