### PR TITLE
feat(corpus): add sender and value mutation in corpus fuzzing

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -117,7 +117,7 @@ impl FuzzedExecutor {
             warp: None,
             roll: None,
             sender: Default::default(),
-            call_details: CallDetails { target: Default::default(), calldata },
+            call_details: CallDetails { target: Default::default(), calldata, value: None },
         });
         // We want to collect at least one trace which will be displayed to user.
         let max_traces_to_collect = std::cmp::max(1, self.config.gas_report_samples) as usize;
@@ -343,7 +343,7 @@ impl FuzzedExecutor {
                 warp: None,
                 roll: None,
                 sender: self.sender,
-                call_details: CallDetails { target: address, calldata: calldata.clone() },
+                call_details: CallDetails { target: address, calldata: calldata.clone(), value: None },
             }],
             new_coverage,
         );

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1031,8 +1031,9 @@ pub(crate) fn execute_tx(executor: &mut Executor, tx: &BasicTxDetails) -> Result
     }
 
     // Perform the raw call.
+    let value = tx.call_details.value.unwrap_or(U256::ZERO);
     let mut call_result = executor
-        .call_raw(tx.sender, tx.call_details.target, tx.call_details.calldata.clone(), U256::ZERO)
+        .call_raw(tx.sender, tx.call_details.target, tx.call_details.calldata.clone(), value)
         .map_err(|e| eyre!(format!("Could not make raw evm call: {e}")))?;
 
     // Propagate block adjustments to call result which will be committed.

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -53,6 +53,9 @@ pub struct CallDetails {
     pub target: Address,
     // The data of the transaction.
     pub calldata: Bytes,
+    // Ether value to send with the transaction.
+    #[serde(default)]
+    pub value: Option<U256>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -152,6 +152,6 @@ pub fn fuzz_contract_with_calldata(
     ]
     .prop_map(move |calldata| {
         trace!(input=?calldata);
-        CallDetails { target, calldata }
+        CallDetails { target, calldata, value: None }
     })
 }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -786,6 +786,7 @@ impl<'a> FunctionRunner<'a> {
                         call_details: CallDetails {
                             target: seq.addr.unwrap_or_default(),
                             calldata: seq.calldata.clone(),
+                            value: None,
                         },
                     }
                 })


### PR DESCRIPTION
Fixes TODO: mutate sender and value in corpus fuzzing.

Only calldata was being mutated, so we missed bugs in contracts that depend on msg.sender or msg.value. Added mutation for both fields with 15% probability each.

Added value field to CallDetails with serde default for backward compatibility.