### PR TITLE
perf(verify): eliminate unnecessary allocation and fix ignored user config in Etherscan client builder

### DIFF
--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -267,9 +267,7 @@ impl EtherscanVerificationProvider {
             || (verifier_type.is_sourcify() && etherscan_key.is_some());
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
 
-        let etherscan_api_url = verifier_url.or(None).map(str::to_owned);
-
-        let api_url = etherscan_api_url.as_deref();
+        let api_url = verifier_url.or_else(|| etherscan_config.as_ref().map(|c| c.api_url.as_str()));
         let base_url = etherscan_config
             .as_ref()
             .and_then(|c| c.browser_url.as_deref())


### PR DESCRIPTION
Fixed bug where user's `etherscan_config.api_url` was completely ignored, removed unnecessary string allocation in hot path (`str::to_owned` + `as_deref` cycle), eliminated pointless `.or(None)` operation