### PR TITLE
fix(script): update sender nonce when using startBroadcast(privateKey) without libraries

### DIFF
--- a/testdata/default/cheats/Broadcast.t.sol
+++ b/testdata/default/cheats/Broadcast.t.sol
@@ -247,6 +247,20 @@ contract BroadcastTestNoLinking is ForgeTest {
         vm.broadcast();
         test11.view_me();
     }
+
+    /// Tests that using vm.startBroadcast(privateKey) without --sender CLI flag
+    /// correctly updates the sender nonce even when there are no libraries to predeploy.
+    /// This is a regression test for https://github.com/foundry-rs/foundry/issues/12646
+    function deployWithPrivateKeyNoLibraries() public {
+        // Use the 3rd anvil account private key
+        uint256 privateKey = 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a;
+        // Expected address: 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC
+
+        vm.startBroadcast(privateKey);
+        NoLink test1 = new NoLink();
+        NoLink test2 = new NoLink();
+        vm.stopBroadcast();
+    }
 }
 
 contract BroadcastMix is ForgeTest {


### PR DESCRIPTION
## Summary

When using `vm.startBroadcast(privateKey)` in a script without the `--sender` CLI flag, the sender nonce was not updated if there were no libraries to predeploy. This caused transactions to be rejected due to incorrect nonces.

## Problem

The `maybe_new_sender` function in [execute.rs](https://github.com/foundry-rs/foundry/blob/master/crates/script/src/execute.rs#L180-L209) previously only checked for a new sender when `libraries_count() > 0`:

```rust
if self.build_data.predeploy_libraries.libraries_count() > 0
    && self.args.evm.sender.is_none()
```

This meant that when a script used `vm.startBroadcast(pk)` to set a different sender, but had no libraries to predeploy, `update_sender` was never called. The `sender_nonce` in `ScriptConfig` remained set to the default sender's nonce, causing nonce mismatches during broadcast.

## Solution

This PR relaxes the condition to also detect sender changes when there are no libraries, ensuring the sender nonce is updated correctly for all broadcast scenarios.

## Testing

Added a new test case `can_deploy_script_private_key_no_lib` that:
1. Uses `vm.startBroadcast(privateKey)` without `--sender` CLI flag
2. Has no libraries to predeploy
3. Verifies correct nonce increment during broadcast

Fixes #12646