### PR TITLE
fix(config): reject bare versions in compilation restrictions

### DIFF
--- a/crates/config/src/compilation.rs
+++ b/crates/config/src/compilation.rs
@@ -7,7 +7,7 @@ use foundry_compilers::{
     solc::{Restriction, SolcRestrictions},
 };
 use semver::VersionReq;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Keeps possible overrides for default settings which users may configure to construct additional
 /// settings profile.
@@ -69,6 +69,7 @@ pub enum RestrictionsError {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CompilationRestrictions {
     pub paths: GlobMatcher,
+    #[serde(default, deserialize_with = "deserialize_version_req")]
     pub version: Option<VersionReq>,
     pub via_ir: Option<bool>,
     pub bytecode_hash: Option<BytecodeHash>,
@@ -83,6 +84,36 @@ pub struct CompilationRestrictions {
     pub evm_version: Option<EvmVersion>,
     #[serde(default, with = "serde_helpers::display_from_str_opt")]
     pub max_evm_version: Option<EvmVersion>,
+}
+
+/// Custom deserializer for version field that rejects ambiguous bare version numbers.
+fn deserialize_version_req<'de, D>(deserializer: D) -> Result<Option<VersionReq>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt_string: Option<String> = Option::deserialize(deserializer)?;
+    let Some(opt_string) = opt_string else {
+        return Ok(None);
+    };
+
+    let version = opt_string.trim();
+    // Reject bare versions like "0.8.11" that lack an operator prefix
+    if version.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        return Err(serde::de::Error::custom(format!(
+            "Invalid version format '{opt_string}' in compilation_restrictions. \
+             Bare version numbers are ambiguous and default to caret requirements (e.g. '^{version}'). \
+             Use an explicit constraint such as '={version}' for an exact version or '>={version}' for a minimum version."
+        )));
+    }
+
+    let req = VersionReq::parse(&opt_string).map_err(|e| {
+        serde::de::Error::custom(format!(
+            "Invalid version requirement '{opt_string}': {e}. \
+             Examples: '=0.8.11' (exact), '>=0.8.11' (minimum), '>=0.8.11 <0.9.0' (range)."
+        ))
+    })?;
+
+    Ok(Some(req))
 }
 
 impl TryFrom<CompilationRestrictions> for RestrictionsWithVersion<MultiCompilerRestrictions> {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6443,4 +6443,57 @@ mod tests {
             Ok(())
         });
     }
+
+    #[test]
+    fn fails_on_ambiguous_version_in_compilation_restrictions() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                src = "src"
+
+                [[profile.default.compilation_restrictions]]
+                paths = "src/*.sol"
+                version = "0.8.11"
+                "#,
+            )?;
+
+            let err = Config::load().expect_err("expected bare version to fail");
+            let err_msg = err.to_string();
+            assert!(
+                err_msg.contains("Invalid version format '0.8.11'")
+                    && err_msg.contains("Bare version numbers are ambiguous"),
+                "Expected error about ambiguous version, got: {err_msg}"
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn accepts_explicit_version_requirements() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                src = "src"
+
+                [[profile.default.compilation_restrictions]]
+                paths = "src/*.sol"
+                version = "=0.8.11"
+
+                [[profile.default.compilation_restrictions]]
+                paths = "test/*.sol"
+                version = ">=0.8.11"
+                "#,
+            )?;
+
+            let config = Config::load().expect("should accept explicit version requirements");
+            assert_eq!(config.compilation_restrictions.len(), 2);
+
+            Ok(())
+        });
+    }
 }


### PR DESCRIPTION
closes #12794

Version '0.8.11' silently matches 0.8.12+ due to caret parsing, require explicit operators like '=0.8.11' to prevent security issues.