### PR TITLE
resolve absolute and relative paths on Windows

### DIFF
--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -451,7 +451,11 @@ fn resolve_path(path: &Path) -> Result<PathBuf, ()> {
     {
         return Ok(path.to_path_buf());
     }
-    Err(())
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        std::env::current_dir().map(|d| d.join(path)).map_err(drop)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
On Windows, when connecting to a local node via IPC file path (e.g., `cast block --rpc-url ./geth.ipc`), the call fails with:

  ```
  Error: invalid provider URL: "./geth.ipc": relative URL without a base
  ```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This is because `Url::parse("./geth.ipc")` returns `ParseError::RelativeUrlWithoutBase`, and the fallback path calls `resolve_path()` which on Windows only accepts named pipe paths (`\\.\pipe\...`), returning `Err(())` for everything else. The error propagates back as the
  original `ParseError`, wrapped with the "invalid provider URL" message.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Fix `resolve_path` on Windows to handle absolute and relative file paths, not just named pipe paths (`\\.\pipe\`)
## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
