### PR TITLE
fix(script): add missing #[serde(default)] for backward compat in TransactionWithMetadata

### DIFF
--- a/crates/script-sequence/src/transaction.rs
+++ b/crates/script-sequence/src/transaction.rs
@@ -30,7 +30,9 @@ pub struct TransactionWithMetadata {
     #[serde(skip)]
     pub rpc: String,
     pub transaction: TransactionMaybeSigned,
+    #[serde(default)]
     pub additional_contracts: Vec<AdditionalContract>,
+    #[serde(default)]
     pub is_fixed_gas_limit: bool,
 }
 


### PR DESCRIPTION
## Summary

- Add `#[serde(default)]` to `additional_contracts` and `is_fixed_gas_limit` fields in `TransactionWithMetadata`
- These fields were missing backward compatibility handling, while other fields in the same struct (`contract_name`, `contract_address`, `function`, `arguments`) already had `#[serde(default = "...")]`
- Old broadcast JSON files created before these fields were introduced would fail to deserialize, breaking `forge script --resume`