### PR TITLE
refactor(cheatcodes): migrate Inspector body to trait method

### DIFF
--- a/crates/cheatcodes/src/base64.rs
+++ b/crates/cheatcodes/src/base64.rs
@@ -2,28 +2,28 @@ use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
 use alloy_sol_types::SolValue;
 use base64::prelude::*;
 
-impl Cheatcode for toBase64_0Call {
+impl<CTX> Cheatcode<CTX> for toBase64_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { data } = self;
         Ok(BASE64_STANDARD.encode(data).abi_encode())
     }
 }
 
-impl Cheatcode for toBase64_1Call {
+impl<CTX> Cheatcode<CTX> for toBase64_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { data } = self;
         Ok(BASE64_STANDARD.encode(data).abi_encode())
     }
 }
 
-impl Cheatcode for toBase64URL_0Call {
+impl<CTX> Cheatcode<CTX> for toBase64URL_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { data } = self;
         Ok(BASE64_URL_SAFE.encode(data).abi_encode())
     }
 }
 
-impl Cheatcode for toBase64URL_1Call {
+impl<CTX> Cheatcode<CTX> for toBase64URL_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { data } = self;
         Ok(BASE64_URL_SAFE.encode(data).abi_encode())

--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -29,28 +29,28 @@ use ed25519_consensus::{
 /// The BIP32 default derivation path prefix.
 const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/60'/0'/0/";
 
-impl Cheatcode for createWallet_0Call {
+impl<CTX> Cheatcode<CTX> for createWallet_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { walletLabel } = self;
         create_wallet(&U256::from_be_bytes(keccak256(walletLabel).0), Some(walletLabel), state)
     }
 }
 
-impl Cheatcode for createWallet_1Call {
+impl<CTX> Cheatcode<CTX> for createWallet_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { privateKey } = self;
         create_wallet(privateKey, None, state)
     }
 }
 
-impl Cheatcode for createWallet_2Call {
+impl<CTX> Cheatcode<CTX> for createWallet_2Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { privateKey, walletLabel } = self;
         create_wallet(privateKey, Some(walletLabel), state)
     }
 }
 
-impl Cheatcode for sign_0Call {
+impl<CTX> Cheatcode<CTX> for sign_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { wallet, digest } = self;
         let sig = sign(&wallet.privateKey, digest)?;
@@ -58,7 +58,7 @@ impl Cheatcode for sign_0Call {
     }
 }
 
-impl Cheatcode for signWithNonceUnsafeCall {
+impl<CTX> Cheatcode<CTX> for signWithNonceUnsafeCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let pk: U256 = self.privateKey;
         let digest: B256 = self.digest;
@@ -68,7 +68,7 @@ impl Cheatcode for signWithNonceUnsafeCall {
     }
 }
 
-impl Cheatcode for signCompact_0Call {
+impl<CTX> Cheatcode<CTX> for signCompact_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { wallet, digest } = self;
         let sig = sign(&wallet.privateKey, digest)?;
@@ -76,35 +76,35 @@ impl Cheatcode for signCompact_0Call {
     }
 }
 
-impl Cheatcode for deriveKey_0Call {
+impl<CTX> Cheatcode<CTX> for deriveKey_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { mnemonic, index } = self;
         derive_key::<English>(mnemonic, DEFAULT_DERIVATION_PATH_PREFIX, *index)
     }
 }
 
-impl Cheatcode for deriveKey_1Call {
+impl<CTX> Cheatcode<CTX> for deriveKey_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { mnemonic, derivationPath, index } = self;
         derive_key::<English>(mnemonic, derivationPath, *index)
     }
 }
 
-impl Cheatcode for deriveKey_2Call {
+impl<CTX> Cheatcode<CTX> for deriveKey_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { mnemonic, index, language } = self;
         derive_key_str(mnemonic, DEFAULT_DERIVATION_PATH_PREFIX, *index, language)
     }
 }
 
-impl Cheatcode for deriveKey_3Call {
+impl<CTX> Cheatcode<CTX> for deriveKey_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { mnemonic, derivationPath, index, language } = self;
         derive_key_str(mnemonic, derivationPath, *index, language)
     }
 }
 
-impl Cheatcode for rememberKeyCall {
+impl<CTX> Cheatcode<CTX> for rememberKeyCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { privateKey } = self;
         let wallet = parse_wallet(privateKey)?;
@@ -113,7 +113,7 @@ impl Cheatcode for rememberKeyCall {
     }
 }
 
-impl Cheatcode for rememberKeys_0Call {
+impl<CTX> Cheatcode<CTX> for rememberKeys_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { mnemonic, derivationPath, count } = self;
         let wallets = derive_wallets::<English>(mnemonic, derivationPath, *count)?;
@@ -127,7 +127,7 @@ impl Cheatcode for rememberKeys_0Call {
     }
 }
 
-impl Cheatcode for rememberKeys_1Call {
+impl<CTX> Cheatcode<CTX> for rememberKeys_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { mnemonic, derivationPath, language, count } = self;
         let wallets = derive_wallets_str(mnemonic, derivationPath, language, *count)?;
@@ -147,7 +147,7 @@ fn inject_wallet(state: &mut Cheatcodes, wallet: LocalSigner<SigningKey>) -> Add
     address
 }
 
-impl Cheatcode for sign_1Call {
+impl<CTX> Cheatcode<CTX> for sign_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { privateKey, digest } = self;
         let sig = sign(privateKey, digest)?;
@@ -155,7 +155,7 @@ impl Cheatcode for sign_1Call {
     }
 }
 
-impl Cheatcode for signCompact_1Call {
+impl<CTX> Cheatcode<CTX> for signCompact_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { privateKey, digest } = self;
         let sig = sign(privateKey, digest)?;
@@ -163,7 +163,7 @@ impl Cheatcode for signCompact_1Call {
     }
 }
 
-impl Cheatcode for sign_2Call {
+impl<CTX> Cheatcode<CTX> for sign_2Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { digest } = self;
         let sig = sign_with_wallet(state, None, digest)?;
@@ -171,7 +171,7 @@ impl Cheatcode for sign_2Call {
     }
 }
 
-impl Cheatcode for signCompact_2Call {
+impl<CTX> Cheatcode<CTX> for signCompact_2Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { digest } = self;
         let sig = sign_with_wallet(state, None, digest)?;
@@ -179,7 +179,7 @@ impl Cheatcode for signCompact_2Call {
     }
 }
 
-impl Cheatcode for sign_3Call {
+impl<CTX> Cheatcode<CTX> for sign_3Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { signer, digest } = self;
         let sig = sign_with_wallet(state, Some(*signer), digest)?;
@@ -187,7 +187,7 @@ impl Cheatcode for sign_3Call {
     }
 }
 
-impl Cheatcode for signCompact_3Call {
+impl<CTX> Cheatcode<CTX> for signCompact_3Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { signer, digest } = self;
         let sig = sign_with_wallet(state, Some(*signer), digest)?;
@@ -195,14 +195,14 @@ impl Cheatcode for signCompact_3Call {
     }
 }
 
-impl Cheatcode for signP256Call {
+impl<CTX> Cheatcode<CTX> for signP256Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { privateKey, digest } = self;
         sign_p256(privateKey, digest)
     }
 }
 
-impl Cheatcode for publicKeyP256Call {
+impl<CTX> Cheatcode<CTX> for publicKeyP256Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { privateKey } = self;
         let pub_key =
@@ -214,28 +214,28 @@ impl Cheatcode for publicKeyP256Call {
     }
 }
 
-impl Cheatcode for createEd25519KeyCall {
+impl<CTX> Cheatcode<CTX> for createEd25519KeyCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { salt } = self;
         create_ed25519_key(salt)
     }
 }
 
-impl Cheatcode for publicKeyEd25519Call {
+impl<CTX> Cheatcode<CTX> for publicKeyEd25519Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { privateKey } = self;
         public_key_ed25519(privateKey)
     }
 }
 
-impl Cheatcode for signEd25519Call {
+impl<CTX> Cheatcode<CTX> for signEd25519Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { namespace, message, privateKey } = self;
         sign_ed25519(namespace, message, privateKey)
     }
 }
 
-impl Cheatcode for verifyEd25519Call {
+impl<CTX> Cheatcode<CTX> for verifyEd25519Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { signature, namespace, message, publicKey } = self;
         verify_ed25519(signature, namespace, message, publicKey)

--- a/crates/cheatcodes/src/env.rs
+++ b/crates/cheatcodes/src/env.rs
@@ -8,7 +8,7 @@ use std::{env, sync::OnceLock};
 /// Stores the forge execution context for the duration of the program.
 pub static FORGE_CONTEXT: OnceLock<ForgeContext> = OnceLock::new();
 
-impl Cheatcode for setEnvCall {
+impl<CTX> Cheatcode<CTX> for setEnvCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name: key, value } = self;
         if key.is_empty() {
@@ -28,7 +28,7 @@ impl Cheatcode for setEnvCall {
     }
 }
 
-impl Cheatcode for resolveEnvCall {
+impl<CTX> Cheatcode<CTX> for resolveEnvCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { input } = self;
         let resolved = foundry_config::resolve::interpolate(input)
@@ -37,105 +37,105 @@ impl Cheatcode for resolveEnvCall {
     }
 }
 
-impl Cheatcode for envExistsCall {
+impl<CTX> Cheatcode<CTX> for envExistsCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
         Ok(env::var(name).is_ok().abi_encode())
     }
 }
 
-impl Cheatcode for envBool_0Call {
+impl<CTX> Cheatcode<CTX> for envBool_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Bool)
     }
 }
 
-impl Cheatcode for envUint_0Call {
+impl<CTX> Cheatcode<CTX> for envUint_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Uint(256))
     }
 }
 
-impl Cheatcode for envInt_0Call {
+impl<CTX> Cheatcode<CTX> for envInt_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Int(256))
     }
 }
 
-impl Cheatcode for envAddress_0Call {
+impl<CTX> Cheatcode<CTX> for envAddress_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Address)
     }
 }
 
-impl Cheatcode for envBytes32_0Call {
+impl<CTX> Cheatcode<CTX> for envBytes32_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::FixedBytes(32))
     }
 }
 
-impl Cheatcode for envString_0Call {
+impl<CTX> Cheatcode<CTX> for envString_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::String)
     }
 }
 
-impl Cheatcode for envBytes_0Call {
+impl<CTX> Cheatcode<CTX> for envBytes_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Bytes)
     }
 }
 
-impl Cheatcode for envBool_1Call {
+impl<CTX> Cheatcode<CTX> for envBool_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Bool)
     }
 }
 
-impl Cheatcode for envUint_1Call {
+impl<CTX> Cheatcode<CTX> for envUint_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Uint(256))
     }
 }
 
-impl Cheatcode for envInt_1Call {
+impl<CTX> Cheatcode<CTX> for envInt_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Int(256))
     }
 }
 
-impl Cheatcode for envAddress_1Call {
+impl<CTX> Cheatcode<CTX> for envAddress_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Address)
     }
 }
 
-impl Cheatcode for envBytes32_1Call {
+impl<CTX> Cheatcode<CTX> for envBytes32_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::FixedBytes(32))
     }
 }
 
-impl Cheatcode for envString_1Call {
+impl<CTX> Cheatcode<CTX> for envString_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::String)
     }
 }
 
-impl Cheatcode for envBytes_1Call {
+impl<CTX> Cheatcode<CTX> for envBytes_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Bytes)
@@ -143,7 +143,7 @@ impl Cheatcode for envBytes_1Call {
 }
 
 // bool
-impl Cheatcode for envOr_0Call {
+impl<CTX> Cheatcode<CTX> for envOr_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Bool)
@@ -151,7 +151,7 @@ impl Cheatcode for envOr_0Call {
 }
 
 // uint256
-impl Cheatcode for envOr_1Call {
+impl<CTX> Cheatcode<CTX> for envOr_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Uint(256))
@@ -159,7 +159,7 @@ impl Cheatcode for envOr_1Call {
 }
 
 // int256
-impl Cheatcode for envOr_2Call {
+impl<CTX> Cheatcode<CTX> for envOr_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Int(256))
@@ -167,7 +167,7 @@ impl Cheatcode for envOr_2Call {
 }
 
 // address
-impl Cheatcode for envOr_3Call {
+impl<CTX> Cheatcode<CTX> for envOr_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Address)
@@ -175,7 +175,7 @@ impl Cheatcode for envOr_3Call {
 }
 
 // bytes32
-impl Cheatcode for envOr_4Call {
+impl<CTX> Cheatcode<CTX> for envOr_4Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::FixedBytes(32))
@@ -183,7 +183,7 @@ impl Cheatcode for envOr_4Call {
 }
 
 // string
-impl Cheatcode for envOr_5Call {
+impl<CTX> Cheatcode<CTX> for envOr_5Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::String)
@@ -191,7 +191,7 @@ impl Cheatcode for envOr_5Call {
 }
 
 // bytes
-impl Cheatcode for envOr_6Call {
+impl<CTX> Cheatcode<CTX> for envOr_6Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Bytes)
@@ -199,7 +199,7 @@ impl Cheatcode for envOr_6Call {
 }
 
 // bool[]
-impl Cheatcode for envOr_7Call {
+impl<CTX> Cheatcode<CTX> for envOr_7Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::Bool)
@@ -207,7 +207,7 @@ impl Cheatcode for envOr_7Call {
 }
 
 // uint256[]
-impl Cheatcode for envOr_8Call {
+impl<CTX> Cheatcode<CTX> for envOr_8Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::Uint(256))
@@ -215,7 +215,7 @@ impl Cheatcode for envOr_8Call {
 }
 
 // int256[]
-impl Cheatcode for envOr_9Call {
+impl<CTX> Cheatcode<CTX> for envOr_9Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::Int(256))
@@ -223,7 +223,7 @@ impl Cheatcode for envOr_9Call {
 }
 
 // address[]
-impl Cheatcode for envOr_10Call {
+impl<CTX> Cheatcode<CTX> for envOr_10Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::Address)
@@ -231,7 +231,7 @@ impl Cheatcode for envOr_10Call {
 }
 
 // bytes32[]
-impl Cheatcode for envOr_11Call {
+impl<CTX> Cheatcode<CTX> for envOr_11Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::FixedBytes(32))
@@ -239,7 +239,7 @@ impl Cheatcode for envOr_11Call {
 }
 
 // string[]
-impl Cheatcode for envOr_12Call {
+impl<CTX> Cheatcode<CTX> for envOr_12Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::String)
@@ -247,7 +247,7 @@ impl Cheatcode for envOr_12Call {
 }
 
 // bytes[]
-impl Cheatcode for envOr_13Call {
+impl<CTX> Cheatcode<CTX> for envOr_13Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
         let default = defaultValue.to_vec();
@@ -255,7 +255,7 @@ impl Cheatcode for envOr_13Call {
     }
 }
 
-impl Cheatcode for isContextCall {
+impl<CTX> Cheatcode<CTX> for isContextCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { context } = self;
         Ok((FORGE_CONTEXT.get() == Some(context)).abi_encode())

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -2,8 +2,7 @@
 
 use crate::{
     BroadcastableTransaction, Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Error, Result,
-    Vm::*,
-    inspector::{Ecx, RecordDebugStepInfo},
+    Vm::*, inspector::RecordDebugStepInfo,
 };
 use alloy_consensus::TxEnvelope;
 use alloy_evm::{Evm as _, FromRecoveredTx};
@@ -24,9 +23,9 @@ use foundry_common::{
 };
 use foundry_compilers::artifacts::EvmVersion;
 use foundry_evm_core::{
-    ContextExt,
-    backend::{DatabaseExt, RevertStateSnapshotAction},
+    backend::{DatabaseExt, FoundryJournalExt, RevertStateSnapshotAction},
     constants::{CALLER, CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, TEST_CONTRACT_ADDRESS},
+    env::FoundryContextExt,
     evm::new_evm_with_inspector,
     utils::get_blob_base_fee_update_fraction_by_spec_id,
 };
@@ -37,6 +36,8 @@ use rand::Rng;
 use revm::{
     bytecode::Bytecode,
     context::{Block, JournalTr, TxEnv, result::ExecutionResult},
+    context_interface::ContextTr,
+    inspector::JournalExt,
     primitives::{KECCAK_EMPTY, hardfork::SpecId},
     state::{Account, AccountStatus},
 };
@@ -244,7 +245,7 @@ impl Display for AccountStateDiffs {
     }
 }
 
-impl Cheatcode for addrCall {
+impl<CTX> Cheatcode<CTX> for addrCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { privateKey } = self;
         let wallet = super::crypto::parse_wallet(privateKey)?;
@@ -252,29 +253,30 @@ impl Cheatcode for addrCall {
     }
 }
 
-impl Cheatcode for getNonce_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for getNonce_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { account } = self;
         get_nonce(ccx, account)
     }
 }
 
-impl Cheatcode for getNonce_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for getNonce_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { wallet } = self;
         get_nonce(ccx, &wallet.addr)
     }
 }
 
-impl Cheatcode for loadCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for loadCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { target, slot } = *self;
         ccx.ensure_not_precompile(&target)?;
 
-        let (db, journal, _) = ccx.ecx.as_db_env_and_journal();
-        journal.load_account(db, target)?;
-        let mut val = journal
-            .sload(db, target, slot.into(), false)
+        ccx.ecx.journal_mut().load_account(target)?;
+        let mut val = ccx
+            .ecx
+            .journal_mut()
+            .sload(target, slot.into())
             .map_err(|e| fmt_err!("failed to load storage slot: {:?}", e))?;
 
         if val.is_cold && val.data.is_zero() {
@@ -307,8 +309,8 @@ impl Cheatcode for loadCall {
     }
 }
 
-impl Cheatcode for loadAllocsCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX> for loadAllocsCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { pathToAllocsJson } = self;
 
         let path = Path::new(pathToAllocsJson);
@@ -325,29 +327,31 @@ impl Cheatcode for loadAllocsCall {
         };
 
         // Then, load the allocs into the database.
-        let (db, journal, _) = ccx.ecx.as_db_env_and_journal();
-        db.load_allocs(&allocs, journal)
+        ccx.ecx
+            .journal_mut()
+            .load_allocs(&allocs)
             .map(|()| Vec::default())
             .map_err(|e| fmt_err!("failed to load allocs: {e}"))
     }
 }
 
-impl Cheatcode for cloneAccountCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for cloneAccountCall
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { source, target } = self;
 
-        let (db, journal, _) = ccx.ecx.as_db_env_and_journal();
-        let account = journal.load_account(db, *source)?;
-        let genesis = &genesis_account(account.data);
-        db.clone_account(genesis, target, journal)?;
+        let account = ccx.ecx.journal_mut().load_account(*source)?;
+        let genesis = genesis_account(account.data);
+        ccx.ecx.journal_mut().clone_account(&genesis, target)?;
         // Cloned account should persist in forked envs.
-        ccx.ecx.journaled_state.database.add_persistent_account(*target);
+        ccx.ecx.db_mut().add_persistent_account(*target);
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for dumpStateCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Journal: JournalExt>> Cheatcode<CTX> for dumpStateCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { pathToStateJson } = self;
         let path = Path::new(pathToStateJson);
 
@@ -364,8 +368,8 @@ impl Cheatcode for dumpStateCall {
 
         let alloc = ccx
             .ecx
-            .journaled_state
-            .state()
+            .journal_mut()
+            .evm_state_mut()
             .iter_mut()
             .filter(|(key, val)| !skip(key, val))
             .map(|(key, val)| (key, genesis_account(val)))
@@ -376,7 +380,7 @@ impl Cheatcode for dumpStateCall {
     }
 }
 
-impl Cheatcode for recordCall {
+impl<CTX> Cheatcode<CTX> for recordCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         state.recording_accesses = true;
@@ -385,14 +389,14 @@ impl Cheatcode for recordCall {
     }
 }
 
-impl Cheatcode for stopRecordCall {
+impl<CTX> Cheatcode<CTX> for stopRecordCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         state.recording_accesses = false;
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for accessesCall {
+impl<CTX> Cheatcode<CTX> for accessesCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { target } = *self;
         let result = (
@@ -403,7 +407,7 @@ impl Cheatcode for accessesCall {
     }
 }
 
-impl Cheatcode for recordLogsCall {
+impl<CTX> Cheatcode<CTX> for recordLogsCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         state.recorded_logs = Some(Default::default());
@@ -411,14 +415,14 @@ impl Cheatcode for recordLogsCall {
     }
 }
 
-impl Cheatcode for getRecordedLogsCall {
+impl<CTX> Cheatcode<CTX> for getRecordedLogsCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         Ok(state.recorded_logs.replace(Default::default()).unwrap_or_default().abi_encode())
     }
 }
 
-impl Cheatcode for getRecordedLogsJsonCall {
+impl<CTX> Cheatcode<CTX> for getRecordedLogsJsonCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         let logs = state.recorded_logs.replace(Default::default()).unwrap_or_default();
@@ -434,7 +438,7 @@ impl Cheatcode for getRecordedLogsJsonCall {
     }
 }
 
-impl Cheatcode for pauseGasMeteringCall {
+impl<CTX> Cheatcode<CTX> for pauseGasMeteringCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         state.gas_metering.paused = true;
@@ -442,7 +446,7 @@ impl Cheatcode for pauseGasMeteringCall {
     }
 }
 
-impl Cheatcode for resumeGasMeteringCall {
+impl<CTX> Cheatcode<CTX> for resumeGasMeteringCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         state.gas_metering.resume();
@@ -450,7 +454,7 @@ impl Cheatcode for resumeGasMeteringCall {
     }
 }
 
-impl Cheatcode for resetGasMeteringCall {
+impl<CTX> Cheatcode<CTX> for resetGasMeteringCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         state.gas_metering.reset();
@@ -458,7 +462,7 @@ impl Cheatcode for resetGasMeteringCall {
     }
 }
 
-impl Cheatcode for lastCallGasCall {
+impl<CTX> Cheatcode<CTX> for lastCallGasCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         let Some(last_call_gas) = &state.gas_metering.last_call_gas else {
@@ -468,170 +472,171 @@ impl Cheatcode for lastCallGasCall {
     }
 }
 
-impl Cheatcode for getChainIdCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for getChainIdCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
-        Ok(U256::from(ccx.ecx.cfg.chain_id).abi_encode())
+        Ok(U256::from(ccx.ecx.cfg().chain_id).abi_encode())
     }
 }
 
-impl Cheatcode for chainIdCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for chainIdCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { newChainId } = self;
         ensure!(*newChainId <= U256::from(u64::MAX), "chain ID must be less than 2^64");
-        ccx.ecx.cfg.chain_id = newChainId.to();
+        ccx.ecx.cfg_mut().chain_id = newChainId.to();
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for coinbaseCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for coinbaseCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { newCoinbase } = self;
-        ccx.ecx.block.beneficiary = *newCoinbase;
+        ccx.ecx.block_mut().beneficiary = *newCoinbase;
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for difficultyCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for difficultyCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { newDifficulty } = self;
         ensure!(
-            ccx.ecx.cfg.spec < SpecId::MERGE,
+            ccx.ecx.cfg().spec < SpecId::MERGE,
             "`difficulty` is not supported after the Paris hard fork, use `prevrandao` instead; \
              see EIP-4399: https://eips.ethereum.org/EIPS/eip-4399"
         );
-        ccx.ecx.block.difficulty = *newDifficulty;
+        ccx.ecx.block_mut().difficulty = *newDifficulty;
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for feeCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for feeCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { newBasefee } = self;
         ensure!(*newBasefee <= U256::from(u64::MAX), "base fee must be less than 2^64");
-        ccx.ecx.block.basefee = newBasefee.saturating_to();
+        ccx.ecx.block_mut().basefee = newBasefee.saturating_to();
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for prevrandao_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for prevrandao_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { newPrevrandao } = self;
         ensure!(
-            ccx.ecx.cfg.spec >= SpecId::MERGE,
+            ccx.ecx.cfg().spec >= SpecId::MERGE,
             "`prevrandao` is not supported before the Paris hard fork, use `difficulty` instead; \
              see EIP-4399: https://eips.ethereum.org/EIPS/eip-4399"
         );
-        ccx.ecx.block.prevrandao = Some(*newPrevrandao);
+        ccx.ecx.block_mut().prevrandao = Some(*newPrevrandao);
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for prevrandao_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for prevrandao_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { newPrevrandao } = self;
         ensure!(
-            ccx.ecx.cfg.spec >= SpecId::MERGE,
+            ccx.ecx.cfg().spec >= SpecId::MERGE,
             "`prevrandao` is not supported before the Paris hard fork, use `difficulty` instead; \
              see EIP-4399: https://eips.ethereum.org/EIPS/eip-4399"
         );
-        ccx.ecx.block.prevrandao = Some((*newPrevrandao).into());
+        ccx.ecx.block_mut().prevrandao = Some((*newPrevrandao).into());
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for blobhashesCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for blobhashesCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { hashes } = self;
         ensure!(
-            ccx.ecx.cfg.spec >= SpecId::CANCUN,
+            ccx.ecx.cfg().spec >= SpecId::CANCUN,
             "`blobhashes` is not supported before the Cancun hard fork; \
              see EIP-4844: https://eips.ethereum.org/EIPS/eip-4844"
         );
-        ccx.ecx.tx.blob_hashes.clone_from(hashes);
+        ccx.ecx.tx_mut().blob_hashes.clone_from(hashes);
         // force this as 4844 txtype
-        ccx.ecx.tx.tx_type = EIP4844_TX_TYPE_ID;
+        ccx.ecx.tx_mut().tx_type = EIP4844_TX_TYPE_ID;
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for getBlobhashesCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for getBlobhashesCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         ensure!(
-            ccx.ecx.cfg.spec >= SpecId::CANCUN,
+            ccx.ecx.cfg().spec >= SpecId::CANCUN,
             "`getBlobhashes` is not supported before the Cancun hard fork; \
              see EIP-4844: https://eips.ethereum.org/EIPS/eip-4844"
         );
-        Ok(ccx.ecx.tx.blob_hashes.clone().abi_encode())
+        Ok(ccx.ecx.tx().blob_hashes.clone().abi_encode())
     }
 }
 
-impl Cheatcode for rollCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for rollCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { newHeight } = self;
-        ccx.ecx.block.number = *newHeight;
+        ccx.ecx.block_mut().number = *newHeight;
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for getBlockNumberCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for getBlockNumberCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
-        Ok(ccx.ecx.block.number.abi_encode())
+        Ok(ccx.ecx.block().number.abi_encode())
     }
 }
 
-impl Cheatcode for txGasPriceCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for txGasPriceCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { newGasPrice } = self;
         ensure!(*newGasPrice <= U256::from(u64::MAX), "gas price must be less than 2^64");
-        ccx.ecx.tx.gas_price = newGasPrice.saturating_to();
+        ccx.ecx.tx_mut().gas_price = newGasPrice.saturating_to();
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for warpCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for warpCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { newTimestamp } = self;
-        ccx.ecx.block.timestamp = *newTimestamp;
+        ccx.ecx.block_mut().timestamp = *newTimestamp;
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for getBlockTimestampCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for getBlockTimestampCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
-        Ok(ccx.ecx.block.timestamp.abi_encode())
+        Ok(ccx.ecx.block().timestamp.abi_encode())
     }
 }
 
-impl Cheatcode for blobBaseFeeCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for blobBaseFeeCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { newBlobBaseFee } = self;
         ensure!(
-            ccx.ecx.cfg.spec >= SpecId::CANCUN,
+            ccx.ecx.cfg().spec >= SpecId::CANCUN,
             "`blobBaseFee` is not supported before the Cancun hard fork; \
              see EIP-4844: https://eips.ethereum.org/EIPS/eip-4844"
         );
 
-        ccx.ecx.block.set_blob_excess_gas_and_price(
+        let spec = ccx.ecx.cfg().spec;
+        ccx.ecx.block_mut().set_blob_excess_gas_and_price(
             (*newBlobBaseFee).to(),
-            get_blob_base_fee_update_fraction_by_spec_id(ccx.ecx.cfg.spec),
+            get_blob_base_fee_update_fraction_by_spec_id(spec),
         );
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for getBlobBaseFeeCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for getBlobBaseFeeCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
-        Ok(ccx.ecx.block.blob_excess_gas().unwrap_or(0).abi_encode())
+        Ok(ccx.ecx.block().blob_excess_gas().unwrap_or(0).abi_encode())
     }
 }
 
-impl Cheatcode for dealCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for dealCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { account: address, newBalance: new_balance } = *self;
         let account = journaled_account(ccx.ecx, address)?;
         let old_balance = std::mem::replace(&mut account.info.balance, new_balance);
@@ -641,21 +646,20 @@ impl Cheatcode for dealCall {
     }
 }
 
-impl Cheatcode for etchCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for etchCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { target, newRuntimeBytecode } = self;
         ccx.ensure_not_precompile(target)?;
-        let (db, journal, _) = ccx.ecx.as_db_env_and_journal();
-        journal.load_account(db, *target)?;
+        ccx.ecx.journal_mut().load_account(*target)?;
         let bytecode = Bytecode::new_raw_checked(newRuntimeBytecode.clone())
             .map_err(|e| fmt_err!("failed to create bytecode: {e}"))?;
-        journal.set_code(*target, bytecode);
+        ccx.ecx.journal_mut().set_code(*target, bytecode);
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for resetNonceCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for resetNonceCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { account } = self;
         let account = journaled_account(ccx.ecx, *account)?;
         // Per EIP-161, EOA nonces start at 0, but contract nonces
@@ -669,8 +673,8 @@ impl Cheatcode for resetNonceCall {
     }
 }
 
-impl Cheatcode for setNonceCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for setNonceCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { account, newNonce } = *self;
         let account = journaled_account(ccx.ecx, account)?;
         // nonce must increment only
@@ -685,8 +689,8 @@ impl Cheatcode for setNonceCall {
     }
 }
 
-impl Cheatcode for setNonceUnsafeCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for setNonceUnsafeCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { account, newNonce } = *self;
         let account = journaled_account(ccx.ecx, account)?;
         account.info.nonce = newNonce;
@@ -694,23 +698,23 @@ impl Cheatcode for setNonceUnsafeCall {
     }
 }
 
-impl Cheatcode for storeCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for storeCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { target, slot, value } = *self;
         ccx.ensure_not_precompile(&target)?;
         ensure_loaded_account(ccx.ecx, target)?;
-        let (db, journal, _) = ccx.ecx.as_db_env_and_journal();
-        journal
-            .sstore(db, target, slot.into(), value.into(), false)
+        ccx.ecx
+            .journal_mut()
+            .sstore(target, slot.into(), value.into())
             .map_err(|e| fmt_err!("failed to store storage slot: {:?}", e))?;
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for coolCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Journal: JournalExt>> Cheatcode<CTX> for coolCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { target } = self;
-        if let Some(account) = ccx.ecx.journaled_state.state.get_mut(target) {
+        if let Some(account) = ccx.ecx.journal_mut().evm_state_mut().get_mut(target) {
             account.unmark_touch();
             account.storage.values_mut().for_each(|slot| slot.mark_cold());
         }
@@ -718,7 +722,7 @@ impl Cheatcode for coolCall {
     }
 }
 
-impl Cheatcode for accessListCall {
+impl<CTX> Cheatcode<CTX> for accessListCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { access } = self;
         let access_list = access
@@ -733,7 +737,7 @@ impl Cheatcode for accessListCall {
     }
 }
 
-impl Cheatcode for noAccessListCall {
+impl<CTX> Cheatcode<CTX> for noAccessListCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         // Set to empty option in order to override previous applied access list.
@@ -744,45 +748,45 @@ impl Cheatcode for noAccessListCall {
     }
 }
 
-impl Cheatcode for warmSlotCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Journal: JournalExt>> Cheatcode<CTX> for warmSlotCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { target, slot } = *self;
         set_cold_slot(ccx, target, slot.into(), false);
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for coolSlotCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Journal: JournalExt>> Cheatcode<CTX> for coolSlotCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { target, slot } = *self;
         set_cold_slot(ccx, target, slot.into(), true);
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for readCallersCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for readCallersCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
-        read_callers(ccx.state, &ccx.ecx.tx.caller, ccx.ecx.journaled_state.depth())
+        read_callers(ccx.state, &ccx.ecx.tx().caller, ccx.ecx.journal().depth())
     }
 }
 
-impl Cheatcode for snapshotValue_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for snapshotValue_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { name, value } = self;
         inner_value_snapshot(ccx, None, Some(name.clone()), value.to_string())
     }
 }
 
-impl Cheatcode for snapshotValue_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for snapshotValue_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { group, name, value } = self;
         inner_value_snapshot(ccx, Some(group.clone()), Some(name.clone()), value.to_string())
     }
 }
 
-impl Cheatcode for snapshotGasLastCall_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for snapshotGasLastCall_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { name } = self;
         let Some(last_call_gas) = &ccx.state.gas_metering.last_call_gas else {
             bail!("no external call was made yet");
@@ -791,8 +795,8 @@ impl Cheatcode for snapshotGasLastCall_0Call {
     }
 }
 
-impl Cheatcode for snapshotGasLastCall_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for snapshotGasLastCall_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { name, group } = self;
         let Some(last_call_gas) = &ccx.state.gas_metering.last_call_gas else {
             bail!("no external call was made yet");
@@ -806,117 +810,129 @@ impl Cheatcode for snapshotGasLastCall_1Call {
     }
 }
 
-impl Cheatcode for startSnapshotGas_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for startSnapshotGas_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { name } = self;
         inner_start_gas_snapshot(ccx, None, Some(name.clone()))
     }
 }
 
-impl Cheatcode for startSnapshotGas_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for startSnapshotGas_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { group, name } = self;
         inner_start_gas_snapshot(ccx, Some(group.clone()), Some(name.clone()))
     }
 }
 
-impl Cheatcode for stopSnapshotGas_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for stopSnapshotGas_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         inner_stop_gas_snapshot(ccx, None, None)
     }
 }
 
-impl Cheatcode for stopSnapshotGas_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for stopSnapshotGas_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { name } = self;
         inner_stop_gas_snapshot(ccx, None, Some(name.clone()))
     }
 }
 
-impl Cheatcode for stopSnapshotGas_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for stopSnapshotGas_2Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { group, name } = self;
         inner_stop_gas_snapshot(ccx, Some(group.clone()), Some(name.clone()))
     }
 }
 
 // Deprecated in favor of `snapshotStateCall`
-impl Cheatcode for snapshotCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for snapshotCall
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         inner_snapshot_state(ccx)
     }
 }
 
-impl Cheatcode for snapshotStateCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for snapshotStateCall
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         inner_snapshot_state(ccx)
     }
 }
 
 // Deprecated in favor of `revertToStateCall`
-impl Cheatcode for revertToCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for revertToCall
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state(ccx, *snapshotId)
     }
 }
 
-impl Cheatcode for revertToStateCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for revertToStateCall
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state(ccx, *snapshotId)
     }
 }
 
 // Deprecated in favor of `revertToStateAndDeleteCall`
-impl Cheatcode for revertToAndDeleteCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for revertToAndDeleteCall
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state_and_delete(ccx, *snapshotId)
     }
 }
 
-impl Cheatcode for revertToStateAndDeleteCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for revertToStateAndDeleteCall
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state_and_delete(ccx, *snapshotId)
     }
 }
 
 // Deprecated in favor of `deleteStateSnapshotCall`
-impl Cheatcode for deleteSnapshotCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for deleteSnapshotCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { snapshotId } = self;
         inner_delete_state_snapshot(ccx, *snapshotId)
     }
 }
 
-impl Cheatcode for deleteStateSnapshotCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for deleteStateSnapshotCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { snapshotId } = self;
         inner_delete_state_snapshot(ccx, *snapshotId)
     }
 }
 
 // Deprecated in favor of `deleteStateSnapshotsCall`
-impl Cheatcode for deleteSnapshotsCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for deleteSnapshotsCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         inner_delete_state_snapshots(ccx)
     }
 }
 
-impl Cheatcode for deleteStateSnapshotsCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for deleteStateSnapshotsCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         inner_delete_state_snapshots(ccx)
     }
 }
 
-impl Cheatcode for startStateDiffRecordingCall {
+impl<CTX> Cheatcode<CTX> for startStateDiffRecordingCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         state.recorded_account_diffs_stack = Some(Default::default());
@@ -926,15 +942,15 @@ impl Cheatcode for startStateDiffRecordingCall {
     }
 }
 
-impl Cheatcode for stopAndReturnStateDiffCall {
+impl<CTX> Cheatcode<CTX> for stopAndReturnStateDiffCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         get_state_diff(state)
     }
 }
 
-impl Cheatcode for getStateDiffCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for getStateDiffCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let mut diffs = String::new();
         let state_diffs = get_recorded_state_diffs(ccx);
         for (address, state_diffs) in state_diffs {
@@ -945,15 +961,15 @@ impl Cheatcode for getStateDiffCall {
     }
 }
 
-impl Cheatcode for getStateDiffJsonCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for getStateDiffJsonCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let state_diffs = get_recorded_state_diffs(ccx);
         Ok(serde_json::to_string(&state_diffs)?.abi_encode())
     }
 }
 
-impl Cheatcode for getStorageSlotsCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for getStorageSlotsCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { target, variableName } = self;
 
         let storage_layout = get_contract_data(ccx, *target)
@@ -1009,8 +1025,7 @@ impl Cheatcode for getStorageSlotsCall {
         if storage_type.encoding == ENCODING_BYTES {
             // Try to check if it's a long bytes/string by reading the current storage
             // value
-            let (db, journal, _) = ccx.ecx.as_db_env_and_journal();
-            if let Ok(value) = journal.sload(db, *target, slot, false) {
+            if let Ok(value) = ccx.ecx.journal_mut().sload(*target, slot) {
                 let value_bytes = value.data.to_be_bytes::<32>();
                 let length_byte = value_bytes[31];
                 // Check if it's a long bytes/string (LSB is 1)
@@ -1031,7 +1046,7 @@ impl Cheatcode for getStorageSlotsCall {
     }
 }
 
-impl Cheatcode for getStorageAccessesCall {
+impl<CTX> Cheatcode<CTX> for getStorageAccessesCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let mut storage_accesses = Vec::new();
 
@@ -1045,22 +1060,26 @@ impl Cheatcode for getStorageAccessesCall {
     }
 }
 
-impl Cheatcode for broadcastRawTransactionCall {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for broadcastRawTransactionCall
+{
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let tx = TxEnvelope::decode(&mut self.data.as_ref())
             .map_err(|err| fmt_err!("failed to decode RLP-encoded transaction: {err}"))?;
 
-        let (db, journal, env) = ccx.ecx.as_db_env_and_journal();
-        db.transact_from_tx(
-            &tx.clone().into(),
-            env.to_owned(),
-            journal,
-            &mut *executor.get_inspector(ccx.state),
-        )?;
+        let env = ccx.ecx.to_env();
+        let mut inspector = executor.get_inspector(ccx.state);
+        let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
+        db.transact_from_tx(&tx.clone().into(), env, inner, &mut *inspector)?;
+        drop(inspector);
 
         if ccx.state.broadcast.is_some() {
             ccx.state.broadcastable_transactions.push_back(BroadcastableTransaction {
-                rpc: ccx.ecx.journaled_state.database.active_fork_url(),
+                rpc: ccx.ecx.db().active_fork_url(),
                 transaction: tx.try_into()?,
             });
         }
@@ -1069,23 +1088,29 @@ impl Cheatcode for broadcastRawTransactionCall {
     }
 }
 
-impl Cheatcode for setBlockhashCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for setBlockhashCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { blockNumber, blockHash } = *self;
         ensure!(blockNumber <= U256::from(u64::MAX), "blockNumber must be less than 2^64");
         ensure!(
-            blockNumber <= U256::from(ccx.ecx.block.number),
+            blockNumber <= U256::from(ccx.ecx.block().number),
             "block number must be less than or equal to the current block number"
         );
 
-        ccx.ecx.journaled_state.database.set_blockhash(blockNumber, blockHash);
+        ccx.ecx.db_mut().set_blockhash(blockNumber, blockHash);
 
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for executeTransactionCall {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for executeTransactionCall
+{
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         use crate::env::FORGE_CONTEXT;
 
         // Block in script contexts.
@@ -1117,6 +1142,25 @@ impl Cheatcode for executeTransactionCall {
         // Build TxEnv from the recovered transaction.
         let tx_env = <TxEnv as FromRecoveredTx<FoundryTxEnvelope>>::from_recovered_tx(&tx, sender);
 
+        // Save current env for restoration after execution.
+        let cached_env = ccx.ecx.to_env();
+
+        // Override env for isolated execution.
+        ccx.ecx.block_mut().basefee = 0;
+        *ccx.ecx.tx_mut() = tx_env;
+        ccx.ecx.tx_mut().gas_price = 0;
+        ccx.ecx.tx_mut().gas_priority_fee = None;
+
+        // Enable nonce checks for realistic simulation.
+        ccx.ecx.cfg_mut().disable_nonce_check = false;
+
+        // EIP-3860: enforce initcode size limit.
+        ccx.ecx.cfg_mut().limit_contract_initcode_size =
+            Some(revm::primitives::eip3860::MAX_INITCODE_SIZE);
+
+        // Snapshot the modified env for EVM construction.
+        let modified_env = ccx.ecx.to_env();
+
         // Mark as inner context so isolation mode doesn't trigger a nested transact_inner
         // when the inner EVM executes calls at depth == 1.
         executor.set_in_inner_context(true, Some(sender));
@@ -1125,25 +1169,10 @@ impl Cheatcode for executeTransactionCall {
             let mut inspector = executor.get_inspector(ccx.state);
 
             let res = {
-                let (db, journal, env) = ccx.ecx.as_db_env_and_journal();
-                let cached_env =
-                    foundry_evm_core::Env::from(env.cfg.clone(), env.block.clone(), env.tx.clone());
-
-                // Override env for isolated execution.
-                env.block.basefee = 0;
-                *env.tx = tx_env;
-                env.tx.gas_price = 0;
-                env.tx.gas_priority_fee = None;
-
-                // Enable nonce checks for realistic simulation.
-                env.cfg.disable_nonce_check = false;
-
-                // EIP-3860: enforce initcode size limit.
-                env.cfg.limit_contract_initcode_size =
-                    Some(revm::primitives::eip3860::MAX_INITCODE_SIZE);
+                let (db, journal) = ccx.ecx.journal_mut().as_db_and_inner();
 
                 // Create a new EVM instance with the inspector.
-                let mut evm = new_evm_with_inspector(db, env.to_owned(), &mut *inspector);
+                let mut evm = new_evm_with_inspector(db, modified_env.clone(), &mut *inspector);
 
                 // Clone journaled state and mark all accounts/slots cold.
                 evm.journaled_state.state = {
@@ -1163,20 +1192,16 @@ impl Cheatcode for executeTransactionCall {
                 // Set depth to 1 for proper trace collection.
                 evm.journaled_state.depth = 1;
 
-                let res = evm.transact(env.tx.clone());
-
-                // Restore the original environment.
-                *env.tx = cached_env.tx;
-                *env.cfg = cached_env.evm_env.cfg_env;
-                env.block.basefee = cached_env.evm_env.block_env.basefee;
-
-                res
+                evm.transact(modified_env.tx)
             };
 
             // Inspector must be dropped before we can call set_in_inner_context again.
             drop(inspector);
             res
         };
+
+        // Restore the original environment.
+        ccx.ecx.apply_env(cached_env);
 
         // Reset inner context flag.
         executor.set_in_inner_context(false, None);
@@ -1185,8 +1210,8 @@ impl Cheatcode for executeTransactionCall {
 
         // Merge state changes back into the parent journaled state.
         for (addr, mut acc) in res.state {
-            let Some(acc_mut) = ccx.ecx.journaled_state.state.get_mut(&addr) else {
-                ccx.ecx.journaled_state.state.insert(addr, acc);
+            let Some(acc_mut) = ccx.ecx.journal_mut().evm_state_mut().get_mut(&addr) else {
+                ccx.ecx.journal_mut().evm_state_mut().insert(addr, acc);
                 continue;
             };
 
@@ -1225,8 +1250,12 @@ impl Cheatcode for executeTransactionCall {
     }
 }
 
-impl Cheatcode for startDebugTraceRecordingCall {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<CTX> Cheatcode<CTX> for startDebugTraceRecordingCall {
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             return Err(Error::from("no tracer initiated, consider adding -vvv flag"));
         };
@@ -1251,8 +1280,12 @@ impl Cheatcode for startDebugTraceRecordingCall {
     }
 }
 
-impl Cheatcode for stopAndReturnDebugTraceRecordingCall {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<CTX> Cheatcode<CTX> for stopAndReturnDebugTraceRecordingCall {
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             return Err(Error::from("no tracer initiated, consider adding -vvv flag"));
         };
@@ -1286,8 +1319,8 @@ impl Cheatcode for stopAndReturnDebugTraceRecordingCall {
     }
 }
 
-impl Cheatcode for setEvmVersionCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for setEvmVersionCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { evm } = self;
         let spec_id = evm_spec_id(
             EvmVersion::from_str(evm)
@@ -1298,64 +1331,79 @@ impl Cheatcode for setEvmVersionCall {
     }
 }
 
-impl Cheatcode for getEvmVersionCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
-        Ok(ccx.ecx.cfg.spec.to_string().to_lowercase().abi_encode())
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for getEvmVersionCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+        Ok(ccx.ecx.cfg().spec.to_string().to_lowercase().abi_encode())
     }
 }
 
-pub(super) fn get_nonce(ccx: &mut CheatsCtxt, address: &Address) -> Result {
-    let (db, journal, _) = ccx.ecx.as_db_env_and_journal();
-    let account = journal.load_account(db, *address)?;
+pub(super) fn get_nonce<CTX: ContextTr<Db: DatabaseExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
+    address: &Address,
+) -> Result {
+    let account = ccx.ecx.journal_mut().load_account(*address)?;
     Ok(account.info.nonce.abi_encode())
 }
 
-fn inner_snapshot_state(ccx: &mut CheatsCtxt) -> Result {
-    let (db, journal, mut env) = ccx.ecx.as_db_env_and_journal();
-    Ok(db.snapshot_state(journal, &mut env).abi_encode())
+fn inner_snapshot_state<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
+) -> Result {
+    let (journal, mut env) = ccx.ecx.journal_and_env_mut();
+    let (db, inner) = journal.as_db_and_inner();
+    Ok(db.snapshot_state(inner, &mut env).abi_encode())
 }
 
-fn inner_revert_to_state(ccx: &mut CheatsCtxt, snapshot_id: U256) -> Result {
-    let (db, journal, mut env) = ccx.ecx.as_db_env_and_journal();
-    let result = if let Some(journaled_state) =
-        db.revert_state(snapshot_id, &*journal, &mut env, RevertStateSnapshotAction::RevertKeep)
+fn inner_revert_to_state<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
+    snapshot_id: U256,
+) -> Result {
+    let (journal, mut env) = ccx.ecx.journal_and_env_mut();
+    let (db, inner) = journal.as_db_and_inner();
+    if let Some(restored) =
+        db.revert_state(snapshot_id, inner, &mut env, RevertStateSnapshotAction::RevertKeep)
     {
-        // we reset the evm's journaled_state to the state of the snapshot previous state
-        ccx.ecx.journaled_state.inner = journaled_state;
-        true
+        *inner = restored;
+        Ok(true.abi_encode())
     } else {
-        false
-    };
-    Ok(result.abi_encode())
+        Ok(false.abi_encode())
+    }
 }
 
-fn inner_revert_to_state_and_delete(ccx: &mut CheatsCtxt, snapshot_id: U256) -> Result {
-    let (db, journal, mut env) = ccx.ecx.as_db_env_and_journal();
-
-    let result = if let Some(journaled_state) =
-        db.revert_state(snapshot_id, &*journal, &mut env, RevertStateSnapshotAction::RevertRemove)
+fn inner_revert_to_state_and_delete<
+    CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>,
+>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
+    snapshot_id: U256,
+) -> Result {
+    let (journal, mut env) = ccx.ecx.journal_and_env_mut();
+    let (db, inner) = journal.as_db_and_inner();
+    if let Some(restored) =
+        db.revert_state(snapshot_id, inner, &mut env, RevertStateSnapshotAction::RevertRemove)
     {
-        // we reset the evm's journaled_state to the state of the snapshot previous state
-        ccx.ecx.journaled_state.inner = journaled_state;
-        true
+        *inner = restored;
+        Ok(true.abi_encode())
     } else {
-        false
-    };
+        Ok(false.abi_encode())
+    }
+}
+
+fn inner_delete_state_snapshot<CTX: ContextTr<Db: DatabaseExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
+    snapshot_id: U256,
+) -> Result {
+    let result = ccx.ecx.db_mut().delete_state_snapshot(snapshot_id);
     Ok(result.abi_encode())
 }
 
-fn inner_delete_state_snapshot(ccx: &mut CheatsCtxt, snapshot_id: U256) -> Result {
-    let result = ccx.ecx.journaled_state.database.delete_state_snapshot(snapshot_id);
-    Ok(result.abi_encode())
-}
-
-fn inner_delete_state_snapshots(ccx: &mut CheatsCtxt) -> Result {
-    ccx.ecx.journaled_state.database.delete_state_snapshots();
+fn inner_delete_state_snapshots<CTX: ContextTr<Db: DatabaseExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
+) -> Result {
+    ccx.ecx.db_mut().delete_state_snapshots();
     Ok(Default::default())
 }
 
-fn inner_value_snapshot(
-    ccx: &mut CheatsCtxt,
+fn inner_value_snapshot<CTX>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
     group: Option<String>,
     name: Option<String>,
     value: String,
@@ -1367,8 +1415,8 @@ fn inner_value_snapshot(
     Ok(Default::default())
 }
 
-fn inner_last_gas_snapshot(
-    ccx: &mut CheatsCtxt,
+fn inner_last_gas_snapshot<CTX>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
     group: Option<String>,
     name: Option<String>,
     value: u64,
@@ -1380,8 +1428,8 @@ fn inner_last_gas_snapshot(
     Ok(value.abi_encode())
 }
 
-fn inner_start_gas_snapshot(
-    ccx: &mut CheatsCtxt,
+fn inner_start_gas_snapshot<CTX: ContextTr>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
     group: Option<String>,
     name: Option<String>,
 ) -> Result {
@@ -1396,7 +1444,7 @@ fn inner_start_gas_snapshot(
         group: group.clone(),
         name: name.clone(),
         gas_used: 0,
-        depth: ccx.ecx.journaled_state.depth(),
+        depth: ccx.ecx.journal().depth(),
     });
 
     ccx.state.gas_metering.active_gas_snapshot = Some((group, name));
@@ -1406,8 +1454,8 @@ fn inner_start_gas_snapshot(
     Ok(Default::default())
 }
 
-fn inner_stop_gas_snapshot(
-    ccx: &mut CheatsCtxt,
+fn inner_stop_gas_snapshot<CTX>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
     group: Option<String>,
     name: Option<String>,
 ) -> Result {
@@ -1457,8 +1505,8 @@ fn inner_stop_gas_snapshot(
 }
 
 // Derives the snapshot group and name from the provided group and name or the running contract.
-fn derive_snapshot_name(
-    ccx: &CheatsCtxt,
+fn derive_snapshot_name<CTX>(
+    ccx: &CheatsCtxt<'_, CTX>,
     group: Option<String>,
     name: Option<String>,
 ) -> (String, String) {
@@ -1516,18 +1564,20 @@ fn read_callers(state: &Cheatcodes, default_sender: &Address, call_depth: usize)
 }
 
 /// Ensures the `Account` is loaded and touched.
-pub(super) fn journaled_account<'a>(
-    ecx: Ecx<'a, '_, '_>,
+pub(super) fn journaled_account<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+    ecx: &mut CTX,
     addr: Address,
-) -> Result<&'a mut Account> {
+) -> Result<&mut Account> {
     ensure_loaded_account(ecx, addr)?;
-    Ok(ecx.journaled_state.state.get_mut(&addr).expect("account is loaded"))
+    Ok(ecx.journal_mut().evm_state_mut().get_mut(&addr).expect("account is loaded"))
 }
 
-pub(super) fn ensure_loaded_account(ecx: Ecx, addr: Address) -> Result<()> {
-    let (db, journal, _) = ecx.as_db_env_and_journal();
-    journal.load_account(db, addr)?;
-    journal.touch(addr);
+pub(super) fn ensure_loaded_account<CTX: ContextTr<Db: DatabaseExt>>(
+    ecx: &mut CTX,
+    addr: Address,
+) -> Result<()> {
+    ecx.journal_mut().load_account(addr)?;
+    ecx.journal_mut().touch_account(addr);
     Ok(())
 }
 
@@ -1567,7 +1617,9 @@ fn genesis_account(account: &Account) -> GenesisAccount {
 }
 
 /// Helper function to returns state diffs recorded for each changed account.
-fn get_recorded_state_diffs(ccx: &mut CheatsCtxt) -> BTreeMap<Address, AccountStateDiffs> {
+fn get_recorded_state_diffs<CTX: ContextTr<Db: DatabaseExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
+) -> BTreeMap<Address, AccountStateDiffs> {
     let mut state_diffs: BTreeMap<Address, AccountStateDiffs> = BTreeMap::default();
 
     // First, collect all unique addresses we need to look up
@@ -1744,16 +1796,15 @@ const EIP1822_PROXIABLE_SLOT: &str =
     "c5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7";
 
 /// Helper function to get the contract data from the deployed code at an address.
-fn get_contract_data<'a>(
-    ccx: &'a mut CheatsCtxt,
+fn get_contract_data<'a, CTX: ContextTr<Db: DatabaseExt>>(
+    ccx: &'a mut CheatsCtxt<'_, CTX>,
     address: Address,
 ) -> Option<(&'a foundry_compilers::ArtifactId, &'a foundry_common::contracts::ContractData)> {
     // Check if we have available artifacts to match against
     let artifacts = ccx.state.config.available_artifacts.as_ref()?;
 
     // Try to load the account and get its code
-    let (db, journal, _) = ccx.ecx.as_db_env_and_journal();
-    let account = journal.load_account(db, address).ok()?;
+    let account = ccx.ecx.journal_mut().load_account(address).ok()?;
     let code = account.info.code.as_ref()?;
 
     // Skip if code is empty
@@ -1788,8 +1839,13 @@ fn get_contract_data<'a>(
 }
 
 /// Helper function to set / unset cold storage slot of the target address.
-fn set_cold_slot(ccx: &mut CheatsCtxt, target: Address, slot: U256, cold: bool) {
-    if let Some(account) = ccx.ecx.journaled_state.state.get_mut(&target)
+fn set_cold_slot<CTX: ContextTr<Journal: JournalExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
+    target: Address,
+    slot: U256,
+    cold: bool,
+) {
+    if let Some(account) = ccx.ecx.journal_mut().evm_state_mut().get_mut(&target)
         && let Some(storage_slot) = account.storage.get_mut(&slot)
     {
         storage_slot.is_cold = cold;

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -9,211 +9,240 @@ use alloy_provider::Provider;
 use alloy_rpc_types::Filter;
 use alloy_sol_types::SolValue;
 use foundry_common::provider::ProviderBuilder;
-use foundry_evm_core::{AsEnvMut, ContextExt, fork::CreateFork};
+use foundry_evm_core::{FoundryContextExt, backend::FoundryJournalExt, fork::CreateFork};
+use revm::context_interface::ContextTr;
 
-impl Cheatcode for activeForkCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for activeForkCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         ccx.ecx
-            .journaled_state
-            .database
+            .db()
             .active_fork_id()
             .map(|id| id.abi_encode())
             .ok_or_else(|| fmt_err!("no active fork"))
     }
 }
 
-impl Cheatcode for createFork_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for createFork_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { urlOrAlias } = self;
         create_fork(ccx, urlOrAlias, None)
     }
 }
 
-impl Cheatcode for createFork_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for createFork_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { urlOrAlias, blockNumber } = self;
         create_fork(ccx, urlOrAlias, Some(blockNumber.saturating_to()))
     }
 }
 
-impl Cheatcode for createFork_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for createFork_2Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { urlOrAlias, txHash } = self;
         create_fork_at_transaction(ccx, urlOrAlias, txHash)
     }
 }
 
-impl Cheatcode for createSelectFork_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for createSelectFork_0Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { urlOrAlias } = self;
         create_select_fork(ccx, urlOrAlias, None)
     }
 }
 
-impl Cheatcode for createSelectFork_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for createSelectFork_1Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { urlOrAlias, blockNumber } = self;
         create_select_fork(ccx, urlOrAlias, Some(blockNumber.saturating_to()))
     }
 }
 
-impl Cheatcode for createSelectFork_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for createSelectFork_2Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { urlOrAlias, txHash } = self;
         create_select_fork_at_transaction(ccx, urlOrAlias, txHash)
     }
 }
 
-impl Cheatcode for rollFork_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for rollFork_0Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { blockNumber } = self;
         persist_caller(ccx);
-        let (db, journal, mut env) = ccx.ecx.as_db_env_and_journal();
-        db.roll_fork(None, (*blockNumber).to(), &mut env, journal)?;
+        let (journal, mut env) = ccx.ecx.journal_and_env_mut();
+        let (db, inner) = journal.as_db_and_inner();
+        db.roll_fork(None, (*blockNumber).to(), &mut env, inner)?;
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for rollFork_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for rollFork_1Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { txHash } = self;
         persist_caller(ccx);
-        let (db, journal, mut env) = ccx.ecx.as_db_env_and_journal();
-        db.roll_fork_to_transaction(None, *txHash, &mut env, journal)?;
+        let (journal, mut env) = ccx.ecx.journal_and_env_mut();
+        let (db, inner) = journal.as_db_and_inner();
+        db.roll_fork_to_transaction(None, *txHash, &mut env, inner)?;
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for rollFork_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for rollFork_2Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { forkId, blockNumber } = self;
         persist_caller(ccx);
-        let (db, journal, mut env) = ccx.ecx.as_db_env_and_journal();
-        db.roll_fork(Some(*forkId), (*blockNumber).to(), &mut env, journal)?;
+        let (journal, mut env) = ccx.ecx.journal_and_env_mut();
+        let (db, inner) = journal.as_db_and_inner();
+        db.roll_fork(Some(*forkId), (*blockNumber).to(), &mut env, inner)?;
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for rollFork_3Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for rollFork_3Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { forkId, txHash } = self;
         persist_caller(ccx);
-        let (db, journal, mut env) = ccx.ecx.as_db_env_and_journal();
-        db.roll_fork_to_transaction(Some(*forkId), *txHash, &mut env, journal)?;
+        let (journal, mut env) = ccx.ecx.journal_and_env_mut();
+        let (db, inner) = journal.as_db_and_inner();
+        db.roll_fork_to_transaction(Some(*forkId), *txHash, &mut env, inner)?;
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for selectForkCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for selectForkCall
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { forkId } = self;
         persist_caller(ccx);
         check_broadcast(ccx.state)?;
-        let (db, journal, mut env) = ccx.ecx.as_db_env_and_journal();
-        db.select_fork(*forkId, &mut env, journal)?;
+        let (journal, mut env) = ccx.ecx.journal_and_env_mut();
+        let (db, inner) = journal.as_db_and_inner();
+        db.select_fork(*forkId, &mut env, inner)?;
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for transact_0Call {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for transact_0Call
+{
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let Self { txHash } = *self;
         transact(ccx, executor, txHash, None)
     }
 }
 
-impl Cheatcode for transact_1Call {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
+    for transact_1Call
+{
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let Self { forkId, txHash } = *self;
         transact(ccx, executor, txHash, Some(forkId))
     }
 }
 
-impl Cheatcode for allowCheatcodesCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for allowCheatcodesCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { account } = self;
-        ccx.ecx.journaled_state.database.allow_cheatcode_access(*account);
+        ccx.ecx.db_mut().allow_cheatcode_access(*account);
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for makePersistent_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for makePersistent_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { account } = self;
-        ccx.ecx.journaled_state.database.add_persistent_account(*account);
+        ccx.ecx.db_mut().add_persistent_account(*account);
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for makePersistent_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for makePersistent_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { account0, account1 } = self;
-        ccx.ecx.journaled_state.database.add_persistent_account(*account0);
-        ccx.ecx.journaled_state.database.add_persistent_account(*account1);
+        ccx.ecx.db_mut().add_persistent_account(*account0);
+        ccx.ecx.db_mut().add_persistent_account(*account1);
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for makePersistent_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for makePersistent_2Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { account0, account1, account2 } = self;
-        ccx.ecx.journaled_state.database.add_persistent_account(*account0);
-        ccx.ecx.journaled_state.database.add_persistent_account(*account1);
-        ccx.ecx.journaled_state.database.add_persistent_account(*account2);
+        ccx.ecx.db_mut().add_persistent_account(*account0);
+        ccx.ecx.db_mut().add_persistent_account(*account1);
+        ccx.ecx.db_mut().add_persistent_account(*account2);
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for makePersistent_3Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for makePersistent_3Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { accounts } = self;
         for account in accounts {
-            ccx.ecx.journaled_state.database.add_persistent_account(*account);
+            ccx.ecx.db_mut().add_persistent_account(*account);
         }
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for revokePersistent_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for revokePersistent_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { account } = self;
-        ccx.ecx.journaled_state.database.remove_persistent_account(account);
+        ccx.ecx.db_mut().remove_persistent_account(account);
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for revokePersistent_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for revokePersistent_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { accounts } = self;
         for account in accounts {
-            ccx.ecx.journaled_state.database.remove_persistent_account(account);
+            ccx.ecx.db_mut().remove_persistent_account(account);
         }
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for isPersistentCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for isPersistentCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { account } = self;
-        Ok(ccx.ecx.journaled_state.database.is_persistent(account).abi_encode())
+        Ok(ccx.ecx.db().is_persistent(account).abi_encode())
     }
 }
 
-impl Cheatcode for rpc_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for rpc_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { method, params } = self;
-        let url = ccx
-            .ecx
-            .journaled_state
-            .database
-            .active_fork_url()
-            .ok_or_else(|| fmt_err!("no active fork URL found"))?;
+        let url =
+            ccx.ecx.db().active_fork_url().ok_or_else(|| fmt_err!("no active fork URL found"))?;
         rpc_call(&url, method, params)
     }
 }
 
-impl Cheatcode for rpc_1Call {
+impl<CTX> Cheatcode<CTX> for rpc_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { urlOrAlias, method, params } = self;
         let url = state.config.rpc_endpoint(urlOrAlias)?.url()?;
@@ -221,8 +250,8 @@ impl Cheatcode for rpc_1Call {
     }
 }
 
-impl Cheatcode for eth_getLogsCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for eth_getLogsCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { fromBlock, toBlock, target, topics } = self;
         let (Ok(from_block), Ok(to_block)) = (u64::try_from(fromBlock), u64::try_from(toBlock))
         else {
@@ -233,12 +262,8 @@ impl Cheatcode for eth_getLogsCall {
             bail!("topics array must contain at most 4 elements")
         }
 
-        let url = ccx
-            .ecx
-            .journaled_state
-            .database
-            .active_fork_url()
-            .ok_or_else(|| fmt_err!("no active fork URL found"))?;
+        let url =
+            ccx.ecx.db().active_fork_url().ok_or_else(|| fmt_err!("no active fork URL found"))?;
         let provider = ProviderBuilder::<AnyNetwork>::new(&url).build()?;
         let mut filter = Filter::new().address(*target).from_block(from_block).to_block(to_block);
         for (i, &topic) in topics.iter().enumerate() {
@@ -267,15 +292,10 @@ impl Cheatcode for eth_getLogsCall {
     }
 }
 
-impl Cheatcode for getRawBlockHeaderCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for getRawBlockHeaderCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { blockNumber } = self;
-        let url = ccx
-            .ecx
-            .journaled_state
-            .database
-            .active_fork_url()
-            .ok_or_else(|| fmt_err!("no active fork"))?;
+        let url = ccx.ecx.db().active_fork_url().ok_or_else(|| fmt_err!("no active fork"))?;
         let provider = ProviderBuilder::<AnyNetwork>::new(&url).build()?;
         let block_number = u64::try_from(blockNumber)
             .map_err(|_| fmt_err!("block number must be less than 2^64"))?;
@@ -295,50 +315,64 @@ impl Cheatcode for getRawBlockHeaderCall {
 }
 
 /// Creates and then also selects the new fork
-fn create_select_fork(ccx: &mut CheatsCtxt, url_or_alias: &str, block: Option<u64>) -> Result {
+fn create_select_fork<
+    CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournalExt>,
+>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
+    url_or_alias: &str,
+    block: Option<u64>,
+) -> Result {
     check_broadcast(ccx.state)?;
 
     let fork = create_fork_request(ccx, url_or_alias, block)?;
-    let (db, journal, mut env) = ccx.ecx.as_db_env_and_journal();
-    let id = db.create_select_fork(fork, &mut env, journal)?;
+    let (journal, mut env) = ccx.ecx.journal_and_env_mut();
+    let (db, inner) = journal.as_db_and_inner();
+    let id = db.create_select_fork(fork, &mut env, inner)?;
     Ok(id.abi_encode())
 }
 
 /// Creates a new fork
-fn create_fork(ccx: &mut CheatsCtxt, url_or_alias: &str, block: Option<u64>) -> Result {
+fn create_fork<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
+    url_or_alias: &str,
+    block: Option<u64>,
+) -> Result {
     let fork = create_fork_request(ccx, url_or_alias, block)?;
-    let id = ccx.ecx.journaled_state.database.create_fork(fork)?;
+    let id = ccx.ecx.db_mut().create_fork(fork)?;
     Ok(id.abi_encode())
 }
 
 /// Creates and then also selects the new fork at the given transaction
-fn create_select_fork_at_transaction(
-    ccx: &mut CheatsCtxt,
+fn create_select_fork_at_transaction<
+    CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournalExt>,
+>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
     url_or_alias: &str,
     transaction: &B256,
 ) -> Result {
     check_broadcast(ccx.state)?;
 
     let fork = create_fork_request(ccx, url_or_alias, None)?;
-    let (db, journal, mut env) = ccx.ecx.as_db_env_and_journal();
-    let id = db.create_select_fork_at_transaction(fork, &mut env, journal, *transaction)?;
+    let (journal, mut env) = ccx.ecx.journal_and_env_mut();
+    let (db, inner) = journal.as_db_and_inner();
+    let id = db.create_select_fork_at_transaction(fork, &mut env, inner, *transaction)?;
     Ok(id.abi_encode())
 }
 
 /// Creates a new fork at the given transaction
-fn create_fork_at_transaction(
-    ccx: &mut CheatsCtxt,
+fn create_fork_at_transaction<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
     url_or_alias: &str,
     transaction: &B256,
 ) -> Result {
     let fork = create_fork_request(ccx, url_or_alias, None)?;
-    let id = ccx.ecx.journaled_state.database.create_fork_at_transaction(fork, *transaction)?;
+    let id = ccx.ecx.db_mut().create_fork_at_transaction(fork, *transaction)?;
     Ok(id.abi_encode())
 }
 
 /// Creates the request object for a new fork request
-fn create_fork_request(
-    ccx: &mut CheatsCtxt,
+fn create_fork_request<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
     url_or_alias: &str,
     block: Option<u64>,
 ) -> Result<CreateFork> {
@@ -357,7 +391,7 @@ fn create_fork_request(
         enable_caching: !ccx.state.config.no_storage_caching
             && ccx.state.config.rpc_storage_caching.enable_for_endpoint(&url),
         url,
-        env: ccx.ecx.as_env_mut().to_owned(),
+        env: ccx.ecx.to_env(),
         evm_opts,
     };
     Ok(fork)
@@ -371,20 +405,16 @@ fn check_broadcast(state: &Cheatcodes) -> Result<()> {
     }
 }
 
-fn transact(
-    ccx: &mut CheatsCtxt,
+fn transact<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
     executor: &mut dyn CheatcodesExecutor,
     transaction: B256,
     fork_id: Option<U256>,
 ) -> Result {
-    let (db, journal, env) = ccx.ecx.as_db_env_and_journal();
-    db.transact(
-        fork_id,
-        transaction,
-        env.to_owned(),
-        journal,
-        &mut *executor.get_inspector(ccx.state),
-    )?;
+    let env = ccx.ecx.to_env();
+    let mut inspector = executor.get_inspector(ccx.state);
+    let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
+    db.transact(fork_id, transaction, env, inner, &mut *inspector)?;
     Ok(Default::default())
 }
 
@@ -392,8 +422,8 @@ fn transact(
 // state of caller contract is not lost when fork changes).
 // Applies to create, select and roll forks actions.
 // https://github.com/foundry-rs/foundry/issues/8004
-fn persist_caller(ccx: &mut CheatsCtxt) {
-    ccx.ecx.journaled_state.database.add_persistent_account(ccx.caller);
+fn persist_caller<CTX: ContextTr<Db: DatabaseExt>>(ccx: &mut CheatsCtxt<'_, CTX>) {
+    ccx.ecx.db_mut().add_persistent_account(ccx.caller);
 }
 
 /// Performs an Ethereum JSON-RPC request to the given endpoint.

--- a/crates/cheatcodes/src/evm/mapping.rs
+++ b/crates/cheatcodes/src/evm/mapping.rs
@@ -3,7 +3,7 @@ use alloy_primitives::{Address, B256};
 use alloy_sol_types::SolValue;
 use foundry_common::mapping_slots::MappingSlots;
 
-impl Cheatcode for startMappingRecordingCall {
+impl<CTX> Cheatcode<CTX> for startMappingRecordingCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         state.mapping_slots.get_or_insert_default();
@@ -11,7 +11,7 @@ impl Cheatcode for startMappingRecordingCall {
     }
 }
 
-impl Cheatcode for stopMappingRecordingCall {
+impl<CTX> Cheatcode<CTX> for stopMappingRecordingCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         state.mapping_slots = None;
@@ -19,7 +19,7 @@ impl Cheatcode for stopMappingRecordingCall {
     }
 }
 
-impl Cheatcode for getMappingLengthCall {
+impl<CTX> Cheatcode<CTX> for getMappingLengthCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { target, mappingSlot } = self;
         let result = slot_child(state, target, mappingSlot).map(Vec::len).unwrap_or(0);
@@ -27,7 +27,7 @@ impl Cheatcode for getMappingLengthCall {
     }
 }
 
-impl Cheatcode for getMappingSlotAtCall {
+impl<CTX> Cheatcode<CTX> for getMappingSlotAtCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { target, mappingSlot, idx } = self;
         let result = slot_child(state, target, mappingSlot)
@@ -38,7 +38,7 @@ impl Cheatcode for getMappingSlotAtCall {
     }
 }
 
-impl Cheatcode for getMappingKeyAndParentOfCall {
+impl<CTX> Cheatcode<CTX> for getMappingKeyAndParentOfCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { target, elementSlot: slot } = self;
         let mut found = false;

--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -1,6 +1,10 @@
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, Result, Vm::*};
 use alloy_primitives::{Address, Bytes, U256};
-use revm::{bytecode::Bytecode, context::JournalTr, interpreter::InstructionResult};
+use foundry_evm_core::backend::DatabaseExt;
+use revm::{
+    bytecode::Bytecode, context::JournalTr, context_interface::ContextTr,
+    interpreter::InstructionResult,
+};
 use std::{cmp::Ordering, collections::VecDeque};
 
 /// Mocked call data.
@@ -38,7 +42,7 @@ impl Ord for MockCallDataContext {
     }
 }
 
-impl Cheatcode for clearMockedCallsCall {
+impl<CTX> Cheatcode<CTX> for clearMockedCallsCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         state.mocked_calls = Default::default();
@@ -46,8 +50,8 @@ impl Cheatcode for clearMockedCallsCall {
     }
 }
 
-impl Cheatcode for mockCall_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for mockCall_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { callee, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
 
@@ -56,8 +60,8 @@ impl Cheatcode for mockCall_0Call {
     }
 }
 
-impl Cheatcode for mockCall_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for mockCall_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { callee, msgValue, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
 
@@ -66,8 +70,8 @@ impl Cheatcode for mockCall_1Call {
     }
 }
 
-impl Cheatcode for mockCall_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for mockCall_2Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { callee, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
 
@@ -83,8 +87,8 @@ impl Cheatcode for mockCall_2Call {
     }
 }
 
-impl Cheatcode for mockCall_3Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for mockCall_3Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { callee, msgValue, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
 
@@ -100,8 +104,8 @@ impl Cheatcode for mockCall_3Call {
     }
 }
 
-impl Cheatcode for mockCalls_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for mockCalls_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { callee, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
 
@@ -110,8 +114,8 @@ impl Cheatcode for mockCalls_0Call {
     }
 }
 
-impl Cheatcode for mockCalls_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for mockCalls_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { callee, msgValue, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
 
@@ -120,8 +124,8 @@ impl Cheatcode for mockCalls_1Call {
     }
 }
 
-impl Cheatcode for mockCallRevert_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for mockCallRevert_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { callee, data, revertData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
 
@@ -130,8 +134,8 @@ impl Cheatcode for mockCallRevert_0Call {
     }
 }
 
-impl Cheatcode for mockCallRevert_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for mockCallRevert_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { callee, msgValue, data, revertData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
 
@@ -140,8 +144,8 @@ impl Cheatcode for mockCallRevert_1Call {
     }
 }
 
-impl Cheatcode for mockCallRevert_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for mockCallRevert_2Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { callee, data, revertData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
 
@@ -157,8 +161,8 @@ impl Cheatcode for mockCallRevert_2Call {
     }
 }
 
-impl Cheatcode for mockCallRevert_3Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for mockCallRevert_3Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { callee, msgValue, data, revertData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
 
@@ -174,7 +178,7 @@ impl Cheatcode for mockCallRevert_3Call {
     }
 }
 
-impl Cheatcode for mockFunctionCall {
+impl<CTX> Cheatcode<CTX> for mockFunctionCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { callee, target, data } = self;
         state.mocked_functions.entry(*callee).or_default().insert(data.clone(), *target);
@@ -213,13 +217,17 @@ fn mock_calls(
 
 // Etches a single byte onto the account if it is empty to circumvent the `extcodesize`
 // check Solidity might perform.
-fn make_acc_non_empty(callee: &Address, ecx: &mut CheatsCtxt) -> Result {
-    let acc = ecx.journaled_state.load_account(*callee)?;
-
-    let empty_bytecode = acc.info.code.as_ref().is_none_or(Bytecode::is_empty);
+fn make_acc_non_empty<CTX: ContextTr<Db: DatabaseExt>>(
+    callee: &Address,
+    ccx: &mut CheatsCtxt<'_, CTX>,
+) -> Result {
+    let empty_bytecode = {
+        let acc = ccx.ecx.journal_mut().load_account(*callee)?;
+        acc.info.code.as_ref().is_none_or(Bytecode::is_empty)
+    };
     if empty_bytecode {
         let code = Bytecode::new_raw(Bytes::from_static(&[0u8]));
-        ecx.journaled_state.set_code(*callee, code);
+        ccx.ecx.journal_mut().set_code(*callee, code);
     }
 
     Ok(Default::default())

--- a/crates/cheatcodes/src/evm/prank.rs
+++ b/crates/cheatcodes/src/evm/prank.rs
@@ -1,6 +1,10 @@
 use crate::{Cheatcode, CheatsCtxt, Result, Vm::*, evm::journaled_account};
 use alloy_primitives::Address;
-use revm::context::JournalTr;
+use foundry_evm_core::{backend::DatabaseExt, env::FoundryContextExt};
+use revm::{
+    context::{ContextTr, JournalTr},
+    inspector::JournalExt,
+};
 
 /// Prank information.
 #[derive(Clone, Copy, Debug, Default)]
@@ -53,72 +57,88 @@ impl Prank {
     }
 }
 
-impl Cheatcode for prank_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for prank_0Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { msgSender } = self;
         prank(ccx, msgSender, None, true, false)
     }
 }
 
-impl Cheatcode for startPrank_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for startPrank_0Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { msgSender } = self;
         prank(ccx, msgSender, None, false, false)
     }
 }
 
-impl Cheatcode for prank_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for prank_1Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { msgSender, txOrigin } = self;
         prank(ccx, msgSender, Some(txOrigin), true, false)
     }
 }
 
-impl Cheatcode for startPrank_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for startPrank_1Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { msgSender, txOrigin } = self;
         prank(ccx, msgSender, Some(txOrigin), false, false)
     }
 }
 
-impl Cheatcode for prank_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for prank_2Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { msgSender, delegateCall } = self;
         prank(ccx, msgSender, None, true, *delegateCall)
     }
 }
 
-impl Cheatcode for startPrank_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for startPrank_2Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { msgSender, delegateCall } = self;
         prank(ccx, msgSender, None, false, *delegateCall)
     }
 }
 
-impl Cheatcode for prank_3Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for prank_3Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { msgSender, txOrigin, delegateCall } = self;
         prank(ccx, msgSender, Some(txOrigin), true, *delegateCall)
     }
 }
 
-impl Cheatcode for startPrank_3Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for startPrank_3Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { msgSender, txOrigin, delegateCall } = self;
         prank(ccx, msgSender, Some(txOrigin), false, *delegateCall)
     }
 }
 
-impl Cheatcode for stopPrankCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for stopPrankCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
-        ccx.state.pranks.remove(&ccx.ecx.journaled_state.depth());
+        ccx.state.pranks.remove(&ccx.ecx.journal().depth());
         Ok(Default::default())
     }
 }
 
-fn prank(
-    ccx: &mut CheatsCtxt,
+fn prank<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
     new_caller: &Address,
     new_origin: Option<&Address>,
     single_call: bool,
@@ -137,7 +157,7 @@ fn prank(
         );
     }
 
-    let depth = ccx.ecx.journaled_state.depth();
+    let depth = ccx.ecx.journal().depth();
     if let Some(Prank { used, single_call: current_single_call, .. }) = ccx.state.get_prank(depth) {
         ensure!(used, "cannot overwrite a prank until it is applied at least once");
         // This case can only fail if the user calls `vm.startPrank` and then `vm.prank` later on.
@@ -151,7 +171,7 @@ fn prank(
 
     let prank = Prank::new(
         ccx.caller,
-        ccx.ecx.tx.caller,
+        ccx.ecx.tx().caller,
         *new_caller,
         new_origin.copied(),
         depth,

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -1,8 +1,9 @@
 //! Implementations of [`Filesystem`](spec::Group::Filesystem) cheatcodes.
 
 use super::string::parse;
-use crate::{Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Result, Vm::*};
+use crate::{Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, EthCheatsCtxt, Result, Vm::*};
 use alloy_dyn_abi::DynSolType;
+use alloy_evm::eth::EthEvmContext;
 use alloy_json_abi::ContractObject;
 use alloy_network::AnyTransactionReceipt;
 use alloy_primitives::{Bytes, U256, hex, map::Entry};
@@ -12,8 +13,10 @@ use dialoguer::{Input, Password};
 use forge_script_sequence::{BroadcastReader, TransactionWithMetadata};
 use foundry_common::fs;
 use foundry_config::fs_permissions::FsAccessKind;
+use foundry_evm_core::{backend::DatabaseExt, env::FoundryContextExt};
 use revm::{
     context::{CreateScheme, JournalTr},
+    context_interface::ContextTr,
     interpreter::CreateInputs,
 };
 use revm_inspectors::tracing::types::CallKind;
@@ -28,7 +31,7 @@ use std::{
 };
 use walkdir::WalkDir;
 
-impl Cheatcode for existsCall {
+impl<CTX> Cheatcode<CTX> for existsCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
@@ -36,7 +39,7 @@ impl Cheatcode for existsCall {
     }
 }
 
-impl Cheatcode for fsMetadataCall {
+impl<CTX> Cheatcode<CTX> for fsMetadataCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
@@ -62,7 +65,7 @@ impl Cheatcode for fsMetadataCall {
     }
 }
 
-impl Cheatcode for isDirCall {
+impl<CTX> Cheatcode<CTX> for isDirCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
@@ -70,7 +73,7 @@ impl Cheatcode for isDirCall {
     }
 }
 
-impl Cheatcode for isFileCall {
+impl<CTX> Cheatcode<CTX> for isFileCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
@@ -78,14 +81,14 @@ impl Cheatcode for isFileCall {
     }
 }
 
-impl Cheatcode for projectRootCall {
+impl<CTX> Cheatcode<CTX> for projectRootCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         Ok(state.config.root.display().to_string().abi_encode())
     }
 }
 
-impl Cheatcode for unixTimeCall {
+impl<CTX> Cheatcode<CTX> for unixTimeCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         let difference = SystemTime::now()
@@ -95,7 +98,7 @@ impl Cheatcode for unixTimeCall {
     }
 }
 
-impl Cheatcode for closeFileCall {
+impl<CTX> Cheatcode<CTX> for closeFileCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
@@ -106,7 +109,7 @@ impl Cheatcode for closeFileCall {
     }
 }
 
-impl Cheatcode for copyFileCall {
+impl<CTX> Cheatcode<CTX> for copyFileCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { from, to } = self;
         let from = state.config.ensure_path_allowed(from, FsAccessKind::Read)?;
@@ -118,7 +121,7 @@ impl Cheatcode for copyFileCall {
     }
 }
 
-impl Cheatcode for createDirCall {
+impl<CTX> Cheatcode<CTX> for createDirCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path, recursive } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
@@ -127,28 +130,28 @@ impl Cheatcode for createDirCall {
     }
 }
 
-impl Cheatcode for readDir_0Call {
+impl<CTX> Cheatcode<CTX> for readDir_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
         read_dir(state, path.as_ref(), 1, false)
     }
 }
 
-impl Cheatcode for readDir_1Call {
+impl<CTX> Cheatcode<CTX> for readDir_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path, maxDepth } = self;
         read_dir(state, path.as_ref(), *maxDepth, false)
     }
 }
 
-impl Cheatcode for readDir_2Call {
+impl<CTX> Cheatcode<CTX> for readDir_2Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path, maxDepth, followLinks } = self;
         read_dir(state, path.as_ref(), *maxDepth, *followLinks)
     }
 }
 
-impl Cheatcode for readFileCall {
+impl<CTX> Cheatcode<CTX> for readFileCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
@@ -156,7 +159,7 @@ impl Cheatcode for readFileCall {
     }
 }
 
-impl Cheatcode for readFileBinaryCall {
+impl<CTX> Cheatcode<CTX> for readFileBinaryCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
@@ -164,7 +167,7 @@ impl Cheatcode for readFileBinaryCall {
     }
 }
 
-impl Cheatcode for readLineCall {
+impl<CTX> Cheatcode<CTX> for readLineCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
@@ -190,7 +193,7 @@ impl Cheatcode for readLineCall {
     }
 }
 
-impl Cheatcode for readLinkCall {
+impl<CTX> Cheatcode<CTX> for readLinkCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { linkPath: path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
@@ -199,7 +202,7 @@ impl Cheatcode for readLinkCall {
     }
 }
 
-impl Cheatcode for removeDirCall {
+impl<CTX> Cheatcode<CTX> for removeDirCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path, recursive } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
@@ -208,7 +211,7 @@ impl Cheatcode for removeDirCall {
     }
 }
 
-impl Cheatcode for removeFileCall {
+impl<CTX> Cheatcode<CTX> for removeFileCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
@@ -225,21 +228,21 @@ impl Cheatcode for removeFileCall {
     }
 }
 
-impl Cheatcode for writeFileCall {
+impl<CTX> Cheatcode<CTX> for writeFileCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path, data } = self;
         write_file(state, path.as_ref(), data.as_bytes())
     }
 }
 
-impl Cheatcode for writeFileBinaryCall {
+impl<CTX> Cheatcode<CTX> for writeFileBinaryCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path, data } = self;
         write_file(state, path.as_ref(), data)
     }
 }
 
-impl Cheatcode for writeLineCall {
+impl<CTX> Cheatcode<CTX> for writeLineCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path, data: line } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
@@ -253,7 +256,7 @@ impl Cheatcode for writeLineCall {
     }
 }
 
-impl Cheatcode for getArtifactPathByCodeCall {
+impl<CTX> Cheatcode<CTX> for getArtifactPathByCodeCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { code } = self;
         let (artifact_id, _) = state
@@ -267,7 +270,7 @@ impl Cheatcode for getArtifactPathByCodeCall {
     }
 }
 
-impl Cheatcode for getArtifactPathByDeployedCodeCall {
+impl<CTX> Cheatcode<CTX> for getArtifactPathByDeployedCodeCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { deployedCode } = self;
         let (artifact_id, _) = state
@@ -281,71 +284,103 @@ impl Cheatcode for getArtifactPathByDeployedCodeCall {
     }
 }
 
-impl Cheatcode for getCodeCall {
+impl<CTX> Cheatcode<CTX> for getCodeCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { artifactPath: path } = self;
         Ok(get_artifact_code(state, path, false)?.abi_encode())
     }
 }
 
-impl Cheatcode for getDeployedCodeCall {
+impl<CTX> Cheatcode<CTX> for getDeployedCodeCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { artifactPath: path } = self;
         Ok(get_artifact_code(state, path, true)?.abi_encode())
     }
 }
 
-impl Cheatcode for deployCode_0Call {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<'db, 'db2> Cheatcode<EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>> for deployCode_0Call {
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let Self { artifactPath: path } = self;
         deploy_code(ccx, executor, path, None, None, None)
     }
 }
 
-impl Cheatcode for deployCode_1Call {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<'db, 'db2> Cheatcode<EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>> for deployCode_1Call {
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let Self { artifactPath: path, constructorArgs: args } = self;
         deploy_code(ccx, executor, path, Some(args), None, None)
     }
 }
 
-impl Cheatcode for deployCode_2Call {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<'db, 'db2> Cheatcode<EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>> for deployCode_2Call {
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let Self { artifactPath: path, value } = self;
         deploy_code(ccx, executor, path, None, Some(*value), None)
     }
 }
 
-impl Cheatcode for deployCode_3Call {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<'db, 'db2> Cheatcode<EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>> for deployCode_3Call {
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let Self { artifactPath: path, constructorArgs: args, value } = self;
         deploy_code(ccx, executor, path, Some(args), Some(*value), None)
     }
 }
 
-impl Cheatcode for deployCode_4Call {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<'db, 'db2> Cheatcode<EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>> for deployCode_4Call {
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let Self { artifactPath: path, salt } = self;
         deploy_code(ccx, executor, path, None, None, Some((*salt).into()))
     }
 }
 
-impl Cheatcode for deployCode_5Call {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<'db, 'db2> Cheatcode<EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>> for deployCode_5Call {
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let Self { artifactPath: path, constructorArgs: args, salt } = self;
         deploy_code(ccx, executor, path, Some(args), None, Some((*salt).into()))
     }
 }
 
-impl Cheatcode for deployCode_6Call {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<'db, 'db2> Cheatcode<EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>> for deployCode_6Call {
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let Self { artifactPath: path, value, salt } = self;
         deploy_code(ccx, executor, path, None, Some(*value), Some((*salt).into()))
     }
 }
 
-impl Cheatcode for deployCode_7Call {
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+impl<'db, 'db2> Cheatcode<EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>> for deployCode_7Call {
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let Self { artifactPath: path, constructorArgs: args, value, salt } = self;
         deploy_code(ccx, executor, path, Some(args), Some(*value), Some((*salt).into()))
     }
@@ -354,7 +389,7 @@ impl Cheatcode for deployCode_7Call {
 /// Helper function to deploy contract from artifact code.
 /// Uses CREATE2 scheme if salt specified.
 fn deploy_code(
-    ccx: &mut CheatsCtxt,
+    ccx: &mut EthCheatsCtxt,
     executor: &mut dyn CheatcodesExecutor,
     path: &str,
     constructor_args: Option<&Bytes>,
@@ -376,10 +411,8 @@ fn deploy_code(
         if let Some(salt) = salt { CreateScheme::Create2 { salt } } else { CreateScheme::Create };
 
     // If prank active at current depth, then use it as caller for create input.
-    let caller = ccx
-        .state
-        .get_prank(ccx.ecx.journaled_state.depth())
-        .map_or(ccx.caller, |prank| prank.new_caller);
+    let caller =
+        ccx.state.get_prank(ccx.ecx.journal().depth()).map_or(ccx.caller, |prank| prank.new_caller);
 
     let outcome = executor.exec_create(
         CreateInputs::new(
@@ -552,7 +585,7 @@ fn get_artifact_code(state: &Cheatcodes, path: &str, deployed: bool) -> Result<B
     maybe_bytecode.ok_or_else(|| fmt_err!("no bytecode for contract; is it abstract or unlinked?"))
 }
 
-impl Cheatcode for ffiCall {
+impl<CTX> Cheatcode<CTX> for ffiCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { commandInput: input } = self;
 
@@ -580,42 +613,42 @@ impl Cheatcode for ffiCall {
     }
 }
 
-impl Cheatcode for tryFfiCall {
+impl<CTX> Cheatcode<CTX> for tryFfiCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { commandInput: input } = self;
         ffi(state, input).map(|res| res.abi_encode())
     }
 }
 
-impl Cheatcode for promptCall {
+impl<CTX> Cheatcode<CTX> for promptCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { promptText: text } = self;
         prompt(state, text, prompt_input).map(|res| res.abi_encode())
     }
 }
 
-impl Cheatcode for promptSecretCall {
+impl<CTX> Cheatcode<CTX> for promptSecretCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { promptText: text } = self;
         prompt(state, text, prompt_password).map(|res| res.abi_encode())
     }
 }
 
-impl Cheatcode for promptSecretUintCall {
+impl<CTX> Cheatcode<CTX> for promptSecretUintCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { promptText: text } = self;
         parse(&prompt(state, text, prompt_password)?, &DynSolType::Uint(256))
     }
 }
 
-impl Cheatcode for promptAddressCall {
+impl<CTX> Cheatcode<CTX> for promptAddressCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { promptText: text } = self;
         parse(&prompt(state, text, prompt_input)?, &DynSolType::Address)
     }
 }
 
-impl Cheatcode for promptUintCall {
+impl<CTX> Cheatcode<CTX> for promptUintCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { promptText: text } = self;
         parse(&prompt(state, text, prompt_input)?, &DynSolType::Uint(256))
@@ -729,7 +762,7 @@ fn prompt(
     }
 }
 
-impl Cheatcode for getBroadcastCall {
+impl<CTX> Cheatcode<CTX> for getBroadcastCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { contractName, chainId, txType } = self;
 
@@ -744,7 +777,7 @@ impl Cheatcode for getBroadcastCall {
     }
 }
 
-impl Cheatcode for getBroadcasts_0Call {
+impl<CTX> Cheatcode<CTX> for getBroadcasts_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { contractName, chainId, txType } = self;
 
@@ -765,7 +798,7 @@ impl Cheatcode for getBroadcasts_0Call {
     }
 }
 
-impl Cheatcode for getBroadcasts_1Call {
+impl<CTX> Cheatcode<CTX> for getBroadcasts_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { contractName, chainId } = self;
 
@@ -785,10 +818,10 @@ impl Cheatcode for getBroadcasts_1Call {
     }
 }
 
-impl Cheatcode for getDeployment_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt> Cheatcode<CTX> for getDeployment_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { contractName } = self;
-        let chain_id = ccx.ecx.cfg.chain_id;
+        let chain_id = ccx.ecx.cfg().chain_id;
 
         let latest_broadcast = latest_broadcast(
             contractName,
@@ -801,7 +834,7 @@ impl Cheatcode for getDeployment_0Call {
     }
 }
 
-impl Cheatcode for getDeployment_1Call {
+impl<CTX> Cheatcode<CTX> for getDeployment_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { contractName, chainId } = self;
 
@@ -816,7 +849,7 @@ impl Cheatcode for getDeployment_1Call {
     }
 }
 
-impl Cheatcode for getDeploymentsCall {
+impl<CTX> Cheatcode<CTX> for getDeploymentsCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { contractName, chainId } = self;
 
@@ -897,7 +930,7 @@ fn latest_broadcast(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::CheatsConfig;
+    use crate::{AnyCtx, CheatsConfig};
     use std::sync::Arc;
 
     fn cheats() -> Cheatcodes {
@@ -937,7 +970,7 @@ mod tests {
         #[cfg(windows)]
         let args = vec!["cmd".to_string(), "/c".to_string(), "exit 1".to_string()];
 
-        let result = ffiCall { commandInput: args }.apply(&mut cheats);
+        let result = Cheatcode::<AnyCtx>::apply(&ffiCall { commandInput: args }, &mut cheats);
 
         // Assert that the cheatcode returned an error.
         assert!(result.is_err(), "Expected ffi cheatcode to fail, but it succeeded");

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1,7 +1,7 @@
 //! Cheatcode EVM inspector.
 
 use crate::{
-    CheatsConfig, CheatsCtxt, DynCheatcode, Error, Result,
+    Cheatcode, CheatsConfig, Error, EthCheatsCtxt, Result,
     Vm::{self, AccountAccess},
     evm::{
         DealRecord, GasRecord, RecordAccess, journaled_account,
@@ -37,10 +37,11 @@ use foundry_common::{
     mapping_slots::{MappingSlots, step as mapping_step},
 };
 use foundry_evm_core::{
-    Breakpoints, ContextExt, InspectorExt,
+    Breakpoints, InspectorExt,
     abi::Vm::stopExpectSafeMemoryCall,
     backend::{DatabaseError, DatabaseExt, RevertDiagnostic},
     constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME},
+    env::FoundryContextExt,
     evm::{FoundryEvm, new_evm_with_existing_context},
 };
 use foundry_evm_traces::{
@@ -54,8 +55,9 @@ use revm::{
     Inspector, Journal,
     bytecode::opcode as op,
     context::{BlockEnv, JournalTr, LocalContext, TransactionType, result::EVMError},
-    context_interface::{CreateScheme, transaction::SignedAuthorization},
+    context_interface::{ContextTr, CreateScheme, transaction::SignedAuthorization},
     handler::FrameResult,
+    inspector::JournalExt,
     interpreter::{
         CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, FrameInput, Gas, Host,
         InstructionResult, Interpreter, InterpreterAction, InterpreterResult,
@@ -79,6 +81,8 @@ mod utils;
 pub mod analysis;
 pub use analysis::CheatcodeAnalysis;
 
+/// Concrete EVM context type alias, used by [`with_evm`] and other entry points
+/// that remain concrete until context-cloning is upstreamed.
 pub type Ecx<'a, 'b, 'c> = &'a mut EthEvmContext<&'b mut (dyn DatabaseExt + 'c)>;
 
 /// Helper trait for obtaining complete [revm::Inspector] instance from mutable reference to
@@ -95,7 +99,7 @@ pub trait CheatcodesExecutor {
     fn exec_create(
         &mut self,
         inputs: CreateInputs,
-        ccx: &mut CheatsCtxt,
+        ccx: &mut EthCheatsCtxt,
     ) -> Result<CreateOutcome, EVMError<DatabaseError>> {
         with_evm(self, ccx, |evm| {
             evm.journaled_state.depth += 1;
@@ -113,8 +117,8 @@ pub trait CheatcodesExecutor {
         })
     }
 
-    fn console_log(&mut self, ccx: &mut CheatsCtxt, msg: &str) {
-        self.get_inspector(ccx.state).console_log(msg);
+    fn console_log(&mut self, cheats: &mut Cheatcodes, msg: &str) {
+        self.get_inspector(cheats).console_log(msg);
     }
 
     /// Returns a mutable reference to the tracing inspector if it is available.
@@ -131,7 +135,7 @@ pub trait CheatcodesExecutor {
 /// Constructs [FoundryEvm] and runs a given closure with it.
 fn with_evm<E, F, O>(
     executor: &mut E,
-    ccx: &mut CheatsCtxt,
+    ccx: &mut EthCheatsCtxt,
     f: F,
 ) -> Result<O, EVMError<DatabaseError>>
 where
@@ -319,12 +323,17 @@ impl ArbitraryStorage {
     /// Saves arbitrary storage value for a given address:
     /// - store value in changed values cache.
     /// - update account's storage with given value.
-    pub fn save(&mut self, ecx: Ecx, address: Address, slot: U256, data: U256) {
+    pub fn save<CTX: ContextTr<Db: DatabaseExt>>(
+        &mut self,
+        ecx: &mut CTX,
+        address: Address,
+        slot: U256,
+        data: U256,
+    ) {
         self.values.get_mut(&address).expect("missing arbitrary address entry").insert(slot, data);
-        let (db, journal, _) = ecx.as_db_env_and_journal();
-        if journal.load_account(db, address).is_ok() {
-            journal
-                .sstore(db, address, slot, data, false)
+        if ecx.journal_mut().load_account(address).is_ok() {
+            ecx.journal_mut()
+                .sstore(address, slot, data)
                 .expect("could not set arbitrary storage value");
         }
     }
@@ -334,7 +343,13 @@ impl ArbitraryStorage {
     ///   existing value.
     /// - if no value was yet generated for given slot, then save new value in cache and update both
     ///   source and target storages.
-    pub fn copy(&mut self, ecx: Ecx, target: Address, slot: U256, new_value: U256) -> U256 {
+    pub fn copy<CTX: ContextTr<Db: DatabaseExt>>(
+        &mut self,
+        ecx: &mut CTX,
+        target: Address,
+        slot: U256,
+        new_value: U256,
+    ) -> U256 {
         let source = self.copies.get(&target).expect("missing arbitrary copy target entry");
         let storage_cache = self.values.get_mut(source).expect("missing arbitrary source storage");
         let value = match storage_cache.get(&slot) {
@@ -342,19 +357,17 @@ impl ArbitraryStorage {
             None => {
                 storage_cache.insert(slot, new_value);
                 // Update source storage with new value.
-                let (db, journal, _) = ecx.as_db_env_and_journal();
-                if journal.load_account(db, *source).is_ok() {
-                    journal
-                        .sstore(db, *source, slot, new_value, false)
+                if ecx.journal_mut().load_account(*source).is_ok() {
+                    ecx.journal_mut()
+                        .sstore(*source, slot, new_value)
                         .expect("could not copy arbitrary storage value");
                 }
                 new_value
             }
         };
         // Update target storage with new value.
-        let (db, journal, _) = ecx.as_db_env_and_journal();
-        if journal.load_account(db, target).is_ok() {
-            journal.sstore(db, target, slot, value, false).expect("could not set storage");
+        if ecx.journal_mut().load_account(target).is_ok() {
+            ecx.journal_mut().sstore(target, slot, value).expect("could not set storage");
         }
         value
     }
@@ -638,11 +651,11 @@ impl Cheatcodes {
 
         // ensure the caller is allowed to execute cheatcodes,
         // but only if the backend is in forking mode
-        ecx.journaled_state.database.ensure_cheatcode_access_forking_mode(&caller)?;
+        ecx.db().ensure_cheatcode_access_forking_mode(&caller)?;
 
         apply_dispatch(
             &decoded,
-            &mut CheatsCtxt { state: self, ecx, gas_limit: call.gas_limit, caller },
+            &mut EthCheatsCtxt { state: self, ecx, gas_limit: call.gas_limit, caller },
             executor,
         )
     }
@@ -652,11 +665,14 @@ impl Cheatcodes {
     ///
     /// There may be cheatcodes in the constructor of the new contract, in order to allow them
     /// automatically we need to determine the new address.
-    fn allow_cheatcodes_on_create(&self, ecx: Ecx, caller: Address, created_address: Address) {
-        if ecx.journaled_state.depth <= 1
-            || ecx.journaled_state.database.has_cheatcode_access(&caller)
-        {
-            ecx.journaled_state.database.allow_cheatcode_access(created_address);
+    fn allow_cheatcodes_on_create<CTX: ContextTr<Db: DatabaseExt>>(
+        &self,
+        ecx: &mut CTX,
+        caller: Address,
+        created_address: Address,
+    ) {
+        if ecx.journal().depth() <= 1 || ecx.db().has_cheatcode_access(&caller) {
+            ecx.db_mut().allow_cheatcode_access(created_address);
         }
     }
 
@@ -665,12 +681,12 @@ impl Cheatcodes {
     /// If the transaction type is [TransactionType::Legacy] we need to upgrade it to
     /// [TransactionType::Eip2930] in order to use access lists. Other transaction types support
     /// access lists themselves.
-    fn apply_accesslist(&mut self, ecx: Ecx) {
+    fn apply_accesslist<CTX: FoundryContextExt>(&mut self, ecx: &mut CTX) {
         if let Some(access_list) = &self.access_list {
-            ecx.tx.access_list = access_list.clone();
+            ecx.tx_mut().access_list = access_list.clone();
 
-            if ecx.tx.tx_type == TransactionType::Legacy as u8 {
-                ecx.tx.tx_type = TransactionType::Eip2930 as u8;
+            if ecx.tx().tx_type == TransactionType::Legacy as u8 {
+                ecx.tx_mut().tx_type = TransactionType::Eip2930 as u8;
             }
         }
     }
@@ -679,7 +695,7 @@ impl Cheatcodes {
     ///
     /// Cleanup any previously applied cheatcodes that altered the state in such a way that revm's
     /// revert would run into issues.
-    pub fn on_revert(&mut self, ecx: Ecx) {
+    pub fn on_revert<CTX: ContextTr<Journal: JournalExt>>(&mut self, ecx: &mut CTX) {
         trace!(deals=?self.eth_deals.len(), "rolling back deals");
 
         // Delay revert clean up until expected revert is handled, if set.
@@ -688,7 +704,7 @@ impl Cheatcodes {
         }
 
         // we only want to apply cleanup top level
-        if ecx.journaled_state.depth() > 0 {
+        if ecx.journal().depth() > 0 {
             return;
         }
 
@@ -696,7 +712,7 @@ impl Cheatcodes {
         // This will prevent overflow issues in revm's [`JournaledState::journal_revert`] routine
         // which rolls back any transfers.
         while let Some(record) = self.eth_deals.pop() {
-            if let Some(acc) = ecx.journaled_state.state.get_mut(&record.address) {
+            if let Some(acc) = ecx.journal_mut().evm_state_mut().get_mut(&record.address) {
                 acc.info.balance = record.old_balance;
             }
         }
@@ -710,17 +726,17 @@ impl Cheatcodes {
     ) -> Option<CallOutcome> {
         // Apply custom execution evm version.
         if let Some(spec_id) = self.execution_evm_version {
-            ecx.cfg.spec = spec_id;
+            ecx.cfg_mut().spec = spec_id;
         }
 
         let gas = Gas::new(call.gas_limit);
-        let curr_depth = ecx.journaled_state.depth();
+        let curr_depth = ecx.journal().depth();
 
         // At the root call to test function or script `run()`/`setUp()` functions, we are
         // decreasing sender nonce to ensure that it matches on-chain nonce once we start
         // broadcasting.
         if curr_depth == 0 {
-            let sender = ecx.tx.caller;
+            let sender = ecx.tx().caller;
             let account = match super::evm::journaled_account(ecx, sender) {
                 Ok(account) => account,
                 Err(err) => {
@@ -849,7 +865,7 @@ impl Cheatcodes {
                 call.target_address = prank.new_caller;
                 call.caller = prank.new_caller;
                 if let Some(new_origin) = prank.new_origin {
-                    ecx.tx.caller = new_origin;
+                    ecx.tx_mut().caller = new_origin;
                 }
             }
 
@@ -866,7 +882,7 @@ impl Cheatcodes {
 
                 // At the target depth, or deeper, we set `tx.origin`
                 if let Some(new_origin) = prank.new_origin {
-                    ecx.tx.caller = new_origin;
+                    ecx.tx_mut().caller = new_origin;
                     prank_applied = true;
                 }
 
@@ -895,7 +911,7 @@ impl Cheatcodes {
                 // At the target depth we set `msg.sender` & tx.origin.
                 // We are simulating the caller as being an EOA, so *both* must be set to the
                 // broadcast.origin.
-                ecx.tx.caller = broadcast.new_origin;
+                ecx.tx_mut().caller = broadcast.new_origin;
 
                 call.caller = broadcast.new_origin;
                 // Add a `legacy` transaction to the VecDeque. We use a legacy transaction here
@@ -903,8 +919,7 @@ impl Cheatcodes {
                 // into 1559, in the cli package, relatively easily once we
                 // know the target chain supports EIP-1559.
                 if !call.is_static {
-                    let (db, journal, _) = ecx.as_db_env_and_journal();
-                    if let Err(err) = journal.load_account(db, broadcast.new_origin) {
+                    if let Err(err) = ecx.journal_mut().load_account(broadcast.new_origin) {
                         return Some(CallOutcome {
                             result: InterpreterResult {
                                 result: InstructionResult::Revert,
@@ -918,9 +933,11 @@ impl Cheatcodes {
                     }
 
                     let input = TransactionInput::new(call.input.bytes(ecx));
+                    let rpc = ecx.db().active_fork_url();
+                    let chain_id = ecx.cfg().chain_id;
 
                     let account =
-                        ecx.journaled_state.inner.state().get_mut(&broadcast.new_origin).unwrap();
+                        ecx.journal_mut().evm_state_mut().get_mut(&broadcast.new_origin).unwrap();
 
                     let mut tx_req = TransactionRequest {
                         from: Some(broadcast.new_origin),
@@ -928,7 +945,7 @@ impl Cheatcodes {
                         value: call.transfer_value(),
                         input,
                         nonce: Some(account.info.nonce),
-                        chain_id: Some(ecx.cfg.chain_id),
+                        chain_id: Some(chain_id),
                         gas: if is_fixed_gas_limit { Some(call.gas_limit) } else { None },
                         ..Default::default()
                     };
@@ -972,10 +989,8 @@ impl Cheatcodes {
                         tx_req.authorization_list = Some(active_delegations);
                     }
 
-                    self.broadcastable_transactions.push_back(BroadcastableTransaction {
-                        rpc: ecx.journaled_state.database.active_fork_url(),
-                        transaction: tx_req.into(),
-                    });
+                    self.broadcastable_transactions
+                        .push_back(BroadcastableTransaction { rpc, transaction: tx_req.into() });
                     debug!(target: "cheatcodes", tx=?self.broadcastable_transactions.back().unwrap(), "broadcastable call");
 
                     // Explicitly increment nonce if calls are not isolated.
@@ -1008,8 +1023,7 @@ impl Cheatcodes {
             let old_balance;
             let old_nonce;
 
-            let (db, journal, _) = ecx.as_db_env_and_journal();
-            if let Ok(acc) = journal.load_account(db, call.target_address) {
+            if let Ok(acc) = ecx.journal_mut().load_account(call.target_address) {
                 initialized = acc.info.exists();
                 old_balance = acc.info.balance;
                 old_nonce = acc.info.nonce;
@@ -1033,8 +1047,8 @@ impl Cheatcodes {
             // as "warm" if the call from which they were accessed is reverted
             recorded_account_diffs_stack.push(vec![AccountAccess {
                 chainInfo: crate::Vm::ChainInfo {
-                    forkId: ecx.journaled_state.db().active_fork_id().unwrap_or_default(),
-                    chainId: U256::from(ecx.cfg.chain_id),
+                    forkId: ecx.db().active_fork_id().unwrap_or_default(),
+                    chainId: U256::from(ecx.cfg().chain_id),
                 },
                 accessor: call.caller,
                 account: call.bytecode_address,
@@ -1135,10 +1149,10 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
         // When the first interpreter is initialized we've circumvented the balance and gas checks,
         // so we apply our actual block data with the correct fees and all.
         if let Some(block) = self.block.take() {
-            ecx.block = block;
+            *ecx.block_mut() = block;
         }
         if let Some(gas_price) = self.gas_price.take() {
-            ecx.tx.gas_price = gas_price;
+            ecx.tx_mut().gas_price = gas_price;
         }
 
         // Record gas for current frame.
@@ -1148,7 +1162,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
 
         // `expectRevert`: track the max call depth during `expectRevert`
         if let Some(expected) = &mut self.expected_revert {
-            expected.max_depth = max(ecx.journaled_state.depth(), expected.max_depth);
+            expected.max_depth = max(ecx.journal().depth(), expected.max_depth);
         }
     }
 
@@ -1183,7 +1197,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
         if !self.allowed_mem_writes.is_empty() {
             self.check_mem_opcodes(
                 interpreter,
-                ecx.journaled_state.depth().try_into().expect("journaled state depth exceeds u64"),
+                ecx.journal().depth().try_into().expect("journaled state depth exceeds u64"),
             );
         }
 
@@ -1249,11 +1263,11 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
         // This should be placed before the revert handling, because we might exit early there
         if !cheatcode_call {
             // Clean up pranks
-            let curr_depth = ecx.journaled_state.depth();
+            let curr_depth = ecx.journal().depth();
             if let Some(prank) = &self.get_prank(curr_depth)
                 && curr_depth == prank.depth
             {
-                ecx.tx.caller = prank.prank_origin;
+                ecx.tx_mut().caller = prank.prank_origin;
 
                 // Clean single-call prank once we have returned to the original depth
                 if prank.single_call {
@@ -1265,7 +1279,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
             if let Some(broadcast) = &self.broadcast
                 && curr_depth == broadcast.depth
             {
-                ecx.tx.caller = broadcast.original_origin;
+                ecx.tx_mut().caller = broadcast.original_origin;
 
                 // Clean single-call broadcast once we have returned to the original depth
                 if broadcast.single_call {
@@ -1283,7 +1297,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
             }
 
             // allow multiple cheatcode calls at the same depth
-            let curr_depth = ecx.journaled_state.depth();
+            let curr_depth = ecx.journal().depth();
             if curr_depth <= assume_no_revert.depth && !cheatcode_call {
                 // Discard run if we're at the same depth as cheatcode, call reverted, and no
                 // specific reason was supplied
@@ -1330,7 +1344,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
                 }
             }
 
-            let curr_depth = ecx.journaled_state.depth();
+            let curr_depth = ecx.journal().depth();
             if curr_depth <= expected_revert.depth {
                 let needs_processing = match expected_revert.kind {
                     ExpectedRevertKind::Default => !cheatcode_call,
@@ -1399,7 +1413,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
         // previous call depth's recorded accesses, if any
         if let Some(recorded_account_diffs_stack) = &mut self.recorded_account_diffs_stack {
             // The root call cannot be recorded.
-            if ecx.journaled_state.depth() > 0
+            if ecx.journal().depth() > 0
                 && let Some(mut last_recorded_depth) = recorded_account_diffs_stack.pop()
             {
                 // Update the reverted status of all deeper calls if this call reverted, in
@@ -1419,10 +1433,9 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
                     // changes. Depending on the depth the cheat was
                     // called at, there may not be any pending
                     // calls to update if execution has percolated up to a higher depth.
-                    let (db, journal, _) = ecx.as_db_env_and_journal();
-                    let curr_depth = journal.depth;
+                    let curr_depth = ecx.journal().depth();
                     if call_access.depth == curr_depth as u64
-                        && let Ok(acc) = journal.load_account(db, call.target_address)
+                        && let Ok(acc) = ecx.journal_mut().load_account(call.target_address)
                     {
                         debug_assert!(access_is_call(call_access.kind));
                         call_access.newBalance = acc.info.balance;
@@ -1456,7 +1469,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
             .expected_emits
             .iter()
             .any(|(expected, _)| {
-                let curr_depth = ecx.journaled_state.depth();
+                let curr_depth = ecx.journal().depth();
                 expected.depth == curr_depth
             }) &&
             // Ignore staticcalls
@@ -1533,21 +1546,20 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
 
         // try to diagnose reverts in multi-fork mode where a call is made to an address that does
         // not exist
-        if let TxKind::Call(test_contract) = ecx.tx.kind {
+        if let TxKind::Call(test_contract) = ecx.tx().kind {
             // if a call to a different contract than the original test contract returned with
             // `Stop` we check if the contract actually exists on the active fork
-            if ecx.journaled_state.db().is_forked_mode()
+            if ecx.db().is_forked_mode()
                 && outcome.result.result == InstructionResult::Stop
                 && call.target_address != test_contract
             {
-                let journaled_state = ecx.journaled_state.clone();
                 self.fork_revert_diagnostic =
-                    ecx.journaled_state.db().diagnose_revert(call.target_address, &journaled_state);
+                    ecx.db().diagnose_revert(call.target_address, ecx.journal().evm_state());
             }
         }
 
         // If the depth is 0, then this is the root call terminating
-        if ecx.journaled_state.depth() == 0 {
+        if ecx.journal().depth() == 0 {
             // If we already have a revert, we shouldn't run the below logic as it can obfuscate an
             // earlier error that happened first with unrelated information about
             // another error when using cheatcodes.
@@ -1647,7 +1659,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
     fn create(&mut self, ecx: Ecx, mut input: &mut CreateInputs) -> Option<CreateOutcome> {
         // Apply custom execution evm version.
         if let Some(spec_id) = self.execution_evm_version {
-            ecx.cfg.spec = spec_id;
+            ecx.cfg_mut().spec = spec_id;
         }
 
         let gas = Gas::new(input.gas_limit());
@@ -1666,7 +1678,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
             });
         }
 
-        let curr_depth = ecx.journaled_state.depth();
+        let curr_depth = ecx.journal().depth();
 
         // Apply our prank
         if let Some(prank) = &self.get_prank(curr_depth)
@@ -1685,7 +1697,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
 
             // At the target depth, or deeper, we set `tx.origin`
             if let Some(new_origin) = prank.new_origin {
-                ecx.tx.caller = new_origin;
+                ecx.tx_mut().caller = new_origin;
                 prank_applied = true;
             }
 
@@ -1703,8 +1715,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
             && curr_depth >= broadcast.depth
             && input.caller() == broadcast.original_caller
         {
-            let (db, journal, _) = ecx.as_db_env_and_journal();
-            if let Err(err) = journal.load_account(db, broadcast.new_origin) {
+            if let Err(err) = ecx.journal_mut().load_account(broadcast.new_origin) {
                 return Some(CreateOutcome {
                     result: InterpreterResult {
                         result: InstructionResult::Revert,
@@ -1715,7 +1726,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
                 });
             }
 
-            ecx.tx.caller = broadcast.new_origin;
+            ecx.tx_mut().caller = broadcast.new_origin;
 
             if curr_depth == broadcast.depth || broadcast.deploy_from_code {
                 // Reset deploy from code flag for upcoming calls;
@@ -1723,9 +1734,10 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
 
                 input.set_caller(broadcast.new_origin);
 
-                let account = &ecx.journaled_state.inner.state()[&broadcast.new_origin];
+                let rpc = ecx.db().active_fork_url();
+                let account = &ecx.journal().evm_state()[&broadcast.new_origin];
                 self.broadcastable_transactions.push_back(BroadcastableTransaction {
-                    rpc: ecx.journaled_state.database.active_fork_url(),
+                    rpc,
                     transaction: TransactionRequest {
                         from: Some(broadcast.new_origin),
                         to: None,
@@ -1748,8 +1760,8 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
         if let Some(recorded_account_diffs_stack) = &mut self.recorded_account_diffs_stack {
             recorded_account_diffs_stack.push(vec![AccountAccess {
                 chainInfo: crate::Vm::ChainInfo {
-                    forkId: ecx.journaled_state.db().active_fork_id().unwrap_or_default(),
-                    chainId: U256::from(ecx.cfg.chain_id),
+                    forkId: ecx.db().active_fork_id().unwrap_or_default(),
+                    chainId: U256::from(ecx.cfg().chain_id),
                 },
                 accessor: input.caller(),
                 account: address,
@@ -1773,13 +1785,13 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
 
     fn create_end(&mut self, ecx: Ecx, call: &CreateInputs, outcome: &mut CreateOutcome) {
         let call = Some(call);
-        let curr_depth = ecx.journaled_state.depth();
+        let curr_depth = ecx.journal().depth();
 
         // Clean up pranks
         if let Some(prank) = &self.get_prank(curr_depth)
             && curr_depth == prank.depth
         {
-            ecx.tx.caller = prank.prank_origin;
+            ecx.tx_mut().caller = prank.prank_origin;
 
             // Clean single-call prank once we have returned to the original depth
             if prank.single_call {
@@ -1791,7 +1803,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
         if let Some(broadcast) = &self.broadcast
             && curr_depth == broadcast.depth
         {
-            ecx.tx.caller = broadcast.original_origin;
+            ecx.tx_mut().caller = broadcast.original_origin;
 
             // Clean single-call broadcast once we have returned to the original depth
             if broadcast.single_call {
@@ -1855,15 +1867,14 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
                     // changes. Depending on what depth the cheat was called at, there
                     // may not be any pending calls to update if execution has
                     // percolated up to a higher depth.
-                    let depth = ecx.journaled_state.depth();
+                    let depth = ecx.journal().depth();
                     if create_access.depth == depth as u64 {
                         debug_assert_eq!(
                             create_access.kind as u8,
                             crate::Vm::AccountAccessKind::Create as u8
                         );
-                        let (db, journal, _) = ecx.as_db_env_and_journal();
                         if let Some(address) = outcome.address
-                            && let Ok(created_acc) = journal.load_account(db, address)
+                            && let Ok(created_acc) = ecx.journal_mut().load_account(address)
                         {
                             create_access.newBalance = created_acc.info.balance;
                             create_access.newNonce = created_acc.info.nonce;
@@ -1885,10 +1896,9 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
         }
 
         // Match the create against expected_creates
-        let (db, journal, _) = ecx.as_db_env_and_journal();
         if !self.expected_creates.is_empty()
             && let (Some(address), Some(call)) = (outcome.address, call)
-            && let Ok(created_acc) = journal.load_account(db, address)
+            && let Ok(created_acc) = ecx.journal_mut().load_account(address)
         {
             let bytecode = created_acc.info.code.clone().unwrap_or_default().original_bytes();
             if let Some((index, _)) =
@@ -1907,7 +1917,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
 impl InspectorExt for Cheatcodes {
     fn should_use_create2_factory(&mut self, ecx: Ecx, inputs: &CreateInputs) -> bool {
         if let CreateScheme::Create2 { .. } = inputs.scheme() {
-            let depth = ecx.journaled_state.depth();
+            let depth = ecx.journal().depth();
             let target_depth = if let Some(prank) = &self.get_prank(depth) {
                 prank.depth
             } else if let Some(broadcast) = &self.broadcast {
@@ -1948,7 +1958,7 @@ impl Cheatcodes {
     fn meter_gas_record(&mut self, interpreter: &mut Interpreter, ecx: Ecx) {
         if interpreter.bytecode.action.as_ref().and_then(|i| i.instruction_result()).is_none() {
             self.gas_metering.gas_records.iter_mut().for_each(|record| {
-                let curr_depth = ecx.journaled_state.depth();
+                let curr_depth = ecx.journal().depth();
                 if curr_depth == record.depth {
                     // Skip the first opcode of the first call frame as it includes the gas cost of
                     // creating the snapshot.
@@ -2071,9 +2081,9 @@ impl Cheatcodes {
                 // get previous balance, nonce and initialized status of the target account
                 let target = try_or_return!(interpreter.stack.peek(0));
                 let target = Address::from_word(B256::from(target));
-                let (db, journal, _) = ecx.as_db_env_and_journal();
-                let (initialized, old_balance, old_nonce) = journal
-                    .load_account(db, target)
+                let (initialized, old_balance, old_nonce) = ecx
+                    .journal_mut()
+                    .load_account(target)
                     .map(|account| {
                         (account.info.exists(), account.info.balance, account.info.nonce)
                     })
@@ -2088,8 +2098,8 @@ impl Cheatcodes {
                 // register access for the target account
                 last.push(crate::Vm::AccountAccess {
                     chainInfo: crate::Vm::ChainInfo {
-                        forkId: ecx.journaled_state.database.active_fork_id().unwrap_or_default(),
-                        chainId: U256::from(ecx.cfg.chain_id),
+                        forkId: ecx.db().active_fork_id().unwrap_or_default(),
+                        chainId: U256::from(ecx.cfg().chain_id),
                     },
                     accessor: interpreter.input.target_address,
                     account: target,
@@ -2122,8 +2132,7 @@ impl Cheatcodes {
                 // it's not set (zero value)
                 let mut present_value = U256::ZERO;
                 // Try to load the account and the slot's present value
-                let (db, journal, _) = ecx.as_db_env_and_journal();
-                if journal.load_account(db, address).is_ok()
+                if ecx.journal_mut().load_account(address).is_ok()
                     && let Some(previous) = ecx.sload(address, key)
                 {
                     present_value = previous.data;
@@ -2136,11 +2145,8 @@ impl Cheatcodes {
                     newValue: present_value.into(),
                     reverted: false,
                 };
-                let curr_depth = ecx
-                    .journaled_state
-                    .depth()
-                    .try_into()
-                    .expect("journaled state depth exceeds u64");
+                let curr_depth =
+                    ecx.journal().depth().try_into().expect("journaled state depth exceeds u64");
                 append_storage_access(last, access, curr_depth);
             }
             op::SSTORE => {
@@ -2152,8 +2158,7 @@ impl Cheatcodes {
                 // Try to load the account and the slot's previous value, otherwise, assume it's
                 // not set (zero value)
                 let mut previous_value = U256::ZERO;
-                let (db, journal, _) = ecx.as_db_env_and_journal();
-                if journal.load_account(db, address).is_ok()
+                if ecx.journal_mut().load_account(address).is_ok()
                     && let Some(previous) = ecx.sload(address, key)
                 {
                     previous_value = previous.data;
@@ -2167,11 +2172,8 @@ impl Cheatcodes {
                     newValue: value.into(),
                     reverted: false,
                 };
-                let curr_depth = ecx
-                    .journaled_state
-                    .depth()
-                    .try_into()
-                    .expect("journaled state depth exceeds u64");
+                let curr_depth =
+                    ecx.journal().depth().try_into().expect("journaled state depth exceeds u64");
                 append_storage_access(last, access, curr_depth);
             }
 
@@ -2189,8 +2191,7 @@ impl Cheatcodes {
                 let initialized;
                 let balance;
                 let nonce;
-                let (db, journal, _) = ecx.as_db_env_and_journal();
-                if let Ok(acc) = journal.load_account(db, address) {
+                if let Ok(acc) = ecx.journal_mut().load_account(address) {
                     initialized = acc.info.exists();
                     balance = acc.info.balance;
                     nonce = acc.info.nonce;
@@ -2206,8 +2207,8 @@ impl Cheatcodes {
                     .expect("journaled state depth exceeds u64");
                 let account_access = crate::Vm::AccountAccess {
                     chainInfo: crate::Vm::ChainInfo {
-                        forkId: ecx.journaled_state.database.active_fork_id().unwrap_or_default(),
-                        chainId: U256::from(ecx.cfg.chain_id),
+                        forkId: ecx.db().active_fork_id().unwrap_or_default(),
+                        chainId: U256::from(ecx.cfg().chain_id),
                     },
                     accessor: interpreter.input.target_address,
                     account: address,
@@ -2519,29 +2520,61 @@ fn append_storage_access(
     }
 }
 
+/// Returns the [`spec::Cheatcode`] definition for a given [`spec::CheatcodeDef`] implementor.
+fn cheatcode_of<T: spec::CheatcodeDef>(_: &T) -> &'static spec::Cheatcode<'static> {
+    T::CHEATCODE
+}
+
+fn cheatcode_name(cheat: &spec::Cheatcode<'static>) -> &'static str {
+    cheat.func.signature.split('(').next().unwrap()
+}
+
+fn cheatcode_id(cheat: &spec::Cheatcode<'static>) -> &'static str {
+    cheat.func.id
+}
+
+fn cheatcode_signature(cheat: &spec::Cheatcode<'static>) -> &'static str {
+    cheat.func.signature
+}
+
 /// Dispatches the cheatcode call to the appropriate function.
 fn apply_dispatch(
     calls: &Vm::VmCalls,
-    ccx: &mut CheatsCtxt,
+    ccx: &mut EthCheatsCtxt,
     executor: &mut dyn CheatcodesExecutor,
 ) -> Result {
-    let cheat = calls_as_dyn_cheatcode(calls);
+    // Extract metadata for logging/deprecation via CheatcodeDef.
+    macro_rules! get_cheatcode {
+        ($($variant:ident),*) => {
+            match calls {
+                $(Vm::VmCalls::$variant(cheat) => cheatcode_of(cheat),)*
+            }
+        };
+    }
+    let cheat = vm_calls!(get_cheatcode);
 
-    let _guard = debug_span!(target: "cheatcodes", "apply", id = %cheat.id()).entered();
-    trace!(target: "cheatcodes", ?cheat, "applying");
+    let _guard = debug_span!(target: "cheatcodes", "apply", id = %cheatcode_id(cheat)).entered();
+    trace!(target: "cheatcodes", cheat = %cheatcode_signature(cheat), "applying");
 
-    if let spec::Status::Deprecated(replacement) = *cheat.status() {
-        ccx.state.deprecated.insert(cheat.signature(), replacement);
+    if let spec::Status::Deprecated(replacement) = cheat.status {
+        ccx.state.deprecated.insert(cheatcode_signature(cheat), replacement);
     }
 
-    // Apply the cheatcode.
-    let mut result = cheat.dyn_apply(ccx, executor);
+    // Monomorphized dispatch: calls apply_full directly, no trait objects.
+    macro_rules! dispatch {
+        ($($variant:ident),*) => {
+            match calls {
+                $(Vm::VmCalls::$variant(cheat) => Cheatcode::apply_full(cheat, ccx, executor),)*
+            }
+        };
+    }
+    let mut result = vm_calls!(dispatch);
 
     // Format the error message to include the cheatcode name.
     if let Err(e) = &mut result
         && e.is_str()
     {
-        let name = cheat.name();
+        let name = cheatcode_name(cheat);
         // Skip showing the cheatcode name for:
         // - assertions: too verbose, and can already be inferred from the error message
         // - `rpcUrl`: forge-std relies on it in `getChainWithUpdatedRpcUrl`
@@ -2559,17 +2592,6 @@ fn apply_dispatch(
     );
 
     result
-}
-
-fn calls_as_dyn_cheatcode(calls: &Vm::VmCalls) -> &dyn DynCheatcode {
-    macro_rules! as_dyn {
-        ($($variant:ident),*) => {
-            match calls {
-                $(Vm::VmCalls::$variant(cheat) => cheat,)*
-            }
-        };
-    }
-    vm_calls!(as_dyn)
 }
 
 /// Helper function to check if frame execution will exit.

--- a/crates/cheatcodes/src/inspector/utils.rs
+++ b/crates/cheatcodes/src/inspector/utils.rs
@@ -1,7 +1,11 @@
 use super::Ecx;
 use crate::inspector::Cheatcodes;
 use alloy_primitives::{Address, Bytes, U256};
-use revm::interpreter::{CreateInputs, CreateScheme};
+use revm::{
+    context_interface::ContextTr,
+    inspector::JournalExt,
+    interpreter::{CreateInputs, CreateScheme},
+};
 
 /// Common behaviour of legacy and EOF create inputs.
 pub(crate) trait CommonCreateInput {
@@ -45,7 +49,7 @@ impl CommonCreateInput for &mut CreateInputs {
     fn allow_cheatcodes(&self, cheatcodes: &mut Cheatcodes, ecx: Ecx) -> Address {
         let caller = CreateInputs::caller(self);
         let old_nonce =
-            ecx.journaled_state.state.get(&caller).map(|acc| acc.info.nonce).unwrap_or_default();
+            ecx.journal().evm_state().get(&caller).map(|acc| acc.info.nonce).unwrap_or_default();
         let created_address = self.created_address(old_nonce);
         cheatcodes.allow_cheatcodes_on_create(ecx, caller, created_address);
         created_address

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -12,133 +12,133 @@ use std::{
     collections::{BTreeMap, BTreeSet},
 };
 
-impl Cheatcode for keyExistsCall {
+impl<CTX> Cheatcode<CTX> for keyExistsCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         check_json_key_exists(json, key)
     }
 }
 
-impl Cheatcode for keyExistsJsonCall {
+impl<CTX> Cheatcode<CTX> for keyExistsJsonCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         check_json_key_exists(json, key)
     }
 }
 
-impl Cheatcode for parseJson_0Call {
+impl<CTX> Cheatcode<CTX> for parseJson_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json } = self;
         parse_json(json, "$", state.struct_defs())
     }
 }
 
-impl Cheatcode for parseJson_1Call {
+impl<CTX> Cheatcode<CTX> for parseJson_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json(json, key, state.struct_defs())
     }
 }
 
-impl Cheatcode for parseJsonUintCall {
+impl<CTX> Cheatcode<CTX> for parseJsonUintCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Uint(256))
     }
 }
 
-impl Cheatcode for parseJsonUintArrayCall {
+impl<CTX> Cheatcode<CTX> for parseJsonUintArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Uint(256))))
     }
 }
 
-impl Cheatcode for parseJsonIntCall {
+impl<CTX> Cheatcode<CTX> for parseJsonIntCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Int(256))
     }
 }
 
-impl Cheatcode for parseJsonIntArrayCall {
+impl<CTX> Cheatcode<CTX> for parseJsonIntArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Int(256))))
     }
 }
 
-impl Cheatcode for parseJsonBoolCall {
+impl<CTX> Cheatcode<CTX> for parseJsonBoolCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Bool)
     }
 }
 
-impl Cheatcode for parseJsonBoolArrayCall {
+impl<CTX> Cheatcode<CTX> for parseJsonBoolArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Bool)))
     }
 }
 
-impl Cheatcode for parseJsonAddressCall {
+impl<CTX> Cheatcode<CTX> for parseJsonAddressCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Address)
     }
 }
 
-impl Cheatcode for parseJsonAddressArrayCall {
+impl<CTX> Cheatcode<CTX> for parseJsonAddressArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Address)))
     }
 }
 
-impl Cheatcode for parseJsonStringCall {
+impl<CTX> Cheatcode<CTX> for parseJsonStringCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::String)
     }
 }
 
-impl Cheatcode for parseJsonStringArrayCall {
+impl<CTX> Cheatcode<CTX> for parseJsonStringArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::String)))
     }
 }
 
-impl Cheatcode for parseJsonBytesCall {
+impl<CTX> Cheatcode<CTX> for parseJsonBytesCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Bytes)
     }
 }
 
-impl Cheatcode for parseJsonBytesArrayCall {
+impl<CTX> Cheatcode<CTX> for parseJsonBytesArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Bytes)))
     }
 }
 
-impl Cheatcode for parseJsonBytes32Call {
+impl<CTX> Cheatcode<CTX> for parseJsonBytes32Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::FixedBytes(32))
     }
 }
 
-impl Cheatcode for parseJsonBytes32ArrayCall {
+impl<CTX> Cheatcode<CTX> for parseJsonBytes32ArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::FixedBytes(32))))
     }
 }
 
-impl Cheatcode for parseJsonType_0Call {
+impl<CTX> Cheatcode<CTX> for parseJsonType_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json, typeDescription } = self;
         parse_json_coerce(json, "$", &resolve_type(typeDescription, state.struct_defs())?)
@@ -146,7 +146,7 @@ impl Cheatcode for parseJsonType_0Call {
     }
 }
 
-impl Cheatcode for parseJsonType_1Call {
+impl<CTX> Cheatcode<CTX> for parseJsonType_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json, key, typeDescription } = self;
         parse_json_coerce(json, key, &resolve_type(typeDescription, state.struct_defs())?)
@@ -154,7 +154,7 @@ impl Cheatcode for parseJsonType_1Call {
     }
 }
 
-impl Cheatcode for parseJsonTypeArrayCall {
+impl<CTX> Cheatcode<CTX> for parseJsonTypeArrayCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json, key, typeDescription } = self;
         let ty = resolve_type(typeDescription, state.struct_defs())?;
@@ -162,14 +162,14 @@ impl Cheatcode for parseJsonTypeArrayCall {
     }
 }
 
-impl Cheatcode for parseJsonKeysCall {
+impl<CTX> Cheatcode<CTX> for parseJsonKeysCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
         parse_json_keys(json, key)
     }
 }
 
-impl Cheatcode for serializeJsonCall {
+impl<CTX> Cheatcode<CTX> for serializeJsonCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, value } = self;
         *state.serialized_jsons.entry(objectKey.into()).or_default() = serde_json::from_str(value)?;
@@ -177,56 +177,56 @@ impl Cheatcode for serializeJsonCall {
     }
 }
 
-impl Cheatcode for serializeBool_0Call {
+impl<CTX> Cheatcode<CTX> for serializeBool_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, (*value).into())
     }
 }
 
-impl Cheatcode for serializeUint_0Call {
+impl<CTX> Cheatcode<CTX> for serializeUint_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, (*value).into())
     }
 }
 
-impl Cheatcode for serializeInt_0Call {
+impl<CTX> Cheatcode<CTX> for serializeInt_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, (*value).into())
     }
 }
 
-impl Cheatcode for serializeAddress_0Call {
+impl<CTX> Cheatcode<CTX> for serializeAddress_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, (*value).into())
     }
 }
 
-impl Cheatcode for serializeBytes32_0Call {
+impl<CTX> Cheatcode<CTX> for serializeBytes32_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, DynSolValue::FixedBytes(*value, 32))
     }
 }
 
-impl Cheatcode for serializeString_0Call {
+impl<CTX> Cheatcode<CTX> for serializeString_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, value.clone().into())
     }
 }
 
-impl Cheatcode for serializeBytes_0Call {
+impl<CTX> Cheatcode<CTX> for serializeBytes_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, value.to_vec().into())
     }
 }
 
-impl Cheatcode for serializeBool_1Call {
+impl<CTX> Cheatcode<CTX> for serializeBool_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
@@ -238,7 +238,7 @@ impl Cheatcode for serializeBool_1Call {
     }
 }
 
-impl Cheatcode for serializeUint_1Call {
+impl<CTX> Cheatcode<CTX> for serializeUint_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
@@ -250,7 +250,7 @@ impl Cheatcode for serializeUint_1Call {
     }
 }
 
-impl Cheatcode for serializeInt_1Call {
+impl<CTX> Cheatcode<CTX> for serializeInt_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
@@ -262,7 +262,7 @@ impl Cheatcode for serializeInt_1Call {
     }
 }
 
-impl Cheatcode for serializeAddress_1Call {
+impl<CTX> Cheatcode<CTX> for serializeAddress_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
@@ -274,7 +274,7 @@ impl Cheatcode for serializeAddress_1Call {
     }
 }
 
-impl Cheatcode for serializeBytes32_1Call {
+impl<CTX> Cheatcode<CTX> for serializeBytes32_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
@@ -286,7 +286,7 @@ impl Cheatcode for serializeBytes32_1Call {
     }
 }
 
-impl Cheatcode for serializeString_1Call {
+impl<CTX> Cheatcode<CTX> for serializeString_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
@@ -298,7 +298,7 @@ impl Cheatcode for serializeString_1Call {
     }
 }
 
-impl Cheatcode for serializeBytes_1Call {
+impl<CTX> Cheatcode<CTX> for serializeBytes_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
@@ -312,7 +312,7 @@ impl Cheatcode for serializeBytes_1Call {
     }
 }
 
-impl Cheatcode for serializeJsonType_0Call {
+impl<CTX> Cheatcode<CTX> for serializeJsonType_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { typeDescription, value } = self;
         let ty = resolve_type(typeDescription, state.struct_defs())?;
@@ -322,7 +322,7 @@ impl Cheatcode for serializeJsonType_0Call {
     }
 }
 
-impl Cheatcode for serializeJsonType_1Call {
+impl<CTX> Cheatcode<CTX> for serializeJsonType_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, typeDescription, value } = self;
         let ty = resolve_type(typeDescription, state.struct_defs())?;
@@ -331,7 +331,7 @@ impl Cheatcode for serializeJsonType_1Call {
     }
 }
 
-impl Cheatcode for serializeUintToHexCall {
+impl<CTX> Cheatcode<CTX> for serializeUintToHexCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, valueKey, value } = self;
         let hex = format!("0x{value:x}");
@@ -339,7 +339,7 @@ impl Cheatcode for serializeUintToHexCall {
     }
 }
 
-impl Cheatcode for writeJson_0Call {
+impl<CTX> Cheatcode<CTX> for writeJson_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json, path } = self;
         let json = serde_json::from_str(json).unwrap_or_else(|_| Value::String(json.to_owned()));
@@ -348,7 +348,7 @@ impl Cheatcode for writeJson_0Call {
     }
 }
 
-impl Cheatcode for writeJson_1Call {
+impl<CTX> Cheatcode<CTX> for writeJson_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json: value, path, valueKey } = self;
 

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -18,7 +18,7 @@ extern crate tracing;
 use alloy_evm::eth::EthEvmContext;
 use alloy_primitives::Address;
 use foundry_evm_core::backend::DatabaseExt;
-use spec::Status;
+use revm::context_interface::{ContextTr, JournalTr};
 
 pub use Vm::ForgeContext;
 pub use config::CheatsConfig;
@@ -64,7 +64,7 @@ mod toml;
 mod utils;
 
 /// Cheatcode implementation.
-pub(crate) trait Cheatcode: CheatcodeDef + DynCheatcode {
+pub(crate) trait Cheatcode<CTX>: CheatcodeDef {
     /// Applies this cheatcode to the given state.
     ///
     /// Implement this function if you don't need access to the EVM data.
@@ -77,7 +77,7 @@ pub(crate) trait Cheatcode: CheatcodeDef + DynCheatcode {
     ///
     /// Implement this function if you need access to the EVM data.
     #[inline(always)]
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         self.apply(ccx.state)
     }
 
@@ -85,60 +85,39 @@ pub(crate) trait Cheatcode: CheatcodeDef + DynCheatcode {
     ///
     /// Implement this function if you need access to the executor.
     #[inline(always)]
-    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+    fn apply_full(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX>,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
         let _ = executor;
         self.apply_stateful(ccx)
     }
 }
 
-pub(crate) trait DynCheatcode: 'static + std::fmt::Debug {
-    fn cheatcode(&self) -> &'static spec::Cheatcode<'static>;
-
-    fn dyn_apply(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result;
-}
-
-impl<T: Cheatcode> DynCheatcode for T {
-    fn cheatcode(&self) -> &'static spec::Cheatcode<'static> {
-        Self::CHEATCODE
-    }
-
-    fn dyn_apply(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
-        self.apply_full(ccx, executor)
-    }
-}
-
-impl dyn DynCheatcode {
-    pub(crate) fn name(&self) -> &'static str {
-        self.cheatcode().func.signature.split('(').next().unwrap()
-    }
-
-    pub(crate) fn id(&self) -> &'static str {
-        self.cheatcode().func.id
-    }
-
-    pub(crate) fn signature(&self) -> &'static str {
-        self.cheatcode().func.signature
-    }
-
-    pub(crate) fn status(&self) -> &Status<'static> {
-        &self.cheatcode().status
-    }
-}
-
-/// The cheatcode context, used in `Cheatcode`.
-pub struct CheatsCtxt<'cheats, 'evm, 'db, 'db2> {
+/// The cheatcode context.
+pub struct CheatsCtxt<'a, CTX> {
     /// The cheatcodes inspector state.
-    pub(crate) state: &'cheats mut Cheatcodes,
-    /// The EVM data.
-    pub(crate) ecx: &'evm mut EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>,
+    pub(crate) state: &'a mut Cheatcodes,
+    /// The EVM context.
+    pub(crate) ecx: &'a mut CTX,
     /// The original `msg.sender`.
     pub(crate) caller: Address,
     /// Gas limit of the current cheatcode call.
     pub(crate) gas_limit: u64,
 }
 
-impl<'db, 'db2> std::ops::Deref for CheatsCtxt<'_, '_, 'db, 'db2> {
-    type Target = EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>;
+/// Concrete [`CheatsCtxt`] for the Ethereum EVM context.
+pub type EthCheatsCtxt<'a, 'db, 'db2> =
+    CheatsCtxt<'a, EthEvmContext<&'db mut (dyn DatabaseExt + 'db2)>>;
+
+/// Placeholder context type for cheatcodes that don't need EVM context access
+/// (i.e., they only use `apply`, not `apply_stateful` or `apply_full`).
+#[cfg(test)]
+pub(crate) type AnyCtx = ();
+
+impl<CTX> std::ops::Deref for CheatsCtxt<'_, CTX> {
+    type Target = CTX;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
@@ -146,20 +125,20 @@ impl<'db, 'db2> std::ops::Deref for CheatsCtxt<'_, '_, 'db, 'db2> {
     }
 }
 
-impl std::ops::DerefMut for CheatsCtxt<'_, '_, '_, '_> {
+impl<CTX> std::ops::DerefMut for CheatsCtxt<'_, CTX> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut *self.ecx
+        self.ecx
     }
 }
 
-impl CheatsCtxt<'_, '_, '_, '_> {
+impl<CTX: ContextTr> CheatsCtxt<'_, CTX> {
     pub(crate) fn ensure_not_precompile(&self, address: &Address) -> Result<()> {
         if self.is_precompile(address) { Err(precompile_error(address)) } else { Ok(()) }
     }
 
     pub(crate) fn is_precompile(&self, address: &Address) -> bool {
-        self.ecx.journaled_state.warm_addresses.precompiles().contains(address)
+        self.ecx.journal().precompile_addresses().contains(address)
     }
 }
 

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -7,103 +7,127 @@ use alloy_rpc_types::Authorization;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolValue;
+use foundry_evm_core::{backend::DatabaseExt, env::FoundryContextExt};
 use foundry_wallets::{WalletSigner, wallet_multi::MultiWallet};
 use parking_lot::Mutex;
 use revm::{
     bytecode::Bytecode,
     context::JournalTr,
-    context_interface::transaction::SignedAuthorization,
+    context_interface::{ContextTr, transaction::SignedAuthorization},
+    inspector::JournalExt,
     primitives::{KECCAK_EMPTY, hardfork::SpecId},
 };
 use std::sync::Arc;
 
-impl Cheatcode for broadcast_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for broadcast_0Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         broadcast(ccx, None, true)
     }
 }
 
-impl Cheatcode for broadcast_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for broadcast_1Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { signer } = self;
         broadcast(ccx, Some(signer), true)
     }
 }
 
-impl Cheatcode for broadcast_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for broadcast_2Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { privateKey } = self;
         broadcast_key(ccx, privateKey, true)
     }
 }
 
-impl Cheatcode for attachDelegation_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for attachDelegation_0Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { signedDelegation } = self;
         attach_delegation(ccx, signedDelegation, false)
     }
 }
 
-impl Cheatcode for attachDelegation_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for attachDelegation_1Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { signedDelegation, crossChain } = self;
         attach_delegation(ccx, signedDelegation, *crossChain)
     }
 }
 
-impl Cheatcode for signDelegation_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for signDelegation_0Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { implementation, privateKey } = *self;
         sign_delegation(ccx, privateKey, implementation, None, false, false)
     }
 }
 
-impl Cheatcode for signDelegation_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for signDelegation_1Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { implementation, privateKey, nonce } = *self;
         sign_delegation(ccx, privateKey, implementation, Some(nonce), false, false)
     }
 }
 
-impl Cheatcode for signDelegation_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for signDelegation_2Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { implementation, privateKey, crossChain } = *self;
         sign_delegation(ccx, privateKey, implementation, None, crossChain, false)
     }
 }
 
-impl Cheatcode for signAndAttachDelegation_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for signAndAttachDelegation_0Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { implementation, privateKey } = *self;
         sign_delegation(ccx, privateKey, implementation, None, false, true)
     }
 }
 
-impl Cheatcode for signAndAttachDelegation_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for signAndAttachDelegation_1Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { implementation, privateKey, nonce } = *self;
         sign_delegation(ccx, privateKey, implementation, Some(nonce), false, true)
     }
 }
 
-impl Cheatcode for signAndAttachDelegation_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for signAndAttachDelegation_2Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { implementation, privateKey, crossChain } = *self;
         sign_delegation(ccx, privateKey, implementation, None, crossChain, true)
     }
 }
 
 /// Helper function to attach an EIP-7702 delegation.
-fn attach_delegation(
-    ccx: &mut CheatsCtxt,
+fn attach_delegation<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
     delegation: &SignedDelegation,
     cross_chain: bool,
 ) -> Result {
     let SignedDelegation { v, r, s, nonce, implementation } = delegation;
     // Set chain id to 0 if universal deployment is preferred.
     // See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md#protection-from-malleability-cross-chain
-    let chain_id = if cross_chain { U256::from(0) } else { U256::from(ccx.ecx.cfg.chain_id) };
+    let chain_id = if cross_chain { U256::from(0) } else { U256::from(ccx.ecx.cfg().chain_id) };
 
     let auth = Authorization { address: *implementation, nonce: *nonce, chain_id };
     let signed_auth = SignedAuthorization::new_unchecked(
@@ -119,8 +143,8 @@ fn attach_delegation(
 
 /// Helper function to sign and attach (if needed) an EIP-7702 delegation.
 /// Uses the provided nonce, otherwise retrieves and increments the nonce of the EOA.
-fn sign_delegation(
-    ccx: &mut CheatsCtxt,
+fn sign_delegation<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
     private_key: Uint<256, 4>,
     implementation: Address,
     nonce: Option<u64>,
@@ -131,16 +155,19 @@ fn sign_delegation(
     let nonce = if let Some(nonce) = nonce {
         nonce
     } else {
-        let authority_acc = ccx.ecx.journaled_state.load_account(signer.address())?;
+        let account_nonce = {
+            let authority_acc = ccx.ecx.journal_mut().load_account(signer.address())?;
+            authority_acc.info.nonce
+        };
         // Calculate next nonce considering existing active delegations
         next_delegation_nonce(
             &ccx.state.active_delegations,
             signer.address(),
             &ccx.state.broadcast,
-            authority_acc.data.info.nonce,
+            account_nonce,
         )
     };
-    let chain_id = if cross_chain { U256::from(0) } else { U256::from(ccx.ecx.cfg.chain_id) };
+    let chain_id = if cross_chain { U256::from(0) } else { U256::from(ccx.ecx.cfg().chain_id) };
 
     let auth = Authorization { address: implementation, nonce, chain_id };
     let sig = signer.sign_hash_sync(&auth.signature_hash())?;
@@ -189,15 +216,21 @@ fn next_delegation_nonce(
     }
 }
 
-fn write_delegation(ccx: &mut CheatsCtxt, auth: SignedAuthorization) -> Result<()> {
+fn write_delegation<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
+    auth: SignedAuthorization,
+) -> Result<()> {
     let authority = auth.recover_authority().map_err(|e| format!("{e}"))?;
-    let authority_acc = ccx.ecx.journaled_state.load_account(authority)?;
+    let account_nonce = {
+        let authority_acc = ccx.ecx.journal_mut().load_account(authority)?;
+        authority_acc.info.nonce
+    };
 
     let expected_nonce = next_delegation_nonce(
         &ccx.state.active_delegations,
         authority,
         &ccx.state.broadcast,
-        authority_acc.data.info.nonce,
+        account_nonce,
     );
 
     if expected_nonce != auth.nonce {
@@ -211,24 +244,26 @@ fn write_delegation(ccx: &mut CheatsCtxt, auth: SignedAuthorization) -> Result<(
     if auth.address.is_zero() {
         // Set empty code if the delegation address of authority is 0x.
         // See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md#behavior.
-        ccx.ecx.journaled_state.set_code_with_hash(authority, Bytecode::default(), KECCAK_EMPTY);
+        ccx.ecx.journal_mut().set_code_with_hash(authority, Bytecode::default(), KECCAK_EMPTY);
     } else {
         let bytecode = Bytecode::new_eip7702(*auth.address());
-        ccx.ecx.journaled_state.set_code(authority, bytecode);
+        ccx.ecx.journal_mut().set_code(authority, bytecode);
     }
     Ok(())
 }
 
-impl Cheatcode for attachBlobCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for attachBlobCall
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { blob } = self;
         ensure!(
-            ccx.ecx.cfg.spec >= SpecId::CANCUN,
+            ccx.ecx.cfg().spec >= SpecId::CANCUN,
             "`attachBlob` is not supported before the Cancun hard fork; \
              see EIP-4844: https://eips.ethereum.org/EIPS/eip-4844"
         );
         let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(blob);
-        let sidecar_variant = if ccx.ecx.cfg.spec < SpecId::OSAKA {
+        let sidecar_variant = if ccx.ecx.cfg().spec < SpecId::OSAKA {
             sidecar.build_4844().map_err(|e| format!("{e}"))?.into()
         } else {
             sidecar.build_7594().map_err(|e| format!("{e}"))?.into()
@@ -238,29 +273,35 @@ impl Cheatcode for attachBlobCall {
     }
 }
 
-impl Cheatcode for startBroadcast_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for startBroadcast_0Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         broadcast(ccx, None, false)
     }
 }
 
-impl Cheatcode for startBroadcast_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for startBroadcast_1Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { signer } = self;
         broadcast(ccx, Some(signer), false)
     }
 }
 
-impl Cheatcode for startBroadcast_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+    for startBroadcast_2Call
+{
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { privateKey } = self;
         broadcast_key(ccx, privateKey, false)
     }
 }
 
-impl Cheatcode for stopBroadcastCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for stopBroadcastCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         let Some(broadcast) = ccx.state.broadcast.take() else {
             bail!("no broadcast in progress to stop");
@@ -270,8 +311,8 @@ impl Cheatcode for stopBroadcastCall {
     }
 }
 
-impl Cheatcode for getWalletsCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for getWalletsCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let wallets = ccx.state.wallets().signers().unwrap_or_default();
         Ok(wallets.abi_encode())
     }
@@ -351,8 +392,12 @@ impl Wallets {
 }
 
 /// Sets up broadcasting from a script using `new_origin` as the sender.
-fn broadcast(ccx: &mut CheatsCtxt, new_origin: Option<&Address>, single_call: bool) -> Result {
-    let depth = ccx.ecx.journaled_state.depth();
+fn broadcast<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
+    new_origin: Option<&Address>,
+    single_call: bool,
+) -> Result {
+    let depth = ccx.ecx.journal().depth();
     ensure!(
         ccx.state.get_prank(depth).is_none(),
         "you have an active prank; broadcasting and pranks are not compatible"
@@ -373,14 +418,14 @@ fn broadcast(ccx: &mut CheatsCtxt, new_origin: Option<&Address>, single_call: bo
             }
         }
     }
-    let new_origin = new_origin.unwrap_or(ccx.ecx.tx.caller);
+    let new_origin = new_origin.unwrap_or(ccx.ecx.tx().caller);
     // Ensure new origin is loaded and touched.
     let _ = journaled_account(ccx.ecx, new_origin)?;
 
     let broadcast = Broadcast {
         new_origin,
         original_caller: ccx.caller,
-        original_origin: ccx.ecx.tx.caller,
+        original_origin: ccx.ecx.tx().caller,
         depth,
         single_call,
         deploy_from_code: false,
@@ -393,7 +438,11 @@ fn broadcast(ccx: &mut CheatsCtxt, new_origin: Option<&Address>, single_call: bo
 /// Sets up broadcasting from a script with the sender derived from `private_key`.
 /// Adds this private key to `state`'s `wallets` vector to later be used for signing
 /// if broadcast is successful.
-fn broadcast_key(ccx: &mut CheatsCtxt, private_key: &U256, single_call: bool) -> Result {
+fn broadcast_key<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
+    private_key: &U256,
+    single_call: bool,
+) -> Result {
     let wallet = super::crypto::parse_wallet(private_key)?;
     let new_origin = wallet.address();
 

--- a/crates/cheatcodes/src/string.rs
+++ b/crates/cheatcodes/src/string.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{U256, hex};
 use alloy_sol_types::SolValue;
 
 // address
-impl Cheatcode for toString_0Call {
+impl<CTX> Cheatcode<CTX> for toString_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
@@ -14,7 +14,7 @@ impl Cheatcode for toString_0Call {
 }
 
 // bytes
-impl Cheatcode for toString_1Call {
+impl<CTX> Cheatcode<CTX> for toString_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
@@ -22,7 +22,7 @@ impl Cheatcode for toString_1Call {
 }
 
 // bytes32
-impl Cheatcode for toString_2Call {
+impl<CTX> Cheatcode<CTX> for toString_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
@@ -30,7 +30,7 @@ impl Cheatcode for toString_2Call {
 }
 
 // bool
-impl Cheatcode for toString_3Call {
+impl<CTX> Cheatcode<CTX> for toString_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
@@ -38,7 +38,7 @@ impl Cheatcode for toString_3Call {
 }
 
 // uint256
-impl Cheatcode for toString_4Call {
+impl<CTX> Cheatcode<CTX> for toString_4Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
@@ -46,84 +46,84 @@ impl Cheatcode for toString_4Call {
 }
 
 // int256
-impl Cheatcode for toString_5Call {
+impl<CTX> Cheatcode<CTX> for toString_5Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
     }
 }
 
-impl Cheatcode for parseBytesCall {
+impl<CTX> Cheatcode<CTX> for parseBytesCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Bytes)
     }
 }
 
-impl Cheatcode for parseAddressCall {
+impl<CTX> Cheatcode<CTX> for parseAddressCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Address)
     }
 }
 
-impl Cheatcode for parseUintCall {
+impl<CTX> Cheatcode<CTX> for parseUintCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Uint(256))
     }
 }
 
-impl Cheatcode for parseIntCall {
+impl<CTX> Cheatcode<CTX> for parseIntCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Int(256))
     }
 }
 
-impl Cheatcode for parseBytes32Call {
+impl<CTX> Cheatcode<CTX> for parseBytes32Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::FixedBytes(32))
     }
 }
 
-impl Cheatcode for parseBoolCall {
+impl<CTX> Cheatcode<CTX> for parseBoolCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Bool)
     }
 }
 
-impl Cheatcode for toLowercaseCall {
+impl<CTX> Cheatcode<CTX> for toLowercaseCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { input } = self;
         Ok(input.to_lowercase().abi_encode())
     }
 }
 
-impl Cheatcode for toUppercaseCall {
+impl<CTX> Cheatcode<CTX> for toUppercaseCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { input } = self;
         Ok(input.to_uppercase().abi_encode())
     }
 }
 
-impl Cheatcode for trimCall {
+impl<CTX> Cheatcode<CTX> for trimCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { input } = self;
         Ok(input.trim().abi_encode())
     }
 }
 
-impl Cheatcode for replaceCall {
+impl<CTX> Cheatcode<CTX> for replaceCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { input, from, to } = self;
         Ok(input.replace(from, to).abi_encode())
     }
 }
 
-impl Cheatcode for splitCall {
+impl<CTX> Cheatcode<CTX> for splitCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { input, delimiter } = self;
         let parts: Vec<&str> = input.split(delimiter).collect();
@@ -131,14 +131,14 @@ impl Cheatcode for splitCall {
     }
 }
 
-impl Cheatcode for indexOfCall {
+impl<CTX> Cheatcode<CTX> for indexOfCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { input, key } = self;
         Ok(input.find(key).map(U256::from).unwrap_or(U256::MAX).abi_encode())
     }
 }
 
-impl Cheatcode for containsCall {
+impl<CTX> Cheatcode<CTX> for containsCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { subject, search } = self;
         Ok(subject.contains(search).abi_encode())

--- a/crates/cheatcodes/src/test.rs
+++ b/crates/cheatcodes/src/test.rs
@@ -6,6 +6,7 @@ use alloy_primitives::{Address, U256};
 use alloy_sol_types::SolValue;
 use foundry_common::version::SEMVER_VERSION;
 use foundry_evm_core::constants::MAGIC_SKIP;
+use revm::context_interface::{ContextTr, JournalTr};
 use std::str::FromStr;
 
 pub(crate) mod assert;
@@ -13,28 +14,28 @@ pub(crate) mod assume;
 pub(crate) mod expect;
 pub(crate) mod revert_handlers;
 
-impl Cheatcode for breakpoint_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for breakpoint_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { char } = self;
         breakpoint(ccx.state, &ccx.caller, char, true)
     }
 }
 
-impl Cheatcode for breakpoint_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for breakpoint_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { char, value } = self;
         breakpoint(ccx.state, &ccx.caller, char, *value)
     }
 }
 
-impl Cheatcode for getFoundryVersionCall {
+impl<CTX> Cheatcode<CTX> for getFoundryVersionCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         Ok(SEMVER_VERSION.abi_encode())
     }
 }
 
-impl Cheatcode for rpcUrlCall {
+impl<CTX> Cheatcode<CTX> for rpcUrlCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { rpcAlias } = self;
         let url = state.config.rpc_endpoint(rpcAlias)?.url()?.abi_encode();
@@ -42,21 +43,21 @@ impl Cheatcode for rpcUrlCall {
     }
 }
 
-impl Cheatcode for rpcUrlsCall {
+impl<CTX> Cheatcode<CTX> for rpcUrlsCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         state.config.rpc_urls().map(|urls| urls.abi_encode())
     }
 }
 
-impl Cheatcode for rpcUrlStructsCall {
+impl<CTX> Cheatcode<CTX> for rpcUrlStructsCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         state.config.rpc_urls().map(|urls| urls.abi_encode())
     }
 }
 
-impl Cheatcode for sleepCall {
+impl<CTX> Cheatcode<CTX> for sleepCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { duration } = self;
         let sleep_duration = std::time::Duration::from_millis(duration.saturating_to());
@@ -65,20 +66,20 @@ impl Cheatcode for sleepCall {
     }
 }
 
-impl Cheatcode for skip_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for skip_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { skipTest } = *self;
         skip_1Call { skipTest, reason: String::new() }.apply_stateful(ccx)
     }
 }
 
-impl Cheatcode for skip_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for skip_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { skipTest, reason } = self;
         if *skipTest {
             // Skip should not work if called deeper than at test level.
             // Since we're not returning the magic skip bytes, this will cause a test failure.
-            ensure!(ccx.ecx.journaled_state.depth <= 1, "`skip` can only be used at test level");
+            ensure!(ccx.ecx.journal().depth() <= 1, "`skip` can only be used at test level");
             Err([MAGIC_SKIP, reason.as_bytes()].concat().into())
         } else {
             Ok(Default::default())
@@ -86,14 +87,14 @@ impl Cheatcode for skip_1Call {
     }
 }
 
-impl Cheatcode for getChain_0Call {
+impl<CTX> Cheatcode<CTX> for getChain_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { chainAlias } = self;
         get_chain(state, chainAlias)
     }
 }
 
-impl Cheatcode for getChain_1Call {
+impl<CTX> Cheatcode<CTX> for getChain_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { chainId } = self;
         // Convert the chainId to a string and use the existing get_chain function

--- a/crates/cheatcodes/src/test/assert.rs
+++ b/crates/cheatcodes/src/test/assert.rs
@@ -2,11 +2,11 @@ use crate::{CheatcodesExecutor, CheatsCtxt, Result, Vm::*};
 use alloy_primitives::{I256, U256, U512};
 use foundry_evm_core::{
     abi::console::{format_units_int, format_units_uint},
-    backend::GLOBAL_FAIL_SLOT,
+    backend::{DatabaseExt, GLOBAL_FAIL_SLOT},
     constants::CHEATCODE_ADDRESS,
 };
 use itertools::Itertools;
-use revm::context::JournalTr;
+use revm::context::{ContextTr, JournalTr};
 use std::{borrow::Cow, fmt};
 
 const EQ_REL_DELTA_RESOLUTION: U256 = U256::from_limbs([18, 0, 0, 0]);
@@ -187,8 +187,8 @@ impl EqRelAssertionError<I256> {
 type ComparisonResult<'a, T> = Result<(), ComparisonAssertionError<'a, T>>;
 
 #[cold]
-fn handle_assertion_result<E>(
-    ccx: &mut CheatsCtxt,
+fn handle_assertion_result<CTX: ContextTr<Db: DatabaseExt>, E>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
     executor: &mut dyn CheatcodesExecutor,
     err: E,
     error_formatter: Option<&dyn Fn(&E) -> String>,
@@ -203,16 +203,16 @@ fn handle_assertion_result<E>(
     handle_assertion_result_mono(ccx, executor, msg)
 }
 
-fn handle_assertion_result_mono(
-    ccx: &mut CheatsCtxt,
+fn handle_assertion_result_mono<CTX: ContextTr<Db: DatabaseExt>>(
+    ccx: &mut CheatsCtxt<'_, CTX>,
     executor: &mut dyn CheatcodesExecutor,
     msg: Cow<'_, str>,
 ) -> Result {
     if ccx.state.config.assertions_revert {
         Err(msg.into_owned().into())
     } else {
-        executor.console_log(ccx, &msg);
-        ccx.ecx.journaled_state.sstore(CHEATCODE_ADDRESS, GLOBAL_FAIL_SLOT, U256::from(1))?;
+        executor.console_log(ccx.state, &msg);
+        ccx.ecx.journal_mut().sstore(CHEATCODE_ADDRESS, GLOBAL_FAIL_SLOT, U256::from(1))?;
         Ok(Default::default())
     }
 }
@@ -245,10 +245,10 @@ macro_rules! impl_assertions {
     };
 
     (@impl $no_error:ident, $with_error:ident, ($($arg:ident),*), $body:expr, $error_formatter:expr) => {
-        impl crate::Cheatcode for $no_error {
+        impl<CTX: revm::context::ContextTr<Db: foundry_evm_core::backend::DatabaseExt>> crate::Cheatcode<CTX> for $no_error {
             fn apply_full(
                 &self,
-                ccx: &mut CheatsCtxt,
+                ccx: &mut CheatsCtxt<'_, CTX>,
                 executor: &mut dyn CheatcodesExecutor,
             ) -> Result {
                 let Self { $($arg),* } = self;
@@ -259,10 +259,10 @@ macro_rules! impl_assertions {
             }
         }
 
-        impl crate::Cheatcode for $with_error {
+        impl<CTX: revm::context::ContextTr<Db: foundry_evm_core::backend::DatabaseExt>> crate::Cheatcode<CTX> for $with_error {
             fn apply_full(
                 &self,
-                ccx: &mut CheatsCtxt,
+                ccx: &mut CheatsCtxt<'_, CTX>,
                 executor: &mut dyn CheatcodesExecutor,
             ) -> Result {
                 let Self { $($arg,)* error } = self;

--- a/crates/cheatcodes/src/test/assume.rs
+++ b/crates/cheatcodes/src/test/assume.rs
@@ -1,6 +1,7 @@
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, Error, Result};
 use alloy_primitives::Address;
 use foundry_evm_core::constants::MAGIC_ASSUME;
+use revm::context_interface::{ContextTr, JournalTr};
 use spec::Vm::{
     PotentialRevert, assumeCall, assumeNoRevert_0Call, assumeNoRevert_1Call, assumeNoRevert_2Call,
 };
@@ -43,36 +44,36 @@ impl AcceptableRevertParameters {
     }
 }
 
-impl Cheatcode for assumeCall {
+impl<CTX> Cheatcode<CTX> for assumeCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { condition } = self;
         if *condition { Ok(Default::default()) } else { Err(Error::from(MAGIC_ASSUME)) }
     }
 }
 
-impl Cheatcode for assumeNoRevert_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
-        assume_no_revert(ccx.state, ccx.ecx.journaled_state.depth, vec![])
+impl<CTX: ContextTr> Cheatcode<CTX> for assumeNoRevert_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+        assume_no_revert(ccx.state, ccx.ecx.journal().depth(), vec![])
     }
 }
 
-impl Cheatcode for assumeNoRevert_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for assumeNoRevert_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { potentialRevert } = self;
         assume_no_revert(
             ccx.state,
-            ccx.ecx.journaled_state.depth,
+            ccx.ecx.journal().depth(),
             vec![AcceptableRevertParameters::from(potentialRevert)],
         )
     }
 }
 
-impl Cheatcode for assumeNoRevert_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for assumeNoRevert_2Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { potentialReverts } = self;
         assume_no_revert(
             ccx.state,
-            ccx.ecx.journaled_state.depth,
+            ccx.ecx.journal().depth(),
             potentialReverts.iter().map(AcceptableRevertParameters::from).collect(),
         )
     }

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -14,6 +14,7 @@ use foundry_common::{abi::get_indexed_event, fmt::format_token};
 use foundry_evm_traces::DecodedCallLog;
 use revm::{
     context::JournalTr,
+    context_interface::ContextTr,
     interpreter::{
         InstructionResult, Interpreter, InterpreterAction, interpreter_types::LoopControl,
     },
@@ -162,28 +163,28 @@ impl CreateScheme {
     }
 }
 
-impl Cheatcode for expectCall_0Call {
+impl<CTX> Cheatcode<CTX> for expectCall_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { callee, data } = self;
         expect_call(state, callee, data, None, None, None, 1, ExpectedCallType::NonCount)
     }
 }
 
-impl Cheatcode for expectCall_1Call {
+impl<CTX> Cheatcode<CTX> for expectCall_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { callee, data, count } = self;
         expect_call(state, callee, data, None, None, None, *count, ExpectedCallType::Count)
     }
 }
 
-impl Cheatcode for expectCall_2Call {
+impl<CTX> Cheatcode<CTX> for expectCall_2Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { callee, msgValue, data } = self;
         expect_call(state, callee, data, Some(msgValue), None, None, 1, ExpectedCallType::NonCount)
     }
 }
 
-impl Cheatcode for expectCall_3Call {
+impl<CTX> Cheatcode<CTX> for expectCall_3Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { callee, msgValue, data, count } = self;
         expect_call(
@@ -199,7 +200,7 @@ impl Cheatcode for expectCall_3Call {
     }
 }
 
-impl Cheatcode for expectCall_4Call {
+impl<CTX> Cheatcode<CTX> for expectCall_4Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { callee, msgValue, gas, data } = self;
         expect_call(
@@ -215,7 +216,7 @@ impl Cheatcode for expectCall_4Call {
     }
 }
 
-impl Cheatcode for expectCall_5Call {
+impl<CTX> Cheatcode<CTX> for expectCall_5Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { callee, msgValue, gas, data, count } = self;
         expect_call(
@@ -231,7 +232,7 @@ impl Cheatcode for expectCall_5Call {
     }
 }
 
-impl Cheatcode for expectCallMinGas_0Call {
+impl<CTX> Cheatcode<CTX> for expectCallMinGas_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { callee, msgValue, minGas, data } = self;
         expect_call(
@@ -247,7 +248,7 @@ impl Cheatcode for expectCallMinGas_0Call {
     }
 }
 
-impl Cheatcode for expectCallMinGas_1Call {
+impl<CTX> Cheatcode<CTX> for expectCallMinGas_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { callee, msgValue, minGas, data, count } = self;
         expect_call(
@@ -263,12 +264,12 @@ impl Cheatcode for expectCallMinGas_1Call {
     }
 }
 
-impl Cheatcode for expectEmit_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectEmit_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData } = *self;
         expect_emit(
             ccx.state,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             [true, checkTopic1, checkTopic2, checkTopic3, checkData],
             None,
             false,
@@ -277,12 +278,12 @@ impl Cheatcode for expectEmit_0Call {
     }
 }
 
-impl Cheatcode for expectEmit_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectEmit_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData, emitter } = *self;
         expect_emit(
             ccx.state,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             [true, checkTopic1, checkTopic2, checkTopic3, checkData],
             Some(emitter),
             false,
@@ -291,26 +292,26 @@ impl Cheatcode for expectEmit_1Call {
     }
 }
 
-impl Cheatcode for expectEmit_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectEmit_2Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
-        expect_emit(ccx.state, ccx.ecx.journaled_state.depth(), [true; 5], None, false, 1)
+        expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], None, false, 1)
     }
 }
 
-impl Cheatcode for expectEmit_3Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectEmit_3Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { emitter } = *self;
-        expect_emit(ccx.state, ccx.ecx.journaled_state.depth(), [true; 5], Some(emitter), false, 1)
+        expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], Some(emitter), false, 1)
     }
 }
 
-impl Cheatcode for expectEmit_4Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectEmit_4Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData, count } = *self;
         expect_emit(
             ccx.state,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             [true, checkTopic1, checkTopic2, checkTopic3, checkData],
             None,
             false,
@@ -319,12 +320,12 @@ impl Cheatcode for expectEmit_4Call {
     }
 }
 
-impl Cheatcode for expectEmit_5Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectEmit_5Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData, emitter, count } = *self;
         expect_emit(
             ccx.state,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             [true, checkTopic1, checkTopic2, checkTopic3, checkData],
             Some(emitter),
             false,
@@ -333,33 +334,26 @@ impl Cheatcode for expectEmit_5Call {
     }
 }
 
-impl Cheatcode for expectEmit_6Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectEmit_6Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { count } = *self;
-        expect_emit(ccx.state, ccx.ecx.journaled_state.depth(), [true; 5], None, false, count)
+        expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], None, false, count)
     }
 }
 
-impl Cheatcode for expectEmit_7Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectEmit_7Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { emitter, count } = *self;
-        expect_emit(
-            ccx.state,
-            ccx.ecx.journaled_state.depth(),
-            [true; 5],
-            Some(emitter),
-            false,
-            count,
-        )
+        expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], Some(emitter), false, count)
     }
 }
 
-impl Cheatcode for expectEmitAnonymous_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectEmitAnonymous_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { checkTopic0, checkTopic1, checkTopic2, checkTopic3, checkData } = *self;
         expect_emit(
             ccx.state,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             [checkTopic0, checkTopic1, checkTopic2, checkTopic3, checkData],
             None,
             true,
@@ -368,12 +362,12 @@ impl Cheatcode for expectEmitAnonymous_0Call {
     }
 }
 
-impl Cheatcode for expectEmitAnonymous_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectEmitAnonymous_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { checkTopic0, checkTopic1, checkTopic2, checkTopic3, checkData, emitter } = *self;
         expect_emit(
             ccx.state,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             [checkTopic0, checkTopic1, checkTopic2, checkTopic3, checkData],
             Some(emitter),
             true,
@@ -382,48 +376,48 @@ impl Cheatcode for expectEmitAnonymous_1Call {
     }
 }
 
-impl Cheatcode for expectEmitAnonymous_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectEmitAnonymous_2Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
-        expect_emit(ccx.state, ccx.ecx.journaled_state.depth(), [true; 5], None, true, 1)
+        expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], None, true, 1)
     }
 }
 
-impl Cheatcode for expectEmitAnonymous_3Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectEmitAnonymous_3Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { emitter } = *self;
-        expect_emit(ccx.state, ccx.ecx.journaled_state.depth(), [true; 5], Some(emitter), true, 1)
+        expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], Some(emitter), true, 1)
     }
 }
 
-impl Cheatcode for expectCreateCall {
+impl<CTX> Cheatcode<CTX> for expectCreateCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { bytecode, deployer } = self;
         expect_create(state, bytecode.clone(), *deployer, CreateScheme::Create)
     }
 }
 
-impl Cheatcode for expectCreate2Call {
+impl<CTX> Cheatcode<CTX> for expectCreate2Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { bytecode, deployer } = self;
         expect_create(state, bytecode.clone(), *deployer, CreateScheme::Create2)
     }
 }
 
-impl Cheatcode for expectRevert_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectRevert_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
-        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), false, false, None, 1)
+        expect_revert(ccx.state, None, ccx.ecx.journal().depth(), false, false, None, 1)
     }
 }
 
-impl Cheatcode for expectRevert_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectRevert_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { revertData } = self;
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             None,
@@ -432,43 +426,27 @@ impl Cheatcode for expectRevert_1Call {
     }
 }
 
-impl Cheatcode for expectRevert_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectRevert_2Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { revertData } = self;
-        expect_revert(
-            ccx.state,
-            Some(revertData),
-            ccx.ecx.journaled_state.depth(),
-            false,
-            false,
-            None,
-            1,
-        )
+        expect_revert(ccx.state, Some(revertData), ccx.ecx.journal().depth(), false, false, None, 1)
     }
 }
 
-impl Cheatcode for expectRevert_3Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectRevert_3Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { reverter } = self;
-        expect_revert(
-            ccx.state,
-            None,
-            ccx.ecx.journaled_state.depth(),
-            false,
-            false,
-            Some(*reverter),
-            1,
-        )
+        expect_revert(ccx.state, None, ccx.ecx.journal().depth(), false, false, Some(*reverter), 1)
     }
 }
 
-impl Cheatcode for expectRevert_4Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectRevert_4Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { revertData, reverter } = self;
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             Some(*reverter),
@@ -477,13 +455,13 @@ impl Cheatcode for expectRevert_4Call {
     }
 }
 
-impl Cheatcode for expectRevert_5Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectRevert_5Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { revertData, reverter } = self;
         expect_revert(
             ccx.state,
             Some(revertData),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             Some(*reverter),
@@ -492,20 +470,20 @@ impl Cheatcode for expectRevert_5Call {
     }
 }
 
-impl Cheatcode for expectRevert_6Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectRevert_6Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { count } = self;
-        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), false, false, None, *count)
+        expect_revert(ccx.state, None, ccx.ecx.journal().depth(), false, false, None, *count)
     }
 }
 
-impl Cheatcode for expectRevert_7Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectRevert_7Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { revertData, count } = self;
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             None,
@@ -514,13 +492,13 @@ impl Cheatcode for expectRevert_7Call {
     }
 }
 
-impl Cheatcode for expectRevert_8Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectRevert_8Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { revertData, count } = self;
         expect_revert(
             ccx.state,
             Some(revertData),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             None,
@@ -529,13 +507,13 @@ impl Cheatcode for expectRevert_8Call {
     }
 }
 
-impl Cheatcode for expectRevert_9Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectRevert_9Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { reverter, count } = self;
         expect_revert(
             ccx.state,
             None,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             Some(*reverter),
@@ -544,13 +522,13 @@ impl Cheatcode for expectRevert_9Call {
     }
 }
 
-impl Cheatcode for expectRevert_10Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectRevert_10Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { revertData, reverter, count } = self;
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             Some(*reverter),
@@ -559,13 +537,13 @@ impl Cheatcode for expectRevert_10Call {
     }
 }
 
-impl Cheatcode for expectRevert_11Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectRevert_11Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { revertData, reverter, count } = self;
         expect_revert(
             ccx.state,
             Some(revertData),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             Some(*reverter),
@@ -574,13 +552,13 @@ impl Cheatcode for expectRevert_11Call {
     }
 }
 
-impl Cheatcode for expectPartialRevert_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectPartialRevert_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { revertData } = self;
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             true,
             None,
@@ -589,13 +567,13 @@ impl Cheatcode for expectPartialRevert_0Call {
     }
 }
 
-impl Cheatcode for expectPartialRevert_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectPartialRevert_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { revertData, reverter } = self;
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             true,
             Some(*reverter),
@@ -604,19 +582,19 @@ impl Cheatcode for expectPartialRevert_1Call {
     }
 }
 
-impl Cheatcode for _expectCheatcodeRevert_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
-        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), true, false, None, 1)
+impl<CTX: ContextTr> Cheatcode<CTX> for _expectCheatcodeRevert_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+        expect_revert(ccx.state, None, ccx.ecx.journal().depth(), true, false, None, 1)
     }
 }
 
-impl Cheatcode for _expectCheatcodeRevert_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for _expectCheatcodeRevert_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { revertData } = self;
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             true,
             false,
             None,
@@ -625,40 +603,32 @@ impl Cheatcode for _expectCheatcodeRevert_1Call {
     }
 }
 
-impl Cheatcode for _expectCheatcodeRevert_2Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for _expectCheatcodeRevert_2Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { revertData } = self;
-        expect_revert(
-            ccx.state,
-            Some(revertData),
-            ccx.ecx.journaled_state.depth(),
-            true,
-            false,
-            None,
-            1,
-        )
+        expect_revert(ccx.state, Some(revertData), ccx.ecx.journal().depth(), true, false, None, 1)
     }
 }
 
-impl Cheatcode for expectSafeMemoryCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectSafeMemoryCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { min, max } = *self;
-        expect_safe_memory(ccx.state, min, max, ccx.ecx.journaled_state.depth().try_into()?)
+        expect_safe_memory(ccx.state, min, max, ccx.ecx.journal().depth().try_into()?)
     }
 }
 
-impl Cheatcode for stopExpectSafeMemoryCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for stopExpectSafeMemoryCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
-        ccx.state.allowed_mem_writes.remove(&ccx.ecx.journaled_state.depth().try_into()?);
+        ccx.state.allowed_mem_writes.remove(&ccx.ecx.journal().depth().try_into()?);
         Ok(Default::default())
     }
 }
 
-impl Cheatcode for expectSafeMemoryCallCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr> Cheatcode<CTX> for expectSafeMemoryCallCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { min, max } = *self;
-        expect_safe_memory(ccx.state, min, max, (ccx.ecx.journaled_state.depth() + 1).try_into()?)
+        expect_safe_memory(ccx.state, min, max, (ccx.ecx.journal().depth() + 1).try_into()?)
     }
 }
 

--- a/crates/cheatcodes/src/toml.rs
+++ b/crates/cheatcodes/src/toml.rs
@@ -15,14 +15,14 @@ use foundry_config::fs_permissions::FsAccessKind;
 use serde_json::Value as JsonValue;
 use toml::Value as TomlValue;
 
-impl Cheatcode for keyExistsTomlCall {
+impl<CTX> Cheatcode<CTX> for keyExistsTomlCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         check_json_key_exists(&toml_to_json_string(toml)?, key)
     }
 }
 
-impl Cheatcode for parseToml_0Call {
+impl<CTX> Cheatcode<CTX> for parseToml_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { toml } = self;
         parse_toml(
@@ -33,7 +33,7 @@ impl Cheatcode for parseToml_0Call {
     }
 }
 
-impl Cheatcode for parseToml_1Call {
+impl<CTX> Cheatcode<CTX> for parseToml_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml(
@@ -44,105 +44,105 @@ impl Cheatcode for parseToml_1Call {
     }
 }
 
-impl Cheatcode for parseTomlUintCall {
+impl<CTX> Cheatcode<CTX> for parseTomlUintCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Uint(256))
     }
 }
 
-impl Cheatcode for parseTomlUintArrayCall {
+impl<CTX> Cheatcode<CTX> for parseTomlUintArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Uint(256))))
     }
 }
 
-impl Cheatcode for parseTomlIntCall {
+impl<CTX> Cheatcode<CTX> for parseTomlIntCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Int(256))
     }
 }
 
-impl Cheatcode for parseTomlIntArrayCall {
+impl<CTX> Cheatcode<CTX> for parseTomlIntArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Int(256))))
     }
 }
 
-impl Cheatcode for parseTomlBoolCall {
+impl<CTX> Cheatcode<CTX> for parseTomlBoolCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Bool)
     }
 }
 
-impl Cheatcode for parseTomlBoolArrayCall {
+impl<CTX> Cheatcode<CTX> for parseTomlBoolArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Bool)))
     }
 }
 
-impl Cheatcode for parseTomlAddressCall {
+impl<CTX> Cheatcode<CTX> for parseTomlAddressCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Address)
     }
 }
 
-impl Cheatcode for parseTomlAddressArrayCall {
+impl<CTX> Cheatcode<CTX> for parseTomlAddressArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Address)))
     }
 }
 
-impl Cheatcode for parseTomlStringCall {
+impl<CTX> Cheatcode<CTX> for parseTomlStringCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::String)
     }
 }
 
-impl Cheatcode for parseTomlStringArrayCall {
+impl<CTX> Cheatcode<CTX> for parseTomlStringArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::String)))
     }
 }
 
-impl Cheatcode for parseTomlBytesCall {
+impl<CTX> Cheatcode<CTX> for parseTomlBytesCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Bytes)
     }
 }
 
-impl Cheatcode for parseTomlBytesArrayCall {
+impl<CTX> Cheatcode<CTX> for parseTomlBytesArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Bytes)))
     }
 }
 
-impl Cheatcode for parseTomlBytes32Call {
+impl<CTX> Cheatcode<CTX> for parseTomlBytes32Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::FixedBytes(32))
     }
 }
 
-impl Cheatcode for parseTomlBytes32ArrayCall {
+impl<CTX> Cheatcode<CTX> for parseTomlBytes32ArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::FixedBytes(32))))
     }
 }
 
-impl Cheatcode for parseTomlType_0Call {
+impl<CTX> Cheatcode<CTX> for parseTomlType_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { toml, typeDescription } = self;
         parse_toml_coerce(
@@ -157,7 +157,7 @@ impl Cheatcode for parseTomlType_0Call {
     }
 }
 
-impl Cheatcode for parseTomlType_1Call {
+impl<CTX> Cheatcode<CTX> for parseTomlType_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { toml, key, typeDescription } = self;
         parse_toml_coerce(
@@ -172,7 +172,7 @@ impl Cheatcode for parseTomlType_1Call {
     }
 }
 
-impl Cheatcode for parseTomlTypeArrayCall {
+impl<CTX> Cheatcode<CTX> for parseTomlTypeArrayCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { toml, key, typeDescription } = self;
         let ty = resolve_type(
@@ -183,14 +183,14 @@ impl Cheatcode for parseTomlTypeArrayCall {
     }
 }
 
-impl Cheatcode for parseTomlKeysCall {
+impl<CTX> Cheatcode<CTX> for parseTomlKeysCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_keys(toml, key)
     }
 }
 
-impl Cheatcode for writeToml_0Call {
+impl<CTX> Cheatcode<CTX> for writeToml_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json, path } = self;
         let value =
@@ -201,7 +201,7 @@ impl Cheatcode for writeToml_0Call {
     }
 }
 
-impl Cheatcode for writeToml_1Call {
+impl<CTX> Cheatcode<CTX> for writeToml_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json: value, path, valueKey } = self;
 

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -12,7 +12,7 @@ use foundry_evm_core::constants::DEFAULT_CREATE2_DEPLOYER;
 use foundry_evm_fuzz::strategies::BoundMutator;
 use proptest::prelude::Strategy;
 use rand::{Rng, RngCore, seq::SliceRandom};
-use revm::context::JournalTr;
+use revm::{context::JournalTr, context_interface::ContextTr, inspector::JournalExt};
 use std::path::PathBuf;
 
 /// Contains locations of traces ignored via cheatcodes.
@@ -29,7 +29,7 @@ pub struct IgnoredTraces {
     pub last_pause_call: Option<(usize, usize)>,
 }
 
-impl Cheatcode for labelCall {
+impl<CTX> Cheatcode<CTX> for labelCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { account, newLabel } = self;
         state.labels.insert(*account, newLabel.clone());
@@ -37,7 +37,7 @@ impl Cheatcode for labelCall {
     }
 }
 
-impl Cheatcode for getLabelCall {
+impl<CTX> Cheatcode<CTX> for getLabelCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { account } = self;
         Ok(match state.labels.get(account) {
@@ -47,7 +47,7 @@ impl Cheatcode for getLabelCall {
     }
 }
 
-impl Cheatcode for computeCreateAddressCall {
+impl<CTX> Cheatcode<CTX> for computeCreateAddressCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { nonce, deployer } = self;
         ensure!(*nonce <= U256::from(u64::MAX), "nonce must be less than 2^64");
@@ -55,28 +55,28 @@ impl Cheatcode for computeCreateAddressCall {
     }
 }
 
-impl Cheatcode for computeCreate2Address_0Call {
+impl<CTX> Cheatcode<CTX> for computeCreate2Address_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { salt, initCodeHash, deployer } = self;
         Ok(deployer.create2(salt, initCodeHash).abi_encode())
     }
 }
 
-impl Cheatcode for computeCreate2Address_1Call {
+impl<CTX> Cheatcode<CTX> for computeCreate2Address_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { salt, initCodeHash } = self;
         Ok(DEFAULT_CREATE2_DEPLOYER.create2(salt, initCodeHash).abi_encode())
     }
 }
 
-impl Cheatcode for ensNamehashCall {
+impl<CTX> Cheatcode<CTX> for ensNamehashCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
         Ok(namehash(name).abi_encode())
     }
 }
 
-impl Cheatcode for bound_0Call {
+impl<CTX> Cheatcode<CTX> for bound_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { current, min, max } = *self;
         let Some(mutated) = U256::bound(current, min, max, state.test_runner()) else {
@@ -86,7 +86,7 @@ impl Cheatcode for bound_0Call {
     }
 }
 
-impl Cheatcode for bound_1Call {
+impl<CTX> Cheatcode<CTX> for bound_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { current, min, max } = *self;
         let Some(mutated) = I256::bound(current, min, max, state.test_runner()) else {
@@ -96,27 +96,27 @@ impl Cheatcode for bound_1Call {
     }
 }
 
-impl Cheatcode for randomUint_0Call {
+impl<CTX> Cheatcode<CTX> for randomUint_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         random_uint(state, None, None)
     }
 }
 
-impl Cheatcode for randomUint_1Call {
+impl<CTX> Cheatcode<CTX> for randomUint_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { min, max } = *self;
         random_uint(state, None, Some((min, max)))
     }
 }
 
-impl Cheatcode for randomUint_2Call {
+impl<CTX> Cheatcode<CTX> for randomUint_2Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { bits } = *self;
         random_uint(state, Some(bits), None)
     }
 }
 
-impl Cheatcode for randomAddressCall {
+impl<CTX> Cheatcode<CTX> for randomAddressCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         Ok(DynSolValue::type_strategy(&DynSolType::Address)
             .new_tree(state.test_runner())
@@ -126,27 +126,27 @@ impl Cheatcode for randomAddressCall {
     }
 }
 
-impl Cheatcode for randomInt_0Call {
+impl<CTX> Cheatcode<CTX> for randomInt_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         random_int(state, None)
     }
 }
 
-impl Cheatcode for randomInt_1Call {
+impl<CTX> Cheatcode<CTX> for randomInt_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { bits } = *self;
         random_int(state, Some(bits))
     }
 }
 
-impl Cheatcode for randomBoolCall {
+impl<CTX> Cheatcode<CTX> for randomBoolCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let rand_bool: bool = state.rng().random();
         Ok(rand_bool.abi_encode())
     }
 }
 
-impl Cheatcode for randomBytesCall {
+impl<CTX> Cheatcode<CTX> for randomBytesCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { len } = *self;
         ensure!(
@@ -159,24 +159,24 @@ impl Cheatcode for randomBytesCall {
     }
 }
 
-impl Cheatcode for randomBytes4Call {
+impl<CTX> Cheatcode<CTX> for randomBytes4Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let rand_u32 = state.rng().next_u32();
         Ok(B32::from(rand_u32).abi_encode())
     }
 }
 
-impl Cheatcode for randomBytes8Call {
+impl<CTX> Cheatcode<CTX> for randomBytes8Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let rand_u64 = state.rng().next_u64();
         Ok(B64::from(rand_u64).abi_encode())
     }
 }
 
-impl Cheatcode for pauseTracingCall {
+impl<CTX> Cheatcode<CTX> for pauseTracingCall {
     fn apply_full(
         &self,
-        ccx: &mut crate::CheatsCtxt,
+        ccx: &mut CheatsCtxt<'_, CTX>,
         executor: &mut dyn CheatcodesExecutor,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
@@ -196,10 +196,10 @@ impl Cheatcode for pauseTracingCall {
     }
 }
 
-impl Cheatcode for resumeTracingCall {
+impl<CTX> Cheatcode<CTX> for resumeTracingCall {
     fn apply_full(
         &self,
-        ccx: &mut crate::CheatsCtxt,
+        ccx: &mut CheatsCtxt<'_, CTX>,
         executor: &mut dyn CheatcodesExecutor,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
@@ -219,7 +219,7 @@ impl Cheatcode for resumeTracingCall {
     }
 }
 
-impl Cheatcode for interceptInitcodeCall {
+impl<CTX> Cheatcode<CTX> for interceptInitcodeCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         if !state.intercept_next_create_call {
@@ -231,8 +231,8 @@ impl Cheatcode for interceptInitcodeCall {
     }
 }
 
-impl Cheatcode for setArbitraryStorage_0Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for setArbitraryStorage_0Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { target } = self;
         ccx.state.arbitrary_storage().mark_arbitrary(target, false);
 
@@ -240,8 +240,8 @@ impl Cheatcode for setArbitraryStorage_0Call {
     }
 }
 
-impl Cheatcode for setArbitraryStorage_1Call {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for setArbitraryStorage_1Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { target, overwrite } = self;
         ccx.state.arbitrary_storage().mark_arbitrary(target, *overwrite);
 
@@ -249,8 +249,8 @@ impl Cheatcode for setArbitraryStorage_1Call {
     }
 }
 
-impl Cheatcode for copyStorageCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX: ContextTr<Journal: JournalExt>> Cheatcode<CTX> for copyStorageCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { from, to } = self;
 
         ensure!(
@@ -258,11 +258,11 @@ impl Cheatcode for copyStorageCall {
             "target address cannot have arbitrary storage"
         );
 
-        if let Ok(from_account) = ccx.ecx.journaled_state.load_account(*from) {
+        if let Ok(from_account) = ccx.ecx.journal_mut().load_account(*from) {
             let from_storage = from_account.storage.clone();
-            if ccx.ecx.journaled_state.load_account(*to).is_ok() {
+            if ccx.ecx.journal_mut().load_account(*to).is_ok() {
                 // SAFETY: We ensured the account was already loaded.
-                ccx.ecx.journaled_state.state.get_mut(to).unwrap().storage = from_storage;
+                ccx.ecx.journal_mut().evm_state_mut().get_mut(to).unwrap().storage = from_storage;
                 if let Some(arbitrary_storage) = &mut ccx.state.arbitrary_storage {
                     arbitrary_storage.mark_copy(from, to);
                 }
@@ -273,7 +273,7 @@ impl Cheatcode for copyStorageCall {
     }
 }
 
-impl Cheatcode for sortCall {
+impl<CTX> Cheatcode<CTX> for sortCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { array } = self;
 
@@ -284,7 +284,7 @@ impl Cheatcode for sortCall {
     }
 }
 
-impl Cheatcode for shuffleCall {
+impl<CTX> Cheatcode<CTX> for shuffleCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { array } = self;
 
@@ -296,8 +296,8 @@ impl Cheatcode for shuffleCall {
     }
 }
 
-impl Cheatcode for setSeedCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+impl<CTX> Cheatcode<CTX> for setSeedCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { seed } = self;
         ccx.state.set_seed(*seed);
         Ok(Default::default())
@@ -349,7 +349,7 @@ fn random_int(state: &mut Cheatcodes, bits: Option<U256>) -> Result {
         .abi_encode())
 }
 
-impl Cheatcode for eip712HashType_0Call {
+impl<CTX> Cheatcode<CTX> for eip712HashType_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { typeNameOrDefinition } = self;
 
@@ -359,7 +359,7 @@ impl Cheatcode for eip712HashType_0Call {
     }
 }
 
-impl Cheatcode for eip712HashType_1Call {
+impl<CTX> Cheatcode<CTX> for eip712HashType_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { bindingsPath, typeName } = self;
 
@@ -370,7 +370,7 @@ impl Cheatcode for eip712HashType_1Call {
     }
 }
 
-impl Cheatcode for eip712HashStruct_0Call {
+impl<CTX> Cheatcode<CTX> for eip712HashStruct_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { typeNameOrDefinition, abiEncodedData } = self;
 
@@ -381,7 +381,7 @@ impl Cheatcode for eip712HashStruct_0Call {
     }
 }
 
-impl Cheatcode for eip712HashStruct_1Call {
+impl<CTX> Cheatcode<CTX> for eip712HashStruct_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { bindingsPath, typeName, abiEncodedData } = self;
 
@@ -392,7 +392,7 @@ impl Cheatcode for eip712HashStruct_1Call {
     }
 }
 
-impl Cheatcode for eip712HashTypedDataCall {
+impl<CTX> Cheatcode<CTX> for eip712HashTypedDataCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { jsonData } = self;
         let typed_data: TypedData = serde_json::from_str(jsonData)?;
@@ -494,7 +494,7 @@ fn get_struct_hash(primary: &str, type_def: &String, abi_encoded_data: &Bytes) -
     Ok(keccak256(&bytes_to_hash).to_vec())
 }
 
-impl Cheatcode for toRlpCall {
+impl<CTX> Cheatcode<CTX> for toRlpCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { data } = self;
 
@@ -505,7 +505,7 @@ impl Cheatcode for toRlpCall {
     }
 }
 
-impl Cheatcode for fromRlpCall {
+impl<CTX> Cheatcode<CTX> for fromRlpCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { rlp } = self;
 

--- a/crates/cheatcodes/src/version.rs
+++ b/crates/cheatcodes/src/version.rs
@@ -4,14 +4,14 @@ use foundry_common::version::SEMVER_VERSION;
 use semver::Version;
 use std::cmp::Ordering;
 
-impl Cheatcode for foundryVersionCmpCall {
+impl<CTX> Cheatcode<CTX> for foundryVersionCmpCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { version } = self;
         foundry_version_cmp(version).map(|cmp| (cmp as i8).abi_encode())
     }
 }
 
-impl Cheatcode for foundryVersionAtLeastCall {
+impl<CTX> Cheatcode<CTX> for foundryVersionAtLeastCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { version } = self;
         foundry_version_cmp(version).map(|cmp| cmp.is_ge().abi_encode())

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -21,7 +21,7 @@ use revm::{
     context_interface::result::ResultAndState,
     database::DatabaseRef,
     primitives::{HashMap as Map, hardfork::SpecId},
-    state::{Account, AccountInfo},
+    state::{Account, AccountInfo, EvmState},
 };
 use std::{borrow::Cow, collections::BTreeMap};
 
@@ -232,12 +232,8 @@ impl DatabaseExt for CowBackend<'_> {
         self.backend.ensure_fork_id(id)
     }
 
-    fn diagnose_revert(
-        &self,
-        callee: Address,
-        journaled_state: &JournaledState,
-    ) -> Option<RevertDiagnostic> {
-        self.backend.diagnose_revert(callee, journaled_state)
+    fn diagnose_revert(&self, callee: Address, evm_state: &EvmState) -> Option<RevertDiagnostic> {
+        self.backend.diagnose_revert(callee, evm_state)
     }
 
     fn load_allocs(

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -18,7 +18,7 @@ use eyre::Context;
 use foundry_common::{SYSTEM_TRANSACTION_TYPE, is_known_system_sender};
 pub use foundry_fork_db::{BlockchainDb, SharedBackend, cache::BlockchainDbMeta};
 use revm::{
-    Database, DatabaseCommit, JournalEntry,
+    Database, DatabaseCommit, Journal, JournalEntry,
     bytecode::Bytecode,
     context::JournalInner,
     context_interface::{
@@ -26,7 +26,7 @@ use revm::{
         result::ResultAndState,
     },
     database::{CacheDB, DatabaseRef},
-    inspector::NoOpInspector,
+    inspector::{JournalExt, NoOpInspector},
     precompile::{PrecompileSpecId, Precompiles},
     primitives::{HashMap as Map, KECCAK_EMPTY, Log, hardfork::SpecId},
     state::{Account, AccountInfo, EvmState, EvmStorageSlot},
@@ -274,11 +274,7 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
     /// the contract is deployed there.
     ///
     /// Returns a more useful error message if that's the case
-    fn diagnose_revert(
-        &self,
-        callee: Address,
-        journaled_state: &JournaledState,
-    ) -> Option<RevertDiagnostic>;
+    fn diagnose_revert(&self, callee: Address, evm_state: &EvmState) -> Option<RevertDiagnostic>;
 
     /// Loads the account allocs from the given `allocs` map into the passed [JournaledState].
     ///
@@ -381,6 +377,57 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
 }
 
 struct _ObjectSafe(dyn DatabaseExt);
+
+/// Extension trait for [`Journal`] that wraps [`DatabaseExt`] methods requiring simultaneous
+/// mutable access to the database and journal.
+///
+/// Inside `Journal<DB, JournalEntry>`, the `database` and `inner` fields can be borrowed
+/// independently, avoiding the need to destructure the context.
+///
+/// Most cheatcodes should use [`as_db_and_inner()`](FoundryJournalExt::as_db_and_inner) to get
+/// direct access to the [`DatabaseExt`] and [`JournaledState`], calling `DatabaseExt` methods
+/// directly. This avoids the clone→apply pattern and enables zero-copy borrow splitting.
+pub trait FoundryJournalExt: JournalExt {
+    /// Loads account allocations into the journal.
+    fn load_allocs(
+        &mut self,
+        allocs: &BTreeMap<Address, GenesisAccount>,
+    ) -> Result<(), BackendError>;
+
+    /// Clones account data from source to target address.
+    fn clone_account(
+        &mut self,
+        source: &GenesisAccount,
+        target: &Address,
+    ) -> Result<(), BackendError>;
+
+    /// Returns mutable references to the database and journal inner state.
+    ///
+    /// This enables calling `DatabaseExt` methods directly with zero-copy borrow splitting,
+    /// combined with `FoundryContextExt::journal_and_env_mut()` for simultaneous env access.
+    fn as_db_and_inner(&mut self) -> (&mut dyn DatabaseExt, &mut JournaledState);
+}
+
+impl<DB: DatabaseExt> FoundryJournalExt for Journal<DB, JournalEntry> {
+    fn load_allocs(
+        &mut self,
+        allocs: &BTreeMap<Address, GenesisAccount>,
+    ) -> Result<(), BackendError> {
+        self.database.load_allocs(allocs, &mut self.inner)
+    }
+
+    fn clone_account(
+        &mut self,
+        source: &GenesisAccount,
+        target: &Address,
+    ) -> Result<(), BackendError> {
+        self.database.clone_account(source, target, &mut self.inner)
+    }
+
+    fn as_db_and_inner(&mut self) -> (&mut dyn DatabaseExt, &mut JournaledState) {
+        (&mut self.database, &mut self.inner)
+    }
+}
 
 /// Provides the underlying `revm::Database` implementation.
 ///
@@ -1355,11 +1402,7 @@ impl DatabaseExt for Backend {
         self.inner.ensure_fork_id(id)
     }
 
-    fn diagnose_revert(
-        &self,
-        callee: Address,
-        journaled_state: &JournaledState,
-    ) -> Option<RevertDiagnostic> {
+    fn diagnose_revert(&self, callee: Address, evm_state: &EvmState) -> Option<RevertDiagnostic> {
         let active_id = self.active_fork_id()?;
         let active_fork = self.active_fork()?;
 
@@ -1369,7 +1412,7 @@ impl DatabaseExt for Backend {
             return None;
         }
 
-        if !active_fork.is_contract(callee) && !is_contract_in_state(journaled_state, callee) {
+        if !active_fork.is_contract(callee) && !is_contract_in_state(evm_state, callee) {
             // no contract for `callee` available on current fork, check if available on other forks
             let mut available_on = Vec::new();
             for (id, fork) in self.inner.forks_iter().filter(|(id, _)| *id != active_id) {
@@ -1606,7 +1649,7 @@ impl Fork {
         {
             return true;
         }
-        is_contract_in_state(&self.journaled_state, acc)
+        is_contract_in_state(&self.journaled_state.state, acc)
     }
 }
 
@@ -1936,12 +1979,8 @@ fn merge_db_account_data<ExtDB: DatabaseRef>(
 }
 
 /// Returns true of the address is a contract
-fn is_contract_in_state(journaled_state: &JournaledState, acc: Address) -> bool {
-    journaled_state
-        .state
-        .get(&acc)
-        .map(|acc| acc.info.code_hash != KECCAK_EMPTY)
-        .unwrap_or_default()
+fn is_contract_in_state(evm_state: &EvmState, acc: Address) -> bool {
+    evm_state.get(&acc).map(|acc| acc.info.code_hash != KECCAK_EMPTY).unwrap_or_default()
 }
 
 /// Updates the env's block with the block's data

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -1,7 +1,8 @@
 pub use alloy_evm::EvmEnv;
 use revm::{
-    Context, Database, Journal, JournalEntry,
-    context::{BlockEnv, CfgEnv, JournalInner, JournalTr, TxEnv},
+    Context, Database,
+    context::{BlockEnv, CfgEnv, JournalTr, TxEnv},
+    context_interface::ContextTr,
     primitives::hardfork::SpecId,
 };
 
@@ -78,25 +79,58 @@ impl<DB: Database, J: JournalTr<Database = DB>, C> AsEnvMut
     }
 }
 
-pub trait ContextExt {
-    type DB: Database;
+/// Extension trait providing mutable field access to block/tx/cfg.
+///
+/// Needed because [`ContextTr::all_mut()`] only returns immutable references for
+/// block, tx, and cfg. Cheatcodes like `vm.warp()`, `vm.roll()`, `vm.chainId()`
+/// need to mutate these fields.
+pub trait FoundryContextExt: ContextTr<Block = BlockEnv, Tx = TxEnv, Cfg = CfgEnv> {
+    /// Get a mutable reference to the block environment.
+    fn block_mut(&mut self) -> &mut BlockEnv;
+    /// Get a mutable reference to the transaction environment.
+    fn tx_mut(&mut self) -> &mut TxEnv;
+    /// Get a mutable reference to the configuration environment.
+    fn cfg_mut(&mut self) -> &mut CfgEnv;
 
-    fn as_db_env_and_journal(
-        &mut self,
-    ) -> (&mut Self::DB, &mut JournalInner<JournalEntry>, EnvMut<'_>);
+    /// Returns a cloned snapshot of the current environment.
+    fn to_env(&self) -> Env {
+        Env {
+            evm_env: EvmEnv { cfg_env: self.cfg().clone(), block_env: self.block().clone() },
+            tx: self.tx().clone(),
+        }
+    }
+
+    /// Applies an owned [`Env`] to this context, replacing block, cfg, and tx.
+    fn apply_env(&mut self, env: Env) {
+        *self.block_mut() = env.evm_env.block_env;
+        *self.cfg_mut() = env.evm_env.cfg_env;
+        *self.tx_mut() = env.tx;
+    }
+
+    /// Returns mutable references to the journal and environment simultaneously.
+    ///
+    /// This enables the caller to hold `&mut Journal` and `&mut EnvMut` at the same time,
+    /// which is needed for `DatabaseExt` methods that require both.
+    /// A single `&mut self` call avoids the borrow-splitting problem that arises
+    /// when calling `journal_mut()` and `block_mut()`/`tx_mut()`/`cfg_mut()` separately.
+    fn journal_and_env_mut(&mut self) -> (&mut Self::Journal, EnvMut<'_>);
 }
 
-impl<DB: Database, C> ContextExt
-    for Context<BlockEnv, TxEnv, CfgEnv, DB, Journal<DB, JournalEntry>, C>
+impl<DB: Database, J: JournalTr<Database = DB>, C> FoundryContextExt
+    for Context<BlockEnv, TxEnv, CfgEnv, DB, J, C>
 {
-    type DB = DB;
-
-    fn as_db_env_and_journal(
-        &mut self,
-    ) -> (&mut Self::DB, &mut JournalInner<JournalEntry>, EnvMut<'_>) {
+    fn block_mut(&mut self) -> &mut BlockEnv {
+        &mut self.block
+    }
+    fn tx_mut(&mut self) -> &mut TxEnv {
+        &mut self.tx
+    }
+    fn cfg_mut(&mut self) -> &mut CfgEnv {
+        &mut self.cfg
+    }
+    fn journal_and_env_mut(&mut self) -> (&mut J, EnvMut<'_>) {
         (
-            &mut self.journaled_state.database,
-            &mut self.journaled_state.inner,
+            &mut self.journaled_state,
             EnvMut { block: &mut self.block, cfg: &mut self.cfg, tx: &mut self.tx },
         )
     }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -11,8 +11,8 @@ use foundry_cheatcodes::{CheatcodeAnalysis, CheatcodesExecutor, Wallets};
 use foundry_common::compile::Analysis;
 use foundry_compilers::ProjectPathsConfig;
 use foundry_evm_core::{
-    ContextExt, Env, InspectorExt,
-    backend::{DatabaseExt, JournaledState},
+    Env, InspectorExt,
+    backend::{DatabaseExt, FoundryJournalExt, JournaledState},
     evm::new_evm_with_inspector,
 };
 use foundry_evm_coverage::HitMaps;
@@ -699,8 +699,9 @@ impl InspectorStackRefMut<'_> {
         self.in_inner_context = true;
 
         let res = self.with_inspector(|inspector| {
-            let (db, journal, env) = ecx.as_db_env_and_journal();
-            let mut evm = new_evm_with_inspector(db, env.to_owned(), inspector);
+            let env = Env::from(ecx.cfg.clone(), ecx.block.clone(), ecx.tx.clone());
+            let (db, journal) = ecx.journaled_state.as_db_and_inner();
+            let mut evm = new_evm_with_inspector(db, env.clone(), inspector);
 
             evm.journaled_state.state = {
                 let mut state = journal.state.clone();
@@ -724,14 +725,14 @@ impl InspectorStackRefMut<'_> {
             // set depth to 1 to make sure traces are collected correctly
             evm.journaled_state.depth = 1;
 
-            let res = evm.transact(env.tx.clone());
+            let res = evm.transact(env.tx);
 
             // need to reset the env in case it was modified via cheatcodes during execution
-            *env.cfg = evm.cfg.clone();
-            *env.block = evm.block.clone();
+            ecx.cfg = evm.cfg.clone();
+            ecx.block = evm.block.clone();
 
-            *env.tx = cached_env.tx;
-            env.block.basefee = cached_env.evm_env.block_env.basefee;
+            ecx.tx = cached_env.tx;
+            ecx.block.basefee = cached_env.evm_env.block_env.basefee;
 
             res
         });


### PR DESCRIPTION
### **_WIP — merge after #13536_**

Migrates remaining direct field accesses to revm trait method calls across the Inspector impl body, `ArbitraryStorage`, and cheatcode helpers.

### Changes

**`inspector.rs`**
- Replace all `ecx.journaled_state.depth()` → `ecx.journal().depth()`
- Replace all `ecx.journaled_state.db()` → `ecx.db()`
- Replace `ecx.block = block` → `*ecx.block_mut() = block`
- Replace `ecx.journaled_state.inner.state()` → `ecx.journal().evm_state()`
- Replace `ecx.as_db_env_and_journal()` + `journal.load_account(db, addr)` → `ecx.journal_mut().load_account(addr)`
- Eliminate `JournaledState` clone in `diagnose_revert` call
- Make `allow_cheatcodes_on_create`, `apply_accesslist`, `on_revert` generic
- Migrate `ArbitraryStorage::save/copy` from `ContextExt` → `ContextTr` + `JournalTr`
- Remove unused `ContextExt` import

**`evm/mock.rs`**
- Migrate `make_acc_non_empty` from `ContextExt` → `ContextTr` + `JournalTr`
- Simplify trait bounds on 10 mock cheatcode impls: `ContextTr + ContextExt<DB: DatabaseExt>` → `ContextTr<Db: DatabaseExt>`

**`backend/mod.rs` + `backend/cow.rs`**
- `diagnose_revert` takes `&EvmState` instead of `&JournaledState` (only field it ever accessed)