### PR TITLE
fix(config): normalize deny_warnings from env vars

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2327,8 +2327,8 @@ impl Config {
             figment = figment.merge(("evm_version", version));
         }
 
-        // Normalize `deny` based on the provided `deny_warnings` version.
-        if self.deny_warnings
+        // Normalize `deny` based on the provided `deny_warnings` value.
+        if figment.extract_inner::<bool>("deny_warnings").unwrap_or(false)
             && let Ok(DenyLevel::Never) = figment.extract_inner("deny")
         {
             figment = figment.merge(("deny", DenyLevel::Warnings));


### PR DESCRIPTION
`normalize_defaults` uses `self.deny_warnings` to check if the deprecated `deny_warnings` flag was set, but `self` here is always `Config::default()` (where `deny_warnings = false`), so the condition is dead code.

The TOML path works fine because `BackwardsCompatTomlProvider` converts the `deny_warnings` key to `deny` in the dict directly. But env vars like `FOUNDRY_DENY_WARNINGS=true` bypass that provider and rely on `normalize_defaults` to do the conversion — which never triggers.

The fix reads `deny_warnings` from the figment, same pattern already used for `solc`/`evm_version` a few lines above in the same function.

Introduced in c7d97039b (#11445).