### PR TITLE
chore(primitives): remove tmp `FoundryNetwork` impls

### DIFF
--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -1,6 +1,6 @@
 use alloy_consensus::{
-    Sealed, SignableTransaction, Signed, TransactionEnvelope, TxEip1559, TxEip2930, TxEnvelope,
-    TxLegacy, TxType, Typed2718,
+    Sealed, Signed, TransactionEnvelope, TxEip1559, TxEip2930, TxEnvelope, TxLegacy, TxType,
+    Typed2718,
     crypto::RecoveryError,
     transaction::{
         SignerRecoverable, TxEip7702, TxHashRef,
@@ -9,10 +9,8 @@ use alloy_consensus::{
 };
 use alloy_evm::FromRecoveredTx;
 use alloy_network::{AnyRpcTransaction, AnyTxEnvelope, TransactionResponse};
-use alloy_primitives::{Address, B256, ChainId, TxHash};
-use alloy_rlp::BufMut;
+use alloy_primitives::{Address, B256, TxHash};
 use alloy_rpc_types::ConversionError;
-use alloy_signer::Signature;
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpTransaction as OpTransactionTrait, TxDeposit};
 use op_revm::OpTransaction;
 use revm::context::TxEnv;
@@ -201,39 +199,6 @@ impl TryFrom<AnyRpcTransaction> for FoundryTxEnvelope {
     }
 }
 
-// TODO: This is tmp implementation, remove it after Cast refactor being finished
-impl From<Signed<FoundryTypedTx>> for FoundryTxEnvelope {
-    fn from(value: Signed<FoundryTypedTx>) -> Self {
-        let (tx, sig, hash) = value.into_parts();
-        match tx {
-            FoundryTypedTx::Legacy(tx_legacy) => {
-                let tx = Signed::new_unchecked(tx_legacy, sig, hash);
-                Self::Legacy(tx)
-            }
-            FoundryTypedTx::Eip2930(tx_eip2930) => {
-                let tx = Signed::new_unchecked(tx_eip2930, sig, hash);
-                Self::Eip2930(tx)
-            }
-            FoundryTypedTx::Eip1559(tx_eip1559) => {
-                let tx = Signed::new_unchecked(tx_eip1559, sig, hash);
-                Self::Eip1559(tx)
-            }
-            FoundryTypedTx::Eip4844(tx_eip4844) => {
-                let tx = Signed::new_unchecked(tx_eip4844, sig, hash);
-                Self::Eip4844(tx)
-            }
-            FoundryTypedTx::Eip7702(tx_eip7702) => {
-                let tx = Signed::new_unchecked(tx_eip7702, sig, hash);
-                Self::Eip7702(tx)
-            }
-            FoundryTypedTx::Deposit(tx) => Self::Deposit(Sealed::new_unchecked(tx, hash)),
-            FoundryTypedTx::Tempo(tempo_transaction) => {
-                Self::Tempo(tempo_transaction.into_signed(sig.into()))
-            }
-        }
-    }
-}
-
 impl FromRecoveredTx<FoundryTxEnvelope> for TxEnv {
     fn from_recovered_tx(tx: &FoundryTxEnvelope, caller: Address) -> Self {
         match tx {
@@ -306,150 +271,13 @@ impl From<FoundryTxEnvelope> for FoundryTypedTx {
     }
 }
 
-// TODO: This is tmp implementation, remove it after Cast refactor being finished
-impl alloy_consensus::transaction::RlpEcdsaEncodableTx for FoundryTypedTx {
-    fn rlp_encoded_fields_length(&self) -> usize {
-        match self {
-            Self::Legacy(tx) => tx.rlp_encoded_fields_length(),
-            Self::Eip2930(tx) => tx.rlp_encoded_fields_length(),
-            Self::Eip1559(tx) => tx.rlp_encoded_fields_length(),
-            Self::Eip4844(tx) => tx.rlp_encoded_fields_length(),
-            Self::Eip7702(tx) => tx.rlp_encoded_fields_length(),
-            // TxDeposit & TempoTransaction impls are private
-            Self::Deposit(_) => 0,
-            Self::Tempo(_) => 0,
-        }
-    }
-
-    fn rlp_encode_fields(&self, out: &mut dyn BufMut) {
-        match self {
-            Self::Legacy(tx) => tx.rlp_encode_fields(out),
-            Self::Eip2930(tx) => tx.rlp_encode_fields(out),
-            Self::Eip1559(tx) => tx.rlp_encode_fields(out),
-            Self::Eip4844(tx) => tx.rlp_encode_fields(out),
-            Self::Eip7702(tx) => tx.rlp_encode_fields(out),
-            Self::Deposit(_) => {}
-            Self::Tempo(_) => {}
-        }
-    }
-
-    fn eip2718_encode_with_type(&self, signature: &Signature, _ty: u8, out: &mut dyn BufMut) {
-        match self {
-            Self::Legacy(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
-            Self::Eip2930(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
-            Self::Eip1559(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
-            Self::Eip4844(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
-            Self::Eip7702(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
-            Self::Deposit(_) => {}
-            Self::Tempo(_) => {}
-        }
-    }
-
-    fn eip2718_encode(&self, signature: &Signature, out: &mut dyn BufMut) {
-        match self {
-            Self::Legacy(tx) => tx.eip2718_encode(signature, out),
-            Self::Eip2930(tx) => tx.eip2718_encode(signature, out),
-            Self::Eip1559(tx) => tx.eip2718_encode(signature, out),
-            Self::Eip4844(tx) => tx.eip2718_encode(signature, out),
-            Self::Eip7702(tx) => tx.eip2718_encode(signature, out),
-            Self::Deposit(_) => {}
-            Self::Tempo(_) => {}
-        }
-    }
-
-    fn network_encode_with_type(&self, signature: &Signature, _ty: u8, out: &mut dyn BufMut) {
-        match self {
-            Self::Legacy(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
-            Self::Eip2930(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
-            Self::Eip1559(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
-            Self::Eip4844(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
-            Self::Eip7702(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
-            Self::Deposit(_) => {}
-            Self::Tempo(_) => {}
-        }
-    }
-
-    fn network_encode(&self, signature: &Signature, out: &mut dyn BufMut) {
-        match self {
-            Self::Legacy(tx) => tx.network_encode(signature, out),
-            Self::Eip2930(tx) => tx.network_encode(signature, out),
-            Self::Eip1559(tx) => tx.network_encode(signature, out),
-            Self::Eip4844(tx) => tx.network_encode(signature, out),
-            Self::Eip7702(tx) => tx.network_encode(signature, out),
-            Self::Deposit(_) => {}
-            Self::Tempo(_) => {}
-        }
-    }
-
-    fn tx_hash_with_type(&self, signature: &Signature, _ty: u8) -> TxHash {
-        match self {
-            Self::Legacy(tx) => tx.tx_hash_with_type(signature, tx.ty()),
-            Self::Eip2930(tx) => tx.tx_hash_with_type(signature, tx.ty()),
-            Self::Eip1559(tx) => tx.tx_hash_with_type(signature, tx.ty()),
-            Self::Eip4844(tx) => tx.tx_hash_with_type(signature, tx.ty()),
-            Self::Eip7702(tx) => tx.tx_hash_with_type(signature, tx.ty()),
-            Self::Deposit(_) => Default::default(),
-            Self::Tempo(_) => Default::default(),
-        }
-    }
-
-    fn tx_hash(&self, signature: &Signature) -> TxHash {
-        match self {
-            Self::Legacy(tx) => tx.tx_hash(signature),
-            Self::Eip2930(tx) => tx.tx_hash(signature),
-            Self::Eip1559(tx) => tx.tx_hash(signature),
-            Self::Eip4844(tx) => tx.tx_hash(signature),
-            Self::Eip7702(tx) => tx.tx_hash(signature),
-            Self::Deposit(_) => Default::default(),
-            Self::Tempo(_) => Default::default(),
-        }
-    }
-}
-
-impl SignableTransaction<Signature> for FoundryTypedTx {
-    fn set_chain_id(&mut self, chain_id: ChainId) {
-        match self {
-            Self::Legacy(tx) => tx.set_chain_id(chain_id),
-            Self::Eip2930(tx) => tx.set_chain_id(chain_id),
-            Self::Eip1559(tx) => tx.set_chain_id(chain_id),
-            Self::Eip4844(tx) => tx.set_chain_id(chain_id),
-            Self::Eip7702(tx) => tx.set_chain_id(chain_id),
-            Self::Deposit(_) => {}
-            Self::Tempo(tx) => tx.set_chain_id(chain_id),
-        }
-    }
-
-    fn encode_for_signing(&self, out: &mut dyn BufMut) {
-        match self {
-            Self::Legacy(tx) => tx.encode_for_signing(out),
-            Self::Eip2930(tx) => tx.encode_for_signing(out),
-            Self::Eip1559(tx) => tx.encode_for_signing(out),
-            Self::Eip4844(tx) => tx.encode_for_signing(out),
-            Self::Eip7702(tx) => tx.encode_for_signing(out),
-            Self::Deposit(_) => {}
-            Self::Tempo(tx) => tx.encode_for_signing(out),
-        }
-    }
-
-    fn payload_len_for_signature(&self) -> usize {
-        match self {
-            Self::Legacy(tx) => tx.payload_len_for_signature(),
-            Self::Eip2930(tx) => tx.payload_len_for_signature(),
-            Self::Eip1559(tx) => tx.payload_len_for_signature(),
-            Self::Eip4844(tx) => tx.payload_len_for_signature(),
-            Self::Eip7702(tx) => tx.payload_len_for_signature(),
-            Self::Deposit(_) => 0,
-            Self::Tempo(tx) => tx.payload_len_for_signature(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
 
     use alloy_primitives::{Bytes, TxKind, U256, b256, hex};
     use alloy_rlp::Decodable;
+    use alloy_signer::Signature;
 
     use super::*;
 


### PR DESCRIPTION
## Motivation

Since #13587 is merged we can now remove tmp `SignableTransaction<Signature>`, `RlpEcdsaEncodableTx`, `From<Signed<FoundryTypedTx>>` trait impls.
