### PR TITLE
perf(otterscan): fix pagination overflow and eliminate N+1 block queries

### DIFF
--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -21,6 +21,7 @@ use alloy_rpc_types::{
 };
 use futures::future::join_all;
 use itertools::Itertools;
+use std::collections::HashMap;
 
 impl EthApi {
     /// Otterscan currently requires this endpoint, even though it's not part of the `ots_*`.
@@ -172,11 +173,12 @@ impl EthApi {
                     .filter_map(|trace| trace.transaction_hash)
                     .unique();
 
-                if res.len() >= page_size {
+                let remaining = page_size.saturating_sub(res.len());
+                if remaining == 0 {
                     break;
                 }
 
-                res.extend(hashes);
+                res.extend(hashes.take(remaining));
             }
 
             if n == to {
@@ -220,11 +222,12 @@ impl EthApi {
                     .filter_map(|trace| trace.transaction_hash)
                     .unique();
 
-                if res.len() >= page_size {
+                let remaining = page_size.saturating_sub(res.len());
+                if remaining == 0 {
                     break;
                 }
 
-                res.extend(hashes);
+                res.extend(hashes.take(remaining));
             }
 
             if n == to {
@@ -416,26 +419,48 @@ impl EthApi {
             .collect::<Result<Vec<_>>>()?;
 
         let receipt_futs = hashes.iter().map(|hash| self.transaction_receipt(*hash));
+        let receipt_results = join_all(receipt_futs).await;
 
-        let receipts = join_all(receipt_futs.map(|r| async {
-            if let Ok(Some(r)) = r.await {
-                // Try to get timestamp from receipt's other fields first (set by mined receipts),
-                // fallback to block lookup for fork receipts that may not have it
-                let timestamp = if let Some(ts) = r.block_timestamp() {
-                    ts
-                } else {
-                    let block = self.block_by_number(r.block_number().unwrap().into()).await?;
-                    block.ok_or(BlockchainError::BlockNotFound)?.header.timestamp
-                };
-                let receipt = r.as_ref().inner.clone().map_inner(OtsReceipt::from);
-                Ok(OtsTransactionReceipt { receipt, timestamp: Some(timestamp) })
+        let mut raw_receipts = Vec::with_capacity(receipt_results.len());
+        let mut block_numbers = Vec::with_capacity(receipt_results.len());
+        for result in receipt_results {
+            if let Ok(Some(receipt)) = result {
+                let block_number =
+                    receipt.block_number().ok_or(BlockchainError::BlockNotFound)?;
+                raw_receipts.push(receipt);
+                block_numbers.push(block_number);
             } else {
-                Err(BlockchainError::BlockNotFound)
+                return Err(BlockchainError::BlockNotFound);
             }
-        }))
-        .await
-        .into_iter()
-        .collect::<Result<Vec<_>>>()?;
+        }
+
+        block_numbers.sort_unstable();
+        block_numbers.dedup();
+
+        let mut timestamps = HashMap::with_capacity(block_numbers.len());
+        let timestamp_futs = block_numbers.iter().map(|&number| async move {
+            let block = self.block_by_number(number.into()).await?;
+            let timestamp = block.ok_or(BlockchainError::BlockNotFound)?.header.timestamp;
+            Ok::<_, BlockchainError>((number, timestamp))
+        });
+
+        for result in join_all(timestamp_futs).await {
+            let (number, timestamp) = result?;
+            timestamps.insert(number, timestamp);
+        }
+
+        let receipts = raw_receipts
+            .into_iter()
+            .map(|receipt| {
+                let block_number =
+                    receipt.block_number().ok_or(BlockchainError::BlockNotFound)?;
+                let timestamp = *timestamps
+                    .get(&block_number)
+                    .ok_or(BlockchainError::BlockNotFound)?;
+                let receipt = receipt.as_ref().inner.clone().map_inner(OtsReceipt::from);
+                Ok(OtsTransactionReceipt { receipt, timestamp: Some(timestamp) })
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(TransactionsWithReceipts { txs, receipts, first_page, last_page })
     }


### PR DESCRIPTION
Fixes pagination overflow and reduces redundant RPC calls in Otterscan API endpoints.
