### PR TITLE
fix: remove unused needs_clear and is_cleared methods

### DIFF
--- a/crates/common/src/io/shell.rs
+++ b/crates/common/src/io/shell.rs
@@ -253,16 +253,6 @@ impl Shell {
         self.output_mode.is_quiet()
     }
 
-    /// Returns `true` if the `needs_clear` flag is set.
-    pub fn needs_clear(&self) -> bool {
-        self.needs_clear.load(Ordering::Relaxed)
-    }
-
-    /// Returns `true` if the `needs_clear` flag is unset.
-    pub fn is_cleared(&self) -> bool {
-        !self.needs_clear()
-    }
-
     /// Gets the output format of the shell.
     pub fn output_format(&self) -> OutputFormat {
         self.output_format


### PR DESCRIPTION
he Shell struct had two public methods (needs_clear and is_cleared) that were never called anywhere in the codebase. The needs_clear AtomicBool field was initialized to false and never set to true, making these methods dead code. Removed both methods to clean up the codebase.