### PR TITLE
fix(evm): use DbAccount::info() method in ForkDbStateSnapshot::basic_ref

### DIFF
--- a/crates/evm/core/src/fork/database.rs
+++ b/crates/evm/core/src/fork/database.rs
@@ -228,7 +228,7 @@ impl<N: Network> DatabaseRef for ForkDbStateSnapshot<N> {
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         match self.local.cache.accounts.get(&address) {
-            Some(account) => Ok(Some(account.info.clone())),
+            Some(account) => Ok(account.info()),
             None => {
                 let mut acc = self.state_snapshot.accounts.get(&address).cloned();
 


### PR DESCRIPTION
Fix ForkDbStateSnapshot::basic_ref to call account.info() instead of directly accessing account.info.clone()