### PR TITLE
ci: ignore softprops/action-gh-release in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "softprops/action-gh-release"


### PR DESCRIPTION
## Motivation

Dependabot keeps re-bumping `softprops/action-gh-release` to v2.5.0, which has a draft→finalize race in matrix jobs causing `Too many retries` failures during releases. This was already reverted twice (#13420, #13527).

## Solution

Add an `ignore` rule for `softprops/action-gh-release` in `.github/dependabot.yml` so Dependabot stops proposing the bump.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

Prompted by: zerosnacks