### PR TITLE
return error instead of empty array when filter not found

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1862,7 +1862,7 @@ impl EthApi {
         if let Some(filter) = self.filters.get_log_filter(id).await {
             self.backend.logs(filter).await
         } else {
-            Ok(Vec::new())
+            Err(BlockchainError::FilterNotFound)
         }
     }
 

--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -123,6 +123,8 @@ pub enum BlockchainError {
     },
     #[error("Invalid transaction request: {0}")]
     InvalidTransactionRequest(String),
+    #[error("filter not found")]
+    FilterNotFound,
 }
 
 impl From<eyre::Report> for BlockchainError {
@@ -577,6 +579,11 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                 err @ BlockchainError::RecoveryError(_) => {
                     RpcError::invalid_params(err.to_string())
                 }
+                BlockchainError::FilterNotFound => RpcError {
+                    code: ErrorCode::ServerError(-32000),
+                    message: "filter not found".into(),
+                    data: None,
+                },
             }
             .into(),
         }

--- a/crates/anvil/src/filter.rs
+++ b/crates/anvil/src/filter.rs
@@ -7,7 +7,10 @@ use crate::{
 use alloy_primitives::{TxHash, map::HashMap};
 use alloy_rpc_types::{Filter, FilteredParams, Log};
 use anvil_core::eth::subscription::SubscriptionId;
-use anvil_rpc::response::ResponseResult;
+use anvil_rpc::{
+    error::{ErrorCode, RpcError},
+    response::ResponseResult,
+};
 use futures::{Stream, StreamExt, channel::mpsc::Receiver};
 use std::{
     pin::Pin,
@@ -55,7 +58,11 @@ impl Filters {
             }
         }
         warn!(target: "node::filter", "No filter found for {}", id);
-        ResponseResult::success(Vec::<()>::new())
+        ResponseResult::error(RpcError {
+            code: ErrorCode::ServerError(-32000),
+            message: "filter not found".into(),
+            data: None,
+        })
     }
 
     /// Returns the original `Filter` of an `eth_newFilter`


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
`get_filter_changes` and `get_filter_logs` were silently returning empty arrays when a filter ID didn't exist or had expired. Per the Ethereum JSON-RPC spec, this should return a `-32000` error with "filter not found", which is what Geth does. Without this, clients can't distinguish between "no new logs" and "your filter is gone", so they never recreate expired filters and silently miss events.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Return `-32000 filter not found` error from `get_filter_changes` and `get_filter_logs` instead of silently returning empty arrays when the filter ID doesn't exist or has expired, matching Geth behavior.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
