### PR TITLE
perf: remove redundant allocation in receipt bloom calculation

### DIFF
--- a/crates/primitives/src/transaction/receipt.rs
+++ b/crates/primitives/src/transaction/receipt.rs
@@ -44,7 +44,7 @@ impl FoundryReceiptEnvelope<alloy_rpc_types::Log> {
         deposit_receipt_version: Option<u64>,
     ) -> Self {
         let logs = logs.into_iter().collect::<Vec<_>>();
-        let logs_bloom = logs_bloom(logs.iter().map(|l| &l.inner).collect::<Vec<_>>());
+        let logs_bloom = logs_bloom(logs.iter().map(|l| &l.inner));
         let inner_receipt =
             Receipt { status: Eip658Value::Eip658(status), cumulative_gas_used, logs };
         match tx_type {


### PR DESCRIPTION
Removes an unnecessary intermediate `Vec` allocation when computing the logs bloom filter in `FoundryReceiptEnvelope::from_parts`.