### PR TITLE
fix(cheatcodes): noAccessListCall should clear access list instead of setting empty one

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -733,10 +733,8 @@ impl Cheatcode for accessListCall {
 impl Cheatcode for noAccessListCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
-        // Set to empty option in order to override previous applied access list.
-        if state.access_list.is_some() {
-            state.access_list = Some(alloy_rpc_types::AccessList::default());
-        }
+        // Clear previously applied access list.
+        state.access_list = None;
         Ok(Default::default())
     }
 }


### PR DESCRIPTION
noAccessListCall set access_list to Some(AccessList::default()) instead of None. This caused apply_accesslist to still match on Some, applying an empty access list and potentially upgrading the transaction type from Legacy to Eip2930 - even though the intent is to remove the access list override entirely