### PR TITLE
fix(anvil): honor rpc_storage_caching in fork cache path

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -13,7 +13,6 @@ use foundry_common::shell;
 use foundry_config::{Chain, Config, FigmentProviders};
 use foundry_evm::hardfork::{EthereumHardfork, OpHardfork};
 use foundry_evm_networks::NetworkConfigs;
-use foundry_primitives::FoundryNetwork;
 use futures::FutureExt;
 use rand_08::{SeedableRng, rngs::StdRng};
 use std::{
@@ -224,6 +223,11 @@ impl NodeArgs {
         let genesis_balance = Unit::ETHER.wei().saturating_mul(U256::from(self.balance));
         let compute_units_per_second =
             if self.evm.no_rate_limit { Some(u64::MAX) } else { self.evm.compute_units_per_second };
+        let foundry_config = Config::load_with_providers(FigmentProviders::Anvil).ok();
+        let no_storage_caching = self.evm.no_storage_caching
+            || foundry_config.as_ref().is_some_and(|config| config.no_storage_caching);
+        let rpc_storage_caching =
+            foundry_config.map(|config| config.rpc_storage_caching).unwrap_or_default();
 
         let hardfork = match &self.hardfork {
             Some(hf) => {
@@ -269,7 +273,8 @@ impl NodeArgs {
             .with_eth_rpc_url(self.evm.fork_url.map(|fork| fork.url))
             .with_base_fee(self.evm.block_base_fee_per_gas)
             .disable_min_priority_fee(self.evm.disable_min_priority_fee)
-            .with_no_storage_caching(self.evm.no_storage_caching)
+            .with_no_storage_caching(no_storage_caching)
+            .with_rpc_storage_caching(rpc_storage_caching)
             .with_server_config(self.server_config)
             .with_host(self.host)
             .set_silent(shell::is_quiet())
@@ -640,7 +645,7 @@ impl AnvilEvmArgs {
 /// Helper type to periodically dump the state of the chain to disk
 struct PeriodicStateDumper {
     in_progress_dump: Option<Pin<Box<dyn Future<Output = ()> + Send + Sync + 'static>>>,
-    api: EthApi<FoundryNetwork>,
+    api: EthApi,
     dump_state: Option<PathBuf>,
     preserve_historical_states: bool,
     interval: Interval,
@@ -648,7 +653,7 @@ struct PeriodicStateDumper {
 
 impl PeriodicStateDumper {
     fn new(
-        api: EthApi<FoundryNetwork>,
+        api: EthApi,
         dump_state: Option<PathBuf>,
         interval: Duration,
         preserve_historical_states: bool,
@@ -672,11 +677,7 @@ impl PeriodicStateDumper {
     }
 
     /// Infallible state dump
-    async fn dump_state(
-        api: EthApi<FoundryNetwork>,
-        dump_state: PathBuf,
-        preserve_historical_states: bool,
-    ) {
+    async fn dump_state(api: EthApi, dump_state: PathBuf, preserve_historical_states: bool) {
         trace!(path=?dump_state, "Dumping state on shutdown");
         match api.serialized_state(preserve_historical_states).await {
             Ok(state) => {

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -13,6 +13,7 @@ use foundry_common::shell;
 use foundry_config::{Chain, Config, FigmentProviders};
 use foundry_evm::hardfork::{EthereumHardfork, OpHardfork};
 use foundry_evm_networks::NetworkConfigs;
+use foundry_primitives::FoundryNetwork;
 use futures::FutureExt;
 use rand_08::{SeedableRng, rngs::StdRng};
 use std::{
@@ -645,7 +646,7 @@ impl AnvilEvmArgs {
 /// Helper type to periodically dump the state of the chain to disk
 struct PeriodicStateDumper {
     in_progress_dump: Option<Pin<Box<dyn Future<Output = ()> + Send + Sync + 'static>>>,
-    api: EthApi,
+    api: EthApi<FoundryNetwork>,
     dump_state: Option<PathBuf>,
     preserve_historical_states: bool,
     interval: Interval,
@@ -653,7 +654,7 @@ struct PeriodicStateDumper {
 
 impl PeriodicStateDumper {
     fn new(
-        api: EthApi,
+        api: EthApi<FoundryNetwork>,
         dump_state: Option<PathBuf>,
         interval: Duration,
         preserve_historical_states: bool,
@@ -677,7 +678,11 @@ impl PeriodicStateDumper {
     }
 
     /// Infallible state dump
-    async fn dump_state(api: EthApi, dump_state: PathBuf, preserve_historical_states: bool) {
+    async fn dump_state(
+        api: EthApi<FoundryNetwork>,
+        dump_state: PathBuf,
+        preserve_historical_states: bool,
+    ) {
         trace!(path=?dump_state, "Dumping state on shutdown");
         match api.serialized_state(preserve_historical_states).await {
             Ok(state) => {

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -34,7 +34,7 @@ use foundry_common::{
     ALCHEMY_FREE_TIER_CUPS, NON_ARCHIVE_NODE_WARNING, REQUEST_TIMEOUT,
     provider::{ProviderBuilder, RetryProvider},
 };
-use foundry_config::Config;
+use foundry_config::{Config, cache::StorageCachingConfig};
 use foundry_evm::{
     backend::{BlockchainDb, BlockchainDbMeta, SharedBackend},
     constants::DEFAULT_CREATE2_DEPLOYER,
@@ -149,6 +149,8 @@ pub struct NodeConfig {
     pub enable_tracing: bool,
     /// Explicitly disables the use of RPC caching.
     pub no_storage_caching: bool,
+    /// RPC storage caching strategy from foundry config.
+    pub rpc_storage_caching: StorageCachingConfig,
     /// How to configure the server
     pub server_config: ServerConfig,
     /// The host the server will listen on
@@ -473,6 +475,7 @@ impl Default for NodeConfig {
             print_traces: false,
             enable_auto_impersonate: false,
             no_storage_caching: false,
+            rpc_storage_caching: Default::default(),
             server_config: Default::default(),
             host: vec![IpAddr::V4(Ipv4Addr::LOCALHOST)],
             transaction_order: Default::default(),
@@ -832,6 +835,13 @@ impl NodeConfig {
         self
     }
 
+    /// Sets RPC storage caching strategy.
+    #[must_use]
+    pub fn with_rpc_storage_caching(mut self, rpc_storage_caching: StorageCachingConfig) -> Self {
+        self.rpc_storage_caching = rpc_storage_caching;
+        self
+    }
+
     /// Sets the `eth_rpc_url` to use when forking
     #[must_use]
     pub fn with_eth_rpc_url<U: Into<String>>(mut self, eth_rpc_url: Option<U>) -> Self {
@@ -991,10 +1001,16 @@ impl NodeConfig {
     ///
     /// See also [ Config::foundry_block_cache_file()]
     pub fn block_cache_path(&self, block: u64) -> Option<PathBuf> {
-        if self.no_storage_caching || self.eth_rpc_url.is_none() {
+        let endpoint = self.eth_rpc_url.as_deref()?;
+        let chain_id = self.get_chain_id();
+        if !Config::storage_caching_enabled(
+            self.no_storage_caching,
+            &self.rpc_storage_caching,
+            endpoint,
+            chain_id,
+        ) {
             return None;
         }
-        let chain_id = self.get_chain_id();
 
         Config::foundry_block_cache_file(chain_id, block)
     }
@@ -1670,6 +1686,7 @@ async fn find_latest_fork_block<P: Provider<AnyNetwork>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use foundry_config::cache::{CachedChains, CachedEndpoints};
 
     #[test]
     fn test_prune_history() {
@@ -1679,5 +1696,54 @@ mod tests {
         assert!(!config.is_state_history_supported());
         let config = PruneStateHistoryConfig::from_args(Some(Some(10)));
         assert!(config.is_state_history_supported());
+    }
+
+    #[test]
+    fn block_cache_path_respects_storage_caching_endpoint_policy() {
+        let config = NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_eth_rpc_url(Some("http://127.0.0.1:8545"))
+            .with_rpc_storage_caching(StorageCachingConfig {
+                chains: CachedChains::All,
+                endpoints: CachedEndpoints::Remote,
+            });
+        assert_eq!(config.block_cache_path(100), None);
+    }
+
+    #[test]
+    fn block_cache_path_respects_storage_caching_chain_policy() {
+        let config = NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_eth_rpc_url(Some("https://rpc.example"))
+            .with_rpc_storage_caching(StorageCachingConfig {
+                chains: CachedChains::None,
+                endpoints: CachedEndpoints::All,
+            });
+        assert_eq!(config.block_cache_path(100), None);
+    }
+
+    #[test]
+    fn block_cache_path_honors_cli_no_storage_caching_override() {
+        let config = NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_eth_rpc_url(Some("https://rpc.example"))
+            .with_rpc_storage_caching(StorageCachingConfig {
+                chains: CachedChains::All,
+                endpoints: CachedEndpoints::All,
+            })
+            .with_no_storage_caching(true);
+        assert_eq!(config.block_cache_path(100), None);
+    }
+
+    #[test]
+    fn block_cache_path_enabled_when_policy_allows() {
+        let config = NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_eth_rpc_url(Some("https://rpc.example"))
+            .with_rpc_storage_caching(StorageCachingConfig {
+                chains: CachedChains::All,
+                endpoints: CachedEndpoints::All,
+            });
+        assert_eq!(config.block_cache_path(100), Config::foundry_block_cache_file(1u64, 100));
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1342,11 +1342,26 @@ impl Config {
         self.auto_detect_solc
     }
 
-    /// Whether caching should be enabled for the given chain id
+    /// Returns whether storage caching is enabled for the given endpoint and chain id.
+    pub fn storage_caching_enabled(
+        no_storage_caching: bool,
+        rpc_storage_caching: &StorageCachingConfig,
+        endpoint: &str,
+        chain_id: impl Into<u64>,
+    ) -> bool {
+        !no_storage_caching
+            && rpc_storage_caching.enable_for_chain_id(chain_id.into())
+            && rpc_storage_caching.enable_for_endpoint(endpoint)
+    }
+
+    /// Whether caching should be enabled for the given chain id.
     pub fn enable_caching(&self, endpoint: &str, chain_id: impl Into<u64>) -> bool {
-        !self.no_storage_caching
-            && self.rpc_storage_caching.enable_for_chain_id(chain_id.into())
-            && self.rpc_storage_caching.enable_for_endpoint(endpoint)
+        Self::storage_caching_enabled(
+            self.no_storage_caching,
+            &self.rpc_storage_caching,
+            endpoint,
+            chain_id,
+        )
     }
 
     /// Returns the `ProjectPathsConfig` sub set of the config.


### PR DESCRIPTION
Align anvil fork cache behavior with foundry.toml rpc_storage_caching policies, while preserving the CLI no-storage-caching override and adding policy-focused tests.