### PR TITLE
chore: update RPC URLs from ithaca.xyz to reth.rs

### DIFF
--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -44,30 +44,28 @@ shuffled_list!(
     HTTP_ARCHIVE_DOMAINS,
     vec![
         //
-        "reth-ethereum.ithaca.xyz/rpc",
+        "ethereum.reth.rs/rpc",
     ],
 );
 shuffled_list!(
     HTTP_DOMAINS,
     vec![
         //
-        "reth-ethereum.ithaca.xyz/rpc",
-        // "reth-ethereum-full.ithaca.xyz/rpc",
+        "ethereum.reth.rs/rpc",
     ],
 );
 shuffled_list!(
     WS_ARCHIVE_DOMAINS,
     vec![
         //
-        "reth-ethereum.ithaca.xyz/ws",
+        "ethereum.reth.rs/ws",
     ],
 );
 shuffled_list!(
     WS_DOMAINS,
     vec![
         //
-        "reth-ethereum.ithaca.xyz/ws",
-        // "reth-ethereum-full.ithaca.xyz/ws",
+        "ethereum.reth.rs/ws",
     ],
 );
 


### PR DESCRIPTION
## Summary
Updates RPC endpoint URLs from `ithaca.xyz` to `reth.rs`.

## Changes
- `reth-ethereum.ithaca.xyz/rpc` -> `ethereum.reth.rs/rpc`
- `reth-ethereum.ithaca.xyz/ws` -> `ethereum.reth.rs/ws`

Related: https://github.com/paradigmxyz/reth/pull/21574