### PR TITLE
fix(trace): distinguish receive() from fallback() in trace output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -501,7 +501,7 @@ rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6
 ## revm
 # revm = { git = "https://github.com/bluealloy/revm.git", rev = "7e59936" }
 # op-revm = { git = "https://github.com/bluealloy/revm.git", rev = "7e59936" }
-# revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors.git", branch = "staging-revm" }
+revm-inspectors = { git = "https://github.com/AlexeySamosadov/revm-inspectors.git", branch = "fix/receive-vs-fallback" }
 
 ## foundry
 # foundry-block-explorers = { git = "https://github.com/foundry-rs/block-explorers.git", rev = "f5b46b2" }


### PR DESCRIPTION
## Summary
- Use patched revm-inspectors to show `receive()` for empty calldata calls that succeed
- Currently always shows `fallback()` for calls with < 4 bytes of calldata

## Motivation
Per Solidity semantics:
- `receive()` is invoked when `msg.data` is empty AND call succeeds
- `fallback()` is invoked when `msg.data` is non-empty OR `receive()` doesn't exist

## Changes
- Patched revm-inspectors dependency to use https://github.com/paradigmxyz/revm-inspectors/pull/403

## Test Plan
- [x] `cargo check -p revm-inspectors` passes
- [ ] Upstream revm-inspectors PR merged and version bumped

Fixes #12962

🤖 Generated with [Claude Code](https://claude.com/claude-code)