### PR TITLE
chore(cast): granular bounds on `Cast`

### DIFF
--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -11,13 +11,9 @@ use foundry_cli::{
     opts::{RpcOpts, TransactionOpts},
     utils::LoadConfig,
 };
-use foundry_common::{
-    fmt::{UIfmt, UIfmtHeaderExt, UIfmtSignatureExt},
-    provider::ProviderBuilder,
-};
+use foundry_common::provider::ProviderBuilder;
 use foundry_primitives::FoundryTransactionBuilder;
 use foundry_wallets::WalletOpts;
-use serde::Serialize;
 use std::str::FromStr;
 use tempo_alloy::TempoNetwork;
 
@@ -73,11 +69,7 @@ impl AccessListArgs {
 
     pub async fn run_with_network<N: Network + Unpin>(self) -> Result<()>
     where
-        N::TxEnvelope: Serialize + UIfmtSignatureExt,
         N::TransactionRequest: FoundryTransactionBuilder<N>,
-        N::TransactionResponse: UIfmt,
-        N::HeaderResponse: UIfmtHeaderExt,
-        N::BlockResponse: UIfmt,
     {
         let Self { to, mut sig, args, data, tx, rpc, wallet, block } = self;
 

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -21,7 +21,6 @@ use foundry_cli::{
 };
 use foundry_common::{
     abi::{encode_function_args, get_func},
-    fmt::{UIfmt, UIfmtHeaderExt, UIfmtSignatureExt},
     provider::{ProviderBuilder, curl_transport::generate_curl_command},
     sh_println, shell,
 };
@@ -43,7 +42,6 @@ use foundry_wallets::WalletOpts;
 use itertools::Either;
 use regex::Regex;
 use revm::context::TransactionType;
-use serde::Serialize;
 use std::{str::FromStr, sync::LazyLock};
 use tempo_alloy::TempoNetwork;
 
@@ -231,11 +229,7 @@ impl CallArgs {
 
     pub async fn run_with_network<N: Network + Unpin>(self) -> Result<()>
     where
-        N::TxEnvelope: Serialize + UIfmtSignatureExt,
         N::TransactionRequest: FoundryTransactionBuilder<N>,
-        N::TransactionResponse: UIfmt,
-        N::HeaderResponse: UIfmtHeaderExt,
-        N::BlockResponse: UIfmt,
     {
         let figment = self.rpc.clone().into_figment(self.with_local_artifacts).merge(&self);
         let evm_opts = figment.extract::<EvmOpts>()?;

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -72,13 +72,7 @@ pub struct Cast<P, N = AnyNetwork> {
     _phantom: PhantomData<N>,
 }
 
-impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N>
-where
-    N::TxEnvelope: Serialize + UIfmtSignatureExt,
-    N::TransactionResponse: UIfmt,
-    N::HeaderResponse: UIfmtHeaderExt,
-    N::BlockResponse: UIfmt,
-{
+impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
     /// Creates a new Cast instance from the provided client
     ///
     /// # Example
@@ -287,152 +281,6 @@ where
         let res = self.provider.send_raw_transaction(&tx).await?;
 
         Ok(res)
-    }
-
-    /// # Example
-    ///
-    /// ```
-    /// use alloy_provider::{ProviderBuilder, RootProvider, network::AnyNetwork};
-    /// use cast::Cast;
-    ///
-    /// # async fn foo() -> eyre::Result<()> {
-    /// let provider =
-    ///     ProviderBuilder::<_, _, AnyNetwork>::default().connect("http://localhost:8545").await?;
-    /// let cast = Cast::new(provider);
-    /// let block = cast.block(5, true, vec![]).await?;
-    /// println!("{}", block);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn block<B: Into<BlockId>>(
-        &self,
-        block: B,
-        full: bool,
-        fields: Vec<String>,
-    ) -> Result<String> {
-        let block = block.into();
-        if fields.contains(&"transactions".into()) && !full {
-            eyre::bail!("use --full to view transactions")
-        }
-
-        let block = self
-            .provider
-            .get_block(block)
-            .kind(full.into())
-            .await?
-            .ok_or_else(|| eyre::eyre!("block {:?} not found", block))?;
-
-        Ok(if !fields.is_empty() {
-            let mut result = String::new();
-            for field in fields {
-                result.push_str(
-                    &get_pretty_block_attr::<N>(&block, &field)
-                        .unwrap_or_else(|| format!("{field} is not a valid block field")),
-                );
-
-                result.push('\n');
-            }
-            result.trim_end().to_string()
-        } else if shell::is_json() {
-            serde_json::to_value(&block).unwrap().to_string()
-        } else {
-            block.pretty()
-        })
-    }
-
-    async fn block_field_as_num<B: Into<BlockId>>(&self, block: B, field: String) -> Result<U256> {
-        Self::block(
-            self,
-            block.into(),
-            false,
-            // Select only select field
-            vec![field],
-        )
-        .await?
-        .parse()
-        .map_err(Into::into)
-    }
-
-    pub async fn base_fee<B: Into<BlockId>>(&self, block: B) -> Result<U256> {
-        Self::block_field_as_num(self, block, String::from("baseFeePerGas")).await
-    }
-
-    pub async fn age<B: Into<BlockId>>(&self, block: B) -> Result<String> {
-        let timestamp_str =
-            Self::block_field_as_num(self, block, String::from("timestamp")).await?.to_string();
-        let datetime = DateTime::from_timestamp(timestamp_str.parse::<i64>().unwrap(), 0).unwrap();
-        Ok(datetime.format("%a %b %e %H:%M:%S %Y").to_string())
-    }
-
-    pub async fn timestamp<B: Into<BlockId>>(&self, block: B) -> Result<U256> {
-        Self::block_field_as_num(self, block, "timestamp".to_string()).await
-    }
-
-    pub async fn chain(&self) -> Result<&str> {
-        let genesis_hash = Self::block(
-            self,
-            0,
-            false,
-            // Select only block hash
-            vec![String::from("hash")],
-        )
-        .await?;
-
-        Ok(match &genesis_hash[..] {
-            "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" => {
-                match &(Self::block(self, 1920000, false, vec![String::from("hash")]).await?)[..] {
-                    "0x94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f" => {
-                        "etclive"
-                    }
-                    _ => "ethlive",
-                }
-            }
-            "0xa3c565fc15c7478862d50ccd6561e3c06b24cc509bf388941c25ea985ce32cb9" => "kovan",
-            "0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d" => "ropsten",
-            "0x7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b" => {
-                "optimism-mainnet"
-            }
-            "0xc1fc15cd51159b1f1e5cbc4b82e85c1447ddfa33c52cf1d98d14fba0d6354be1" => {
-                "optimism-goerli"
-            }
-            "0x02adc9b449ff5f2467b8c674ece7ff9b21319d76c4ad62a67a70d552655927e5" => {
-                "optimism-kovan"
-            }
-            "0x521982bd54239dc71269eefb58601762cc15cfb2978e0becb46af7962ed6bfaa" => "fraxtal",
-            "0x910f5c4084b63fd860d0c2f9a04615115a5a991254700b39ba072290dbd77489" => {
-                "fraxtal-testnet"
-            }
-            "0x7ee576b35482195fc49205cec9af72ce14f003b9ae69f6ba0faef4514be8b442" => {
-                "arbitrum-mainnet"
-            }
-            "0x0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303" => "morden",
-            "0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177" => "rinkeby",
-            "0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a" => "goerli",
-            "0x14c2283285a88fe5fce9bf5c573ab03d6616695d717b12a127188bcacfc743c4" => "kotti",
-            "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b" => "polygon-pos",
-            "0x7202b2b53c5a0836e773e319d18922cc756dd67432f9a1f65352b61f4406c697" => {
-                "polygon-pos-amoy-testnet"
-            }
-            "0x81005434635456a16f74ff7023fbe0bf423abbc8a8deb093ffff455c0ad3b741" => "polygon-zkevm",
-            "0x676c1a76a6c5855a32bdf7c61977a0d1510088a4eeac1330466453b3d08b60b9" => {
-                "polygon-zkevm-cardona-testnet"
-            }
-            "0x4f1dd23188aab3a76b463e4af801b52b1248ef073c648cbdc4c9333d3da79756" => "gnosis",
-            "0xada44fd8d2ecab8b08f256af07ad3e777f17fb434f8f8e678b312f576212ba9a" => "chiado",
-            "0x6d3c66c5357ec91d5c43af47e234a939b22557cbb552dc45bebbceeed90fbe34" => "bsctest",
-            "0x0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b" => "bsc",
-            "0x31ced5b9beb7f8782b014660da0cb18cc409f121f408186886e1ca3e8eeca96b" => {
-                match &(Self::block(self, 1, false, vec![String::from("hash")]).await?)[..] {
-                    "0x738639479dc82d199365626f90caa82f7eafcfe9ed354b456fb3d294597ceb53" => {
-                        "avalanche-fuji"
-                    }
-                    _ => "avalanche",
-                }
-            }
-            "0x23a2658170ba70d014ba0d0d2709f8fbfe2fa660cd868c5f282f991eecbe38ee" => "ink",
-            "0xe5fd5cf0be56af58ad5751b401410d6b7a09d830fa459789746a3d0dd1c79834" => "ink-sepolia",
-            _ => "unknown",
-        })
     }
 
     pub async fn chain_id(&self) -> Result<u64> {
@@ -695,71 +543,6 @@ where
         let code =
             self.provider.get_code_at(who).block_id(block.unwrap_or_default()).await?.to_vec();
         Ok(code.len().to_string())
-    }
-
-    /// # Example
-    ///
-    /// ```
-    /// use alloy_provider::{ProviderBuilder, RootProvider, network::AnyNetwork};
-    /// use cast::Cast;
-    ///
-    /// # async fn foo() -> eyre::Result<()> {
-    /// let provider =
-    ///     ProviderBuilder::<_, _, AnyNetwork>::default().connect("http://localhost:8545").await?;
-    /// let cast = Cast::new(provider);
-    /// let tx_hash = "0xf8d1713ea15a81482958fb7ddf884baee8d3bcc478c5f2f604e008dc788ee4fc";
-    /// let tx = cast.transaction(Some(tx_hash.to_string()), None, None, None, false, false).await?;
-    /// println!("{}", tx);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn transaction(
-        &self,
-        tx_hash: Option<String>,
-        from: Option<NameOrAddress>,
-        nonce: Option<u64>,
-        field: Option<String>,
-        raw: bool,
-        to_request: bool,
-    ) -> Result<String> {
-        let tx = if let Some(tx_hash) = tx_hash {
-            let tx_hash = TxHash::from_str(&tx_hash).wrap_err("invalid tx hash")?;
-            self.provider
-                .get_transaction_by_hash(tx_hash)
-                .await?
-                .ok_or_else(|| eyre::eyre!("tx not found: {:?}", tx_hash))?
-        } else if let Some(from) = from {
-            // If nonce is not provided, uses 0.
-            let nonce = U64::from(nonce.unwrap_or_default());
-            let from = from.resolve(self.provider.root()).await?;
-
-            self.provider
-                .raw_request::<_, Option<N::TransactionResponse>>(
-                    "eth_getTransactionBySenderAndNonce".into(),
-                    (from, nonce),
-                )
-                .await?
-                .ok_or_else(|| {
-                    eyre::eyre!("tx not found for sender {from} and nonce {:?}", nonce.to::<u64>())
-                })?
-        } else {
-            eyre::bail!("tx hash or from address is required")
-        };
-
-        Ok(if raw {
-            let encoded = tx.as_ref().encoded_2718();
-            format!("0x{}", hex::encode(encoded))
-        } else if let Some(ref field) = field {
-            get_pretty_tx_attr::<N>(&tx, field.as_str())
-                .ok_or_else(|| eyre::eyre!("invalid tx field: {}", field.to_string()))?
-        } else if shell::is_json() {
-            // to_value first to sort json object keys
-            serde_json::to_value(&tx)?.to_string()
-        } else if to_request {
-            serde_json::to_string_pretty(&Into::<N::TransactionRequest>::into(tx))?
-        } else {
-            tx.pretty()
-        })
     }
 
     /// Perform a raw JSON-RPC request
@@ -1099,6 +882,158 @@ where
 
 impl<P: Provider<N>, N: Network> Cast<P, N>
 where
+    N::HeaderResponse: UIfmtHeaderExt,
+    N::BlockResponse: UIfmt,
+{
+    /// # Example
+    ///
+    /// ```
+    /// use alloy_provider::{ProviderBuilder, RootProvider, network::AnyNetwork};
+    /// use cast::Cast;
+    ///
+    /// # async fn foo() -> eyre::Result<()> {
+    /// let provider =
+    ///     ProviderBuilder::<_, _, AnyNetwork>::default().connect("http://localhost:8545").await?;
+    /// let cast = Cast::new(provider);
+    /// let block = cast.block(5, true, vec![]).await?;
+    /// println!("{}", block);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn block<B: Into<BlockId>>(
+        &self,
+        block: B,
+        full: bool,
+        fields: Vec<String>,
+    ) -> Result<String> {
+        let block = block.into();
+        if fields.contains(&"transactions".into()) && !full {
+            eyre::bail!("use --full to view transactions")
+        }
+
+        let block = self
+            .provider
+            .get_block(block)
+            .kind(full.into())
+            .await?
+            .ok_or_else(|| eyre::eyre!("block {:?} not found", block))?;
+
+        Ok(if !fields.is_empty() {
+            let mut result = String::new();
+            for field in fields {
+                result.push_str(
+                    &get_pretty_block_attr::<N>(&block, &field)
+                        .unwrap_or_else(|| format!("{field} is not a valid block field")),
+                );
+
+                result.push('\n');
+            }
+            result.trim_end().to_string()
+        } else if shell::is_json() {
+            serde_json::to_value(&block).unwrap().to_string()
+        } else {
+            block.pretty()
+        })
+    }
+
+    async fn block_field_as_num<B: Into<BlockId>>(&self, block: B, field: String) -> Result<U256> {
+        Self::block(
+            self,
+            block.into(),
+            false,
+            // Select only select field
+            vec![field],
+        )
+        .await?
+        .parse()
+        .map_err(Into::into)
+    }
+
+    pub async fn base_fee<B: Into<BlockId>>(&self, block: B) -> Result<U256> {
+        Self::block_field_as_num(self, block, String::from("baseFeePerGas")).await
+    }
+
+    pub async fn age<B: Into<BlockId>>(&self, block: B) -> Result<String> {
+        let timestamp_str =
+            Self::block_field_as_num(self, block, String::from("timestamp")).await?.to_string();
+        let datetime = DateTime::from_timestamp(timestamp_str.parse::<i64>().unwrap(), 0).unwrap();
+        Ok(datetime.format("%a %b %e %H:%M:%S %Y").to_string())
+    }
+
+    pub async fn timestamp<B: Into<BlockId>>(&self, block: B) -> Result<U256> {
+        Self::block_field_as_num(self, block, "timestamp".to_string()).await
+    }
+
+    pub async fn chain(&self) -> Result<&str> {
+        let genesis_hash = Self::block(
+            self,
+            0,
+            false,
+            // Select only block hash
+            vec![String::from("hash")],
+        )
+        .await?;
+
+        Ok(match &genesis_hash[..] {
+            "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" => {
+                match &(Self::block(self, 1920000, false, vec![String::from("hash")]).await?)[..] {
+                    "0x94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f" => {
+                        "etclive"
+                    }
+                    _ => "ethlive",
+                }
+            }
+            "0xa3c565fc15c7478862d50ccd6561e3c06b24cc509bf388941c25ea985ce32cb9" => "kovan",
+            "0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d" => "ropsten",
+            "0x7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b" => {
+                "optimism-mainnet"
+            }
+            "0xc1fc15cd51159b1f1e5cbc4b82e85c1447ddfa33c52cf1d98d14fba0d6354be1" => {
+                "optimism-goerli"
+            }
+            "0x02adc9b449ff5f2467b8c674ece7ff9b21319d76c4ad62a67a70d552655927e5" => {
+                "optimism-kovan"
+            }
+            "0x521982bd54239dc71269eefb58601762cc15cfb2978e0becb46af7962ed6bfaa" => "fraxtal",
+            "0x910f5c4084b63fd860d0c2f9a04615115a5a991254700b39ba072290dbd77489" => {
+                "fraxtal-testnet"
+            }
+            "0x7ee576b35482195fc49205cec9af72ce14f003b9ae69f6ba0faef4514be8b442" => {
+                "arbitrum-mainnet"
+            }
+            "0x0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303" => "morden",
+            "0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177" => "rinkeby",
+            "0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a" => "goerli",
+            "0x14c2283285a88fe5fce9bf5c573ab03d6616695d717b12a127188bcacfc743c4" => "kotti",
+            "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b" => "polygon-pos",
+            "0x7202b2b53c5a0836e773e319d18922cc756dd67432f9a1f65352b61f4406c697" => {
+                "polygon-pos-amoy-testnet"
+            }
+            "0x81005434635456a16f74ff7023fbe0bf423abbc8a8deb093ffff455c0ad3b741" => "polygon-zkevm",
+            "0x676c1a76a6c5855a32bdf7c61977a0d1510088a4eeac1330466453b3d08b60b9" => {
+                "polygon-zkevm-cardona-testnet"
+            }
+            "0x4f1dd23188aab3a76b463e4af801b52b1248ef073c648cbdc4c9333d3da79756" => "gnosis",
+            "0xada44fd8d2ecab8b08f256af07ad3e777f17fb434f8f8e678b312f576212ba9a" => "chiado",
+            "0x6d3c66c5357ec91d5c43af47e234a939b22557cbb552dc45bebbceeed90fbe34" => "bsctest",
+            "0x0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b" => "bsc",
+            "0x31ced5b9beb7f8782b014660da0cb18cc409f121f408186886e1ca3e8eeca96b" => {
+                match &(Self::block(self, 1, false, vec![String::from("hash")]).await?)[..] {
+                    "0x738639479dc82d199365626f90caa82f7eafcfe9ed354b456fb3d294597ceb53" => {
+                        "avalanche-fuji"
+                    }
+                    _ => "avalanche",
+                }
+            }
+            "0x23a2658170ba70d014ba0d0d2709f8fbfe2fa660cd868c5f282f991eecbe38ee" => "ink",
+            "0xe5fd5cf0be56af58ad5751b401410d6b7a09d830fa459789746a3d0dd1c79834" => "ink-sepolia",
+            _ => "unknown",
+        })
+    }
+}
+
+impl<P: Provider<N>, N: Network> Cast<P, N>
+where
     N::Header: Encodable,
 {
     /// # Example
@@ -1129,6 +1064,77 @@ where
         let encoded = alloy_rlp::encode(block.header().as_ref());
 
         Ok(format!("0x{}", hex::encode(encoded)))
+    }
+}
+
+impl<P: Provider<N>, N: Network> Cast<P, N>
+where
+    N::TxEnvelope: Serialize + UIfmtSignatureExt,
+    N::TransactionResponse: UIfmt,
+{
+    /// # Example
+    ///
+    /// ```
+    /// use alloy_provider::{ProviderBuilder, RootProvider, network::AnyNetwork};
+    /// use cast::Cast;
+    ///
+    /// # async fn foo() -> eyre::Result<()> {
+    /// let provider =
+    ///     ProviderBuilder::<_, _, AnyNetwork>::default().connect("http://localhost:8545").await?;
+    /// let cast = Cast::new(provider);
+    /// let tx_hash = "0xf8d1713ea15a81482958fb7ddf884baee8d3bcc478c5f2f604e008dc788ee4fc";
+    /// let tx = cast.transaction(Some(tx_hash.to_string()), None, None, None, false, false).await?;
+    /// println!("{}", tx);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn transaction(
+        &self,
+        tx_hash: Option<String>,
+        from: Option<NameOrAddress>,
+        nonce: Option<u64>,
+        field: Option<String>,
+        raw: bool,
+        to_request: bool,
+    ) -> Result<String> {
+        let tx = if let Some(tx_hash) = tx_hash {
+            let tx_hash = TxHash::from_str(&tx_hash).wrap_err("invalid tx hash")?;
+            self.provider
+                .get_transaction_by_hash(tx_hash)
+                .await?
+                .ok_or_else(|| eyre::eyre!("tx not found: {:?}", tx_hash))?
+        } else if let Some(from) = from {
+            // If nonce is not provided, uses 0.
+            let nonce = U64::from(nonce.unwrap_or_default());
+            let from = from.resolve(self.provider.root()).await?;
+
+            self.provider
+                .raw_request::<_, Option<N::TransactionResponse>>(
+                    "eth_getTransactionBySenderAndNonce".into(),
+                    (from, nonce),
+                )
+                .await?
+                .ok_or_else(|| {
+                    eyre::eyre!("tx not found for sender {from} and nonce {:?}", nonce.to::<u64>())
+                })?
+        } else {
+            eyre::bail!("tx hash or from address is required")
+        };
+
+        Ok(if raw {
+            let encoded = tx.as_ref().encoded_2718();
+            format!("0x{}", hex::encode(encoded))
+        } else if let Some(ref field) = field {
+            get_pretty_tx_attr::<N>(&tx, field.as_str())
+                .ok_or_else(|| eyre::eyre!("invalid tx field: {}", field.to_string()))?
+        } else if shell::is_json() {
+            // to_value first to sort json object keys
+            serde_json::to_value(&tx)?.to_string()
+        } else if to_request {
+            serde_json::to_string_pretty(&Into::<N::TransactionRequest>::into(tx))?
+        } else {
+            tx.pretty()
+        })
     }
 }
 


### PR DESCRIPTION
## Motivation

#13745 && #13754 follow-up, made `Cast` bounds granular,  to avoid unnecessary requirements for methods that don’t depend on `Cast::transaction`, `Cast::block` and `Cast::block_raw`.

The three latest are now in the own `Cast` impl with minimal bounds.

Benefits to `access-list` and `call` commands.
