### PR TITLE
chore(anvil,cast): remove unnecessary `populate_blob_hashes()`

### DIFF
--- a/crates/anvil/tests/it/beacon_api.rs
+++ b/crates/anvil/tests/it/beacon_api.rs
@@ -66,8 +66,7 @@ async fn test_beacon_api_get_blobs() {
             .with_blob_sidecar(sidecar)
             .value(U256::from(100));
 
-        let mut tx = WithOtherFields::new(tx);
-        tx.populate_blob_hashes();
+        let tx = WithOtherFields::new(tx);
 
         let pending = provider.send_transaction(tx).await.unwrap();
         pending_txs.push(pending);

--- a/crates/anvil/tests/it/eip4844.rs
+++ b/crates/anvil/tests/it/eip4844.rs
@@ -39,9 +39,7 @@ async fn can_send_eip4844_transaction() {
         .with_blob_sidecar(sidecar)
         .value(U256::from(5));
 
-    let mut tx = WithOtherFields::new(tx);
-
-    tx.populate_blob_hashes();
+    let tx = WithOtherFields::new(tx);
 
     let receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
 
@@ -154,9 +152,7 @@ async fn can_send_multiple_blobs_in_one_tx() {
         .with_max_fee_per_gas(eip1559_est.max_fee_per_gas)
         .with_max_priority_fee_per_gas(eip1559_est.max_priority_fee_per_gas)
         .with_blob_sidecar(sidecar);
-    let mut tx = WithOtherFields::new(tx);
-
-    tx.populate_blob_hashes();
+    let tx = WithOtherFields::new(tx);
 
     let receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
 
@@ -192,9 +188,7 @@ async fn cannot_exceed_six_blobs() {
         .with_max_fee_per_gas(eip1559_est.max_fee_per_gas)
         .with_max_priority_fee_per_gas(eip1559_est.max_priority_fee_per_gas)
         .with_blob_sidecar(sidecar);
-    let mut tx = WithOtherFields::new(tx);
-
-    tx.populate_blob_hashes();
+    let tx = WithOtherFields::new(tx);
 
     let err = provider.send_transaction(tx).await.unwrap_err();
 
@@ -234,8 +228,6 @@ async fn can_mine_blobs_when_exceeds_max_blobs() {
         .with_blob_sidecar(sidecar);
     let mut tx = WithOtherFields::new(tx);
 
-    tx.populate_blob_hashes();
-
     let first_tx = provider.send_transaction(tx.clone()).await.unwrap();
 
     let second_batch = vec![1u8; DATA_GAS_PER_BLOB as usize * 2];
@@ -247,7 +239,6 @@ async fn can_mine_blobs_when_exceeds_max_blobs() {
     let sidecar = sidecar.build().unwrap();
     tx.set_blob_sidecar(sidecar);
     tx.set_nonce(1);
-    tx.populate_blob_hashes();
     let second_tx = provider.send_transaction(tx).await.unwrap();
 
     api.mine_one().await;
@@ -451,9 +442,7 @@ async fn can_get_blobs_by_versioned_hash() {
         .with_blob_sidecar(sidecar.clone())
         .value(U256::from(5));
 
-    let mut tx = WithOtherFields::new(tx);
-
-    tx.populate_blob_hashes();
+    let tx = WithOtherFields::new(tx);
 
     let _receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
 
@@ -489,10 +478,7 @@ async fn can_get_blobs_by_tx_hash() {
         .with_blob_sidecar(sidecar.clone())
         .value(U256::from(5));
 
-    let mut tx = WithOtherFields::new(tx);
-
-    tx.populate_blob_hashes();
-
+    let tx = WithOtherFields::new(tx);
     let receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
     let hash = receipt.transaction_hash;
     api.anvil_set_auto_mine(true).await.unwrap();

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -682,8 +682,6 @@ where
             self.tx.set_blob_sidecar_7594(sidecar);
         }
 
-        self.tx.populate_blob_hashes();
-
         Ok(self)
     }
 }


### PR DESCRIPTION
## Motivation

Smol simplification as both [`TransactionBuilder4844::set_blob_sidecar`](https://docs.rs/alloy-rpc-types-eth/1.6.1/src/alloy_rpc_types_eth/transaction/request.rs.html#1076-1079) & [`TransactionBuilder7594::set_blob_sidecar_7594`](https://docs.rs/alloy-rpc-types-eth/1.6.1/src/alloy_rpc_types_eth/transaction/request.rs.html#1105-1108) implementations do `populate_blob_hashes()`, so it's useless to call it again after setting a blob.

## PR Checklist

- [ ] Added Tests (all existing pass)
- [ ] Added Documentation
- [ ] Breaking changes
