### PR TITLE
feat(invariant): add fail_on_assert for Solidity assert failures

### DIFF
--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -13,6 +13,9 @@ pub struct InvariantConfig {
     pub depth: u32,
     /// Fails the invariant fuzzing if a revert occurs
     pub fail_on_revert: bool,
+    /// Fails the invariant fuzzing if a Solidity assert failure occurs (`Panic(0x01)` or legacy
+    /// invalid opcode assert behavior), even if `fail_on_revert` is `false`.
+    pub fail_on_assert: bool,
     /// Allows overriding an unsafe external call when running invariant tests. eg. reentrancy
     /// checks
     pub call_override: bool,
@@ -57,6 +60,7 @@ impl Default for InvariantConfig {
             runs: 256,
             depth: 500,
             fail_on_revert: false,
+            fail_on_assert: false,
             call_override: false,
             dictionary: FuzzDictionaryConfig { dictionary_weight: 80, ..Default::default() },
             shrink_run_limit: 5000,

--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -3,7 +3,7 @@ use crate::executors::RawCallResult;
 use alloy_primitives::{Address, Bytes};
 use foundry_config::InvariantConfig;
 use foundry_evm_core::decode::RevertDecoder;
-use foundry_evm_fuzz::{BasicTxDetails, Reason, invariant::FuzzRunIdentifiedContracts};
+use foundry_evm_fuzz::{invariant::FuzzRunIdentifiedContracts, BasicTxDetails, Reason};
 use proptest::test_runner::TestError;
 
 /// Stores information about failures and reverts of the invariant tests.
@@ -67,6 +67,8 @@ pub struct FailedInvariantCaseData {
     pub fail_on_revert: bool,
     /// Fail on Solidity assert failures, used to check sequence when shrinking.
     pub fail_on_assert: bool,
+    /// Handler function that triggered a fail-on-assert violation, when available.
+    pub failing_handler: Option<String>,
 }
 
 impl FailedInvariantCaseData {
@@ -100,6 +102,12 @@ impl FailedInvariantCaseData {
             shrink_run_limit: invariant_config.shrink_run_limit,
             fail_on_revert: invariant_config.fail_on_revert,
             fail_on_assert: invariant_config.fail_on_assert,
+            failing_handler: None,
         }
+    }
+
+    pub fn with_failing_handler(mut self, failing_handler: Option<String>) -> Self {
+        self.failing_handler = failing_handler;
+        self
     }
 }

--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -65,6 +65,8 @@ pub struct FailedInvariantCaseData {
     pub shrink_run_limit: u32,
     /// Fail on revert, used to check sequence when shrinking.
     pub fail_on_revert: bool,
+    /// Fail on Solidity assert failures, used to check sequence when shrinking.
+    pub fail_on_assert: bool,
 }
 
 impl FailedInvariantCaseData {
@@ -97,6 +99,7 @@ impl FailedInvariantCaseData {
             inner_sequence: inner_sequence.to_vec(),
             shrink_run_limit: invariant_config.shrink_run_limit,
             fail_on_revert: invariant_config.fail_on_revert,
+            fail_on_assert: invariant_config.fail_on_assert,
         }
     }
 }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -504,7 +504,44 @@ impl<'a> InvariantExecutor<'a> {
                             invariant_test.test_data.failures.reverts += 1;
                             let should_fail_on_assert =
                                 self.config.fail_on_assert && is_assertion_failure(&call_result);
-                            if should_fail_on_assert || self.config.fail_on_revert {
+                            if should_fail_on_assert {
+                                let failing_handler =
+                                    current_run.inputs.last().and_then(|last_input| {
+                                        invariant_test
+                                            .targeted_contracts
+                                            .targets
+                                            .lock()
+                                            .fuzzed_metric_key(last_input)
+                                            .map(|metric_key| {
+                                                metric_key
+                                                    .rsplit('.')
+                                                    .next()
+                                                    .unwrap_or(metric_key.as_str())
+                                                    .to_string()
+                                            })
+                                    });
+                                let case_data = error::FailedInvariantCaseData::new(
+                                    &invariant_contract,
+                                    &self.config,
+                                    &invariant_test.targeted_contracts,
+                                    &current_run.inputs,
+                                    call_result,
+                                    &[],
+                                )
+                                .with_failing_handler(failing_handler);
+                                invariant_test.test_data.failures.revert_reason =
+                                    Some(case_data.revert_reason.clone());
+                                invariant_test
+                                    .test_data
+                                    .failures
+                                    .record_assertion_failure(case_data);
+                                if !invariant_contract.is_optimization() {
+                                    // In optimization mode, keep reverted calls to preserve
+                                    // warp/roll values for correct replay during shrinking.
+                                    current_run.inputs.pop();
+                                }
+                                result::RichInvariantResults::new(true, None)
+                            } else if self.config.fail_on_revert {
                                 let case_data = error::FailedInvariantCaseData::new(
                                     &invariant_contract,
                                     &self.config,
@@ -516,11 +553,7 @@ impl<'a> InvariantExecutor<'a> {
                                 invariant_test.test_data.failures.revert_reason =
                                     Some(case_data.revert_reason.clone());
                                 invariant_test.test_data.failures.error =
-                                    Some(if should_fail_on_assert {
-                                        InvariantFuzzError::BrokenInvariant(case_data)
-                                    } else {
-                                        InvariantFuzzError::Revert(case_data)
-                                    });
+                                    Some(InvariantFuzzError::Revert(case_data));
                                 result::RichInvariantResults::new(false, None)
                             } else if !invariant_contract.is_optimization() {
                                 // In optimization mode, keep reverted calls to preserve
@@ -600,10 +633,37 @@ impl<'a> InvariantExecutor<'a> {
         invariant_test.fuzz_state.log_stats();
 
         let result = invariant_test.test_data;
+        let mut failures = result.failures;
+        let assertion_failures: Vec<String> = failures.assertion_failures.keys().cloned().collect();
+        if failures.error.is_none() && self.config.fail_on_assert {
+            if let Some((handler, case_data)) = failures.assertion_failures.iter().next() {
+                failures.error = Some(InvariantFuzzError::BrokenInvariant(case_data.clone()));
+                let base_reason = if case_data.revert_reason.is_empty() {
+                    "assertion failure".to_string()
+                } else {
+                    case_data.revert_reason.clone()
+                };
+                let extra_handlers: Vec<_> = assertion_failures
+                    .iter()
+                    .filter(|name| name.as_str() != handler.as_str())
+                    .cloned()
+                    .collect();
+                failures.revert_reason = Some(if extra_handlers.is_empty() {
+                    format!("assertion failure in {handler}: {base_reason}")
+                } else {
+                    format!(
+                        "assertion failure in {handler}: {base_reason}; other assertion failures in {}",
+                        extra_handlers.join(", ")
+                    )
+                });
+            }
+        }
+
         Ok(InvariantFuzzTestResult {
-            error: result.failures.error,
+            error: failures.error,
+            assertion_failures,
             cases: result.fuzz_cases,
-            reverts: result.failures.reverts,
+            reverts: failures.reverts,
             last_run_inputs: result.last_run_inputs,
             gas_report_traces: result.gas_report_traces,
             line_coverage: result.line_coverage,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -732,6 +732,9 @@ impl<'a> FunctionRunner<'a> {
 
         let runner = self.invariant_runner();
         let invariant_config = &self.config.invariant;
+        let invariant_depth = invariant_config.depth as usize;
+        let fail_on_revert = invariant_config.fail_on_revert;
+        let fail_on_assert = invariant_config.fail_on_assert;
 
         let mut executor = self.clone_executor();
         // Enable edge coverage if running with coverage guided fuzzing or with edge coverage
@@ -789,11 +792,11 @@ impl<'a> FunctionRunner<'a> {
             if let Ok((success, replayed_entirely)) = check_sequence(
                 self.clone_executor(),
                 &txes,
-                (0..min(txes.len(), invariant_config.depth as usize)).collect(),
+                (0..min(txes.len(), invariant_depth)).collect(),
                 invariant_contract.address,
                 invariant_contract.invariant_function.selector().to_vec().into(),
-                invariant_config.fail_on_revert,
-                invariant_config.fail_on_assert,
+                fail_on_revert,
+                fail_on_assert,
                 invariant_contract.call_after_invariant,
             ) && !success
             {
@@ -843,11 +846,32 @@ impl<'a> FunctionRunner<'a> {
                     }
                 }
 
-                self.result.invariant_replay_fail(
-                    replayed_entirely,
-                    &invariant_contract.invariant_function.name,
-                    call_sequence,
-                );
+                let replay_label = if fail_on_assert {
+                    let assert_only_failure = check_sequence(
+                        self.clone_executor(),
+                        &txes,
+                        (0..min(txes.len(), invariant_depth)).collect(),
+                        invariant_contract.address,
+                        invariant_contract.invariant_function.selector().to_vec().into(),
+                        false,
+                        false,
+                        invariant_contract.call_after_invariant,
+                    )
+                    .map(|(success, _)| success)
+                    .unwrap_or(false);
+                    if assert_only_failure {
+                        call_sequence
+                            .last()
+                            .and_then(|counterexample| counterexample.func_name.clone())
+                            .map(|handler| format!("assertion failure in {handler}"))
+                            .unwrap_or_else(|| invariant_contract.invariant_function.name.clone())
+                    } else {
+                        invariant_contract.invariant_function.name.clone()
+                    }
+                } else {
+                    invariant_contract.invariant_function.name.clone()
+                };
+                self.result.invariant_replay_fail(replayed_entirely, &replay_label, call_sequence);
                 return self.result;
             }
         }
@@ -870,13 +894,23 @@ impl<'a> FunctionRunner<'a> {
 
         let mut counterexample = None;
         let success = invariant_result.error.is_none();
-        let reason = invariant_result.error.as_ref().and_then(|err| err.revert_reason());
+        let mut reason = invariant_result.error.as_ref().and_then(|err| err.revert_reason());
 
         match invariant_result.error {
             // If invariants were broken, replay the error to collect logs and traces
             Some(error) => match error {
                 InvariantFuzzError::BrokenInvariant(case_data)
                 | InvariantFuzzError::Revert(case_data) => {
+                    if case_data.fail_on_assert
+                        && let Some(handler) = case_data.failing_handler.as_ref()
+                    {
+                        let assert_reason = if case_data.revert_reason.is_empty() {
+                            "assertion failure".to_string()
+                        } else {
+                            case_data.revert_reason.clone()
+                        };
+                        reason = Some(format!("assertion failure in {handler}: {assert_reason}"));
+                    }
                     // Replay error to create counterexample and to collect logs, traces and
                     // coverage.
                     match case_data.test_error {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -793,6 +793,7 @@ impl<'a> FunctionRunner<'a> {
                 invariant_contract.address,
                 invariant_contract.invariant_function.selector().to_vec().into(),
                 invariant_config.fail_on_revert,
+                invariant_config.fail_on_assert,
                 invariant_contract.call_after_invariant,
             ) && !success
             {

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -198,6 +198,7 @@ show_logs = false
 runs = 256
 depth = 500
 fail_on_revert = false
+fail_on_assert = false
 call_override = false
 dictionary_weight = 80
 include_storage = true
@@ -1280,6 +1281,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "runs": 256,
     "depth": 500,
     "fail_on_revert": false,
+    "fail_on_assert": false,
     "call_override": false,
     "dictionary_weight": 80,
     "include_storage": true,


### PR DESCRIPTION
## Summary
- add `[invariant].fail_on_assert` to `InvariantConfig` (default `false`)
- fail invariant campaigns on Solidity assert failures even when `fail_on_revert = false`
  - `Panic(0x01)`
  - legacy invalid-opcode assertion behavior (`InstructionResult::InvalidFEOpcode`)
- keep behavior unchanged for:
  - `require`/generic reverts
  - non-assert panics (e.g. `Panic(0x11)`)
  - `vm.assert*` / `GLOBAL_FAIL_SLOT` semantics
- classify `fail_on_assert` failures as `BrokenInvariant` (not generic `Revert`)
- apply the same condition in replay/shrink paths so persisted failures stay reproducible

## Implementation Notes
- config model
  - `crates/config/src/invariant.rs`
- runtime decision paths
  - `crates/evm/evm/src/executors/invariant/result.rs`
  - `crates/evm/evm/src/executors/invariant/mod.rs`
- replay/shrink parity
  - `crates/evm/evm/src/executors/invariant/shrink.rs`
  - `crates/forge/src/runner.rs`
- propagated case data
  - `crates/evm/evm/src/executors/invariant/error.rs`
- config snapshots
  - `crates/forge/tests/cli/config.rs`
- regression tests
  - `crates/forge/tests/cli/test_cmd/invariant/common.rs`

## Tests
- `cargo +1.91.0 test -p foundry-evm invariant::result::tests --lib --locked`
- `cargo +1.91.0 test -p forge --test cli fail_on_assert --locked`
- `cargo +1.91.0 test -p forge --test cli invariant_ignore_assert_panic_when_flag_off --locked`
- `cargo +1.91.0 test -p forge --test cli test_default_config --locked`

Closes #13322 
