### PR TITLE
fix(cast): correct max_int boundary check for uint255

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1158,7 +1158,7 @@ impl SimpleCast {
             DynSolType::Uint(n) => {
                 if MAX {
                     let mut max = U256::MAX;
-                    if n < 255 {
+                    if n < 256 {
                         max &= U256::from(1).wrapping_shl(n).wrapping_sub(U256::from(1));
                     }
                     Ok(max.to_string())


### PR DESCRIPTION
The condition `n < 255` was introduced in #4269 and later partially fixed in #8800, but the boundary check remained off-by-one. This caused `cast max-int uint255` to  incorrectly return U256::MAX (2^256-1) instead of the correct value (2^255-1).