### PR TITLE
refactor(cli): extract common signature cache path logic

### DIFF
--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -318,13 +318,17 @@ pub async fn print_traces(
     Ok(())
 }
 
-/// Traverse the artifacts in the project to generate local signatures and merge them into the cache
-/// file.
-pub fn cache_local_signatures(output: &ProjectCompileOutput) -> Result<()> {
+fn signatures_cache_path() -> Result<PathBuf> {
     let Some(cache_dir) = Config::foundry_cache_dir() else {
         eyre::bail!("Failed to get `cache_dir` to generate local signatures.");
     };
-    let path = cache_dir.join("signatures");
+    Ok(cache_dir.join("signatures"))
+}
+
+/// Traverse the artifacts in the project to generate local signatures and merge them into the cache
+/// file.
+pub fn cache_local_signatures(output: &ProjectCompileOutput) -> Result<()> {
+    let path = signatures_cache_path()?;
     let mut signatures = SignaturesCache::load(&path);
     for (_, artifact) in output.artifacts() {
         if let Some(abi) = &artifact.abi {
@@ -345,10 +349,7 @@ pub fn cache_local_signatures(output: &ProjectCompileOutput) -> Result<()> {
 /// Traverses all files at `folder_path`, parses any JSON ABI files found,
 /// and caches their function/event/error signatures to the local signatures cache.
 pub fn cache_signatures_from_abis(folder_path: impl AsRef<Path>) -> Result<()> {
-    let Some(cache_dir) = Config::foundry_cache_dir() else {
-        eyre::bail!("Failed to get `cache_dir` to generate local signatures.");
-    };
-    let path = cache_dir.join("signatures");
+    let path = signatures_cache_path()?;
     let mut signatures = SignaturesCache::load(&path);
 
     json_files(folder_path.as_ref())


### PR DESCRIPTION


Eliminates code duplication between `cache_local_signatures` and `cache_signatures_from_abis` by extracting the shared cache path resolution into a private helper function.

