### PR TITLE
ci: use shared cache mounts for parallel builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,9 @@ ENV CARGO_INCREMENTAL=0 \
     SCCACHE_DIR=/sccache
 
 # Build dependencies.
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=shared \
+    --mount=type=cache,target=$SCCACHE_DIR,sharing=shared \
     cargo chef cook --recipe-path recipe.json --profile ${RUST_PROFILE} --no-default-features --features "${RUST_FEATURES}"
 
 ARG TAG_NAME="dev"
@@ -35,9 +35,9 @@ ARG VERGEN_GIT_SHA="ffffffffffffffffffffffffffffffffffffffff"
 
 # Build the project.
 COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=shared \
+    --mount=type=cache,target=$SCCACHE_DIR,sharing=shared \
     cargo build --profile ${RUST_PROFILE} --no-default-features --features "${RUST_FEATURES}"
 
 # `dev` profile outputs to the `target/debug` directory.


### PR DESCRIPTION
Change cache mount sharing mode from `locked` to `shared` for cargo registry, git, and sccache directories.

With `sharing=locked`, parallel builds must wait for exclusive access to each cache, causing builds to queue up even when compilation itself is fast.

Both cargo and sccache handle concurrent access correctly, so `shared` is safe and allows parallel builds to proceed without blocking.

Mirrors paradigmxyz/reth#21451 / paradigmxyz/reth#21450