### PR TITLE
refactor(mutation): extract workspace utilities into shared module

### DIFF
--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -26,6 +26,8 @@ pub use multi_runner::{MultiContractRunner, MultiContractRunnerBuilder};
 
 pub mod mutation;
 
+pub mod workspace;
+
 mod runner;
 pub use runner::ContractRunner;
 

--- a/crates/forge/src/mutation/runner.rs
+++ b/crates/forge/src/mutation/runner.rs
@@ -7,7 +7,7 @@ use std::{
     collections::BTreeMap,
     fs,
     panic::{self, AssertUnwindSafe},
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -30,26 +30,8 @@ use crate::{
         progress::MutationProgress,
     },
     result::SuiteResult,
+    workspace,
 };
-
-/// Check if a path is safe for use as a relative path within a workspace.
-/// Rejects absolute paths, parent directory components (..), and other unsafe patterns.
-fn is_safe_relative_path(p: &Path) -> bool {
-    !p.is_absolute()
-        && p.components().all(|c| matches!(c, Component::Normal(_) | Component::CurDir))
-}
-
-/// Validates that `rel` is a safe relative path. Returns an error mentioning `label` and `orig`
-/// if the path contains `..`, is absolute, or otherwise escapes the project root.
-fn ensure_safe_relative_path(rel: &Path, label: &str, orig: &Path) -> Result<()> {
-    if !is_safe_relative_path(rel) {
-        eyre::bail!(
-            "mutation testing requires {label} directory under project root, got: {}",
-            orig.display()
-        );
-    }
-    Ok(())
-}
 
 /// Result of testing a single mutant.
 #[derive(Debug, Clone)]
@@ -136,203 +118,6 @@ impl SharedMutationState {
     }
 }
 
-/// Compute relative path of `path` under `root`, or return the path unchanged if not under root.
-fn relative_to_root(root: &Path, path: &Path) -> PathBuf {
-    path.strip_prefix(root).map(|p| p.to_path_buf()).unwrap_or_else(|_| path.to_path_buf())
-}
-
-/// Copy only essential project files for mutation testing.
-/// Uses symlinks for lib directories (read-only dependencies) to avoid expensive copies.
-/// Preserves the project's directory layout (handles custom src/test paths).
-fn copy_project_for_mutation(config: &Config, temp_dir: &Path) -> Result<()> {
-    let src_rel = relative_to_root(&config.root, &config.src);
-    ensure_safe_relative_path(&src_rel, "src", &config.src)?;
-
-    let test_rel = relative_to_root(&config.root, &config.test);
-    ensure_safe_relative_path(&test_rel, "test", &config.test)?;
-
-    // Copy src directory (will be mutated)
-    copy_dir_recursive(&config.src, &temp_dir.join(&src_rel))?;
-
-    // Copy test directory (needs to be in temp for compilation)
-    // Only copy if different from src to avoid double-copying
-    if config.test != config.src {
-        copy_dir_recursive(&config.test, &temp_dir.join(&test_rel))?;
-    }
-
-    // Symlink all library directories (read-only, no need to copy)
-    // Preserve relative paths to maintain remapping compatibility
-    for lib_path in &config.libs {
-        if lib_path.exists() {
-            let lib_rel = relative_to_root(&config.root, lib_path);
-            ensure_safe_relative_path(&lib_rel, "lib", lib_path)?;
-            let target = temp_dir.join(&lib_rel);
-
-            if !target.exists() {
-                // Ensure parent directories exist
-                if let Some(parent) = target.parent() {
-                    fs::create_dir_all(parent)?;
-                }
-                // Try symlink first, fall back to copy on failure (Windows without privileges)
-                if symlink_dir(lib_path, &target).is_err() {
-                    copy_dir_recursive(lib_path, &target)?;
-                }
-            }
-
-            // Recursively symlink nested lib directories within each library.
-            // This handles projects with nested submodules (e.g., lib/euler-earn/lib/*)
-            // that have their own dependencies with context-specific remappings.
-            symlink_nested_libs(lib_path, &target)?;
-        }
-    }
-
-    // Symlink common external dependency directories (npm, soldeer)
-    // These are not always included in config.libs but are required for compilation
-    for dep_dir in ["node_modules", "dependencies"] {
-        let dep_path = config.root.join(dep_dir);
-        if dep_path.exists() && dep_path.is_dir() {
-            let target = temp_dir.join(dep_dir);
-            if !target.exists() {
-                // Try symlink first, fall back to copy on failure (Windows without privileges)
-                if symlink_dir(&dep_path, &target).is_err() {
-                    copy_dir_recursive(&dep_path, &target)?;
-                }
-            }
-        }
-    }
-
-    // Copy foundry.toml if exists
-    let foundry_toml = config.root.join("foundry.toml");
-    if foundry_toml.exists() {
-        fs::copy(&foundry_toml, temp_dir.join("foundry.toml"))?;
-    }
-
-    // Copy remappings.txt if exists
-    let remappings = config.root.join("remappings.txt");
-    if remappings.exists() {
-        fs::copy(&remappings, temp_dir.join("remappings.txt"))?;
-    }
-
-    Ok(())
-}
-
-/// Create a symlink to a directory (cross-platform).
-/// Returns Err if symlink creation fails (e.g., on Windows without privileges).
-fn symlink_dir(src: &Path, dst: &Path) -> Result<()> {
-    #[cfg(unix)]
-    {
-        std::os::unix::fs::symlink(src, dst)?;
-    }
-    #[cfg(windows)]
-    {
-        std::os::windows::fs::symlink_dir(src, dst)?;
-    }
-    Ok(())
-}
-
-/// Recursively symlink nested lib directories within a library.
-///
-/// Many projects use git submodules that themselves have dependencies in their own
-/// `lib/` directories. When the top-level lib is symlinked, these nested libs are
-/// included via the symlink. However, if remappings reference these nested paths
-/// with context-specific prefixes (e.g., `lib/euler-earn:@openzeppelin=lib/euler-earn/lib/...`),
-/// the mutation workspace needs these paths to exist.
-///
-/// This function walks through each top-level library and symlinks any nested `lib/`
-/// directories to ensure they're accessible in the temp workspace.
-fn symlink_nested_libs(lib_src: &Path, lib_dst: &Path) -> Result<()> {
-    // Try to load nested library's config to get its actual lib paths.
-    // Fall back to default "lib" if no config exists.
-    let nested_lib_dirs: Vec<PathBuf> =
-        if let Ok(config) = Config::load_with_root_and_fallback(lib_src) {
-            config.libs
-        } else {
-            vec![PathBuf::from("lib")]
-        };
-
-    for nested_lib_dir in nested_lib_dirs {
-        let nested_lib = lib_src.join(&nested_lib_dir);
-        if !nested_lib.exists() || !nested_lib.is_dir() {
-            continue;
-        }
-
-        process_nested_lib_dir(&nested_lib, lib_dst, &nested_lib_dir)?;
-    }
-
-    Ok(())
-}
-
-/// Process a single nested lib directory, symlinking its contents.
-fn process_nested_lib_dir(nested_lib: &Path, lib_dst: &Path, lib_rel: &Path) -> Result<()> {
-    if !nested_lib.exists() || !nested_lib.is_dir() {
-        return Ok(());
-    }
-
-    // Read entries in the nested lib directory
-    let entries = match fs::read_dir(nested_lib) {
-        Ok(e) => e,
-        Err(_) => return Ok(()), // Skip if we can't read
-    };
-
-    for entry in entries.flatten() {
-        let entry_path = entry.path();
-        if !entry_path.is_dir() {
-            continue;
-        }
-
-        let entry_name = entry.file_name();
-        let nested_dst = lib_dst.join(lib_rel).join(&entry_name);
-
-        // Only create if doesn't exist (symlinked parent may already provide it)
-        if !nested_dst.exists() {
-            // Ensure parent exists
-            if let Some(parent) = nested_dst.parent() {
-                let _ = fs::create_dir_all(parent);
-            }
-            // Symlink the nested library
-            let _ = symlink_dir(&entry_path, &nested_dst);
-        }
-
-        // Recurse into nested libs (handles deeply nested submodules)
-        symlink_nested_libs(&entry_path, &nested_dst)?;
-    }
-
-    Ok(())
-}
-
-/// Recursively copy a directory, skipping symlinked directories for safety.
-fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
-    if !src.exists() {
-        return Ok(());
-    }
-
-    fs::create_dir_all(dst)?;
-
-    for entry in fs::read_dir(src)? {
-        let entry = entry?;
-        let path = entry.path();
-        let dest_path = dst.join(entry.file_name());
-
-        // Use symlink_metadata to detect symlinks without following them
-        let meta = fs::symlink_metadata(&path)?;
-
-        if meta.file_type().is_symlink() {
-            // Skip symlinked directories to prevent traversal attacks
-            // For symlinked files, we copy the target content
-            if path.is_dir() {
-                continue;
-            }
-            fs::copy(&path, &dest_path)?;
-        } else if meta.is_dir() {
-            copy_dir_recursive(&path, &dest_path)?;
-        } else {
-            fs::copy(&path, &dest_path)?;
-        }
-    }
-
-    Ok(())
-}
-
 /// Run mutation tests in parallel with optional progress display.
 #[allow(clippy::too_many_arguments)]
 pub fn run_mutations_parallel_with_progress(
@@ -381,7 +166,7 @@ pub fn run_mutations_parallel_with_progress(
         })?
         .to_path_buf();
 
-    ensure_safe_relative_path(&source_relative, "source", &source_abs)?;
+    workspace::ensure_safe_relative_path(&source_relative, "source", &source_abs)?;
 
     // Default to available parallelism if num_workers is 0
     let num_workers = if num_workers == 0 {
@@ -526,7 +311,7 @@ fn test_single_mutant_isolated(
     };
 
     // Copy project to temp directory
-    if let Err(e) = copy_project_for_mutation(config, temp_dir.path()) {
+    if let Err(e) = workspace::copy_project(config, temp_dir.path()) {
         let _ = sh_eprintln!("Failed to copy project: {}", e);
         return MutantTestResult { mutant, result: MutationResult::Invalid };
     }
@@ -540,8 +325,8 @@ fn test_single_mutant_isolated(
 
     // Create a config for the temp directory, preserving relative paths
     let temp_path = temp_dir.path().to_path_buf();
-    let src_rel = relative_to_root(&config.root, &config.src);
-    let test_rel = relative_to_root(&config.root, &config.test);
+    let src_rel = workspace::relative_to_root(&config.root, &config.src);
+    let test_rel = workspace::relative_to_root(&config.root, &config.test);
 
     let mut temp_config = Config::load_with_root(&temp_path).unwrap_or_else(|_| {
         let mut c = Config::clone(config.as_ref());
@@ -563,7 +348,7 @@ fn test_single_mutant_isolated(
         .libs
         .iter()
         .map(|lib| {
-            let lib_rel = relative_to_root(&config.root, lib);
+            let lib_rel = workspace::relative_to_root(&config.root, lib);
             temp_path.join(lib_rel)
         })
         .collect();
@@ -665,219 +450,4 @@ fn compile_and_test(config: &Arc<Config>, evm_opts: &EvmOpts, env: &Env) -> Resu
     let killed = results.values().any(|suite| suite.failed() > 0);
 
     Ok(killed)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Helper to create a directory structure for testing
-    fn create_test_dir_structure(base: &Path, structure: &[&str]) {
-        for path in structure {
-            let full_path = base.join(path);
-            if path.ends_with('/') {
-                fs::create_dir_all(&full_path).unwrap();
-            } else {
-                if let Some(parent) = full_path.parent() {
-                    fs::create_dir_all(parent).unwrap();
-                }
-                fs::write(&full_path, format!("// {path}")).unwrap();
-            }
-        }
-    }
-
-    #[test]
-    fn test_symlink_dir_creates_symlink() {
-        let temp = TempDir::new().unwrap();
-        let src = temp.path().join("source_dir");
-        let dst = temp.path().join("target_link");
-
-        fs::create_dir(&src).unwrap();
-        fs::write(src.join("file.txt"), "content").unwrap();
-
-        symlink_dir(&src, &dst).unwrap();
-
-        assert!(dst.exists());
-        assert!(dst.is_symlink());
-        assert!(dst.join("file.txt").exists());
-    }
-
-    #[test]
-    fn test_symlink_nested_libs_single_level() {
-        let temp = TempDir::new().unwrap();
-
-        // Create source lib with nested lib directory
-        let lib_src = temp.path().join("lib_src");
-        create_test_dir_structure(
-            &lib_src,
-            &[
-                "src/Contract.sol",
-                "lib/",
-                "lib/openzeppelin/contracts/token/ERC20.sol",
-                "lib/solmate/src/tokens/ERC20.sol",
-            ],
-        );
-
-        // Create destination (simulating symlinked lib in temp workspace)
-        let lib_dst = temp.path().join("lib_dst");
-        fs::create_dir(&lib_dst).unwrap();
-
-        symlink_nested_libs(&lib_src, &lib_dst).unwrap();
-
-        // Verify nested libs are symlinked
-        assert!(lib_dst.join("lib/openzeppelin").exists());
-        assert!(lib_dst.join("lib/solmate").exists());
-        assert!(lib_dst.join("lib/openzeppelin/contracts/token/ERC20.sol").exists());
-        assert!(lib_dst.join("lib/solmate/src/tokens/ERC20.sol").exists());
-    }
-
-    #[test]
-    fn test_symlink_nested_libs_deeply_nested() {
-        let temp = TempDir::new().unwrap();
-
-        // Create deeply nested structure (3 levels)
-        let lib_src = temp.path().join("lib_src");
-        create_test_dir_structure(
-            &lib_src,
-            &[
-                "src/Main.sol",
-                "lib/",
-                "lib/dep-a/src/A.sol",
-                "lib/dep-a/lib/",
-                "lib/dep-a/lib/dep-b/src/B.sol",
-                "lib/dep-a/lib/dep-b/lib/",
-                "lib/dep-a/lib/dep-b/lib/dep-c/src/C.sol",
-            ],
-        );
-
-        let lib_dst = temp.path().join("lib_dst");
-        fs::create_dir(&lib_dst).unwrap();
-
-        symlink_nested_libs(&lib_src, &lib_dst).unwrap();
-
-        // All levels should be accessible
-        assert!(lib_dst.join("lib/dep-a").exists());
-        assert!(lib_dst.join("lib/dep-a/lib/dep-b").exists());
-        assert!(lib_dst.join("lib/dep-a/lib/dep-b/lib/dep-c").exists());
-        assert!(lib_dst.join("lib/dep-a/lib/dep-b/lib/dep-c/src/C.sol").exists());
-    }
-
-    #[test]
-    fn test_symlink_nested_libs_no_nested_lib_dir() {
-        let temp = TempDir::new().unwrap();
-
-        // Create lib without nested lib directory
-        let lib_src = temp.path().join("lib_src");
-        create_test_dir_structure(&lib_src, &["src/Contract.sol", "test/Test.sol"]);
-
-        let lib_dst = temp.path().join("lib_dst");
-        fs::create_dir(&lib_dst).unwrap();
-
-        // Should not error when no lib/ exists
-        symlink_nested_libs(&lib_src, &lib_dst).unwrap();
-
-        // lib_dst/lib should not exist
-        assert!(!lib_dst.join("lib").exists());
-    }
-
-    #[test]
-    fn test_symlink_nested_libs_skips_existing() {
-        let temp = TempDir::new().unwrap();
-
-        let lib_src = temp.path().join("lib_src");
-        create_test_dir_structure(&lib_src, &["lib/", "lib/existing/src/File.sol"]);
-
-        let lib_dst = temp.path().join("lib_dst");
-        fs::create_dir_all(lib_dst.join("lib/existing")).unwrap();
-        fs::write(lib_dst.join("lib/existing/marker.txt"), "pre-existing").unwrap();
-
-        symlink_nested_libs(&lib_src, &lib_dst).unwrap();
-
-        // Should not overwrite existing directory
-        assert!(lib_dst.join("lib/existing/marker.txt").exists());
-    }
-
-    #[test]
-    fn test_copy_dir_recursive_basic() {
-        let temp = TempDir::new().unwrap();
-
-        let src = temp.path().join("src");
-        create_test_dir_structure(
-            &src,
-            &["file1.sol", "subdir/file2.sol", "subdir/nested/file3.sol"],
-        );
-
-        let dst = temp.path().join("dst");
-        copy_dir_recursive(&src, &dst).unwrap();
-
-        assert!(dst.join("file1.sol").exists());
-        assert!(dst.join("subdir/file2.sol").exists());
-        assert!(dst.join("subdir/nested/file3.sol").exists());
-    }
-
-    #[test]
-    fn test_copy_dir_recursive_skips_symlinked_dirs() {
-        let temp = TempDir::new().unwrap();
-
-        let src = temp.path().join("src");
-        let external = temp.path().join("external");
-
-        // Create external directory and symlink to it
-        fs::create_dir_all(&external).unwrap();
-        fs::write(external.join("secret.txt"), "should not be copied").unwrap();
-
-        fs::create_dir_all(&src).unwrap();
-        fs::write(src.join("file.sol"), "content").unwrap();
-
-        // Create symlink inside src pointing to external
-        symlink_dir(&external, &src.join("external_link")).unwrap();
-
-        let dst = temp.path().join("dst");
-        copy_dir_recursive(&src, &dst).unwrap();
-
-        // Regular file should be copied
-        assert!(dst.join("file.sol").exists());
-        // Symlinked directory should be skipped
-        assert!(!dst.join("external_link").exists());
-    }
-
-    #[test]
-    fn test_copy_dir_recursive_nonexistent_src() {
-        let temp = TempDir::new().unwrap();
-
-        let src = temp.path().join("nonexistent");
-        let dst = temp.path().join("dst");
-
-        // Should not error for nonexistent source
-        copy_dir_recursive(&src, &dst).unwrap();
-        assert!(!dst.exists());
-    }
-
-    #[test]
-    fn test_relative_to_root_basic() {
-        let root = PathBuf::from("/project");
-        let path = PathBuf::from("/project/src/contracts");
-
-        let rel = relative_to_root(&root, &path);
-        assert_eq!(rel, PathBuf::from("src/contracts"));
-    }
-
-    #[test]
-    fn test_relative_to_root_same_path() {
-        let root = PathBuf::from("/project");
-        let path = PathBuf::from("/project");
-
-        let rel = relative_to_root(&root, &path);
-        assert_eq!(rel, PathBuf::from(""));
-    }
-
-    #[test]
-    fn test_relative_to_root_outside_root() {
-        let root = PathBuf::from("/project");
-        let path = PathBuf::from("/other/location");
-
-        // When path is outside root, returns the original path
-        let rel = relative_to_root(&root, &path);
-        assert_eq!(rel, path);
-    }
 }

--- a/crates/forge/src/workspace.rs
+++ b/crates/forge/src/workspace.rs
@@ -1,0 +1,387 @@
+//! Shared utilities for creating isolated project workspaces.
+//!
+//! Used by both mutation testing and brutalization to copy a project
+//! to a temporary directory for safe source-level modifications.
+
+use std::{
+    fs,
+    path::{Component, Path, PathBuf},
+};
+
+use eyre::Result;
+use foundry_config::Config;
+
+/// Check if a path is safe for use as a relative path within a workspace.
+/// Rejects absolute paths, parent directory components (..), and other unsafe patterns.
+pub fn is_safe_relative_path(p: &Path) -> bool {
+    !p.is_absolute()
+        && p.components().all(|c| matches!(c, Component::Normal(_) | Component::CurDir))
+}
+
+/// Validates that `rel` is a safe relative path. Returns an error mentioning `label` and `orig`
+/// if the path contains `..`, is absolute, or otherwise escapes the project root.
+pub fn ensure_safe_relative_path(rel: &Path, label: &str, orig: &Path) -> Result<()> {
+    if !is_safe_relative_path(rel) {
+        eyre::bail!("requires {label} directory under project root, got: {}", orig.display());
+    }
+    Ok(())
+}
+
+/// Compute relative path of `path` under `root`, or return the path unchanged if not under root.
+pub fn relative_to_root(root: &Path, path: &Path) -> PathBuf {
+    path.strip_prefix(root).map(|p| p.to_path_buf()).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Copy essential project files to a temp workspace.
+///
+/// Copies src and test directories, symlinks library directories (read-only),
+/// and copies config files (foundry.toml, remappings.txt).
+pub fn copy_project(config: &Config, temp_dir: &Path) -> Result<()> {
+    let src_rel = relative_to_root(&config.root, &config.src);
+    ensure_safe_relative_path(&src_rel, "src", &config.src)?;
+
+    let test_rel = relative_to_root(&config.root, &config.test);
+    ensure_safe_relative_path(&test_rel, "test", &config.test)?;
+
+    copy_dir_recursive(&config.src, &temp_dir.join(&src_rel))?;
+
+    if config.test != config.src {
+        copy_dir_recursive(&config.test, &temp_dir.join(&test_rel))?;
+    }
+
+    for lib_path in &config.libs {
+        if lib_path.exists() {
+            let lib_rel = relative_to_root(&config.root, lib_path);
+            ensure_safe_relative_path(&lib_rel, "lib", lib_path)?;
+            let target = temp_dir.join(&lib_rel);
+
+            if !target.exists() {
+                if let Some(parent) = target.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                if symlink_dir(lib_path, &target).is_err() {
+                    copy_dir_recursive(lib_path, &target)?;
+                }
+            }
+
+            symlink_nested_libs(lib_path, &target)?;
+        }
+    }
+
+    for dep_dir in ["node_modules", "dependencies"] {
+        let dep_path = config.root.join(dep_dir);
+        if dep_path.exists() && dep_path.is_dir() {
+            let target = temp_dir.join(dep_dir);
+            if !target.exists() && symlink_dir(&dep_path, &target).is_err() {
+                copy_dir_recursive(&dep_path, &target)?;
+            }
+        }
+    }
+
+    let foundry_toml = config.root.join("foundry.toml");
+    if foundry_toml.exists() {
+        fs::copy(&foundry_toml, temp_dir.join("foundry.toml"))?;
+    }
+
+    let remappings = config.root.join("remappings.txt");
+    if remappings.exists() {
+        fs::copy(&remappings, temp_dir.join("remappings.txt"))?;
+    }
+
+    Ok(())
+}
+
+/// Create a symlink to a directory (cross-platform).
+pub fn symlink_dir(src: &Path, dst: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(src, dst)?;
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(src, dst)?;
+    }
+    Ok(())
+}
+
+/// Recursively symlink nested lib directories within a library.
+fn symlink_nested_libs(lib_src: &Path, lib_dst: &Path) -> Result<()> {
+    let nested_lib_dirs: Vec<PathBuf> =
+        if let Ok(config) = Config::load_with_root_and_fallback(lib_src) {
+            config.libs
+        } else {
+            vec![PathBuf::from("lib")]
+        };
+
+    for nested_lib_dir in nested_lib_dirs {
+        let nested_lib = lib_src.join(&nested_lib_dir);
+        if !nested_lib.exists() || !nested_lib.is_dir() {
+            continue;
+        }
+        process_nested_lib_dir(&nested_lib, lib_dst, &nested_lib_dir)?;
+    }
+
+    Ok(())
+}
+
+fn process_nested_lib_dir(nested_lib: &Path, lib_dst: &Path, lib_rel: &Path) -> Result<()> {
+    if !nested_lib.exists() || !nested_lib.is_dir() {
+        return Ok(());
+    }
+
+    let entries = match fs::read_dir(nested_lib) {
+        Ok(e) => e,
+        Err(_) => return Ok(()),
+    };
+
+    for entry in entries.flatten() {
+        let entry_path = entry.path();
+        if !entry_path.is_dir() {
+            continue;
+        }
+
+        let entry_name = entry.file_name();
+        let nested_dst = lib_dst.join(lib_rel).join(&entry_name);
+
+        if !nested_dst.exists() {
+            if let Some(parent) = nested_dst.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            let _ = symlink_dir(&entry_path, &nested_dst);
+        }
+
+        symlink_nested_libs(&entry_path, &nested_dst)?;
+    }
+
+    Ok(())
+}
+
+/// Recursively copy a directory, skipping symlinked directories for safety.
+pub fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    if !src.exists() {
+        return Ok(());
+    }
+
+    fs::create_dir_all(dst)?;
+
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        let dest_path = dst.join(entry.file_name());
+
+        let meta = fs::symlink_metadata(&path)?;
+
+        if meta.file_type().is_symlink() {
+            if path.is_dir() {
+                continue;
+            }
+            fs::copy(&path, &dest_path)?;
+        } else if meta.is_dir() {
+            copy_dir_recursive(&path, &dest_path)?;
+        } else {
+            fs::copy(&path, &dest_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_test_dir_structure(base: &Path, structure: &[&str]) {
+        for path in structure {
+            let full_path = base.join(path);
+            if path.ends_with('/') {
+                fs::create_dir_all(&full_path).unwrap();
+            } else {
+                if let Some(parent) = full_path.parent() {
+                    fs::create_dir_all(parent).unwrap();
+                }
+                fs::write(&full_path, format!("// {path}")).unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn test_symlink_dir_creates_symlink() {
+        let temp = TempDir::new().unwrap();
+        let src = temp.path().join("source_dir");
+        let dst = temp.path().join("target_link");
+
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("file.txt"), "content").unwrap();
+
+        symlink_dir(&src, &dst).unwrap();
+
+        assert!(dst.exists());
+        assert!(dst.is_symlink());
+        assert!(dst.join("file.txt").exists());
+    }
+
+    #[test]
+    fn test_symlink_nested_libs_single_level() {
+        let temp = TempDir::new().unwrap();
+
+        let lib_src = temp.path().join("lib_src");
+        create_test_dir_structure(
+            &lib_src,
+            &[
+                "src/Contract.sol",
+                "lib/",
+                "lib/openzeppelin/contracts/token/ERC20.sol",
+                "lib/solmate/src/tokens/ERC20.sol",
+            ],
+        );
+
+        let lib_dst = temp.path().join("lib_dst");
+        fs::create_dir(&lib_dst).unwrap();
+
+        symlink_nested_libs(&lib_src, &lib_dst).unwrap();
+
+        assert!(lib_dst.join("lib/openzeppelin").exists());
+        assert!(lib_dst.join("lib/solmate").exists());
+        assert!(lib_dst.join("lib/openzeppelin/contracts/token/ERC20.sol").exists());
+        assert!(lib_dst.join("lib/solmate/src/tokens/ERC20.sol").exists());
+    }
+
+    #[test]
+    fn test_symlink_nested_libs_deeply_nested() {
+        let temp = TempDir::new().unwrap();
+
+        let lib_src = temp.path().join("lib_src");
+        create_test_dir_structure(
+            &lib_src,
+            &[
+                "src/Main.sol",
+                "lib/",
+                "lib/dep-a/src/A.sol",
+                "lib/dep-a/lib/",
+                "lib/dep-a/lib/dep-b/src/B.sol",
+                "lib/dep-a/lib/dep-b/lib/",
+                "lib/dep-a/lib/dep-b/lib/dep-c/src/C.sol",
+            ],
+        );
+
+        let lib_dst = temp.path().join("lib_dst");
+        fs::create_dir(&lib_dst).unwrap();
+
+        symlink_nested_libs(&lib_src, &lib_dst).unwrap();
+
+        assert!(lib_dst.join("lib/dep-a").exists());
+        assert!(lib_dst.join("lib/dep-a/lib/dep-b").exists());
+        assert!(lib_dst.join("lib/dep-a/lib/dep-b/lib/dep-c").exists());
+        assert!(lib_dst.join("lib/dep-a/lib/dep-b/lib/dep-c/src/C.sol").exists());
+    }
+
+    #[test]
+    fn test_symlink_nested_libs_no_nested_lib_dir() {
+        let temp = TempDir::new().unwrap();
+
+        let lib_src = temp.path().join("lib_src");
+        create_test_dir_structure(&lib_src, &["src/Contract.sol", "test/Test.sol"]);
+
+        let lib_dst = temp.path().join("lib_dst");
+        fs::create_dir(&lib_dst).unwrap();
+
+        symlink_nested_libs(&lib_src, &lib_dst).unwrap();
+
+        assert!(!lib_dst.join("lib").exists());
+    }
+
+    #[test]
+    fn test_symlink_nested_libs_skips_existing() {
+        let temp = TempDir::new().unwrap();
+
+        let lib_src = temp.path().join("lib_src");
+        create_test_dir_structure(&lib_src, &["lib/", "lib/existing/src/File.sol"]);
+
+        let lib_dst = temp.path().join("lib_dst");
+        fs::create_dir_all(lib_dst.join("lib/existing")).unwrap();
+        fs::write(lib_dst.join("lib/existing/marker.txt"), "pre-existing").unwrap();
+
+        symlink_nested_libs(&lib_src, &lib_dst).unwrap();
+
+        assert!(lib_dst.join("lib/existing/marker.txt").exists());
+    }
+
+    #[test]
+    fn test_copy_dir_recursive_basic() {
+        let temp = TempDir::new().unwrap();
+
+        let src = temp.path().join("src");
+        create_test_dir_structure(
+            &src,
+            &["file1.sol", "subdir/file2.sol", "subdir/nested/file3.sol"],
+        );
+
+        let dst = temp.path().join("dst");
+        copy_dir_recursive(&src, &dst).unwrap();
+
+        assert!(dst.join("file1.sol").exists());
+        assert!(dst.join("subdir/file2.sol").exists());
+        assert!(dst.join("subdir/nested/file3.sol").exists());
+    }
+
+    #[test]
+    fn test_copy_dir_recursive_skips_symlinked_dirs() {
+        let temp = TempDir::new().unwrap();
+
+        let src = temp.path().join("src");
+        let external = temp.path().join("external");
+
+        fs::create_dir_all(&external).unwrap();
+        fs::write(external.join("secret.txt"), "should not be copied").unwrap();
+
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("file.sol"), "content").unwrap();
+
+        symlink_dir(&external, &src.join("external_link")).unwrap();
+
+        let dst = temp.path().join("dst");
+        copy_dir_recursive(&src, &dst).unwrap();
+
+        assert!(dst.join("file.sol").exists());
+        assert!(!dst.join("external_link").exists());
+    }
+
+    #[test]
+    fn test_copy_dir_recursive_nonexistent_src() {
+        let temp = TempDir::new().unwrap();
+
+        let src = temp.path().join("nonexistent");
+        let dst = temp.path().join("dst");
+
+        copy_dir_recursive(&src, &dst).unwrap();
+        assert!(!dst.exists());
+    }
+
+    #[test]
+    fn test_relative_to_root_basic() {
+        let root = PathBuf::from("/project");
+        let path = PathBuf::from("/project/src/contracts");
+
+        let rel = relative_to_root(&root, &path);
+        assert_eq!(rel, PathBuf::from("src/contracts"));
+    }
+
+    #[test]
+    fn test_relative_to_root_same_path() {
+        let root = PathBuf::from("/project");
+        let path = PathBuf::from("/project");
+
+        let rel = relative_to_root(&root, &path);
+        assert_eq!(rel, PathBuf::from(""));
+    }
+
+    #[test]
+    fn test_relative_to_root_outside_root() {
+        let root = PathBuf::from("/project");
+        let path = PathBuf::from("/other/location");
+
+        let rel = relative_to_root(&root, &path);
+        assert_eq!(rel, path);
+    }
+}


### PR DESCRIPTION
## Summary

Extracts project-copying logic from `mutation/runner.rs` into a new shared `crates/forge/src/workspace.rs` module.

This enables reuse by other features that need isolated temporary workspaces (e.g., the upcoming `--brutalize` flag).

## Changes

```
+396 / -437 across 3 files

New:
  crates/forge/src/workspace.rs          — shared workspace utilities + 11 tests

Modified:
  crates/forge/src/lib.rs                — pub mod workspace
  crates/forge/src/mutation/runner.rs     — use workspace:: instead of local definitions
```

## Extracted functions

| Function | Visibility | Purpose |
|---|---|---|
| `copy_project` | `pub` | Copy src/test dirs, symlink libs, copy config files |
| `copy_dir_recursive` | `pub` | Recursive copy skipping symlinked dirs |
| `symlink_dir` | `pub` | Cross-platform directory symlink |
| `relative_to_root` | `pub` | Compute relative path under project root |
| `ensure_safe_relative_path` | `pub` | Validate path does not escape project root |
| `is_safe_relative_path` | `pub` | Check for absolute paths and `..` components |
| `symlink_nested_libs` | `fn` | Recursively symlink nested lib subdirectories |
| `process_nested_lib_dir` | `fn` | Process a single nested lib directory |

## Testing

- `make lint` passes (fmt + clippy + typos)
- All 100 lib tests pass (including 11 workspace tests moved from runner.rs and 57 mutation tests)