### PR TITLE
fix: correct path format in get_paths doc comment

### DIFF
--- a/crates/script-sequence/src/sequence.rs
+++ b/crates/script-sequence/src/sequence.rs
@@ -166,8 +166,8 @@ impl ScriptSequence {
     }
 
     /// Gets paths in the formats
-    /// `./broadcast/[contract_filename]/[chain_id]/[sig]-[timestamp].json` and
-    /// `./cache/[contract_filename]/[chain_id]/[sig]-[timestamp].json`.
+    /// `./broadcast/[contract_filename]/[chain_id]/[sig]-latest.json` and
+    /// `./cache/[contract_filename]/[chain_id]/[sig]-latest.json`.
     pub fn get_paths(
         config: &Config,
         sig: &str,


### PR DESCRIPTION
**Description:** The doc comment for `get_paths` referenced `[sig]-[timestamp].json` but the function actually returns paths ending in `{sig}-latest.json`. Timestamped copies are only created later in `save()`. Updated the comment to match the code.