### PR TITLE
feat(evm): add `to_env()` method to `NestedEvm` 

### DIFF
--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -272,8 +272,6 @@ pub trait NestedEvm {
     ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>>;
 
     /// Returns a snapshot of the current environment (cfg, block, tx).
-    ///
-    /// Used after `transact()` to read back cheatcode-modified cfg/block from the nested EVM.
     fn to_env(&self) -> Env;
 }
 


### PR DESCRIPTION
this allows us to get the env inside a nested EVM to preserve cheatcode modifications