### PR TITLE
fix(selectors): use consistent 0x prefix stripping in calldata methods

### DIFF
--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -251,7 +251,8 @@ impl OpenChainClient {
         offline: bool,
     ) -> eyre::Result<PossibleSigs> {
         let mut possible_info = PossibleSigs::new();
-        let calldata = calldata.as_ref().trim_start_matches("0x");
+        let calldata = calldata.as_ref();
+        let calldata = calldata.strip_prefix("0x").unwrap_or(calldata);
 
         let selector =
             calldata.get(..8).ok_or_else(|| eyre::eyre!("calldata cannot be less that 4 bytes"))?;


### PR DESCRIPTION

The `pretty_calldata` and `decode_calldata` methods in `OpenChainClient` were using different approaches to strip the `0x` prefix:
- `decode_calldata` used `strip_prefix("0x").unwrap_or(...)` (removes at most one prefix)
- `pretty_calldata` used `trim_start_matches("0x")` (removes all repeated prefixes)

This inconsistency could silently mask malformed input like `"0x0x..."` in one method while the other would handle it differently, leading to unpredictable behavior.

