### PR TITLE
fix(cheatcodes): fix vm.expectRevert for direct precompile calls

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -766,6 +766,13 @@ impl Cheatcodes {
             return None;
         }
 
+        // `expectRevert`: track max call depth. This is also done in `initialize_interp`, but
+        // precompile calls don't create an interpreter frame so we must also track it here.
+        // The callee executes at `curr_depth + 1`.
+        if let Some(expected) = &mut self.expected_revert {
+            expected.max_depth = max(curr_depth + 1, expected.max_depth);
+        }
+
         // Handle expected calls
 
         // Grab the different calldatas expected.

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -413,6 +413,18 @@ contract ExpectRevertCountWithReverter is Test {
     }
 }
 
+contract ExpectRevertPrecompileTest is Test {
+    /// Test that vm.expectRevert works when the next external call targets a
+    /// precompile address directly. Precompile calls don't create an interpreter
+    /// frame (no `initialize_interp`), so depth tracking must account for them.
+    function testExpectRevertDirectPrecompileCall() public {
+        // BLAKE2F precompile (0x09) expects exactly 213 bytes of input.
+        // Calling it with invalid input reverts.
+        vm.expectRevert();
+        address(0x09).call(hex"00");
+    }
+}
+
 contract ExpectRevertWithErrorTest is Test {
     /// Ref: <https://github.com/foundry-rs/foundry/issues/12511>
     function test_f() external {


### PR DESCRIPTION
## Summary
Fix `vm.expectRevert` failing with `call didn't revert at a lower depth than cheatcode call depth` when the next external call targets a precompile address directly.

## Motivation
`vm.expectRevert` tracks `max_depth` only in `initialize_interp`, which fires when a new interpreter frame is created. Precompile calls don't create interpreter frames — they're handled inline by the EVM. So `max_depth` never exceeds the cheatcode call `depth`, and the depth check in `handle_expect_revert` always fails.

## Changes
- Track `max_depth` in the `call` hook (`call_with_executor`) after cheatcode/console early returns — the callee executes at `curr_depth + 1`
- Add regression test calling BLAKE2F precompile (`0x09`) with invalid input via high-level interface

Prompted by: danipopes