### PR TITLE
feat(verify): default to Blockscout for Tempo chains

### DIFF
--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -175,6 +175,16 @@ impl VerificationProviderType {
         has_url: bool,
     ) -> Result<Box<dyn VerificationProvider>> {
         let has_key = key.as_ref().is_some_and(|k| !k.is_empty());
+
+        // 0. For Tempo chains, default to Blockscout (no API key required).
+        if let Some(chain) = chain
+            && chain.is_tempo()
+            && !has_key
+            && self.is_sourcify()
+        {
+            return Ok(Box::<EtherscanVerificationProvider>::default());
+        }
+
         // 1. If no verifier or `--verifier sourcify` is set and no API key provided, use Sourcify.
         if !has_key && self.is_sourcify() {
             sh_println!(


### PR DESCRIPTION
## Summary

Tempo's contract verifier at `contracts.tempo.xyz` is Blockscout-compatible and doesn't require an API key. This makes verification work out of the box for Tempo chains without needing to explicitly specify `--verifier blockscout` or provide an API key.

## Changes

When the chain is detected as a Tempo chain (mainnet, testnet, or moderato) and no API key is provided, we now default to using the Etherscan/Blockscout verification provider which will use the etherscan URLs already configured in alloy-chains for Tempo.

## Before

Users had to run:
```bash
forge verify-contract --verifier blockscout --verifier-url https://contracts.tempo.xyz <address> <contract>
```

## After

Users can simply run:
```bash
forge verify-contract <address> <contract>
```

The chain's etherscan URLs from alloy-chains (`https://contracts.tempo.xyz`) will be used automatically.