### PR TITLE
refactor(anvil): make block-by-hash path network-generic

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -666,23 +666,8 @@ impl<T> EthApi<T> {
     pub fn is_impersonated(&self, addr: Address) -> bool {
         self.backend.cheats().is_impersonated(addr)
     }
-}
 
-// == impl EthApi anvil endpoints ==
-
-impl EthApi {
-    // TODO: move to `impl<T> EthApi<T>` once `Backend::block_by_hash` is network-generic.
-
-    /// Revert the state of the blockchain to a previous snapshot.
-    /// Takes a single parameter, which is the snapshot id to revert to.
-    ///
-    /// Handler for RPC call: `evm_revert`
-    pub async fn evm_revert(&self, id: U256) -> Result<bool> {
-        node_info!("evm_revert");
-        self.backend.revert_state_snapshot(id).await
-    }
-
-    async fn block_request(&self, block_number: Option<BlockId>) -> Result<BlockRequest> {
+    async fn block_request(&self, block_number: Option<BlockId>) -> Result<BlockRequest<T>> {
         let block_request = match block_number {
             Some(BlockId::Number(BlockNumber::Pending)) => {
                 let pending_txs = self.pool.ready_transactions().collect();
@@ -694,6 +679,19 @@ impl EthApi {
             }
         };
         Ok(block_request)
+    }
+}
+
+// == impl EthApi anvil endpoints ==
+
+impl EthApi {
+    /// Revert the state of the blockchain to a previous snapshot.
+    /// Takes a single parameter, which is the snapshot id to revert to.
+    ///
+    /// Handler for RPC call: `evm_revert`
+    pub async fn evm_revert(&self, id: U256) -> Result<bool> {
+        node_info!("evm_revert");
+        self.backend.revert_state_snapshot(id).await
     }
 
     /// Increases the balance of an account.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -719,6 +719,65 @@ impl<N: Network> Backend<N> {
         self.blockchain.get_block_by_hash(&hash)
     }
 
+    pub async fn block_by_hash(&self, hash: B256) -> Result<Option<AnyRpcBlock>, BlockchainError> {
+        trace!(target: "backend", "get block by hash {:?}", hash);
+        if let tx @ Some(_) = self.mined_block_by_hash(hash) {
+            return Ok(tx);
+        }
+
+        if let Some(fork) = self.get_fork() {
+            return Ok(fork.block_by_hash(hash).await?);
+        }
+
+        Ok(None)
+    }
+
+    fn mined_block_by_hash(&self, hash: B256) -> Option<AnyRpcBlock> {
+        let block = self.blockchain.get_block_by_hash(&hash)?;
+        Some(self.convert_block_with_hash(block, Some(hash)))
+    }
+
+    /// Takes a block as it's stored internally and returns the eth api conform block format.
+    pub fn convert_block(&self, block: Block) -> AnyRpcBlock {
+        self.convert_block_with_hash(block, None)
+    }
+
+    /// Takes a block as it's stored internally and returns the eth api conform block format.
+    /// If `known_hash` is provided, it will be used instead of computing `hash_slow()`.
+    pub fn convert_block_with_hash(&self, block: Block, known_hash: Option<B256>) -> AnyRpcBlock {
+        let size = U256::from(alloy_rlp::encode(&block).len() as u32);
+
+        let header = block.header.clone();
+        let transactions = block.body.transactions;
+
+        let hash = known_hash.unwrap_or_else(|| header.hash_slow());
+        let Header { number, withdrawals_root, .. } = header;
+
+        let block = AlloyBlock {
+            header: AlloyHeader {
+                inner: AnyHeader::from(header),
+                hash,
+                total_difficulty: Some(self.total_difficulty()),
+                size: Some(size),
+            },
+            transactions: alloy_rpc_types::BlockTransactions::Hashes(
+                transactions.into_iter().map(|tx| tx.hash()).collect(),
+            ),
+            uncles: vec![],
+            withdrawals: withdrawals_root.map(|_| Default::default()),
+        };
+
+        let mut block = WithOtherFields::new(block);
+
+        // If Arbitrum, apply chain specifics to converted block.
+        if is_arbitrum(self.env.read().evm_env.cfg_env.chain_id) {
+            // Set `l1BlockNumber` field.
+            block.other.insert("l1BlockNumber".to_string(), number.into());
+        }
+
+        AnyRpcBlock::from(block)
+    }
+
     /// Returns the traces for the given transaction
     pub(crate) fn mined_parity_trace_transaction(
         &self,


### PR DESCRIPTION
Move block-by-hash and block conversion helpers into `impl<N: Network> Backend<N>`, and move `block_request` to `impl<T> EthApi<T>` to complete this genericization step.