### PR TITLE
move `sccache --show-stats` into build RUN to show actual stats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=shared \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=shared \
-    cargo build --profile ${RUST_PROFILE} --no-default-features --features "${RUST_FEATURES}"
+    cargo build --profile ${RUST_PROFILE} --no-default-features --features "${RUST_FEATURES}" \
+    && sccache --show-stats || true
 
 # `dev` profile outputs to the `target/debug` directory.
 RUN ln -s /app/target/debug /app/target/dev \
@@ -50,8 +51,6 @@ RUN ln -s /app/target/debug /app/target/dev \
     /app/target/${RUST_PROFILE}/anvil \
     /app/target/${RUST_PROFILE}/chisel \
     /app/output/
-
-RUN sccache --show-stats || true
 
 FROM ubuntu:22.04 AS runtime
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
`sccache --show-stats` was in a separate `RUN` from `cargo build`, so the
daemon (and its stats) was already dead. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Moved it into the same `RUN`.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
