### PR TITLE
fix / refactor(verify): dedupe standard JSON input logic + avoid unnecessary work for Vyper branch

### DIFF
--- a/crates/verify/src/etherscan/standard_json.rs
+++ b/crates/verify/src/etherscan/standard_json.rs
@@ -22,7 +22,7 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
 
         let source = match lang {
             ContractLanguage::Solidity => {
-                let input = context.get_standard_json_input()?;
+                let input = context.get_solc_standard_json_input()?;
                 serde_json::to_string(&input).wrap_err("Failed to parse standard json input")?
             }
             ContractLanguage::Vyper => {

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -46,7 +46,7 @@ impl VerificationContext {
         Ok(Self { config, project, target_name, target_path, compiler_version, compiler_settings })
     }
 
-    pub fn get_standard_json_input(&self) -> Result<StandardJsonCompilerInput> {
+    pub fn get_solc_standard_json_input(&self) -> Result<StandardJsonCompilerInput> {
         let mut input: StandardJsonCompilerInput = self
             .project
             .standard_json_input(&self.target_path)

--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -235,7 +235,7 @@ impl SourcifyVerificationProvider {
 
         match lang {
             ContractLanguage::Solidity => {
-                let input = context.get_standard_json_input()?;
+                let input = context.get_solc_standard_json_input()?;
 
                 let std_json_input = serde_json::to_value(&input)
                     .wrap_err("Failed to serialize standard json input")?;


### PR DESCRIPTION
Extract repeated StandardJsonCompilerInput setup into VerificationContext::get_standard_json_input(). Was copy-pasted in sourcify.rs and etherscan/standard_json.rs.