### PR TITLE
chore(celo): awkward error message in transfer precompile

### DIFF
--- a/crates/evm/networks/src/celo/transfer.rs
+++ b/crates/evm/networks/src/celo/transfer.rs
@@ -73,7 +73,7 @@ pub fn celo_transfer_precompile(mut input: PrecompileInput<'_>) -> PrecompileRes
         Ok(account) => account,
         Err(e) => {
             return Err(PrecompileError::Other(
-                format!("Failed to load from account: {e:?}").into(),
+                format!("Failed to load sender account: {e:?}").into(),
             ));
         }
     };
@@ -86,7 +86,9 @@ pub fn celo_transfer_precompile(mut input: PrecompileInput<'_>) -> PrecompileRes
     let to_account = match internals.load_account(to_address) {
         Ok(account) => account,
         Err(e) => {
-            return Err(PrecompileError::Other(format!("Failed to load to account: {e:?}").into()));
+            return Err(PrecompileError::Other(
+                format!("Failed to load recipient account: {e:?}").into(),
+            ));
         }
     };
 


### PR DESCRIPTION
Improved the error messages for account loading failures in the Celo transfer precompile, replacing "from/to account" with "sender/recipient account" to resolve grammatical ambiguity.