### PR TITLE
fix(cheatcodes): create file in writeJson/writeToml 3-arg overload

### DIFF
--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -352,11 +352,15 @@ impl Cheatcode for writeJson_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json: value, path, valueKey } = self;
 
-        // Read, parse, and update the JSON object
+        // Read, parse, and update the JSON object.
+        // If the file doesn't exist, start with an empty JSON object so the file is created.
         let data_path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
-        let data_string = fs::locked_read_to_string(&data_path)?;
-        let mut data =
-            serde_json::from_str(&data_string).unwrap_or_else(|_| Value::String(data_string));
+        let mut data = if data_path.exists() {
+            let data_string = fs::locked_read_to_string(&data_path)?;
+            serde_json::from_str(&data_string).unwrap_or_else(|_| Value::String(data_string))
+        } else {
+            Value::Object(Default::default())
+        };
         upsert_json_value(&mut data, value, valueKey)?;
 
         // Write the updated content back to the file

--- a/crates/cheatcodes/src/toml.rs
+++ b/crates/cheatcodes/src/toml.rs
@@ -205,13 +205,15 @@ impl Cheatcode for writeToml_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json: value, path, valueKey } = self;
 
-        // Read and parse the TOML file
+        // Read and parse the TOML file.
+        // If the file doesn't exist, start with an empty object so the file is created.
         let data_path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
-        let toml_data = fs::locked_read_to_string(&data_path)?;
-
-        // Convert to JSON and update the object
-        let mut json_data: JsonValue =
-            toml::from_str(&toml_data).map_err(|e| fmt_err!("failed parsing TOML: {e}"))?;
+        let mut json_data: JsonValue = if data_path.exists() {
+            let toml_data = fs::locked_read_to_string(&data_path)?;
+            toml::from_str(&toml_data).map_err(|e| fmt_err!("failed parsing TOML: {e}"))?
+        } else {
+            JsonValue::Object(Default::default())
+        };
         upsert_json_value(&mut json_data, value, valueKey)?;
 
         // Serialize back to TOML and write the updated content back to the file

--- a/testdata/default/cheats/Json.t.sol
+++ b/testdata/default/cheats/Json.t.sol
@@ -510,4 +510,19 @@ contract WriteJsonTest is Test {
         vm.removeFile(path);
         vm.writeJson("{\"a\": 123, \"b\": \"0x000000000000000000000000000000000000bEEF\"}", path);
     }
+
+    function test_writeJson_createFile() public {
+        string memory path = "fixtures/Json/write_test_nonexistent.json";
+
+        // Write to a file that does not exist using the 3-arg overload
+        vm.writeJson(vm.toString(uint256(99)), path, ".x.y");
+
+        // Verify the file was created with the correct content
+        string memory json = vm.readFile(path);
+        uint256 value = abi.decode(vm.parseJson(json, ".x.y"), (uint256));
+        assertEq(value, 99);
+
+        // Clean up
+        vm.removeFile(path);
+    }
 }


### PR DESCRIPTION
## Summary
Closes #13775

`vm.writeJson(content, path, property)` fails if the file doesn't exist, while `vm.writeJson(content, path)` creates it. Same inconsistency in `writeToml`.

## Changes
- `crates/cheatcodes/src/json.rs`: if file doesn't exist in `writeJson_1Call`, start with empty `{}` instead of erroring on read
- `crates/cheatcodes/src/toml.rs`: same fix for `writeToml_1Call`
- `testdata/default/cheats/Json.t.sol`: add `test_writeJson_createFile` covering the 3-arg overload on a non-existent file

## Testing
`cargo check -p foundry-cheatcodes` passes. Added Solidity test verifying the 3-arg overload creates the file and writes the correct nested value.

Co-Authored-By: zerosnacks <95942363+zerosnacks@users.noreply.github.com>

Prompted by: zerosnacks