### PR TITLE
fix: use imported Duration instead of full path

### DIFF
--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -104,7 +104,7 @@ impl<'a> SendTransactionKind<'a> {
                             warn!(
                                 "Expected nonce ({tx_nonce}) is ahead of provider nonce ({nonce}). Retrying in 1 second..."
                             );
-                            tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+                            tokio::time::sleep(Duration::from_millis(1000)).await;
                         }
                         Ordering::Equal => {
                             // Nonces are equal, we can proceed.


### PR DESCRIPTION
Replace std::time::Duration::from_millis() with Duration::from_millis()  on line 107 to match the import style used elsewhere in the file. The  Duration type is already imported at the top of the file, so the full  path is unnecessary.
