### PR TITLE
feat(script): `Network`-generic `ScriptSequenceKind<N>`

### DIFF
--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -238,7 +238,7 @@ pub struct BundledState {
     pub script_config: ScriptConfig,
     pub script_wallets: Wallets<Ethereum>,
     pub build_data: LinkedBuildData,
-    pub sequence: ScriptSequenceKind,
+    pub sequence: ScriptSequenceKind<Ethereum>,
 }
 
 impl BundledState {
@@ -276,7 +276,7 @@ impl BundledState {
     }
 
     /// Broadcasts transactions from all sequences.
-    pub async fn broadcast(mut self) -> Result<BroadcastedState> {
+    pub async fn broadcast(mut self) -> Result<BroadcastedState<Ethereum>> {
         let required_addresses = self
             .sequence
             .sequences()

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -333,7 +333,11 @@ impl CompiledState {
         })
     }
 
-    fn try_load_sequence(&self, chain: Option<u64>, dry_run: bool) -> Result<ScriptSequenceKind> {
+    fn try_load_sequence(
+        &self,
+        chain: Option<u64>,
+        dry_run: bool,
+    ) -> Result<ScriptSequenceKind<Ethereum>> {
         if let Some(chain) = chain {
             let sequence = ScriptSequence::load(
                 &self.script_config.config,

--- a/crates/script/src/multi_sequence.rs
+++ b/crates/script/src/multi_sequence.rs
@@ -1,4 +1,4 @@
-use alloy_network::Ethereum;
+use alloy_network::Network;
 use eyre::{ContextCompat, Result, WrapErr};
 use forge_script_sequence::{
     DRY_RUN_DIR, ScriptSequence, SensitiveScriptSequence, now, sig_to_file_name,
@@ -11,8 +11,12 @@ use std::path::PathBuf;
 
 /// Holds the sequences of multiple chain deployments.
 #[derive(Clone, Default, Serialize, Deserialize)]
-pub struct MultiChainSequence {
-    pub deployments: Vec<ScriptSequence<Ethereum>>,
+#[serde(bound(
+    serialize = "N::TransactionRequest: Serialize, N::TxEnvelope: Serialize",
+    deserialize = "N::TransactionRequest: for<'de2> Deserialize<'de2>, N::TxEnvelope: for<'de2> Deserialize<'de2>"
+))]
+pub struct MultiChainSequence<N: Network> {
+    pub deployments: Vec<ScriptSequence<N>>,
     #[serde(skip)]
     pub path: PathBuf,
     #[serde(skip)]
@@ -27,16 +31,16 @@ pub struct SensitiveMultiChainSequence {
 }
 
 impl SensitiveMultiChainSequence {
-    fn from_multi_sequence(sequence: &MultiChainSequence) -> Self {
+    fn from_multi_sequence<N: Network>(sequence: &MultiChainSequence<N>) -> Self {
         Self {
             deployments: sequence.deployments.iter().map(SensitiveScriptSequence::from).collect(),
         }
     }
 }
 
-impl MultiChainSequence {
+impl<N: Network> MultiChainSequence<N> {
     pub fn new(
-        deployments: Vec<ScriptSequence<Ethereum>>,
+        deployments: Vec<ScriptSequence<N>>,
         sig: &str,
         target: &ArtifactId,
         config: &Config,
@@ -89,7 +93,10 @@ impl MultiChainSequence {
     }
 
     /// Loads the sequences for the multi chain deployment.
-    pub fn load(config: &Config, sig: &str, target: &ArtifactId, dry_run: bool) -> Result<Self> {
+    pub fn load(config: &Config, sig: &str, target: &ArtifactId, dry_run: bool) -> Result<Self>
+    where
+        N::TxEnvelope: for<'d> Deserialize<'d>,
+    {
         let (path, sensitive_path) = Self::get_paths(config, sig, target, dry_run)?;
         let mut sequence: Self = foundry_compilers::utils::read_json_file(&path)
             .wrap_err("Multi-chain deployment not found.")?;
@@ -108,7 +115,10 @@ impl MultiChainSequence {
     }
 
     /// Saves the transactions as file if it's a standalone deployment.
-    pub fn save(&mut self, silent: bool, save_ts: bool) -> Result<()> {
+    pub fn save(&mut self, silent: bool, save_ts: bool) -> Result<()>
+    where
+        N::TxEnvelope: Serialize,
+    {
         self.deployments.iter_mut().for_each(|sequence| sequence.sort_receipts());
 
         self.timestamp = now().as_millis();

--- a/crates/script/src/progress.rs
+++ b/crates/script/src/progress.rs
@@ -1,6 +1,6 @@
 use crate::receipts::{PendingReceiptError, TxStatus, check_tx_status, format_receipt};
 use alloy_chains::Chain;
-use alloy_network::{Ethereum, ReceiptResponse};
+use alloy_network::{Network, ReceiptResponse};
 use alloy_primitives::{
     B256,
     map::{B256HashMap, HashMap},
@@ -32,9 +32,9 @@ pub struct SequenceProgressState {
 }
 
 impl SequenceProgressState {
-    pub fn new(
+    pub fn new<N: Network>(
         sequence_idx: usize,
-        sequence: &ScriptSequence<Ethereum>,
+        sequence: &ScriptSequence<N>,
         multi: MultiProgress,
     ) -> Self {
         let mut state = if shell::is_quiet() || shell::is_json() {
@@ -147,9 +147,9 @@ pub struct SequenceProgress {
 }
 
 impl SequenceProgress {
-    pub fn new(
+    pub fn new<N: Network>(
         sequence_idx: usize,
-        sequence: &ScriptSequence<Ethereum>,
+        sequence: &ScriptSequence<N>,
         multi: MultiProgress,
     ) -> Self {
         Self {
@@ -168,10 +168,10 @@ pub struct ScriptProgress {
 impl ScriptProgress {
     /// Returns a [SequenceProgress] instance for the given sequence index. If it doesn't exist,
     /// creates one.
-    pub fn get_sequence_progress(
+    pub fn get_sequence_progress<N: Network>(
         &self,
         sequence_idx: usize,
-        sequence: &ScriptSequence<Ethereum>,
+        sequence: &ScriptSequence<N>,
     ) -> SequenceProgress {
         if let Some(progress) = self.state.read().get(&sequence_idx) {
             return progress.clone();
@@ -191,11 +191,11 @@ impl ScriptProgress {
     /// has not confirmed, and cannot be found in the mempool, we remove it from
     /// the `deploy_sequence.pending` vector so that it will be rebroadcast in
     /// later steps.
-    pub async fn wait_for_pending(
+    pub async fn wait_for_pending<N: Network>(
         &self,
         sequence_idx: usize,
-        deployment_sequence: &mut ScriptSequence<Ethereum>,
-        provider: &RootProvider<Ethereum>,
+        deployment_sequence: &mut ScriptSequence<N>,
+        provider: &RootProvider<N>,
         timeout: u64,
     ) -> Result<()> {
         if deployment_sequence.pending.is_empty() {

--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -1,6 +1,6 @@
 use alloy_chains::{Chain, NamedChain};
-use alloy_network::{Ethereum, Network, ReceiptResponse};
-use alloy_primitives::{TxHash, U256, utils::format_units};
+use alloy_network::{Network, ReceiptResponse};
+use alloy_primitives::{Address, TxHash, U256, utils::format_units};
 use alloy_provider::{
     PendingTransactionBuilder, PendingTransactionError, Provider, RootProvider, WatchTxError,
 };
@@ -9,6 +9,18 @@ use eyre::{Result, eyre};
 use forge_script_sequence::ScriptSequence;
 use foundry_common::{retry, retry::RetryError, shell};
 use std::time::Duration;
+
+/// Helper trait providing `contract_address` setter for generic `ReceiptResponse`
+pub trait FoundryReceiptResponse {
+    /// Sets address of the created contract, or `None` if the transaction was not a deployment.
+    fn set_contract_address(&mut self, contract_address: Address);
+}
+
+impl FoundryReceiptResponse for TransactionReceipt {
+    fn set_contract_address(&mut self, contract_address: Address) {
+        self.contract_address = Some(contract_address);
+    }
+}
 
 /// Marker error type for pending receipts
 #[derive(Debug, thiserror::Error)]
@@ -89,10 +101,10 @@ pub async fn check_tx_status<N: Network>(
 }
 
 /// Prints parts of the receipt to stdout
-pub fn format_receipt(
+pub fn format_receipt<N: Network>(
     chain: Chain,
-    receipt: &TransactionReceipt,
-    sequence: Option<&ScriptSequence<Ethereum>>,
+    receipt: &N::ReceiptResponse,
+    sequence: Option<&ScriptSequence<N>>,
 ) -> String {
     let gas_used = receipt.gas_used();
     let gas_price = receipt.effective_gas_price();
@@ -182,6 +194,7 @@ pub fn format_receipt(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_network::Ethereum;
     use alloy_primitives::B256;
     use std::collections::VecDeque;
 
@@ -232,7 +245,7 @@ mod tests {
     #[test]
     fn format_receipt_without_sequence_omits_metadata() {
         let hash = B256::repeat_byte(0x42);
-        let out = format_receipt(Chain::mainnet(), &mock_receipt(hash, true), None);
+        let out = format_receipt::<Ethereum>(Chain::mainnet(), &mock_receipt(hash, true), None);
 
         assert!(!out.contains("Contract:"));
         assert!(!out.contains("Function:"));

--- a/crates/script/src/sequence.rs
+++ b/crates/script/src/sequence.rs
@@ -1,18 +1,27 @@
 use crate::multi_sequence::MultiChainSequence;
-use alloy_network::Ethereum;
+use alloy_network::Network;
 use eyre::Result;
 use forge_script_sequence::{ScriptSequence, TransactionWithMetadata};
 use foundry_cli::utils::Git;
 use foundry_common::fmt::UIfmt;
 use foundry_compilers::ArtifactId;
 use foundry_config::Config;
+use foundry_primitives::FoundryTransactionBuilder;
+use serde::{Deserialize, Serialize};
 use std::{
     fmt::{Error, Write},
     path::Path,
 };
 
 /// Format transaction details for display
-fn format_transaction(index: usize, tx: &TransactionWithMetadata) -> Result<String, Error> {
+fn format_transaction<N: Network>(
+    index: usize,
+    tx: &TransactionWithMetadata<N>,
+) -> Result<String, Error>
+where
+    N::TxEnvelope: UIfmt,
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+{
     let mut output = String::new();
     writeln!(output, "### Transaction {index} ###")?;
     writeln!(output, "{}", tx.tx().pretty())?;
@@ -46,12 +55,20 @@ pub fn get_commit_hash(root: &Path) -> Option<String> {
     Git::new(root).commit_hash(true, "HEAD").ok()
 }
 
-pub enum ScriptSequenceKind {
-    Single(ScriptSequence<Ethereum>),
-    Multi(MultiChainSequence),
+pub enum ScriptSequenceKind<N: Network>
+where
+    N::TxEnvelope: for<'d> Deserialize<'d> + Serialize,
+    N::TransactionRequest: for<'d> Deserialize<'d> + Serialize,
+{
+    Single(ScriptSequence<N>),
+    Multi(MultiChainSequence<N>),
 }
 
-impl ScriptSequenceKind {
+impl<N: Network> ScriptSequenceKind<N>
+where
+    N::TxEnvelope: for<'d> Deserialize<'d> + Serialize,
+    N::TransactionRequest: for<'d> Deserialize<'d> + Serialize,
+{
     pub fn save(&mut self, silent: bool, save_ts: bool) -> Result<()> {
         match self {
             Self::Single(sequence) => sequence.save(silent, save_ts),
@@ -59,14 +76,14 @@ impl ScriptSequenceKind {
         }
     }
 
-    pub fn sequences(&self) -> &[ScriptSequence<Ethereum>] {
+    pub fn sequences(&self) -> &[ScriptSequence<N>] {
         match self {
             Self::Single(sequence) => std::slice::from_ref(sequence),
             Self::Multi(sequence) => &sequence.deployments,
         }
     }
 
-    pub fn sequences_mut(&mut self) -> &mut [ScriptSequence<Ethereum>] {
+    pub fn sequences_mut(&mut self) -> &mut [ScriptSequence<N>] {
         match self {
             Self::Single(sequence) => std::slice::from_mut(sequence),
             Self::Multi(sequence) => &mut sequence.deployments,
@@ -81,7 +98,7 @@ impl ScriptSequenceKind {
     ) -> Result<()> {
         match self {
             Self::Single(sequence) => {
-                sequence.paths = Some(ScriptSequence::<Ethereum>::get_paths(
+                sequence.paths = Some(ScriptSequence::<N>::get_paths(
                     config,
                     sig,
                     target,
@@ -91,14 +108,18 @@ impl ScriptSequenceKind {
             }
             Self::Multi(sequence) => {
                 (sequence.path, sequence.sensitive_path) =
-                    MultiChainSequence::get_paths(config, sig, target, false)?;
+                    MultiChainSequence::<N>::get_paths(config, sig, target, false)?;
             }
         };
 
         Ok(())
     }
 
-    pub fn show_transactions(&self) -> Result<()> {
+    pub fn show_transactions(&self) -> Result<()>
+    where
+        N::TxEnvelope: UIfmt,
+        N::TransactionRequest: FoundryTransactionBuilder<N>,
+    {
         for sequence in self.sequences() {
             if !sequence.transactions.is_empty() {
                 sh_println!("\nChain {}\n", sequence.chain)?;
@@ -113,7 +134,11 @@ impl ScriptSequenceKind {
     }
 }
 
-impl Drop for ScriptSequenceKind {
+impl<N: Network> Drop for ScriptSequenceKind<N>
+where
+    N::TxEnvelope: for<'d> Deserialize<'d> + Serialize,
+    N::TransactionRequest: for<'d> Deserialize<'d> + Serialize,
+{
     fn drop(&mut self) {
         if let Err(err) = self.save(false, true) {
             error!(?err, "could not save deployment sequence");

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -1,9 +1,10 @@
 use crate::{
     ScriptArgs, ScriptConfig,
     build::LinkedBuildData,
+    receipts::FoundryReceiptResponse,
     sequence::{ScriptSequenceKind, get_commit_hash},
 };
-use alloy_network::{Ethereum, ReceiptResponse};
+use alloy_network::{Network, ReceiptResponse};
 use alloy_primitives::{Address, hex};
 use eyre::{Result, eyre};
 use forge_script_sequence::{AdditionalContract, ScriptSequence};
@@ -13,18 +14,28 @@ use foundry_common::ContractsByArtifact;
 use foundry_compilers::{Project, artifacts::EvmVersion, info::ContractInfo};
 use foundry_config::{Chain, Config};
 use semver::Version;
+use serde::{Deserialize, Serialize};
 
 /// State after we have broadcasted the script.
 /// It is assumed that at this point [BroadcastedState::sequence] contains receipts for all
 /// broadcasted transactions.
-pub struct BroadcastedState {
+pub struct BroadcastedState<N: Network>
+where
+    N::TxEnvelope: for<'d> Deserialize<'d> + Serialize,
+    N::TransactionRequest: for<'d> Deserialize<'d> + Serialize,
+{
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
     pub build_data: LinkedBuildData,
-    pub sequence: ScriptSequenceKind,
+    pub sequence: ScriptSequenceKind<N>,
 }
 
-impl BroadcastedState {
+impl<N: Network> BroadcastedState<N>
+where
+    N::TxEnvelope: for<'d> Deserialize<'d> + Serialize,
+    N::TransactionRequest: for<'d> Deserialize<'d> + Serialize,
+    N::ReceiptResponse: FoundryReceiptResponse,
+{
     pub async fn verify(self) -> Result<()> {
         let Self { args, script_config, build_data, mut sequence, .. } = self;
 
@@ -179,8 +190,8 @@ impl VerifyBundle {
 
 /// Given the broadcast log, it matches transactions with receipts, and tries to verify any
 /// created contract on etherscan.
-async fn verify_contracts(
-    sequence: &mut ScriptSequence<Ethereum>,
+async fn verify_contracts<N: Network<ReceiptResponse: FoundryReceiptResponse>>(
+    sequence: &mut ScriptSequence<N>,
     config: &Config,
     mut verify: VerifyBundle,
 ) -> Result<()> {
@@ -202,8 +213,10 @@ async fn verify_contracts(
             // create2 hash offset
             let mut offset = 0;
 
-            if tx.is_create2() {
-                receipt.contract_address = tx.contract_address;
+            if tx.is_create2()
+                && let Some(contract_address) = tx.contract_address
+            {
+                receipt.set_contract_address(contract_address);
                 offset = 32;
             }
 
@@ -266,8 +279,8 @@ async fn verify_contracts(
     Ok(())
 }
 
-fn check_unverified(
-    sequence: &ScriptSequence<Ethereum>,
+fn check_unverified<N: Network>(
+    sequence: &ScriptSequence<N>,
     unverifiable_contracts: Vec<Address>,
     verify: VerifyBundle,
 ) {


### PR DESCRIPTION
## Motivation

#13768 #13770 #13795 #13803 Follow-up. Towards generic script-sequence.

Propagate `N: Network` type parameter through `ScriptSequenceKind`, `MultiChainSequence`, and related script broadcasting/verification types to align with the prior `ScriptSequence<N>` generalization.

Introduced `FoundryReceiptResponse` helper trait providing `contract_address` setter for generic `ReceiptResponse`
