### PR TITLE
fix(anvil-rpc): avoid panic in response success serialization

### DIFF
--- a/crates/anvil/rpc/src/response.rs
+++ b/crates/anvil/rpc/src/response.rs
@@ -46,7 +46,10 @@ impl ResponseResult {
     where
         S: Serialize + 'static,
     {
-        Self::Success(serde_json::to_value(&content).unwrap())
+        match serde_json::to_value(&content) {
+            Ok(value) => Self::Success(value),
+            Err(_) => Self::Error(RpcError::internal_error()),
+        }
     }
 
     pub fn error(error: RpcError) -> Self {


### PR DESCRIPTION
Handle `ResponseResult::success` serialization failure as an internal RPC error, avoiding panic paths while preserving normal success responses.