### PR TITLE
refactor(wallets): browser wallet generic `Network`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5166,7 +5166,6 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-network",
  "alloy-primitives",
- "alloy-rpc-types",
  "alloy-signer",
  "alloy-signer-aws",
  "alloy-signer-gcp",

--- a/crates/wallets/Cargo.toml
+++ b/crates/wallets/Cargo.toml
@@ -26,7 +26,6 @@ alloy-sol-types.workspace = true
 alloy-dyn-abi.workspace = true
 
 # browser wallet
-alloy-rpc-types.workspace = true
 axum.workspace = true
 foundry-common.workspace = true
 serde_json.workspace = true

--- a/crates/wallets/src/wallet_browser/handlers.rs
+++ b/crates/wallets/src/wallet_browser/handlers.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use alloy_network::Network;
 use axum::{
     Json,
     extract::State,
@@ -46,8 +47,8 @@ pub(crate) async fn serve_css() -> impl axum::response::IntoResponse {
 }
 
 /// Serve main.js with injected session token.
-pub(crate) async fn serve_js(
-    State(state): State<Arc<BrowserWalletState>>,
+pub(crate) async fn serve_js<N: Network>(
+    State(state): State<Arc<BrowserWalletState<N>>>,
 ) -> impl axum::response::IntoResponse {
     let token = state.session_token();
     let js = format!("window.__SESSION_TOKEN__ = \"{}\";\n{}", token, contents::MAIN_JS);
@@ -81,9 +82,9 @@ pub(crate) async fn serve_logo_png() -> impl axum::response::IntoResponse {
 
 /// Get the next pending transaction request.
 /// Route: GET /api/transaction/request
-pub(crate) async fn get_next_transaction_request(
-    State(state): State<Arc<BrowserWalletState>>,
-) -> Json<BrowserApiResponse<BrowserTransactionRequest>> {
+pub(crate) async fn get_next_transaction_request<N: Network>(
+    State(state): State<Arc<BrowserWalletState<N>>>,
+) -> Json<BrowserApiResponse<BrowserTransactionRequest<N>>> {
     match state.read_next_transaction_request().await {
         Some(tx) => Json(BrowserApiResponse::with_data(tx)),
         None => Json(BrowserApiResponse::error("No pending transaction request")),
@@ -92,8 +93,8 @@ pub(crate) async fn get_next_transaction_request(
 
 /// Post a transaction response (signed or error).
 /// Route: POST /api/transaction/response
-pub(crate) async fn post_transaction_response(
-    State(state): State<Arc<BrowserWalletState>>,
+pub(crate) async fn post_transaction_response<N: Network>(
+    State(state): State<Arc<BrowserWalletState<N>>>,
     Json(body): Json<BrowserTransactionResponse>,
 ) -> Json<BrowserApiResponse> {
     // Ensure that the transaction request exists.
@@ -134,8 +135,8 @@ pub(crate) async fn post_transaction_response(
 
 /// Get the next pending signing request.
 /// Route: GET /api/signing/request
-pub(crate) async fn get_next_signing_request(
-    State(state): State<Arc<BrowserWalletState>>,
+pub(crate) async fn get_next_signing_request<N: Network>(
+    State(state): State<Arc<BrowserWalletState<N>>>,
 ) -> Json<BrowserApiResponse<BrowserSignRequest>> {
     match state.read_next_signing_request().await {
         Some(req) => Json(BrowserApiResponse::with_data(req)),
@@ -145,8 +146,8 @@ pub(crate) async fn get_next_signing_request(
 
 /// Post a signing response (signature or error).
 /// Route: POST /api/signing/response
-pub(crate) async fn post_signing_response(
-    State(state): State<Arc<BrowserWalletState>>,
+pub(crate) async fn post_signing_response<N: Network>(
+    State(state): State<Arc<BrowserWalletState<N>>>,
     Json(body): Json<BrowserSignResponse>,
 ) -> Json<BrowserApiResponse> {
     // Ensure that the signing request exists.
@@ -174,8 +175,8 @@ pub(crate) async fn post_signing_response(
 
 /// Get current connection information.
 /// Route: GET /api/connection
-pub(crate) async fn get_connection_info(
-    State(state): State<Arc<BrowserWalletState>>,
+pub(crate) async fn get_connection_info<N: Network>(
+    State(state): State<Arc<BrowserWalletState<N>>>,
 ) -> Json<BrowserApiResponse<Option<Connection>>> {
     let connection = state.get_connection().await;
 
@@ -184,8 +185,8 @@ pub(crate) async fn get_connection_info(
 
 /// Post connection update (connect or disconnect).
 /// Route: POST /api/connection
-pub(crate) async fn post_connection_update(
-    State(state): State<Arc<BrowserWalletState>>,
+pub(crate) async fn post_connection_update<N: Network>(
+    State(state): State<Arc<BrowserWalletState<N>>>,
     Json(body): Json<Option<Connection>>,
 ) -> Json<BrowserApiResponse> {
     state.set_connection(body).await;

--- a/crates/wallets/src/wallet_browser/mod.rs
+++ b/crates/wallets/src/wallet_browser/mod.rs
@@ -13,8 +13,8 @@ mod types;
 mod tests {
     use std::time::Duration;
 
+    use alloy_network::{Ethereum, Network, TransactionBuilder};
     use alloy_primitives::{Address, Bytes, TxHash, TxKind, U256, address};
-    use alloy_rpc_types::TransactionRequest;
     use axum::http::{HeaderMap, HeaderValue};
     use tokio::task::JoinHandle;
     use uuid::Uuid;
@@ -36,7 +36,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_setup_server() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
 
         // Check initial state
@@ -56,7 +56,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_connect_disconnect_wallet() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
 
@@ -93,7 +93,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_switch_wallet() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
 
@@ -116,7 +116,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_transaction_response_both_hash_and_error_rejected() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -151,7 +151,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_transaction_response_neither_hash_nor_error_rejected() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -181,7 +181,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_transaction_response_zero_hash_rejected() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -216,7 +216,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_transaction_client_accept() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -252,7 +252,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_transaction_client_not_requested() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -288,7 +288,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_transaction_invalid_response_format() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -314,7 +314,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_transaction_client_reject() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -356,7 +356,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_multiple_transaction_requests() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -377,8 +377,10 @@ mod tests {
                 .await
                 .unwrap();
 
-            let BrowserApiResponse::Ok(pending_tx) =
-                resp.json::<BrowserApiResponse<BrowserTransactionRequest>>().await.unwrap()
+            let BrowserApiResponse::Ok(pending_tx) = resp
+                .json::<BrowserApiResponse<BrowserTransactionRequest<Ethereum>>>()
+                .await
+                .unwrap()
             else {
                 panic!("expected BrowserApiResponse::Ok with a pending transaction");
             };
@@ -421,8 +423,10 @@ mod tests {
                 .await
                 .unwrap();
 
-            let BrowserApiResponse::Ok(pending_tx) =
-                resp.json::<BrowserApiResponse<BrowserTransactionRequest>>().await.unwrap()
+            let BrowserApiResponse::Ok(pending_tx) = resp
+                .json::<BrowserApiResponse<BrowserTransactionRequest<Ethereum>>>()
+                .await
+                .unwrap()
             else {
                 panic!("expected BrowserApiResponse::Ok with a pending transaction");
             };
@@ -467,7 +471,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_sign_response_both_signature_and_error_rejected() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -501,7 +505,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_sign_response_neither_hash_nor_error_rejected() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -531,7 +535,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_sign_client_accept() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -567,7 +571,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_sign_client_not_requested() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -603,7 +607,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_sign_invalid_response_format() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -629,7 +633,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_sign_client_reject() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -666,7 +670,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_multiple_sign_requests() {
-        let mut server = create_server();
+        let mut server = create_server::<Ethereum>();
         let client = client_with_token(&server);
         server.start().await.unwrap();
         connect_wallet(&client, &server, Connection::new(ALICE, 1)).await;
@@ -770,21 +774,21 @@ mod tests {
     }
 
     /// Helper to create a default browser wallet server.
-    fn create_server() -> BrowserWalletServer {
+    fn create_server<N: Network>() -> BrowserWalletServer<N> {
         BrowserWalletServer::new(0, false, DEFAULT_TIMEOUT, DEFAULT_DEVELOPMENT)
     }
 
     /// Helper to create a reqwest client with the session token header.
-    fn client_with_token(server: &BrowserWalletServer) -> reqwest::Client {
+    fn client_with_token<N: Network>(server: &BrowserWalletServer<N>) -> reqwest::Client {
         let mut headers = HeaderMap::new();
         headers.insert("X-Session-Token", HeaderValue::from_str(server.session_token()).unwrap());
         reqwest::Client::builder().default_headers(headers).build().unwrap()
     }
 
     /// Helper to connect a wallet to the server.
-    async fn connect_wallet(
+    async fn connect_wallet<N: Network>(
         client: &reqwest::Client,
-        server: &BrowserWalletServer,
+        server: &BrowserWalletServer<N>,
         connection: Connection,
     ) {
         let resp = client
@@ -795,7 +799,10 @@ mod tests {
     }
 
     /// Helper to disconnect a wallet from the server.
-    async fn disconnect_wallet(client: &reqwest::Client, server: &BrowserWalletServer) {
+    async fn disconnect_wallet<N: Network>(
+        client: &reqwest::Client,
+        server: &BrowserWalletServer<N>,
+    ) {
         let resp = client
             .post(format!("http://localhost:{}/api/connection", server.port()))
             .json(&Option::<Connection>::None)
@@ -804,9 +811,9 @@ mod tests {
     }
 
     /// Spawn the transaction signing flow in the background and return the join handle.
-    async fn wait_for_transaction_signing(
-        server: &BrowserWalletServer,
-        tx_request: BrowserTransactionRequest,
+    async fn wait_for_transaction_signing<N: Network>(
+        server: &BrowserWalletServer<N>,
+        tx_request: BrowserTransactionRequest<N>,
     ) -> JoinHandle<Result<TxHash, BrowserWalletError>> {
         // Spawn the signing flow in the background
         let browser_server = server.clone();
@@ -819,8 +826,8 @@ mod tests {
     }
 
     /// Spawn the message signing flow in the background and return the join handle.
-    async fn wait_for_message_signing(
-        server: &BrowserWalletServer,
+    async fn wait_for_message_signing<N: Network>(
+        server: &BrowserWalletServer<N>,
         sign_request: BrowserSignRequest,
     ) -> JoinHandle<Result<Bytes, BrowserWalletError>> {
         // Spawn the signing flow in the background
@@ -834,32 +841,25 @@ mod tests {
     }
 
     /// Create a simple browser transaction request.
-    fn create_browser_transaction_request() -> (Uuid, BrowserTransactionRequest) {
+    fn create_browser_transaction_request<N: Network>() -> (Uuid, BrowserTransactionRequest<N>) {
         let id = Uuid::new_v4();
-        let tx = BrowserTransactionRequest {
-            id,
-            request: TransactionRequest {
-                from: Some(ALICE),
-                to: Some(TxKind::Call(BOB)),
-                value: Some(U256::from(1000)),
-                ..Default::default()
-            },
-        };
+        let request = N::TransactionRequest::default()
+            .with_from(ALICE)
+            .with_to(BOB)
+            .with_value(U256::from(1000));
+        let tx = BrowserTransactionRequest { id, request };
         (id, tx)
     }
 
     /// Create a different browser transaction request (from the first one).
-    fn create_different_browser_transaction_request() -> (Uuid, BrowserTransactionRequest) {
+    fn create_different_browser_transaction_request<N: Network>()
+    -> (Uuid, BrowserTransactionRequest<N>) {
         let id = Uuid::new_v4();
-        let tx = BrowserTransactionRequest {
-            id,
-            request: TransactionRequest {
-                from: Some(BOB),
-                to: Some(TxKind::Call(ALICE)),
-                value: Some(U256::from(2000)),
-                ..Default::default()
-            },
-        };
+        let request = N::TransactionRequest::default()
+            .with_from(BOB)
+            .with_to(ALICE)
+            .with_value(U256::from(2000));
+        let tx = BrowserTransactionRequest { id, request };
         (id, tx)
     }
 
@@ -886,9 +886,9 @@ mod tests {
     }
 
     /// Check that the transaction request queue is empty, if not panic.
-    async fn check_transaction_request_queue_empty(
+    async fn check_transaction_request_queue_empty<N: Network>(
         client: &reqwest::Client,
-        server: &BrowserWalletServer,
+        server: &BrowserWalletServer<N>,
     ) {
         let resp = client
             .get(format!("http://localhost:{}/api/transaction/request", server.port()))
@@ -897,7 +897,7 @@ mod tests {
             .unwrap();
 
         let BrowserApiResponse::Error { message } =
-            resp.json::<BrowserApiResponse<BrowserTransactionRequest>>().await.unwrap()
+            resp.json::<BrowserApiResponse<BrowserTransactionRequest<N>>>().await.unwrap()
         else {
             panic!("expected BrowserApiResponse::Error (no pending transaction), but got Ok");
         };
@@ -906,9 +906,9 @@ mod tests {
     }
 
     /// Check that the transaction request matches the expected request ID and fields.
-    async fn check_transaction_request_content(
+    async fn check_transaction_request_content<N: Network>(
         client: &reqwest::Client,
-        server: &BrowserWalletServer,
+        server: &BrowserWalletServer<N>,
         tx_request_id: Uuid,
     ) {
         let resp = client
@@ -918,21 +918,21 @@ mod tests {
             .unwrap();
 
         let BrowserApiResponse::Ok(pending_tx) =
-            resp.json::<BrowserApiResponse<BrowserTransactionRequest>>().await.unwrap()
+            resp.json::<BrowserApiResponse<BrowserTransactionRequest<N>>>().await.unwrap()
         else {
             panic!("expected BrowserApiResponse::Ok with a pending transaction");
         };
 
         assert_eq!(pending_tx.id, tx_request_id);
-        assert_eq!(pending_tx.request.from, Some(ALICE));
-        assert_eq!(pending_tx.request.to, Some(TxKind::Call(BOB)));
-        assert_eq!(pending_tx.request.value, Some(U256::from(1000)));
+        assert_eq!(pending_tx.request.from(), Some(ALICE));
+        assert_eq!(pending_tx.request.kind(), Some(TxKind::Call(BOB)));
+        assert_eq!(pending_tx.request.value(), Some(U256::from(1000)));
     }
 
     /// Check that the sign request queue is empty, if not panic.
-    async fn check_sign_request_queue_empty(
+    async fn check_sign_request_queue_empty<N: Network>(
         client: &reqwest::Client,
-        server: &BrowserWalletServer,
+        server: &BrowserWalletServer<N>,
     ) {
         let resp = client
             .get(format!("http://localhost:{}/api/signing/request", server.port()))
@@ -950,9 +950,9 @@ mod tests {
     }
 
     /// Check that the sign request matches the expected request ID and fields.
-    async fn check_sign_request_content(
+    async fn check_sign_request_content<N: Network>(
         client: &reqwest::Client,
-        server: &BrowserWalletServer,
+        server: &BrowserWalletServer<N>,
         sign_request_id: Uuid,
     ) {
         let resp = client

--- a/crates/wallets/src/wallet_browser/queue.rs
+++ b/crates/wallets/src/wallet_browser/queue.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 
+use alloy_network::Network;
 use uuid::Uuid;
 
 use crate::wallet_browser::types::{BrowserSignRequest, BrowserTransactionRequest};
@@ -69,7 +70,7 @@ pub(crate) trait HasId {
     fn id(&self) -> &Uuid;
 }
 
-impl HasId for BrowserTransactionRequest {
+impl<N: Network> HasId for BrowserTransactionRequest<N> {
     fn id(&self) -> &Uuid {
         &self.id
     }

--- a/crates/wallets/src/wallet_browser/router.rs
+++ b/crates/wallets/src/wallet_browser/router.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use alloy_network::Network;
 use axum::{
     Router,
     extract::{Request, State},
@@ -13,7 +14,7 @@ use tower_http::{cors::CorsLayer, set_header::SetResponseHeaderLayer};
 
 use crate::wallet_browser::{handlers, state::BrowserWalletState};
 
-pub async fn build_router(state: Arc<BrowserWalletState>, port: u16) -> Router {
+pub async fn build_router<N: Network>(state: Arc<BrowserWalletState<N>>, port: u16) -> Router {
     let api = Router::new()
         .route("/transaction/request", get(handlers::get_next_transaction_request))
         .route("/transaction/response", post(handlers::post_transaction_response))
@@ -76,8 +77,8 @@ pub async fn build_router(state: Arc<BrowserWalletState>, port: u16) -> Router {
         .with_state(state)
 }
 
-async fn require_session_token(
-    State(state): State<Arc<BrowserWalletState>>,
+async fn require_session_token<N: Network>(
+    State(state): State<Arc<BrowserWalletState<N>>>,
     req: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {

--- a/crates/wallets/src/wallet_browser/server.rs
+++ b/crates/wallets/src/wallet_browser/server.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use alloy_dyn_abi::TypedData;
+use alloy_network::Network;
 use alloy_primitives::{Address, Bytes, TxHash};
 use tokio::{
     net::TcpListener,
@@ -24,15 +25,15 @@ use crate::wallet_browser::{
 
 /// Browser wallet server.
 #[derive(Debug, Clone)]
-pub struct BrowserWalletServer {
+pub struct BrowserWalletServer<N: Network> {
     port: u16,
-    state: Arc<BrowserWalletState>,
+    state: Arc<BrowserWalletState<N>>,
     shutdown_tx: Option<Arc<Mutex<Option<oneshot::Sender<()>>>>>,
     open_browser: bool,
     timeout: Duration,
 }
 
-impl BrowserWalletServer {
+impl<N: Network> BrowserWalletServer<N> {
     /// Create a new browser wallet server.
     pub fn new(port: u16, open_browser: bool, timeout: Duration, development: bool) -> Self {
         Self {
@@ -118,7 +119,7 @@ impl BrowserWalletServer {
     /// Request a transaction to be signed and sent via the browser wallet.
     pub async fn request_transaction(
         &self,
-        request: BrowserTransactionRequest,
+        request: BrowserTransactionRequest<N>,
     ) -> Result<TxHash, BrowserWalletError> {
         if !self.is_connected().await {
             return Err(BrowserWalletError::NotConnected);

--- a/crates/wallets/src/wallet_browser/state.rs
+++ b/crates/wallets/src/wallet_browser/state.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use alloy_network::Network;
 use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
@@ -12,11 +13,12 @@ use crate::wallet_browser::{
 };
 
 #[derive(Debug, Clone)]
-pub(crate) struct BrowserWalletState {
+pub(crate) struct BrowserWalletState<N: Network> {
     /// Current information about the wallet connection.
     connection: Arc<RwLock<Option<Connection>>>,
     /// Request/response queue for transactions.
-    transactions: Arc<Mutex<RequestQueue<BrowserTransactionRequest, BrowserTransactionResponse>>>,
+    transactions:
+        Arc<Mutex<RequestQueue<BrowserTransactionRequest<N>, BrowserTransactionResponse>>>,
     /// Request/response queue for signings.
     signings: Arc<Mutex<RequestQueue<BrowserSignRequest, BrowserSignResponse>>>,
     /// Unique session token for the wallet browser instance.
@@ -29,7 +31,7 @@ pub(crate) struct BrowserWalletState {
     development: bool,
 }
 
-impl BrowserWalletState {
+impl<N: Network> BrowserWalletState<N> {
     /// Create a new browser wallet state.
     pub fn new(session_token: String, development: bool) -> Self {
         Self {
@@ -70,7 +72,7 @@ impl BrowserWalletState {
     }
 
     /// Add a transaction request.
-    pub async fn add_transaction_request(&self, request: BrowserTransactionRequest) {
+    pub async fn add_transaction_request(&self, request: BrowserTransactionRequest<N>) {
         self.transactions.lock().await.add_request(request);
     }
 
@@ -80,7 +82,7 @@ impl BrowserWalletState {
     }
 
     /// Read the next transaction request.
-    pub async fn read_next_transaction_request(&self) -> Option<BrowserTransactionRequest> {
+    pub async fn read_next_transaction_request(&self) -> Option<BrowserTransactionRequest<N>> {
         self.transactions.lock().await.read_request().cloned()
     }
 

--- a/crates/wallets/src/wallet_browser/types.rs
+++ b/crates/wallets/src/wallet_browser/types.rs
@@ -1,6 +1,6 @@
 use alloy_dyn_abi::TypedData;
+use alloy_network::Network;
 use alloy_primitives::{Address, Bytes, ChainId, TxHash};
-use alloy_rpc_types::TransactionRequest;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -37,11 +37,11 @@ impl<T> BrowserApiResponse<T> {
 /// Represents a transaction request sent to the browser wallet.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct BrowserTransactionRequest {
+pub struct BrowserTransactionRequest<N: Network> {
     /// The unique identifier for the transaction.
     pub id: Uuid,
     /// The transaction request details.
-    pub request: TransactionRequest,
+    pub request: N::TransactionRequest,
 }
 
 /// Represents a transaction response sent from the browser wallet.


### PR DESCRIPTION
## Motivation

Prepare browser wallet for generic `Network` support. There’s no breaking change yet, just a fast-to-review chunk.

## Solution

- Use generic `Network::TransactionRequest`, and `TransactionBuilder` methods
- Remove useless alloy-rpc-types dependency
- Set `BrowserSigner` generic default to `Ethereum` to avoid breaking for now

## PR Checklist

- [ ] Added Tests (added generic to helpers to be future-proof)
- [ ] Added Documentation
- [ ] Breaking changes (default to `Ethereum` as it was before)
