### PR TITLE
fix(chisel): skip external identifiers for local execution

### DIFF
--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -165,10 +165,13 @@ impl ChiselDispatcher {
             )?)
             .build();
 
-        let mut identifier = TraceIdentifiers::new().with_external(
-            &session_config.foundry_config,
-            session_config.evm_opts.get_remote_chain_id().await,
-        )?;
+        let remote_chain = session_config.evm_opts.get_remote_chain_id().await;
+        let mut identifier = TraceIdentifiers::new();
+        // Only use external identifiers when connected to a remote chain to avoid unnecessary
+        // network requests that significantly slow down local REPL execution.
+        if let Some(chain) = remote_chain {
+            identifier = identifier.with_external(&session_config.foundry_config, Some(chain))?;
+        }
         if !identifier.is_empty() {
             for (_, trace) in &mut result.traces {
                 decoder.identify(trace, &mut identifier);


### PR DESCRIPTION
Chisel was creating external identifiers unconditionally in decode_traces, causing unnecessary Etherscan/Sourcify requests even for purely local REPL sessions. This adds the same 5s delay that was reported in the original issue.

Applied the same fix as forge test - only create external identifiers when there's actually a remote chain connected. No point hitting external APIs when running locally.

inspired by https://github.com/foundry-rs/foundry/pull/13189