### PR TITLE
add missing JSON output support for `erc20 decimals`

### DIFF
--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -428,7 +428,11 @@ impl Erc20Subcommand {
                     .block(block.unwrap_or_default())
                     .call()
                     .await?;
-                sh_println!("{}", decimals)?
+                if shell::is_json() {
+                    sh_println!("{}", serde_json::to_string(&decimals)?)?
+                } else {
+                    sh_println!("{}", decimals)?
+                }
             }
             Self::TotalSupply { token, block, .. } => {
                 let provider = get_provider(&config)?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
`cast erc20 decimals` was the only query subcommand not respecting `--json` flag, while all other subcommands (balance, allowance, name, symbol, total-supply) already handle it.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add the missing `shell::is_json()` check to keep it consistent.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
