### PR TITLE
feat(forge): generic Network support for `forge create`

### DIFF
--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -54,15 +54,17 @@ foundry-debugger.workspace = true
 foundry-wallets = { workspace = true, optional = true }
 
 alloy-chains.workspace = true
+alloy-consensus.workspace = true
 alloy-dyn-abi.workspace = true
 alloy-json-abi.workspace = true
 alloy-network.workspace = true
 alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-provider = { workspace = true, features = ["reqwest", "ws", "ipc"] }
-alloy-rpc-types.workspace = true
-alloy-serde.workspace = true
 alloy-signer.workspace = true
 alloy-transport.workspace = true
+
+foundry-primitives.workspace = true
+tempo-alloy.workspace = true
 
 revm.workspace = true
 

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -1,24 +1,24 @@
 use crate::cmd::install;
 use alloy_chains::Chain;
+use alloy_consensus::{SignableTransaction, Signed};
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt, Specifier};
 use alloy_json_abi::{Constructor, JsonAbi};
-use alloy_network::{AnyNetwork, AnyTransactionReceipt, EthereumWallet, TransactionBuilder};
+use alloy_network::{AnyNetwork, EthereumWallet, Network, ReceiptResponse, TransactionBuilder};
 use alloy_primitives::{Address, Bytes, hex};
-use alloy_provider::{PendingTransactionError, Provider, ProviderBuilder};
-use alloy_rpc_types::TransactionRequest;
-use alloy_serde::WithOtherFields;
-use alloy_signer::Signer;
+use alloy_provider::{PendingTransactionError, Provider, ProviderBuilder as AlloyProviderBuilder};
+use alloy_signer::{Signature, Signer};
 use alloy_transport::TransportError;
 use clap::{Parser, ValueHint};
 use eyre::{Context, Result};
 use forge_verify::{RetryArgs, VerifierArgs, VerifyArgs};
 use foundry_cli::{
     opts::{BuildOpts, EthereumOpts, EtherscanOpts, TransactionOpts},
-    utils::{self, LoadConfig, find_contract_artifacts, read_constructor_args_file},
+    utils::{LoadConfig, find_contract_artifacts, read_constructor_args_file},
 };
 use foundry_common::{
     compile::{self},
     fmt::parse_tokens,
+    provider::ProviderBuilder,
     shell,
 };
 use foundry_compilers::{
@@ -32,8 +32,10 @@ use foundry_config::{
     },
     merge_impl_figment_convert,
 };
+use foundry_primitives::FoundryTransactionBuilder;
 use serde_json::json;
 use std::{borrow::Borrow, marker::PhantomData, path::PathBuf, sync::Arc, time::Duration};
+use tempo_alloy::TempoNetwork;
 
 merge_impl_figment_convert!(CreateArgs, build, eth);
 
@@ -102,7 +104,21 @@ pub struct CreateArgs {
 
 impl CreateArgs {
     /// Executes the command to create a contract
-    pub async fn run(mut self) -> Result<()> {
+    pub async fn run(self) -> Result<()> {
+        if self.tx.tempo.is_tempo() {
+            self.run_generic::<TempoNetwork>().await
+        } else {
+            self.run_generic::<AnyNetwork>().await
+        }
+    }
+
+    async fn run_generic<N: Network>(mut self) -> Result<()>
+    where
+        N::TxEnvelope: From<Signed<N::UnsignedTx>>,
+        N::UnsignedTx: SignableTransaction<Signature>,
+        N::TransactionRequest: FoundryTransactionBuilder<N> + serde::Serialize,
+        N::ReceiptResponse: serde::Serialize,
+    {
         let mut config = self.load_config()?;
 
         // Install missing dependencies.
@@ -155,7 +171,7 @@ impl CreateArgs {
             vec![]
         };
 
-        let provider = utils::get_provider(&config)?;
+        let provider = ProviderBuilder::<N>::from_config(&config)?.build()?;
 
         // respect chain, if set explicitly via cmd args
         let chain_id = if let Some(chain_id) = self.chain_id() {
@@ -186,7 +202,7 @@ impl CreateArgs {
             // Deploy with signer
             let signer = self.eth.wallet.signer().await?;
             let deployer = signer.address();
-            let provider = ProviderBuilder::<_, _, AnyNetwork>::default()
+            let provider = AlloyProviderBuilder::<_, _, N>::default()
                 .wallet(EthereumWallet::new(signer))
                 .connect_provider(provider);
             self.deploy(
@@ -268,7 +284,7 @@ impl CreateArgs {
 
     /// Deploys the contract
     #[expect(clippy::too_many_arguments)]
-    async fn deploy<P: Provider<AnyNetwork>>(
+    async fn deploy<N: Network, P: Provider<N>>(
         self,
         abi: JsonAbi,
         bin: BytecodeObject,
@@ -279,14 +295,19 @@ impl CreateArgs {
         timeout: u64,
         id: ArtifactId,
         dry_run: bool,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        N::TransactionRequest: FoundryTransactionBuilder<N> + serde::Serialize,
+        N::ReceiptResponse: serde::Serialize,
+    {
         let bin = bin.into_bytes().unwrap_or_default();
         if bin.is_empty() {
             eyre::bail!("no bytecode found in bin object for {}", self.contract.name)
         }
 
         let provider = Arc::new(provider);
-        let factory = ContractFactory::new(abi.clone(), bin.clone(), provider.clone(), timeout);
+        let factory =
+            ContractFactory::<N, _>::new(abi.clone(), bin.clone(), provider.clone(), timeout);
 
         let is_args_empty = args.is_empty();
         let mut deployer =
@@ -302,18 +323,16 @@ impl CreateArgs {
         deployer.tx.set_from(deployer_address);
         deployer.tx.set_chain_id(chain);
         // `to` field must be set explicitly, cannot be None.
-        if deployer.tx.to.is_none() {
+        if deployer.tx.to().is_none() {
             deployer.tx.set_create();
         }
-        deployer.tx.set_nonce(if let Some(nonce) = self.tx.nonce {
-            Ok(nonce.to())
-        } else {
-            provider.get_transaction_count(deployer_address).await
-        }?);
 
-        // set tx value if specified
-        if let Some(value) = self.tx.value {
-            deployer.tx.set_value(value);
+        // Apply user-provided gas, fee, nonce, and Tempo options.
+        self.tx.apply::<N>(&mut deployer.tx, is_legacy);
+
+        // Fetch defaults from provider for values not specified by user.
+        if self.tx.nonce.is_none() && !self.tx.tempo.expiring_nonce {
+            deployer.tx.set_nonce(provider.get_transaction_count(deployer_address).await?);
         }
 
         // set access list if specified
@@ -325,34 +344,22 @@ impl CreateArgs {
             deployer.tx.set_access_list(access_list);
         }
 
-        deployer.tx.set_gas_limit(if let Some(gas_limit) = self.tx.gas_limit {
-            Ok(gas_limit.to())
-        } else {
-            provider.estimate_gas(deployer.tx.clone()).await
-        }?);
+        if self.tx.gas_limit.is_none() {
+            deployer.tx.set_gas_limit(provider.estimate_gas(deployer.tx.clone()).await?);
+        }
 
         if is_legacy {
-            let gas_price = if let Some(gas_price) = self.tx.gas_price {
-                gas_price.to()
-            } else {
-                provider.get_gas_price().await?
-            };
-            deployer.tx.set_gas_price(gas_price);
-        } else {
+            if self.tx.gas_price.is_none() {
+                deployer.tx.set_gas_price(provider.get_gas_price().await?);
+            }
+        } else if self.tx.gas_price.is_none() || self.tx.priority_gas_price.is_none() {
             let estimate = provider.estimate_eip1559_fees().await.wrap_err("Failed to estimate EIP1559 fees. This chain might not support EIP1559, try adding --legacy to your command.")?;
-            let priority_fee = if let Some(priority_fee) = self.tx.priority_gas_price {
-                priority_fee.to()
-            } else {
-                estimate.max_priority_fee_per_gas
-            };
-            let max_fee = if let Some(max_fee) = self.tx.gas_price {
-                max_fee.to()
-            } else {
-                estimate.max_fee_per_gas
-            };
-
-            deployer.tx.set_max_fee_per_gas(max_fee);
-            deployer.tx.set_max_priority_fee_per_gas(priority_fee);
+            if self.tx.priority_gas_price.is_none() {
+                deployer.tx.set_max_priority_fee_per_gas(estimate.max_priority_fee_per_gas);
+            }
+            if self.tx.gas_price.is_none() {
+                deployer.tx.set_max_fee_per_gas(estimate.max_fee_per_gas);
+            }
         }
 
         // Before we actually deploy the contract we try check if the verify settings are valid
@@ -399,17 +406,18 @@ impl CreateArgs {
         let (deployed_contract, receipt) = deployer.send_with_receipt().await?;
 
         let address = deployed_contract;
+        let tx_hash = receipt.transaction_hash();
         if shell::is_json() {
             let output = json!({
                 "deployer": deployer_address.to_string(),
                 "deployedTo": address.to_string(),
-                "transactionHash": receipt.transaction_hash
+                "transactionHash": tx_hash
             });
             sh_println!("{}", serde_json::to_string_pretty(&output)?)?;
         } else {
             sh_println!("Deployer: {deployer_address}")?;
             sh_println!("Deployed to: {address}")?;
-            sh_println!("Transaction hash: {:?}", receipt.transaction_hash)?;
+            sh_println!("Transaction hash: {tx_hash:?}")?;
         };
 
         if !self.verify {
@@ -449,7 +457,7 @@ impl CreateArgs {
             guess_constructor_args: false,
             compilation_profile: Some(id.profile.to_string()),
             language: None,
-            creation_transaction_hash: Some(receipt.transaction_hash),
+            creation_transaction_hash: Some(tx_hash),
         };
         sh_println!("Waiting for {} to detect contract deployment...", verify.verifier.verifier)?;
         verify.run().await
@@ -504,30 +512,30 @@ impl figment::Provider for CreateArgs {
 /// compatibility with less-abstract Contracts.
 ///
 /// For full usage docs, see [`DeploymentTxFactory`].
-pub type ContractFactory<P> = DeploymentTxFactory<P>;
+pub type ContractFactory<N, P> = DeploymentTxFactory<N, P>;
 
 /// Helper which manages the deployment transaction of a smart contract. It
 /// wraps a deployment transaction, and retrieves the contract address output
 /// by it.
 #[derive(Debug)]
 #[must_use = "ContractDeploymentTx does nothing unless you `send` it"]
-pub struct ContractDeploymentTx<P, C> {
+pub struct ContractDeploymentTx<N: Network, P, C> {
     /// the actual deployer, exposed for overriding the defaults
-    pub deployer: Deployer<P>,
+    pub deployer: Deployer<N, P>,
     /// marker for the `Contract` type to create afterwards
     ///
     /// this type will be used to construct it via `From::from(Contract)`
     _contract: PhantomData<C>,
 }
 
-impl<P: Clone, C> Clone for ContractDeploymentTx<P, C> {
+impl<N: Network, P: Clone, C> Clone for ContractDeploymentTx<N, P, C> {
     fn clone(&self) -> Self {
         Self { deployer: self.deployer.clone(), _contract: self._contract }
     }
 }
 
-impl<P, C> From<Deployer<P>> for ContractDeploymentTx<P, C> {
-    fn from(deployer: Deployer<P>) -> Self {
+impl<N: Network, P, C> From<Deployer<N, P>> for ContractDeploymentTx<N, P, C> {
+    fn from(deployer: Deployer<N, P>) -> Self {
         Self { deployer, _contract: PhantomData }
     }
 }
@@ -535,21 +543,21 @@ impl<P, C> From<Deployer<P>> for ContractDeploymentTx<P, C> {
 /// Helper which manages the deployment transaction of a smart contract
 #[derive(Clone, Debug)]
 #[must_use = "Deployer does nothing unless you `send` it"]
-pub struct Deployer<P> {
+pub struct Deployer<N: Network, P> {
     /// The deployer's transaction, exposed for overriding the defaults
-    pub tx: WithOtherFields<TransactionRequest>,
+    pub tx: N::TransactionRequest,
     client: P,
     confs: usize,
     timeout: u64,
 }
 
-impl<P: Provider<AnyNetwork>> Deployer<P> {
+impl<N: Network, P: Provider<N>> Deployer<N, P> {
     /// Broadcasts the contract deployment transaction and after waiting for it to
     /// be sufficiently confirmed (default: 1), it returns a tuple with the [`Address`] at the
-    /// deployed contract's address and the corresponding [`AnyTransactionReceipt`].
+    /// deployed contract's address and the corresponding receipt.
     pub async fn send_with_receipt(
         self,
-    ) -> Result<(Address, AnyTransactionReceipt), ContractDeploymentError> {
+    ) -> Result<(Address, N::ReceiptResponse), ContractDeploymentError> {
         let receipt = self
             .client
             .borrow()
@@ -561,7 +569,7 @@ impl<P: Provider<AnyNetwork>> Deployer<P> {
             .await?;
 
         let address =
-            receipt.contract_address.ok_or(ContractDeploymentError::ContractNotDeployed)?;
+            receipt.contract_address().ok_or(ContractDeploymentError::ContractNotDeployed)?;
 
         Ok((address, receipt))
     }
@@ -571,19 +579,20 @@ impl<P: Provider<AnyNetwork>> Deployer<P> {
 /// created which manages the Contract bytecode and Application Binary Interface
 /// (ABI), usually generated from the Solidity compiler.
 #[derive(Clone, Debug)]
-pub struct DeploymentTxFactory<P> {
+pub struct DeploymentTxFactory<N: Network, P> {
     client: P,
     abi: JsonAbi,
     bytecode: Bytes,
     timeout: u64,
+    _network: PhantomData<N>,
 }
 
-impl<P: Provider<AnyNetwork> + Clone> DeploymentTxFactory<P> {
+impl<N: Network, P: Provider<N> + Clone> DeploymentTxFactory<N, P> {
     /// Creates a factory for deployment of the Contract with bytecode, and the
     /// constructor defined in the abi. The client will be used to send any deployment
     /// transaction.
     pub fn new(abi: JsonAbi, bytecode: Bytes, client: P, timeout: u64) -> Self {
-        Self { client, abi, bytecode, timeout }
+        Self { client, abi, bytecode, timeout, _network: PhantomData }
     }
 
     /// Create a deployment tx using the provided tokens as constructor
@@ -591,7 +600,7 @@ impl<P: Provider<AnyNetwork> + Clone> DeploymentTxFactory<P> {
     pub fn deploy_tokens(
         self,
         params: Vec<DynSolValue>,
-    ) -> Result<Deployer<P>, ContractDeploymentError> {
+    ) -> Result<Deployer<N, P>, ContractDeploymentError> {
         // Encode the constructor args & concatenate with the bytecode if necessary
         let data: Bytes = match (self.abi.constructor(), params.is_empty()) {
             (None, false) => return Err(ContractDeploymentError::ConstructorError),
@@ -607,7 +616,8 @@ impl<P: Provider<AnyNetwork> + Clone> DeploymentTxFactory<P> {
         };
 
         // create the tx object. Since we're deploying a contract, `to` is `None`
-        let tx = WithOtherFields::new(TransactionRequest::default().input(data.into()));
+        let mut tx = N::TransactionRequest::default();
+        tx.set_input(data);
 
         Ok(Deployer { client: self.client.clone(), tx, confs: 1, timeout: self.timeout })
     }


### PR DESCRIPTION
## Summary
- Replace hardcoded `AnyNetwork` with `is_tempo()` dispatch pattern in `forge create`, enabling Tempo network options (`--tempo.fee-token`, `--tempo.seq`, etc.) for contract deployment
- Replace ~50 lines of inline tx option application with centralized `TransactionOpts::apply::<N>()`
- Make `Deployer`, `DeploymentTxFactory`, and type aliases generic over `N: Network`

Follows the same pattern established in `cast send` (#13721) and `cast erc20` (#13732).