### PR TITLE
fix(verify): respect user etherscan config URL when verifier-url not …

### DIFF
--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -267,7 +267,9 @@ impl EtherscanVerificationProvider {
             || (verifier_type.is_sourcify() && etherscan_key.is_some());
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
 
-        let etherscan_api_url = verifier_url.or(None).map(str::to_owned);
+        let etherscan_api_url = verifier_url
+            .or_else(|| etherscan_config.as_ref().map(|c| c.api_url.as_str()))
+            .map(str::to_owned);
 
         let api_url = etherscan_api_url.as_deref();
         let base_url = etherscan_config


### PR DESCRIPTION
Fixes etherscan config URL being ignored by replacing no-op `.or(None)` with proper fallback to `etherscan_config.api_url`.