### PR TITLE
feat: add support for constructing tempo tx

### DIFF
--- a/crates/primitives/src/transaction/request.rs
+++ b/crates/primitives/src/transaction/request.rs
@@ -9,6 +9,7 @@ use derive_more::{AsMut, AsRef, From, Into};
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, TxDeposit};
 use op_revm::transaction::deposit::DepositTransactionParts;
 use serde::{Deserialize, Serialize};
+use tempo_primitives::{TEMPO_TX_TYPE_ID, TempoTransaction, transaction::Call};
 
 use super::{FoundryTxEnvelope, FoundryTxType, FoundryTypedTx};
 use crate::FoundryNetwork;
@@ -46,10 +47,53 @@ impl FoundryTransactionRequest {
         Self(inner)
     }
 
+    /// Consume self and return the inner [`WithOtherFields<TransactionRequest>`].
+    #[inline]
+    pub fn into_inner(self) -> WithOtherFields<TransactionRequest> {
+        self.0
+    }
+
     /// Check if this is a deposit transaction.
     #[inline]
     pub fn is_deposit(&self) -> bool {
         self.as_ref().transaction_type == Some(DEPOSIT_TX_TYPE_ID)
+    }
+
+    /// Check if this is a Tempo transaction.
+    ///
+    /// Returns true if the transaction type is explicitly set to Tempo (0x76) or if
+    /// a `feeToken` is set in OtherFields.
+    #[inline]
+    pub fn is_tempo(&self) -> bool {
+        self.as_ref().transaction_type == Some(TEMPO_TX_TYPE_ID)
+            || self.as_ref().other.contains_key("feeToken")
+    }
+
+    /// Get the Tempo fee token from OtherFields if present.
+    pub fn get_tempo_fee_token(&self) -> Option<Address> {
+        self.as_ref().other.get_deserialized::<Address>("feeToken").transpose().ok().flatten()
+    }
+
+    /// Check if all necessary keys are present to build a Tempo transaction, returning a list of
+    /// keys that are missing.
+    pub fn complete_tempo(&self) -> Result<(), Vec<&'static str>> {
+        let mut missing = Vec::new();
+        if self.chain_id().is_none() {
+            missing.push("chain_id");
+        }
+        if self.gas_limit().is_none() {
+            missing.push("gas_limit");
+        }
+        if self.max_fee_per_gas().is_none() {
+            missing.push("max_fee_per_gas");
+        }
+        if self.max_priority_fee_per_gas().is_none() {
+            missing.push("max_priority_fee_per_gas");
+        }
+        if self.nonce().is_none() {
+            missing.push("nonce");
+        }
+        if missing.is_empty() { Ok(()) } else { Err(missing) }
     }
 
     /// Returns the minimal transaction type this request can be converted into based on the fields
@@ -57,6 +101,8 @@ impl FoundryTransactionRequest {
     pub fn preferred_type(&self) -> FoundryTxType {
         if self.is_deposit() {
             FoundryTxType::Deposit
+        } else if self.is_tempo() {
+            FoundryTxType::Tempo
         } else {
             self.as_ref().preferred_type().into()
         }
@@ -95,8 +141,7 @@ impl FoundryTransactionRequest {
             FoundryTxType::Eip4844 => self.as_ref().complete_4844().ok(),
             FoundryTxType::Eip7702 => self.as_ref().complete_7702().ok(),
             FoundryTxType::Deposit => self.complete_deposit().ok(),
-            // TODO: implement Tempo transaction completeness check
-            FoundryTxType::Tempo => None,
+            FoundryTxType::Tempo => self.complete_tempo().ok(),
         }?;
         Some(pref)
     }
@@ -116,8 +161,7 @@ impl FoundryTransactionRequest {
             FoundryTxType::Eip4844 => self.complete_4844(),
             FoundryTxType::Eip7702 => self.as_ref().complete_7702(),
             FoundryTxType::Deposit => self.complete_deposit(),
-            // TODO: implement Tempo transaction completeness check
-            FoundryTxType::Tempo => Err(vec!["tempo transaction building not yet supported"]),
+            FoundryTxType::Tempo => self.complete_tempo(),
         } {
             Err((pref, missing))
         } else {
@@ -141,6 +185,24 @@ impl FoundryTransactionRequest {
                 gas_limit: self.gas_limit().unwrap_or_default(),
                 is_system_transaction: deposit_tx_parts.is_system_transaction,
                 input: self.input().cloned().unwrap_or_default(),
+            }))
+        } else if self.is_tempo() {
+            // Build Tempo transaction from request fields
+            Ok(FoundryTypedTx::Tempo(TempoTransaction {
+                chain_id: self.chain_id().unwrap_or_default(),
+                fee_token: self.get_tempo_fee_token(),
+                max_fee_per_gas: self.max_fee_per_gas().unwrap_or_default(),
+                max_priority_fee_per_gas: self.max_priority_fee_per_gas().unwrap_or_default(),
+                gas_limit: self.gas_limit().unwrap_or_default(),
+                nonce_key: U256::ZERO, // Use protocol nonce space
+                nonce: self.nonce().unwrap_or_default(),
+                calls: vec![Call {
+                    to: self.kind().unwrap_or_default(),
+                    value: self.value().unwrap_or_default(),
+                    input: self.input().cloned().unwrap_or_default(),
+                }],
+                access_list: self.access_list().cloned().unwrap_or_default(),
+                ..Default::default()
             }))
         } else if self.as_ref().has_eip4844_fields() && self.as_ref().blob_sidecar().is_none() {
             // if request has eip4844 fields but no blob sidecar, try to build to eip4844 without
@@ -181,8 +243,25 @@ impl From<FoundryTypedTx> for FoundryTransactionRequest {
                 ]);
                 WithOtherFields { inner: Into::<TransactionRequest>::into(tx), other }.into()
             }
-            // TODO: implement conversion from Tempo transaction to request
-            FoundryTypedTx::Tempo(_) => unimplemented!("tempo transaction request conversion"),
+            FoundryTypedTx::Tempo(tx) => {
+                let mut other = OtherFields::default();
+                if let Some(fee_token) = tx.fee_token {
+                    other.insert("feeToken".to_string(), serde_json::to_value(fee_token).unwrap());
+                }
+                let first_call = tx.calls.first();
+                let mut inner = TransactionRequest::default()
+                    .with_chain_id(tx.chain_id)
+                    .with_nonce(tx.nonce)
+                    .with_gas_limit(tx.gas_limit)
+                    .with_max_fee_per_gas(tx.max_fee_per_gas)
+                    .with_max_priority_fee_per_gas(tx.max_priority_fee_per_gas)
+                    .with_kind(first_call.map(|c| c.to).unwrap_or_default())
+                    .with_value(first_call.map(|c| c.value).unwrap_or_default())
+                    .with_input(first_call.map(|c| c.input.clone()).unwrap_or_default())
+                    .with_access_list(tx.access_list);
+                inner.transaction_type = Some(TEMPO_TX_TYPE_ID);
+                WithOtherFields { inner, other }.into()
+            }
         }
     }
 }
@@ -316,8 +395,7 @@ impl TransactionBuilder<FoundryNetwork> for FoundryTransactionRequest {
             FoundryTxType::Eip4844 => self.as_ref().complete_4844(),
             FoundryTxType::Eip7702 => self.as_ref().complete_7702(),
             FoundryTxType::Deposit => self.complete_deposit(),
-            // TODO: implement Tempo transaction completeness check
-            FoundryTxType::Tempo => Err(vec!["tempo transaction building not yet supported"]),
+            FoundryTxType::Tempo => self.complete_tempo(),
         }
     }
 
@@ -326,7 +404,9 @@ impl TransactionBuilder<FoundryNetwork> for FoundryTransactionRequest {
     }
 
     fn can_build(&self) -> bool {
-        self.as_ref().can_build() || get_deposit_tx_parts(&self.as_ref().other).is_ok()
+        self.as_ref().can_build()
+            || get_deposit_tx_parts(&self.as_ref().other).is_ok()
+            || self.is_tempo()
     }
 
     fn output_tx_type(&self) -> FoundryTxType {
@@ -344,9 +424,11 @@ impl TransactionBuilder<FoundryNetwork> for FoundryTransactionRequest {
         let inner = self.as_mut();
         inner.transaction_type = Some(preferred_type as u8);
         inner.gas_limit().is_none().then(|| inner.set_gas_limit(Default::default()));
-        if preferred_type != FoundryTxType::Deposit {
+        if !matches!(preferred_type, FoundryTxType::Deposit | FoundryTxType::Tempo) {
             inner.trim_conflicting_keys();
             inner.populate_blob_hashes();
+        }
+        if preferred_type != FoundryTxType::Deposit {
             inner.nonce().is_none().then(|| inner.set_nonce(Default::default()));
         }
         if matches!(preferred_type, FoundryTxType::Legacy | FoundryTxType::Eip2930) {
@@ -357,7 +439,10 @@ impl TransactionBuilder<FoundryNetwork> for FoundryTransactionRequest {
         }
         if matches!(
             preferred_type,
-            FoundryTxType::Eip1559 | FoundryTxType::Eip4844 | FoundryTxType::Eip7702
+            FoundryTxType::Eip1559
+                | FoundryTxType::Eip4844
+                | FoundryTxType::Eip7702
+                | FoundryTxType::Tempo
         ) {
             inner
                 .max_priority_fee_per_gas()


### PR DESCRIPTION
We want to add support for constructing Tempo transactions in e.g. Cast. This requires support in the primitives crate, which this PR adds.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
