### PR TITLE
feat: alias `cast erc20 transfer` to `cast erc20 send`

### DIFF
--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -57,7 +57,7 @@ pub enum Erc20Subcommand {
     },
 
     /// Transfer ERC20 tokens.
-    #[command(visible_alias = "t")]
+    #[command(visible_aliases = ["t", "send"])]
     Transfer {
         /// The ERC20 token contract address.
         #[arg(value_parser = NameOrAddress::from_str)]


### PR DESCRIPTION
## Motivation

I write `cast erc20 send` out of habit, and I think it should be an alias.

## Solution

Add `cast erc20 send` as an alias for `cast erc20 transfer`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
