### PR TITLE
fix(script): prevent infinite loop when tx known but receipt unavailable

### DIFF
--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -2,7 +2,7 @@ use alloy_chains::{Chain, NamedChain};
 use alloy_network::AnyTransactionReceipt;
 use alloy_primitives::{TxHash, U256, utils::format_units};
 use alloy_provider::{PendingTransactionBuilder, PendingTransactionError, Provider, WatchTxError};
-use eyre::{Result, eyre};
+use eyre::Result;
 use forge_script_sequence::ScriptSequence;
 use foundry_common::{provider::RetryProvider, retry, retry::RetryError, shell};
 use std::time::Duration;
@@ -74,9 +74,7 @@ pub async fn check_tx_status(
                 Err(e) => match provider.get_transaction_by_hash(hash).await {
                     Ok(_) => match e {
                         PendingTransactionError::TxWatcher(WatchTxError::Timeout) => {
-                            Err(RetryError::Continue(eyre!(
-                                "tx is still known to the node, waiting for receipt"
-                            )))
+                            Err(RetryError::Retry(PendingReceiptError { tx_hash: hash }.into()))
                         }
                         _ => Err(RetryError::Retry(e.into())),
                     },


### PR DESCRIPTION
## Motivation

When using `forge script --resume` with private RPCs (e.g., Alchemy), the script can hang indefinitely under specific conditions:

1. A transaction is forwarded to Flashbots but expires without being mined
2. `get_transaction_by_hash` returns the transaction (node still knows about it)
3. `get_receipt` never succeeds because the transaction was never mined

In this scenario, the code was returning `RetryError::Continue`, which does not decrement the retry counter, causing an infinite loop.

## Solution

Change `RetryError::Continue` to `RetryError::Retry` with `PendingReceiptError` when a transaction times out but is still known to the node. This ensures:

1. The retry counter is decremented, preventing infinite loops
2. `PendingReceiptError` is used so that `progress.rs` will call `remove_pending()` when retries are exhausted, allowing `--resume` to re-broadcast the transaction

---

### AI Disclosure

This PR was written with assistance from Claude Opus 4.5.