### PR TITLE
chore: respect configured thread count

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -2236,7 +2236,7 @@ impl SimpleCast {
             eyre::bail!("invalid function signature");
         };
 
-        let num_threads = std::thread::available_parallelism().map_or(1, |n| n.get());
+        let num_threads = rayon::current_num_threads();
         let found = AtomicBool::new(false);
 
         let result: Option<(u32, String, String)> =


### PR DESCRIPTION
Replaced `available_parallelism` with `rayon::current_num_threads` in [get_selector], ensuring parallel execution respects the global thread pool configuration.