### PR TITLE
refactor(evm): propagate env types through `FoundryJournalExt`

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -319,7 +319,7 @@ impl Cheatcode for loadCall {
 }
 
 impl Cheatcode for loadAllocsCall {
-    fn apply_stateful<CTX: ContextTr<Journal: FoundryJournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: FoundryJournalExt<CTX>, Db: DatabaseExt>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -347,7 +347,7 @@ impl Cheatcode for loadAllocsCall {
 }
 
 impl Cheatcode for cloneAccountCall {
-    fn apply_stateful<CTX: ContextTr<Journal: FoundryJournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: FoundryJournalExt<CTX>, Db: DatabaseExt>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -131,7 +131,7 @@ impl Cheatcode for selectForkCall {
 }
 
 impl Cheatcode for transact_0Call {
-    fn apply_full<CTX: ContextTr<Journal: FoundryJournalExt>>(
+    fn apply_full<CTX: ContextTr<Journal: FoundryJournalExt<CTX>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
         executor: &mut dyn CheatcodesExecutor<CTX>,
@@ -142,7 +142,7 @@ impl Cheatcode for transact_0Call {
 }
 
 impl Cheatcode for transact_1Call {
-    fn apply_full<CTX: ContextTr<Journal: FoundryJournalExt>>(
+    fn apply_full<CTX: ContextTr<Journal: FoundryJournalExt<CTX>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
         executor: &mut dyn CheatcodesExecutor<CTX>,
@@ -429,7 +429,7 @@ fn check_broadcast(state: &Cheatcodes) -> Result<()> {
     }
 }
 
-fn transact<CTX: ContextTr<Journal: FoundryJournalExt>>(
+fn transact<CTX: ContextTr<Journal: FoundryJournalExt<CTX>>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     executor: &mut dyn CheatcodesExecutor<CTX>,
     transaction: B256,

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -22,7 +22,7 @@ pub use foundry_fork_db::{BlockchainDb, SharedBackend, cache::BlockchainDbMeta};
 use revm::{
     Database, DatabaseCommit, Journal, JournalEntry,
     bytecode::Bytecode,
-    context::{BlockEnv, JournalInner, TxEnv},
+    context::{BlockEnv, Cfg, ContextTr, JournalInner, TxEnv},
     context_interface::{
         block::BlobExcessGasAndPrice, journaled_state::account::JournaledAccountTr,
         result::ResultAndState,
@@ -399,9 +399,9 @@ struct _ObjectSafe(dyn DatabaseExt);
 /// Generic code accesses the journal via `ctx.journal_mut()` which returns `&mut impl JournalTr`.
 /// This trait adds the ability to split the journal into its database and inner state components,
 /// enabling direct [`DatabaseExt`] method calls with zero-copy borrow splitting.
-pub trait FoundryJournalExt: JournalExt {
+pub trait FoundryJournalExt<CTX: ContextTr + ?Sized>: JournalExt {
     /// The database type backing this journal.
-    type DB: DatabaseExt;
+    type DB: DatabaseExt<<CTX::Cfg as Cfg>::Spec, CTX::Block, CTX::Tx>;
 
     /// Returns mutable references to the database and journal inner state.
     fn as_db_and_inner(&mut self) -> (&mut Self::DB, &mut JournaledState);
@@ -412,7 +412,11 @@ pub trait FoundryJournalExt: JournalExt {
     fn set_inner(&mut self, inner: JournaledState);
 }
 
-impl<DB: DatabaseExt> FoundryJournalExt for Journal<DB, JournalEntry> {
+impl<DB, CTX> FoundryJournalExt<CTX> for Journal<DB, JournalEntry>
+where
+    CTX: ContextTr + ?Sized,
+    DB: DatabaseExt<<CTX::Cfg as Cfg>::Spec, CTX::Block, CTX::Tx>,
+{
     type DB = DB;
 
     fn as_db_and_inner(&mut self) -> (&mut DB, &mut JournaledState) {

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -327,7 +327,7 @@ pub trait EthCheatCtx:
         Block = BlockEnv,
         Tx = TxEnv,
         Cfg = CfgEnv,
-        Journal: FoundryJournalExt,
+        Journal: FoundryJournalExt<Self>,
         Db: DatabaseExt,
     >
 {
@@ -337,7 +337,7 @@ impl<CTX> EthCheatCtx for CTX where
             Block = BlockEnv,
             Tx = TxEnv,
             Cfg = CfgEnv,
-            Journal: FoundryJournalExt,
+            Journal: FoundryJournalExt<Self>,
             Db: DatabaseExt,
         >
 {


### PR DESCRIPTION
## Summary
- Parameterize `FoundryJournalExt<CTX: ContextTr>` so its `DB` associated type is connected to the context
- Update all usage sites: `Journal: FoundryJournalExt` → `Journal: FoundryJournalExt<CTX>`
- Follows the same pattern as `CheatcodesExecutor<CTX>`

https://github.com/foundry-rs/foundry/pull/13797 Follow-up