### PR TITLE
Persist environment's `Spec` on fork creations

### DIFF
--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -539,7 +539,8 @@ async fn create_fork(mut fork: CreateFork) -> eyre::Result<(ForkId, CreatedFork,
     let provider = fork.evm_opts.fork_provider_with_url(&fork.url)?;
 
     // Initialise the fork environment.
-    let (env, block) = fork.evm_opts.fork_evm_env_with_provider(&fork.url, &provider).await?;
+    let (mut env, block) = fork.evm_opts.fork_evm_env_with_provider(&fork.url, &provider).await?;
+    env.evm_env.cfg_env.spec = *fork.env.evm_env.spec_id();
     fork.env = env;
     let meta = BlockchainDbMeta::new(fork.env.evm_env.block_env.clone(), fork.url.clone());
 

--- a/testdata/default/cheats/Fork.t.sol
+++ b/testdata/default/cheats/Fork.t.sol
@@ -120,4 +120,12 @@ contract ForkTest is Test {
     function testStorageCaching() public {
         vm.createSelectFork("mainnet", 19800000);
     }
+
+    // ensures forks keep the context' evm version
+    /// forge-config: default.evm_version = "cancun"
+    function testKeepsEvmVersion() public {
+        assertEq(vm.getEvmVersion(), "cancun");
+        vm.createSelectFork("mainnet", 23935694); // first block of fusaka hardfork
+        assertEq(vm.getEvmVersion(), "cancun");
+    }
 }


### PR DESCRIPTION
Fixes #13040 by creating forks with the environment's `Spec`.

Another option would have been to try and determine the `Spec` by chain id and block timestamp with `alloy_hardforks` and `alloy_op_hardforks` but I decided against it because it would introduce unpredictability when the mappings aren't known for a chain or are lagging behind (which is opaque to the user).

This is a breaking change.