### PR TITLE
fix(fmt): correct trailing comment handling in Yul switch cases

### DIFF
--- a/crates/fmt/src/state/yul.rs
+++ b/crates/fmt/src/state/yul.rs
@@ -101,7 +101,7 @@ impl<'ast> State<'_, 'ast> {
                     }
                     self.print_yul_block(body, *span, false, 0);
 
-                    self.print_trailing_comment(selector.span.hi(), None);
+                    self.print_trailing_comment(span.hi(), None);
                 }
             }
             yul::StmtKind::Leave => self.print_word("leave"),


### PR DESCRIPTION
The trailing comment lookup after each switch case incorrectly used `selector.span.hi()` instead of the case's own `span.hi()`. This caused trailing comments after individual cases to be skipped or misprocessed, since the lookup was searching on the wrong source line.