### PR TITLE
fix(forge): prevent gas underflow in delete operations on Cancun

### DIFF
--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -561,8 +561,9 @@ impl TestResult {
         reason: Option<String>,
         raw_call_result: RawCallResult,
     ) {
-        self.kind =
-            TestKind::Unit { gas: raw_call_result.gas_used.wrapping_sub(raw_call_result.stipend) };
+        self.kind = TestKind::Unit {
+            gas: raw_call_result.gas_used.saturating_sub(raw_call_result.stipend),
+        };
 
         extend!(self, raw_call_result, TraceKind::Execution);
 


### PR DESCRIPTION
Fixes a gas underflow issue that occurs when using `delete` operations within a `pauseGasMetering` block on the Cancun EVM version.

In Cancun, the reported gas usage can drop below the stipend due to the absence of the EIP-7702 gas floor (unlike in Prague). This previously triggered a wrapping subtraction panic in the test runner's gas calculation.

This PR replaces the wrapping subtraction with a saturating subtraction to correctly handle this scenario, ensuring that gas usage is reported as 0 rather than underflowing to a large integer.

Fixes https://github.com/foundry-rs/foundry/issues/12803

---

This is a clean version of https://github.com/foundry-rs/foundry/pull/12861 without the unrelated CI changes.

Co-authored-by: subwaycookiecrunch <185599332+subwaycookiecrunch@users.noreply.github.com>