### PR TITLE
fix(forge): add browser wallet support for forge create

### DIFF
--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -50,7 +50,7 @@ forge-script.workspace = true
 forge-sol-macro-gen.workspace = true
 foundry-cli.workspace = true
 foundry-debugger.workspace = true
-foundry-wallets = { workspace = true, optional = true }
+foundry-wallets.workspace = true
 
 alloy-chains.workspace = true
 alloy-dyn-abi.workspace = true
@@ -121,7 +121,7 @@ asm-keccak = ["alloy-primitives/asm-keccak"]
 jemalloc = ["foundry-cli/jemalloc"]
 mimalloc = ["foundry-cli/mimalloc"]
 tracy-allocator = ["foundry-cli/tracy-allocator"]
-aws-kms = ["dep:foundry-wallets", "foundry-wallets/aws-kms"]
-gcp-kms = ["dep:foundry-wallets", "foundry-wallets/gcp-kms"]
-turnkey = ["dep:foundry-wallets", "foundry-wallets/turnkey"]
+aws-kms = ["foundry-wallets/aws-kms"]
+gcp-kms = ["foundry-wallets/gcp-kms"]
+turnkey = ["foundry-wallets/turnkey"]
 isolate-by-default = ["foundry-config/isolate-by-default"]

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -589,7 +589,9 @@ impl CreateArgs {
         }
 
         // Send transaction via browser wallet
-        let tx_hash = browser_signer.send_transaction_via_browser(deployer.tx.into_inner()).await
+        let tx_hash = browser_signer
+            .send_transaction_via_browser(deployer.tx.into_inner())
+            .await
             .map_err(|e| eyre::eyre!("Failed to send transaction via browser: {}", e))?;
 
         // Wait for receipt
@@ -598,8 +600,8 @@ impl CreateArgs {
             .await?
             .ok_or_else(|| eyre::eyre!("Transaction receipt not found"))?;
 
-        let address = receipt.contract_address
-            .ok_or_else(|| eyre::eyre!("Contract not deployed"))?;
+        let address =
+            receipt.contract_address.ok_or_else(|| eyre::eyre!("Contract not deployed"))?;
 
         if shell::is_json() {
             let output = json!({

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -9,10 +9,6 @@ extern crate foundry_common;
 #[macro_use]
 extern crate tracing;
 
-// Required for optional features (aws-kms, gcp-kms, turnkey)
-#[cfg(any(feature = "aws-kms", feature = "gcp-kms", feature = "turnkey"))]
-use foundry_wallets as _;
-
 pub mod args;
 pub mod cmd;
 pub mod opts;


### PR DESCRIPTION
Fixes #12958                                                               

`forge create --browser` now works correctly. Previously it failed with "Use send_transaction_via_browser for browser wallets" error.  The fix detects browser wallet signers and uses `send_transaction_via_browser()` instead of wrapping them in `EthereumWallet`.              