### PR TITLE
refactor(evm): split `Env` into `(EvmEnv, TxEnv)`

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1120,7 +1120,7 @@ impl Cheatcode for executeTransactionCall {
         let tx_env = <TxEnv as FromRecoveredTx<FoundryTxEnvelope>>::from_recovered_tx(&tx, sender);
 
         // Save current env for restoration after execution.
-        let cached_env = Env::clone_from_context(ccx.ecx);
+        let (cached_evm_env, cached_tx_env) = Env::clone_evm_and_tx(ccx.ecx);
 
         // Override env for isolated execution.
         ccx.ecx.block_mut().set_basefee(0);
@@ -1137,7 +1137,7 @@ impl Cheatcode for executeTransactionCall {
             .set_limit_contract_initcode_size(Some(revm::primitives::eip3860::MAX_INITCODE_SIZE));
 
         // Snapshot the modified env for EVM construction.
-        let modified_env = Env::clone_from_context(ccx.ecx);
+        let (modified_evm_env, modified_tx_env) = Env::clone_evm_and_tx(ccx.ecx);
 
         // Mark as inner context so isolation mode doesn't trigger a nested transact_inner
         // when the inner EVM executes calls at depth == 1.
@@ -1162,32 +1162,35 @@ impl Cheatcode for executeTransactionCall {
         let mut res = None;
         let mut nested_env = None;
         let mut cold_state = Some(cold_state);
-        let modified_tx = modified_env.tx.clone();
+        let modified_tx = modified_tx_env.clone();
         {
             let (db, _) = ccx.ecx.journal_mut().as_db_and_inner();
-            executor.with_fresh_nested_evm(ccx.state, db, modified_env, &mut |evm| {
-                // SAFETY: closure is called exactly once by the executor.
-                evm.journal_inner_mut().state = cold_state.take().expect("called once");
-                // Set depth to 1 for proper trace collection.
-                evm.journal_inner_mut().depth = 1;
-                res = Some(evm.transact(modified_tx.clone()));
-                nested_env = Some(evm.to_env());
-                Ok(())
-            })?;
+            executor.with_fresh_nested_evm(
+                ccx.state,
+                db,
+                modified_evm_env,
+                modified_tx_env,
+                &mut |evm| {
+                    // SAFETY: closure is called exactly once by the executor.
+                    evm.journal_inner_mut().state = cold_state.take().expect("called once");
+                    // Set depth to 1 for proper trace collection.
+                    evm.journal_inner_mut().depth = 1;
+                    res = Some(evm.transact(modified_tx.clone()));
+                    nested_env = Some(evm.to_env());
+                    Ok(())
+                },
+            )?;
         }
-        let (res, nested_env) = (res.unwrap(), nested_env.unwrap());
+        let (res, (mut nested_evm_env, _)) = (res.unwrap(), nested_env.unwrap());
 
         // Restore env, preserving cheatcode cfg/block changes from the nested EVM
         // but restoring the original tx and basefee (which we zeroed for the nested call)
         // as well as cfg overrides that were applied only for the nested execution.
-        let mut restored_env = nested_env;
-        restored_env.tx = cached_env.tx;
-        restored_env.evm_env.block_env.basefee = cached_env.evm_env.block_env.basefee;
-        restored_env.evm_env.cfg_env.disable_nonce_check =
-            cached_env.evm_env.cfg_env.disable_nonce_check;
-        restored_env.evm_env.cfg_env.limit_contract_initcode_size =
-            cached_env.evm_env.cfg_env.limit_contract_initcode_size;
-        restored_env.apply_to(ccx.ecx);
+        nested_evm_env.block_env.basefee = cached_evm_env.block_env.basefee;
+        nested_evm_env.cfg_env.disable_nonce_check = cached_evm_env.cfg_env.disable_nonce_check;
+        nested_evm_env.cfg_env.limit_contract_initcode_size =
+            cached_evm_env.cfg_env.limit_contract_initcode_size;
+        Env::apply_evm_and_tx(ccx.ecx, nested_evm_env, cached_tx_env);
 
         // Reset inner context flag.
         executor.set_in_inner_context(false, None);
@@ -1335,10 +1338,9 @@ pub(super) fn get_nonce<CTX: ContextTr<Db: DatabaseExt>>(
 fn inner_snapshot_state<CTX: FoundryContextExt + ContextTr<Journal: FoundryJournalExt>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
 ) -> Result {
-    let mut env = Env::clone_from_context(ccx.ecx);
+    let (evm_env, tx_env) = Env::clone_evm_and_tx(ccx.ecx);
     let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
-    let id = db.snapshot_state(inner, &mut env);
-    env.apply_to(ccx.ecx);
+    let id = db.snapshot_state(inner, &evm_env, &tx_env);
     Ok(id.abi_encode())
 }
 
@@ -1346,13 +1348,17 @@ fn inner_revert_to_state<CTX: FoundryContextExt + ContextTr<Journal: FoundryJour
     ccx: &mut CheatsCtxt<'_, CTX>,
     snapshot_id: U256,
 ) -> Result {
-    let mut env = Env::clone_from_context(ccx.ecx);
+    let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
     let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
-    if let Some(restored) =
-        db.revert_state(snapshot_id, inner, &mut env, RevertStateSnapshotAction::RevertKeep)
-    {
+    if let Some(restored) = db.revert_state(
+        snapshot_id,
+        inner,
+        &mut evm_env,
+        &mut tx_env,
+        RevertStateSnapshotAction::RevertKeep,
+    ) {
         *inner = restored;
-        env.apply_to(ccx.ecx);
+        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
         Ok(true.abi_encode())
     } else {
         Ok(false.abi_encode())
@@ -1365,13 +1371,17 @@ fn inner_revert_to_state_and_delete<
     ccx: &mut CheatsCtxt<'_, CTX>,
     snapshot_id: U256,
 ) -> Result {
-    let mut env = Env::clone_from_context(ccx.ecx);
+    let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
     let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
-    if let Some(restored) =
-        db.revert_state(snapshot_id, inner, &mut env, RevertStateSnapshotAction::RevertRemove)
-    {
+    if let Some(restored) = db.revert_state(
+        snapshot_id,
+        inner,
+        &mut evm_env,
+        &mut tx_env,
+        RevertStateSnapshotAction::RevertRemove,
+    ) {
         *inner = restored;
-        env.apply_to(ccx.ecx);
+        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
         Ok(true.abi_encode())
     } else {
         Ok(false.abi_encode())

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -69,10 +69,10 @@ impl Cheatcode for rollFork_0Call {
     fn apply_stateful<CTX: CheatsCtxExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { blockNumber } = self;
         persist_caller(ccx);
-        let mut env = Env::clone_from_context(ccx.ecx);
+        let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
         let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
-        db.roll_fork(None, (*blockNumber).to(), &mut env, inner)?;
-        env.apply_to(ccx.ecx);
+        db.roll_fork(None, (*blockNumber).to(), &mut evm_env, &mut tx_env, inner)?;
+        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
         Ok(Default::default())
     }
 }
@@ -81,10 +81,10 @@ impl Cheatcode for rollFork_1Call {
     fn apply_stateful<CTX: CheatsCtxExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { txHash } = self;
         persist_caller(ccx);
-        let mut env = Env::clone_from_context(ccx.ecx);
+        let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
         let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
-        db.roll_fork_to_transaction(None, *txHash, &mut env, inner)?;
-        env.apply_to(ccx.ecx);
+        db.roll_fork_to_transaction(None, *txHash, &mut evm_env, &mut tx_env, inner)?;
+        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
         Ok(Default::default())
     }
 }
@@ -93,10 +93,10 @@ impl Cheatcode for rollFork_2Call {
     fn apply_stateful<CTX: CheatsCtxExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { forkId, blockNumber } = self;
         persist_caller(ccx);
-        let mut env = Env::clone_from_context(ccx.ecx);
+        let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
         let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
-        db.roll_fork(Some(*forkId), (*blockNumber).to(), &mut env, inner)?;
-        env.apply_to(ccx.ecx);
+        db.roll_fork(Some(*forkId), (*blockNumber).to(), &mut evm_env, &mut tx_env, inner)?;
+        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
         Ok(Default::default())
     }
 }
@@ -105,10 +105,10 @@ impl Cheatcode for rollFork_3Call {
     fn apply_stateful<CTX: CheatsCtxExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { forkId, txHash } = self;
         persist_caller(ccx);
-        let mut env = Env::clone_from_context(ccx.ecx);
+        let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
         let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
-        db.roll_fork_to_transaction(Some(*forkId), *txHash, &mut env, inner)?;
-        env.apply_to(ccx.ecx);
+        db.roll_fork_to_transaction(Some(*forkId), *txHash, &mut evm_env, &mut tx_env, inner)?;
+        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
         Ok(Default::default())
     }
 }
@@ -118,10 +118,10 @@ impl Cheatcode for selectForkCall {
         let Self { forkId } = self;
         persist_caller(ccx);
         check_broadcast(ccx.state)?;
-        let mut env = Env::clone_from_context(ccx.ecx);
+        let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
         let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
-        db.select_fork(*forkId, &mut env, inner)?;
-        env.apply_to(ccx.ecx);
+        db.select_fork(*forkId, &mut evm_env, &mut tx_env, inner)?;
+        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
         Ok(Default::default())
     }
 }
@@ -310,10 +310,10 @@ fn create_select_fork<
     check_broadcast(ccx.state)?;
 
     let fork = create_fork_request(ccx, url_or_alias, block)?;
-    let mut env = Env::clone_from_context(ccx.ecx);
+    let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
     let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
-    let id = db.create_select_fork(fork, &mut env, inner)?;
-    env.apply_to(ccx.ecx);
+    let id = db.create_select_fork(fork, &mut evm_env, &mut tx_env, inner)?;
+    Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
     Ok(id.abi_encode())
 }
 
@@ -339,10 +339,11 @@ fn create_select_fork_at_transaction<
     check_broadcast(ccx.state)?;
 
     let fork = create_fork_request(ccx, url_or_alias, None)?;
-    let mut env = Env::clone_from_context(ccx.ecx);
+    let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
     let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
-    let id = db.create_select_fork_at_transaction(fork, &mut env, inner, *transaction)?;
-    env.apply_to(ccx.ecx);
+    let id =
+        db.create_select_fork_at_transaction(fork, &mut evm_env, &mut tx_env, inner, *transaction)?;
+    Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
     Ok(id.abi_encode())
 }
 
@@ -378,7 +379,10 @@ fn create_fork_request<CTX: FoundryContextExt + ContextTr<Db: DatabaseExt>>(
         enable_caching: !ccx.state.config.no_storage_caching
             && ccx.state.config.rpc_storage_caching.enable_for_endpoint(&url),
         url,
-        env: Env::clone_from_context(ccx.ecx),
+        env: {
+            let (evm_env, tx_env) = Env::clone_evm_and_tx(ccx.ecx);
+            Env { evm_env, tx: tx_env }
+        },
         evm_opts,
     };
     Ok(fork)

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -36,7 +36,7 @@ use foundry_common::{
     mapping_slots::{MappingSlots, step as mapping_step},
 };
 use foundry_evm_core::{
-    Breakpoints, Env, FoundryInspectorExt, FoundryTransaction,
+    Breakpoints, Env, EvmEnv, FoundryInspectorExt, FoundryTransaction,
     abi::Vm::stopExpectSafeMemoryCall,
     backend::{DatabaseError, DatabaseExt, FoundryJournalExt, RevertDiagnostic},
     constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME},
@@ -54,7 +54,7 @@ use revm::{
     Inspector,
     bytecode::opcode as op,
     context::{
-        BlockEnv, Cfg, ContextTr, JournalTr, Transaction, TransactionType, result::EVMError,
+        BlockEnv, Cfg, ContextTr, JournalTr, Transaction, TransactionType, TxEnv, result::EVMError,
     },
     context_interface::{CreateScheme, transaction::SignedAuthorization},
     handler::FrameResult,
@@ -144,7 +144,8 @@ pub trait CheatcodesExecutor<CTX> {
         &mut self,
         cheats: &mut Cheatcodes,
         db: &mut dyn DatabaseExt,
-        env: Env,
+        evm_env: EvmEnv,
+        tx_env: TxEnv,
         f: NestedEvmClosure<'_>,
     ) -> Result<(), EVMError<DatabaseError>>
     where
@@ -203,13 +204,13 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for TransparentCheatcodesExecuto
         ecx: &mut CTX,
         f: NestedEvmClosure<'_>,
     ) -> Result<(), EVMError<DatabaseError>> {
-        with_cloned_context(ecx, |db, env, journal_inner| {
-            let mut evm = new_evm_with_inspector(db, env, cheats);
+        with_cloned_context(ecx, |db, evm_env, tx_env, journal_inner| {
+            let mut evm = new_evm_with_inspector(db, Env { evm_env, tx: tx_env }, cheats);
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
-            let sub_env = evm.to_env();
+            let (sub_evm_env, sub_tx) = evm.to_env();
             let sub_inner = evm.into_context().journaled_state.inner;
-            Ok(((), sub_env, sub_inner))
+            Ok(((), sub_evm_env, sub_tx, sub_inner))
         })
     }
 
@@ -217,10 +218,11 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for TransparentCheatcodesExecuto
         &mut self,
         cheats: &mut Cheatcodes,
         db: &mut dyn DatabaseExt,
-        env: Env,
+        evm_env: EvmEnv,
+        tx_env: TxEnv,
         f: NestedEvmClosure<'_>,
     ) -> Result<(), EVMError<DatabaseError>> {
-        let mut evm = new_evm_with_inspector(db, env, cheats);
+        let mut evm = new_evm_with_inspector(db, Env { evm_env, tx: tx_env }, cheats);
         f(&mut evm)
     }
 
@@ -231,9 +233,9 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for TransparentCheatcodesExecuto
         fork_id: Option<U256>,
         transaction: B256,
     ) -> eyre::Result<()> {
-        let env = Env::clone_from_context(ecx);
+        let (evm_env, tx_env) = Env::clone_evm_and_tx(ecx);
         let (db, inner) = ecx.journal_mut().as_db_and_inner();
-        db.transact(fork_id, transaction, env, inner, cheats)
+        db.transact(fork_id, transaction, evm_env, tx_env, inner, cheats)
     }
 
     fn transact_from_tx_on_db(
@@ -242,9 +244,9 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for TransparentCheatcodesExecuto
         ecx: &mut CTX,
         tx: &TransactionRequest,
     ) -> eyre::Result<()> {
-        let env = Env::clone_from_context(ecx);
+        let (evm_env, tx_env) = Env::clone_evm_and_tx(ecx);
         let (db, inner) = ecx.journal_mut().as_db_and_inner();
-        db.transact_from_tx(tx, env, inner, cheats)
+        db.transact_from_tx(tx, evm_env, tx_env, inner, cheats)
     }
 
     fn console_log(&mut self, _cheats: &mut Cheatcodes, _msg: &str) {}

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     fork::{CreateFork, ForkId},
 };
-use alloy_evm::Evm;
+use alloy_evm::{Evm, EvmEnv};
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{Address, B256, U256};
 use alloy_rpc_types::TransactionRequest;
@@ -18,6 +18,7 @@ use foundry_fork_db::DatabaseError;
 use revm::{
     Database, DatabaseCommit,
     bytecode::Bytecode,
+    context::TxEnv,
     context_interface::result::ResultAndState,
     database::DatabaseRef,
     primitives::{HashMap as Map, hardfork::SpecId},
@@ -91,10 +92,10 @@ impl<'a> CowBackend<'a> {
     /// Returns a mutable instance of the Backend.
     ///
     /// If this is the first time this is called, the backed is cloned and initialized.
-    fn backend_mut(&mut self, env: &Env) -> &mut Backend {
+    fn backend_mut(&mut self, evm_env: &EvmEnv, tx_env: &TxEnv) -> &mut Backend {
         if let Some(spec_id) = self.spec_id.take() {
             let backend = self.backend.to_mut();
-            let mut env = env.to_owned();
+            let mut env = Env { evm_env: evm_env.clone(), tx: tx_env.clone() };
             env.evm_env.cfg_env.spec = spec_id;
             backend.initialize(&env);
             return backend;
@@ -112,18 +113,24 @@ impl<'a> CowBackend<'a> {
 }
 
 impl DatabaseExt for CowBackend<'_> {
-    fn snapshot_state(&mut self, journaled_state: &JournaledState, env: &mut Env) -> U256 {
-        self.backend_mut(env).snapshot_state(journaled_state, env)
+    fn snapshot_state(
+        &mut self,
+        journaled_state: &JournaledState,
+        evm_env: &EvmEnv,
+        tx_env: &TxEnv,
+    ) -> U256 {
+        self.backend_mut(evm_env, tx_env).snapshot_state(journaled_state, evm_env, tx_env)
     }
 
     fn revert_state(
         &mut self,
         id: U256,
         journaled_state: &JournaledState,
-        current: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         action: RevertStateSnapshotAction,
     ) -> Option<JournaledState> {
-        self.backend_mut(current).revert_state(id, journaled_state, current, action)
+        self.backend_mut(evm_env, tx_env).revert_state(id, journaled_state, evm_env, tx_env, action)
     }
 
     fn delete_state_snapshot(&mut self, id: U256) -> bool {
@@ -155,51 +162,81 @@ impl DatabaseExt for CowBackend<'_> {
     fn select_fork(
         &mut self,
         id: LocalForkId,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
-        self.backend_mut(env).select_fork(id, env, journaled_state)
+        self.backend_mut(evm_env, tx_env).select_fork(id, evm_env, tx_env, journaled_state)
     }
 
     fn roll_fork(
         &mut self,
         id: Option<LocalForkId>,
         block_number: u64,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
-        self.backend_mut(env).roll_fork(id, block_number, env, journaled_state)
+        self.backend_mut(evm_env, tx_env).roll_fork(
+            id,
+            block_number,
+            evm_env,
+            tx_env,
+            journaled_state,
+        )
     }
 
     fn roll_fork_to_transaction(
         &mut self,
         id: Option<LocalForkId>,
         transaction: B256,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
-        self.backend_mut(env).roll_fork_to_transaction(id, transaction, env, journaled_state)
+        self.backend_mut(evm_env, tx_env).roll_fork_to_transaction(
+            id,
+            transaction,
+            evm_env,
+            tx_env,
+            journaled_state,
+        )
     }
 
     fn transact(
         &mut self,
         id: Option<LocalForkId>,
         transaction: B256,
-        env: Env,
+        evm_env: EvmEnv,
+        tx_env: TxEnv,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<()> {
-        self.backend_mut(&env).transact(id, transaction, env, journaled_state, inspector)
+        self.backend_mut(&evm_env, &tx_env).transact(
+            id,
+            transaction,
+            evm_env,
+            tx_env,
+            journaled_state,
+            inspector,
+        )
     }
 
     fn transact_from_tx(
         &mut self,
         transaction: &TransactionRequest,
-        env: Env,
+        evm_env: EvmEnv,
+        tx_env: TxEnv,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<()> {
-        self.backend_mut(&env).transact_from_tx(transaction, env, journaled_state, inspector)
+        self.backend_mut(&evm_env, &tx_env).transact_from_tx(
+            transaction,
+            evm_env,
+            tx_env,
+            journaled_state,
+            inspector,
+        )
     }
 
     fn active_fork_id(&self) -> Option<LocalForkId> {

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     utils::{configure_tx_env, configure_tx_req_env, get_blob_base_fee_update_fraction},
 };
 use alloy_consensus::Typed2718;
-use alloy_evm::Evm;
+use alloy_evm::{Evm, EvmEnv};
 use alloy_genesis::GenesisAccount;
 use alloy_network::{
     AnyNetwork, AnyRpcBlock, AnyRpcTransaction, AnyTxEnvelope, TransactionResponse,
@@ -22,7 +22,7 @@ pub use foundry_fork_db::{BlockchainDb, SharedBackend, cache::BlockchainDbMeta};
 use revm::{
     Database, DatabaseCommit, Journal, JournalEntry,
     bytecode::Bytecode,
-    context::JournalInner,
+    context::{JournalInner, TxEnv},
     context_interface::{
         block::BlobExcessGasAndPrice, journaled_state::account::JournaledAccountTr,
         result::ResultAndState,
@@ -88,7 +88,12 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
     /// A state snapshot is associated with a new unique id that's created for the snapshot.
     /// State snapshots can be reverted: [DatabaseExt::revert_state], however, depending on the
     /// [RevertStateSnapshotAction], it will keep the snapshot alive or delete it.
-    fn snapshot_state(&mut self, journaled_state: &JournaledState, env: &mut Env) -> U256;
+    fn snapshot_state(
+        &mut self,
+        journaled_state: &JournaledState,
+        evm_env: &EvmEnv,
+        tx_env: &TxEnv,
+    ) -> U256;
 
     /// Reverts the snapshot if it exists
     ///
@@ -106,7 +111,8 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
         &mut self,
         id: U256,
         journaled_state: &JournaledState,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         action: RevertStateSnapshotAction,
     ) -> Option<JournaledState>;
 
@@ -125,11 +131,12 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
     fn create_select_fork(
         &mut self,
         fork: CreateFork,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<LocalForkId> {
         let id = self.create_fork(fork)?;
-        self.select_fork(id, env, journaled_state)?;
+        self.select_fork(id, evm_env, tx_env, journaled_state)?;
         Ok(id)
     }
 
@@ -139,12 +146,13 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
     fn create_select_fork_at_transaction(
         &mut self,
         fork: CreateFork,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         journaled_state: &mut JournaledState,
         transaction: B256,
     ) -> eyre::Result<LocalForkId> {
         let id = self.create_fork_at_transaction(fork, transaction)?;
-        self.select_fork(id, env, journaled_state)?;
+        self.select_fork(id, evm_env, tx_env, journaled_state)?;
         Ok(id)
     }
 
@@ -170,7 +178,8 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
     fn select_fork(
         &mut self,
         id: LocalForkId,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()>;
 
@@ -185,7 +194,8 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
         &mut self,
         id: Option<LocalForkId>,
         block_number: u64,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()>;
 
@@ -201,7 +211,8 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
         &mut self,
         id: Option<LocalForkId>,
         transaction: B256,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()>;
 
@@ -210,7 +221,8 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
         &mut self,
         id: Option<LocalForkId>,
         transaction: B256,
-        env: Env,
+        evm_env: EvmEnv,
+        tx_env: TxEnv,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<()>;
@@ -219,7 +231,8 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit + Debug 
     fn transact_from_tx(
         &mut self,
         transaction: &TransactionRequest,
-        env: Env,
+        evm_env: EvmEnv,
+        tx_env: TxEnv,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<()>;
@@ -947,12 +960,18 @@ impl Backend {
 }
 
 impl DatabaseExt for Backend {
-    fn snapshot_state(&mut self, journaled_state: &JournaledState, env: &mut Env) -> U256 {
+    fn snapshot_state(
+        &mut self,
+        journaled_state: &JournaledState,
+        evm_env: &EvmEnv,
+        tx_env: &TxEnv,
+    ) -> U256 {
         trace!("create snapshot");
         let id = self.inner.state_snapshots.insert(BackendStateSnapshot::new(
             self.create_db_snapshot(),
             journaled_state.clone(),
-            env.to_owned(),
+            evm_env.clone(),
+            tx_env.clone(),
         ));
         trace!(target: "backend", "Created new snapshot {}", id);
         id
@@ -962,7 +981,8 @@ impl DatabaseExt for Backend {
         &mut self,
         id: U256,
         current_state: &JournaledState,
-        current: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         action: RevertStateSnapshotAction,
     ) -> Option<JournaledState> {
         trace!(?id, "revert snapshot");
@@ -985,7 +1005,8 @@ impl DatabaseExt for Backend {
 
             // merge additional logs
             snapshot.merge(current_state);
-            let BackendStateSnapshot { db, mut journaled_state, env } = snapshot;
+            let BackendStateSnapshot { db, mut journaled_state, snap_evm_env, snap_tx_env } =
+                snapshot;
             match db {
                 BackendDatabaseSnapshot::InMemory(mem_db) => {
                     self.mem_db = mem_db;
@@ -994,7 +1015,7 @@ impl DatabaseExt for Backend {
                     // there might be the case where the snapshot was created during `setUp` with
                     // another caller, so we need to ensure the caller account is present in the
                     // journaled state and database
-                    let caller = current.tx.caller;
+                    let caller = tx_env.caller;
                     journaled_state.state.entry(caller).or_insert_with(|| {
                         let caller_account = current_state
                             .state
@@ -1013,7 +1034,7 @@ impl DatabaseExt for Backend {
                 }
             }
 
-            update_current_env_with_fork_env(current, env);
+            update_current_env_with_fork_env(evm_env, tx_env, snap_evm_env, snap_tx_env);
             trace!(target: "backend", "Reverted snapshot {}", id);
 
             Some(journaled_state)
@@ -1059,7 +1080,8 @@ impl DatabaseExt for Backend {
         self.roll_fork_to_transaction(
             Some(id),
             transaction,
-            &mut env,
+            &mut env.evm_env,
+            &mut env.tx,
             &mut self.inner.new_journaled_state(),
         )?;
 
@@ -1071,7 +1093,8 @@ impl DatabaseExt for Backend {
     fn select_fork(
         &mut self,
         id: LocalForkId,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         active_journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, "select fork");
@@ -1085,8 +1108,8 @@ impl DatabaseExt for Backend {
         if let Some(active_fork_id) = self.active_fork_id() {
             self.forks.update_block(
                 self.ensure_fork_id(active_fork_id).cloned()?,
-                env.evm_env.block_env.number,
-                env.evm_env.block_env.timestamp,
+                evm_env.block_env.number,
+                evm_env.block_env.timestamp,
             )?;
         }
 
@@ -1102,8 +1125,8 @@ impl DatabaseExt for Backend {
         if let Some(active) = self.active_fork_mut() {
             active.journaled_state = active_journaled_state.clone();
 
-            let caller = env.tx.caller;
-            let caller_account = active.journaled_state.state.get(&env.tx.caller).cloned();
+            let caller = tx_env.caller;
+            let caller_account = active.journaled_state.state.get(&tx_env.caller).cloned();
             let target_fork = self.inner.get_fork_mut(idx);
 
             // depth 0 will be the default value when the fork was created
@@ -1168,11 +1191,11 @@ impl DatabaseExt for Backend {
             // another edge case where a fork is created and selected during setup with not
             // necessarily the same caller as for the test, however we must always
             // ensure that fork's state contains the current sender
-            let caller = env.tx.caller;
+            let caller = tx_env.caller;
             fork.journaled_state.state.entry(caller).or_insert_with(|| {
                 let caller_account = active_journaled_state
                     .state
-                    .get(&env.tx.caller)
+                    .get(&tx_env.caller)
                     .map(|acc| acc.info.clone())
                     .unwrap_or_default();
 
@@ -1191,7 +1214,7 @@ impl DatabaseExt for Backend {
 
         self.active_fork_ids = Some((id, idx));
         // Update current environment with environment of newly selected fork.
-        update_current_env_with_fork_env(env, fork_env);
+        update_current_env_with_fork_env(evm_env, tx_env, fork_env.evm_env, fork_env.tx);
 
         Ok(())
     }
@@ -1202,7 +1225,8 @@ impl DatabaseExt for Backend {
         &mut self,
         id: Option<LocalForkId>,
         block_number: u64,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, ?block_number, "roll fork");
@@ -1217,7 +1241,7 @@ impl DatabaseExt for Backend {
             if active_id == id {
                 // need to update the block's env settings right away, which is otherwise set when
                 // forks are selected `select_fork`
-                update_current_env_with_fork_env(env, fork_env);
+                update_current_env_with_fork_env(evm_env, tx_env, fork_env.evm_env, fork_env.tx);
 
                 // we also need to update the journaled_state right away, this has essentially the
                 // same effect as selecting (`select_fork`) by discarding
@@ -1266,7 +1290,8 @@ impl DatabaseExt for Backend {
         &mut self,
         id: Option<LocalForkId>,
         transaction: B256,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, ?transaction, "roll fork to transaction");
@@ -1278,19 +1303,18 @@ impl DatabaseExt for Backend {
         // roll the fork to the transaction's parent block or latest if it's pending, because we
         // need to fork off the parent block's state for tx level forking and then replay the txs
         // before the tx in that block to get the state at the tx
-        self.roll_fork(Some(id), fork_block, env, journaled_state)?;
+        self.roll_fork(Some(id), fork_block, evm_env, tx_env, journaled_state)?;
 
         // we need to update the env to the block
-        update_env_block(env, &block);
+        update_env_block(evm_env, &block);
 
         // after we forked at the fork block we need to properly update the block env to the block
         // env of the tx's block
-        let _ = self.forks.update_block_env(
-            self.inner.ensure_fork_id(id).cloned()?,
-            env.evm_env.block_env.clone(),
-        );
+        let _ = self
+            .forks
+            .update_block_env(self.inner.ensure_fork_id(id).cloned()?, evm_env.block_env.clone());
 
-        let env = env.to_owned();
+        let env = Env { evm_env: evm_env.clone(), tx: tx_env.clone() };
 
         // replay all transactions that came before
         self.replay_until(id, env, transaction, journaled_state)?;
@@ -1302,7 +1326,8 @@ impl DatabaseExt for Backend {
         &mut self,
         maybe_id: Option<LocalForkId>,
         transaction: B256,
-        mut env: Env,
+        mut evm_env: EvmEnv,
+        tx_env: TxEnv,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<()> {
@@ -1324,8 +1349,9 @@ impl DatabaseExt for Backend {
         // So we modify the env to match the transaction's block.
         let (_fork_block, block) =
             self.get_block_number_and_block_for_transaction(id, transaction)?;
-        update_env_block(&mut env, &block);
+        update_env_block(&mut evm_env, &block);
 
+        let mut env = Env { evm_env, tx: tx_env };
         let fork = self.inner.get_fork_by_id_mut(id)?;
         commit_transaction(
             &tx,
@@ -1341,7 +1367,8 @@ impl DatabaseExt for Backend {
     fn transact_from_tx(
         &mut self,
         tx: &TransactionRequest,
-        mut env: Env,
+        evm_env: EvmEnv,
+        tx_env: TxEnv,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<()> {
@@ -1349,6 +1376,7 @@ impl DatabaseExt for Backend {
 
         self.commit(journaled_state.state.clone());
 
+        let mut env = Env { evm_env, tx: tx_env };
         let res = {
             configure_tx_req_env(&mut env, tx)?;
 
@@ -1888,10 +1916,14 @@ impl Default for BackendInner {
 }
 
 /// This updates the currently used env with the fork's environment
-pub(crate) fn update_current_env_with_fork_env(current: &mut Env, fork: Env) {
-    current.evm_env.block_env = fork.evm_env.block_env;
-    current.evm_env.cfg_env = fork.evm_env.cfg_env;
-    current.tx.chain_id = fork.tx.chain_id;
+pub(crate) fn update_current_env_with_fork_env(
+    evm_env: &mut EvmEnv,
+    tx_env: &mut TxEnv,
+    fork_evm_env: EvmEnv,
+    fork_tx_env: TxEnv,
+) {
+    *evm_env = fork_evm_env;
+    tx_env.chain_id = fork_tx_env.chain_id;
 }
 
 /// Clones the data of the given `accounts` from the `active` database into the `fork_db`
@@ -1968,9 +2000,9 @@ fn is_contract_in_state(evm_state: &EvmState, acc: Address) -> bool {
     evm_state.get(&acc).map(|acc| acc.info.code_hash != KECCAK_EMPTY).unwrap_or_default()
 }
 
-/// Updates the env's block with the block's data
-fn update_env_block(env: &mut Env, block: &AnyRpcBlock) {
-    let block_env = env.block_mut();
+/// Updates the evm env's block with the block's data
+fn update_env_block(evm_env: &mut EvmEnv, block: &AnyRpcBlock) {
+    let block_env = &mut evm_env.block_env;
     block_env.timestamp = U256::from(block.header.timestamp);
     block_env.beneficiary = block.header.beneficiary;
     block_env.difficulty = block.header.difficulty;
@@ -1980,9 +2012,9 @@ fn update_env_block(env: &mut Env, block: &AnyRpcBlock) {
     block_env.number = U256::from(block.header.number);
 
     if let Some(excess_blob_gas) = block.header.excess_blob_gas {
-        env.block_mut().blob_excess_gas_and_price = Some(BlobExcessGasAndPrice::new(
+        evm_env.block_env.blob_excess_gas_and_price = Some(BlobExcessGasAndPrice::new(
             excess_blob_gas,
-            get_blob_base_fee_update_fraction(env.evm_env.cfg_env.chain_id, block.header.timestamp),
+            get_blob_base_fee_update_fraction(evm_env.cfg_env.chain_id, block.header.timestamp),
         ));
     }
 }

--- a/crates/evm/core/src/backend/snapshot.rs
+++ b/crates/evm/core/src/backend/snapshot.rs
@@ -1,10 +1,10 @@
 use super::JournaledState;
-use crate::Env;
+use alloy_evm::EvmEnv;
 use alloy_primitives::{
     B256, U256,
     map::{AddressHashMap, HashMap},
 };
-use revm::state::AccountInfo;
+use revm::{context::TxEnv, state::AccountInfo};
 use serde::{Deserialize, Serialize};
 
 /// A minimal abstraction of a state at a certain point in time
@@ -21,14 +21,16 @@ pub struct BackendStateSnapshot<T> {
     pub db: T,
     /// The journaled_state state at a specific point
     pub journaled_state: JournaledState,
-    /// Contains the env at the time of the snapshot
-    pub env: Env,
+    /// Contains the evm env at the time of the snapshot
+    pub snap_evm_env: EvmEnv,
+    /// Contains the tx env at the time of the snapshot
+    pub snap_tx_env: TxEnv,
 }
 
 impl<T> BackendStateSnapshot<T> {
     /// Takes a new state snapshot.
-    pub fn new(db: T, journaled_state: JournaledState, env: Env) -> Self {
-        Self { db, journaled_state, env }
+    pub fn new(db: T, journaled_state: JournaledState, evm_env: EvmEnv, tx_env: TxEnv) -> Self {
+        Self { db, journaled_state, snap_evm_env: evm_env, snap_tx_env: tx_env }
     }
 
     /// Called when this state snapshot is reverted.

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -39,11 +39,24 @@ impl Env {
         Self::from(ecx.cfg_mut().clone(), ecx.block_mut().clone(), ecx.tx_mut().clone())
     }
 
+    /// Clones the evm env and tx env separately from a [`FoundryContextExt`] context.
+    pub fn clone_evm_and_tx(ecx: &mut impl FoundryContextExt) -> (EvmEnv, TxEnv) {
+        (
+            EvmEnv { cfg_env: ecx.cfg_mut().clone(), block_env: ecx.block_mut().clone() },
+            ecx.tx_mut().clone(),
+        )
+    }
+
+    /// Writes the split evm env and tx env back into a [`FoundryContextExt`] context.
+    pub fn apply_evm_and_tx(ecx: &mut impl FoundryContextExt, evm_env: EvmEnv, tx_env: TxEnv) {
+        *ecx.block_mut() = evm_env.block_env;
+        *ecx.cfg_mut() = evm_env.cfg_env;
+        *ecx.tx_mut() = tx_env;
+    }
+
     /// Writes this env back into a [`FoundryContextExt`] context.
     pub fn apply_to(self, ecx: &mut impl FoundryContextExt) {
-        *ecx.block_mut() = self.evm_env.block_env;
-        *ecx.cfg_mut() = self.evm_env.cfg_env;
-        *ecx.tx_mut() = self.tx;
+        Self::apply_evm_and_tx(ecx, self.evm_env, self.tx);
     }
 
     /// Mutable reference to the block environment.

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -252,8 +252,8 @@ pub trait NestedEvm {
         tx: TxEnv,
     ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>>;
 
-    /// Returns a snapshot of the current environment (cfg, block, tx).
-    fn to_env(&self) -> Env;
+    /// Returns a snapshot of the current environment (cfg + block, tx).
+    fn to_env(&self) -> (EvmEnv, TxEnv);
 }
 
 impl<I: InspectorExt> NestedEvm for FoundryEvm<'_, I> {
@@ -272,14 +272,11 @@ impl<I: InspectorExt> NestedEvm for FoundryEvm<'_, I> {
         Evm::transact_raw(self, tx)
     }
 
-    fn to_env(&self) -> Env {
-        Env {
-            evm_env: EvmEnv {
-                cfg_env: self.inner.ctx.cfg.clone(),
-                block_env: self.inner.ctx.block.clone(),
-            },
-            tx: self.inner.ctx.tx.clone(),
-        }
+    fn to_env(&self) -> (EvmEnv, TxEnv) {
+        (
+            EvmEnv { cfg_env: self.inner.ctx.cfg.clone(), block_env: self.inner.ctx.block.clone() },
+            self.inner.ctx.tx.clone(),
+        )
     }
 }
 
@@ -291,24 +288,25 @@ pub fn with_cloned_context<CTX: FoundryContextExt, R>(
     ecx: &mut CTX,
     f: impl FnOnce(
         &mut dyn DatabaseExt,
-        Env,
+        EvmEnv,
+        TxEnv,
         JournaledState,
-    ) -> Result<(R, Env, JournaledState), EVMError<DatabaseError>>,
+    ) -> Result<(R, EvmEnv, TxEnv, JournaledState), EVMError<DatabaseError>>,
 ) -> Result<R, EVMError<DatabaseError>>
 where
     CTX::Journal: FoundryJournalExt,
 {
-    let env = Env::clone_from_context(ecx);
+    let (evm_env, tx_env) = Env::clone_evm_and_tx(ecx);
 
     let journal = ecx.journal_mut();
     let (db, journal_inner) = journal.as_db_and_inner();
     let journal_inner_clone = journal_inner.clone();
 
-    let (result, sub_env, sub_inner) = f(db, env, journal_inner_clone)?;
+    let (result, sub_evm_env, sub_tx, sub_inner) = f(db, evm_env, tx_env, journal_inner_clone)?;
 
     // Write back modified state. The db borrow was released when f returned.
     ecx.journal_mut().set_inner(sub_inner);
-    sub_env.apply_to(ecx);
+    Env::apply_evm_and_tx(ecx, sub_evm_env, sub_tx);
 
     Ok(result)
 }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -371,13 +371,13 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for InspectorStackInner {
         f: NestedEvmClosure<'_>,
     ) -> Result<(), EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
-        with_cloned_context(ecx, |db, env, journal_inner| {
-            let mut evm = new_evm_with_inspector(db, env, &mut inspector);
+        with_cloned_context(ecx, |db, evm_env, tx_env, journal_inner| {
+            let mut evm = new_evm_with_inspector(db, Env { evm_env, tx: tx_env }, &mut inspector);
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
-            let sub_env = evm.to_env();
+            let (sub_evm_env, sub_tx) = evm.to_env();
             let sub_inner = evm.into_context().journaled_state.inner;
-            Ok(((), sub_env, sub_inner))
+            Ok(((), sub_evm_env, sub_tx, sub_inner))
         })
     }
 
@@ -385,11 +385,12 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for InspectorStackInner {
         &mut self,
         cheats: &mut Cheatcodes,
         db: &mut dyn foundry_evm_core::backend::DatabaseExt,
-        env: foundry_evm_core::Env,
+        evm_env: foundry_evm_core::EvmEnv,
+        tx_env: revm::context::TxEnv,
         f: NestedEvmClosure<'_>,
     ) -> Result<(), EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
-        let mut evm = new_evm_with_inspector(db, env, &mut inspector);
+        let mut evm = new_evm_with_inspector(db, Env { evm_env, tx: tx_env }, &mut inspector);
         f(&mut evm)
     }
 
@@ -400,10 +401,10 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for InspectorStackInner {
         fork_id: Option<U256>,
         transaction: B256,
     ) -> eyre::Result<()> {
-        let env = Env::clone_from_context(ecx);
+        let (evm_env, tx_env) = Env::clone_evm_and_tx(ecx);
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         let (db, inner) = ecx.journal_mut().as_db_and_inner();
-        db.transact(fork_id, transaction, env, inner, &mut inspector)
+        db.transact(fork_id, transaction, evm_env, tx_env, inner, &mut inspector)
     }
 
     fn transact_from_tx_on_db(
@@ -412,10 +413,10 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for InspectorStackInner {
         ecx: &mut CTX,
         tx: &TransactionRequest,
     ) -> eyre::Result<()> {
-        let env = Env::clone_from_context(ecx);
+        let (evm_env, tx_env) = Env::clone_evm_and_tx(ecx);
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         let (db, inner) = ecx.journal_mut().as_db_and_inner();
-        db.transact_from_tx(tx, env, inner, &mut inspector)
+        db.transact_from_tx(tx, evm_env, tx_env, inner, &mut inspector)
     }
 
     fn console_log(&mut self, _cheats: &mut Cheatcodes, msg: &str) {
@@ -738,7 +739,7 @@ impl InspectorStackRefMut<'_> {
     where
         CTX::Journal: FoundryJournalExt,
     {
-        let cached_env = Env::clone_from_context(ecx);
+        let (cached_evm_env, cached_tx_env) = Env::clone_evm_and_tx(ecx);
 
         ecx.block_mut().set_basefee(0);
 
@@ -759,7 +760,7 @@ impl InspectorStackRefMut<'_> {
         }
         ecx.tx_mut().set_gas_price(0);
 
-        self.inner_context_data = Some(InnerContextData { original_origin: cached_env.tx.caller });
+        self.inner_context_data = Some(InnerContextData { original_origin: cached_tx_env.caller });
         self.in_inner_context = true;
 
         let modified_env = Env::clone_from_context(ecx);
@@ -792,16 +793,15 @@ impl InspectorStackRefMut<'_> {
                 evm.journal_inner_mut().depth = 1;
 
                 let res = evm.transact(modified_env.tx);
-                let nested_env = evm.to_env();
-                (res, nested_env)
+                let (nested_evm_env, _) = evm.to_env();
+                (res, nested_evm_env)
             };
 
             // Restore env, preserving cheatcode cfg/block changes from the nested EVM
             // but restoring the original tx and basefee (which we zeroed for the nested call).
-            let mut restored_env = nested_env;
-            restored_env.tx = cached_env.tx;
-            restored_env.evm_env.block_env.basefee = cached_env.evm_env.block_env.basefee;
-            restored_env.apply_to(ecx);
+            let mut restored_evm_env = nested_env;
+            restored_evm_env.block_env.basefee = cached_evm_env.block_env.basefee;
+            Env::apply_evm_and_tx(ecx, restored_evm_env, cached_tx_env);
 
             res
         });


### PR DESCRIPTION
Splits concrete `Env` into separate `(EvmEnv, TxEnv)` at trait boundaries: `DatabaseExt`, `NestedEvm::to_env()`, `with_cloned_context`, and `CheatcodesExecutor::with_fresh_nested_evm`.

`EvmEnv` is already generic (`EvmEnv<Spec, BlockEnv>`) in alloy-evm, making these boundaries ready for generic BLOCK/SPEC types when `FoundryContextExt` returns associated types instead of concrete `BlockEnv`/`CfgEnv`. 

Concrete `Env` stays for Eth-specific internals (`commit_transaction`, `replay_until`, `new_evm_with_inspector`) until `Backend<N>`/ refact later.

Adds `Env::clone_evm_and_tx()` and `Env::apply_evm_and_tx()` as helpers.

Stacked on top of: https://github.com/foundry-rs/foundry/pull/13682