### PR TITLE
fix(cast): remove redundant chain() call in explorer_client

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -2336,7 +2336,7 @@ fn explorer_client(
     api_url: Option<String>,
     explorer_url: Option<String>,
 ) -> Result<Client> {
-    let mut builder = Client::builder().chain(chain)?;
+    let mut builder = Client::builder();
 
     let deduced = chain.etherscan_urls();
 


### PR DESCRIPTION
Fixes similar issue as #13238, `explorer_client` was calling `.chain(chain)?` which fails for chains without default URLs even when custom URLs are provided via `--explorer-api-url` and `--explorer-url` flags.