### PR TITLE
fix(wallets): use turnkey_unsupported() instead of hardcoded error

### DIFF
--- a/crates/wallets/src/signer.rs
+++ b/crates/wallets/src/signer.rs
@@ -160,7 +160,7 @@ impl WalletSigner {
             let _ = api_private_key;
             let _ = organization_id;
             let _ = address;
-            Err(WalletSignerError::UnsupportedSigner("Turnkey"))
+            Err(WalletSignerError::turnkey_unsupported())
         }
     }
 


### PR DESCRIPTION
The `turnkey_unsupported()` method was added in #12026 but never used. Instead, `UnsupportedSigner("Turnkey")` was hardcoded directly in signer.rs.
This aligns Turnkey with AWS and GCP which already use their helper methods.