### PR TITLE
fix(script): use correct variable in debug log

### DIFF
--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -135,7 +135,7 @@ impl ScriptTransactionBuilder {
                     constructor_args=%hex::encode(constructor_args),
                     "Failed to decode constructor arguments",
                 );
-                debug!(full_data=%hex::encode(data), bytecode=%hex::encode(creation_code));
+                debug!(full_data=%hex::encode(data), bytecode=%hex::encode(bytecode));
             })?;
         self.transaction.arguments = Some(values.iter().map(format_token_raw).collect());
 


### PR DESCRIPTION
Fixed debug log in `set_create` that was logging `creation_code` under the name `bytecode`. Now correctly logs the expected bytecode from artifact, making it easier to debug constructor argument decoding failures by comparing actual data with expected bytecode.