### PR TITLE
refactor(linking): remove unnecessary function shadowing in test helper

### DIFF
--- a/crates/linking/src/lib.rs
+++ b/crates/linking/src/lib.rs
@@ -463,11 +463,9 @@ mod tests {
     }
 
     fn link_test(path: impl AsRef<Path>, mut test_fn: impl FnMut(LinkerTest)) {
-        fn link_test(path: &Path, test_fn: &mut dyn FnMut(LinkerTest)) {
-            test_fn(LinkerTest::new(path, true));
-            test_fn(LinkerTest::new(path, false));
-        }
-        link_test(path.as_ref(), &mut test_fn);
+        let path = path.as_ref();
+        test_fn(LinkerTest::new(path, true));
+        test_fn(LinkerTest::new(path, false));
     }
 
     #[test]


### PR DESCRIPTION


The `link_test` helper function contained a nested function with the same name, creating unnecessary name shadowing. This made the code harder to read, as calls to `link_test(...)` inside the function appeared recursive when they actually invoked the nested function.

Removed the nested function and directly call `test_fn` twice with different parameters. This eliminates the shadowing and makes the code's intent clearer.

