### PR TITLE
fix: correct flag name in error message from --compiler-version to --…

### DIFF
--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -422,7 +422,7 @@ impl VerifyArgs {
                 &project.settings
             } else {
                 eyre::bail!(
-                    "If cache is disabled, compilation profile must be provided with `--compiler-version` option or set in foundry.toml"
+                    "If cache is disabled, compilation profile must be provided with `--compilation-profile` option or set in foundry.toml"
                 )
             };
 


### PR DESCRIPTION
The error message when cache is disabled and no compilation profile is available incorrectly references `--compiler-version` instead of `--compilation-profile`.