### PR TITLE
feat(invariant): validate counterexamples using settings instead of bytecode

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -25,8 +25,8 @@ use foundry_evm_core::{
 use foundry_evm_fuzz::{
     BasicTxDetails, FuzzCase, FuzzFixtures, FuzzedCases,
     invariant::{
-        ArtifactFilters, FuzzRunIdentifiedContracts, InvariantContract, RandomCallGenerator,
-        SenderFilters, TargetedContract, TargetedContracts,
+        ArtifactFilters, FuzzRunIdentifiedContracts, InvariantContract, InvariantSettings,
+        RandomCallGenerator, SenderFilters, TargetedContract, TargetedContracts,
     },
     strategies::{EvmFuzzState, invariant_strat, override_call_strat},
 };
@@ -1029,6 +1029,18 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         };
         contract.add_selectors(selectors.iter().copied(), should_exclude)?;
         Ok(())
+    }
+
+    /// Computes the current invariant settings for the given invariant contract address.
+    ///
+    /// This extracts the target contracts, selectors, senders, and fail_on_revert setting
+    /// that are used to determine if a persisted counterexample is still valid.
+    pub fn compute_settings(&mut self, invariant_address: Address) -> Result<InvariantSettings> {
+        self.select_contract_artifacts(invariant_address)?;
+        let (sender_filters, targeted_contracts) =
+            self.select_contracts_and_senders(invariant_address)?;
+        let targets = targeted_contracts.targets.lock();
+        Ok(InvariantSettings::new(&targets, &sender_filters, self.config.fail_on_revert))
     }
 }
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -29,7 +29,8 @@ use foundry_evm::{
     },
     fuzz::{
         BasicTxDetails, CallDetails, CounterExample, FuzzFixtures, fixture_name,
-        invariant::InvariantContract, strategies::EvmFuzzState,
+        invariant::{InvariantContract, InvariantSettings},
+        strategies::EvmFuzzState,
     },
     traces::{TraceKind, TraceMode, load_contracts},
 };
@@ -529,13 +530,7 @@ impl<'a> FunctionRunner<'a> {
             TestFunctionKind::FuzzTest { .. } => self.run_fuzz_test(func),
             TestFunctionKind::TableTest => self.run_table_test(func),
             TestFunctionKind::InvariantTest => {
-                let test_bytecode = &self.cr.contract.bytecode;
-                self.run_invariant_test(
-                    func,
-                    call_after_invariant,
-                    identified_contracts.unwrap(),
-                    test_bytecode,
-                )
+                self.run_invariant_test(func, call_after_invariant, identified_contracts.unwrap())
             }
             _ => unreachable!(),
         }
@@ -717,7 +712,6 @@ impl<'a> FunctionRunner<'a> {
         func: &Function,
         call_after_invariant: bool,
         identified_contracts: &ContractsByAddress,
-        test_bytecode: &Bytes,
     ) -> TestResult {
         // First, run the test normally to see if it needs to be skipped.
         if let Err(EvmError::Skip(reason)) = self.executor.call(
@@ -760,6 +754,15 @@ impl<'a> FunctionRunner<'a> {
             InvariantContract::new(self.address, func, call_after_invariant, &self.cr.contract.abi);
         let show_solidity = invariant_config.show_solidity;
 
+        // Compute current invariant settings for failure validation.
+        let current_settings = match evm.compute_settings(self.address) {
+            Ok(s) => s,
+            Err(e) => {
+                self.result.invariant_setup_fail(e);
+                return self.result;
+            }
+        };
+
         let progress = start_fuzz_progress(
             self.cr.progress,
             self.cr.name,
@@ -770,7 +773,7 @@ impl<'a> FunctionRunner<'a> {
 
         // Try to replay recorded failure if any.
         if let Some(mut call_sequence) =
-            persisted_call_sequence(failure_file.as_path(), test_bytecode)
+            persisted_call_sequence(failure_file.as_path(), &current_settings)
         {
             // Create calls from failed sequence and check if invariant still broken.
             let txes = call_sequence
@@ -837,13 +840,13 @@ impl<'a> FunctionRunner<'a> {
                             failure_dir.as_path(),
                             failure_file.as_path(),
                             &call_sequence,
-                            test_bytecode,
+                            &current_settings,
                         );
                     }
+                    Ok(_) => {}
                     Err(err) => {
                         error!(%err, "Failed to replay invariant error");
                     }
-                    _ => {}
                 }
 
                 self.result.invariant_replay_fail(
@@ -908,7 +911,7 @@ impl<'a> FunctionRunner<'a> {
                                         failure_dir.as_path(),
                                         failure_file.as_path(),
                                         &call_sequence,
-                                        test_bytecode,
+                                        &current_settings,
                                     );
 
                                     let original_seq_len =
@@ -923,10 +926,10 @@ impl<'a> FunctionRunner<'a> {
                                         call_sequence,
                                     ))
                                 }
+                                Ok(_) => {}
                                 Err(err) => {
                                     error!(%err, "Failed to replay invariant error");
                                 }
-                                _ => {}
                             }
                         }
                     };
@@ -1183,26 +1186,27 @@ fn fuzzer_with_cases(seed: Option<U256>, cases: u32, max_global_rejects: u32) ->
 struct InvariantPersistedFailure {
     /// Recorded counterexample.
     call_sequence: Vec<BaseCounterExample>,
-    /// Bytecode of the test contract that generated the counterexample.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    driver_bytecode: Option<Bytes>,
+    /// Invariant settings when the counterexample was generated.
+    /// Used to determine if the counterexample is still valid.
+    settings: InvariantSettings,
 }
 
 /// Helper function to load failed call sequence from file.
-/// Ignores failure if generated with different test contract than the current one.
-fn persisted_call_sequence(path: &Path, bytecode: &Bytes) -> Option<Vec<BaseCounterExample>> {
+/// Ignores failure if generated with different invariant settings than the current ones.
+fn persisted_call_sequence(
+    path: &Path,
+    current_settings: &InvariantSettings,
+) -> Option<Vec<BaseCounterExample>> {
     foundry_common::fs::read_json_file::<InvariantPersistedFailure>(path).ok().and_then(
         |persisted_failure| {
-            if let Some(persisted_bytecode) = &persisted_failure.driver_bytecode {
-                // Ignore persisted sequence if test bytecode doesn't match.
-                if !bytecode.eq(persisted_bytecode) {
-                    let _= sh_warn!("\
-                            Failure from {:?} file was ignored because test contract bytecode has changed.",
-                        path
-                    );
-                    return None;
-                }
-            };
+            if let Some(diff) = persisted_failure.settings.diff(current_settings) {
+                let _ = sh_warn!(
+                    "Failure from {:?} file was ignored because invariant test settings have changed: {}",
+                    path,
+                    diff
+                );
+                return None;
+            }
             Some(persisted_failure.call_sequence)
         },
     )
@@ -1229,7 +1233,7 @@ fn record_invariant_failure(
     failure_dir: &Path,
     failure_file: &Path,
     call_sequence: &[BaseCounterExample],
-    test_bytecode: &Bytes,
+    settings: &InvariantSettings,
 ) {
     if let Err(err) = foundry_common::fs::create_dir_all(failure_dir) {
         error!(%err, "Failed to create invariant failure dir");
@@ -1240,7 +1244,7 @@ fn record_invariant_failure(
         failure_file,
         &InvariantPersistedFailure {
             call_sequence: call_sequence.to_owned(),
-            driver_bytecode: Some(test_bytecode.clone()),
+            settings: settings.clone(),
         },
     ) {
         error!(%err, "Failed to record call sequence");

--- a/crates/forge/tests/cli/test_cmd/invariant/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/mod.rs
@@ -572,7 +572,7 @@ contract OwnableTest is Test {
     );
     cmd.assert_success().stderr_eq(str![[r#"
 ...
-Warning: Failure from "[..]/invariant/failures/OwnableTest/invariant_never_owner" file was ignored because test contract bytecode has changed.
+Warning: Failure from "[..]/invariant/failures/OwnableTest/invariant_never_owner" file was ignored because invariant test settings have changed: target selectors changed
 ...
 "#]])
     .stdout_eq(str![[r#"


### PR DESCRIPTION
## Summary
Previously, invariant counterexamples were invalidated when the test contract bytecode changed, even for minor changes like adding a log statement. This made debugging failing invariants frustrating.

## Changes
Now, counterexamples are validated based on invariant settings that actually affect test execution:
- Target contracts (addresses and identifiers)  
- Target selectors per contract
- Target/excluded senders
- `fail_on_revert` setting

The warning message now shows exactly what settings changed, e.g.:
- `target selectors changed`
- `added target contracts: Foo, Bar`
- `fail_on_revert changed from false to true`

## Backward Compatibility
Old persisted failures (with bytecode) are still loaded but won't trigger the mismatch warning since they lack the new settings field. New failures will only store settings (not bytecode).

## Testing
All 47 invariant CLI tests pass, including the updated `invariant_replay_with_different_bytecode` test.

Closes #10991