### PR TITLE
fix(cli): avoid claiming the global log backend

### DIFF
--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -87,8 +87,7 @@ pub fn subscriber() {
     let registry = tracing_subscriber::Registry::default().with(env_filter());
     #[cfg(feature = "tracy")]
     let registry = registry.with(tracing_tracy::TracyLayer::default());
-    let subscriber =
-        registry.with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr));
+    let subscriber = registry.with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr));
     // NOTE: we use `set_global_default` instead of `init()` to avoid installing a `LogTracer`.
     // `init()` calls `tracing_log::LogTracer::init()` which claims the global `log` backend,
     // preventing downstream libraries (e.g. soldeer) from initializing their own `log` backend


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently, verbose logging in `forge soldeer` (like `forge soldeer install -vvv`) does not work.

`subscriber()` calls `.init()` on the tracing subscriber, which internally installs a `LogTracer`  via `log::set_logger()`. When soldeer later tries to initialize `env_logger` for its own verbose output, `try_init()` silently fails because the log backend is already claimed.
Soldeer's log events get routed through the `LogTracer` bridge into forge's tracing `EnvFilter`, which defaults to ERROR level so no log is shown in normal operation.

## Solution

Replace `.init()` with `tracing::subscriber::set_global_default()`, which sets the tracing subscriber without installing a `LogTracer`. This leaves the `log` backend free for soldeer's `env_logger`.

This is safe because forge itself uses `tracing` macros (not `log`), and the libraries that do use `log` (hyper, rustls, mio, etc.) are already silenced via `default_directives.txt`.

This was tested locally by hand.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
