### PR TITLE
fix(cast): encode non-indexed event params as tuple

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1872,7 +1872,7 @@ impl SimpleCast {
             .collect::<Result<Vec<_>>>()?;
 
         let mut topics = vec![event.selector()];
-        let mut data_tokens: Vec<u8> = Vec::new();
+        let mut non_indexed_tokens: Vec<DynSolValue> = Vec::new();
 
         for (input, token) in event.inputs.iter().zip(tokens) {
             if input.indexed {
@@ -1900,11 +1900,15 @@ impl SimpleCast {
                 }
             } else {
                 // Non-indexed parameters go into data
-                data_tokens.extend_from_slice(&token.abi_encode());
+                non_indexed_tokens.push(token);
             }
         }
 
-        Ok(LogData::new_unchecked(topics, data_tokens.into()))
+        // ABI-encode all non-indexed parameters as a tuple so that dynamic type
+        // offsets are calculated relative to the entire data segment.
+        let data = DynSolValue::Tuple(non_indexed_tokens).abi_encode();
+
+        Ok(LogData::new_unchecked(topics, data.into()))
     }
 
     /// Performs ABI encoding to produce the hexadecimal calldata with the given arguments.


### PR DESCRIPTION
`abi_encode_event` was encoding each non-indexed parameter independently and concatenating the raw bytes. This breaks ABI encoding for events with multiple non-indexed parameters that include dynamic types (string, bytes, arrays).

When parameters are encoded individually, each dynamic value gets an offset relative to itself (e.g. 0x20). But ABI spec requires the data segment to be a single tuple-encoded blob, where offsets point relative to the start of the entire data segment.

For example, `event Transfer(uint256 id, string memo, bytes data)` with all non-indexed:
- Before: each param encoded separately, `memo`'s offset is 0x20 (relative to
  itself) instead of 0x60 (relative to the 3-slot head)
- After:  tuple encoding produces correct offsets, decoders can parse it back


The existing test `abi_encode_event_no_indexed` only covered static types(address, address, uint256) so it didn't catch this.

Fixed by collecting non-indexed params and encoding them with `DynSolValue::Tuple(...).abi_encode()`.