### PR TITLE
refactor(anvil): make executor, miner, and service generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4406,6 +4406,7 @@ dependencies = [
 name = "forge-script-sequence"
 version = "1.6.0"
 dependencies = [
+ "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "eyre",

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -50,18 +50,27 @@ use revm::{
     interpreter::InstructionResult,
     primitives::hardfork::SpecId,
 };
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt, fmt::Debug, sync::Arc};
 
 /// Represents an executed transaction (transacted on the DB)
-#[derive(Debug)]
-pub struct ExecutedTransaction {
-    transaction: Arc<PoolTransaction>,
+pub struct ExecutedTransaction<T = FoundryTxEnvelope> {
+    transaction: Arc<PoolTransaction<T>>,
     exit_reason: InstructionResult,
     out: Option<Output>,
     gas_used: u64,
     logs: Vec<Log>,
     traces: Vec<CallTraceNode>,
     nonce: u64,
+}
+
+impl<T> fmt::Debug for ExecutedTransaction<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExecutedTransaction")
+            .field("exit_reason", &self.exit_reason)
+            .field("gas_used", &self.gas_used)
+            .field("nonce", &self.nonce)
+            .finish_non_exhaustive()
+    }
 }
 
 // == impl ExecutedTransaction ==
@@ -104,25 +113,33 @@ impl ExecutedTransaction {
 }
 
 /// Represents the outcome of mining a new block
-#[derive(Debug)]
-pub struct ExecutedTransactions<N: Network> {
+pub struct ExecutedTransactions<N: Network, T = FoundryTxEnvelope> {
     /// The block created after executing the `included` transactions
     pub block: TypedBlockInfo<N>,
     /// All transactions included in the block
-    pub included: Vec<Arc<PoolTransaction>>,
+    pub included: Vec<Arc<PoolTransaction<T>>>,
     /// All transactions that were invalid at the point of their execution and were not included in
     /// the block
-    pub invalid: Vec<Arc<PoolTransaction>>,
+    pub invalid: Vec<Arc<PoolTransaction<T>>>,
+}
+
+impl<N: Network, T> fmt::Debug for ExecutedTransactions<N, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExecutedTransactions")
+            .field("included", &self.included.len())
+            .field("invalid", &self.invalid.len())
+            .finish_non_exhaustive()
+    }
 }
 
 /// An executor for a series of transactions
-pub struct TransactionExecutor<'a, Db: ?Sized, V: TransactionValidator> {
+pub struct TransactionExecutor<'a, Db: ?Sized, V: TransactionValidator<T>, T = FoundryTxEnvelope> {
     /// where to insert the transactions
     pub db: &'a mut Db,
     /// type used to validate before inclusion
     pub validator: &'a V,
     /// all pending transactions
-    pub pending: std::vec::IntoIter<Arc<PoolTransaction>>,
+    pub pending: std::vec::IntoIter<Arc<PoolTransaction<T>>>,
     pub evm_env: EvmEnv,
     pub parent_hash: B256,
     /// Cumulative gas used by all executed transactions
@@ -335,20 +352,32 @@ impl<DB: Db + ?Sized, V: TransactionValidator> TransactionExecutor<'_, DB, V> {
 }
 
 /// Represents the result of a single transaction execution attempt
-#[derive(Debug)]
-pub enum TransactionExecutionOutcome {
+pub enum TransactionExecutionOutcome<T = FoundryTxEnvelope> {
     /// Transaction successfully executed
-    Executed(ExecutedTransaction),
+    Executed(ExecutedTransaction<T>),
     /// Invalid transaction not executed
-    Invalid(Arc<PoolTransaction>, InvalidTransactionError),
+    Invalid(Arc<PoolTransaction<T>>, InvalidTransactionError),
     /// Execution skipped because could exceed block gas limit
-    BlockGasExhausted(Arc<PoolTransaction>),
+    BlockGasExhausted(Arc<PoolTransaction<T>>),
     /// Execution skipped because it exceeded the blob gas limit
-    BlobGasExhausted(Arc<PoolTransaction>),
+    BlobGasExhausted(Arc<PoolTransaction<T>>),
     /// Execution skipped because it exceeded the transaction gas limit
-    TransactionGasExhausted(Arc<PoolTransaction>),
+    TransactionGasExhausted(Arc<PoolTransaction<T>>),
     /// When an error occurred during execution
-    DatabaseError(Arc<PoolTransaction>, DatabaseError),
+    DatabaseError(Arc<PoolTransaction<T>>, DatabaseError),
+}
+
+impl<T> fmt::Debug for TransactionExecutionOutcome<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Executed(_) => write!(f, "Executed(..)"),
+            Self::Invalid(_, err) => write!(f, "Invalid({err:?})"),
+            Self::BlockGasExhausted(_) => write!(f, "BlockGasExhausted(..)"),
+            Self::BlobGasExhausted(_) => write!(f, "BlobGasExhausted(..)"),
+            Self::TransactionGasExhausted(_) => write!(f, "TransactionGasExhausted(..)"),
+            Self::DatabaseError(_, err) => write!(f, "DatabaseError({err:?})"),
+        }
+    }
 }
 
 impl<DB: Db + ?Sized, V: TransactionValidator> Iterator for &mut TransactionExecutor<'_, DB, V> {

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -32,7 +32,7 @@ use foundry_evm::{
     backend::MemDb,
     traces::{CallKind, ParityTraceBuilder, TracingInspectorConfig},
 };
-use foundry_primitives::FoundryNetwork;
+use foundry_primitives::{FoundryNetwork, FoundryTxEnvelope};
 use parking_lot::RwLock;
 use revm::{context::Block as RevmBlock, primitives::hardfork::SpecId};
 use std::{collections::VecDeque, fmt, path::PathBuf, sync::Arc, time::Duration};
@@ -524,15 +524,34 @@ impl<N: Network> Blockchain<N> {
 }
 
 /// Represents the outcome of mining a new block
-#[derive(Clone, Debug)]
-pub struct MinedBlockOutcome {
+pub struct MinedBlockOutcome<T = FoundryTxEnvelope> {
     /// The block that was mined
     pub block_number: u64,
     /// All transactions included in the block
-    pub included: Vec<Arc<PoolTransaction>>,
+    pub included: Vec<Arc<PoolTransaction<T>>>,
     /// All transactions that were attempted to be included but were invalid at the time of
     /// execution
-    pub invalid: Vec<Arc<PoolTransaction>>,
+    pub invalid: Vec<Arc<PoolTransaction<T>>>,
+}
+
+impl<T> Clone for MinedBlockOutcome<T> {
+    fn clone(&self) -> Self {
+        Self {
+            block_number: self.block_number,
+            included: self.included.clone(),
+            invalid: self.invalid.clone(),
+        }
+    }
+}
+
+impl<T> fmt::Debug for MinedBlockOutcome<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MinedBlockOutcome")
+            .field("block_number", &self.block_number)
+            .field("included", &self.included.len())
+            .field("invalid", &self.invalid.len())
+            .finish()
+    }
 }
 
 /// Container type for a mined transaction
@@ -602,7 +621,6 @@ mod tests {
     use crate::eth::backend::db::Db;
     use alloy_primitives::{Address, hex};
     use alloy_rlp::Decodable;
-    use foundry_primitives::FoundryTxEnvelope;
     use revm::{database::DatabaseRef, state::AccountInfo};
 
     #[test]

--- a/crates/anvil/src/eth/backend/validate.rs
+++ b/crates/anvil/src/eth/backend/validate.rs
@@ -5,24 +5,25 @@ use crate::eth::{
     error::{BlockchainError, InvalidTransactionError},
 };
 use anvil_core::eth::transaction::PendingTransaction;
+use foundry_primitives::FoundryTxEnvelope;
 use revm::state::AccountInfo;
 
 /// A trait for validating transactions
 #[async_trait::async_trait]
-pub trait TransactionValidator {
+pub trait TransactionValidator<T = FoundryTxEnvelope> {
     /// Validates the transaction's validity when it comes to nonce, payment
     ///
     /// This is intended to be checked before the transaction makes it into the pool and whether it
     /// should rather be outright rejected if the sender has insufficient funds.
     async fn validate_pool_transaction(
         &self,
-        tx: &PendingTransaction,
+        tx: &PendingTransaction<T>,
     ) -> Result<(), BlockchainError>;
 
     /// Validates the transaction against a specific account before entering the pool
     fn validate_pool_transaction_for(
         &self,
-        tx: &PendingTransaction,
+        tx: &PendingTransaction<T>,
         account: &AccountInfo,
         env: &Env,
     ) -> Result<(), InvalidTransactionError>;
@@ -32,7 +33,7 @@ pub trait TransactionValidator {
     /// This should succeed if the transaction is ready to be executed
     fn validate_for(
         &self,
-        tx: &PendingTransaction,
+        tx: &PendingTransaction<T>,
         account: &AccountInfo,
         env: &Env,
     ) -> Result<(), InvalidTransactionError>;

--- a/crates/anvil/src/eth/miner.rs
+++ b/crates/anvil/src/eth/miner.rs
@@ -2,6 +2,7 @@
 
 use crate::eth::pool::{Pool, transactions::PoolTransaction};
 use alloy_primitives::TxHash;
+use foundry_primitives::FoundryTxEnvelope;
 use futures::{
     channel::mpsc::Receiver,
     stream::{Fuse, StreamExt},
@@ -16,8 +17,7 @@ use std::{
 };
 use tokio::time::{Interval, MissedTickBehavior};
 
-#[derive(Clone, Debug)]
-pub struct Miner {
+pub struct Miner<T = FoundryTxEnvelope> {
     /// The mode this miner currently operates in
     mode: Arc<RwLock<MiningMode>>,
     /// used for task wake up when the mining mode was forcefully changed
@@ -26,10 +26,29 @@ pub struct Miner {
     inner: Arc<MinerInner>,
     /// Transactions included into the pool before any others are.
     /// Done once on startup.
-    force_transactions: Option<Vec<Arc<PoolTransaction>>>,
+    force_transactions: Option<Vec<Arc<PoolTransaction<T>>>>,
 }
 
-impl Miner {
+impl<T> Clone for Miner<T> {
+    fn clone(&self) -> Self {
+        Self {
+            mode: self.mode.clone(),
+            inner: self.inner.clone(),
+            force_transactions: self.force_transactions.clone(),
+        }
+    }
+}
+
+impl<T> fmt::Debug for Miner<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Miner")
+            .field("mode", &self.mode)
+            .field("force_transactions", &self.force_transactions.as_ref().map(|txs| txs.len()))
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> Miner<T> {
     /// Returns a new miner with that operates in the given `mode`.
     pub fn new(mode: MiningMode) -> Self {
         Self {
@@ -45,7 +64,7 @@ impl Miner {
     /// there are not other transactions in the pool.
     pub fn with_forced_transactions(
         mut self,
-        force_transactions: Option<Vec<PoolTransaction>>,
+        force_transactions: Option<Vec<PoolTransaction<T>>>,
     ) -> Self {
         self.force_transactions =
             force_transactions.map(|tx| tx.into_iter().map(Arc::new).collect());
@@ -85,9 +104,9 @@ impl Miner {
     /// May return an empty list, if no transactions are ready.
     pub fn poll(
         &mut self,
-        pool: &Arc<Pool>,
+        pool: &Arc<Pool<T>>,
         cx: &mut Context<'_>,
-    ) -> Poll<Vec<Arc<PoolTransaction>>> {
+    ) -> Poll<Vec<Arc<PoolTransaction<T>>>> {
         self.inner.register(cx);
         let next = ready!(self.mode.write().poll(pool, cx));
         if let Some(mut transactions) = self.force_transactions.take() {
@@ -160,11 +179,11 @@ impl MiningMode {
     }
 
     /// polls the [Pool] and returns those transactions that should be put in a block, if any.
-    pub fn poll(
+    pub fn poll<T>(
         &mut self,
-        pool: &Arc<Pool>,
+        pool: &Arc<Pool<T>>,
         cx: &mut Context<'_>,
-    ) -> Poll<Vec<Arc<PoolTransaction>>> {
+    ) -> Poll<Vec<Arc<PoolTransaction<T>>>> {
         match self {
             Self::None => Poll::Pending,
             Self::Auto(miner) => miner.poll(pool, cx),
@@ -217,7 +236,11 @@ impl FixedBlockTimeMiner {
         Self { interval }
     }
 
-    fn poll(&mut self, pool: &Arc<Pool>, cx: &mut Context<'_>) -> Poll<Vec<Arc<PoolTransaction>>> {
+    fn poll<T>(
+        &mut self,
+        pool: &Arc<Pool<T>>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Vec<Arc<PoolTransaction<T>>>> {
         if self.interval.poll_tick(cx).is_ready() {
             // drain the pool
             return Poll::Ready(pool.ready_transactions().collect());
@@ -243,7 +266,11 @@ pub struct ReadyTransactionMiner {
 }
 
 impl ReadyTransactionMiner {
-    fn poll(&mut self, pool: &Arc<Pool>, cx: &mut Context<'_>) -> Poll<Vec<Arc<PoolTransaction>>> {
+    fn poll<T>(
+        &mut self,
+        pool: &Arc<Pool<T>>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Vec<Arc<PoolTransaction<T>>>> {
         // always drain the notification stream so that we're woken up as soon as there's a new tx
         while let Poll::Ready(Some(_hash)) = self.rx.poll_next_unpin(cx) {
             self.has_pending_txs = Some(true);

--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -181,7 +181,7 @@ impl<T: Transaction> Pool<T> {
     /// Invoked when a set of transactions ([Self::ready_transactions()]) was executed.
     ///
     /// This will remove the transactions from the pool.
-    pub fn on_mined_block(&self, outcome: MinedBlockOutcome) -> PruneResult<T> {
+    pub fn on_mined_block(&self, outcome: MinedBlockOutcome<T>) -> PruneResult<T> {
         let MinedBlockOutcome { block_number, included, invalid } = outcome;
 
         // remove invalid transactions from the pool

--- a/crates/anvil/src/service.rs
+++ b/crates/anvil/src/service.rs
@@ -10,6 +10,7 @@ use crate::{
     filter::Filters,
     mem::{Backend, storage::MinedBlockOutcome},
 };
+use foundry_primitives::FoundryTxEnvelope;
 use futures::{FutureExt, Stream, StreamExt};
 use std::{
     collections::VecDeque,
@@ -25,13 +26,13 @@ use tokio::{task::JoinHandle, time::Interval};
 /// transactions for the next block, then those transactions are handed off to the backend to
 /// construct a new block, if all transactions were successfully included in a new block they get
 /// purged from the `Pool`.
-pub struct NodeService {
+pub struct NodeService<T = FoundryTxEnvelope> {
     /// The pool that holds all transactions.
-    pool: Arc<Pool>,
+    pool: Arc<Pool<T>>,
     /// Creates new blocks.
-    block_producer: BlockProducer,
+    block_producer: BlockProducer<T>,
     /// The miner responsible to select transactions from the `pool`.
-    miner: Miner,
+    miner: Miner<T>,
     /// Maintenance task for fee history related tasks.
     fee_history: FeeHistoryService,
     /// Tracks all active filters
@@ -102,13 +103,13 @@ impl Future for NodeService {
 
 /// A type that exclusively mines one block at a time
 #[must_use = "streams do nothing unless polled"]
-struct BlockProducer {
+struct BlockProducer<T = FoundryTxEnvelope> {
     /// Holds the backend if no block is being mined
     idle_backend: Option<Arc<Backend>>,
     /// Single active future that mines a new block
-    block_mining: Option<JoinHandle<(MinedBlockOutcome, Arc<Backend>)>>,
+    block_mining: Option<JoinHandle<(MinedBlockOutcome<T>, Arc<Backend>)>>,
     /// backlog of sets of transactions ready to be mined
-    queued: VecDeque<Vec<Arc<PoolTransaction>>>,
+    queued: VecDeque<Vec<Arc<PoolTransaction<T>>>>,
 }
 
 impl BlockProducer {


### PR DESCRIPTION
Makes `TransactionValidator`, `ExecutedTransaction`, `ExecutedTransactions`, `TransactionExecutor`, `TransactionExecutionOutcome`, `Miner`, `MinedBlockOutcome`, `NodeService`, and `BlockProducer` generic over `T = FoundryTxEnvelope`.