### PR TITLE
Forge-script-sequence: avoid redundant max scan in read_latest

### DIFF
--- a/crates/script-sequence/src/reader.rs
+++ b/crates/script-sequence/src/reader.rs
@@ -94,10 +94,9 @@ impl BroadcastReader {
     pub fn read_latest(&self) -> eyre::Result<ScriptSequence> {
         let broadcasts = self.read()?;
 
-        // Find the broadcast with the latest timestamp
         let target = broadcasts
             .into_iter()
-            .max_by_key(|broadcast| broadcast.timestamp)
+            .next()
             .ok_or_else(|| eyre::eyre!("No broadcasts found"))?;
 
         Ok(target)


### PR DESCRIPTION
Change BroadcastReader::read_latest to take the first already-sorted broadcast instead of re-scanning with max_by_key, removing an extra pass. No functional behavior change; just avoids redundant iteration.