### PR TITLE
feat: auto-derive sender from keystore account in forge script

### DIFF
--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -347,6 +347,10 @@ impl ScriptArgs {
             return Ok(Some(turnkey_address));
         }
 
+        if let Some(keystore_address) = self.wallets.keystore_address() {
+            return Ok(Some(keystore_address));
+        }
+
         let maybe_sender = self
             .wallets
             .private_keys()?


### PR DESCRIPTION
When using `--account` (or `--keystore`) with `forge script`, you currently have to also pass `--sender` with the same address that's already in the keystore file. This is redundant and easy to forget.

This PR reads the `address` field from the keystore JSON when a single keystore/account is provided and uses it as the default sender, so you can just do:

```
forge script script/Deploy.s.sol --account my-deployer --broadcast
```

instead of:

```
forge script script/Deploy.s.sol --account my-deployer --sender 0x... --broadcast
```

**Changes:**
- Added `keystore_address()` to `MultiWalletOpts` that reads the address from the keystore JSON without decrypting it
- Hooked it into `maybe_load_private_key()` in forge script, following the same pattern as the existing Turnkey and private key auto-detection

Only kicks in when a single keystore is provided and `--sender` isn't explicitly set. No behavior change for existing usage.

Closes #10632