### PR TITLE
fix: handle absolute library paths in remappings provider

### DIFF
--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -247,7 +247,7 @@ impl RemappingsProvider<'_> {
     fn find_nested_foundry_remappings(&self) -> impl Iterator<Item = Remapping> + '_ {
         self.lib_paths
             .par_iter()
-            .map(|p| if p.is_absolute() { self.root.join("lib") } else { self.root.join(p) })
+            .map(|p| if p.is_absolute() { p.clone() } else { self.root.join(p) })
             .flat_map(foundry_toml_dirs)
             .flat_map_iter(|lib| {
                 trace!(?lib, "find all remappings of nested foundry.toml");
@@ -300,7 +300,7 @@ impl RemappingsProvider<'_> {
         self.lib_paths
             .par_iter()
             .flat_map_iter(|lib| {
-                let lib = self.root.join(lib);
+                let lib = if lib.is_absolute() { lib.clone() } else { self.root.join(lib) };
                 trace!(?lib, "find all remappings");
                 Remapping::find_many(&lib)
             })


### PR DESCRIPTION
Fix incorrect handling of absolute library paths in RemappingsProvider.

Previously, absolute paths in lib_paths were incorrectly replaced with
root.join("lib") in find_nested_foundry_remappings, causing remappings
from absolute library paths to be ignored. The same issue existed in
auto_detect_remappings where absolute paths were incorrectly joined with
root.

Now absolute paths are used directly, allowing remappings to be correctly
detected from libraries specified with absolute paths as documented.