### PR TITLE
sec: bump to `bytes` `^1.11.1` for `RUSTSEC-2026-0007`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,9 +2503,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

https://rustsec.org/advisories/RUSTSEC-2026-0007

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Bumps to bytes 1.11.1, was flagged by `cargo deny` here: https://github.com/tempoxyz/tempo-foundry/actions/runs/21637045417/job/62365484234

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes