### PR TITLE
refactor(anvil): remove redundant CacheDB clone in `fork_db::dump_state`

### DIFF
--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -10,7 +10,7 @@ use foundry_evm::{
 };
 use revm::{
     context::BlockEnv,
-    database::{Database, DbAccount},
+    database::{Database, DatabaseRef, DbAccount},
     state::AccountInfo,
 };
 
@@ -39,7 +39,6 @@ impl Db for ForkedDatabase {
         transactions: Vec<SerializableTransaction>,
         historical_states: Option<SerializableHistoricalStates>,
     ) -> DatabaseResult<Option<SerializableState>> {
-        let mut db = self.database().clone();
         let accounts = self
             .database()
             .cache
@@ -50,7 +49,7 @@ impl Db for ForkedDatabase {
                 let code = if let Some(code) = v.info.code {
                     code
                 } else {
-                    db.code_by_hash(v.info.code_hash)?
+                    self.database().code_by_hash_ref(v.info.code_hash)?
                 };
                 Ok((
                     k,


### PR DESCRIPTION
<!-- Why was this change made? -->
dump_state was cloning the entire CacheDB<SharedBackend> just to call code_by_hash(&mut self), which requires mutable access. This clone is wasteful because:
1. ForkedDatabase already implements DatabaseRef with code_by_hash_ref(&self) available
2. The cloned DB is dropped at the end of the function, so any caching side effects are lost
3. The same pattern in MemDb::dump_state already uses code_by_hash_ref correctly

<!-- What does this change do? -->
Replaced the unnecessary clone + code_by_hash call with code_by_hash_ref and adds DatabaseRef to imports.