### PR TITLE
fix(`forge fmt`): fix incorrect indentation for chained struct calls

### DIFF
--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -83,8 +83,8 @@ impl CallStack {
         self.last().is_some_and(|call| call.is_nested())
     }
 
-    pub(crate) fn is_chain(&self) -> bool {
-        self.last().is_some_and(|call| call.is_chained())
+    pub(crate) fn has_chain(&self) -> bool {
+        self.stack.iter().any(|call| call.is_chained())
     }
 }
 

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1812,7 +1812,7 @@ impl<'ast> State<'_, 'ast> {
                 list_format
                     .break_cmnts()
                     .break_single(true)
-                    .without_ind(self.call_stack.is_chain())
+                    .without_ind(self.call_stack.has_chain())
                     .with_delimiters(!self.call_with_opts_and_args),
             );
         } else if self.config.bracket_spacing {

--- a/crates/fmt/testdata/Repros/fmt.sol
+++ b/crates/fmt/testdata/Repros/fmt.sol
@@ -393,3 +393,37 @@ contract WETHHook is BaseTokenWrapperHook {
         weth = WETH(payable(_weth));
     }
 }
+
+// https://github.com/foundry-rs/foundry/issues/12529
+library TransferMessageLib {
+    struct TransferMessage {
+        bytes32 sender;
+        address receiver;
+        address token;
+        uint256 amount;
+    }
+
+    function pack(TransferMessage memory m)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return "";
+    }
+}
+
+contract ChainedStructCall {
+    using TransferMessageLib for TransferMessageLib.TransferMessage;
+    bytes32 someBytes32Value;
+    address someAddressValue;
+    uint256 someUint256Value;
+
+    function test_chainedStructIndentation() public {
+        bytes memory payload = TransferMessageLib.TransferMessage({
+            sender: someBytes32Value,
+            receiver: someAddressValue,
+            token: someAddressValue,
+            amount: someUint256Value
+        }).pack();
+    }
+}

--- a/crates/fmt/testdata/Repros/original.sol
+++ b/crates/fmt/testdata/Repros/original.sol
@@ -405,3 +405,22 @@ contract WETHHook is BaseTokenWrapperHook {
         weth = WETH(payable(_weth));
     }
 }
+
+// https://github.com/foundry-rs/foundry/issues/12529
+library TransferMessageLib {
+    struct TransferMessage { bytes32 sender; address receiver; address token; uint256 amount; }
+    function pack(TransferMessage memory m) internal pure returns (bytes memory) { return ""; }
+}
+
+contract ChainedStructCall {
+    using TransferMessageLib for TransferMessageLib.TransferMessage;
+    bytes32 someBytes32Value;
+    address someAddressValue;
+    uint256 someUint256Value;
+
+    function test_chainedStructIndentation() public {
+        bytes memory payload = TransferMessageLib.TransferMessage({
+                sender: someBytes32Value, receiver: someAddressValue, token: someAddressValue, amount: someUint256Value
+            }).pack();
+    }
+}

--- a/crates/fmt/testdata/Repros/sorted.fmt.sol
+++ b/crates/fmt/testdata/Repros/sorted.fmt.sol
@@ -394,3 +394,37 @@ contract WETHHook is BaseTokenWrapperHook {
         weth = WETH(payable(_weth));
     }
 }
+
+// https://github.com/foundry-rs/foundry/issues/12529
+library TransferMessageLib {
+    struct TransferMessage {
+        bytes32 sender;
+        address receiver;
+        address token;
+        uint256 amount;
+    }
+
+    function pack(TransferMessage memory m)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return "";
+    }
+}
+
+contract ChainedStructCall {
+    using TransferMessageLib for TransferMessageLib.TransferMessage;
+    bytes32 someBytes32Value;
+    address someAddressValue;
+    uint256 someUint256Value;
+
+    function test_chainedStructIndentation() public {
+        bytes memory payload = TransferMessageLib.TransferMessage({
+            sender: someBytes32Value,
+            receiver: someAddressValue,
+            token: someAddressValue,
+            amount: someUint256Value
+        }).pack();
+    }
+}

--- a/crates/fmt/testdata/Repros/tab.fmt.sol
+++ b/crates/fmt/testdata/Repros/tab.fmt.sol
@@ -394,3 +394,37 @@ contract WETHHook is BaseTokenWrapperHook {
 		weth = WETH(payable(_weth));
 	}
 }
+
+// https://github.com/foundry-rs/foundry/issues/12529
+library TransferMessageLib {
+	struct TransferMessage {
+		bytes32 sender;
+		address receiver;
+		address token;
+		uint256 amount;
+	}
+
+	function pack(TransferMessage memory m)
+		internal
+		pure
+		returns (bytes memory)
+	{
+		return "";
+	}
+}
+
+contract ChainedStructCall {
+	using TransferMessageLib for TransferMessageLib.TransferMessage;
+	bytes32 someBytes32Value;
+	address someAddressValue;
+	uint256 someUint256Value;
+
+	function test_chainedStructIndentation() public {
+		bytes memory payload = TransferMessageLib.TransferMessage({
+			sender: someBytes32Value,
+			receiver: someAddressValue,
+			token: someAddressValue,
+			amount: someUint256Value
+		}).pack();
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #12529.

When a struct initialization like `TransferMessage({...})` is followed by a method call like `.pack()`, the formatter was adding double indentation to the struct's fields.

## Before

```solidity
return Lib.Msg({
        a: value1,
        b: value2,
        c: value3
    }).pack();
```

## After

```solidity
return Lib.Msg({
    a: value1,
    b: value2,
    c: value3
}).pack();
```

## Root Cause

When formatting a chained expression like `Struct({...}).method()`, the formatter's `print_member_or_call_chain` opens an `ibox(indent)` for the chain. Inside the struct call, `print_call_args` pushes a `Nested` context onto the call stack.

When `print_named_args` checked `call_stack.is_chain()`, it only looked at the **last** item on the stack (which was `Nested`), returning `false`. This caused `commasep` to add its own indentation box, resulting in double indentation.

## Fix

Replace `is_chain()` with a new `has_chain()` method that checks if **any** context in the call stack is a chain (using `iter().any()` instead of `last().is_some_and()`). This correctly detects when we're nested inside a chain and should skip the extra indentation.

## Evidence

The test added in this PR correctly fails without the fix:
- **PR with tests only (no fix):** #13164 → [CI failed as expected](https://github.com/foundry-rs/foundry/actions/runs/21180941907/job/60922814637)
- **This PR (tests + fix):** CI should pass

## Changes

- `crates/fmt/src/state/mod.rs`: Rename `is_chain()` to `has_chain()` and change implementation to check the entire stack
- `crates/fmt/src/state/sol.rs`: Update call site to use `has_chain()`  
- Added test case for issue #12529 to the Repros test suite