### PR TITLE
refactor: remove 'static bound from ResponseResult::success

### DIFF
--- a/crates/anvil/rpc/src/response.rs
+++ b/crates/anvil/rpc/src/response.rs
@@ -45,7 +45,7 @@ pub enum ResponseResult {
 impl ResponseResult {
     pub fn success<S>(content: S) -> Self
     where
-        S: Serialize + 'static,
+        S: Serialize,
     {
         Self::Success(serde_json::to_value(&content).unwrap())
     }


### PR DESCRIPTION
Removed the unnecessary `'static` bound from ResponseResult::success. The value is serialized immediately and never stored, so the lifetime constraint does not contribute to safety or behavior, but it does unnecessarily restrict the set of types that can be used.