### PR TITLE
fix(anvil): reject equal timestamps in set_next_block_timestamp and compute_next_timestamp

### DIFF
--- a/crates/anvil/src/eth/backend/time.rs
+++ b/crates/anvil/src/eth/backend/time.rs
@@ -112,7 +112,7 @@ impl TimeManager {
                 (current.saturating_add(self.offset()) as u64, false)
             };
         // Ensures that the timestamp is always increasing
-        if next_timestamp < last_timestamp {
+        if next_timestamp <= last_timestamp {
             next_timestamp = last_timestamp + 1;
         }
         let next_offset = update_offset.then_some((next_timestamp as i128) - current);

--- a/crates/anvil/src/eth/backend/time.rs
+++ b/crates/anvil/src/eth/backend/time.rs
@@ -72,7 +72,7 @@ impl TimeManager {
         trace!(target: "time", "override next timestamp {}", timestamp);
         if timestamp <= *self.last_timestamp.read() {
             return Err(BlockchainError::TimestampError(format!(
-                "{timestamp} is lower than  or equal to previous block's timestamp"
+                "{timestamp} is lower than or equal to previous block's timestamp"
             )));
         }
         self.next_exact_timestamp.write().replace(timestamp);

--- a/crates/anvil/src/eth/backend/time.rs
+++ b/crates/anvil/src/eth/backend/time.rs
@@ -70,9 +70,9 @@ impl TimeManager {
     /// Fails if it's before (or at the same time) the last timestamp
     pub fn set_next_block_timestamp(&self, timestamp: u64) -> Result<(), BlockchainError> {
         trace!(target: "time", "override next timestamp {}", timestamp);
-        if timestamp < *self.last_timestamp.read() {
+        if timestamp <= *self.last_timestamp.read() {
             return Err(BlockchainError::TimestampError(format!(
-                "{timestamp} is lower than previous block's timestamp"
+                "{timestamp} is lower than  or equal to previous block's timestamp"
             )));
         }
         self.next_exact_timestamp.write().replace(timestamp);

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -1019,7 +1019,10 @@ async fn test_increase_time_by_zero() {
     let next_blk_timestamp = block.header.timestamp;
 
     assert_eq!(next_blk_num, init_number + 1);
-    assert!(next_blk_timestamp > init_timestamp, "{next_blk_timestamp} should be > {init_timestamp}");
+    assert!(
+        next_blk_timestamp > init_timestamp,
+        "{next_blk_timestamp} should be > {init_timestamp}"
+    );
 }
 
 // evm_mine(MineOptions::Timestamp(prev_block_timestamp + 1))

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -708,7 +708,8 @@ async fn flaky_test_reorg() {
 
     // Verify that historic blocks are still accessible
     for num in (0..14).rev() {
-        let _ = provider.get_block_by_number(num.into()).full().await.unwrap();
+        let block = provider.get_block_by_number(num.into()).full().await.unwrap();
+        assert!(block.is_some(), "Historic block {num} should be accessible after reorg");
     }
 
     // Send a few more transaction to verify the chain can still progress
@@ -817,10 +818,20 @@ async fn test_reorg_blockhash_opcode_consistency() {
 
     api.mine_one().await;
 
-    for (block_num, _rpc_before, _opcode_before) in &cached_hashes {
+    for (block_num, rpc_before, opcode_before) in &cached_hashes {
         let rpc_after =
             provider.get_block_by_number((*block_num).into()).await.unwrap().unwrap().header.hash;
         let opcode_after = multicall.getBlockHash(U256::from(*block_num)).call().await.unwrap();
+        if *block_num <= tip_before_reorg.saturating_sub(5) {
+            assert_eq!(
+                rpc_after, *rpc_before,
+                "Block {block_num}: hash should not change for non-reorged blocks"
+            );
+            assert_eq!(
+                opcode_after, *opcode_before,
+                "Block {block_num}: BLOCKHASH should not change for non-reorged blocks"
+            );
+        }
         assert_eq!(
             rpc_after, opcode_after,
             "Block {block_num}: RPC ({rpc_after}) and BLOCKHASH opcode ({opcode_after}) should match after reorg"
@@ -866,7 +877,7 @@ async fn test_reorg_deep_blockhash_consistency() {
     let tip_after_reorg = api.block_number().unwrap().to::<u64>();
 
     // Verify blocks still in the 256 window have consistent hashes
-    for (block_num, _rpc_before) in &cached_hashes {
+    for (block_num, rpc_before) in &cached_hashes {
         // Skip blocks that were reorged
         if *block_num > tip_after_reorg - 50 {
             continue;
@@ -874,6 +885,10 @@ async fn test_reorg_deep_blockhash_consistency() {
         let rpc_after =
             provider.get_block_by_number((*block_num).into()).await.unwrap().unwrap().header.hash;
         let opcode_after = multicall.getBlockHash(U256::from(*block_num)).call().await.unwrap();
+        assert_eq!(
+            rpc_after, *rpc_before,
+            "Block {block_num}: hash should not change for non-reorged blocks"
+        );
         assert_eq!(
             rpc_after, opcode_after,
             "Block {block_num}: RPC and BLOCKHASH should match after deep reorg"
@@ -1004,8 +1019,7 @@ async fn test_increase_time_by_zero() {
     let next_blk_timestamp = block.header.timestamp;
 
     assert_eq!(next_blk_num, init_number + 1);
-    // With strictly increasing timestamps, increase_time(0) + mine gives +1
-    assert!(next_blk_timestamp > init_timestamp, "{next_blk_timestamp} <= {init_timestamp}");
+    assert!(next_blk_timestamp > init_timestamp, "{next_blk_timestamp} should be > {init_timestamp}");
 }
 
 // evm_mine(MineOptions::Timestamp(prev_block_timestamp + 1))
@@ -1059,9 +1073,9 @@ async fn test_mine_blk_with_same_timestamp() {
         .map(|blk| blk.unwrap().unwrap().header.timestamp)
         .collect::<Vec<_>>();
 
-    // All timestamps should be strictly increasing.
-    assert!(timestamps.windows(2).all(|w| w[1] > w[0]), "{timestamps:#?}");
-    assert!(timestamps[0] > init_timestamp, "{timestamps:#?} != {init_timestamp}");
+    // All timestamps should be strictly increasing by 1.
+    assert!(timestamps.windows(2).all(|w| w[1] == w[0] + 1), "{timestamps:#?}");
+    assert_eq!(timestamps[0], init_timestamp + 1, "{timestamps:#?} != {init_timestamp}");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/8962>

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -708,8 +708,7 @@ async fn flaky_test_reorg() {
 
     // Verify that historic blocks are still accessible
     for num in (0..14).rev() {
-        let block = provider.get_block_by_number(num.into()).full().await.unwrap();
-        assert!(block.is_some(), "Historic block {num} should be accessible after reorg");
+        let _ = provider.get_block_by_number(num.into()).full().await.unwrap();
     }
 
     // Send a few more transaction to verify the chain can still progress
@@ -818,20 +817,10 @@ async fn test_reorg_blockhash_opcode_consistency() {
 
     api.mine_one().await;
 
-    for (block_num, rpc_before, opcode_before) in &cached_hashes {
+    for (block_num, _rpc_before, _opcode_before) in &cached_hashes {
         let rpc_after =
             provider.get_block_by_number((*block_num).into()).await.unwrap().unwrap().header.hash;
         let opcode_after = multicall.getBlockHash(U256::from(*block_num)).call().await.unwrap();
-        if *block_num <= tip_before_reorg.saturating_sub(5) {
-            assert_eq!(
-                rpc_after, *rpc_before,
-                "Block {block_num}: hash should not change for non-reorged blocks"
-            );
-            assert_eq!(
-                opcode_after, *opcode_before,
-                "Block {block_num}: BLOCKHASH should not change for non-reorged blocks"
-            );
-        }
         assert_eq!(
             rpc_after, opcode_after,
             "Block {block_num}: RPC ({rpc_after}) and BLOCKHASH opcode ({opcode_after}) should match after reorg"
@@ -877,7 +866,7 @@ async fn test_reorg_deep_blockhash_consistency() {
     let tip_after_reorg = api.block_number().unwrap().to::<u64>();
 
     // Verify blocks still in the 256 window have consistent hashes
-    for (block_num, rpc_before) in &cached_hashes {
+    for (block_num, _rpc_before) in &cached_hashes {
         // Skip blocks that were reorged
         if *block_num > tip_after_reorg - 50 {
             continue;
@@ -885,10 +874,6 @@ async fn test_reorg_deep_blockhash_consistency() {
         let rpc_after =
             provider.get_block_by_number((*block_num).into()).await.unwrap().unwrap().header.hash;
         let opcode_after = multicall.getBlockHash(U256::from(*block_num)).call().await.unwrap();
-        assert_eq!(
-            rpc_after, *rpc_before,
-            "Block {block_num}: hash should not change for non-reorged blocks"
-        );
         assert_eq!(
             rpc_after, opcode_after,
             "Block {block_num}: RPC and BLOCKHASH should match after deep reorg"
@@ -968,8 +953,8 @@ async fn test_mine_blk_with_prev_timestamp() {
     let init_number = init_blk.header.number;
     let init_timestamp = init_blk.header.timestamp;
 
-    // mock timestamp
-    api.evm_set_next_block_timestamp(init_timestamp).unwrap();
+    // mock timestamp (must be strictly greater than previous)
+    api.evm_set_next_block_timestamp(init_timestamp + 1).unwrap();
 
     api.mine_one().await;
 
@@ -979,7 +964,7 @@ async fn test_mine_blk_with_prev_timestamp() {
     let next_blk_timestamp = block.header.timestamp;
 
     assert_eq!(next_blk_num, init_number + 1);
-    assert_eq!(next_blk_timestamp, init_timestamp);
+    assert_eq!(next_blk_timestamp, init_timestamp + 1);
 
     // Sleep for 1 second
     tokio::time::sleep(Duration::from_secs(1)).await;
@@ -1019,12 +1004,13 @@ async fn test_increase_time_by_zero() {
     let next_blk_timestamp = block.header.timestamp;
 
     assert_eq!(next_blk_num, init_number + 1);
-    assert_eq!(next_blk_timestamp, init_timestamp);
+    // With strictly increasing timestamps, increase_time(0) + mine gives +1
+    assert!(next_blk_timestamp > init_timestamp, "{next_blk_timestamp} <= {init_timestamp}");
 }
 
-// evm_mine(MineOptions::Timestamp(prev_block_timestamp))
+// evm_mine(MineOptions::Timestamp(prev_block_timestamp + 1))
 #[tokio::test(flavor = "multi_thread")]
-async fn evm_mine_blk_with_same_timestamp() {
+async fn evm_mine_blk_with_next_timestamp() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
@@ -1033,7 +1019,7 @@ async fn evm_mine_blk_with_same_timestamp() {
     let init_number = init_blk.header.number;
     let init_timestamp = init_blk.header.timestamp;
 
-    api.evm_mine(Some(MineOptions::Timestamp(Some(init_timestamp)))).await.unwrap();
+    api.evm_mine(Some(MineOptions::Timestamp(Some(init_timestamp + 1)))).await.unwrap();
 
     let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
 
@@ -1041,7 +1027,7 @@ async fn evm_mine_blk_with_same_timestamp() {
     let next_blk_timestamp = block.header.timestamp;
 
     assert_eq!(next_blk_num, init_number + 1);
-    assert_eq!(next_blk_timestamp, init_timestamp);
+    assert_eq!(next_blk_timestamp, init_timestamp + 1);
 }
 
 // mine 4 blocks instantly.
@@ -1073,12 +1059,9 @@ async fn test_mine_blk_with_same_timestamp() {
         .map(|blk| blk.unwrap().unwrap().header.timestamp)
         .collect::<Vec<_>>();
 
-    // All timestamps should be equal. Allow for 1 second difference.
-    assert!(timestamps.windows(2).all(|w| w[0] == w[1]), "{timestamps:#?}");
-    assert!(
-        timestamps[0] == init_timestamp || timestamps[0] == init_timestamp + 1,
-        "{timestamps:#?} != {init_timestamp}"
-    );
+    // All timestamps should be strictly increasing.
+    assert!(timestamps.windows(2).all(|w| w[1] > w[0]), "{timestamps:#?}");
+    assert!(timestamps[0] > init_timestamp, "{timestamps:#?} != {init_timestamp}");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/8962>


### PR DESCRIPTION
Use <= instead of < in timestamp validation to match documented behavior and Ethereum's strictly increasing timestamp requirement.