### PR TITLE
fix(anvil): clear tx pool on anvil_reset

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2154,12 +2154,14 @@ impl EthApi {
         node_info!("anvil_reset");
         if let Some(forking) = forking {
             // if we're resetting the fork we need to reset the instance id
-            self.backend.reset_fork(forking).await
+            self.backend.reset_fork(forking).await?;
         } else {
             // Reset to a fresh in-memory state
-
-            self.backend.reset_to_in_mem().await
+            self.backend.reset_to_in_mem().await?;
         }
+        // Clear pending transactions since they reference the old chain state.
+        self.pool.clear();
+        Ok(())
     }
 
     pub async fn anvil_set_chain_id(&self, chain_id: u64) -> Result<()> {


### PR DESCRIPTION
`anvil_reset` resets the full chain state (database, block storage, world state) via `reset_fork`/`reset_to_in_mem`, but never clears the transaction pool. Stale transactions referencing the old chain state remain in the pool and get picked up by `ReadyTransactionMiner`, causing nonce mismatches or insufficient balance errors on the new chain.

`anvil_drop_all_transactions` already calls `self.pool.clear()` correctly — this just does the same in `anvil_reset`.