### PR TITLE
fix(anvil): add cancellation to blocking RPC tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,6 +1171,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber 0.3.22",
  "yansi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,6 +372,7 @@ soldeer-core = { version = "=0.10.0", features = ["serde"] }
 strum = "0.27"
 tempfile = "3.23"
 tokio = "1"
+tokio-util = "0.7"
 toml = "0.9"
 toml_edit = "0.24"
 tower = "0.5"

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -81,6 +81,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 # async
 tokio = { workspace = true, features = ["time"] }
+tokio-util.workspace = true
 parking_lot.workspace = true
 futures.workspace = true
 async-trait.workspace = true


### PR DESCRIPTION
Was looking into the resource usage in forking mode and noticed that `on_blocking_task` doesn't handle client disconnects - tasks just keep running even after the client is gone.

Added a `CancellationToken` that listens for when the caller drops the future and aborts the blocking task, covers all the heavy RPC methods like eth_call, eth_estimateGas, and the mining stuff.