### PR TITLE
fix(config): extract test and script paths from ProjectPathsConfig in _with_root()

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1853,6 +1853,8 @@ impl Config {
         // autodetect paths
         let paths = ProjectPathsConfig::builder().build_with_root::<()>(root);
         let artifacts: PathBuf = paths.artifacts.file_name().unwrap().into();
+        // All path fields (src, test, script, out) must be extracted from ProjectPathsConfig
+        // to maintain a single source of truth. See: https://github.com/foundry-rs/foundry/issues/10300
         Self {
             root: paths.root,
             src: paths.sources.file_name().unwrap().into(),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1856,6 +1856,8 @@ impl Config {
         Self {
             root: paths.root,
             src: paths.sources.file_name().unwrap().into(),
+            test: paths.tests.file_name().unwrap().into(),
+            script: paths.scripts.file_name().unwrap().into(),
             out: artifacts.clone(),
             libs: paths.libraries.into_iter().map(|lib| lib.file_name().unwrap().into()).collect(),
             remappings: paths


### PR DESCRIPTION
## Summary

Fixes #10300

## Problem

`Config::_with_root()` has an inconsistency in how it initializes path fields:

- `src` and `out` are extracted from `ProjectPathsConfig` (auto-detected by foundry-compilers)
- `test` and `script` fall through to `Self::default()` (hardcoded defaults)

This creates a leaky abstraction with two sources of truth for path defaults.

## Solution

Extract `test` and `script` from `ProjectPathsConfig` the same way `src` is extracted:

```rust
Self {
    root: paths.root,
    src: paths.sources.file_name().unwrap().into(),
    test: paths.tests.file_name().unwrap().into(),      // NEW
    script: paths.scripts.file_name().unwrap().into(),  // NEW
    out: artifacts.clone(),
    // ...
}
```

## Why this matters

This ensures **architectural consistency** - all path defaults now come from a single source (`ProjectPathsConfig`). If foundry-compilers ever adds auto-detection for test/script directories (like it does for src→contracts), Config will automatically inherit that behavior.

## Testing Note

A regression test is not included because `ProjectPathsConfig` and `Config::default()` currently use identical values for test/script (`"test"` and `"script"`), making it impossible to distinguish implementations via value comparison. The fix is self-documenting with an inline comment.