### PR TITLE
perf(traces): make trace identification async

### DIFF
--- a/crates/cast/src/debug.rs
+++ b/crates/cast/src/debug.rs
@@ -66,7 +66,7 @@ pub(crate) async fn handle_traces(
     let mut decoder = builder.build();
 
     for (_, trace) in result.traces.as_deref_mut().unwrap_or_default() {
-        decoder.identify(trace, &mut identifier);
+        decoder.identify(trace, &mut identifier).await;
     }
 
     if decode_internal || debug {

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -171,7 +171,7 @@ impl ChiselDispatcher {
         )?;
         if !identifier.is_empty() {
             for (_, trace) in &mut result.traces {
-                decoder.identify(trace, &mut identifier);
+                decoder.identify(trace, &mut identifier).await;
             }
         }
         Ok(decoder)

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -235,14 +235,18 @@ impl CallTraceDecoder {
     /// Identify unknown addresses in the specified call trace using the specified identifier.
     ///
     /// Unknown contracts are contracts that either lack a label or an ABI.
-    pub fn identify(&mut self, arena: &CallTraceArena, identifier: &mut impl TraceIdentifier) {
-        self.collect_identified_addresses(self.identify_addresses(arena, identifier));
+    pub async fn identify(
+        &mut self,
+        arena: &CallTraceArena,
+        identifier: &mut impl TraceIdentifier,
+    ) {
+        self.collect_identified_addresses(self.identify_addresses(arena, identifier).await);
     }
 
     /// Identify unknown addresses in the specified call trace using the specified identifier.
     ///
     /// Unknown contracts are contracts that either lack a label or an ABI.
-    pub fn identify_addresses<'a>(
+    pub async fn identify_addresses<'a>(
         &self,
         arena: &CallTraceArena,
         identifier: &'a mut impl TraceIdentifier,
@@ -251,7 +255,7 @@ impl CallTraceDecoder {
             let address = &node.trace.address;
             !self.labels.contains_key(address) || !self.contracts.contains_key(address)
         });
-        identifier.identify_addresses(&nodes.collect::<Vec<_>>())
+        identifier.identify_addresses(&nodes.collect::<Vec<_>>()).await
     }
 
     /// Adds a single event to the decoder.

--- a/crates/evm/traces/src/identifier/external.rs
+++ b/crates/evm/traces/src/identifier/external.rs
@@ -142,8 +142,9 @@ impl ExternalIdentifier {
     }
 }
 
+#[async_trait::async_trait]
 impl TraceIdentifier for ExternalIdentifier {
-    fn identify_addresses(&mut self, nodes: &[&CallTraceNode]) -> Vec<IdentifiedAddress<'_>> {
+    async fn identify_addresses(&mut self, nodes: &[&CallTraceNode]) -> Vec<IdentifiedAddress<'_>> {
         if nodes.is_empty() {
             return Vec::new();
         }
@@ -174,32 +175,31 @@ impl TraceIdentifier for ExternalIdentifier {
 
         let fetchers =
             self.fetchers.iter().map(|fetcher| ExternalFetcher::new(fetcher.clone(), &to_fetch));
-        let fetched_identities = foundry_common::block_on(
-            futures::stream::select_all(fetchers)
-                .filter_map(|(address, value)| {
-                    let addr = value
-                        .1
-                        .as_ref()
-                        .map(|metadata| self.identify_from_metadata(address, metadata));
-                    match self.contracts.entry(address) {
-                        Entry::Occupied(mut occupied_entry) => {
-                            // Override if:
-                            // - new is from Etherscan and old is not
-                            // - new is Some and old is None, meaning verified only in one source
-                            if !matches!(occupied_entry.get().0, FetcherKind::Etherscan)
-                                || value.1.is_none()
-                            {
-                                occupied_entry.insert(value);
-                            }
-                        }
-                        Entry::Vacant(vacant_entry) => {
-                            vacant_entry.insert(value);
+        let fetched_identities = futures::stream::select_all(fetchers)
+            .filter_map(|(address, value)| {
+                let addr = value
+                    .1
+                    .as_ref()
+                    .map(|metadata| self.identify_from_metadata(address, metadata));
+                match self.contracts.entry(address) {
+                    Entry::Occupied(mut occupied_entry) => {
+                        // Override if:
+                        // - new is from Etherscan and old is not
+                        // - new is Some and old is None, meaning verified only in one source
+                        if !matches!(occupied_entry.get().0, FetcherKind::Etherscan)
+                            || value.1.is_none()
+                        {
+                            occupied_entry.insert(value);
                         }
                     }
-                    async move { addr }
-                })
-                .collect::<Vec<IdentifiedAddress<'_>>>(),
-        );
+                    Entry::Vacant(vacant_entry) => {
+                        vacant_entry.insert(value);
+                    }
+                }
+                async move { addr }
+            })
+            .collect::<Vec<IdentifiedAddress<'_>>>()
+            .await;
         trace!(target: "evm::traces::external", "fetched {} addresses: {fetched_identities:#?}", fetched_identities.len());
 
         identities.extend(fetched_identities);
@@ -208,7 +208,7 @@ impl TraceIdentifier for ExternalIdentifier {
 }
 
 type FetchFuture =
-    Pin<Box<dyn Future<Output = (Address, Result<Option<Metadata>, EtherscanError>)>>>;
+    Pin<Box<dyn Future<Output = (Address, Result<Option<Metadata>, EtherscanError>)> + Send>>;
 
 /// A rate limit aware fetcher.
 ///

--- a/crates/evm/traces/src/identifier/local.rs
+++ b/crates/evm/traces/src/identifier/local.rs
@@ -143,8 +143,9 @@ impl<'a> LocalTraceIdentifier<'a> {
     }
 }
 
+#[async_trait::async_trait]
 impl TraceIdentifier for LocalTraceIdentifier<'_> {
-    fn identify_addresses(&mut self, nodes: &[&CallTraceNode]) -> Vec<IdentifiedAddress<'_>> {
+    async fn identify_addresses(&mut self, nodes: &[&CallTraceNode]) -> Vec<IdentifiedAddress<'_>> {
         if nodes.is_empty() {
             return Vec::new();
         }

--- a/crates/evm/traces/src/identifier/mod.rs
+++ b/crates/evm/traces/src/identifier/mod.rs
@@ -33,9 +33,10 @@ pub struct IdentifiedAddress<'a> {
 }
 
 /// Trace identifiers figure out what ABIs and labels belong to all the addresses of the trace.
+#[async_trait::async_trait]
 pub trait TraceIdentifier {
     /// Attempts to identify an address in one or more call traces.
-    fn identify_addresses(&mut self, nodes: &[&CallTraceNode]) -> Vec<IdentifiedAddress<'_>>;
+    async fn identify_addresses(&mut self, nodes: &[&CallTraceNode]) -> Vec<IdentifiedAddress<'_>>;
 }
 
 /// A collection of trace identifiers.
@@ -52,21 +53,22 @@ impl Default for TraceIdentifiers<'_> {
     }
 }
 
+#[async_trait::async_trait]
 impl TraceIdentifier for TraceIdentifiers<'_> {
-    fn identify_addresses(&mut self, nodes: &[&CallTraceNode]) -> Vec<IdentifiedAddress<'_>> {
+    async fn identify_addresses(&mut self, nodes: &[&CallTraceNode]) -> Vec<IdentifiedAddress<'_>> {
         if nodes.is_empty() {
             return Vec::new();
         }
 
         let mut identities = Vec::with_capacity(nodes.len());
         if let Some(local) = &mut self.local {
-            identities.extend(local.identify_addresses(nodes));
+            identities.extend(local.identify_addresses(nodes).await);
             if identities.len() >= nodes.len() {
                 return identities;
             }
         }
         if let Some(external) = &mut self.external {
-            identities.extend(external.identify_addresses(nodes));
+            identities.extend(external.identify_addresses(nodes).await);
         }
         identities
     }

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -267,7 +267,9 @@ pub fn load_contracts<'a>(
     let decoder = CallTraceDecoder::new();
     let mut contracts = ContractsByAddress::new();
     for trace in traces {
-        for address in decoder.identify_addresses(trace, &mut local_identifier) {
+        for address in
+            foundry_common::block_on(decoder.identify_addresses(trace, &mut local_identifier))
+        {
             if let (Some(contract), Some(abi)) = (address.contract, address.abi) {
                 contracts.insert(address.address, (contract, abi.into_owned()));
             }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -646,7 +646,7 @@ impl TestArgs {
                 let mut decoded_traces = Vec::with_capacity(result.traces.len());
                 for (kind, arena) in &mut result.traces {
                     if identify_addresses {
-                        decoder.identify(arena, &mut identifier);
+                        decoder.identify(arena, &mut identifier).await;
                     }
 
                     // verbosity:
@@ -717,12 +717,12 @@ impl TestArgs {
                         // setUp and constructor.
                         for (kind, arena) in &result.traces {
                             if !matches!(kind, TraceKind::Execution) {
-                                decoder.identify(arena, &mut identifier);
+                                decoder.identify(arena, &mut identifier).await;
                             }
                         }
 
                         for arena in trace {
-                            decoder.identify(arena, &mut identifier);
+                            decoder.identify(arena, &mut identifier).await;
                             gas_report.analyze([arena], &decoder).await;
                         }
                     }

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -341,7 +341,7 @@ impl ExecutedState {
         )?;
 
         for (_, trace) in &self.execution_result.traces {
-            decoder.identify(trace, &mut identifier);
+            decoder.identify(trace, &mut identifier).await;
         }
 
         Ok(decoder)


### PR DESCRIPTION
Closes #12714

## Problem

`ExternalIdentifier::identify_addresses()` used `foundry_common::block_on()` to synchronously wait for Etherscan/Sourcify HTTP requests during trace rendering. Since every caller is already in an async context, this unnecessarily blocked tokio worker threads via `block_in_place`.

## Solution

Convert the `TraceIdentifier` trait to async using `async_trait` (already a dependency, already used in the same file for `ExternalFetcherT`), remove the `block_on` wrapper in `ExternalIdentifier`, and add `.await` at all call sites.

The only exception is `load_contracts()` in `lib.rs`, which is called from sync contexts but only uses `LocalTraceIdentifier` (pure in-memory, no I/O) — the `block_on` there resolves immediately with zero overhead.

## Changes

- `TraceIdentifier::identify_addresses()` → `async fn`
- `ExternalIdentifier`: remove `block_on()`, `.await` the stream directly
- `FetchFuture` type alias: add `+ Send` bound (required by `async_trait`)
- `CallTraceDecoder::identify()` / `identify_addresses()` → `async fn`
- All call sites (forge test, forge script, cast debug, chisel): add `.await`