### PR TITLE
Remove redundant trait bounds from RuntimeTransport::boxed

### DIFF
--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -291,10 +291,7 @@ impl RuntimeTransport {
     }
 
     /// Convert this transport into a boxed trait object.
-    pub fn boxed(self) -> BoxTransport
-    where
-        Self: Sized + Clone + Send + Sync + 'static,
-    {
+    pub fn boxed(self) -> BoxTransport {
         BoxTransport::new(self)
     }
 }


### PR DESCRIPTION
Remove unnecessary `where Self: Sized + Clone + Send + Sync + 'static` bound from `RuntimeTransport::boxed()` method.