### PR TITLE
fix(lint): wire up 6 dead LateLintPass hooks to LateLintVisitor`

### DIFF
--- a/crates/lint/src/linter/late.rs
+++ b/crates/lint/src/linter/late.rs
@@ -143,6 +143,43 @@ where
         self.walk_nested_source(id)
     }
 
+    fn visit_nested_item(&mut self, id: &'hir hir::ItemId) -> ControlFlow<Self::BreakValue> {
+        for pass in self.passes.iter_mut() {
+            pass.check_nested_item(self.ctx, self.hir, id);
+        }
+        self.walk_nested_item(id)
+    }
+
+    fn visit_nested_contract(
+        &mut self,
+        id: &'hir hir::ContractId,
+    ) -> ControlFlow<Self::BreakValue> {
+        for pass in self.passes.iter_mut() {
+            pass.check_nested_contract(self.ctx, self.hir, id);
+        }
+        self.walk_nested_contract(id)
+    }
+
+    fn visit_nested_function(
+        &mut self,
+        id: &'hir hir::FunctionId,
+    ) -> ControlFlow<Self::BreakValue> {
+        for pass in self.passes.iter_mut() {
+            pass.check_nested_function(self.ctx, self.hir, id);
+        }
+        self.walk_nested_function(id)
+    }
+
+    fn visit_nested_var(
+        &mut self,
+        id: &'hir hir::VariableId,
+    ) -> ControlFlow<Self::BreakValue> {
+        for pass in self.passes.iter_mut() {
+            pass.check_nested_var(self.ctx, self.hir, id);
+        }
+        self.walk_nested_var(id)
+    }
+
     fn visit_contract(
         &mut self,
         contract: &'hir hir::Contract<'hir>,
@@ -158,6 +195,16 @@ where
             pass.check_function(self.ctx, self.hir, func);
         }
         self.walk_function(func)
+    }
+
+    fn visit_modifier(
+        &mut self,
+        modifier: &'hir hir::Modifier<'hir>,
+    ) -> ControlFlow<Self::BreakValue> {
+        for pass in self.passes.iter_mut() {
+            pass.check_modifier(self.ctx, self.hir, modifier);
+        }
+        self.walk_modifier(modifier)
     }
 
     fn visit_item(&mut self, item: hir::Item<'hir, 'hir>) -> ControlFlow<Self::BreakValue> {
@@ -179,6 +226,16 @@ where
             pass.check_expr(self.ctx, self.hir, expr);
         }
         self.walk_expr(expr)
+    }
+
+    fn visit_call_args(
+        &mut self,
+        args: &'hir hir::CallArgs<'hir>,
+    ) -> ControlFlow<Self::BreakValue> {
+        for pass in self.passes.iter_mut() {
+            pass.check_call_args(self.ctx, self.hir, args);
+        }
+        self.walk_call_args(args)
     }
 
     fn visit_stmt(&mut self, stmt: &'hir hir::Stmt<'hir>) -> ControlFlow<Self::BreakValue> {


### PR DESCRIPTION
**Description:**

## Summary

The `LateLintPass` trait defines 14 hooks, but `LateLintVisitor` only implemented 8 of the corresponding `hir::Visit` methods. The remaining 6 hooks were never called, meaning any lint implementing them would silently produce zero findings.

## Problem

The following `LateLintPass` hooks had no corresponding visitor dispatch in `LateLintVisitor`:

- `check_nested_item`
- `check_nested_contract`
- `check_nested_function`
- `check_nested_var`
- `check_modifier`
- `check_call_args`

Because `LateLintPass` provides default no-op implementations for all hooks, a lint author implementing any of these would get code that compiles, registers, and runs — but never fires. There's no compiler error or runtime warning to indicate the hook is dead.

By contrast, `EarlyLintPass` and `EarlyLintVisitor` maintain a clean 1:1 mapping between hooks and visitor methods, so this issue is specific to the late pass.

## Fix

Added the 6 missing visitor methods to the `hir::Visit` impl for `LateLintVisitor`, following the same pattern as the existing 8:

```rust
fn visit_X(&mut self, ...) -> ControlFlow<Self::BreakValue> {
    for pass in self.passes.iter_mut() {
        pass.check_X(self.ctx, self.hir, ...);
    }
    self.walk_X(...)
}
```

No changes to the `LateLintPass` trait itself — all hooks are now reachable.

## Note

If any of the corresponding `hir::Visit` methods (`visit_nested_item`, `walk_modifier`, etc.) don't yet exist upstream in solar, the alternative fix is to remove the dead hooks from `LateLintPass` until the visitor infrastructure supports them, keeping the same discipline as `EarlyLintPass`.