### PR TITLE
fix(traces): fix rate limit backoff in ExternalFetcher

### DIFF
--- a/crates/evm/traces/src/identifier/external.rs
+++ b/crates/evm/traces/src/identifier/external.rs
@@ -300,7 +300,10 @@ impl Stream for ExternalFetcher {
                         }
                         Err(EtherscanError::RateLimitExceeded) => {
                             warn!(target: "evm::traces::external", "rate limit exceeded on attempt");
-                            pin.backoff = Some(tokio::time::interval(pin.timeout));
+                            pin.backoff = Some(tokio::time::interval_at(
+                                tokio::time::Instant::now() + pin.timeout,
+                                pin.timeout,
+                            ));
                             pin.queue.push(addr);
                         }
                         Err(EtherscanError::InvalidApiKey) => {


### PR DESCRIPTION
Rate limit backoff in `ExternalFetcher` never actually waits.

`tokio::time::interval()` fires its first tick immediately, so after a 429 the loop just takes the interval out, sees `Ready`, drops it, and retries with no delay. Cycle repeats on every rate limit hit.

What happens:

1. 429 → sets `backoff = Some(interval(5s))`
2. Next loop: `.take()` pulls it out, `poll_tick()` → instant `Ready`, if-let falls through, interval dropped
3. `queue_next_reqs()` fires immediately → another 429 → repeat

Fix: `interval_at(now + timeout, timeout)` so the first tick respects the delay.