### PR TITLE
chore(evm): misleading error message in traces serialization

### DIFF
--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -204,7 +204,7 @@ pub fn render_trace_arena_inner(
     with_storage_changes: bool,
 ) -> String {
     if shell::is_json() {
-        return serde_json::to_string(&arena.resolve_arena()).expect("Failed to write traces");
+        return serde_json::to_string(&arena.resolve_arena()).expect("Failed to serialize traces");
     }
 
     let mut w = TraceWriter::new(Vec::<u8>::new())


### PR DESCRIPTION
Corrected an error message in `render_trace_arena_inner` where `serde_json::to_string` failure was reported as "Failed to write traces". Changed to "Failed to serialize traces" to accurately reflect that this is a serialization operation, not an I/O write operation.