### PR TITLE
chore: ignore RUSTSEC-2025-0137

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,8 @@ ignore = [
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2024-0437 protobuf! Crash due to uncontrolled recursion in protobuf crate.
     "RUSTSEC-2024-0437",
+    # https://rustsec.org/advisories/RUSTSEC-2025-0137 `reciprocal_mg10` OOB, unused
+    "RUSTSEC-2025-0137",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Ignores the security advisory for `reciprocal_mg10` out-of-bounds issue in the uint crate. This function is not used by foundry.

ref https://github.com/recmo/uint/issues/550