### PR TITLE
chore: use rpc trait methods instead of direct field accesses

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1467,7 +1467,7 @@ async fn derive_block_and_transactions(
                 .get_transaction_by_hash(transaction_hash.0.into())
                 .await?
                 .ok_or_else(|| eyre::eyre!("failed to get fork transaction by hash"))?;
-            let transaction_block_number = transaction.block_number.ok_or_else(|| {
+            let transaction_block_number = transaction.block_number().ok_or_else(|| {
                 eyre::eyre!("fork transaction is not mined yet (no block number)")
             })?;
 

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use alloy_dyn_abi::DynSolType;
 use alloy_json_abi::ContractObject;
+use alloy_network::ReceiptResponse;
 use alloy_primitives::{Bytes, U256, hex, map::Entry};
 use alloy_rpc_types::TransactionReceipt;
 use alloy_sol_types::SolValue;
@@ -889,8 +890,8 @@ fn parse_broadcast_results(
     results
         .into_iter()
         .map(|(tx, receipt)| BroadcastTxSummary {
-            txHash: receipt.transaction_hash,
-            blockNumber: receipt.block_number.unwrap_or_default(),
+            txHash: receipt.transaction_hash(),
+            blockNumber: receipt.block_number().unwrap_or_default(),
             txType: match tx.opcode {
                 CallKind::Call => BroadcastTxType::Call,
                 CallKind::Create => BroadcastTxType::Create,

--- a/crates/common/fmt/src/ui.rs
+++ b/crates/common/fmt/src/ui.rs
@@ -758,25 +758,25 @@ transactionIndex     {}
 type                 {}
 blobGasPrice         {}
 blobGasUsed          {}",
-            receipt.block_hash.pretty(),
-            receipt.block_number.pretty(),
-            receipt.contract_address.pretty(),
-            receipt.inner.cumulative_gas_used().pretty(),
-            receipt.effective_gas_price.pretty(),
-            receipt.from.pretty(),
-            receipt.gas_used.pretty(),
+            receipt.block_hash().pretty(),
+            receipt.block_number().pretty(),
+            receipt.contract_address().pretty(),
+            receipt.cumulative_gas_used().pretty(),
+            receipt.effective_gas_price().pretty(),
+            receipt.from().pretty(),
+            receipt.gas_used().pretty(),
             serde_json::to_string(receipt.inner.logs()).unwrap(),
             receipt.inner.logs_bloom().pretty(),
             self.state_root().pretty(),
-            receipt.inner.status().pretty(),
-            receipt.transaction_hash.pretty(),
-            receipt.transaction_index.pretty(),
+            receipt.status().pretty(),
+            receipt.transaction_hash().pretty(),
+            receipt.transaction_index().pretty(),
             receipt.inner.tx_type() as u8,
-            receipt.blob_gas_price.pretty(),
-            receipt.blob_gas_used.pretty()
+            receipt.blob_gas_price().pretty(),
+            receipt.blob_gas_used().pretty()
         );
 
-        if let Some(to) = receipt.to {
+        if let Some(to) = receipt.to() {
             pretty.push_str(&format!("\nto                   {}", to.pretty()));
         }
 
@@ -917,25 +917,25 @@ transactionIndex     {}
 type                 {}
 feePayer             {}
 feeToken             {}",
-            receipt.block_hash.pretty(),
-            receipt.block_number.pretty(),
-            receipt.contract_address.pretty(),
-            receipt.inner.cumulative_gas_used().pretty(),
-            receipt.effective_gas_price.pretty(),
-            receipt.from.pretty(),
-            receipt.gas_used.pretty(),
+            receipt.block_hash().pretty(),
+            receipt.block_number().pretty(),
+            receipt.contract_address().pretty(),
+            receipt.cumulative_gas_used().pretty(),
+            receipt.effective_gas_price().pretty(),
+            receipt.from().pretty(),
+            receipt.gas_used().pretty(),
             serde_json::to_string(receipt.inner.logs()).unwrap(),
             receipt.inner.logs_bloom.pretty(),
             self.state_root().pretty(),
-            receipt.inner.status().pretty(),
-            receipt.transaction_hash.pretty(),
-            receipt.transaction_index.pretty(),
+            receipt.status().pretty(),
+            receipt.transaction_hash().pretty(),
+            receipt.transaction_index().pretty(),
             receipt.inner.receipt.tx_type as u8,
             self.fee_payer.pretty(),
             self.fee_token.pretty(),
         );
 
-        if let Some(to) = receipt.to {
+        if let Some(to) = receipt.to() {
             pretty.push_str(&format!("\nto                   {}", to.pretty()));
         }
 


### PR DESCRIPTION
## Summary
- Replace direct field accesses on receipt/transaction RPC types with trait method calls (`ReceiptResponse`, `TransactionResponse`)
- Covers `fmt/ui.rs`, `cheatcodes/fs.rs`, `anvil/config.rs`
- Same pattern as #13693 but for files not covered there

## Test plan
- [x] `cargo check` passes for all affected crates
- No behavioral changes — trait methods return identical values to the fields they replace