### PR TITLE
chore(cheatcodes): relax some bounds to `FoundryContextExt`

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -471,7 +471,7 @@ impl<CTX> Cheatcode<CTX> for lastCallGasCall {
     }
 }
 
-impl<CTX: FoundryContextExt> Cheatcode<CTX> for getChainIdCall {
+impl<CTX: ContextTr> Cheatcode<CTX> for getChainIdCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         Ok(U256::from(ccx.ecx.cfg().chain_id()).abi_encode())
@@ -558,7 +558,7 @@ impl<CTX: FoundryContextExt> Cheatcode<CTX> for blobhashesCall {
     }
 }
 
-impl<CTX: FoundryContextExt> Cheatcode<CTX> for getBlobhashesCall {
+impl<CTX: ContextTr> Cheatcode<CTX> for getBlobhashesCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         ensure!(
@@ -578,7 +578,7 @@ impl<CTX: FoundryContextExt> Cheatcode<CTX> for rollCall {
     }
 }
 
-impl<CTX: FoundryContextExt> Cheatcode<CTX> for getBlockNumberCall {
+impl<CTX: ContextTr> Cheatcode<CTX> for getBlockNumberCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         Ok(ccx.ecx.block().number().abi_encode())
@@ -602,7 +602,7 @@ impl<CTX: FoundryContextExt> Cheatcode<CTX> for warpCall {
     }
 }
 
-impl<CTX: FoundryContextExt> Cheatcode<CTX> for getBlockTimestampCall {
+impl<CTX: ContextTr> Cheatcode<CTX> for getBlockTimestampCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         Ok(ccx.ecx.block().timestamp().abi_encode())
@@ -627,7 +627,7 @@ impl<CTX: FoundryContextExt> Cheatcode<CTX> for blobBaseFeeCall {
     }
 }
 
-impl<CTX: FoundryContextExt> Cheatcode<CTX> for getBlobBaseFeeCall {
+impl<CTX: ContextTr> Cheatcode<CTX> for getBlobBaseFeeCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         Ok(ccx.ecx.block().blob_excess_gas().unwrap_or(0).abi_encode())
@@ -763,7 +763,7 @@ impl<CTX: ContextTr<Journal: JournalExt>> Cheatcode<CTX> for coolSlotCall {
     }
 }
 
-impl<CTX: FoundryContextExt> Cheatcode<CTX> for readCallersCall {
+impl<CTX: ContextTr> Cheatcode<CTX> for readCallersCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         read_callers(ccx.state, &ccx.ecx.tx().caller(), ccx.ecx.journal().depth())
@@ -1087,7 +1087,7 @@ impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: FoundryJournal
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for setBlockhashCall {
+impl<CTX: ContextTr<Db: DatabaseExt>> Cheatcode<CTX> for setBlockhashCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { blockNumber, blockHash } = *self;
         ensure!(blockNumber <= U256::from(u64::MAX), "blockNumber must be less than 2^64");
@@ -1336,7 +1336,7 @@ impl<CTX> Cheatcode<CTX> for setEvmVersionCall {
     }
 }
 
-impl<CTX: FoundryContextExt> Cheatcode<CTX> for getEvmVersionCall {
+impl<CTX: ContextTr> Cheatcode<CTX> for getEvmVersionCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let spec: SpecId = ccx.ecx.cfg().spec().into();
         Ok(spec.to_string().to_lowercase().abi_encode())

--- a/crates/cheatcodes/src/evm/prank.rs
+++ b/crates/cheatcodes/src/evm/prank.rs
@@ -137,7 +137,7 @@ impl<CTX: ContextTr> Cheatcode<CTX> for stopPrankCall {
     }
 }
 
-fn prank<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+fn prank<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     new_caller: &Address,
     new_origin: Option<&Address>,

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -14,7 +14,7 @@ use dialoguer::{Input, Password};
 use forge_script_sequence::{BroadcastReader, TransactionWithMetadata};
 use foundry_common::fs;
 use foundry_config::fs_permissions::FsAccessKind;
-use foundry_evm_core::{backend::FoundryJournalExt, env::FoundryContextExt, evm::NestedEvmExt};
+use foundry_evm_core::{backend::FoundryJournalExt, evm::NestedEvmExt};
 use revm::{
     context::{Cfg, ContextTr, CreateScheme, JournalTr},
     interpreter::CreateInputs,
@@ -835,7 +835,7 @@ impl<CTX> Cheatcode<CTX> for getBroadcasts_1Call {
     }
 }
 
-impl<CTX: FoundryContextExt> Cheatcode<CTX> for getDeployment_0Call {
+impl<CTX: ContextTr> Cheatcode<CTX> for getDeployment_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { contractName } = self;
         let chain_id = ccx.ecx.cfg().chain_id();

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -7,7 +7,7 @@ use alloy_rpc_types::Authorization;
 use alloy_signer::{Signer, SignerSync};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolValue;
-use foundry_evm_core::{backend::DatabaseExt, env::FoundryContextExt};
+use foundry_evm_core::backend::DatabaseExt;
 use foundry_wallets::{WalletSigner, wallet_multi::MultiWallet};
 use parking_lot::Mutex;
 use revm::{
@@ -19,34 +19,28 @@ use revm::{
 };
 use std::sync::Arc;
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
-    for broadcast_0Call
-{
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for broadcast_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         broadcast(ccx, None, true)
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
-    for broadcast_1Call
-{
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for broadcast_1Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { signer } = self;
         broadcast(ccx, Some(signer), true)
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
-    for broadcast_2Call
-{
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for broadcast_2Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { privateKey } = self;
         broadcast_key(ccx, privateKey, true)
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
     for attachDelegation_0Call
 {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
@@ -55,7 +49,7 @@ impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> C
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
     for attachDelegation_1Call
 {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
@@ -64,34 +58,28 @@ impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> C
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
-    for signDelegation_0Call
-{
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for signDelegation_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { implementation, privateKey } = *self;
         sign_delegation(ccx, privateKey, implementation, None, false, false)
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
-    for signDelegation_1Call
-{
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for signDelegation_1Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { implementation, privateKey, nonce } = *self;
         sign_delegation(ccx, privateKey, implementation, Some(nonce), false, false)
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
-    for signDelegation_2Call
-{
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for signDelegation_2Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { implementation, privateKey, crossChain } = *self;
         sign_delegation(ccx, privateKey, implementation, None, crossChain, false)
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
     for signAndAttachDelegation_0Call
 {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
@@ -100,7 +88,7 @@ impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> C
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
     for signAndAttachDelegation_1Call
 {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
@@ -109,7 +97,7 @@ impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> C
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
     for signAndAttachDelegation_2Call
 {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
@@ -119,7 +107,7 @@ impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> C
 }
 
 /// Helper function to attach an EIP-7702 delegation.
-fn attach_delegation<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+fn attach_delegation<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     delegation: &SignedDelegation,
     cross_chain: bool,
@@ -143,7 +131,7 @@ fn attach_delegation<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal
 
 /// Helper function to sign and attach (if needed) an EIP-7702 delegation.
 /// Uses the provided nonce, otherwise retrieves and increments the nonce of the EOA.
-fn sign_delegation<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+fn sign_delegation<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     private_key: Uint<256, 4>,
     implementation: Address,
@@ -216,7 +204,7 @@ fn next_delegation_nonce(
     }
 }
 
-fn write_delegation<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+fn write_delegation<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     auth: SignedAuthorization,
 ) -> Result<()> {
@@ -252,9 +240,7 @@ fn write_delegation<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal:
     Ok(())
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
-    for attachBlobCall
-{
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for attachBlobCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { blob } = self;
         ensure!(
@@ -273,27 +259,21 @@ impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> C
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
-    for startBroadcast_0Call
-{
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for startBroadcast_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         broadcast(ccx, None, false)
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
-    for startBroadcast_1Call
-{
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for startBroadcast_1Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { signer } = self;
         broadcast(ccx, Some(signer), false)
     }
 }
 
-impl<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX>
-    for startBroadcast_2Call
-{
+impl<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>> Cheatcode<CTX> for startBroadcast_2Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { privateKey } = self;
         broadcast_key(ccx, privateKey, false)
@@ -393,7 +373,7 @@ impl Wallets {
 }
 
 /// Sets up broadcasting from a script using `new_origin` as the sender.
-fn broadcast<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+fn broadcast<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     new_origin: Option<&Address>,
     single_call: bool,
@@ -439,7 +419,7 @@ fn broadcast<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: Journa
 /// Sets up broadcasting from a script with the sender derived from `private_key`.
 /// Adds this private key to `state`'s `wallets` vector to later be used for signing
 /// if broadcast is successful.
-fn broadcast_key<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+fn broadcast_key<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     private_key: &U256,
     single_call: bool,


### PR DESCRIPTION
## Motivation

Relax `FoundryContextExt` bound on `CTX`, for cheatcodes that don't mutate tx, block, or cfg.


## PR Checklist

- [x] Clippy is happy

