### PR TITLE
fix: prevent panic on etherscan client creation failure in test command

### DIFF
--- a/crates/evm/traces/src/identifier/external.rs
+++ b/crates/evm/traces/src/identifier/external.rs
@@ -61,7 +61,14 @@ impl ExternalIdentifier {
         }
         if let Some(config) = config {
             debug!(target: "evm::traces::external", chain=?config.chain, url=?config.api_url, "using etherscan identifier");
-            fetchers.push(Arc::new(EtherscanFetcher::new(config.into_client()?)));
+            match config.into_client() {
+                Ok(client) => {
+                    fetchers.push(Arc::new(EtherscanFetcher::new(client)));
+                }
+                Err(err) => {
+                    warn!(target: "evm::traces::external", ?err, "failed to create etherscan client");
+                }
+            }
         }
         if fetchers.is_empty() {
             debug!(target: "evm::traces::external", "no fetchers enabled");


### PR DESCRIPTION
Fixes panic when running `forge test --mc` when etherscan client creation fails.

Previously, if `into_client()` failed, the error would propagate and cause a panic before tests execute. Now the error is handled gracefully with a warning log, allowing the command to continue with other fetchers (e.g., Sourcify) or return `Ok(None)` if no fetchers are available.

Fixes #13365