### PR TITLE
chore(script): eliminate remaining `get_http_provider` / `try_get_http_provider` usage

### DIFF
--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -2,13 +2,14 @@ use crate::{
     ScriptArgs, ScriptConfig, broadcast::BundledState, execute::LinkedState,
     multi_sequence::MultiChainSequence, sequence::ScriptSequenceKind,
 };
+use alloy_network::AnyNetwork;
 use alloy_primitives::{B256, Bytes};
 use alloy_provider::Provider;
 use eyre::{OptionExt, Result};
 use forge_script_sequence::ScriptSequence;
 use foundry_cheatcodes::Wallets;
 use foundry_common::{
-    ContractData, ContractsByArtifact, compile::ProjectCompiler, provider::try_get_http_provider,
+    ContractData, ContractsByArtifact, compile::ProjectCompiler, provider::ProviderBuilder,
 };
 use foundry_compilers::{
     ArtifactId, ProjectCompileOutput,
@@ -42,7 +43,7 @@ impl BuildData {
     pub async fn link(self, script_config: &ScriptConfig) -> Result<LinkedBuildData> {
         let create2_deployer = script_config.evm_opts.create2_deployer;
         let can_use_create2 = if let Some(fork_url) = &script_config.evm_opts.fork_url {
-            let provider = try_get_http_provider(fork_url)?;
+            let provider = ProviderBuilder::<AnyNetwork>::new(fork_url).build()?;
             let deployer_code = provider.get_code_at(create2_deployer).await?;
 
             !deployer_code.is_empty()
@@ -260,7 +261,7 @@ impl CompiledState {
             None
         } else {
             let fork_url = self.script_config.evm_opts.fork_url.clone().ok_or_eyre("Missing --fork-url field, if you were trying to broadcast a multi-chain sequence, please use --multi flag")?;
-            let provider = Arc::new(try_get_http_provider(fork_url)?);
+            let provider = Arc::new(ProviderBuilder::<AnyNetwork>::new(&fork_url).build()?);
             Some(provider.get_chain_id().await?)
         };
 

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use alloy_dyn_abi::FunctionExt;
 use alloy_json_abi::{Function, InternalType, JsonAbi};
+use alloy_network::AnyNetwork;
 use alloy_primitives::{
     Address, Bytes,
     map::{HashMap, HashSet},
@@ -18,7 +19,7 @@ use foundry_cli::utils::{ensure_clean_constructor, needs_setup};
 use foundry_common::{
     ContractsByArtifact,
     fmt::{format_token, format_token_raw},
-    provider::get_http_provider,
+    provider::ProviderBuilder,
 };
 use foundry_config::NamedChain;
 use foundry_debugger::Debugger;
@@ -236,7 +237,7 @@ impl RpcData {
     /// Checks if all RPCs support EIP-3855. Prints a warning if not.
     async fn check_shanghai_support(&self) -> Result<()> {
         let chain_ids = self.total_rpcs.iter().map(|rpc| async move {
-            let provider = get_http_provider(rpc);
+            let provider = ProviderBuilder::<AnyNetwork>::new(rpc).build().ok()?;
             let id = provider.get_chain_id().await.ok()?;
             NamedChain::try_from(id).ok()
         });


### PR DESCRIPTION
## Motivation

Follow-up to #13686. Replaces the remaining `get_http_provider` and `try_get_http_provider` calls in the script crate with `ProviderBuilder::new().build()`, consistent with the rest of the crate after #13686.

## Changes

- `script/src/execute.rs`: `get_http_provider(rpc)` → `ProviderBuilder::new(rpc).build().ok()?` (gracefully handles build failure instead of panicking)
- `script/src/build.rs` (2 sites): `try_get_http_provider(fork_url)?` → `ProviderBuilder::new(fork_url).build()?`