### PR TITLE
fix(anvil): use individual tx gas instead of cumulative in fee history

### DIFF
--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -285,7 +285,10 @@ impl FeeHistoryService {
                 .iter()
                 .enumerate()
                 .map(|(i, receipt)| {
-                    let gas_used = receipt.cumulative_gas_used();
+                    let cumulative = receipt.cumulative_gas_used();
+                    let prev_cumulative =
+                        if i > 0 { receipts[i - 1].cumulative_gas_used() } else { 0 };
+                    let gas_used = cumulative - prev_cumulative;
                     let effective_reward = block
                         .body
                         .transactions


### PR DESCRIPTION
During alloy migration (f840dbd93), `receipt.gas_used()` was replaced with `receipt.cumulative_gas_used()`. This is incorrect - cumulative gas is the sum of all tx gas up to current, not individual tx gas.

This broke eth_feeHistory percentile calculations which require per-tx gas values for weighted reward computation.