### PR TITLE
fix(script): allow `--verify` without `--broadcast`, preserving console logs

### DIFF
--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3172,16 +3172,18 @@ Error: script failed: call to non-contract address [..]
 "#]]);
 });
 
-// Test that --verify without --broadcast fails with a clear error message
-forgetest!(verify_without_broadcast_fails, |prj, cmd| {
+// Test that --verify without --broadcast still shows console logs
+// <https://github.com/foundry-rs/foundry/issues/11009>
+forgetest!(verify_without_broadcast_shows_logs, |prj, cmd| {
     let script = prj.add_source(
         "Counter",
         r#"
 import "forge-std/Script.sol";
+import "forge-std/console.sol";
 
 contract CounterScript is Script {
     function run() external {
-        // Simple script that does nothing
+        console.log("hello from verify");
     }
 }
    "#,
@@ -3191,17 +3193,17 @@ contract CounterScript is Script {
         "script",
         script.to_str().unwrap(),
         "--verify",
-        "--rpc-url",
-        "https://sepolia.infura.io/v3/test",
     ])
-    .assert_failure()
-    .stderr_eq(str![[r#"
-error: the following required arguments were not provided:
-  --broadcast
+    .assert_success()
+    .stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+Script ran successfully.
+[GAS]
 
-Usage: [..] script --broadcast --verify --fork-url <URL> <PATH> [ARGS]...
-
-For more information, try '--help'.
+== Logs ==
+  hello from verify
 
 "#]]);
 });

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -190,7 +190,7 @@ pub struct ScriptArgs {
     pub etherscan_api_key: Option<String>,
 
     /// Verifies all the contracts found in the receipts of a script, if any.
-    #[arg(long, requires = "broadcast")]
+    #[arg(long)]
     pub verify: bool,
 
     /// Gas price for legacy transactions, or max fee per gas for EIP1559 transactions, either
@@ -310,7 +310,7 @@ impl ScriptArgs {
             pre_simulation.fill_metadata().await?.bundle().await?
         };
 
-        // Exit early in case user didn't provide any broadcast/verify related flags.
+        // Exit early in case user didn't provide any broadcast/resume flags.
         if !bundled.args.should_broadcast() {
             if !shell::is_json() {
                 if shell::verbosity() >= 4 {
@@ -492,9 +492,9 @@ impl ScriptArgs {
         Ok(())
     }
 
-    /// We only broadcast transactions if --broadcast, --resume, or --verify was passed.
+    /// We only broadcast transactions if --broadcast or --resume was passed.
     fn should_broadcast(&self) -> bool {
-        self.broadcast || self.resume || self.verify
+        self.broadcast || self.resume
     }
 }
 


### PR DESCRIPTION
## Problem

When running `forge script` with `--verify` but without `--broadcast`, console.log output was suppressed. The `--verify` flag had a hard `requires = "broadcast"` constraint in clap, and was also included in `should_broadcast()`, meaning it couldn't be used standalone for dry-run simulation.

Developers debugging their scripts with `--verify` expected to see console logs regardless of whether they were actually broadcasting.

## Fix

- Remove the `requires = "broadcast"` constraint from the `--verify` arg so it can be passed independently
- Remove `self.verify` from `should_broadcast()` so that `--verify` alone follows the normal simulation path (traces + console logs + "SIMULATION COMPLETE" message)
- When both `--verify` and `--broadcast` are used together, behavior is unchanged

## Test

Updated the existing test to verify that `--verify` without `--broadcast` now succeeds and prints console logs.

Fixes #11009