### PR TITLE
fix(bind): add consistency check for single_file mode

### DIFF
--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -314,11 +314,20 @@ edition = "2021"
                 self.check_file_contents(&path, &tokens)?;
                 write_mod_name(&mut super_contents, &name)?;
             }
-
-            let super_path =
-                if is_mod { crate_path.join("mod.rs") } else { crate_path.join("src/lib.rs") };
-            self.check_file_contents(&super_path, &super_contents)?;
+        } else {
+            for instance in &self.instances {
+                let tokens = instance
+                    .expansion
+                    .as_ref()
+                    .ok_or_eyre("TokenStream for single file does not exist")?
+                    .to_string();
+                write!(&mut super_contents, "{tokens}")?;
+            }
         }
+
+        let super_path =
+            if is_mod { crate_path.join("mod.rs") } else { crate_path.join("src/lib.rs") };
+        self.check_file_contents(&super_path, &super_contents)?;
 
         Ok(())
     }


### PR DESCRIPTION
`check_consistency()` skipped all file content verification when `single_file` is true, so `forge bind --check --single-file` always reported "OK" even with stale bindings. This adds the missing check by reconstructing the expected single-file content and comparing it against the generated file.

Before: `if !single_file { check... }` — single_file mode silently skipped
After:  `if !single_file { check per-file... } else { check combined file... }` + shared lib.rs/mod.rs check