### PR TITLE
fix(evm): read snapshot storage from state_snapshot instead of local cache

### DIFF
--- a/crates/evm/core/src/fork/database.rs
+++ b/crates/evm/core/src/fork/database.rs
@@ -211,11 +211,7 @@ pub struct ForkDbStateSnapshot<N: Network> {
 
 impl<N: Network> ForkDbStateSnapshot<N> {
     fn get_storage(&self, address: Address, index: U256) -> Option<U256> {
-        self.state_snapshot
-            .storage
-            .get(&address)
-            .and_then(|storage| storage.get(&index))
-            .copied()
+        self.state_snapshot.storage.get(&address).and_then(|storage| storage.get(&index)).copied()
     }
 }
 

--- a/crates/evm/core/src/fork/database.rs
+++ b/crates/evm/core/src/fork/database.rs
@@ -211,11 +211,10 @@ pub struct ForkDbStateSnapshot<N: Network> {
 
 impl<N: Network> ForkDbStateSnapshot<N> {
     fn get_storage(&self, address: Address, index: U256) -> Option<U256> {
-        self.local
-            .cache
-            .accounts
+        self.state_snapshot
+            .storage
             .get(&address)
-            .and_then(|account| account.storage.get(&index))
+            .and_then(|storage| storage.get(&index))
             .copied()
     }
 }


### PR DESCRIPTION
Fix ForkDbStateSnapshot::get_storage to read from state_snapshot.storage instead of local.cache.accounts, which was a no-op duplicate of the outer check in storage_ref