### PR TITLE
fix: revert diagnostic encoding to match encodePacked format

### DIFF
--- a/crates/evm/evm/src/inspectors/revert_diagnostic.rs
+++ b/crates/evm/evm/src/inspectors/revert_diagnostic.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, Bytes, U256};
 use alloy_sol_types::SolValue;
 use foundry_evm_core::{
     backend::DatabaseError,
@@ -102,7 +102,7 @@ impl RevertDiagnostic {
         if let Some(reason) = self.reason() {
             interpreter.bytecode.set_action(InterpreterAction::new_return(
                 InstructionResult::Revert,
-                reason.to_string().abi_encode().into(),
+                Bytes::from(reason.to_string().into_bytes()),
                 interpreter.gas,
             ));
         }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -606,9 +606,9 @@ impl InspectorStackRefMut<'_> {
             [
                 &mut self.fuzzer,
                 &mut self.tracer,
+                &mut self.revert_diag,
                 &mut self.cheatcodes,
                 &mut self.printer,
-                &mut self.revert_diag
             ],
             |inspector| {
                 let previous_outcome = outcome.clone();

--- a/testdata/default/repros/Issue11344.t.sol
+++ b/testdata/default/repros/Issue11344.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "utils/Test.sol";
+
+contract EOA {
+    function foo() external { }
+}
+
+contract Mock {
+    function callEOA(address eoa) external {
+        EOA(eoa).foo();
+    }
+}
+
+// https://github.com/foundry-rs/foundry/issues/11344
+// Bug: different revertData depending on verbosity (-v vs -vvvv)
+contract Issue11344 is Test {
+    function testIssue(address eoa) public {
+        Mock mock = new Mock();
+        vm.assume(eoa.code.length == 0);
+        assumeNotPrecompile(eoa);
+
+        vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(eoa)));
+        mock.callEOA(eoa);
+    }
+}
+


### PR DESCRIPTION
Fixes #11344

RevertDiagnostic now uses raw string bytes instead of ABI encoding 
to match abi.encodePacked() format expected by tests.