### PR TITLE
[DNM] chore: prep alloy 2.0

### DIFF
--- a/crates/anvil/tests/it/eip4844.rs
+++ b/crates/anvil/tests/it/eip4844.rs
@@ -28,7 +28,7 @@ async fn can_send_eip4844_transaction() {
 
     let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(b"Hello World");
 
-    let sidecar = sidecar.build().unwrap();
+    let sidecar: BlobTransactionSidecar = sidecar.build().unwrap();
     let tx = TransactionRequest::default()
         .with_from(from)
         .with_to(to)
@@ -142,7 +142,7 @@ async fn can_send_multiple_blobs_in_one_tx() {
     let large_data = vec![1u8; DATA_GAS_PER_BLOB as usize * 5]; // 131072 is DATA_GAS_PER_BLOB and also BYTE_PER_BLOB
     let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(&large_data);
 
-    let sidecar = sidecar.build().unwrap();
+    let sidecar: BlobTransactionSidecar = sidecar.build().unwrap();
 
     let tx = TransactionRequest::default()
         .with_from(from)
@@ -178,7 +178,7 @@ async fn cannot_exceed_six_blobs() {
     let large_data = vec![1u8; DATA_GAS_PER_BLOB as usize * 6]; // 131072 is DATA_GAS_PER_BLOB and also BYTE_PER_BLOB
     let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(&large_data);
 
-    let sidecar = sidecar.build().unwrap();
+    let sidecar: BlobTransactionSidecar = sidecar.build().unwrap();
 
     let tx = TransactionRequest::default()
         .with_from(from)
@@ -216,7 +216,7 @@ async fn can_mine_blobs_when_exceeds_max_blobs() {
 
     let num_blobs_first = sidecar.clone().take().len() as u64;
 
-    let sidecar = sidecar.build().unwrap();
+    let sidecar: BlobTransactionSidecar = sidecar.build().unwrap();
 
     let tx = TransactionRequest::default()
         .with_from(from)
@@ -291,7 +291,7 @@ async fn can_correctly_estimate_blob_gas_with_recommended_fillers() {
     let bob = accounts[1];
 
     let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(b"Blobs are fun!");
-    let sidecar = sidecar.build().unwrap();
+    let sidecar: BlobTransactionSidecar = sidecar.build().unwrap();
 
     let tx = TransactionRequest::default().with_to(bob).with_blob_sidecar_4844(sidecar);
     let tx = WithOtherFields::new(tx);
@@ -337,7 +337,7 @@ async fn can_correctly_estimate_blob_gas_with_recommended_fillers_with_signer() 
     let bob = accounts[1];
 
     let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(b"Blobs are fun!");
-    let sidecar = sidecar.build().unwrap();
+    let sidecar: BlobTransactionSidecar = sidecar.build().unwrap();
 
     let tx = TransactionRequest::default().with_to(bob).with_blob_sidecar_4844(sidecar);
     let tx = WithOtherFields::new(tx);


### PR DESCRIPTION
## alloy 2.0.0-rc.0

Bump all `alloy-*` dependencies to `2.0.0-rc.0` (pinned to rev `5cc71c46`).

### Breaking API changes adapted

- `BlobTransactionSidecar` → `BlobTransactionSidecarVariant` (wrap with `::Eip4844()`)
- `TransactionBuilder7594` merged into `TransactionBuilder4844`
- `set_blob_sidecar()` → `set_blob_sidecar_4844()`
- `SidecarBuilder::build()` now requires explicit type parameter
- `SimulateError` gained a `data` field
- `GethDebugTracerType` now wraps `BuiltInTracer` variant
- `BlockOverrides` gained new fields (use `..` rest pattern)
- `PrimitiveSignature` → `Signature` (op-alloy)
- `TxDeposit.mint`: `Option<u128>` → `u128` (op-alloy)

### Dependency forks (`alloy-2.0` branches)

- [`stevencartavia/evm`](https://github.com/alloy-rs/evm/compare/main...stevencartavia:evm:alloy-2.0) — alloy-evm, alloy-op-evm
- [`stevencartavia/op-alloy`](https://github.com/alloy-rs/op-alloy/compare/main...stevencartavia:op-alloy:alloy-2.0) — op-alloy-consensus, op-alloy-rpc-types (rebased to v0.23.1)
- [`stevencartavia/revm-inspectors`](https://github.com/paradigmxyz/revm-inspectors/compare/main...stevencartavia:revm-inspectors:alloy-2.0) — mux tracer fix
- [`stevencartavia/foundry-fork-db`](https://github.com/foundry-rs/foundry-fork-db/compare/main...stevencartavia:foundry-fork-db:alloy-2.0) — dep bump only
- [`stevencartavia/tempo`](https://github.com/tempoxyz/tempo/compare/main...stevencartavia:tempo:alloy-2.0) — `InMemorySize` impl, non-reth `TempoReceipt` fall