### PR TITLE
chore(common): remove dead `with_spinner_reporter` function

### DIFF
--- a/crates/common/src/term.rs
+++ b/crates/common/src/term.rs
@@ -1,7 +1,7 @@
 //! terminal utils
 use foundry_compilers::{
     artifacts::remappings::Remapping,
-    report::{self, BasicStdoutReporter, Reporter},
+    report::{self, Reporter},
 };
 use itertools::Itertools;
 use semver::Version;
@@ -207,19 +207,6 @@ impl Reporter for SpinnerReporter {
     fn on_unresolved_imports(&self, imports: &[(&Path, &Path)], remappings: &[Remapping]) {
         self.send_msg(report::format_unresolved_imports(imports, remappings));
     }
-}
-
-/// If the output medium is terminal, this calls `f` within the [`SpinnerReporter`] that displays a
-/// spinning cursor to display solc progress.
-///
-/// If no terminal is available this falls back to common `println!` in [`BasicStdoutReporter`].
-pub fn with_spinner_reporter<T>(project_root: Option<PathBuf>, f: impl FnOnce() -> T) -> T {
-    let reporter = if TERM_SETTINGS.indicate_progress {
-        report::Report::new(SpinnerReporter::spawn(project_root))
-    } else {
-        report::Report::new(BasicStdoutReporter::default())
-    };
-    report::with_scoped(&reporter, f)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`with_spinner_reporter` in term.rs has been unused since `with_compilation_reporter` https://github.com/foundry-rs/foundry/blob/cbcf28363fb436f4afc2f9edb18411a6d0574a19/crates/common/src/compile.rs#L556-L574
was introduced in compile.rs during the shell unification refactor (PR #9109). The new function is a strict superset — it additionally handles `quiet` https://github.com/foundry-rs/foundry/blob/cbcf28363fb436f4afc2f9edb18411a6d0574a19/crates/common/src/compile.rs#L104-L110 and `json` output modes — while the old one was simply forgotten during cleanup.

Removed the dead function and its now-unused `BasicStdoutReporter` import.