### PR TITLE
refactor(cheatcodes): tighten verbose bounds to `EthCheatCtx`

### DIFF
--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -2,7 +2,8 @@
 
 use super::string::parse;
 use crate::{
-    Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Result, Vm::*, inspector::exec_create,
+    Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, EthCheatCtx, Result, Vm::*,
+    inspector::exec_create,
 };
 use alloy_dyn_abi::DynSolType;
 use alloy_json_abi::ContractObject;
@@ -14,7 +15,6 @@ use dialoguer::{Input, Password};
 use forge_script_sequence::{BroadcastReader, TransactionWithMetadata};
 use foundry_common::fs;
 use foundry_config::fs_permissions::FsAccessKind;
-use foundry_evm_core::{backend::FoundryJournalExt, env::FoundryContextExt};
 use revm::{
     context::{Cfg, ContextTr, CreateScheme, JournalTr},
     interpreter::CreateInputs,
@@ -299,7 +299,7 @@ impl Cheatcode for getDeployedCodeCall {
 }
 
 impl Cheatcode for deployCode_0Call {
-    fn apply_full<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
+    fn apply_full<CTX: EthCheatCtx>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
         executor: &mut dyn CheatcodesExecutor<CTX>,
@@ -310,7 +310,7 @@ impl Cheatcode for deployCode_0Call {
 }
 
 impl Cheatcode for deployCode_1Call {
-    fn apply_full<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
+    fn apply_full<CTX: EthCheatCtx>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
         executor: &mut dyn CheatcodesExecutor<CTX>,
@@ -321,7 +321,7 @@ impl Cheatcode for deployCode_1Call {
 }
 
 impl Cheatcode for deployCode_2Call {
-    fn apply_full<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
+    fn apply_full<CTX: EthCheatCtx>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
         executor: &mut dyn CheatcodesExecutor<CTX>,
@@ -332,7 +332,7 @@ impl Cheatcode for deployCode_2Call {
 }
 
 impl Cheatcode for deployCode_3Call {
-    fn apply_full<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
+    fn apply_full<CTX: EthCheatCtx>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
         executor: &mut dyn CheatcodesExecutor<CTX>,
@@ -343,7 +343,7 @@ impl Cheatcode for deployCode_3Call {
 }
 
 impl Cheatcode for deployCode_4Call {
-    fn apply_full<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
+    fn apply_full<CTX: EthCheatCtx>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
         executor: &mut dyn CheatcodesExecutor<CTX>,
@@ -354,7 +354,7 @@ impl Cheatcode for deployCode_4Call {
 }
 
 impl Cheatcode for deployCode_5Call {
-    fn apply_full<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
+    fn apply_full<CTX: EthCheatCtx>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
         executor: &mut dyn CheatcodesExecutor<CTX>,
@@ -365,7 +365,7 @@ impl Cheatcode for deployCode_5Call {
 }
 
 impl Cheatcode for deployCode_6Call {
-    fn apply_full<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
+    fn apply_full<CTX: EthCheatCtx>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
         executor: &mut dyn CheatcodesExecutor<CTX>,
@@ -376,7 +376,7 @@ impl Cheatcode for deployCode_6Call {
 }
 
 impl Cheatcode for deployCode_7Call {
-    fn apply_full<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
+    fn apply_full<CTX: EthCheatCtx>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
         executor: &mut dyn CheatcodesExecutor<CTX>,
@@ -388,7 +388,7 @@ impl Cheatcode for deployCode_7Call {
 
 /// Helper function to deploy contract from artifact code.
 /// Uses CREATE2 scheme if salt specified.
-fn deploy_code<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
+fn deploy_code<CTX: EthCheatCtx>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     executor: &mut dyn CheatcodesExecutor<CTX>,
     path: &str,

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -142,7 +142,7 @@ pub trait CheatcodesExecutor<CTX: ContextTr> {
 }
 
 /// Builds a sub-EVM from the current context and executes the given CREATE frame.
-pub(crate) fn exec_create<CTX: FoundryContextExt<Journal: FoundryJournalExt>>(
+pub(crate) fn exec_create<CTX: EthCheatCtx>(
     executor: &mut dyn CheatcodesExecutor<CTX>,
     inputs: CreateInputs,
     ccx: &mut CheatsCtxt<'_, CTX>,


### PR DESCRIPTION
## Summary

Replaces verbose `FoundryContextExt<Journal: FoundryJournalExt>` bounds with `EthCheatCtx` in `fs.rs` and `inspector.rs`.

These functions all call into `DatabaseExt` (via `exec_create` → `CheatcodesExecutor`), which requires the full Eth-pinned context. The old bound was both verbose and weaker than the actual requirement — `EthCheatCtx` is shorter, more accurate, and makes Eth-specific call sites easy to find as we genericize the codebase.

- `fs.rs`: 8 `apply_full` impls + `deploy_code` helper
- `inspector.rs`: `exec_create`

cc: @mablr 