### PR TITLE
refactor(anvil): make storage types generic over Network

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -190,7 +190,7 @@ pub struct Backend {
     /// executed.
     db: Arc<AsyncRwLock<Box<dyn Db>>>,
     /// stores all block related data in memory.
-    blockchain: Blockchain,
+    blockchain: Blockchain<FoundryNetwork>,
     /// Historic states of previous blocks.
     states: Arc<RwLock<InMemoryBlockStates>>,
     /// Env data of the chain
@@ -3154,7 +3154,10 @@ impl Backend {
     }
 
     /// Returns the transaction receipt for the given hash
-    pub(crate) fn mined_transaction_receipt(&self, hash: B256) -> Option<MinedTransactionReceipt> {
+    pub(crate) fn mined_transaction_receipt(
+        &self,
+        hash: B256,
+    ) -> Option<MinedTransactionReceipt<FoundryNetwork>> {
         let MinedTransaction { info, receipt: tx_receipt, block_hash, .. } =
             self.blockchain.get_transaction_by_hash(&hash)?;
 

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -32,7 +32,7 @@ use foundry_evm::{
     backend::MemDb,
     traces::{CallKind, ParityTraceBuilder, TracingInspectorConfig},
 };
-use foundry_primitives::{FoundryNetwork, FoundryTxReceipt};
+use foundry_primitives::FoundryNetwork;
 use parking_lot::RwLock;
 use revm::{context::Block as RevmBlock, primitives::hardfork::SpecId};
 use std::{collections::VecDeque, fmt, path::PathBuf, sync::Arc, time::Duration};
@@ -259,7 +259,7 @@ impl Default for InMemoryBlockStates {
 
 /// Stores the blockchain data (blocks, transactions)
 #[derive(Clone, Debug)]
-pub struct BlockchainStorage {
+pub struct BlockchainStorage<N: Network> {
     /// all stored blocks (block hash -> block)
     pub blocks: B256HashMap<Block>,
     /// mapping from block number -> block hash
@@ -272,12 +272,12 @@ pub struct BlockchainStorage {
     pub genesis_hash: B256,
     /// Mapping from the transaction hash to a tuple containing the transaction as well as the
     /// transaction receipt
-    pub transactions: B256HashMap<MinedTransaction<FoundryNetwork>>,
+    pub transactions: B256HashMap<MinedTransaction<N>>,
     /// The total difficulty of the chain until this block
     pub total_difficulty: U256,
 }
 
-impl BlockchainStorage {
+impl BlockchainStorage<FoundryNetwork> {
     /// Creates a new storage with a genesis block
     pub fn new(
         env: &Env,
@@ -395,7 +395,7 @@ impl BlockchainStorage {
     }
 }
 
-impl BlockchainStorage {
+impl<N: Network> BlockchainStorage<N> {
     /// Returns the hash for [BlockNumberOrTag]
     pub fn hash(&self, number: BlockNumberOrTag) -> Option<B256> {
         let slots_in_an_epoch = 32;
@@ -420,7 +420,9 @@ impl BlockchainStorage {
             }
         }
     }
+}
 
+impl BlockchainStorage<FoundryNetwork> {
     pub fn serialized_blocks(&self) -> Vec<SerializableBlock> {
         self.blocks.values().map(|block| block.clone().into()).collect()
     }
@@ -462,12 +464,12 @@ impl BlockchainStorage {
 
 /// A simple in-memory blockchain
 #[derive(Clone, Debug)]
-pub struct Blockchain {
+pub struct Blockchain<N: Network> {
     /// underlying storage that supports concurrent reads
-    pub storage: Arc<RwLock<BlockchainStorage>>,
+    pub storage: Arc<RwLock<BlockchainStorage<N>>>,
 }
 
-impl Blockchain {
+impl Blockchain<FoundryNetwork> {
     /// Creates a new storage with a genesis block
     pub fn new(
         env: &Env,
@@ -496,7 +498,9 @@ impl Blockchain {
             ))),
         }
     }
+}
 
+impl<N: Network> Blockchain<N> {
     /// returns the header hash of given block
     pub fn hash(&self, id: BlockId) -> Option<B256> {
         match id {
@@ -509,7 +513,7 @@ impl Blockchain {
         self.storage.read().blocks.get(hash).cloned()
     }
 
-    pub fn get_transaction_by_hash(&self, hash: &B256) -> Option<MinedTransaction<FoundryNetwork>> {
+    pub fn get_transaction_by_hash(&self, hash: &B256) -> Option<MinedTransaction<N>> {
         self.storage.read().transactions.get(hash).cloned()
     }
 
@@ -585,9 +589,9 @@ impl<N: Network> MinedTransaction<N> {
 
 /// Intermediary Anvil representation of a receipt
 #[derive(Clone, Debug)]
-pub struct MinedTransactionReceipt {
+pub struct MinedTransactionReceipt<N: Network> {
     /// The actual json rpc receipt object
-    pub inner: FoundryTxReceipt,
+    pub inner: N::ReceiptResponse,
     /// Output data for the transaction
     pub out: Option<Bytes>,
 }
@@ -700,7 +704,7 @@ mod tests {
     // reloaded
     #[test]
     fn test_storage_dump_reload_cycle() {
-        let mut dump_storage = BlockchainStorage::empty();
+        let mut dump_storage = BlockchainStorage::<FoundryNetwork>::empty();
 
         let header = Header { gas_limit: 123456, ..Default::default() };
         let bytes_first = &mut &hex::decode("f86b02843b9aca00830186a094d3e8763675e4c425df46cc3b5c0f6cbdac39604687038d7ea4c68000802ba00eb96ca19e8a77102767a41fc85a36afd5c61ccb09911cec5d3e86e193d9c5aea03a456401896b1b6055311536bf00a718568c744d8c1f9df59879e8350220ca18").unwrap()[..];
@@ -713,7 +717,7 @@ mod tests {
         let serialized_blocks = dump_storage.serialized_blocks();
         let serialized_transactions = dump_storage.serialized_transactions();
 
-        let mut load_storage = BlockchainStorage::empty();
+        let mut load_storage = BlockchainStorage::<FoundryNetwork>::empty();
 
         load_storage.load_blocks(serialized_blocks);
         load_storage.load_transactions(serialized_transactions);


### PR DESCRIPTION
Propagates `N: Network` through the anvil storage layer — `BlockchainStorage`, `Blockchain`, and `MinedTransactionReceipt`. Impl blocks are split by minimum required bounds, following the same pattern as `MinedTransaction` and `ExecutedTransactions`.