### PR TITLE
refactor(common): eliminate code duplication in locked_read_to_string

### DIFF
--- a/crates/common/src/fs.rs
+++ b/crates/common/src/fs.rs
@@ -62,11 +62,7 @@ pub fn read_json_gzip_file<T: DeserializeOwned>(path: &Path) -> Result<T> {
 /// Reads the entire contents of a locked shared file into a string.
 pub fn locked_read_to_string(path: impl AsRef<Path>) -> Result<String> {
     let path = path.as_ref();
-    let mut file =
-        fs::OpenOptions::new().read(true).open(path).map_err(|err| FsPathError::open(err, path))?;
-    file.lock_shared().map_err(|err| FsPathError::lock(err, path))?;
-    let contents = read_inner(path, &mut file)?;
-    file.unlock().map_err(|err| FsPathError::unlock(err, path))?;
+    let contents = locked_read(path)?;
     String::from_utf8(contents).map_err(|err| FsPathError::read(std::io::Error::other(err), path))
 }
 


### PR DESCRIPTION


The `locked_read_to_string` function duplicated the entire file locking logic from `locked_read` (open → lock_shared → read → unlock), differing only in the final UTF-8 conversion. This duplication creates a maintenance risk: any future changes to the locking mechanism or error handling would need to be applied in two places, increasing the chance of inconsistencies.

