### PR TITLE
chore(cli-markdown): remove redundant clap dev-dependency

### DIFF
--- a/crates/cli-markdown/Cargo.toml
+++ b/crates/cli-markdown/Cargo.toml
@@ -16,5 +16,4 @@ workspace = true
 clap = { version = "4", features = ["env"] }
 
 [dev-dependencies]
-clap = { version = "4", features = ["derive"] }
 pretty_assertions = "1"

--- a/crates/cli-markdown/src/lib.rs
+++ b/crates/cli-markdown/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
 //! Generate Markdown documentation for clap command-line tools.
 //!
 //! This is a fork of [`clap-markdown`](https://crates.io/crates/clap-markdown) with the following


### PR DESCRIPTION
Remove the duplicate `clap` declaration from `dev-dependencies` in `foundry-cli-markdown`, add `unused_crate_dependencies` lint at crate root to catch future dependency drift.