### PR TITLE
fix(test): update DEFAULT_CONFIG snapshot for mixed_case_exceptions

### DIFF
--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -157,6 +157,14 @@ lint_on_build = true
 mixed_case_exceptions = [
     "ERC",
     "URI",
+    "ID",
+    "URL",
+    "API",
+    "JSON",
+    "XML",
+    "HTML",
+    "HTTP",
+    "HTTPS",
 ]
 
 [doc]
@@ -1362,7 +1370,15 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "lint_on_build": true,
     "mixed_case_exceptions": [
       "ERC",
-      "URI"
+      "URI",
+      "ID",
+      "URL",
+      "API",
+      "JSON",
+      "XML",
+      "HTML",
+      "HTTP",
+      "HTTPS"
     ]
   },
   "doc": {


### PR DESCRIPTION
After fix the test in https://github.com/foundry-rs/foundry/pull/13267?notification_referrer_id=NT_kwHOBBpSjdoAJVJlcG9zaXRvcnk7NDA0MzIwMDUzO0lzc3VlOzM4NzIyNDY3NTQ#pullrequestreview-3752328420, the CI is still failing, after investigation, found the reason:

PR #13305 added new default values to mixed_case_exceptions but forgot to update the test snapshot. This caused test_default_config to fail.

cc @onbjerg 