### PR TITLE
chore(evm):  separate `EvmEnv`/`TxEnv`  in  `new_evm_with_inspector`

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -205,7 +205,7 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for TransparentCheatcodesExecuto
         f: NestedEvmClosure<'_>,
     ) -> Result<(), EVMError<DatabaseError>> {
         with_cloned_context(ecx, |db, evm_env, tx_env, journal_inner| {
-            let mut evm = new_evm_with_inspector(db, Env { evm_env, tx: tx_env }, cheats);
+            let mut evm = new_evm_with_inspector(db, evm_env, tx_env, cheats);
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
             let (sub_evm_env, sub_tx) = evm.to_env();
@@ -222,7 +222,7 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for TransparentCheatcodesExecuto
         tx_env: TxEnv,
         f: NestedEvmClosure<'_>,
     ) -> Result<(), EVMError<DatabaseError>> {
-        let mut evm = new_evm_with_inspector(db, Env { evm_env, tx: tx_env }, cheats);
+        let mut evm = new_evm_with_inspector(db, evm_env, tx_env, cheats);
         f(&mut evm)
     }
 

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -73,7 +73,12 @@ impl<'a> CowBackend<'a> {
         // already, we reset the initialized state
         self.spec_id = Some(env.evm_env.cfg_env.spec);
 
-        let mut evm = crate::evm::new_evm_with_inspector(self, env.to_owned(), inspector);
+        let mut evm = crate::evm::new_evm_with_inspector(
+            self,
+            env.evm_env.clone(),
+            env.tx.clone(),
+            inspector,
+        );
 
         let res = evm.transact(env.tx.clone()).wrap_err("EVM error")?;
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -817,7 +817,12 @@ impl Backend {
         inspector: I,
     ) -> eyre::Result<ResultAndState> {
         self.initialize(env);
-        let mut evm = crate::evm::new_evm_with_inspector(self, env.to_owned(), inspector);
+        let mut evm = crate::evm::new_evm_with_inspector(
+            self,
+            env.evm_env.to_owned(),
+            env.tx.to_owned(),
+            inspector,
+        );
 
         let res = evm.transact(env.tx.clone()).wrap_err("EVM error")?;
 
@@ -1381,7 +1386,12 @@ impl DatabaseExt for Backend {
             configure_tx_req_env(&mut env, tx)?;
 
             let mut db = self.clone();
-            let mut evm = new_evm_with_inspector(&mut db, env.to_owned(), inspector);
+            let mut evm = new_evm_with_inspector(
+                &mut db,
+                env.evm_env.to_owned(),
+                env.tx.to_owned(),
+                inspector,
+            );
             evm.journaled_state.depth = journaled_state.depth + 1;
             evm.transact(env.tx)?
         };
@@ -2039,7 +2049,12 @@ fn commit_transaction(
         let depth = journaled_state.depth;
         let mut db = Backend::new_with_fork(fork_id, fork, journaled_state)?;
 
-        let mut evm = crate::evm::new_evm_with_inspector(&mut db as _, env.to_owned(), inspector);
+        let mut evm = crate::evm::new_evm_with_inspector(
+            &mut db as _,
+            env.evm_env.to_owned(),
+            env.tx.to_owned(),
+            inspector,
+        );
         // Adjust inner EVM depth to ensure that inspectors receive accurate data.
         evm.journaled_state.depth = depth + 1;
         evm.transact(env.tx.clone()).wrap_err("backend: failed committing transaction")?

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -27,11 +27,6 @@ impl Env {
         Self::from(cfg, block, tx)
     }
 
-    /// Creates a clone of the env from a [`FoundryContextExt`] context.
-    pub fn clone_from_context(ecx: &mut impl FoundryContextExt) -> Self {
-        Self::from(ecx.cfg_mut().clone(), ecx.block_mut().clone(), ecx.tx_mut().clone())
-    }
-
     /// Clones the evm env and tx env separately from a [`FoundryContextExt`] context.
     pub fn clone_evm_and_tx(ecx: &mut impl FoundryContextExt) -> (EvmEnv, TxEnv) {
         (
@@ -281,7 +276,7 @@ impl FoundryCfg for CfgEnv {
 /// [`ContextTr`] only exposes immutable references for block, tx, and cfg.
 /// Cheatcodes like `vm.warp()`, `vm.roll()`, `vm.chainId()` need to mutate these fields.
 pub trait FoundryContextExt:
-    ContextTr<Block: FoundryBlock, Tx: FoundryTransaction, Cfg: FoundryCfg>
+    ContextTr<Block: FoundryBlock + Clone, Tx: FoundryTransaction + Clone, Cfg: FoundryCfg + Clone>
 {
     /// Mutable reference to the block environment.
     fn block_mut(&mut self) -> &mut BlockEnv;

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -35,18 +35,19 @@ use revm::{
 
 pub fn new_evm_with_inspector<'db, I: InspectorExt>(
     db: &'db mut dyn DatabaseExt,
-    env: Env,
+    evm_env: EvmEnv,
+    tx_env: TxEnv,
     inspector: I,
 ) -> FoundryEvm<'db, I> {
     let mut ctx = EthEvmContext {
         journaled_state: {
             let mut journal = Journal::new(db);
-            journal.set_spec_id(env.evm_env.cfg_env.spec);
+            journal.set_spec_id(evm_env.cfg_env.spec);
             journal
         },
-        block: env.evm_env.block_env,
-        cfg: env.evm_env.cfg_env,
-        tx: env.tx,
+        block: evm_env.block_env,
+        cfg: evm_env.cfg_env,
+        tx: tx_env,
         chain: (),
         local: LocalContext::default(),
         error: Ok(()),

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -372,7 +372,7 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for InspectorStackInner {
     ) -> Result<(), EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         with_cloned_context(ecx, |db, evm_env, tx_env, journal_inner| {
-            let mut evm = new_evm_with_inspector(db, Env { evm_env, tx: tx_env }, &mut inspector);
+            let mut evm = new_evm_with_inspector(db, evm_env, tx_env, &mut inspector);
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
             let (sub_evm_env, sub_tx) = evm.to_env();
@@ -390,7 +390,7 @@ impl<CTX: CheatsCtxExt> CheatcodesExecutor<CTX> for InspectorStackInner {
         f: NestedEvmClosure<'_>,
     ) -> Result<(), EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
-        let mut evm = new_evm_with_inspector(db, Env { evm_env, tx: tx_env }, &mut inspector);
+        let mut evm = new_evm_with_inspector(db, evm_env, tx_env, &mut inspector);
         f(&mut evm)
     }
 
@@ -763,12 +763,12 @@ impl InspectorStackRefMut<'_> {
         self.inner_context_data = Some(InnerContextData { original_origin: cached_tx_env.caller });
         self.in_inner_context = true;
 
-        let modified_env = Env::clone_from_context(ecx);
+        let (evm_env, tx_env) = Env::clone_evm_and_tx(ecx);
 
         let res = self.with_inspector(|mut inspector| {
             let (res, nested_env) = {
                 let (db, journal) = ecx.journal_mut().as_db_and_inner();
-                let mut evm = new_evm_with_inspector(db, modified_env.clone(), &mut inspector);
+                let mut evm = new_evm_with_inspector(db, evm_env, tx_env.clone(), &mut inspector);
 
                 evm.journal_inner_mut().state = {
                     let mut state = journal.state.clone();
@@ -792,7 +792,7 @@ impl InspectorStackRefMut<'_> {
                 // set depth to 1 to make sure traces are collected correctly
                 evm.journal_inner_mut().depth = 1;
 
-                let res = evm.transact(modified_env.tx);
+                let res = evm.transact(tx_env);
                 let (nested_evm_env, _) = evm.to_env();
                 (res, nested_evm_env)
             };


### PR DESCRIPTION
## Motivation

To make EVM context generic, we need to make a series of cleanups to get rid of useless concrete type abstractions. `Env` struct is often used while not necessary.

Iteration: 1/X

## Solution

- Separate `EvmEnv`/`TxEnv`  in  `new_evm_with_inspector`
- Remove useless `Env::clone_from_context` method


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
