### PR TITLE
 chore(anvil): remove unused alloy-eip5792 dev-dependency

### DIFF
--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -111,7 +111,6 @@ fdlimit = { version = "0.3", optional = true }
 [dev-dependencies]
 alloy-provider = { workspace = true, features = ["txpool-api"] }
 alloy-pubsub.workspace = true
-alloy-eip5792.workspace = true
 rand.workspace = true
 reqwest.workspace = true
 foundry-test-utils.workspace = true


### PR DESCRIPTION
not used in anvil tests, only in anvil-core