### PR TITLE
perf(common): remove redundant clone in selector import

### DIFF
--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -307,10 +307,10 @@ impl OpenChainClient {
 
                 SelectorImportRequest { function: functions_and_errors, event: events }
             }
-            SelectorImportData::Raw(raw) => {
-                let function_and_error =
-                    raw.function.iter().chain(raw.error.iter()).cloned().collect::<Vec<_>>();
-                SelectorImportRequest { function: function_and_error, event: raw.event }
+            SelectorImportData::Raw(mut raw) => {
+                // Reuse owned vectors instead of cloning function and error signatures.
+                raw.function.extend(raw.error);
+                SelectorImportRequest { function: raw.function, event: raw.event }
             }
         };
 


### PR DESCRIPTION
Remove unnecessary allocation and cloning when importing raw selectors to OpenChain.