### PR TITLE
fix: use stored hi position in DisableEnd handler

### DIFF
--- a/crates/common/src/comments/inline_config.rs
+++ b/crates/common/src/comments/inline_config.rs
@@ -262,6 +262,7 @@ impl<I: ItemIdIterator> InlineConfig<I> {
                         *depth = depth.saturating_sub(1);
 
                         if *depth == 0 {
+                            let lo = *lo;
                             let (id, (_, _, hi)) = entry.remove_entry();
 
                             self.disable(id, DisabledRange { lo, hi });

--- a/crates/common/src/comments/inline_config.rs
+++ b/crates/common/src/comments/inline_config.rs
@@ -262,10 +262,9 @@ impl<I: ItemIdIterator> InlineConfig<I> {
                         *depth = depth.saturating_sub(1);
 
                         if *depth == 0 {
-                            let lo = *lo;
-                            let (id, _) = entry.remove_entry();
+                            let (id, (_, _, hi)) = entry.remove_entry();
 
-                            self.disable(id, DisabledRange { lo, hi: span.hi() });
+                            self.disable(id, DisabledRange { lo, hi });
                         }
                     }
                 }


### PR DESCRIPTION
What was wrong: In the DisableEnd handler, the code was ignoring the stored `hi` position from the disabled_blocks entry and using `span.hi()` instead. This caused incorrect range calculation when multiple disable-start/disable-end pairs were nested.

Changes: Modified the DisableEnd case to use the stored `hi` value from the entry when creating the disabled range, ensuring the range correctly ends at the first disable-end (outermost) rather than the last one.