### PR TITLE
refactor(evm): remove dead BackendError::Other variant

### DIFF
--- a/crates/evm/core/src/backend/error.rs
+++ b/crates/evm/core/src/backend/error.rs
@@ -24,8 +24,6 @@ pub enum BackendError {
          For a test environment, you can use `etch` to place the required bytecode at that address."
     )]
     MissingCreate2Deployer,
-    #[error("{0}")]
-    Other(String),
 }
 
 impl BackendError {


### PR DESCRIPTION
Remove unused BackendError::Other(String) variant that fully duplicates BackendError::Message(String) - both have identical #[error("{0}")] formatting, but Other is never constructed or matched anywhere in the codebase