### PR TITLE
fix(verify): respect user-configured etherscan URL over chain defaults

### DIFF
--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -267,9 +267,8 @@ impl EtherscanVerificationProvider {
             || (verifier_type.is_sourcify() && etherscan_key.is_some());
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
 
-        let etherscan_api_url = verifier_url.or(None).map(str::to_owned);
-
-        let api_url = etherscan_api_url.as_deref();
+        let api_url =
+            verifier_url.or_else(|| etherscan_config.as_ref().map(|c| c.api_url.as_str()));
         let base_url = etherscan_config
             .as_ref()
             .and_then(|c| c.browser_url.as_deref())
@@ -492,10 +491,8 @@ mod tests {
 
         let etherscan = EtherscanVerificationProvider::default();
         let client = etherscan.client(&args.etherscan, &args.verifier, &config).unwrap();
-        assert_eq!(
-            client.etherscan_api_url().as_str(),
-            "https://api.etherscan.io/v2/api?chainid=80002"
-        );
+        // Custom URL from foundry.toml should be used
+        assert_eq!(client.etherscan_api_url().as_str(), "https://amoy.polygonscan.com/");
 
         assert!(format!("{client:?}").contains("dummykey"));
 
@@ -552,10 +549,8 @@ mod tests {
 
         let client = etherscan.client(&args.etherscan, &args.verifier, &config).unwrap();
 
-        assert_eq!(
-            client.etherscan_api_url().as_str(),
-            "https://api.etherscan.io/v2/api?chainid=80002"
-        );
+        // Custom URL from foundry.toml should be used
+        assert_eq!(client.etherscan_api_url().as_str(), "https://amoy.polygonscan.com/");
         assert!(format!("{client:?}").contains("dummykey"));
 
         let args: VerifyArgs = VerifyArgs::parse_from([


### PR DESCRIPTION
Fixes similar issue as #13238, use etherscan URL from foundry.toml when  --verifier-url is not provided.  Previously only checked the command-line flag and fell back to chain defaults, skipping the config file entirely. 