### PR TITLE
fix: swap incorrect doc comments for archive RPC URL functions in rpc.

### DIFF
--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -137,12 +137,12 @@ pub fn next_ws_endpoint(chain: NamedChain) -> String {
     next_url(true, chain)
 }
 
-/// Returns a websocket URL that has access to archive state
+/// Returns an HTTP URL that has access to archive state
 pub fn next_http_archive_rpc_url() -> String {
     next_archive_url(false)
 }
 
-/// Returns an HTTP URL that has access to archive state
+/// Returns a websocket URL that has access to archive state
 pub fn next_ws_archive_rpc_url() -> String {
     next_archive_url(true)
 }


### PR DESCRIPTION
**Description:**

The doc comments for `next_http_archive_rpc_url` and `next_ws_archive_rpc_url` were swapped — the HTTP function's doc said "websocket" and the WS function's doc said "HTTP." Corrected each to match its actual return type.