### PR TITLE
fix(fmt): don't inline while/for/if blocks with multiple statements

### DIFF
--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -2529,10 +2529,16 @@ impl<'ast> State<'_, 'ast> {
         false
     }
 
-    /// Checks if a block statement `{ ... }` contains more than one line of actual code.
+    /// Checks if a block statement `{ ... }` should be treated as multiline,
+    /// either because it spans multiple lines or contains multiple statements.
     fn is_multiline_block(&self, block: &'ast ast::Block<'ast>, empty_as_multiline: bool) -> bool {
         if block.stmts.is_empty() {
             return empty_as_multiline;
+        }
+        // A block with multiple statements should never be inlined, regardless of
+        // whether it was written on a single line in the source.
+        if block.stmts.len() > 1 {
+            return true;
         }
         if self.sm.is_multiline(block.span)
             && let Ok(snip) = self.sm.span_to_snippet(block.span)

--- a/crates/fmt/testdata/WhileStatement/block-multi.fmt.sol
+++ b/crates/fmt/testdata/WhileStatement/block-multi.fmt.sol
@@ -55,6 +55,11 @@ contract WhileStatement {
 
         while (condition) {
             doIt();
+            doIt();
+        }
+
+        while (condition) {
+            doIt();
         }
 
         while ( // comment1

--- a/crates/fmt/testdata/WhileStatement/block-single.fmt.sol
+++ b/crates/fmt/testdata/WhileStatement/block-single.fmt.sol
@@ -33,6 +33,11 @@ contract WhileStatement {
 
         while (condition) doIt();
 
+        while (condition) {
+            doIt();
+            doIt();
+        }
+
         while (condition) doIt();
 
         while ( // comment1

--- a/crates/fmt/testdata/WhileStatement/fmt.sol
+++ b/crates/fmt/testdata/WhileStatement/fmt.sol
@@ -40,6 +40,11 @@ contract WhileStatement {
 
         while (condition) doIt();
 
+        while (condition) {
+            doIt();
+            doIt();
+        }
+
         while (condition) doIt();
 
         while ( // comment1

--- a/crates/fmt/testdata/WhileStatement/original.sol
+++ b/crates/fmt/testdata/WhileStatement/original.sol
@@ -36,6 +36,8 @@ contract WhileStatement {
 
         while(condition) { doIt(); }
 
+        while(condition) { doIt(); doIt(); }
+
         while 
         (condition) doIt();
 


### PR DESCRIPTION
Fixes #13555

`forge fmt` silently drops statements from single-line blocks with multiple statements (e.g. `while (x) { a++; b++; }`) by only keeping the first inside the loop, changing program semantics without warning.