### PR TITLE
fix(fmt): correct indentation of named args nested inside chained calls

### DIFF
--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -86,10 +86,17 @@ impl CallStack {
         self.last().is_some_and(|call| call.is_nested())
     }
 
-    /// Returns true if any chained call in the stack has its own indentation.
+    /// Returns true if the direct parent chain has its own indentation.
     /// Used to determine if commasep should skip its own indentation (to avoid double indent).
-    pub(crate) fn has_chain_with_indent(&self) -> bool {
-        self.stack.iter().any(|call| call.is_chained() && call.has_indent)
+    ///
+    /// Only suppresses indent when named args belong directly to the chained call itself
+    /// (stack ends with `[Chained(has_indent), Nested]`), not when they are nested deeper
+    /// inside another function call (e.g. `.initialize(PoolKey({...}))`).
+    pub(crate) fn has_indented_parent_chain(&self) -> bool {
+        matches!(
+            self.stack.as_slice(),
+            [.., parent, last] if last.is_nested() && parent.is_chained() && parent.has_indent
+        )
     }
 }
 

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1821,7 +1821,7 @@ impl<'ast> State<'_, 'ast> {
                 list_format
                     .break_cmnts()
                     .break_single(true)
-                    .without_ind(self.call_stack.has_chain_with_indent())
+                    .without_ind(self.call_stack.has_indented_parent_chain())
                     .with_delimiters(!self.call_with_opts_and_args),
             );
         } else if self.config.bracket_spacing {

--- a/crates/fmt/testdata/Repros/fmt.sol
+++ b/crates/fmt/testdata/Repros/fmt.sol
@@ -427,3 +427,46 @@ contract ChainedStructCall {
         }).pack();
     }
 }
+
+// https://github.com/foundry-rs/foundry/issues/13362
+type V4PoolManager is address;
+type Currency is address;
+
+interface IHooks {}
+
+struct PoolKey {
+    Currency currency0;
+    Currency currency1;
+    uint24 fee;
+    int24 tickSpacing;
+    IHooks hooks;
+}
+
+interface IPoolManager {
+    function initialize(PoolKey memory key, uint160 sqrtPriceX96)
+        external
+        returns (int24);
+}
+
+contract NestedNamedArgsInChainedCall {
+    function test_nestedNamedArgs(
+        V4PoolManager pool,
+        address currency0,
+        address currency1,
+        uint24 fee,
+        int24 tickSpacing,
+        uint160 sqrtPriceX96
+    ) internal returns (int24 tick) {
+        tick = IPoolManager(V4PoolManager.unwrap(pool))
+            .initialize(
+                PoolKey({
+                    currency0: Currency.wrap(currency0),
+                    currency1: Currency.wrap(currency1),
+                    fee: fee,
+                    tickSpacing: tickSpacing,
+                    hooks: IHooks(address(0))
+                }),
+                sqrtPriceX96
+            );
+    }
+}

--- a/crates/fmt/testdata/Repros/original.sol
+++ b/crates/fmt/testdata/Repros/original.sol
@@ -424,3 +424,16 @@ contract ChainedStructCall {
             }).pack();
     }
 }
+
+// https://github.com/foundry-rs/foundry/issues/13362
+type V4PoolManager is address;
+type Currency is address;
+interface IHooks {}
+struct PoolKey { Currency currency0; Currency currency1; uint24 fee; int24 tickSpacing; IHooks hooks; }
+interface IPoolManager { function initialize(PoolKey memory key, uint160 sqrtPriceX96) external returns (int24); }
+
+contract NestedNamedArgsInChainedCall {
+    function test_nestedNamedArgs(V4PoolManager pool, address currency0, address currency1, uint24 fee, int24 tickSpacing, uint160 sqrtPriceX96) internal returns (int24 tick) {
+        tick = IPoolManager(V4PoolManager.unwrap(pool)).initialize(PoolKey({currency0: Currency.wrap(currency0), currency1: Currency.wrap(currency1), fee: fee, tickSpacing: tickSpacing, hooks: IHooks(address(0))}), sqrtPriceX96);
+    }
+}

--- a/crates/fmt/testdata/Repros/sorted.fmt.sol
+++ b/crates/fmt/testdata/Repros/sorted.fmt.sol
@@ -428,3 +428,46 @@ contract ChainedStructCall {
         }).pack();
     }
 }
+
+// https://github.com/foundry-rs/foundry/issues/13362
+type V4PoolManager is address;
+type Currency is address;
+
+interface IHooks {}
+
+struct PoolKey {
+    Currency currency0;
+    Currency currency1;
+    uint24 fee;
+    int24 tickSpacing;
+    IHooks hooks;
+}
+
+interface IPoolManager {
+    function initialize(PoolKey memory key, uint160 sqrtPriceX96)
+        external
+        returns (int24);
+}
+
+contract NestedNamedArgsInChainedCall {
+    function test_nestedNamedArgs(
+        V4PoolManager pool,
+        address currency0,
+        address currency1,
+        uint24 fee,
+        int24 tickSpacing,
+        uint160 sqrtPriceX96
+    ) internal returns (int24 tick) {
+        tick = IPoolManager(V4PoolManager.unwrap(pool))
+            .initialize(
+                PoolKey({
+                    currency0: Currency.wrap(currency0),
+                    currency1: Currency.wrap(currency1),
+                    fee: fee,
+                    tickSpacing: tickSpacing,
+                    hooks: IHooks(address(0))
+                }),
+                sqrtPriceX96
+            );
+    }
+}

--- a/crates/fmt/testdata/Repros/tab.fmt.sol
+++ b/crates/fmt/testdata/Repros/tab.fmt.sol
@@ -428,3 +428,46 @@ contract ChainedStructCall {
 		}).pack();
 	}
 }
+
+// https://github.com/foundry-rs/foundry/issues/13362
+type V4PoolManager is address;
+type Currency is address;
+
+interface IHooks {}
+
+struct PoolKey {
+	Currency currency0;
+	Currency currency1;
+	uint24 fee;
+	int24 tickSpacing;
+	IHooks hooks;
+}
+
+interface IPoolManager {
+	function initialize(PoolKey memory key, uint160 sqrtPriceX96)
+		external
+		returns (int24);
+}
+
+contract NestedNamedArgsInChainedCall {
+	function test_nestedNamedArgs(
+		V4PoolManager pool,
+		address currency0,
+		address currency1,
+		uint24 fee,
+		int24 tickSpacing,
+		uint160 sqrtPriceX96
+	) internal returns (int24 tick) {
+		tick = IPoolManager(V4PoolManager.unwrap(pool))
+			.initialize(
+				PoolKey({
+					currency0: Currency.wrap(currency0),
+					currency1: Currency.wrap(currency1),
+					fee: fee,
+					tickSpacing: tickSpacing,
+					hooks: IHooks(address(0))
+				}),
+				sqrtPriceX96
+			);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes incorrect indentation of struct literal members inside function call arguments in chained calls.

## Motivation

Closes #13362. Named args inside a call that is itself an argument to a chained call (e.g. `.initialize(PoolKey({...}))`) were losing their indentation — struct members were aligned with the opening `PoolKey({` instead of being indented one level deeper.

## Changes

- Replaced `has_chain_with_indent()` with `has_indented_parent_chain()` in `crates/fmt/src/state/mod.rs` — only suppresses indent when named args belong directly to the chained call itself (stack ends with `[Chained(has_indent), Nested]`), not when nested deeper inside another function call
- Updated call site in `crates/fmt/src/state/sol.rs`
- Added regression test from the issue reproduction to `testdata/Repros/`

## Testing

```
cargo test -p forge-fmt  # 58 passed, 0 failed
cargo clippy -p forge-fmt --all-targets -- -D warnings  # clean
```

Prompted by: zerosnacks