### PR TITLE
fix(preprocessor): mark getCode as view in VmContractHelper

### DIFF
--- a/crates/common/src/preprocessor/deps.rs
+++ b/crates/common/src/preprocessor/deps.rs
@@ -462,7 +462,7 @@ interface {vm_interface_name} {{
     function deployCode(string memory _artifact, uint256 _value, bytes32 _salt) external returns (address);
     function deployCode(string memory _artifact, bytes memory _args, uint256 _value) external returns (address);
     function deployCode(string memory _artifact, bytes memory _args, uint256 _value, bytes32 _salt) external returns (address);
-    function getCode(string memory _artifact) external returns (bytes memory);
+    function getCode(string memory _artifact) external view returns (bytes memory);
 }}"#
             ),
         ));


### PR DESCRIPTION
## Summary

When using `type(Contract).creationCode` in test files with `dynamic_test_linking = true`, Foundry transforms it to `VmContractHelper.getCode()`. The generated interface was missing the `view` modifier, which broke `view` function compatibility.

## Fix

Added `view` modifier to the `getCode` function in the generated `VmContractHelper` interface.

## Test

Added `preprocess_creation_code_in_view_function` test to verify `type(Contract).creationCode` works in `view` functions with dynamic linking.

Fixes #13086