### PR TITLE
fix(lint): remove unreachable macro arm in declare_forge_lint

### DIFF
--- a/crates/lint/src/sol/macros.rs
+++ b/crates/lint/src/sol/macros.rs
@@ -23,10 +23,6 @@ macro_rules! declare_forge_lint {
             help: concat!("https://book.getfoundry.sh/reference/forge/forge-lint#", $str_id),
         };
     };
-
-    ($id:ident, $severity:expr, $str_id:expr, $desc:expr) => {
-        $crate::declare_forge_lint!($id, $severity, $str_id, $desc, "");
-    };
 }
 
 /// Registers Solidity linter passes that can have both early and late variants.


### PR DESCRIPTION
Remove duplicate macro pattern that was unreachable dead code.

The deleted arm had an identical signature to the first arm (`$id:ident, $severity:expr, $str_id:expr, $desc:expr`), 
making it impossible to match since Rust macros are matched top-to-bottom. Additionally, the removed arm 
attempted to call a 5-argument variant of the macro that doesn't exist, which would cause a compilation 
error if it were ever reached.