### PR TITLE
fix(script): use pending block tag for nonce fetching with fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4329,6 +4329,7 @@ dependencies = [
  "foundry-debugger",
  "foundry-evm",
  "foundry-linking",
+ "foundry-test-utils",
  "foundry-wallets",
  "futures",
  "indicatif",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,6 +4315,7 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-serde",
  "alloy-signer",
+ "anvil",
  "clap",
  "dialoguer",
  "dunce",

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -59,3 +59,4 @@ thiserror.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 foundry-test-utils.workspace = true
+anvil.workspace = true

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -58,3 +58,4 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+foundry-test-utils.workspace = true

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -582,7 +582,6 @@ impl BundledState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use foundry_config::NamedChain;
     use foundry_test_utils::rpc::next_rpc_endpoint;
 
     #[test]
@@ -604,42 +603,10 @@ mod tests {
         cache.write().remove(url);
     }
 
-    /// Tests that Base mainnet RPC (which doesn't support `pending` block tag on standard endpoints)
-    /// triggers the fallback to `latest` and gets memoized.
-    ///
-    /// This test is flaky because it depends on external infrastructure.
-    #[tokio::test]
-    #[ignore = "flaky: depends on external RPC"]
-    async fn flaky_next_nonce_fallback_on_base() {
-        // Base standard RPC doesn't support pending block tag (only Flashblocks-aware RPCs do)
-        let url = next_rpc_endpoint(NamedChain::Base);
-        let addr = Address::ZERO;
-
-        // Clear any previous state for this URL
-        pending_unsupported().write().remove(&url);
-
-        // First call should try pending, fail, and fall back to latest
-        let result = next_nonce(addr, &url, None).await;
-        assert!(result.is_ok(), "nonce fetch should succeed via fallback");
-
-        // URL should now be in the unsupported cache
-        assert!(
-            pending_unsupported().read().contains(&url),
-            "Base RPC should be marked as not supporting pending"
-        );
-
-        // Second call should skip pending entirely (memoized)
-        let result2 = next_nonce(addr, &url, None).await;
-        assert!(result2.is_ok(), "subsequent nonce fetch should also succeed");
-    }
-
-    /// Tests that Ethereum mainnet RPC (which supports `pending` block tag) works without fallback.
-    ///
-    /// This test is flaky because it depends on external infrastructure.
+    /// Tests that Ethereum mainnet RPC supports `pending` block tag and works without fallback.
     #[tokio::test]
     #[ignore = "flaky: depends on external RPC"]
     async fn flaky_next_nonce_pending_supported_on_mainnet() {
-        // Ethereum mainnet RPC (reth) supports pending block tag
         let url = next_rpc_endpoint(NamedChain::Mainnet);
         let addr = Address::ZERO;
 
@@ -654,6 +621,27 @@ mod tests {
         assert!(
             !pending_unsupported().read().contains(&url),
             "Mainnet RPC should support pending and not be cached as unsupported"
+        );
+    }
+
+    /// Tests that Base RPC supports `pending` block tag and works without fallback.
+    #[tokio::test]
+    #[ignore = "flaky: depends on external RPC"]
+    async fn flaky_next_nonce_pending_supported_on_base() {
+        let url = next_rpc_endpoint(NamedChain::Base);
+        let addr = Address::ZERO;
+
+        // Clear any previous state for this URL
+        pending_unsupported().write().remove(&url);
+
+        // Call should succeed using pending
+        let result = next_nonce(addr, &url, None).await;
+        assert!(result.is_ok(), "nonce fetch should succeed with pending");
+
+        // URL should NOT be in the unsupported cache (pending worked)
+        assert!(
+            !pending_unsupported().read().contains(&url),
+            "Base RPC should support pending and not be cached as unsupported"
         );
     }
 }

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -630,4 +630,28 @@ mod tests {
         let result2 = next_nonce(addr, url, None).await;
         assert!(result2.is_ok(), "subsequent nonce fetch should also succeed");
     }
+
+    /// Tests that Ethereum mainnet RPC (which supports `pending` block tag) works without fallback.
+    ///
+    /// This test is flaky because it depends on external infrastructure.
+    #[tokio::test]
+    #[ignore = "flaky: depends on external RPC"]
+    async fn flaky_next_nonce_pending_supported_on_mainnet() {
+        // Ethereum mainnet RPC (reth) supports pending block tag
+        let url = "https://reth-ethereum.ithaca.xyz/rpc";
+        let addr = Address::ZERO;
+
+        // Clear any previous state for this URL
+        pending_unsupported().write().remove(url);
+
+        // Call should succeed using pending
+        let result = next_nonce(addr, url, None).await;
+        assert!(result.is_ok(), "nonce fetch should succeed with pending");
+
+        // URL should NOT be in the unsupported cache (pending worked)
+        assert!(
+            !pending_unsupported().read().contains(url),
+            "Mainnet RPC should support pending and not be cached as unsupported"
+        );
+    }
 }

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -584,49 +584,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pending_unsupported_cache_is_initialized() {
+    fn pending_unsupported_cache_memoizes_per_url() {
         let cache = pending_unsupported();
-        assert!(cache.read().is_empty());
-    }
+        let url = "http://test-provider-unique.local:8545";
 
-    #[test]
-    fn pending_unsupported_cache_memoizes() {
-        let cache = pending_unsupported();
-        let url = "http://test-provider-1.local:8545";
-
+        // Initially should not contain the URL
         assert!(!cache.read().contains(url));
 
+        // After insertion, should contain it
         cache.write().insert(url.to_string());
         assert!(cache.read().contains(url));
 
         // Different URL should not be affected
-        assert!(!cache.read().contains("http://other-provider.local:8545"));
-    }
+        assert!(!cache.read().contains("http://other-provider-unique.local:8545"));
 
-    #[tokio::test]
-    async fn next_nonce_with_explicit_block_number() {
-        // When block_number is provided, it should be used directly
-        let (api, handle) = anvil::spawn(anvil::NodeConfig::test()).await;
-        let url = &handle.http_endpoint();
-        let addr = Address::ZERO;
-
-        // Should not error with explicit block number
-        let result = next_nonce(addr, url, Some(0)).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn next_nonce_uses_pending_on_anvil() {
-        // Anvil supports pending, so this should work without fallback
-        let (_api, handle) = anvil::spawn(anvil::NodeConfig::test()).await;
-        let url = &handle.http_endpoint();
-        let addr = Address::ZERO;
-
-        let result = next_nonce(addr, url, None).await;
-        assert!(result.is_ok());
-
-        // Anvil supports pending, so it should NOT be in the unsupported cache
-        assert!(!pending_unsupported().read().contains(url));
+        // Cleanup
+        cache.write().remove(url);
     }
 
     /// Tests that Base mainnet RPC (which doesn't support `pending` block tag on standard endpoints)


### PR DESCRIPTION
## Summary

Fixes nonce collisions when running forge scripts with pending transactions in the mempool.

## Problem

When the script fetches the nonce for an account, it uses `latest` instead of `pending`, so if there are pending transactions, we submit with a colliding nonce.

Ref: #12683

## Solution

- Use `pending` block tag by default to account for mempool transactions
- Memoize per-provider fallback to `latest` for RPCs that don't support `pending` (some L2s, older providers)
- Avoids repeated failed requests after first fallback detection

## Tradeoffs

| Aspect | Notes |
|--------|-------|
| **Correctness** | `pending` gives accurate nonces accounting for mempool |
| **Compatibility** | Graceful fallback handles RPCs without `pending` support |
| **Performance** | One extra request only on first failure per provider URL |
