### PR TITLE
perf(verify): clone only VyperSettings instead of entire context

### DIFF
--- a/crates/verify/src/etherscan/standard_json.rs
+++ b/crates/verify/src/etherscan/standard_json.rs
@@ -56,7 +56,7 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
                 let sources = Source::read_all_from(path, &["vy", "vyi"])?;
                 let input = VyperInput::new(
                     sources,
-                    context.clone().compiler_settings.vyper,
+                    context.compiler_settings.vyper.clone(),
                     &context.compiler_version,
                 );
 


### PR DESCRIPTION
Replace context.clone().compiler_settings.vyper with  context.compiler_settings.vyper.clone() to avoid unnecessary  cloning of the entire VerificationContext. This reduces memory  allocations when creating VyperInput instances.
Applied to both etherscan and sourcify verification providers.

