### PR TITLE
Add --enable-tx-gas-limit CLI flag for EIP-7825 support

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -234,6 +234,7 @@ impl NodeArgs {
         Ok(NodeConfig::default()
             .with_gas_limit(self.evm.gas_limit)
             .disable_block_gas_limit(self.evm.disable_block_gas_limit)
+            .enable_tx_gas_limit(self.evm.enable_tx_gas_limit)
             .with_gas_price(self.evm.gas_price)
             .with_hardfork(hardfork)
             .with_blocktime(self.block_time)
@@ -543,6 +544,10 @@ pub struct AnvilEvmArgs {
         conflicts_with = "gas_limit"
     )]
     pub disable_block_gas_limit: bool,
+
+    /// Enable the transaction gas limit check as imposed by EIP-7825 (Osaka hardfork).
+    #[arg(long, visible_alias = "tx-gas-limit", help_heading = "Environment config")]
+    pub enable_tx_gas_limit: bool,
 
     /// EIP-170: Contract code size limit in bytes. Useful to increase this because of tests. To
     /// disable entirely, use `--disable-code-size-limit`. By default, it is 0x6000 (~25kb).
@@ -893,6 +898,16 @@ mod tests {
         let args =
             NodeArgs::try_parse_from(["anvil", "--disable-block-gas-limit", "--gas-limit", "100"]);
         assert!(args.is_err());
+    }
+
+    #[test]
+    fn can_parse_enable_tx_gas_limit() {
+        let args: NodeArgs = NodeArgs::parse_from(["anvil", "--enable-tx-gas-limit"]);
+        assert!(args.evm.enable_tx_gas_limit);
+
+        // Also test the alias
+        let args: NodeArgs = NodeArgs::parse_from(["anvil", "--tx-gas-limit"]);
+        assert!(args.evm.enable_tx_gas_limit);
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I was looking at anvil's gas limit options and noticed that `NodeConfig` has an `enable_tx_gas_limit` field for EIP-7825 (Osaka hardfork), and it's actually being used in the code. Forge/cast already have this flag exposed in their CLI, but anvil was missing it - so users couldn't actually enable this feature.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
dded the `--enable-tx-gas-limit` flag (with `--tx-gas-limit` alias) and wired it through `into_node_config()`. Also added a test for the CLI parsing.
## PR Checklist

- [ ✅] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
