### PR TITLE
feat: uncomment transaction replacement test

### DIFF
--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -165,7 +165,7 @@ async fn can_replace_transaction() {
 
     tx.set_gas_price(gas_price);
     // send transaction with lower gas price
-    let lower_priced_pending_tx = provider.send_transaction(tx.clone()).await.unwrap();
+    let _lower_priced_pending_tx = provider.send_transaction(tx.clone()).await.unwrap();
 
     tx.set_gas_price(gas_price + 1);
     // send the same transaction with higher gas price
@@ -180,10 +180,11 @@ async fn can_replace_transaction() {
     assert_eq!(block.transactions.len(), 1);
     assert_eq!(BlockTransactions::Hashes(vec![higher_tx_hash]), block.transactions);
 
-    // lower priced transaction was replaced
-    let _lower_priced_receipt = lower_priced_pending_tx.get_receipt().await.unwrap();
+    // verify the higher priced transaction was included
     let higher_priced_receipt = higher_priced_pending_tx.get_receipt().await.unwrap();
+    assert_eq!(higher_priced_receipt.transaction_hash, higher_tx_hash);
 
+    // verify only one transaction was included in the block (lower priced was replaced)
     assert_eq!(1, block.transactions.len());
     assert_eq!(
         BlockTransactions::Hashes(vec![higher_priced_receipt.transaction_hash]),


### PR DESCRIPTION
The FIXME referenced alloy-rs/alloy#614 which was merged back in April 2024. Since we're now on alloy 1.1.3, the receipt polling issue has been fixed for a while. 

Restored the test assertions with a small fix - removed the attempt to get receipt for the replaced transaction since it never gets mined.