### PR TITLE
fix(config): add symmetric serialization for FuzzDictionaryConfig usize fields

### DIFF
--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -71,16 +71,25 @@ pub struct FuzzDictionaryConfig {
     /// Once the fuzzer exceeds this limit, it will start evicting random entries
     ///
     /// This limit is put in place to prevent memory blowup.
-    #[serde(deserialize_with = "crate::deserialize_usize_or_max")]
+    #[serde(
+        deserialize_with = "crate::deserialize_usize_or_max",
+        serialize_with = "crate::serialize_usize_or_max"
+    )]
     pub max_fuzz_dictionary_addresses: usize,
     /// How many values to record at most.
     /// Once the fuzzer exceeds this limit, it will start evicting random entries
-    #[serde(deserialize_with = "crate::deserialize_usize_or_max")]
+    #[serde(
+        deserialize_with = "crate::deserialize_usize_or_max",
+        serialize_with = "crate::serialize_usize_or_max"
+    )]
     pub max_fuzz_dictionary_values: usize,
     /// How many literal values to seed from the AST, at most.
     ///
     /// This value is independent from the max amount of addresses and values.
-    #[serde(deserialize_with = "crate::deserialize_usize_or_max")]
+    #[serde(
+        deserialize_with = "crate::deserialize_usize_or_max",
+        serialize_with = "crate::serialize_usize_or_max"
+    )]
     pub max_fuzz_dictionary_literals: usize,
 }
 

--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -213,6 +213,21 @@ where
     deserialize_u64_or_max(deserializer)?.try_into().map_err(D::Error::custom)
 }
 
+/// Serialize a `usize` as `"max"` if it equals `usize::MAX`, as a string if it exceeds
+/// `i64::MAX` (TOML integer limit), or as a plain number otherwise.
+pub(crate) fn serialize_usize_or_max<S>(value: &usize, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if *value == usize::MAX {
+        serializer.serialize_str("max")
+    } else if *value > i64::MAX as usize {
+        serializer.serialize_str(&value.to_string())
+    } else {
+        serializer.serialize_u64(*value as u64)
+    }
+}
+
 /// Deserialize into `U256` from either a `u64`, a `U256` hex string, or a decimal string.
 pub fn deserialize_u64_to_u256<'de, D>(deserializer: D) -> Result<U256, D::Error>
 where


### PR DESCRIPTION
The three `max_fuzz_dictionary_*` fields use `deserialize_usize_or_max` to accept "max" as `usize::MAX`, but had no custom serializer. This means `usize::MAX` gets written as a raw integer that exceeds TOML's i64 range, causing serialization to fail. Added `serialize_usize_or_max` mirroring what `GasLimit` already does — same pattern, just wasn't done here.
