### PR TITLE
Add source-diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,9 +2640,11 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "serde_json",
+ "similar",
  "tempfile",
  "tokio",
  "tracing",
+ "walkdir",
  "yansi",
 ]
 

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -81,8 +81,10 @@ itertools.workspace = true
 regex = { workspace = true, default-features = false }
 rpassword = "7"
 semver.workspace = true
+similar = { version = "2", features = ["inline"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "signal"] }
+walkdir.workspace = true
 tracing.workspace = true
 yansi.workspace = true
 evmole.workspace = true

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -731,6 +731,52 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
                 }
             }
         }
+        CastSubcommand::SourceDiff {
+            address1,
+            address2,
+            output,
+            etherscan,
+            explorer_api_url,
+            explorer_url,
+            second_chain,
+            second_explorer_api_url,
+            second_explorer_url,
+        } => {
+            let config = etherscan.load_config()?;
+            let chain = config.chain.unwrap_or_default();
+            let chain2 = second_chain.unwrap_or(chain);
+            let api_key1 = config.get_etherscan_api_key(Some(chain));
+            let api_key2 = config.get_etherscan_api_key(Some(chain2));
+            let dir1 = tempfile::tempdir()?;
+            let dir2 = tempfile::tempdir()?;
+            SimpleCast::expand_etherscan_source_to_directory(
+                chain,
+                address1.clone(),
+                api_key1,
+                dir1.path().to_path_buf(),
+                explorer_api_url.clone(),
+                explorer_url.clone(),
+            )
+            .await?;
+            SimpleCast::expand_etherscan_source_to_directory(
+                chain2,
+                address2.clone(),
+                api_key2,
+                dir2.path().to_path_buf(),
+                second_explorer_api_url.or(explorer_api_url),
+                second_explorer_url.or(explorer_url),
+            )
+            .await?;
+            let patch = crate::directory_unified_diff(dir1.path(), dir2.path())?;
+            if let Some(path) = output {
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                std::fs::write(&path, patch)?;
+            } else {
+                sh_println!("{patch}")?;
+            }
+        }
         CastSubcommand::Create2(cmd) => {
             cmd.run()?;
         }

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -43,15 +43,17 @@ use foundry_primitives::FoundryTxEnvelope;
 use futures::{FutureExt, StreamExt, future::Either};
 
 use rayon::prelude::*;
+use similar::TextDiff;
 use std::{
     borrow::Cow,
     fmt::Write,
     io,
-    path::PathBuf,
+    path::{Path, PathBuf},
     str::FromStr,
     sync::atomic::{AtomicBool, Ordering},
 };
 use tokio::signal::ctrl_c;
+use walkdir::WalkDir;
 
 pub use foundry_evm::*;
 
@@ -2330,6 +2332,60 @@ pub(crate) fn strip_0x(s: &str) -> &str {
     s.strip_prefix("0x").unwrap_or(s)
 }
 
+/// Produces a unified diff (patch) between two directories. Walks both trees, compares
+/// text files as UTF-8, and returns a single patch string with a/ and b/ path prefixes.
+/// Skips binary / non-UTF-8 files.
+pub(crate) fn directory_unified_diff(dir_a: &Path, dir_b: &Path) -> Result<String> {
+    let mut all_paths = std::collections::BTreeSet::new();
+    for entry in WalkDir::new(dir_a).into_iter().filter_map(|e| e.ok()) {
+        if entry.file_type().is_file() {
+            if let Ok(rel) = entry.path().strip_prefix(dir_a) {
+                if rel.as_os_str().as_encoded_bytes().iter().all(|&b| b != 0) {
+                    all_paths.insert(rel.to_path_buf());
+                }
+            }
+        }
+    }
+    for entry in WalkDir::new(dir_b).into_iter().filter_map(|e| e.ok()) {
+        if entry.file_type().is_file() {
+            if let Ok(rel) = entry.path().strip_prefix(dir_b) {
+                if rel.as_os_str().as_encoded_bytes().iter().all(|&b| b != 0) {
+                    all_paths.insert(rel.to_path_buf());
+                }
+            }
+        }
+    }
+
+    let mut out = String::new();
+    for rel in all_paths {
+        let path_a = dir_a.join(&rel);
+        let path_b = dir_b.join(&rel);
+        let rel_slash = rel.to_string_lossy().replace('\\', "/");
+        let header_old = format!("a/{rel_slash}");
+        let header_new = format!("b/{rel_slash}");
+
+        let (old_content, new_content) =
+            match (std::fs::read_to_string(&path_a), std::fs::read_to_string(&path_b)) {
+                (Ok(a), Ok(b)) => (a, b),
+                (Ok(a), Err(_)) => (a, String::new()), // only in a -> removed
+                (Err(_), Ok(b)) => (String::new(), b), // only in b -> added
+                (Err(_), Err(_)) => continue,          // skip unreadable/binary
+            };
+
+        let text_diff = TextDiff::from_lines(&old_content, &new_content);
+        let diff_str =
+            text_diff.unified_diff().context_radius(3).header(&header_old, &header_new).to_string();
+        if diff_str.is_empty() {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(&diff_str);
+    }
+    Ok(out)
+}
+
 fn explorer_client(
     chain: Chain,
     api_key: Option<String>,
@@ -2359,8 +2415,28 @@ fn explorer_client(
 
 #[cfg(test)]
 mod tests {
-    use super::{DynSolValue, SimpleCast as Cast, serialize_value_as_json};
+    use super::{DynSolValue, SimpleCast as Cast, directory_unified_diff, serialize_value_as_json};
     use alloy_primitives::hex;
+
+    #[test]
+    fn directory_unified_diff_produces_patch() {
+        let dir_a = tempfile::tempdir().unwrap();
+        let dir_b = tempfile::tempdir().unwrap();
+        let a_path = dir_a.path().join("foo.sol");
+        let b_path = dir_b.path().join("foo.sol");
+        std::fs::write(&a_path, "contract Foo { uint x = 1; }\n").unwrap();
+        std::fs::write(&b_path, "contract Foo { uint x = 2; }\n").unwrap();
+        std::fs::write(dir_a.path().join("only_in_a.sol"), "// only a\n").unwrap();
+        std::fs::write(dir_b.path().join("only_in_b.sol"), "// only b\n").unwrap();
+
+        let patch = directory_unified_diff(dir_a.path(), dir_b.path()).unwrap();
+        assert!(patch.contains("--- a/foo.sol"), "patch should contain --- a/foo.sol");
+        assert!(patch.contains("+++ b/foo.sol"), "patch should contain +++ b/foo.sol");
+        assert!(patch.contains("x = 1"), "patch should show old line");
+        assert!(patch.contains("x = 2"), "patch should show new line");
+        assert!(patch.contains("only_in_a.sol"), "patch should mention file only in a");
+        assert!(patch.contains("only_in_b.sol"), "patch should mention file only in b");
+    }
 
     #[test]
     fn simple_selector() {

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -11,8 +11,9 @@ use alloy_primitives::{Address, B256, Selector, U256};
 use alloy_rpc_types::BlockId;
 use clap::{ArgAction, Parser, Subcommand, ValueHint};
 use eyre::Result;
-use foundry_cli::opts::{EtherscanOpts, GlobalArgs, RpcOpts};
+use foundry_cli::opts::{ChainValueParser, EtherscanOpts, GlobalArgs, RpcOpts};
 use foundry_common::version::{LONG_VERSION, SHORT_VERSION};
+use foundry_config::Chain;
 use std::{path::PathBuf, str::FromStr};
 /// A Swiss Army knife for interacting with Ethereum applications from the command line.
 #[derive(Parser)]
@@ -1025,6 +1026,43 @@ pub enum CastSubcommand {
         explorer_url: Option<String>,
     },
 
+    /// Generate a unified diff (patch) between the verified source trees of two contracts.
+    #[command(visible_aliases = &["srcd"])]
+    SourceDiff {
+        /// First contract address.
+        address1: String,
+
+        /// Second contract address.
+        address2: String,
+
+        /// Write patch to this file instead of stdout.
+        #[arg(short, long, value_hint = ValueHint::FilePath)]
+        output: Option<PathBuf>,
+
+        #[command(flatten)]
+        etherscan: EtherscanOpts,
+
+        /// Explorer API URL for the first contract. If not provided, defaults to Etherscan.
+        #[arg(long, env = "EXPLORER_API_URL")]
+        explorer_api_url: Option<String>,
+
+        /// Explorer browser URL for the first contract.
+        #[arg(long, env = "EXPLORER_URL")]
+        explorer_url: Option<String>,
+
+        /// Chain for the second contract (if different from first).
+        #[arg(long, value_parser = ChainValueParser::default())]
+        second_chain: Option<Chain>,
+
+        /// Explorer API URL for the second contract.
+        #[arg(long)]
+        second_explorer_api_url: Option<String>,
+
+        /// Explorer browser URL for the second contract.
+        #[arg(long)]
+        second_explorer_url: Option<String>,
+    },
+
     /// Wallet management utilities.
     #[command(visible_alias = "w")]
     Wallet {
@@ -1239,6 +1277,19 @@ mod tests {
             }
             _ => unreachable!(),
         };
+    }
+
+    #[test]
+    fn parse_source_diff() {
+        let args: Cast = Cast::parse_from(["cast", "source-diff", "0xaaa", "0xbbb"]);
+        match &args.cmd {
+            CastSubcommand::SourceDiff { address1, address2, output, .. } => {
+                assert_eq!(address1, "0xaaa");
+                assert_eq!(address2, "0xbbb");
+                assert!(output.is_none());
+            }
+            _ => unreachable!(),
+        }
     }
 
     // <https://github.com/foundry-rs/book/issues/1019>


### PR DESCRIPTION
disclaimer:  This PR was written primarily by cursor's "auto" models.

## Motivation

I need a quick way to compare the source code of 2 contracts to verify proxy implementation upgrades.

## Solution

Use utilities from the "source" sub-command to grab the source of 2 contracts into 2 tmp dirs. Then generate a diff file using `similar`. 

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
