### PR TITLE
feat(anvil): add [anvil] section to foundry.toml

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -32,16 +32,22 @@ use tokio::time::{Instant, Interval};
 #[derive(Clone, Debug, Parser)]
 pub struct NodeArgs {
     /// Port number to listen on.
-    #[arg(long, short, default_value = "8545", value_name = "NUM")]
-    pub port: u16,
+    ///
+    /// Can also be set in `foundry.toml` under `[anvil]`. CLI flags take precedence.
+    #[arg(long, short, value_name = "NUM")]
+    pub port: Option<u16>,
 
     /// Number of dev accounts to generate and configure.
-    #[arg(long, short, default_value = "10", value_name = "NUM")]
-    pub accounts: u64,
+    ///
+    /// Can also be set in `foundry.toml` under `[anvil]`. CLI flags take precedence.
+    #[arg(long, short, value_name = "NUM")]
+    pub accounts: Option<u64>,
 
     /// The balance of every dev account in Ether.
-    #[arg(long, default_value = "10000", value_name = "NUM")]
-    pub balance: u64,
+    ///
+    /// Can also be set in `foundry.toml` under `[anvil]`. CLI flags take precedence.
+    #[arg(long, value_name = "NUM")]
+    pub balance: Option<u64>,
 
     /// The timestamp of the genesis block.
     #[arg(long, value_name = "NUM")]
@@ -89,8 +95,10 @@ pub struct NodeArgs {
     pub block_time: Option<Duration>,
 
     /// Slots in an epoch
-    #[arg(long, value_name = "SLOTS_IN_AN_EPOCH", default_value_t = 32)]
-    pub slots_in_an_epoch: u64,
+    ///
+    /// Can also be set in `foundry.toml` under `[anvil]`. CLI flags take precedence.
+    #[arg(long, value_name = "SLOTS_IN_AN_EPOCH")]
+    pub slots_in_an_epoch: Option<u64>,
 
     /// Writes output of `anvil` as json to user-specified file.
     #[arg(long, value_name = "FILE", value_hint = clap::ValueHint::FilePath)]
@@ -104,19 +112,22 @@ pub struct NodeArgs {
     pub mixed_mining: bool,
 
     /// The hosts the server will listen on.
+    ///
+    /// Can also be set in `foundry.toml` under `[anvil]`. CLI flags take precedence.
     #[arg(
         long,
         value_name = "IP_ADDR",
         env = "ANVIL_IP_ADDR",
-        default_value = "127.0.0.1",
         help_heading = "Server options",
         value_delimiter = ','
     )]
-    pub host: Vec<IpAddr>,
+    pub host: Option<Vec<IpAddr>>,
 
     /// How transactions are sorted in the mempool.
-    #[arg(long, default_value = "fees")]
-    pub order: TransactionOrder,
+    ///
+    /// Can also be set in `foundry.toml` under `[anvil]`. CLI flags take precedence.
+    #[arg(long)]
+    pub order: Option<TransactionOrder>,
 
     /// Initialize the genesis block with the given `genesis.json` file.
     #[arg(long, value_name = "PATH", value_parser= read_genesis_file)]
@@ -220,13 +231,103 @@ const DEFAULT_DUMP_INTERVAL: Duration = Duration::from_secs(60);
 
 impl NodeArgs {
     pub fn into_node_config(self) -> eyre::Result<NodeConfig> {
-        let genesis_balance = Unit::ETHER.wei().saturating_mul(U256::from(self.balance));
-        let compute_units_per_second =
-            if self.evm.no_rate_limit { Some(u64::MAX) } else { self.evm.compute_units_per_second };
+        // Load [anvil] from foundry.toml (if in a foundry project)
+        let anvil_config = Config::load_with_providers(FigmentProviders::Anvil)?.anvil;
 
-        let hardfork = match &self.hardfork {
+        // Build account generator before destructuring self.
+        // CLI mnemonic flags (--mnemonic, --mnemonic-random, --mnemonic-seed-unsafe) suppress
+        // config mnemonic to avoid surprising override behavior.
+        let has_cli_mnemonic = self.mnemonic.is_some()
+            || self.mnemonic_random.is_some()
+            || self.mnemonic_seed.is_some();
+        let config_mnemonic = if has_cli_mnemonic { None } else { anvil_config.mnemonic.clone() };
+        let config_derivation_path =
+            if has_cli_mnemonic { None } else { anvil_config.derivation_path.clone() };
+
+        let merged_chain_id = self
+            .evm
+            .chain_id
+            .unwrap_or_else(|| anvil_config.chain_id.map(Chain::from).unwrap_or(CHAIN_ID.into()));
+
+        let merged_accounts = self.accounts.unwrap_or(anvil_config.accounts);
+        let account_generator = self.account_generator(
+            merged_accounts,
+            merged_chain_id,
+            &config_mnemonic,
+            &config_derivation_path,
+        );
+
+        // Destructure self to take ownership of all fields.
+        let Self {
+            port,
+            accounts: _,
+            balance,
+            timestamp,
+            number,
+            mnemonic: _,
+            mnemonic_random: _,
+            mnemonic_seed: _,
+            derivation_path: _,
+            hardfork,
+            block_time,
+            slots_in_an_epoch,
+            config_out,
+            no_mining,
+            mixed_mining,
+            host,
+            order,
+            init,
+            state,
+            state_interval: _,
+            dump_state: _,
+            preserve_historical_states: _,
+            load_state,
+            ipc,
+            prune_history,
+            max_persisted_states,
+            transaction_block_keeper,
+            max_transactions,
+            evm,
+            server_config,
+            cache_path,
+        } = self;
+
+        // Merge CLI > config > defaults for required fields
+        let port = port.unwrap_or(anvil_config.port);
+        let balance = balance.unwrap_or(anvil_config.balance);
+        let slots_in_an_epoch = slots_in_an_epoch.unwrap_or(anvil_config.slots_in_an_epoch);
+
+        let genesis_balance = Unit::ETHER.wei().saturating_mul(U256::from(balance));
+
+        // Merge host: CLI > config > default (127.0.0.1)
+        let host = host.unwrap_or_else(|| {
+            if !anvil_config.host.is_empty() {
+                anvil_config
+                    .host
+                    .iter()
+                    .map(|h| {
+                        h.parse::<IpAddr>().unwrap_or(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))
+                    })
+                    .collect()
+            } else {
+                vec![IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)]
+            }
+        });
+
+        // Merge order: CLI > config > default (fees)
+        let order = order.unwrap_or_else(|| {
+            if let Some(ref order_str) = anvil_config.order {
+                order_str.parse::<TransactionOrder>().unwrap_or(TransactionOrder::Fees)
+            } else {
+                TransactionOrder::Fees
+            }
+        });
+
+        // Merge hardfork: CLI > config
+        let hardfork_str = hardfork.or(anvil_config.hardfork);
+        let hardfork = match &hardfork_str {
             Some(hf) => {
-                if self.evm.networks.is_optimism() {
+                if evm.networks.is_optimism() {
                     Some(OpHardfork::from_str(hf)?.into())
                 } else {
                     Some(EthereumHardfork::from_str(hf)?.into())
@@ -235,71 +336,129 @@ impl NodeArgs {
             None => None,
         };
 
+        // Merge block_time: CLI > config
+        let block_time = block_time.or_else(|| anvil_config.block_time.map(Duration::from_secs));
+
+        // Merge bool flags: CLI || config
+        let no_mining = no_mining || anvil_config.no_mining;
+        let mixed_mining = mixed_mining || anvil_config.mixed_mining;
+
+        // Merge EVM options: CLI > config
+        let gas_limit = evm.gas_limit.or(anvil_config.gas_limit.map(|g| g.0));
+        let disable_block_gas_limit =
+            evm.disable_block_gas_limit || anvil_config.disable_block_gas_limit;
+        let enable_tx_gas_limit = evm.enable_tx_gas_limit || anvil_config.enable_tx_gas_limit;
+        let gas_price = evm.gas_price.or(anvil_config.gas_price);
+        let block_base_fee_per_gas =
+            evm.block_base_fee_per_gas.or(anvil_config.block_base_fee_per_gas);
+        let disable_min_priority_fee =
+            evm.disable_min_priority_fee || anvil_config.disable_min_priority_fee;
+        let no_storage_caching = evm.no_storage_caching || anvil_config.no_storage_caching;
+        let steps_tracing = evm.steps_tracing || anvil_config.steps_tracing;
+        let disable_console_log = evm.disable_console_log || anvil_config.disable_console_log;
+        let print_traces = evm.print_traces || anvil_config.print_traces;
+        let auto_impersonate = evm.auto_impersonate || anvil_config.auto_impersonate;
+        let disable_default_create2_deployer =
+            evm.disable_default_create2_deployer || anvil_config.disable_default_create2_deployer;
+        let disable_pool_balance_checks =
+            evm.disable_pool_balance_checks || anvil_config.disable_pool_balance_checks;
+        let no_rate_limit = evm.no_rate_limit || anvil_config.no_rate_limit;
+
+        // Merge Option<T> fields: CLI > config
+        let code_size_limit = evm.code_size_limit.or(anvil_config.code_size_limit);
+        let disable_code_size_limit =
+            evm.disable_code_size_limit || anvil_config.disable_code_size_limit;
+        let memory_limit = evm.memory_limit.or(anvil_config.memory_limit);
+        let max_transactions = max_transactions.or(anvil_config.max_transactions);
+        let prune_history = prune_history.or(anvil_config.prune_history);
+        let max_persisted_states = max_persisted_states.or(anvil_config.max_persisted_states);
+        let transaction_block_keeper =
+            transaction_block_keeper.or(anvil_config.transaction_block_keeper);
+        let cache_path = cache_path.or(anvil_config.cache_path);
+        let ipc_merged: Option<Option<String>> =
+            if ipc.is_some() { ipc } else { anvil_config.ipc.map(Some) };
+
+        // Merge fork settings: CLI > config
+        let fork_url_str = evm.fork_url.as_ref().map(|f| f.url.clone()).or(anvil_config.fork_url);
+        let fork_block = evm.fork_url.as_ref().and_then(|f| f.block);
+        let fork_block_number = evm.fork_block_number.or(anvil_config.fork_block_number);
+        let fork_headers =
+            if evm.fork_headers.is_empty() { anvil_config.fork_headers } else { evm.fork_headers };
+        let fork_chain_id = evm.fork_chain_id.or(anvil_config.fork_chain_id.map(Chain::from));
+        let fork_request_timeout = evm.fork_request_timeout.or(anvil_config.fork_request_timeout);
+        let fork_request_retries = evm.fork_request_retries.or(anvil_config.fork_request_retries);
+        let fork_retry_backoff = evm.fork_retry_backoff.or(anvil_config.fork_retry_backoff);
+        let compute_units_per_second = if no_rate_limit {
+            Some(u64::MAX)
+        } else {
+            evm.compute_units_per_second.or(anvil_config.compute_units_per_second)
+        };
+
         Ok(NodeConfig::default()
-            .with_gas_limit(self.evm.gas_limit)
-            .disable_block_gas_limit(self.evm.disable_block_gas_limit)
-            .enable_tx_gas_limit(self.evm.enable_tx_gas_limit)
-            .with_gas_price(self.evm.gas_price)
+            .with_gas_limit(gas_limit)
+            .disable_block_gas_limit(disable_block_gas_limit)
+            .enable_tx_gas_limit(enable_tx_gas_limit)
+            .with_gas_price(gas_price)
             .with_hardfork(hardfork)
-            .with_blocktime(self.block_time)
-            .with_no_mining(self.no_mining)
-            .with_mixed_mining(self.mixed_mining, self.block_time)
-            .with_account_generator(self.account_generator())?
+            .with_blocktime(block_time)
+            .with_no_mining(no_mining)
+            .with_mixed_mining(mixed_mining, block_time)
+            .with_account_generator(account_generator)?
             .with_genesis_balance(genesis_balance)
-            .with_genesis_timestamp(self.timestamp)
-            .with_genesis_block_number(self.number)
-            .with_port(self.port)
-            .with_fork_choice(match (self.evm.fork_block_number, self.evm.fork_transaction_hash) {
+            .with_genesis_timestamp(timestamp)
+            .with_genesis_block_number(number)
+            .with_port(port)
+            .with_fork_choice(match (fork_block_number, evm.fork_transaction_hash) {
                 (Some(block), None) => Some(ForkChoice::Block(block)),
                 (None, Some(hash)) => Some(ForkChoice::Transaction(hash)),
-                _ => self
-                    .evm
-                    .fork_url
-                    .as_ref()
-                    .and_then(|f| f.block)
-                    .map(|num| ForkChoice::Block(num as i128)),
+                _ => fork_block.map(|num| ForkChoice::Block(num as i128)),
             })
-            .with_fork_headers(self.evm.fork_headers)
-            .with_fork_chain_id(self.evm.fork_chain_id.map(u64::from).map(U256::from))
-            .fork_request_timeout(self.evm.fork_request_timeout.map(Duration::from_millis))
-            .fork_request_retries(self.evm.fork_request_retries)
-            .fork_retry_backoff(self.evm.fork_retry_backoff.map(Duration::from_millis))
+            .with_fork_headers(fork_headers)
+            .with_fork_chain_id(fork_chain_id.map(u64::from).map(U256::from))
+            .fork_request_timeout(fork_request_timeout.map(Duration::from_millis))
+            .fork_request_retries(fork_request_retries)
+            .fork_retry_backoff(fork_retry_backoff.map(Duration::from_millis))
             .fork_compute_units_per_second(compute_units_per_second)
-            .with_eth_rpc_url(self.evm.fork_url.map(|fork| fork.url))
-            .with_base_fee(self.evm.block_base_fee_per_gas)
-            .disable_min_priority_fee(self.evm.disable_min_priority_fee)
-            .with_no_storage_caching(self.evm.no_storage_caching)
-            .with_server_config(self.server_config)
-            .with_host(self.host)
+            .with_eth_rpc_url(fork_url_str)
+            .with_base_fee(block_base_fee_per_gas)
+            .disable_min_priority_fee(disable_min_priority_fee)
+            .with_no_storage_caching(no_storage_caching)
+            .with_server_config(server_config)
+            .with_host(host)
             .set_silent(shell::is_quiet())
-            .set_config_out(self.config_out)
-            .with_chain_id(self.evm.chain_id)
-            .with_transaction_order(self.order)
-            .with_genesis(self.init)
-            .with_steps_tracing(self.evm.steps_tracing)
-            .with_print_logs(!self.evm.disable_console_log)
-            .with_print_traces(self.evm.print_traces)
-            .with_auto_impersonate(self.evm.auto_impersonate)
-            .with_ipc(self.ipc)
-            .with_code_size_limit(self.evm.code_size_limit)
-            .disable_code_size_limit(self.evm.disable_code_size_limit)
-            .set_pruned_history(self.prune_history)
-            .with_init_state(self.load_state.or_else(|| self.state.and_then(|s| s.state)))
-            .with_transaction_block_keeper(self.transaction_block_keeper)
-            .with_max_transactions(self.max_transactions)
-            .with_max_persisted_states(self.max_persisted_states)
-            .with_networks(self.evm.networks)
-            .with_disable_default_create2_deployer(self.evm.disable_default_create2_deployer)
-            .with_disable_pool_balance_checks(self.evm.disable_pool_balance_checks)
-            .with_slots_in_an_epoch(self.slots_in_an_epoch)
-            .with_memory_limit(self.evm.memory_limit)
-            .with_cache_path(self.cache_path))
+            .set_config_out(config_out)
+            .with_chain_id(Some(merged_chain_id))
+            .with_transaction_order(order)
+            .with_genesis(init)
+            .with_steps_tracing(steps_tracing)
+            .with_print_logs(!disable_console_log)
+            .with_print_traces(print_traces)
+            .with_auto_impersonate(auto_impersonate)
+            .with_ipc(ipc_merged)
+            .with_code_size_limit(code_size_limit)
+            .disable_code_size_limit(disable_code_size_limit)
+            .set_pruned_history(prune_history)
+            .with_init_state(load_state.or_else(|| state.and_then(|s| s.state)))
+            .with_transaction_block_keeper(transaction_block_keeper)
+            .with_max_transactions(max_transactions)
+            .with_max_persisted_states(max_persisted_states)
+            .with_networks(evm.networks)
+            .with_disable_default_create2_deployer(disable_default_create2_deployer)
+            .with_disable_pool_balance_checks(disable_pool_balance_checks)
+            .with_slots_in_an_epoch(slots_in_an_epoch)
+            .with_memory_limit(memory_limit)
+            .with_cache_path(cache_path))
     }
 
-    fn account_generator(&self) -> AccountGenerator {
-        let mut generator = AccountGenerator::new(self.accounts as usize)
-            .phrase(DEFAULT_MNEMONIC)
-            .chain_id(self.evm.chain_id.unwrap_or(CHAIN_ID.into()));
+    fn account_generator(
+        &self,
+        accounts: u64,
+        chain_id: Chain,
+        config_mnemonic: &Option<String>,
+        config_derivation_path: &Option<String>,
+    ) -> AccountGenerator {
+        let mut generator =
+            AccountGenerator::new(accounts as usize).phrase(DEFAULT_MNEMONIC).chain_id(chain_id);
         if let Some(ref mnemonic) = self.mnemonic {
             generator = generator.phrase(mnemonic);
         } else if let Some(count) = self.mnemonic_random {
@@ -308,8 +467,6 @@ impl NodeArgs {
                 Ok(mnemonic) => mnemonic.to_phrase(),
                 Err(err) => {
                     warn!(target: "node", ?count, %err, "failed to generate mnemonic, falling back to 12-word random mnemonic");
-                    // Fallback: generate a valid 12-word random mnemonic instead of using
-                    // DEFAULT_MNEMONIC
                     Mnemonic::<English>::new_with_count(&mut rng, 12)
                         .expect("valid default word count")
                         .to_phrase()
@@ -320,8 +477,12 @@ impl NodeArgs {
             let mut seed = StdRng::seed_from_u64(seed);
             let mnemonic = Mnemonic::<English>::new(&mut seed).to_phrase();
             generator = generator.phrase(mnemonic);
+        } else if let Some(mnemonic) = config_mnemonic {
+            generator = generator.phrase(mnemonic);
         }
         if let Some(ref derivation) = self.derivation_path {
+            generator = generator.derivation_path(derivation);
+        } else if let Some(derivation) = config_derivation_path {
             generator = generator.derivation_path(derivation);
         }
         generator
@@ -812,7 +973,7 @@ fn duration_from_secs_f64(s: &str) -> Result<Duration, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{env, net::Ipv4Addr};
+    use std::env;
 
     #[test]
     fn test_parse_fork_url() {
@@ -933,31 +1094,31 @@ mod tests {
     #[test]
     fn can_parse_host() {
         let args = NodeArgs::parse_from(["anvil"]);
-        assert_eq!(args.host, vec![IpAddr::V4(Ipv4Addr::LOCALHOST)]);
+        assert_eq!(args.host, None);
 
         let args = NodeArgs::parse_from([
             "anvil", "--host", "::1", "--host", "1.1.1.1", "--host", "2.2.2.2",
         ]);
         assert_eq!(
             args.host,
-            ["::1", "1.1.1.1", "2.2.2.2"].map(|ip| ip.parse::<IpAddr>().unwrap()).to_vec()
+            Some(["::1", "1.1.1.1", "2.2.2.2"].map(|ip| ip.parse::<IpAddr>().unwrap()).to_vec())
         );
 
         let args = NodeArgs::parse_from(["anvil", "--host", "::1,1.1.1.1,2.2.2.2"]);
         assert_eq!(
             args.host,
-            ["::1", "1.1.1.1", "2.2.2.2"].map(|ip| ip.parse::<IpAddr>().unwrap()).to_vec()
+            Some(["::1", "1.1.1.1", "2.2.2.2"].map(|ip| ip.parse::<IpAddr>().unwrap()).to_vec())
         );
 
         unsafe { env::set_var("ANVIL_IP_ADDR", "1.1.1.1") };
         let args = NodeArgs::parse_from(["anvil"]);
-        assert_eq!(args.host, vec!["1.1.1.1".parse::<IpAddr>().unwrap()]);
+        assert_eq!(args.host, Some(vec!["1.1.1.1".parse::<IpAddr>().unwrap()]));
 
         unsafe { env::set_var("ANVIL_IP_ADDR", "::1,1.1.1.1,2.2.2.2") };
         let args = NodeArgs::parse_from(["anvil"]);
         assert_eq!(
             args.host,
-            ["::1", "1.1.1.1", "2.2.2.2"].map(|ip| ip.parse::<IpAddr>().unwrap()).to_vec()
+            Some(["::1", "1.1.1.1", "2.2.2.2"].map(|ip| ip.parse::<IpAddr>().unwrap()).to_vec())
         );
     }
 }

--- a/crates/config/src/anvil.rs
+++ b/crates/config/src/anvil.rs
@@ -1,0 +1,249 @@
+//! Configuration specific to the `anvil` command.
+
+use crate::GasLimit;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Contains the config for `anvil` node settings.
+///
+/// This can be configured in `foundry.toml` under the `[anvil]` section:
+///
+/// ```toml
+/// [anvil]
+/// port = 8545
+/// accounts = 10
+/// balance = 10000
+/// ```
+///
+/// Or under a profile-specific section:
+///
+/// ```toml
+/// [profile.ci.anvil]
+/// no_storage_caching = true
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnvilConfig {
+    /// Port number to listen on.
+    pub port: u16,
+
+    /// The hosts the server will listen on.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub host: Vec<String>,
+
+    /// The chain ID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chain_id: Option<u64>,
+
+    /// The EVM hardfork to use.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hardfork: Option<String>,
+
+    /// Number of dev accounts to generate and configure.
+    pub accounts: u64,
+
+    /// The balance of every dev account in Ether.
+    pub balance: u64,
+
+    /// BIP39 mnemonic phrase used for generating accounts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mnemonic: Option<String>,
+
+    /// Sets the derivation path of the child key to be derived.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub derivation_path: Option<String>,
+
+    /// Block time in seconds for interval mining.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_time: Option<u64>,
+
+    /// Disable auto and interval mining, and mine on demand instead.
+    #[serde(default)]
+    pub no_mining: bool,
+
+    /// Enable mixed mining (interval + on-demand).
+    #[serde(default)]
+    pub mixed_mining: bool,
+
+    /// How transactions are sorted in the mempool.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub order: Option<String>,
+
+    /// Slots in an epoch.
+    pub slots_in_an_epoch: u64,
+
+    /// The block gas limit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gas_limit: Option<GasLimit>,
+
+    /// Disable the `call.gas_limit <= block.gas_limit` constraint.
+    #[serde(default)]
+    pub disable_block_gas_limit: bool,
+
+    /// Enable the transaction gas limit check (EIP-7825).
+    #[serde(default)]
+    pub enable_tx_gas_limit: bool,
+
+    /// The gas price.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gas_price: Option<u128>,
+
+    /// The base fee in a block.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_base_fee_per_gas: Option<u64>,
+
+    /// Disable the enforcement of a minimum suggested priority fee.
+    #[serde(default)]
+    pub disable_min_priority_fee: bool,
+
+    /// Fetch state over a remote endpoint instead of starting from an empty state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_url: Option<String>,
+
+    /// Fetch state from a specific block number over a remote endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_block_number: Option<i128>,
+
+    /// Specify chain id to skip fetching it from remote endpoint (offline mode).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_chain_id: Option<u64>,
+
+    /// Headers to use for the rpc client.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fork_headers: Vec<String>,
+
+    /// Timeout in ms for requests sent to remote JSON-RPC server in forking mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_request_timeout: Option<u64>,
+
+    /// Number of retry requests for spurious networks (timed out requests).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_request_retries: Option<u32>,
+
+    /// Initial retry backoff on encountering errors.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_retry_backoff: Option<u64>,
+
+    /// Sets the number of assumed available compute units per second for the provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compute_units_per_second: Option<u64>,
+
+    /// Disables rate limiting for this node's provider.
+    #[serde(default)]
+    pub no_rate_limit: bool,
+
+    /// Explicitly disables the use of RPC caching.
+    #[serde(default)]
+    pub no_storage_caching: bool,
+
+    /// EIP-170: Contract code size limit in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code_size_limit: Option<usize>,
+
+    /// Disable EIP-170: Contract code size limit.
+    #[serde(default)]
+    pub disable_code_size_limit: bool,
+
+    /// The memory limit per EVM execution in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_limit: Option<u64>,
+
+    /// Maximum number of transactions in a block.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_transactions: Option<usize>,
+
+    /// Enable steps tracing used for debug calls returning geth-style traces.
+    #[serde(default)]
+    pub steps_tracing: bool,
+
+    /// Disable printing of `console.log` invocations to stdout.
+    #[serde(default)]
+    pub disable_console_log: bool,
+
+    /// Enable printing of traces for executed transactions.
+    #[serde(default)]
+    pub print_traces: bool,
+
+    /// Enables automatic impersonation on startup.
+    #[serde(default)]
+    pub auto_impersonate: bool,
+
+    /// Disable the default create2 deployer.
+    #[serde(default)]
+    pub disable_default_create2_deployer: bool,
+
+    /// Disable pool balance checks.
+    #[serde(default)]
+    pub disable_pool_balance_checks: bool,
+
+    /// Don't keep full chain history. If a number is specified, at most this number of states is
+    /// kept in memory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prune_history: Option<Option<usize>>,
+
+    /// Max number of states to persist on disk.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_persisted_states: Option<usize>,
+
+    /// Number of blocks with transactions to keep in memory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transaction_block_keeper: Option<usize>,
+
+    /// Path to the cache directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_path: Option<PathBuf>,
+
+    /// Launch an ipc server at the given path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ipc: Option<String>,
+}
+
+impl Default for AnvilConfig {
+    fn default() -> Self {
+        Self {
+            port: 8545,
+            host: vec![],
+            chain_id: None,
+            hardfork: None,
+            accounts: 10,
+            balance: 10000,
+            mnemonic: None,
+            derivation_path: None,
+            block_time: None,
+            no_mining: false,
+            mixed_mining: false,
+            order: None,
+            slots_in_an_epoch: 32,
+            gas_limit: None,
+            disable_block_gas_limit: false,
+            enable_tx_gas_limit: false,
+            gas_price: None,
+            block_base_fee_per_gas: None,
+            disable_min_priority_fee: false,
+            fork_url: None,
+            fork_block_number: None,
+            fork_chain_id: None,
+            fork_headers: vec![],
+            fork_request_timeout: None,
+            fork_request_retries: None,
+            fork_retry_backoff: None,
+            compute_units_per_second: None,
+            no_rate_limit: false,
+            no_storage_caching: false,
+            code_size_limit: None,
+            disable_code_size_limit: false,
+            memory_limit: None,
+            max_transactions: None,
+            steps_tracing: false,
+            disable_console_log: false,
+            print_traces: false,
+            auto_impersonate: false,
+            disable_default_create2_deployer: false,
+            disable_pool_balance_checks: false,
+            prune_history: None,
+            max_persisted_states: None,
+            transaction_block_keeper: None,
+            cache_path: None,
+            ipc: None,
+        }
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -85,6 +85,9 @@ pub mod error;
 use error::ExtractConfigError;
 pub use error::SolidityErrorCode;
 
+pub mod anvil;
+pub use anvil::AnvilConfig;
+
 pub mod doc;
 pub use doc::DocConfig;
 
@@ -490,6 +493,8 @@ pub struct Config {
     pub lint: LinterConfig,
     /// Configuration for `forge doc`
     pub doc: DocConfig,
+    /// Configuration for `anvil`
+    pub anvil: AnvilConfig,
     /// Configuration for `forge bind-json`
     pub bind_json: BindJsonConfig,
     /// Configures the permissions of cheat codes that touch the file system.
@@ -708,6 +713,7 @@ impl Config {
         "soldeer",
         "vyper",
         "bind_json",
+        "anvil",
     ];
 
     pub(crate) fn is_standalone_section<T: ?Sized + PartialEq<str>>(section: &T) -> bool {
@@ -2630,6 +2636,7 @@ impl Default for Config {
             fmt: Default::default(),
             lint: Default::default(),
             doc: Default::default(),
+            anvil: Default::default(),
             bind_json: Default::default(),
             labels: Default::default(),
             unchecked_cheatcode_artifacts: false,
@@ -4384,6 +4391,96 @@ mod tests {
             assert_eq!(config.fuzz.runs, 420);
             assert_eq!(config.invariant.runs, 500);
 
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_anvil_config_standalone_section() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                src = "src"
+
+                [anvil]
+                port = 9999
+                gas_limit = "18446744073709551615"
+                no_mining = true
+                fork_url = "https://eth.llamarpc.com"
+            "#,
+            )?;
+
+            let config = Config::load().unwrap();
+            assert_eq!(config.anvil.port, 9999);
+            assert_eq!(config.anvil.gas_limit, Some(GasLimit(u64::MAX)));
+            assert!(config.anvil.no_mining);
+            assert_eq!(config.anvil.fork_url, Some("https://eth.llamarpc.com".to_string()));
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_anvil_config_profile_override() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r"
+                [anvil]
+                port = 9999
+
+                [profile.ci.anvil]
+                port = 8888
+            ",
+            )?;
+
+            let config = Config::load().unwrap();
+            assert_eq!(config.anvil.port, 9999);
+
+            jail.set_env("FOUNDRY_PROFILE", "ci");
+            let config = Config::load().unwrap();
+            assert_eq!(config.anvil.port, 8888);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_anvil_config_env_override() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r"
+                [anvil]
+                port = 9999
+            ",
+            )?;
+
+            jail.set_env("FOUNDRY_ANVIL_PORT", "7777");
+            let config = Config::load().unwrap();
+            assert_eq!(config.anvil.port, 7777);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_anvil_config_defaults() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r"
+                [profile.default]
+                src = 'src'
+            ",
+            )?;
+            let config = Config::load().unwrap();
+            assert_eq!(config.anvil.port, 8545);
+            assert_eq!(config.anvil.accounts, 10);
+            assert_eq!(config.anvil.balance, 10000);
+            assert_eq!(config.anvil.slots_in_an_epoch, 32);
+            assert!(!config.anvil.no_mining);
+            assert!(config.anvil.gas_limit.is_none());
+            assert!(config.anvil.fork_url.is_none());
             Ok(())
         });
     }

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -229,6 +229,26 @@ out = "utils/JsonBindings.sol"
 include = []
 exclude = []
 
+[anvil]
+port = 8545
+accounts = 10
+balance = 10000
+no_mining = false
+mixed_mining = false
+slots_in_an_epoch = 32
+disable_block_gas_limit = false
+enable_tx_gas_limit = false
+disable_min_priority_fee = false
+no_rate_limit = false
+no_storage_caching = false
+disable_code_size_limit = false
+steps_tracing = false
+disable_console_log = false
+print_traces = false
+auto_impersonate = false
+disable_default_create2_deployer = false
+disable_pool_balance_checks = false
+
 "#;
 
 // tests all config values that are in use
@@ -362,6 +382,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         fmt: Default::default(),
         lint: Default::default(),
         doc: Default::default(),
+        anvil: Default::default(),
         bind_json: Default::default(),
         fs_permissions: Default::default(),
         labels: Default::default(),
@@ -1399,6 +1420,26 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "book": "book.toml",
     "homepage": "README.md",
     "ignore": []
+  },
+  "anvil": {
+    "port": 8545,
+    "accounts": 10,
+    "balance": 10000,
+    "no_mining": false,
+    "mixed_mining": false,
+    "slots_in_an_epoch": 32,
+    "disable_block_gas_limit": false,
+    "enable_tx_gas_limit": false,
+    "disable_min_priority_fee": false,
+    "no_rate_limit": false,
+    "no_storage_caching": false,
+    "disable_code_size_limit": false,
+    "steps_tracing": false,
+    "disable_console_log": false,
+    "print_traces": false,
+    "auto_impersonate": false,
+    "disable_default_create2_deployer": false,
+    "disable_pool_balance_checks": false
   },
   "bind_json": {
     "out": "utils/JsonBindings.sol",


### PR DESCRIPTION
## Summary

Adds support for configuring Anvil via `foundry.toml`, matching the existing pattern used by `[fmt]`, `[doc]`, `[fuzz]`, and other standalone sections. This closes a long-standing feature request to make Anvil project-aware.

- New `AnvilConfig` struct in `crates/config/src/anvil.rs` with 40+ fields covering all persistent Anvil settings (network, accounts, gas, fork, tracing, etc.)
- Registered as a standalone section in `STANDALONE_SECTIONS`, giving us `[anvil]`, `[profile.ci.anvil]`, and `FOUNDRY_ANVIL_*` env var support for free
- Modified `NodeArgs` to load config and merge with CLI args (CLI always wins)
- Changed 6 CLI fields from `T` to `Option<T>` (`port`, `accounts`, `balance`, `slots_in_an_epoch`, `host`, `order`) so config file defaults can apply when CLI flags aren't explicitly passed

### Motivation

We're building a perpetual swap protocol at [Strobe Labs](https://github.com/StrobeLabs) that relies heavily on Anvil for testing (Prague EVM, `gas_limit = u64::MAX`, `no_storage_caching`, custom fork configs). Today, these settings live as CLI flags in our CI scripts, duplicating what's already partially expressed in `foundry.toml`. Having an `[anvil]` section lets us colocate all Foundry configuration in one file and leverage profiles for CI vs local development.

### Example

```toml
[anvil]
port = 9545
hardfork = "prague"
gas_limit = "max"
no_storage_caching = true
auto_impersonate = true

[profile.ci.anvil]
accounts = 5
```

### Design decisions

- **CLI precedence**: CLI flags always override config values. Fields with clap `default_value` were changed to `Option<T>` so we can distinguish "user passed a flag" from "clap used its default"
- **Error surfacing**: Invalid config values (bad host addresses, unknown order values, malformed TOML) produce clear errors instead of being silently ignored
- **Excluded fields**: Session-specific flags (`--load-state`, `--dump-state`, `--state`, `--config-out`, `--silent`, `--timestamp`, `--number`) are intentionally excluded from the config struct since they don't make sense as persistent project configuration
- **Fork URL block selector**: The `@block` suffix in fork URLs (e.g., `http://localhost:8545@1400000`) is preserved during merge, not dropped

Closes #4226
Ref #10779

## Test plan

- [x] `cargo build -p foundry-config` compiles
- [x] `cargo build -p anvil` compiles
- [x] 148 existing config unit tests pass (no regressions)
- [x] 4 new tests: standalone section parsing, profile overrides, env var overrides, defaults
- [ ] Manual: create `foundry.toml` with `[anvil]` section, run `anvil`, verify settings apply
- [ ] Manual: verify CLI flags override config file values
- [ ] Manual: verify `FOUNDRY_ANVIL_PORT=1234 anvil` works
- [ ] Manual: verify `[profile.ci.anvil]` with `FOUNDRY_PROFILE=ci` works