### PR TITLE
refactor(evm): remove unused `alloy_evm::Evm` import in cow backend

### DIFF
--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -9,7 +9,6 @@ use crate::{
     },
     fork::{CreateFork, ForkId},
 };
-use alloy_evm::Evm;
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{Address, B256, U256};
 use alloy_rpc_types::TransactionRequest;


### PR DESCRIPTION
Removes dead `alloy_evm::Evm` import from `foundry/crates/evm/core/src/backend/cow.rs`.