### PR TITLE
fix(cli): redirect tracing logs to stderr

### DIFF
--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -87,8 +87,6 @@ pub fn subscriber() {
     let registry = tracing_subscriber::Registry::default().with(env_filter());
     #[cfg(feature = "tracy")]
     let registry = registry.with(tracing_tracy::TracyLayer::default());
-    registry
-        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
     registry.with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr)).init()
 }
 


### PR DESCRIPTION
Fixes #13034
Tracing logs were going to stdout and breaking  `--show-standard-json-input` output, redirected them to stderr where they belong.