### PR TITLE
feat(script): generic `BundledState` impl

### DIFF
--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -1,16 +1,16 @@
 use std::{cmp::Ordering, sync::Arc, time::Duration};
 
 use alloy_chains::{Chain, NamedChain};
-use alloy_consensus::TxEnvelope;
+use alloy_consensus::{SignableTransaction, Signed};
 use alloy_eips::{BlockId, eip2718::Encodable2718};
-use alloy_network::{Ethereum, EthereumWallet, Network, ReceiptResponse, TransactionBuilder};
+use alloy_network::{EthereumWallet, Network, ReceiptResponse, TransactionBuilder};
 use alloy_primitives::{
     Address, TxHash,
     map::{AddressHashMap, AddressHashSet},
     utils::format_units,
 };
 use alloy_provider::{Provider, RootProvider, utils::Eip1559Estimation};
-use alloy_rpc_types::TransactionRequest;
+use alloy_signer::Signature;
 use eyre::{Context, Result, bail};
 use forge_verify::provider::VerificationProviderType;
 use foundry_cheatcodes::Wallets;
@@ -25,6 +25,7 @@ use foundry_primitives::FoundryTransactionBuilder;
 use foundry_wallets::wallet_browser::signer::BrowserSigner;
 use futures::{FutureExt, StreamExt, future::join_all, stream::FuturesUnordered};
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     ScriptArgs, ScriptConfig, build::LinkedBuildData, progress::ScriptProgress,
@@ -65,14 +66,19 @@ pub async fn next_nonce(
 
 /// Represents how to send a single transaction.
 #[derive(Clone)]
-pub enum SendTransactionKind<'a> {
-    Unlocked(TransactionRequest),
-    Raw(TransactionRequest, &'a EthereumWallet),
-    Browser(TransactionRequest, &'a BrowserSigner),
-    Signed(TxEnvelope),
+pub enum SendTransactionKind<'a, N: Network> {
+    Unlocked(N::TransactionRequest),
+    Raw(N::TransactionRequest, &'a EthereumWallet),
+    Browser(N::TransactionRequest, &'a BrowserSigner<N>),
+    Signed(N::TxEnvelope),
 }
 
-impl<'a> SendTransactionKind<'a> {
+impl<'a, N: Network> SendTransactionKind<'a, N>
+where
+    N::TxEnvelope: From<Signed<N::UnsignedTx>>,
+    N::UnsignedTx: SignableTransaction<Signature>,
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+{
     /// Prepares the transaction for broadcasting by synchronizing nonce and estimating gas.
     ///
     /// This method performs two key operations:
@@ -81,7 +87,7 @@ impl<'a> SendTransactionKind<'a> {
     /// 2. Gas estimation: Re-estimates gas right before broadcasting for chains that require it
     pub async fn prepare(
         &mut self,
-        provider: &RootProvider<Ethereum>,
+        provider: &RootProvider<N>,
         sequential_broadcast: bool,
         is_fixed_gas_limit: bool,
         estimate_via_rpc: bool,
@@ -89,9 +95,9 @@ impl<'a> SendTransactionKind<'a> {
     ) -> Result<()> {
         if let Self::Raw(tx, _) | Self::Unlocked(tx) | Self::Browser(tx, _) = self {
             if sequential_broadcast {
-                let from = tx.from.expect("no sender");
+                let from = tx.from().expect("no sender");
 
-                let tx_nonce = tx.nonce.expect("no nonce");
+                let tx_nonce = tx.nonce().expect("no nonce");
                 for attempt in 0..5 {
                     let nonce = provider.get_transaction_count(from).await?;
                     match nonce.cmp(&tx_nonce) {
@@ -135,7 +141,7 @@ impl<'a> SendTransactionKind<'a> {
     /// - Submit via `eth_sendTransaction` for unlocked accounts
     /// - Sign and submit via `eth_sendRawTransaction` for raw transactions
     /// - Submit pre-signed transaction via `eth_sendRawTransaction`
-    pub async fn send(self, provider: Arc<RootProvider<Ethereum>>) -> Result<TxHash> {
+    pub async fn send(self, provider: Arc<RootProvider<N>>) -> Result<TxHash> {
         match self {
             Self::Unlocked(tx) => {
                 debug!("sending transaction from unlocked account {:?}", tx);
@@ -172,7 +178,7 @@ impl<'a> SendTransactionKind<'a> {
     /// [`send`](Self::send) into a single call.
     pub async fn prepare_and_send(
         mut self,
-        provider: Arc<RootProvider<Ethereum>>,
+        provider: Arc<RootProvider<N>>,
         sequential_broadcast: bool,
         is_fixed_gas_limit: bool,
         estimate_via_rpc: bool,
@@ -192,22 +198,22 @@ impl<'a> SendTransactionKind<'a> {
 }
 
 /// Represents how to send _all_ transactions
-pub enum SendTransactionsKind {
+pub enum SendTransactionsKind<N: Network> {
     /// Send via `eth_sendTransaction` and rely on the  `from` address being unlocked.
     Unlocked(AddressHashSet),
     /// Send a signed transaction via `eth_sendRawTransaction`, or via browser
-    Raw { eth_wallets: AddressHashMap<EthereumWallet>, browser: Option<BrowserSigner> },
+    Raw { eth_wallets: AddressHashMap<EthereumWallet>, browser: Option<BrowserSigner<N>> },
 }
 
-impl SendTransactionsKind {
+impl<N: Network> SendTransactionsKind<N> {
     /// Returns the [`SendTransactionKind`] for the given address
     ///
     /// Returns an error if no matching signer is found or the address is not unlocked
     pub fn for_sender(
         &self,
         addr: &Address,
-        tx: TransactionRequest,
-    ) -> Result<SendTransactionKind<'_>> {
+        tx: N::TransactionRequest,
+    ) -> Result<SendTransactionKind<'_, N>> {
         match self {
             Self::Unlocked(unlocked) => {
                 if !unlocked.contains(addr) {
@@ -233,15 +239,23 @@ impl SendTransactionsKind {
 /// State after we have bundled all
 /// [`TransactionWithMetadata`](forge_script_sequence::TransactionWithMetadata) objects into a
 /// single [`ScriptSequenceKind`] object containing one or more script sequences.
-pub struct BundledState {
+pub struct BundledState<N: Network>
+where
+    N::TxEnvelope: for<'d> Deserialize<'d> + Serialize,
+    N::TransactionRequest: for<'d> Deserialize<'d> + Serialize,
+{
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets<Ethereum>,
+    pub script_wallets: Wallets<N>,
     pub build_data: LinkedBuildData,
-    pub sequence: ScriptSequenceKind<Ethereum>,
+    pub sequence: ScriptSequenceKind<N>,
 }
 
-impl BundledState {
+impl<N: Network> BundledState<N>
+where
+    N::TxEnvelope: for<'d> Deserialize<'d> + Serialize,
+    N::TransactionRequest: for<'d> Deserialize<'d> + Serialize,
+{
     pub async fn wait_for_pending(mut self) -> Result<Self> {
         let progress = ScriptProgress::default();
         let progress_ref = &progress;
@@ -276,7 +290,12 @@ impl BundledState {
     }
 
     /// Broadcasts transactions from all sequences.
-    pub async fn broadcast(mut self) -> Result<BroadcastedState<Ethereum>> {
+    pub async fn broadcast(mut self) -> Result<BroadcastedState<N>>
+    where
+        N::TxEnvelope: From<Signed<N::UnsignedTx>>,
+        N::UnsignedTx: SignableTransaction<Signature>,
+        N::TransactionRequest: FoundryTransactionBuilder<N>,
+    {
         let required_addresses = self
             .sequence
             .sequences()
@@ -379,7 +398,7 @@ impl BundledState {
                                 SendTransactionKind::Signed(tx)
                             }
                             TransactionMaybeSigned::Unsigned(mut tx) => {
-                                let from = tx.from.expect("No sender for onchain transaction!");
+                                let from = tx.from().expect("No sender for onchain transaction!");
 
                                 tx.set_chain_id(sequence.chain);
 

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -256,7 +256,7 @@ impl CompiledState {
     }
 
     /// Tries loading the resumed state from the cache files, skipping simulation stage.
-    pub async fn resume(self) -> Result<BundledState> {
+    pub async fn resume(self) -> Result<BundledState<Ethereum>> {
         let chain = if self.args.multi {
             None
         } else {

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -264,7 +264,7 @@ impl FilledTransactionsState {
     /// chain deployment.
     ///
     /// Each transaction will be added with the correct transaction type and gas estimation.
-    pub async fn bundle(mut self) -> Result<BundledState> {
+    pub async fn bundle(mut self) -> Result<BundledState<Ethereum>> {
         let is_multi_deployment = self.execution_artifacts.rpc_data.total_rpcs.len() > 1;
 
         if is_multi_deployment && !self.build_data.libraries.is_empty() {

--- a/crates/wallets/src/wallet_browser/signer.rs
+++ b/crates/wallets/src/wallet_browser/signer.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use alloy_network::{Ethereum, Network, TransactionBuilder};
+use alloy_network::{Network, TransactionBuilder};
 use alloy_primitives::{Address, B256, ChainId};
 use alloy_signer::Result;
 use tokio::sync::Mutex;
@@ -15,7 +15,7 @@ use crate::wallet_browser::{
 };
 
 #[derive(Clone, Debug)]
-pub struct BrowserSigner<N: Network = Ethereum> {
+pub struct BrowserSigner<N: Network> {
     server: Arc<Mutex<BrowserWalletServer<N>>>,
     address: Address,
     chain_id: ChainId,


### PR DESCRIPTION
## Motivation

#13768 #13770 #13795 #13803 #13809 Follow-up. Towards generic script-sequence.

Makes `BundledState` impl generic.

This also introduces generic `SendTransactionsKind`/`SendTransactionKind` and proper wiring with `BrowserSigner<N>` (so that its default generic is not necessary anymore)
