### PR TITLE
chore: remove TODO comment from Safety enum

### DIFF
--- a/crates/cheatcodes/spec/src/cheatcode.rs
+++ b/crates/cheatcodes/spec/src/cheatcode.rs
@@ -166,7 +166,6 @@ impl Group {
     }
 }
 
-// TODO: Find a better name for this
 /// Cheatcode safety.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]


### PR DESCRIPTION
### Motivation
The TODO comment about finding a better name for Safety was misleading. The current name is clear in context, well-documented, and part of the stable public API. Renaming would be a breaking change with no clear benefit.
### Solution
Remove the TODO comment. The Safety enum name is acceptable and the context is clear from documentation.