### PR TITLE
fix(anvil): validate blob count against per-tx limit, not per-block

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3678,10 +3678,10 @@ impl TransactionValidator for Backend {
                 return Err(InvalidTransactionError::NoBlobHashes);
             }
 
-            // Ensure the tx does not exceed the max blobs per block.
-            let max_blob_count = self.blob_params().max_blob_count as usize;
-            if blob_count > max_blob_count {
-                return Err(InvalidTransactionError::TooManyBlobs(blob_count, max_blob_count));
+            // Ensure the tx does not exceed the max blobs per transaction.
+            let max_blobs_per_tx = self.blob_params().max_blobs_per_tx as usize;
+            if blob_count > max_blobs_per_tx {
+                return Err(InvalidTransactionError::TooManyBlobs(blob_count, max_blobs_per_tx));
             }
 
             // Check for any blob validation errors if not impersonating.


### PR DESCRIPTION
`validate_pool_transaction` was checking blob count against `max_blob_count` (per-block limit) instead of `max_blobs_per_tx` (per-transaction limit).

Before Osaka these values are identical (both 6), so the bug was invisible. Osaka sets `max_blob_count=9` and `max_blobs_per_tx=6`, which means anvil would accept transactions with 7-9 blobs that real nodes would reject.
