### PR TITLE
feat(cast): add eip7594 support

### DIFF
--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -313,8 +313,8 @@ pub struct CastTxBuilder<P, S> {
     /// Whether the transaction should be sent as a legacy transaction.
     legacy: bool,
     blob: bool,
-    /// Whether the blob transaction should use EIP-7594 format instead of EIP-4844.
-    peerdas: bool,
+    /// Whether the blob transaction should use EIP-4844 (legacy) format instead of EIP-7594.
+    eip4844: bool,
     auth: Vec<CliAuthorizationList>,
     chain: Chain,
     etherscan_api_key: Option<String>,
@@ -375,7 +375,7 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InitState> {
             tx,
             legacy,
             blob: tx_opts.blob,
-            peerdas: tx_opts.peerdas,
+            eip4844: tx_opts.eip4844,
             chain,
             etherscan_api_key,
             auth: tx_opts.auth,
@@ -392,7 +392,7 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InitState> {
             tx: self.tx,
             legacy: self.legacy,
             blob: self.blob,
-            peerdas: self.peerdas,
+            eip4844: self.eip4844,
             chain: self.chain,
             etherscan_api_key: self.etherscan_api_key,
             auth: self.auth,
@@ -449,7 +449,7 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, ToState> {
             tx: self.tx,
             legacy: self.legacy,
             blob: self.blob,
-            peerdas: self.peerdas,
+            eip4844: self.eip4844,
             chain: self.chain,
             etherscan_api_key: self.etherscan_api_key,
             auth: self.auth,
@@ -674,12 +674,12 @@ where
         let mut coder = SidecarBuilder::<SimpleCoder>::default();
         coder.ingest(&blob_data);
 
-        if self.peerdas {
-            let sidecar = coder.build_7594()?;
-            self.tx.set_blob_sidecar_7594(sidecar);
-        } else {
+        if self.eip4844 {
             let sidecar = coder.build()?;
             alloy_network::TransactionBuilder4844::set_blob_sidecar(&mut self.tx, sidecar);
+        } else {
+            let sidecar = coder.build_7594()?;
+            self.tx.set_blob_sidecar_7594(sidecar);
         }
 
         self.tx.populate_blob_hashes();

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -4344,7 +4344,7 @@ casttest!(cast_mktx_negative_numbers, |_prj, cmd| {
     .assert_success();
 });
 
-// Test cast mktx with EIP-4844 blob transaction
+// Test cast mktx with EIP-4844 blob transaction (legacy format)
 casttest!(cast_mktx_eip4844_blob, |prj, cmd| {
     // Create a temporary blob data file
     let blob_data = b"dummy blob data for testing";
@@ -4366,6 +4366,7 @@ casttest!(cast_mktx_eip4844_blob, |prj, cmd| {
         "--priority-gas-price",
         "1000000000",
         "--blob",
+        "--eip4844",
         "--blob-gas-price",
         "1000000",
         "--path",
@@ -4375,7 +4376,7 @@ casttest!(cast_mktx_eip4844_blob, |prj, cmd| {
     .assert_success();
 });
 
-// Test cast mktx with EIP-7594 blob transaction
+// Test cast mktx with EIP-7594 blob transaction (default format)
 casttest!(cast_mktx_eip7594_blob, |prj, cmd| {
     // Create a temporary blob data file
     let blob_data = b"dummy peerdas blob data for testing";
@@ -4397,7 +4398,6 @@ casttest!(cast_mktx_eip7594_blob, |prj, cmd| {
         "--priority-gas-price",
         "1000000000",
         "--blob",
-        "--peerdas",
         "--blob-gas-price",
         "1000000",
         "--path",

--- a/crates/cli/src/opts/transaction.rs
+++ b/crates/cli/src/opts/transaction.rs
@@ -77,19 +77,18 @@ pub struct TransactionOpts {
     #[arg(long)]
     pub legacy: bool,
 
-    /// Send a EIP-4844 blob transaction.
+    /// Send a blob transaction using EIP-7594 (PeerDAS) format.
     ///
-    /// Note: This is the current default blob variant. After the Fusaka hardfork,
-    /// EIP-7594 (PeerDAS) will become the default blob variant.
+    /// Note: Use with `--eip4844` for the legacy EIP-4844 format.
     #[arg(long, conflicts_with = "legacy")]
     pub blob: bool,
 
-    /// Send a blob transaction using EIP-7594 format instead of EIP-4844. Must be used with
-    /// `--blob`.
-    #[arg(long, conflicts_with = "legacy", requires = "blob", alias = "eip7594")]
-    pub peerdas: bool,
+    /// Send a blob transaction using EIP-4844 (legacy) format instead of EIP-7594. Must be used
+    /// with `--blob`.
+    #[arg(long, conflicts_with = "legacy", requires = "blob")]
+    pub eip4844: bool,
 
-    /// Gas price for EIP-4844/EIP-7594 blob transaction.
+    /// Gas price for EIP-7594/EIP-4844 blob transaction.
     #[arg(long, conflicts_with = "legacy", value_parser = parse_ether_value, env = "ETH_BLOB_GAS_PRICE", value_name = "BLOB_PRICE")]
     pub blob_gas_price: Option<U256>,
 


### PR DESCRIPTION
## Motivation

Close #12449 

## Solution

- Added support for EIP-7594 (PeerDAS) in transaction handling, allowing users to specify the new blob format.
- Added tests for both EIP-4844 and EIP-7594 blob transactions in the CLI.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes (no, since eip7594 format is not the default one yet)
