### PR TITLE
cull corpus prior to export

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -245,7 +245,7 @@ impl FuzzedExecutor {
             .executor
             .call_raw(self.sender, address, calldata.clone(), U256::ZERO)
             .map_err(|e| TestCaseError::fail(e.to_string()))?;
-        let new_coverage = coverage_metrics.merge_edge_coverage(&mut call);
+        let (new_coverage, edges) = coverage_metrics.merge_edge_coverage(&mut call);
         coverage_metrics.process_inputs(
             &[BasicTxDetails {
                 warp: None,
@@ -254,6 +254,7 @@ impl FuzzedExecutor {
                 call_details: CallDetails { target: address, calldata: calldata.clone() },
             }],
             new_coverage,
+            edges,
         );
 
         // Handle `vm.assume`.

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1184,6 +1184,7 @@ fn test_paths(
 ) -> (PathBuf, PathBuf) {
     let contract = contract_name.split(':').next_back().unwrap();
     // Update config with corpus dir for current test.
+    // FIXME: collapse folder structure to reduce storage
     corpus_config.with_test(contract, test_name);
 
     let failures_dir = canonicalized(persist_dir.join("failures").join(contract));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Currently, workers may export corpus entries with intersecting edges, creating some level of duplicating and/or longer sequences than necessary to reach a given edge. Also, the notion of "favorite" does not guarantee all edges are covered by the in-memory corpus entries.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Redefine favorites to cover the intersection of all currently observed edges, prioritizing entries by rarity of the edge (how many other corpus entries reference the edge id) and length of the sequence (shorter sequences are considered more valuable). The intuition is that mutating the smallest inputs that reach the most rare paths (changes during campaign) is more likely to reach additional coverage. This also ensures, or at least aims to ensure, the global corpus coordinated between master-worker threads is small and interesting as opposed to bloated with duplicates they independently discovered.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist
- [ ] TODO deprecate `corpus_min_mutations`
- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
