### PR TITLE
ci(bench): use depot runner for benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   run-benchmarks:
     name: Run All Benchmarks
-    runs-on: foundry-runner
+    runs-on: depot-ubuntu-24.04-32
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
The foundry-runner group doesn't exist anymore, or is unresponsive. Just use depot.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
