### PR TITLE
refactor(anvil): extract `block_env_from_header` utility

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -42,7 +42,10 @@ use foundry_evm::{
         FoundryHardfork, OpHardfork, ethereum_hardfork_from_block_tag,
         spec_id_from_ethereum_hardfork,
     },
-    utils::{apply_chain_and_block_specific_env_changes, get_blob_base_fee_update_fraction},
+    utils::{
+        apply_chain_and_block_specific_env_changes, block_env_from_header,
+        get_blob_base_fee_update_fraction,
+    },
 };
 use itertools::Itertools;
 use op_revm::OpTransaction;
@@ -1286,16 +1289,11 @@ latest block number: {latest_block}"
         self.gas_limit = Some(gas_limit);
 
         env.evm_env.block_env = BlockEnv {
-            number: U256::from(fork_block_number),
-            timestamp: U256::from(block.header.timestamp()),
-            difficulty: block.header.difficulty(),
-            // ensures prevrandao is set
-            prevrandao: Some(block.header.mix_hash().unwrap_or_default()),
             gas_limit,
             // Keep previous `coinbase` and `basefee` value
             beneficiary: env.evm_env.block_env.beneficiary,
             basefee: env.evm_env.block_env.basefee,
-            ..Default::default()
+            ..block_env_from_header(&block.header)
         };
 
         // Determine chain_id early so we can use it consistently

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -96,7 +96,10 @@ use foundry_evm::{
         CallTraceDecoder, FourByteInspector, GethTraceBuilder, TracingInspector,
         TracingInspectorConfig,
     },
-    utils::{get_blob_base_fee_update_fraction, get_blob_base_fee_update_fraction_by_spec_id},
+    utils::{
+        block_env_from_header, get_blob_base_fee_update_fraction,
+        get_blob_base_fee_update_fraction_by_spec_id,
+    },
 };
 use foundry_primitives::{
     FoundryNetwork, FoundryReceiptEnvelope, FoundryTransactionRequest, FoundryTxEnvelope,
@@ -4199,20 +4202,6 @@ impl Backend<FoundryNetwork> {
         }
 
         Ok(None)
-    }
-}
-
-/// Constructs a `BlockEnv` from a block header.
-fn block_env_from_header(header: &impl BlockHeader) -> BlockEnv {
-    BlockEnv {
-        number: U256::from(header.number()),
-        beneficiary: header.beneficiary(),
-        timestamp: U256::from(header.timestamp()),
-        difficulty: header.difficulty(),
-        prevrandao: header.mix_hash(),
-        basefee: header.base_fee_per_gas().unwrap_or_default(),
-        gas_limit: header.gas_limit(),
-        ..Default::default()
     }
 }
 

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -1,4 +1,7 @@
-use crate::{debug::handle_traces, utils::apply_chain_and_block_specific_env_changes};
+use crate::{
+    debug::handle_traces,
+    utils::{apply_chain_and_block_specific_env_changes, block_env_from_header},
+};
 use alloy_consensus::{BlockHeader, Transaction};
 use alloy_evm::FromRecoveredTx;
 use alloy_network::{AnyNetwork, TransactionResponse};
@@ -182,12 +185,7 @@ impl RunArgs {
         evm_env.block_env.number = U256::from(tx_block_number);
 
         if let Some(block) = &block {
-            evm_env.block_env.timestamp = U256::from(block.header.timestamp());
-            evm_env.block_env.beneficiary = block.header.beneficiary();
-            evm_env.block_env.difficulty = block.header.difficulty();
-            evm_env.block_env.prevrandao = Some(block.header.mix_hash().unwrap_or_default());
-            evm_env.block_env.basefee = block.header.base_fee_per_gas().unwrap_or_default();
-            evm_env.block_env.gas_limit = block.header.gas_limit();
+            evm_env.block_env = block_env_from_header(&block.header);
 
             // TODO: we need a smarter way to map the block to the corresponding evm_version for
             // commonly used chains

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -1,6 +1,8 @@
 use crate::{
-    EvmEnv, constants::DEFAULT_CREATE2_DEPLOYER, fork::CreateFork,
-    utils::apply_chain_and_block_specific_env_changes,
+    EvmEnv,
+    constants::DEFAULT_CREATE2_DEPLOYER,
+    fork::CreateFork,
+    utils::{apply_chain_and_block_specific_env_changes, block_env_from_header},
 };
 use alloy_consensus::BlockHeader;
 use alloy_network::{AnyNetwork, BlockResponse, Network};
@@ -200,16 +202,7 @@ impl EvmOpts {
         let block_number = block.header().number();
         let mut evm_env = EvmEnv {
             cfg_env: self.cfg_env(chain_id),
-            block_env: BlockEnv {
-                number: U256::from(block_number),
-                timestamp: U256::from(block.header().timestamp()),
-                beneficiary: block.header().beneficiary(),
-                difficulty: block.header().difficulty(),
-                prevrandao: block.header().mix_hash(),
-                basefee: block.header().base_fee_per_gas().unwrap_or_default(),
-                gas_limit: block.header().gas_limit(),
-                ..Default::default()
-            },
+            block_env: block_env_from_header(block.header()),
         };
 
         apply_chain_and_block_specific_env_changes::<N>(&mut evm_env, &block, self.networks);

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -7,17 +7,34 @@ use alloy_primitives::{B256, ChainId, Selector, U256};
 use alloy_provider::{Network, network::BlockResponse};
 use foundry_config::NamedChain;
 use foundry_evm_networks::NetworkConfigs;
-use revm::primitives::{
-    eip4844::{BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE},
-    hardfork::SpecId,
-};
 pub use revm::state::EvmState as StateChangeset;
+use revm::{
+    context::BlockEnv,
+    primitives::{
+        eip4844::{BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE},
+        hardfork::SpecId,
+    },
+};
 
 /// Hints to the compiler that this is a cold path, i.e. unlikely to be taken.
 #[cold]
 #[inline(always)]
 pub fn cold_path() {
     // TODO: remove `#[cold]` and call `std::hint::cold_path` once stable.
+}
+
+/// Constructs a [`BlockEnv`] from a block header.
+pub fn block_env_from_header(header: &impl BlockHeader) -> BlockEnv {
+    BlockEnv {
+        number: U256::from(header.number()),
+        beneficiary: header.beneficiary(),
+        timestamp: U256::from(header.timestamp()),
+        difficulty: header.difficulty(),
+        prevrandao: header.mix_hash(),
+        basefee: header.base_fee_per_gas().unwrap_or_default(),
+        gas_limit: header.gas_limit(),
+        ..Default::default()
+    }
 }
 
 /// Depending on the configured chain id and block number this should apply any specific changes

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -1,8 +1,7 @@
 use crate::{bytecode::VerifyBytecodeArgs, types::VerificationType};
-use alloy_consensus::BlockHeader;
 use alloy_dyn_abi::DynSolValue;
 use alloy_evm::EvmEnv;
-use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_primitives::{Address, Bytes, TxKind};
 use alloy_provider::{
     Provider,
     network::{AnyNetwork, AnyRpcBlock},
@@ -19,8 +18,12 @@ use foundry_common::{abi::encode_args, compile::ProjectCompiler, ignore_metadata
 use foundry_compilers::artifacts::{BytecodeHash, CompactContractBytecode, EvmVersion};
 use foundry_config::Config;
 use foundry_evm::{
-    constants::DEFAULT_CREATE2_DEPLOYER, core::decode::RevertDecoder, executors::TracingExecutor,
-    opts::EvmOpts, traces::TraceMode, utils::apply_chain_and_block_specific_env_changes,
+    constants::DEFAULT_CREATE2_DEPLOYER,
+    core::decode::RevertDecoder,
+    executors::TracingExecutor,
+    opts::EvmOpts,
+    traces::TraceMode,
+    utils::{apply_chain_and_block_specific_env_changes, block_env_from_header},
 };
 use foundry_evm_networks::NetworkConfigs;
 use reqwest::Url;
@@ -287,12 +290,9 @@ pub async fn get_tracing_executor(
 }
 
 pub fn configure_env_block(evm_env: &mut EvmEnv, block: &AnyRpcBlock, config: NetworkConfigs) {
-    evm_env.block_env.timestamp = U256::from(block.header.timestamp());
-    evm_env.block_env.beneficiary = block.header.beneficiary();
-    evm_env.block_env.difficulty = block.header.difficulty();
-    evm_env.block_env.prevrandao = Some(block.header.mix_hash().unwrap_or_default());
-    evm_env.block_env.basefee = block.header.base_fee_per_gas().unwrap_or_default();
-    evm_env.block_env.gas_limit = block.header.gas_limit();
+    let number = evm_env.block_env.number;
+    evm_env.block_env = block_env_from_header(&block.header);
+    evm_env.block_env.number = number;
     apply_chain_and_block_specific_env_changes::<AnyNetwork>(evm_env, block, config);
 }
 


### PR DESCRIPTION
## Summary
- Extract `block_env_from_header` to `foundry-evm-core/src/utils.rs` — single source of truth for constructing `BlockEnv` from a block header
- Replace 6 duplicate call sites across `opts.rs`, `cast/run.rs`, `anvil/config.rs`, `anvil/mem/mod.rs`, and `verify/utils.rs`
- Remove anvil's local copy of the same function

cc: @stevencartavia (might step on your toes .-.)