### PR TITLE
fix(fuzz): correct comment mismatch for call override probability

### DIFF
--- a/crates/evm/fuzz/src/invariant/call_override.rs
+++ b/crates/evm/fuzz/src/invariant/call_override.rs
@@ -68,13 +68,13 @@ impl RandomCallGenerator {
                 "to have same size as the number of (unsafe) external calls of the sequence.",
             )
         } else {
-            // TODO: Do we want it to be 80% chance only too ?
             let sender = original_target;
 
-            // Set which contract we mostly (80% chance) want to generate calldata from.
+            // Set which contract we mostly (90% chance) want to generate calldata from.
             *self.target_reference.write() = original_caller;
 
-            // `original_caller` has a 80% chance of being the `new_target`.
+            // Generate a call using the strategy, which has a 90% chance of returning
+            // `Some(CallDetails)` and 10% chance of returning `None`.
             let choice = self.strategy.new_tree(&mut self.runner.lock()).unwrap().current().map(
                 |call_details| BasicTxDetails { warp: None, roll: None, sender, call_details },
             );


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

A comment mismatch in `RandomCallGenerator::next()` where comments incorrectly stated 80% probability while the code actually uses 90% probability via `weighted(0.9, strategy)`.

## Solution

Updated all comments to match the actual implementation:
- Changed "80% chance" references to "90%"
- Removed unclear TODO comment
- Improved clarity of what the probability actually controls

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
