### PR TITLE
chore: respect configured thread count in create2

### DIFF
--- a/crates/cast/src/cmd/create2.rs
+++ b/crates/cast/src/cmd/create2.rs
@@ -167,7 +167,7 @@ impl Create2Args {
 
         let mut n_threads = threads.unwrap_or(0);
         if n_threads == 0 {
-            n_threads = std::thread::available_parallelism().map_or(1, |n| n.get());
+            n_threads = rayon::current_num_threads();
         }
         if cfg!(test) {
             n_threads = n_threads.min(2);


### PR DESCRIPTION
Use `rayon::current_num_threads()` instead of `std::thread::available_parallelism()`, respecting user-configured thread count.