### PR TITLE
feat: revert on `msg.sender` usage inside broadcast in script contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4321,7 +4321,6 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-serde",
- "alloy-signer",
  "clap",
  "dialoguer",
  "dunce",

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1164,7 +1164,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
             interpreter.bytecode.set_action(InterpreterAction::new_return(
                 InstructionResult::Revert,
                 Bytes::from(format!(
-                    "Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `{:#x}`, not the broadcast signer `{:#x}`. Use `vm.addr(<pk>)` instead.",
+                    "Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `{:#x}`, not the broadcast signer `{:#x}`. Use the `--sender` flag or store the deployer address in a variable instead.",
                     broadcast.original_origin,
                     broadcast.new_origin,
                 ).into_bytes()),

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1164,7 +1164,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
             interpreter.bytecode.set_action(InterpreterAction::new_return(
                 InstructionResult::Revert,
                 Bytes::from(format!(
-                    "Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `{:#x}`, not the broadcast signer `{:#x}`. Use the `--sender` flag or store the deployer address in a variable instead.",
+                    "Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `{:#x}`, not the broadcast signer `{:#x}`. Use the `--sender` flag or pass the deployer address directly instead.",
                     broadcast.original_origin,
                     broadcast.new_origin,
                 ).into_bytes()),

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -409,10 +409,8 @@ impl InspectorStack {
     /// Set the script execution inspector and propagate the script address to cheatcodes.
     #[inline]
     pub fn script(&mut self, script_address: Address) {
-        self.inner
-            .script_execution_inspector
-            .get_or_insert_with(Default::default)
-            .script_address = script_address;
+        self.inner.script_execution_inspector.get_or_insert_with(Default::default).script_address =
+            script_address;
         if let Some(cheatcodes) = &mut self.cheatcodes {
             cheatcodes.script_address = Some(script_address);
         }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -406,6 +406,18 @@ impl InspectorStack {
         self.analysis = Some(analysis);
     }
 
+    /// Set the script execution inspector and propagate the script address to cheatcodes.
+    #[inline]
+    pub fn script(&mut self, script_address: Address) {
+        self.inner
+            .script_execution_inspector
+            .get_or_insert_with(Default::default)
+            .script_address = script_address;
+        if let Some(cheatcodes) = &mut self.cheatcodes {
+            cheatcodes.script_address = Some(script_address);
+        }
+    }
+
     /// Set variables from an environment for the relevant inspectors.
     #[inline]
     pub fn set_env(&mut self, env: &Env) {
@@ -501,13 +513,6 @@ impl InspectorStack {
         } else {
             self.tracer = None;
         }
-    }
-
-    /// Set whether to enable script execution inspector.
-    #[inline]
-    pub fn script(&mut self, script_address: Address) {
-        self.script_execution_inspector.get_or_insert_with(Default::default).script_address =
-            script_address;
     }
 
     #[inline(always)]

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2682,7 +2682,7 @@ forgetest_init!(should_revert_on_msg_sender_in_broadcast, |prj, cmd| {
     );
 
     cmd.arg("script").arg("ScriptWithMsgSender").assert_failure().stderr_eq(str![[r#"
-Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`, not the broadcast signer `0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266`. Use `vm.addr(<pk>)` instead.
+Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`, not the broadcast signer `0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266`. Use the `--sender` flag or store the deployer address in a variable instead.
 
 "#]]);
 
@@ -2716,7 +2716,7 @@ forgetest_init!(should_revert_on_msg_sender_in_single_broadcast, |prj, cmd| {
     );
 
     cmd.arg("script").arg("ScriptWithSingleBroadcast").assert_failure().stderr_eq(str![[r#"
-Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`, not the broadcast signer `0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266`. Use `vm.addr(<pk>)` instead.
+Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`, not the broadcast signer `0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266`. Use the `--sender` flag or store the deployer address in a variable instead.
 
 "#]]);
 });
@@ -2739,7 +2739,7 @@ forgetest_init!(should_revert_on_msg_sender_in_broadcast_with_address, |prj, cmd
     );
 
     cmd.arg("script").arg("ScriptWithBroadcastAddr").assert_failure().stderr_eq(str![[r#"
-Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`, not the broadcast signer `0x0000000000000000000000000000000000001337`. Use `vm.addr(<pk>)` instead.
+Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`, not the broadcast signer `0x0000000000000000000000000000000000001337`. Use the `--sender` flag or store the deployer address in a variable instead.
 
 "#]]);
 });

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2682,7 +2682,7 @@ forgetest_init!(should_revert_on_msg_sender_in_broadcast, |prj, cmd| {
     );
 
     cmd.arg("script").arg("ScriptWithMsgSender").assert_failure().stderr_eq(str![[r#"
-Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`, not the broadcast signer `0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266`. Use the `--sender` flag or store the deployer address in a variable instead.
+Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`, not the broadcast signer `0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266`. Use the `--sender` flag or pass the deployer address directly instead.
 
 "#]]);
 
@@ -2716,7 +2716,7 @@ forgetest_init!(should_revert_on_msg_sender_in_single_broadcast, |prj, cmd| {
     );
 
     cmd.arg("script").arg("ScriptWithSingleBroadcast").assert_failure().stderr_eq(str![[r#"
-Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`, not the broadcast signer `0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266`. Use the `--sender` flag or store the deployer address in a variable instead.
+Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`, not the broadcast signer `0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266`. Use the `--sender` flag or pass the deployer address directly instead.
 
 "#]]);
 });
@@ -2739,7 +2739,7 @@ forgetest_init!(should_revert_on_msg_sender_in_broadcast_with_address, |prj, cmd
     );
 
     cmd.arg("script").arg("ScriptWithBroadcastAddr").assert_failure().stderr_eq(str![[r#"
-Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`, not the broadcast signer `0x0000000000000000000000000000000000001337`. Use the `--sender` flag or store the deployer address in a variable instead.
+Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is the default sender `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`, not the broadcast signer `0x0000000000000000000000000000000000001337`. Use the `--sender` flag or pass the deployer address directly instead.
 
 "#]]);
 });

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -45,7 +45,6 @@ alloy-json-abi.workspace = true
 dialoguer.workspace = true
 indicatif.workspace = true
 
-alloy-signer.workspace = true
 alloy-serde.workspace = true
 alloy-network.workspace = true
 alloy-provider.workspace = true

--- a/testdata/default/cheats/Broadcast.t.sol
+++ b/testdata/default/cheats/Broadcast.t.sol
@@ -499,19 +499,14 @@ contract CheckOverrides is ForgeTest {
 
         vm.stopBroadcast();
 
-        // startBroadcast(msg.sender)
+        // startBroadcast(address(0x1337))
+        // Note: msg.sender inside script is still script_caller, NOT 0x1337.
+        // Using msg.sender here would revert with script_execution_protection enabled
+        // because it would resolve to the default sender, not the broadcast signer.
         vm.startBroadcast(address(0x1337));
-        require(tx.origin == script_caller);
-        require(msg.sender == script_caller);
-        require(msg.sender != address(0x1337));
 
         ContractB b = new ContractB(script_caller);
-        require(tx.origin == script_caller);
-        require(msg.sender == script_caller);
-
         b.method(script_caller);
-        require(tx.origin == script_caller);
-        require(msg.sender == script_caller);
 
         vm.stopBroadcast();
     }


### PR DESCRIPTION
## Summary

Prevents the class of bugs where `msg.sender` in forge scripts resolves to the wrong address inside broadcast blocks.

Ref: https://github.com/foundry-rs/foundry/discussions/13346

## Changes

### `crates/cheatcodes/src/inspector.rs`

Added `script_address: Option<Address>` field to `Cheatcodes`. In `step()`, when the `CALLER` opcode executes inside the script contract while a broadcast is active and `broadcast.original_origin != broadcast.new_origin`, the script reverts with:

```
Usage of `msg.sender` inside a `broadcast` in script contract detected.
`msg.sender` is the default sender `0x1804...`, not the broadcast signer `0xf39f...`.
Use `vm.addr(<pk>)` instead.
```

Same pattern as the existing `address(this)` / `ADDRESS` opcode protection. Gated behind `script_execution_protection`.

### `crates/evm/evm/src/inspectors/stack.rs`

Moved `InspectorStack::script()` from `InspectorStackInner` to `InspectorStack` so it can propagate the script address to both `ScriptExecutionInspector` and `Cheatcodes`.

### `crates/script/src/lib.rs`

Replaced `maybe_load_private_key()` with `maybe_load_sender()`. The old method only checked raw private keys and Turnkey to infer `--sender`, so Ledger, Trezor, AWS KMS, GCP KMS, keystore, and browser wallet users would always get the default sender even with a single signer. Now uses `Wallets::signers()` which includes all wallet backends.

Removes the `alloy-signer` dependency from `forge-script`.

### `crates/forge/tests/cli/script.rs`

Two new tests:
- `should_revert_on_msg_sender_in_broadcast` — `msg.sender` inside `startBroadcast(pk)` reverts; disabled with `script_execution_protection = false`
- `should_allow_msg_sender_in_broadcast_when_matching` — `msg.sender` inside `startBroadcast()` with `--private-key` passes (sender matches)

### `testdata/default/cheats/Broadcast.t.sol`

Updated `CheckOverrides`: removed `msg.sender` / `tx.origin` assertions from inside the `startBroadcast(0x1337)` block since these now correctly revert.