### PR TITLE
feat: faster `cast run` when ran against anvil

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -722,6 +722,10 @@ pub enum EthRequest {
     /// Set the executor (sponsor) wallet
     #[serde(rename = "anvil_setExecutor", with = "sequence")]
     AnvilSetExecutor(String),
+
+    /// Returns a decoded CallTraceArena for a transaction
+    #[serde(rename = "anvil_revmTrace", with = "sequence")]
+    AnvilRevmTrace(B256),
 }
 
 /// Represents ethereum JSON-RPC API

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -76,7 +76,7 @@ use anvil_core::{
 };
 use anvil_rpc::{error::RpcError, response::ResponseResult};
 use foundry_common::provider::ProviderBuilder;
-use foundry_evm::decode::RevertDecoder;
+use foundry_evm::{decode::RevertDecoder, traces::CallTraceArena};
 use foundry_primitives::{
     FoundryTransactionRequest, FoundryTxEnvelope, FoundryTxReceipt, FoundryTxType, FoundryTypedTx,
 };
@@ -521,6 +521,7 @@ impl EthApi {
             EthRequest::AnvilSetExecutor(executor_pk) => {
                 self.anvil_set_executor(executor_pk).to_rpc_result()
             }
+            EthRequest::AnvilRevmTrace(hash) => self.anvil_revm_trace(hash).await.to_rpc_result(),
         };
 
         if let ResponseResult::Error(err) = &response {
@@ -2835,6 +2836,14 @@ impl EthApi {
     pub async fn anvil_enable_traces(&self) -> Result<()> {
         node_info!("anvil_enableTraces");
         Err(BlockchainError::RpcUnimplemented)
+    }
+
+    /// Returns the decoded CallTraceArena for a transaction
+    ///
+    /// Handler for RPC call: `anvil_revmTrace`
+    pub async fn anvil_revm_trace(&self, hash: B256) -> Result<CallTraceArena> {
+        node_info!("anvil_revmTrace");
+        self.backend.anvil_revm_trace(hash).await
     }
 
     /// Execute a transaction regardless of signature status


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Much faster tracing response for `cast run` when running against remote anvil instances because it saves 100s of sequential network requests querying the contract states.


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Introduce a new rpc method in anvil `anvil_revmTrace` that returns `CallTraceArena` as response which then cast can print directly instead of doing local simulation which is very slow over network because it doesn't know which state it will need and the state gets queried sequentially as revm steps through the execution.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
