### PR TITLE
perf(anvil): batch mine empty blocks to skip redundant state root computation

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2101,8 +2101,7 @@ impl EthApi {
             if !has_pending && num_blocks > 1 {
                 // Fast path: pool is empty, batch mine all empty blocks at once.
                 // This avoids redundant state root recomputation per block.
-                let outcomes =
-                    this.backend.mine_empty_blocks(num_blocks, interval).await;
+                let outcomes = this.backend.mine_empty_blocks(num_blocks, interval).await;
                 for outcome in outcomes {
                     this.pool.on_mined_block(outcome);
                 }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2092,14 +2092,28 @@ impl EthApi {
             return Ok(());
         }
 
+        let num_blocks = blocks.to::<u64>();
+
         self.on_blocking_task(|this| async move {
-            // mine all the blocks
-            for _ in 0..blocks.to::<u64>() {
-                // If we have an interval, jump forwards in time to the "next" timestamp
-                if let Some(interval) = interval {
-                    this.backend.time().increase_time(interval);
+            // Check if pool has any ready transactions.
+            let has_pending = this.pool.ready_transactions().next().is_some();
+
+            if !has_pending && num_blocks > 1 {
+                // Fast path: pool is empty, batch mine all empty blocks at once.
+                // This avoids redundant state root recomputation per block.
+                let outcomes =
+                    this.backend.mine_empty_blocks(num_blocks, interval).await;
+                for outcome in outcomes {
+                    this.pool.on_mined_block(outcome);
                 }
-                this.mine_one().await;
+            } else {
+                // Slow path: mine blocks one by one (original behavior).
+                for _ in 0..num_blocks {
+                    if let Some(interval) = interval {
+                        this.backend.time().increase_time(interval);
+                    }
+                    this.mine_one().await;
+                }
             }
             Ok(())
         })

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -33,14 +33,15 @@ use crate::{
 };
 use alloy_chains::NamedChain;
 use alloy_consensus::{
-    Blob, BlockHeader, EnvKzgSettings, Header, Signed, Transaction as TransactionTrait,
-    TrieAccount, TxEnvelope, Typed2718,
+    Blob, BlockHeader, EMPTY_OMMER_ROOT_HASH, EnvKzgSettings, Header, Signed,
+    Transaction as TransactionTrait, TrieAccount, TxEnvelope, Typed2718,
+    constants::EMPTY_WITHDRAWALS,
     proofs::{calculate_receipt_root, calculate_transaction_root},
     transaction::Recovered,
 };
 use alloy_eips::{
-    BlockNumHash, Encodable2718, eip2935, eip4844::kzg_to_versioned_hash, eip7840::BlobParams,
-    eip7910::SystemContract,
+    BlockNumHash, Encodable2718, eip2935, eip4844::kzg_to_versioned_hash,
+    eip7685::EMPTY_REQUESTS_HASH, eip7840::BlobParams, eip7910::SystemContract,
 };
 use alloy_evm::{
     Database, Evm, FromRecoveredTx,
@@ -53,7 +54,7 @@ use alloy_network::{
     ReceiptResponse, TransactionBuilder, UnknownTxEnvelope, UnknownTypedTransaction,
 };
 use alloy_primitives::{
-    Address, B256, Bytes, TxHash, TxKind, U64, U256, hex, keccak256, logs_bloom,
+    Address, B256, Bloom, Bytes, TxHash, TxKind, U64, U256, hex, keccak256, logs_bloom,
     map::{AddressMap, HashMap, HashSet},
 };
 use alloy_rpc_types::{
@@ -78,7 +79,7 @@ use alloy_serde::{OtherFields, WithOtherFields};
 use alloy_signer::Signature;
 use alloy_trie::{HashBuilder, Nibbles, proof::ProofRetainer};
 use anvil_core::eth::{
-    block::{Block, BlockInfo},
+    block::{Block, BlockInfo, create_block},
     transaction::{MaybeImpersonatedTransaction, PendingTransaction, TransactionInfo},
 };
 use anvil_rpc::error::RpcError;
@@ -1445,6 +1446,186 @@ impl Backend {
         self.notify_on_new_block(header, block_hash);
 
         outcome
+    }
+
+    /// Mines `num_blocks` empty blocks in a batch, reusing the cached state root.
+    ///
+    /// This is the fast path for `anvil_mine(n)` when there are no pending transactions.
+    /// Instead of running the full `TransactionExecutor` and recomputing the Merkle state root
+    /// for each block, it constructs minimal block headers with the same state root
+    /// (since no state changes occur in empty blocks).
+    ///
+    /// This reduces per-block cost from O(accounts * log(accounts)) to O(1).
+    pub async fn mine_empty_blocks(
+        &self,
+        num_blocks: u64,
+        interval: Option<u64>,
+    ) -> Vec<MinedBlockOutcome> {
+        let _mining_guard = self.mining.lock().await;
+
+        let mut outcomes = Vec::with_capacity(num_blocks as usize);
+
+        // Read the current state root from the latest block — this will be reused
+        // for all empty blocks since no state transitions occur.
+        let cached_state_root = {
+            let storage = self.blockchain.storage.read();
+            storage
+                .blocks
+                .get(&storage.best_hash)
+                .map(|b| b.header.state_root)
+                .unwrap_or_default()
+        };
+
+        // Snapshot spec-level flags once (constant for the batch).
+        let spec = *self.env.read().evm_env.spec_id();
+        let is_london = spec.is_enabled_in(SpecId::LONDON);
+        let is_shanghai = spec >= SpecId::SHANGHAI;
+        let is_cancun = spec >= SpecId::CANCUN;
+        let is_prague = spec >= SpecId::PRAGUE;
+        let is_post_merge = self.is_eip3675();
+        let is_arb = is_arbitrum(self.env.read().evm_env.cfg_env.chain_id);
+        let gas_limit = self.env.read().evm_env.block_env.gas_limit;
+        let beneficiary = self.env.read().evm_env.block_env.beneficiary;
+
+        // Acquire DB write lock once for all block hash insertions.
+        let mut db = self.db.write().await;
+
+        for _ in 0..num_blocks {
+            // Advance time if interval is set.
+            if let Some(interval) = interval {
+                self.time.increase_time(interval);
+            }
+            let timestamp = self.time.next_timestamp();
+
+            // Read current chain tip.
+            let (best_hash, best_number) = {
+                let storage = self.blockchain.storage.read();
+                (storage.best_hash, storage.best_number)
+            };
+            let block_number = best_number.saturating_add(1);
+
+            // Compute prevrandao deterministically from parent hash + block number.
+            let prevrandao = {
+                let mut input = Vec::with_capacity(40);
+                input.extend_from_slice(best_hash.as_slice());
+                input.extend_from_slice(&block_number.to_le_bytes());
+                keccak256(&input)
+            };
+
+            // Store state snapshot for history if configured.
+            if self.prune_state_history_config.is_state_history_supported() {
+                let state_db = db.current_state();
+                self.states.write().insert(best_hash, state_db);
+            }
+
+            // Read current fee values.
+            let current_base_fee = self.base_fee();
+            let base_fee_per_gas = if is_london { Some(current_base_fee) } else { None };
+            let excess_blob_gas = if is_cancun {
+                self.excess_blob_gas_and_price().map(|e| e.excess_blob_gas)
+            } else {
+                None
+            };
+
+            // Construct the empty block header.
+            let header = Header {
+                parent_hash: best_hash,
+                ommers_hash: EMPTY_OMMER_ROOT_HASH,
+                beneficiary,
+                state_root: cached_state_root,
+                transactions_root: Default::default(),
+                receipts_root: Default::default(),
+                logs_bloom: Bloom::default(),
+                difficulty: U256::ZERO,
+                number: block_number,
+                gas_limit,
+                gas_used: 0,
+                timestamp,
+                extra_data: Default::default(),
+                mix_hash: prevrandao,
+                nonce: Default::default(),
+                base_fee_per_gas,
+                parent_beacon_block_root: is_cancun.then_some(Default::default()),
+                blob_gas_used: if is_cancun { Some(0u64) } else { None },
+                excess_blob_gas,
+                withdrawals_root: is_shanghai.then_some(EMPTY_WITHDRAWALS),
+                requests_hash: is_prague.then_some(EMPTY_REQUESTS_HASH),
+            };
+
+            // Create block with empty transaction list.
+            let block =
+                create_block(header, std::iter::empty::<MaybeImpersonatedTransaction>());
+            let block_hash = block.header.hash_slow();
+            let header = block.header.clone();
+
+            // Insert block hash into the DB (for BLOCKHASH opcode).
+            db.insert_block_hash(U256::from(block_number), block_hash);
+
+            // Update blockchain storage.
+            {
+                let mut storage = self.blockchain.storage.write();
+                storage.best_number = block_number;
+                storage.best_hash = block_hash;
+                if !is_post_merge {
+                    storage.total_difficulty =
+                        storage.total_difficulty.saturating_add(header.difficulty);
+                }
+                storage.blocks.insert(block_hash, block);
+                storage.hashes.insert(block_number, block_hash);
+
+                // Prune old transactions if keeper limit is exceeded.
+                if let Some(keeper) = self.transaction_block_keeper
+                    && storage.blocks.len() > keeper
+                {
+                    let to_clear = block_number
+                        .saturating_sub(keeper.try_into().unwrap_or(u64::MAX));
+                    storage.remove_block_transactions_by_number(to_clear);
+                }
+            }
+
+            // Update env with new block number.
+            {
+                let mut env = self.env.write();
+                if is_arb {
+                    env.evm_env.block_env.number = U256::from(block_number);
+                } else {
+                    env.evm_env.block_env.number =
+                        env.evm_env.block_env.number.saturating_add(U256::from(1));
+                }
+                env.evm_env.block_env.difficulty = U256::ZERO;
+                env.evm_env.block_env.timestamp = U256::from(timestamp);
+                env.evm_env.block_env.basefee = self.base_fee();
+            }
+
+            // Update base fee for next block (gas_used=0 for empty blocks).
+            let next_base_fee = self.fees.get_next_block_base_fee_per_gas(
+                header.gas_used,
+                header.gas_limit,
+                header.base_fee_per_gas.unwrap_or_default(),
+            );
+            self.fees.set_base_fee(next_base_fee);
+
+            // Update blob gas for next block (blob_gas_used=0).
+            let next_blob_excess = self.fees.get_next_block_blob_excess_gas(
+                header.excess_blob_gas.unwrap_or_default(),
+                header.blob_gas_used.unwrap_or_default(),
+            );
+            self.fees.set_blob_excess_gas_and_price(BlobExcessGasAndPrice::new(
+                next_blob_excess,
+                get_blob_base_fee_update_fraction_by_spec_id(spec),
+            ));
+
+            // Notify listeners.
+            self.notify_on_new_block(header, block_hash);
+
+            outcomes.push(MinedBlockOutcome {
+                block_number,
+                included: vec![],
+                invalid: vec![],
+            });
+        }
+
+        outcomes
     }
 
     /// Executes the [TransactionRequest] without writing to the DB

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 use alloy_chains::NamedChain;
 use alloy_consensus::{
-    Blob, BlockHeader, EMPTY_OMMER_ROOT_HASH, EnvKzgSettings, Header, Signed,
+    Blob, BlockHeader, EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH, EnvKzgSettings, Header, Signed,
     Transaction as TransactionTrait, TrieAccount, TxEnvelope, Typed2718,
     constants::EMPTY_WITHDRAWALS,
     proofs::{calculate_receipt_root, calculate_transaction_root},
@@ -1469,11 +1469,7 @@ impl Backend {
         // for all empty blocks since no state transitions occur.
         let cached_state_root = {
             let storage = self.blockchain.storage.read();
-            storage
-                .blocks
-                .get(&storage.best_hash)
-                .map(|b| b.header.state_root)
-                .unwrap_or_default()
+            storage.blocks.get(&storage.best_hash).map(|b| b.header.state_root).unwrap_or_default()
         };
 
         // Snapshot spec-level flags once (constant for the batch).
@@ -1533,8 +1529,8 @@ impl Backend {
                 ommers_hash: EMPTY_OMMER_ROOT_HASH,
                 beneficiary,
                 state_root: cached_state_root,
-                transactions_root: Default::default(),
-                receipts_root: Default::default(),
+                transactions_root: EMPTY_ROOT_HASH,
+                receipts_root: EMPTY_ROOT_HASH,
                 logs_bloom: Bloom::default(),
                 difficulty: U256::ZERO,
                 number: block_number,
@@ -1553,8 +1549,7 @@ impl Backend {
             };
 
             // Create block with empty transaction list.
-            let block =
-                create_block(header, std::iter::empty::<MaybeImpersonatedTransaction>());
+            let block = create_block(header, std::iter::empty::<MaybeImpersonatedTransaction>());
             let block_hash = block.header.hash_slow();
             let header = block.header.clone();
 
@@ -1577,8 +1572,8 @@ impl Backend {
                 if let Some(keeper) = self.transaction_block_keeper
                     && storage.blocks.len() > keeper
                 {
-                    let to_clear = block_number
-                        .saturating_sub(keeper.try_into().unwrap_or(u64::MAX));
+                    let to_clear =
+                        block_number.saturating_sub(keeper.try_into().unwrap_or(u64::MAX));
                     storage.remove_block_transactions_by_number(to_clear);
                 }
             }
@@ -1618,11 +1613,7 @@ impl Backend {
             // Notify listeners.
             self.notify_on_new_block(header, block_hash);
 
-            outcomes.push(MinedBlockOutcome {
-                block_number,
-                included: vec![],
-                invalid: vec![],
-            });
+            outcomes.push(MinedBlockOutcome { block_number, included: vec![], invalid: vec![] });
         }
 
         outcomes

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -1160,6 +1160,22 @@ async fn test_mine_empty_blocks_base_fee_decay() {
     assert!(final_base_fee <= init_base_fee);
 }
 
+// Verify that batch mining 1000 empty blocks completes quickly.
+// Before the optimization this took ~276s (issue #5499).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mine_empty_blocks_throughput() {
+    let (api, _) = spawn(NodeConfig::test()).await;
+
+    let start = std::time::Instant::now();
+    let _ = api.anvil_mine(Some(U256::from(1000)), None).await;
+    let elapsed = start.elapsed();
+
+    assert!(elapsed.as_secs() < 10, "anvil_mine(1000) took {elapsed:?}, expected < 10s");
+
+    let latest = api.block_number().unwrap().to::<u64>();
+    assert_eq!(latest, 1000); // genesis (0) + 1000 mined
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_anvil_reset_non_fork() {
     let (api, handle) = spawn(NodeConfig::test()).await;

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -1099,6 +1099,67 @@ async fn test_mine_first_block_with_interval() {
     assert_eq!(second_block.header.timestamp, init_timestamp + 120);
 }
 
+// Batch mine many empty blocks and verify block chain integrity.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mine_many_empty_blocks() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let init_blk = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    let init_number = init_blk.header.number;
+
+    // Mine 100 empty blocks (exercises the batch path).
+    let _ = api.anvil_mine(Some(U256::from(100)), None).await;
+
+    let latest_number = api.block_number().unwrap().to::<u64>();
+    assert_eq!(latest_number, init_number + 100);
+
+    // Verify parent_hash chain for a few consecutive blocks.
+    let blk_50 = provider.get_block(50u64.into()).await.unwrap().unwrap();
+    let blk_51 = provider.get_block(51u64.into()).await.unwrap().unwrap();
+    assert_eq!(blk_51.header.parent_hash, blk_50.header.hash);
+    assert_eq!(blk_51.header.number, 51);
+
+    // All empty blocks should have the same state root (no state changes).
+    assert_eq!(blk_50.header.state_root, blk_51.header.state_root);
+}
+
+// Batch mine with interval and verify timestamps increase correctly.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mine_empty_blocks_with_interval() {
+    let (api, _) = spawn(NodeConfig::test()).await;
+
+    let init_block = api.block_by_number(0.into()).await.unwrap().unwrap();
+    let init_timestamp = init_block.header.timestamp;
+
+    // Mine 5 empty blocks with 10-second interval.
+    let _ = api.anvil_mine(Some(U256::from(5)), Some(U256::from(10))).await;
+
+    for i in 1..=5u64 {
+        let blk = api.block_by_number(i.into()).await.unwrap().unwrap();
+        assert_eq!(blk.header.timestamp, init_timestamp + i * 10);
+    }
+}
+
+// Base fee should decay across empty blocks (gas_used = 0).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mine_empty_blocks_base_fee_decay() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let init_blk = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    let init_base_fee = init_blk.header.base_fee_per_gas.unwrap();
+
+    // Mine 10 empty blocks.
+    let _ = api.anvil_mine(Some(U256::from(10)), None).await;
+
+    let final_blk = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    let final_base_fee = final_blk.header.base_fee_per_gas.unwrap();
+
+    // Base fee should decrease (or stay at floor) since gas_used is 0.
+    assert!(final_base_fee <= init_base_fee);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_anvil_reset_non_fork() {
     let (api, handle) = spawn(NodeConfig::test()).await;


### PR DESCRIPTION
`anvil_mine(n)` calls [`do_mine_block()`](https://github.com/foundry-rs/foundry/blob/2e3f9b5668951ceaaf6b2f04c544f3e038a58d16/crates/anvil/src/eth/backend/mem/mod.rs#L1260) in a loop — each iteration spins up a `TransactionExecutor`, commits state, and recomputes the Merkle `state_root`, even when the pool is empty and there's nothing to execute. For `anvil_mine(1000)` that's 1000 redundant state root computations.

This adds a `mine_empty_blocks()` fast path that kicks in when the pool is empty and `num_blocks > 1`. It reuses the parent's `state_root` (no state transitions = same root) and builds block headers directly, skipping the EVM entirely. Everything else — base fee decay, blob gas, notifications, state history snapshots — is still computed per-block in the loop so downstream behavior doesn't change. `anvil_mine(1)` always goes through the existing path.

`anvil_mine(1000)` with an empty pool completes in ~1.5s (debug build, Windows). Before the optimization this took ~276s as reported in #5499.

Fixes #5499.