### PR TITLE
feat(cast): add `--data` flag to access-list command

### DIFF
--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -31,7 +31,7 @@ pub struct AccessListArgs {
     #[arg(value_name = "ARGS", allow_negative_numbers = true)]
     args: Vec<String>,
 
-    /// Raw hex-encoded data for the transaction. Used instead of [SIG] and [ARGS].
+    /// Raw hex-encoded data for the transaction. Used instead of \[SIG\] and \[ARGS\].
     #[arg(
         long,
         conflicts_with_all = &["sig", "args"]


### PR DESCRIPTION
The `cast access-list` command was missing the `--data` flag that exists in `cast call` and `cast send`, making the API inconsistent. Users had to pass raw hex calldata through the positional `sig` argument, which was undocumented and non-obvious.

Added `--data` flag to `AccessListArgs` with proper conflicts_with_all constraint, matching the pattern used in call.rs and send.rs.