### PR TITLE
feat(evm): add `FoundryContextExt` trait

### DIFF
--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -2,6 +2,7 @@ pub use alloy_evm::EvmEnv;
 use revm::{
     Context, Database, Journal, JournalEntry,
     context::{BlockEnv, CfgEnv, JournalInner, JournalTr, TxEnv},
+    context_interface::ContextTr,
     primitives::hardfork::SpecId,
 };
 
@@ -108,6 +109,67 @@ impl<DB: Database, C> ContextExt
         (
             &mut self.journaled_state.database,
             &mut self.journaled_state.inner,
+            EnvMut { block: &mut self.block, cfg: &mut self.cfg, tx: &mut self.tx },
+        )
+    }
+}
+
+/// Extension trait providing mutable field access to block, tx, and cfg environments.
+///
+/// [`ContextTr`] only exposes immutable references for block, tx, and cfg.
+/// Cheatcodes like `vm.warp()`, `vm.roll()`, `vm.chainId()` need to mutate these fields.
+///
+/// Also provides [`journal_and_env_mut`](FoundryContextExt::journal_and_env_mut) for
+/// simultaneous mutable access to journal and env — needed because calling `journal_mut()`
+/// and `block_mut()` separately would create conflicting borrows on `&mut self`.
+pub trait FoundryContextExt: ContextTr {
+    /// Mutable reference to the block environment.
+    fn block_mut(&mut self) -> &mut BlockEnv;
+    /// Mutable reference to the transaction environment.
+    fn tx_mut(&mut self) -> &mut TxEnv;
+    /// Mutable reference to the configuration environment.
+    fn cfg_mut(&mut self) -> &mut CfgEnv;
+
+    /// Returns a cloned snapshot of the current environment.
+    fn to_env(&self) -> Env;
+
+    /// Applies an owned [`Env`] to this context, replacing block, cfg, and tx.
+    fn apply_env(&mut self, env: Env);
+
+    /// Returns mutable references to the journal and environment simultaneously.
+    ///
+    /// This solves the borrow-splitting problem: calling `self.journal_mut()` and
+    /// `self.block_mut()` separately would both borrow `&mut self`. This method
+    /// splits the borrows at the field level in one call.
+    fn journal_and_env_mut(&mut self) -> (&mut Self::Journal, EnvMut<'_>);
+}
+
+impl<DB: Database, J: JournalTr<Database = DB>, C> FoundryContextExt
+    for Context<BlockEnv, TxEnv, CfgEnv, DB, J, C>
+{
+    fn block_mut(&mut self) -> &mut BlockEnv {
+        &mut self.block
+    }
+    fn tx_mut(&mut self) -> &mut TxEnv {
+        &mut self.tx
+    }
+    fn cfg_mut(&mut self) -> &mut CfgEnv {
+        &mut self.cfg
+    }
+    fn to_env(&self) -> Env {
+        Env {
+            evm_env: EvmEnv { cfg_env: self.cfg.clone(), block_env: self.block.clone() },
+            tx: self.tx.clone(),
+        }
+    }
+    fn apply_env(&mut self, env: Env) {
+        self.block = env.evm_env.block_env;
+        self.cfg = env.evm_env.cfg_env;
+        self.tx = env.tx;
+    }
+    fn journal_and_env_mut(&mut self) -> (&mut J, EnvMut<'_>) {
+        (
+            &mut self.journaled_state,
             EnvMut { block: &mut self.block, cfg: &mut self.cfg, tx: &mut self.tx },
         )
     }


### PR DESCRIPTION
Adds `FoundryContextExt` trait alongside existing `ContextExt`. Provides mutable field access to block, tx, and cfg environments for generic code that goes through `ContextTr`.

`ContextTr` only exposes immutable references (`block()`, `tx()`, `cfg()`). Cheatcodes like `vm.warp()`, `vm.roll()`, `vm.chainId()` need to mutate these fields. `FoundryContextExt` adds `block_mut()`, `tx_mut()`, `cfg_mut()`, plus:

- `to_env()` / `apply_env()` — snapshot and restore the full environment
- `journal_and_env_mut()` — simultaneous mutable access to journal and env, solving the borrow-splitting problem where `self.journal_mut()` and `self.block_mut()` would create conflicting borrows

Blanket impl provided for `Context<BlockEnv, TxEnv, CfgEnv, DB, J, C>`.

Prerequisite for #13536 (generic `Cheatcode<CTX>`). `ContextExt` will be removed once all callers migrate.