### PR TITLE
feat(docker): add semver major/minor floating tags on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,15 +65,24 @@ jobs:
       - name: Finalize Docker Metadata
         id: docker_tagging
         run: |
+          TAG="${{ inputs.tag_name }}"
+          REGISTRY="${{ env.REGISTRY }}"
+          IMAGE="${{ env.IMAGE_NAME }}"
+
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             printf "cron trigger, assigning nightly tag\n"
-            printf "docker_tags=%s/%s:nightly,%s/%s:nightly-%s\n" "${{ env.REGISTRY }}" "${{ env.IMAGE_NAME }}" "${{ env.REGISTRY }}" "${{ env.IMAGE_NAME }}" "$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+            printf "docker_tags=%s/%s:nightly,%s/%s:nightly-%s\n" "$REGISTRY" "$IMAGE" "$REGISTRY" "$IMAGE" "$GITHUB_SHA" >> "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_REF##*/}" == "main" ]] || [[ "${GITHUB_REF##*/}" == "master" ]]; then
             printf "manual trigger from master/main branch, assigning latest tag\n"
-            printf "docker_tags=%s/%s:%s,%s/%s:latest\n" "${{ env.REGISTRY }}" "${{ env.IMAGE_NAME }}" "${GITHUB_REF##*/}" "${{ env.REGISTRY }}" "${{ env.IMAGE_NAME }}" >> "$GITHUB_OUTPUT"
+            printf "docker_tags=%s/%s:%s,%s/%s:latest\n" "$REGISTRY" "$IMAGE" "${GITHUB_REF##*/}" "$REGISTRY" "$IMAGE" >> "$GITHUB_OUTPUT"
+          elif [[ "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            MAJOR="v${BASH_REMATCH[1]}"
+            MINOR="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+            printf "version tag release, assigning %s, %s, and %s tags\n" "$TAG" "$MINOR" "$MAJOR"
+            printf "docker_tags=%s/%s:%s,%s/%s:%s,%s/%s:%s\n" "$REGISTRY" "$IMAGE" "$TAG" "$REGISTRY" "$IMAGE" "$MINOR" "$REGISTRY" "$IMAGE" "$MAJOR" >> "$GITHUB_OUTPUT"
           else
             printf "Neither scheduled nor manual release from main branch. Just tagging as branch name\n"
-            printf "docker_tags=%s/%s:%s\n" "${{ env.REGISTRY }}" "${{ env.IMAGE_NAME }}" "${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
+            printf "docker_tags=%s/%s:%s\n" "$REGISTRY" "$IMAGE" "${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
           fi
 
       # Log docker metadata to explicitly know what is being pushed


### PR DESCRIPTION
Closes: https://github.com/foundry-rs/foundry/issues/12123

When publishing Docker images for version releases, this adds floating major and minor tags alongside the exact version tag.

For example, releasing `v1.2.3` now produces three tags:
- `ghcr.io/foundry-rs/foundry:v1.2.3` (exact version)
- `ghcr.io/foundry-rs/foundry:v1.2` (minor floating)
- `ghcr.io/foundry-rs/foundry:v1` (major floating)

This allows users to pin to a major or minor version and automatically receive patch updates.

## How it works

The regex `^v([0-9]+)\.([0-9]+)\.([0-9]+)$` captures semver components into `BASH_REMATCH`:

```bash
TAG="v1.2.3"
[[ "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]
# BASH_REMATCH[1] = "1" (major)
# BASH_REMATCH[2] = "2" (minor)
# BASH_REMATCH[3] = "3" (patch)
```

These are then used to construct the floating tags `v1` and `v1.2`.

## Pre-release handling

Release candidates (e.g., `v1.2.3-rc1`) are intentionally excluded by the `$` anchor in the regex, which requires the string to end after the patch number. RC tags only get their exact tag, ensuring the floating `v1` and `v1.2` tags continue pointing to the latest stable release.