### PR TITLE
fix: correct comment filtering logic in peek_comment_between

### DIFF
--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -952,7 +952,8 @@ impl<'sess> State<'sess, '_> {
     {
         self.comments
             .iter()
-            .take_while(|c| pos_lo < c.pos() && c.pos() < pos_hi)
+            .take_while(|c| c.pos() < pos_hi)
+            .filter(|c| c.pos() > pos_lo)
             .find(|c| !c.style.is_blank())
     }
 


### PR DESCRIPTION
### Fix
`peek_comment_between` could miss comments in the range when earlier comments existed before pos_lo because take_while stopped early.
### Changes
- Split into `take_while(|c| c.pos() < pos_hi)` for early termination and` filter(|c| c.pos() > pos_lo)` for range filtering
- Now correctly finds all comments within `(pos_lo, pos_hi)`