### PR TITLE
refactor(anvil): useless tx lookup in eth_getTransactionBySenderAndNonce

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1546,11 +1546,8 @@ impl EthApi {
                 self.backend.mined_transactions_by_block_number(target_block.into()).await
         {
             for tx in txs {
-                if tx.from() == sender
-                    && tx.nonce() == target_nonce
-                    && let Some(mined_tx) = self.backend.transaction_by_hash(tx.tx_hash()).await?
-                {
-                    return Ok(Some(mined_tx));
+                if tx.from() == sender && tx.nonce() == target_nonce {
+                    return Ok(Some(tx));
                 }
             }
         }


### PR DESCRIPTION
`mined_transactions_by_block_number` already returns the full `AnyRpcTransaction`, but the code was throwing it away and re-fetching via `transaction_by_hash` —  which walks the same storage path and returns the same data.

Dropped the extra lookup, just return the `tx` we already have.