### PR TITLE
fix(invariant): preserve state across calls during replay

### DIFF
--- a/crates/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/evm/evm/src/executors/invariant/replay.rs
@@ -36,10 +36,13 @@ pub fn replay_run(
 
     // Replay each call from the sequence, collect logs, traces and coverage.
     for tx in inputs {
-        let call_result = execute_tx(&mut executor, tx)?;
-        logs.extend(call_result.logs);
+        let mut call_result = execute_tx(&mut executor, tx)?;
+        logs.extend(call_result.logs.clone());
         traces.push((TraceKind::Execution, call_result.traces.clone().unwrap()));
-        HitMaps::merge_opt(line_coverage, call_result.line_coverage);
+        HitMaps::merge_opt(line_coverage, call_result.line_coverage.clone());
+
+        // Commit state changes to persist across calls in the sequence.
+        executor.commit(&mut call_result);
 
         // Identify newly generated contracts, if they exist.
         ided_contracts

--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -1615,3 +1615,60 @@ Ran 1 test for test/HandlerWarpAndRoll.t.sol:HandlerWarpAndRoll
 
 "#]]);
 });
+
+// Test that state is preserved across calls during invariant replay.
+// Regression test for commit 0584a581b which changed replay_run to use execute_tx
+// (which uses call_raw) instead of transact_raw, but forgot to add the commit() call.
+forgetest_init!(invariant_replay_state_preserved, |prj, cmd| {
+    prj.update_config(|config| {
+        config.fuzz.seed = Some(U256::from(123u32));
+        config.invariant.runs = 1;
+        config.invariant.depth = 5;
+    });
+
+    prj.add_test(
+        "InvariantReplayState.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract Handler is Test {
+    uint256 public counter;
+
+    function increment(uint256 amount) public {
+        amount = bound(amount, 1, 100);
+        uint256 before = counter;
+        counter += amount;
+        console.log("before:", before, "after:", counter);
+    }
+}
+
+contract InvariantReplayStateTest is Test {
+    Handler handler;
+
+    function setUp() public {
+        handler = new Handler();
+        targetContract(address(handler));
+    }
+
+    function invariant_counter_increases() public view {
+        assertTrue(true);
+    }
+}
+"#,
+    );
+
+    // With -vvv we see logs from replay. The "before" value of each call should
+    // match the "after" value from the previous call, proving state persists.
+    cmd.args(["test", "-vvv"]).assert_success().stdout_eq(str![[r#"
+...
+[PASS] invariant_counter_increases() (runs: 1, calls: 5, reverts: 0)
+...
+Logs:
+  before: 0 after: 38
+  before: 38 after: 86
+  before: 86 after: 87
+  before: 87 after: 172
+  before: 172 after: 272
+...
+"#]]);
+});


### PR DESCRIPTION
## Summary

Fixes a regression introduced in commit 0584a581b (`feat(forge): warp and roll on invariant tx`) where state was not being preserved between handler calls during invariant test replay.

## Problem

The commit refactored `replay_run` to use `execute_tx` (which internally uses `call_raw`) instead of `transact_raw`. However, `call_raw` does not commit state changes, while `transact_raw` does automatically.

The main invariant execution loop correctly calls `executor.commit(&mut call_result)` after `execute_tx`, but this was missing in `replay_run`.

This caused:
- State to reset between handler calls during replay
- Incorrect traces/logs that didn't match actual test execution
- `console.log` output showing wrong values (e.g., balance always starting from initial value instead of accumulating)

## Solution

Add `executor.commit(&mut call_result)` after each `execute_tx` call in `replay_run`, matching the pattern used in the main invariant execution loop and in `shrink_sequence`.

## Test

Added `invariant_replay_state_preserved` test that verifies state persists across calls by checking that `console.log` output shows accumulating values (each call's "before" value matches the previous call's "after" value).