### PR TITLE
feat(evm): add `AsEnvMut::set_env`

### DIFF
--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -48,22 +48,21 @@ impl EnvMut<'_> {
             tx: self.tx.to_owned(),
         }
     }
+
+    /// Writes an owned [`Env`] back into the context.
+    ///
+    /// Counterpart to [`to_owned`](Self::to_owned): completes the read/write pair so callers
+    /// that receive an updated [`Env`] by value (e.g. after a fork switch or snapshot revert)
+    /// can apply it without manually assigning each field.
+    pub fn set_env(&mut self, env: Env) {
+        *self.block = env.evm_env.block_env;
+        *self.cfg = env.evm_env.cfg_env;
+        *self.tx = env.tx;
+    }
 }
 
 pub trait AsEnvMut {
     fn as_env_mut(&mut self) -> EnvMut<'_>;
-
-    /// Writes an owned [`Env`] back into the context.
-    ///
-    /// Counterpart to `as_env_mut().to_owned()`: completes the read/write pair so callers
-    /// that receive an updated [`Env`] by value (e.g. after a fork switch or snapshot revert)
-    /// can apply it without manually assigning each field.
-    fn set_env(&mut self, env: Env) {
-        let m = self.as_env_mut();
-        *m.block = env.evm_env.block_env;
-        *m.cfg = env.evm_env.cfg_env;
-        *m.tx = env.tx;
-    }
 }
 
 impl AsEnvMut for EnvMut<'_> {


### PR DESCRIPTION
`AsEnvMut` has a read path — `as_env_mut().to_owned()` — but no counterpart to write an owned Env back. Adds `set_env` as a default method.

This complements #13570 (FoundryJournalExt), where `select_fork`, `roll_fork`, `roll_fork_to_transaction`, `create_select_fork`, `create_select_fork_at_transaction` and `revert_state` all return an updated Env by value.
Without `set_env`, every caller must manually assign all three fields back into the context. With it: `ctx.set_env(ctx.journal_mut().select_fork(id, env)?);`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
