### PR TITLE
fix(docker): expose VERGEN_GIT_SHA to build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
 ARG TAG_NAME="dev"
 ENV TAG_NAME=$TAG_NAME
 ARG VERGEN_GIT_SHA="ffffffffffffffffffffffffffffffffffffffff"
+ENV VERGEN_GIT_SHA=$VERGEN_GIT_SHA
 
 # Build the project.
 COPY . .


### PR DESCRIPTION
ARG VERGEN_GIT_SHA was defined but never exposed via ENV, so build.rs couldn't read it during cargo build. TAG_NAME had the matching ENV line but this one was missing.                                                                                                              
                                                                                                                                                                                                                                                                                       Fixes the git sha always falling back to the placeholder value in docker builds.