### PR TITLE
fix(invariant): remove unused FuzzCase.calldata field to prevent OOM

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -280,7 +280,7 @@ impl FuzzedExecutor {
 
         if success {
             Ok(FuzzOutcome::Case(CaseOutcome {
-                case: FuzzCase { calldata, gas: call.gas_used, stipend: call.stipend },
+                case: FuzzCase { gas: call.gas_used, stipend: call.stipend },
                 traces: call.traces,
                 coverage: call.line_coverage,
                 breakpoints,

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -470,11 +470,9 @@ impl<'a> InvariantExecutor<'a> {
                     {
                         warn!(target: "forge::test", "{error}");
                     }
-                    current_run.fuzz_runs.push(FuzzCase {
-                        calldata: tx.call_details.calldata.clone(),
-                        gas: call_result.gas_used,
-                        stipend: call_result.stipend,
-                    });
+                    current_run
+                        .fuzz_runs
+                        .push(FuzzCase { gas: call_result.gas_used, stipend: call_result.stipend });
 
                     // Determine if test can continue or should exit.
                     // Check invariants based on check_interval to improve deep run performance.

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -317,8 +317,6 @@ impl FuzzTestResult {
 /// Data of a single fuzz test case
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct FuzzCase {
-    /// The calldata used for this fuzz test
-    pub calldata: Bytes,
     /// Consumed gas
     pub gas: u64,
     /// The initial gas stipend for the transaction


### PR DESCRIPTION
## Problem
Unbounded memory usage in `InvariantExecutor` due to retaining `calldata` for every successful fuzz case leads to OOM crashes during long invariant test runs.

Fixes #12397

## Solution
Based on @grandizzy's observation that fuzz cases aren't shared between runs, I investigated and found that `FuzzCase.calldata` is stored but **never read after construction**.

The simplest fix is to remove the field entirely - no pruning logic, ring buffers, or config flags needed.

## Changes
- Removed `FuzzCase.calldata` field (never used after construction)
- Updated construction sites to omit calldata

This supersedes #12893 with a cleaner approach that addresses review feedback:
- Does NOT delete unrelated vyper test files (per @DaniPopes)
- Simpler than rolling window approach (per @0xalpharush and @grandizzy)

Net: -4 lines, simpler struct, no memory accumulation.