### PR TITLE
fix(doc): use relative paths for generated links

### DIFF
--- a/crates/doc/src/preprocessor/infer_hyperlinks.rs
+++ b/crates/doc/src/preprocessor/infer_hyperlinks.rs
@@ -96,7 +96,12 @@ impl InferInlineHyperlinks {
                             ));
                         }
                         // try to find the referenced item in the contract's children
-                        return Self::find_match(link, target_path, current_path, item.children.iter());
+                        return Self::find_match(
+                            link,
+                            target_path,
+                            current_path,
+                            item.children.iter(),
+                        );
                     }
                 }
                 ParseSource::Function(fun) => {

--- a/crates/doc/src/preprocessor/mod.rs
+++ b/crates/doc/src/preprocessor/mod.rs
@@ -11,7 +11,7 @@ mod inheritdoc;
 pub use inheritdoc::{INHERITDOC_ID, Inheritdoc};
 
 mod infer_hyperlinks;
-pub use infer_hyperlinks::{INFER_INLINE_HYPERLINKS_ID, InferInlineHyperlinks};
+pub use infer_hyperlinks::{INFER_INLINE_HYPERLINKS_ID, InferInlineHyperlinks, make_relative_link};
 
 mod git_source;
 pub use git_source::{GIT_SOURCE_ID, GitSource};

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -106,8 +106,7 @@ contract Derived is IBase {
     let content = std::fs::read_to_string(&doc_path).unwrap();
 
     assert!(
-        content.contains("[IBase](/src/IBase.sol/interface.IBase.md")
-            || content.contains("[IBase](\\src\\IBase.sol\\interface.IBase.md"),
+        content.contains("[IBase](../IBase.sol/interface.IBase.md)"),
         "Hyperlink should use relative path but found: {:?}",
         content.lines().find(|line| line.contains("[IBase]")).unwrap_or("not found")
     );


### PR DESCRIPTION
## Summary

Fixes #11677

This change addresses several issues with `forge doc` link generation:

### Changes

1. **Same-file function references**: Links like `{toEthSignedMessageHash}` now generate anchor-only links (`#toethsignedmessagehash`) instead of absolute paths like `/src/MultiContract.sol/library.ECDSA.md#toethsignedmessagehash`.

2. **Cross-contract references in same file**: `{ECDSA-tryRecover}` syntax now correctly resolves to the current document when the contract/function is defined in the same file, instead of searching external files first.

3. **Inheritance links**: Base contract links now use relative paths (`interface.IERC20.md` or `../Policy.sol/abstract.Policy.md`) instead of absolute paths (`/src/...`).

### Implementation

- Added `make_relative_link` helper function in `infer_hyperlinks.rs` that computes relative paths between documents
- Modified `InlineLinkTarget` to store both target and current paths, outputting anchor-only (`#...`) for same-file or relative paths for different files  
- Changed link resolution to search current document first, then fall back to external documents
- Updated inheritance link rendering in `as_doc.rs` to use relative paths

### Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Same-file function | `[toEthSignedMessageHash](/src/Foo.sol/library.ECDSA.md#...)` | `[toEthSignedMessageHash](#toethsignedmessagehash)` |
| Same-file `{Contract-function}` | Searched external files incorrectly | `[ECDSA-tryRecover](#tryrecover)` |
| Same-dir inheritance | `[IERC20](/src/Foo.sol/interface.IERC20.md)` | `[IERC20](interface.IERC20.md)` |
| Cross-dir inheritance | `[Policy](/src/Policy.sol/abstract.Policy.md)` | `[Policy](../Policy.sol/abstract.Policy.md)` |

### Testing

- Added unit test for `make_relative_link` function covering same-directory, cross-directory, and deeply nested paths
- All 19 existing tests pass