### PR TITLE
Revert "fix(config): err on unknown profile (#12946)"

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -774,40 +774,28 @@ impl Config {
     }
 
     fn from_figment(figment: Figment) -> Result<Self, ExtractConfigError> {
-        // Helper to add a profile only if it's not already present
-        fn add_profile(profiles: &mut Vec<Profile>, profile: &Profile) {
-            if !profiles.contains(profile) {
-                profiles.push(profile.clone());
-            }
-        }
-
         let mut config = figment.extract::<Self>().map_err(ExtractConfigError::new)?;
-        let active_profile = figment.profile().clone();
+        config.profile = figment.profile().clone();
 
-        // Collect profiles from the profile section.
         // The `"profile"` profile contains all the profiles as keys.
+        let mut add_profile = |profile: &Profile| {
+            if !config.profiles.contains(profile) {
+                config.profiles.push(profile.clone());
+            }
+        };
         let figment = figment.select(Self::PROFILE_SECTION);
         if let Ok(data) = figment.data()
             && let Some(profiles) = data.get(&Profile::new(Self::PROFILE_SECTION))
         {
             for profile in profiles.keys() {
-                add_profile(&mut config.profiles, &Profile::new(profile));
+                add_profile(&Profile::new(profile));
             }
         }
-
-        // Always include the default profile
-        add_profile(&mut config.profiles, &Self::DEFAULT_PROFILE);
-
-        // Ensure the active profile exists.
-        if config.profiles.contains(&active_profile) {
-            config.profile = active_profile;
-        } else {
-            return Err(ExtractConfigError::new(Error::from(format!(
-                "Profile {active_profile} does not exist"
-            ))));
-        }
+        add_profile(&Self::DEFAULT_PROFILE);
+        add_profile(&config.profile);
 
         config.normalize_optimizer_settings();
+
         Ok(config)
     }
 
@@ -6422,24 +6410,6 @@ mod tests {
             assert!(cfg.warnings.iter().any(
                 |w| matches!(w, crate::Warning::UnknownKey { key, .. } if key == "unknown_key_xyz")
             ));
-            Ok(())
-        });
-    }
-
-    #[test]
-    fn fails_on_unknown_profile() {
-        figment::Jail::expect_with(|jail| {
-            jail.create_file(
-                "foundry.toml",
-                r#"
-                [profile.default]
-                "#,
-            )?;
-
-            jail.set_env("FOUNDRY_PROFILE", "foo");
-            let err = Config::load().expect_err("expected unknown profile to fail");
-            assert!(err.to_string().contains("Profile foo does not exist"));
-
             Ok(())
         });
     }


### PR DESCRIPTION
This reverts commit 6ff4b52e2e572e93d0cd81591b1bd0e6ad9ed507.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- closes #12963 
- profiles are iterated multiple times and the approach in https://github.com/foundry-rs/foundry/pull/12946 stops at first iteration if profile not found, need to find the proper solution / add more tests
- reopened #12844
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
