### PR TITLE
fix(config): error on unknown profile with fallback for nested libs

### DIFF
--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -258,8 +258,9 @@ impl RemappingsProvider<'_> {
     }
 
     fn nested_foundry_remappings(&self, lib: &Path) -> Vec<Remapping> {
-        // load config, of the nested lib if it exists
-        let Ok(config) = Config::load_with_root(lib) else { return vec![] };
+        // load config of the nested lib if it exists, using fallback mode since libs may not
+        // define all profiles the main project uses
+        let Ok(config) = Config::load_with_root_and_fallback(lib) else { return vec![] };
         let config = config.sanitized();
 
         // if the configured _src_ directory is set to something that


### PR DESCRIPTION
## Summary

Fixes #12844 - `FOUNDRY_PROFILE=nonexistent` now properly fails with a clear error message instead of silently succeeding.

## Background

The original fix (#12946) was reverted (#12964) because it broke loading nested lib configs that don't define all profiles the main project uses (see #12963). The issue was that `from_figment` is called for both main project configs AND nested library configs during remapping resolution, and libraries may not define the same profiles as the main project.

## Solution

This fix introduces a two-tier approach:

1. **Strict validation for main project**: `Config::load()` and `Config::load_with_root()` fail if the selected profile doesn't exist
2. **Lenient fallback for nested libs**: New `Config::load_with_root_and_fallback()` falls back to default profile when the requested profile doesn't exist

The `nested_foundry_remappings()` function now uses the fallback variant, so libraries without the requested profile still work correctly.

## Changes

- Added `from_figment_inner(figment, strict_profile)` with configurable validation
- Added `from_figment_fallback()` for lenient profile handling
- Added `load_with_root_and_fallback()` public API for nested lib loading
- Updated `nested_foundry_remappings()` to use fallback mode

## Tests Added

- `fails_on_unknown_profile`: Verifies `FOUNDRY_PROFILE=nonexistent` fails
- `succeeds_on_known_profile`: Verifies defined profiles work correctly
- `nested_lib_config_falls_back_to_default_profile`: Verifies libs without the requested profile fall back to default
- `nested_lib_config_uses_profile_if_exists`: Verifies libs use the requested profile when available

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes