### PR TITLE
refactor(lint): extract duplicate help formatting logic

### DIFF
--- a/crates/lint/src/linter/mod.rs
+++ b/crates/lint/src/linter/mod.rs
@@ -70,6 +70,7 @@ impl<'s, 'c> LintContext<'s, 'c> {
     }
 
     fn add_help<'a>(&self, diag: DiagBuilder<'a, ()>, help: &'static str) -> DiagBuilder<'a, ()> {
+        // Avoid ANSI characters when using a JSON emitter
         if self.with_json_emitter { diag.help(help) } else { diag.help(hyperlink(help)) }
     }
 


### PR DESCRIPTION


The same conditional logic for formatting help messages (with/without ANSI escape codes) was duplicated in both `LintContext::emit()` and `LintContext::emit_with_suggestion()`. This duplication increases the risk of inconsistent behavior if the logic needs to be modified in the future.

