### PR TITLE
feat(anvil): add optional verbose rpc payload logging 

### DIFF
--- a/crates/anvil/server/src/handler.rs
+++ b/crates/anvil/server/src/handler.rs
@@ -6,18 +6,20 @@ use anvil_rpc::{
 };
 use axum::{
     Json,
-    extract::{State, rejection::JsonRejection},
+    extract::{ConnectInfo, State, rejection::JsonRejection},
 };
 use futures::{FutureExt, future};
+use std::net::SocketAddr;
 
 /// Handles incoming JSON-RPC Request.
 // NOTE: `handler` must come first because the `request` extractor consumes the request body.
 pub async fn handle<Http: RpcHandler, Ws>(
     State((handler, _)): State<(Http, Ws)>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
     request: Result<Json<Request>, JsonRejection>,
 ) -> Json<Response> {
     Json(match request {
-        Ok(Json(req)) => handle_request(req, handler)
+        Ok(Json(req)) => handle_request(req, handler, Some(peer_addr))
             .await
             .unwrap_or_else(|| Response::error(RpcError::invalid_request())),
         Err(err) => {
@@ -34,6 +36,7 @@ pub async fn handle<Http: RpcHandler, Ws>(
 pub async fn handle_request<Handler: RpcHandler>(
     req: Request,
     handler: Handler,
+    peer_addr: Option<SocketAddr>,
 ) -> Option<Response> {
     /// processes batch calls
     fn responses_as_batch(outs: Vec<Option<RpcResponse>>) -> Option<Response> {
@@ -42,21 +45,33 @@ pub async fn handle_request<Handler: RpcHandler>(
     }
 
     match req {
-        Request::Single(call) => handle_call(call, handler).await.map(Response::Single),
+        Request::Single(call) => handle_call(call, handler, peer_addr).await.map(Response::Single),
         Request::Batch(calls) => {
-            future::join_all(calls.into_iter().map(move |call| handle_call(call, handler.clone())))
-                .map(responses_as_batch)
-                .await
+            future::join_all(
+                calls.into_iter().map(move |call| handle_call(call, handler.clone(), peer_addr)),
+            )
+            .map(responses_as_batch)
+            .await
         }
     }
 }
 
 /// handle a single RPC method call
-async fn handle_call<Handler: RpcHandler>(call: RpcCall, handler: Handler) -> Option<RpcResponse> {
+async fn handle_call<Handler: RpcHandler>(
+    call: RpcCall,
+    handler: Handler,
+    peer_addr: Option<SocketAddr>,
+) -> Option<RpcResponse> {
     match call {
         RpcCall::MethodCall(call) => {
-            trace!(target: "rpc", id = ?call.id , method = ?call.method,  "handling call");
-            Some(handler.on_call(call).await)
+            trace!(
+                target: "rpc",
+                id = ?call.id ,
+                method = ?call.method,
+                ?peer_addr,
+                "handling call"
+            );
+            Some(handler.on_call(call, peer_addr).await)
         }
         RpcCall::Notification(notification) => {
             trace!(target: "rpc", method = ?notification.method, "received rpc notification");

--- a/crates/anvil/server/src/handler.rs
+++ b/crates/anvil/server/src/handler.rs
@@ -71,7 +71,7 @@ async fn handle_call<Handler: RpcHandler>(
                 ?peer_addr,
                 "handling call"
             );
-            Some(handler.on_call(call, peer_addr).await)
+            Some(handler.on_call_with_addr(call, peer_addr).await)
         }
         RpcCall::Notification(notification) => {
             trace!(target: "rpc", method = ?notification.method, "received rpc notification");

--- a/crates/anvil/server/src/lib.rs
+++ b/crates/anvil/server/src/lib.rs
@@ -18,7 +18,7 @@ use axum::{
     routing::{MethodRouter, post},
 };
 use serde::de::DeserializeOwned;
-use std::fmt;
+use std::{fmt, net::SocketAddr};
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
 mod config;
@@ -96,8 +96,15 @@ pub trait RpcHandler: Clone + Send + Sync + 'static {
     ///
     /// **Note**: override this function if the expected `Request` deviates from `{ "method" :
     /// "<name>", "params": "<params>" }`
-    async fn on_call(&self, call: RpcMethodCall) -> RpcResponse {
-        trace!(target: "rpc",  id = ?call.id , method = ?call.method, params = ?call.params, "received method call");
+    async fn on_call(&self, call: RpcMethodCall, peer_addr: Option<SocketAddr>) -> RpcResponse {
+        trace!(
+            target: "rpc",
+            id = ?call.id,
+            method = ?call.method,
+            params = ?call.params,
+            ?peer_addr,
+            "received method call"
+        );
         let RpcMethodCall { method, params, id, .. } = call;
 
         let params: serde_json::Value = params.into();

--- a/crates/anvil/server/src/lib.rs
+++ b/crates/anvil/server/src/lib.rs
@@ -106,13 +106,17 @@ pub trait RpcHandler: Clone + Send + Sync + 'static {
     /// This method is similar to [`Self::on_call`] but includes the optional peer socket address,
     /// which can be useful for logging, rate limiting, or other peer-specific logic.
     ///
-    /// The default implementation attempts to deserialize a `{ "method" : "<name>", "params": "<params>" }`
-    /// message into the `Request` type of this handler. If a `Request` instance was deserialized
-    /// successfully, [`Self::on_request`] will be invoked.
+    /// The default implementation attempts to deserialize a `{ "method" : "<name>", "params":
+    /// "<params>" }` message into the `Request` type of this handler. If a `Request` instance
+    /// was deserialized successfully, [`Self::on_request`] will be invoked.
     ///
     /// **Note**: override this function if you need access to the peer address or if the expected
     /// `Request` deviates from `{ "method" : "<name>", "params": "<params>" }`
-    async fn on_call_with_addr(&self, call: RpcMethodCall, peer_addr: Option<SocketAddr>) -> RpcResponse {
+    async fn on_call_with_addr(
+        &self,
+        call: RpcMethodCall,
+        peer_addr: Option<SocketAddr>,
+    ) -> RpcResponse {
         trace!(
             target: "rpc",
             id = ?call.id,

--- a/crates/anvil/server/src/lib.rs
+++ b/crates/anvil/server/src/lib.rs
@@ -106,11 +106,11 @@ pub trait RpcHandler: Clone + Send + Sync + 'static {
     /// This method is similar to [`Self::on_call`] but includes the optional peer socket address,
     /// which can be useful for logging, rate limiting, or other peer-specific logic.
     ///
-    /// The default implementation attempts to deserialize a `{ "method" : "<name>", "params": "<params>" }` 
+    /// The default implementation attempts to deserialize a `{ "method" : "<name>", "params": "<params>" }`
     /// message into the `Request` type of this handler. If a `Request` instance was deserialized
     /// successfully, [`Self::on_request`] will be invoked.
     ///
-    /// **Note**: override this function if you need access to the peer address or if the expected 
+    /// **Note**: override this function if you need access to the peer address or if the expected
     /// `Request` deviates from `{ "method" : "<name>", "params": "<params>" }`
     async fn on_call_with_addr(&self, call: RpcMethodCall, peer_addr: Option<SocketAddr>) -> RpcResponse {
         trace!(

--- a/crates/anvil/server/src/lib.rs
+++ b/crates/anvil/server/src/lib.rs
@@ -96,7 +96,23 @@ pub trait RpcHandler: Clone + Send + Sync + 'static {
     ///
     /// **Note**: override this function if the expected `Request` deviates from `{ "method" :
     /// "<name>", "params": "<params>" }`
-    async fn on_call(&self, call: RpcMethodCall, peer_addr: Option<SocketAddr>) -> RpcResponse {
+    async fn on_call(&self, call: RpcMethodCall) -> RpcResponse {
+        // Default implementation delegates to on_call_with_addr with None
+        self.on_call_with_addr(call, None).await
+    }
+
+    /// Invoked for every incoming `RpcMethodCall` with peer address information
+    ///
+    /// This method is similar to [`Self::on_call`] but includes the optional peer socket address,
+    /// which can be useful for logging, rate limiting, or other peer-specific logic.
+    ///
+    /// The default implementation attempts to deserialize a `{ "method" : "<name>", "params": "<params>" }` 
+    /// message into the `Request` type of this handler. If a `Request` instance was deserialized
+    /// successfully, [`Self::on_request`] will be invoked.
+    ///
+    /// **Note**: override this function if you need access to the peer address or if the expected 
+    /// `Request` deviates from `{ "method" : "<name>", "params": "<params>" }`
+    async fn on_call_with_addr(&self, call: RpcMethodCall, peer_addr: Option<SocketAddr>) -> RpcResponse {
         trace!(
             target: "rpc",
             id = ?call.id,

--- a/crates/anvil/server/src/pubsub.rs
+++ b/crates/anvil/server/src/pubsub.rs
@@ -142,7 +142,7 @@ impl<Handler: PubSubRpcHandler, Connection> PubSubConnection<Handler, Connection
         let handler = self.compat_helper();
         self.processing.push(Box::pin(async move {
             match req {
-                Ok(req) => handle_request(req, handler)
+                Ok(req) => handle_request(req, handler, None)
                     .await
                     .unwrap_or_else(|| Response::error(RpcError::invalid_request())),
                 Err(err) => {

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -201,8 +201,10 @@ pub struct NodeArgs {
     /// Enable verbose logging of all RPC request and response payloads, including parameters and results.
     ///
     /// This CLI flag controls the initial payload-level logging state at node startup. At runtime,
-    /// the `anvil_setLoggingEnabled` RPC method can be used to toggle both standard RPC logging and
-    /// RPC payload logging, overriding the initial CLI setting.
+    /// the `anvil_setLoggingEnabled` RPC method toggles both standard RPC logging and RPC payload
+    /// logging together, overriding the initial CLI setting. Once the node is running, standard RPC
+    /// logging and RPC payload logging cannot be controlled independently; they remain permanently
+    /// coupled for the lifetime of the process.
     #[arg(long, help_heading = "Logging options")]
     pub rpc_log: bool,
 }

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -198,13 +198,14 @@ pub struct NodeArgs {
     #[arg(long, value_name = "PATH")]
     pub cache_path: Option<PathBuf>,
 
-    /// Enable verbose logging of all RPC request and response payloads, including parameters and results.
+    /// Enable verbose logging of all RPC request and response payloads, including parameters and
+    /// results.
     ///
     /// This CLI flag controls the initial payload-level logging state at node startup. At runtime,
     /// the `anvil_setLoggingEnabled` RPC method toggles both standard RPC logging and RPC payload
-    /// logging together, overriding the initial CLI setting. Once the node is running, standard RPC
-    /// logging and RPC payload logging cannot be controlled independently; they remain permanently
-    /// coupled for the lifetime of the process.
+    /// logging together, overriding the initial CLI setting. Once the node is running, standard
+    /// RPC logging and RPC payload logging cannot be controlled independently; they remain
+    /// permanently coupled for the lifetime of the process.
     #[arg(long, help_heading = "Logging options")]
     pub rpc_log: bool,
 }

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -200,8 +200,9 @@ pub struct NodeArgs {
 
     /// Enable verbose logging of all RPC request and response payloads, including parameters and results.
     ///
-    /// This CLI flag controls payload-level logging at node startup and is independent of the
-    /// `anvil_setLoggingEnabled` RPC method, which can be used at runtime to toggle standard RPC logging.
+    /// This CLI flag controls the initial payload-level logging state at node startup. At runtime,
+    /// the `anvil_setLoggingEnabled` RPC method can be used to toggle both standard RPC logging and
+    /// RPC payload logging, overriding the initial CLI setting.
     #[arg(long, help_heading = "Logging options")]
     pub rpc_log: bool,
 }

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -197,6 +197,10 @@ pub struct NodeArgs {
     /// Path to the cache directory where states are stored.
     #[arg(long, value_name = "PATH")]
     pub cache_path: Option<PathBuf>,
+
+    /// Enable logging of RPC request and response payloads.
+    #[arg(long, help_heading = "Logging options")]
+    pub rpc_log: bool,
 }
 
 #[cfg(windows)]
@@ -283,7 +287,8 @@ impl NodeArgs {
             .with_disable_pool_balance_checks(self.evm.disable_pool_balance_checks)
             .with_slots_in_an_epoch(self.slots_in_an_epoch)
             .with_memory_limit(self.evm.memory_limit)
-            .with_cache_path(self.cache_path))
+            .with_cache_path(self.cache_path)
+            .with_rpc_logging(self.rpc_log))
     }
 
     fn account_generator(&self) -> AccountGenerator {

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -198,7 +198,10 @@ pub struct NodeArgs {
     #[arg(long, value_name = "PATH")]
     pub cache_path: Option<PathBuf>,
 
-    /// Enable logging of RPC request and response payloads.
+    /// Enable verbose logging of all RPC request and response payloads, including parameters and results.
+    ///
+    /// This CLI flag controls payload-level logging at node startup and is independent of the
+    /// `anvil_setLoggingEnabled` RPC method, which can be used at runtime to toggle standard RPC logging.
     #[arg(long, help_heading = "Logging options")]
     pub rpc_log: bool,
 }

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -516,10 +516,6 @@ impl NodeConfig {
         self
     }
 
-    /// Returns true if RPC payload logging is enabled.
-    pub fn rpc_logging(&self) -> bool {
-        self.rpc_log
-    }
     /// Returns the base fee to use
     pub fn get_base_fee(&self) -> u64 {
         self.base_fee

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -208,7 +208,7 @@ pub struct NodeConfig {
     pub silent: bool,
     /// The path where states are cached.
     pub cache_path: Option<PathBuf>,
-    /// Whether RPC payload logging is enabled.
+    /// Whether RPC request/response payload logging (via `rpc_log`) is enabled.
     pub rpc_log: bool,
 }
 

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -208,6 +208,8 @@ pub struct NodeConfig {
     pub silent: bool,
     /// The path where states are cached.
     pub cache_path: Option<PathBuf>,
+    /// Whether RPC payload logging is enabled.
+    pub rpc_log: bool,
 }
 
 impl NodeConfig {
@@ -501,6 +503,7 @@ impl Default for NodeConfig {
             networks: Default::default(),
             silent: false,
             cache_path: None,
+            rpc_log: false,
         }
     }
 }
@@ -511,6 +514,11 @@ impl NodeConfig {
     pub fn with_memory_limit(mut self, mems_value: Option<u64>) -> Self {
         self.memory_limit = mems_value;
         self
+    }
+
+    /// Returns true if RPC payload logging is enabled.
+    pub fn rpc_logging(&self) -> bool {
+        self.rpc_log
     }
     /// Returns the base fee to use
     pub fn get_base_fee(&self) -> u64 {
@@ -1048,6 +1056,13 @@ impl NodeConfig {
     #[must_use]
     pub fn with_cache_path(mut self, cache_path: Option<PathBuf>) -> Self {
         self.cache_path = cache_path;
+        self
+    }
+
+    /// Sets whether RPC payload logging is enabled.
+    #[must_use]
+    pub fn with_rpc_logging(mut self, rpc_log: bool) -> Self {
+        self.rpc_log = rpc_log;
         self
     }
 

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -141,7 +141,7 @@ pub struct RpcCallLogContext {
     pub method: Option<String>,
     pub peer_addr: Option<SocketAddr>,
     pub timestamp: Option<DateTime<Utc>>,
-    /// The JSON-RPC version and params value, stored for lazy raw JSON construction
+    /// The JSON-RPC version and params value used when constructing raw JSON for RPC logging.
     pub jsonrpc_version: Option<Version>,
     pub params_value: Option<serde_json::Value>,
 }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -690,8 +690,10 @@ impl EthApi {
         if let ResponseResult::Error(err) = &response {
             let label = context.format_label("\nRPC request failed");
             node_info!("{label}:");
-            if let Some(raw) = &raw_request {
-                match serde_json::to_string(raw) {
+            // Try to use provided raw request, or lazily construct it from context
+            let resolved_raw = raw_request.or_else(|| context.to_raw_json());
+            if let Some(raw) = resolved_raw {
+                match serde_json::to_string(&raw) {
                     Ok(serialized) => node_info!("    Request: {serialized}"),
                     Err(_) => node_info!("    Request: {:?}", request),
                 }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -133,7 +133,7 @@ pub const CLIENT_VERSION: &str = concat!("anvil/v", env!("CARGO_PKG_VERSION"));
 /// When verbose RPC logging is enabled, this context is used to format log labels with
 /// additional metadata. For example, a log message might be formatted as:
 /// ```text
-/// RPC request [id=1, method=eth_getBalance, peer=127.0.0.1:8545, ts=2024-01-01T00:00:00Z]: {...}
+/// RPC request [id=1, method=eth_getBalance, peer=127.0.0.1:8545, ts=2025-12-19T00:00:00Z]: {...}
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct RpcCallLogContext {

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -74,7 +74,8 @@ use anvil_core::{
     },
     types::{ReorgOptions, TransactionData},
 };
-use anvil_rpc::{error::RpcError, response::ResponseResult};
+use anvil_rpc::{error::RpcError, request::Id as RpcId, response::ResponseResult};
+use chrono::{DateTime, Utc};
 use foundry_common::provider::ProviderBuilder;
 use foundry_evm::decode::RevertDecoder;
 use foundry_primitives::{
@@ -92,7 +93,16 @@ use revm::{
     interpreter::{InstructionResult, return_ok, return_revert},
     primitives::eip7702::PER_EMPTY_ACCOUNT_COST,
 };
-use std::{sync::Arc, time::Duration};
+use serde_json::Value;
+use std::{
+    borrow::Cow,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 use tokio::{
     sync::mpsc::{UnboundedReceiver, unbounded_channel},
     try_join,
@@ -100,6 +110,45 @@ use tokio::{
 
 /// The client version: `anvil/v{major}.{minor}.{patch}`
 pub const CLIENT_VERSION: &str = concat!("anvil/v", env!("CARGO_PKG_VERSION"));
+
+#[derive(Clone, Debug, Default)]
+pub struct RpcCallLogContext {
+    pub id: Option<RpcId>,
+    pub method: Option<String>,
+    pub peer_addr: Option<SocketAddr>,
+    pub timestamp: Option<DateTime<Utc>>,
+}
+
+impl RpcCallLogContext {
+    fn label_suffix(&self) -> Option<String> {
+        let mut parts = Vec::new();
+
+        if let Some(id) = self.id.as_ref() {
+            parts.push(format!("id={id}"));
+        }
+
+        if let Some(method) = self.method.as_ref() {
+            parts.push(format!("method={method}"));
+        }
+
+        if let Some(peer_addr) = self.peer_addr {
+            parts.push(format!("peer={peer_addr}"));
+        }
+
+        if let Some(timestamp) = self.timestamp.as_ref() {
+            parts.push(format!("ts={}", timestamp.to_rfc3339()));
+        }
+
+        (!parts.is_empty()).then(|| parts.join(", "))
+    }
+
+    fn format_label<'a>(&self, base: &'a str) -> Cow<'a, str> {
+        match self.label_suffix() {
+            Some(suffix) => Cow::Owned(format!("{base} [{suffix}]")),
+            None => Cow::Borrowed(base),
+        }
+    }
+}
 
 /// The entry point for executing eth api RPC call - The Eth RPC interface.
 ///
@@ -134,6 +183,8 @@ pub struct EthApi {
     net_listening: bool,
     /// The instance ID. Changes on every reset.
     instance_id: Arc<RwLock<B256>>,
+    /// Whether RPC payload logging is enabled.
+    rpc_payload_logging: Arc<AtomicBool>,
 }
 
 impl EthApi {
@@ -149,6 +200,7 @@ impl EthApi {
         logger: LoggingManager,
         filters: Filters,
         transactions_order: TransactionOrder,
+        rpc_payload_logging: bool,
     ) -> Self {
         Self {
             pool,
@@ -163,12 +215,26 @@ impl EthApi {
             net_listening: true,
             transaction_order: Arc::new(RwLock::new(transactions_order)),
             instance_id: Arc::new(RwLock::new(B256::random())),
+            rpc_payload_logging: Arc::new(AtomicBool::new(rpc_payload_logging)),
         }
     }
 
     /// Executes the [EthRequest] and returns an RPC [ResponseResult].
     pub async fn execute(&self, request: EthRequest) -> ResponseResult {
+        self.execute_with_raw(request, None, RpcCallLogContext::default()).await
+    }
+
+    pub async fn execute_with_raw(
+        &self,
+        request: EthRequest,
+        raw_request: Option<Value>,
+        context: RpcCallLogContext,
+    ) -> ResponseResult {
         trace!(target: "rpc::api", "executing eth request");
+        let should_log_rpc_payloads = self.should_log_rpc_payloads();
+        if should_log_rpc_payloads {
+            self.log_rpc_payload("RPC request", raw_request.as_ref(), &request, &context);
+        }
         let response = match request.clone() {
             EthRequest::EthProtocolVersion(()) => self.protocol_version().to_rpc_result(),
             EthRequest::Web3ClientVersion(()) => self.client_version().to_rpc_result(),
@@ -523,13 +589,55 @@ impl EthApi {
             }
         };
 
+        if should_log_rpc_payloads {
+            let response_json = serde_json::to_value(&response).ok();
+            self.log_rpc_payload("RPC response", response_json.as_ref(), &response, &context);
+        }
+
         if let ResponseResult::Error(err) = &response {
-            node_info!("\nRPC request failed:");
-            node_info!("    Request: {:?}", request);
+            let label = context.format_label("\nRPC request failed");
+            node_info!("{label}:");
+            if let Some(raw) = &raw_request {
+                match serde_json::to_string(raw) {
+                    Ok(serialized) => node_info!("    Request: {serialized}"),
+                    Err(_) => node_info!("    Request: {:?}", request),
+                }
+            } else {
+                node_info!("    Request: {:?}", request);
+            }
             node_info!("    Error: {}\n", err);
         }
 
         response
+    }
+
+    fn should_log_rpc_payloads(&self) -> bool {
+        self.logger.is_enabled() && self.rpc_payload_logging.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn log_rpc_method(&self, method: &str) {
+        if !self.should_log_rpc_payloads() {
+            node_info!("{method}");
+        }
+    }
+
+    fn log_rpc_payload<T>(
+        &self,
+        label: &str,
+        json_value: Option<&Value>,
+        debug_value: &T,
+        context: &RpcCallLogContext,
+    ) where
+        T: std::fmt::Debug,
+    {
+        let payload = match json_value {
+            Some(value) => {
+                serde_json::to_string(value).unwrap_or_else(|_| format!("{:?}", debug_value))
+            }
+            None => format!("{:?}", debug_value),
+        };
+        let label = context.format_label(label);
+        node_info!("{label}: {payload}");
     }
 
     fn sign_request(&self, from: &Address, request: FoundryTypedTx) -> Result<FoundryTxEnvelope> {
@@ -582,7 +690,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `web3_clientVersion`
     pub fn client_version(&self) -> Result<String> {
-        node_info!("web3_clientVersion");
+        self.log_rpc_method("web3_clientVersion");
         Ok(CLIENT_VERSION.to_string())
     }
 
@@ -590,7 +698,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `web3_sha3`
     pub fn sha3(&self, bytes: Bytes) -> Result<String> {
-        node_info!("web3_sha3");
+        self.log_rpc_method("web3_sha3");
         let hash = alloy_primitives::keccak256(bytes.as_ref());
         Ok(alloy_primitives::hex::encode_prefixed(&hash[..]))
     }
@@ -599,7 +707,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_protocolVersion`
     pub fn protocol_version(&self) -> Result<u64> {
-        node_info!("eth_protocolVersion");
+        self.log_rpc_method("eth_protocolVersion");
         Ok(1)
     }
 
@@ -607,7 +715,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_hashrate`
     pub fn hashrate(&self) -> Result<U256> {
-        node_info!("eth_hashrate");
+        self.log_rpc_method("eth_hashrate");
         Ok(U256::ZERO)
     }
 
@@ -615,7 +723,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_coinbase`
     pub fn author(&self) -> Result<Address> {
-        node_info!("eth_coinbase");
+        self.log_rpc_method("eth_coinbase");
         Ok(self.backend.coinbase())
     }
 
@@ -623,7 +731,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_mining`
     pub fn is_mining(&self) -> Result<bool> {
-        node_info!("eth_mining");
+        self.log_rpc_method("eth_mining");
         Ok(self.is_mining)
     }
 
@@ -633,7 +741,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_chainId`
     pub fn eth_chain_id(&self) -> Result<Option<U64>> {
-        node_info!("eth_chainId");
+        self.log_rpc_method("eth_chainId");
         Ok(Some(self.backend.chain_id().to::<U64>()))
     }
 
@@ -641,7 +749,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_networkId`
     pub fn network_id(&self) -> Result<Option<String>> {
-        node_info!("eth_networkId");
+        self.log_rpc_method("eth_networkId");
         let chain_id = self.backend.chain_id().to::<u64>();
         Ok(Some(format!("{chain_id}")))
     }
@@ -650,13 +758,13 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `net_listening`
     pub fn net_listening(&self) -> Result<bool> {
-        node_info!("net_listening");
+        self.log_rpc_method("net_listening");
         Ok(self.net_listening)
     }
 
     /// Returns the current gas price
     fn eth_gas_price(&self) -> Result<U256> {
-        node_info!("eth_gasPrice");
+        self.log_rpc_method("eth_gasPrice");
         Ok(U256::from(self.gas_price()))
     }
 
@@ -702,7 +810,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_accounts`
     pub fn accounts(&self) -> Result<Vec<Address>> {
-        node_info!("eth_accounts");
+        self.log_rpc_method("eth_accounts");
         let mut unique = HashSet::new();
         let mut accounts: Vec<Address> = Vec::new();
         for signer in self.signers.iter() {
@@ -722,7 +830,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_blockNumber`
     pub fn block_number(&self) -> Result<U256> {
-        node_info!("eth_blockNumber");
+        self.log_rpc_method("eth_blockNumber");
         Ok(U256::from(self.backend.best_number()))
     }
 
@@ -730,7 +838,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getBalance`
     pub async fn balance(&self, address: Address, block_number: Option<BlockId>) -> Result<U256> {
-        node_info!("eth_getBalance");
+        self.log_rpc_method("eth_getBalance");
         let block_request = self.block_request(block_number).await?;
 
         // check if the number predates the fork, if in fork mode
@@ -752,7 +860,7 @@ impl EthApi {
         address: Address,
         block_number: Option<BlockId>,
     ) -> Result<Account> {
-        node_info!("eth_getAccount");
+        self.log_rpc_method("eth_getAccount");
         let block_request = self.block_request(block_number).await?;
 
         // check if the number predates the fork, if in fork mode
@@ -774,7 +882,7 @@ impl EthApi {
         address: Address,
         block_number: Option<BlockId>,
     ) -> Result<alloy_rpc_types::eth::AccountInfo> {
-        node_info!("eth_getAccountInfo");
+        self.log_rpc_method("eth_getAccountInfo");
 
         if let Some(fork) = self.get_fork() {
             let block_request = self.block_request(block_number).await?;
@@ -822,7 +930,7 @@ impl EthApi {
         index: U256,
         block_number: Option<BlockId>,
     ) -> Result<B256> {
-        node_info!("eth_getStorageAt");
+        self.log_rpc_method("eth_getStorageAt");
         let block_request = self.block_request(block_number).await?;
 
         // check if the number predates the fork, if in fork mode
@@ -842,7 +950,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getBlockByHash`
     pub async fn block_by_hash(&self, hash: B256) -> Result<Option<AnyRpcBlock>> {
-        node_info!("eth_getBlockByHash");
+        self.log_rpc_method("eth_getBlockByHash");
         self.backend.block_by_hash(hash).await
     }
 
@@ -850,7 +958,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getBlockByHash`
     pub async fn block_by_hash_full(&self, hash: B256) -> Result<Option<AnyRpcBlock>> {
-        node_info!("eth_getBlockByHash");
+        self.log_rpc_method("eth_getBlockByHash");
         self.backend.block_by_hash_full(hash).await
     }
 
@@ -858,7 +966,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getBlockByNumber`
     pub async fn block_by_number(&self, number: BlockNumber) -> Result<Option<AnyRpcBlock>> {
-        node_info!("eth_getBlockByNumber");
+        self.log_rpc_method("eth_getBlockByNumber");
         if number == BlockNumber::Pending {
             return Ok(Some(self.pending_block().await));
         }
@@ -870,7 +978,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getBlockByNumber`
     pub async fn block_by_number_full(&self, number: BlockNumber) -> Result<Option<AnyRpcBlock>> {
-        node_info!("eth_getBlockByNumber");
+        self.log_rpc_method("eth_getBlockByNumber");
         if number == BlockNumber::Pending {
             return Ok(self.pending_block_full().await);
         }
@@ -888,7 +996,7 @@ impl EthApi {
         address: Address,
         block_number: Option<BlockId>,
     ) -> Result<U256> {
-        node_info!("eth_getTransactionCount");
+        self.log_rpc_method("eth_getTransactionCount");
         self.get_transaction_count(address, block_number).await.map(U256::from)
     }
 
@@ -896,7 +1004,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getBlockTransactionCountByHash`
     pub async fn block_transaction_count_by_hash(&self, hash: B256) -> Result<Option<U256>> {
-        node_info!("eth_getBlockTransactionCountByHash");
+        self.log_rpc_method("eth_getBlockTransactionCountByHash");
         let block = self.backend.block_by_hash(hash).await?;
         let txs = block.map(|b| match b.transactions() {
             BlockTransactions::Full(txs) => U256::from(txs.len()),
@@ -913,7 +1021,7 @@ impl EthApi {
         &self,
         block_number: BlockNumber,
     ) -> Result<Option<U256>> {
-        node_info!("eth_getBlockTransactionCountByNumber");
+        self.log_rpc_method("eth_getBlockTransactionCountByNumber");
         let block_request = self.block_request(Some(block_number.into())).await?;
         if let BlockRequest::Pending(txs) = block_request {
             let block = self.backend.pending_block(txs).await;
@@ -932,7 +1040,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getUncleCountByBlockHash`
     pub async fn block_uncles_count_by_hash(&self, hash: B256) -> Result<U256> {
-        node_info!("eth_getUncleCountByBlockHash");
+        self.log_rpc_method("eth_getUncleCountByBlockHash");
         let block =
             self.backend.block_by_hash(hash).await?.ok_or(BlockchainError::BlockNotFound)?;
         Ok(U256::from(block.uncles.len()))
@@ -942,7 +1050,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getUncleCountByBlockNumber`
     pub async fn block_uncles_count_by_number(&self, block_number: BlockNumber) -> Result<U256> {
-        node_info!("eth_getUncleCountByBlockNumber");
+        self.log_rpc_method("eth_getUncleCountByBlockNumber");
         let block = self
             .backend
             .block_by_number(block_number)
@@ -955,7 +1063,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getCode`
     pub async fn get_code(&self, address: Address, block_number: Option<BlockId>) -> Result<Bytes> {
-        node_info!("eth_getCode");
+        self.log_rpc_method("eth_getCode");
         let block_request = self.block_request(block_number).await?;
         // check if the number predates the fork, if in fork mode
         if let BlockRequest::Number(number) = block_request
@@ -977,7 +1085,7 @@ impl EthApi {
         keys: Vec<B256>,
         block_number: Option<BlockId>,
     ) -> Result<EIP1186AccountProofResponse> {
-        node_info!("eth_getProof");
+        self.log_rpc_method("eth_getProof");
         let block_request = self.block_request(block_number).await?;
 
         // If we're in forking mode, or still on the forked block (no blocks mined yet) then we can
@@ -1001,7 +1109,7 @@ impl EthApi {
         _address: Address,
         _data: serde_json::Value,
     ) -> Result<String> {
-        node_info!("eth_signTypedData");
+        self.log_rpc_method("eth_signTypedData");
         Err(BlockchainError::RpcUnimplemented)
     }
 
@@ -1013,7 +1121,7 @@ impl EthApi {
         _address: Address,
         _data: serde_json::Value,
     ) -> Result<String> {
-        node_info!("eth_signTypedData_v3");
+        self.log_rpc_method("eth_signTypedData_v3");
         Err(BlockchainError::RpcUnimplemented)
     }
 
@@ -1021,7 +1129,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_signTypedData_v4`
     pub async fn sign_typed_data_v4(&self, address: Address, data: &TypedData) -> Result<String> {
-        node_info!("eth_signTypedData_v4");
+        self.log_rpc_method("eth_signTypedData_v4");
         let signer = self.get_signer(address).ok_or(BlockchainError::NoSignerAvailable)?;
         let signature = signer.sign_typed_data(address, data).await?;
         let signature = alloy_primitives::hex::encode(signature.as_bytes());
@@ -1032,7 +1140,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_sign`
     pub async fn sign(&self, address: Address, content: impl AsRef<[u8]>) -> Result<String> {
-        node_info!("eth_sign");
+        self.log_rpc_method("eth_sign");
         let signer = self.get_signer(address).ok_or(BlockchainError::NoSignerAvailable)?;
         let signature =
             alloy_primitives::hex::encode(signer.sign(address, content.as_ref()).await?.as_bytes());
@@ -1046,7 +1154,7 @@ impl EthApi {
         &self,
         request: WithOtherFields<TransactionRequest>,
     ) -> Result<String> {
-        node_info!("eth_signTransaction");
+        self.log_rpc_method("eth_signTransaction");
 
         let from = request.from.map(Ok).unwrap_or_else(|| {
             self.accounts()?.first().copied().ok_or(BlockchainError::NoSignerAvailable)
@@ -1067,7 +1175,7 @@ impl EthApi {
         &self,
         request: WithOtherFields<TransactionRequest>,
     ) -> Result<TxHash> {
-        node_info!("eth_sendTransaction");
+        self.log_rpc_method("eth_sendTransaction");
 
         let from = request.from.map(Ok).unwrap_or_else(|| {
             self.accounts()?.first().copied().ok_or(BlockchainError::NoSignerAvailable)
@@ -1137,7 +1245,7 @@ impl EthApi {
         &self,
         request: WithOtherFields<TransactionRequest>,
     ) -> Result<FoundryTxReceipt> {
-        node_info!("eth_sendTransactionSync");
+        self.log_rpc_method("eth_sendTransactionSync");
         let hash = self.send_transaction(request).await?;
 
         let receipt = self.check_transaction_inclusion(hash).await?;
@@ -1149,7 +1257,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_sendRawTransaction`
     pub async fn send_raw_transaction(&self, tx: Bytes) -> Result<TxHash> {
-        node_info!("eth_sendRawTransaction");
+        self.log_rpc_method("eth_sendRawTransaction");
         let mut data = tx.as_ref();
         if data.is_empty() {
             return Err(BlockchainError::EmptyRawTransactionData);
@@ -1187,7 +1295,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_sendRawTransactionSync`
     pub async fn send_raw_transaction_sync(&self, tx: Bytes) -> Result<FoundryTxReceipt> {
-        node_info!("eth_sendRawTransactionSync");
+        self.log_rpc_method("eth_sendRawTransactionSync");
 
         let hash = self.send_raw_transaction(tx).await?;
         let receipt = self.check_transaction_inclusion(hash).await?;
@@ -1204,7 +1312,7 @@ impl EthApi {
         block_number: Option<BlockId>,
         overrides: EvmOverrides,
     ) -> Result<Bytes> {
-        node_info!("eth_call");
+        self.log_rpc_method("eth_call");
         let block_request = self.block_request(block_number).await?;
         // check if the number predates the fork, if in fork mode
         if let BlockRequest::Number(number) = block_request
@@ -1243,7 +1351,7 @@ impl EthApi {
         request: SimulatePayload,
         block_number: Option<BlockId>,
     ) -> Result<Vec<SimulatedBlock<AnyRpcBlock>>> {
-        node_info!("eth_simulateV1");
+        self.log_rpc_method("eth_simulateV1");
         let block_request = self.block_request(block_number).await?;
         // check if the number predates the fork, if in fork mode
         if let BlockRequest::Number(number) = block_request
@@ -1282,7 +1390,7 @@ impl EthApi {
         mut request: WithOtherFields<TransactionRequest>,
         block_number: Option<BlockId>,
     ) -> Result<AccessListResult> {
-        node_info!("eth_createAccessList");
+        self.log_rpc_method("eth_createAccessList");
         let block_request = self.block_request(block_number).await?;
         // check if the number predates the fork, if in fork mode
         if let BlockRequest::Number(number) = block_request
@@ -1332,7 +1440,7 @@ impl EthApi {
         block_number: Option<BlockId>,
         overrides: EvmOverrides,
     ) -> Result<U256> {
-        node_info!("eth_estimateGas");
+        self.log_rpc_method("eth_estimateGas");
         self.do_estimate_gas(
             request,
             block_number.or_else(|| Some(BlockNumber::Pending.into())),
@@ -1397,13 +1505,13 @@ impl EthApi {
         &self,
         hash: B256,
     ) -> Result<Option<alloy_consensus::Blob>> {
-        node_info!("anvil_getBlobByHash");
+        self.log_rpc_method("anvil_getBlobByHash");
         Ok(self.backend.get_blob_by_versioned_hash(hash)?)
     }
 
     /// Handler for RPC call: `anvil_getBlobsByTransactionHash`
     pub fn anvil_get_blob_by_tx_hash(&self, hash: B256) -> Result<Option<Vec<Blob>>> {
-        node_info!("anvil_getBlobsByTransactionHash");
+        self.log_rpc_method("anvil_getBlobsByTransactionHash");
         Ok(self.backend.get_blob_by_tx_hash(hash)?)
     }
 
@@ -1413,7 +1521,7 @@ impl EthApi {
         block_id: impl Into<BlockId>,
         versioned_hashes: Vec<B256>,
     ) -> Result<Option<Vec<Blob>>> {
-        node_info!("anvil_getBlobsByBlockId");
+        self.log_rpc_method("anvil_getBlobsByBlockId");
         Ok(self.backend.get_blobs_by_block_id(block_id, versioned_hashes)?)
     }
 
@@ -1422,7 +1530,7 @@ impl EthApi {
         &self,
         block_id: BlockId,
     ) -> Result<Option<BlobTransactionSidecar>> {
-        node_info!("anvil_getBlobSidecarsByBlockId");
+        self.log_rpc_method("anvil_getBlobSidecarsByBlockId");
         Ok(self.backend.get_blob_sidecars_by_block_id(block_id)?)
     }
 
@@ -1441,7 +1549,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getTransactionByHash`
     pub async fn transaction_by_hash(&self, hash: B256) -> Result<Option<AnyRpcTransaction>> {
-        node_info!("eth_getTransactionByHash");
+        self.log_rpc_method("eth_getTransactionByHash");
         let mut tx = self.pool.get_transaction(hash).map(|pending| {
             let from = *pending.sender();
             let tx = transaction_build(
@@ -1474,7 +1582,7 @@ impl EthApi {
         hash: B256,
         index: Index,
     ) -> Result<Option<AnyRpcTransaction>> {
-        node_info!("eth_getTransactionByBlockHashAndIndex");
+        self.log_rpc_method("eth_getTransactionByBlockHashAndIndex");
         self.backend.transaction_by_block_hash_and_index(hash, index).await
     }
 
@@ -1486,7 +1594,7 @@ impl EthApi {
         block: BlockNumber,
         idx: Index,
     ) -> Result<Option<AnyRpcTransaction>> {
-        node_info!("eth_getTransactionByBlockNumberAndIndex");
+        self.log_rpc_method("eth_getTransactionByBlockNumberAndIndex");
         self.backend.transaction_by_block_number_and_index(block, idx).await
     }
 
@@ -1579,7 +1687,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getTransactionReceipt`
     pub async fn transaction_receipt(&self, hash: B256) -> Result<Option<FoundryTxReceipt>> {
-        node_info!("eth_getTransactionReceipt");
+        self.log_rpc_method("eth_getTransactionReceipt");
         self.backend.transaction_receipt(hash).await
     }
 
@@ -1587,7 +1695,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getBlockReceipts`
     pub async fn block_receipts(&self, number: BlockId) -> Result<Option<Vec<FoundryTxReceipt>>> {
-        node_info!("eth_getBlockReceipts");
+        self.log_rpc_method("eth_getBlockReceipts");
         self.backend.block_receipts(number).await
     }
 
@@ -1599,7 +1707,7 @@ impl EthApi {
         block_hash: B256,
         idx: Index,
     ) -> Result<Option<AnyRpcBlock>> {
-        node_info!("eth_getUncleByBlockHashAndIndex");
+        self.log_rpc_method("eth_getUncleByBlockHashAndIndex");
         let number =
             self.backend.ensure_block_number(Some(BlockId::Hash(block_hash.into()))).await?;
         if let Some(fork) = self.get_fork()
@@ -1619,7 +1727,7 @@ impl EthApi {
         block_number: BlockNumber,
         idx: Index,
     ) -> Result<Option<AnyRpcBlock>> {
-        node_info!("eth_getUncleByBlockNumberAndIndex");
+        self.log_rpc_method("eth_getUncleByBlockNumberAndIndex");
         let number = self.backend.ensure_block_number(Some(BlockId::Number(block_number))).await?;
         if let Some(fork) = self.get_fork()
             && fork.predates_fork_inclusive(number)
@@ -1634,7 +1742,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getLogs`
     pub async fn logs(&self, filter: Filter) -> Result<Vec<Log>> {
-        node_info!("eth_getLogs");
+        self.log_rpc_method("eth_getLogs");
         self.backend.logs(filter).await
     }
 
@@ -1642,7 +1750,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getWork`
     pub fn work(&self) -> Result<Work> {
-        node_info!("eth_getWork");
+        self.log_rpc_method("eth_getWork");
         Err(BlockchainError::RpcUnimplemented)
     }
 
@@ -1650,7 +1758,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_syncing`
     pub fn syncing(&self) -> Result<bool> {
-        node_info!("eth_syncing");
+        self.log_rpc_method("eth_syncing");
         Ok(false)
     }
 
@@ -1665,7 +1773,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_config`
     pub fn config(&self) -> Result<EthConfig> {
-        node_info!("eth_config");
+        self.log_rpc_method("eth_config");
         Ok(EthConfig {
             current: EthForkConfig {
                 activation_time: 0,
@@ -1684,7 +1792,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_submitWork`
     pub fn submit_work(&self, _: B64, _: B256, _: B256) -> Result<bool> {
-        node_info!("eth_submitWork");
+        self.log_rpc_method("eth_submitWork");
         Err(BlockchainError::RpcUnimplemented)
     }
 
@@ -1692,7 +1800,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_submitHashrate`
     pub fn submit_hashrate(&self, _: U256, _: B256) -> Result<bool> {
-        node_info!("eth_submitHashrate");
+        self.log_rpc_method("eth_submitHashrate");
         Err(BlockchainError::RpcUnimplemented)
     }
 
@@ -1705,7 +1813,7 @@ impl EthApi {
         newest_block: BlockNumber,
         reward_percentiles: Vec<f64>,
     ) -> Result<FeeHistory> {
-        node_info!("eth_feeHistory");
+        self.log_rpc_method("eth_feeHistory");
         // max number of blocks in the requested range
 
         let current = self.backend.best_number();
@@ -1804,7 +1912,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_maxPriorityFeePerGas`
     pub fn max_priority_fee_per_gas(&self) -> Result<U256> {
-        node_info!("eth_maxPriorityFeePerGas");
+        self.log_rpc_method("eth_maxPriorityFeePerGas");
         Ok(U256::from(self.lowest_suggestion_tip()))
     }
 
@@ -1827,7 +1935,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_newFilter`
     pub async fn new_filter(&self, filter: Filter) -> Result<String> {
-        node_info!("eth_newFilter");
+        self.log_rpc_method("eth_newFilter");
         // all logs that are already available that match the filter if the filter's block range is
         // in the past
         let historic = if filter.block_option.get_from_block().is_some() {
@@ -1848,7 +1956,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_newBlockFilter`
     pub async fn new_block_filter(&self) -> Result<String> {
-        node_info!("eth_newBlockFilter");
+        self.log_rpc_method("eth_newBlockFilter");
         let filter = EthFilter::Blocks(self.new_block_notifications());
         Ok(self.filters.add_filter(filter).await)
     }
@@ -1857,7 +1965,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_newPendingTransactionFilter`
     pub async fn new_pending_transaction_filter(&self) -> Result<String> {
-        node_info!("eth_newPendingTransactionFilter");
+        self.log_rpc_method("eth_newPendingTransactionFilter");
         let filter = EthFilter::PendingTransactions(self.new_ready_transactions());
         Ok(self.filters.add_filter(filter).await)
     }
@@ -1866,7 +1974,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getFilterChanges`
     pub async fn get_filter_changes(&self, id: &str) -> ResponseResult {
-        node_info!("eth_getFilterChanges");
+        self.log_rpc_method("eth_getFilterChanges");
         self.filters.get_filter_changes(id).await
     }
 
@@ -1874,7 +1982,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `eth_getFilterLogs`
     pub async fn get_filter_logs(&self, id: &str) -> Result<Vec<Log>> {
-        node_info!("eth_getFilterLogs");
+        self.log_rpc_method("eth_getFilterLogs");
         if let Some(filter) = self.filters.get_log_filter(id).await {
             self.backend.logs(filter).await
         } else {
@@ -1884,7 +1992,7 @@ impl EthApi {
 
     /// Handler for ETH RPC call: `eth_uninstallFilter`
     pub async fn uninstall_filter(&self, id: &str) -> Result<bool> {
-        node_info!("eth_uninstallFilter");
+        self.log_rpc_method("eth_uninstallFilter");
         Ok(self.filters.uninstall_filter(id).await.is_some())
     }
 
@@ -1892,7 +2000,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `debug_getRawTransaction`
     pub async fn raw_transaction(&self, hash: B256) -> Result<Option<Bytes>> {
-        node_info!("debug_getRawTransaction");
+        self.log_rpc_method("debug_getRawTransaction");
         self.inner_raw_transaction(hash).await
     }
 
@@ -1904,7 +2012,7 @@ impl EthApi {
         block_hash: B256,
         index: Index,
     ) -> Result<Option<Bytes>> {
-        node_info!("eth_getRawTransactionByBlockHashAndIndex");
+        self.log_rpc_method("eth_getRawTransactionByBlockHashAndIndex");
         match self.backend.transaction_by_block_hash_and_index(block_hash, index).await? {
             Some(tx) => self.inner_raw_transaction(tx.tx_hash()).await,
             None => Ok(None),
@@ -1919,7 +2027,7 @@ impl EthApi {
         block_number: BlockNumber,
         index: Index,
     ) -> Result<Option<Bytes>> {
-        node_info!("eth_getRawTransactionByBlockNumberAndIndex");
+        self.log_rpc_method("eth_getRawTransactionByBlockNumberAndIndex");
         match self.backend.transaction_by_block_number_and_index(block_number, index).await? {
             Some(tx) => self.inner_raw_transaction(tx.tx_hash()).await,
             None => Ok(None),
@@ -1934,7 +2042,7 @@ impl EthApi {
         tx_hash: B256,
         opts: GethDebugTracingOptions,
     ) -> Result<GethTrace> {
-        node_info!("debug_traceTransaction");
+        self.log_rpc_method("debug_traceTransaction");
         self.backend.debug_trace_transaction(tx_hash, opts).await
     }
 
@@ -1947,7 +2055,7 @@ impl EthApi {
         block_number: Option<BlockId>,
         opts: GethDebugTracingCallOptions,
     ) -> Result<GethTrace> {
-        node_info!("debug_traceCall");
+        self.log_rpc_method("debug_traceCall");
         let block_request = self.block_request(block_number).await?;
         let fees = FeeDetails::new(
             request.gas_price,
@@ -1970,7 +2078,7 @@ impl EthApi {
         hash: B256,
         block_id: Option<BlockId>,
     ) -> Result<Option<Bytes>> {
-        node_info!("debug_codeByHash");
+        self.log_rpc_method("debug_codeByHash");
         self.backend.debug_code_by_hash(hash, block_id).await
     }
 
@@ -1987,7 +2095,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `trace_transaction`
     pub async fn trace_transaction(&self, tx_hash: B256) -> Result<Vec<LocalizedTransactionTrace>> {
-        node_info!("trace_transaction");
+        self.log_rpc_method("trace_transaction");
         self.backend.trace_transaction(tx_hash).await
     }
 
@@ -1995,7 +2103,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `trace_block`
     pub async fn trace_block(&self, block: BlockNumber) -> Result<Vec<LocalizedTransactionTrace>> {
-        node_info!("trace_block");
+        self.log_rpc_method("trace_block");
         self.backend.trace_block(block).await
     }
 
@@ -2006,7 +2114,7 @@ impl EthApi {
         &self,
         filter: TraceFilter,
     ) -> Result<Vec<LocalizedTransactionTrace>> {
-        node_info!("trace_filter");
+        self.log_rpc_method("trace_filter");
         self.backend.trace_filter(filter).await
     }
 }
@@ -2018,7 +2126,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `anvil_impersonateAccount`
     pub async fn anvil_impersonate_account(&self, address: Address) -> Result<()> {
-        node_info!("anvil_impersonateAccount");
+        self.log_rpc_method("anvil_impersonateAccount");
         self.backend.impersonate(address);
         Ok(())
     }
@@ -2027,7 +2135,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `anvil_stopImpersonatingAccount`
     pub async fn anvil_stop_impersonating_account(&self, address: Address) -> Result<()> {
-        node_info!("anvil_stopImpersonatingAccount");
+        self.log_rpc_method("anvil_stopImpersonatingAccount");
         self.backend.stop_impersonating(address);
         Ok(())
     }
@@ -2036,7 +2144,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `anvil_autoImpersonateAccount`
     pub async fn anvil_auto_impersonate_account(&self, enabled: bool) -> Result<()> {
-        node_info!("anvil_autoImpersonateAccount");
+        self.log_rpc_method("anvil_autoImpersonateAccount");
         self.backend.auto_impersonate_account(enabled);
         Ok(())
     }
@@ -2047,7 +2155,7 @@ impl EthApi {
         signature: Bytes,
         address: Address,
     ) -> Result<()> {
-        node_info!("anvil_impersonateSignature");
+        self.log_rpc_method("anvil_impersonateSignature");
         self.backend.impersonate_signature(signature, address).await
     }
 
@@ -2055,7 +2163,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `anvil_getAutomine`
     pub fn anvil_get_auto_mine(&self) -> Result<bool> {
-        node_info!("anvil_getAutomine");
+        self.log_rpc_method("anvil_getAutomine");
         Ok(self.miner.is_auto_mine())
     }
 
@@ -2063,7 +2171,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `anvil_getIntervalMining`.
     pub fn anvil_get_interval_mining(&self) -> Result<Option<u64>> {
-        node_info!("anvil_getIntervalMining");
+        self.log_rpc_method("anvil_getIntervalMining");
         Ok(self.miner.get_interval())
     }
 
@@ -2072,7 +2180,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `evm_setAutomine`
     pub async fn anvil_set_auto_mine(&self, enable_automine: bool) -> Result<()> {
-        node_info!("evm_setAutomine");
+        self.log_rpc_method("evm_setAutomine");
         if self.miner.is_auto_mine() {
             if enable_automine {
                 return Ok(());
@@ -2090,7 +2198,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `anvil_mine`
     pub async fn anvil_mine(&self, num_blocks: Option<U256>, interval: Option<U256>) -> Result<()> {
-        node_info!("anvil_mine");
+        self.log_rpc_method("anvil_mine");
         let interval = interval.map(|i| i.to::<u64>());
         let blocks = num_blocks.unwrap_or(U256::from(1));
         if blocks.is_zero() {
@@ -2117,7 +2225,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `evm_setIntervalMining`
     pub fn anvil_set_interval_mining(&self, secs: u64) -> Result<()> {
-        node_info!("evm_setIntervalMining");
+        self.log_rpc_method("evm_setIntervalMining");
         let mining_mode = if secs == 0 {
             MiningMode::None
         } else {
@@ -2136,7 +2244,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_dropTransaction`
     pub async fn anvil_drop_transaction(&self, tx_hash: B256) -> Result<Option<B256>> {
-        node_info!("anvil_dropTransaction");
+        self.log_rpc_method("anvil_dropTransaction");
         Ok(self.pool.drop_transaction(tx_hash).map(|tx| tx.hash()))
     }
 
@@ -2144,7 +2252,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_dropAllTransactions`
     pub async fn anvil_drop_all_transactions(&self) -> Result<()> {
-        node_info!("anvil_dropAllTransactions");
+        self.log_rpc_method("anvil_dropAllTransactions");
         self.pool.clear();
         Ok(())
     }
@@ -2156,7 +2264,7 @@ impl EthApi {
     /// Handler for RPC call: `anvil_reset`
     pub async fn anvil_reset(&self, forking: Option<Forking>) -> Result<()> {
         self.reset_instance_id();
-        node_info!("anvil_reset");
+        self.log_rpc_method("anvil_reset");
         if let Some(forking) = forking {
             // if we're resetting the fork we need to reset the instance id
             self.backend.reset_fork(forking).await
@@ -2168,7 +2276,7 @@ impl EthApi {
     }
 
     pub async fn anvil_set_chain_id(&self, chain_id: u64) -> Result<()> {
-        node_info!("anvil_setChainId");
+        self.log_rpc_method("anvil_setChainId");
         self.backend.set_chain_id(chain_id);
         Ok(())
     }
@@ -2177,7 +2285,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_setBalance`
     pub async fn anvil_set_balance(&self, address: Address, balance: U256) -> Result<()> {
-        node_info!("anvil_setBalance");
+        self.log_rpc_method("anvil_setBalance");
         self.backend.set_balance(address, balance).await?;
         Ok(())
     }
@@ -2186,7 +2294,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_addBalance`
     pub async fn anvil_add_balance(&self, address: Address, balance: U256) -> Result<()> {
-        node_info!("anvil_addBalance");
+        self.log_rpc_method("anvil_addBalance");
         let current_balance = self.backend.get_balance(address, None).await?;
         self.backend.set_balance(address, current_balance + balance).await?;
         Ok(())
@@ -2268,7 +2376,7 @@ impl EthApi {
         token_address: Address,
         balance: U256,
     ) -> Result<()> {
-        node_info!("anvil_dealERC20");
+        self.log_rpc_method("anvil_dealERC20");
 
         sol! {
             #[sol(rpc)]
@@ -2306,7 +2414,7 @@ impl EthApi {
         token_address: Address,
         amount: U256,
     ) -> Result<()> {
-        node_info!("anvil_setERC20Allowance");
+        self.log_rpc_method("anvil_setERC20Allowance");
 
         sol! {
             #[sol(rpc)]
@@ -2338,7 +2446,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_setCode`
     pub async fn anvil_set_code(&self, address: Address, code: Bytes) -> Result<()> {
-        node_info!("anvil_setCode");
+        self.log_rpc_method("anvil_setCode");
         self.backend.set_code(address, code).await?;
         Ok(())
     }
@@ -2347,7 +2455,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_setNonce`
     pub async fn anvil_set_nonce(&self, address: Address, nonce: U256) -> Result<()> {
-        node_info!("anvil_setNonce");
+        self.log_rpc_method("anvil_setNonce");
         self.backend.set_nonce(address, nonce).await?;
         Ok(())
     }
@@ -2361,7 +2469,7 @@ impl EthApi {
         slot: U256,
         val: B256,
     ) -> Result<bool> {
-        node_info!("anvil_setStorageAt");
+        self.log_rpc_method("anvil_setStorageAt");
         self.backend.set_storage_at(address, slot, val).await?;
         Ok(true)
     }
@@ -2370,7 +2478,8 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_setLoggingEnabled`
     pub async fn anvil_set_logging(&self, enable: bool) -> Result<()> {
-        node_info!("anvil_setLoggingEnabled");
+        self.log_rpc_method("anvil_setLoggingEnabled");
+        self.rpc_payload_logging.store(enable, Ordering::Relaxed);
         self.logger.set_enabled(enable);
         Ok(())
     }
@@ -2379,7 +2488,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_setMinGasPrice`
     pub async fn anvil_set_min_gas_price(&self, gas: U256) -> Result<()> {
-        node_info!("anvil_setMinGasPrice");
+        self.log_rpc_method("anvil_setMinGasPrice");
         if self.backend.is_eip1559() {
             return Err(RpcError::invalid_params(
                 "anvil_setMinGasPrice is not supported when EIP-1559 is active",
@@ -2394,7 +2503,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_setNextBlockBaseFeePerGas`
     pub async fn anvil_set_next_block_base_fee_per_gas(&self, basefee: U256) -> Result<()> {
-        node_info!("anvil_setNextBlockBaseFeePerGas");
+        self.log_rpc_method("anvil_setNextBlockBaseFeePerGas");
         if !self.backend.is_eip1559() {
             return Err(RpcError::invalid_params(
                 "anvil_setNextBlockBaseFeePerGas is only supported when EIP-1559 is active",
@@ -2409,7 +2518,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_setCoinbase`
     pub async fn anvil_set_coinbase(&self, address: Address) -> Result<()> {
-        node_info!("anvil_setCoinbase");
+        self.log_rpc_method("anvil_setCoinbase");
         self.backend.set_coinbase(address);
         Ok(())
     }
@@ -2422,7 +2531,7 @@ impl EthApi {
         &self,
         preserve_historical_states: Option<bool>,
     ) -> Result<Bytes> {
-        node_info!("anvil_dumpState");
+        self.log_rpc_method("anvil_dumpState");
         self.backend.dump_state(preserve_historical_states.unwrap_or(false)).await
     }
 
@@ -2439,7 +2548,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_loadState`
     pub async fn anvil_load_state(&self, buf: Bytes) -> Result<bool> {
-        node_info!("anvil_loadState");
+        self.log_rpc_method("anvil_loadState");
         self.backend.load_state_bytes(buf).await
     }
 
@@ -2447,7 +2556,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_nodeInfo`
     pub async fn anvil_node_info(&self) -> Result<NodeInfo> {
-        node_info!("anvil_nodeInfo");
+        self.log_rpc_method("anvil_nodeInfo");
 
         let env = self.backend.env().read();
         let fork_config = self.backend.get_fork();
@@ -2487,7 +2596,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_metadata`
     pub async fn anvil_metadata(&self) -> Result<Metadata> {
-        node_info!("anvil_metadata");
+        self.log_rpc_method("anvil_metadata");
         let fork_config = self.backend.get_fork();
 
         Ok(Metadata {
@@ -2506,7 +2615,7 @@ impl EthApi {
     }
 
     pub async fn anvil_remove_pool_transactions(&self, address: Address) -> Result<()> {
-        node_info!("anvil_removePoolTransactions");
+        self.log_rpc_method("anvil_removePoolTransactions");
         self.pool.remove_transactions_by_address(address);
         Ok(())
     }
@@ -2525,7 +2634,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_reorg`
     pub async fn anvil_reorg(&self, options: ReorgOptions) -> Result<()> {
-        node_info!("anvil_reorg");
+        self.log_rpc_method("anvil_reorg");
         let depth = options.depth;
         let tx_block_pairs = options.tx_block_pairs;
 
@@ -2635,7 +2744,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_rollback`
     pub async fn anvil_rollback(&self, depth: Option<u64>) -> Result<()> {
-        node_info!("anvil_rollback");
+        self.log_rpc_method("anvil_rollback");
         let depth = depth.unwrap_or(1);
 
         // Check reorg depth doesn't exceed current chain height
@@ -2658,7 +2767,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `evm_snapshot`
     pub async fn evm_snapshot(&self) -> Result<U256> {
-        node_info!("evm_snapshot");
+        self.log_rpc_method("evm_snapshot");
         Ok(self.backend.create_state_snapshot().await)
     }
 
@@ -2667,7 +2776,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `evm_revert`
     pub async fn evm_revert(&self, id: U256) -> Result<bool> {
-        node_info!("evm_revert");
+        self.log_rpc_method("evm_revert");
         self.backend.revert_state_snapshot(id).await
     }
 
@@ -2675,7 +2784,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `evm_increaseTime`
     pub async fn evm_increase_time(&self, seconds: U256) -> Result<i64> {
-        node_info!("evm_increaseTime");
+        self.log_rpc_method("evm_increaseTime");
         Ok(self.backend.time().increase_time(seconds.try_into().unwrap_or(u64::MAX)) as i64)
     }
 
@@ -2683,7 +2792,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `evm_setNextBlockTimestamp`
     pub fn evm_set_next_block_timestamp(&self, seconds: u64) -> Result<()> {
-        node_info!("evm_setNextBlockTimestamp");
+        self.log_rpc_method("evm_setNextBlockTimestamp");
         self.backend.time().set_next_block_timestamp(seconds)
     }
 
@@ -2692,7 +2801,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `evm_setTime`
     pub fn evm_set_time(&self, timestamp: u64) -> Result<u64> {
-        node_info!("evm_setTime");
+        self.log_rpc_method("evm_setTime");
         let now = self.backend.time().current_call_timestamp();
         self.backend.time().reset(timestamp);
 
@@ -2705,7 +2814,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `evm_setBlockGasLimit`
     pub fn evm_set_block_gas_limit(&self, gas_limit: U256) -> Result<bool> {
-        node_info!("evm_setBlockGasLimit");
+        self.log_rpc_method("evm_setBlockGasLimit");
         self.backend.set_gas_limit(gas_limit.to());
         Ok(true)
     }
@@ -2714,7 +2823,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_setBlockTimestampInterval`
     pub fn evm_set_block_timestamp_interval(&self, seconds: u64) -> Result<()> {
-        node_info!("anvil_setBlockTimestampInterval");
+        self.log_rpc_method("anvil_setBlockTimestampInterval");
         self.backend.time().set_block_timestamp_interval(seconds);
         Ok(())
     }
@@ -2723,7 +2832,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `anvil_removeBlockTimestampInterval`
     pub fn evm_remove_block_timestamp_interval(&self) -> Result<bool> {
-        node_info!("anvil_removeBlockTimestampInterval");
+        self.log_rpc_method("anvil_removeBlockTimestampInterval");
         Ok(self.backend.time().remove_block_timestamp_interval())
     }
 
@@ -2734,7 +2843,7 @@ impl EthApi {
     /// This will mine the blocks regardless of the configured mining mode.
     /// **Note**: ganache returns `0x0` here as placeholder for additional meta-data in the future.
     pub async fn evm_mine(&self, opts: Option<MineOptions>) -> Result<String> {
-        node_info!("evm_mine");
+        self.log_rpc_method("evm_mine");
 
         self.do_evm_mine(opts).await?;
 
@@ -2751,7 +2860,7 @@ impl EthApi {
     /// compatibility reasons, this is a separate call since `evm_mine` is not an anvil original.
     /// and `ganache` may change the `0x0` placeholder.
     pub async fn evm_mine_detailed(&self, opts: Option<MineOptions>) -> Result<Vec<AnyRpcBlock>> {
-        node_info!("evm_mine_detailed");
+        self.log_rpc_method("evm_mine_detailed");
 
         let mined_blocks = self.do_evm_mine(opts).await?;
 
@@ -2798,7 +2907,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `anvil_setBlock`
     pub fn anvil_set_block(&self, block_number: u64) -> Result<()> {
-        node_info!("anvil_setBlock");
+        self.log_rpc_method("anvil_setBlock");
         self.backend.set_block_number(block_number);
         Ok(())
     }
@@ -2807,7 +2916,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `anvil_setRpcUrl`
     pub fn anvil_set_rpc_url(&self, url: String) -> Result<()> {
-        node_info!("anvil_setRpcUrl");
+        self.log_rpc_method("anvil_setRpcUrl");
         if let Some(fork) = self.backend.get_fork() {
             let mut config = fork.config.write();
             // let interval = config.provider.get_interval();
@@ -2833,7 +2942,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `anvil_enableTraces`
     pub async fn anvil_enable_traces(&self) -> Result<()> {
-        node_info!("anvil_enableTraces");
+        self.log_rpc_method("anvil_enableTraces");
         Err(BlockchainError::RpcUnimplemented)
     }
 
@@ -2844,7 +2953,7 @@ impl EthApi {
         &self,
         request: WithOtherFields<TransactionRequest>,
     ) -> Result<TxHash> {
-        node_info!("eth_sendUnsignedTransaction");
+        self.log_rpc_method("eth_sendUnsignedTransaction");
         // either use the impersonated account of the request's `from` field
         let from = request.from.ok_or(BlockchainError::NoSignerAvailable)?;
 
@@ -2874,7 +2983,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `txpool_status`
     pub async fn txpool_status(&self) -> Result<TxpoolStatus> {
-        node_info!("txpool_status");
+        self.log_rpc_method("txpool_status");
         Ok(self.pool.txpool_status())
     }
 
@@ -2885,7 +2994,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `txpool_inspect`
     pub async fn txpool_inspect(&self) -> Result<TxpoolInspect> {
-        node_info!("txpool_inspect");
+        self.log_rpc_method("txpool_inspect");
         let mut inspect = TxpoolInspect::default();
 
         fn convert(tx: Arc<PoolTransaction>) -> TxpoolInspectSummary {
@@ -2923,7 +3032,7 @@ impl EthApi {
     ///
     /// Handler for ETH RPC call: `txpool_inspect`
     pub async fn txpool_content(&self) -> Result<TxpoolContent<AnyRpcTransaction>> {
-        node_info!("txpool_content");
+        self.log_rpc_method("txpool_content");
         let mut content = TxpoolContent::<AnyRpcTransaction>::default();
         fn convert(tx: Arc<PoolTransaction>) -> Result<AnyRpcTransaction> {
             let from = *tx.pending_transaction.sender();
@@ -2969,7 +3078,7 @@ impl EthApi {
     ///
     /// [eip-5792]: https://eips.ethereum.org/EIPS/eip-5792
     pub fn get_capabilities(&self) -> Result<WalletCapabilities> {
-        node_info!("wallet_getCapabilities");
+        self.log_rpc_method("wallet_getCapabilities");
         Ok(self.backend.get_capabilities())
     }
 
@@ -2977,13 +3086,13 @@ impl EthApi {
     ///
     /// This entails that the executor will now be able to sponsor transactions to this address.
     pub fn anvil_add_capability(&self, address: Address) -> Result<()> {
-        node_info!("anvil_addCapability");
+        self.log_rpc_method("anvil_addCapability");
         self.backend.add_capability(address);
         Ok(())
     }
 
     pub fn anvil_set_executor(&self, executor_pk: String) -> Result<Address> {
-        node_info!("anvil_setExecutor");
+        self.log_rpc_method("anvil_setExecutor");
         self.backend.set_executor(executor_pk)
     }
 }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -76,7 +76,7 @@ use anvil_core::{
 };
 use anvil_rpc::{
     error::RpcError,
-    request::{Id as RpcId, RequestParams, Version},
+    request::{Id as RpcId, Version},
     response::ResponseResult,
 };
 use chrono::{DateTime, Utc};
@@ -141,9 +141,9 @@ pub struct RpcCallLogContext {
     pub method: Option<String>,
     pub peer_addr: Option<SocketAddr>,
     pub timestamp: Option<DateTime<Utc>>,
-    /// The JSON-RPC version and params, stored for lazy raw JSON construction
+    /// The JSON-RPC version and params value, stored for lazy raw JSON construction
     pub jsonrpc_version: Option<Version>,
-    pub params: Option<RequestParams>,
+    pub params_value: Option<serde_json::Value>,
 }
 
 impl RpcCallLogContext {
@@ -202,20 +202,19 @@ impl RpcCallLogContext {
     /// Constructs the raw JSON-RPC request from stored context data.
     ///
     /// This method lazily builds the full JSON-RPC request payload only when needed
-    /// (e.g., for verbose logging). It requires jsonrpc_version, method, params, and id
+    /// (e.g., for verbose logging). It requires jsonrpc_version, method, params_value, and id
     /// to be present in the context.
     ///
     /// # Returns
     ///
     /// * `Some(Value)` - The constructed JSON-RPC request object
     /// * `None` - If any required field is missing
-    fn to_raw_json(&self) -> Option<Value> {
+    pub(crate) fn to_raw_json(&self) -> Option<Value> {
         let jsonrpc = self.jsonrpc_version.as_ref()?;
         let method = self.method.as_ref()?;
-        let params = self.params.as_ref()?;
+        let params_value = self.params_value.as_ref()?;
         let id = self.id.as_ref()?;
 
-        let params_value: serde_json::Value = params.clone().into();
         Some(serde_json::json!({
             "jsonrpc": jsonrpc,
             "method": method,

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -325,7 +325,7 @@ impl EthApi {
         let should_log_rpc_payloads = self.should_log_rpc_payloads();
         if should_log_rpc_payloads {
             // Lazily construct raw JSON from context if not provided
-            let resolved_raw_json = raw_request.or_else(|| context.to_raw_json());
+            let resolved_raw_json = raw_request.as_ref().cloned().or_else(|| context.to_raw_json());
             self.log_rpc_payload("RPC request", resolved_raw_json.as_ref(), &request, &context);
         }
         let response = match request.clone() {

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -325,8 +325,8 @@ impl EthApi {
         let should_log_rpc_payloads = self.should_log_rpc_payloads();
         if should_log_rpc_payloads {
             // Lazily construct raw JSON from context if not provided
-            let raw_json = raw_request.or_else(|| context.to_raw_json());
-            self.log_rpc_payload("RPC request", raw_json.as_ref(), &request, &context);
+            let resolved_raw_json = raw_request.or_else(|| context.to_raw_json());
+            self.log_rpc_payload("RPC request", resolved_raw_json.as_ref(), &request, &context);
         }
         let response = match request.clone() {
             EthRequest::EthProtocolVersion(()) => self.protocol_version().to_rpc_result(),

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -304,7 +304,7 @@ impl EthApi {
 
     /// Executes the [EthRequest] with optional raw JSON request data and logging context.
     ///
-    /// This method extends [execute] by accepting the raw JSON-RPC request payload and metadata
+    /// This method extends [`Self::execute`] by accepting the raw JSON-RPC request payload and metadata
     /// for verbose RPC logging. When verbose logging is enabled, both the request and response
     /// payloads are logged with contextual information (RPC ID, method, peer address, timestamp).
     ///
@@ -318,7 +318,7 @@ impl EthApi {
     ///
     /// This method should be called by RPC handlers that have access to the raw request payload
     /// and want to enable verbose logging. For simple execution without logging context, use
-    /// [execute] instead.
+    /// [`Self::execute`] instead.
     pub async fn execute_with_raw(
         &self,
         request: EthRequest,
@@ -733,7 +733,7 @@ impl EthApi {
     /// * `T` - The type of the debug_value, must implement [std::fmt::Debug]
     ///
     /// This method can be called unconditionally; it will only log if verbose RPC logging
-    /// is enabled (via [should_log_rpc_payloads]).
+    /// is enabled (via [`Self::should_log_rpc_payloads`]).
     fn log_rpc_payload<T>(
         &self,
         label: &str,
@@ -760,7 +760,7 @@ impl EthApi {
 
     /// Logs an RPC payload with automatic serialization.
     ///
-    /// This is a convenience wrapper around [log_rpc_payload] that handles serialization
+    /// This is a convenience wrapper around [`Self::log_rpc_payload`] that handles serialization
     /// of the debug value to JSON. This is useful when you don't have a pre-serialized JSON
     /// value and want the method to handle lazy serialization only when logging is enabled.
     ///

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -750,9 +750,9 @@ impl EthApi {
         let resolved_json = json_value.cloned().or_else(|| context.to_raw_json());
         let payload = match resolved_json.as_ref() {
             Some(value) => {
-                serde_json::to_string(value).unwrap_or_else(|_| format!("{:?}", debug_value))
+                serde_json::to_string(value).unwrap_or_else(|_| format!("{debug_value:?}"))
             }
-            None => format!("{:?}", debug_value),
+            None => format!("{debug_value:?}"),
         };
         let label = context.format_label(label);
         node_info!("{label}: {payload}");

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -267,6 +267,23 @@ impl EthApi {
         self.execute_with_raw(request, None, RpcCallLogContext::default()).await
     }
 
+    /// Executes the [EthRequest] with optional raw JSON request data and logging context.
+    ///
+    /// This method extends [execute] by accepting the raw JSON-RPC request payload and metadata
+    /// for verbose RPC logging. When verbose logging is enabled, both the request and response
+    /// payloads are logged with contextual information (RPC ID, method, peer address, timestamp).
+    ///
+    /// # Parameters
+    ///
+    /// * `request` - The parsed [EthRequest] to execute
+    /// * `raw_request` - Optional raw JSON value from the original RPC request for logging
+    /// * `context` - Metadata about the RPC call (ID, method, peer address, timestamp)
+    ///
+    /// # Usage
+    ///
+    /// This method should be called by RPC handlers that have access to the raw request payload
+    /// and want to enable verbose logging. For simple execution without logging context, use
+    /// [execute] instead.
     pub async fn execute_with_raw(
         &self,
         request: EthRequest,
@@ -664,6 +681,25 @@ impl EthApi {
         }
     }
 
+    /// Logs an RPC payload (request or response) with contextual information.
+    ///
+    /// This helper method is used for verbose RPC logging. It attempts to serialize the JSON
+    /// value if available, otherwise falls back to the debug representation. The log output
+    /// includes contextual metadata from [RpcCallLogContext] (RPC ID, method, peer, timestamp).
+    ///
+    /// # Parameters
+    ///
+    /// * `label` - Base label for the log entry (e.g., "RPC request", "RPC response")
+    /// * `json_value` - Optional JSON representation of the payload for clean serialization
+    /// * `debug_value` - The typed value to log if JSON serialization is not available
+    /// * `context` - Metadata about the RPC call for enriching the log output
+    ///
+    /// # Type Parameters
+    ///
+    /// * `T` - The type of the debug_value, must implement [std::fmt::Debug]
+    ///
+    /// This method should only be called when verbose RPC logging is enabled
+    /// (checked via [should_log_rpc_payloads]).
     fn log_rpc_payload<T>(
         &self,
         label: &str,

--- a/crates/anvil/src/eth/macros.rs
+++ b/crates/anvil/src/eth/macros.rs
@@ -1,9 +1,7 @@
 /// A `info!` helper macro that emits to the target, the node logger listens for
 macro_rules! node_info {
     ($($arg:tt)*) => {
-        {
-            tracing::info!(target: $crate::logging::NODE_USER_LOG_TARGET, $($arg)*);
-        }
+        tracing::info!(target: $crate::logging::NODE_USER_LOG_TARGET, $($arg)*);
     };
 }
 

--- a/crates/anvil/src/eth/macros.rs
+++ b/crates/anvil/src/eth/macros.rs
@@ -1,7 +1,9 @@
 /// A `info!` helper macro that emits to the target, the node logger listens for
 macro_rules! node_info {
     ($($arg:tt)*) => {
-         tracing::info!(target: $crate::logging::NODE_USER_LOG_TARGET, $($arg)*);
+        {
+            tracing::info!(target: $crate::logging::NODE_USER_LOG_TARGET, $($arg)*);
+        }
     };
 }
 

--- a/crates/anvil/src/eth/macros.rs
+++ b/crates/anvil/src/eth/macros.rs
@@ -1,7 +1,9 @@
 /// A `info!` helper macro that emits to the target, the node logger listens for
 macro_rules! node_info {
     ($($arg:tt)*) => {
-        tracing::info!(target: $crate::logging::NODE_USER_LOG_TARGET, $($arg)*);
+        {
+            tracing::info!(target: $crate::logging::NODE_USER_LOG_TARGET, $($arg)*);
+        }
     };
 }
 

--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -1,7 +1,6 @@
 use crate::eth::{
     EthApi,
     error::{BlockchainError, Result},
-    macros::node_info,
 };
 use alloy_consensus::Transaction as TransactionTrait;
 use alloy_network::{
@@ -32,7 +31,7 @@ impl EthApi {
         &self,
         number: BlockNumber,
     ) -> Result<Option<AnyRpcBlock>> {
-        node_info!("erigon_getHeaderByNumber");
+        self.log_rpc_method("erigon_getHeaderByNumber");
 
         self.backend.block_by_number(number).await
     }
@@ -40,7 +39,7 @@ impl EthApi {
     /// As per the latest Otterscan source code, at least version 8 is needed.
     /// Ref: <https://github.com/otterscan/otterscan/blob/071d8c55202badf01804f6f8d53ef9311d4a9e47/src/params.ts#L1C2-L1C2>
     pub async fn ots_get_api_level(&self) -> Result<u64> {
-        node_info!("ots_getApiLevel");
+        self.log_rpc_method("ots_getApiLevel");
 
         // as required by current otterscan's source code
         Ok(8)
@@ -49,7 +48,7 @@ impl EthApi {
     /// Trace internal ETH transfers, contracts creation (CREATE/CREATE2) and self-destructs for a
     /// certain transaction.
     pub async fn ots_get_internal_operations(&self, hash: B256) -> Result<Vec<InternalOperation>> {
-        node_info!("ots_getInternalOperations");
+        self.log_rpc_method("ots_getInternalOperations");
 
         self.backend
             .mined_transaction(hash)
@@ -59,7 +58,7 @@ impl EthApi {
 
     /// Check if an ETH address contains code at a certain block number.
     pub async fn ots_has_code(&self, address: Address, block_number: BlockNumber) -> Result<bool> {
-        node_info!("ots_hasCode");
+        self.log_rpc_method("ots_hasCode");
         let block_id = Some(BlockId::Number(block_number));
         Ok(!self.get_code(address, block_id).await?.is_empty())
     }
@@ -69,7 +68,7 @@ impl EthApi {
     ///
     /// Follows format specified in the [`ots_traceTransaction`](https://docs.otterscan.io/api-docs/ots-api#ots_tracetransaction) spec.
     pub async fn ots_trace_transaction(&self, hash: B256) -> Result<Vec<TraceEntry>> {
-        node_info!("ots_traceTransaction");
+        self.log_rpc_method("ots_traceTransaction");
         let traces = self
             .backend
             .trace_transaction(hash)
@@ -82,7 +81,7 @@ impl EthApi {
 
     /// Given a transaction hash, returns its raw revert reason.
     pub async fn ots_get_transaction_error(&self, hash: B256) -> Result<Bytes> {
-        node_info!("ots_getTransactionError");
+        self.log_rpc_method("ots_getTransactionError");
 
         if let Some(receipt) = self.backend.mined_transaction_receipt(hash)
             && !receipt.inner.as_ref().status()
@@ -100,7 +99,7 @@ impl EthApi {
         &self,
         number: BlockNumber,
     ) -> Result<BlockDetails<AnyRpcHeader>> {
-        node_info!("ots_getBlockDetails");
+        self.log_rpc_method("ots_getBlockDetails");
 
         if let Some(block) = self.backend.block_by_number(number).await? {
             let ots_block = self.build_ots_block_details(block).await?;
@@ -117,7 +116,7 @@ impl EthApi {
         &self,
         hash: B256,
     ) -> Result<BlockDetails<AnyRpcHeader>> {
-        node_info!("ots_getBlockDetailsByHash");
+        self.log_rpc_method("ots_getBlockDetailsByHash");
 
         if let Some(block) = self.backend.block_by_hash(hash).await? {
             let ots_block = self.build_ots_block_details(block).await?;
@@ -135,7 +134,7 @@ impl EthApi {
         page: usize,
         page_size: usize,
     ) -> Result<OtsBlockTransactions<AnyRpcTransaction, AnyRpcHeader>> {
-        node_info!("ots_getBlockTransactions");
+        self.log_rpc_method("ots_getBlockTransactions");
 
         match self.backend.block_by_number_full(number.into()).await? {
             Some(block) => self.build_ots_block_tx(block, page, page_size).await,
@@ -150,7 +149,7 @@ impl EthApi {
         block_number: u64,
         page_size: usize,
     ) -> Result<TransactionsWithReceipts<alloy_rpc_types::Transaction<AnyTxEnvelope>>> {
-        node_info!("ots_searchTransactionsBefore");
+        self.log_rpc_method("ots_searchTransactionsBefore");
 
         let best = self.backend.best_number();
         // we go from given block (defaulting to best) down to first block
@@ -194,7 +193,7 @@ impl EthApi {
         block_number: u64,
         page_size: usize,
     ) -> Result<TransactionsWithReceipts<alloy_rpc_types::Transaction<AnyTxEnvelope>>> {
-        node_info!("ots_searchTransactionsAfter");
+        self.log_rpc_method("ots_searchTransactionsAfter");
 
         let best = self.backend.best_number();
         // we go from the first post-fork block, up to the tip
@@ -245,7 +244,7 @@ impl EthApi {
         address: Address,
         nonce: U256,
     ) -> Result<Option<B256>> {
-        node_info!("ots_getTransactionBySenderAndNonce");
+        self.log_rpc_method("ots_getTransactionBySenderAndNonce");
 
         let from = self.get_fork().map(|f| f.block_number() + 1).unwrap_or_default();
         let to = self.backend.best_number();
@@ -266,7 +265,7 @@ impl EthApi {
     /// Given an ETH contract address, returns the tx hash and the direct address who created the
     /// contract.
     pub async fn ots_get_contract_creator(&self, addr: Address) -> Result<Option<ContractCreator>> {
-        node_info!("ots_getContractCreator");
+        self.log_rpc_method("ots_getContractCreator");
 
         let from = self.get_fork().map(|f| f.block_number()).unwrap_or_default();
         let to = self.backend.best_number();

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -227,6 +227,7 @@ pub async fn try_spawn(mut config: NodeConfig) -> Result<(EthApi, NodeHandle)> {
         logger,
         filters.clone(),
         transaction_order,
+        config.rpc_log,
     );
 
     // spawn the node service

--- a/crates/anvil/src/server/mod.rs
+++ b/crates/anvil/src/server/mod.rs
@@ -31,7 +31,11 @@ pub async fn serve_on(
     api: EthApi,
     config: ServerConfig,
 ) -> io::Result<()> {
-    axum::serve(tcp_listener, router(api, config).into_make_service()).await
+    axum::serve(
+        tcp_listener,
+        router(api, config).into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
 }
 
 /// Configures an [`axum::Router`] that handles [`EthApi`] related JSON-RPC calls via HTTP and WS,

--- a/crates/anvil/src/server/rpc_handlers.rs
+++ b/crates/anvil/src/server/rpc_handlers.rs
@@ -59,7 +59,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let raw = serde_json::Value::deserialize(deserializer)?;
-        let parsed = serde_json::from_value(raw.clone()).map_err(serde::de::Error::custom)?;
+        let parsed = T::deserialize(&raw).map_err(serde::de::Error::custom)?;
         Ok(Self { parsed, raw, metadata: RpcCallLogContext::default() })
     }
 }

--- a/crates/anvil/src/server/rpc_handlers.rs
+++ b/crates/anvil/src/server/rpc_handlers.rs
@@ -21,9 +21,22 @@ use std::{fmt, net::SocketAddr};
 use tracing::{error, trace};
 
 #[derive(Clone)]
+/// Wrapper around a JSON-RPC request used by `RpcHandler`.
+///
+/// This type keeps together:
+/// - the parsed, strongly-typed representation of the request (`parsed`),
+/// - the original raw JSON value as it was received over the wire (`raw`), and
+/// - additional logging/telemetry metadata associated with the call (`metadata`).
+///
+/// Keeping both the parsed and raw forms allows handlers and logging code to
+/// inspect or record the exact request payload while still working with a
+/// typed representation.
 pub struct JsonRpcRequest<T> {
+    /// The strongly-typed, already-deserialized representation of the request.
     parsed: T,
+    /// The original JSON-RPC request payload as received from the client.
     raw: serde_json::Value,
+    /// Context metadata used for logging, tracing, and metrics for this call.
     metadata: RpcCallLogContext,
 }
 

--- a/crates/anvil/src/server/rpc_handlers.rs
+++ b/crates/anvil/src/server/rpc_handlers.rs
@@ -102,10 +102,12 @@ impl HttpEthRpcHandler {
         peer_addr: Option<SocketAddr>,
     ) -> Result<JsonRpcRequest<EthRequest>, serde_json::Error> {
         // Clone and convert params to Value once - will be used for both deserialization
-        // and lazy raw JSON construction when logging is enabled
+        // and lazy raw JSON construction when logging is enabled.
         let params_value: serde_json::Value = call.params.clone().into();
 
-        // Build metadata context, storing the params value for lazy raw JSON construction
+        // Store params value in metadata for lazy raw JSON construction.
+        // Note: Cloning the Value here is cheaper than eagerly constructing the raw JSON,
+        // especially when logging is disabled (which is the common case).
         let metadata = RpcCallLogContext {
             id: Some(call.id.clone()),
             method: Some(call.method.clone()),

--- a/crates/anvil/src/server/rpc_handlers.rs
+++ b/crates/anvil/src/server/rpc_handlers.rs
@@ -145,26 +145,23 @@ impl RpcHandler for HttpEthRpcHandler {
             "handling call"
         );
 
-        let method = &call.method;
-        let id = call.id.clone();
-
         match Self::try_into_request(&call, peer_addr) {
             Ok(request) => {
                 let result = self.on_request(request).await;
-                RpcResponse::new(id, result)
+                RpcResponse::new(call.id, result)
             }
             Err(err) => {
                 let err = err.to_string();
                 if err.contains("unknown variant") {
                     error!(
                         target: "rpc",
-                        method = ?method,
+                        method = ?call.method,
                         "failed to deserialize method due to unknown variant"
                     );
-                    RpcResponse::new(id, RpcError::method_not_found())
+                    RpcResponse::new(call.id, RpcError::method_not_found())
                 } else {
-                    error!(target: "rpc", method = ?method, ?err, "failed to deserialize method");
-                    RpcResponse::new(id, RpcError::invalid_params(err))
+                    error!(target: "rpc", method = ?call.method, ?err, "failed to deserialize method");
+                    RpcResponse::new(call.id, RpcError::invalid_params(err))
                 }
             }
         }

--- a/crates/anvil/src/server/rpc_handlers.rs
+++ b/crates/anvil/src/server/rpc_handlers.rs
@@ -136,7 +136,11 @@ impl RpcHandler for HttpEthRpcHandler {
         self.api.execute_with_raw(request, raw, metadata).await
     }
 
-    async fn on_call_with_addr(&self, call: RpcMethodCall, peer_addr: Option<SocketAddr>) -> RpcResponse {
+    async fn on_call_with_addr(
+        &self,
+        call: RpcMethodCall,
+        peer_addr: Option<SocketAddr>,
+    ) -> RpcResponse {
         trace!(
             target: "rpc",
             id = ?call.id,

--- a/crates/anvil/src/server/rpc_handlers.rs
+++ b/crates/anvil/src/server/rpc_handlers.rs
@@ -136,7 +136,7 @@ impl RpcHandler for HttpEthRpcHandler {
         self.api.execute_with_raw(request, Some(raw), metadata).await
     }
 
-    async fn on_call(&self, call: RpcMethodCall, peer_addr: Option<SocketAddr>) -> RpcResponse {
+    async fn on_call_with_addr(&self, call: RpcMethodCall, peer_addr: Option<SocketAddr>) -> RpcResponse {
         trace!(
             target: "rpc",
             id = ?call.id,

--- a/crates/anvil/src/server/rpc_handlers.rs
+++ b/crates/anvil/src/server/rpc_handlers.rs
@@ -154,17 +154,8 @@ impl RpcHandler for HttpEthRpcHandler {
             }
             Err(err) => {
                 let err = err.to_string();
-                if err.contains("unknown variant") {
-                    error!(
-                        target: "rpc",
-                        method = ?call.method,
-                        "failed to deserialize method due to unknown variant"
-                    );
-                    RpcResponse::new(call.id, RpcError::method_not_found())
-                } else {
-                    error!(target: "rpc", method = ?call.method, ?err, "failed to deserialize method");
-                    RpcResponse::new(call.id, RpcError::invalid_params(err))
-                }
+                error!(target: "rpc", method = ?call.method, ?err, "failed to deserialize method");
+                RpcResponse::new(call.id, RpcError::invalid_params(err))
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Often times when testing client integrations I wish to quickly debug what successful RPC calls (and their params) are made. To get around this I typically resort to setting up a Man In the Middle style proxy to simply log the requests and responses, but this is a nuisance. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
This PR introduces a backward compatible **optional** `--rpc-log` flag which, when enabled provides verbose logging of the form:

```
RPC request [id=10390, method=eth_maxPriorityFeePerGas, peer=127.0.0.1:58496, ts=2025-12-18T01:14:59.489792+00:00]: {"jsonrpc":"2.0","method":"eth_maxPriorityFeePerGas","params":null,"id":10390}
RPC response [id=10390, method=eth_maxPriorityFeePerGas, peer=127.0.0.1:58496, ts=2025-12-18T01:14:59.489792+00:00]: {"result":"0x3b9aca00"}
```  

Specific code changes:
- Added a --rpc-log CLI flag that feeds into NodeConfig, persists the RPC payload logging preference, and exposes a with_rpc_logging builder to propagate the setting
- Introduced an RpcCallLogContext (id, method, peer address, timestamp) and a centralized log_rpc_method helper so method banners are suppressed when payload logging is enabled while request/response payloads continue to include contextual metadata
- Wrapped HTTP RPC handling to capture raw JSON, attach the logging context (including peer/timestamp), and pass everything through to EthApi::execute_with_raw; Otterscan handlers now reuse the shared method-logging helper.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes


This PR used ChatGPT's copilot for implementation. 