### PR TITLE
fix: use shared `display_chain` helper in CLI error handler

### DIFF
--- a/crates/cli/src/handler.rs
+++ b/crates/cli/src/handler.rs
@@ -91,4 +91,3 @@ pub fn install() {
         debug!("failed to install eyre error hook: {e}");
     }
 }
-


### PR DESCRIPTION


The CLI error handler duplicated the behavior of `display_chain` by manually joining `dedup_chain(error)` with `"; "`. Keeping this logic in two places makes it easy for the formats to diverge over time and breaks the “single source of truth” for how error chains are rendered.

