### PR TITLE
fix: update EtherlinkTestnet to EtherlinkShadownet

### DIFF
--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -120,7 +120,7 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
                     | NamedChain::AcalaMandalaTestnet
                     | NamedChain::AcalaTestnet
                     | NamedChain::Etherlink
-                    | NamedChain::EtherlinkTestnet
+                    | NamedChain::EtherlinkShadownet
                     | NamedChain::Karura
                     | NamedChain::KaruraTestnet
                     | NamedChain::Mantle


### PR DESCRIPTION
## Summary
Update `NamedChain::EtherlinkTestnet` → `NamedChain::EtherlinkShadownet` to fix build after alloy-chains v0.2.31 update.

## Motivation
`EtherlinkTestnet` was removed in [alloy-chains v0.2.31](https://github.com/alloy-rs/chains/pull/258) and replaced with `EtherlinkShadownet`. This breaks all CI jobs on #13760.

## Changes
- `crates/cli/src/utils/cmd.rs`: Update the match arm in `has_different_gas_calc`

## Testing
CI should go green on #13760 once merged.

Co-Authored-By: zerosnacks <95942363+zerosnacks@users.noreply.github.com>

Prompted by: zerosnacks