### PR TITLE
feat: make mutation test operators configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4799,6 +4799,7 @@ dependencies = [
  "snapbox",
  "solar-compiler",
  "soldeer-core",
+ "strum",
  "tempfile",
  "thiserror 2.0.18",
  "toml",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -50,6 +50,7 @@ tracing.workspace = true
 walkdir.workspace = true
 yansi.workspace = true
 clap = { version = "4", features = ["derive"] }
+strum = { workspace = true, features = ["derive"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 path-slash = "0.2"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -110,6 +110,9 @@ pub use fuzz::{FuzzConfig, FuzzCorpusConfig, FuzzDictionaryConfig};
 mod invariant;
 pub use invariant::InvariantConfig;
 
+pub mod mutation;
+pub use mutation::{MutationConfig, MutatorType};
+
 mod inline;
 pub use inline::{InlineConfig, InlineConfigError, NatSpec};
 
@@ -352,6 +355,8 @@ pub struct Config {
     pub fuzz: FuzzConfig,
     /// Configuration for invariant testing
     pub invariant: InvariantConfig,
+    /// Configuration for mutation testing
+    pub mutation: MutationConfig,
     /// Whether to allow ffi cheatcodes in test
     pub ffi: bool,
     /// Whether to allow `expectRevert` for internal functions.
@@ -701,6 +706,7 @@ impl Config {
         "doc",
         "fuzz",
         "invariant",
+        "mutation",
         "labels",
         "dependencies",
         "soldeer",
@@ -2574,6 +2580,7 @@ impl Default for Config {
             show_progress: false,
             fuzz: FuzzConfig::new("cache/fuzz".into()),
             invariant: InvariantConfig::new("cache/invariant".into()),
+            mutation: MutationConfig::default(),
             always_use_create_2_factory: false,
             ffi: false,
             allow_internal_expect_revert: false,
@@ -6590,6 +6597,9 @@ mod tests {
                 runs = 256
                 unknown_invariant_key = "should_warn"
 
+                [mutation]
+                unknown_mutation_key = "should_warn"
+
                 [vyper]
                 unknown_vyper_key = "should_warn"
 
@@ -6617,6 +6627,9 @@ mod tests {
                 [profile.default.invariant]
                 runs = 512
                 unknown_nested_invariant_key = "should_warn"
+
+                [profile.default.mutation]
+                unknown_nested_mutation_key = "should_warn"
 
                 [profile.default.vyper]
                 unknown_nested_vyper_key = "should_warn"
@@ -6656,6 +6669,7 @@ mod tests {
                 ("unknown_doc_key", "doc"),
                 ("unknown_fuzz_key", "fuzz"),
                 ("unknown_invariant_key", "invariant"),
+                ("unknown_mutation_key", "mutation"),
                 ("unknown_vyper_key", "vyper"),
                 ("unknown_bind_json_key", "bind_json"),
             ];
@@ -6681,6 +6695,7 @@ mod tests {
                 ("unknown_nested_doc_key", "doc"),
                 ("unknown_nested_fuzz_key", "fuzz"),
                 ("unknown_nested_invariant_key", "invariant"),
+                ("unknown_nested_mutation_key", "mutation"),
                 ("unknown_nested_vyper_key", "vyper"),
                 ("unknown_nested_bind_json_key", "bind_json"),
             ];
@@ -6729,11 +6744,11 @@ mod tests {
                 })
                 .collect();
 
-            // 1 profile key + 7 standalone + 7 nested + 2 array = 17 total
+            // 1 profile key + 8 standalone + 8 nested + 2 array = 19 total
             assert_eq!(
                 unknown_key_warnings.len(),
-                17,
-                "Expected 17 unknown key warnings (1 profile + 7 standalone + 7 nested + 2 array), got {}: {:?}",
+                19,
+                "Expected 19 unknown key warnings (1 profile + 8 standalone + 8 nested + 2 array), got {}: {:?}",
                 unknown_key_warnings.len(),
                 unknown_key_warnings
             );

--- a/crates/config/src/mutation.rs
+++ b/crates/config/src/mutation.rs
@@ -1,0 +1,68 @@
+//! Configuration for mutation testing.
+
+use serde::{Deserialize, Serialize};
+use strum::IntoEnumIterator;
+
+/// Represents each available mutation operator.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    strum::Display,
+    strum::EnumString,
+    strum::EnumIter,
+)]
+#[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
+pub enum MutatorType {
+    Assembly,
+    Assignment,
+    BinaryOp,
+    DeleteExpression,
+    ElimDelegate,
+    Require,
+    UnaryOp,
+}
+
+impl MutatorType {
+    /// Returns a list of all available mutator types.
+    pub fn all() -> Vec<Self> {
+        Self::iter().collect()
+    }
+
+    /// Returns the operators that are excluded by default.
+    pub fn default_excluded() -> Vec<Self> {
+        vec![]
+    }
+}
+
+/// Configuration for mutation testing.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MutationConfig {
+    /// Re-enable operators that are excluded by default.
+    pub include_operators: Vec<MutatorType>,
+    /// Exclude additional operators beyond the defaults.
+    pub exclude_operators: Vec<MutatorType>,
+}
+
+impl MutationConfig {
+    /// Returns the list of operators that are currently enabled.
+    ///
+    /// Effective set: `all() - default_excluded - exclude_operators + include_operators`
+    pub fn enabled_operators(&self) -> Vec<MutatorType> {
+        let default_excluded = MutatorType::default_excluded();
+        MutatorType::all()
+            .into_iter()
+            .filter(|op| {
+                let excluded = default_excluded.contains(op) || self.exclude_operators.contains(op);
+                let included = self.include_operators.contains(op);
+                !excluded || included
+            })
+            .collect()
+    }
+}

--- a/crates/forge/src/mutation/mod.rs
+++ b/crates/forge/src/mutation/mod.rs
@@ -370,8 +370,9 @@ impl MutationHandler {
 
             let ast = parser.parse_file().map_err(|e| e.emit())?;
 
-            // Create visitor with adaptive span filter and source code for original text
-            let mut mutant_visitor = MutantVisitor::default(path.clone())
+            // Create visitor with configured operators, adaptive span filter, and source code
+            let operators = self.config.mutation.enabled_operators();
+            let mut mutant_visitor = MutantVisitor::with_operators(path.clone(), &operators)
                 .with_span_filter(move |span| survived_spans_clone.should_skip(span))
                 .with_source(&target_content);
             let _ = mutant_visitor.visit_source_unit(&ast);

--- a/crates/forge/src/mutation/mutators/mutator_registry.rs
+++ b/crates/forge/src/mutation/mutators/mutator_registry.rs
@@ -1,4 +1,5 @@
 use crate::mutation::mutant::Mutant;
+use foundry_config::MutatorType;
 
 use super::{
     MutationContext, Mutator, assembly_mutator, assignment_mutator, binary_op_mutator,
@@ -11,16 +12,41 @@ pub struct MutatorRegistry {
 }
 
 impl MutatorRegistry {
+    #[cfg(test)]
     pub fn default() -> Self {
+        Self::from_enabled(&MutatorType::all())
+    }
+
+    pub fn from_enabled(enabled: &[MutatorType]) -> Self {
         let mut registry = Self { mutators: Vec::new() };
 
-        registry.mutators.push(Box::new(assembly_mutator::AssemblyMutator::new()));
-        registry.mutators.push(Box::new(assignment_mutator::AssignmentMutator));
-        registry.mutators.push(Box::new(binary_op_mutator::BinaryOpMutator));
-        registry.mutators.push(Box::new(delete_expression_mutator::DeleteExpressionMutator));
-        registry.mutators.push(Box::new(elim_delegate_mutator::ElimDelegateMutator));
-        registry.mutators.push(Box::new(require_mutator::RequireMutator));
-        registry.mutators.push(Box::new(unary_op_mutator::UnaryOperatorMutator));
+        for ty in enabled {
+            match ty {
+                MutatorType::Assembly => {
+                    registry.mutators.push(Box::new(assembly_mutator::AssemblyMutator::new()));
+                }
+                MutatorType::Assignment => {
+                    registry.mutators.push(Box::new(assignment_mutator::AssignmentMutator));
+                }
+                MutatorType::BinaryOp => {
+                    registry.mutators.push(Box::new(binary_op_mutator::BinaryOpMutator));
+                }
+                MutatorType::DeleteExpression => {
+                    registry
+                        .mutators
+                        .push(Box::new(delete_expression_mutator::DeleteExpressionMutator));
+                }
+                MutatorType::ElimDelegate => {
+                    registry.mutators.push(Box::new(elim_delegate_mutator::ElimDelegateMutator));
+                }
+                MutatorType::Require => {
+                    registry.mutators.push(Box::new(require_mutator::RequireMutator));
+                }
+                MutatorType::UnaryOp => {
+                    registry.mutators.push(Box::new(unary_op_mutator::UnaryOperatorMutator));
+                }
+            }
+        }
 
         registry
     }

--- a/crates/forge/src/mutation/visitor.rs
+++ b/crates/forge/src/mutation/visitor.rs
@@ -8,6 +8,7 @@ use crate::mutation::{
     mutant::{Mutant, OwnedLiteral},
     mutators::{MutationContext, mutator_registry::MutatorRegistry},
 };
+use foundry_config::MutatorType;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum AssignVarTypes {
@@ -26,7 +27,20 @@ pub struct MutantVisitor<'src> {
 }
 
 impl<'src> MutantVisitor<'src> {
-    /// Use all mutator from registry::default
+    /// Create a visitor with the specified mutator operators enabled
+    pub fn with_operators(path: PathBuf, operators: &[MutatorType]) -> Self {
+        Self {
+            mutation_to_conduct: Vec::new(),
+            mutator_registry: MutatorRegistry::from_enabled(operators),
+            path,
+            span_filter: None,
+            skipped_count: 0,
+            source: None,
+        }
+    }
+
+    /// Use all mutators from registry (all operators enabled)
+    #[cfg(test)]
     pub fn default(path: PathBuf) -> Self {
         Self {
             mutation_to_conduct: Vec::new(),

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -216,6 +216,10 @@ show_metrics = true
 show_solidity = false
 check_interval = 1
 
+[mutation]
+include_operators = []
+exclude_operators = []
+
 [labels]
 
 [vyper]
@@ -297,6 +301,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
             },
             ..Default::default()
         },
+        mutation: Default::default(),
         ffi: true,
         allow_internal_expect_revert: false,
         always_use_create_2_factory: false,
@@ -1300,6 +1305,10 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "max_time_delay": null,
     "max_block_delay": null,
     "check_interval": 1
+  },
+  "mutation": {
+    "include_operators": [],
+    "exclude_operators": []
   },
   "ffi": false,
   "allow_internal_expect_revert": false,


### PR DESCRIPTION
Adds a `[mutation]` section to `foundry.toml` for configuring which mutation operators are active.

All operators are enabled by default. New operators added in future versions are automatically active. Users can exclude specific operators or re-include ones that are excluded by default:

```toml
[mutation]
# Exclude additional operators beyond the defaults
exclude_operators = ["elim-delegate", "assembly"]

# Re-enable operators that are excluded by default
include_operators = []
```

Effective operator set: `all() - default_excluded - exclude_operators + include_operators`

Available operators: `assembly`, `assignment`, `binary-op`, `delete-expression`, `elim-delegate`, `require`, `unary-op`.

**Implementation**

- Adds `MutatorType` enum and `MutationConfig` in `foundry-config` (uses `strum` for `Display`, `FromStr`, `EnumIter`)
- Adds `mutation: MutationConfig` to the `Config` struct
- Updates `MutatorRegistry::from_enabled()` to construct the registry from the resolved operator list
- Threads config through `MutationHandler` → `MutantVisitor` → `MutatorRegistry`