### PR TITLE
refactor(evm): use `EvmEnv` in `CreateFork`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,6 +4419,7 @@ dependencies = [
 name = "forge-verify"
 version = "1.6.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -3,6 +3,7 @@ use crate::{
     Vm::*, json::json_value_to_token,
 };
 use alloy_dyn_abi::DynSolValue;
+use alloy_evm::EvmEnv;
 use alloy_network::AnyNetwork;
 use alloy_primitives::{B256, U256};
 use alloy_provider::Provider;
@@ -420,9 +421,9 @@ fn create_fork_request<CTX: FoundryContextExt<Db: DatabaseExt>>(
         enable_caching: !ccx.state.config.no_storage_caching
             && ccx.state.config.rpc_storage_caching.enable_for_endpoint(&url),
         url,
-        env: {
-            let (evm_env, tx_env) = Env::clone_evm_and_tx(ccx.ecx);
-            Env { evm_env, tx: tx_env }
+        evm_env: EvmEnv {
+            cfg_env: ccx.ecx.cfg_mut().clone(),
+            block_env: ccx.ecx.block_mut().clone(),
         },
         evm_opts,
     };

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -204,7 +204,8 @@ impl SessionSource {
         let backend = match self.config.backend.clone() {
             Some(backend) => backend,
             None => {
-                let fork = self.config.evm_opts.get_fork(&self.config.foundry_config, env.clone());
+                let fork =
+                    self.config.evm_opts.get_fork(&self.config.foundry_config, env.evm_env.clone());
                 let backend = Backend::spawn(fork)?;
                 self.config.backend = Some(backend.clone());
                 backend

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1010,7 +1010,7 @@ impl DatabaseExt for Backend {
 
             // merge additional logs
             snapshot.merge(current_state);
-            let BackendStateSnapshot { db, mut journaled_state, snap_evm_env, snap_tx_env } =
+            let BackendStateSnapshot { db, mut journaled_state, snap_evm_env, snap_tx_env: _ } =
                 snapshot;
             match db {
                 BackendDatabaseSnapshot::InMemory(mem_db) => {
@@ -1039,7 +1039,7 @@ impl DatabaseExt for Backend {
                 }
             }
 
-            update_current_env_with_fork_env(evm_env, tx_env, snap_evm_env, snap_tx_env);
+            update_current_env_with_fork_env(evm_env, tx_env, snap_evm_env);
             trace!(target: "backend", "Reverted snapshot {}", id);
 
             Some(journaled_state)
@@ -1075,9 +1075,9 @@ impl DatabaseExt for Backend {
         trace!(?transaction, "create fork at transaction");
         let id = self.create_fork(fork)?;
         let fork_id = self.ensure_fork_id(id).cloned()?;
-        let mut env = self
+        let mut evm_env = self
             .forks
-            .get_env(fork_id)?
+            .get_evm_env(fork_id)?
             .ok_or_else(|| eyre::eyre!("Requested fork `{}` does not exist", id))?;
 
         // we still need to roll to the transaction, but we only need an empty dummy state since we
@@ -1085,8 +1085,8 @@ impl DatabaseExt for Backend {
         self.roll_fork_to_transaction(
             Some(id),
             transaction,
-            &mut env.evm_env,
-            &mut env.tx,
+            &mut evm_env,
+            &mut TxEnv::default(),
             &mut self.inner.new_journaled_state(),
         )?;
 
@@ -1120,9 +1120,9 @@ impl DatabaseExt for Backend {
 
         let fork_id = self.ensure_fork_id(id).cloned()?;
         let idx = self.inner.ensure_fork_index(&fork_id)?;
-        let fork_env = self
+        let fork_evm_env = self
             .forks
-            .get_env(fork_id)?
+            .get_evm_env(fork_id)?
             .ok_or_else(|| eyre::eyre!("Requested fork `{}` does not exist", id))?;
 
         // If we're currently in forking mode we need to update the journaled_state to this point,
@@ -1219,7 +1219,7 @@ impl DatabaseExt for Backend {
 
         self.active_fork_ids = Some((id, idx));
         // Update current environment with environment of newly selected fork.
-        update_current_env_with_fork_env(evm_env, tx_env, fork_env.evm_env, fork_env.tx);
+        update_current_env_with_fork_env(evm_env, tx_env, fork_evm_env);
 
         Ok(())
     }
@@ -1246,7 +1246,7 @@ impl DatabaseExt for Backend {
             if active_id == id {
                 // need to update the block's env settings right away, which is otherwise set when
                 // forks are selected `select_fork`
-                update_current_env_with_fork_env(evm_env, tx_env, fork_env.evm_env, fork_env.tx);
+                update_current_env_with_fork_env(evm_env, tx_env, fork_env);
 
                 // we also need to update the journaled_state right away, this has essentially the
                 // same effect as selecting (`select_fork`) by discarding
@@ -1930,10 +1930,9 @@ pub(crate) fn update_current_env_with_fork_env(
     evm_env: &mut EvmEnv,
     tx_env: &mut TxEnv,
     fork_evm_env: EvmEnv,
-    fork_tx_env: TxEnv,
 ) {
+    tx_env.chain_id = Some(fork_evm_env.cfg_env.chain_id);
     *evm_env = fork_evm_env;
-    tx_env.chain_id = fork_tx_env.chain_id;
 }
 
 /// Clones the data of the given `accounts` from the `active` database into the `fork_db`
@@ -2124,7 +2123,7 @@ mod tests {
 
         let env = evm_opts.env().await.unwrap();
 
-        let fork = evm_opts.get_fork(&Config::default(), env.clone()).unwrap();
+        let fork = evm_opts.get_fork(&Config::default(), env.evm_env.clone()).unwrap();
 
         let backend = Backend::spawn(Some(fork)).unwrap();
 

--- a/crates/evm/core/src/fork/mod.rs
+++ b/crates/evm/core/src/fork/mod.rs
@@ -1,5 +1,5 @@
 use super::opts::EvmOpts;
-use crate::Env;
+use alloy_evm::EvmEnv;
 
 pub mod database;
 
@@ -13,8 +13,8 @@ pub struct CreateFork {
     pub enable_caching: bool,
     /// The URL to a node for fetching remote state
     pub url: String,
-    /// The env to create this fork, main purpose is to provide some metadata for the fork
-    pub env: Env,
+    /// The EVM environment for this fork (main purpose is to provide some block and cfg metadata).
+    pub evm_env: EvmEnv,
     /// All env settings as configured by the user
     pub evm_opts: EvmOpts,
 }

--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -4,7 +4,7 @@
 //! concurrently active pairs at once.
 
 use super::CreateFork;
-use crate::Env;
+use alloy_evm::EvmEnv;
 use alloy_network::Network;
 use alloy_primitives::{U256, map::HashMap};
 use foundry_config::Config;
@@ -124,7 +124,10 @@ impl<N: Network> MultiFork<N> {
     /// Returns a fork backend.
     ///
     /// If no matching fork backend exists it will be created.
-    pub fn create_fork(&self, fork: CreateFork) -> eyre::Result<(ForkId, SharedBackend<N>, Env)> {
+    pub fn create_fork(
+        &self,
+        fork: CreateFork,
+    ) -> eyre::Result<(ForkId, SharedBackend<N>, EvmEnv)> {
         trace!("Creating new fork, url={}, block={:?}", fork.url, fork.evm_opts.fork_block_number);
         let (sender, rx) = oneshot_channel();
         let req = Request::CreateFork(Box::new(fork), sender);
@@ -139,7 +142,7 @@ impl<N: Network> MultiFork<N> {
         &self,
         fork: ForkId,
         block: u64,
-    ) -> eyre::Result<(ForkId, SharedBackend<N>, Env)> {
+    ) -> eyre::Result<(ForkId, SharedBackend<N>, EvmEnv)> {
         trace!(?fork, ?block, "rolling fork");
         let (sender, rx) = oneshot_channel();
         let req = Request::RollFork(fork, block, sender);
@@ -147,11 +150,11 @@ impl<N: Network> MultiFork<N> {
         rx.recv()?
     }
 
-    /// Returns the `Env` of the given fork, if any.
-    pub fn get_env(&self, fork: ForkId) -> eyre::Result<Option<Env>> {
+    /// Returns the `EvmEnv` of the given fork, if any.
+    pub fn get_evm_env(&self, fork: ForkId) -> eyre::Result<Option<EvmEnv>> {
         trace!(?fork, "getting env config");
         let (sender, rx) = oneshot_channel();
-        let req = Request::GetEnv(fork, sender);
+        let req = Request::GetEvmEnv(fork, sender);
         self.handler.clone().try_send(req).map_err(|e| eyre::eyre!("{:?}", e))?;
         Ok(rx.recv()?)
     }
@@ -202,8 +205,8 @@ impl<N: Network> MultiFork<N> {
 
 type CreateFuture<N> =
     Pin<Box<dyn Future<Output = eyre::Result<(ForkId, CreatedFork<N>, BackendHandler<N>)>> + Send>>;
-type CreateSender<N> = OneshotSender<eyre::Result<(ForkId, SharedBackend<N>, Env)>>;
-type GetEnvSender = OneshotSender<Option<Env>>;
+type CreateSender<N> = OneshotSender<eyre::Result<(ForkId, SharedBackend<N>, EvmEnv)>>;
+type GetEvmEnvSender = OneshotSender<Option<EvmEnv>>;
 
 /// Request that's send to the handler.
 #[derive(Debug)]
@@ -215,7 +218,7 @@ enum Request<N: Network> {
     /// Adjusts the block that's being forked, by creating a new fork at the new block.
     RollFork(ForkId, u64, CreateSender<N>),
     /// Returns the environment of the fork.
-    GetEnv(ForkId, GetEnvSender),
+    GetEvmEnv(ForkId, GetEvmEnvSender),
     /// Updates the block number and timestamp of the fork.
     UpdateBlock(ForkId, U256, U256),
     /// Updates the block the entire block env,
@@ -306,28 +309,29 @@ impl<N: Network> MultiForkHandler<N> {
         additional_senders: Vec<CreateSender<N>>,
     ) {
         self.forks.insert(fork_id.clone(), fork.clone());
-        let _ = sender.send(Ok((fork_id.clone(), fork.backend.clone(), fork.opts.env.clone())));
+        let _ = sender.send(Ok((fork_id.clone(), fork.backend.clone(), fork.opts.evm_env.clone())));
 
         // Notify all additional senders and track unique forkIds.
         for sender in additional_senders {
             let next_fork_id = fork.inc_senders(fork_id.clone());
             self.forks.insert(next_fork_id.clone(), fork.clone());
-            let _ = sender.send(Ok((next_fork_id, fork.backend.clone(), fork.opts.env.clone())));
+            let _ =
+                sender.send(Ok((next_fork_id, fork.backend.clone(), fork.opts.evm_env.clone())));
         }
     }
 
     /// Update the fork's block entire env
     fn update_env(&mut self, fork_id: ForkId, env: BlockEnv) {
         if let Some(fork) = self.forks.get_mut(&fork_id) {
-            fork.opts.env.evm_env.block_env = env;
+            fork.opts.evm_env.block_env = env;
         }
     }
     /// Update fork block number and timestamp. Used to preserve values set by `roll` and `warp`
     /// cheatcodes when new fork selected.
     fn update_block(&mut self, fork_id: ForkId, block_number: U256, block_timestamp: U256) {
         if let Some(fork) = self.forks.get_mut(&fork_id) {
-            fork.opts.env.evm_env.block_env.number = block_number;
-            fork.opts.env.evm_env.block_env.timestamp = block_timestamp;
+            fork.opts.evm_env.block_env.number = block_number;
+            fork.opts.evm_env.block_env.timestamp = block_timestamp;
         }
     }
 
@@ -349,8 +353,8 @@ impl<N: Network> MultiForkHandler<N> {
                         sender.send(Err(eyre::eyre!("No matching fork exists for {}", fork_id)));
                 }
             }
-            Request::GetEnv(fork_id, sender) => {
-                let _ = sender.send(self.forks.get(&fork_id).map(|fork| fork.opts.env.clone()));
+            Request::GetEvmEnv(fork_id, sender) => {
+                let _ = sender.send(self.forks.get(&fork_id).map(|fork| fork.opts.evm_env.clone()));
             }
             Request::UpdateBlock(fork_id, block_number, block_timestamp) => {
                 self.update_block(fork_id, block_number, block_timestamp);
@@ -541,12 +545,12 @@ async fn create_fork<N: Network>(
 
     // Initialise the fork environment.
     let (evm_env, number) = fork.evm_opts.fork_evm_env(&provider).await?;
-    fork.env.evm_env = evm_env;
-    let meta = BlockchainDbMeta::new(fork.env.evm_env.block_env.clone(), fork.url.clone());
+    fork.evm_env = evm_env;
+    let meta = BlockchainDbMeta::new(fork.evm_env.block_env.clone(), fork.url.clone());
 
     // Determine the cache path if caching is enabled.
     let cache_path = if fork.enable_caching {
-        Config::foundry_block_cache_dir(fork.env.evm_env.cfg_env.chain_id, number)
+        Config::foundry_block_cache_dir(fork.evm_env.cfg_env.chain_id, number)
     } else {
         None
     };

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -295,19 +295,19 @@ impl EvmOpts {
     ///
     /// for `mainnet` and `--fork-block-number 14435000` on mac the corresponding storage cache will
     /// be at `~/.foundry/cache/mainnet/14435000/storage.json`.
-    pub fn get_fork(&self, config: &Config, env: crate::Env) -> Option<CreateFork> {
+    pub fn get_fork(&self, config: &Config, evm_env: EvmEnv) -> Option<CreateFork> {
         let url = self.fork_url.clone()?;
-        let enable_caching = config.enable_caching(&url, env.evm_env.cfg_env.chain_id);
+        let enable_caching = config.enable_caching(&url, evm_env.cfg_env.chain_id);
 
         // Pin fork_block_number to the block that was already fetched in env, so subsequent
         // fork operations use the same block. This prevents inconsistencies when forking at
         // "latest" where the chain could advance between calls.
         let mut evm_opts = self.clone();
         if evm_opts.fork_block_number.is_none() {
-            evm_opts.fork_block_number = Some(env.evm_env.block_env.number.to());
+            evm_opts.fork_block_number = Some(evm_env.block_env.number.to());
         }
 
-        Some(CreateFork { url, enable_caching, env, evm_opts })
+        Some(CreateFork { url, enable_caching, evm_env, evm_opts })
     }
 
     /// Returns the gas limit to use
@@ -433,7 +433,7 @@ mod tests {
         assert!(resolved_block > U256::ZERO, "should have resolved to a real block number");
 
         // Create the fork - this should pin the block number
-        let fork = evm_opts.get_fork(&Config::default(), env).unwrap();
+        let fork = evm_opts.get_fork(&Config::default(), env.evm_env).unwrap();
 
         // The fork's evm_opts should now have fork_block_number set to the resolved block
         assert_eq!(
@@ -455,7 +455,7 @@ mod tests {
 
         let env = evm_opts.env().await.unwrap();
 
-        let fork = evm_opts.get_fork(&Config::default(), env).unwrap();
+        let fork = evm_opts.get_fork(&Config::default(), env.evm_env).unwrap();
 
         // Should preserve the explicit block number, not override it
         assert_eq!(

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -85,7 +85,7 @@ impl TracingExecutor {
 
         let env = evm_opts.env().await?;
 
-        let fork = evm_opts.get_fork(config, env.clone()).unwrap();
+        let fork = evm_opts.get_fork(config, env.evm_env.clone()).unwrap();
         let networks = evm_opts.networks.with_chain_id(env.evm_env.cfg_env.chain_id);
         config.labels.extend(networks.precompiles_label());
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -345,7 +345,7 @@ impl TestArgs {
             .initial_balance(evm_opts.initial_balance)
             .evm_spec(config.evm_spec_id())
             .sender(evm_opts.sender)
-            .with_fork(evm_opts.get_fork(&config, env.clone()))
+            .with_fork(evm_opts.get_fork(&config, env.evm_env.clone()))
             .enable_isolation(evm_opts.isolate)
             .networks(evm_opts.networks)
             .fail_fast(self.fail_fast)

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -642,7 +642,7 @@ impl ScriptConfig {
             match self.backends.get(fork_url) {
                 Some(db) => db.clone(),
                 None => {
-                    let fork = self.evm_opts.get_fork(&self.config, env.clone());
+                    let fork = self.evm_opts.get_fork(&self.config, env.evm_env.clone());
                     let backend = Backend::spawn(fork)?;
                     self.backends.insert(fork_url.clone(), backend.clone());
                     backend


### PR DESCRIPTION
## Motivation

It's useless to carry `TxEnv` in `CreateFork`, as `CfgEnv` is the source of truth for `chain_id`. 

We can simplify `MultiFork` impl to just handle `EvmEnv`.