### PR TITLE
chore: use `BlockHeader` trait methods instead of direct field access

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1285,10 +1285,10 @@ latest block number: {latest_block}"
 
         env.evm_env.block_env = BlockEnv {
             number: U256::from(fork_block_number),
-            timestamp: U256::from(block.header.timestamp),
-            difficulty: block.header.difficulty,
+            timestamp: U256::from(block.header.timestamp()),
+            difficulty: block.header.difficulty(),
             // ensures prevrandao is set
-            prevrandao: Some(block.header.mix_hash.unwrap_or_default()),
+            prevrandao: Some(block.header.mix_hash().unwrap_or_default()),
             gas_limit,
             // Keep previous `coinbase` and `basefee` value
             beneficiary: env.evm_env.block_env.beneficiary,
@@ -1315,25 +1315,25 @@ latest block number: {latest_block}"
 
         // if not set explicitly we use the base fee of the latest block
         if self.base_fee.is_none() {
-            if let Some(base_fee) = block.header.base_fee_per_gas {
+            if let Some(base_fee) = block.header.base_fee_per_gas() {
                 self.base_fee = Some(base_fee);
                 env.evm_env.block_env.basefee = base_fee;
                 // this is the base fee of the current block, but we need the base fee of
                 // the next block
                 let next_block_base_fee = fees.get_next_block_base_fee_per_gas(
-                    block.header.gas_used,
+                    block.header.gas_used(),
                     gas_limit,
-                    block.header.base_fee_per_gas.unwrap_or_default(),
+                    block.header.base_fee_per_gas().unwrap_or_default(),
                 );
 
                 // update next base fee
                 fees.set_base_fee(next_block_base_fee);
             }
             if let (Some(blob_excess_gas), Some(blob_gas_used)) =
-                (block.header.excess_blob_gas, block.header.blob_gas_used)
+                (block.header.excess_blob_gas(), block.header.blob_gas_used())
             {
                 // derive the blobparams that are active at this timestamp
-                let blob_params = get_blob_params(chain_id, block.header.timestamp);
+                let blob_params = get_blob_params(chain_id, block.header.timestamp());
 
                 env.evm_env.block_env.blob_excess_gas_and_price = Some(BlobExcessGasAndPrice::new(
                     blob_excess_gas,
@@ -1393,14 +1393,14 @@ latest block number: {latest_block}"
             provider,
             chain_id,
             override_chain_id,
-            timestamp: block.header.timestamp,
-            base_fee: block.header.base_fee_per_gas.map(|g| g as u128),
+            timestamp: block.header.timestamp(),
+            base_fee: block.header.base_fee_per_gas().map(|g| g as u128),
             timeout: self.fork_request_timeout,
             retries: self.fork_request_retries,
             backoff: self.fork_retry_backoff,
             compute_units_per_second: self.compute_units_per_second,
             total_difficulty: block.header.total_difficulty.unwrap_or_default(),
-            blob_gas_used: block.header.blob_gas_used.map(|g| g as u128),
+            blob_gas_used: block.header.blob_gas_used().map(|g| g as u128),
             blob_excess_gas_and_price: env.evm_env.block_env.blob_excess_gas_and_price,
             force_transactions,
         };

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -29,7 +29,9 @@ use crate::{
     filter::{EthFilter, Filters, LogsFilter},
     mem::transaction_build,
 };
-use alloy_consensus::{Blob, Transaction, TrieAccount, TxEip4844Variant, transaction::Recovered};
+use alloy_consensus::{
+    Blob, BlockHeader, Transaction, TrieAccount, TxEip4844Variant, transaction::Recovered,
+};
 use alloy_dyn_abi::TypedData;
 use alloy_eips::{
     eip2718::Encodable2718,
@@ -2941,7 +2943,7 @@ impl EthApi {
                         let curr_nonce = nonces.entry(from).or_insert(
                             self.get_transaction_count(
                                 from,
-                                Some(common_block.header.number.into()),
+                                Some(common_block.header.number().into()),
                             )
                             .await?,
                         );

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -518,10 +518,10 @@ impl Backend {
                     env.evm_env.cfg_env.chain_id = fork.chain_id();
                     env.evm_env.block_env = BlockEnv {
                         number: U256::from(fork_block_number),
-                        timestamp: U256::from(fork_block.header.timestamp),
+                        timestamp: U256::from(fork_block.header.timestamp()),
                         gas_limit,
-                        difficulty: fork_block.header.difficulty,
-                        prevrandao: Some(fork_block.header.mix_hash.unwrap_or_default()),
+                        difficulty: fork_block.header.difficulty(),
+                        prevrandao: Some(fork_block.header.mix_hash().unwrap_or_default()),
                         // Keep previous `beneficiary` and `basefee` value
                         beneficiary: env.evm_env.block_env.beneficiary,
                         basefee: env.evm_env.block_env.basefee,
@@ -531,16 +531,16 @@ impl Backend {
                     // this is the base fee of the current block, but we need the base fee of
                     // the next block
                     let next_block_base_fee = self.fees.get_next_block_base_fee_per_gas(
-                        fork_block.header.gas_used,
+                        fork_block.header.gas_used(),
                         gas_limit,
-                        fork_block.header.base_fee_per_gas.unwrap_or_default(),
+                        fork_block.header.base_fee_per_gas().unwrap_or_default(),
                     );
 
                     self.fees.set_base_fee(next_block_base_fee);
                 }
 
                 // reset the time to the timestamp of the forked block
-                self.time.reset(fork_block.header.timestamp);
+                self.time.reset(fork_block.header.timestamp());
 
                 // also reset the total difficulty
                 self.blockchain.storage.write().total_difficulty = fork.total_difficulty();
@@ -946,17 +946,17 @@ impl Backend {
             let block =
                 self.block_by_hash(best_block_hash).await?.ok_or(BlockchainError::BlockNotFound)?;
 
-            let reset_time = block.header.timestamp;
+            let reset_time = block.header.timestamp();
             self.time.reset(reset_time);
 
             let mut env = self.env.write();
             env.evm_env.block_env = BlockEnv {
                 number: U256::from(num),
-                timestamp: U256::from(block.header.timestamp),
-                difficulty: block.header.difficulty,
+                timestamp: U256::from(block.header.timestamp()),
+                difficulty: block.header.difficulty(),
                 // ensures prevrandao is set
-                prevrandao: Some(block.header.mix_hash.unwrap_or_default()),
-                gas_limit: block.header.gas_limit,
+                prevrandao: Some(block.header.mix_hash().unwrap_or_default()),
+                gas_limit: block.header.gas_limit(),
                 // Keep previous `beneficiary` and `basefee` value
                 beneficiary: env.evm_env.block_env.beneficiary,
                 basefee: env.evm_env.block_env.basefee,
@@ -1062,16 +1062,16 @@ impl Backend {
             }
         }
 
-        if let Some(latest) = state.blocks.iter().max_by_key(|b| b.header.number) {
+        if let Some(latest) = state.blocks.iter().max_by_key(|b| b.header.number()) {
             let header = &latest.header;
             let next_block_base_fee = self.fees.get_next_block_base_fee_per_gas(
-                header.gas_used,
-                header.gas_limit,
-                header.base_fee_per_gas.unwrap_or_default(),
+                header.gas_used(),
+                header.gas_limit(),
+                header.base_fee_per_gas().unwrap_or_default(),
             );
             let next_block_excess_blob_gas = self.fees.get_next_block_blob_excess_gas(
-                header.excess_blob_gas.unwrap_or_default(),
-                header.blob_gas_used.unwrap_or_default(),
+                header.excess_blob_gas().unwrap_or_default(),
+                header.blob_gas_used().unwrap_or_default(),
             );
 
             // update next base fee
@@ -1346,7 +1346,10 @@ impl Backend {
 
                 // we also need to update the new blockhash in the db itself
                 let block_hash = executed_tx.block.block.header.hash_slow();
-                db.insert_block_hash(U256::from(executed_tx.block.block.header.number), block_hash);
+                db.insert_block_hash(
+                    U256::from(executed_tx.block.block.header.number()),
+                    block_hash,
+                );
 
                 (executed_tx, block_hash)
             };
@@ -2089,8 +2092,8 @@ impl Backend {
                     all_logs.push(Log {
                         inner: log.clone(),
                         block_hash: Some(block_hash),
-                        block_number: Some(block.header.number),
-                        block_timestamp: Some(block.header.timestamp),
+                        block_number: Some(block.header.number()),
+                        block_timestamp: Some(block.header.timestamp()),
                         transaction_hash: Some(transaction_hash),
                         transaction_index: Some(tx.info.transaction_index),
                         log_index: Some(block_log_index as u64),
@@ -2209,7 +2212,7 @@ impl Backend {
         block: &Block,
     ) -> Option<Vec<AnyRpcTransaction>> {
         let mut transactions = Vec::with_capacity(block.body.transactions.len());
-        let base_fee = block.header.base_fee_per_gas;
+        let base_fee = block.header.base_fee_per_gas();
         let storage = self.blockchain.storage.read();
         for hash in block.body.transactions.iter().map(|tx| tx.hash()) {
             let info = storage.transactions.get(&hash)?.info.clone();
@@ -2417,13 +2420,13 @@ impl Backend {
                     .with_pending_block(pool_transactions, |state, block| {
                         let block = block.block;
                         let block = BlockEnv {
-                            number: U256::from(block.header.number),
-                            beneficiary: block.header.beneficiary,
-                            timestamp: U256::from(block.header.timestamp),
-                            difficulty: block.header.difficulty,
-                            prevrandao: Some(block.header.mix_hash),
-                            basefee: block.header.base_fee_per_gas.unwrap_or_default(),
-                            gas_limit: block.header.gas_limit,
+                            number: U256::from(block.header.number()),
+                            beneficiary: block.header.beneficiary(),
+                            timestamp: U256::from(block.header.timestamp()),
+                            difficulty: block.header.difficulty(),
+                            prevrandao: block.header.mix_hash(),
+                            basefee: block.header.base_fee_per_gas().unwrap_or_default(),
+                            gas_limit: block.header.gas_limit(),
                             ..Default::default()
                         };
                         f(state, block)
@@ -2700,13 +2703,13 @@ impl Backend {
             let mut env = self.env.read().clone();
 
             env.evm_env.block_env = BlockEnv {
-                number: U256::from(block.header.number),
-                beneficiary: block.header.beneficiary,
-                timestamp: U256::from(block.header.timestamp),
-                difficulty: block.header.difficulty,
-                prevrandao: Some(block.header.mix_hash),
-                basefee: block.header.base_fee_per_gas.unwrap_or_default(),
-                gas_limit: block.header.gas_limit,
+                number: U256::from(block.header.number()),
+                beneficiary: block.header.beneficiary(),
+                timestamp: U256::from(block.header.timestamp()),
+                difficulty: block.header.difficulty(),
+                prevrandao: block.header.mix_hash(),
+                basefee: block.header.base_fee_per_gas().unwrap_or_default(),
+                gas_limit: block.header.gas_limit(),
                 ..Default::default()
             };
 
@@ -3018,13 +3021,13 @@ impl Backend {
         // Configure the block environment
         let mut env = self.env.read().clone();
         env.evm_env.block_env = BlockEnv {
-            number: U256::from(block.header.number),
-            beneficiary: block.header.beneficiary,
-            timestamp: U256::from(block.header.timestamp),
-            difficulty: block.header.difficulty,
-            prevrandao: Some(block.header.mix_hash),
-            basefee: block.header.base_fee_per_gas.unwrap_or_default(),
-            gas_limit: block.header.gas_limit,
+            number: U256::from(block.header.number()),
+            beneficiary: block.header.beneficiary(),
+            timestamp: U256::from(block.header.timestamp()),
+            difficulty: block.header.difficulty(),
+            prevrandao: block.header.mix_hash(),
+            basefee: block.header.base_fee_per_gas().unwrap_or_default(),
+            gas_limit: block.header.gas_limit(),
             ..Default::default()
         };
 
@@ -3174,19 +3177,19 @@ impl Backend {
         let transaction = block.body.transactions[index].clone();
 
         // Cancun specific
-        let excess_blob_gas = block.header.excess_blob_gas;
+        let excess_blob_gas = block.header.excess_blob_gas();
         let blob_gas_price =
             alloy_eips::eip4844::calc_blob_gasprice(excess_blob_gas.unwrap_or_default());
         let blob_gas_used = transaction.blob_gas_used();
 
-        let effective_gas_price = transaction.effective_gas_price(block.header.base_fee_per_gas);
+        let effective_gas_price = transaction.effective_gas_price(block.header.base_fee_per_gas());
 
         let receipts = self.get_receipts(block.body.transactions.iter().map(|tx| tx.hash()));
         let next_log_index = receipts[..index].iter().map(|r| r.logs().len()).sum::<usize>();
 
         let tx_receipt = tx_receipt.convert_logs_rpc(
-            BlockNumHash::new(block.header.number, block_hash),
-            block.header.timestamp,
+            BlockNumHash::new(block.header.number(), block_hash),
+            block.header.timestamp(),
             info.transaction_hash,
             info.transaction_index,
             next_log_index,
@@ -3196,7 +3199,7 @@ impl Backend {
             inner: tx_receipt,
             transaction_hash: info.transaction_hash,
             transaction_index: Some(info.transaction_index),
-            block_number: Some(block.header.number),
+            block_number: Some(block.header.number()),
             gas_used: info.gas_used,
             contract_address: info.contract_address,
             effective_gas_price,
@@ -3208,7 +3211,7 @@ impl Backend {
         };
 
         // Include timestamp in receipt to avoid extra block lookups (e.g., in Otterscan API)
-        let inner = FoundryTxReceipt::with_timestamp(receipt, block.header.timestamp);
+        let inner = FoundryTxReceipt::with_timestamp(receipt, block.header.timestamp());
         Some(MinedTransactionReceipt { inner, out: info.out })
     }
 
@@ -3293,7 +3296,7 @@ impl Backend {
             tx,
             Some(&block),
             Some(info),
-            block.header.base_fee_per_gas,
+            block.header.base_fee_per_gas(),
         ))
     }
 
@@ -3331,7 +3334,7 @@ impl Backend {
             tx,
             Some(&block),
             Some(info),
-            block.header.base_fee_per_gas,
+            block.header.base_fee_per_gas(),
         ))
     }
 
@@ -3539,15 +3542,15 @@ impl Backend {
             self.blockchain
                 .storage
                 .write()
-                .unwind_to(common_block.header.number, common_block.header.hash_slow());
+                .unwind_to(common_block.header.number(), common_block.header.hash_slow());
 
             // Set environment back to common block
             let mut env = self.env.write();
-            env.evm_env.block_env.number = U256::from(common_block.header.number);
-            env.evm_env.block_env.timestamp = U256::from(common_block.header.timestamp);
-            env.evm_env.block_env.gas_limit = common_block.header.gas_limit;
-            env.evm_env.block_env.difficulty = common_block.header.difficulty;
-            env.evm_env.block_env.prevrandao = Some(common_block.header.mix_hash);
+            env.evm_env.block_env.number = U256::from(common_block.header.number());
+            env.evm_env.block_env.timestamp = U256::from(common_block.header.timestamp());
+            env.evm_env.block_env.gas_limit = common_block.header.gas_limit();
+            env.evm_env.block_env.difficulty = common_block.header.difficulty();
+            env.evm_env.block_env.prevrandao = common_block.header.mix_hash();
 
             self.time.reset(env.evm_env.block_env.timestamp.saturating_to());
         }
@@ -3558,7 +3561,7 @@ impl Backend {
             // access.
             let block_hashes: Vec<_> = {
                 let storage = self.blockchain.storage.read();
-                let min_block = common_block.header.number.saturating_sub(256);
+                let min_block = common_block.header.number().saturating_sub(256);
                 storage
                     .hashes
                     .iter()
@@ -3596,12 +3599,12 @@ where
 {
     let block = BlockEnv {
         number: U256::from(block_number),
-        beneficiary: block.header.beneficiary,
-        timestamp: U256::from(block.header.timestamp),
-        difficulty: block.header.difficulty,
-        prevrandao: block.header.mix_hash,
-        basefee: block.header.base_fee_per_gas.unwrap_or_default(),
-        gas_limit: block.header.gas_limit,
+        beneficiary: block.header.beneficiary(),
+        timestamp: U256::from(block.header.timestamp()),
+        difficulty: block.header.difficulty(),
+        prevrandao: block.header.mix_hash(),
+        basefee: block.header.base_fee_per_gas().unwrap_or_default(),
+        gas_limit: block.header.gas_limit(),
         ..Default::default()
     };
     f(Box::new(state), block)
@@ -3860,7 +3863,7 @@ pub fn transaction_build(
                     block_hash: block
                         .as_ref()
                         .map(|block| B256::from(keccak256(alloy_rlp::encode(&block.header)))),
-                    block_number: block.as_ref().map(|block| block.header.number),
+                    block_number: block.as_ref().map(|block| block.header.number()),
                     transaction_index: info.as_ref().map(|info| info.transaction_index),
                     effective_gas_price: None,
                 };
@@ -3920,7 +3923,7 @@ pub fn transaction_build(
     let tx = Transaction {
         inner: Recovered::new_unchecked(envelope, from),
         block_hash: block.as_ref().map(|block| block.header.hash_slow()),
-        block_number: block.as_ref().map(|block| block.header.number),
+        block_number: block.as_ref().map(|block| block.header.number()),
         transaction_index: info.as_ref().map(|info| info.transaction_index),
         // deprecated
         effective_gas_price: Some(effective_gas_price),

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -10,7 +10,7 @@ use crate::eth::{
     },
     pool::transactions::PoolTransaction,
 };
-use alloy_consensus::{Header, constants::EMPTY_WITHDRAWALS};
+use alloy_consensus::{BlockHeader, Header, constants::EMPTY_WITHDRAWALS};
 use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
 use alloy_network::Network;
 use alloy_primitives::{
@@ -439,7 +439,7 @@ impl BlockchainStorage<FoundryNetwork> {
         for serializable_block in &serializable_blocks {
             let block: Block = serializable_block.clone().into();
             let block_hash = block.header.hash_slow();
-            let block_number = block.header.number;
+            let block_number = block.header.number();
             self.blocks.insert(block_hash, block);
             self.hashes.insert(block_number, block_hash);
 
@@ -741,7 +741,7 @@ mod tests {
         load_storage.load_transactions(serialized_transactions);
 
         let loaded_block = load_storage.blocks.get(&block_hash).unwrap();
-        assert_eq!(loaded_block.header.gas_limit, { header.gas_limit });
+        assert_eq!(loaded_block.header.gas_limit(), header.gas_limit());
         let loaded_tx = loaded_block.body.transactions.first().unwrap();
         assert_eq!(loaded_tx, &tx);
     }

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use alloy_consensus::{Header, Transaction};
+use alloy_consensus::{BlockHeader, Header, Transaction};
 use alloy_eips::{calc_next_block_base_fee, eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_primitives::B256;
 use futures::StreamExt;
@@ -268,11 +268,11 @@ impl FeeHistoryService {
         let current_receipts = self.storage_info.receipts(hash);
 
         if let (Some(block), Some(receipts)) = (current_block, current_receipts) {
-            block_number = Some(block.header.number);
+            block_number = Some(block.header.number());
 
-            let gas_used = block.header.gas_used as f64;
-            let blob_gas_used = block.header.blob_gas_used.map(|g| g as f64);
-            item.gas_used_ratio = gas_used / block.header.gas_limit as f64;
+            let gas_used = block.header.gas_used() as f64;
+            let blob_gas_used = block.header.blob_gas_used().map(|g| g as f64);
+            item.gas_used_ratio = gas_used / block.header.gas_limit() as f64;
             item.blob_gas_used_ratio = blob_gas_used
                 .map(|g| {
                     let max = self.blob_params.max_blob_gas_per_block() as f64;

--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -3,7 +3,7 @@ use crate::eth::{
     error::{BlockchainError, Result},
     macros::node_info,
 };
-use alloy_consensus::Transaction as TransactionTrait;
+use alloy_consensus::{BlockHeader, Transaction as TransactionTrait};
 use alloy_network::{
     AnyHeader, AnyRpcBlock, AnyRpcHeader, AnyRpcTransaction, AnyTxEnvelope, BlockResponse,
     ReceiptResponse, TransactionResponse,
@@ -376,7 +376,7 @@ impl EthApi {
         let receipt_futs = block.transactions.hashes().map(|hash| self.transaction_receipt(hash));
 
         // Reuse timestamp from the block we already have
-        let timestamp = block.header.timestamp;
+        let timestamp = block.header.timestamp();
 
         let receipts = join_all(receipt_futs.map(|r| async move {
             if let Ok(Some(r)) = r.await {
@@ -425,7 +425,7 @@ impl EthApi {
                     ts
                 } else {
                     let block = self.block_by_number(r.block_number().unwrap().into()).await?;
-                    block.ok_or(BlockchainError::BlockNotFound)?.header.timestamp
+                    block.ok_or(BlockchainError::BlockNotFound)?.header.timestamp()
                 };
                 let receipt = r.as_ref().inner.clone().map_inner(OtsReceipt::from);
                 Ok(OtsTransactionReceipt { receipt, timestamp: Some(timestamp) })

--- a/crates/anvil/src/pubsub.rs
+++ b/crates/anvil/src/pubsub.rs
@@ -2,7 +2,7 @@ use crate::{
     StorageInfo,
     eth::{backend::notifications::NewBlockNotifications, error::to_rpc_result},
 };
-use alloy_consensus::TxReceipt;
+use alloy_consensus::{BlockHeader, TxReceipt};
 use alloy_network::AnyRpcTransaction;
 use alloy_primitives::{B256, TxHash};
 use alloy_rpc_types::{FilteredParams, Log, Transaction, pubsub::SubscriptionResult};
@@ -160,7 +160,7 @@ where
         params: &FilteredParams,
     ) -> bool {
         if params.filter.is_some() {
-            let block_number = block.header.number;
+            let block_number = block.header.number();
             if !params.filter_block_range(block_number)
                 || !params.filter_block_hash(block_hash)
                 || !params.filter_address(&l.address)
@@ -182,12 +182,12 @@ where
                 logs.push(Log {
                     inner: log.clone(),
                     block_hash: Some(block_hash),
-                    block_number: Some(block.header.number),
+                    block_number: Some(block.header.number()),
                     transaction_hash: Some(transaction_hash),
                     transaction_index: Some(receipt_index as u64),
                     log_index: Some(log_index as u64),
                     removed: false,
-                    block_timestamp: Some(block.header.timestamp),
+                    block_timestamp: Some(block.header.timestamp()),
                 });
             }
             log_index += 1;

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -1,5 +1,5 @@
 use crate::{debug::handle_traces, utils::apply_chain_and_block_specific_env_changes};
-use alloy_consensus::Transaction;
+use alloy_consensus::{BlockHeader, Transaction};
 use alloy_network::{AnyNetwork, TransactionResponse};
 use alloy_primitives::{
     Address, Bytes, U256,
@@ -183,18 +183,18 @@ impl RunArgs {
         env.evm_env.block_env.number = U256::from(tx_block_number);
 
         if let Some(block) = &block {
-            env.evm_env.block_env.timestamp = U256::from(block.header.timestamp);
-            env.evm_env.block_env.beneficiary = block.header.beneficiary;
-            env.evm_env.block_env.difficulty = block.header.difficulty;
-            env.evm_env.block_env.prevrandao = Some(block.header.mix_hash.unwrap_or_default());
-            env.evm_env.block_env.basefee = block.header.base_fee_per_gas.unwrap_or_default();
-            env.evm_env.block_env.gas_limit = block.header.gas_limit;
+            env.evm_env.block_env.timestamp = U256::from(block.header.timestamp());
+            env.evm_env.block_env.beneficiary = block.header.beneficiary();
+            env.evm_env.block_env.difficulty = block.header.difficulty();
+            env.evm_env.block_env.prevrandao = Some(block.header.mix_hash().unwrap_or_default());
+            env.evm_env.block_env.basefee = block.header.base_fee_per_gas().unwrap_or_default();
+            env.evm_env.block_env.gas_limit = block.header.gas_limit();
 
             // TODO: we need a smarter way to map the block to the corresponding evm_version for
             // commonly used chains
             if evm_version.is_none() {
                 // if the block has the excess_blob_gas field, we assume it's a Cancun block
-                if block.header.excess_blob_gas.is_some() {
+                if block.header.excess_blob_gas().is_some() {
                     evm_version = Some(EvmVersion::Prague);
                 }
             }

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -7,7 +7,7 @@
 extern crate foundry_common;
 #[macro_use]
 extern crate tracing;
-use alloy_consensus::Header;
+use alloy_consensus::{BlockHeader, Header};
 use alloy_dyn_abi::{DynSolType, DynSolValue, FunctionExt};
 use alloy_ens::NameOrAddress;
 use alloy_json_abi::Function;
@@ -1007,7 +1007,7 @@ impl<P: Provider<AnyNetwork> + Clone + Unpin> Cast<P> {
                 BlockId::Number(block_number) => Ok(Some(block_number)),
                 BlockId::Hash(hash) => {
                     let block = self.provider.get_block_by_hash(hash.block_hash).await?;
-                    Ok(block.map(|block| block.header.number).map(BlockNumberOrTag::from))
+                    Ok(block.map(|block| block.header.number()).map(BlockNumberOrTag::from))
                 }
             },
             None => Ok(None),

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     state_snapshot::StateSnapshots,
     utils::{configure_tx_env, configure_tx_req_env, get_blob_base_fee_update_fraction},
 };
-use alloy_consensus::Typed2718;
+use alloy_consensus::{BlockHeader, Typed2718};
 use alloy_evm::{Evm, EvmEnv};
 use alloy_genesis::GenesisAccount;
 use alloy_network::{
@@ -908,7 +908,7 @@ impl Backend {
         } else {
             let block = fork.db.db.get_full_block(BlockNumberOrTag::Latest)?;
 
-            let number = block.header.number;
+            let number = block.header.number();
 
             Ok((number, block))
         }
@@ -2013,18 +2013,18 @@ fn is_contract_in_state(evm_state: &EvmState, acc: Address) -> bool {
 /// Updates the evm env's block with the block's data
 fn update_env_block(evm_env: &mut EvmEnv, block: &AnyRpcBlock) {
     let block_env = &mut evm_env.block_env;
-    block_env.timestamp = U256::from(block.header.timestamp);
-    block_env.beneficiary = block.header.beneficiary;
-    block_env.difficulty = block.header.difficulty;
-    block_env.prevrandao = Some(block.header.mix_hash.unwrap_or_default());
-    block_env.basefee = block.header.base_fee_per_gas.unwrap_or_default();
-    block_env.gas_limit = block.header.gas_limit;
-    block_env.number = U256::from(block.header.number);
+    block_env.timestamp = U256::from(block.header.timestamp());
+    block_env.beneficiary = block.header.beneficiary();
+    block_env.difficulty = block.header.difficulty();
+    block_env.prevrandao = Some(block.header.mix_hash().unwrap_or_default());
+    block_env.basefee = block.header.base_fee_per_gas().unwrap_or_default();
+    block_env.gas_limit = block.header.gas_limit();
+    block_env.number = U256::from(block.header.number());
 
-    if let Some(excess_blob_gas) = block.header.excess_blob_gas {
+    if let Some(excess_blob_gas) = block.header.excess_blob_gas() {
         evm_env.block_env.blob_excess_gas_and_price = Some(BlobExcessGasAndPrice::new(
             excess_blob_gas,
-            get_blob_base_fee_update_fraction(evm_env.cfg_env.chain_id, block.header.timestamp),
+            get_blob_base_fee_update_fraction(evm_env.cfg_env.chain_id, block.header.timestamp()),
         ));
     }
 }


### PR DESCRIPTION
## Summary
- Replace direct field access on block headers (`.header.number`, `.header.timestamp`, etc.) with `BlockHeader` trait methods (`.header.number()`, `.header.timestamp()`, etc.) across anvil, cast, and evm-core.
- Prepares the codebase for generic network support where concrete header types won't expose public fields.

## Test plan
- [x] `cargo check` passes for all affected crates (anvil, cast, foundry-evm-core)
- [x] `cargo clippy` clean
- [x] `cargo +nightly fmt --all` clean
- [ ] CI passes