### PR TITLE
refactor(cast): deduplicate browser wallet receipt handling in `cast send`

### DIFF
--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -202,34 +202,18 @@ impl SendTxArgs {
             )
             .await
         // Case 2:
+        // Browser wallet signs and sends the transaction in one step.
+        } else if let Some(browser) = browser {
+            let (tx_request, _) = builder.build(browser.address()).await?;
+            let tx_hash = browser.send_transaction_via_browser(tx_request).await?;
+
+            let cast = CastTxSender::new(&provider);
+            cast.print_tx_result(tx_hash, send_tx.cast_async, send_tx.confirmations, timeout).await
+        // Case 3:
         // An option to use a local signer was provided.
         // If we cannot successfully instantiate a local signer, then we will assume we don't have
         // enough information to sign and we must bail.
         } else {
-            // Browser wallet work differently as it sign and send the transaction in one step.
-            if let Some(browser) = browser {
-                let (tx_request, _) = builder.build(browser.address()).await?;
-                let tx_hash = browser.send_transaction_via_browser(tx_request).await?;
-
-                if send_tx.cast_async {
-                    sh_println!("{tx_hash:#x}")?;
-                } else {
-                    let receipt = CastTxSender::new(&provider)
-                        .receipt(
-                            format!("{tx_hash:#x}"),
-                            None,
-                            send_tx.confirmations,
-                            Some(timeout),
-                            false,
-                        )
-                        .await?;
-                    sh_println!("{receipt}")?;
-                }
-
-                return Ok(());
-            }
-
-            // Retrieve the signer, and bail if it can't be constructed.
             let signer = send_tx.eth.wallet.signer().await?;
             let from = signer.address();
 
@@ -275,15 +259,8 @@ where
         sh_println!("{receipt}")?;
     } else {
         let pending_tx = cast.send(tx).await?;
-        let tx_hash = pending_tx.inner().tx_hash();
-
-        if cast_async {
-            sh_println!("{tx_hash:#x}")?;
-        } else {
-            let receipt =
-                cast.receipt(format!("{tx_hash:#x}"), None, confs, Some(timeout), false).await?;
-            sh_println!("{receipt}")?;
-        }
+        let tx_hash = *pending_tx.inner().tx_hash();
+        cast.print_tx_result(tx_hash, cast_async, confs, timeout).await?;
     }
 
     Ok(())

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -4,7 +4,7 @@ use alloy_dyn_abi::ErrorExt;
 use alloy_ens::NameOrAddress;
 use alloy_json_abi::Function;
 use alloy_network::{Network, TransactionBuilder};
-use alloy_primitives::{Address, Bytes, TxHash, TxKind, U256, hex};
+use alloy_primitives::{Address, B256, Bytes, TxHash, TxKind, U256, hex};
 use alloy_provider::{PendingTransactionBuilder, Provider};
 use alloy_rpc_types::{AccessList, Authorization, TransactionInputKind};
 use alloy_signer::Signer;
@@ -234,6 +234,27 @@ where
     pub async fn send_raw(&self, raw_tx: &[u8]) -> Result<PendingTransactionBuilder<N>> {
         let res = self.provider.send_raw_transaction(raw_tx).await?;
         Ok(res)
+    }
+
+    /// Prints the transaction hash (if async) or waits for the receipt and prints it.
+    ///
+    /// This is the shared "output" path used by both the normal send flow and the browser wallet
+    /// flow (which sends the transaction out-of-band and only has a tx hash).
+    pub async fn print_tx_result(
+        &self,
+        tx_hash: B256,
+        cast_async: bool,
+        confs: u64,
+        timeout: u64,
+    ) -> Result<()> {
+        if cast_async {
+            sh_println!("{tx_hash:#x}")?;
+        } else {
+            let receipt =
+                self.receipt(format!("{tx_hash:#x}"), None, confs, Some(timeout), false).await?;
+            sh_println!("{receipt}")?;
+        }
+        Ok(())
     }
 
     /// # Example


### PR DESCRIPTION
## Summary
- Extract `CastTxSender::print_tx_result()` to share the "print hash or wait for receipt" logic between the normal send flow and the browser wallet flow
- Flatten the browser case into its own `else if` branch so `--browser` takes priority over `--unlocked` instead of being silently ignored