### PR TITLE
ci(release): revert action-gh-release to v2.4.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,7 +279,7 @@ jobs:
 
       # Creates the release for this specific version
       - name: Create release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2.4.2
         with:
           name: ${{ needs.prepare.outputs.release_name }}
           tag_name: ${{ needs.prepare.outputs.tag_name }}
@@ -294,7 +294,7 @@ jobs:
       # tagged `nightly` for compatibility with `foundryup`
       - name: Update nightly release
         if: ${{ env.IS_NIGHTLY == 'true' }}
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2.4.2
         with:
           name: "Nightly"
           tag_name: "nightly"


### PR DESCRIPTION
## Summary
Reverts `softprops/action-gh-release` from v2.5.0 back to v2.4.2.

## Motivation
Dependabot re-bumped to v2.5.0 in #13469, re-introducing the release regression that was fixed in #13420.

v2.5.0 has a draft→finalize flow that races in matrix jobs, causing `Too many retries` failures in the `Create release` step. See: https://github.com/softprops/action-gh-release/issues/704

## Changes
- Pin `softprops/action-gh-release` to `v2.4.2` (`5be0e66`) in both release steps

Prompted by: zerosnacks