### PR TITLE
chore(anvil): simplify `evm` tests by removing useless `Env` wrapper.

### DIFF
--- a/crates/anvil/src/evm.rs
+++ b/crates/anvil/src/evm.rs
@@ -15,19 +15,18 @@ mod tests {
 
     use crate::PrecompileFactory;
     use alloy_evm::{
-        EthEvm, Evm, EvmEnv,
+        EthEvm, Evm,
         eth::EthEvmContext,
         precompiles::{DynPrecompile, PrecompilesMap},
     };
     use alloy_op_evm::OpEvm;
     use alloy_primitives::{Address, Bytes, TxKind, U256, address};
     use foundry_evm::core::either_evm::EitherEvm;
-    use foundry_evm_networks::NetworkConfigs;
     use itertools::Itertools;
     use op_revm::{L1BlockInfo, OpContext, OpSpecId, OpTransaction, precompiles::OpPrecompiles};
     use revm::{
         Journal,
-        context::{CfgEnv, Evm as RevmEvm, JournalTr, LocalContext, TxEnv},
+        context::{BlockEnv, CfgEnv, Evm as RevmEvm, JournalTr, LocalContext, TxEnv},
         database::{EmptyDB, EmptyDBTyped},
         handler::{EthPrecompiles, instructions::EthInstructions},
         inspector::NoOpInspector,
@@ -72,22 +71,18 @@ mod tests {
     /// Creates a new EVM instance with the custom precompile factory.
     fn create_eth_evm(
         spec: SpecId,
-    ) -> (foundry_evm::Env, EitherEvm<EmptyDBTyped<Infallible>, NoOpInspector, PrecompilesMap>)
-    {
-        let eth_env = foundry_evm::Env {
-            evm_env: EvmEnv { block_env: Default::default(), cfg_env: CfgEnv::new_with_spec(spec) },
-            tx: TxEnv {
-                kind: TxKind::Call(PRECOMPILE_ADDR),
-                data: PAYLOAD.into(),
-                ..Default::default()
-            },
+    ) -> (TxEnv, EitherEvm<EmptyDBTyped<Infallible>, NoOpInspector, PrecompilesMap>) {
+        let tx_env = TxEnv {
+            kind: TxKind::Call(PRECOMPILE_ADDR),
+            data: PAYLOAD.into(),
+            ..Default::default()
         };
 
         let eth_evm_context = EthEvmContext {
             journaled_state: Journal::new(EmptyDB::default()),
-            block: eth_env.evm_env.block_env.clone(),
-            cfg: eth_env.evm_env.cfg_env.clone(),
-            tx: eth_env.tx.clone(),
+            block: BlockEnv::default(),
+            cfg: CfgEnv::new_with_spec(spec),
+            tx: tx_env.clone(),
             chain: (),
             local: LocalContext::default(),
             error: Ok(()),
@@ -108,28 +103,22 @@ mod tests {
             true,
         ));
 
-        (eth_env, eth_evm)
+        (tx_env, eth_evm)
     }
 
     /// Creates a new OP EVM instance with the custom precompile factory.
     fn create_op_evm(
         spec: SpecId,
         op_spec: OpSpecId,
-    ) -> (
-        crate::eth::backend::env::Env,
-        EitherEvm<EmptyDBTyped<Infallible>, NoOpInspector, PrecompilesMap>,
-    ) {
-        let op_env = crate::eth::backend::env::Env {
-            evm_env: EvmEnv { block_env: Default::default(), cfg_env: CfgEnv::new_with_spec(spec) },
-            tx: OpTransaction::<TxEnv> {
-                base: TxEnv {
-                    kind: TxKind::Call(PRECOMPILE_ADDR),
-                    data: PAYLOAD.into(),
-                    ..Default::default()
-                },
+    ) -> (OpTransaction<TxEnv>, EitherEvm<EmptyDBTyped<Infallible>, NoOpInspector, PrecompilesMap>)
+    {
+        let tx = OpTransaction::<TxEnv> {
+            base: TxEnv {
+                kind: TxKind::Call(PRECOMPILE_ADDR),
+                data: PAYLOAD.into(),
                 ..Default::default()
             },
-            networks: NetworkConfigs::with_optimism(),
+            ..Default::default()
         };
 
         let mut chain = L1BlockInfo::default();
@@ -144,12 +133,12 @@ mod tests {
             journaled_state: {
                 let mut journal = Journal::new(EmptyDB::default());
                 // Converting SpecId into OpSpecId
-                journal.set_spec_id(op_env.evm_env.cfg_env.spec);
+                journal.set_spec_id(spec);
                 journal
             },
-            block: op_env.evm_env.block_env.clone(),
+            block: BlockEnv::default(),
             cfg: op_cfg.clone(),
-            tx: op_env.tx.clone(),
+            tx: tx.clone(),
             chain,
             local: LocalContext::default(),
             error: Ok(()),
@@ -166,12 +155,12 @@ mod tests {
             true,
         ));
 
-        (op_env, op_evm)
+        (tx, op_evm)
     }
 
     #[test]
     fn build_eth_evm_with_extra_precompiles_osaka_spec() {
-        let (env, mut evm) = create_eth_evm(SpecId::OSAKA);
+        let (tx_env, mut evm) = create_eth_evm(SpecId::OSAKA);
 
         // Check that the Osaka precompile IS present when using the Osaka spec.
         assert!(evm.precompiles().addresses().contains(&ETH_OSAKA_PRECOMPILE));
@@ -186,7 +175,7 @@ mod tests {
         assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         let result = match &mut evm {
-            EitherEvm::Eth(eth_evm) => eth_evm.transact(env.tx).unwrap(),
+            EitherEvm::Eth(eth_evm) => eth_evm.transact(tx_env).unwrap(),
             _ => unreachable!(),
         };
 
@@ -196,7 +185,7 @@ mod tests {
 
     #[test]
     fn build_eth_evm_with_extra_precompiles_london_spec() {
-        let (env, mut evm) = create_eth_evm(SpecId::LONDON);
+        let (tx_env, mut evm) = create_eth_evm(SpecId::LONDON);
 
         // Check that the Osaka precompile IS NOT present when using the London spec.
         assert!(!evm.precompiles().addresses().contains(&ETH_OSAKA_PRECOMPILE));
@@ -211,7 +200,7 @@ mod tests {
         assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         let result = match &mut evm {
-            EitherEvm::Eth(eth_evm) => eth_evm.transact(env.tx).unwrap(),
+            EitherEvm::Eth(eth_evm) => eth_evm.transact(tx_env).unwrap(),
             _ => unreachable!(),
         };
 
@@ -221,7 +210,7 @@ mod tests {
 
     #[test]
     fn build_eth_evm_with_extra_precompiles_prague_spec() {
-        let (env, mut evm) = create_eth_evm(SpecId::PRAGUE);
+        let (tx_env, mut evm) = create_eth_evm(SpecId::PRAGUE);
 
         // Check that the Osaka precompile IS NOT present when using the Prague spec.
         assert!(!evm.precompiles().addresses().contains(&ETH_OSAKA_PRECOMPILE));
@@ -236,7 +225,7 @@ mod tests {
         assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         let result = match &mut evm {
-            EitherEvm::Eth(eth_evm) => eth_evm.transact(env.tx).unwrap(),
+            EitherEvm::Eth(eth_evm) => eth_evm.transact(tx_env).unwrap(),
             _ => unreachable!(),
         };
 
@@ -246,7 +235,7 @@ mod tests {
 
     #[test]
     fn build_op_evm_with_extra_precompiles_isthmus_spec() {
-        let (env, mut evm) = create_op_evm(SpecId::OSAKA, OpSpecId::ISTHMUS);
+        let (tx, mut evm) = create_op_evm(SpecId::OSAKA, OpSpecId::ISTHMUS);
 
         // Check that the Isthmus precompile IS present when using the Isthmus spec.
         assert!(evm.precompiles().addresses().contains(&OP_ISTHMUS_PRECOMPILE));
@@ -261,7 +250,7 @@ mod tests {
         assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         let result = match &mut evm {
-            EitherEvm::Op(op_evm) => op_evm.transact(env.tx).unwrap(),
+            EitherEvm::Op(op_evm) => op_evm.transact(tx).unwrap(),
             _ => unreachable!(),
         };
 
@@ -271,7 +260,7 @@ mod tests {
 
     #[test]
     fn build_op_evm_with_extra_precompiles_bedrock_spec() {
-        let (env, mut evm) = create_op_evm(SpecId::OSAKA, OpSpecId::BEDROCK);
+        let (tx, mut evm) = create_op_evm(SpecId::OSAKA, OpSpecId::BEDROCK);
 
         // Check that the Isthmus precompile IS NOT present when using the `OpSpecId::BEDROCK` spec.
         assert!(!evm.precompiles().addresses().contains(&OP_ISTHMUS_PRECOMPILE));
@@ -286,7 +275,7 @@ mod tests {
         assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         let result = match &mut evm {
-            EitherEvm::Op(op_evm) => op_evm.transact(env.tx).unwrap(),
+            EitherEvm::Op(op_evm) => op_evm.transact(tx).unwrap(),
             _ => unreachable!(),
         };
 


### PR DESCRIPTION
## Motivation

Smol tests simplification removing useless `Env` wrappers, as only `Tx` is used.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
