### PR TITLE
fix(cheatcodes): fix expectRevert with internal reverts for non-contract calls

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1331,7 +1331,8 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
                         // (e.g., calls to non-contract addresses that return Stop).
                         //
                         // Only process if:
-                        // 1. It's not a cheatcode call, AND
+                        // 1. It's not a cheatcode call (unless internal_expect_revert is enabled
+                        //    and the cheatcode reverted), AND
                         // 2. Either the call reverted, OR we made an external call (max_depth >
                         //    depth), OR we're at the root call (depth 0)
                         //
@@ -1340,7 +1341,10 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
                         // Solidity-generated revert (from extcodesize/returndata check) from
                         // satisfying the expectation.
                         if cheatcode_call {
-                            false
+                            // For cheatcode calls, only process if internal_expect_revert is
+                            // enabled AND the cheatcode reverted. This allows catching cheatcode
+                            // reverts with expectRevert when the flag is set.
+                            self.config.internal_expect_revert && outcome.result.is_revert()
                         } else if outcome.result.is_revert() {
                             // Call reverted - should process
                             true

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1333,7 +1333,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
                         // Only process if:
                         // 1. It's not a cheatcode call, AND
                         // 2. Either the call reverted, OR we made an external call (max_depth >
-                        //    depth)
+                        //    depth), OR we're at the root call (depth 0)
                         //
                         // This fixes the bug where calling a non-contract address would consume
                         // the expectRevert even though the call succeeded, preventing the actual
@@ -1347,6 +1347,11 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
                         } else if expected_revert.max_depth > expected_revert.depth {
                             // Call succeeded but we went to a deeper depth (external call was made)
                             // This is the traditional expectRevert case
+                            true
+                        } else if curr_depth == 0 {
+                            // Root call (test function) ended - must process any pending
+                            // expectation to catch "dangling"
+                            // expectReverts
                             true
                         } else if !self.config.internal_expect_revert {
                             // Call succeeded, no deeper call was made, internal_expect_revert is

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1332,7 +1332,8 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
                         //
                         // Only process if:
                         // 1. It's not a cheatcode call, AND
-                        // 2. Either the call reverted, OR we made an external call (max_depth > depth)
+                        // 2. Either the call reverted, OR we made an external call (max_depth >
+                        //    depth)
                         //
                         // This fixes the bug where calling a non-contract address would consume
                         // the expectRevert even though the call succeeded, preventing the actual

--- a/testdata/default/repros/Issue11559.t.sol
+++ b/testdata/default/repros/Issue11559.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "utils/Test.sol";
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+}
+
+// https://github.com/foundry-rs/foundry/issues/11559
+contract Issue11559Test is Test {
+    // When allow_internal_expect_revert is enabled, expectRevert should work with calls to
+    // non-contract addresses. Solidity 0.8+ automatically reverts after calling an address
+    // with no code due to return data validation, and this revert should satisfy the expectation.
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testExpectRevertCallToNonContractAddress() public {
+        vm.expectRevert();
+        IERC20(address(0)).totalSupply();
+    }
+
+    // Same test but with a specific revert message check
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testExpectRevertCallToNonContractAddressWithMessage() public {
+        // The revert message is injected by the RevertDiagnostic inspector
+        vm.expectRevert("call to non-contract address 0x0000000000000000000000000000000000000000");
+        IERC20(address(0)).totalSupply();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #11559

When `allow_internal_expect_revert = true`, calling a non-contract address (e.g., `IERC20(address(0)).totalSupply()`) with `expectRevert` would fail with "next call did not revert as expected".

## Root Cause

The issue is that calls to addresses with no code return immediately with success (`Stop`), and the `expectRevert` was being consumed by this successful call. The actual revert happens afterward when Solidity's generated code checks the return data (or extcodesize) and reverts.

The sequence was:
1. `vm.expectRevert()` sets up the expectation at depth N
2. `IERC20(address(0)).totalSupply()` makes an external call to address(0)
3. The call returns `Stop` (success with no data) because there's no code
4. `call_end` is triggered, sees `curr_depth <= expected_revert.depth`, and consumes the expectation
5. The expectation fails because the call didn't revert
6. Solidity's code then reverts (too late - expectation already consumed)

## Fix

The fix modifies the `call_end` hook to only consume the `expectRevert` when:
1. The call actually reverted, OR
2. An external call was made (`max_depth > depth`), OR  
3. `internal_expect_revert` is disabled (maintaining backward compatibility)

When `internal_expect_revert` is enabled and a call succeeds without going deeper, the expectation is preserved, allowing the subsequent internal revert (from Solidity's code validation) to satisfy it.

## Test

Added `Issue11559.t.sol` in testdata/default/repros/ with test cases.
