### PR TITLE
feat(script): generic `estimate_gas` + `FoundryTransactionBuilder::reset_gas_limit` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4386,6 +4386,7 @@ dependencies = [
  "foundry-debugger",
  "foundry-evm",
  "foundry-linking",
+ "foundry-primitives",
  "foundry-wallets",
  "futures",
  "indicatif",

--- a/crates/primitives/src/network/transaction.rs
+++ b/crates/primitives/src/network/transaction.rs
@@ -30,6 +30,9 @@ use tempo_alloy::TempoNetwork;
 /// - [`FoundryTransactionBuilder::set_fee_token`]
 /// - [`FoundryTransactionBuilder::set_nonce_key`]
 pub trait FoundryTransactionBuilder<N: Network>: TransactionBuilder<N> {
+    /// Reset gas limit
+    fn reset_gas_limit(&mut self);
+
     /// Get the max fee per blob gas for the transaction.
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         None
@@ -144,6 +147,10 @@ pub trait FoundryTransactionBuilder<N: Network>: TransactionBuilder<N> {
 }
 
 impl FoundryTransactionBuilder<Ethereum> for <Ethereum as Network>::TransactionRequest {
+    fn reset_gas_limit(&mut self) {
+        self.gas = None;
+    }
+
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         self.max_fee_per_blob_gas
     }
@@ -179,6 +186,10 @@ impl FoundryTransactionBuilder<Ethereum> for <Ethereum as Network>::TransactionR
 }
 
 impl FoundryTransactionBuilder<AnyNetwork> for <AnyNetwork as Network>::TransactionRequest {
+    fn reset_gas_limit(&mut self) {
+        self.gas = None;
+    }
+
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         self.max_fee_per_blob_gas
     }
@@ -214,6 +225,10 @@ impl FoundryTransactionBuilder<AnyNetwork> for <AnyNetwork as Network>::Transact
 }
 
 impl FoundryTransactionBuilder<TempoNetwork> for <TempoNetwork as Network>::TransactionRequest {
+    fn reset_gas_limit(&mut self) {
+        self.gas = None;
+    }
+
     fn authorization_list(&self) -> Option<&Vec<SignedAuthorization>> {
         self.authorization_list.as_ref()
     }

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -23,6 +23,7 @@ foundry-debugger.workspace = true
 foundry-cheatcodes.workspace = true
 foundry-wallets.workspace = true
 foundry-linking.workspace = true
+foundry-primitives.workspace = true
 forge-script-sequence.workspace = true
 
 serde.workspace = true

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, sync::Arc, time::Duration};
 use alloy_chains::{Chain, NamedChain};
 use alloy_consensus::TxEnvelope;
 use alloy_eips::{BlockId, eip2718::Encodable2718};
-use alloy_network::{Ethereum, EthereumWallet, ReceiptResponse, TransactionBuilder};
+use alloy_network::{Ethereum, EthereumWallet, Network, ReceiptResponse, TransactionBuilder};
 use alloy_primitives::{
     Address, TxHash,
     map::{AddressHashMap, AddressHashSet},
@@ -21,6 +21,7 @@ use foundry_common::{
     shell,
 };
 use foundry_config::Config;
+use foundry_primitives::FoundryTransactionBuilder;
 use foundry_wallets::wallet_browser::signer::BrowserSigner;
 use futures::{FutureExt, StreamExt, future::join_all, stream::FuturesUnordered};
 use itertools::Itertools;
@@ -30,14 +31,17 @@ use crate::{
     sequence::ScriptSequenceKind, verify::BroadcastedState,
 };
 
-pub async fn estimate_gas<P: Provider<Ethereum>>(
-    tx: &mut TransactionRequest,
+pub async fn estimate_gas<N: Network, P: Provider<N>>(
+    tx: &mut N::TransactionRequest,
     provider: &P,
     estimate_multiplier: u64,
-) -> Result<()> {
+) -> Result<()>
+where
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+{
     // if already set, some RPC endpoints might simply return the gas value that is already
     // set in the request and omit the estimate altogether, so we remove it here
-    tx.gas = None;
+    tx.reset_gas_limit();
 
     tx.set_gas_limit(
         provider.estimate_gas(tx.clone()).await.wrap_err("Failed to estimate gas for tx")?


### PR DESCRIPTION
## Motivation

Prepare `estimate_gas`  helper to generic Network support in `forge-script`

## Solution

- add `FoundryTransactionBuilder::reset_gas_limit` method.
- add generic to `estimate_gas`  helper
