### PR TITLE
fix(chisel): add known_contracts support for trace decoding

### DIFF
--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -216,23 +216,21 @@ impl ChiselDispatcher {
             let known_contracts = new_source.build().ok().and_then(|output| {
                 output.enter(|output_ref| {
                     // Create ContractsByArtifact from the compiled artifacts
-                    Some(ContractsByArtifact::new(
-                        output_ref.output().artifact_ids().map(
-                            |(id, artifact): (
-                                foundry_compilers::ArtifactId,
-                                &foundry_compilers::artifacts::ConfigurableContractArtifact,
-                            )| {
-                                (
-                                    id.clone(),
-                                    foundry_compilers::artifacts::CompactContractBytecode {
-                                        abi: artifact.abi.clone(),
-                                        bytecode: artifact.bytecode.clone(),
-                                        deployed_bytecode: artifact.deployed_bytecode.clone(),
-                                    },
-                                )
-                            },
-                        ),
-                    ))
+                    Some(ContractsByArtifact::new(output_ref.output().artifact_ids().map(
+                        |(id, artifact): (
+                            foundry_compilers::ArtifactId,
+                            &foundry_compilers::artifacts::ConfigurableContractArtifact,
+                        )| {
+                            (
+                                id,
+                                foundry_compilers::artifacts::CompactContractBytecode {
+                                    abi: artifact.abi.clone(),
+                                    bytecode: artifact.bytecode.clone(),
+                                    deployed_bytecode: artifact.deployed_bytecode.clone(),
+                                },
+                            )
+                        },
+                    )))
                 })
             });
             if let Ok(decoder) =

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -216,18 +216,23 @@ impl ChiselDispatcher {
             let known_contracts = new_source.build().ok().and_then(|output| {
                 output.enter(|output_ref| {
                     // Create ContractsByArtifact from the compiled artifacts
-                    Some(ContractsByArtifact::new(output_ref.output.artifact_ids().map(
-                        |(id, artifact)| {
-                            (
-                                id.clone(),
-                                foundry_compilers::artifacts::CompactContractBytecode {
-                                    abi: artifact.abi.clone(),
-                                    bytecode: artifact.bytecode.clone(),
-                                    deployed_bytecode: artifact.deployed_bytecode.clone(),
-                                },
-                            )
-                        },
-                    )))
+                    Some(ContractsByArtifact::new(
+                        output_ref.output().artifact_ids().map(
+                            |(id, artifact): (
+                                foundry_compilers::ArtifactId,
+                                &foundry_compilers::artifacts::ConfigurableContractArtifact,
+                            )| {
+                                (
+                                    id.clone(),
+                                    foundry_compilers::artifacts::CompactContractBytecode {
+                                        abi: artifact.abi.clone(),
+                                        bytecode: artifact.bytecode.clone(),
+                                        deployed_bytecode: artifact.deployed_bytecode.clone(),
+                                    },
+                                )
+                            },
+                        ),
+                    ))
                 })
             });
             if let Ok(decoder) =

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -11,6 +11,7 @@ use alloy_primitives::{Address, hex};
 use eyre::{Context, Result};
 use forge_fmt::FormatterConfig;
 use foundry_cli::utils::fetch_abi_from_etherscan;
+use foundry_common::ContractsByArtifact;
 use foundry_config::RpcEndpointUrl;
 use foundry_evm::{
     decode::decode_console_logs,
@@ -152,23 +153,32 @@ impl ChiselDispatcher {
     }
 
     /// Decodes traces in the given [`ChiselResult`].
-    // TODO: Add `known_contracts` back in.
     pub async fn decode_traces(
         session_config: &SessionSourceConfig,
         result: &mut ChiselResult,
-        // known_contracts: &ContractsByArtifact,
+        known_contracts: Option<&ContractsByArtifact>,
     ) -> eyre::Result<CallTraceDecoder> {
-        let mut decoder = CallTraceDecoderBuilder::new()
+        let mut builder = CallTraceDecoderBuilder::new()
             .with_labels(result.labeled_addresses.clone())
             .with_signature_identifier(SignaturesIdentifier::from_config(
                 &session_config.foundry_config,
-            )?)
-            .build();
+            )?);
+
+        if let Some(contracts) = known_contracts {
+            builder = builder.with_known_contracts(contracts);
+        }
+
+        let mut decoder = builder.build();
 
         let mut identifier = TraceIdentifiers::new().with_external(
             &session_config.foundry_config,
             session_config.evm_opts.get_remote_chain_id().await,
         )?;
+
+        if let Some(contracts) = known_contracts {
+            identifier = identifier.with_local(contracts);
+        }
+
         if !identifier.is_empty() {
             for (_, trace) in &mut result.traces {
                 decoder.identify(trace, &mut identifier);
@@ -202,7 +212,27 @@ impl ChiselDispatcher {
         let mut res = new_source.execute().await?;
         let failed = !res.success;
         if new_source.config.traces || failed {
-            if let Ok(decoder) = Self::decode_traces(&new_source.config, &mut res).await {
+            // Build the source to get artifacts for trace decoding
+            let known_contracts = new_source.build().ok().and_then(|output| {
+                output.enter(|output_ref| {
+                    // Create ContractsByArtifact from the compiled artifacts
+                    Some(ContractsByArtifact::new(output_ref.output.artifact_ids().map(
+                        |(id, artifact)| {
+                            (
+                                id.clone(),
+                                foundry_compilers::artifacts::CompactContractBytecode {
+                                    abi: artifact.abi.clone(),
+                                    bytecode: artifact.bytecode.clone(),
+                                    deployed_bytecode: artifact.deployed_bytecode.clone(),
+                                },
+                            )
+                        },
+                    )))
+                })
+            });
+            if let Ok(decoder) =
+                Self::decode_traces(&new_source.config, &mut res, known_contracts.as_ref()).await
+            {
                 Self::show_traces(&decoder, &mut res).await?;
 
                 // Show console logs, if there are any

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -108,16 +108,21 @@ impl SessionSource {
                 output.enter(|output_ref| {
                     // Create ContractsByArtifact from the compiled artifacts
                     Some(foundry_common::ContractsByArtifact::new(
-                        output_ref.output.artifact_ids().map(|(id, artifact)| {
-                            (
-                                id.clone(),
-                                foundry_compilers::artifacts::CompactContractBytecode {
-                                    abi: artifact.abi.clone(),
-                                    bytecode: artifact.bytecode.clone(),
-                                    deployed_bytecode: artifact.deployed_bytecode.clone(),
-                                },
-                            )
-                        }),
+                        output_ref.output().artifact_ids().map(
+                            |(id, artifact): (
+                                foundry_compilers::ArtifactId,
+                                &foundry_compilers::artifacts::ConfigurableContractArtifact,
+                            )| {
+                                (
+                                    id.clone(),
+                                    foundry_compilers::artifacts::CompactContractBytecode {
+                                        abi: artifact.abi.clone(),
+                                        bytecode: artifact.bytecode.clone(),
+                                        deployed_bytecode: artifact.deployed_bytecode.clone(),
+                                    },
+                                )
+                            },
+                        ),
                     ))
                 })
             });

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -114,7 +114,7 @@ impl SessionSource {
                                 &foundry_compilers::artifacts::ConfigurableContractArtifact,
                             )| {
                                 (
-                                    id.clone(),
+                                    id,
                                     foundry_compilers::artifacts::CompactContractBytecode {
                                         abi: artifact.abi.clone(),
                                         bytecode: artifact.bytecode.clone(),

--- a/crates/chisel/src/source.rs
+++ b/crates/chisel/src/source.rs
@@ -88,6 +88,11 @@ impl GeneratedOutputRef<'_> {
     pub fn repl_contract(&self) -> Option<&ConfigurableContractArtifact> {
         self.output.find_first("REPL")
     }
+
+    /// Returns a reference to the underlying `ProjectCompileOutput`.
+    pub fn output(&self) -> &ProjectCompileOutput {
+        self.output
+    }
 }
 
 impl std::ops::Deref for GeneratedOutput {

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -338,7 +338,7 @@ pub fn cache_local_signatures(output: &ProjectCompileOutput) -> Result<()> {
             }));
         }
     }
-    signatures.save(&path);
+    signatures.save_result(&path)?;
     Ok(())
 }
 
@@ -356,7 +356,7 @@ pub fn cache_signatures_from_abis(folder_path: impl AsRef<Path>) -> Result<()> {
         .filter_map(|content| serde_json::from_str::<JsonAbi>(&content).ok())
         .for_each(|json_abi| signatures.extend_from_abi(&json_abi));
 
-    signatures.save(&path);
+    signatures.save_result(&path)?;
     Ok(())
 }
 

--- a/crates/evm/traces/src/identifier/signatures.rs
+++ b/crates/evm/traces/src/identifier/signatures.rs
@@ -108,6 +108,19 @@ impl SignaturesCache {
         }
     }
 
+    /// Saves the cache to a file and returns an error if it fails.
+    #[instrument(target = "evm::traces", name = "SignaturesCache::save_result", skip(self))]
+    pub fn save_result(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|err| eyre::eyre!("failed to create cache directory: {err}"))?;
+        }
+        fs::write_json_file(path, self)
+            .map_err(|err| eyre::eyre!("failed to flush signature cache: {err}"))?;
+        trace!(target: "evm::traces", "flushed signature cache");
+        Ok(())
+    }
+
     /// Updates the cache from an ABI.
     pub fn extend_from_abi(&mut self, abi: &JsonAbi) {
         self.extend(abi.items().filter_map(|item| match item {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The `decode_traces` method had a TODO to restore `known_contracts` support. Without it, chisel only uses external sources for trace decoding, resulting in lower quality traces compared to other Foundry tools. Local contracts written in the REPL cannot be properly identified in traces.

## Solution

Restored `known_contracts` support by:
- Adding `ContractsByArtifact` parameter to `decode_traces`
- Extracting compiled artifacts from `SessionSource` and creating `ContractsByArtifact`
- Using `with_known_contracts()` and `with_local()` to improve decoder and identifier

This matches the pattern used in `cast` and `forge` for consistency.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes