### PR TITLE
refactor(wallets): extract `Browser` from `WalletSigner`

### DIFF
--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -13,7 +13,6 @@ use foundry_cli::{
     opts::TransactionOpts,
     utils::{LoadConfig, get_provider},
 };
-use foundry_wallets::WalletSigner;
 
 use crate::tx::{self, CastTxBuilder, CastTxSender, SendTxOpts};
 
@@ -139,8 +138,11 @@ impl SendTxArgs {
         // Check if this is a Tempo transaction - requires special handling for local signing
         let is_tempo = builder.is_tempo();
 
-        // Tempo transactions with browser wallets are not supported
-        if is_tempo && send_tx.eth.wallet.browser.browser {
+        // Launch browser signer if `--browser` flag is set
+        let browser = send_tx.browser.run().await?;
+
+        // Tempo transactions with browser signer are not supported
+        if is_tempo && browser.is_some() {
             return Err(eyre!("Tempo transactions are not supported with browser wallets."));
         }
 
@@ -148,7 +150,7 @@ impl SendTxArgs {
         // Default to sending via eth_sendTransaction if the --unlocked flag is passed.
         // This should be the only way this RPC method is used as it requires a local node
         // or remote RPC with unlocked accounts.
-        if unlocked && !send_tx.eth.wallet.browser.browser {
+        if unlocked && browser.is_none() {
             // only check current chain id if it was specified in the config
             if let Some(config_chain) = config.chain {
                 let current_chain_id = provider.get_chain_id().await?;
@@ -184,19 +186,10 @@ impl SendTxArgs {
         // If we cannot successfully instantiate a local signer, then we will assume we don't have
         // enough information to sign and we must bail.
         } else {
-            // Retrieve the signer, and bail if it can't be constructed.
-            let signer = send_tx.eth.wallet.signer().await?;
-            let from = signer.address();
-
-            tx::validate_from_address(send_tx.eth.wallet.from, from)?;
-
-            // Browser wallets work differently as they sign and send the transaction in one step.
-            if send_tx.eth.wallet.browser.browser
-                && let WalletSigner::Browser(ref browser_signer) = signer
-            {
-                let (tx_request, _) = builder.build(from).await?;
-                let tx_hash =
-                    browser_signer.send_transaction_via_browser(tx_request.into_inner()).await?;
+            // Browser wallet work differently as it sign and send the transaction in one step.
+            if let Some(browser) = browser {
+                let (tx_request, _) = builder.build(browser.address()).await?;
+                let tx_hash = browser.send_transaction_via_browser(tx_request.into_inner()).await?;
 
                 if send_tx.cast_async {
                     sh_println!("{tx_hash:#x}")?;
@@ -216,6 +209,11 @@ impl SendTxArgs {
                 return Ok(());
             }
 
+            // Retrieve the signer, and bail if it can't be constructed.
+            let signer = send_tx.eth.wallet.signer().await?;
+            let from = signer.address();
+
+            tx::validate_from_address(send_tx.eth.wallet.from, from)?;
             // Tempo transactions need to be signed locally and sent as raw transactions
             // because EthereumWallet doesn't understand type 0x76
             // TODO(onbjerg): All of this is a side effect of a few things, most notably that we do

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -24,7 +24,7 @@ use foundry_common::{
 };
 use foundry_config::{Chain, Config};
 use foundry_primitives::{FoundryTransactionRequest, FoundryTypedTx};
-use foundry_wallets::{WalletOpts, WalletSigner};
+use foundry_wallets::{BrowserWalletOpts, WalletOpts, WalletSigner};
 use itertools::Itertools;
 use serde_json::value::RawValue;
 use std::{fmt::Write, str::FromStr, time::Duration};
@@ -55,6 +55,10 @@ pub struct SendTxOpts {
     /// Ethereum options
     #[command(flatten)]
     pub eth: EthereumOpts,
+
+    /// Browser wallet options
+    #[command(flatten)]
+    pub browser: BrowserWalletOpts,
 }
 
 /// Different sender kinds used by [`CastTxBuilder`].

--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -377,7 +377,7 @@ fn sign_with_wallet(
 
     let mut wallets = state.wallets().inner.lock();
     let maybe_provided_sender = wallets.provided_sender;
-    let signers = wallets.multi_wallet.signers()?;
+    let (signers, _) = wallets.multi_wallet.signers()?;
 
     let signer = if let Some(signer) = signer {
         signer

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -4,7 +4,7 @@ use crate::{Cheatcode, CheatsCtxt, Result, Vm::*, evm::journaled_account};
 use alloy_consensus::{SidecarBuilder, SimpleCoder};
 use alloy_primitives::{Address, B256, U256, Uint};
 use alloy_rpc_types::Authorization;
-use alloy_signer::SignerSync;
+use alloy_signer::{Signer, SignerSync};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolValue;
 use foundry_wallets::{WalletSigner, wallet_multi::MultiWallet};
@@ -331,17 +331,18 @@ impl Wallets {
 
     /// Locks inner Mutex and returns all signer addresses in the [MultiWallet].
     pub fn signers(&self) -> Result<Vec<Address>> {
-        Ok(self.inner.lock().multi_wallet.signers()?.keys().copied().collect())
+        let mut wallets = self.inner.lock();
+        let (signers, browser) = wallets.multi_wallet.signers()?;
+        Ok(signers.keys().copied().chain(browser.map(|b| b.address())).collect())
     }
 
     /// Number of signers in the [MultiWallet].
     pub fn len(&self) -> usize {
         let mut inner = self.inner.lock();
-        let signers = inner.multi_wallet.signers();
-        if signers.is_err() {
-            return 0;
+        match inner.multi_wallet.signers() {
+            Ok((signers, browser)) => signers.len() + usize::from(browser.is_some()),
+            Err(_) => 0,
         }
-        signers.unwrap().len()
     }
 
     /// Whether the [MultiWallet] is empty.
@@ -366,7 +367,7 @@ fn broadcast(ccx: &mut CheatsCtxt, new_origin: Option<&Address>, single_call: bo
         if let Some(provided_sender) = wallets.provided_sender {
             new_origin = Some(provided_sender);
         } else {
-            let signers = wallets.multi_wallet.signers()?;
+            let (signers, _) = wallets.multi_wallet.signers()?;
             if signers.len() == 1 {
                 let address = signers.keys().next().unwrap();
                 new_origin = Some(*address);

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -12,6 +12,7 @@ use alloy_primitives::{
 use alloy_provider::{Provider, utils::Eip1559Estimation};
 use alloy_rpc_types::TransactionRequest;
 use alloy_serde::WithOtherFields;
+use alloy_signer::Signer;
 use eyre::{Context, Result, bail};
 use forge_verify::provider::VerificationProviderType;
 use foundry_cheatcodes::Wallets;
@@ -202,11 +203,7 @@ impl From<EthereumWallet> for EitherSigner {
 
 impl From<WalletSigner> for EitherSigner {
     fn from(wallet: WalletSigner) -> Self {
-        match wallet {
-            WalletSigner::Browser(wallet) => Self::Browser(wallet),
-            // Convert any other signer to an Ethereum wallet
-            signer => EthereumWallet::new(signer).into(),
-        }
+        EthereumWallet::new(wallet).into()
     }
 }
 
@@ -324,11 +321,12 @@ impl BundledState {
         let send_kind = if self.args.unlocked {
             SendTransactionsKind::Unlocked(required_addresses.clone())
         } else {
-            let signers = self.script_wallets.into_multi_wallet().into_signers()?;
+            let signers: Vec<Address> =
+                self.script_wallets.signers().map_err(|e| eyre::eyre!("{e}"))?;
             let mut missing_addresses = Vec::new();
 
             for addr in &required_addresses {
-                if !signers.contains_key(addr) {
+                if !signers.contains(addr) {
                     missing_addresses.push(addr);
                 }
             }
@@ -337,11 +335,16 @@ impl BundledState {
                 eyre::bail!(
                     "No associated wallet for addresses: {:?}. Unlocked wallets: {:?}",
                     missing_addresses,
-                    signers.keys().collect::<Vec<_>>()
+                    signers
                 );
             }
 
-            let signers = signers.into_iter().map(|(addr, signer)| (addr, signer.into())).collect();
+            let (signers, browser) = self.script_wallets.into_multi_wallet().into_signers()?;
+            let mut signers: AddressHashMap<EitherSigner> =
+                signers.into_iter().map(|(addr, signer)| (addr, signer.into())).collect();
+            if let Some(browser) = browser {
+                signers.insert(browser.address(), browser.into());
+            }
 
             SendTransactionsKind::Raw(signers)
         };

--- a/crates/wallets/src/opts.rs
+++ b/crates/wallets/src/opts.rs
@@ -1,4 +1,4 @@
-use crate::{BrowserWalletOpts, signer::WalletSigner, utils, wallet_raw::RawWalletOpts};
+use crate::{signer::WalletSigner, utils, wallet_raw::RawWalletOpts};
 use alloy_primitives::Address;
 use clap::Parser;
 use eyre::Result;
@@ -102,10 +102,6 @@ pub struct WalletOpts {
     /// See: <https://docs.turnkey.com/getting-started/quickstart>
     #[arg(long, help_heading = "Wallet options - remote", hide = !cfg!(feature = "turnkey"))]
     pub turnkey: bool,
-
-    /// Browser wallet options
-    #[command(flatten)]
-    pub browser: BrowserWalletOpts,
 }
 
 impl WalletOpts {
@@ -143,13 +139,6 @@ impl WalletOpts {
                 eyre::eyre!("TURNKEY_ADDRESS could not be parsed as an Ethereum address")
             })?;
             WalletSigner::from_turnkey(api_private_key, organization_id, address)?
-        } else if self.browser.browser {
-            WalletSigner::from_browser(
-                self.browser.browser_port,
-                !self.browser.browser_disable_open,
-                self.browser.browser_development,
-            )
-            .await?
         } else if let Some(raw_wallet) = self.raw.signer()? {
             raw_wallet
         } else if let Some(path) = utils::maybe_get_keystore_path(
@@ -255,7 +244,6 @@ mod tests {
             aws: false,
             gcp: false,
             turnkey: false,
-            browser: Default::default(),
         };
         match wallet.signer().await {
             Ok(_) => {

--- a/crates/wallets/src/wallet_browser/opts.rs
+++ b/crates/wallets/src/wallet_browser/opts.rs
@@ -1,5 +1,10 @@
+use std::time::Duration;
+
 use clap::Parser;
+use eyre::Result;
 use serde::Serialize;
+
+use crate::wallet_browser::signer::BrowserSigner;
 
 /// Browser wallet options
 #[derive(Clone, Debug, Default, Serialize, Parser)]
@@ -23,4 +28,22 @@ pub struct BrowserWalletOpts {
     /// **WARNING**: This should only be used in a development environment.
     #[arg(long, hide = true)]
     pub browser_development: bool,
+}
+
+impl BrowserWalletOpts {
+    pub async fn run(&self) -> Result<Option<BrowserSigner>> {
+        Ok(if self.browser {
+            Some(
+                BrowserSigner::new(
+                    self.browser_port,
+                    !self.browser_disable_open,
+                    Duration::from_secs(300),
+                    self.browser_development,
+                )
+                .await?,
+            )
+        } else {
+            None
+        })
+    }
 }

--- a/crates/wallets/src/wallet_multi/mod.rs
+++ b/crates/wallets/src/wallet_multi/mod.rs
@@ -2,6 +2,7 @@ use crate::{
     BrowserWalletOpts,
     signer::{PendingSigner, WalletSigner},
     utils,
+    wallet_browser::signer::BrowserSigner,
 };
 use alloy_primitives::map::AddressHashMap;
 use alloy_signer::Signer;
@@ -20,12 +21,18 @@ pub struct MultiWallet {
     pending_signers: Vec<PendingSigner>,
     /// Contains unlocked signers.
     signers: AddressHashMap<WalletSigner>,
+    /// Browser signer
+    browser: Option<BrowserSigner>,
 }
 
 impl MultiWallet {
-    pub fn new(pending_signers: Vec<PendingSigner>, signers: Vec<WalletSigner>) -> Self {
+    pub fn new(
+        pending_signers: Vec<PendingSigner>,
+        signers: Vec<WalletSigner>,
+        browser: Option<BrowserSigner>,
+    ) -> Self {
         let signers = signers.into_iter().map(|signer| (signer.address(), signer)).collect();
-        Self { pending_signers, signers }
+        Self { pending_signers, signers, browser }
     }
 
     fn maybe_unlock_pending(&mut self) -> Result<()> {
@@ -36,14 +43,14 @@ impl MultiWallet {
         Ok(())
     }
 
-    pub fn signers(&mut self) -> Result<&AddressHashMap<WalletSigner>> {
+    pub fn signers(&mut self) -> Result<(&AddressHashMap<WalletSigner>, Option<&BrowserSigner>)> {
         self.maybe_unlock_pending()?;
-        Ok(&self.signers)
+        Ok((&self.signers, self.browser.as_ref()))
     }
 
-    pub fn into_signers(mut self) -> Result<AddressHashMap<WalletSigner>> {
+    pub fn into_signers(mut self) -> Result<(AddressHashMap<WalletSigner>, Option<BrowserSigner>)> {
         self.maybe_unlock_pending()?;
-        Ok(self.signers)
+        Ok((self.signers, self.browser))
     }
 
     pub fn add_signer(&mut self, signer: WalletSigner) {
@@ -241,6 +248,7 @@ impl MultiWalletOpts {
     pub async fn get_multi_wallet(&self) -> Result<MultiWallet> {
         let mut pending = Vec::new();
         let mut signers: Vec<WalletSigner> = Vec::new();
+        let browser = self.browser_signer().await?;
 
         if let Some(ledgers) = self.ledgers().await? {
             signers.extend(ledgers);
@@ -256,9 +264,6 @@ impl MultiWalletOpts {
         }
         if let Some(turnkey_signers) = self.turnkey_signers()? {
             signers.extend(turnkey_signers);
-        }
-        if let Some(browser_signer) = self.browser_signer().await? {
-            signers.push(browser_signer);
         }
         if let Some((pending_keystores, unlocked)) = self.keystores()? {
             pending.extend(pending_keystores);
@@ -280,7 +285,7 @@ impl MultiWalletOpts {
             ));
         }
 
-        Ok(MultiWallet::new(pending, signers))
+        Ok(MultiWallet::new(pending, signers, browser))
     }
 
     pub fn private_keys(&self) -> Result<Option<Vec<WalletSigner>>> {
@@ -496,18 +501,9 @@ impl MultiWalletOpts {
         None
     }
 
-    pub async fn browser_signer(&self) -> Result<Option<WalletSigner>> {
-        if self.browser.browser {
-            let browser_signer = WalletSigner::from_browser(
-                self.browser.browser_port,
-                !self.browser.browser_disable_open,
-                self.browser.browser_development,
-            )
-            .await?;
-            Ok(Some(browser_signer))
-        } else {
-            Ok(None)
-        }
+    /// Launches and returns the Browser signer if `--browser` flag is set
+    pub async fn browser_signer(&self) -> Result<Option<BrowserSigner>> {
+        self.browser.run().await
     }
 }
 


### PR DESCRIPTION
## Motivation

Extract `Browser` from `WalletSigner` to close #13574.

## Solution

- Extracts `BrowserSigner` from `WalletSigner` enum as browser supports only one-step tx sign/send 
- Move `browser: BrowserWalletOpts` args from `WalletOpts`, to `SendTxOpts`, to restrict browser usage only in supported contexts (sending tx)
- `MultiWallet` now holds browser signer separately, stores `Option<BrowserSigner>` alongside `AddressHashMap<WalletSigner>`

## PR Checklist

- [ ] Added Tests (all existing pass, no functional changes)
- [x] Added Documentation
- [ ] Breaking changes
