### PR TITLE
fix(cli): Git::is_repo_root always returns false

### DIFF
--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -476,7 +476,7 @@ impl<'a> Git<'a> {
     }
 
     pub fn is_repo_root(self) -> Result<bool> {
-        self.cmd().args(["rev-parse", "--show-cdup"]).exec().map(|out| out.stdout.is_empty())
+        self.cmd().args(["rev-parse", "--show-cdup"]).get_stdout_lossy().map(|s| s.is_empty())
     }
 
     pub fn is_clean(self) -> Result<bool> {


### PR DESCRIPTION
Git::is_repo_root uses raw stdout.is_empty() to check the output of git rev-parse --show-cdup. At the repo root, git outputs a single \n byte, so is_empty() is always false.

Switched to get_stdout_lossy() which trims whitespace before the check, consistent with other Git methods like head(), commit_hash(), and has_branch().