### PR TITLE
chore: eliminate `RetryProvider` type alias

### DIFF
--- a/crates/cast/src/cmd/creation_code.rs
+++ b/crates/cast/src/cmd/creation_code.rs
@@ -1,8 +1,9 @@
 use super::interface::load_abi_from_file;
 use crate::SimpleCast;
 use alloy_consensus::Transaction;
+use alloy_network::AnyNetwork;
 use alloy_primitives::{Address, Bytes};
-use alloy_provider::{Provider, ext::TraceApi};
+use alloy_provider::{Provider, RootProvider, ext::TraceApi};
 use alloy_rpc_types::trace::parity::{Action, CreateAction, CreateOutput, TraceOutput};
 use clap::Parser;
 use eyre::{OptionExt, Result, eyre};
@@ -11,7 +12,6 @@ use foundry_cli::{
     opts::{EtherscanOpts, RpcOpts},
     utils::{self, LoadConfig, fetch_abi_from_etherscan},
 };
-use foundry_common::provider::RetryProvider;
 use foundry_config::Config;
 
 foundry_config::impl_figment_convert!(CreationCodeArgs, etherscan, rpc);
@@ -136,7 +136,7 @@ pub async fn parse_code_output(
 pub async fn fetch_creation_code_from_etherscan(
     contract: Address,
     config: &Config,
-    provider: RetryProvider,
+    provider: RootProvider<AnyNetwork>,
 ) -> Result<Bytes> {
     let chain = config.chain.unwrap_or_default();
     let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -1,11 +1,8 @@
 use alloy_json_abi::JsonAbi;
 use alloy_primitives::{Address, U256, map::HashMap};
-use alloy_provider::{Provider, network::AnyNetwork};
+use alloy_provider::{Provider, RootProvider, network::AnyNetwork};
 use eyre::{ContextCompat, Result};
-use foundry_common::{
-    provider::{ProviderBuilder, RetryProvider},
-    shell,
-};
+use foundry_common::{provider::ProviderBuilder, shell};
 use foundry_config::{Chain, Config};
 use itertools::Itertools;
 use path_slash::PathExt;
@@ -99,8 +96,8 @@ fn env_filter() -> tracing_subscriber::EnvFilter {
     filter
 }
 
-/// Returns a [RetryProvider] instantiated using [Config]'s RPC settings.
-pub fn get_provider(config: &Config) -> Result<RetryProvider> {
+/// Returns a [`RootProvider`] instantiated using [Config]'s RPC settings.
+pub fn get_provider(config: &Config) -> Result<RootProvider<AnyNetwork>> {
     get_provider_builder(config)?.build()
 }
 

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -13,10 +13,7 @@ use foundry_block_explorers::{
     errors::EtherscanError,
     utils::lookup_compiler_version,
 };
-use foundry_common::{
-    abi::encode_args, compile::ProjectCompiler, ignore_metadata_hash, provider::RetryProvider,
-    shell,
-};
+use foundry_common::{abi::encode_args, compile::ProjectCompiler, ignore_metadata_hash, shell};
 use foundry_compilers::artifacts::{BytecodeHash, CompactContractBytecode, EvmVersion};
 use foundry_config::Config;
 use foundry_evm::{
@@ -356,7 +353,7 @@ pub fn deploy_contract(
 
 pub async fn get_runtime_codes(
     executor: &mut TracingExecutor,
-    provider: &RetryProvider,
+    provider: &impl Provider<AnyNetwork>,
     address: Address,
     fork_address: Address,
     block: Option<u64>,


### PR DESCRIPTION
## Motivation

Follow-up to #13686. Replaces usage of the `RetryProvider` type alias with the concrete `RootProvider<AnyNetwork>` type it aliases, removing an unnecessary layer of indirection.

## Changes

- `cli/src/utils/mod.rs`: `get_provider` return type → `RootProvider<AnyNetwork>`
- `verify/src/utils.rs`: `get_runtime_codes` param → `&impl Provider<AnyNetwork>`
- `cast/src/cmd/creation_code.rs`: `fetch_creation_code_from_etherscan` param → `RootProvider<AnyNetwork>`