### PR TITLE
fix(invariant): preserve state across calls during replay

### DIFF
--- a/crates/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/evm/evm/src/executors/invariant/replay.rs
@@ -36,10 +36,13 @@ pub fn replay_run(
 
     // Replay each call from the sequence, collect logs, traces and coverage.
     for tx in inputs {
-        let call_result = execute_tx(&mut executor, tx)?;
-        logs.extend(call_result.logs);
+        let mut call_result = execute_tx(&mut executor, tx)?;
+        logs.extend(call_result.logs.clone());
         traces.push((TraceKind::Execution, call_result.traces.clone().unwrap()));
-        HitMaps::merge_opt(line_coverage, call_result.line_coverage);
+        HitMaps::merge_opt(line_coverage, call_result.line_coverage.clone());
+
+        // Commit state changes to persist across calls in the sequence.
+        executor.commit(&mut call_result);
 
         // Identify newly generated contracts, if they exist.
         ided_contracts


### PR DESCRIPTION
## Summary

Fixes a regression introduced in commit 0584a581b (`feat(forge): warp and roll on invariant tx`) where state was not being preserved between handler calls during invariant test replay.

## Problem

The commit refactored `replay_run` to use `execute_tx` (which internally uses `call_raw`) instead of `transact_raw`. However, `call_raw` does not commit state changes, while `transact_raw` does automatically.

The main invariant execution loop correctly calls `executor.commit(&mut call_result)` after `execute_tx`, but this was missing in `replay_run`.

This caused:
- State to reset between handler calls during replay
- Incorrect traces/logs that didn't match actual test execution
- `console.log` output showing wrong values (e.g., balance always starting from initial value instead of accumulating)

## Solution

Add `executor.commit(&mut call_result)` after each `execute_tx` call in `replay_run`, matching the pattern used in the main invariant execution loop and in `shrink_sequence`.

## Test

Added `invariant_replay_state_preserved` test that verifies state persists across calls by checking that `console.log` output shows accumulating values (each call's "before" value matches the previous call's "after" value).