### PR TITLE
chore(evm): rename `InspectorExt` to `EthInspectorExt`

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -85,9 +85,6 @@ pub mod analysis;
 pub use analysis::CheatcodeAnalysis;
 
 /// Helper trait for running nested EVM operations from inside cheatcode implementations.
-///
-/// The executor assembles the full inspector stack internally and never exposes it across the
-/// trait boundary. This keeps the trait free of `InspectorExt` (which is Eth-specific).
 pub trait CheatcodesExecutor<CTX: ContextTr> {
     /// Runs a closure with a nested EVM built from the current context.
     /// The inspector is assembled internally — never exposed to the caller.

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -2,7 +2,7 @@
 
 use super::BackendError;
 use crate::{
-    InspectorExt,
+    EthInspectorExt,
     backend::{
         Backend, DatabaseExt, JournaledState, LocalForkId, RevertStateSnapshotAction,
         diagnostic::RevertDiagnostic,
@@ -64,7 +64,7 @@ impl<'a> CowBackend<'a> {
     /// Note: in case there are any cheatcodes executed that modify the environment, this will
     /// update the given `env` with the new values.
     #[instrument(name = "inspect", level = "debug", skip_all)]
-    pub fn inspect<I: InspectorExt>(
+    pub fn inspect<I: EthInspectorExt>(
         &mut self,
         evm_env: &mut EvmEnv,
         tx_env: &mut TxEnv,
@@ -200,7 +200,7 @@ impl DatabaseExt for CowBackend<'_> {
         evm_env: EvmEnv,
         tx_env: TxEnv,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt,
+        inspector: &mut dyn EthInspectorExt,
     ) -> eyre::Result<()> {
         self.backend_mut().transact(id, transaction, evm_env, tx_env, journaled_state, inspector)
     }
@@ -211,7 +211,7 @@ impl DatabaseExt for CowBackend<'_> {
         evm_env: EvmEnv,
         tx_env: TxEnv,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt,
+        inspector: &mut dyn EthInspectorExt,
     ) -> eyre::Result<()> {
         self.backend_mut().transact_from_tx(
             transaction,

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1,7 +1,7 @@
 //! Foundry's main executor backend abstraction and implementation.
 
 use crate::{
-    Env, InspectorExt,
+    Env, EthInspectorExt,
     constants::{CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, TEST_CONTRACT_ADDRESS},
     evm::new_evm_with_inspector,
     fork::{CreateFork, ForkId, MultiFork},
@@ -225,7 +225,7 @@ pub trait DatabaseExt<Spec = SpecId, Block = BlockEnv, Tx = TxEnv>:
         evm_env: EvmEnv<Spec, Block>,
         tx_env: Tx,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt,
+        inspector: &mut dyn EthInspectorExt,
     ) -> eyre::Result<()>;
 
     /// Executes a given TransactionRequest, commits the new state to the DB
@@ -235,7 +235,7 @@ pub trait DatabaseExt<Spec = SpecId, Block = BlockEnv, Tx = TxEnv>:
         evm_env: EvmEnv<Spec, Block>,
         tx_env: Tx,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt,
+        inspector: &mut dyn EthInspectorExt,
     ) -> eyre::Result<()>;
 
     /// Returns the `ForkId` that's currently used in the database, if fork mode is on
@@ -812,7 +812,7 @@ impl Backend {
     /// Note: in case there are any cheatcodes executed that modify the environment, this will
     /// update the given `env` with the new values.
     #[instrument(name = "inspect", level = "debug", skip_all)]
-    pub fn inspect<I: InspectorExt>(
+    pub fn inspect<I: EthInspectorExt>(
         &mut self,
         evm_env: &mut EvmEnv,
         tx_env: &mut TxEnv,
@@ -1330,7 +1330,7 @@ impl DatabaseExt for Backend {
         mut evm_env: EvmEnv,
         tx_env: TxEnv,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt,
+        inspector: &mut dyn EthInspectorExt,
     ) -> eyre::Result<()> {
         trace!(?maybe_id, ?transaction, "execute transaction");
         let persistent_accounts = self.inner.persistent_accounts.clone();
@@ -1371,7 +1371,7 @@ impl DatabaseExt for Backend {
         evm_env: EvmEnv,
         tx_env: TxEnv,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt,
+        inspector: &mut dyn EthInspectorExt,
     ) -> eyre::Result<()> {
         trace!(?tx, "execute signed transaction");
 
@@ -2033,7 +2033,7 @@ fn commit_transaction(
     fork: &mut Fork,
     fork_id: &ForkId,
     persistent_accounts: &HashSet<Address>,
-    inspector: &mut dyn InspectorExt,
+    inspector: &mut dyn EthInspectorExt,
 ) -> eyre::Result<()> {
     if let Some(tx_envelope) = tx.as_envelope() {
         env.tx = TxEnv::from_recovered_tx(tx_envelope, tx.from());

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    EthCheatCtx, InspectorExt,
+    EthCheatCtx, EthInspectorExt,
     backend::{DatabaseExt, FoundryJournalExt, JournaledState},
     constants::DEFAULT_CREATE2_DEPLOYER_CODEHASH,
 };
@@ -33,7 +33,7 @@ use revm::{
     primitives::hardfork::SpecId,
 };
 
-pub fn new_evm_with_inspector<'db, I: InspectorExt>(
+pub fn new_evm_with_inspector<'db, I: EthInspectorExt>(
     db: &'db mut dyn DatabaseExt,
     evm_env: EvmEnv,
     tx_env: TxEnv,
@@ -100,7 +100,7 @@ fn get_create2_factory_call_inputs(
     }
 }
 
-pub struct FoundryEvm<'db, I: InspectorExt> {
+pub struct FoundryEvm<'db, I: EthInspectorExt> {
     #[allow(clippy::type_complexity)]
     inner: RevmEvm<
         EthEvmContext<&'db mut dyn DatabaseExt>,
@@ -110,7 +110,7 @@ pub struct FoundryEvm<'db, I: InspectorExt> {
         EthFrame<EthInterpreter>,
     >,
 }
-impl<'db, I: InspectorExt> FoundryEvm<'db, I> {
+impl<'db, I: EthInspectorExt> FoundryEvm<'db, I> {
     /// Consumes the EVM and returns the inner context.
     pub fn into_context(self) -> EthEvmContext<&'db mut dyn DatabaseExt> {
         self.inner.ctx
@@ -137,7 +137,7 @@ impl<'db, I: InspectorExt> FoundryEvm<'db, I> {
     }
 }
 
-impl<'db, I: InspectorExt> Evm for FoundryEvm<'db, I> {
+impl<'db, I: EthInspectorExt> Evm for FoundryEvm<'db, I> {
     type Precompiles = PrecompilesMap;
     type Inspector = I;
     type DB = &'db mut dyn DatabaseExt;
@@ -222,7 +222,7 @@ impl<'db, I: InspectorExt> Evm for FoundryEvm<'db, I> {
     }
 }
 
-impl<'db, I: InspectorExt> Deref for FoundryEvm<'db, I> {
+impl<'db, I: EthInspectorExt> Deref for FoundryEvm<'db, I> {
     type Target = Context<BlockEnv, TxEnv, CfgEnv, &'db mut dyn DatabaseExt>;
 
     fn deref(&self) -> &Self::Target {
@@ -230,7 +230,7 @@ impl<'db, I: InspectorExt> Deref for FoundryEvm<'db, I> {
     }
 }
 
-impl<I: InspectorExt> DerefMut for FoundryEvm<'_, I> {
+impl<I: EthInspectorExt> DerefMut for FoundryEvm<'_, I> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner.ctx
     }
@@ -264,7 +264,7 @@ pub trait NestedEvm {
     fn to_env(&self) -> (EvmEnv<Self::Spec, Self::Block>, Self::Tx);
 }
 
-impl<I: InspectorExt> NestedEvm for FoundryEvm<'_, I> {
+impl<I: EthInspectorExt> NestedEvm for FoundryEvm<'_, I> {
     type Tx = TxEnv;
     type Block = BlockEnv;
     type Spec = SpecId;
@@ -332,12 +332,12 @@ pub fn with_cloned_context<CTX: EthCheatCtx, R>(
     Ok(result)
 }
 
-pub struct FoundryHandler<'db, I: InspectorExt> {
+pub struct FoundryHandler<'db, I: EthInspectorExt> {
     create2_overrides: Vec<(usize, CallInputs)>,
     _phantom: PhantomData<(&'db mut dyn DatabaseExt, I)>,
 }
 
-impl<I: InspectorExt> Default for FoundryHandler<'_, I> {
+impl<I: EthInspectorExt> Default for FoundryHandler<'_, I> {
     fn default() -> Self {
         Self { create2_overrides: Vec::new(), _phantom: PhantomData }
     }
@@ -345,7 +345,7 @@ impl<I: InspectorExt> Default for FoundryHandler<'_, I> {
 
 // Blanket Handler implementation for FoundryHandler, needed for implementing the InspectorHandler
 // trait.
-impl<'db, I: InspectorExt> Handler for FoundryHandler<'db, I> {
+impl<'db, I: EthInspectorExt> Handler for FoundryHandler<'db, I> {
     type Evm = RevmEvm<
         EthEvmContext<&'db mut dyn DatabaseExt>,
         I,
@@ -357,7 +357,7 @@ impl<'db, I: InspectorExt> Handler for FoundryHandler<'db, I> {
     type HaltReason = HaltReason;
 }
 
-impl<'db, I: InspectorExt> FoundryHandler<'db, I> {
+impl<'db, I: EthInspectorExt> FoundryHandler<'db, I> {
     /// Handles CREATE2 frame initialization, potentially transforming it to use the CREATE2
     /// factory.
     fn handle_create_frame(
@@ -451,7 +451,7 @@ impl<'db, I: InspectorExt> FoundryHandler<'db, I> {
     }
 }
 
-impl<I: InspectorExt> InspectorHandler for FoundryHandler<'_, I> {
+impl<I: EthInspectorExt> InspectorHandler for FoundryHandler<'_, I> {
     type IT = EthInterpreter;
 
     fn inspect_run_exec_loop(

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -76,14 +76,13 @@ pub trait FoundryInspectorExt {
 
 /// Combined trait: `Inspector<EthEvmContext<...>>` + [`FoundryInspectorExt`].
 ///
-/// Used as a trait object (`dyn InspectorExt`) in backend code that is Eth-specific.
 /// For generic multi-network code, use `I: FoundryInspectorExt + Inspector<CTX>` instead.
-pub trait InspectorExt:
+pub trait EthInspectorExt:
     for<'a> Inspector<EthEvmContext<&'a mut dyn DatabaseExt>> + FoundryInspectorExt
 {
 }
 
-impl<T> InspectorExt for T where
+impl<T> EthInspectorExt for T where
     T: for<'a> Inspector<EthEvmContext<&'a mut dyn DatabaseExt>> + FoundryInspectorExt
 {
 }

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -540,7 +540,7 @@ impl Executor {
     ) -> eyre::Result<RawCallResult> {
         let mut stack = self.inspector().clone();
         let mut backend = CowBackend::new_borrowed(self.backend());
-        let result = backend.inspect(&mut evm_env, &mut tx_env, stack.as_inspector())?;
+        let result = backend.inspect(&mut evm_env, &mut tx_env, &mut stack)?;
         convert_executed_result(
             evm_env,
             tx_env,
@@ -560,7 +560,7 @@ impl Executor {
         let mut stack = self.inspector().clone();
         let backend = self.backend_mut();
         let result: revm::context::result::ExecResultAndState<ExecutionResult> =
-            backend.inspect(&mut evm_env, &mut tx_env, stack.as_inspector())?;
+            backend.inspect(&mut evm_env, &mut tx_env, &mut stack)?;
         let mut result = convert_executed_result(
             evm_env,
             tx_env,

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -15,7 +15,7 @@ use foundry_cheatcodes::{
 use foundry_common::compile::Analysis;
 use foundry_compilers::ProjectPathsConfig;
 use foundry_evm_core::{
-    FoundryBlock, FoundryInspectorExt, FoundryTransaction, InspectorExt,
+    FoundryBlock, FoundryInspectorExt, FoundryTransaction,
     backend::{DatabaseError, DatabaseExt, FoundryJournalExt, JournaledState},
     env::FoundryContextExt,
     evm::{NestedEvm, new_evm_with_inspector, with_cloned_context},
@@ -347,7 +347,7 @@ pub struct InspectorStackInner {
     pub script_execution_inspector: Option<Box<ScriptExecutionInspector>>,
     pub tracer: Option<Box<TracingInspector>>,
 
-    // InspectorExt and other internal data.
+    // EthInspectorExt and other internal data.
     pub enable_isolation: bool,
     pub networks: NetworkConfigs,
     pub create2_deployer: Address,
@@ -600,12 +600,6 @@ impl InspectorStack {
     #[inline(always)]
     fn as_mut(&mut self) -> InspectorStackRefMut<'_> {
         InspectorStackRefMut { cheatcodes: self.cheatcodes.as_deref_mut(), inner: &mut self.inner }
-    }
-
-    /// Returns an [`InspectorExt`] using this stack's inspectors.
-    #[inline]
-    pub fn as_inspector(&mut self) -> impl InspectorExt + '_ {
-        self
     }
 
     /// Collects all the data gathered during inspection into a single struct.

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -13,7 +13,7 @@ pub mod inspectors;
 
 pub use foundry_evm_core as core;
 pub use foundry_evm_core::{
-    Env, EvmEnv, FoundryInspectorExt, InspectorExt, backend, constants, decode, fork, hardfork,
+    Env, EthInspectorExt, EvmEnv, FoundryInspectorExt, backend, constants, decode, fork, hardfork,
     opts, utils,
 };
 pub use foundry_evm_coverage as coverage;


### PR DESCRIPTION
readability change, let's flag this to make it less confusing 👍 

+ we also remove `as_inspector()` since we can reach it directly through `stack`