### PR TITLE
fix(forge): lookup path artifact if not in available artifacts

### DIFF
--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -477,63 +477,76 @@ fn get_artifact_code(state: &Cheatcodes, path: &str, deployed: bool) -> Result<B
                 .collect::<Vec<_>>();
 
             let artifact = match &filtered[..] {
-                [] => Err(fmt_err!("no matching artifact found")),
-                [artifact] => Ok(*artifact),
+                [] => None,
+                [artifact] => Some(Ok(*artifact)),
                 filtered => {
                     let mut filtered = filtered.to_vec();
                     // If we know the current script/test contract solc version, try to filter by it
-                    state
-                        .config
-                        .running_artifact
-                        .as_ref()
-                        .and_then(|running| {
-                            // Firstly filter by version
-                            filtered.retain(|(id, _)| id.version == running.version);
+                    Some(
+                        state
+                            .config
+                            .running_artifact
+                            .as_ref()
+                            .and_then(|running| {
+                                // Firstly filter by version
+                                filtered.retain(|(id, _)| id.version == running.version);
 
-                            // Return artifact if only one matched
-                            if filtered.len() == 1 {
-                                return Some(filtered[0]);
-                            }
+                                // Return artifact if only one matched
+                                if filtered.len() == 1 {
+                                    return Some(filtered[0]);
+                                }
 
-                            // Try filtering by profile as well
-                            filtered.retain(|(id, _)| id.profile == running.profile);
+                                // Try filtering by profile as well
+                                filtered.retain(|(id, _)| id.profile == running.profile);
 
-                            if filtered.len() == 1 { Some(filtered[0]) } else { None }
-                        })
-                        .ok_or_else(|| fmt_err!("multiple matching artifacts found"))
+                                if filtered.len() == 1 { Some(filtered[0]) } else { None }
+                            })
+                            .ok_or_else(|| fmt_err!("multiple matching artifacts found")),
+                    )
                 }
-            }?;
-
-            let maybe_bytecode = if deployed {
-                artifact.1.deployed_bytecode().cloned()
-            } else {
-                artifact.1.bytecode().cloned()
             };
 
-            return maybe_bytecode
-                .ok_or_else(|| fmt_err!("no bytecode for contract; is it abstract or unlinked?"));
-        } else {
-            let path_in_artifacts =
-                match (file.map(|f| f.to_string_lossy().to_string()), contract_name) {
-                    (Some(file), Some(contract_name)) => {
-                        PathBuf::from(format!("{file}/{contract_name}.json"))
-                    }
-                    (None, Some(contract_name)) => {
-                        PathBuf::from(format!("{contract_name}.sol/{contract_name}.json"))
-                    }
-                    (Some(file), None) => {
-                        let name = file.replace(".sol", "");
-                        PathBuf::from(format!("{file}/{name}.json"))
-                    }
-                    _ => bail!("invalid artifact path"),
+            if let Some(artifact) = artifact {
+                let artifact = artifact?;
+                let maybe_bytecode = if deployed {
+                    artifact.1.deployed_bytecode().cloned()
+                } else {
+                    artifact.1.bytecode().cloned()
                 };
 
-            state.config.paths.artifacts.join(path_in_artifacts)
+                return maybe_bytecode.ok_or_else(|| {
+                    fmt_err!("no bytecode for contract; is it abstract or unlinked?")
+                });
+            }
         }
+
+        // Fallback: construct path manually when no artifacts list or no match found
+        let path_in_artifacts = match (file.map(|f| f.to_string_lossy().to_string()), contract_name)
+        {
+            (Some(file), Some(contract_name)) => {
+                PathBuf::from(format!("{file}/{contract_name}.json"))
+            }
+            (None, Some(contract_name)) => {
+                PathBuf::from(format!("{contract_name}.sol/{contract_name}.json"))
+            }
+            (Some(file), None) => {
+                let name = file.replace(".sol", "");
+                PathBuf::from(format!("{file}/{name}.json"))
+            }
+            _ => bail!("invalid artifact path"),
+        };
+
+        state.config.paths.artifacts.join(path_in_artifacts)
     };
 
     let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
-    let data = fs::read_to_string(path)?;
+    let data = fs::read_to_string(path).map_err(|e| {
+        if state.config.available_artifacts.is_some() {
+            fmt_err!("no matching artifact found")
+        } else {
+            e.into()
+        }
+    })?;
     let artifact = serde_json::from_str::<ContractObject>(&data)?;
     let maybe_bytecode = if deployed { artifact.deployed_bytecode } else { artifact.bytecode };
     maybe_bytecode.ok_or_else(|| fmt_err!("no bytecode for contract; is it abstract or unlinked?"))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #12231 and closes #12967 
- construct path manually when no artifacts list or no match found. requires the artifact to be available so `forge build` needed before `forge test --mt testDeployMorpho` in repro
- tested with https://github.com/QGarchery/forge-deploy-code
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
