### PR TITLE
fix: remove code duplication in `get_runtime_codes`

### DIFF
--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -382,11 +382,8 @@ pub async fn get_runtime_codes(
             )
         })?;
 
-    let onchain_runtime_code = if let Some(block) = block {
-        provider.get_code_at(address).block_id(BlockId::number(block)).await?
-    } else {
-        provider.get_code_at(address).await?
-    };
+    let block_id = block.map_or_else(BlockId::latest, BlockId::number);
+    let onchain_runtime_code = provider.get_code_at(address).block_id(block_id).await?;
 
     Ok((fork_runtime_code, onchain_runtime_code))
 }


### PR DESCRIPTION

Removes redundant `if/else` branches in `get_runtime_codes` that duplicated the `get_code_at` call, differing only by the presence of `block_id`.
