### PR TITLE
chore(evm): simplify `CowBackend` init logic by using `Option<SpecId>`

### DIFF
--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -47,16 +47,15 @@ pub struct CowBackend<'a> {
     ///
     /// No calls on the `CowBackend` will ever persistently modify the `backend`'s state.
     pub backend: Cow<'a, Backend>,
-    /// Keeps track of whether the backed is already initialized
-    is_initialized: bool,
-    /// The [SpecId] of the current backend.
-    spec_id: SpecId,
+    /// The [SpecId] to initialize the backend with on first mutable access.
+    /// `None` means the backend has already been initialized for the current call.
+    spec_id: Option<SpecId>,
 }
 
 impl<'a> CowBackend<'a> {
     /// Creates a new `CowBackend` with the given `Backend`.
     pub fn new_borrowed(backend: &'a Backend) -> Self {
-        Self { backend: Cow::Borrowed(backend), is_initialized: false, spec_id: SpecId::default() }
+        Self { backend: Cow::Borrowed(backend), spec_id: Some(SpecId::default()) }
     }
 
     /// Executes the configured transaction of the `env` without committing state changes
@@ -71,8 +70,7 @@ impl<'a> CowBackend<'a> {
     ) -> eyre::Result<ResultAndState> {
         // this is a new call to inspect with a new env, so even if we've cloned the backend
         // already, we reset the initialized state
-        self.is_initialized = false;
-        self.spec_id = env.evm_env.cfg_env.spec;
+        self.spec_id = Some(env.evm_env.cfg_env.spec);
 
         let mut evm = crate::evm::new_evm_with_inspector(self, env.to_owned(), inspector);
 
@@ -94,12 +92,11 @@ impl<'a> CowBackend<'a> {
     ///
     /// If this is the first time this is called, the backed is cloned and initialized.
     fn backend_mut(&mut self, env: &EnvMut<'_>) -> &mut Backend {
-        if !self.is_initialized {
+        if let Some(spec_id) = self.spec_id.take() {
             let backend = self.backend.to_mut();
             let mut env = env.to_owned();
-            env.evm_env.cfg_env.spec = self.spec_id;
+            env.evm_env.cfg_env.spec = spec_id;
             backend.initialize(&env);
-            self.is_initialized = true;
             return backend;
         }
         self.backend.to_mut()
@@ -107,7 +104,7 @@ impl<'a> CowBackend<'a> {
 
     /// Returns a mutable instance of the Backend if it is initialized.
     fn initialized_backend_mut(&mut self) -> Option<&mut Backend> {
-        if self.is_initialized {
+        if self.spec_id.is_none() {
             return Some(self.backend.to_mut());
         }
         None


### PR DESCRIPTION
## Motivation

Simplify `CowBackend` initialization logic by using `Option<SpecId>`

## Solution

- handle the initialization through an `Option<>` that is taken.
- get rid of the boolean `is_initialized`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
