### PR TITLE
fix(config): use DAPP_TEST_NUMBER as fallback for fork_block_number

### DIFF
--- a/crates/config/src/providers/ext.rs
+++ b/crates/config/src/providers/ext.rs
@@ -419,7 +419,8 @@ impl Provider for DappEnvCompatProvider {
         use std::env;
 
         let mut dict = Dict::new();
-        if let Ok(val) = env::var("DAPP_TEST_NUMBER") {
+        let test_number = env::var("DAPP_TEST_NUMBER").ok();
+        if let Some(val) = &test_number {
             dict.insert(
                 "block_number".to_string(),
                 val.parse::<u64>().map_err(figment::Error::custom)?.into(),
@@ -433,7 +434,7 @@ impl Provider for DappEnvCompatProvider {
                 "fork_block_number".to_string(),
                 val.parse::<u64>().map_err(figment::Error::custom)?.into(),
             );
-        } else if let Ok(val) = env::var("DAPP_TEST_NUMBER") {
+        } else if let Some(val) = &test_number {
             dict.insert(
                 "fork_block_number".to_string(),
                 val.parse::<u64>().map_err(figment::Error::custom)?.into(),


### PR DESCRIPTION
The code read `DAPP_TEST_NUMBER` twice - first in an if block for `block_number`, then in an else if for `fork_block_number`. Since the first if always succeeds when the env var is set, the fallback logic for `fork_block_number` was never executed.

Read `DAPP_TEST_NUMBER` once and store it in a variable, then use it for both `block_number` and as fallback for `fork_block_number` when `DAPP_FORK_BLOCK `is not set.