### PR TITLE
perf(forge): skip external identifiers for local tests

### DIFF
--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -532,8 +532,9 @@ impl TestArgs {
         let mut identifier = TraceIdentifiers::new().with_local(&known_contracts);
 
         // Avoid using external identifiers for gas report as we decode more traces and this will be
-        // expensive.
-        if !self.gas_report {
+        // expensive. Also skip external identifiers for local tests (no remote chain) to avoid
+        // unnecessary Etherscan API calls that significantly slow down test execution.
+        if !self.gas_report && remote_chain.is_some() {
             identifier = identifier.with_external(&config, remote_chain)?;
         }
 


### PR DESCRIPTION
## Summary

When `ETHERSCAN_API_KEY` is set in `.env`, `forge test` was making HTTP requests to Etherscan for every contract address in test traces, even for purely local tests. This caused a **10x slowdown** (200ms → 5s).

## Root Cause

1. Config loads `ETHERSCAN_API_KEY` from `.env` via `EtherscanEnvProvider`
2. `TestArgs::run_tests` creates external trace identifiers by default (unless `--gas-report`)
3. `ExternalIdentifier::new` sees the API key → creates `EtherscanFetcher`
4. During trace decoding, every address triggers HTTP calls to Etherscan
5. Rate limits + timeouts cause massive slowdown

## Fix

Only enable external trace identifiers when actually forking from a remote chain, where looking up verified contract ABIs is useful. Local tests don't benefit from external lookups.

## Edge Case

Users running tests against a manually-forked local node (e.g., `anvil --fork-url ...` in a separate terminal) without passing `--fork-url` to `forge test` will no longer see Etherscan-resolved contract names in traces. This is rare compared to the common case of users experiencing unexpected slowdowns from having an API key set.

Fixes #13186