### PR TITLE
fix(chisel): avoid cloning session for inspect-only inputs

### DIFF
--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -129,11 +129,6 @@ impl ChiselDispatcher {
             return Ok(ControlFlow::Continue(()));
         }
 
-        // Create new source with exact input appended and parse
-        let (new_source, do_execute) = source.clone_with_new_line(input.to_string())?;
-
-        // TODO: Cloning / parsing the session source twice on non-inspected inputs kinda sucks.
-        // Should change up how this works.
         let (cf, res) = source.inspect(input).await?;
         if let Some(res) = &res {
             let _ = sh_println!("{res}");
@@ -142,6 +137,9 @@ impl ChiselDispatcher {
             debug!(%input, ?res, "inspect success");
             return Ok(ControlFlow::Continue(()));
         }
+
+        // Create new source with exact input appended and parse
+        let (new_source, do_execute) = source.clone_with_new_line(input.to_string())?;
 
         if do_execute {
             self.execute_and_replace(new_source).await.map(ControlFlow::Continue)


### PR DESCRIPTION
## Motivation

There is redundancy: for purely inspection expressions, currently unnecessarily performing cloning + parsing 
clone_with_new_line(input) even before inspect says that the session does not need to be modified.

## Solution

ChiselDispatcher::dispatch now calls SessionSource::inspect before clone_with_new_line. When inspect returns Break (pure inspection expressions), we no longer build a new SessionSource, which avoids an unnecessary clone and parse of the REPL contract. For inputs where inspect indicates that execution should continue, we still append the line via clone_with_new_line and execute or rebuild the source as before, so the observable behavior of the REPL remains unchanged while reducing overhead for inspect-only inputs.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
