### PR TITLE
fix(anvil): avoid panic on unsupported Tempo transactions

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3462,7 +3462,7 @@ impl EthApi {
             FoundryTxEnvelope::Legacy(_) => Ok(()),
             // TODO(onbjerg): we should impl support for Tempo transactions
             FoundryTxEnvelope::Tempo(_) => {
-                return Err(BlockchainError::FailedToDecodeTransaction);
+                return Err(BlockchainError::UnknownTransactionType);
             }
         }
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3387,7 +3387,9 @@ impl EthApi {
                 false,
             ),
             // TODO(onbjerg): we should impl support for Tempo transactions
-            FoundryTypedTx::Tempo(_) => todo!(),
+            FoundryTypedTx::Tempo(_) => {
+                panic!("Tempo transactions not supported yet")
+            }
         }
     }
 
@@ -3459,7 +3461,9 @@ impl EthApi {
             FoundryTxEnvelope::Deposit(_) => self.backend.ensure_op_deposits_active(),
             FoundryTxEnvelope::Legacy(_) => Ok(()),
             // TODO(onbjerg): we should impl support for Tempo transactions
-            FoundryTxEnvelope::Tempo(_) => todo!(),
+            FoundryTxEnvelope::Tempo(_) => {
+                return Err(BlockchainError::FailedToDecodeTransaction);
+            }
         }
     }
 }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3388,7 +3388,7 @@ impl EthApi {
             ),
             // TODO(onbjerg): we should impl support for Tempo transactions
             FoundryTypedTx::Tempo(_) => {
-                panic!("Tempo transactions not supported yet")
+                todo!()
             }
         }
     }


### PR DESCRIPTION
Replace remaining todo!() for Tempo transactions with proper error handling. Prevents runtime panic if an unsupported Tempo transaction is encountered during RPC or decoding.
