### PR TITLE
docs(foundryup): add version examples to -i/--install help text

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -446,7 +446,7 @@ OPTIONS:
     -h, --help      Print help information
     -v, --version   Print the version of foundryup
     -U, --update    Update foundryup to the latest version
-    -i, --install   Install a specific version from built binaries
+    -i, --install   Install a specific version from built binaries (e.g., stable, nightly, 0.3.0)
     -l, --list      List versions installed from built binaries
     -u, --use       Use a specific installed version from built binaries
     -b, --branch    Build and install a specific branch


### PR DESCRIPTION
## Summary
Add `(e.g., stable, nightly, 0.3.0)` to the `-i, --install` help text in the legacy foundryup shell script, matching the new Rust-based foundryup's documentation.

## Motivation
The `-i` flag documentation currently just says "Install a specific version from built binaries" without indicating what valid version values look like. This was flagged in https://github.com/foundry-rs/foundry/issues/13794#issuecomment-4073452983.

## Changes
- Updated `foundryup/foundryup` usage text for `-i, --install` to include version examples

Prompted by: zerosnacks