### PR TITLE
feat(anvil): cache block timestamp in mined receipts

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3082,7 +3082,8 @@ impl Backend {
             blob_gas_used,
         };
 
-        let inner = FoundryTxReceipt::new(receipt);
+        // Include timestamp in receipt to avoid extra block lookups (e.g., in Otterscan API)
+        let inner = FoundryTxReceipt::with_timestamp(receipt, block.header.timestamp);
         Some(MinedTransactionReceipt { inner, out: info.out })
     }
 

--- a/crates/primitives/src/network/receipt.rs
+++ b/crates/primitives/src/network/receipt.rs
@@ -17,6 +17,24 @@ impl FoundryTxReceipt {
     pub fn new(inner: TransactionReceipt<FoundryReceiptEnvelope<Log>>) -> Self {
         Self(WithOtherFields::new(inner))
     }
+
+    /// Creates a new receipt with a timestamp in the other fields.
+    /// This avoids extra block lookups when timestamp is needed later.
+    pub fn with_timestamp(
+        inner: TransactionReceipt<FoundryReceiptEnvelope<Log>>,
+        timestamp: u64,
+    ) -> Self {
+        let mut receipt = WithOtherFields::new(inner);
+        receipt
+            .other
+            .insert("blockTimestamp".to_string(), serde_json::to_value(timestamp).unwrap());
+        Self(receipt)
+    }
+
+    /// Get block timestamp from other fields if present.
+    pub fn block_timestamp(&self) -> Option<u64> {
+        self.0.other.get_deserialized::<u64>("blockTimestamp").transpose().ok().flatten()
+    }
 }
 
 impl ReceiptResponse for FoundryTxReceipt {


### PR DESCRIPTION
Otterscan's `build_ots_search_transactions` was calling `block_by_number` for every receipt just to get the timestamp. Now we stash it in the receipt's `other` field when mining, so we skip those extra lookups. Falls back to the old behavior for fork receipts that don't have it.  