### PR TITLE
feat(anvil): add `AnvilBlockExecutor` and `FoundryReceiptBuilder`

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -14,8 +14,8 @@ use crate::{
     mem::inspector::AnvilInspector,
 };
 use alloy_consensus::{
-    Header, Receipt, ReceiptWithBloom, Transaction, constants::EMPTY_WITHDRAWALS,
-    proofs::calculate_receipt_root, transaction::Either,
+    Eip658Value, Header, Receipt, ReceiptWithBloom, Transaction, TransactionEnvelope,
+    constants::EMPTY_WITHDRAWALS, proofs::calculate_receipt_root, transaction::Either,
 };
 use alloy_eips::{
     Encodable2718, eip2935, eip4788,
@@ -24,13 +24,20 @@ use alloy_eips::{
     eip7840::BlobParams,
 };
 use alloy_evm::{
-    EthEvmFactory, Evm, EvmEnv, EvmFactory, FromRecoveredTx,
-    eth::EthEvmContext,
+    EthEvmFactory, Evm, EvmEnv, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
+    block::{
+        BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockValidationError,
+        ExecutableTx, OnStateHook, StateChangeSource, StateDB, TxResult,
+    },
+    eth::{
+        EthEvmContext, EthTxResult,
+        receipt_builder::{ReceiptBuilder, ReceiptBuilderCtx},
+    },
     precompiles::{DynPrecompile, Precompile, PrecompilesMap},
 };
 use alloy_network::Network;
 use alloy_op_evm::OpEvmFactory;
-use alloy_primitives::{B256, Bloom, BloomInput, Bytes, Log};
+use alloy_primitives::{Address, B256, Bloom, BloomInput, Bytes, Log};
 use anvil_core::eth::{
     block::{TypedBlockInfo, create_block},
     transaction::{PendingTransaction, TransactionInfo},
@@ -41,16 +48,280 @@ use foundry_evm::{
     traces::{CallTraceDecoder, CallTraceNode},
 };
 use foundry_evm_networks::NetworkConfigs;
-use foundry_primitives::{FoundryNetwork, FoundryReceiptEnvelope, FoundryTxEnvelope};
+use foundry_primitives::{
+    FoundryNetwork, FoundryReceiptEnvelope, FoundryTxEnvelope, FoundryTxType,
+};
 use op_revm::{OpContext, OpTransaction};
 use revm::{
-    Database, Inspector,
+    Database, DatabaseCommit, Inspector,
     context::{Block as RevmBlock, Cfg, TxEnv},
-    context_interface::result::{EVMError, ExecutionResult, Output},
+    context_interface::result::{EVMError, ExecutionResult, Output, ResultAndState},
     interpreter::InstructionResult,
     primitives::hardfork::SpecId,
 };
 use std::{fmt, fmt::Debug, sync::Arc};
+
+/// Receipt builder for Foundry/Anvil that handles all transaction types
+#[derive(Debug, Default, Clone, Copy)]
+#[non_exhaustive]
+pub struct FoundryReceiptBuilder;
+
+impl ReceiptBuilder for FoundryReceiptBuilder {
+    type Transaction = FoundryTxEnvelope;
+    type Receipt = FoundryReceiptEnvelope;
+
+    fn build_receipt<E: Evm>(
+        &self,
+        ctx: ReceiptBuilderCtx<'_, FoundryTxType, E>,
+    ) -> FoundryReceiptEnvelope {
+        let receipt = alloy_consensus::Receipt {
+            status: Eip658Value::Eip658(ctx.result.is_success()),
+            cumulative_gas_used: ctx.cumulative_gas_used,
+            logs: ctx.result.into_logs(),
+        }
+        .with_bloom();
+
+        match ctx.tx_type {
+            FoundryTxType::Legacy => FoundryReceiptEnvelope::Legacy(receipt),
+            FoundryTxType::Eip2930 => FoundryReceiptEnvelope::Eip2930(receipt),
+            FoundryTxType::Eip1559 => FoundryReceiptEnvelope::Eip1559(receipt),
+            FoundryTxType::Eip4844 => FoundryReceiptEnvelope::Eip4844(receipt),
+            FoundryTxType::Eip7702 => FoundryReceiptEnvelope::Eip7702(receipt),
+            FoundryTxType::Deposit => {
+                unreachable!("deposit receipts are built in commit_transaction")
+            }
+            FoundryTxType::Tempo => FoundryReceiptEnvelope::Tempo(receipt),
+        }
+    }
+}
+
+/// Result of executing a transaction in [`AnvilBlockExecutor`].
+///
+/// Wraps [`EthTxResult`] with the sender address, needed for deposit nonce resolution.
+#[derive(Debug)]
+pub struct AnvilTxResult<H> {
+    pub inner: EthTxResult<H, FoundryTxType>,
+    pub sender: Address,
+}
+
+impl<H> TxResult for AnvilTxResult<H> {
+    type HaltReason = H;
+
+    fn result(&self) -> &ResultAndState<Self::HaltReason> {
+        self.inner.result()
+    }
+}
+
+/// Execution context for [`AnvilBlockExecutor`], providing block-level data
+/// needed for pre/post execution system calls.
+#[derive(Debug, Clone)]
+pub struct AnvilExecutionCtx {
+    /// Parent block hash — needed for EIP-2935 system call.
+    pub parent_hash: B256,
+    /// Whether Prague hardfork is active.
+    pub is_prague: bool,
+    /// Whether Cancun hardfork is active.
+    pub is_cancun: bool,
+}
+
+/// Block executor for Anvil that implements [`BlockExecutor`].
+///
+/// Wraps an EVM instance and produces [`FoundryReceiptEnvelope`] receipts.
+/// Validation (gas limits, blob gas, transaction validity) is handled by the
+/// caller before transactions are fed to this executor.
+pub struct AnvilBlockExecutor<E> {
+    /// The EVM instance used for execution.
+    evm: E,
+    /// Execution context.
+    ctx: AnvilExecutionCtx,
+    /// Receipt builder.
+    receipt_builder: FoundryReceiptBuilder,
+    /// Receipts of executed transactions.
+    receipts: Vec<FoundryReceiptEnvelope>,
+    /// Total gas used by transactions in this block.
+    gas_used: u64,
+    /// Blob gas used by the block.
+    blob_gas_used: u64,
+    /// Optional state change hook.
+    state_hook: Option<Box<dyn OnStateHook>>,
+}
+
+impl<E: fmt::Debug> fmt::Debug for AnvilBlockExecutor<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AnvilBlockExecutor")
+            .field("evm", &self.evm)
+            .field("ctx", &self.ctx)
+            .field("gas_used", &self.gas_used)
+            .field("blob_gas_used", &self.blob_gas_used)
+            .field("receipts", &self.receipts.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<E> AnvilBlockExecutor<E> {
+    /// Creates a new [`AnvilBlockExecutor`].
+    pub fn new(evm: E, ctx: AnvilExecutionCtx) -> Self {
+        Self {
+            evm,
+            ctx,
+            receipt_builder: FoundryReceiptBuilder,
+            receipts: Vec::new(),
+            gas_used: 0,
+            blob_gas_used: 0,
+            state_hook: None,
+        }
+    }
+}
+
+impl<E> BlockExecutor for AnvilBlockExecutor<E>
+where
+    E: Evm<
+            DB: StateDB,
+            Tx: FromRecoveredTx<FoundryTxEnvelope> + FromTxWithEncoded<FoundryTxEnvelope>,
+        >,
+{
+    type Transaction = FoundryTxEnvelope;
+    type Receipt = FoundryReceiptEnvelope;
+    type Evm = E;
+    type Result = AnvilTxResult<E::HaltReason>;
+
+    fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
+        // EIP-2935: store parent block hash in history storage contract.
+        if self.ctx.is_prague {
+            let result = self
+                .evm
+                .transact_system_call(
+                    eip4788::SYSTEM_ADDRESS,
+                    eip2935::HISTORY_STORAGE_ADDRESS,
+                    Bytes::copy_from_slice(self.ctx.parent_hash.as_slice()),
+                )
+                .map_err(BlockExecutionError::other)?;
+
+            if let Some(hook) = &mut self.state_hook {
+                hook.on_state(
+                    StateChangeSource::PreBlock(
+                        alloy_evm::block::StateChangePreBlockSource::BlockHashesContract,
+                    ),
+                    &result.state,
+                );
+            }
+            self.evm.db_mut().commit(result.state);
+        }
+        Ok(())
+    }
+
+    fn execute_transaction_without_commit(
+        &mut self,
+        tx: impl ExecutableTx<Self>,
+    ) -> Result<Self::Result, BlockExecutionError> {
+        let (tx_env, tx) = tx.into_parts();
+
+        let block_available_gas = self.evm.block().gas_limit() - self.gas_used;
+        if tx.tx().gas_limit() > block_available_gas {
+            return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                transaction_gas_limit: tx.tx().gas_limit(),
+                block_available_gas,
+            }
+            .into());
+        }
+
+        let sender = *tx.signer();
+
+        let result = self.evm.transact(tx_env).map_err(|err| {
+            let hash = tx.tx().trie_hash();
+            BlockExecutionError::evm(err, hash)
+        })?;
+
+        Ok(AnvilTxResult {
+            inner: EthTxResult {
+                result,
+                blob_gas_used: tx.tx().blob_gas_used().unwrap_or_default(),
+                tx_type: tx.tx().tx_type(),
+            },
+            sender,
+        })
+    }
+
+    fn commit_transaction(&mut self, output: Self::Result) -> Result<u64, BlockExecutionError> {
+        let AnvilTxResult {
+            inner: EthTxResult { result: ResultAndState { result, state }, blob_gas_used, tx_type },
+            sender,
+        } = output;
+
+        if let Some(hook) = &mut self.state_hook {
+            hook.on_state(StateChangeSource::Transaction(self.receipts.len()), &state);
+        }
+
+        let gas_used = result.gas_used();
+        self.gas_used += gas_used;
+
+        if self.ctx.is_cancun {
+            self.blob_gas_used = self.blob_gas_used.saturating_add(blob_gas_used);
+        }
+
+        let receipt = if tx_type == FoundryTxType::Deposit {
+            let deposit_nonce = state.get(&sender).map(|acc| acc.info.nonce);
+            let receipt = alloy_consensus::Receipt {
+                status: Eip658Value::Eip658(result.is_success()),
+                cumulative_gas_used: self.gas_used,
+                logs: result.into_logs(),
+            }
+            .with_bloom();
+            FoundryReceiptEnvelope::Deposit(op_alloy_consensus::OpDepositReceiptWithBloom {
+                receipt: op_alloy_consensus::OpDepositReceipt {
+                    inner: receipt.receipt,
+                    deposit_nonce,
+                    deposit_receipt_version: deposit_nonce.map(|_| 1),
+                },
+                logs_bloom: receipt.logs_bloom,
+            })
+        } else {
+            self.receipt_builder.build_receipt(ReceiptBuilderCtx {
+                tx_type,
+                evm: &self.evm,
+                result,
+                state: &state,
+                cumulative_gas_used: self.gas_used,
+            })
+        };
+
+        self.receipts.push(receipt);
+        self.evm.db_mut().commit(state);
+
+        Ok(gas_used)
+    }
+
+    fn finish(
+        self,
+    ) -> Result<(Self::Evm, BlockExecutionResult<FoundryReceiptEnvelope>), BlockExecutionError>
+    {
+        Ok((
+            self.evm,
+            BlockExecutionResult {
+                receipts: self.receipts,
+                requests: Default::default(),
+                gas_used: self.gas_used,
+                blob_gas_used: self.blob_gas_used,
+            },
+        ))
+    }
+
+    fn set_state_hook(&mut self, hook: Option<Box<dyn OnStateHook>>) {
+        self.state_hook = hook;
+    }
+
+    fn evm_mut(&mut self) -> &mut Self::Evm {
+        &mut self.evm
+    }
+
+    fn evm(&self) -> &Self::Evm {
+        &self.evm
+    }
+
+    fn receipts(&self) -> &[FoundryReceiptEnvelope] {
+        &self.receipts
+    }
+}
 
 /// Represents an executed transaction (transacted on the DB)
 pub struct ExecutedTransaction<T = FoundryTxEnvelope> {

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -7,12 +7,12 @@ use alloy_consensus::{
         eip4844::{TxEip4844Variant, TxEip4844WithSidecar},
     },
 };
-use alloy_evm::FromRecoveredTx;
+use alloy_evm::{FromRecoveredTx, FromTxWithEncoded};
 use alloy_network::{AnyRpcTransaction, AnyTxEnvelope, TransactionResponse};
-use alloy_primitives::{Address, B256, TxHash};
+use alloy_primitives::{Address, B256, Bytes, TxHash};
 use alloy_rpc_types::ConversionError;
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpTransaction as OpTransactionTrait, TxDeposit};
-use op_revm::OpTransaction;
+use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
 use revm::context::TxEnv;
 use tempo_primitives::{AASigned, TempoTransaction};
 
@@ -210,7 +210,7 @@ impl FromRecoveredTx<FoundryTxEnvelope> for TxEnv {
             FoundryTxEnvelope::Deposit(sealed_tx) => {
                 Self::from_recovered_tx(sealed_tx.inner(), caller)
             }
-            FoundryTxEnvelope::Tempo(_) => panic!("unsupported tx type on ethereum"),
+            FoundryTxEnvelope::Tempo(_) => unreachable!("Tempo tx in Ethereum context"),
         }
     }
 }
@@ -226,7 +226,51 @@ impl FromRecoveredTx<FoundryTxEnvelope> for OpTransaction<TxEnv> {
             FoundryTxEnvelope::Deposit(sealed_tx) => {
                 Self::from_recovered_tx(sealed_tx.inner(), caller)
             }
-            FoundryTxEnvelope::Tempo(_) => panic!("unsupported tx type on optimism"),
+            FoundryTxEnvelope::Tempo(_) => unreachable!("Tempo tx in Optimism context"),
+        }
+    }
+}
+
+impl FromTxWithEncoded<FoundryTxEnvelope> for TxEnv {
+    fn from_encoded_tx(tx: &FoundryTxEnvelope, sender: Address, _encoded: Bytes) -> Self {
+        Self::from_recovered_tx(tx, sender)
+    }
+}
+
+impl FromTxWithEncoded<FoundryTxEnvelope> for OpTransaction<TxEnv> {
+    fn from_encoded_tx(tx: &FoundryTxEnvelope, caller: Address, encoded: Bytes) -> Self {
+        match tx {
+            FoundryTxEnvelope::Legacy(signed_tx) => {
+                let base = TxEnv::from_recovered_tx(signed_tx, caller);
+                Self { base, enveloped_tx: Some(encoded), deposit: Default::default() }
+            }
+            FoundryTxEnvelope::Eip2930(signed_tx) => {
+                let base = TxEnv::from_recovered_tx(signed_tx, caller);
+                Self { base, enveloped_tx: Some(encoded), deposit: Default::default() }
+            }
+            FoundryTxEnvelope::Eip1559(signed_tx) => {
+                let base = TxEnv::from_recovered_tx(signed_tx, caller);
+                Self { base, enveloped_tx: Some(encoded), deposit: Default::default() }
+            }
+            FoundryTxEnvelope::Eip4844(signed_tx) => {
+                let base = TxEnv::from_recovered_tx(signed_tx, caller);
+                Self { base, enveloped_tx: Some(encoded), deposit: Default::default() }
+            }
+            FoundryTxEnvelope::Eip7702(signed_tx) => {
+                let base = TxEnv::from_recovered_tx(signed_tx, caller);
+                Self { base, enveloped_tx: Some(encoded), deposit: Default::default() }
+            }
+            FoundryTxEnvelope::Deposit(sealed_tx) => {
+                let deposit_tx = sealed_tx.inner();
+                let base = TxEnv::from_recovered_tx(deposit_tx, caller);
+                let deposit = DepositTransactionParts {
+                    source_hash: deposit_tx.source_hash,
+                    mint: Some(deposit_tx.mint),
+                    is_system_transaction: deposit_tx.is_system_transaction,
+                };
+                Self { base, enveloped_tx: Some(encoded), deposit }
+            }
+            FoundryTxEnvelope::Tempo(_) => unreachable!("Tempo tx in Optimism context"),
         }
     }
 }
@@ -275,7 +319,7 @@ impl From<FoundryTxEnvelope> for FoundryTypedTx {
 mod tests {
     use std::str::FromStr;
 
-    use alloy_primitives::{Bytes, TxKind, U256, b256, hex};
+    use alloy_primitives::{TxKind, U256, b256, hex};
     use alloy_rlp::Decodable;
     use alloy_signer::Signature;
 


### PR DESCRIPTION
Adds the execution layer building blocks needed to replace `TransactionExecutor` with alloy-evm's `BlockExecutor` interface.

`foundry-primitives`
- `FromTxWithEncoded<FoundryTxEnvelope>` impls for `TxEnv` and `OpTransaction<TxEnv>` — required to satisfy `BlockExecutor`'s EVM bounds.

`anvil/executor.rs` (additive, nothing existing touched)
- `FoundryReceiptBuilder` — implements `ReceiptBuilder` for all `FoundryTxType` variants including Deposit and Tempo.
- `AnvilExecutionCtx` — block-level context (parent hash, hardfork flags).
- `AnvilBlockExecutor<E>` — implements `BlockExecutor`: pre-execution system calls (EIP-2935), per-transaction execute/commit, receipt accumulation via `FoundryReceiptBuilder`.

Next steps

Follow-up - wiring `AnvilBlockExecutor` into `Backend::mine_block`, replacing `TransactionExecutor::execute()`. That swap moves `mine_block` from `impl Backend<FoundryNetwork>` to `impl<N: Network> Backend<N>`, which unblocks `NodeService` and `BlockProducer` from being fully generic.