### PR TITLE
fix(foundryup): tempo-foundry now ships all binaries

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -3,7 +3,7 @@ set -eo pipefail
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-FOUNDRYUP_INSTALLER_VERSION="1.6.0"
+FOUNDRYUP_INSTALLER_VERSION="1.6.1"
 
 BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
 FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}
@@ -334,7 +334,7 @@ main() {
     ensure mkdir -p "$FOUNDRY_VERSIONS_DIR"
 
     # Download and extract the binaries archive
-    say "downloading forge and cast for $FOUNDRYUP_TAG version"
+    say "downloading forge, cast, anvil, and chisel for $FOUNDRYUP_TAG version"
     if [ "$PLATFORM" = "win32" ]; then
       tmp="$(mktemp -d 2>/dev/null)" || err "failed to create temp dir"
       tmp="$tmp/foundry.zip"


### PR DESCRIPTION
message when downloading `tempo-foundry` still displayed only installing forge and cast