### PR TITLE
refactor(cast): unify tx signing via FoundryTransactionRequest

### DIFF
--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -1,6 +1,6 @@
 use alloy_json_abi::JsonAbi;
 use alloy_primitives::{Address, U256, map::HashMap};
-use alloy_provider::{Provider, network::AnyNetwork};
+use alloy_provider::{Network, Provider};
 use eyre::{ContextCompat, Result};
 use foundry_common::{
     provider::{ProviderBuilder, RetryProvider},
@@ -111,9 +111,10 @@ pub fn get_provider_builder(config: &Config) -> Result<ProviderBuilder> {
     ProviderBuilder::from_config(config)
 }
 
-pub async fn get_chain<P>(chain: Option<Chain>, provider: P) -> Result<Chain>
+pub async fn get_chain<P, N>(chain: Option<Chain>, provider: P) -> Result<Chain>
 where
-    P: Provider<AnyNetwork>,
+    N: Network,
+    P: Provider<N>,
 {
     match chain {
         Some(chain) => Ok(chain),


### PR DESCRIPTION
## Summary

Unify the local-signer tx path in Cast by introducing `CastTxSender::sign_and_send()` — signs a `FoundryTransactionRequest` with an `EthereumWallet` and sends raw via `eth_sendRawTransaction`. Removes the Tempo-specific special-case branches.

## Motivation

`send.rs`, `mktx.rs`, and `erc20.rs` all had duplicated Tempo workaround code that manually signed transactions and sent them raw because `EthereumWallet` didn't understand type 0x76. Now that `NetworkWallet<FoundryNetwork>` is implemented for `EthereumWallet` (#13248) and `FoundryTransactionRequest` auto-routes to the correct variant (#13278), we can unify all local-signer flows through a single path.

The TODO comments in the code explicitly called for this:
> *All of this is a side effect of a few things, most notably that we do not use `FoundryNetwork` and `FoundryTransactionRequest` everywhere* — `send.rs` L221

## Changes

- **`tx.rs`**: Add `CastTxSender::sign_and_send()` — signs via `FoundryTransactionRequest::build(wallet)`, encodes 2718, sends raw
- **`send.rs`**: Remove Tempo branch (was L219-253). Local-signer path now uses `sign_and_send` for all tx types
- **`mktx.rs`**: Remove Tempo branch (was L148-165). All tx types go through `FoundryTransactionRequest::build()`
- **`erc20.rs`**: Remove Tempo-specific branching in `send_erc20_tx()`. Uses `sign_and_send` uniformly
- **`cli/utils`**: Make `get_chain()` generic over `N: Network` (unblocks future work)

## Context

Builds on:
- #12722 — `FoundryNetwork` type
- #13248 — `NetworkWallet<FoundryNetwork>` for `EthereumWallet`
- #13278 — `FoundryTransactionRequest` enum routing
- #13459 — `ForkDatabase`/`MultiFork` generic over `Network`

Prompted by: zerosnacks