### PR TITLE
fix(anvil): reject invalid versioned_hashes in beacon blobs endpoint

### DIFF
--- a/crates/anvil/src/server/beacon/handlers.rs
+++ b/crates/anvil/src/server/beacon/handlers.rs
@@ -43,12 +43,31 @@ pub async fn handle_get_blobs(
         return BeaconError::invalid_block_id(block_id).into_response();
     };
 
-    // Parse indices from query parameters
-    // Supports both comma-separated (?indices=1,2,3) and repeated parameters (?indices=1&indices=2)
-    let versioned_hashes: Vec<B256> = versioned_hashes
-        .get("versioned_hashes")
-        .map(|s| s.split(',').filter_map(|hash| B256::from_str(hash.trim()).ok()).collect())
-        .unwrap_or_default();
+    // Parse versioned hashes from query parameters
+    // Supports comma-separated format: ?versioned_hashes=0x...,0x...
+    let versioned_hashes: Vec<B256> = match versioned_hashes.get("versioned_hashes") {
+        Some(s) => {
+            let mut hashes = Vec::new();
+            for hash in s.split(',') {
+                let hash = hash.trim();
+                if hash.is_empty() {
+                    continue;
+                }
+                match B256::from_str(hash) {
+                    Ok(h) => hashes.push(h),
+                    Err(_) => {
+                        return BeaconError::new(
+                            super::error::BeaconErrorCode::BadRequest,
+                            format!("Invalid versioned hash: {hash}"),
+                        )
+                        .into_response();
+                    }
+                }
+            }
+            hashes
+        }
+        None => Vec::new(),
+    };
 
     // Get the blob sidecars using existing EthApi logic
     match api.anvil_get_blobs_by_block_id(block_id, versioned_hashes) {


### PR DESCRIPTION
## Summary

While debugging a blob indexer that was silently returning incomplete data against a local Anvil node, I traced the issue to the `GET /eth/v1/beacon/blobs/{block_id}` endpoint. Turned out a few `versioned_hashes` in my query had a truncated prefix (`0x01a0...` got copy-pasted as `01a0...` without `0x`), and the endpoint was happily ignoring them and returning a subset of the blobs I asked for.

The root cause is that the parameter parsing used `filter_map(|hash| B256::from_str(hash).ok())`, which silently drops any hash that fails to parse. This means a request like:

`versioned_hashes=0xabc123...,GARBAGE,0xdef456...`


returns a 200 with only 2 blobs instead of telling you one of your inputs was bad.  `curl` the endpoint directly and count the response items vs. what I sent.

## Changes

- Replace `filter_map(.ok())` with explicit per-hash validation
- Return 400 Bad Request with a clear message (`Invalid versioned hash: <value>`) on the first unparseable hash
- Skip empty segments (trailing comma, etc.) for ergonomics

This is consistent with how `block_id` parsing already works a few lines above — invalid input gets a proper error, not a silent fallback

