### PR TITLE
ci(release): pin action-gh-release to v2.4.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,7 +279,7 @@ jobs:
 
       # Creates the release for this specific version
       - name: Create release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2.4.2
         with:
           name: ${{ needs.prepare.outputs.release_name }}
           tag_name: ${{ needs.prepare.outputs.tag_name }}
@@ -294,7 +294,7 @@ jobs:
       # tagged `nightly` for compatibility with `foundryup`
       - name: Update nightly release
         if: ${{ env.IS_NIGHTLY == 'true' }}
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2.4.2
         with:
           name: "Nightly"
           tag_name: "nightly"


### PR DESCRIPTION
## Summary

Pin `softprops/action-gh-release` to v2.4.2 to fix intermittent nightly release failures.

## Motivation

v2.5.0 (merged in https://github.com/foundry-rs/foundry/commit/2d6d70004de3d492dde19a666d3061b12d3d47f6) introduced a draft→finalize flow that races in matrix jobs, causing intermittent `Too many retries` failures in the `Create release` step. The issue is flaky — 2 failures in the last 30 nightly runs (today and Jan 19).

- Failing run: https://github.com/foundry-rs/foundry/actions/runs/21894846206/job/63218795305
- Upstream bug: https://github.com/softprops/action-gh-release/issues/704

## Changes

- Pinned both `softprops/action-gh-release` usages in `release.yml` from v2.5.0 to v2.4.2