### PR TITLE
fix(`forge-lint`): ignore compilation warnings in exit code

### DIFF
--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -1,5 +1,5 @@
 use forge_lint::{linter::Lint, sol::med::REGISTERED_LINTS};
-use foundry_config::{DenyLevel, LintSeverity, LinterConfig};
+use foundry_config::{DenyLevel, LintSeverity, LinterConfig, SolidityErrorCode};
 
 mod geiger;
 
@@ -786,6 +786,51 @@ fn ensure_no_privileged_lint_id() {
         assert_ne!(lint.id(), "all", "lint-id 'all' is reserved. Please use a different id");
     }
 }
+
+// <https://github.com/foundry-rs/foundry/issues/13107>
+forgetest!(dependency_warnings_do_not_affect_lint_exit_code, |prj, cmd| {
+    // Library with code that triggers a solc warning (unused local variable)
+    const LIB_WITH_WARNING: &str = r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library LibWithWarning {
+    function foo() internal pure returns (uint256) {
+        uint256 unusedVar = 42;
+        return 1;
+    }
+}
+"#;
+
+    // Clean contract that imports the library but has no lint issues
+    const CLEAN_CONTRACT: &str = r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { LibWithWarning } from "../lib/LibWithWarning.sol";
+
+contract CleanContract {
+    function bar() public pure returns (uint256) {
+        return LibWithWarning.foo();
+    }
+}
+"#;
+
+    prj.add_lib("LibWithWarning", LIB_WITH_WARNING);
+    prj.add_source("CleanContract", CLEAN_CONTRACT);
+
+    // Ignore the solc warning so compilation succeeds, but it still gets counted in diagnostics
+    prj.update_config(|config| {
+        config.ignored_error_codes = vec![SolidityErrorCode::UnusedLocalVariable];
+    });
+
+    // Clear cache to force recompilation during lint
+    prj.clear_cache();
+
+    // Lint with deny = notes via CLI flag.
+    // Should succeed because the linter only counts lint diagnostics, not build-phase warnings.
+    cmd.args(["lint", "-D", "notes"]).assert_success();
+});
 
 forgetest!(skips_linting_for_old_solidity_versions, |prj, cmd| {
     const OLD_CONTRACT: &str = r#"

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -232,6 +232,10 @@ impl<'a> Linter for SolidityLinter<'a> {
     ) -> eyre::Result<()> {
         convert_solar_errors(compiler.dcx())?;
 
+        // Cache diagnostic count before linting to isolate from the build phase.
+        let warn_count_before = compiler.dcx().warn_count();
+        let note_count_before = compiler.dcx().note_count();
+
         let ui_testing = std::env::var_os("FOUNDRY_LINT_UI_TESTING").is_some();
 
         let sm = compiler.sess().clone_source_map();
@@ -293,9 +297,11 @@ impl<'a> Linter for SolidityLinter<'a> {
             sess.reconfigure();
         }
 
-        // Handle diagnostics and fail if necessary.
+        let lint_warn_count = compiler.dcx().warn_count().saturating_sub(warn_count_before);
+        let lint_note_count = compiler.dcx().note_count().saturating_sub(note_count_before);
+
         const MSG: &str = "aborting due to ";
-        match (deny, compiler.dcx().warn_count(), compiler.dcx().note_count()) {
+        match (deny, lint_warn_count, lint_note_count) {
             // Deny warnings.
             (DenyLevel::Warnings, w, n) if w > 0 => {
                 if n > 0 {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

closes #13107 

## Solution

count the emitted diagnostics in the build phase, and only account for the delta when generating the exitcode

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
