### PR TITLE
refactor(anvil): remove redundant tx lookup in transaction_by_sender_and_nonce

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1546,11 +1546,8 @@ impl EthApi {
                 self.backend.mined_transactions_by_block_number(target_block.into()).await
         {
             for tx in txs {
-                if tx.from() == sender
-                    && tx.nonce() == target_nonce
-                    && let Some(mined_tx) = self.backend.transaction_by_hash(tx.tx_hash()).await?
-                {
-                    return Ok(Some(mined_tx));
+                if tx.from() == sender && tx.nonce() == target_nonce {
+                    return Ok(Some(tx));
                 }
             }
         }


### PR DESCRIPTION
## Summary

`transaction_by_sender_and_nonce` was re-fetching a transaction via `transaction_by_hash()` even though `mined_transactions_by_block_number()` already returns fully populated `AnyRpcTransaction` objects. The second lookup walks the same storage path and returns identical data - just unnecessary work.

This removes the redundant call and returns the transaction directly.

Closes #13625

## Changes

- `crates/anvil/src/eth/api.rs`: removed the `transaction_by_hash()` call, return `tx` directly instead of `mined_tx`