### PR TITLE
fix: use max instead of min in TraceMode::with_verbosity for high verbosity levels

### DIFF
--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -372,7 +372,7 @@ impl TraceMode {
             3..=4 => std::cmp::max(self, Self::Call),
             // Enable step recording for backtraces when verbosity is 5 or higher.
             // We need to ensure we're recording JUMP AND JUMPDEST steps.
-            _ => std::cmp::min(self, Self::Steps),
+            _ => std::cmp::max(self, Self::Steps),
         }
     }
 


### PR DESCRIPTION
TraceMode::with_verbosity used std::cmp::min for verbosity >= 5, which downgrades the trace mode to Steps instead of elevating it.

All other with_* methods (with_debug, with_decode_internal, with_state_changes) use std::cmp::max to ensure the mode is raised, never lowered. This change aligns with_verbosity with the same pattern.