### PR TITLE
refactor(evm): make `NestedEvm` trait generic with associated types

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -66,6 +66,7 @@ use revm::{
         InstructionResult, Interpreter, InterpreterAction, InterpreterResult,
         interpreter_types::{Jumps, LoopControl, MemoryTr},
     },
+    primitives::hardfork::SpecId,
 };
 use serde_json::Value;
 use std::{
@@ -111,8 +112,12 @@ impl<CTX> CheatsCtxExt for CTX where
 }
 
 /// Closure type used by [`CheatcodesExecutor`] methods that run nested EVM operations.
-pub type NestedEvmClosure<'a> =
-    &'a mut dyn FnMut(&mut dyn NestedEvm) -> Result<(), EVMError<DatabaseError>>;
+///
+/// The associated types are pinned to Eth types for now. When Tempo support is added,
+/// this will either become generic or a separate `TempoNestedEvmClosure` will be introduced.
+pub type NestedEvmClosure<'a> = &'a mut dyn FnMut(
+    &mut dyn NestedEvm<Tx = TxEnv, Block = BlockEnv, Spec = SpecId>,
+) -> Result<(), EVMError<DatabaseError>>;
 
 /// Helper trait for running nested EVM operations from inside cheatcode implementations.
 ///

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -241,23 +241,34 @@ impl<I: InspectorExt> DerefMut for FoundryEvm<'_, I> {
 /// This abstracts over the concrete EVM type (`FoundryEvm`, future `TempoEvm`, etc.)
 /// so that cheatcode impls can build and run nested EVMs without knowing the concrete type.
 pub trait NestedEvm {
+    /// The transaction environment type.
+    type Tx;
+    /// The block environment type.
+    type Block;
+    /// The EVM spec (hardfork) type.
+    type Spec;
+
     /// Returns a mutable reference to the journal inner state (`JournaledState`).
     fn journal_inner_mut(&mut self) -> &mut JournaledState;
 
     /// Runs a single execution frame (create or call) through the EVM handler loop.
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>>;
 
-    /// Executes a full transaction with the given `TxEnv`.
+    /// Executes a full transaction with the given tx env.
     fn transact(
         &mut self,
-        tx: TxEnv,
+        tx: Self::Tx,
     ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>>;
 
     /// Returns a snapshot of the current environment (cfg + block, tx).
-    fn to_env(&self) -> (EvmEnv, TxEnv);
+    fn to_env(&self) -> (EvmEnv<Self::Spec, Self::Block>, Self::Tx);
 }
 
 impl<I: InspectorExt> NestedEvm for FoundryEvm<'_, I> {
+    type Tx = TxEnv;
+    type Block = BlockEnv;
+    type Spec = SpecId;
+
     fn journal_inner_mut(&mut self) -> &mut JournaledState {
         &mut self.inner.ctx.journaled_state.inner
     }


### PR DESCRIPTION
## Summary
- Add `Tx`, `Block`, and `Spec` associated types to `NestedEvm` trait so each network can specify its own environment types
- Update `transact()` and `to_env()` signatures to use `Self::Tx`, `EvmEnv<Self::Spec, Self::Block>` instead of concrete Eth types
- Update `NestedEvmClosure` to pin associated types to Eth types (`TxEnv`, `BlockEnv`, `SpecId`)
- Set concrete types in the `FoundryEvm` implementation

The trait remains object-safe when used as `dyn NestedEvm<Tx = TxEnv, Block = BlockEnv, Spec = SpecId>`.

Same pattern as `CheatcodesExecutor` (#13774).