### PR TITLE
fix: correct trace message in dynamic linking preprocessor

### DIFF
--- a/crates/common/src/preprocessor/mod.rs
+++ b/crates/common/src/preprocessor/mod.rs
@@ -46,7 +46,7 @@ impl Preprocessor<SolcCompiler> for DynamicTestLinkingPreprocessor {
     ) -> Result<()> {
         // Skip if we are not preprocessing any tests or scripts. Avoids unnecessary AST parsing.
         if !input.input.sources.iter().any(|(path, _)| paths.is_test_or_script(path)) {
-            trace!("no tests or sources to preprocess");
+            trace!("no tests or scripts to preprocess");
             return Ok(());
         }
 


### PR DESCRIPTION

The trace message incorrectly said "no tests or sources to preprocess", but the logic only checks for tests or scripts (see adjacent comment on line 47). This mismatch was misleading when reading debug logs since "sources" implies all source files while the code specifically targets test and script files only.


Fixed trace message to correctly say "scripts" instead of "sources" to match the actual conditional check (`is_test_or_script`) and the explanatory comment.