### PR TITLE
Remove redundant logs allocation in convert_logs_rpc

### DIFF
--- a/crates/primitives/src/transaction/receipt.rs
+++ b/crates/primitives/src/transaction/receipt.rs
@@ -103,8 +103,7 @@ impl FoundryReceiptEnvelope<Log> {
                 transaction_index: Some(transaction_index),
                 log_index: Some((next_log_index + index) as u64),
                 removed: false,
-            })
-            .collect::<Vec<_>>();
+            });
         FoundryReceiptEnvelope::<alloy_rpc_types::Log>::from_parts(
             self.status(),
             self.cumulative_gas_used(),


### PR DESCRIPTION
Pass the iterator of converted logs directly into from_parts in FoundryReceiptEnvelope::convert_logs_rpc, eliminating the intermediate Vec allocation while keeping behavior identical.