### PR TITLE
fix(anvil): use consistent chain_id fallback for blob params

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -534,7 +534,7 @@ impl NodeConfig {
             BlobExcessGasAndPrice::new(
                 excess_blob_gas,
                 get_blob_base_fee_update_fraction(
-                    self.chain_id.unwrap_or(Chain::mainnet().id()),
+                    self.get_chain_id(),
                     self.get_genesis_timestamp(),
                 ),
             )
@@ -543,10 +543,7 @@ impl NodeConfig {
 
     /// Returns the [`BlobParams`] that should be used.
     pub fn get_blob_params(&self) -> BlobParams {
-        get_blob_params(
-            self.chain_id.unwrap_or(Chain::mainnet().id()),
-            self.get_genesis_timestamp(),
-        )
+        get_blob_params(self.get_chain_id(), self.get_genesis_timestamp())
     }
 
     /// Returns the hardfork to use


### PR DESCRIPTION
`get_blob_params()` and `get_blob_excess_gas_and_price()` were falling back to mainnet (1) when chain_id is None, while `get_chain_id()` falls back to 31337. This caused blob fee calculations to use mainnet params in local test environments.                                                                                                                                                                                                Now both `use get_chain_id()` so the fallback is consistent. 