### PR TITLE
refactor(cheatcodes,evm): use JournalTr and JournalExt trait methods

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -37,6 +37,7 @@ use rand::Rng;
 use revm::{
     bytecode::Bytecode,
     context::{Block, ContextTr, JournalTr, TxEnv, result::ExecutionResult},
+    inspector::JournalExt,
     primitives::{KECCAK_EMPTY, hardfork::SpecId},
     state::{Account, AccountStatus},
 };
@@ -341,7 +342,7 @@ impl Cheatcode for cloneAccountCall {
         let genesis = &genesis_account(account.data);
         db.clone_account(genesis, target, journal)?;
         // Cloned account should persist in forked envs.
-        ccx.ecx.journaled_state.database.add_persistent_account(*target);
+        ccx.ecx.db_mut().add_persistent_account(*target);
         Ok(Default::default())
     }
 }
@@ -364,8 +365,8 @@ impl Cheatcode for dumpStateCall {
 
         let alloc = ccx
             .ecx
-            .journaled_state
-            .state()
+            .journal_mut()
+            .evm_state_mut()
             .iter_mut()
             .filter(|(key, val)| !skip(key, val))
             .map(|(key, val)| (key, genesis_account(val)))
@@ -710,7 +711,7 @@ impl Cheatcode for storeCall {
 impl Cheatcode for coolCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { target } = self;
-        if let Some(account) = ccx.ecx.journaled_state.state.get_mut(target) {
+        if let Some(account) = ccx.ecx.journal_mut().evm_state_mut().get_mut(target) {
             account.unmark_touch();
             account.storage.values_mut().for_each(|slot| slot.mark_cold());
         }
@@ -763,7 +764,7 @@ impl Cheatcode for coolSlotCall {
 impl Cheatcode for readCallersCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self {} = self;
-        read_callers(ccx.state, &ccx.ecx.tx().caller, ccx.ecx.journaled_state.depth())
+        read_callers(ccx.state, &ccx.ecx.tx().caller, ccx.ecx.journal().depth())
     }
 }
 
@@ -1060,7 +1061,7 @@ impl Cheatcode for broadcastRawTransactionCall {
 
         if ccx.state.broadcast.is_some() {
             ccx.state.broadcastable_transactions.push_back(BroadcastableTransaction {
-                rpc: ccx.ecx.journaled_state.database.active_fork_url(),
+                rpc: ccx.ecx.db().active_fork_url(),
                 transaction: tx.try_into()?,
             });
         }
@@ -1078,7 +1079,7 @@ impl Cheatcode for setBlockhashCall {
             "block number must be less than or equal to the current block number"
         );
 
-        ccx.ecx.journaled_state.database.set_blockhash(blockNumber, blockHash);
+        ccx.ecx.db_mut().set_blockhash(blockNumber, blockHash);
 
         Ok(Default::default())
     }
@@ -1185,8 +1186,8 @@ impl Cheatcode for executeTransactionCall {
 
         // Merge state changes back into the parent journaled state.
         for (addr, mut acc) in res.state {
-            let Some(acc_mut) = ccx.ecx.journaled_state.state.get_mut(&addr) else {
-                ccx.ecx.journaled_state.state.insert(addr, acc);
+            let Some(acc_mut) = ccx.ecx.journal_mut().evm_state_mut().get_mut(&addr) else {
+                ccx.ecx.journal_mut().evm_state_mut().insert(addr, acc);
                 continue;
             };
 
@@ -1345,12 +1346,12 @@ fn inner_revert_to_state_and_delete(ccx: &mut CheatsCtxt, snapshot_id: U256) -> 
 }
 
 fn inner_delete_state_snapshot(ccx: &mut CheatsCtxt, snapshot_id: U256) -> Result {
-    let result = ccx.ecx.journaled_state.database.delete_state_snapshot(snapshot_id);
+    let result = ccx.ecx.db_mut().delete_state_snapshot(snapshot_id);
     Ok(result.abi_encode())
 }
 
 fn inner_delete_state_snapshots(ccx: &mut CheatsCtxt) -> Result {
-    ccx.ecx.journaled_state.database.delete_state_snapshots();
+    ccx.ecx.db_mut().delete_state_snapshots();
     Ok(Default::default())
 }
 
@@ -1396,7 +1397,7 @@ fn inner_start_gas_snapshot(
         group: group.clone(),
         name: name.clone(),
         gas_used: 0,
-        depth: ccx.ecx.journaled_state.depth(),
+        depth: ccx.ecx.journal().depth(),
     });
 
     ccx.state.gas_metering.active_gas_snapshot = Some((group, name));
@@ -1521,7 +1522,7 @@ pub(super) fn journaled_account<'a>(
     addr: Address,
 ) -> Result<&'a mut Account> {
     ensure_loaded_account(ecx, addr)?;
-    Ok(ecx.journaled_state.state.get_mut(&addr).expect("account is loaded"))
+    Ok(ecx.journal_mut().evm_state_mut().get_mut(&addr).expect("account is loaded"))
 }
 
 pub(super) fn ensure_loaded_account(ecx: Ecx, addr: Address) -> Result<()> {
@@ -1789,7 +1790,7 @@ fn get_contract_data<'a>(
 
 /// Helper function to set / unset cold storage slot of the target address.
 fn set_cold_slot(ccx: &mut CheatsCtxt, target: Address, slot: U256, cold: bool) {
-    if let Some(account) = ccx.ecx.journaled_state.state.get_mut(&target)
+    if let Some(account) = ccx.ecx.journal_mut().evm_state_mut().get_mut(&target)
         && let Some(storage_slot) = account.storage.get_mut(&slot)
     {
         storage_slot.is_cold = cold;

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -10,13 +10,13 @@ use alloy_rpc_types::Filter;
 use alloy_sol_types::SolValue;
 use foundry_common::provider::ProviderBuilder;
 use foundry_evm_core::{AsEnvMut, ContextExt, fork::CreateFork};
+use revm::context::ContextTr;
 
 impl Cheatcode for activeForkCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self {} = self;
         ccx.ecx
-            .journaled_state
-            .database
+            .db()
             .active_fork_id()
             .map(|id| id.abi_encode())
             .ok_or_else(|| fmt_err!("no active fork"))
@@ -133,7 +133,7 @@ impl Cheatcode for transact_1Call {
 impl Cheatcode for allowCheatcodesCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account } = self;
-        ccx.ecx.journaled_state.database.allow_cheatcode_access(*account);
+        ccx.ecx.db_mut().allow_cheatcode_access(*account);
         Ok(Default::default())
     }
 }
@@ -141,7 +141,7 @@ impl Cheatcode for allowCheatcodesCall {
 impl Cheatcode for makePersistent_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account } = self;
-        ccx.ecx.journaled_state.database.add_persistent_account(*account);
+        ccx.ecx.db_mut().add_persistent_account(*account);
         Ok(Default::default())
     }
 }
@@ -149,8 +149,8 @@ impl Cheatcode for makePersistent_0Call {
 impl Cheatcode for makePersistent_1Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account0, account1 } = self;
-        ccx.ecx.journaled_state.database.add_persistent_account(*account0);
-        ccx.ecx.journaled_state.database.add_persistent_account(*account1);
+        ccx.ecx.db_mut().add_persistent_account(*account0);
+        ccx.ecx.db_mut().add_persistent_account(*account1);
         Ok(Default::default())
     }
 }
@@ -158,9 +158,9 @@ impl Cheatcode for makePersistent_1Call {
 impl Cheatcode for makePersistent_2Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account0, account1, account2 } = self;
-        ccx.ecx.journaled_state.database.add_persistent_account(*account0);
-        ccx.ecx.journaled_state.database.add_persistent_account(*account1);
-        ccx.ecx.journaled_state.database.add_persistent_account(*account2);
+        ccx.ecx.db_mut().add_persistent_account(*account0);
+        ccx.ecx.db_mut().add_persistent_account(*account1);
+        ccx.ecx.db_mut().add_persistent_account(*account2);
         Ok(Default::default())
     }
 }
@@ -169,7 +169,7 @@ impl Cheatcode for makePersistent_3Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { accounts } = self;
         for account in accounts {
-            ccx.ecx.journaled_state.database.add_persistent_account(*account);
+            ccx.ecx.db_mut().add_persistent_account(*account);
         }
         Ok(Default::default())
     }
@@ -178,7 +178,7 @@ impl Cheatcode for makePersistent_3Call {
 impl Cheatcode for revokePersistent_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account } = self;
-        ccx.ecx.journaled_state.database.remove_persistent_account(account);
+        ccx.ecx.db_mut().remove_persistent_account(account);
         Ok(Default::default())
     }
 }
@@ -187,7 +187,7 @@ impl Cheatcode for revokePersistent_1Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { accounts } = self;
         for account in accounts {
-            ccx.ecx.journaled_state.database.remove_persistent_account(account);
+            ccx.ecx.db_mut().remove_persistent_account(account);
         }
         Ok(Default::default())
     }
@@ -196,19 +196,15 @@ impl Cheatcode for revokePersistent_1Call {
 impl Cheatcode for isPersistentCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account } = self;
-        Ok(ccx.ecx.journaled_state.database.is_persistent(account).abi_encode())
+        Ok(ccx.ecx.db().is_persistent(account).abi_encode())
     }
 }
 
 impl Cheatcode for rpc_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { method, params } = self;
-        let url = ccx
-            .ecx
-            .journaled_state
-            .database
-            .active_fork_url()
-            .ok_or_else(|| fmt_err!("no active fork URL found"))?;
+        let url =
+            ccx.ecx.db().active_fork_url().ok_or_else(|| fmt_err!("no active fork URL found"))?;
         rpc_call(&url, method, params)
     }
 }
@@ -233,12 +229,8 @@ impl Cheatcode for eth_getLogsCall {
             bail!("topics array must contain at most 4 elements")
         }
 
-        let url = ccx
-            .ecx
-            .journaled_state
-            .database
-            .active_fork_url()
-            .ok_or_else(|| fmt_err!("no active fork URL found"))?;
+        let url =
+            ccx.ecx.db().active_fork_url().ok_or_else(|| fmt_err!("no active fork URL found"))?;
         let provider = ProviderBuilder::<AnyNetwork>::new(&url).build()?;
         let mut filter = Filter::new().address(*target).from_block(from_block).to_block(to_block);
         for (i, &topic) in topics.iter().enumerate() {
@@ -270,12 +262,7 @@ impl Cheatcode for eth_getLogsCall {
 impl Cheatcode for getRawBlockHeaderCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { blockNumber } = self;
-        let url = ccx
-            .ecx
-            .journaled_state
-            .database
-            .active_fork_url()
-            .ok_or_else(|| fmt_err!("no active fork"))?;
+        let url = ccx.ecx.db().active_fork_url().ok_or_else(|| fmt_err!("no active fork"))?;
         let provider = ProviderBuilder::<AnyNetwork>::new(&url).build()?;
         let block_number = u64::try_from(blockNumber)
             .map_err(|_| fmt_err!("block number must be less than 2^64"))?;
@@ -307,7 +294,7 @@ fn create_select_fork(ccx: &mut CheatsCtxt, url_or_alias: &str, block: Option<u6
 /// Creates a new fork
 fn create_fork(ccx: &mut CheatsCtxt, url_or_alias: &str, block: Option<u64>) -> Result {
     let fork = create_fork_request(ccx, url_or_alias, block)?;
-    let id = ccx.ecx.journaled_state.database.create_fork(fork)?;
+    let id = ccx.ecx.db_mut().create_fork(fork)?;
     Ok(id.abi_encode())
 }
 
@@ -332,7 +319,7 @@ fn create_fork_at_transaction(
     transaction: &B256,
 ) -> Result {
     let fork = create_fork_request(ccx, url_or_alias, None)?;
-    let id = ccx.ecx.journaled_state.database.create_fork_at_transaction(fork, *transaction)?;
+    let id = ccx.ecx.db_mut().create_fork_at_transaction(fork, *transaction)?;
     Ok(id.abi_encode())
 }
 
@@ -393,7 +380,7 @@ fn transact(
 // Applies to create, select and roll forks actions.
 // https://github.com/foundry-rs/foundry/issues/8004
 fn persist_caller(ccx: &mut CheatsCtxt) {
-    ccx.ecx.journaled_state.database.add_persistent_account(ccx.caller);
+    ccx.ecx.db_mut().add_persistent_account(ccx.caller);
 }
 
 /// Performs an Ethereum JSON-RPC request to the given endpoint.

--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -1,6 +1,10 @@
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, Result, Vm::*};
 use alloy_primitives::{Address, Bytes, U256};
-use revm::{bytecode::Bytecode, context::JournalTr, interpreter::InstructionResult};
+use revm::{
+    bytecode::Bytecode,
+    context::{ContextTr, JournalTr},
+    interpreter::InstructionResult,
+};
 use std::{cmp::Ordering, collections::VecDeque};
 
 /// Mocked call data.
@@ -214,12 +218,12 @@ fn mock_calls(
 // Etches a single byte onto the account if it is empty to circumvent the `extcodesize`
 // check Solidity might perform.
 fn make_acc_non_empty(callee: &Address, ecx: &mut CheatsCtxt) -> Result {
-    let acc = ecx.journaled_state.load_account(*callee)?;
+    let acc = ecx.journal_mut().load_account(*callee)?;
 
     let empty_bytecode = acc.info.code.as_ref().is_none_or(Bytecode::is_empty);
     if empty_bytecode {
         let code = Bytecode::new_raw(Bytes::from_static(&[0u8]));
-        ecx.journaled_state.set_code(*callee, code);
+        ecx.journal_mut().set_code(*callee, code);
     }
 
     Ok(Default::default())

--- a/crates/cheatcodes/src/evm/prank.rs
+++ b/crates/cheatcodes/src/evm/prank.rs
@@ -112,7 +112,7 @@ impl Cheatcode for startPrank_3Call {
 impl Cheatcode for stopPrankCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self {} = self;
-        ccx.state.pranks.remove(&ccx.ecx.journaled_state.depth());
+        ccx.state.pranks.remove(&ccx.ecx.journal().depth());
         Ok(Default::default())
     }
 }
@@ -137,7 +137,7 @@ fn prank(
         );
     }
 
-    let depth = ccx.ecx.journaled_state.depth();
+    let depth = ccx.ecx.journal().depth();
     if let Some(Prank { used, single_call: current_single_call, .. }) = ccx.state.get_prank(depth) {
         ensure!(used, "cannot overwrite a prank until it is applied at least once");
         // This case can only fail if the user calls `vm.startPrank` and then `vm.prank` later on.

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -376,10 +376,8 @@ fn deploy_code(
         if let Some(salt) = salt { CreateScheme::Create2 { salt } } else { CreateScheme::Create };
 
     // If prank active at current depth, then use it as caller for create input.
-    let caller = ccx
-        .state
-        .get_prank(ccx.ecx.journaled_state.depth())
-        .map_or(ccx.caller, |prank| prank.new_caller);
+    let caller =
+        ccx.state.get_prank(ccx.ecx.journal().depth()).map_or(ccx.caller, |prank| prank.new_caller);
 
     let outcome = executor.exec_create(
         CreateInputs::new(

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -56,6 +56,7 @@ use revm::{
     context::{BlockEnv, ContextTr, JournalTr, LocalContext, TransactionType, result::EVMError},
     context_interface::{CreateScheme, transaction::SignedAuthorization},
     handler::FrameResult,
+    inspector::JournalExt,
     interpreter::{
         CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, FrameInput, Gas, Host,
         InstructionResult, Interpreter, InterpreterAction, InterpreterResult,
@@ -638,7 +639,7 @@ impl Cheatcodes {
 
         // ensure the caller is allowed to execute cheatcodes,
         // but only if the backend is in forking mode
-        ecx.journaled_state.database.ensure_cheatcode_access_forking_mode(&caller)?;
+        ecx.db_mut().ensure_cheatcode_access_forking_mode(&caller)?;
 
         apply_dispatch(
             &decoded,
@@ -653,10 +654,8 @@ impl Cheatcodes {
     /// There may be cheatcodes in the constructor of the new contract, in order to allow them
     /// automatically we need to determine the new address.
     fn allow_cheatcodes_on_create(&self, ecx: Ecx, caller: Address, created_address: Address) {
-        if ecx.journaled_state.depth <= 1
-            || ecx.journaled_state.database.has_cheatcode_access(&caller)
-        {
-            ecx.journaled_state.database.allow_cheatcode_access(created_address);
+        if ecx.journal().depth() <= 1 || ecx.db().has_cheatcode_access(&caller) {
+            ecx.db_mut().allow_cheatcode_access(created_address);
         }
     }
 
@@ -688,7 +687,7 @@ impl Cheatcodes {
         }
 
         // we only want to apply cleanup top level
-        if ecx.journaled_state.depth() > 0 {
+        if ecx.journal().depth() > 0 {
             return;
         }
 
@@ -696,7 +695,7 @@ impl Cheatcodes {
         // This will prevent overflow issues in revm's [`JournaledState::journal_revert`] routine
         // which rolls back any transfers.
         while let Some(record) = self.eth_deals.pop() {
-            if let Some(acc) = ecx.journaled_state.state.get_mut(&record.address) {
+            if let Some(acc) = ecx.journal_mut().evm_state_mut().get_mut(&record.address) {
                 acc.info.balance = record.old_balance;
             }
         }
@@ -714,7 +713,7 @@ impl Cheatcodes {
         }
 
         let gas = Gas::new(call.gas_limit);
-        let curr_depth = ecx.journaled_state.depth();
+        let curr_depth = ecx.journal().depth();
 
         // At the root call to test function or script `run()`/`setUp()` functions, we are
         // decreasing sender nonce to ensure that it matches on-chain nonce once we start
@@ -920,8 +919,9 @@ impl Cheatcodes {
                     let input = TransactionInput::new(call.input.bytes(ecx));
 
                     let chain_id = ecx.cfg().chain_id;
+                    let rpc = ecx.db().active_fork_url();
                     let account =
-                        ecx.journaled_state.inner.state().get_mut(&broadcast.new_origin).unwrap();
+                        ecx.journal_mut().evm_state_mut().get_mut(&broadcast.new_origin).unwrap();
 
                     let mut tx_req = TransactionRequest {
                         from: Some(broadcast.new_origin),
@@ -973,10 +973,8 @@ impl Cheatcodes {
                         tx_req.authorization_list = Some(active_delegations);
                     }
 
-                    self.broadcastable_transactions.push_back(BroadcastableTransaction {
-                        rpc: ecx.journaled_state.database.active_fork_url(),
-                        transaction: tx_req.into(),
-                    });
+                    self.broadcastable_transactions
+                        .push_back(BroadcastableTransaction { rpc, transaction: tx_req.into() });
                     debug!(target: "cheatcodes", tx=?self.broadcastable_transactions.back().unwrap(), "broadcastable call");
 
                     // Explicitly increment nonce if calls are not isolated.
@@ -1034,7 +1032,7 @@ impl Cheatcodes {
             // as "warm" if the call from which they were accessed is reverted
             recorded_account_diffs_stack.push(vec![AccountAccess {
                 chainInfo: crate::Vm::ChainInfo {
-                    forkId: ecx.journaled_state.db().active_fork_id().unwrap_or_default(),
+                    forkId: ecx.db().active_fork_id().unwrap_or_default(),
                     chainId: U256::from(ecx.cfg().chain_id),
                 },
                 accessor: call.caller,
@@ -1050,11 +1048,7 @@ impl Cheatcodes {
                 reverted: false,
                 deployedCode: Bytes::new(),
                 storageAccesses: vec![], // updated on step
-                depth: ecx
-                    .journaled_state
-                    .depth()
-                    .try_into()
-                    .expect("journaled state depth exceeds u64"),
+                depth: ecx.journal().depth().try_into().expect("journaled state depth exceeds u64"),
             }]);
         }
 
@@ -1149,7 +1143,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
 
         // `expectRevert`: track the max call depth during `expectRevert`
         if let Some(expected) = &mut self.expected_revert {
-            expected.max_depth = max(ecx.journaled_state.depth(), expected.max_depth);
+            expected.max_depth = max(ecx.journal().depth(), expected.max_depth);
         }
     }
 
@@ -1184,7 +1178,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
         if !self.allowed_mem_writes.is_empty() {
             self.check_mem_opcodes(
                 interpreter,
-                ecx.journaled_state.depth().try_into().expect("journaled state depth exceeds u64"),
+                ecx.journal().depth().try_into().expect("journaled state depth exceeds u64"),
             );
         }
 
@@ -1250,7 +1244,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
         // This should be placed before the revert handling, because we might exit early there
         if !cheatcode_call {
             // Clean up pranks
-            let curr_depth = ecx.journaled_state.depth();
+            let curr_depth = ecx.journal().depth();
             if let Some(prank) = &self.get_prank(curr_depth)
                 && curr_depth == prank.depth
             {
@@ -1284,7 +1278,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
             }
 
             // allow multiple cheatcode calls at the same depth
-            let curr_depth = ecx.journaled_state.depth();
+            let curr_depth = ecx.journal().depth();
             if curr_depth <= assume_no_revert.depth && !cheatcode_call {
                 // Discard run if we're at the same depth as cheatcode, call reverted, and no
                 // specific reason was supplied
@@ -1331,7 +1325,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
                 }
             }
 
-            let curr_depth = ecx.journaled_state.depth();
+            let curr_depth = ecx.journal().depth();
             if curr_depth <= expected_revert.depth {
                 let needs_processing = match expected_revert.kind {
                     ExpectedRevertKind::Default => !cheatcode_call,
@@ -1400,7 +1394,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
         // previous call depth's recorded accesses, if any
         if let Some(recorded_account_diffs_stack) = &mut self.recorded_account_diffs_stack {
             // The root call cannot be recorded.
-            if ecx.journaled_state.depth() > 0
+            if ecx.journal().depth() > 0
                 && let Some(mut last_recorded_depth) = recorded_account_diffs_stack.pop()
             {
                 // Update the reverted status of all deeper calls if this call reverted, in
@@ -1457,7 +1451,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
             .expected_emits
             .iter()
             .any(|(expected, _)| {
-                let curr_depth = ecx.journaled_state.depth();
+                let curr_depth = ecx.journal().depth();
                 expected.depth == curr_depth
             }) &&
             // Ignore staticcalls
@@ -1537,18 +1531,18 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
         if let TxKind::Call(test_contract) = ecx.tx().kind {
             // if a call to a different contract than the original test contract returned with
             // `Stop` we check if the contract actually exists on the active fork
-            if ecx.journaled_state.db().is_forked_mode()
+            if ecx.db().is_forked_mode()
                 && outcome.result.result == InstructionResult::Stop
                 && call.target_address != test_contract
             {
                 let journaled_state = ecx.journaled_state.clone();
                 self.fork_revert_diagnostic =
-                    ecx.journaled_state.db().diagnose_revert(call.target_address, &journaled_state);
+                    ecx.db().diagnose_revert(call.target_address, &journaled_state);
             }
         }
 
         // If the depth is 0, then this is the root call terminating
-        if ecx.journaled_state.depth() == 0 {
+        if ecx.journal().depth() == 0 {
             // If we already have a revert, we shouldn't run the below logic as it can obfuscate an
             // earlier error that happened first with unrelated information about
             // another error when using cheatcodes.
@@ -1667,7 +1661,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
             });
         }
 
-        let curr_depth = ecx.journaled_state.depth();
+        let curr_depth = ecx.journal().depth();
 
         // Apply our prank
         if let Some(prank) = &self.get_prank(curr_depth)
@@ -1724,9 +1718,9 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
 
                 input.set_caller(broadcast.new_origin);
 
-                let account = &ecx.journaled_state.inner.state()[&broadcast.new_origin];
+                let account = &ecx.journal().evm_state()[&broadcast.new_origin];
                 self.broadcastable_transactions.push_back(BroadcastableTransaction {
-                    rpc: ecx.journaled_state.database.active_fork_url(),
+                    rpc: ecx.db().active_fork_url(),
                     transaction: TransactionRequest {
                         from: Some(broadcast.new_origin),
                         to: None,
@@ -1749,7 +1743,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
         if let Some(recorded_account_diffs_stack) = &mut self.recorded_account_diffs_stack {
             recorded_account_diffs_stack.push(vec![AccountAccess {
                 chainInfo: crate::Vm::ChainInfo {
-                    forkId: ecx.journaled_state.db().active_fork_id().unwrap_or_default(),
+                    forkId: ecx.db().active_fork_id().unwrap_or_default(),
                     chainId: U256::from(ecx.cfg().chain_id),
                 },
                 accessor: input.caller(),
@@ -1774,7 +1768,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
 
     fn create_end(&mut self, ecx: Ecx, call: &CreateInputs, outcome: &mut CreateOutcome) {
         let call = Some(call);
-        let curr_depth = ecx.journaled_state.depth();
+        let curr_depth = ecx.journal().depth();
 
         // Clean up pranks
         if let Some(prank) = &self.get_prank(curr_depth)
@@ -1856,7 +1850,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
                     // changes. Depending on what depth the cheat was called at, there
                     // may not be any pending calls to update if execution has
                     // percolated up to a higher depth.
-                    let depth = ecx.journaled_state.depth();
+                    let depth = ecx.journal().depth();
                     if create_access.depth == depth as u64 {
                         debug_assert_eq!(
                             create_access.kind as u8,
@@ -1908,7 +1902,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for Cheatcodes {
 impl InspectorExt for Cheatcodes {
     fn should_use_create2_factory(&mut self, ecx: Ecx, inputs: &CreateInputs) -> bool {
         if let CreateScheme::Create2 { .. } = inputs.scheme() {
-            let depth = ecx.journaled_state.depth();
+            let depth = ecx.journal().depth();
             let target_depth = if let Some(prank) = &self.get_prank(depth) {
                 prank.depth
             } else if let Some(broadcast) = &self.broadcast {
@@ -1949,7 +1943,7 @@ impl Cheatcodes {
     fn meter_gas_record(&mut self, interpreter: &mut Interpreter, ecx: Ecx) {
         if interpreter.bytecode.action.as_ref().and_then(|i| i.instruction_result()).is_none() {
             self.gas_metering.gas_records.iter_mut().for_each(|record| {
-                let curr_depth = ecx.journaled_state.depth();
+                let curr_depth = ecx.journal().depth();
                 if curr_depth == record.depth {
                     // Skip the first opcode of the first call frame as it includes the gas cost of
                     // creating the snapshot.
@@ -2089,7 +2083,7 @@ impl Cheatcodes {
                 // register access for the target account
                 last.push(crate::Vm::AccountAccess {
                     chainInfo: crate::Vm::ChainInfo {
-                        forkId: ecx.journaled_state.database.active_fork_id().unwrap_or_default(),
+                        forkId: ecx.db().active_fork_id().unwrap_or_default(),
                         chainId: U256::from(ecx.cfg().chain_id),
                     },
                     accessor: interpreter.input.target_address,
@@ -2106,7 +2100,7 @@ impl Cheatcodes {
                     deployedCode: Bytes::new(),
                     storageAccesses: vec![],
                     depth: ecx
-                        .journaled_state
+                        .journal()
                         .depth()
                         .try_into()
                         .expect("journaled state depth exceeds u64"),
@@ -2137,11 +2131,8 @@ impl Cheatcodes {
                     newValue: present_value.into(),
                     reverted: false,
                 };
-                let curr_depth = ecx
-                    .journaled_state
-                    .depth()
-                    .try_into()
-                    .expect("journaled state depth exceeds u64");
+                let curr_depth =
+                    ecx.journal().depth().try_into().expect("journaled state depth exceeds u64");
                 append_storage_access(last, access, curr_depth);
             }
             op::SSTORE => {
@@ -2168,11 +2159,8 @@ impl Cheatcodes {
                     newValue: value.into(),
                     reverted: false,
                 };
-                let curr_depth = ecx
-                    .journaled_state
-                    .depth()
-                    .try_into()
-                    .expect("journaled state depth exceeds u64");
+                let curr_depth =
+                    ecx.journal().depth().try_into().expect("journaled state depth exceeds u64");
                 append_storage_access(last, access, curr_depth);
             }
 
@@ -2200,14 +2188,11 @@ impl Cheatcodes {
                     balance = U256::ZERO;
                     nonce = 0;
                 }
-                let curr_depth = ecx
-                    .journaled_state
-                    .depth()
-                    .try_into()
-                    .expect("journaled state depth exceeds u64");
+                let curr_depth =
+                    ecx.journal().depth().try_into().expect("journaled state depth exceeds u64");
                 let account_access = crate::Vm::AccountAccess {
                     chainInfo: crate::Vm::ChainInfo {
-                        forkId: ecx.journaled_state.database.active_fork_id().unwrap_or_default(),
+                        forkId: ecx.db().active_fork_id().unwrap_or_default(),
                         chainId: U256::from(ecx.cfg().chain_id),
                     },
                     accessor: interpreter.input.target_address,

--- a/crates/cheatcodes/src/inspector/utils.rs
+++ b/crates/cheatcodes/src/inspector/utils.rs
@@ -1,7 +1,11 @@
 use super::Ecx;
 use crate::inspector::Cheatcodes;
 use alloy_primitives::{Address, Bytes, U256};
-use revm::interpreter::{CreateInputs, CreateScheme};
+use revm::{
+    context::ContextTr,
+    inspector::JournalExt,
+    interpreter::{CreateInputs, CreateScheme},
+};
 
 /// Common behaviour of legacy and EOF create inputs.
 pub(crate) trait CommonCreateInput {
@@ -45,7 +49,7 @@ impl CommonCreateInput for &mut CreateInputs {
     fn allow_cheatcodes(&self, cheatcodes: &mut Cheatcodes, ecx: Ecx) -> Address {
         let caller = CreateInputs::caller(self);
         let old_nonce =
-            ecx.journaled_state.state.get(&caller).map(|acc| acc.info.nonce).unwrap_or_default();
+            ecx.journal().evm_state().get(&caller).map(|acc| acc.info.nonce).unwrap_or_default();
         let created_address = self.created_address(old_nonce);
         cheatcodes.allow_cheatcodes_on_create(ecx, caller, created_address);
         created_address

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -18,6 +18,7 @@ extern crate tracing;
 use alloy_evm::eth::EthEvmContext;
 use alloy_primitives::Address;
 use foundry_evm_core::backend::DatabaseExt;
+use revm::context::ContextTr;
 use spec::Status;
 
 pub use Vm::ForgeContext;
@@ -159,7 +160,7 @@ impl CheatsCtxt<'_, '_, '_, '_> {
     }
 
     pub(crate) fn is_precompile(&self, address: &Address) -> bool {
-        self.ecx.journaled_state.warm_addresses.precompiles().contains(address)
+        self.ecx.journal().warm_addresses.precompiles().contains(address)
     }
 }
 

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -131,7 +131,7 @@ fn sign_delegation(
     let nonce = if let Some(nonce) = nonce {
         nonce
     } else {
-        let authority_acc = ccx.ecx.journaled_state.load_account(signer.address())?;
+        let authority_acc = ccx.ecx.journal_mut().load_account(signer.address())?;
         // Calculate next nonce considering existing active delegations
         next_delegation_nonce(
             &ccx.state.active_delegations,
@@ -191,7 +191,7 @@ fn next_delegation_nonce(
 
 fn write_delegation(ccx: &mut CheatsCtxt, auth: SignedAuthorization) -> Result<()> {
     let authority = auth.recover_authority().map_err(|e| format!("{e}"))?;
-    let authority_acc = ccx.ecx.journaled_state.load_account(authority)?;
+    let authority_acc = ccx.ecx.journal_mut().load_account(authority)?;
 
     let expected_nonce = next_delegation_nonce(
         &ccx.state.active_delegations,
@@ -211,10 +211,10 @@ fn write_delegation(ccx: &mut CheatsCtxt, auth: SignedAuthorization) -> Result<(
     if auth.address.is_zero() {
         // Set empty code if the delegation address of authority is 0x.
         // See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md#behavior.
-        ccx.ecx.journaled_state.set_code_with_hash(authority, Bytecode::default(), KECCAK_EMPTY);
+        ccx.ecx.journal_mut().set_code_with_hash(authority, Bytecode::default(), KECCAK_EMPTY);
     } else {
         let bytecode = Bytecode::new_eip7702(*auth.address());
-        ccx.ecx.journaled_state.set_code(authority, bytecode);
+        ccx.ecx.journal_mut().set_code(authority, bytecode);
     }
     Ok(())
 }
@@ -352,7 +352,7 @@ impl Wallets {
 
 /// Sets up broadcasting from a script using `new_origin` as the sender.
 fn broadcast(ccx: &mut CheatsCtxt, new_origin: Option<&Address>, single_call: bool) -> Result {
-    let depth = ccx.ecx.journaled_state.depth();
+    let depth = ccx.ecx.journal().depth();
     ensure!(
         ccx.state.get_prank(depth).is_none(),
         "you have an active prank; broadcasting and pranks are not compatible"

--- a/crates/cheatcodes/src/test.rs
+++ b/crates/cheatcodes/src/test.rs
@@ -6,6 +6,7 @@ use alloy_primitives::{Address, U256};
 use alloy_sol_types::SolValue;
 use foundry_common::version::SEMVER_VERSION;
 use foundry_evm_core::constants::MAGIC_SKIP;
+use revm::context::{ContextTr, JournalTr};
 use std::str::FromStr;
 
 pub(crate) mod assert;
@@ -78,7 +79,7 @@ impl Cheatcode for skip_1Call {
         if *skipTest {
             // Skip should not work if called deeper than at test level.
             // Since we're not returning the magic skip bytes, this will cause a test failure.
-            ensure!(ccx.ecx.journaled_state.depth <= 1, "`skip` can only be used at test level");
+            ensure!(ccx.ecx.journal().depth() <= 1, "`skip` can only be used at test level");
             Err([MAGIC_SKIP, reason.as_bytes()].concat().into())
         } else {
             Ok(Default::default())

--- a/crates/cheatcodes/src/test/assert.rs
+++ b/crates/cheatcodes/src/test/assert.rs
@@ -6,7 +6,7 @@ use foundry_evm_core::{
     constants::CHEATCODE_ADDRESS,
 };
 use itertools::Itertools;
-use revm::context::JournalTr;
+use revm::context::{ContextTr, JournalTr};
 use std::{borrow::Cow, fmt};
 
 const EQ_REL_DELTA_RESOLUTION: U256 = U256::from_limbs([18, 0, 0, 0]);
@@ -212,7 +212,7 @@ fn handle_assertion_result_mono(
         Err(msg.into_owned().into())
     } else {
         executor.console_log(ccx, &msg);
-        ccx.ecx.journaled_state.sstore(CHEATCODE_ADDRESS, GLOBAL_FAIL_SLOT, U256::from(1))?;
+        ccx.ecx.journal_mut().sstore(CHEATCODE_ADDRESS, GLOBAL_FAIL_SLOT, U256::from(1))?;
         Ok(Default::default())
     }
 }

--- a/crates/cheatcodes/src/test/assume.rs
+++ b/crates/cheatcodes/src/test/assume.rs
@@ -1,6 +1,7 @@
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, Error, Result};
 use alloy_primitives::Address;
 use foundry_evm_core::constants::MAGIC_ASSUME;
+use revm::context::{ContextTr, JournalTr};
 use spec::Vm::{
     PotentialRevert, assumeCall, assumeNoRevert_0Call, assumeNoRevert_1Call, assumeNoRevert_2Call,
 };
@@ -52,7 +53,7 @@ impl Cheatcode for assumeCall {
 
 impl Cheatcode for assumeNoRevert_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
-        assume_no_revert(ccx.state, ccx.ecx.journaled_state.depth, vec![])
+        assume_no_revert(ccx.state, ccx.ecx.journal().depth(), vec![])
     }
 }
 
@@ -61,7 +62,7 @@ impl Cheatcode for assumeNoRevert_1Call {
         let Self { potentialRevert } = self;
         assume_no_revert(
             ccx.state,
-            ccx.ecx.journaled_state.depth,
+            ccx.ecx.journal().depth(),
             vec![AcceptableRevertParameters::from(potentialRevert)],
         )
     }
@@ -72,7 +73,7 @@ impl Cheatcode for assumeNoRevert_2Call {
         let Self { potentialReverts } = self;
         assume_no_revert(
             ccx.state,
-            ccx.ecx.journaled_state.depth,
+            ccx.ecx.journal().depth(),
             potentialReverts.iter().map(AcceptableRevertParameters::from).collect(),
         )
     }

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -13,7 +13,7 @@ use alloy_primitives::{
 use foundry_common::{abi::get_indexed_event, fmt::format_token};
 use foundry_evm_traces::DecodedCallLog;
 use revm::{
-    context::JournalTr,
+    context::{ContextTr, JournalTr},
     interpreter::{
         InstructionResult, Interpreter, InterpreterAction, interpreter_types::LoopControl,
     },
@@ -268,7 +268,7 @@ impl Cheatcode for expectEmit_0Call {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData } = *self;
         expect_emit(
             ccx.state,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             [true, checkTopic1, checkTopic2, checkTopic3, checkData],
             None,
             false,
@@ -282,7 +282,7 @@ impl Cheatcode for expectEmit_1Call {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData, emitter } = *self;
         expect_emit(
             ccx.state,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             [true, checkTopic1, checkTopic2, checkTopic3, checkData],
             Some(emitter),
             false,
@@ -294,14 +294,14 @@ impl Cheatcode for expectEmit_1Call {
 impl Cheatcode for expectEmit_2Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self {} = self;
-        expect_emit(ccx.state, ccx.ecx.journaled_state.depth(), [true; 5], None, false, 1)
+        expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], None, false, 1)
     }
 }
 
 impl Cheatcode for expectEmit_3Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { emitter } = *self;
-        expect_emit(ccx.state, ccx.ecx.journaled_state.depth(), [true; 5], Some(emitter), false, 1)
+        expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], Some(emitter), false, 1)
     }
 }
 
@@ -310,7 +310,7 @@ impl Cheatcode for expectEmit_4Call {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData, count } = *self;
         expect_emit(
             ccx.state,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             [true, checkTopic1, checkTopic2, checkTopic3, checkData],
             None,
             false,
@@ -324,7 +324,7 @@ impl Cheatcode for expectEmit_5Call {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData, emitter, count } = *self;
         expect_emit(
             ccx.state,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             [true, checkTopic1, checkTopic2, checkTopic3, checkData],
             Some(emitter),
             false,
@@ -336,21 +336,14 @@ impl Cheatcode for expectEmit_5Call {
 impl Cheatcode for expectEmit_6Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { count } = *self;
-        expect_emit(ccx.state, ccx.ecx.journaled_state.depth(), [true; 5], None, false, count)
+        expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], None, false, count)
     }
 }
 
 impl Cheatcode for expectEmit_7Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { emitter, count } = *self;
-        expect_emit(
-            ccx.state,
-            ccx.ecx.journaled_state.depth(),
-            [true; 5],
-            Some(emitter),
-            false,
-            count,
-        )
+        expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], Some(emitter), false, count)
     }
 }
 
@@ -359,7 +352,7 @@ impl Cheatcode for expectEmitAnonymous_0Call {
         let Self { checkTopic0, checkTopic1, checkTopic2, checkTopic3, checkData } = *self;
         expect_emit(
             ccx.state,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             [checkTopic0, checkTopic1, checkTopic2, checkTopic3, checkData],
             None,
             true,
@@ -373,7 +366,7 @@ impl Cheatcode for expectEmitAnonymous_1Call {
         let Self { checkTopic0, checkTopic1, checkTopic2, checkTopic3, checkData, emitter } = *self;
         expect_emit(
             ccx.state,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             [checkTopic0, checkTopic1, checkTopic2, checkTopic3, checkData],
             Some(emitter),
             true,
@@ -385,14 +378,14 @@ impl Cheatcode for expectEmitAnonymous_1Call {
 impl Cheatcode for expectEmitAnonymous_2Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self {} = self;
-        expect_emit(ccx.state, ccx.ecx.journaled_state.depth(), [true; 5], None, true, 1)
+        expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], None, true, 1)
     }
 }
 
 impl Cheatcode for expectEmitAnonymous_3Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { emitter } = *self;
-        expect_emit(ccx.state, ccx.ecx.journaled_state.depth(), [true; 5], Some(emitter), true, 1)
+        expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], Some(emitter), true, 1)
     }
 }
 
@@ -413,7 +406,7 @@ impl Cheatcode for expectCreate2Call {
 impl Cheatcode for expectRevert_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self {} = self;
-        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), false, false, None, 1)
+        expect_revert(ccx.state, None, ccx.ecx.journal().depth(), false, false, None, 1)
     }
 }
 
@@ -423,7 +416,7 @@ impl Cheatcode for expectRevert_1Call {
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             None,
@@ -435,30 +428,14 @@ impl Cheatcode for expectRevert_1Call {
 impl Cheatcode for expectRevert_2Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { revertData } = self;
-        expect_revert(
-            ccx.state,
-            Some(revertData),
-            ccx.ecx.journaled_state.depth(),
-            false,
-            false,
-            None,
-            1,
-        )
+        expect_revert(ccx.state, Some(revertData), ccx.ecx.journal().depth(), false, false, None, 1)
     }
 }
 
 impl Cheatcode for expectRevert_3Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { reverter } = self;
-        expect_revert(
-            ccx.state,
-            None,
-            ccx.ecx.journaled_state.depth(),
-            false,
-            false,
-            Some(*reverter),
-            1,
-        )
+        expect_revert(ccx.state, None, ccx.ecx.journal().depth(), false, false, Some(*reverter), 1)
     }
 }
 
@@ -468,7 +445,7 @@ impl Cheatcode for expectRevert_4Call {
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             Some(*reverter),
@@ -483,7 +460,7 @@ impl Cheatcode for expectRevert_5Call {
         expect_revert(
             ccx.state,
             Some(revertData),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             Some(*reverter),
@@ -495,7 +472,7 @@ impl Cheatcode for expectRevert_5Call {
 impl Cheatcode for expectRevert_6Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { count } = self;
-        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), false, false, None, *count)
+        expect_revert(ccx.state, None, ccx.ecx.journal().depth(), false, false, None, *count)
     }
 }
 
@@ -505,7 +482,7 @@ impl Cheatcode for expectRevert_7Call {
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             None,
@@ -520,7 +497,7 @@ impl Cheatcode for expectRevert_8Call {
         expect_revert(
             ccx.state,
             Some(revertData),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             None,
@@ -535,7 +512,7 @@ impl Cheatcode for expectRevert_9Call {
         expect_revert(
             ccx.state,
             None,
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             Some(*reverter),
@@ -550,7 +527,7 @@ impl Cheatcode for expectRevert_10Call {
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             Some(*reverter),
@@ -565,7 +542,7 @@ impl Cheatcode for expectRevert_11Call {
         expect_revert(
             ccx.state,
             Some(revertData),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             false,
             Some(*reverter),
@@ -580,7 +557,7 @@ impl Cheatcode for expectPartialRevert_0Call {
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             true,
             None,
@@ -595,7 +572,7 @@ impl Cheatcode for expectPartialRevert_1Call {
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             false,
             true,
             Some(*reverter),
@@ -606,7 +583,7 @@ impl Cheatcode for expectPartialRevert_1Call {
 
 impl Cheatcode for _expectCheatcodeRevert_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
-        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), true, false, None, 1)
+        expect_revert(ccx.state, None, ccx.ecx.journal().depth(), true, false, None, 1)
     }
 }
 
@@ -616,7 +593,7 @@ impl Cheatcode for _expectCheatcodeRevert_1Call {
         expect_revert(
             ccx.state,
             Some(revertData.as_ref()),
-            ccx.ecx.journaled_state.depth(),
+            ccx.ecx.journal().depth(),
             true,
             false,
             None,
@@ -628,29 +605,21 @@ impl Cheatcode for _expectCheatcodeRevert_1Call {
 impl Cheatcode for _expectCheatcodeRevert_2Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { revertData } = self;
-        expect_revert(
-            ccx.state,
-            Some(revertData),
-            ccx.ecx.journaled_state.depth(),
-            true,
-            false,
-            None,
-            1,
-        )
+        expect_revert(ccx.state, Some(revertData), ccx.ecx.journal().depth(), true, false, None, 1)
     }
 }
 
 impl Cheatcode for expectSafeMemoryCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { min, max } = *self;
-        expect_safe_memory(ccx.state, min, max, ccx.ecx.journaled_state.depth().try_into()?)
+        expect_safe_memory(ccx.state, min, max, ccx.ecx.journal().depth().try_into()?)
     }
 }
 
 impl Cheatcode for stopExpectSafeMemoryCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self {} = self;
-        ccx.state.allowed_mem_writes.remove(&ccx.ecx.journaled_state.depth().try_into()?);
+        ccx.state.allowed_mem_writes.remove(&ccx.ecx.journal().depth().try_into()?);
         Ok(Default::default())
     }
 }
@@ -658,7 +627,7 @@ impl Cheatcode for stopExpectSafeMemoryCall {
 impl Cheatcode for expectSafeMemoryCallCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { min, max } = *self;
-        expect_safe_memory(ccx.state, min, max, (ccx.ecx.journaled_state.depth() + 1).try_into()?)
+        expect_safe_memory(ccx.state, min, max, (ccx.ecx.journal().depth() + 1).try_into()?)
     }
 }
 

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -12,7 +12,10 @@ use foundry_evm_core::constants::DEFAULT_CREATE2_DEPLOYER;
 use foundry_evm_fuzz::strategies::BoundMutator;
 use proptest::prelude::Strategy;
 use rand::{Rng, RngCore, seq::SliceRandom};
-use revm::context::JournalTr;
+use revm::{
+    context::{ContextTr, JournalTr},
+    inspector::JournalExt,
+};
 use std::path::PathBuf;
 
 /// Contains locations of traces ignored via cheatcodes.
@@ -258,11 +261,11 @@ impl Cheatcode for copyStorageCall {
             "target address cannot have arbitrary storage"
         );
 
-        if let Ok(from_account) = ccx.ecx.journaled_state.load_account(*from) {
+        if let Ok(from_account) = ccx.ecx.journal_mut().load_account(*from) {
             let from_storage = from_account.storage.clone();
-            if ccx.ecx.journaled_state.load_account(*to).is_ok() {
+            if ccx.ecx.journal_mut().load_account(*to).is_ok() {
                 // SAFETY: We ensured the account was already loaded.
-                ccx.ecx.journaled_state.state.get_mut(to).unwrap().storage = from_storage;
+                ccx.ecx.journal_mut().evm_state_mut().get_mut(to).unwrap().storage = from_storage;
                 if let Some(arbitrary_storage) = &mut ccx.state.arbitrary_storage {
                     arbitrary_storage.mark_copy(from, to);
                 }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -25,6 +25,7 @@ use revm::{
         result::{ExecutionResult, Output},
     },
     context_interface::CreateScheme,
+    inspector::JournalExt,
     interpreter::{
         CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, Gas, InstructionResult,
         Interpreter, InterpreterResult,
@@ -749,8 +750,8 @@ impl InspectorStackRefMut<'_> {
         };
 
         for (addr, mut acc) in res.state {
-            let Some(acc_mut) = ecx.journaled_state.state.get_mut(&addr) else {
-                ecx.journaled_state.state.insert(addr, acc);
+            let Some(acc_mut) = ecx.journal_mut().evm_state_mut().get_mut(&addr) else {
+                ecx.journal_mut().evm_state_mut().insert(addr, acc);
                 continue;
             };
 
@@ -820,7 +821,7 @@ impl InspectorStackRefMut<'_> {
         if self.enable_isolation {
             // If we're in isolation mode, we need to keep track of the state at the beginning of
             // the frame to be able to roll back on revert
-            self.top_frame_journal.clone_from(&ecx.journaled_state.state);
+            self.top_frame_journal.clone_from(ecx.journal().evm_state());
         }
     }
 
@@ -844,7 +845,7 @@ impl InspectorStackRefMut<'_> {
         // created We can't rely on revm's journal because it doesn't account for changes
         // made by isolated calls
         if self.enable_isolation {
-            ecx.journaled_state.state = std::mem::take(&mut self.top_frame_journal);
+            *ecx.journal_mut().evm_state_mut() = std::mem::take(&mut self.top_frame_journal);
         }
     }
 
@@ -957,12 +958,12 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for InspectorStackRefMut<'_>
         ecx: &mut EthEvmContext<&mut dyn DatabaseExt>,
         call: &mut CallInputs,
     ) -> Option<CallOutcome> {
-        if self.in_inner_context && ecx.journaled_state.depth == 1 {
+        if self.in_inner_context && ecx.journal().depth == 1 {
             self.adjust_evm_data_for_inner_context(ecx);
             return None;
         }
 
-        if ecx.journaled_state.depth == 0 {
+        if ecx.journal().depth == 0 {
             self.top_level_frame_start(ecx);
         }
 
@@ -1004,7 +1005,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for InspectorStackRefMut<'_>
             }
         }
 
-        if self.enable_isolation && !self.in_inner_context && ecx.journaled_state.depth == 1 {
+        if self.enable_isolation && !self.in_inner_context && ecx.journal().depth == 1 {
             match call.scheme {
                 // Isolate CALLs
                 CallScheme::Call => {
@@ -1061,13 +1062,13 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for InspectorStackRefMut<'_>
     ) {
         // We are processing inner context outputs in the outer context, so need to avoid processing
         // twice.
-        if self.in_inner_context && ecx.journaled_state.depth == 1 {
+        if self.in_inner_context && ecx.journal().depth == 1 {
             return;
         }
 
         self.do_call_end(ecx, inputs, outcome);
 
-        if ecx.journaled_state.depth == 0 {
+        if ecx.journal().depth == 0 {
             self.top_level_frame_end(ecx, outcome.result.result);
         }
     }
@@ -1077,12 +1078,12 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for InspectorStackRefMut<'_>
         ecx: &mut EthEvmContext<&mut dyn DatabaseExt>,
         create: &mut CreateInputs,
     ) -> Option<CreateOutcome> {
-        if self.in_inner_context && ecx.journaled_state.depth == 1 {
+        if self.in_inner_context && ecx.journal().depth == 1 {
             self.adjust_evm_data_for_inner_context(ecx);
             return None;
         }
 
-        if ecx.journaled_state.depth == 0 {
+        if ecx.journal().depth == 0 {
             self.top_level_frame_start(ecx);
         }
 
@@ -1095,7 +1096,7 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for InspectorStackRefMut<'_>
         if !matches!(create.scheme(), CreateScheme::Create2 { .. })
             && self.enable_isolation
             && !self.in_inner_context
-            && ecx.journaled_state.depth == 1
+            && ecx.journal().depth == 1
         {
             let (result, address) = self.transact_inner(
                 ecx,
@@ -1119,13 +1120,13 @@ impl Inspector<EthEvmContext<&mut dyn DatabaseExt>> for InspectorStackRefMut<'_>
     ) {
         // We are processing inner context outputs in the outer context, so need to avoid processing
         // twice.
-        if self.in_inner_context && ecx.journaled_state.depth == 1 {
+        if self.in_inner_context && ecx.journal().depth == 1 {
             return;
         }
 
         self.do_create_end(ecx, call, outcome);
 
-        if ecx.journaled_state.depth == 0 {
+        if ecx.journal().depth == 0 {
             self.top_level_frame_end(ecx, outcome.result.result);
         }
     }


### PR DESCRIPTION
## Summary

- Replace direct `journaled_state.*` field accesses with `JournalTr` and `JournalExt` trait methods across cheatcodes and the inspector stack
- Uses `journal()` / `journal_mut()`, `db()` / `db_mut()`, `evm_state()` / `evm_state_mut()`, `depth()`, `load_account()`, `set_code()`, `sstore()` instead of reaching into `journaled_state.inner`, `journaled_state.database`, etc.
- ~150 lines changed across 15 files, zero behavioral change

## Motivation

Prepares the cheatcodes and inspector crates for generic context support (#13536). The `JournalTr` and `JournalExt` traits abstract over the concrete `Journal` type, so using trait methods now means fewer changes when the context becomes generic.

## Test plan

- No behavioral changes — pure mechanical refactor
- CI should pass as-is