### PR TITLE
chore(script): use rpc trait methods instead of direct field accesses

### DIFF
--- a/crates/script-sequence/Cargo.toml
+++ b/crates/script-sequence/Cargo.toml
@@ -25,5 +25,6 @@ walkdir.workspace = true
 
 revm-inspectors.workspace = true
 
+alloy-network.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-eth.workspace = true

--- a/crates/script-sequence/src/reader.rs
+++ b/crates/script-sequence/src/reader.rs
@@ -1,4 +1,5 @@
 use crate::{ScriptSequence, TransactionWithMetadata};
+use alloy_network::ReceiptResponse;
 use alloy_rpc_types_eth::TransactionReceipt;
 use eyre::{Result, bail};
 use foundry_common::fs;
@@ -148,7 +149,7 @@ impl BroadcastReader {
         for tx in transactions.into_iter().filter(|tx| self.matches_filters(tx)) {
             let maybe_receipt = receipts
                 .iter()
-                .find(|receipt| tx.hash.is_some_and(|hash| hash == receipt.transaction_hash));
+                .find(|receipt| tx.hash.is_some_and(|hash| hash == receipt.transaction_hash()));
 
             if let Some(receipt) = maybe_receipt {
                 targets.push((tx, receipt.clone()));
@@ -156,7 +157,7 @@ impl BroadcastReader {
         }
 
         // Sort by descending block number
-        targets.sort_by_key(|t| std::cmp::Reverse(t.1.block_number));
+        targets.sort_by_key(|t| std::cmp::Reverse(t.1.block_number()));
 
         targets
     }

--- a/crates/script-sequence/src/sequence.rs
+++ b/crates/script-sequence/src/sequence.rs
@@ -1,4 +1,5 @@
 use crate::transaction::TransactionWithMetadata;
+use alloy_network::ReceiptResponse;
 use alloy_primitives::{TxHash, hex, map::HashMap};
 use alloy_rpc_types_eth::TransactionReceipt;
 use eyre::{ContextCompat, Result, WrapErr};
@@ -146,7 +147,7 @@ impl ScriptSequence {
 
     /// Sorts all receipts with ascending transaction index
     pub fn sort_receipts(&mut self) {
-        self.receipts.sort_by_key(|r| (r.block_number, r.transaction_index));
+        self.receipts.sort_by_key(|r| (r.block_number(), r.transaction_index()));
     }
 
     pub fn add_pending(&mut self, index: usize, tx_hash: TxHash) {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, sync::Arc, time::Duration};
 use alloy_chains::{Chain, NamedChain};
 use alloy_consensus::TxEnvelope;
 use alloy_eips::{BlockId, eip2718::Encodable2718};
-use alloy_network::{Ethereum, EthereumWallet, TransactionBuilder};
+use alloy_network::{Ethereum, EthereumWallet, ReceiptResponse, TransactionBuilder};
 use alloy_primitives::{
     Address, TxHash,
     map::{AddressHashMap, AddressHashSet},
@@ -381,7 +381,7 @@ impl BundledState {
 
                                 // Set TxKind::Create explicitly to satisfy `check_reqd_fields` in
                                 // alloy
-                                if tx.to.is_none() {
+                                if tx.kind().is_none() {
                                     tx.set_create();
                                 }
 
@@ -511,8 +511,8 @@ impl BundledState {
 
             let (total_gas, total_gas_price, total_paid) =
                 sequence.receipts.iter().fold((0, 0, 0), |acc, receipt| {
-                    let gas_used = receipt.gas_used;
-                    let gas_price = receipt.effective_gas_price as u64;
+                    let gas_used = receipt.gas_used();
+                    let gas_price = receipt.effective_gas_price() as u64;
                     (acc.0 + gas_used, acc.1 + gas_price, acc.2 + gas_used * gas_price)
                 });
             let paid = format_units(total_paid, 18).unwrap_or_else(|_| "N/A".to_string());

--- a/crates/script/src/progress.rs
+++ b/crates/script/src/progress.rs
@@ -1,6 +1,6 @@
 use crate::receipts::{PendingReceiptError, TxStatus, check_tx_status, format_receipt};
 use alloy_chains::Chain;
-use alloy_network::Ethereum;
+use alloy_network::{Ethereum, ReceiptResponse};
 use alloy_primitives::{
     B256,
     map::{B256HashMap, HashMap},
@@ -251,7 +251,7 @@ impl ScriptProgress {
                     );
                     seq_progress.inner.write().finish_tx_spinner_with_msg(tx_hash, &msg)?;
 
-                    deployment_sequence.remove_pending(receipt.transaction_hash);
+                    deployment_sequence.remove_pending(receipt.transaction_hash());
                     deployment_sequence.add_receipt(receipt);
                 }
                 Ok(TxStatus::Revert(receipt)) => {
@@ -259,7 +259,7 @@ impl ScriptProgress {
                     // if this is not removed from pending, then the script becomes
                     // un-resumable. Is this desirable on reverts?
                     warn!(tx_hash=?tx_hash, "Transaction Failure");
-                    deployment_sequence.remove_pending(receipt.transaction_hash);
+                    deployment_sequence.remove_pending(receipt.transaction_hash());
 
                     let msg = format_receipt(
                         deployment_sequence.chain.into(),
@@ -268,7 +268,7 @@ impl ScriptProgress {
                     );
                     seq_progress.inner.write().finish_tx_spinner_with_msg(tx_hash, &msg)?;
 
-                    errors.push(format!("Transaction Failure: {:?}", receipt.transaction_hash));
+                    errors.push(format!("Transaction Failure: {:?}", receipt.transaction_hash()));
                 }
             }
         }

--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -1,5 +1,5 @@
 use alloy_chains::{Chain, NamedChain};
-use alloy_network::Ethereum;
+use alloy_network::{Ethereum, ReceiptResponse};
 use alloy_primitives::{TxHash, U256, utils::format_units};
 use alloy_provider::{
     PendingTransactionBuilder, PendingTransactionError, Provider, RootProvider, WatchTxError,
@@ -48,9 +48,9 @@ pub async fn check_tx_status(
             {
                 Ok(receipt) => {
                     // Check if the receipt is pending (missing block information)
-                    let is_pending = receipt.block_number.is_none()
-                        || receipt.block_hash.is_none()
-                        || receipt.transaction_index.is_none();
+                    let is_pending = receipt.block_number().is_none()
+                        || receipt.block_hash().is_none()
+                        || receipt.transaction_index().is_none();
 
                     if !is_pending {
                         return Ok(receipt.into());
@@ -94,16 +94,16 @@ pub fn format_receipt(
     receipt: &TransactionReceipt,
     sequence: Option<&ScriptSequence>,
 ) -> String {
-    let gas_used = receipt.gas_used;
-    let gas_price = receipt.effective_gas_price;
-    let block_number = receipt.block_number.unwrap_or_default();
+    let gas_used = receipt.gas_used();
+    let gas_price = receipt.effective_gas_price();
+    let block_number = receipt.block_number().unwrap_or_default();
     let success = receipt.status();
 
     let (contract_name, function) = sequence
         .and_then(|seq| {
             seq.transactions
                 .iter()
-                .find(|tx| tx.hash == Some(receipt.transaction_hash))
+                .find(|tx| tx.hash == Some(receipt.transaction_hash()))
                 .map(|tx| (tx.contract_name.clone(), tx.function.clone()))
         })
         .unwrap_or((None, None));
@@ -116,8 +116,8 @@ pub fn format_receipt(
             } else {
                 "failed"
             },
-            "tx_hash": receipt.transaction_hash,
-            "contract_address": receipt.contract_address.map(|addr| addr.to_string()),
+            "tx_hash": receipt.transaction_hash(),
+            "contract_address": receipt.contract_address().map(|addr| addr.to_string()),
             "block_number": block_number,
             "gas_used": gas_used,
             "gas_price": gas_price,
@@ -151,8 +151,8 @@ pub fn format_receipt(
         format!(
             "\n##### {chain}\n{status} Hash: {tx_hash:?}{contract_info}{function_info}{contract_address}\nBlock: {block_number}\n{gas}\n\n",
             status = if success { "✅  [Success]" } else { "❌  [Failed]" },
-            tx_hash = receipt.transaction_hash,
-            contract_address = if let Some(addr) = &receipt.contract_address {
+            tx_hash = receipt.transaction_hash(),
+            contract_address = if let Some(addr) = receipt.contract_address() {
                 format!("\nContract Address: {}", addr.to_checksum(None))
             } else {
                 String::new()

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -1,6 +1,7 @@
 use super::ScriptResult;
 use crate::build::LinkedBuildData;
 use alloy_dyn_abi::JsonAbiExt;
+use alloy_network::TransactionBuilder;
 use alloy_primitives::{Address, B256, TxKind, hex};
 use eyre::Result;
 use forge_script_sequence::TransactionWithMetadata;
@@ -164,7 +165,7 @@ impl ScriptTransactionBuilder {
             && let Some(unsigned) = self.transaction.transaction.as_unsigned_mut()
         {
             // We inflate the gas used by the user specified percentage
-            unsigned.gas = Some(result.gas_used * gas_estimate_multiplier / 100);
+            unsigned.set_gas_limit(result.gas_used * gas_estimate_multiplier / 100);
         }
 
         self

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -3,6 +3,7 @@ use crate::{
     build::LinkedBuildData,
     sequence::{ScriptSequenceKind, get_commit_hash},
 };
+use alloy_network::ReceiptResponse;
 use alloy_primitives::{Address, hex};
 use eyre::{Result, eyre};
 use forge_script_sequence::{AdditionalContract, ScriptSequence};
@@ -207,7 +208,7 @@ async fn verify_contracts(
             }
 
             // Verify contract created directly from the transaction
-            if let (Some(address), Some(data)) = (receipt.contract_address, tx.tx().input()) {
+            if let (Some(address), Some(data)) = (receipt.contract_address(), tx.tx().input()) {
                 match verify.get_verify_args(
                     address,
                     offset,


### PR DESCRIPTION
## Motivation

Toward generic `Network` in `script` crate.

## Solution

These are all non-breaking direct field accesses replacements by RPC trait methods we can do far. Helping to shape the extension trait that will be necessary for receipts handling.

