### PR TITLE
fix(sol-macro-gen): correct identifier check in write_mod_name

### DIFF
--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -391,7 +391,7 @@ edition = "2021"
 }
 
 fn write_mod_name(contents: &mut String, name: &str) -> Result<()> {
-    if syn::parse_str::<syn::Ident>(&format!("pub mod {name};")).is_ok() {
+    if syn::parse_str::<syn::Ident>(name).is_ok() {
         write!(contents, "pub mod {name};")?;
     } else {
         write!(contents, "pub mod r#{name};")?;


### PR DESCRIPTION
Was parsing "pub mod {name};" as Ident which always returns false. Now parses just "name", correctly distinguishing normal identifiers from reserved keywords.