### PR TITLE
perf(config): skip redundant remapping detection in _with_root

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1863,11 +1863,6 @@ impl Config {
             src: paths.sources.file_name().unwrap().into(),
             out: artifacts.clone(),
             libs: paths.libraries.into_iter().map(|lib| lib.file_name().unwrap().into()).collect(),
-            remappings: paths
-                .remappings
-                .into_iter()
-                .map(|r| RelativeRemapping::new(r, root))
-                .collect(),
             fs_permissions: FsPermissions::new([PathPermission::read(artifacts)]),
             ..Self::default()
         }


### PR DESCRIPTION
Closes #10215

`_with_root` calls `ProjectPathsConfig::builder().build_with_root()`
which scans lib directories and auto-detects remappings. These
remappings are then overwritten when `to_figment` runs the
`RemappingsProvider`, which performs the same scan with proper
precedence handling (env vars, remappings.txt, toml config,
auto-detect).

Remove the redundant extraction from `_with_root` and let
`RemappingsProvider` be the single source of truth, avoiding a
duplicate filesystem scan on every config load.