### PR TITLE
perf(verify): reuse transaction from earlier RPC call instead of fetching twice

### DIFF
--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -335,6 +335,7 @@ impl VerifyBytecodeArgs {
             );
         };
 
+        let creation_block = transaction.block_number;
         let mut transaction: TransactionRequest = match transaction.inner.inner.inner() {
             AnyTxEnvelope::Ethereum(tx) => tx.clone().into(),
             AnyTxEnvelope::Unknown(_) => unreachable!("Unknown transaction type"),
@@ -440,7 +441,7 @@ impl VerifyBytecodeArgs {
                 Some(BlockId::Number(BlockNumberOrTag::Number(block))) => block,
                 Some(_) => eyre::bail!("Invalid block number"),
                 None => {
-                    transaction.block_number.ok_or_else(|| {
+                    creation_block.ok_or_else(|| {
                         eyre::eyre!("Failed to get block number of the contract creation tx, specify using the --block flag")
                     })?
                 }


### PR DESCRIPTION
`verify-bytecode` was calling `get_transaction_by_hash` twice with the same hash — once at the top to get the transaction, and again ~120 lines later just to read `block_number`. Reuse the already-fetched transaction object instead.