### PR TITLE
feat(anvil): add `AnvilBlockExecutorFactory`

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -622,6 +622,20 @@ impl<DB: Db + ?Sized, V: TransactionValidator> TransactionExecutor<'_, DB, V> {
     }
 }
 
+pub struct AnvilBlockExecutorFactory;
+
+impl AnvilBlockExecutorFactory {
+    pub fn create_executor<DB>(
+        evm: EitherEvm<DB, AnvilInspector, PrecompilesMap>,
+        ctx: AnvilExecutionCtx,
+    ) -> AnvilBlockExecutor<EitherEvm<DB, AnvilInspector, PrecompilesMap>>
+    where
+        DB: StateDB,
+    {
+        AnvilBlockExecutor::new(evm, ctx)
+    }
+}
+
 /// Represents the result of a single transaction execution attempt
 pub enum TransactionExecutionOutcome<T = FoundryTxEnvelope> {
     /// Transaction successfully executed


### PR DESCRIPTION
Adds `AnvilBlockExecutorFactory`, with a single `create_executor` method that wraps `AnvilBlockExecutor::new`.

No callers yet. It exists as a named entry point for the follow-up PR that wires it into `Backend::mine_block`, replacing `TransactionExecutor::execute()` and moving `mine_block` from `impl Backend<FoundryNetwork>` to `impl<N: Network> Backend<N>`.