### PR TITLE
feat(anvil): add hint for --disable-pool-balance-checks on insufficient funds 

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3648,7 +3648,7 @@ impl TransactionValidator for Backend {
                     //    sufficient funds `tx.value <= existing account value + deposited value`
                     if value > account.balance + U256::from(deposit_tx.mint) {
                         warn!(target: "backend", "[{:?}] insufficient balance={}, required={} account={:?}", tx.hash(), account.balance + U256::from(deposit_tx.mint), value, *pending.sender());
-                        return Err(InvalidTransactionError::InsufficientFunds);
+                        return Err(InvalidTransactionError::InsufficientFundsForPoolValidation);
                     }
                 }
                 _ => {
@@ -3656,11 +3656,11 @@ impl TransactionValidator for Backend {
                     let req_funds =
                         max_cost.checked_add(value.saturating_to()).ok_or_else(|| {
                             warn!(target: "backend", "[{:?}] cost too high", tx.hash());
-                            InvalidTransactionError::InsufficientFunds
+                            InvalidTransactionError::InsufficientFundsForPoolValidation
                         })?;
                     if account.balance < U256::from(req_funds) {
                         warn!(target: "backend", "[{:?}] insufficient balance={}, required={} account={:?}", tx.hash(), account.balance, req_funds, *pending.sender());
-                        return Err(InvalidTransactionError::InsufficientFunds);
+                        return Err(InvalidTransactionError::InsufficientFundsForPoolValidation);
                     }
                 }
             }

--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -250,6 +250,12 @@ pub enum InvalidTransactionError {
     /// Represents the inability to cover max cost + value (account balance too low).
     #[error("Insufficient funds for gas * price + value")]
     InsufficientFunds,
+    /// Thrown when transaction pool validation fails due to insufficient balance.
+    /// This check can be disabled with --disable-pool-balance-checks flag.
+    #[error(
+        "Insufficient funds for gas * price + value. Hint: Use --disable-pool-balance-checks to skip pool balance validation for testing"
+    )]
+    InsufficientFundsForPoolValidation,
     /// Thrown when calculating gas usage
     #[error("gas uint64 overflow")]
     GasUintOverflow,


### PR DESCRIPTION
 I was debugging why my tx kept failing with "Insufficient funds" in the pool, took me a while to realize there's a `--disable-pool-balance-checks` flag. Would've been nice to have a hint in the error message, so here it is.   :0                                                              