### PR TITLE
fix(config): warn on unknown keys in all config sections

### DIFF
--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -4,7 +4,31 @@ use figment::{
     value::{Dict, Map, Value},
 };
 use heck::ToSnakeCase;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Allowed keys for CompilationRestrictions.
+const COMPILATION_RESTRICTIONS_KEYS: &[&str] = &[
+    "paths",
+    "version",
+    "via_ir",
+    "bytecode_hash",
+    "min_optimizer_runs",
+    "optimizer_runs",
+    "max_optimizer_runs",
+    "min_evm_version",
+    "evm_version",
+    "max_evm_version",
+];
+
+/// Allowed keys for SettingsOverrides.
+const SETTINGS_OVERRIDES_KEYS: &[&str] =
+    &["name", "via_ir", "evm_version", "optimizer", "optimizer_runs", "bytecode_hash"];
+
+/// Reserved keys that should not trigger unknown key warnings.
+const RESERVED_KEYS: &[&str] = &["extends"];
+
+/// Keys kept for backward compatibility that should not trigger unknown key warnings.
+const BACKWARD_COMPATIBLE_KEYS: &[&str] = &["solc_version"];
 
 /// Generate warnings for unknown sections and deprecated keys
 pub struct WarningsProvider<P> {
@@ -84,9 +108,8 @@ impl<P: Provider> WarningsProvider<P> {
         if let Ok(default_map) = figment::providers::Serialized::defaults(&Config::default()).data()
             && let Some(default_dict) = default_map.get(&Config::DEFAULT_PROFILE)
         {
-            let allowed_keys: std::collections::BTreeSet<String> =
-                default_dict.keys().cloned().collect();
-            for profile_map in profiles {
+            let allowed_keys: BTreeSet<String> = default_dict.keys().cloned().collect();
+            for profile_map in profiles.clone() {
                 for (profile, value) in profile_map {
                     let Some(profile_dict) = value.as_dict() else {
                         continue;
@@ -103,8 +126,10 @@ impl<P: Provider> WarningsProvider<P> {
                             !DEPRECATIONS.iter().any(|(deprecated_key, _)| *deprecated_key == key);
                         let is_not_allowed = !allowed_keys.contains(key)
                             && !allowed_keys.contains(&key.to_snake_case());
-                        let is_not_reserved = key != "extends" && key != Self::WARNINGS_KEY;
-                        let is_not_backward_compatible = key != "solc_version";
+                        let is_not_reserved =
+                            !RESERVED_KEYS.contains(&key.as_str()) && key != Self::WARNINGS_KEY;
+                        let is_not_backward_compatible =
+                            !BACKWARD_COMPATIBLE_KEYS.contains(&key.as_str());
 
                         if is_not_deprecated
                             && is_not_allowed
@@ -118,11 +143,145 @@ impl<P: Provider> WarningsProvider<P> {
                             });
                         }
                     }
+
+                    // Add warning for unknown keys in nested sections within profiles.
+                    self.collect_nested_section_warnings(
+                        profile_dict,
+                        default_dict,
+                        &source,
+                        &mut out,
+                    );
                 }
             }
+
+            // Add warning for unknown keys in standalone sections.
+            self.collect_standalone_section_warnings(&data, default_dict, &mut out);
         }
 
         Ok(out)
+    }
+
+    /// Collects warnings for unknown keys in standalone sections like `[lint]`, `[fmt]`, etc.
+    fn collect_standalone_section_warnings(
+        &self,
+        data: &Map<Profile, Dict>,
+        default_dict: &Dict,
+        out: &mut Vec<Warning>,
+    ) {
+        let source = self
+            .provider
+            .metadata()
+            .source
+            .map(|s| s.to_string())
+            .unwrap_or(Config::FILE_NAME.to_string());
+
+        for section_name in Config::STANDALONE_SECTIONS {
+            // Get the section from the parsed data
+            let section_profile = Profile::new(section_name);
+            let Some(section_dict) = data.get(&section_profile) else {
+                continue;
+            };
+
+            // Get allowed keys for this section from the default config
+            let Some(default_section_value) = default_dict.get(*section_name) else {
+                continue;
+            };
+            let Some(default_section_dict) = default_section_value.as_dict() else {
+                continue;
+            };
+
+            let allowed_keys: BTreeSet<String> = default_section_dict.keys().cloned().collect();
+
+            for key in section_dict.keys() {
+                let is_not_allowed =
+                    !allowed_keys.contains(key) && !allowed_keys.contains(&key.to_snake_case());
+                if is_not_allowed {
+                    out.push(Warning::UnknownSectionKey {
+                        key: key.clone(),
+                        section: section_name.to_string(),
+                        source: source.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    /// Collects warnings for unknown keys in nested sections within profiles,
+    /// like `compilation_restrictions`.
+    fn collect_nested_section_warnings(
+        &self,
+        profile_dict: &Dict,
+        default_dict: &Dict,
+        source: &str,
+        out: &mut Vec<Warning>,
+    ) {
+        // Check nested sections that are dicts (like `lint`, `fmt` when defined in profile)
+        for (key, value) in profile_dict {
+            let Some(nested_dict) = value.as_dict() else {
+                // Also check arrays of dicts (like `compilation_restrictions`)
+                if let Some(arr) = value.as_array() {
+                    // Get allowed keys for known array item types
+                    let allowed_keys = Self::get_array_item_allowed_keys(key);
+
+                    if allowed_keys.is_empty() {
+                        continue;
+                    }
+
+                    for item in arr {
+                        let Some(item_dict) = item.as_dict() else {
+                            continue;
+                        };
+                        for item_key in item_dict.keys() {
+                            let is_not_allowed = !allowed_keys.contains(item_key)
+                                && !allowed_keys.contains(&item_key.to_snake_case());
+                            if is_not_allowed {
+                                out.push(Warning::UnknownSectionKey {
+                                    key: item_key.clone(),
+                                    section: key.clone(),
+                                    source: source.to_string(),
+                                });
+                            }
+                        }
+                    }
+                }
+                continue;
+            };
+
+            // Get allowed keys from the default config for this nested section
+            let Some(default_value) = default_dict.get(key) else {
+                continue;
+            };
+            let Some(default_nested_dict) = default_value.as_dict() else {
+                continue;
+            };
+
+            let allowed_keys: BTreeSet<String> = default_nested_dict.keys().cloned().collect();
+
+            for nested_key in nested_dict.keys() {
+                let is_not_allowed = !allowed_keys.contains(nested_key)
+                    && !allowed_keys.contains(&nested_key.to_snake_case());
+                if is_not_allowed {
+                    out.push(Warning::UnknownSectionKey {
+                        key: nested_key.clone(),
+                        section: key.clone(),
+                        source: source.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    /// Returns the allowed keys for array item types based on the section name.
+    fn get_array_item_allowed_keys(section_name: &str) -> BTreeSet<String> {
+        match section_name {
+            "compilation_restrictions" => {
+                COMPILATION_RESTRICTIONS_KEYS.iter().map(|s| s.to_string()).collect()
+            }
+            "additional_compiler_profiles" => {
+                SETTINGS_OVERRIDES_KEYS.iter().map(|s| s.to_string()).collect()
+            }
+            _ => BTreeSet::new(),
+        }
     }
 }
 

--- a/crates/config/src/warning.rs
+++ b/crates/config/src/warning.rs
@@ -55,6 +55,15 @@ pub enum Warning {
         /// The config file where the key was found
         source: String,
     },
+    /// An unknown key was encountered in a section in a TOML file
+    UnknownSectionKey {
+        /// The unknown key name
+        key: String,
+        /// The section where the key was found
+        section: String,
+        /// The config file where the key was found
+        source: String,
+    },
 }
 
 impl fmt::Display for Warning {
@@ -100,6 +109,12 @@ impl fmt::Display for Warning {
                 write!(
                     f,
                     "Found unknown `{key}` config for profile `{profile}` defined in {source}."
+                )
+            }
+            Self::UnknownSectionKey { key, section, source } => {
+                write!(
+                    f,
+                    "Found unknown `{key}` config key in section `{section}` defined in {source}."
                 )
             }
         }


### PR DESCRIPTION
## Motivation

Closes #12792

Previously, unknown keys in standalone sections like `[lint]`, `[fmt]`, `[fuzz]`, etc. and nested profile sections failed silently without any warning. This made it easy to misconfigure `foundry.toml` without noticing (e.g., using `version` instead of `solc_version`).

## Solution

This PR extends the warnings system to validate keys in:
- **Standalone sections**: `[lint]`, `[fmt]`, `[doc]`, `[fuzz]`, `[invariant]`, `[vyper]`, `[bind_json]`
- **Nested profile sections**: `[profile.default.lint]`, `[profile.default.fmt]`, etc.
- **Array item sections**: `compilation_restrictions`, `additional_compiler_profiles`

## Changes

- Add `UnknownSectionKey` warning variant for unknown keys in sections
- Extend `WarningsProvider` with:
  - `collect_standalone_section_warnings()` - validates keys in standalone sections
  - `collect_nested_section_warnings()` - validates keys in nested dict sections and arrays
- Add comprehensive test covering all 17 possible unknown key locations

## Example

With this change, the following config:
```toml
[lint]
unknown_key = true
severity = ["high"]
```

Will produce:
```
warning: Found unknown `unknown_key` config key in section `lint` defined in foundry.toml.
```