### PR TITLE
fix(anvil): swap param order in get_next_block_blob_excess_gas to match callers

### DIFF
--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -167,9 +167,9 @@ impl FeeManager {
         self.blob_params().calc_blob_fee(self.blob_excess_gas_and_price.read().excess_blob_gas)
     }
 
-    /// Calculates the next block blob excess gas, using the provided parent blob gas used and
-    /// parent blob excess gas
-    pub fn get_next_block_blob_excess_gas(&self, blob_gas_used: u64, blob_excess_gas: u64) -> u64 {
+    /// Calculates the next block blob excess gas, using the provided parent blob excess gas and
+    /// parent blob gas used
+    pub fn get_next_block_blob_excess_gas(&self, blob_excess_gas: u64, blob_gas_used: u64) -> u64 {
         self.blob_params().next_block_excess_blob_gas_osaka(
             blob_excess_gas,
             blob_gas_used,


### PR DESCRIPTION
The param names were swapped relative to what callers actually pass — worked by accident since the osaka formula uses addition (commutative), but the double-reversal was confusing and fragile. Just aligned the signature with all three call sites.