### PR TITLE
Simplify `maybe_predeploy_contract` by removing redundant flag

### DIFF
--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -200,20 +200,17 @@ fn find_mismatch_in_settings(
 pub fn maybe_predeploy_contract(
     creation_data: Result<ContractCreationData, EtherscanError>,
 ) -> Result<(Option<ContractCreationData>, bool), eyre::ErrReport> {
-    let mut maybe_predeploy = false;
-    match creation_data {
-        Ok(creation_data) => Ok((Some(creation_data), maybe_predeploy)),
+        match creation_data {
+        Ok(creation_data) => Ok((Some(creation_data), false)),
         // Ref: https://explorer.mode.network/api?module=contract&action=getcontractcreation&contractaddresses=0xC0d3c0d3c0D3c0d3C0D3c0D3C0d3C0D3C0D30010
         Err(EtherscanError::EmptyResult { status, message })
             if status == "1" && message == "OK" =>
         {
-            maybe_predeploy = true;
-            Ok((None, maybe_predeploy))
+            Ok((None, true))
         }
         // Ref: https://api.basescan.org/api?module=contract&action=getcontractcreation&contractaddresses=0xC0d3c0d3c0D3c0d3C0D3c0D3C0d3C0D3C0D30010&apiKey=YourAPIKey
         Err(EtherscanError::Serde { error: _, content }) if content.contains("GENESIS") => {
-            maybe_predeploy = true;
-            Ok((None, maybe_predeploy))
+            Ok((None, true))
         }
         Err(e) => eyre::bail!("Error fetching creation data from verifier-url: {:?}", e),
     }


### PR DESCRIPTION

This PR removes an unnecessary mutable `maybe_predeploy` variable in `crates/verify/src/utils.rs` by returning `true/false` directly from each `match` branch.

- No behavior change (pure refactor)
- Reduces dead/duplicated state and improves readability