### PR TITLE
fix(verify): use chain's etherscan API URL when no verifier-url specified

### DIFF
--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -267,7 +267,9 @@ impl EtherscanVerificationProvider {
             || (verifier_type.is_sourcify() && etherscan_key.is_some());
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
 
-        let etherscan_api_url = verifier_url.or(None).map(str::to_owned);
+        let etherscan_api_url = verifier_url
+            .or_else(|| chain.etherscan_urls().map(|(api, _)| api))
+            .map(str::to_owned);
 
         let api_url = etherscan_api_url.as_deref();
         let base_url = etherscan_config


### PR DESCRIPTION
## Summary

The `etherscan_api_url` was only set from the `--verifier-url` flag, never falling back to the chain's default etherscan API URL from `alloy-chains`. This caused verification to fail for chains that have URLs defined in `alloy-chains` but not in `foundry-block-explorers`.

## Bug

```rust
// Before (broken) - .or(None) is a no-op
let etherscan_api_url = verifier_url.or(None).map(str::to_owned);
```

The `base_url` (explorer URL) already had the correct fallback to `chain.etherscan_urls()`, but `api_url` was missing it.

## Fix

```rust
// After - falls back to chain's etherscan API URL
let etherscan_api_url = verifier_url
    .or_else(|| chain.etherscan_urls().map(|(api, _)| api))
    .map(str::to_owned);
```

## Testing

- Existing tests pass: `cargo test -p forge-verify -- can_extract_etherscan`