### PR TITLE
chore(evm): remove `Env::{clone_evm_and_tx,apply_evm_and_tx}` methods

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -24,7 +24,7 @@ use foundry_common::{
 };
 use foundry_compilers::artifacts::EvmVersion;
 use foundry_evm_core::{
-    Env, FoundryBlock, FoundryTransaction,
+    FoundryBlock, FoundryTransaction,
     backend::{DatabaseExt, FoundryJournalExt, RevertStateSnapshotAction},
     constants::{CALLER, CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, TEST_CONTRACT_ADDRESS},
     env::FoundryContextExt,
@@ -1190,7 +1190,8 @@ impl Cheatcode for executeTransactionCall {
         let tx_env = <TxEnv as FromRecoveredTx<FoundryTxEnvelope>>::from_recovered_tx(&tx, sender);
 
         // Save current env for restoration after execution.
-        let (cached_evm_env, cached_tx_env) = Env::clone_evm_and_tx(ccx.ecx);
+        let cached_evm_env = ccx.ecx.evm_clone();
+        let cached_tx_env = ccx.ecx.tx_clone();
 
         // Override env for isolated execution.
         ccx.ecx.block_mut().set_basefee(0);
@@ -1206,7 +1207,8 @@ impl Cheatcode for executeTransactionCall {
             Some(revm::primitives::eip3860::MAX_INITCODE_SIZE);
 
         // Snapshot the modified env for EVM construction.
-        let (modified_evm_env, modified_tx_env) = Env::clone_evm_and_tx(ccx.ecx);
+        let modified_evm_env = ccx.ecx.evm_clone();
+        let modified_tx_env = ccx.ecx.tx_clone();
 
         // Mark as inner context so isolation mode doesn't trigger a nested transact_inner
         // when the inner EVM executes calls at depth == 1.
@@ -1259,7 +1261,8 @@ impl Cheatcode for executeTransactionCall {
         nested_evm_env.cfg_env.disable_nonce_check = cached_evm_env.cfg_env.disable_nonce_check;
         nested_evm_env.cfg_env.limit_contract_initcode_size =
             cached_evm_env.cfg_env.limit_contract_initcode_size;
-        Env::apply_evm_and_tx(ccx.ecx, nested_evm_env, cached_tx_env);
+        ccx.ecx.set_evm(nested_evm_env);
+        ccx.ecx.set_tx(cached_tx_env);
 
         // Reset inner context flag.
         executor.set_in_inner_context(false, None);
@@ -1416,7 +1419,8 @@ fn inner_revert_to_state<CTX: EthCheatCtx>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     snapshot_id: U256,
 ) -> Result {
-    let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
+    let mut evm_env = ccx.ecx.evm_clone();
+    let mut tx_env = ccx.ecx.tx_clone();
     let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
     if let Some(restored) = db.revert_state(
         snapshot_id,
@@ -1426,7 +1430,8 @@ fn inner_revert_to_state<CTX: EthCheatCtx>(
         RevertStateSnapshotAction::RevertKeep,
     ) {
         *inner = restored;
-        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
+        ccx.ecx.set_evm(evm_env);
+        ccx.ecx.set_tx(tx_env);
         Ok(true.abi_encode())
     } else {
         Ok(false.abi_encode())
@@ -1437,7 +1442,8 @@ fn inner_revert_to_state_and_delete<CTX: EthCheatCtx>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     snapshot_id: U256,
 ) -> Result {
-    let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
+    let mut evm_env = ccx.ecx.evm_clone();
+    let mut tx_env = ccx.ecx.tx_clone();
     let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
     if let Some(restored) = db.revert_state(
         snapshot_id,
@@ -1447,7 +1453,8 @@ fn inner_revert_to_state_and_delete<CTX: EthCheatCtx>(
         RevertStateSnapshotAction::RevertRemove,
     ) {
         *inner = restored;
-        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
+        ccx.ecx.set_evm(evm_env);
+        ccx.ecx.set_tx(tx_env);
         Ok(true.abi_encode())
     } else {
         Ok(false.abi_encode())

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -10,7 +10,7 @@ use alloy_provider::Provider;
 use alloy_rpc_types::Filter;
 use alloy_sol_types::SolValue;
 use foundry_common::provider::ProviderBuilder;
-use foundry_evm_core::{Env, backend::FoundryJournalExt, fork::CreateFork};
+use foundry_evm_core::{backend::FoundryJournalExt, fork::CreateFork};
 use revm::context::ContextTr;
 
 impl Cheatcode for activeForkCall {
@@ -73,10 +73,12 @@ impl Cheatcode for rollFork_0Call {
     fn apply_stateful<CTX: EthCheatCtx>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { blockNumber } = self;
         persist_caller(ccx);
-        let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
+        let mut evm_env = ccx.ecx.evm_clone();
+        let mut tx_env = ccx.ecx.tx_clone();
         let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
         db.roll_fork(None, (*blockNumber).to(), &mut evm_env, &mut tx_env, inner)?;
-        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
+        ccx.ecx.set_evm(evm_env);
+        ccx.ecx.set_tx(tx_env);
         Ok(Default::default())
     }
 }
@@ -85,10 +87,12 @@ impl Cheatcode for rollFork_1Call {
     fn apply_stateful<CTX: EthCheatCtx>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { txHash } = self;
         persist_caller(ccx);
-        let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
+        let mut evm_env = ccx.ecx.evm_clone();
+        let mut tx_env = ccx.ecx.tx_clone();
         let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
         db.roll_fork_to_transaction(None, *txHash, &mut evm_env, &mut tx_env, inner)?;
-        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
+        ccx.ecx.set_evm(evm_env);
+        ccx.ecx.set_tx(tx_env);
         Ok(Default::default())
     }
 }
@@ -97,10 +101,12 @@ impl Cheatcode for rollFork_2Call {
     fn apply_stateful<CTX: EthCheatCtx>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { forkId, blockNumber } = self;
         persist_caller(ccx);
-        let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
+        let mut evm_env = ccx.ecx.evm_clone();
+        let mut tx_env = ccx.ecx.tx_clone();
         let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
         db.roll_fork(Some(*forkId), (*blockNumber).to(), &mut evm_env, &mut tx_env, inner)?;
-        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
+        ccx.ecx.set_evm(evm_env);
+        ccx.ecx.set_tx(tx_env);
         Ok(Default::default())
     }
 }
@@ -109,10 +115,12 @@ impl Cheatcode for rollFork_3Call {
     fn apply_stateful<CTX: EthCheatCtx>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { forkId, txHash } = self;
         persist_caller(ccx);
-        let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
+        let mut evm_env = ccx.ecx.evm_clone();
+        let mut tx_env = ccx.ecx.tx_clone();
         let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
         db.roll_fork_to_transaction(Some(*forkId), *txHash, &mut evm_env, &mut tx_env, inner)?;
-        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
+        ccx.ecx.set_evm(evm_env);
+        ccx.ecx.set_tx(tx_env);
         Ok(Default::default())
     }
 }
@@ -122,10 +130,12 @@ impl Cheatcode for selectForkCall {
         let Self { forkId } = self;
         persist_caller(ccx);
         check_broadcast(ccx.state)?;
-        let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
+        let mut evm_env = ccx.ecx.evm_clone();
+        let mut tx_env = ccx.ecx.tx_clone();
         let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
         db.select_fork(*forkId, &mut evm_env, &mut tx_env, inner)?;
-        Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
+        ccx.ecx.set_evm(evm_env);
+        ccx.ecx.set_tx(tx_env);
         Ok(Default::default())
     }
 }
@@ -345,10 +355,12 @@ fn create_select_fork<CTX: EthCheatCtx>(
     check_broadcast(ccx.state)?;
 
     let fork = create_fork_request(ccx, url_or_alias, block)?;
-    let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
+    let mut evm_env = ccx.ecx.evm_clone();
+    let mut tx_env = ccx.ecx.tx_clone();
     let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
     let id = db.create_select_fork(fork, &mut evm_env, &mut tx_env, inner)?;
-    Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
+    ccx.ecx.set_evm(evm_env);
+    ccx.ecx.set_tx(tx_env);
     Ok(id.abi_encode())
 }
 
@@ -372,11 +384,13 @@ fn create_select_fork_at_transaction<CTX: EthCheatCtx>(
     check_broadcast(ccx.state)?;
 
     let fork = create_fork_request(ccx, url_or_alias, None)?;
-    let (mut evm_env, mut tx_env) = Env::clone_evm_and_tx(ccx.ecx);
+    let mut evm_env = ccx.ecx.evm_clone();
+    let mut tx_env = ccx.ecx.tx_clone();
     let (db, inner) = ccx.ecx.journal_mut().as_db_and_inner();
     let id =
         db.create_select_fork_at_transaction(fork, &mut evm_env, &mut tx_env, inner, *transaction)?;
-    Env::apply_evm_and_tx(ccx.ecx, evm_env, tx_env);
+    ccx.ecx.set_evm(evm_env);
+    ccx.ecx.set_tx(tx_env);
     Ok(id.abi_encode())
 }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -36,7 +36,7 @@ use foundry_common::{
     mapping_slots::{MappingSlots, step as mapping_step},
 };
 use foundry_evm_core::{
-    Breakpoints, Env, EthCheatCtx, EvmEnv, FoundryCfg, FoundryInspectorExt, FoundryTransaction,
+    Breakpoints, EthCheatCtx, EvmEnv, FoundryCfg, FoundryInspectorExt, FoundryTransaction,
     abi::Vm::stopExpectSafeMemoryCall,
     backend::{DatabaseError, DatabaseExt, FoundryJournalExt, RevertDiagnostic},
     constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME},
@@ -209,7 +209,8 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
         fork_id: Option<U256>,
         transaction: B256,
     ) -> eyre::Result<()> {
-        let (evm_env, tx_env) = Env::clone_evm_and_tx(ecx);
+        let evm_env = ecx.evm_clone();
+        let tx_env = ecx.tx_clone();
         let (db, inner) = ecx.journal_mut().as_db_and_inner();
         db.transact(fork_id, transaction, evm_env, tx_env, inner, cheats)
     }
@@ -220,7 +221,8 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
         ecx: &mut CTX,
         tx: &TransactionRequest,
     ) -> eyre::Result<()> {
-        let (evm_env, tx_env) = Env::clone_evm_and_tx(ecx);
+        let evm_env = ecx.evm_clone();
+        let tx_env = ecx.tx_clone();
         let (db, inner) = ecx.journal_mut().as_db_and_inner();
         db.transact_from_tx(tx, evm_env, tx_env, inner, cheats)
     }

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -23,21 +23,6 @@ impl Env {
     pub fn from(cfg: CfgEnv, block: BlockEnv, tx: TxEnv) -> Self {
         Self { evm_env: EvmEnv { cfg_env: cfg, block_env: block }, tx }
     }
-
-    /// Clones the evm env and tx env separately from a [`EthCheatCtx`] context.
-    pub fn clone_evm_and_tx(ecx: &mut impl EthCheatCtx) -> (EvmEnv, TxEnv) {
-        (
-            EvmEnv { cfg_env: ecx.cfg_mut().clone(), block_env: ecx.block_mut().clone() },
-            ecx.tx_mut().clone(),
-        )
-    }
-
-    /// Writes the split evm env and tx env back into a [`EthCheatCtx`] context.
-    pub fn apply_evm_and_tx(ecx: &mut impl EthCheatCtx, evm_env: EvmEnv, tx_env: TxEnv) {
-        *ecx.block_mut() = evm_env.block_env;
-        *ecx.cfg_mut() = evm_env.cfg_env;
-        *ecx.tx_mut() = tx_env;
-    }
 }
 
 /// Extension of [`Block`] with mutable setters, allowing EVM-agnostic mutation of block fields.

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    Env, EthCheatCtx, InspectorExt,
+    EthCheatCtx, InspectorExt,
     backend::{DatabaseExt, FoundryJournalExt, JournaledState},
     constants::DEFAULT_CREATE2_DEPLOYER_CODEHASH,
 };
@@ -315,7 +315,8 @@ pub fn with_cloned_context<CTX: EthCheatCtx, R>(
         EVMError<DatabaseError>,
     >,
 ) -> Result<R, EVMError<DatabaseError>> {
-    let (evm_env, tx_env) = Env::clone_evm_and_tx(ecx);
+    let evm_env = ecx.evm_clone();
+    let tx_env = ecx.tx_clone();
 
     let journal = ecx.journal_mut();
     let (db, journal_inner) = journal.as_db_and_inner();
@@ -325,7 +326,8 @@ pub fn with_cloned_context<CTX: EthCheatCtx, R>(
 
     // Write back modified state. The db borrow was released when f returned.
     ecx.journal_mut().set_inner(sub_inner);
-    Env::apply_evm_and_tx(ecx, sub_evm_env, sub_tx);
+    ecx.set_evm(sub_evm_env);
+    ecx.set_tx(sub_tx);
 
     Ok(result)
 }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -15,7 +15,7 @@ use foundry_cheatcodes::{
 use foundry_common::compile::Analysis;
 use foundry_compilers::ProjectPathsConfig;
 use foundry_evm_core::{
-    Env, FoundryBlock, FoundryInspectorExt, FoundryTransaction, InspectorExt,
+    FoundryBlock, FoundryInspectorExt, FoundryTransaction, InspectorExt,
     backend::{DatabaseError, DatabaseExt, FoundryJournalExt, JournaledState},
     env::FoundryContextExt,
     evm::{NestedEvm, new_evm_with_inspector, with_cloned_context},
@@ -404,7 +404,8 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for InspectorStackInner {
         fork_id: Option<U256>,
         transaction: B256,
     ) -> eyre::Result<()> {
-        let (evm_env, tx_env) = Env::clone_evm_and_tx(ecx);
+        let evm_env = ecx.evm_clone();
+        let tx_env = ecx.tx_clone();
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         let (db, inner) = ecx.journal_mut().as_db_and_inner();
         db.transact(fork_id, transaction, evm_env, tx_env, inner, &mut inspector)
@@ -416,7 +417,8 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for InspectorStackInner {
         ecx: &mut CTX,
         tx: &TransactionRequest,
     ) -> eyre::Result<()> {
-        let (evm_env, tx_env) = Env::clone_evm_and_tx(ecx);
+        let evm_env = ecx.evm_clone();
+        let tx_env = ecx.tx_clone();
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         let (db, inner) = ecx.journal_mut().as_db_and_inner();
         db.transact_from_tx(tx, evm_env, tx_env, inner, &mut inspector)
@@ -739,7 +741,8 @@ impl InspectorStackRefMut<'_> {
         gas_limit: u64,
         value: U256,
     ) -> (InterpreterResult, Option<Address>) {
-        let (cached_evm_env, cached_tx_env) = Env::clone_evm_and_tx(ecx);
+        let cached_evm_env = ecx.evm_clone();
+        let cached_tx_env = ecx.tx_clone();
 
         ecx.block_mut().set_basefee(0);
 
@@ -763,7 +766,8 @@ impl InspectorStackRefMut<'_> {
         self.inner_context_data = Some(InnerContextData { original_origin: cached_tx_env.caller });
         self.in_inner_context = true;
 
-        let (evm_env, tx_env) = Env::clone_evm_and_tx(ecx);
+        let evm_env = ecx.evm_clone();
+        let tx_env = ecx.tx_clone();
 
         let res = self.with_inspector(|mut inspector| {
             let (res, nested_env) = {
@@ -801,7 +805,8 @@ impl InspectorStackRefMut<'_> {
             // but restoring the original tx and basefee (which we zeroed for the nested call).
             let mut restored_evm_env = nested_env;
             restored_evm_env.block_env.basefee = cached_evm_env.block_env.basefee;
-            Env::apply_evm_and_tx(ecx, restored_evm_env, cached_tx_env);
+            ecx.set_evm(restored_evm_env);
+            ecx.set_tx(cached_tx_env);
 
             res
         });


### PR DESCRIPTION
## Motivation

#13812 follow-up.

We can now remove `Env::{clone_evm_and_tx,apply_evm_and_tx}` methods 🎉 !
