### PR TITLE
fix(cast): remove duplicate receipt handling in Tempo transactions

### DIFF
--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -237,18 +237,6 @@ impl SendTxArgs {
 
                 if send_tx.cast_async {
                     sh_println!("{tx_hash:#x}")?;
-                } else if send_tx.sync {
-                    // For sync mode, we already have the hash, just wait for receipt
-                    let receipt = cast
-                        .receipt(
-                            format!("{tx_hash:#x}"),
-                            None,
-                            send_tx.confirmations,
-                            Some(timeout),
-                            false,
-                        )
-                        .await?;
-                    sh_println!("{receipt}")?;
                 } else {
                     let receipt = cast
                         .receipt(


### PR DESCRIPTION
The `else if send_tx.sync` and `else` branches were identical - both just called `cast.receipt()` with the same args. Removed the redundant branch.

https://github.com/foundry-rs/foundry/blob/b523fd29ad7e1fe872005a2dacd806a3a1b73fc8/crates/cast/src/cmd/send.rs#L252-L264