### PR TITLE
docs: update Foundry Book link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ Releases are automatically done by the release workflow when a tag is pushed, ho
 
 [rust-coc]: https://www.rust-lang.org/policies/code-of-conduct
 [dev-tg]: https://t.me/foundry_rs
-[foundry-book]: https://github.com/foundry-rs/foundry-book
+[foundry-book]: https://book.getfoundry.sh
 [support-tg]: https://t.me/foundry_support
 [mcve]: https://stackoverflow.com/help/mcve
 [hiding-a-comment]: https://docs.github.com/en/communities/moderating-comments-and-conversations/managing-disruptive-comments


### PR DESCRIPTION
The old GitHub repository (foundry-rs/foundry-book) now redirects to foundry-rs/book. Update the link to use the official docs site https://book.getfoundry.sh, consistent with docs/dev/README.md.

## Motivation
The Foundry Book link in CONTRIBUTING.md pointed to the old GitHub 
repository (foundry-rs/foundry-book) which now returns a 301 redirect 
to foundry-rs/book.

## Solution
Updated the link to https://book.getfoundry.sh — the official deployed 
docs site, consistent with docs/dev/README.md which already uses this URL.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
