### PR TITLE
feat(cheatcodes): inversion of control for `CheatcodesExecutor`

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1,8 +1,8 @@
 //! Implementations of [`Evm`](spec::Group::Evm) cheatcodes.
 
 use crate::{
-    BroadcastableTransaction, Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Error, Result,
-    Vm::*, inspector::RecordDebugStepInfo,
+    BroadcastableTransaction, Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxExt, CheatsCtxt,
+    Error, Result, Vm::*, inspector::RecordDebugStepInfo,
 };
 use alloy_consensus::TxEnvelope;
 use alloy_evm::FromRecoveredTx;
@@ -26,7 +26,6 @@ use foundry_evm_core::{
     backend::{DatabaseExt, FoundryJournalExt, RevertStateSnapshotAction},
     constants::{CALLER, CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, TEST_CONTRACT_ADDRESS},
     env::FoundryContextExt,
-    evm::NestedEvmExt,
     utils::get_blob_base_fee_update_fraction_by_spec_id,
 };
 use foundry_evm_traces::TraceMode;
@@ -1059,9 +1058,7 @@ impl<CTX> Cheatcode<CTX> for getStorageAccessesCall {
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournalExt>> Cheatcode<CTX>
-    for broadcastRawTransactionCall
-{
+impl<CTX: CheatsCtxExt> Cheatcode<CTX> for broadcastRawTransactionCall {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
@@ -1070,11 +1067,7 @@ impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournal
         let tx = TxEnvelope::decode(&mut self.data.as_ref())
             .map_err(|err| fmt_err!("failed to decode RLP-encoded transaction: {err}"))?;
 
-        let env = ccx.ecx.to_env();
-        let mut inspector = executor.get_inspector(ccx.state);
-        let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
-        db.transact_from_tx(&tx.clone().into(), env, inner, &mut *inspector)?;
-        drop(inspector);
+        executor.transact_from_tx_on_db(ccx.state, ccx.ecx, &tx.clone().into())?;
 
         if ccx.state.broadcast.is_some() {
             ccx.state.broadcastable_transactions.push_back(BroadcastableTransaction {
@@ -1102,9 +1095,7 @@ impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for setBlockhashCall {
     }
 }
 
-impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
-    for executeTransactionCall
-{
+impl<CTX: CheatsCtxExt> Cheatcode<CTX> for executeTransactionCall {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
@@ -1164,42 +1155,39 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
         // when the inner EVM executes calls at depth == 1.
         executor.set_in_inner_context(true, Some(sender));
 
-        let (res, nested_env) = {
-            let mut inspector = executor.get_inspector(ccx.state);
+        // Clone journaled state and mark all accounts/slots cold.
+        let cold_state = {
+            let (_, journal) = ccx.ecx.journal_mut().as_db_and_inner();
+            let mut state = journal.state.clone();
+            for (addr, acc_mut) in &mut state {
+                if journal.warm_addresses.is_cold(addr) {
+                    acc_mut.mark_cold();
+                }
+                for slot_mut in acc_mut.storage.values_mut() {
+                    slot_mut.is_cold = true;
+                    slot_mut.original_value = slot_mut.present_value;
+                }
+            }
+            state
+        };
 
-            let (res, nested_env) = {
-                let (db, journal) = ccx.ecx.journal_mut().as_db_and_inner();
-
-                // Create a new EVM instance with the inspector.
-                let mut evm = CTX::new_nested_evm(db, modified_env.clone(), &mut *inspector);
-
-                // Clone journaled state and mark all accounts/slots cold.
-                evm.journal_inner_mut().state = {
-                    let mut state = journal.state.clone();
-                    for (addr, acc_mut) in &mut state {
-                        if journal.warm_addresses.is_cold(addr) {
-                            acc_mut.mark_cold();
-                        }
-                        for slot_mut in acc_mut.storage.values_mut() {
-                            slot_mut.is_cold = true;
-                            slot_mut.original_value = slot_mut.present_value;
-                        }
-                    }
-                    state
-                };
-
+        let mut res = None;
+        let mut nested_env = None;
+        let mut cold_state = Some(cold_state);
+        let modified_tx = modified_env.tx.clone();
+        {
+            let (db, _) = ccx.ecx.journal_mut().as_db_and_inner();
+            executor.with_fresh_nested_evm(ccx.state, db, modified_env, &mut |evm| {
+                // SAFETY: closure is called exactly once by the executor.
+                evm.journal_inner_mut().state = cold_state.take().expect("called once");
                 // Set depth to 1 for proper trace collection.
                 evm.journal_inner_mut().depth = 1;
-
-                let res = evm.transact(modified_env.tx);
-                let nested_env = evm.to_env();
-                (res, nested_env)
-            };
-
-            // Inspector must be dropped before we can call set_in_inner_context again.
-            drop(inspector);
-            (res, nested_env)
-        };
+                res = Some(evm.transact(modified_tx.clone()));
+                nested_env = Some(evm.to_env());
+                Ok(())
+            })?;
+        }
+        let (res, nested_env) = (res.unwrap(), nested_env.unwrap());
 
         // Restore env, preserving cheatcode cfg/block changes from the nested EVM
         // but restoring the original tx and basefee (which we zeroed for the nested call).

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, DatabaseExt, Result, Vm::*,
-    json::json_value_to_token,
+    Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxExt, CheatsCtxt, DatabaseExt, Result,
+    Vm::*, json::json_value_to_token,
 };
 use alloy_dyn_abi::DynSolValue;
 use alloy_network::AnyNetwork;
@@ -137,9 +137,7 @@ impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournal
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
-    for transact_0Call
-{
+impl<CTX: CheatsCtxExt> Cheatcode<CTX> for transact_0Call {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
@@ -150,9 +148,7 @@ impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<C
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
-    for transact_1Call
-{
+impl<CTX: CheatsCtxExt> Cheatcode<CTX> for transact_1Call {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
@@ -405,16 +401,13 @@ fn check_broadcast(state: &Cheatcodes) -> Result<()> {
     }
 }
 
-fn transact<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>>(
+fn transact<CTX: CheatsCtxExt>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     executor: &mut dyn CheatcodesExecutor<CTX>,
     transaction: B256,
     fork_id: Option<U256>,
 ) -> Result {
-    let env = ccx.ecx.to_env();
-    let mut inspector = executor.get_inspector(ccx.state);
-    let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
-    db.transact(fork_id, transaction, env, inner, &mut *inspector)?;
+    executor.transact_on_db(ccx.state, ccx.ecx, fork_id, transaction)?;
     Ok(Default::default())
 }
 

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -2,7 +2,8 @@
 
 use super::string::parse;
 use crate::{
-    Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Result, Vm::*, inspector::exec_create,
+    Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxExt, CheatsCtxt, Result, Vm::*,
+    inspector::exec_create,
 };
 use alloy_dyn_abi::DynSolType;
 use alloy_json_abi::ContractObject;
@@ -14,7 +15,6 @@ use dialoguer::{Input, Password};
 use forge_script_sequence::{BroadcastReader, TransactionWithMetadata};
 use foundry_common::fs;
 use foundry_config::fs_permissions::FsAccessKind;
-use foundry_evm_core::{backend::FoundryJournalExt, evm::NestedEvmExt};
 use revm::{
     context::{Cfg, ContextTr, CreateScheme, JournalTr},
     interpreter::CreateInputs,
@@ -298,9 +298,7 @@ impl<CTX> Cheatcode<CTX> for getDeployedCodeCall {
     }
 }
 
-impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
-    for deployCode_0Call
-{
+impl<CTX: CheatsCtxExt> Cheatcode<CTX> for deployCode_0Call {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
@@ -311,9 +309,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     }
 }
 
-impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
-    for deployCode_1Call
-{
+impl<CTX: CheatsCtxExt> Cheatcode<CTX> for deployCode_1Call {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
@@ -324,9 +320,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     }
 }
 
-impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
-    for deployCode_2Call
-{
+impl<CTX: CheatsCtxExt> Cheatcode<CTX> for deployCode_2Call {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
@@ -337,9 +331,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     }
 }
 
-impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
-    for deployCode_3Call
-{
+impl<CTX: CheatsCtxExt> Cheatcode<CTX> for deployCode_3Call {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
@@ -350,9 +342,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     }
 }
 
-impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
-    for deployCode_4Call
-{
+impl<CTX: CheatsCtxExt> Cheatcode<CTX> for deployCode_4Call {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
@@ -363,9 +353,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     }
 }
 
-impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
-    for deployCode_5Call
-{
+impl<CTX: CheatsCtxExt> Cheatcode<CTX> for deployCode_5Call {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
@@ -376,9 +364,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     }
 }
 
-impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
-    for deployCode_6Call
-{
+impl<CTX: CheatsCtxExt> Cheatcode<CTX> for deployCode_6Call {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
@@ -389,9 +375,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
     }
 }
 
-impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
-    for deployCode_7Call
-{
+impl<CTX: CheatsCtxExt> Cheatcode<CTX> for deployCode_7Call {
     fn apply_full(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
@@ -404,7 +388,7 @@ impl<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>> Cheatcode<CTX>
 
 /// Helper function to deploy contract from artifact code.
 /// Uses CREATE2 scheme if salt specified.
-fn deploy_code<CTX: NestedEvmExt + ContextTr<Journal: FoundryJournalExt>>(
+fn deploy_code<CTX: CheatsCtxExt>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     executor: &mut dyn CheatcodesExecutor<CTX>,
     path: &str,

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -36,12 +36,12 @@ use foundry_common::{
     mapping_slots::{MappingSlots, step as mapping_step},
 };
 use foundry_evm_core::{
-    Breakpoints, FoundryInspectorExt, InspectorExt,
+    Breakpoints, Env, FoundryInspectorExt,
     abi::Vm::stopExpectSafeMemoryCall,
     backend::{DatabaseError, DatabaseExt, FoundryJournalExt, RevertDiagnostic},
     constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME},
     env::FoundryContextExt,
-    evm::NestedEvmExt,
+    evm::{NestedEvm, NestedEvmExt},
 };
 use foundry_evm_traces::{
     TracingInspector, TracingInspectorConfig, identifier::SignaturesIdentifier,
@@ -96,19 +96,62 @@ impl<CTX> CheatsCtxExt for CTX where
 {
 }
 
-/// Helper trait for obtaining complete [revm::Inspector] instance from mutable reference to
-/// [Cheatcodes].
-///
-/// This is needed for cases when inspector itself needs mutable access to [Cheatcodes] state and
-/// allows us to correctly execute arbitrary EVM frames from inside cheatcode implementations.
-pub trait CheatcodesExecutor<CTX> {
-    /// Core trait method accepting mutable reference to [Cheatcodes] and returning
-    /// [revm::Inspector].
-    fn get_inspector<'a>(&'a mut self, cheats: &'a mut Cheatcodes) -> Box<dyn InspectorExt + 'a>;
+/// Closure type used by [`CheatcodesExecutor`] methods that run nested EVM operations.
+pub type NestedEvmClosure<'a> =
+    &'a mut dyn FnMut(&mut dyn NestedEvm) -> Result<(), EVMError<DatabaseError>>;
 
-    fn console_log(&mut self, cheats: &mut Cheatcodes, msg: &str) {
-        self.get_inspector(cheats).console_log(msg);
-    }
+/// Helper trait for running nested EVM operations from inside cheatcode implementations.
+///
+/// The executor assembles the full inspector stack internally and never exposes it across the
+/// trait boundary. This keeps the trait free of `InspectorExt` (which is Eth-specific).
+pub trait CheatcodesExecutor<CTX> {
+    /// Runs a closure with a nested EVM built from the current context.
+    /// The inspector is assembled internally — never exposed to the caller.
+    fn with_nested_evm(
+        &mut self,
+        cheats: &mut Cheatcodes,
+        ecx: &mut CTX,
+        f: NestedEvmClosure<'_>,
+    ) -> Result<(), EVMError<DatabaseError>>
+    where
+        CTX: CheatsCtxExt;
+
+    /// Replays a historical transaction on the database. Inspector is assembled internally.
+    fn transact_on_db(
+        &mut self,
+        cheats: &mut Cheatcodes,
+        ecx: &mut CTX,
+        fork_id: Option<U256>,
+        transaction: B256,
+    ) -> eyre::Result<()>
+    where
+        CTX: CheatsCtxExt;
+
+    /// Executes a `TransactionRequest` on the database. Inspector is assembled internally.
+    fn transact_from_tx_on_db(
+        &mut self,
+        cheats: &mut Cheatcodes,
+        ecx: &mut CTX,
+        tx: &TransactionRequest,
+    ) -> eyre::Result<()>
+    where
+        CTX: CheatsCtxExt;
+
+    /// Runs a closure with a fresh nested EVM built from a raw database and environment.
+    /// Unlike `with_nested_evm`, this does NOT clone from `ecx` and does NOT write back.
+    /// The caller is responsible for state merging. Used by `executeTransactionCall`.
+    fn with_fresh_nested_evm(
+        &mut self,
+        cheats: &mut Cheatcodes,
+        db: &mut dyn DatabaseExt,
+        env: Env,
+        f: NestedEvmClosure<'_>,
+    ) -> Result<(), EVMError<DatabaseError>>
+    where
+        CTX: CheatsCtxExt;
+
+    /// Simulates `console.log` invocation.
+    fn console_log(&mut self, cheats: &mut Cheatcodes, msg: &str);
 
     /// Returns a mutable reference to the tracing inspector if it is available.
     fn tracing_inspector(&mut self) -> Option<&mut TracingInspector> {
@@ -122,29 +165,30 @@ pub trait CheatcodesExecutor<CTX> {
 }
 
 /// Builds a sub-EVM from the current context and executes the given CREATE frame.
-pub(crate) fn exec_create<CTX: NestedEvmExt>(
+pub(crate) fn exec_create<CTX: CheatsCtxExt>(
     executor: &mut dyn CheatcodesExecutor<CTX>,
     inputs: CreateInputs,
     ccx: &mut CheatsCtxt<'_, CTX>,
-) -> std::result::Result<CreateOutcome, EVMError<DatabaseError>>
-where
-    CTX::Journal: FoundryJournalExt,
-{
-    let mut inspector = executor.get_inspector(ccx.state);
-    ccx.ecx.with_nested_evm(&mut *inspector, |evm| {
+) -> std::result::Result<CreateOutcome, EVMError<DatabaseError>> {
+    let mut inputs = Some(inputs);
+    let mut outcome = None;
+    executor.with_nested_evm(ccx.state, ccx.ecx, &mut |evm| {
+        let inputs = inputs.take().unwrap();
         evm.journal_inner_mut().depth += 1;
 
         let frame = FrameInput::Create(Box::new(inputs));
 
-        let outcome = match evm.run_execution(frame)? {
+        let result = match evm.run_execution(frame)? {
             FrameResult::Call(_) => unreachable!(),
             FrameResult::Create(create) => create,
         };
 
         evm.journal_inner_mut().depth -= 1;
 
-        Ok(outcome)
-    })
+        outcome = Some(result);
+        Ok(())
+    })?;
+    Ok(outcome.unwrap())
 }
 
 /// Basic implementation of [CheatcodesExecutor] that simply returns the [Cheatcodes] instance as an
@@ -152,10 +196,51 @@ where
 #[derive(Debug, Default, Clone, Copy)]
 struct TransparentCheatcodesExecutor;
 
-impl<CTX> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor {
-    fn get_inspector<'a>(&'a mut self, cheats: &'a mut Cheatcodes) -> Box<dyn InspectorExt + 'a> {
-        Box::new(cheats)
+impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor {
+    fn with_nested_evm(
+        &mut self,
+        cheats: &mut Cheatcodes,
+        ecx: &mut CTX,
+        f: NestedEvmClosure<'_>,
+    ) -> Result<(), EVMError<DatabaseError>> {
+        ecx.with_nested_evm(cheats, |evm| f(evm))
     }
+
+    fn with_fresh_nested_evm(
+        &mut self,
+        cheats: &mut Cheatcodes,
+        db: &mut dyn DatabaseExt,
+        env: Env,
+        f: NestedEvmClosure<'_>,
+    ) -> Result<(), EVMError<DatabaseError>> {
+        let mut evm = CTX::new_nested_evm(db, env, cheats);
+        f(&mut *evm)
+    }
+
+    fn transact_on_db(
+        &mut self,
+        cheats: &mut Cheatcodes,
+        ecx: &mut CTX,
+        fork_id: Option<U256>,
+        transaction: B256,
+    ) -> eyre::Result<()> {
+        let env = ecx.to_env();
+        let (db, inner) = ecx.journal_mut().as_db_and_inner();
+        db.transact(fork_id, transaction, env, inner, cheats)
+    }
+
+    fn transact_from_tx_on_db(
+        &mut self,
+        cheats: &mut Cheatcodes,
+        ecx: &mut CTX,
+        tx: &TransactionRequest,
+    ) -> eyre::Result<()> {
+        let env = ecx.to_env();
+        let (db, inner) = ecx.journal_mut().as_db_and_inner();
+        db.transact_from_tx(tx, env, inner, cheats)
+    }
+
+    fn console_log(&mut self, _cheats: &mut Cheatcodes, _msg: &str) {}
 }
 
 macro_rules! try_or_return {

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -24,7 +24,7 @@ pub use config::CheatsConfig;
 pub use error::{Error, ErrorKind, Result};
 pub use inspector::{
     BroadcastableTransaction, BroadcastableTransactions, Cheatcodes, CheatcodesExecutor,
-    CheatsCtxExt,
+    CheatsCtxExt, NestedEvmClosure,
 };
 pub use spec::{CheatcodeDef, Vm};
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -3,15 +3,18 @@ use super::{
     LogCollector, RevertDiagnostic, ScriptExecutionInspector, TracingInspector,
 };
 use alloy_primitives::{
-    Address, Bytes, Log, TxKind, U256,
+    Address, B256, Bytes, Log, TxKind, U256,
     map::{AddressHashMap, HashMap},
 };
-use foundry_cheatcodes::{CheatcodeAnalysis, CheatcodesExecutor, CheatsCtxExt, Wallets};
+use alloy_rpc_types::request::TransactionRequest;
+use foundry_cheatcodes::{
+    CheatcodeAnalysis, CheatcodesExecutor, CheatsCtxExt, NestedEvmClosure, Wallets,
+};
 use foundry_common::compile::Analysis;
 use foundry_compilers::ProjectPathsConfig;
 use foundry_evm_core::{
     Env, FoundryInspectorExt, InspectorExt,
-    backend::{FoundryJournalExt, JournaledState},
+    backend::{DatabaseError, FoundryJournalExt, JournaledState},
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_networks::NetworkConfigs;
@@ -19,8 +22,8 @@ use foundry_evm_traces::{SparsedTraceArena, TraceMode};
 use revm::{
     Inspector,
     context::{
-        BlockEnv, Cfg, ContextTr, JournalTr,
-        result::{ExecutionResult, Output},
+        Block, BlockEnv, Cfg, ContextTr, JournalTr,
+        result::{EVMError, ExecutionResult, Output},
     },
     context_interface::CreateScheme,
     inspector::JournalExt,
@@ -353,16 +356,64 @@ pub struct InspectorStackInner {
 }
 
 /// Struct keeping mutable references to both parts of [InspectorStack] and implementing
-/// [revm::Inspector]. This struct can be obtained via [InspectorStack::as_mut] or via
-/// [CheatcodesExecutor::get_inspector] method implemented for [InspectorStackInner].
+/// [revm::Inspector]. This struct can be obtained via [InspectorStack::as_mut].
 pub struct InspectorStackRefMut<'a> {
     pub cheatcodes: Option<&'a mut Cheatcodes>,
     pub inner: &'a mut InspectorStackInner,
 }
 
-impl<CTX> CheatcodesExecutor<CTX> for InspectorStackInner {
-    fn get_inspector<'a>(&'a mut self, cheats: &'a mut Cheatcodes) -> Box<dyn InspectorExt + 'a> {
-        Box::new(InspectorStackRefMut { cheatcodes: Some(cheats), inner: self })
+impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for InspectorStackInner {
+    fn with_nested_evm(
+        &mut self,
+        cheats: &mut Cheatcodes,
+        ecx: &mut CTX,
+        f: NestedEvmClosure<'_>,
+    ) -> Result<(), EVMError<DatabaseError>> {
+        let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
+        ecx.with_nested_evm(&mut inspector, |evm| f(evm))
+    }
+
+    fn with_fresh_nested_evm(
+        &mut self,
+        cheats: &mut Cheatcodes,
+        db: &mut dyn foundry_evm_core::backend::DatabaseExt,
+        env: foundry_evm_core::Env,
+        f: NestedEvmClosure<'_>,
+    ) -> Result<(), EVMError<DatabaseError>> {
+        let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
+        let mut evm = CTX::new_nested_evm(db, env, &mut inspector);
+        f(&mut *evm)
+    }
+
+    fn transact_on_db(
+        &mut self,
+        cheats: &mut Cheatcodes,
+        ecx: &mut CTX,
+        fork_id: Option<U256>,
+        transaction: B256,
+    ) -> eyre::Result<()> {
+        let env = ecx.to_env();
+        let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
+        let (db, inner) = ecx.journal_mut().as_db_and_inner();
+        db.transact(fork_id, transaction, env, inner, &mut inspector)
+    }
+
+    fn transact_from_tx_on_db(
+        &mut self,
+        cheats: &mut Cheatcodes,
+        ecx: &mut CTX,
+        tx: &TransactionRequest,
+    ) -> eyre::Result<()> {
+        let env = ecx.to_env();
+        let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
+        let (db, inner) = ecx.journal_mut().as_db_and_inner();
+        db.transact_from_tx(tx, env, inner, &mut inspector)
+    }
+
+    fn console_log(&mut self, _cheats: &mut Cheatcodes, msg: &str) {
+        if let Some(ref mut collector) = self.log_collector {
+            FoundryInspectorExt::console_log(&mut **collector, msg);
+        }
     }
 
     fn tracing_inspector(&mut self) -> Option<&mut TracingInspector> {
@@ -692,9 +743,8 @@ impl InspectorStackRefMut<'_> {
 
         // If we haven't disabled gas limit checks, ensure that transaction gas limit will not
         // exceed block gas limit.
-        if !ecx.cfg_mut().disable_block_gas_limit {
-            ecx.tx_mut().gas_limit =
-                std::cmp::min(ecx.tx_mut().gas_limit, ecx.block_mut().gas_limit);
+        if !ecx.cfg().is_block_gas_limit_disabled() {
+            ecx.tx_mut().gas_limit = std::cmp::min(ecx.tx_mut().gas_limit, ecx.block().gas_limit());
         }
         ecx.tx_mut().gas_price = 0;
 


### PR DESCRIPTION
## Summary
- Remove `get_inspector() -> Box<dyn InspectorExt>` from `CheatcodesExecutor`
- Instead, the executor assembles the inspector internally and owns the operation
- New methods: `with_nested_evm`, `with_fresh_nested_evm`, `transact_on_db`, `transact_from_tx_on_db`
- `InspectorExt` no longer appears on the `CheatcodesExecutor` trait boundary

**Stack**: #13650 → PR 2/3 → #next

Depends on #13650

## Test plan
- [x] `cargo check` passes (zero errors, zero warnings)
- [x] All cheatcode callsites updated mechanically