### PR TITLE
fix(anvil): use EIP-2718 encoding for OP enveloped_tx

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -18,6 +18,7 @@ use alloy_consensus::{
     proofs::calculate_receipt_root, transaction::Either,
 };
 use alloy_eips::{
+    Encodable2718,
     eip7685::EMPTY_REQUESTS_HASH,
     eip7702::{RecoveredAuthority, RecoveredAuthorization},
     eip7840::BlobParams,
@@ -305,7 +306,7 @@ impl<DB: Db + ?Sized, V: TransactionValidator> TransactionExecutor<'_, DB, V> {
         }
 
         if self.networks.is_optimism() {
-            tx_env.enveloped_tx = Some(alloy_rlp::encode(tx.transaction.as_ref()).into());
+            tx_env.enveloped_tx = Some(tx.transaction.encoded_2718().into());
         }
 
         Env::new(self.evm_env.clone(), tx_env, self.networks)

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1167,8 +1167,7 @@ impl Backend {
         );
 
         if env.networks.is_optimism() {
-            env.tx.enveloped_tx =
-                Some(alloy_rlp::encode(tx.pending_transaction.transaction.as_ref()).into());
+            env.tx.enveloped_tx = Some(tx.pending_transaction.transaction.encoded_2718().into());
         }
 
         let db = self.db.read().await;


### PR DESCRIPTION
## Summary

When forking an OP chain and sending typed transactions (EIP-1559, EIP-2930, etc.), the L1 data cost was being calculated against incorrectly encoded transaction bytes.

Two out of four places that set `enveloped_tx` on `OpTransaction` were using `alloy_rlp::encode()` (network encoding) instead of `encoded_2718()` (EIP-2718 encoding). For typed transactions these produce different bytes — network encoding wraps the payload in an extra RLP string header, which throws off the L1 cost calculation in `op-revm`.

Found this while debugging a gas estimation mismatch on an OP fork — the L1 portion of the fee was consistently off for EIP-1559 txs. Turned out `executor.rs` and one path in `mem/mod.rs` were encoding `enveloped_tx` differently from the other two call sites that already used `encoded_2718()`.

Now unifies all four sites to use `encoded_2718()`, matching what OP's `OpTransaction` field documents and expects.
