### PR TITLE
fix(wallets): remove redundant B256 length check

### DIFF
--- a/crates/wallets/src/wallet_browser/handlers.rs
+++ b/crates/wallets/src/wallet_browser/handlers.rs
@@ -119,13 +119,6 @@ pub(crate) async fn post_transaction_response<N: Network>(
         if hash.is_zero() {
             return Json(BrowserApiResponse::error("Invalid (zero) transaction hash"));
         }
-
-        // Sanity check: ensure the hash is exactly 32 bytes
-        if hash.as_slice().len() != 32 {
-            return Json(BrowserApiResponse::error(
-                "Malformed transaction hash (expected 32 bytes)",
-            ));
-        }
     }
 
     state.add_transaction_response(body).await;


### PR DESCRIPTION
Remove dead code that checks `hash.as_slice().len() != 32`.

B256 is a fixed-size type (FixedBytes<32>) - its length is guaranteed at compile time. This check can never fail and serves no purpose.