### PR TITLE
fix(traces): clear non_fallback_contracts in decoder reset

### DIFF
--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -230,6 +230,7 @@ impl CallTraceDecoder {
 
         self.receive_contracts.clear();
         self.fallback_contracts.clear();
+        self.non_fallback_contracts.clear();
     }
 
     /// Identify unknown addresses in the specified call trace using the specified identifier.


### PR DESCRIPTION
## Summary

`CallTraceDecoder::clear_addresses()` clears `fallback_contracts` but misses its counterpart `non_fallback_contracts`. These two maps are mutually exclusive — contracts go into one or the other based on whether they have a fallback function.

When running multiple tests with a shared decoder, stale entries from a previous test's `non_fallback_contracts` leak into subsequent tests. This can cause the decoder to incorrectly flag valid calls as "unrecognized function selector for contract which has no fallback function" at an address that was redeployed with a different ABI in the current test.
