### PR TITLE
refactor(evm): remove `Env` abstraction from `Executor` impl

### DIFF
--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -266,16 +266,20 @@ impl RunArgs {
 
                     if let Some(to) = Transaction::to(tx) {
                         trace!(tx=?tx.tx_hash(),?to, "executing previous call transaction");
-                        executor.transact_with_env(env.clone()).wrap_err_with(|| {
-                            format!(
-                                "Failed to execute transaction: {:?} in block {}",
-                                tx.tx_hash(),
-                                env.evm_env.block_env.number
-                            )
-                        })?;
+                        executor
+                            .transact_with_env(env.evm_env.clone(), env.tx.clone())
+                            .wrap_err_with(|| {
+                                format!(
+                                    "Failed to execute transaction: {:?} in block {}",
+                                    tx.tx_hash(),
+                                    env.evm_env.block_env.number
+                                )
+                            })?;
                     } else {
                         trace!(tx=?tx.tx_hash(), "executing previous create transaction");
-                        if let Err(error) = executor.deploy_with_env(env.clone(), None) {
+                        if let Err(error) =
+                            executor.deploy_with_env(env.evm_env.clone(), env.tx.clone(), None)
+                        {
                             match error {
                                 // Reverted transactions should be skipped
                                 EvmError::Execution(_) => (),
@@ -310,10 +314,10 @@ impl RunArgs {
 
             if let Some(to) = Transaction::to(&tx) {
                 trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");
-                TraceResult::try_from(executor.transact_with_env(env))?
+                TraceResult::try_from(executor.transact_with_env(env.evm_env, env.tx))?
             } else {
                 trace!(tx=?tx.tx_hash(), "executing create transaction");
-                TraceResult::try_from(executor.deploy_with_env(env, None))?
+                TraceResult::try_from(executor.deploy_with_env(env.evm_env, env.tx, None))?
             }
         };
 

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -231,7 +231,7 @@ impl SessionSource {
             .gas_limit(self.config.evm_opts.gas_limit())
             .spec_id(self.config.foundry_config.evm_spec_id())
             .legacy_assertions(self.config.foundry_config.legacy_assertions)
-            .build(env, backend);
+            .build(env.evm_env, env.tx, backend);
 
         Ok(ChiselRunner::new(executor, U256::MAX, Address::ZERO, self.config.calldata.clone()))
     }

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -2,7 +2,7 @@
 
 use super::BackendError;
 use crate::{
-    Env, InspectorExt,
+    InspectorExt,
     backend::{
         Backend, DatabaseExt, JournaledState, LocalForkId, RevertStateSnapshotAction,
         diagnostic::RevertDiagnostic,
@@ -66,23 +66,21 @@ impl<'a> CowBackend<'a> {
     #[instrument(name = "inspect", level = "debug", skip_all)]
     pub fn inspect<I: InspectorExt>(
         &mut self,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         inspector: I,
     ) -> eyre::Result<ResultAndState> {
         // this is a new call to inspect with a new env, so even if we've cloned the backend
         // already, we reset the initialized state
-        self.pending_init = Some((env.evm_env.cfg_env.spec, env.tx.caller, env.tx.kind));
+        self.pending_init = Some((evm_env.cfg_env.spec, tx_env.caller, tx_env.kind));
 
-        let mut evm = crate::evm::new_evm_with_inspector(
-            self,
-            env.evm_env.clone(),
-            env.tx.clone(),
-            inspector,
-        );
+        let mut evm =
+            crate::evm::new_evm_with_inspector(self, evm_env.clone(), tx_env.clone(), inspector);
 
-        let res = evm.transact(env.tx.clone()).wrap_err("EVM error")?;
+        let res = evm.transact(tx_env.clone()).wrap_err("EVM error")?;
 
-        *env = Env::from(evm.cfg.clone(), evm.block.clone(), evm.tx.clone());
+        *evm_env = EvmEnv::new(evm.cfg.clone(), evm.block.clone());
+        *tx_env = evm.tx.clone();
 
         Ok(res)
     }

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -806,20 +806,22 @@ impl Backend {
     #[instrument(name = "inspect", level = "debug", skip_all)]
     pub fn inspect<I: InspectorExt>(
         &mut self,
-        env: &mut Env,
+        evm_env: &mut EvmEnv,
+        tx_env: &mut TxEnv,
         inspector: I,
     ) -> eyre::Result<ResultAndState> {
-        self.initialize(env.evm_env.cfg_env.spec, env.tx.caller, env.tx.kind);
+        self.initialize(evm_env.cfg_env.spec, tx_env.caller, tx_env.kind);
         let mut evm = crate::evm::new_evm_with_inspector(
             self,
-            env.evm_env.to_owned(),
-            env.tx.to_owned(),
+            evm_env.to_owned(),
+            tx_env.to_owned(),
             inspector,
         );
 
-        let res = evm.transact(env.tx.clone()).wrap_err("EVM error")?;
+        let res = evm.transact(tx_env.clone()).wrap_err("EVM error")?;
 
-        *env = Env::from(evm.cfg.clone(), evm.block.clone(), evm.tx.clone());
+        *evm_env = EvmEnv::new(evm.cfg.clone(), evm.block.clone());
+        *tx_env = evm.tx.clone();
 
         Ok(res)
     }

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -1,6 +1,6 @@
 use crate::{executors::Executor, inspectors::InspectorStackBuilder};
-use foundry_evm_core::{Env, backend::Backend};
-use revm::primitives::hardfork::SpecId;
+use foundry_evm_core::{EvmEnv, backend::Backend};
+use revm::{context::TxEnv, primitives::hardfork::SpecId};
 
 /// The builder that allows to configure an evm [`Executor`] which a stack of optional
 /// [`revm::Inspector`]s, such as [`Cheatcodes`].
@@ -73,21 +73,16 @@ impl ExecutorBuilder {
 
     /// Builds the executor as configured.
     #[inline]
-    pub fn build(self, env: Env, db: Backend) -> Executor {
+    pub fn build(self, mut evm_env: EvmEnv, tx_env: TxEnv, db: Backend) -> Executor {
         let Self { mut stack, gas_limit, spec_id, legacy_assertions } = self;
         if stack.block.is_none() {
-            stack.block = Some(env.evm_env.block_env.clone());
+            stack.block = Some(evm_env.block_env.clone());
         }
         if stack.gas_price.is_none() {
-            stack.gas_price = Some(env.tx.gas_price);
+            stack.gas_price = Some(tx_env.gas_price);
         }
-        let gas_limit = gas_limit.unwrap_or(env.evm_env.block_env.gas_limit);
-        let env = Env::new_with_spec_id(
-            env.evm_env.cfg_env.clone(),
-            env.evm_env.block_env.clone(),
-            env.tx,
-            spec_id,
-        );
-        Executor::new(db, env, stack.build(), gas_limit, legacy_assertions)
+        let gas_limit = gas_limit.unwrap_or(evm_env.block_env.gas_limit);
+        evm_env.cfg_env.set_spec(spec_id);
+        Executor::new(db, evm_env, tx_env, stack.build(), gas_limit, legacy_assertions)
     }
 }

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -6,11 +6,8 @@
 // `Executor` struct should be accessed using a trait defined in `foundry-evm-core` instead of
 // the concrete `Executor` type.
 
-use crate::{
-    Env,
-    inspectors::{
-        Cheatcodes, InspectorData, InspectorStack, cheatcodes::BroadcastableTransactions,
-    },
+use crate::inspectors::{
+    Cheatcodes, InspectorData, InspectorStack, cheatcodes::BroadcastableTransactions,
 };
 use alloy_dyn_abi::{DynSolValue, FunctionExt, JsonAbiExt};
 use alloy_json_abi::Function;
@@ -116,7 +113,8 @@ impl Executor {
     #[inline]
     pub fn new(
         mut backend: Backend,
-        env: Env,
+        evm_env: EvmEnv,
+        tx_env: TxEnv,
         inspector: InspectorStack,
         gas_limit: u64,
         legacy_assertions: bool,
@@ -136,8 +134,8 @@ impl Executor {
 
         Self {
             backend: Arc::new(backend),
-            evm_env: env.evm_env,
-            tx_env: env.tx,
+            evm_env,
+            tx_env,
             inspector,
             gas_limit,
             legacy_assertions,
@@ -356,8 +354,8 @@ impl Executor {
         value: U256,
         rd: Option<&RevertDecoder>,
     ) -> Result<DeployResult, EvmError> {
-        let env = self.build_test_env(from, TxKind::Create, code, value);
-        self.deploy_with_env(env, rd)
+        let (evm_env, tx_env) = self.build_test_env(from, TxKind::Create, code, value);
+        self.deploy_with_env(evm_env, tx_env, rd)
     }
 
     /// Deploys a contract using the given `env` and commits the new state to the underlying
@@ -369,17 +367,18 @@ impl Executor {
     #[instrument(name = "deploy", level = "debug", skip_all)]
     pub fn deploy_with_env(
         &mut self,
-        env: Env,
+        evm_env: EvmEnv,
+        tx_env: TxEnv,
         rd: Option<&RevertDecoder>,
     ) -> Result<DeployResult, EvmError> {
         assert!(
-            matches!(env.tx.kind, TxKind::Create),
+            matches!(tx_env.kind, TxKind::Create),
             "Expected create transaction, got {:?}",
-            env.tx.kind
+            tx_env.kind
         );
-        trace!(sender=%env.tx.caller, "deploying contract");
+        trace!(sender=%tx_env.caller, "deploying contract");
 
-        let mut result = self.transact_with_env(env)?;
+        let mut result = self.transact_with_env(evm_env, tx_env)?;
         result = result.into_result(rd)?;
         let Some(Output::Create(_, Some(address))) = result.out else {
             panic!("Deployment succeeded, but no address was returned: {result:#?}");
@@ -416,9 +415,9 @@ impl Executor {
         res = res.into_result(rd)?;
 
         // record any changes made to the block's environment during setup
-        self.evm_env_mut().block_env = res.env.evm_env.block_env.clone();
+        self.evm_env_mut().block_env = res.evm_env.block_env.clone();
         // and also the chainid, which can be set manually
-        self.evm_env_mut().cfg_env.chain_id = res.env.evm_env.cfg_env.chain_id;
+        self.evm_env_mut().cfg_env.chain_id = res.evm_env.cfg_env.chain_id;
 
         let success =
             self.is_raw_call_success(to, Cow::Borrowed(&res.state_changeset), &res, false);
@@ -482,8 +481,8 @@ impl Executor {
         calldata: Bytes,
         value: U256,
     ) -> eyre::Result<RawCallResult> {
-        let env = self.build_test_env(from, TxKind::Call(to), calldata, value);
-        self.call_with_env(env)
+        let (evm_env, tx_env) = self.build_test_env(from, TxKind::Call(to), calldata, value);
+        self.call_with_env(evm_env, tx_env)
     }
 
     /// Performs a raw call to an account on the current state of the VM with an EIP-7702
@@ -496,10 +495,10 @@ impl Executor {
         value: U256,
         authorization_list: Vec<SignedAuthorization>,
     ) -> eyre::Result<RawCallResult> {
-        let mut env = self.build_test_env(from, to.into(), calldata, value);
-        env.tx.set_signed_authorization(authorization_list);
-        env.tx.tx_type = 4;
-        self.call_with_env(env)
+        let (evm_env, mut tx_env) = self.build_test_env(from, to.into(), calldata, value);
+        tx_env.set_signed_authorization(authorization_list);
+        tx_env.tx_type = 4;
+        self.call_with_env(evm_env, tx_env)
     }
 
     /// Performs a raw call to an account on the current state of the VM.
@@ -510,8 +509,8 @@ impl Executor {
         calldata: Bytes,
         value: U256,
     ) -> eyre::Result<RawCallResult> {
-        let env = self.build_test_env(from, TxKind::Call(to), calldata, value);
-        self.transact_with_env(env)
+        let (evm_env, tx_env) = self.build_test_env(from, TxKind::Call(to), calldata, value);
+        self.transact_with_env(evm_env, tx_env)
     }
 
     /// Performs a raw call to an account on the current state of the VM with an EIP-7702
@@ -524,31 +523,51 @@ impl Executor {
         value: U256,
         authorization_list: Vec<SignedAuthorization>,
     ) -> eyre::Result<RawCallResult> {
-        let mut env = self.build_test_env(from, TxKind::Call(to), calldata, value);
-        env.tx.set_signed_authorization(authorization_list);
-        env.tx.tx_type = 4;
-        self.transact_with_env(env)
+        let (evm_env, mut tx_env) = self.build_test_env(from, TxKind::Call(to), calldata, value);
+        tx_env.set_signed_authorization(authorization_list);
+        tx_env.tx_type = 4;
+        self.transact_with_env(evm_env, tx_env)
     }
 
     /// Execute the transaction configured in `env.tx`.
     ///
     /// The state after the call is **not** persisted.
     #[instrument(name = "call", level = "debug", skip_all)]
-    pub fn call_with_env(&self, mut env: Env) -> eyre::Result<RawCallResult> {
+    pub fn call_with_env(
+        &self,
+        mut evm_env: EvmEnv,
+        mut tx_env: TxEnv,
+    ) -> eyre::Result<RawCallResult> {
         let mut stack = self.inspector().clone();
         let mut backend = CowBackend::new_borrowed(self.backend());
-        let result = backend.inspect(&mut env, stack.as_inspector())?;
-        convert_executed_result(env, stack, result, backend.has_state_snapshot_failure())
+        let result = backend.inspect(&mut evm_env, &mut tx_env, stack.as_inspector())?;
+        convert_executed_result(
+            evm_env,
+            tx_env,
+            stack,
+            result,
+            backend.has_state_snapshot_failure(),
+        )
     }
 
     /// Execute the transaction configured in `env.tx`.
     #[instrument(name = "transact", level = "debug", skip_all)]
-    pub fn transact_with_env(&mut self, mut env: Env) -> eyre::Result<RawCallResult> {
+    pub fn transact_with_env(
+        &mut self,
+        mut evm_env: EvmEnv,
+        mut tx_env: TxEnv,
+    ) -> eyre::Result<RawCallResult> {
         let mut stack = self.inspector().clone();
         let backend = self.backend_mut();
-        let result = backend.inspect(&mut env, stack.as_inspector())?;
-        let mut result =
-            convert_executed_result(env, stack, result, backend.has_state_snapshot_failure())?;
+        let result: revm::context::result::ExecResultAndState<ExecutionResult> =
+            backend.inspect(&mut evm_env, &mut tx_env, stack.as_inspector())?;
+        let mut result = convert_executed_result(
+            evm_env,
+            tx_env,
+            stack,
+            result,
+            backend.has_state_snapshot_failure(),
+        )?;
         self.commit(&mut result);
         Ok(result)
     }
@@ -577,7 +596,7 @@ impl Executor {
         }
 
         // Persist the changed environment.
-        self.inspector_mut().set_env(&result.env);
+        self.inspector_mut().set_env(&result.evm_env, &result.tx_env);
     }
 
     /// Returns `true` if a test can be considered successful.
@@ -719,36 +738,41 @@ impl Executor {
     ///
     /// If using a backend with cheatcodes, `tx.gas_price` and `block.number` will be overwritten by
     /// the cheatcode state in between calls.
-    fn build_test_env(&self, caller: Address, kind: TxKind, data: Bytes, value: U256) -> Env {
-        Env {
-            evm_env: EvmEnv {
-                cfg_env: {
-                    let mut cfg = self.evm_env.cfg_env.clone();
-                    cfg.spec = self.spec_id();
-                    cfg
-                },
-                // We always set the gas price to 0 so we can execute the transaction regardless of
-                // network conditions - the actual gas price is kept in `self.block` and is applied
-                // by the cheatcode handler if it is enabled
-                block_env: BlockEnv {
-                    basefee: 0,
-                    gas_limit: self.gas_limit,
-                    ..self.evm_env.block_env.clone()
-                },
+    fn build_test_env(
+        &self,
+        caller: Address,
+        kind: TxKind,
+        data: Bytes,
+        value: U256,
+    ) -> (EvmEnv, TxEnv) {
+        let evm_env = EvmEnv {
+            cfg_env: {
+                let mut cfg = self.evm_env.cfg_env.clone();
+                cfg.spec = self.spec_id();
+                cfg
             },
-            tx: TxEnv {
-                caller,
-                kind,
-                data,
-                value,
-                // As above, we set the gas price to 0.
-                gas_price: 0,
-                gas_priority_fee: None,
+            // We always set the gas price to 0 so we can execute the transaction regardless of
+            // network conditions - the actual gas price is kept in `self.block` and is applied
+            // by the cheatcode handler if it is enabled
+            block_env: BlockEnv {
+                basefee: 0,
                 gas_limit: self.gas_limit,
-                chain_id: Some(self.evm_env.cfg_env.chain_id),
-                ..self.tx_env.clone()
+                ..self.evm_env.block_env.clone()
             },
-        }
+        };
+        let tx_env = TxEnv {
+            caller,
+            kind,
+            data,
+            value,
+            // As above, we set the gas price to 0.
+            gas_price: 0,
+            gas_priority_fee: None,
+            gas_limit: self.gas_limit,
+            chain_id: Some(self.evm_env.cfg_env.chain_id),
+            ..self.tx_env.clone()
+        };
+        (evm_env, tx_env)
     }
 
     pub fn call_sol_default<C: SolCall>(&self, to: Address, args: &C) -> C::Return
@@ -885,8 +909,10 @@ pub struct RawCallResult {
     pub transactions: Option<BroadcastableTransactions>,
     /// The changeset of the state.
     pub state_changeset: StateChangeset,
-    /// The `revm::Env` after the call
-    pub env: Env,
+    /// The `EvmEnv` after the call
+    pub evm_env: EvmEnv,
+    /// The `TxEnv` after the call
+    pub tx_env: TxEnv,
     /// The cheatcode states after execution
     pub cheatcodes: Option<Box<Cheatcodes>>,
     /// The raw output of the execution
@@ -913,7 +939,8 @@ impl Default for RawCallResult {
             edge_coverage: None,
             transactions: None,
             state_changeset: HashMap::default(),
-            env: Env::default(),
+            evm_env: EvmEnv::default(),
+            tx_env: TxEnv::default(),
             cheatcodes: Default::default(),
             out: None,
             chisel_state: None,
@@ -1048,7 +1075,8 @@ impl std::ops::DerefMut for CallResult {
 
 /// Converts the data aggregated in the `inspector` and `call` to a `RawCallResult`
 fn convert_executed_result(
-    env: Env,
+    evm_env: EvmEnv,
+    tx_env: TxEnv,
     inspector: InspectorStack,
     ResultAndState { result, state: state_changeset }: ResultAndState,
     has_state_snapshot_failure: bool,
@@ -1066,10 +1094,10 @@ fn convert_executed_result(
         }
     };
     let gas = revm::interpreter::gas::calculate_initial_tx_gas(
-        env.evm_env.cfg_env.spec,
-        &env.tx.data,
-        env.tx.kind.is_create(),
-        env.tx.access_list.len().try_into()?,
+        evm_env.cfg_env.spec,
+        &tx_env.data,
+        tx_env.kind.is_create(),
+        tx_env.access_list.len().try_into()?,
         0,
         0,
     );
@@ -1114,7 +1142,8 @@ fn convert_executed_result(
         edge_coverage,
         transactions,
         state_changeset,
-        env,
+        evm_env,
+        tx_env,
         cheatcodes,
         out,
         chisel_state,

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -36,7 +36,7 @@ impl TracingExecutor {
                 stack.trace_mode(trace_mode).networks(networks).create2_deployer(create2_deployer)
             })
             .spec_id(evm_spec_id(version.unwrap_or_default()))
-            .build(env, db);
+            .build(env.evm_env, env.tx, db);
 
         // Apply the state overrides.
         if let Some(state_overrides) = state_overrides {

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -26,7 +26,7 @@ use foundry_evm_traces::{SparsedTraceArena, TraceMode};
 use revm::{
     Inspector,
     context::{
-        Block, BlockEnv, Cfg, ContextTr, JournalTr, Transaction,
+        Block, BlockEnv, Cfg, ContextTr, JournalTr, Transaction, TxEnv,
         result::{EVMError, ExecutionResult, Output},
     },
     context_interface::CreateScheme,
@@ -484,9 +484,9 @@ impl InspectorStack {
 
     /// Set variables from an environment for the relevant inspectors.
     #[inline]
-    pub fn set_env(&mut self, env: &Env) {
-        self.set_block(&env.evm_env.block_env);
-        self.set_gas_price(env.tx.gas_price);
+    pub fn set_env(&mut self, evm_env: &EvmEnv, tx_env: &TxEnv) {
+        self.set_block(&evm_env.block_env);
+        self.set_gas_price(tx_env.gas_price);
     }
 
     /// Sets the block for the relevant inspectors.

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -389,7 +389,7 @@ impl TestRunnerConfig {
             .spec_id(self.spec_id)
             .gas_limit(self.evm_opts.gas_limit())
             .legacy_assertions(self.config.legacy_assertions)
-            .build(self.env.clone(), db)
+            .build(self.env.evm_env.clone(), self.env.tx.clone(), db)
     }
 
     fn trace_mode(&self) -> TraceMode {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -686,7 +686,7 @@ impl ScriptConfig {
             });
         }
 
-        Ok(ScriptRunner::new(builder.build(env, db), self.evm_opts.clone()))
+        Ok(ScriptRunner::new(builder.build(env.evm_env, env.tx, db), self.evm_opts.clone()))
     }
 }
 

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -267,8 +267,13 @@ impl VerifyBytecodeArgs {
             };
             executor.backend_mut().insert_account_info(deployer, account_info);
 
-            let fork_address =
-                crate::utils::deploy_contract(&mut executor, &env, config.evm_spec_id(), kind)?;
+            let fork_address = crate::utils::deploy_contract(
+                &mut executor,
+                &env.evm_env,
+                &env.tx,
+                config.evm_spec_id(),
+                kind,
+            )?;
 
             // Compare runtime bytecode
             let (deployed_bytecode, onchain_runtime_code) = crate::utils::get_runtime_codes(
@@ -488,14 +493,18 @@ impl VerifyBytecodeArgs {
                     }
 
                     if let TxKind::Call(_) = tx.inner.kind() {
-                        executor.transact_with_env(env.clone()).wrap_err_with(|| {
-                            format!(
-                                "Failed to execute transaction: {:?} in block {}",
-                                tx.tx_hash(),
-                                env.evm_env.block_env.number
-                            )
-                        })?;
-                    } else if let Err(error) = executor.deploy_with_env(env.clone(), None) {
+                        executor
+                            .transact_with_env(env.evm_env.clone(), env.tx.clone())
+                            .wrap_err_with(|| {
+                                format!(
+                                    "Failed to execute transaction: {:?} in block {}",
+                                    tx.tx_hash(),
+                                    env.evm_env.block_env.number
+                                )
+                            })?;
+                    } else if let Err(error) =
+                        executor.deploy_with_env(env.evm_env.clone(), env.tx.clone(), None)
+                    {
                         match error {
                             // Reverted transactions should be skipped
                             EvmError::Execution(_) => (),
@@ -530,8 +539,13 @@ impl VerifyBytecodeArgs {
             let kind = transaction.kind();
             env.tx = transaction.try_into_tx_env(&env.evm_env)?;
 
-            let fork_address =
-                crate::utils::deploy_contract(&mut executor, &env, config.evm_spec_id(), kind)?;
+            let fork_address = crate::utils::deploy_contract(
+                &mut executor,
+                &env.evm_env,
+                &env.tx,
+                config.evm_spec_id(),
+                kind,
+            )?;
 
             // State committed using deploy_with_env, now get the runtime bytecode from the db.
             let (fork_runtime_code, onchain_runtime_code) = crate::utils::get_runtime_codes(

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -1,6 +1,7 @@
 use crate::{bytecode::VerifyBytecodeArgs, types::VerificationType};
 use alloy_consensus::BlockHeader;
 use alloy_dyn_abi::DynSolValue;
+use alloy_evm::EvmEnv;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_provider::{
     Provider,
@@ -24,7 +25,7 @@ use foundry_evm::{
 };
 use foundry_evm_networks::NetworkConfigs;
 use reqwest::Url;
-use revm::{bytecode::Bytecode, database::Database, primitives::hardfork::SpecId};
+use revm::{bytecode::Bytecode, context::TxEnv, database::Database, primitives::hardfork::SpecId};
 use semver::{BuildMetadata, Version};
 use serde::{Deserialize, Serialize};
 use yansi::Paint;
@@ -298,16 +299,13 @@ pub fn configure_env_block(env: &mut Env, block: &AnyRpcBlock, config: NetworkCo
 
 pub fn deploy_contract(
     executor: &mut TracingExecutor,
-    env: &Env,
+    evm_env: &EvmEnv,
+    tx_env: &TxEnv,
     spec_id: SpecId,
     to: Option<TxKind>,
 ) -> Result<Address, eyre::ErrReport> {
-    let env = Env::new_with_spec_id(
-        env.evm_env.cfg_env.clone(),
-        env.evm_env.block_env.clone(),
-        env.tx.clone(),
-        spec_id,
-    );
+    let mut evm_env = evm_env.clone();
+    evm_env.cfg_env.set_spec(spec_id);
 
     if to.is_some_and(|to| to.is_call()) {
         let TxKind::Call(to) = to.unwrap() else { unreachable!() };
@@ -316,7 +314,7 @@ pub fn deploy_contract(
                 "Transaction `to` address is not the default create2 deployer i.e the tx is not a contract creation tx."
             );
         }
-        let result = executor.transact_with_env(env)?;
+        let result = executor.transact_with_env(evm_env, tx_env.clone())?;
 
         trace!(transact_result = ?result.exit_reason);
 
@@ -346,7 +344,7 @@ pub fn deploy_contract(
 
         Ok(Address::from_slice(&result.result))
     } else {
-        let deploy_result = executor.deploy_with_env(env, None)?;
+        let deploy_result = executor.deploy_with_env(evm_env, tx_env.clone(), None)?;
         trace!(deploy_result = ?deploy_result.raw.exit_reason);
         Ok(deploy_result.address)
     }


### PR DESCRIPTION
## Motivation

#13773 Follow-up.

- Remove `Env` abstraction from `Executor` impl, to use directly `EvmEvm`/`TxEnv`.
- Updated `Backend`,`CowBackend`,`RawCallResult` accordingly
- The `ExecutorBuilder` callers still use `Env`(w/ `env.evm_env, env.tx`), will be handled in the next iteration to keep things contained for review.