### PR TITLE
refactor(cast): use centralized check for Tempo transactions

### DIFF
--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -497,8 +497,7 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InputState> {
 
     /// Returns whether this builder will produce a Tempo transaction.
     pub fn is_tempo(&self) -> bool {
-        // TODO: Replace this with `FoundryTransactionRequest::is_tempo`
-        self.tx.other.contains_key("feeToken") || self.tx.other.contains_key("nonceKey")
+        FoundryTransactionRequest::new(self.tx.clone()).is_tempo()
     }
 
     async fn _build(


### PR DESCRIPTION
Replace manual field checks with `FoundryTransactionRequest::is_tempo` in `cast`, correctly handling transactions with explicit Tempo type but no extra fields.