### PR TITLE
fix(test): skip solady testSafeMoveETHViaMover in isolation mode

### DIFF
--- a/crates/forge/tests/cli/ext_integration.rs
+++ b/crates/forge/tests/cli/ext_integration.rs
@@ -64,7 +64,17 @@ fn sablier_v2_core() {
 // <https://github.com/Vectorized/solady>
 #[test]
 fn solady() {
-    ExtTester::new("Vectorized", "solady", "cbcfe0009477aa329574f17e8db0a05703bb8bdd").run();
+    let mut tester =
+        ExtTester::new("Vectorized", "solady", "cbcfe0009477aa329574f17e8db0a05703bb8bdd");
+
+    // This test expects the mover contract created via CREATE2 to be selfdestructed within the
+    // same transaction. In isolation mode, each top-level call runs as a separate transaction
+    // context, so the selfdestruct doesn't clear the code as expected by the test.
+    if cfg!(feature = "isolate-by-default") {
+        tester = tester.args(["--nmt", "testSafeMoveETHViaMover"]);
+    }
+
+    tester.run();
 }
 
 // <https://github.com/pcaversaccio/snekmate>


### PR DESCRIPTION
## Summary

Fixes #13147

The daily `test-isolate` workflow was failing because the solady `testSafeMoveETHViaMover` test doesn't work correctly in isolation mode.

## Problem

The `testSafeMoveETHViaMover` test in solady's SafeTransferLib tests:
1. Creates a "mover" contract via CREATE2
2. Calls the mover which selfdestructs after transferring ETH
3. Asserts the mover address returns `address(0)` (no code exists)

In isolation mode (`--features=isolate-by-default`), each top-level call runs as a separate transaction context via `transact_inner()`. This means the selfdestruct behavior differs:
- The mover contract is created in one inner transaction context
- But from the outer test's perspective, the code may still exist due to how isolation manages state

## Solution

Skip the `testSafeMoveETHViaMover` test when running in isolation mode, similar to how we handle other tests that have isolation-incompatible behavior (e.g., sablier's `test_RevertWhen_LoopCalculationOverflowsBlockGasLimit`).

## Test

This fix can be verified by running:
```bash
cargo nextest run --features=isolate-by-default -E 'package(=forge) & test(/\bext_integration/)' --no-fail-fast
```