### PR TITLE
fix(forge): respect lint ignore config in solar compilation

### DIFF
--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -175,7 +175,7 @@ impl BuildArgs {
                 .collect::<Vec<_>>();
 
             let solar_sources =
-                get_solar_sources_from_compile_output(config, output, Some(&input_files))?;
+                get_solar_sources_from_compile_output(config, output, Some(&input_files), None)?;
             if solar_sources.input.sources.is_empty() {
                 if !input_files.is_empty() {
                     sh_warn!(

--- a/crates/forge/src/cmd/lint.rs
+++ b/crates/forge/src/cmd/lint.rs
@@ -108,7 +108,8 @@ impl LintArgs {
             .with_mixed_case_exceptions(&config.lint.mixed_case_exceptions);
 
         let output = ProjectCompiler::new().files(input.iter().cloned()).compile(&project)?;
-        let solar_sources = get_solar_sources_from_compile_output(&config, &output, Some(&input))?;
+        let solar_sources =
+            get_solar_sources_from_compile_output(&config, &output, Some(&input), Some(&ignored))?;
         if solar_sources.input.sources.is_empty() {
             return Err(eyre!(
                 "unable to lint. Solar only supports Solidity versions prior to 0.8.0"


### PR DESCRIPTION
Fixes #12721, skips ignored files when traversing imports to prevent solar from compiling files with unresolvable imports in parent project context.