### PR TITLE
fix(test-utils): create destination directory in copy_dir_filtered

### DIFF
--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -235,6 +235,7 @@ pub fn read_string(path: impl AsRef<Path>) -> String {
 /// like `out/`, `cache/`, and `broadcast/` which are build artifacts that should not be
 /// copied to temporary test workspaces.
 pub fn copy_dir_filtered(src: &Path, dst: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
     copy_dir_filtered_inner(src, dst, true)
 }
 


### PR DESCRIPTION
## Motivation

The `copy_dir_filtered` function introduced in #13266 replaced `fs_extra::dir::copy` but does not create the root destination directory. The old `fs_extra` call with `copy_inside: true` implicitly created it.

In `initialize()`, the template path is removed with `remove_dir_all(tpath)` before calling `copy_dir_filtered(prj.root(), tpath)` at line 108. Since `tpath` no longer exists, the first `fs::copy()` call fails with:

```
/var/folders/.../T/foundry-forge-test-template: No such file or directory (os error 2)
```

This manifests on macOS CI (`aarch64-apple-darwin`) because those runners start with a clean temp directory, while Linux runners may have a cached template from a previous run that masks the bug.

## Solution

Add `fs::create_dir_all(dst)?` at the top of `copy_dir_filtered` to ensure the destination directory exists before copying files into it. This restores the implicit behavior of the old `fs_extra::dir::copy`.

Closes #13345