### PR TITLE
chore: fix clippy lints

### DIFF
--- a/crates/anvil/src/eth/backend/mem/state.rs
+++ b/crates/anvil/src/eth/backend/mem/state.rs
@@ -35,7 +35,7 @@ pub fn trie_storage(storage: &HashMap<U256, U256>) -> Vec<(Nibbles, Vec<u8>)> {
             (Nibbles::unpack(keccak256(key.to_be_bytes::<32>())), data)
         })
         .collect::<Vec<_>>();
-    storage.sort_by(|(key1, _), (key2, _)| key1.cmp(key2));
+    storage.sort_by_key(|(key, _)| *key);
 
     storage
 }
@@ -49,7 +49,7 @@ pub fn trie_accounts(accounts: &AddressMap<DbAccount>) -> Vec<(Nibbles, Vec<u8>)
             (Nibbles::unpack(keccak256(*address)), data)
         })
         .collect();
-    accounts.sort_by(|(key1, _), (key2, _)| key1.cmp(key2));
+    accounts.sort_by_key(|(key, _)| *key);
 
     accounts
 }

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -297,7 +297,7 @@ impl FeeHistoryService {
                 .collect();
 
             // sort by effective reward asc
-            transactions.sort_by(|(_, a), (_, b)| a.cmp(b));
+            transactions.sort_by_key(|(_, reward)| *reward);
 
             // calculate percentile rewards
             item.rewards = reward_percentiles

--- a/crates/script-sequence/src/reader.rs
+++ b/crates/script-sequence/src/reader.rs
@@ -125,7 +125,7 @@ impl BroadcastReader {
             .collect::<Vec<_>>();
 
         // Sort by descending timestamp
-        seqs.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        seqs.sort_by_key(|s| std::cmp::Reverse(s.timestamp));
 
         seqs
     }
@@ -163,7 +163,7 @@ impl BroadcastReader {
         }
 
         // Sort by descending block number
-        targets.sort_by(|a, b| b.1.block_number.cmp(&a.1.block_number));
+        targets.sort_by_key(|t| std::cmp::Reverse(t.1.block_number));
 
         targets
     }


### PR DESCRIPTION
Fixes `clippy::unnecessary_sort_by` lints by replacing `sort_by` with `sort_by_key` in:

- `crates/script-sequence/src/reader.rs` (2 occurrences)
- `crates/anvil/src/eth/backend/mem/state.rs` (2 occurrences)  
- `crates/anvil/src/eth/fees.rs` (1 occurrence)