### PR TITLE
fix: remove unused `no_storage_caching()` method from `NodeConfig`

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -819,12 +819,6 @@ impl NodeConfig {
         self
     }
 
-    /// Disables storage caching
-    #[must_use]
-    pub fn no_storage_caching(self) -> Self {
-        self.with_storage_caching(true)
-    }
-
     #[must_use]
     pub fn with_storage_caching(mut self, storage_caching: bool) -> Self {
         self.no_storage_caching = storage_caching;


### PR DESCRIPTION
The `no_storage_caching()` method was never called anywhere in the codebase - it was dead code that could cause confusion due to its inverted semantics (`no_storage_caching()` calling `with_storage_caching(true)`).
Removed the unused `no_storage_caching()` method from `NodeConfig`. Users can directly use `with_storage_caching(true)` to disable caching.