### PR TITLE
canonicalize ignore paths like other modules

### DIFF
--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -98,8 +98,11 @@ impl DocBuilder {
         fs::create_dir_all(self.root.join(&self.config.out))
             .wrap_err("failed to create output directory")?;
 
-        // Expand ignore globs
-        let ignored = expand_globs(&self.root, self.config.ignore.iter())?;
+        // Expand ignore globs and canonicalize from the get go
+        let ignored = expand_globs(&self.root, self.config.ignore.iter())?
+            .iter()
+            .flat_map(foundry_common::fs::canonicalize_path)
+            .collect::<Vec<_>>();
 
         // Collect and parse source files
         let sources = source_files_iter(&self.sources, SOLC_EXTENSIONS)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
expand_globs in the doc builder was missing the canonicalize_path step that fmt, lint, and build all have, which could cause doc.ignore entries to not match when symlinks or relative paths are involved.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
canonicalize ignore paths like other modules
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
