### PR TITLE
refactor(evm): add `FoundryCfg` conversion bounds

### DIFF
--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -215,7 +215,9 @@ impl FoundryTransaction for TxEnv {
 
 /// Extension of [`Cfg`] with mutable setters, allowing EVM-agnostic mutation of EVM configuration
 /// fields.
-pub trait FoundryCfg: Cfg<Spec: Debug> {
+pub trait FoundryCfg:
+    Cfg<Spec: Debug> + Into<CfgEnv<Self::Spec>> + From<CfgEnv<Self::Spec>>
+{
     /// Sets the EVM spec (hardfork).
     fn set_spec(&mut self, spec: Self::Spec);
 


### PR DESCRIPTION
## Summary
- Add `Into<CfgEnv<Self::Spec>> + From<CfgEnv<Self::Spec>>` bounds to `FoundryCfg`
- Enables generic code to convert between `FoundryCfg` and `CfgEnv<Spec>`, needed for constructing/destructuring `EvmEnv` in network-agnostic contexts

## Test plan
- [x] `cargo check --workspace` passes