### PR TITLE
fix(traces): filter empty string labels

### DIFF
--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -323,7 +323,7 @@ impl CallTraceDecoder {
                 self.contracts.entry(address).or_insert(contract);
             }
 
-            if let Some(label) = label {
+            if let Some(label) = label.filter(|s| !s.is_empty()) {
                 self.labels.entry(address).or_insert(label);
             }
 


### PR DESCRIPTION
Ignore empty-string labels from trace identifiers (e.g. Sourcify) to prevent missing contract names and addresses in trace output.

This should reduce flaky behavior where labels (for some reason) show up as `Some("")`, preventing the trace display from showing `<unknown>@...`.