### PR TITLE
perf(anvil): avoid cloning tx hashes

### DIFF
--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -370,8 +370,8 @@ impl PoolInner {
         }
         trace!(target: "txpool", "Removing invalid transactions: {:?}", tx_hashes);
 
-        let mut removed = self.ready_transactions.remove_with_markers(tx_hashes.clone(), None);
-        removed.extend(self.pending_transactions.remove(tx_hashes));
+        let mut removed = self.pending_transactions.remove(&tx_hashes);
+        removed.extend(self.ready_transactions.remove_with_markers(tx_hashes, None));
 
         trace!(target: "txpool", "Removed invalid transactions: {:?}", removed);
 
@@ -389,8 +389,8 @@ impl PoolInner {
 
         trace!(target: "txpool", "Removing transactions: {:?}", tx_hashes);
 
-        let mut removed = self.ready_transactions.remove_with_markers(tx_hashes.clone(), None);
-        removed.extend(self.pending_transactions.remove(tx_hashes));
+        let mut removed = self.pending_transactions.remove(&tx_hashes);
+        removed.extend(self.ready_transactions.remove_with_markers(tx_hashes, None));
 
         trace!(target: "txpool", "Removed transactions: {:?}", removed);
 

--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -246,14 +246,14 @@ impl PendingTransactions {
     /// Removes the transactions associated with the given hashes
     ///
     /// Returns all removed transactions.
-    pub fn remove(&mut self, hashes: Vec<TxHash>) -> Vec<Arc<PoolTransaction>> {
+    pub fn remove(&mut self, hashes: &[TxHash]) -> Vec<Arc<PoolTransaction>> {
         let mut removed = vec![];
         for hash in hashes {
-            if let Some(waiting_tx) = self.waiting_queue.remove(&hash) {
+            if let Some(waiting_tx) = self.waiting_queue.remove(hash) {
                 self.waiting_markers.remove(&waiting_tx.transaction.provides);
                 for marker in waiting_tx.missing_markers {
                     let remove = if let Some(required) = self.required_markers.get_mut(&marker) {
-                        required.remove(&hash);
+                        required.remove(hash);
                         required.is_empty()
                     } else {
                         false


### PR DESCRIPTION
`pending_transactions.remove` only iterates over the hashes, so take `&[TxHash]` instead of `Vec<TxHash>`. 
Swap the call order in `remove_invalid` and `remove_transactions_by_address` so we borrow first then move into `remove_with_markers`, eliminating the `tx_hashes.clone()`.