### PR TITLE
refactor(anvil): make mined_receipts generic

### DIFF
--- a/crates/anvil/src/eth/backend/info.rs
+++ b/crates/anvil/src/eth/backend/info.rs
@@ -1,10 +1,10 @@
 //! Handler that can get current storage related data
 
 use crate::mem::Backend;
+use alloy_consensus::TxReceipt;
 use alloy_network::{AnyRpcBlock, Network};
 use alloy_primitives::B256;
 use anvil_core::eth::block::Block;
-use foundry_primitives::{FoundryNetwork, FoundryReceiptEnvelope};
 use std::{fmt, sync::Arc};
 
 /// A type that can fetch data related to the ethereum storage.
@@ -39,16 +39,17 @@ impl<N: Network> StorageInfo<N> {
     }
 }
 
-impl StorageInfo<FoundryNetwork> {
-    // TODO: receipts methods require N::ReceiptEnvelope generalization
-
+impl<N: Network> StorageInfo<N>
+where
+    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log> + Clone,
+{
     /// Returns the receipts of the current block
-    pub fn current_receipts(&self) -> Option<Vec<FoundryReceiptEnvelope>> {
+    pub fn current_receipts(&self) -> Option<Vec<N::ReceiptEnvelope>> {
         self.backend.mined_receipts(self.backend.best_hash())
     }
 
     /// Returns the receipts of the block with the given hash
-    pub fn receipts(&self, hash: B256) -> Option<Vec<FoundryReceiptEnvelope>> {
+    pub fn receipts(&self, hash: B256) -> Option<Vec<N::ReceiptEnvelope>> {
         self.backend.mined_receipts(hash)
     }
 }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1570,7 +1570,7 @@ impl<N: Network> Backend<N> {
 
 impl<N: Network> Backend<N>
 where
-    N::ReceiptEnvelope: alloy_consensus::TxReceipt<Log = alloy_primitives::Log>,
+    N::ReceiptEnvelope: alloy_consensus::TxReceipt<Log = alloy_primitives::Log> + Clone,
 {
     /// Returns all `Log`s mined by the node that were emitted in the `block` and match the `Filter`
     fn mined_logs_for_block(&self, filter: Filter, block: Block, block_hash: B256) -> Vec<Log> {
@@ -1677,6 +1677,18 @@ where
 
             self.logs_for_range(&filter, from_block, to_block).await
         }
+    }
+
+    /// Returns all receipts of the block
+    pub fn mined_receipts(&self, hash: B256) -> Option<Vec<N::ReceiptEnvelope>> {
+        let block = self.mined_block_by_hash(hash)?;
+        let mut receipts = Vec::new();
+        let storage = self.blockchain.storage.read();
+        for tx in block.transactions.hashes() {
+            let receipt = storage.transactions.get(&tx)?.receipt.clone();
+            receipts.push(receipt);
+        }
+        Some(receipts)
     }
 }
 
@@ -3325,18 +3337,6 @@ impl Backend<FoundryNetwork> {
         }
 
         Ok(None)
-    }
-
-    /// Returns all receipts of the block
-    pub fn mined_receipts(&self, hash: B256) -> Option<Vec<FoundryReceiptEnvelope>> {
-        let block = self.mined_block_by_hash(hash)?;
-        let mut receipts = Vec::new();
-        let storage = self.blockchain.storage.read();
-        for tx in block.transactions.hashes() {
-            let receipt = storage.transactions.get(&tx)?.receipt.clone();
-            receipts.push(receipt);
-        }
-        Some(receipts)
     }
 
     /// Returns all transaction receipts of the block


### PR DESCRIPTION
Moves `mined_receipts` from `impl Backend<FoundryNetwork>` to the bounded generic `impl<N: Network> Backend<N>` block, and updates `StorageInfo::receipts` and `StorageInfo::current_receipts` accordingly.