### PR TITLE
fix(common): remove trailing space in `state_root` match pattern

### DIFF
--- a/crates/common/src/transactions.rs
+++ b/crates/common/src/transactions.rs
@@ -161,7 +161,7 @@ pub fn get_pretty_tx_receipt_attr(
         "gasUsed" | "gas_used" => Some(receipt.receipt.gas_used.to_string()),
         "logs" => Some(receipt.receipt.inner.inner.inner.receipt.logs.as_slice().pretty()),
         "logsBloom" | "logs_bloom" => Some(receipt.receipt.inner.inner.inner.logs_bloom.pretty()),
-        "root" | "stateRoot" | "state_root " => Some(receipt.receipt.state_root().pretty()),
+        "root" | "stateRoot" | "state_root" => Some(receipt.receipt.state_root().pretty()),
         "status" | "statusCode" | "status_code" => {
             Some(receipt.receipt.inner.inner.inner.receipt.status.pretty())
         }


### PR DESCRIPTION
`"state_root "` had a trailing space, causing `cast receipt <tx> state_root` to fail with "invalid receipt field" because `"state_root" == "state_root "` is false.