### PR TITLE
refactor: remove code duplication in `locked_read_to_string`

### DIFF
--- a/crates/common/src/fs.rs
+++ b/crates/common/src/fs.rs
@@ -62,11 +62,7 @@ pub fn read_json_gzip_file<T: DeserializeOwned>(path: &Path) -> Result<T> {
 /// Reads the entire contents of a locked shared file into a string.
 pub fn locked_read_to_string(path: impl AsRef<Path>) -> Result<String> {
     let path = path.as_ref();
-    let mut file =
-        fs::OpenOptions::new().read(true).open(path).map_err(|err| FsPathError::open(err, path))?;
-    file.lock_shared().map_err(|err| FsPathError::lock(err, path))?;
-    let contents = read_inner(path, &mut file)?;
-    file.unlock().map_err(|err| FsPathError::unlock(err, path))?;
+    let contents = locked_read(path)?;
     String::from_utf8(contents).map_err(|err| FsPathError::read(std::io::Error::other(err), path))
 }
 


### PR DESCRIPTION
The `locked_read_to_string` function duplicated the entire file locking and reading logic from `locked_read`, differing only in the final UTF-8 conversion step. This code duplication increases maintenance burden and risk of divergence between the two functions when changes are made to the file locking logic.

Refactor `locked_read_to_string` to delegate the file reading logic to `locked_read`, making it a thin wrapper that only handles UTF-8 conversion. This eliminates code duplication while maintaining identical behavior.

