### PR TITLE
fix(anvil): add missing optional EIP features to revm dependency

### DIFF
--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -20,6 +20,9 @@ revm = { workspace = true, default-features = false, features = [
     "std",
     "serde",
     "memory_limit",
+    "optional_eip3607",
+    "optional_block_gas_limit",
+    "optional_no_base_fee",
     "c-kzg",
 ] }
 


### PR DESCRIPTION
Was debugging fuzz test failures and found that anvil-core is missing optional_eip3607, optional_block_gas_limit, and optional_no_base_fee features on revm.

All other evm crates already have these features, just missed in anvil-core.