### PR TITLE
add missing doc section keys to config validation

### DIFF
--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -29,6 +29,11 @@ const SETTINGS_OVERRIDES_KEYS: &[&str] =
 /// causing the default serialization to produce an empty dict.
 const VYPER_KEYS: &[&str] = &["optimize", "path", "experimental_codegen"];
 
+/// Allowed keys for DocConfig.
+/// Required because DocConfig uses `skip_serializing_if = "Option::is_none"` on some fields
+/// (`repository`, `path`), whose defaults are `None` and thus excluded from serialization.
+const DOC_KEYS: &[&str] = &["out", "title", "book", "homepage", "repository", "path", "ignore"];
+
 /// Reserved keys that should not trigger unknown key warnings.
 const RESERVED_KEYS: &[&str] = &["extends"];
 
@@ -192,6 +197,8 @@ impl<P: Provider> WarningsProvider<P> {
             // so the default serialization produces an empty dict. Use explicit keys instead.
             let allowed_keys: BTreeSet<String> = if *section_name == "vyper" {
                 VYPER_KEYS.iter().map(|s| s.to_string()).collect()
+            } else if *section_name == "doc" {
+                DOC_KEYS.iter().map(|s| s.to_string()).collect()
             } else {
                 let Some(default_section_value) = default_dict.get(*section_name) else {
                     continue;
@@ -262,6 +269,8 @@ impl<P: Provider> WarningsProvider<P> {
             // so the default serialization produces an empty dict. Use explicit keys instead.
             let allowed_keys: BTreeSet<String> = if key == "vyper" {
                 VYPER_KEYS.iter().map(|s| s.to_string()).collect()
+            } else if key == "doc" {
+                DOC_KEYS.iter().map(|s| s.to_string()).collect()
             } else {
                 let Some(default_value) = default_dict.get(key) else {
                     continue;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
`DocConfig` has `repository` and `path` fields with `skip_serializing_if = "Option::is_none"` and `None` defaults, so they're absent from the serialized default dict. This causes the validation logic to flag them as unknown keys when users set them in `[doc]`. Same issue that was already fixed for vyper in the existing `VYPER_KEYS` approach
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
adds a `DOC_KEYS` constant for doc.
## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
