### PR TITLE
refactor(evm): remove `EnvMut/AsEnvMut`

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -38,7 +38,6 @@ use foundry_config::Config;
 use foundry_evm::{
     backend::{BlockchainDb, BlockchainDbMeta, SharedBackend},
     constants::DEFAULT_CREATE2_DEPLOYER,
-    core::AsEnvMut,
     hardfork::{
         FoundryHardfork, OpHardfork, ethereum_hardfork_from_block_tag,
         spec_id_from_ethereum_hardfork,
@@ -1365,7 +1364,7 @@ latest block number: {latest_block}"
         let override_chain_id = self.chain_id;
         // apply changes such as difficulty -> prevrandao and chain specifics for current chain id
         apply_chain_and_block_specific_env_changes::<AnyNetwork>(
-            env.as_env_mut(),
+            &mut env.evm_env,
             &block,
             self.networks,
         );

--- a/crates/anvil/src/eth/backend/env.rs
+++ b/crates/anvil/src/eth/backend/env.rs
@@ -1,5 +1,4 @@
 use alloy_evm::EvmEnv;
-use foundry_evm::{EnvMut, core::AsEnvMut};
 use foundry_evm_networks::NetworkConfigs;
 use op_revm::OpTransaction;
 use revm::context::TxEnv;
@@ -16,15 +15,5 @@ pub struct Env {
 impl Env {
     pub fn new(evm_env: EvmEnv, tx: OpTransaction<TxEnv>, networks: NetworkConfigs) -> Self {
         Self { evm_env, tx, networks }
-    }
-}
-
-impl AsEnvMut for Env {
-    fn as_env_mut(&mut self) -> EnvMut<'_> {
-        EnvMut {
-            block: &mut self.evm_env.block_env,
-            cfg: &mut self.evm_env.cfg_env,
-            tx: &mut self.tx.base,
-        }
     }
 }

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -24,7 +24,6 @@ use foundry_config::{
 };
 use foundry_evm::{
     Env,
-    core::env::AsEnvMut,
     executors::{EvmError, Executor, TracingExecutor},
     opts::EvmOpts,
     traces::{InternalTraceMode, TraceMode, Traces},
@@ -200,7 +199,7 @@ impl RunArgs {
                 }
             }
             apply_chain_and_block_specific_env_changes::<AnyNetwork>(
-                env.as_env_mut(),
+                &mut env.evm_env,
                 block,
                 config.networks,
             );
@@ -259,7 +258,7 @@ impl RunArgs {
                         break;
                     }
 
-                    configure_tx_env(&mut env.as_env_mut(), tx);
+                    configure_tx_env(&mut env, tx);
 
                     env.evm_env.cfg_env.disable_balance_check = true;
 
@@ -300,7 +299,7 @@ impl RunArgs {
         let result = {
             executor.set_trace_printer(self.trace_printer);
 
-            configure_tx_env(&mut env.as_env_mut(), &tx);
+            configure_tx_env(&mut env, &tx);
             if is_impersonated_tx(tx.as_ref()) {
                 env.evm_env.cfg_env.disable_balance_check = true;
             }

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -23,7 +23,7 @@ use foundry_common::{
 };
 use foundry_compilers::artifacts::EvmVersion;
 use foundry_evm_core::{
-    FoundryBlock, FoundryCfg, FoundryTransaction,
+    Env, FoundryBlock, FoundryCfg, FoundryTransaction,
     backend::{DatabaseExt, FoundryJournalExt, RevertStateSnapshotAction},
     constants::{CALLER, CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, TEST_CONTRACT_ADDRESS},
     env::FoundryContextExt,
@@ -1120,7 +1120,7 @@ impl Cheatcode for executeTransactionCall {
         let tx_env = <TxEnv as FromRecoveredTx<FoundryTxEnvelope>>::from_recovered_tx(&tx, sender);
 
         // Save current env for restoration after execution.
-        let cached_env = ccx.ecx.to_env();
+        let cached_env = Env::clone_from_context(ccx.ecx);
 
         // Override env for isolated execution.
         ccx.ecx.block_mut().set_basefee(0);
@@ -1137,7 +1137,7 @@ impl Cheatcode for executeTransactionCall {
             .set_limit_contract_initcode_size(Some(revm::primitives::eip3860::MAX_INITCODE_SIZE));
 
         // Snapshot the modified env for EVM construction.
-        let modified_env = ccx.ecx.to_env();
+        let modified_env = Env::clone_from_context(ccx.ecx);
 
         // Mark as inner context so isolation mode doesn't trigger a nested transact_inner
         // when the inner EVM executes calls at depth == 1.
@@ -1187,7 +1187,7 @@ impl Cheatcode for executeTransactionCall {
             cached_env.evm_env.cfg_env.disable_nonce_check;
         restored_env.evm_env.cfg_env.limit_contract_initcode_size =
             cached_env.evm_env.cfg_env.limit_contract_initcode_size;
-        ccx.ecx.apply_env(restored_env);
+        restored_env.apply_to(ccx.ecx);
 
         // Reset inner context flag.
         executor.set_in_inner_context(false, None);
@@ -1335,21 +1335,24 @@ pub(super) fn get_nonce<CTX: ContextTr<Db: DatabaseExt>>(
 fn inner_snapshot_state<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
 ) -> Result {
-    let (journal, mut env) = ccx.ecx.journal_and_env_mut();
-    let (db, inner) = journal.as_db_and_inner();
-    Ok(db.snapshot_state(inner, &mut env).abi_encode())
+    let mut env = Env::clone_from_context(ccx.ecx);
+    let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
+    let id = db.snapshot_state(inner, &mut env);
+    env.apply_to(ccx.ecx);
+    Ok(id.abi_encode())
 }
 
 fn inner_revert_to_state<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     snapshot_id: U256,
 ) -> Result {
-    let (journal, mut env) = ccx.ecx.journal_and_env_mut();
-    let (db, inner) = journal.as_db_and_inner();
+    let mut env = Env::clone_from_context(ccx.ecx);
+    let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
     if let Some(restored) =
         db.revert_state(snapshot_id, inner, &mut env, RevertStateSnapshotAction::RevertKeep)
     {
         *inner = restored;
+        env.apply_to(ccx.ecx);
         Ok(true.abi_encode())
     } else {
         Ok(false.abi_encode())
@@ -1362,12 +1365,13 @@ fn inner_revert_to_state_and_delete<
     ccx: &mut CheatsCtxt<'_, CTX>,
     snapshot_id: U256,
 ) -> Result {
-    let (journal, mut env) = ccx.ecx.journal_and_env_mut();
-    let (db, inner) = journal.as_db_and_inner();
+    let mut env = Env::clone_from_context(ccx.ecx);
+    let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
     if let Some(restored) =
         db.revert_state(snapshot_id, inner, &mut env, RevertStateSnapshotAction::RevertRemove)
     {
         *inner = restored;
+        env.apply_to(ccx.ecx);
         Ok(true.abi_encode())
     } else {
         Ok(false.abi_encode())

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -9,7 +9,7 @@ use alloy_provider::Provider;
 use alloy_rpc_types::Filter;
 use alloy_sol_types::SolValue;
 use foundry_common::provider::ProviderBuilder;
-use foundry_evm_core::{FoundryContextExt, backend::FoundryJournalExt, fork::CreateFork};
+use foundry_evm_core::{Env, FoundryContextExt, backend::FoundryJournalExt, fork::CreateFork};
 use revm::context::ContextTr;
 
 impl Cheatcode for activeForkCall {
@@ -69,9 +69,10 @@ impl Cheatcode for rollFork_0Call {
     fn apply_stateful<CTX: CheatsCtxExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { blockNumber } = self;
         persist_caller(ccx);
-        let (journal, mut env) = ccx.ecx.journal_and_env_mut();
-        let (db, inner) = journal.as_db_and_inner();
+        let mut env = Env::clone_from_context(ccx.ecx);
+        let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
         db.roll_fork(None, (*blockNumber).to(), &mut env, inner)?;
+        env.apply_to(ccx.ecx);
         Ok(Default::default())
     }
 }
@@ -80,9 +81,10 @@ impl Cheatcode for rollFork_1Call {
     fn apply_stateful<CTX: CheatsCtxExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { txHash } = self;
         persist_caller(ccx);
-        let (journal, mut env) = ccx.ecx.journal_and_env_mut();
-        let (db, inner) = journal.as_db_and_inner();
+        let mut env = Env::clone_from_context(ccx.ecx);
+        let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
         db.roll_fork_to_transaction(None, *txHash, &mut env, inner)?;
+        env.apply_to(ccx.ecx);
         Ok(Default::default())
     }
 }
@@ -91,9 +93,10 @@ impl Cheatcode for rollFork_2Call {
     fn apply_stateful<CTX: CheatsCtxExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { forkId, blockNumber } = self;
         persist_caller(ccx);
-        let (journal, mut env) = ccx.ecx.journal_and_env_mut();
-        let (db, inner) = journal.as_db_and_inner();
+        let mut env = Env::clone_from_context(ccx.ecx);
+        let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
         db.roll_fork(Some(*forkId), (*blockNumber).to(), &mut env, inner)?;
+        env.apply_to(ccx.ecx);
         Ok(Default::default())
     }
 }
@@ -102,9 +105,10 @@ impl Cheatcode for rollFork_3Call {
     fn apply_stateful<CTX: CheatsCtxExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { forkId, txHash } = self;
         persist_caller(ccx);
-        let (journal, mut env) = ccx.ecx.journal_and_env_mut();
-        let (db, inner) = journal.as_db_and_inner();
+        let mut env = Env::clone_from_context(ccx.ecx);
+        let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
         db.roll_fork_to_transaction(Some(*forkId), *txHash, &mut env, inner)?;
+        env.apply_to(ccx.ecx);
         Ok(Default::default())
     }
 }
@@ -114,9 +118,10 @@ impl Cheatcode for selectForkCall {
         let Self { forkId } = self;
         persist_caller(ccx);
         check_broadcast(ccx.state)?;
-        let (journal, mut env) = ccx.ecx.journal_and_env_mut();
-        let (db, inner) = journal.as_db_and_inner();
+        let mut env = Env::clone_from_context(ccx.ecx);
+        let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
         db.select_fork(*forkId, &mut env, inner)?;
+        env.apply_to(ccx.ecx);
         Ok(Default::default())
     }
 }
@@ -305,9 +310,10 @@ fn create_select_fork<
     check_broadcast(ccx.state)?;
 
     let fork = create_fork_request(ccx, url_or_alias, block)?;
-    let (journal, mut env) = ccx.ecx.journal_and_env_mut();
-    let (db, inner) = journal.as_db_and_inner();
+    let mut env = Env::clone_from_context(ccx.ecx);
+    let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
     let id = db.create_select_fork(fork, &mut env, inner)?;
+    env.apply_to(ccx.ecx);
     Ok(id.abi_encode())
 }
 
@@ -333,9 +339,10 @@ fn create_select_fork_at_transaction<
     check_broadcast(ccx.state)?;
 
     let fork = create_fork_request(ccx, url_or_alias, None)?;
-    let (journal, mut env) = ccx.ecx.journal_and_env_mut();
-    let (db, inner) = journal.as_db_and_inner();
+    let mut env = Env::clone_from_context(ccx.ecx);
+    let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
     let id = db.create_select_fork_at_transaction(fork, &mut env, inner, *transaction)?;
+    env.apply_to(ccx.ecx);
     Ok(id.abi_encode())
 }
 
@@ -371,7 +378,7 @@ fn create_fork_request<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt>>(
         enable_caching: !ccx.state.config.no_storage_caching
             && ccx.state.config.rpc_storage_caching.enable_for_endpoint(&url),
         url,
-        env: ccx.ecx.to_env(),
+        env: Env::clone_from_context(ccx.ecx),
         evm_opts,
     };
     Ok(fork)

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -231,7 +231,7 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for TransparentCheatcodesExecuto
         fork_id: Option<U256>,
         transaction: B256,
     ) -> eyre::Result<()> {
-        let env = ecx.to_env();
+        let env = Env::clone_from_context(ecx);
         let (db, inner) = ecx.journal_mut().as_db_and_inner();
         db.transact(fork_id, transaction, env, inner, cheats)
     }
@@ -242,7 +242,7 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for TransparentCheatcodesExecuto
         ecx: &mut CTX,
         tx: &TransactionRequest,
     ) -> eyre::Result<()> {
-        let env = ecx.to_env();
+        let env = Env::clone_from_context(ecx);
         let (db, inner) = ecx.journal_mut().as_db_and_inner();
         db.transact_from_tx(tx, env, inner, cheats)
     }

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -2,7 +2,7 @@
 
 use super::BackendError;
 use crate::{
-    AsEnvMut, Env, EnvMut, InspectorExt,
+    Env, InspectorExt,
     backend::{
         Backend, DatabaseExt, JournaledState, LocalForkId, RevertStateSnapshotAction,
         diagnostic::RevertDiagnostic,
@@ -76,7 +76,7 @@ impl<'a> CowBackend<'a> {
 
         let res = evm.transact(env.tx.clone()).wrap_err("EVM error")?;
 
-        *env = evm.as_env_mut().to_owned();
+        *env = Env::from(evm.cfg.clone(), evm.block.clone(), evm.tx.clone());
 
         Ok(res)
     }
@@ -91,7 +91,7 @@ impl<'a> CowBackend<'a> {
     /// Returns a mutable instance of the Backend.
     ///
     /// If this is the first time this is called, the backed is cloned and initialized.
-    fn backend_mut(&mut self, env: &EnvMut<'_>) -> &mut Backend {
+    fn backend_mut(&mut self, env: &Env) -> &mut Backend {
         if let Some(spec_id) = self.spec_id.take() {
             let backend = self.backend.to_mut();
             let mut env = env.to_owned();
@@ -112,7 +112,7 @@ impl<'a> CowBackend<'a> {
 }
 
 impl DatabaseExt for CowBackend<'_> {
-    fn snapshot_state(&mut self, journaled_state: &JournaledState, env: &mut EnvMut<'_>) -> U256 {
+    fn snapshot_state(&mut self, journaled_state: &JournaledState, env: &mut Env) -> U256 {
         self.backend_mut(env).snapshot_state(journaled_state, env)
     }
 
@@ -120,7 +120,7 @@ impl DatabaseExt for CowBackend<'_> {
         &mut self,
         id: U256,
         journaled_state: &JournaledState,
-        current: &mut EnvMut<'_>,
+        current: &mut Env,
         action: RevertStateSnapshotAction,
     ) -> Option<JournaledState> {
         self.backend_mut(current).revert_state(id, journaled_state, current, action)
@@ -155,7 +155,7 @@ impl DatabaseExt for CowBackend<'_> {
     fn select_fork(
         &mut self,
         id: LocalForkId,
-        env: &mut EnvMut<'_>,
+        env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         self.backend_mut(env).select_fork(id, env, journaled_state)
@@ -165,7 +165,7 @@ impl DatabaseExt for CowBackend<'_> {
         &mut self,
         id: Option<LocalForkId>,
         block_number: u64,
-        env: &mut EnvMut<'_>,
+        env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         self.backend_mut(env).roll_fork(id, block_number, env, journaled_state)
@@ -175,7 +175,7 @@ impl DatabaseExt for CowBackend<'_> {
         &mut self,
         id: Option<LocalForkId>,
         transaction: B256,
-        env: &mut EnvMut<'_>,
+        env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         self.backend_mut(env).roll_fork_to_transaction(id, transaction, env, journaled_state)
@@ -185,32 +185,21 @@ impl DatabaseExt for CowBackend<'_> {
         &mut self,
         id: Option<LocalForkId>,
         transaction: B256,
-        mut env: Env,
+        env: Env,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<()> {
-        self.backend_mut(&env.as_env_mut()).transact(
-            id,
-            transaction,
-            env,
-            journaled_state,
-            inspector,
-        )
+        self.backend_mut(&env).transact(id, transaction, env, journaled_state, inspector)
     }
 
     fn transact_from_tx(
         &mut self,
         transaction: &TransactionRequest,
-        mut env: Env,
+        env: Env,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<()> {
-        self.backend_mut(&env.as_env_mut()).transact_from_tx(
-            transaction,
-            env,
-            journaled_state,
-            inspector,
-        )
+        self.backend_mut(&env).transact_from_tx(transaction, env, journaled_state, inspector)
     }
 
     fn active_fork_id(&self) -> Option<LocalForkId> {

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1,7 +1,7 @@
 //! Foundry's main executor backend abstraction and implementation.
 
 use crate::{
-    AsEnvMut, Env, EnvMut, InspectorExt,
+    Env, InspectorExt,
     constants::{CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, TEST_CONTRACT_ADDRESS},
     evm::new_evm_with_inspector,
     fork::{CreateFork, ForkId, MultiFork},
@@ -88,7 +88,7 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
     /// A state snapshot is associated with a new unique id that's created for the snapshot.
     /// State snapshots can be reverted: [DatabaseExt::revert_state], however, depending on the
     /// [RevertStateSnapshotAction], it will keep the snapshot alive or delete it.
-    fn snapshot_state(&mut self, journaled_state: &JournaledState, env: &mut EnvMut<'_>) -> U256;
+    fn snapshot_state(&mut self, journaled_state: &JournaledState, env: &mut Env) -> U256;
 
     /// Reverts the snapshot if it exists
     ///
@@ -106,7 +106,7 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
         &mut self,
         id: U256,
         journaled_state: &JournaledState,
-        env: &mut EnvMut<'_>,
+        env: &mut Env,
         action: RevertStateSnapshotAction,
     ) -> Option<JournaledState>;
 
@@ -125,7 +125,7 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
     fn create_select_fork(
         &mut self,
         fork: CreateFork,
-        env: &mut EnvMut<'_>,
+        env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<LocalForkId> {
         let id = self.create_fork(fork)?;
@@ -139,7 +139,7 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
     fn create_select_fork_at_transaction(
         &mut self,
         fork: CreateFork,
-        env: &mut EnvMut<'_>,
+        env: &mut Env,
         journaled_state: &mut JournaledState,
         transaction: B256,
     ) -> eyre::Result<LocalForkId> {
@@ -170,7 +170,7 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
     fn select_fork(
         &mut self,
         id: LocalForkId,
-        env: &mut EnvMut<'_>,
+        env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()>;
 
@@ -185,7 +185,7 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
         &mut self,
         id: Option<LocalForkId>,
         block_number: u64,
-        env: &mut EnvMut<'_>,
+        env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()>;
 
@@ -201,7 +201,7 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
         &mut self,
         id: Option<LocalForkId>,
         transaction: B256,
-        env: &mut EnvMut<'_>,
+        env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()>;
 
@@ -808,7 +808,7 @@ impl Backend {
 
         let res = evm.transact(env.tx.clone()).wrap_err("EVM error")?;
 
-        *env = evm.as_env_mut().to_owned();
+        *env = Env::from(evm.cfg.clone(), evm.block.clone(), evm.tx.clone());
 
         Ok(res)
     }
@@ -933,7 +933,7 @@ impl Backend {
 
             commit_transaction(
                 tx,
-                &mut env.as_env_mut(),
+                &mut env,
                 journaled_state,
                 fork,
                 &fork_id,
@@ -947,7 +947,7 @@ impl Backend {
 }
 
 impl DatabaseExt for Backend {
-    fn snapshot_state(&mut self, journaled_state: &JournaledState, env: &mut EnvMut<'_>) -> U256 {
+    fn snapshot_state(&mut self, journaled_state: &JournaledState, env: &mut Env) -> U256 {
         trace!("create snapshot");
         let id = self.inner.state_snapshots.insert(BackendStateSnapshot::new(
             self.create_db_snapshot(),
@@ -962,7 +962,7 @@ impl DatabaseExt for Backend {
         &mut self,
         id: U256,
         current_state: &JournaledState,
-        current: &mut EnvMut<'_>,
+        current: &mut Env,
         action: RevertStateSnapshotAction,
     ) -> Option<JournaledState> {
         trace!(?id, "revert snapshot");
@@ -1013,7 +1013,7 @@ impl DatabaseExt for Backend {
                 }
             }
 
-            update_current_env_with_fork_env(&mut current.as_env_mut(), env);
+            update_current_env_with_fork_env(current, env);
             trace!(target: "backend", "Reverted snapshot {}", id);
 
             Some(journaled_state)
@@ -1059,7 +1059,7 @@ impl DatabaseExt for Backend {
         self.roll_fork_to_transaction(
             Some(id),
             transaction,
-            &mut env.as_env_mut(),
+            &mut env,
             &mut self.inner.new_journaled_state(),
         )?;
 
@@ -1071,7 +1071,7 @@ impl DatabaseExt for Backend {
     fn select_fork(
         &mut self,
         id: LocalForkId,
-        env: &mut EnvMut<'_>,
+        env: &mut Env,
         active_journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, "select fork");
@@ -1085,8 +1085,8 @@ impl DatabaseExt for Backend {
         if let Some(active_fork_id) = self.active_fork_id() {
             self.forks.update_block(
                 self.ensure_fork_id(active_fork_id).cloned()?,
-                env.block.number,
-                env.block.timestamp,
+                env.evm_env.block_env.number,
+                env.evm_env.block_env.timestamp,
             )?;
         }
 
@@ -1202,7 +1202,7 @@ impl DatabaseExt for Backend {
         &mut self,
         id: Option<LocalForkId>,
         block_number: u64,
-        env: &mut EnvMut<'_>,
+        env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, ?block_number, "roll fork");
@@ -1266,7 +1266,7 @@ impl DatabaseExt for Backend {
         &mut self,
         id: Option<LocalForkId>,
         transaction: B256,
-        env: &mut EnvMut<'_>,
+        env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, ?transaction, "roll fork to transaction");
@@ -1285,8 +1285,10 @@ impl DatabaseExt for Backend {
 
         // after we forked at the fork block we need to properly update the block env to the block
         // env of the tx's block
-        let _ =
-            self.forks.update_block_env(self.inner.ensure_fork_id(id).cloned()?, env.block.clone());
+        let _ = self.forks.update_block_env(
+            self.inner.ensure_fork_id(id).cloned()?,
+            env.evm_env.block_env.clone(),
+        );
 
         let env = env.to_owned();
 
@@ -1322,12 +1324,12 @@ impl DatabaseExt for Backend {
         // So we modify the env to match the transaction's block.
         let (_fork_block, block) =
             self.get_block_number_and_block_for_transaction(id, transaction)?;
-        update_env_block(&mut env.as_env_mut(), &block);
+        update_env_block(&mut env, &block);
 
         let fork = self.inner.get_fork_by_id_mut(id)?;
         commit_transaction(
             &tx,
-            &mut env.as_env_mut(),
+            &mut env,
             journaled_state,
             fork,
             &fork_id,
@@ -1348,7 +1350,7 @@ impl DatabaseExt for Backend {
         self.commit(journaled_state.state.clone());
 
         let res = {
-            configure_tx_req_env(&mut env.as_env_mut(), tx)?;
+            configure_tx_req_env(&mut env, tx)?;
 
             let mut db = self.clone();
             let mut evm = new_evm_with_inspector(&mut db, env.to_owned(), inspector);
@@ -1886,9 +1888,9 @@ impl Default for BackendInner {
 }
 
 /// This updates the currently used env with the fork's environment
-pub(crate) fn update_current_env_with_fork_env(current: &mut EnvMut<'_>, fork: Env) {
-    *current.block = fork.evm_env.block_env;
-    *current.cfg = fork.evm_env.cfg_env;
+pub(crate) fn update_current_env_with_fork_env(current: &mut Env, fork: Env) {
+    current.evm_env.block_env = fork.evm_env.block_env;
+    current.evm_env.cfg_env = fork.evm_env.cfg_env;
     current.tx.chain_id = fork.tx.chain_id;
 }
 
@@ -1967,19 +1969,20 @@ fn is_contract_in_state(evm_state: &EvmState, acc: Address) -> bool {
 }
 
 /// Updates the env's block with the block's data
-fn update_env_block(env: &mut EnvMut<'_>, block: &AnyRpcBlock) {
-    env.block.timestamp = U256::from(block.header.timestamp);
-    env.block.beneficiary = block.header.beneficiary;
-    env.block.difficulty = block.header.difficulty;
-    env.block.prevrandao = Some(block.header.mix_hash.unwrap_or_default());
-    env.block.basefee = block.header.base_fee_per_gas.unwrap_or_default();
-    env.block.gas_limit = block.header.gas_limit;
-    env.block.number = U256::from(block.header.number);
+fn update_env_block(env: &mut Env, block: &AnyRpcBlock) {
+    let block_env = env.block_mut();
+    block_env.timestamp = U256::from(block.header.timestamp);
+    block_env.beneficiary = block.header.beneficiary;
+    block_env.difficulty = block.header.difficulty;
+    block_env.prevrandao = Some(block.header.mix_hash.unwrap_or_default());
+    block_env.basefee = block.header.base_fee_per_gas.unwrap_or_default();
+    block_env.gas_limit = block.header.gas_limit;
+    block_env.number = U256::from(block.header.number);
 
     if let Some(excess_blob_gas) = block.header.excess_blob_gas {
-        env.block.blob_excess_gas_and_price = Some(BlobExcessGasAndPrice::new(
+        env.block_mut().blob_excess_gas_and_price = Some(BlobExcessGasAndPrice::new(
             excess_blob_gas,
-            get_blob_base_fee_update_fraction(env.cfg.chain_id, block.header.timestamp),
+            get_blob_base_fee_update_fraction(env.evm_env.cfg_env.chain_id, block.header.timestamp),
         ));
     }
 }
@@ -1988,7 +1991,7 @@ fn update_env_block(env: &mut EnvMut<'_>, block: &AnyRpcBlock) {
 /// state, with an inspector.
 fn commit_transaction(
     tx: &AnyRpcTransaction,
-    env: &mut EnvMut<'_>,
+    env: &mut Env,
     journaled_state: &mut JournaledState,
     fork: &mut Fork,
     fork_id: &ForkId,

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -33,61 +33,27 @@ impl Env {
 
         Self::from(cfg, block, tx)
     }
-}
 
-/// Helper struct with mutable references to the block and cfg environments.
-pub struct EnvMut<'a> {
-    pub block: &'a mut BlockEnv,
-    pub cfg: &'a mut CfgEnv,
-    pub tx: &'a mut TxEnv,
-}
-
-impl EnvMut<'_> {
-    /// Returns a copy of the environment.
-    pub fn to_owned(&self) -> Env {
-        Env {
-            evm_env: EvmEnv { cfg_env: self.cfg.to_owned(), block_env: self.block.to_owned() },
-            tx: self.tx.to_owned(),
-        }
+    /// Creates a clone of the env from a [`FoundryContextExt`] context.
+    pub fn clone_from_context(ecx: &mut impl FoundryContextExt) -> Self {
+        Self::from(ecx.cfg_mut().clone(), ecx.block_mut().clone(), ecx.tx_mut().clone())
     }
 
-    /// Writes an owned [`Env`] back into the context.
-    ///
-    /// Counterpart to [`to_owned`](Self::to_owned): completes the read/write pair so callers
-    /// that receive an updated [`Env`] by value (e.g. after a fork switch or snapshot revert)
-    /// can apply it without manually assigning each field.
-    pub fn set_env(&mut self, env: Env) {
-        *self.block = env.evm_env.block_env;
-        *self.cfg = env.evm_env.cfg_env;
-        *self.tx = env.tx;
+    /// Writes this env back into a [`FoundryContextExt`] context.
+    pub fn apply_to(self, ecx: &mut impl FoundryContextExt) {
+        *ecx.block_mut() = self.evm_env.block_env;
+        *ecx.cfg_mut() = self.evm_env.cfg_env;
+        *ecx.tx_mut() = self.tx;
     }
-}
 
-pub trait AsEnvMut {
-    fn as_env_mut(&mut self) -> EnvMut<'_>;
-}
-
-impl AsEnvMut for EnvMut<'_> {
-    fn as_env_mut(&mut self) -> EnvMut<'_> {
-        EnvMut { block: self.block, cfg: self.cfg, tx: self.tx }
+    /// Mutable reference to the block environment.
+    pub fn block_mut(&mut self) -> &mut BlockEnv {
+        &mut self.evm_env.block_env
     }
-}
 
-impl AsEnvMut for Env {
-    fn as_env_mut(&mut self) -> EnvMut<'_> {
-        EnvMut {
-            block: &mut self.evm_env.block_env,
-            cfg: &mut self.evm_env.cfg_env,
-            tx: &mut self.tx,
-        }
-    }
-}
-
-impl<DB: Database, J: JournalTr<Database = DB>, C> AsEnvMut
-    for Context<BlockEnv, TxEnv, CfgEnv, DB, J, C>
-{
-    fn as_env_mut(&mut self) -> EnvMut<'_> {
-        EnvMut { block: &mut self.block, cfg: &mut self.cfg, tx: &mut self.tx }
+    /// Mutable reference to the cfg environment.
+    pub fn cfg_mut(&mut self) -> &mut CfgEnv {
+        &mut self.evm_env.cfg_env
     }
 }
 
@@ -323,10 +289,6 @@ impl FoundryCfg for CfgEnv {
 ///
 /// [`ContextTr`] only exposes immutable references for block, tx, and cfg.
 /// Cheatcodes like `vm.warp()`, `vm.roll()`, `vm.chainId()` need to mutate these fields.
-///
-/// Also provides [`journal_and_env_mut`](FoundryContextExt::journal_and_env_mut) for
-/// simultaneous mutable access to journal and env — needed because calling `journal_mut()`
-/// and `block_mut()` separately would create conflicting borrows on `&mut self`.
 pub trait FoundryContextExt:
     ContextTr<Block: FoundryBlock, Tx: FoundryTransaction, Cfg: FoundryCfg>
 {
@@ -336,19 +298,6 @@ pub trait FoundryContextExt:
     fn tx_mut(&mut self) -> &mut TxEnv;
     /// Mutable reference to the configuration environment.
     fn cfg_mut(&mut self) -> &mut CfgEnv;
-
-    /// Returns a cloned snapshot of the current environment.
-    fn to_env(&self) -> Env;
-
-    /// Applies an owned [`Env`] to this context, replacing block, cfg, and tx.
-    fn apply_env(&mut self, env: Env);
-
-    /// Returns mutable references to the journal and environment simultaneously.
-    ///
-    /// This solves the borrow-splitting problem: calling `self.journal_mut()` and
-    /// `self.block_mut()` separately would both borrow `&mut self`. This method
-    /// splits the borrows at the field level in one call.
-    fn journal_and_env_mut(&mut self) -> (&mut Self::Journal, EnvMut<'_>);
 }
 
 impl<DB: Database, J: JournalTr<Database = DB>, C> FoundryContextExt
@@ -362,22 +311,5 @@ impl<DB: Database, J: JournalTr<Database = DB>, C> FoundryContextExt
     }
     fn cfg_mut(&mut self) -> &mut CfgEnv {
         &mut self.cfg
-    }
-    fn to_env(&self) -> Env {
-        Env {
-            evm_env: EvmEnv { cfg_env: self.cfg.clone(), block_env: self.block.clone() },
-            tx: self.tx.clone(),
-        }
-    }
-    fn apply_env(&mut self, env: Env) {
-        self.block = env.evm_env.block_env;
-        self.cfg = env.evm_env.cfg_env;
-        self.tx = env.tx;
-    }
-    fn journal_and_env_mut(&mut self) -> (&mut J, EnvMut<'_>) {
-        (
-            &mut self.journaled_state,
-            EnvMut { block: &mut self.block, cfg: &mut self.cfg, tx: &mut self.tx },
-        )
     }
 }

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -298,19 +298,17 @@ pub fn with_cloned_context<CTX: FoundryContextExt, R>(
 where
     CTX::Journal: FoundryJournalExt,
 {
-    let (journal, env_mut) = ecx.journal_and_env_mut();
-    let env = env_mut.to_owned();
+    let env = Env::clone_from_context(ecx);
 
+    let journal = ecx.journal_mut();
     let (db, journal_inner) = journal.as_db_and_inner();
     let journal_inner_clone = journal_inner.clone();
 
     let (result, sub_env, sub_inner) = f(db, env, journal_inner_clone)?;
 
     // Write back modified state. The db borrow was released when f returned.
-    journal.set_inner(sub_inner);
-    *env_mut.block = sub_env.evm_env.block_env;
-    *env_mut.cfg = sub_env.evm_env.cfg_env;
-    *env_mut.tx = sub_env.tx;
+    ecx.journal_mut().set_inner(sub_inner);
+    sub_env.apply_to(ecx);
 
     Ok(result)
 }

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -1,4 +1,4 @@
-use crate::{AsEnvMut, Env, EvmEnv, utils::apply_chain_and_block_specific_env_changes};
+use crate::{Env, EvmEnv, utils::apply_chain_and_block_specific_env_changes};
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{Address, U256};
 use alloy_provider::{Network, Provider, network::BlockResponse};
@@ -87,7 +87,7 @@ pub async fn environment<N: Network, P: Provider<N>>(
         },
     };
 
-    apply_chain_and_block_specific_env_changes::<N>(env.as_env_mut(), &block, configs);
+    apply_chain_and_block_specific_env_changes::<N>(&mut env.evm_env, &block, configs);
 
     Ok((env, block))
 }

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::EnvMut;
+use crate::{Env, EvmEnv};
 use alloy_chains::Chain;
 use alloy_consensus::{BlockHeader, private::alloy_eips::eip7840::BlobParams};
 use alloy_hardforks::EthereumHardfork;
@@ -29,20 +29,21 @@ pub fn cold_path() {
 ///
 /// Should be called with proper chain id (retrieved from provider if not provided).
 pub fn apply_chain_and_block_specific_env_changes<N: Network>(
-    env: EnvMut<'_>,
+    evm_env: &mut EvmEnv,
     block: &N::BlockResponse,
     configs: NetworkConfigs,
 ) {
     use NamedChain::*;
 
-    if let Ok(chain) = NamedChain::try_from(env.cfg.chain_id) {
+    if let Ok(chain) = NamedChain::try_from(evm_env.cfg_env.chain_id) {
         let block_number = block.header().number();
 
         match chain {
             Mainnet => {
                 // after merge difficulty is supplanted with prevrandao EIP-4399
                 if block_number >= 15_537_351u64 {
-                    env.block.difficulty = env.block.prevrandao.unwrap_or_default().into();
+                    evm_env.block_env.difficulty =
+                        evm_env.block_env.prevrandao.unwrap_or_default().into();
                 }
 
                 return;
@@ -54,7 +55,7 @@ pub fn apply_chain_and_block_specific_env_changes<N: Network>(
                 // (`mixHash`) is always zero, even though bsc adopts the newer EVM
                 // specification. This will confuse revm and causes emulation
                 // failure.
-                env.block.prevrandao = Some(env.block.difficulty.into());
+                evm_env.block_env.prevrandao = Some(evm_env.block_env.difficulty.into());
                 return;
             }
             c if c.is_arbitrum() => {
@@ -67,21 +68,22 @@ pub fn apply_chain_and_block_specific_env_changes<N: Network>(
                         serde_json::from_value::<U256>(l1_block_number).ok()
                     })
                 {
-                    env.block.number = l1_block_number.to();
+                    evm_env.block_env.number = l1_block_number.to();
                 }
             }
             _ => {}
         }
     }
 
-    if configs.bypass_prevrandao(env.cfg.chain_id) && env.block.prevrandao.is_none() {
+    if configs.bypass_prevrandao(evm_env.cfg_env.chain_id) && evm_env.block_env.prevrandao.is_none()
+    {
         // <https://github.com/foundry-rs/foundry/issues/4232>
-        env.block.prevrandao = Some(B256::random());
+        evm_env.block_env.prevrandao = Some(B256::random());
     }
 
     // if difficulty is `0` we assume it's past merge
     if block.header().difficulty().is_zero() {
-        env.block.difficulty = env.block.prevrandao.unwrap_or_default().into();
+        evm_env.block_env.difficulty = evm_env.block_env.prevrandao.unwrap_or_default().into();
     }
 }
 
@@ -138,7 +140,7 @@ pub fn get_function<'a>(
 
 /// Configures the env for the given RPC transaction.
 /// Accounts for an impersonated transaction by resetting the `env.tx.caller` field to `tx.from`.
-pub fn configure_tx_env(env: &mut EnvMut<'_>, tx: &AnyRpcTransaction) {
+pub fn configure_tx_env(env: &mut Env, tx: &AnyRpcTransaction) {
     let from = tx.from();
     if let Some(tx) = tx.as_envelope() {
         configure_tx_req_env(
@@ -150,7 +152,7 @@ pub fn configure_tx_env(env: &mut EnvMut<'_>, tx: &AnyRpcTransaction) {
 }
 
 /// Configures the env for the given RPC transaction request.
-pub fn configure_tx_req_env(env: &mut EnvMut<'_>, tx: &TransactionRequest) -> eyre::Result<()> {
+pub fn configure_tx_req_env(env: &mut Env, tx: &TransactionRequest) -> eyre::Result<()> {
     // If no transaction type is provided, we need to infer it from the other fields.
     let tx_type = tx.transaction_type.unwrap_or_else(|| tx.minimal_tx_type() as u8);
     env.tx.tx_type = tx_type;

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -400,7 +400,7 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for InspectorStackInner {
         fork_id: Option<U256>,
         transaction: B256,
     ) -> eyre::Result<()> {
-        let env = ecx.to_env();
+        let env = Env::clone_from_context(ecx);
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         let (db, inner) = ecx.journal_mut().as_db_and_inner();
         db.transact(fork_id, transaction, env, inner, &mut inspector)
@@ -412,7 +412,7 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for InspectorStackInner {
         ecx: &mut CTX,
         tx: &TransactionRequest,
     ) -> eyre::Result<()> {
-        let env = ecx.to_env();
+        let env = Env::clone_from_context(ecx);
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         let (db, inner) = ecx.journal_mut().as_db_and_inner();
         db.transact_from_tx(tx, env, inner, &mut inspector)
@@ -738,7 +738,7 @@ impl InspectorStackRefMut<'_> {
     where
         CTX::Journal: FoundryJournalExt,
     {
-        let cached_env = ecx.to_env();
+        let cached_env = Env::clone_from_context(ecx);
 
         ecx.block_mut().set_basefee(0);
 
@@ -762,12 +762,11 @@ impl InspectorStackRefMut<'_> {
         self.inner_context_data = Some(InnerContextData { original_origin: cached_env.tx.caller });
         self.in_inner_context = true;
 
-        let modified_env = ecx.to_env();
+        let modified_env = Env::clone_from_context(ecx);
 
         let res = self.with_inspector(|mut inspector| {
             let (res, nested_env) = {
-                let (journal, _env) = ecx.journal_and_env_mut();
-                let (db, journal) = journal.as_db_and_inner();
+                let (db, journal) = ecx.journal_mut().as_db_and_inner();
                 let mut evm = new_evm_with_inspector(db, modified_env.clone(), &mut inspector);
 
                 evm.journal_inner_mut().state = {
@@ -802,7 +801,7 @@ impl InspectorStackRefMut<'_> {
             let mut restored_env = nested_env;
             restored_env.tx = cached_env.tx;
             restored_env.evm_env.block_env.basefee = cached_env.evm_env.block_env.basefee;
-            ecx.apply_env(restored_env);
+            restored_env.apply_to(ecx);
 
             res
         });

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -13,8 +13,8 @@ pub mod inspectors;
 
 pub use foundry_evm_core as core;
 pub use foundry_evm_core::{
-    Env, EnvMut, EvmEnv, FoundryInspectorExt, InspectorExt, backend, constants, decode, fork,
-    hardfork, opts, utils,
+    Env, EvmEnv, FoundryInspectorExt, InspectorExt, backend, constants, decode, fork, hardfork,
+    opts, utils,
 };
 pub use foundry_evm_coverage as coverage;
 pub use foundry_evm_fuzz as fuzz;

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -30,7 +30,6 @@ use foundry_compilers::{artifacts::EvmVersion, info::ContractInfo};
 use foundry_config::{Config, figment, impl_figment_convert};
 use foundry_evm::{
     constants::DEFAULT_CREATE2_DEPLOYER,
-    core::AsEnvMut,
     executors::EvmError,
     utils::{configure_tx_env, configure_tx_req_env},
 };
@@ -253,13 +252,13 @@ impl VerifyBytecodeArgs {
                 .into_create();
 
             if let Some(ref block) = genesis_block {
-                configure_env_block(&mut env.as_env_mut(), block, config.networks);
+                configure_env_block(&mut env, block, config.networks);
                 gen_tx_req.max_fee_per_gas = block.header.base_fee_per_gas.map(|g| g as u128);
                 gen_tx_req.gas = Some(block.header.gas_limit);
                 gen_tx_req.gas_price = block.header.base_fee_per_gas.map(|g| g as u128);
             }
 
-            configure_tx_req_env(&mut env.as_env_mut(), &gen_tx_req)
+            configure_tx_req_env(&mut env, &gen_tx_req)
                 .wrap_err("Failed to configure tx request env")?;
 
             // Seed deployer account with funds
@@ -472,7 +471,7 @@ impl VerifyBytecodeArgs {
             transaction.set_nonce(prev_block_nonce);
 
             if let Some(ref block) = block {
-                configure_env_block(&mut env.as_env_mut(), block, config.networks);
+                configure_env_block(&mut env, block, config.networks);
 
                 let BlockTransactions::Full(ref txs) = block.transactions else {
                     return Err(eyre::eyre!("Could not get block txs"));
@@ -490,7 +489,7 @@ impl VerifyBytecodeArgs {
                         break;
                     }
 
-                    configure_tx_env(&mut env.as_env_mut(), tx);
+                    configure_tx_env(&mut env, tx);
 
                     if let TxKind::Call(_) = tx.inner.kind() {
                         executor.transact_with_env(env.clone()).wrap_err_with(|| {
@@ -533,7 +532,7 @@ impl VerifyBytecodeArgs {
             }
 
             // configure_req__env(&mut env, &transaction.inner);
-            configure_tx_req_env(&mut env.as_env_mut(), &transaction)
+            configure_tx_req_env(&mut env, &transaction)
                 .wrap_err("Failed to configure tx request env")?;
 
             let fork_address = crate::utils::deploy_contract(

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -20,12 +20,8 @@ use foundry_common::{
 use foundry_compilers::artifacts::{BytecodeHash, CompactContractBytecode, EvmVersion};
 use foundry_config::Config;
 use foundry_evm::{
-    Env, EnvMut,
-    constants::DEFAULT_CREATE2_DEPLOYER,
-    core::{AsEnvMut, decode::RevertDecoder},
-    executors::TracingExecutor,
-    opts::EvmOpts,
-    traces::TraceMode,
+    Env, constants::DEFAULT_CREATE2_DEPLOYER, core::decode::RevertDecoder,
+    executors::TracingExecutor, opts::EvmOpts, traces::TraceMode,
     utils::apply_chain_and_block_specific_env_changes,
 };
 use foundry_evm_networks::NetworkConfigs;
@@ -292,14 +288,14 @@ pub async fn get_tracing_executor(
     Ok((env, executor))
 }
 
-pub fn configure_env_block(env: &mut EnvMut<'_>, block: &AnyRpcBlock, config: NetworkConfigs) {
-    env.block.timestamp = U256::from(block.header.timestamp);
-    env.block.beneficiary = block.header.beneficiary;
-    env.block.difficulty = block.header.difficulty;
-    env.block.prevrandao = Some(block.header.mix_hash.unwrap_or_default());
-    env.block.basefee = block.header.base_fee_per_gas.unwrap_or_default();
-    env.block.gas_limit = block.header.gas_limit;
-    apply_chain_and_block_specific_env_changes::<AnyNetwork>(env.as_env_mut(), block, config);
+pub fn configure_env_block(env: &mut Env, block: &AnyRpcBlock, config: NetworkConfigs) {
+    env.evm_env.block_env.timestamp = U256::from(block.header.timestamp);
+    env.evm_env.block_env.beneficiary = block.header.beneficiary;
+    env.evm_env.block_env.difficulty = block.header.difficulty;
+    env.evm_env.block_env.prevrandao = Some(block.header.mix_hash.unwrap_or_default());
+    env.evm_env.block_env.basefee = block.header.base_fee_per_gas.unwrap_or_default();
+    env.evm_env.block_env.gas_limit = block.header.gas_limit;
+    apply_chain_and_block_specific_env_changes::<AnyNetwork>(&mut env.evm_env, block, config);
 }
 
 pub fn deploy_contract(


### PR DESCRIPTION
Removes `EnvMut`, `AsEnvMut`, `to_env()`, `apply_env()`, and `journal_and_env_mut()` from `FoundryContextExt` and replaces them with `Env::clone_from_context()` and `Env::apply_to()`

This simplifies the trait surface and removes the coupling between `FoundryContextExt` and concrete `Env`.