### PR TITLE
fix(anvil): return error instead of empty vec for out-of-range log queries

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2141,8 +2141,7 @@ impl Backend {
             let from_block =
                 self.convert_block_number(filter.block_option.get_from_block().copied());
             if from_block > best {
-                // requested log range does not exist yet
-                return Ok(vec![]);
+                return Err(BlockchainError::BlockOutOfRange(best, from_block));
             }
 
             self.logs_for_range(&filter, from_block, to_block).await


### PR DESCRIPTION
When querying logs with `from_block > best_number`, now return `BlockOutOfRange` error instead of silently returning an empty array. This lets users distinguish between "no logs in range" vs "queried a block that doesn't exist yet".                                              
Matches the behavior already used elsewhere in the codebase (e.g. convert_block_number).