### PR TITLE
chore(evm): fix stale `Env` references in doc comments

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -104,8 +104,8 @@ pub trait DatabaseExt<Spec = SpecId, Block = BlockEnv, Tx = TxEnv>:
     /// **N.B.** While this reverts the state of the evm to the snapshot, it keeps new logs made
     /// since the snapshots was created. This way we can show logs that were emitted between
     /// snapshot and its revert.
-    /// This will also revert any changes in the `Env` and replace it with the captured `Env` of
-    /// `Self::snapshot_state`.
+    /// This will also revert any changes in the `EvmEnv` and `TxEnv` and replace them with the
+    /// captured values from `Self::snapshot_state`.
     ///
     /// Depending on [RevertStateSnapshotAction] it will keep the snapshot alive or delete it.
     fn revert_state(
@@ -169,7 +169,7 @@ pub trait DatabaseExt<Spec = SpecId, Block = BlockEnv, Tx = TxEnv>:
 
     /// Selects the fork's state
     ///
-    /// This will also modify the current `Env`.
+    /// This will also modify the current `EvmEnv` and `TxEnv`.
     ///
     /// **Note**: this does not change the local state, but swaps the remote state
     ///
@@ -459,7 +459,7 @@ where
 /// Multiple "forks" can be created `Backend::create_fork()`, however only 1 can be used by the
 /// `db`. However, their state can be hot-swapped by swapping the read half of `db` from one fork to
 /// another.
-/// When swapping forks (`Backend::select_fork()`) we also update the current `Env` of the `EVM`
+/// When swapping forks (`Backend::select_fork()`) we also update the current `EvmEnv` of the `EVM`
 /// accordingly, so that all `block.*` config values match
 ///
 /// When another for is selected [`DatabaseExt::select_fork()`] the entire storage, including

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -363,7 +363,7 @@ impl Executor {
     ///
     /// # Panics
     ///
-    /// Panics if `env.tx.kind` is not `TxKind::Create(_)`.
+    /// Panics if `tx_env.kind` is not `TxKind::Create(_)`.
     #[instrument(name = "deploy", level = "debug", skip_all)]
     pub fn deploy_with_env(
         &mut self,
@@ -529,7 +529,7 @@ impl Executor {
         self.transact_with_env(evm_env, tx_env)
     }
 
-    /// Execute the transaction configured in `env.tx`.
+    /// Execute the transaction configured in `tx_env`.
     ///
     /// The state after the call is **not** persisted.
     #[instrument(name = "call", level = "debug", skip_all)]
@@ -550,7 +550,7 @@ impl Executor {
         )
     }
 
-    /// Execute the transaction configured in `env.tx`.
+    /// Execute the transaction configured in `tx_env`.
     #[instrument(name = "transact", level = "debug", skip_all)]
     pub fn transact_with_env(
         &mut self,


### PR DESCRIPTION
## Summary
- Update doc comments that still reference the removed `Env` wrapper struct (removed in #13826) to use the current `EvmEnv`/`TxEnv` names instead
- Fixes references in `DatabaseExt::revert_state`, `DatabaseExt::select_fork`, `Backend` module docs, and `Executor` method docs