### PR TITLE
chore: allow bincode unmaintained advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,8 @@ yanked = "warn"
 ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
     "RUSTSEC-2024-0436",
+    # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
+    "RUSTSEC-2025-0141",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Adds RUSTSEC-2025-0141 to the ignored advisories list in deny.toml.

bincode has been marked unmaintained due to the team ceasing development. Since v1.3.3 is considered complete and stable by its maintainers, this advisory can be safely ignored.

See: https://rustsec.org/advisories/RUSTSEC-2025-0141