### PR TITLE
fix(config): avoid reading DAPP_TEST_NUMBER env var twice

### DIFF
--- a/crates/config/src/providers/ext.rs
+++ b/crates/config/src/providers/ext.rs
@@ -419,7 +419,8 @@ impl Provider for DappEnvCompatProvider {
         use std::env;
 
         let mut dict = Dict::new();
-        if let Ok(val) = env::var("DAPP_TEST_NUMBER") {
+        let dapp_test_number = env::var("DAPP_TEST_NUMBER").ok();
+        if let Some(ref val) = dapp_test_number {
             dict.insert(
                 "block_number".to_string(),
                 val.parse::<u64>().map_err(figment::Error::custom)?.into(),
@@ -433,7 +434,7 @@ impl Provider for DappEnvCompatProvider {
                 "fork_block_number".to_string(),
                 val.parse::<u64>().map_err(figment::Error::custom)?.into(),
             );
-        } else if let Ok(val) = env::var("DAPP_TEST_NUMBER") {
+        } else if let Some(val) = dapp_test_number {
             dict.insert(
                 "fork_block_number".to_string(),
                 val.parse::<u64>().map_err(figment::Error::custom)?.into(),


### PR DESCRIPTION
The `DAPP_TEST_NUMBER` environment variable was being read twice - once for setting `block_number` and again in the else if branch for `fork_block_number` when `DAPP_FORK_BLOCK` was not set.
Save `DAPP_TEST_NUMBER` after first read and reuse the stored value instead of querying the environment variable twice. This eliminates redundant system calls.