### PR TITLE
fix(fmt): correct closing brace indentation for empty contracts with comments

### DIFF
--- a/crates/fmt/testdata/Repros/fmt.sol
+++ b/crates/fmt/testdata/Repros/fmt.sol
@@ -427,3 +427,12 @@ contract ChainedStructCall {
         }).pack();
     }
 }
+
+// https://github.com/foundry-rs/foundry/issues/13315
+contract EmptyWithComment {
+    // comment only, no body items
+}
+
+contract EmptyWithBlankLine {
+    // comment followed by blank line
+}

--- a/crates/fmt/testdata/Repros/original.sol
+++ b/crates/fmt/testdata/Repros/original.sol
@@ -424,3 +424,14 @@ contract ChainedStructCall {
             }).pack();
     }
 }
+
+// https://github.com/foundry-rs/foundry/issues/13315
+contract EmptyWithComment {
+    // comment only, no body items
+
+}
+
+contract EmptyWithBlankLine {
+    // comment followed by blank line
+
+}

--- a/crates/fmt/testdata/Repros/sorted.fmt.sol
+++ b/crates/fmt/testdata/Repros/sorted.fmt.sol
@@ -428,3 +428,12 @@ contract ChainedStructCall {
         }).pack();
     }
 }
+
+// https://github.com/foundry-rs/foundry/issues/13315
+contract EmptyWithComment {
+    // comment only, no body items
+}
+
+contract EmptyWithBlankLine {
+    // comment followed by blank line
+}

--- a/crates/fmt/testdata/Repros/tab.fmt.sol
+++ b/crates/fmt/testdata/Repros/tab.fmt.sol
@@ -428,3 +428,12 @@ contract ChainedStructCall {
 		}).pack();
 	}
 }
+
+// https://github.com/foundry-rs/foundry/issues/13315
+contract EmptyWithComment {
+	// comment only, no body items
+}
+
+contract EmptyWithBlankLine {
+	// comment followed by blank line
+}


### PR DESCRIPTION
Fixes #13315

When a contract body is empty but contains a comment, the closing brace
was incorrectly indented. This was caused by not applying the offset
adjustment before closing the indentation box.

The fix replaces the `zerobreak()` with `offset(-self.ind)` to properly
deindent the closing brace, matching the behavior of contracts with
non-empty bodies.