### PR TITLE
test: mark clone CLI tests as flaky

### DIFF
--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -696,7 +696,7 @@ Initializing [..] from https://github.com/foundry-rs/forge-template...
 });
 
 // checks that clone works
-forgetest!(can_clone, |prj, cmd| {
+forgetest!(flaky_can_clone, |prj, cmd| {
     prj.wipe();
 
     let foundry_toml = prj.root().join(Config::FILE_NAME);
@@ -728,7 +728,7 @@ Compiler run successful!
 });
 
 // Checks that quiet mode does not print anything for clone
-forgetest!(can_clone_quiet, |prj, cmd| {
+forgetest!(flaky_can_clone_quiet, |prj, cmd| {
     prj.wipe();
 
     cmd.args([
@@ -743,7 +743,7 @@ forgetest!(can_clone_quiet, |prj, cmd| {
 });
 
 // checks that clone works with sourcify
-forgetest!(can_clone_sourcify, |prj, cmd| {
+forgetest!(flaky_can_clone_sourcify, |prj, cmd| {
     prj.wipe();
 
     let foundry_toml = prj.root().join(Config::FILE_NAME);
@@ -770,7 +770,7 @@ Compiler run successful!
 });
 
 // checks that clone works with --no-remappings-txt
-forgetest!(can_clone_no_remappings_txt, |prj, cmd| {
+forgetest!(flaky_can_clone_no_remappings_txt, |prj, cmd| {
     prj.wipe();
 
     let foundry_toml = prj.root().join(Config::FILE_NAME);
@@ -803,7 +803,7 @@ Compiler run successful!
 });
 
 // checks that clone works with --keep-directory-structure
-forgetest!(can_clone_keep_directory_structure, |prj, cmd| {
+forgetest!(flaky_can_clone_keep_directory_structure, |prj, cmd| {
     prj.wipe();
 
     let foundry_toml = prj.root().join(Config::FILE_NAME);
@@ -935,7 +935,7 @@ Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: N
 
 // checks that clone works with raw src containing `node_modules`
 // <https://github.com/foundry-rs/foundry/issues/10115>
-forgetest!(can_clone_with_node_modules, |prj, cmd| {
+forgetest!(flaky_can_clone_with_node_modules, |prj, cmd| {
     prj.wipe();
 
     let foundry_toml = prj.root().join(Config::FILE_NAME);


### PR DESCRIPTION
The `can_clone*` CLI tests in `cmd.rs` hit real Etherscan/Sourcify APIs and fail intermittently due to rate limiting and network issues. These have been causing CI flakiness across PRs (seen in recent runs: 22080389446, 22018531190, 22018340944).

Rename them with the `flaky_` prefix so they are:
- Excluded from regular CI via nextest `default-filter`
- Run in the nightly `test-flaky.yml` workflow with 5 retries + exponential backoff

This follows the established convention used by other flaky tests (e.g., `flaky_verify_bytecode_*`, `flaky_can_get_broadcast_txs`).