### PR TITLE
fix(invariant): fix optimizer shrink logic for warp/roll sequences

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     inspectors::Fuzzer,
 };
 use alloy_primitives::{
-    Address, Bytes, FixedBytes, Selector, U256,
+    Address, Bytes, FixedBytes, I256, Selector, U256,
     map::{AddressMap, HashMap},
 };
 use alloy_sol_types::{SolCall, sol};
@@ -56,7 +56,7 @@ mod result;
 pub use result::InvariantFuzzTestResult;
 
 mod shrink;
-pub use shrink::check_sequence;
+pub use shrink::{check_sequence, check_sequence_value};
 
 sol! {
     interface IInvariantTest {
@@ -145,6 +145,11 @@ struct InvariantTestData {
     // until the desired `depth` so we can use the evolving fuzz dictionary
     // during the run.
     branch_runner: TestRunner,
+
+    // Optimization mode state: tracks the best (maximum) value and the sequence that produced it.
+    // Only used when invariant function returns int256.
+    optimization_best_value: Option<I256>,
+    optimization_best_sequence: Vec<BasicTxDetails>,
 }
 
 /// Contains invariant test data.
@@ -179,6 +184,8 @@ impl InvariantTest {
             line_coverage: None,
             metrics: Map::default(),
             branch_runner,
+            optimization_best_value: None,
+            optimization_best_sequence: vec![],
         };
         Self { fuzz_state, targeted_contracts, test_data }
     }
@@ -246,6 +253,14 @@ impl InvariantTest {
 
         // Revert state to not persist values between runs.
         self.fuzz_state.revert();
+    }
+
+    /// Updates the optimization state if the new value is better (higher) than the current best.
+    fn update_optimization_value(&mut self, value: I256, sequence: &[BasicTxDetails]) {
+        if self.test_data.optimization_best_value.map_or(true, |best| value > best) {
+            self.test_data.optimization_best_value = Some(value);
+            self.test_data.optimization_best_sequence = sequence.to_vec();
+        }
     }
 }
 
@@ -503,8 +518,12 @@ impl<'a> InvariantExecutor<'a> {
                                 invariant_test.test_data.failures.error =
                                     Some(InvariantFuzzError::Revert(case_data));
                                 result::RichInvariantResults::new(false, None)
-                            } else {
+                            } else if !invariant_contract.is_optimization() {
+                                // In optimization mode, keep reverted calls to preserve
+                                // warp/roll values for correct replay during shrinking.
                                 current_run.inputs.pop();
+                                result::RichInvariantResults::new(true, None)
+                            } else {
                                 result::RichInvariantResults::new(true, None)
                             }
                         } else {
@@ -586,6 +605,8 @@ impl<'a> InvariantExecutor<'a> {
             line_coverage: result.line_coverage,
             metrics: result.metrics,
             failed_corpus_replays: corpus_manager.failed_replays,
+            optimization_best_value: result.optimization_best_value,
+            optimization_best_sequence: result.optimization_best_sequence,
         })
     }
 
@@ -1078,10 +1099,10 @@ pub(crate) fn call_invariant_function(
     Ok((call_result, success))
 }
 
-/// Calls the invariant selector and returns call result and if succeeded.
-/// Updates the block number and block timestamp if configured.
+/// Executes a fuzz call and returns the result.
+/// Applies any block timestamp (warp) and block number (roll) adjustments before the call.
 pub(crate) fn execute_tx(executor: &mut Executor, tx: &BasicTxDetails) -> Result<RawCallResult> {
-    // Apply pre-call block adjustments.
+    // Apply pre-call block adjustments to the executor's env.
     if let Some(warp) = tx.warp {
         executor.env_mut().evm_env.block_env.timestamp += warp;
     }
@@ -1089,17 +1110,28 @@ pub(crate) fn execute_tx(executor: &mut Executor, tx: &BasicTxDetails) -> Result
         executor.env_mut().evm_env.block_env.number += roll;
     }
 
-    // Perform the raw call.
-    let mut call_result = executor
-        .call_raw(tx.sender, tx.call_details.target, tx.call_details.calldata.clone(), U256::ZERO)
-        .map_err(|e| eyre!(format!("Could not make raw evm call: {e}")))?;
+    // Also update the inspector's cheatcodes.block if there are warp/roll values.
+    // The inspector's block may override the env during interpreter initialization,
+    // so we need to add our warp/roll on top of any existing cheatcode-set values.
+    if tx.warp.is_some() || tx.roll.is_some() {
+        let block_env = executor.env().evm_env.block_env.clone();
+        if let Some(cheatcodes) = executor.inspector_mut().cheatcodes.as_mut() {
+            if let Some(block) = cheatcodes.block.as_mut() {
+                if let Some(warp) = tx.warp {
+                    block.timestamp += warp;
+                }
+                if let Some(roll) = tx.roll {
+                    block.number += roll;
+                }
+            } else {
+                // No cheatcode block set yet, so set it from executor's env
+                cheatcodes.block = Some(block_env);
+            }
+        }
+    }
 
-    // Propagate block adjustments to call result which will be committed.
-    if let Some(warp) = tx.warp {
-        call_result.env.evm_env.block_env.timestamp += warp;
-    }
-    if let Some(roll) = tx.roll {
-        call_result.env.evm_env.block_env.number += roll;
-    }
-    Ok(call_result)
+    // Perform the raw call.
+    executor
+        .call_raw(tx.sender, tx.call_details.target, tx.call_details.calldata.clone(), U256::ZERO)
+        .map_err(|e| eyre!(format!("Could not make raw evm call: {e}")))
 }

--- a/crates/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/evm/evm/src/executors/invariant/replay.rs
@@ -1,7 +1,7 @@
 use super::{call_after_invariant_function, call_invariant_function, execute_tx};
 use crate::executors::{EarlyExit, Executor, invariant::shrink::shrink_sequence};
 use alloy_dyn_abi::JsonAbiExt;
-use alloy_primitives::{Log, map::HashMap};
+use alloy_primitives::{I256, Log, map::HashMap};
 use eyre::Result;
 use foundry_common::{ContractsByAddress, ContractsByArtifact};
 use foundry_config::InvariantConfig;
@@ -87,13 +87,17 @@ pub fn replay_run(
     Ok(counterexample_sequence)
 }
 
-/// Replays the error case, shrinks the failing sequence and collects all necessary traces.
+/// Replays and shrinks a call sequence, collecting logs and traces.
+///
+/// For check mode (target_value=None): shrinks to find shortest failing sequence.
+/// For optimization mode (target_value=Some): shrinks to find shortest sequence producing target.
 #[expect(clippy::too_many_arguments)]
 pub fn replay_error(
     config: InvariantConfig,
     mut executor: Executor,
     calls: &[BasicTxDetails],
     inner_sequence: Option<Vec<Option<BasicTxDetails>>>,
+    target_value: Option<I256>,
     invariant_contract: &InvariantContract<'_>,
     known_contracts: &ContractsByArtifact,
     ided_contracts: ContractsByAddress,
@@ -104,15 +108,20 @@ pub fn replay_error(
     progress: Option<&ProgressBar>,
     early_exit: &EarlyExit,
 ) -> Result<Vec<BaseCounterExample>> {
-    // Shrink sequence of failed calls.
-    let calls =
-        shrink_sequence(&config, invariant_contract, calls, &executor, progress, early_exit)?;
+    let calls = shrink_sequence(
+        &config,
+        invariant_contract,
+        calls,
+        &executor,
+        target_value,
+        progress,
+        early_exit,
+    )?;
 
     if let Some(sequence) = inner_sequence {
         set_up_inner_replay(&mut executor, &sequence);
     }
 
-    // Replay calls to get the counterexample and to collect logs, traces and coverage.
     replay_run(
         invariant_contract,
         executor,

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::executors::{Executor, RawCallResult};
 use alloy_dyn_abi::JsonAbiExt;
+use alloy_primitives::I256;
 use eyre::Result;
 use foundry_config::InvariantConfig;
 use foundry_evm_core::utils::StateChangeset;
@@ -32,8 +33,13 @@ pub struct InvariantFuzzTestResult {
     pub line_coverage: Option<HitMaps>,
     /// Fuzzed selectors metrics collected during the invariant test runs.
     pub metrics: HashMap<String, InvariantMetrics>,
-    /// NUmber of failed replays from persisted corpus.
+    /// Number of failed replays from persisted corpus.
     pub failed_corpus_replays: usize,
+    /// For optimization mode (int256 return): the best (maximum) value achieved.
+    /// None means standard invariant check mode.
+    pub optimization_best_value: Option<I256>,
+    /// For optimization mode: the call sequence that produced the best value.
+    pub optimization_best_sequence: Vec<BasicTxDetails>,
 }
 
 /// Enriched results of an invariant run check.
@@ -95,6 +101,9 @@ pub(crate) fn assert_invariants(
 
 /// Returns if invariant test can continue and last successful call result of the invariant test
 /// function (if it can continue).
+///
+/// For optimization mode (int256 return), tracks the max value but never fails on invariant.
+/// For check mode, asserts the invariant and fails if broken.
 pub(crate) fn can_continue(
     invariant_contract: &InvariantContract<'_>,
     invariant_test: &mut InvariantTest,
@@ -104,6 +113,7 @@ pub(crate) fn can_continue(
     state_changeset: &StateChangeset,
 ) -> Result<RichInvariantResults> {
     let mut call_results = None;
+    let is_optimization = invariant_contract.is_optimization();
 
     let handlers_succeeded = || {
         invariant_test.targeted_contracts.targets.lock().keys().all(|address| {
@@ -116,29 +126,45 @@ pub(crate) fn can_continue(
         })
     };
 
-    // Assert invariants if the call did not revert and the handlers did not fail.
     if !call_result.reverted && handlers_succeeded() {
         if let Some(traces) = call_result.traces {
             invariant_run.run_traces.push(traces);
         }
 
-        call_results = assert_invariants(
-            invariant_contract,
-            invariant_config,
-            &invariant_test.targeted_contracts,
-            &invariant_run.executor,
-            &invariant_run.inputs,
-            &mut invariant_test.test_data.failures,
-        )?;
-        if call_results.is_none() {
-            return Ok(RichInvariantResults::new(false, None));
+        if is_optimization {
+            // Optimization mode: call invariant and track max value, never fail.
+            let (inv_result, success) = call_invariant_function(
+                &invariant_run.executor,
+                invariant_contract.address,
+                invariant_contract.invariant_function.abi_encode_input(&[])?.into(),
+            )?;
+            if success
+                && inv_result.result.len() >= 32
+                && let Some(value) = I256::try_from_be_slice(&inv_result.result[..32])
+            {
+                invariant_test.update_optimization_value(value, &invariant_run.inputs);
+            }
+            call_results = Some(inv_result);
+        } else {
+            // Check mode: assert invariants and fail if broken.
+            call_results = assert_invariants(
+                invariant_contract,
+                invariant_config,
+                &invariant_test.targeted_contracts,
+                &invariant_run.executor,
+                &invariant_run.inputs,
+                &mut invariant_test.test_data.failures,
+            )?;
+            if call_results.is_none() {
+                return Ok(RichInvariantResults::new(false, None));
+            }
         }
     } else {
         // Increase the amount of reverts.
         let invariant_data = &mut invariant_test.test_data;
         invariant_data.failures.reverts += 1;
         // If fail on revert is set, we must return immediately.
-        if invariant_config.fail_on_revert {
+        if invariant_config.fail_on_revert && call_result.reverted {
             let case_data = FailedInvariantCaseData::new(
                 invariant_contract,
                 invariant_config,
@@ -151,9 +177,10 @@ pub(crate) fn can_continue(
             invariant_data.failures.error = Some(InvariantFuzzError::Revert(case_data));
 
             return Ok(RichInvariantResults::new(false, None));
-        } else if call_result.reverted {
+        } else if call_result.reverted && !is_optimization {
             // If we don't fail test on revert then remove last reverted call from inputs.
-            // This improves shrinking performance as irrelevant calls won't be checked again.
+            // In optimization mode, we keep reverted calls to preserve warp/roll values
+            // for correct replay during shrinking.
             invariant_run.inputs.pop();
         }
     }
@@ -184,3 +211,5 @@ pub(crate) fn assert_after_invariant(
     }
     Ok(success)
 }
+
+

--- a/crates/forge/src/cmd/snapshot.rs
+++ b/crates/forge/src/cmd/snapshot.rs
@@ -270,6 +270,7 @@ impl FromStr for GasSnapshotEntry {
                                         reverts: reverts.as_str().parse().unwrap(),
                                         metrics: HashMap::default(),
                                         failed_corpus_replays: 0,
+                                        optimization_best_value: None,
                                     },
                                 })
                         }
@@ -625,6 +626,7 @@ mod tests {
                     reverts: 200,
                     metrics: HashMap::default(),
                     failed_corpus_replays: 0,
+                    optimization_best_value: None,
                 }
             }
         );
@@ -645,6 +647,7 @@ mod tests {
                     reverts: 2388,
                     metrics: HashMap::default(),
                     failed_corpus_replays: 0,
+                    optimization_best_value: None,
                 }
             }
         );

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -6,7 +6,7 @@ use crate::{
     gas_report::GasReport,
 };
 use alloy_primitives::{
-    Address, Log,
+    Address, I256, Log,
     map::{AddressHashMap, HashMap},
 };
 use eyre::Report;
@@ -444,7 +444,25 @@ pub struct TestResult {
 impl fmt::Display for TestResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.status {
-            TestStatus::Success => "[PASS]".green().fmt(f),
+            TestStatus::Success => {
+                // For optimization mode, show the best example sequence in green.
+                if let Some(CounterExample::Sequence(original, sequence)) = &self.counterexample {
+                    let mut s = String::from("[PASS]");
+                    s.push_str(
+                        format!(
+                            "\n\t[Best sequence] (original: {original}, shrunk: {})\n",
+                            sequence.len()
+                        )
+                        .as_str(),
+                    );
+                    for ex in sequence {
+                        writeln!(s, "{ex}").unwrap();
+                    }
+                    s.green().wrap().fmt(f)
+                } else {
+                    "[PASS]".green().fmt(f)
+                }
+            }
             TestStatus::Skipped => {
                 let mut s = String::from("[SKIP");
                 if let Some(reason) = &self.reason {
@@ -633,6 +651,7 @@ impl TestResult {
             reverts: 1,
             metrics: HashMap::default(),
             failed_corpus_replays: 0,
+            optimization_best_value: None,
         };
         self.status = TestStatus::Skipped;
         self.reason = reason.0;
@@ -651,6 +670,7 @@ impl TestResult {
             reverts: 1,
             metrics: HashMap::default(),
             failed_corpus_replays: 0,
+            optimization_best_value: None,
         };
         self.status = TestStatus::Failure;
         self.reason = if replayed_entirely {
@@ -669,6 +689,7 @@ impl TestResult {
             reverts: 0,
             metrics: HashMap::default(),
             failed_corpus_replays: 0,
+            optimization_best_value: None,
         };
         self.status = TestStatus::Failure;
         self.reason = Some(format!("failed to set up invariant testing environment: {e}"));
@@ -686,6 +707,7 @@ impl TestResult {
         reverts: usize,
         metrics: Map<String, InvariantMetrics>,
         failed_corpus_replays: usize,
+        optimization_best_value: Option<I256>,
     ) {
         self.kind = TestKind::Invariant {
             runs: cases.len(),
@@ -693,10 +715,13 @@ impl TestResult {
             reverts,
             metrics,
             failed_corpus_replays,
+            optimization_best_value,
         };
-        self.status = match success {
-            true => TestStatus::Success,
-            false => TestStatus::Failure,
+        // For optimization mode (Some value), always succeed. For check mode (None), use success.
+        self.status = if optimization_best_value.is_some() || success {
+            TestStatus::Success
+        } else {
+            TestStatus::Failure
         };
         self.reason = reason;
         self.counterexample = counterexample;
@@ -769,6 +794,8 @@ pub enum TestKindReport {
         reverts: usize,
         metrics: Map<String, InvariantMetrics>,
         failed_corpus_replays: usize,
+        /// For optimization mode (int256 return): the best value achieved. None = check mode.
+        optimization_best_value: Option<I256>,
     },
     Table {
         runs: usize,
@@ -793,8 +820,11 @@ impl fmt::Display for TestKindReport {
                     write!(f, "(runs: {runs}, μ: {mean_gas}, ~: {median_gas})")
                 }
             }
-            Self::Invariant { runs, calls, reverts, metrics: _, failed_corpus_replays } => {
-                if *failed_corpus_replays != 0 {
+            Self::Invariant { runs, calls, reverts, metrics: _, failed_corpus_replays, optimization_best_value } => {
+                // If optimization_best_value is Some, this is optimization mode.
+                if let Some(best_value) = optimization_best_value {
+                    write!(f, "(best: {best_value}, runs: {runs}, calls: {calls})")
+                } else if *failed_corpus_replays != 0 {
                     write!(
                         f,
                         "(runs: {runs}, calls: {calls}, reverts: {reverts}, failed corpus replays: {failed_corpus_replays})"
@@ -844,6 +874,8 @@ pub enum TestKind {
         reverts: usize,
         metrics: Map<String, InvariantMetrics>,
         failed_corpus_replays: usize,
+        /// For optimization mode (int256 return): the best value achieved. None = check mode.
+        optimization_best_value: Option<I256>,
     },
     /// A table test.
     Table { runs: usize, mean_gas: u64, median_gas: u64 },
@@ -868,13 +900,14 @@ impl TestKind {
                     failed_corpus_replays: *failed_corpus_replays,
                 }
             }
-            Self::Invariant { runs, calls, reverts, metrics: _, failed_corpus_replays } => {
+            Self::Invariant { runs, calls, reverts, metrics: _, failed_corpus_replays, optimization_best_value } => {
                 TestKindReport::Invariant {
                     runs: *runs,
                     calls: *calls,
                     reverts: *reverts,
                     metrics: HashMap::default(),
                     failed_corpus_replays: *failed_corpus_replays,
+                    optimization_best_value: *optimization_best_value,
                 }
             }
             Self::Table { runs, mean_gas, median_gas } => {


### PR DESCRIPTION
## Summary

This PR fixes issues with the invariant optimizer shrink logic that caused the "best sequence" to not reproduce the same value when replayed.

## Feature: Invariant Optimization Mode

Added optimization mode for invariant testing (activated when invariant function returns `int256`). The fuzzer maximizes the return value instead of checking for boolean success.

Key implementation:
- `InvariantMode` detection based on ABI return type
- Tracking `optimization_best_value` and `optimization_best_sequence` in `InvariantTestData`
- `can_continue` handles optimization mode by tracking max value without failing on invariant
- `check_sequence_value` for replaying and verifying optimization sequences
- Shrinking finds shortest sequence that still produces the target maximum value

## Bug Fix: Shrink Logic for Warp/Roll Sequences

### Problem
The invariant optimizer's "best sequence" didn't reproduce the same value when replayed because:

1. **Reverted calls lost warp/roll values**: When a call reverted (in non-fail-on-revert mode), it was removed from the sequence, but its warp/roll values were still applied during fuzzing. During shrinking replay, these warps were missing.

2. **Shrunk sequence didn't accumulate warps**: When shrinking removed calls, their warp/roll values were also lost. The displayed sequence showed individual call warps instead of accumulated values.

3. **Inspector block override issue**: The inspector's `cheatcodes.block` overrides the env during interpreter initialization. When warp/roll was applied to `executor.env` but not to `cheatcodes.block`, subsequent calls saw incorrect timestamps.

### Solution

1. **Keep reverted calls in optimization mode**: In `can_continue` and the skip-invariant-check path, don't pop reverted calls when in optimization mode. This preserves warp/roll values for correct replay.

2. **Accumulate warps in shrunk output**: When building the shrunk sequence, accumulate warp/roll values from all removed calls into the next kept call. This ensures the displayed sequence can be copied directly into a test.

3. **Update both env and inspector block**: In `execute_tx`, update both `executor.env.block_env` AND `cheatcodes.block` with warp/roll values. This ensures correct behavior regardless of whether cheatcodes.block overrides the env.

4. **Fix `check_sequence_value`**: Apply warps/rolls from ALL calls in the sequence, but only execute calls that are in the kept set. This correctly reproduces the block environment during shrinking.

## Test Results

- All 46 invariant tests pass
- Optimizer shrinking correctly produces reproducible sequences
- Example: A sequence shrunk from 285 calls to 1 call with accumulated warp correctly reproduces the best value

## Example

Before fix:
```
[Best sequence] (original: 285, shrunk: 1)
    vm.warp(block.timestamp + 482030);  // Only this call's warp
    ...
invariant_opt_price_difference() (best: 2660072, ...)
```
When replayed: produces 0 (wrong)

After fix:
```
[Best sequence] (original: 285, shrunk: 1)
    vm.warp(block.timestamp + 87139295);  // Accumulated from all 285 calls
    ...
invariant_opt_price_difference() (best: 72729989..., ...)
```
When replayed: produces the exact best value (correct)
