### PR TITLE
refactor(cheatcodes): generic `CheatcodesExecutor<CTX>`

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1065,7 +1065,7 @@ impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournal
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let tx = TxEnvelope::decode(&mut self.data.as_ref())
             .map_err(|err| fmt_err!("failed to decode RLP-encoded transaction: {err}"))?;
@@ -1108,7 +1108,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         use crate::env::FORGE_CONTEXT;
 
@@ -1259,7 +1259,7 @@ impl<CTX> Cheatcode<CTX> for startDebugTraceRecordingCall {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             return Err(Error::from("no tracer initiated, consider adding -vvv flag"));
@@ -1289,7 +1289,7 @@ impl<CTX> Cheatcode<CTX> for stopAndReturnDebugTraceRecordingCall {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             return Err(Error::from("no tracer initiated, consider adding -vvv flag"));

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -143,7 +143,7 @@ impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<C
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Self { txHash } = *self;
         transact(ccx, executor, txHash, None)
@@ -156,7 +156,7 @@ impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<C
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Self { forkId, txHash } = *self;
         transact(ccx, executor, txHash, Some(forkId))
@@ -407,7 +407,7 @@ fn check_broadcast(state: &Cheatcodes) -> Result<()> {
 
 fn transact<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
-    executor: &mut dyn CheatcodesExecutor,
+    executor: &mut dyn CheatcodesExecutor<CTX>,
     transaction: B256,
     fork_id: Option<U256>,
 ) -> Result {

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -304,7 +304,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Self { artifactPath: path } = self;
         deploy_code(ccx, executor, path, None, None, None)
@@ -317,7 +317,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Self { artifactPath: path, constructorArgs: args } = self;
         deploy_code(ccx, executor, path, Some(args), None, None)
@@ -330,7 +330,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Self { artifactPath: path, value } = self;
         deploy_code(ccx, executor, path, None, Some(*value), None)
@@ -343,7 +343,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Self { artifactPath: path, constructorArgs: args, value } = self;
         deploy_code(ccx, executor, path, Some(args), Some(*value), None)
@@ -356,7 +356,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Self { artifactPath: path, salt } = self;
         deploy_code(ccx, executor, path, None, None, Some((*salt).into()))
@@ -369,7 +369,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Self { artifactPath: path, constructorArgs: args, salt } = self;
         deploy_code(ccx, executor, path, Some(args), None, Some((*salt).into()))
@@ -382,7 +382,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Self { artifactPath: path, value, salt } = self;
         deploy_code(ccx, executor, path, None, Some(*value), Some((*salt).into()))
@@ -395,7 +395,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Self { artifactPath: path, constructorArgs: args, value, salt } = self;
         deploy_code(ccx, executor, path, Some(args), Some(*value), Some((*salt).into()))
@@ -406,7 +406,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
 /// Uses CREATE2 scheme if salt specified.
 fn deploy_code<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
-    executor: &mut dyn CheatcodesExecutor,
+    executor: &mut dyn CheatcodesExecutor<CTX>,
     path: &str,
     constructor_args: Option<&Bytes>,
     value: Option<U256>,

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -101,7 +101,7 @@ impl<CTX> CheatsCtxExt for CTX where
 ///
 /// This is needed for cases when inspector itself needs mutable access to [Cheatcodes] state and
 /// allows us to correctly execute arbitrary EVM frames from inside cheatcode implementations.
-pub trait CheatcodesExecutor {
+pub trait CheatcodesExecutor<CTX> {
     /// Core trait method accepting mutable reference to [Cheatcodes] and returning
     /// [revm::Inspector].
     fn get_inspector<'a>(&'a mut self, cheats: &'a mut Cheatcodes) -> Box<dyn InspectorExt + 'a>;
@@ -123,7 +123,7 @@ pub trait CheatcodesExecutor {
 
 /// Builds a sub-EVM from the current context and executes the given CREATE frame.
 pub(crate) fn exec_create<CTX: NestedEvmExt>(
-    executor: &mut dyn CheatcodesExecutor,
+    executor: &mut dyn CheatcodesExecutor<CTX>,
     inputs: CreateInputs,
     ccx: &mut CheatsCtxt<'_, CTX>,
 ) -> std::result::Result<CreateOutcome, EVMError<DatabaseError>>
@@ -152,7 +152,7 @@ where
 #[derive(Debug, Default, Clone, Copy)]
 struct TransparentCheatcodesExecutor;
 
-impl CheatcodesExecutor for TransparentCheatcodesExecutor {
+impl<CTX> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor {
     fn get_inspector<'a>(&'a mut self, cheats: &'a mut Cheatcodes) -> Box<dyn InspectorExt + 'a> {
         Box::new(cheats)
     }
@@ -605,7 +605,7 @@ impl Cheatcodes {
         &mut self,
         ecx: &mut CTX,
         call: &CallInputs,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         // decode the cheatcode call
         let decoded = Vm::VmCalls::abi_decode(&call.input.bytes(ecx)).map_err(|e| {
@@ -695,7 +695,7 @@ impl Cheatcodes {
         &mut self,
         ecx: &mut CTX,
         call: &mut CallInputs,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Option<CallOutcome> {
         // Apply custom execution evm version.
         if let Some(spec_id) = self.execution_evm_version {
@@ -2526,7 +2526,7 @@ fn cheatcode_signature(cheat: &spec::Cheatcode<'static>) -> &'static str {
 fn apply_dispatch<CTX: CheatsCtxExt>(
     calls: &Vm::VmCalls,
     ccx: &mut CheatsCtxt<'_, CTX>,
-    executor: &mut dyn CheatcodesExecutor,
+    executor: &mut dyn CheatcodesExecutor<CTX>,
 ) -> Result {
     // Extract metadata for logging/deprecation via CheatcodeDef.
     macro_rules! get_cheatcode {

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -88,7 +88,7 @@ pub(crate) trait Cheatcode<CTX>: CheatcodeDef {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let _ = executor;
         self.apply_stateful(ccx)

--- a/crates/cheatcodes/src/test/assert.rs
+++ b/crates/cheatcodes/src/test/assert.rs
@@ -189,7 +189,7 @@ type ComparisonResult<'a, T> = Result<(), ComparisonAssertionError<'a, T>>;
 #[cold]
 fn handle_assertion_result<CTX: ContextTr<Db: DatabaseExt>, E>(
     ccx: &mut CheatsCtxt<'_, CTX>,
-    executor: &mut dyn CheatcodesExecutor,
+    executor: &mut dyn CheatcodesExecutor<CTX>,
     err: E,
     error_formatter: Option<&dyn Fn(&E) -> String>,
     error_msg: Option<&str>,
@@ -205,7 +205,7 @@ fn handle_assertion_result<CTX: ContextTr<Db: DatabaseExt>, E>(
 
 fn handle_assertion_result_mono<CTX: ContextTr<Db: DatabaseExt>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
-    executor: &mut dyn CheatcodesExecutor,
+    executor: &mut dyn CheatcodesExecutor<CTX>,
     msg: Cow<'_, str>,
 ) -> Result {
     if ccx.state.config.assertions_revert {
@@ -249,7 +249,7 @@ macro_rules! impl_assertions {
             fn apply_full(
                 &self,
                 ccx: &mut CheatsCtxt<'_, CTX>,
-                executor: &mut dyn CheatcodesExecutor,
+                executor: &mut dyn CheatcodesExecutor<CTX>,
             ) -> Result {
                 let Self { $($arg),* } = self;
                 match $body {
@@ -263,7 +263,7 @@ macro_rules! impl_assertions {
             fn apply_full(
                 &self,
                 ccx: &mut CheatsCtxt<'_, CTX>,
-                executor: &mut dyn CheatcodesExecutor,
+                executor: &mut dyn CheatcodesExecutor<CTX>,
             ) -> Result {
                 let Self { $($arg,)* error } = self;
                 match $body {

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -180,7 +180,7 @@ impl<CTX> Cheatcode<CTX> for pauseTracingCall {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             // No tracer -> nothing to pause
@@ -203,7 +203,7 @@ impl<CTX> Cheatcode<CTX> for resumeTracingCall {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor,
+        executor: &mut dyn CheatcodesExecutor<CTX>,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             // No tracer -> nothing to unpause

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -360,7 +360,7 @@ pub struct InspectorStackRefMut<'a> {
     pub inner: &'a mut InspectorStackInner,
 }
 
-impl CheatcodesExecutor for InspectorStackInner {
+impl<CTX> CheatcodesExecutor<CTX> for InspectorStackInner {
     fn get_inspector<'a>(&'a mut self, cheats: &'a mut Cheatcodes) -> Box<dyn InspectorExt + 'a> {
         Box::new(InspectorStackRefMut { cheatcodes: Some(cheats), inner: self })
     }


### PR DESCRIPTION
## Summary
- Thread the `CTX` type parameter through `CheatcodesExecutor` and all callsites
- Purely mechanical change — `CTX` is unused by the trait methods for now
- Sets up for the upcoming inversion-of-control refactor (PR 2/3)

**Stack**: PR 1/3 → #next → #next

## Test plan
- [x] `cargo check` passes (zero errors, zero warnings)
- [x] No behavioral change — purely type-level threading