### PR TITLE
Deduplicate call input lookup in inspector stack

### DIFF
--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -963,8 +963,8 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for InspectorStackRefMut<'_>
 
         if let Some(cheatcodes) = self.cheatcodes.as_deref_mut() {
             // Handle mocked functions, replace bytecode address with mock if matched.
-            let input_bytes = call.input.bytes(ecx);
             if let Some(mocks) = cheatcodes.mocked_functions.get(&call.target_address) {
+                let input_bytes = call.input.bytes(ecx);
                 // Check if any mock function set for call data or if catch-all mock function set
                 // for selector.
                 if let Some(target) =


### PR DESCRIPTION
Remove double call.input.bytes(ecx) by caching input_bytes when resolving mocked functions; behavior unchanged, avoids redundant work/allocation. Scope: foundry/crates/evm/evm/src/inspectors/stack.rs.