### PR TITLE
perf(debugger): optimize source code display trimming

### DIFF
--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -318,10 +318,9 @@ impl TUIContext<'_> {
         }
 
         // Add after highlighted text.
-        while mid_len + after.len() > end_line {
-            after.pop_back();
-        }
-        for line in after {
+        // Calculate how many lines we need to show after the highlight.
+        let needed_after = end_line.saturating_sub(mid_len);
+        for line in after.iter().take(needed_after) {
             lines.push(u_num, line, u_text);
         }
 


### PR DESCRIPTION
### Fix
Inefficient trimming of source code display in the debugger TUI. When displaying large source files, the code used a while loop that repeatedly called pop_back() on a VecDeque, causing O(n) operations when trimming the "after" section of highlighted code.
### Changes
- Replaced the while loop with a single calculation using saturating_sub() to determine how many lines to display
- Used iterator-based approach with take() instead of modifying the VecDeque
- Improved performance from O(n) to O(1) when trimming large source files