### PR TITLE
refactor: Use `fs::write_pretty_json_file` in `MultiChainSequence::save`

### DIFF
--- a/crates/script/src/multi_sequence.rs
+++ b/crates/script/src/multi_sequence.rs
@@ -6,9 +6,7 @@ use foundry_common::{fs, shell};
 use foundry_compilers::ArtifactId;
 use foundry_config::Config;
 use serde::{Deserialize, Serialize};
-use std::{
-    path::PathBuf,
-};
+use std::path::PathBuf;
 
 /// Holds the sequences of multiple chain deployments.
 #[derive(Clone, Default, Serialize, Deserialize)]


### PR DESCRIPTION
The `MultiChainSequence::save` method manually duplicates the JSON writing logic (create file → BufWriter → `to_writer_pretty` → flush) that already exists in `foundry_common::fs::write_pretty_json_file`. 