### PR TITLE
fix(config): Respect user-configured etherscan URL over chain defaults

### DIFF
--- a/crates/config/src/etherscan.rs
+++ b/crates/config/src/etherscan.rs
@@ -485,10 +485,8 @@ mod tests {
         let config = resolved.remove("mainnet").unwrap().unwrap();
         assert_eq!(config.key, "ABCDEFG");
         let client = config.into_client().unwrap();
-        assert_eq!(
-            client.etherscan_api_url().as_str(),
-            "https://api.etherscan.io/v2/api?chainid=1"
-        );
+        // Custom URL should be used even when chain has a default URL
+        assert_eq!(client.etherscan_api_url().as_str(), "https://api.etherscan.io/api");
 
         unsafe {
             std::env::remove_var(env);
@@ -524,5 +522,51 @@ mod tests {
 
         let resolved = config.resolve(Some("base-sepolia")).unwrap();
         assert_eq!(resolved.chain, Some(Chain::base_sepolia()));
+    }
+
+    #[test]
+    fn can_create_client_with_custom_url_for_chain_without_default_url() {
+        // Chains without default Etherscan URLs (e.g., Dev, AnvilHardhat networks)
+        // should work if a custom URL is provided in foundry.toml.
+        let mut configs = EtherscanConfigs::default();
+        configs.insert(
+            "dev".to_string(),
+            EtherscanConfig {
+                chain: Some(Chain::dev()),
+                url: Some("https://custom.api.url/verify/etherscan".to_string()),
+                key: EtherscanApiKey::Key("test_key".to_string()),
+            },
+        );
+
+        let mut resolved = configs.resolved();
+        let config = resolved.remove("dev").unwrap().unwrap();
+        let result = config.into_client();
+        assert!(
+            result.is_ok(),
+            "Should succeed with custom URL even for chains without default Etherscan URLs"
+        );
+    }
+
+    #[test]
+    fn fails_without_custom_url_for_chain_without_default_url() {
+        // Chains without default Etherscan URLs (e.g., Dev, AnvilHardhat networks)
+        // should fail if no custom URL is provided in foundry.toml.
+        let mut configs = EtherscanConfigs::default();
+        configs.insert(
+            "dev".to_string(),
+            EtherscanConfig {
+                chain: Some(Chain::dev()),
+                url: None,
+                key: EtherscanApiKey::Key("test_key".to_string()),
+            },
+        );
+
+        let mut resolved = configs.resolved();
+        let config = resolved.remove("dev").unwrap();
+
+        assert!(
+            config.is_err(),
+            "Should fail: chains without default Etherscan URLs require custom URL"
+        );
     }
 }


### PR DESCRIPTION
Thank you for maintaining Foundry! I use it regularly and really appreciate the work you do.

## Motivation
User-configured custom Etherscan URLs in `foundry.toml` are ignored for chains without default block explorer URLs (e.g., `NamedChain::Dev` / chain ID 1337), causing deployment failures even when a custom verification URL is explicitly configured.

**Problem**: When using Tenderly Virtual TestNet with chain ID 1337, Foundry fails with "Chain dev not supported" error despite having a custom verification URL in `foundry.toml`. This prevents developers from using Foundry's deployment and verification features with development networks and private chains.

  - Reference: [Tenderly Foundry Contract Verification](https://docs.tenderly.co/contract-verification/foundry)

**Root cause**: The `ResolvedEtherscanConfig::into_client()` method unconditionally calls `client_builder.chain(chain)?`, which:
1. Ignores the `api_url` that was already resolved by `resolve()` (either custom or default)
2. Queries `alloy-chains` again via `etherscan_urls()` to get default URLs
3. Fails for chains without default URLs

The error occurs even without `--verify` flag, as the Etherscan client is built during trace decoder construction for address identification.

**Related to #10893**, but addresses a different use case:
- **#10893**: Production chains (like Fuse) that should be added to `alloy-chains`
- **This PR**: Dev chains/private networks that should NOT be in `alloy-chains` but need custom URLs

## Solution

Respect user-configured URLs by eliminating the redundant `chain()` call in `into_client()`.

The fix modifies `ResolvedEtherscanConfig::into_client()` in `crates/config/src/etherscan.rs` to:

1. **Remove the unconditional `chain()` call**: Since `resolve()` already ensures `api_url` is populated (either custom or default), there's no need to query `alloy-chains` again
2. **Use `api_url` directly**: The `api_url` passed to `into_client()` is guaranteed to be valid (either user-configured or chain's default from `resolve()`)
3. **Browser URL fallback**: Use `api_url` for `browser_url` if not explicitly set

I'd appreciate any feedback on this approach. If there's a better way to handle this, or if I've overlooked something, I'm happy to revise.

This change:
- ✅ Respects user's explicit configuration in `foundry.toml`
- ✅ Maintains backward compatibility (`resolve()` still queries `alloy-chains` for default URLs when no custom URL is set)
- ✅ Eliminates redundant `alloy-chains` query in `into_client()` (already done in `resolve()`)
- ✅ Enables custom block explorers for chains without default URLs (e.g., chain ID 1337)

**Testing**:
- Added 2 unit tests covering chains with/without default URLs
- All 22 tests in `foundry-config` etherscan module pass
- Manually tested with Tenderly Virtual TestNet (chain ID 1337) - deployment and verification both work

**AI Assistance Disclosure**: This PR was developed with assistance from Claude (Anthropic) for codebase analysis, solution design, and documentation. Implementation was verified by the human contributor.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes