### PR TITLE
fix: correct dead condition in command error formatting

### DIFF
--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -289,7 +289,7 @@ impl CommandUtils for Command {
             };
             if !msg.is_empty() {
                 err.push(':');
-                err.push(if msg.lines().count() == 0 { ' ' } else { '\n' });
+                err.push(if msg.lines().count() == 1 { ' ' } else { '\n' });
                 err.push_str(&msg);
             }
             Err(eyre::eyre!(err))


### PR DESCRIPTION
msg.lines().count() == 0 inside if !msg.is_empty() is a dead condition — non-empty string always has lines().count() >= 1

Changed == 0 to == 1 so the branch actually triggers for single-line messages