### PR TITLE
test: actually cache default build artifacts

### DIFF
--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -101,6 +101,9 @@ pub fn initialize(target: &Path) {
 
             // Remove source files.
             prj.wipe_contracts();
+            for file in ["Counter.sol", "Counter.s.sol", "Counter.t.sol"] {
+                let _ = fs::remove_dir_all(prj.paths().artifacts.join(file));
+            }
 
             // Remove the existing template, if any.
             let _ = fs::remove_dir_all(tpath);

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -81,7 +81,7 @@ pub fn initialize(target: &Path) {
             let (prj, mut cmd) = setup_forge("template", foundry_compilers::PathStyle::Dapptools);
             test_debug!("- initializing template dir in {}", prj.root().display());
 
-            cmd.args(["init", "--force", "--empty"]).assert_success();
+            cmd.args(["init", "--force"]).assert_success();
             prj.write_config(Config {
                 solc: Some(foundry_config::SolcReq::Version(SOLC_VERSION.parse().unwrap())),
                 ..Default::default()
@@ -97,6 +97,10 @@ pub fn initialize(target: &Path) {
 
             // Build the project.
             cmd.forge_fuse().arg("build").assert_success();
+            cmd.forge_fuse().arg("test").assert_success();
+
+            // Remove source files.
+            prj.wipe_contracts();
 
             // Remove the existing template, if any.
             let _ = fs::remove_dir_all(tpath);

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -101,8 +101,8 @@ pub fn initialize(target: &Path) {
 
             // Remove source files.
             prj.wipe_contracts();
-            for file in ["Counter.sol", "Counter.s.sol", "Counter.t.sol"] {
-                let _ = fs::remove_dir_all(prj.paths().artifacts.join(file));
+            for artifact in ["Counter.sol", "Counter.s.sol", "Counter.t.sol"] {
+                let _ = fs::remove_dir_all(prj.paths().artifacts.join(artifact));
             }
 
             // Remove the existing template, if any.


### PR DESCRIPTION
`forge build` on an empty project doesn't build anything, not even the libraries. So clear after building. Also run `forge test` since for various reasons it might build different files, messing with the cache of `forge build`.