### PR TITLE
fix: broken config test, currently blocking CI

### DIFF
--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1370,7 +1370,15 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "lint_on_build": true,
     "mixed_case_exceptions": [
       "ERC",
-      "URI"
+      "URI",
+      "ID",
+      "URL",
+      "API",
+      "JSON",
+      "XML",
+      "HTML",
+      "HTTP",
+      "HTTPS"
     ]
   },
   "doc": {


### PR DESCRIPTION
Seeing this unrelated error show up on various PRs: https://github.com/foundry-rs/foundry/actions/runs/21726827877/job/62670977288?pr=13331

Really unclear to me how this was able to get merged on master (maybe forced?): https://github.com/foundry-rs/foundry/pull/13305