### PR TITLE
chore(evm): split `Executor::env` into `evm_env` and `tx_env` fields

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -343,7 +343,7 @@ impl CallArgs {
             let value = tx.value().unwrap_or_default();
             let input = tx.input().cloned().unwrap_or_default();
             let tx_kind = tx.kind().expect("set by builder");
-            let env_tx = &mut executor.env_mut().tx;
+            let env_tx = executor.tx_env_mut();
 
             // Set transaction options with --trace
             if let Some(gas_limit) = tx.gas_limit() {

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1105,13 +1105,13 @@ pub(crate) fn execute_tx(executor: &mut Executor, tx: &BasicTxDetails) -> Result
 
     if warp > 0 || roll > 0 {
         // Apply pre-call block adjustments to the executor's env.
-        executor.env_mut().evm_env.block_env.timestamp += warp;
-        executor.env_mut().evm_env.block_env.number += roll;
+        executor.evm_env_mut().block_env.timestamp += warp;
+        executor.evm_env_mut().block_env.number += roll;
 
         // Also update the inspector's cheatcodes.block if set.
         // The inspector's block may override the env during interpreter initialization,
         // so we need to add our warp/roll on top of any existing cheatcode-set values.
-        let block_env = executor.env().evm_env.block_env.clone();
+        let block_env = executor.evm_env().block_env.clone();
         if let Some(cheatcodes) = executor.inspector_mut().cheatcodes.as_mut() {
             if let Some(block) = cheatcodes.block.as_mut() {
                 block.timestamp += warp;

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -61,10 +61,10 @@ fn apply_warp_roll(call: &BasicTxDetails, warp: U256, roll: U256) -> BasicTxDeta
 /// Applies warp/roll adjustments directly to the executor's environment.
 fn apply_warp_roll_to_env(executor: &mut Executor, warp: U256, roll: U256) {
     if warp > U256::ZERO || roll > U256::ZERO {
-        executor.env_mut().evm_env.block_env.timestamp += warp;
-        executor.env_mut().evm_env.block_env.number += roll;
+        executor.evm_env_mut().block_env.timestamp += warp;
+        executor.evm_env_mut().block_env.number += roll;
 
-        let block_env = executor.env().evm_env.block_env.clone();
+        let block_env = executor.evm_env().block_env.clone();
         if let Some(cheatcodes) = executor.inspector_mut().cheatcodes.as_mut() {
             if let Some(block) = cheatcodes.block.as_mut() {
                 block.timestamp += warp;

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -99,8 +99,10 @@ pub struct Executor {
     // wrapper around spawning a new EVM on every call anyway,
     // so the performance difference should be negligible.
     backend: Arc<Backend>,
-    /// The EVM environment.
-    env: Env,
+    /// The EVM environment (block and cfg).
+    evm_env: EvmEnv,
+    /// The transaction environment.
+    tx_env: TxEnv,
     /// The Revm inspector stack.
     inspector: InspectorStack,
     /// The gas limit for calls and deployments.
@@ -132,19 +134,23 @@ impl Executor {
             },
         );
 
-        Self { backend: Arc::new(backend), env, inspector, gas_limit, legacy_assertions }
+        Self {
+            backend: Arc::new(backend),
+            evm_env: env.evm_env,
+            tx_env: env.tx,
+            inspector,
+            gas_limit,
+            legacy_assertions,
+        }
     }
 
     fn clone_with_backend(&self, backend: Backend) -> Self {
-        let env = Env::new_with_spec_id(
-            self.env.evm_env.cfg_env.clone(),
-            self.env.evm_env.block_env.clone(),
-            self.env.tx.clone(),
-            self.spec_id(),
-        );
+        let mut evm_env = self.evm_env.clone();
+        evm_env.cfg_env.spec = self.spec_id();
         Self {
             backend: Arc::new(backend),
-            env,
+            evm_env,
+            tx_env: self.tx_env.clone(),
             inspector: self.inspector().clone(),
             gas_limit: self.gas_limit,
             legacy_assertions: self.legacy_assertions,
@@ -164,14 +170,24 @@ impl Executor {
         Arc::make_mut(&mut self.backend)
     }
 
-    /// Returns a reference to the EVM environment.
-    pub fn env(&self) -> &Env {
-        &self.env
+    /// Returns a reference to the EVM environment (block and cfg).
+    pub fn evm_env(&self) -> &EvmEnv {
+        &self.evm_env
     }
 
-    /// Returns a mutable reference to the EVM environment.
-    pub fn env_mut(&mut self) -> &mut Env {
-        &mut self.env
+    /// Returns a mutable reference to the EVM environment (block and cfg).
+    pub fn evm_env_mut(&mut self) -> &mut EvmEnv {
+        &mut self.evm_env
+    }
+
+    /// Returns a reference to the transaction environment.
+    pub fn tx_env(&self) -> &TxEnv {
+        &self.tx_env
+    }
+
+    /// Returns a mutable reference to the transaction environment.
+    pub fn tx_env_mut(&mut self) -> &mut TxEnv {
+        &mut self.tx_env
     }
 
     /// Returns a reference to the EVM inspector.
@@ -186,12 +202,12 @@ impl Executor {
 
     /// Returns the EVM spec ID.
     pub fn spec_id(&self) -> SpecId {
-        self.env.evm_env.cfg_env.spec
+        self.evm_env.cfg_env.spec
     }
 
     /// Sets the EVM spec ID.
     pub fn set_spec_id(&mut self, spec_id: SpecId) {
-        self.env.evm_env.cfg_env.spec = spec_id;
+        self.evm_env.cfg_env.spec = spec_id;
     }
 
     /// Returns the gas limit for calls and deployments.
@@ -263,7 +279,7 @@ impl Executor {
         let mut account = self.backend().basic_ref(address)?.unwrap_or_default();
         account.nonce = nonce;
         self.backend_mut().insert_account_info(address, account);
-        self.env_mut().tx.nonce = nonce;
+        self.tx_env_mut().nonce = nonce;
         Ok(())
     }
 
@@ -400,9 +416,9 @@ impl Executor {
         res = res.into_result(rd)?;
 
         // record any changes made to the block's environment during setup
-        self.env_mut().evm_env.block_env = res.env.evm_env.block_env.clone();
+        self.evm_env_mut().block_env = res.env.evm_env.block_env.clone();
         // and also the chainid, which can be set manually
-        self.env_mut().evm_env.cfg_env.chain_id = res.env.evm_env.cfg_env.chain_id;
+        self.evm_env_mut().cfg_env.chain_id = res.env.evm_env.cfg_env.chain_id;
 
         let success =
             self.is_raw_call_success(to, Cow::Borrowed(&res.state_changeset), &res, false);
@@ -707,7 +723,7 @@ impl Executor {
         Env {
             evm_env: EvmEnv {
                 cfg_env: {
-                    let mut cfg = self.env().evm_env.cfg_env.clone();
+                    let mut cfg = self.evm_env.cfg_env.clone();
                     cfg.spec = self.spec_id();
                     cfg
                 },
@@ -717,7 +733,7 @@ impl Executor {
                 block_env: BlockEnv {
                     basefee: 0,
                     gas_limit: self.gas_limit,
-                    ..self.env().evm_env.block_env.clone()
+                    ..self.evm_env.block_env.clone()
                 },
             },
             tx: TxEnv {
@@ -729,8 +745,8 @@ impl Executor {
                 gas_price: 0,
                 gas_priority_fee: None,
                 gas_limit: self.gas_limit,
-                chain_id: Some(self.env().evm_env.cfg_env.chain_id),
-                ..self.env().tx.clone()
+                chain_id: Some(self.evm_env.cfg_env.chain_id),
+                ..self.tx_env.clone()
             },
         }
     }

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -369,14 +369,14 @@ impl ScriptRunner {
         let mut gas_used = res.gas_used;
         if matches!(res.exit_reason, Some(return_ok!())) {
             // Store the current gas limit and reset it later.
-            let init_gas_limit = self.executor.env().tx.gas_limit;
+            let init_gas_limit = self.executor.tx_env().gas_limit;
 
             let mut highest_gas_limit = gas_used * 3;
             let mut lowest_gas_limit = gas_used;
             let mut last_highest_gas_limit = highest_gas_limit;
             while (highest_gas_limit - lowest_gas_limit) > 1 {
                 let mid_gas_limit = (highest_gas_limit + lowest_gas_limit) / 2;
-                self.executor.env_mut().tx.gas_limit = mid_gas_limit;
+                self.executor.tx_env_mut().gas_limit = mid_gas_limit;
                 let res = self.executor.call_raw(from, to, calldata.0.clone().into(), value)?;
                 match res.exit_reason {
                     Some(InstructionResult::Revert)
@@ -402,7 +402,7 @@ impl ScriptRunner {
                 }
             }
             // Reset gas limit in the executor.
-            self.executor.env_mut().tx.gas_limit = init_gas_limit;
+            self.executor.tx_env_mut().gas_limit = init_gas_limit;
         }
         Ok(gas_used)
     }

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -140,7 +140,7 @@ impl PreSimulationState {
 
                 // Simulate mining the transaction if the user passes `--slow`.
                 if self.args.slow {
-                    runner.executor.env_mut().evm_env.block_env.number += U256::from(1);
+                    runner.executor.evm_env_mut().block_env.number += U256::from(1);
                 }
 
                 let is_noop_tx = if let Some(to) = to {


### PR DESCRIPTION
## Motivation

Split `Executor::env` into `evm_env` and `tx_env` field, update the getters and all call sites accordingly.
