### PR TITLE
docs: add beginner-friendly Foundry test example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,28 @@ If the answer is not there:
 - Join the [support Telegram][tg-support-url] to get help, or
 - Open an issue with [the bug](https://github.com/foundry-rs/foundry/issues/new)
 
+## Basic Foundry Test Example
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+
+contract CounterTest is Test {
+    uint256 public counter;
+
+    function setUp() public {
+        counter = 0;
+    }
+
+    function testIncrement() public {
+        counter += 1;
+        assertEq(counter, 1);
+    }
+}
+
+
 #### License
 
 <sup>


### PR DESCRIPTION
Adds a minimal Foundry test example to help new developers understand how to write and run basic Solidity tests using forge-std.
