### PR TITLE
ci: replace merge_group with push on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 permissions: {}
 
 on:
+  push:
+    branches: [master]
   pull_request:
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Motivation

We removed the merge queue, so we need to run the CI workflows on master as well as the PR.

## Solution

Run the workflows on master.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
