### PR TITLE
docs(config): complete foundry.toml configuration reference

### DIFF
--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -54,99 +54,15 @@ and merge, at the per-key level:
 
 The selected profile is the value of the `FOUNDRY_PROFILE` environment variable, or if it is not set, "default".
 
-### All Options
+## Configuration Reference
 
-For a full list of configuration options, see the [Foundry Book](https://getfoundry.sh/config/reference/default-config#default-foundry-configuration).
+For a full list of all configuration options, see the [Foundry Book](https://getfoundry.sh/config/reference/overview):
 
-#### Additional Optimizer settings
-
-Optimizer components can be tweaked with the `OptimizerDetails` object:
-
-See [Compiler Input Description `settings.optimizer.details`](https://docs.soliditylang.org/en/latest/using-the-compiler.html#compiler-input-and-output-json-description)
-
-The `optimizer_details` (`optimizerDetails` also works) settings must be prefixed with the profile they correspond
-to: `[profile.default.optimizer_details]`
-belongs to the `[profile.default]` profile
-
-```toml
-[profile.default.optimizer_details]
-constantOptimizer = true
-yul = true
-# this sets the `yulDetails` of the `optimizer_details` for the `default` profile
-[profile.default.optimizer_details.yulDetails]
-stackAllocation = true
-optimizerSteps = 'dhfoDgvulfnTUtnIf'
-```
-
-#### RPC-Endpoints settings
-
-The `rpc_endpoints` value accepts a list of `alias = "<url|env var>"` pairs.
-
-The following example declares two pairs:
-The alias `optimism` references the endpoint URL directly.
-The alias `mainnet` references the environment variable `RPC_MAINNET` which holds the entire URL.
-The alias `goerli` references an endpoint that will be interpolated with the value the `GOERLI_API_KEY` holds.
-
-Environment variables need to be wrapped in `${}`
-
-```toml
-[rpc_endpoints]
-optimism = "https://optimism.alchemyapi.io/v2/1234567"
-mainnet = "${RPC_MAINNET}"
-goerli = "https://eth-goerli.alchemyapi.io/v2/${GOERLI_API_KEY}"
-```
-
-#### Etherscan API Key settings
-
-The `etherscan` value accepts a list of `alias = "{key = "", url? ="", chain?= """""}"` items.
-
-the `key` attribute is always required and should contain the actual API key for that chain or an env var that holds the key in the form `${ENV_VAR}`
-The `chain` attribute is optional if the `alias` is the already the `chain` name, such as in `mainnet = { key = "${ETHERSCAN_MAINNET_KEY}"}`
-The optional `url` attribute can be used to explicitly set the Etherscan API url, this is the recommended setting for chains not natively supported by name.
-
-```toml
-[etherscan]
-mainnet = { key = "${ETHERSCAN_MAINNET_KEY}" }
-mainnet2 = { key = "ABCDEFG", chain = "mainnet" }
-optimism = { key = "1234576", chain = 42 }
-unknownchain = { key = "ABCDEFG", url = "https://<etherscan-api-url-for-that-chain>" }
-```
-
-##### Additional Model Checker settings
-
-[Solidity's built-in model checker](https://docs.soliditylang.org/en/latest/smtchecker.html#tutorial)
-is an opt-in module that can be enabled via the `ModelChecker` object.
-
-See [Compiler Input Description `settings.modelChecker`](https://docs.soliditylang.org/en/latest/using-the-compiler.html#compiler-input-and-output-json-description)
-and [the model checker's options](https://docs.soliditylang.org/en/latest/smtchecker.html#smtchecker-options-and-tuning).
-
-The module is available in `solc` release binaries for OSX and Linux.
-The latter requires the z3 library version [4.8.8, 4.8.14] to be installed
-in the system (SO version 4.8).
-
-Similarly to the optimizer settings above, the `model_checker` settings must be
-prefixed with the profile they correspond to: `[profile.default.model_checker]` belongs
-to the `[profile.default]` profile.
-
-```toml
-[profile.default.model_checker]
-contracts = { 'src/Contract.sol' = [ 'Contract' ] }
-engine = 'chc'
-timeout = 10000
-targets = [ 'assert' ]
-```
-
-The fields above are recommended when using the model checker.
-Setting which contract should be verified is extremely important, otherwise all
-available contracts will be verified which can consume a lot of time.
-The recommended engine is `chc`, but `bmc` and `all` (runs both) are also
-accepted.
-It is also important to set a proper timeout (given in milliseconds), since the
-default time given to the underlying solvers may not be enough.
-If no verification targets are given, only assertions will be checked.
-
-The model checker will run when `forge build` is invoked, and will show
-findings as warnings if any.
+- [Default Configuration](https://getfoundry.sh/config/reference/default-config) - All `[profile.default]` options
+- [Testing Configuration](https://getfoundry.sh/config/reference/testing) - Fuzz and invariant testing options
+- [Formatter Configuration](https://getfoundry.sh/config/reference/formatter) - Code formatting options
+- [Linter Configuration](https://getfoundry.sh/config/reference/linter) - Linting options
+- [Doc Generator Configuration](https://getfoundry.sh/config/reference/doc-generator) - Documentation generation options
 
 ## Environment Variables
 
@@ -158,4 +74,3 @@ supported, this means that `FOUNDRY_SRC` and `DAPP_SRC` are equivalent.
 Some exceptions to the above are [explicitly ignored](https://github.com/foundry-rs/foundry/blob/10440422e63aae660104e079dfccd5b0ae5fd720/config/src/lib.rs#L1539-L15522) due to security concerns.
 
 Environment variables take precedence over values in `foundry.toml`. Values are parsed as a loose form of TOML syntax.
-Consider the following examples:


### PR DESCRIPTION
Simplifies `crates/config/README.md` by removing duplicated configuration documentation and linking to the [Foundry Book configuration reference](https://getfoundry.sh/config/reference/overview) instead.

The README now points to the comprehensive documentation pages:
- [Default Configuration](https://getfoundry.sh/config/reference/default-config)
- [Testing Configuration](https://getfoundry.sh/config/reference/testing)
- [Formatter Configuration](https://getfoundry.sh/config/reference/formatter)
- [Linter Configuration](https://getfoundry.sh/config/reference/linter)
- [Doc Generator Configuration](https://getfoundry.sh/config/reference/doc-generator)

## Related
- Supersedes #13190
- Closes #12744
- Book PR: foundry-rs/book#1735