### PR TITLE
refactor(common): extract shared build logic in ProviderBuilder

### DIFF
--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -304,6 +304,13 @@ impl<N: Network> ProviderBuilder<N> {
 
     /// Constructs the `RetryProvider` taking all configs into account.
     pub fn build(self) -> Result<RetryProvider<N>> {
+        let root = self.build_root_provider()?;
+        let provider = AlloyProviderBuilder::<_, _, N>::default().connect_provider(root);
+        Ok(provider)
+    }
+
+    /// Builds the shared `RootProvider` used by both `build` and `build_with_wallet`.
+    fn build_root_provider(self) -> Result<RootProvider<N>> {
         let Self {
             url,
             chain,
@@ -328,11 +335,7 @@ impl<N: Network> ProviderBuilder<N> {
         if curl_mode {
             let transport = CurlTransport::new(url).with_headers(headers).with_jwt(jwt);
             let client = ClientBuilder::default().layer(retry_layer).transport(transport, is_local);
-
-            let provider = AlloyProviderBuilder::<_, _, N>::default()
-                .connect_provider(RootProvider::new(client));
-
-            return Ok(provider);
+            return Ok(RootProvider::new(client));
         }
 
         let transport = RuntimeTransportBuilder::new(url)
@@ -356,10 +359,7 @@ impl<N: Network> ProviderBuilder<N> {
             );
         }
 
-        let provider =
-            AlloyProviderBuilder::<_, _, N>::default().connect_provider(RootProvider::new(client));
-
-        Ok(provider)
+        Ok(RootProvider::new(client))
     }
 }
 
@@ -372,66 +372,11 @@ impl<N: Network> ProviderBuilder<N> {
     where
         N: RecommendedFillers,
     {
-        let Self {
-            url,
-            chain,
-            max_retry,
-            initial_backoff,
-            timeout,
-            compute_units_per_second,
-            jwt,
-            headers,
-            is_local,
-            accept_invalid_certs,
-            no_proxy,
-            curl_mode,
-            ..
-        } = self;
-        let url = url?;
-
-        let retry_layer =
-            RetryBackoffLayer::new(max_retry, initial_backoff, compute_units_per_second);
-
-        // If curl_mode is enabled, use CurlTransport instead of RuntimeTransport
-        if curl_mode {
-            let transport = CurlTransport::new(url).with_headers(headers).with_jwt(jwt);
-            let client = ClientBuilder::default().layer(retry_layer).transport(transport, is_local);
-
-            let provider = AlloyProviderBuilder::<_, _, N>::default()
-                .with_recommended_fillers()
-                .wallet(wallet)
-                .connect_provider(RootProvider::new(client));
-
-            return Ok(provider);
-        }
-
-        let transport = RuntimeTransportBuilder::new(url)
-            .with_timeout(timeout)
-            .with_headers(headers)
-            .with_jwt(jwt)
-            .accept_invalid_certs(accept_invalid_certs)
-            .no_proxy(no_proxy)
-            .build();
-
-        let client = ClientBuilder::default().layer(retry_layer).transport(transport, is_local);
-
-        if !is_local {
-            client.set_poll_interval(
-                chain
-                    .average_blocktime_hint()
-                    // we cap the poll interval because if not provided, chain would default to
-                    // mainnet
-                    .map(|hint| hint.min(DEFAULT_UNKNOWN_CHAIN_BLOCK_TIME))
-                    .unwrap_or(DEFAULT_UNKNOWN_CHAIN_BLOCK_TIME)
-                    .mul_f32(POLL_INTERVAL_BLOCK_TIME_SCALE_FACTOR),
-            );
-        }
-
+        let root = self.build_root_provider()?;
         let provider = AlloyProviderBuilder::<_, _, N>::default()
             .with_recommended_fillers()
             .wallet(wallet)
-            .connect_provider(RootProvider::new(client));
-
+            .connect_provider(root);
         Ok(provider)
     }
 }


### PR DESCRIPTION
build and build_with_wallet had the entire transport/client/poll-interval setup duplicated — pulled it into a shared build_root_provider method so there's one place to maintain.