### PR TITLE
feat(cheatcodes): bubble-up `Network` generic to `Wallets`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4869,6 +4869,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-evm",
  "alloy-json-abi",
+ "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types",
  "alloy-sol-types",

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -21,7 +21,7 @@ use crate::{
     utils::IgnoredTraces,
 };
 use alloy_consensus::BlobTransactionSidecarVariant;
-use alloy_network::TransactionBuilder4844;
+use alloy_network::{Ethereum, TransactionBuilder4844};
 use alloy_primitives::{
     Address, B256, Bytes, Log, TxKind, U256, hex,
     map::{AddressHashMap, HashMap, HashSet},
@@ -585,7 +585,7 @@ pub struct Cheatcodes {
     /// Deprecated cheatcodes mapped to the reason. Used to report warnings on test results.
     pub deprecated: HashMap<&'static str, Option<&'static str>>,
     /// Unlocked wallets used in scripts and testing of scripts.
-    pub wallets: Option<Wallets>,
+    pub wallets: Option<Wallets<Ethereum>>,
     /// Signatures identifier for decoding events and functions
     signatures_identifier: OnceLock<Option<SignaturesIdentifier>>,
     /// Used to determine whether the broadcasted call has dynamic gas limit.
@@ -666,12 +666,12 @@ impl Cheatcodes {
     }
 
     /// Returns the configured wallets if available, else creates a new instance.
-    pub fn wallets(&mut self) -> &Wallets {
+    pub fn wallets(&mut self) -> &Wallets<Ethereum> {
         self.wallets.get_or_insert_with(|| Wallets::new(MultiWallet::default(), None))
     }
 
     /// Sets the unlocked wallets.
-    pub fn set_wallets(&mut self, wallets: Wallets) {
+    pub fn set_wallets(&mut self, wallets: Wallets<Ethereum>) {
         self.wallets = Some(wallets);
     }
 

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -2,6 +2,7 @@
 
 use crate::{Cheatcode, CheatsCtxt, Result, Vm::*, evm::journaled_account};
 use alloy_consensus::{SidecarBuilder, SimpleCoder};
+use alloy_network::Network;
 use alloy_primitives::{Address, B256, U256, Uint};
 use alloy_rpc_types::Authorization;
 use alloy_signer::SignerSync;
@@ -348,30 +349,30 @@ pub struct Broadcast {
 
 /// Contains context for wallet management.
 #[derive(Debug)]
-pub struct WalletsInner {
+pub struct WalletsInner<N: Network> {
     /// All signers in scope of the script.
-    pub multi_wallet: MultiWallet,
+    pub multi_wallet: MultiWallet<N>,
     /// Optional signer provided as `--sender` flag.
     pub provided_sender: Option<Address>,
 }
 
 /// Cloneable wrapper around [`WalletsInner`].
 #[derive(Debug, Clone)]
-pub struct Wallets {
+pub struct Wallets<N: Network> {
     /// Inner data.
-    pub inner: Arc<Mutex<WalletsInner>>,
+    pub inner: Arc<Mutex<WalletsInner<N>>>,
 }
 
-impl Wallets {
+impl<N: Network> Wallets<N> {
     #[expect(missing_docs)]
-    pub fn new(multi_wallet: MultiWallet, provided_sender: Option<Address>) -> Self {
+    pub fn new(multi_wallet: MultiWallet<N>, provided_sender: Option<Address>) -> Self {
         Self { inner: Arc::new(Mutex::new(WalletsInner { multi_wallet, provided_sender })) }
     }
 
     /// Consumes [Wallets] and returns [MultiWallet].
     ///
     /// Panics if [Wallets] is still in use.
-    pub fn into_multi_wallet(self) -> MultiWallet {
+    pub fn into_multi_wallet(self) -> MultiWallet<N> {
         Arc::into_inner(self.inner)
             .map(|m| m.into_inner().multi_wallet)
             .unwrap_or_else(|| panic!("not all instances were dropped"))

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -27,6 +27,7 @@ foundry-evm-traces.workspace = true
 alloy-dyn-abi = { workspace = true, features = ["arbitrary", "eip712"] }
 alloy-evm.workspace = true
 alloy-json-abi.workspace = true
+alloy-network.workspace = true
 alloy-primitives = { workspace = true, features = [
     "serde",
     "getrandom",

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -2,6 +2,7 @@ use super::{
     Cheatcodes, CheatsConfig, ChiselState, CustomPrintTracer, Fuzzer, LineCoverageCollector,
     LogCollector, RevertDiagnostic, ScriptExecutionInspector, TracingInspector,
 };
+use alloy_network::Ethereum;
 use alloy_primitives::{
     Address, B256, Bytes, Log, TxKind, U256,
     map::{AddressHashMap, HashMap},
@@ -80,7 +81,7 @@ pub struct InspectorStackBuilder {
     /// Networks with enabled features.
     pub networks: NetworkConfigs,
     /// The wallets to set in the cheatcodes context.
-    pub wallets: Option<Wallets>,
+    pub wallets: Option<Wallets<Ethereum>>,
     /// The CREATE2 deployer address.
     pub create2_deployer: Address,
 }
@@ -122,7 +123,7 @@ impl InspectorStackBuilder {
 
     /// Set the wallets.
     #[inline]
-    pub fn wallets(mut self, wallets: Wallets) -> Self {
+    pub fn wallets(mut self, wallets: Wallets<Ethereum>) -> Self {
         self.wallets = Some(wallets);
         self
     }

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -236,7 +236,7 @@ impl SendTransactionsKind {
 pub struct BundledState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets,
+    pub script_wallets: Wallets<Ethereum>,
     pub build_data: LinkedBuildData,
     pub sequence: ScriptSequenceKind,
 }

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -2,7 +2,7 @@ use crate::{
     ScriptArgs, ScriptConfig, broadcast::BundledState, execute::LinkedState,
     multi_sequence::MultiChainSequence, sequence::ScriptSequenceKind,
 };
-use alloy_network::AnyNetwork;
+use alloy_network::{AnyNetwork, Ethereum};
 use alloy_primitives::{B256, Bytes};
 use alloy_provider::Provider;
 use eyre::{OptionExt, Result};
@@ -156,7 +156,7 @@ impl LinkedBuildData {
 pub struct PreprocessedState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets,
+    pub script_wallets: Wallets<Ethereum>,
 }
 
 impl PreprocessedState {
@@ -241,7 +241,7 @@ impl PreprocessedState {
 pub struct CompiledState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets,
+    pub script_wallets: Wallets<Ethereum>,
     pub build_data: BuildData,
 }
 

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloy_dyn_abi::FunctionExt;
 use alloy_json_abi::{Function, InternalType, JsonAbi};
-use alloy_network::AnyNetwork;
+use alloy_network::{AnyNetwork, Ethereum};
 use alloy_primitives::{
     Address, Bytes,
     map::{HashMap, HashSet},
@@ -42,7 +42,7 @@ use yansi::Paint;
 pub struct LinkedState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets,
+    pub script_wallets: Wallets<Ethereum>,
     pub build_data: LinkedBuildData,
 }
 
@@ -93,7 +93,7 @@ impl LinkedState {
 pub struct PreExecutionState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets,
+    pub script_wallets: Wallets<Ethereum>,
     pub build_data: LinkedBuildData,
     pub execution_data: ExecutionData,
 }
@@ -275,7 +275,7 @@ pub struct ExecutionArtifacts {
 pub struct ExecutedState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets,
+    pub script_wallets: Wallets<Ethereum>,
     pub build_data: LinkedBuildData,
     pub execution_data: ExecutionData,
     pub execution_result: ScriptResult,

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -13,6 +13,7 @@ extern crate tracing;
 
 use crate::runner::ScriptRunner;
 use alloy_json_abi::{Function, JsonAbi};
+use alloy_network::Ethereum;
 use alloy_primitives::{
     Address, Bytes, Log, TxKind, U256, hex,
     map::{AddressHashMap, HashMap},
@@ -623,7 +624,7 @@ impl ScriptConfig {
     async fn get_runner_with_cheatcodes(
         &mut self,
         known_contracts: ContractsByArtifact,
-        script_wallets: Wallets,
+        script_wallets: Wallets<Ethereum>,
         debug: bool,
         target: ArtifactId,
     ) -> Result<ScriptRunner> {
@@ -632,7 +633,7 @@ impl ScriptConfig {
 
     async fn _get_runner(
         &mut self,
-        cheats_data: Option<(ContractsByArtifact, Wallets, ArtifactId)>,
+        cheats_data: Option<(ContractsByArtifact, Wallets<Ethereum>, ArtifactId)>,
         debug: bool,
     ) -> Result<ScriptRunner> {
         trace!("preparing script runner");

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -10,7 +10,7 @@ use crate::{
     sequence::get_commit_hash,
 };
 use alloy_chains::NamedChain;
-use alloy_network::TransactionBuilder;
+use alloy_network::{Ethereum, TransactionBuilder};
 use alloy_primitives::{Address, TxKind, U256, map::HashMap, utils::format_units};
 use dialoguer::Confirm;
 use eyre::{Context, Result};
@@ -35,7 +35,7 @@ use std::{
 pub struct PreSimulationState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets,
+    pub script_wallets: Wallets<Ethereum>,
     pub build_data: LinkedBuildData,
     pub execution_data: ExecutionData,
     pub execution_result: ScriptResult,
@@ -252,7 +252,7 @@ impl PreSimulationState {
 pub struct FilledTransactionsState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets,
+    pub script_wallets: Wallets<Ethereum>,
     pub build_data: LinkedBuildData,
     pub execution_artifacts: ExecutionArtifacts,
     pub transactions: VecDeque<TransactionWithMetadata>,

--- a/crates/wallets/src/wallet_multi/mod.rs
+++ b/crates/wallets/src/wallet_multi/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     utils,
     wallet_browser::signer::BrowserSigner,
 };
-use alloy_network::{Ethereum, Network};
+use alloy_network::Network;
 use alloy_primitives::map::AddressHashMap;
 use alloy_signer::Signer;
 use clap::Parser;
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 
 /// Container for multiple wallets.
 #[derive(Debug)]
-pub struct MultiWallet<N: Network = Ethereum> {
+pub struct MultiWallet<N: Network> {
     /// Vector of wallets that require an action to be unlocked.
     /// Those are lazily unlocked on the first access of the signers.
     pending_signers: Vec<PendingSigner>,


### PR DESCRIPTION
## Motivation

Towards generic `ScriptSequence<N>` and `Cheatcodes<N>`, as it involves updating huge amount of structures, let's start contained, with `Wallets<N: Network>`

Hardcoding `Ethereum` for now to avoid breaking changes.