### PR TITLE
feat(forge): add compiler binary path to `forge compiler resolve`

### DIFF
--- a/crates/forge/tests/cli/compiler.rs
+++ b/crates/forge/tests/cli/compiler.rs
@@ -111,7 +111,7 @@ forgetest!(can_list_resolved_compiler_versions_verbose, |prj, cmd| {
     cmd.args(["compiler", "resolve", "-v"]).assert_success().stdout_eq(str![[r#"
 Solidity:
 
-0.8.33:
+0.8.33 [[..]]:
 ├── src/ContractC.sol
 └── src/ContractD.sol
 
@@ -129,6 +129,7 @@ forgetest!(can_list_resolved_compiler_versions_verbose_json, |prj, cmd| {
   "Solidity": [
     {
       "version": "0.8.33",
+      "compiler_path": "[..]",
       "paths": [
         "src/ContractC.sol",
         "src/ContractD.sol"
@@ -199,6 +200,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_skipped_json, |prj, cmd|
   "Solidity": [
     {
       "version": "0.8.33",
+      "compiler_path": "[..]",
       "paths": [
         "src/ContractD.sol"
       ]
@@ -230,13 +232,13 @@ forgetest!(can_list_resolved_multiple_compiler_versions_verbose, |prj, cmd| {
     cmd.args(["compiler", "resolve", "-vv"]).assert_success().stdout_eq(str![[r#"
 Solidity:
 
-0.8.4 (<= istanbul):
+0.8.4 (<= istanbul) [[..]]:
 └── src/ContractA.sol
 
-0.8.11 (<= london):
+0.8.11 (<= london) [[..]]:
 └── src/ContractB.sol
 
-0.8.33 (<= prague):
+0.8.33 (<= prague) [[..]]:
 ├── src/ContractC.sol
 └── src/ContractD.sol
 
@@ -264,6 +266,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_verbose_json, |prj, cmd|
   "Solidity": [
     {
       "version": "0.8.4",
+      "compiler_path": "[..]",
       "evm_version": "Istanbul",
       "paths": [
         "src/ContractA.sol"
@@ -271,6 +274,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_verbose_json, |prj, cmd|
     },
     {
       "version": "0.8.11",
+      "compiler_path": "[..]",
       "evm_version": "London",
       "paths": [
         "src/ContractB.sol"
@@ -278,6 +282,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_verbose_json, |prj, cmd|
     },
     {
       "version": "0.8.33",
+      "compiler_path": "[..]",
       "evm_version": "[..]",
       "paths": [
         "src/ContractC.sol",


### PR DESCRIPTION
## Summary

Adds the compiler binary path (e.g. `~/.svm/0.8.33/solc-0.8.33`) to the output of `forge compiler resolve` when verbosity is >= 1, as suggested in #5429.

This enables integration with external tooling:
```bash
# Extract solc path for use with Slither or other tools
SOLC=$(forge compiler resolve --json -v | jq -r '.Solidity[0].compiler_path')
slither --solc "$SOLC" .
```

### Changes

- Added `compiler_path` field to `ResolvedCompiler` struct
- Resolved via `Solc::find_svm_installed_version()` for Solidity compilers only
- Displayed in text output as `0.8.33 [/path/to/solc-0.8.33]:` at verbosity >= 1
- Included in JSON output as `"compiler_path"` field at verbosity >= 1
- No change to default (verbosity 0) output — fully backward compatible
- Vyper compilers are unaffected (path resolution is Solidity-only)

### Output Examples

**`forge compiler resolve -v`:**
```
Solidity:

0.8.33 [/Users/user/.svm/0.8.33/solc-0.8.33]:
├── src/ContractA.sol
└── src/ContractB.sol
```

**`forge compiler resolve --json -v`:**
```json
{
  "Solidity": [
    {
      "version": "0.8.33",
      "compiler_path": "/Users/user/.svm/0.8.33/solc-0.8.33",
      "paths": ["src/ContractA.sol", "src/ContractB.sol"]
    }
  ]
}
```

Closes #5429

### AI Disclosure

This PR was developed with assistance from Claude Code (AI). The implementation approach, code structure, and test updates were guided by AI, with human review and decision-making throughout. The contributor understands the code and the changes being proposed.