### PR TITLE
docs(coverage): link to stack-too-deep guide in warnings

### DIFF
--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -137,13 +137,14 @@ impl CoverageArgs {
                  which can result in inaccurate source mappings.\n\
                  Only use this flag as a workaround if you are experiencing \"stack too deep\" errors.\n\
                  Note that `viaIR` is production ready since Solidity 0.8.13 and above.\n\
-                 See more: https://github.com/foundry-rs/foundry/issues/3357"
+                 See more: https://book.getfoundry.sh/guides/best-practices/stack-too-deep"
             )?;
         } else {
             sh_warn!(
                 "optimizer settings and `viaIR` have been disabled for accurate coverage reports.\n\
                  If you encounter \"stack too deep\" errors, consider using `--ir-minimum` which \
-                 enables `viaIR` with minimum optimization resolving most of the errors"
+                 enables `viaIR` with minimum optimization resolving most of the errors.\n\
+                 See more: https://book.getfoundry.sh/guides/best-practices/stack-too-deep"
             )?;
         }
 


### PR DESCRIPTION
## Summary

Updates the `forge coverage` warnings to link to the new Foundry Book guide for resolving "stack too deep" errors.

## Changes

- Replace GitHub issue link with book guide URL
- Add `See more` link to the non-ir-minimum warning as well

## Related

- Depends on foundry-rs/book#1741 being merged first