### PR TITLE
fix(forge): don't reset snapshot diff result on missing file

### DIFF
--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -755,7 +755,7 @@ impl TestArgs {
                         |mut found, (group, snapshots)| {
                             // If the snapshot file doesn't exist, we can't compare so we skip.
                             if !&config.snapshots.join(format!("{group}.json")).exists() {
-                                return false;
+                                return found;
                             }
 
                             let previous_snapshots: BTreeMap<String, String> =


### PR DESCRIPTION
`return false` in the fold closure resets accumulated `found` state when a snapshot file doesn't exist, making the check pass despite earlier diffs. 