### PR TITLE
refactor(evm): remove `eth_*_mut()` from `FoundryContextExt`

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -889,20 +889,14 @@ impl Cheatcode for stopSnapshotGas_2Call {
 
 // Deprecated in favor of `snapshotStateCall`
 impl Cheatcode for snapshotCall {
-    fn apply_stateful<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
-        &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-    ) -> Result {
+    fn apply_stateful<CTX: EthCheatCtx>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         inner_snapshot_state(ccx)
     }
 }
 
 impl Cheatcode for snapshotStateCall {
-    fn apply_stateful<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
-        &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-    ) -> Result {
+    fn apply_stateful<CTX: EthCheatCtx>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self {} = self;
         inner_snapshot_state(ccx)
     }
@@ -910,20 +904,14 @@ impl Cheatcode for snapshotStateCall {
 
 // Deprecated in favor of `revertToStateCall`
 impl Cheatcode for revertToCall {
-    fn apply_stateful<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
-        &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-    ) -> Result {
+    fn apply_stateful<CTX: EthCheatCtx>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state(ccx, *snapshotId)
     }
 }
 
 impl Cheatcode for revertToStateCall {
-    fn apply_stateful<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
-        &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-    ) -> Result {
+    fn apply_stateful<CTX: EthCheatCtx>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state(ccx, *snapshotId)
     }
@@ -931,20 +919,14 @@ impl Cheatcode for revertToStateCall {
 
 // Deprecated in favor of `revertToStateAndDeleteCall`
 impl Cheatcode for revertToAndDeleteCall {
-    fn apply_stateful<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
-        &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-    ) -> Result {
+    fn apply_stateful<CTX: EthCheatCtx>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state_and_delete(ccx, *snapshotId)
     }
 }
 
 impl Cheatcode for revertToStateAndDeleteCall {
-    fn apply_stateful<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
-        &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-    ) -> Result {
+    fn apply_stateful<CTX: EthCheatCtx>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state_and_delete(ccx, *snapshotId)
     }
@@ -1211,7 +1193,7 @@ impl Cheatcode for executeTransactionCall {
 
         // Override env for isolated execution.
         ccx.ecx.block_mut().set_basefee(0);
-        *ccx.ecx.eth_tx_mut() = tx_env;
+        ccx.ecx.set_tx(tx_env);
         ccx.ecx.tx_mut().set_gas_price(0);
         ccx.ecx.tx_mut().set_gas_priority_fee(None);
 
@@ -1422,19 +1404,15 @@ pub(super) fn get_nonce<CTX: ContextTr<Db: DatabaseExt>>(
     Ok(account.data.info.nonce.abi_encode())
 }
 
-fn inner_snapshot_state<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
-) -> Result {
-    let evm_env = EvmEnv {
-        cfg_env: ccx.ecx.eth_cfg_mut().clone(),
-        block_env: ccx.ecx.eth_block_mut().clone(),
-    };
+fn inner_snapshot_state<CTX: EthCheatCtx>(ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    let evm_env =
+        EvmEnv { cfg_env: ccx.ecx.cfg_mut().clone(), block_env: ccx.ecx.block_mut().clone() };
     let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
     let id = db.snapshot_state(inner, &evm_env);
     Ok(id.abi_encode())
 }
 
-fn inner_revert_to_state<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
+fn inner_revert_to_state<CTX: EthCheatCtx>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     snapshot_id: U256,
 ) -> Result {
@@ -1455,7 +1433,7 @@ fn inner_revert_to_state<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
     }
 }
 
-fn inner_revert_to_state_and_delete<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
+fn inner_revert_to_state_and_delete<CTX: EthCheatCtx>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     snapshot_id: U256,
 ) -> Result {

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -10,7 +10,7 @@ use alloy_provider::Provider;
 use alloy_rpc_types::Filter;
 use alloy_sol_types::SolValue;
 use foundry_common::provider::ProviderBuilder;
-use foundry_evm_core::{Env, FoundryContextExt, backend::FoundryJournalExt, fork::CreateFork};
+use foundry_evm_core::{Env, backend::FoundryJournalExt, fork::CreateFork};
 use revm::context::ContextTr;
 
 impl Cheatcode for activeForkCall {
@@ -28,30 +28,21 @@ impl Cheatcode for activeForkCall {
 }
 
 impl Cheatcode for createFork_0Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt>>(
-        &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-    ) -> Result {
+    fn apply_stateful<CTX: EthCheatCtx>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { urlOrAlias } = self;
         create_fork(ccx, urlOrAlias, None)
     }
 }
 
 impl Cheatcode for createFork_1Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt>>(
-        &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-    ) -> Result {
+    fn apply_stateful<CTX: EthCheatCtx>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { urlOrAlias, blockNumber } = self;
         create_fork(ccx, urlOrAlias, Some(blockNumber.saturating_to()))
     }
 }
 
 impl Cheatcode for createFork_2Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt>>(
-        &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-    ) -> Result {
+    fn apply_stateful<CTX: EthCheatCtx>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { urlOrAlias, txHash } = self;
         create_fork_at_transaction(ccx, urlOrAlias, txHash)
     }
@@ -362,7 +353,7 @@ fn create_select_fork<CTX: EthCheatCtx>(
 }
 
 /// Creates a new fork
-fn create_fork<CTX: FoundryContextExt<Db: DatabaseExt>>(
+fn create_fork<CTX: EthCheatCtx>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     url_or_alias: &str,
     block: Option<u64>,
@@ -390,7 +381,7 @@ fn create_select_fork_at_transaction<CTX: EthCheatCtx>(
 }
 
 /// Creates a new fork at the given transaction
-fn create_fork_at_transaction<CTX: FoundryContextExt<Db: DatabaseExt>>(
+fn create_fork_at_transaction<CTX: EthCheatCtx>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     url_or_alias: &str,
     transaction: &B256,
@@ -401,7 +392,7 @@ fn create_fork_at_transaction<CTX: FoundryContextExt<Db: DatabaseExt>>(
 }
 
 /// Creates the request object for a new fork request
-fn create_fork_request<CTX: FoundryContextExt<Db: DatabaseExt>>(
+fn create_fork_request<CTX: EthCheatCtx>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     url_or_alias: &str,
     block: Option<u64>,
@@ -422,8 +413,8 @@ fn create_fork_request<CTX: FoundryContextExt<Db: DatabaseExt>>(
             && ccx.state.config.rpc_storage_caching.enable_for_endpoint(&url),
         url,
         evm_env: EvmEnv {
-            cfg_env: ccx.ecx.eth_cfg_mut().clone(),
-            block_env: ccx.ecx.eth_block_mut().clone(),
+            cfg_env: ccx.ecx.cfg_mut().clone(),
+            block_env: ccx.ecx.block_mut().clone(),
         },
         evm_opts,
     };

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -769,7 +769,7 @@ impl Cheatcodes {
     ) -> Option<CallOutcome> {
         // Apply custom execution evm version.
         if let Some(spec_id) = self.execution_evm_version {
-            ecx.eth_cfg_mut().set_spec(spec_id);
+            ecx.cfg_mut().set_spec(spec_id);
         }
 
         let gas = Gas::new(call.gas_limit);
@@ -1183,7 +1183,7 @@ impl<CTX: EthCheatCtx> Inspector<CTX> for Cheatcodes {
         // When the first interpreter is initialized we've circumvented the balance and gas checks,
         // so we apply our actual block data with the correct fees and all.
         if let Some(block) = self.block.take() {
-            *ecx.eth_block_mut() = block;
+            ecx.set_block(block);
         }
         if let Some(gas_price) = self.gas_price.take() {
             ecx.tx_mut().set_gas_price(gas_price);
@@ -1693,7 +1693,7 @@ impl<CTX: EthCheatCtx> Inspector<CTX> for Cheatcodes {
     fn create(&mut self, ecx: &mut CTX, mut input: &mut CreateInputs) -> Option<CreateOutcome> {
         // Apply custom execution evm version.
         if let Some(spec_id) = self.execution_evm_version {
-            ecx.eth_cfg_mut().set_spec(spec_id);
+            ecx.cfg_mut().set_spec(spec_id);
         }
 
         let gas = Gas::new(input.gas_limit());

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -31,19 +31,19 @@ impl Env {
         Self::from(cfg, block, tx)
     }
 
-    /// Clones the evm env and tx env separately from a [`FoundryContextExt`] context.
-    pub fn clone_evm_and_tx(ecx: &mut impl FoundryContextExt) -> (EvmEnv, TxEnv) {
+    /// Clones the evm env and tx env separately from a [`EthCheatCtx`] context.
+    pub fn clone_evm_and_tx(ecx: &mut impl EthCheatCtx) -> (EvmEnv, TxEnv) {
         (
-            EvmEnv { cfg_env: ecx.eth_cfg_mut().clone(), block_env: ecx.eth_block_mut().clone() },
-            ecx.eth_tx_mut().clone(),
+            EvmEnv { cfg_env: ecx.cfg_mut().clone(), block_env: ecx.block_mut().clone() },
+            ecx.tx_mut().clone(),
         )
     }
 
-    /// Writes the split evm env and tx env back into a [`FoundryContextExt`] context.
-    pub fn apply_evm_and_tx(ecx: &mut impl FoundryContextExt, evm_env: EvmEnv, tx_env: TxEnv) {
-        *ecx.eth_block_mut() = evm_env.block_env;
-        *ecx.eth_cfg_mut() = evm_env.cfg_env;
-        *ecx.eth_tx_mut() = tx_env;
+    /// Writes the split evm env and tx env back into a [`EthCheatCtx`] context.
+    pub fn apply_evm_and_tx(ecx: &mut impl EthCheatCtx, evm_env: EvmEnv, tx_env: TxEnv) {
+        *ecx.block_mut() = evm_env.block_env;
+        *ecx.cfg_mut() = evm_env.cfg_env;
+        *ecx.tx_mut() = tx_env;
     }
 }
 
@@ -282,12 +282,6 @@ impl<S: Into<SpecId> + Clone + Debug> FoundryCfg for CfgEnv<S> {
 pub trait FoundryContextExt:
     ContextTr<Block: FoundryBlock + Clone, Tx: FoundryTransaction + Clone, Cfg: FoundryCfg + Clone>
 {
-    // TODO: to be removed
-    fn eth_block_mut(&mut self) -> &mut BlockEnv;
-    // TODO: to be removed
-    fn eth_tx_mut(&mut self) -> &mut TxEnv;
-    // TODO: to be removed
-    fn eth_cfg_mut(&mut self) -> &mut CfgEnv;
     /// Mutable reference to the block environment.
     fn block_mut(&mut self) -> &mut Self::Block;
     /// Mutable reference to the transaction environment.
@@ -311,17 +305,6 @@ pub trait FoundryContextExt:
 impl<DB: Database, J: JournalTr<Database = DB>, C> FoundryContextExt
     for Context<BlockEnv, TxEnv, CfgEnv, DB, J, C>
 {
-    fn eth_block_mut(&mut self) -> &mut BlockEnv {
-        &mut self.block
-    }
-
-    fn eth_tx_mut(&mut self) -> &mut TxEnv {
-        &mut self.tx
-    }
-
-    fn eth_cfg_mut(&mut self) -> &mut CfgEnv {
-        &mut self.cfg
-    }
     fn block_mut(&mut self) -> &mut Self::Block {
         &mut self.block
     }

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    Env, FoundryContextExt, InspectorExt,
+    Env, EthCheatCtx, InspectorExt,
     backend::{DatabaseExt, FoundryJournalExt, JournaledState},
     constants::DEFAULT_CREATE2_DEPLOYER_CODEHASH,
 };
@@ -303,7 +303,7 @@ pub type EthNestedEvmClosure<'a> = &'a mut dyn FnMut(
 /// and cloned journal inner to the callback. The callback builds whatever EVM it
 /// needs, runs its operations, and returns `(result, modified_env, modified_journal)`.
 /// Modified state is written back after the callback returns.
-pub fn with_cloned_context<CTX: FoundryContextExt, R>(
+pub fn with_cloned_context<CTX: EthCheatCtx, R>(
     ecx: &mut CTX,
     f: impl FnOnce(
         &mut dyn DatabaseExt,
@@ -311,10 +311,7 @@ pub fn with_cloned_context<CTX: FoundryContextExt, R>(
         TxEnv,
         JournaledState,
     ) -> Result<(R, EvmEnv, TxEnv, JournaledState), EVMError<DatabaseError>>,
-) -> Result<R, EVMError<DatabaseError>>
-where
-    CTX::Journal: FoundryJournalExt,
-{
+) -> Result<R, EVMError<DatabaseError>> {
     let (evm_env, tx_env) = Env::clone_evm_and_tx(ecx);
 
     let journal = ecx.journal_mut();

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -730,7 +730,7 @@ impl InspectorStackRefMut<'_> {
         outcome.clone()
     }
 
-    fn transact_inner<CTX: FoundryContextExt>(
+    fn transact_inner<CTX: EthCheatCtx>(
         &mut self,
         ecx: &mut CTX,
         kind: TxKind,
@@ -738,10 +738,7 @@ impl InspectorStackRefMut<'_> {
         input: Bytes,
         gas_limit: u64,
         value: U256,
-    ) -> (InterpreterResult, Option<Address>)
-    where
-        CTX::Journal: FoundryJournalExt,
-    {
+    ) -> (InterpreterResult, Option<Address>) {
         let (cached_evm_env, cached_tx_env) = Env::clone_evm_and_tx(ecx);
 
         ecx.block_mut().set_basefee(0);


### PR DESCRIPTION
Remove `eth_block_mut`, `eth_tx_mut`, `eth_cfg_mut` from `FoundryContextExt` trait and impl. All call sites now use the generic accessors (`cfg_mut()`, `block_mut()`, `tx_mut()`, `set_block()`, `set_tx()`), which resolve to concrete Eth types through existing `EthCheatCtx` bounds.

To get rid of `EthCheatCtx` we'll need to work on `DatabaseExt` extensively so it's prob the next step in the list