### PR TITLE
fix: refactor `maybe_predeploy_contract` flag handling and add unit tests

### DIFF
--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -444,7 +444,8 @@ mod tests {
 
     #[test]
     fn test_maybe_predeploy_contract_empty_result_ok_is_predeploy() {
-        let err = EtherscanError::EmptyResult { status: "1".to_string(), message: "OK".to_string() };
+        let err =
+            EtherscanError::EmptyResult { status: "1".to_string(), message: "OK".to_string() };
         let (data, is_predeploy) = maybe_predeploy_contract(Err(err)).unwrap();
         assert!(data.is_none());
         assert!(is_predeploy);


### PR DESCRIPTION


The `maybe_predeploy_contract` helper was using a mutable `maybe_predeploy` flag whose value was fully determined by the `match` arms, adding unnecessary state and reducing readability without changing behavior.

