### PR TITLE
feat: log broken invariant as soon as it is found

### DIFF
--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -6,6 +6,7 @@ use crate::executors::{Executor, RawCallResult};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_primitives::I256;
 use eyre::Result;
+use foundry_common::sh_println;
 use foundry_config::InvariantConfig;
 use foundry_evm_core::utils::StateChangeset;
 use foundry_evm_coverage::HitMaps;
@@ -14,7 +15,7 @@ use foundry_evm_fuzz::{
     invariant::{FuzzRunIdentifiedContracts, InvariantContract},
 };
 use revm_inspectors::tracing::CallTraceArena;
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::HashMap, time::{SystemTime, UNIX_EPOCH}};
 
 /// The outcome of an invariant fuzz test
 #[derive(Debug)]
@@ -91,6 +92,26 @@ pub(crate) fn assert_invariants(
                 call_result,
                 &inner_sequence,
             );
+            
+            // Log broken invariant as soon as it is found (for benchmarking purposes)
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs_f64())
+                .unwrap_or(0.0);
+            let invariant_name = &invariant_contract.invariant_function.name;
+            let revert_reason = if case_data.revert_reason.is_empty() {
+                "unknown reason".to_string()
+            } else {
+                case_data.revert_reason.clone()
+            };
+            let _ = sh_println!(
+                "[INVARIANT BROKEN] timestamp={:.6} invariant={} reason={} sequence_length={}",
+                timestamp,
+                invariant_name,
+                revert_reason,
+                calldata.len()
+            );
+            
             invariant_failures.error = Some(InvariantFuzzError::BrokenInvariant(case_data));
             return Ok(None);
         }
@@ -173,6 +194,26 @@ pub(crate) fn can_continue(
                 call_result,
                 &[],
             );
+            
+            // Log broken invariant (revert) as soon as it is found (for benchmarking purposes)
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs_f64())
+                .unwrap_or(0.0);
+            let invariant_name = &invariant_contract.invariant_function.name;
+            let revert_reason = if case_data.revert_reason.is_empty() {
+                "revert".to_string()
+            } else {
+                case_data.revert_reason.clone()
+            };
+            let _ = sh_println!(
+                "[INVARIANT BROKEN] timestamp={:.6} invariant={} reason={} sequence_length={}",
+                timestamp,
+                invariant_name,
+                revert_reason,
+                invariant_run.inputs.len()
+            );
+            
             invariant_data.failures.revert_reason = Some(case_data.revert_reason.clone());
             invariant_data.failures.error = Some(InvariantFuzzError::Revert(case_data));
 
@@ -207,6 +248,26 @@ pub(crate) fn assert_after_invariant(
             call_result,
             &[],
         );
+        
+        // Log broken invariant (afterInvariant failure) as soon as it is found (for benchmarking purposes)
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs_f64())
+            .unwrap_or(0.0);
+        let invariant_name = &invariant_contract.invariant_function.name;
+        let revert_reason = if case_data.revert_reason.is_empty() {
+            "afterInvariant failure".to_string()
+        } else {
+            case_data.revert_reason.clone()
+        };
+        let _ = sh_println!(
+            "[INVARIANT BROKEN] timestamp={:.6} invariant={} reason={} sequence_length={}",
+            timestamp,
+            invariant_name,
+            revert_reason,
+            invariant_run.inputs.len()
+        );
+        
         invariant_test.set_error(InvariantFuzzError::BrokenInvariant(case_data));
     }
     Ok(success)


### PR DESCRIPTION
Adds real-time logging when invariants break during fuzzing with timestamp, invariant name, reason, and sequence length for benchmarking purposes.

Closes #13285