### PR TITLE
docs(anvil): remove redundant empty doc line in spawn function

### DIFF
--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -95,7 +95,6 @@ extern crate tracing;
 ///
 /// Panics if any error occurs. For a non-panicking version, use [`try_spawn`].
 ///
-///
 /// # Examples
 ///
 /// ```no_run


### PR DESCRIPTION
Removes an extraneous empty documentation line (///) in the spawn() function docstring in anvil/src/lib.rs.