### PR TITLE
refactor(anvil): make MaybeImpersonatedTransaction generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,7 +1114,6 @@ dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-dyn-abi",
- "alloy-eip5792",
  "alloy-eips",
  "alloy-evm",
  "alloy-genesis",

--- a/crates/anvil/core/src/eth/block.rs
+++ b/crates/anvil/core/src/eth/block.rs
@@ -7,7 +7,7 @@ use alloy_network::Network;
 use foundry_primitives::FoundryNetwork;
 use std::fmt::Debug;
 
-use crate::eth::transaction::{ImpersonatedTransaction, MaybeImpersonatedTransaction};
+use crate::eth::transaction::MaybeImpersonatedTransaction;
 
 /// Type alias for Ethereum Block with Anvil's transaction type
 pub type Block = alloy_consensus::Block<MaybeImpersonatedTransaction>;
@@ -18,7 +18,7 @@ pub type BlockInfo = TypedBlockInfo<FoundryNetwork>;
 /// Container type that gathers all block data, generic over a [`Network`].
 #[derive(Clone, Debug)]
 pub struct TypedBlockInfo<N: Network> {
-    pub block: alloy_consensus::Block<ImpersonatedTransaction<N::TxEnvelope>>,
+    pub block: alloy_consensus::Block<MaybeImpersonatedTransaction<N::TxEnvelope>>,
     pub transactions: Vec<TransactionInfo>,
     pub receipts: Vec<N::ReceiptEnvelope>,
 }

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -1,5 +1,9 @@
 //! Transaction related types
-use alloy_consensus::{Transaction, Typed2718, crypto::RecoveryError};
+use alloy_consensus::{
+    Transaction, Typed2718,
+    crypto::RecoveryError,
+    transaction::{SignerRecoverable, TxHashRef},
+};
 
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxHash};
@@ -11,26 +15,23 @@ use revm::interpreter::InstructionResult;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
-/// Anvil's concrete impersonated transaction type.
-pub type MaybeImpersonatedTransaction = ImpersonatedTransaction<FoundryTxEnvelope>;
-
 /// A wrapper for a transaction envelope that allows impersonating accounts.
 ///
 /// This is a helper that carries the `impersonated` sender so that the right hash
 /// can be created.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ImpersonatedTransaction<T> {
+pub struct MaybeImpersonatedTransaction<T = FoundryTxEnvelope> {
     transaction: T,
     impersonated_sender: Option<Address>,
 }
 
-impl<T: Typed2718> Typed2718 for ImpersonatedTransaction<T> {
+impl<T: Typed2718> Typed2718 for MaybeImpersonatedTransaction<T> {
     fn ty(&self) -> u8 {
         self.transaction.ty()
     }
 }
 
-impl<T> ImpersonatedTransaction<T> {
+impl<T> MaybeImpersonatedTransaction<T> {
     /// Creates a new wrapper for the given transaction
     pub fn new(transaction: T) -> Self {
         Self { transaction, impersonated_sender: None }
@@ -52,25 +53,31 @@ impl<T> ImpersonatedTransaction<T> {
     }
 }
 
-impl ImpersonatedTransaction<FoundryTxEnvelope> {
+impl<T: SignerRecoverable + TxHashRef + Encodable> MaybeImpersonatedTransaction<T> {
     /// Recovers the Ethereum address which was used to sign the transaction.
     pub fn recover(&self) -> Result<Address, RecoveryError> {
         if let Some(sender) = self.impersonated_sender {
             return Ok(sender);
         }
-        self.transaction.recover()
+        self.transaction.recover_signer()
     }
 
-    /// Returns the hash of the transaction
+    /// Returns the hash of the transaction.
+    ///
+    /// If the transaction is impersonated, returns a unique hash derived by appending the
+    /// impersonated sender address to the encoded transaction before hashing.
     pub fn hash(&self) -> B256 {
         if let Some(sender) = self.impersonated_sender {
-            return self.transaction.impersonated_hash(sender);
+            let mut buffer = Vec::new();
+            self.transaction.encode(&mut buffer);
+            buffer.extend_from_slice(sender.as_ref());
+            return B256::from_slice(alloy_primitives::utils::keccak256(&buffer).as_slice());
         }
-        self.transaction.hash()
+        *self.transaction.tx_hash()
     }
 }
 
-impl<T: Encodable2718> Encodable2718 for ImpersonatedTransaction<T> {
+impl<T: Encodable2718> Encodable2718 for MaybeImpersonatedTransaction<T> {
     fn encode_2718_len(&self) -> usize {
         self.transaction.encode_2718_len()
     }
@@ -80,7 +87,7 @@ impl<T: Encodable2718> Encodable2718 for ImpersonatedTransaction<T> {
     }
 }
 
-impl<T: Encodable> Encodable for ImpersonatedTransaction<T> {
+impl<T: Encodable> Encodable for MaybeImpersonatedTransaction<T> {
     fn encode(&self, out: &mut dyn bytes::BufMut) {
         self.transaction.encode(out)
     }
@@ -98,19 +105,19 @@ impl From<FoundryTxEnvelope> for MaybeImpersonatedTransaction {
     }
 }
 
-impl<T: Decodable> Decodable for ImpersonatedTransaction<T> {
+impl<T: Decodable> Decodable for MaybeImpersonatedTransaction<T> {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         T::decode(buf).map(Self::new)
     }
 }
 
-impl<T> AsRef<T> for ImpersonatedTransaction<T> {
+impl<T> AsRef<T> for MaybeImpersonatedTransaction<T> {
     fn as_ref(&self) -> &T {
         &self.transaction
     }
 }
 
-impl<T> Deref for ImpersonatedTransaction<T> {
+impl<T> Deref for MaybeImpersonatedTransaction<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -137,12 +144,9 @@ impl PendingTransaction {
     }
 
     pub fn with_impersonated(transaction: FoundryTxEnvelope, sender: Address) -> Self {
-        let hash = transaction.impersonated_hash(sender);
-        Self {
-            transaction: MaybeImpersonatedTransaction::impersonated(transaction, sender),
-            sender,
-            hash,
-        }
+        let transaction = MaybeImpersonatedTransaction::impersonated(transaction, sender);
+        let hash = transaction.hash();
+        Self { transaction, sender, hash }
     }
 
     /// Converts a [`MaybeImpersonatedTransaction`] into a [`PendingTransaction`].

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -3,14 +3,13 @@ use alloy_consensus::{
     Typed2718,
     crypto::RecoveryError,
     transaction::{
-        TxEip7702,
+        SignerRecoverable, TxEip7702, TxHashRef,
         eip4844::{TxEip4844Variant, TxEip4844WithSidecar},
     },
 };
 use alloy_evm::FromRecoveredTx;
 use alloy_network::{AnyRpcTransaction, AnyTxEnvelope, TransactionResponse};
-use alloy_primitives::{Address, B256};
-use alloy_rlp::Encodable;
+use alloy_primitives::{Address, B256, TxHash};
 use alloy_rpc_types::ConversionError;
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpTransaction as OpTransactionTrait, TxDeposit};
 use op_revm::OpTransaction;
@@ -106,16 +105,6 @@ impl FoundryTxEnvelope {
         }
     }
 
-    /// Returns the hash if the transaction is impersonated (using a fake signature)
-    ///
-    /// This appends the `address` before hashing it
-    pub fn impersonated_hash(&self, sender: Address) -> B256 {
-        let mut buffer = Vec::new();
-        Encodable::encode(self, &mut buffer);
-        buffer.extend_from_slice(sender.as_ref());
-        B256::from_slice(alloy_primitives::utils::keccak256(&buffer).as_slice())
-    }
-
     /// Recovers the Ethereum address which was used to sign the transaction.
     pub fn recover(&self) -> Result<Address, RecoveryError> {
         Ok(match self {
@@ -127,6 +116,30 @@ impl FoundryTxEnvelope {
             Self::Deposit(tx) => tx.from,
             Self::Tempo(tx) => tx.signature().recover_signer(&tx.signature_hash())?,
         })
+    }
+}
+
+impl TxHashRef for FoundryTxEnvelope {
+    fn tx_hash(&self) -> &TxHash {
+        match self {
+            Self::Legacy(t) => t.hash(),
+            Self::Eip2930(t) => t.hash(),
+            Self::Eip1559(t) => t.hash(),
+            Self::Eip4844(t) => t.hash(),
+            Self::Eip7702(t) => t.hash(),
+            Self::Deposit(t) => t.hash_ref(),
+            Self::Tempo(t) => t.hash(),
+        }
+    }
+}
+
+impl SignerRecoverable for FoundryTxEnvelope {
+    fn recover_signer(&self) -> Result<Address, RecoveryError> {
+        self.recover()
+    }
+
+    fn recover_signer_unchecked(&self) -> Result<Address, RecoveryError> {
+        self.recover()
     }
 }
 
@@ -262,7 +275,7 @@ impl From<FoundryTxEnvelope> for FoundryTypedTx {
 mod tests {
     use std::str::FromStr;
 
-    use alloy_primitives::{Bytes, Signature, TxHash, TxKind, U256, b256, hex};
+    use alloy_primitives::{Bytes, Signature, TxKind, U256, b256, hex};
     use alloy_rlp::Decodable;
 
     use super::*;


### PR DESCRIPTION
Renames `ImpersonatedTransaction<T>` to `MaybeImpersonatedTransaction<T = FoundryTxEnvelope>`, eliminating the type alias. 
Replaces the concrete `impl MaybeImpersonatedTransaction<FoundryTxEnvelope>` block with a generic impl bounded on `SignerRecoverable + TxHashRef + Encodable`, moving the impersonated hash logic out of `FoundryTxEnvelope` and into the wrapper. Implements both traits on `FoundryTxEnvelope` to satisfy the bounds.