### PR TITLE
fix(cli): add Etherlink Shadownet to has_different_gas_calc

### DIFF
--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -111,6 +111,11 @@ pub fn init_progress(len: u64, label: &str) -> indicatif::ProgressBar {
 
 /// True if the network calculates gas costs differently.
 pub fn has_different_gas_calc(chain_id: u64) -> bool {
+    // Etherlink Shadownet (not yet in alloy-chains as a NamedChain variant).
+    if chain_id == 127823 {
+        return true;
+    }
+
     if let Some(chain) = Chain::from(chain_id).named() {
         return chain.is_arbitrum()
             || chain.is_elastic()


### PR DESCRIPTION
## Summary
Add Etherlink Shadownet (chain ID 127823) to `has_different_gas_calc` so `forge script --broadcast` re-estimates gas via `eth_estimateGas` on this chain.

## Motivation
Etherlink uses a non-standard gas model with inclusion fees (~600k gas on top of EVM execution gas). Without RPC-based gas estimation, `forge script` sends transactions with gas limits based on local EVM simulation only, which the sequencer rejects.

Etherlink Mainnet (42793) and Ghostnet Testnet (128123) are already handled via `NamedChain`, but Shadownet (127823) is not yet in alloy-chains, so we match the raw chain ID.

Closes #13425

## Changes
- `crates/cli/src/utils/cmd.rs`: add chain ID 127823 check before the `NamedChain` match