### PR TITLE
fix: use network-specific BaseFeeParams for Optimism in Anvil

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4973,7 +4973,9 @@ name = "foundry-evm-networks"
 version = "1.5.1"
 dependencies = [
  "alloy-chains",
+ "alloy-eips",
  "alloy-evm",
+ "alloy-op-hardforks",
  "alloy-primitives",
  "clap",
  "revm",

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use alloy_chains::Chain;
 use alloy_consensus::BlockHeader;
-use alloy_eips::eip7840::BlobParams;
+use alloy_eips::{eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_evm::EvmEnv;
 use alloy_genesis::Genesis;
 use alloy_network::{AnyNetwork, TransactionResponse};
@@ -1094,6 +1094,9 @@ impl NodeConfig {
             self.networks,
         );
 
+        let base_fee_params: BaseFeeParams =
+            self.networks.base_fee_params(self.get_genesis_timestamp());
+
         let fees = FeeManager::new(
             spec_id,
             self.get_base_fee(),
@@ -1101,6 +1104,7 @@ impl NodeConfig {
             self.get_gas_price(),
             self.get_blob_excess_gas_and_price(),
             self.get_blob_params(),
+            base_fee_params,
         );
 
         let (db, fork): (Arc<TokioRwLock<Box<dyn Db>>>, Option<ClientFork>) =

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -41,7 +41,6 @@ use alloy_consensus::{
 use alloy_eip5792::{Capabilities, DelegationCapability};
 use alloy_eips::{
     BlockNumHash, Encodable2718,
-    eip1559::BaseFeeParams,
     eip4844::{BlobTransactionSidecar, kzg_to_versioned_hash},
     eip7840::BlobParams,
     eip7910::SystemContract,
@@ -1857,7 +1856,7 @@ impl Backend {
                 block_env.basefee = simulated_block
                     .inner
                     .header
-                    .next_block_base_fee(BaseFeeParams::ethereum())
+                    .next_block_base_fee(self.fees.base_fee_params())
                     .unwrap_or_default();
 
                 block_res.push(simulated_block);

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -36,10 +36,6 @@ pub const BASE_FEE_CHANGE_DENOMINATOR: u128 = 8;
 /// Minimum suggested priority fee
 pub const MIN_SUGGESTED_PRIORITY_FEE: u128 = 1e9 as u128;
 
-pub fn default_elasticity() -> f64 {
-    1f64 / BaseFeeParams::ethereum().elasticity_multiplier as f64
-}
-
 /// Stores the fee related information
 #[derive(Clone, Debug)]
 pub struct FeeManager {
@@ -62,6 +58,8 @@ pub struct FeeManager {
     /// This will be constant value unless changed manually
     gas_price: Arc<RwLock<u128>>,
     elasticity: Arc<RwLock<f64>>,
+    /// Network-specific base fee params for EIP-1559 calculations
+    base_fee_params: BaseFeeParams,
 }
 
 impl FeeManager {
@@ -72,7 +70,9 @@ impl FeeManager {
         gas_price: u128,
         blob_excess_gas_and_price: BlobExcessGasAndPrice,
         blob_params: BlobParams,
+        base_fee_params: BaseFeeParams,
     ) -> Self {
+        let elasticity = 1f64 / base_fee_params.elasticity_multiplier as f64;
         Self {
             spec_id,
             blob_params: Arc::new(RwLock::new(blob_params)),
@@ -80,8 +80,14 @@ impl FeeManager {
             is_min_priority_fee_enforced,
             gas_price: Arc::new(RwLock::new(gas_price)),
             blob_excess_gas_and_price: Arc::new(RwLock::new(blob_excess_gas_and_price)),
-            elasticity: Arc::new(RwLock::new(default_elasticity())),
+            elasticity: Arc::new(RwLock::new(elasticity)),
+            base_fee_params,
         }
+    }
+
+    /// Returns the base fee params used for EIP-1559 calculations
+    pub fn base_fee_params(&self) -> BaseFeeParams {
+        self.base_fee_params
     }
 
     pub fn elasticity(&self) -> f64 {
@@ -156,7 +162,7 @@ impl FeeManager {
         if self.base_fee() == 0 {
             return 0;
         }
-        calculate_next_block_base_fee(gas_used, gas_limit, last_fee_per_gas)
+        calc_next_block_base_fee(gas_used, gas_limit, last_fee_per_gas, self.base_fee_params)
     }
 
     /// Calculates the next block blob base fee.
@@ -185,7 +191,12 @@ impl FeeManager {
     }
 }
 
-/// Calculate base fee for next block. [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) spec
+/// Calculate base fee for next block using Ethereum mainnet parameters.
+///
+/// See [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) spec.
+///
+/// Note: This uses Ethereum's base fee params. For network-specific calculations
+/// (e.g., Optimism), use [`FeeManager::get_next_block_base_fee_per_gas`] instead.
 pub fn calculate_next_block_base_fee(gas_used: u64, gas_limit: u64, base_fee: u64) -> u64 {
     calc_next_block_base_fee(gas_used, gas_limit, base_fee, BaseFeeParams::ethereum())
 }

--- a/crates/evm/networks/Cargo.toml
+++ b/crates/evm/networks/Cargo.toml
@@ -15,7 +15,9 @@ workspace = true
 
 [dependencies]
 alloy-chains.workspace = true
+alloy-eips.workspace = true
 alloy-evm.workspace = true
+alloy-op-hardforks.workspace = true
 alloy-primitives = { workspace = true, features = [
     "serde",
     "getrandom",

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -9,7 +9,9 @@ use alloy_chains::{
     NamedChain,
     NamedChain::{Chiado, Gnosis, Moonbase, Moonbeam, MoonbeamDev, Moonriver, Rsk, RskTestnet},
 };
+use alloy_eips::eip1559::BaseFeeParams;
 use alloy_evm::precompiles::PrecompilesMap;
+use alloy_op_hardforks::{OpChainHardforks, OpHardforks};
 use alloy_primitives::{Address, map::AddressHashMap};
 use clap::Parser;
 use serde::{Deserialize, Serialize};
@@ -45,6 +47,23 @@ impl NetworkConfigs {
 
     pub fn is_optimism(&self) -> bool {
         self.optimism
+    }
+
+    /// Returns the base fee parameters for the configured network.
+    ///
+    /// For Optimism networks, returns Canyon parameters if the Canyon hardfork is active
+    /// at the given timestamp, otherwise returns pre-Canyon parameters.
+    pub fn base_fee_params(&self, timestamp: u64) -> BaseFeeParams {
+        if self.is_optimism() {
+            let op_hardforks = OpChainHardforks::op_mainnet();
+            if op_hardforks.is_canyon_active_at_timestamp(timestamp) {
+                BaseFeeParams::optimism_canyon()
+            } else {
+                BaseFeeParams::optimism()
+            }
+        } else {
+            BaseFeeParams::ethereum()
+        }
     }
 
     pub fn bypass_prevrandao(&self, chain_id: u64) -> bool {


### PR DESCRIPTION
## Motivation

fix: use network-specific BaseFeeParams for Optimism in Anvil.

Closes #12943.


## Solution

This PR fixes Anvil to use BaseFeeParams::optimism_canyon() when running in Optimism mode instead of always using Ethereum's parameters.

Changes:
  - crates/anvil/src/eth/fees.rs
    - Added base_fee_params field to FeeManager
    - Updated new() to accept network-specific BaseFeeParams
    - Added base_fee_params() getter
    - get_next_block_base_fee_per_gas() now uses stored params
    - Removed unused default_elasticity() function
    - Added doc comment to calculate_next_block_base_fee() clarifying it uses Ethereum params
  - crates/anvil/src/config.rs
    - Select BaseFeeParams::optimism_canyon() when is_optimism() is true
  - crates/anvil/src/eth/backend/mem/mod.rs
    - Use self.fees.base_fee_params() in block simulation instead of hardcoded Ethereum params
  - crates/anvil/tests/it/optimism.rs
    - Added test_optimism_base_fee_params() to verify correct params are used

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
