### PR TITLE
fix(fork): preserve configured evm_version when selecting forks

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1861,9 +1861,17 @@ impl Default for BackendInner {
 
 /// This updates the currently used env with the fork's environment
 pub(crate) fn update_current_env_with_fork_env(current: &mut EnvMut<'_>, fork: Env) {
+    // Preserve the current spec_id (evm_version) - users configure this explicitly
+    // and it should not be overwritten when switching forks.
+    // See: https://github.com/foundry-rs/foundry/issues/13040
+    let spec = current.cfg.spec;
+
     *current.block = fork.evm_env.block_env;
     *current.cfg = fork.evm_env.cfg_env;
     current.tx.chain_id = fork.tx.chain_id;
+
+    // Restore the original spec_id
+    current.cfg.spec = spec;
 }
 
 /// Clones the data of the given `accounts` from the `active` database into the `fork_db`

--- a/crates/forge/tests/cli/test_cmd/spec.rs
+++ b/crates/forge/tests/cli/test_cmd/spec.rs
@@ -1,5 +1,46 @@
 use foundry_test_utils::rpc;
 
+// Test that configured evm_version is preserved when selecting forks.
+// <https://github.com/foundry-rs/foundry/issues/13040>
+forgetest_init!(test_evm_version_preserved_on_fork_select, |prj, cmd| {
+    let endpoint = rpc::next_http_archive_rpc_url();
+    prj.add_test(
+        "TestEvmVersionPreserved.t.sol",
+        &r#"
+import {Test} from "forge-std/Test.sol";
+
+contract TestEvmVersionPreserved is Test {
+    /// forge-config: default.evm_version = "cancun"
+    function test_evm_version_preserved_after_fork() public {
+        // Before fork, should be cancun
+        assertEq(vm.getEvmVersion(), "cancun", "evm version should be cancun before fork");
+
+        // Create and select a fork
+        vm.createSelectFork("<rpc>", 1);
+
+        // After fork selection, should still be cancun (not default prague)
+        assertEq(vm.getEvmVersion(), "cancun", "evm version should remain cancun after fork");
+    }
+}
+   "#.replace("<rpc>", &endpoint),
+    );
+
+    cmd.args(["test", "--mc", "TestEvmVersionPreserved", "-vvvv"]).assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/TestEvmVersionPreserved.t.sol:TestEvmVersionPreserved
+[PASS] test_evm_version_preserved_after_fork() ([GAS])
+...
+
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]);
+});
+
 // Test evm version switch during tests / scripts.
 // <https://github.com/foundry-rs/foundry/issues/9840>
 // <https://github.com/foundry-rs/foundry/issues/6228>


### PR DESCRIPTION
## Summary

When using `vm.createSelectFork()`, the configured `evm_version` was being overwritten with the fork's default spec (currently Prague). This caused tests with explicit `evm_version` configuration to unexpectedly change behavior after fork selection.

**Root cause**: The `update_current_env_with_fork_env` function was overwriting the entire `cfg_env` (including `spec_id`) with the fork's environment, which uses `CfgEnv::default()` that sets `spec` to the default hardfork (Prague).

**Fix**: Preserve the current `spec_id` before updating the environment with fork settings, then restore it afterward.

- [Failing test case from the issue](https://github.com/foundry-rs/foundry/issues/13040#issue-2961851234):
```solidity
/// forge-config: default.evm_version = "cancun"
function testKeepsEvmVersion() public {
    assertEq(vm.getEvmVersion(), "cancun");
    vm.createSelectFork("anyfork", 1);
    vm.assertEq(vm.getEvmVersion(), "cancun"); // was "prague" before fix
}
```

## Changes

- Modified `update_current_env_with_fork_env` in `crates/evm/core/src/backend/mod.rs` to preserve and restore the `spec_id`
- Added test `test_evm_version_preserved_on_fork_select` in `crates/forge/tests/cli/test_cmd/spec.rs`

## Test plan

- [x] Added new test that verifies evm_version is preserved after `createSelectFork`
- [x] Cargo check passes
- [x] Clippy passes with no warnings

Fixes #13040

---
Generated with [Claude Code](https://claude.com/claude-code)