### PR TITLE
feat(cast): support indexed parameters in decode-event

### DIFF
--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -595,10 +595,20 @@ pub enum CastSubcommand {
     #[command(visible_aliases = &["event-decode", "--event-decode", "ed"])]
     DecodeEvent {
         /// The event signature. If none provided then tries to decode from local cache or <https://api.openchain.xyz>.
+        ///
+        /// Supports the `indexed` keyword for indexed parameters, e.g.:
+        /// `Transfer(address indexed from, address indexed to, uint256 value)`
         #[arg(long, visible_alias = "event-sig")]
         sig: Option<String>,
-        /// The event data to decode.
-        data: String,
+        /// The indexed event topics (topic0 is the event selector).
+        ///
+        /// For events with indexed parameters, pass topics separately:
+        /// - topic0: event selector (optional if --sig is provided)
+        /// - topic1..topicN: indexed parameters in order
+        #[arg(long, short)]
+        topics: Vec<String>,
+        /// The non-indexed event data to decode.
+        data: Option<String>,
     },
 
     /// Decode custom error data.

--- a/crates/cast/tests/cli/selectors.rs
+++ b/crates/cast/tests/cli/selectors.rs
@@ -147,6 +147,40 @@ casttest!(event_decode_with_sig, |_prj, cmd| {
 "#]]);
 });
 
+// tests cast can decode event with indexed parameters using --topics
+casttest!(event_decode_with_indexed_params, |_prj, cmd| {
+    // Transfer(address indexed from, address indexed to, uint256 value)
+    // Topics: [selector, from, to]
+    // Data: value (78)
+    let topic0 = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"; // keccak256("Transfer(address,address,uint256)")
+    let topic1 = "0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"; // from
+    let topic2 = "0x000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"; // to
+    let data = "0x000000000000000000000000000000000000000000000000000000000000004e"; // value = 78
+
+    cmd.args([
+        "decode-event",
+        "--sig", "Transfer(address indexed from, address indexed to, uint256 value)",
+        "-t", topic0,
+        "-t", topic1,
+        "-t", topic2,
+        data,
+    ]).assert_success().stdout_eq(str![[r#"
+0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa
+0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB
+78
+
+"#]]);
+
+    cmd.args(["--json"]).assert_success().stdout_eq(str![[r#"
+[
+  "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+  "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+  78
+]
+
+"#]]);
+});
+
 // tests cast can decode event with Openchain API
 casttest!(flaky_event_decode_with_openchain, |prj, cmd| {
     prj.clear_cache();


### PR DESCRIPTION
## Summary
Add `--topics` (`-t`) flag to `cast decode-event` for specifying indexed event parameters.

## Changes
- Added `--topics` / `-t` flag to pass topics (indexed params) separately
- Made `data` argument optional (for events with only indexed params)
- Added `reconstruct_params()` to restore parameter order (indexed + non-indexed interleaved as per the event signature)
- Updated help text to document the new flag and `indexed` keyword support

## Example
```bash
# Transfer(address indexed from, address indexed to, uint256 value)
cast decode-event \
  --sig 'Transfer(address indexed from, address indexed to, uint256 value)' \
  -t 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef \
  -t 0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
  -t 0x000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
  0x000000000000000000000000000000000000000000000000000000000000004e

# Output:
# 0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa
# 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB
# 78
```

Closes #12588