### PR TITLE
fix(anvil): update fee history cache synchronously during mining

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -21,7 +21,10 @@ use crate::{
             validate::TransactionValidator,
         },
         error::{BlockchainError, ErrDetail, InvalidTransactionError},
-        fees::{FeeDetails, FeeManager, MIN_SUGGESTED_PRIORITY_FEE},
+        fees::{
+            FeeDetails, FeeHistoryCache, FeeManager, MAX_FEE_HISTORY_CACHE_SIZE,
+            MIN_SUGGESTED_PRIORITY_FEE, create_fee_history_cache_item,
+        },
         macros::node_info,
         pool::transactions::PoolTransaction,
         sign::build_impersonated,
@@ -234,6 +237,8 @@ pub struct Backend<N: Network> {
     mining: Arc<tokio::sync::Mutex<()>>,
     /// Disable pool balance checks
     disable_pool_balance_checks: bool,
+    /// Fee history cache, updated synchronously during mining to avoid race conditions
+    fee_history_cache: FeeHistoryCache,
 }
 
 impl<N: Network> Clone for Backend<N> {
@@ -261,6 +266,7 @@ impl<N: Network> Clone for Backend<N> {
             precompile_factory: self.precompile_factory.clone(),
             mining: self.mining.clone(),
             disable_pool_balance_checks: self.disable_pool_balance_checks,
+            fee_history_cache: self.fee_history_cache.clone(),
         }
     }
 }
@@ -349,6 +355,11 @@ impl<N: Network> Backend<N> {
     /// Returns the `FeeManager` that manages fee/pricings
     pub fn fees(&self) -> &FeeManager {
         &self.fees
+    }
+
+    /// Returns the fee history cache
+    pub fn fee_history_cache(&self) -> &FeeHistoryCache {
+        &self.fee_history_cache
     }
 
     /// The env data of the blockchain
@@ -1787,6 +1798,7 @@ impl Backend<FoundryNetwork> {
             precompile_factory,
             mining: Arc::new(tokio::sync::Mutex::new(())),
             disable_pool_balance_checks,
+            fee_history_cache: Arc::new(Mutex::new(Default::default())),
         };
 
         if let Some(interval_block_time) = automine_block_time {
@@ -2418,6 +2430,24 @@ impl Backend<FoundryNetwork> {
             let BlockInfo { block, transactions, receipts } = block;
 
             let header = block.header.clone();
+
+            // Update fee history cache synchronously to avoid stale reads from
+            // eth_feeHistory before the async FeeHistoryService processes the notification.
+            {
+                let item = create_fee_history_cache_item(
+                    &header,
+                    &block.body.transactions,
+                    &receipts,
+                    self.blob_params(),
+                );
+                let mut cache = self.fee_history_cache.lock();
+                cache.insert(block_number, item);
+                let pop_next = block_number.saturating_sub(MAX_FEE_HISTORY_CACHE_SIZE);
+                let num_remove = (cache.len() as u64).saturating_sub(MAX_FEE_HISTORY_CACHE_SIZE);
+                for num in 0..num_remove {
+                    cache.remove(&(pop_next - num));
+                }
+            }
 
             trace!(
                 target: "backend",

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use alloy_consensus::{BlockHeader, Header, Transaction};
+use alloy_consensus::{BlockHeader, Header, Transaction, TxReceipt};
 use alloy_eips::{calc_next_block_base_fee, eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_primitives::B256;
 use futures::StreamExt;
@@ -236,93 +236,30 @@ impl FeeHistoryService {
         hash: B256,
         header: &Header,
     ) -> (FeeHistoryCacheItem, Option<u64>) {
-        // percentile list from 0.0 to 100.0 with a 0.5 resolution.
-        // this will create 200 percentile points
-        let reward_percentiles: Vec<f64> = {
-            let mut percentile: f64 = 0.0;
-            (0..=200)
-                .map(|_| {
-                    let val = percentile;
-                    percentile += 0.5;
-                    val
-                })
-                .collect()
-        };
-
-        let mut block_number: Option<u64> = None;
-        let base_fee = header.base_fee_per_gas.unwrap_or_default();
-        let excess_blob_gas = header.excess_blob_gas.map(|g| g as u128);
-        let blob_gas_used = header.blob_gas_used.map(|g| g as u128);
-        let base_fee_per_blob_gas = header.blob_fee(self.blob_params);
-
-        let mut item = FeeHistoryCacheItem {
-            base_fee: base_fee as u128,
-            gas_used_ratio: 0f64,
-            blob_gas_used_ratio: 0f64,
-            rewards: Vec::new(),
-            excess_blob_gas,
-            base_fee_per_blob_gas,
-            blob_gas_used,
-        };
-
         let current_block = self.storage_info.block(hash);
         let current_receipts = self.storage_info.receipts(hash);
 
         if let (Some(block), Some(receipts)) = (current_block, current_receipts) {
-            block_number = Some(block.header.number());
-
-            let gas_used = block.header.gas_used() as f64;
-            let blob_gas_used = block.header.blob_gas_used().map(|g| g as f64);
-            item.gas_used_ratio = gas_used / block.header.gas_limit() as f64;
-            item.blob_gas_used_ratio = blob_gas_used
-                .map(|g| {
-                    let max = self.blob_params.max_blob_gas_per_block() as f64;
-                    if max == 0.0 { 0.0 } else { g / max }
-                })
-                .unwrap_or(0.0);
-
-            // extract useful tx info (gas_used, effective_reward)
-            let mut transactions: Vec<(_, _)> = receipts
-                .iter()
-                .enumerate()
-                .map(|(i, receipt)| {
-                    let cumulative = receipt.cumulative_gas_used();
-                    let prev_cumulative =
-                        if i > 0 { receipts[i - 1].cumulative_gas_used() } else { 0 };
-                    let gas_used = cumulative - prev_cumulative;
-                    let effective_reward = block
-                        .body
-                        .transactions
-                        .get(i)
-                        .map(|tx| tx.as_ref().effective_tip_per_gas(base_fee).unwrap_or(0))
-                        .unwrap_or(0);
-
-                    (gas_used, effective_reward)
-                })
-                .collect();
-
-            // sort by effective reward asc
-            transactions.sort_by_key(|(_, reward)| *reward);
-
-            // calculate percentile rewards
-            item.rewards = reward_percentiles
-                .into_iter()
-                .filter_map(|p| {
-                    let target_gas = (p * gas_used / 100f64) as u64;
-                    let mut sum_gas = 0;
-                    for (gas_used, effective_reward) in transactions.iter().copied() {
-                        sum_gas += gas_used;
-                        if target_gas <= sum_gas {
-                            return Some(effective_reward);
-                        }
-                    }
-                    None
-                })
-                .collect();
+            let item = create_fee_history_cache_item(
+                header,
+                &block.body.transactions,
+                &receipts,
+                self.blob_params,
+            );
+            (item, Some(block.header.number()))
         } else {
-            item.rewards = vec![0; reward_percentiles.len()];
+            let base_fee = header.base_fee_per_gas.unwrap_or_default();
+            let item = FeeHistoryCacheItem {
+                base_fee: base_fee as u128,
+                gas_used_ratio: 0f64,
+                blob_gas_used_ratio: 0f64,
+                rewards: vec![0; 201],
+                excess_blob_gas: header.excess_blob_gas.map(|g| g as u128),
+                base_fee_per_blob_gas: header.blob_fee(self.blob_params),
+                blob_gas_used: header.blob_gas_used.map(|g| g as u128),
+            };
+            (item, None)
         }
-        (item, block_number)
     }
 
     fn insert_cache_entry(&self, item: FeeHistoryCacheItem, block_number: Option<u64>) {
@@ -356,6 +293,96 @@ impl Future for FeeHistoryService {
         }
 
         Poll::Pending
+    }
+}
+
+/// Creates a [`FeeHistoryCacheItem`] from block data.
+///
+/// This is a standalone function so it can be called both from [`FeeHistoryService`] (async
+/// notification path) and synchronously during block mining to keep the cache consistent with the
+/// chain head.
+pub fn create_fee_history_cache_item<T, R>(
+    header: &Header,
+    transactions: &[T],
+    receipts: &[R],
+    blob_params: BlobParams,
+) -> FeeHistoryCacheItem
+where
+    T: std::ops::Deref,
+    T::Target: Transaction,
+    R: TxReceipt,
+{
+    // percentile list from 0.0 to 100.0 with a 0.5 resolution.
+    // this will create 200 percentile points
+    let reward_percentiles: Vec<f64> = {
+        let mut percentile: f64 = 0.0;
+        (0..=200)
+            .map(|_| {
+                let val = percentile;
+                percentile += 0.5;
+                val
+            })
+            .collect()
+    };
+
+    let base_fee = header.base_fee_per_gas.unwrap_or_default();
+    let excess_blob_gas = header.excess_blob_gas.map(|g| g as u128);
+    let blob_gas_used = header.blob_gas_used.map(|g| g as u128);
+    let base_fee_per_blob_gas = header.blob_fee(blob_params);
+
+    let gas_used = header.gas_used as f64;
+    let gas_used_ratio = gas_used / header.gas_limit as f64;
+    let blob_gas_used_ratio = header
+        .blob_gas_used
+        .map(|g| {
+            let max = blob_params.max_blob_gas_per_block() as f64;
+            if max == 0.0 { 0.0 } else { g as f64 / max }
+        })
+        .unwrap_or(0.0);
+
+    // extract useful tx info (gas_used, effective_reward)
+    let mut tx_gas_and_reward: Vec<(u64, u128)> = receipts
+        .iter()
+        .enumerate()
+        .map(|(i, receipt)| {
+            let cumulative = receipt.cumulative_gas_used();
+            let prev_cumulative = if i > 0 { receipts[i - 1].cumulative_gas_used() } else { 0 };
+            let gas_used = cumulative - prev_cumulative;
+            let effective_reward = transactions
+                .get(i)
+                .map(|tx| tx.effective_tip_per_gas(base_fee).unwrap_or(0))
+                .unwrap_or(0);
+            (gas_used, effective_reward)
+        })
+        .collect();
+
+    // sort by effective reward asc
+    tx_gas_and_reward.sort_by_key(|(_, reward)| *reward);
+
+    // calculate percentile rewards
+    let rewards = reward_percentiles
+        .into_iter()
+        .filter_map(|p| {
+            let target_gas = (p * gas_used / 100f64) as u64;
+            let mut sum_gas = 0;
+            for &(gas_used, effective_reward) in &tx_gas_and_reward {
+                sum_gas += gas_used;
+                if target_gas <= sum_gas {
+                    return Some(effective_reward);
+                }
+            }
+            None
+        })
+        .collect();
+
+    FeeHistoryCacheItem {
+        base_fee: base_fee as u128,
+        gas_used_ratio,
+        blob_gas_used_ratio,
+        rewards,
+        excess_blob_gas,
+        base_fee_per_blob_gas,
+        blob_gas_used,
     }
 }
 

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -28,7 +28,6 @@ use foundry_common::provider::{ProviderBuilder, RetryProvider};
 pub use foundry_evm::hardfork::EthereumHardfork;
 use foundry_primitives::FoundryNetwork;
 use futures::{FutureExt, TryFutureExt};
-use parking_lot::Mutex;
 use revm::primitives::hardfork::SpecId;
 use server::try_spawn_ipc;
 use std::{
@@ -200,7 +199,7 @@ pub async fn try_spawn(mut config: NodeConfig) -> Result<(EthApi<FoundryNetwork>
         }
     }
 
-    let fee_history_cache = Arc::new(Mutex::new(Default::default()));
+    let fee_history_cache = backend.fee_history_cache().clone();
     let fee_history_service = FeeHistoryService::new(
         match backend.spec_id() {
             SpecId::OSAKA => BlobParams::osaka(),
@@ -208,7 +207,7 @@ pub async fn try_spawn(mut config: NodeConfig) -> Result<(EthApi<FoundryNetwork>
             _ => BlobParams::cancun(),
         },
         backend.new_block_notifications(),
-        Arc::clone(&fee_history_cache),
+        fee_history_cache.clone(),
         StorageInfo::new(Arc::clone(&backend)),
     );
     // create an entry for the best block


### PR DESCRIPTION
## Problem

`eth_feeHistory` can return fewer entries than requested when called right after a block is mined.

The fee history cache is populated by `FeeHistoryService`, which runs as a separate `Future` inside `NodeService::poll`. The timeline looks like:

1. `do_mine_block()` stores the block in `BlockchainStorage`
2. `do_mine_block()` calls `notify_on_new_block()` — sends a notification on a channel
3. **← race window: `eth_feeHistory` reads the cache here, before step 4 runs →**
4. `FeeHistoryService::poll` receives the notification and updates the cache

During step 3, the new block exists in storage (so `best_number` is incremented), but the cache hasn't been updated yet. `eth_feeHistory` sees the new block number, tries to look it up in the cache, finds nothing, silently skips it, and returns a short response.

## Fix

Share the `FeeHistoryCache` between `Backend` and `FeeHistoryService`. Update it synchronously in `do_mine_block()` **before** `notify_on_new_block()`, closing the race window. The async `FeeHistoryService` still runs but becomes a no-op for already-cached blocks.

Closes #13680