### PR TITLE
refactor(anvil): remove redundant  param

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -113,17 +113,17 @@ impl ExecutedTransaction {
 }
 
 /// Represents the outcome of mining a new block
-pub struct ExecutedTransactions<N: Network, T = FoundryTxEnvelope> {
+pub struct ExecutedTransactions<N: Network> {
     /// The block created after executing the `included` transactions
     pub block: TypedBlockInfo<N>,
     /// All transactions included in the block
-    pub included: Vec<Arc<PoolTransaction<T>>>,
+    pub included: Vec<Arc<PoolTransaction<N::TxEnvelope>>>,
     /// All transactions that were invalid at the point of their execution and were not included in
     /// the block
-    pub invalid: Vec<Arc<PoolTransaction<T>>>,
+    pub invalid: Vec<Arc<PoolTransaction<N::TxEnvelope>>>,
 }
 
-impl<N: Network, T> fmt::Debug for ExecutedTransactions<N, T> {
+impl<N: Network> fmt::Debug for ExecutedTransactions<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ExecutedTransactions")
             .field("included", &self.included.len())

--- a/crates/anvil/src/service.rs
+++ b/crates/anvil/src/service.rs
@@ -11,7 +11,7 @@ use crate::{
     mem::{Backend, storage::MinedBlockOutcome},
 };
 use alloy_network::Network;
-use foundry_primitives::{FoundryNetwork, FoundryTxEnvelope};
+use foundry_primitives::FoundryNetwork;
 use futures::{FutureExt, Stream, StreamExt};
 use std::{
     collections::VecDeque,
@@ -27,13 +27,13 @@ use tokio::{task::JoinHandle, time::Interval};
 /// transactions for the next block, then those transactions are handed off to the backend to
 /// construct a new block, if all transactions were successfully included in a new block they get
 /// purged from the `Pool`.
-pub struct NodeService<N: Network, T = FoundryTxEnvelope> {
+pub struct NodeService<N: Network> {
     /// The pool that holds all transactions.
-    pool: Arc<Pool<T>>,
+    pool: Arc<Pool<N::TxEnvelope>>,
     /// Creates new blocks.
-    block_producer: BlockProducer<N, T>,
+    block_producer: BlockProducer<N>,
     /// The miner responsible to select transactions from the `pool`.
-    miner: Miner<T>,
+    miner: Miner<N::TxEnvelope>,
     /// Maintenance task for fee history related tasks.
     fee_history: FeeHistoryService,
     /// Tracks all active filters
@@ -102,17 +102,17 @@ impl Future for NodeService<FoundryNetwork> {
     }
 }
 
-type MiningResult<N, T> = (MinedBlockOutcome<T>, Arc<Backend<N>>);
+type MiningResult<N> = (MinedBlockOutcome<<N as Network>::TxEnvelope>, Arc<Backend<N>>);
 
 /// A type that exclusively mines one block at a time
 #[must_use = "streams do nothing unless polled"]
-struct BlockProducer<N: Network, T = FoundryTxEnvelope> {
+struct BlockProducer<N: Network> {
     /// Holds the backend if no block is being mined
     idle_backend: Option<Arc<Backend<N>>>,
     /// Single active future that mines a new block
-    block_mining: Option<JoinHandle<MiningResult<N, T>>>,
+    block_mining: Option<JoinHandle<MiningResult<N>>>,
     /// backlog of sets of transactions ready to be mined
-    queued: VecDeque<Vec<Arc<PoolTransaction<T>>>>,
+    queued: VecDeque<Vec<Arc<PoolTransaction<N::TxEnvelope>>>>,
 }
 
 impl BlockProducer<FoundryNetwork> {


### PR DESCRIPTION
`NodeService`, `BlockProducer`, `MiningResult`, and `ExecutedTransactions` all carried a redundant `T = FoundryTxEnvelope` param alongside `N: Network`. Since `T` was always `N::TxEnvelope`, replace it with `N::TxEnvelope` directly.