### PR TITLE
ci: use dedicated template for isolate flaky test failures

### DIFF
--- a/.github/FLAKY_TEST_ISOLATE_FAILURE_TEMPLATE.md
+++ b/.github/FLAKY_TEST_ISOLATE_FAILURE_TEMPLATE.md
@@ -1,0 +1,10 @@
+---
+title: "bug: flaky tests workflow failed (isolate)"
+labels: P-normal, T-bug
+---
+
+The nightly flaky tests workflow (with isolation mode enabled) has failed. This indicates external API rate limiting, RPC reliability issues, or other intermittent failures that may affect users.
+
+Check the [flaky tests workflow page]({{ env.WORKFLOW_URL }}) for details.
+
+This issue was raised by the workflow at `.github/workflows/test-isolate.yml`.

--- a/.github/workflows/test-isolate.yml
+++ b/.github/workflows/test-isolate.yml
@@ -91,4 +91,4 @@ jobs:
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           update_existing: true
-          filename: .github/FLAKY_TEST_FAILURE_TEMPLATE.md
+          filename: .github/FLAKY_TEST_ISOLATE_FAILURE_TEMPLATE.md


### PR DESCRIPTION
## Summary
Give `test-isolate.yml`'s `issue-flaky` job its own issue template so it stops overwriting the `test-flaky` issue.

## Motivation
Fixes https://github.com/foundry-rs/foundry/issues/13403 — the workflow URL in that issue resolves to a `test-isolate` run instead of `test-flaky`.

Root cause: both workflows used `FLAKY_TEST_FAILURE_TEMPLATE.md` with `update_existing: true`. `JasonEtco/create-an-issue` matches by title, so whichever workflow fails last wins and overwrites the URL.

## Changes
- Added `.github/FLAKY_TEST_ISOLATE_FAILURE_TEMPLATE.md` with a distinct title (`bug: flaky tests workflow failed (isolate)`)
- Updated `test-isolate.yml` `issue-flaky` job to reference the new template