### PR TITLE
fix: wrong error message in cache write

### DIFF
--- a/crates/anvil/src/eth/backend/mem/cache.rs
+++ b/crates/anvil/src/eth/backend/mem/cache.rs
@@ -68,7 +68,7 @@ impl DiskStateCache {
                         trace!(target: "backend", ?hash, "wrote state json file");
                     }
                     Err(err) => {
-                        error!(target: "backend", %err, ?hash, "Failed to load state snapshot");
+                        error!(target: "backend", %err, ?hash, "Failed to write state snapshot");
                     }
                 };
             });


### PR DESCRIPTION
Was debugging a disk cache issue and got this in my logs:

```
[2026-01-12T10:23:45Z TRACE backend] created disk state cache dir path="/tmp/anvil-state-12-01-2026-10-23"
[2026-01-12T10:23:45Z TRACE backend] wrote state json file hash=0xabcd...
[2026-01-12T10:23:46Z ERROR backend] Failed to load state snapshot hash=0xef01... err="Permission denied (os error 13)"
```

Spent way too long checking the read path because the error said "Failed to load", but the actual problem was the write failing due to permissions. Then I checked the code and realized line 71 in the write function just copied the error message from the read function below it. Changed it to say "Failed to write" so it actually matches what's happening.