### PR TITLE
foundryup: tempo now distributes all binaries

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -55,11 +55,6 @@ main() {
     esac; shift
   done
 
-  # Tempo only distributes a subset of the binaries
-  if [[ "$FOUNDRYUP_NETWORK" == "tempo" ]]; then
-    BINS=(forge cast)
-  fi
-
   CARGO_BUILD_ARGS=(--release)
 
   if [ -n "$FOUNDRYUP_JOBS" ]; then


### PR DESCRIPTION
Tempo now distributes all foundry binaries (forge, cast, anvil, chisel), so the constraint limiting the tempo network to only forge and cast is no longer needed.

This removes the `BINS=(forge cast)` override that was previously applied when `--network tempo` was used.