### PR TITLE
feat(fuzz): add cheatcode to populate in-memory corpus

### DIFF
--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -984,6 +984,12 @@ interface Vm {
     #[cheatcode(group = Testing, safety = Safe)]
     function assume(bool condition) external pure;
 
+    /// Permanently add the current fuzz input to the in-memory corpus for mutation.
+    /// The hash parameter allows users to define how interesting a state is (as fine-or-coarse grained as you please).
+    /// Similar to IJON (<https://github.com/RUB-SysSec/ijon>).
+    #[cheatcode(group = Testing, safety = Safe)]
+    function addToCorpus(bytes32 hash) external;
+
     /// Discard this run's fuzz inputs and generate new ones if next call reverted.
     #[cheatcode(group = Testing, safety = Safe)]
     function assumeNoRevert() external pure;

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -516,6 +516,14 @@ pub struct Cheatcodes {
     pub dynamic_gas_limit: bool,
     // Custom execution evm version.
     pub execution_evm_version: Option<SpecId>,
+
+    /// Current fuzz input being executed, if any.
+    /// Set by the fuzzer before each fuzz call.
+    pub current_fuzz_input: Option<foundry_evm_fuzz::BasicTxDetails>,
+
+    /// Input that should be added to corpus unconditionally.
+    /// Set by the addToCorpus cheatcode, checked by the fuzzer after each call.
+    pub input_to_add_to_corpus: Option<foundry_evm_fuzz::BasicTxDetails>,
 }
 
 // This is not derived because calling this in `fn new` with `..Default::default()` creates a second
@@ -559,6 +567,8 @@ impl Cheatcodes {
             access_list: Default::default(),
             test_context: Default::default(),
             serialized_jsons: Default::default(),
+            current_fuzz_input: Default::default(),
+            input_to_add_to_corpus: Default::default(),
             eth_deals: Default::default(),
             gas_metering: Default::default(),
             gas_snapshots: Default::default(),

--- a/crates/cheatcodes/src/test/assume.rs
+++ b/crates/cheatcodes/src/test/assume.rs
@@ -99,7 +99,7 @@ impl Cheatcode for addToCorpusCall {
         
         // Get the current fuzz input
         let Some(ref input) = state.current_fuzz_input else {
-            return Err(Error::from_str(
+            return Err(Error::from(
                 "addToCorpus can only be called during fuzz test execution"
             ));
         };

--- a/crates/cheatcodes/src/test/assume.rs
+++ b/crates/cheatcodes/src/test/assume.rs
@@ -2,7 +2,7 @@ use crate::{Cheatcode, Cheatcodes, CheatsCtxt, Error, Result};
 use alloy_primitives::Address;
 use foundry_evm_core::constants::MAGIC_ASSUME;
 use spec::Vm::{
-    PotentialRevert, assumeCall, assumeNoRevert_0Call, assumeNoRevert_1Call, assumeNoRevert_2Call,
+    PotentialRevert, addToCorpusCall, assumeCall, assumeNoRevert_0Call, assumeNoRevert_1Call, assumeNoRevert_2Call,
 };
 use std::fmt::Debug;
 
@@ -91,4 +91,23 @@ fn assume_no_revert(
     state.assume_no_revert = Some(AssumeNoRevert { depth, reasons: parameters, reverted_by: None });
 
     Ok(Default::default())
+}
+
+impl Cheatcode for addToCorpusCall {
+    fn apply(&self, state: &mut Cheatcodes) -> Result {
+        let Self { hash: _hash } = self;
+        
+        // Get the current fuzz input
+        let Some(ref input) = state.current_fuzz_input else {
+            return Err(Error::from_str(
+                "addToCorpus can only be called during fuzz test execution"
+            ));
+        };
+
+        // Mark this input to be added to corpus unconditionally
+        // The fuzzer will check this after the call and add it to the corpus
+        state.input_to_add_to_corpus = Some(input.clone());
+
+        Ok(Default::default())
+    }
 }

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -237,7 +237,7 @@ impl FuzzedExecutor {
     /// or a `CounterExampleOutcome`
     fn single_fuzz(
         &self,
-        executor: &Executor,
+        executor: &mut Executor,
         address: Address,
         calldata: Bytes,
         coverage_metrics: &mut WorkerCorpus,
@@ -543,7 +543,7 @@ impl FuzzedExecutor {
             };
 
             worker.last_run_timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
-            match self.single_fuzz(&executor, address, input, &mut corpus) {
+            match self.single_fuzz(&mut executor, address, input, &mut corpus) {
                 Ok(fuzz_outcome) => match fuzz_outcome {
                     FuzzOutcome::Case(case) => {
                         let total_runs = inc_runs();


### PR DESCRIPTION
Implements `vm.addToCorpus(bytes32 hash)` cheatcode that allows users to permanently add the current fuzz input to the in-memory corpus for mutation.

This enables power users to define interesting states with a hash (as fine-or-coarse grained as desired), similar to IJON. The cheatcode marks the current input during execution, and the fuzzer adds it to the corpus unconditionally after the call completes.

**Changes:**
- Add `addToCorpus(bytes32 hash)` cheatcode definition
- Track current fuzz input in `Cheatcodes` state
- Add `add_input_unconditionally()` method to `WorkerCorpus`
- Integrate with both stateless fuzz tests and invariant tests

Closes #12526