### PR TITLE
refactor(script): extract `BrowserSigner` from `MultiWallet`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4854,7 +4854,6 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-evm",
  "alloy-json-abi",
- "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types",
  "alloy-sol-types",

--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -377,7 +377,7 @@ fn sign_with_wallet(
 
     let mut wallets = state.wallets().inner.lock();
     let maybe_provided_sender = wallets.provided_sender;
-    let (signers, _) = wallets.multi_wallet.signers()?;
+    let signers = wallets.multi_wallet.signers()?;
 
     let signer = if let Some(signer) = signer {
         signer

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -568,7 +568,7 @@ pub struct Cheatcodes<CTX: FoundryContextExt = Context<BlockEnv, TxEnv, CfgEnv>>
     /// Deprecated cheatcodes mapped to the reason. Used to report warnings on test results.
     pub deprecated: HashMap<&'static str, Option<&'static str>>,
     /// Unlocked wallets used in scripts and testing of scripts.
-    pub wallets: Option<Wallets<Ethereum>>,
+    pub wallets: Option<Wallets>,
     /// Signatures identifier for decoding events and functions
     signatures_identifier: OnceLock<Option<SignaturesIdentifier>>,
     /// Used to determine whether the broadcasted call has dynamic gas limit.
@@ -649,12 +649,12 @@ impl Cheatcodes {
     }
 
     /// Returns the configured wallets if available, else creates a new instance.
-    pub fn wallets(&mut self) -> &Wallets<Ethereum> {
+    pub fn wallets(&mut self) -> &Wallets {
         self.wallets.get_or_insert_with(|| Wallets::new(MultiWallet::default(), None))
     }
 
     /// Sets the unlocked wallets.
-    pub fn set_wallets(&mut self, wallets: Wallets<Ethereum>) {
+    pub fn set_wallets(&mut self, wallets: Wallets) {
         self.wallets = Some(wallets);
     }
 

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -2,7 +2,6 @@
 
 use crate::{Cheatcode, CheatsCtxt, Result, Vm::*, evm::journaled_account};
 use alloy_consensus::{SidecarBuilder, SimpleCoder};
-use alloy_network::Network;
 use alloy_primitives::{Address, B256, U256, Uint};
 use alloy_rpc_types::Authorization;
 use alloy_signer::SignerSync;
@@ -349,30 +348,30 @@ pub struct Broadcast {
 
 /// Contains context for wallet management.
 #[derive(Debug)]
-pub struct WalletsInner<N: Network> {
+pub struct WalletsInner {
     /// All signers in scope of the script.
-    pub multi_wallet: MultiWallet<N>,
+    pub multi_wallet: MultiWallet,
     /// Optional signer provided as `--sender` flag.
     pub provided_sender: Option<Address>,
 }
 
 /// Cloneable wrapper around [`WalletsInner`].
 #[derive(Debug, Clone)]
-pub struct Wallets<N: Network> {
+pub struct Wallets {
     /// Inner data.
-    pub inner: Arc<Mutex<WalletsInner<N>>>,
+    pub inner: Arc<Mutex<WalletsInner>>,
 }
 
-impl<N: Network> Wallets<N> {
+impl Wallets {
     #[expect(missing_docs)]
-    pub fn new(multi_wallet: MultiWallet<N>, provided_sender: Option<Address>) -> Self {
+    pub fn new(multi_wallet: MultiWallet, provided_sender: Option<Address>) -> Self {
         Self { inner: Arc::new(Mutex::new(WalletsInner { multi_wallet, provided_sender })) }
     }
 
     /// Consumes [Wallets] and returns [MultiWallet].
     ///
     /// Panics if [Wallets] is still in use.
-    pub fn into_multi_wallet(self) -> MultiWallet<N> {
+    pub fn into_multi_wallet(self) -> MultiWallet {
         Arc::into_inner(self.inner)
             .map(|m| m.into_inner().multi_wallet)
             .unwrap_or_else(|| panic!("not all instances were dropped"))
@@ -385,18 +384,13 @@ impl<N: Network> Wallets<N> {
 
     /// Locks inner Mutex and returns all signer addresses in the [MultiWallet].
     pub fn signers(&self) -> Result<Vec<Address>> {
-        let mut wallets = self.inner.lock();
-        let (signers, browser) = wallets.multi_wallet.signers()?;
-        Ok(signers.keys().copied().chain(browser.map(|b| b.address())).collect())
+        Ok(self.inner.lock().multi_wallet.signers()?.keys().copied().collect())
     }
 
     /// Number of signers in the [MultiWallet].
     pub fn len(&self) -> usize {
         let mut inner = self.inner.lock();
-        match inner.multi_wallet.signers() {
-            Ok((signers, browser)) => signers.len() + usize::from(browser.is_some()),
-            Err(_) => 0,
-        }
+        inner.multi_wallet.signers().map_or(0, |signers| signers.len())
     }
 
     /// Whether the [MultiWallet] is empty.
@@ -425,7 +419,7 @@ fn broadcast<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
         if let Some(provided_sender) = wallets.provided_sender {
             new_origin = Some(provided_sender);
         } else {
-            let (signers, _) = wallets.multi_wallet.signers()?;
+            let signers = wallets.multi_wallet.signers()?;
             if signers.len() == 1 {
                 let address = signers.keys().next().unwrap();
                 new_origin = Some(*address);

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -27,7 +27,6 @@ foundry-evm-traces.workspace = true
 alloy-dyn-abi = { workspace = true, features = ["arbitrary", "eip712"] }
 alloy-evm.workspace = true
 alloy-json-abi.workspace = true
-alloy-network.workspace = true
 alloy-primitives = { workspace = true, features = [
     "serde",
     "getrandom",

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -3,7 +3,6 @@ use super::{
     LogCollector, RevertDiagnostic, ScriptExecutionInspector, TracingInspector,
 };
 use alloy_evm::EvmEnv;
-use alloy_network::Ethereum;
 use alloy_primitives::{
     Address, B256, Bytes, Log, TxKind, U256,
     map::{AddressHashMap, HashMap},
@@ -82,7 +81,7 @@ pub struct InspectorStackBuilder {
     /// Networks with enabled features.
     pub networks: NetworkConfigs,
     /// The wallets to set in the cheatcodes context.
-    pub wallets: Option<Wallets<Ethereum>>,
+    pub wallets: Option<Wallets>,
     /// The CREATE2 deployer address.
     pub create2_deployer: Address,
 }
@@ -124,7 +123,7 @@ impl InspectorStackBuilder {
 
     /// Set the wallets.
     #[inline]
-    pub fn wallets(mut self, wallets: Wallets<Ethereum>) -> Self {
+    pub fn wallets(mut self, wallets: Wallets) -> Self {
         self.wallets = Some(wallets);
         self
     }

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -246,7 +246,8 @@ where
 {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets<N>,
+    pub script_wallets: Wallets,
+    pub browser_wallet: Option<BrowserSigner<N>>,
     pub build_data: LinkedBuildData,
     pub sequence: ScriptSequenceKind<N>,
 }
@@ -317,8 +318,13 @@ where
         let send_kind = if self.args.unlocked {
             SendTransactionsKind::Unlocked(required_addresses.clone())
         } else {
-            let signers: Vec<Address> =
-                self.script_wallets.signers().map_err(|e| eyre::eyre!("{e}"))?;
+            let signers: Vec<Address> = self
+                .script_wallets
+                .signers()
+                .map_err(|e| eyre::eyre!("{e}"))?
+                .into_iter()
+                .chain(self.browser_wallet.as_ref().map(|b| b.address()))
+                .collect();
             let mut missing_addresses = Vec::new();
 
             for addr in &required_addresses {
@@ -335,11 +341,11 @@ where
                 );
             }
 
-            let (signers, browser) = self.script_wallets.into_multi_wallet().into_signers()?;
+            let signers = self.script_wallets.into_multi_wallet().into_signers()?;
             let eth_wallets =
                 signers.into_iter().map(|(addr, signer)| (addr, signer.into())).collect();
 
-            SendTransactionsKind::Raw { eth_wallets, browser }
+            SendTransactionsKind::Raw { eth_wallets, browser: self.browser_wallet }
         };
 
         let progress = ScriptProgress::default();

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -20,6 +20,7 @@ use foundry_compilers::{
 };
 use foundry_evm::traces::debug::ContractSources;
 use foundry_linking::Linker;
+use foundry_wallets::wallet_browser::signer::BrowserSigner;
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 /// Container for the compiled contracts.
@@ -156,14 +157,15 @@ impl LinkedBuildData {
 pub struct PreprocessedState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets<Ethereum>,
+    pub script_wallets: Wallets,
+    pub browser_wallet: Option<BrowserSigner<Ethereum>>,
 }
 
 impl PreprocessedState {
     /// Parses user input and compiles the contracts depending on script target.
     /// After compilation, finds exact [ArtifactId] of the target contract.
     pub fn compile(self) -> Result<CompiledState> {
-        let Self { args, script_config, script_wallets } = self;
+        let Self { args, script_config, script_wallets, browser_wallet } = self;
         let project = script_config.config.project()?;
 
         let mut target_name = args.target_contract.clone();
@@ -232,6 +234,7 @@ impl PreprocessedState {
             args,
             script_config,
             script_wallets,
+            browser_wallet,
             build_data: BuildData { output, target, project_root: project.root().to_path_buf() },
         })
     }
@@ -241,18 +244,19 @@ impl PreprocessedState {
 pub struct CompiledState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets<Ethereum>,
+    pub script_wallets: Wallets,
+    pub browser_wallet: Option<BrowserSigner<Ethereum>>,
     pub build_data: BuildData,
 }
 
 impl CompiledState {
     /// Uses provided sender address to compute library addresses and link contracts with them.
     pub async fn link(self) -> Result<LinkedState> {
-        let Self { args, script_config, script_wallets, build_data } = self;
+        let Self { args, script_config, script_wallets, browser_wallet, build_data } = self;
 
         let build_data = build_data.link(&script_config).await?;
 
-        Ok(LinkedState { args, script_config, script_wallets, build_data })
+        Ok(LinkedState { args, script_config, script_wallets, browser_wallet, build_data })
     }
 
     /// Tries loading the resumed state from the cache files, skipping simulation stage.
@@ -285,35 +289,49 @@ impl CompiledState {
             }
         };
 
-        let (args, build_data, script_wallets, script_config) = if !self.args.unlocked {
-            let mut froms = sequence.sequences().iter().flat_map(|s| {
-                s.transactions
-                    .iter()
-                    .skip(s.receipts.len())
-                    .map(|t| t.transaction.from().expect("from is missing in script artifact"))
-            });
+        let (args, build_data, script_wallets, browser_wallet, script_config) =
+            if !self.args.unlocked {
+                let mut froms = sequence.sequences().iter().flat_map(|s| {
+                    s.transactions
+                        .iter()
+                        .skip(s.receipts.len())
+                        .map(|t| t.transaction.from().expect("from is missing in script artifact"))
+                });
 
-            let available_signers = self
-                .script_wallets
-                .signers()
-                .map_err(|e| eyre::eyre!("Failed to get available signers: {}", e))?;
+                let available_signers = self
+                    .script_wallets
+                    .signers()
+                    .map_err(|e| eyre::eyre!("Failed to get available signers: {}", e))?;
 
-            if !froms.all(|from| available_signers.contains(&from)) {
-                // IF we are missing required signers, execute script as we might need to collect
-                // private keys from the execution.
-                let executed = self.link().await?.prepare_execution().await?.execute().await?;
-                (
-                    executed.args,
-                    executed.build_data.build_data,
-                    executed.script_wallets,
-                    executed.script_config,
-                )
+                if !froms.all(|from| available_signers.contains(&from)) {
+                    // IF we are missing required signers, execute script as we might need to
+                    // collect private keys from the execution.
+                    let executed = self.link().await?.prepare_execution().await?.execute().await?;
+                    (
+                        executed.args,
+                        executed.build_data.build_data,
+                        executed.script_wallets,
+                        executed.browser_wallet,
+                        executed.script_config,
+                    )
+                } else {
+                    (
+                        self.args,
+                        self.build_data,
+                        self.script_wallets,
+                        self.browser_wallet,
+                        self.script_config,
+                    )
+                }
             } else {
-                (self.args, self.build_data, self.script_wallets, self.script_config)
-            }
-        } else {
-            (self.args, self.build_data, self.script_wallets, self.script_config)
-        };
+                (
+                    self.args,
+                    self.build_data,
+                    self.script_wallets,
+                    self.browser_wallet,
+                    self.script_config,
+                )
+            };
 
         // Collect libraries from sequence and link contracts with them.
         let libraries = match sequence {
@@ -328,6 +346,7 @@ impl CompiledState {
             args,
             script_config,
             script_wallets,
+            browser_wallet,
             build_data: linked_build_data,
             sequence,
         })

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -32,6 +32,7 @@ use foundry_evm::{
         render_trace_arena,
     },
 };
+use foundry_wallets::wallet_browser::signer::BrowserSigner;
 use futures::future::join_all;
 use itertools::Itertools;
 use std::path::Path;
@@ -42,7 +43,8 @@ use yansi::Paint;
 pub struct LinkedState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets<Ethereum>,
+    pub script_wallets: Wallets,
+    pub browser_wallet: Option<BrowserSigner<Ethereum>>,
     pub build_data: LinkedBuildData,
 }
 
@@ -63,7 +65,7 @@ impl LinkedState {
     /// Given linked and compiled artifacts, prepares data we need for execution.
     /// This includes the function to call and the calldata to pass to it.
     pub async fn prepare_execution(self) -> Result<PreExecutionState> {
-        let Self { args, script_config, script_wallets, build_data } = self;
+        let Self { args, script_config, script_wallets, browser_wallet, build_data } = self;
 
         let target_contract = build_data.get_target_contract()?;
 
@@ -77,6 +79,7 @@ impl LinkedState {
             args,
             script_config,
             script_wallets,
+            browser_wallet,
             execution_data: ExecutionData {
                 func,
                 calldata,
@@ -93,7 +96,8 @@ impl LinkedState {
 pub struct PreExecutionState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets<Ethereum>,
+    pub script_wallets: Wallets,
+    pub browser_wallet: Option<BrowserSigner<Ethereum>>,
     pub build_data: LinkedBuildData,
     pub execution_data: ExecutionData,
 }
@@ -123,6 +127,7 @@ impl PreExecutionState {
                 args: self.args,
                 script_config: self.script_config,
                 script_wallets: self.script_wallets,
+                browser_wallet: self.browser_wallet,
                 build_data: self.build_data.build_data,
             };
 
@@ -133,6 +138,7 @@ impl PreExecutionState {
             args: self.args,
             script_config: self.script_config,
             script_wallets: self.script_wallets,
+            browser_wallet: self.browser_wallet,
             build_data: self.build_data,
             execution_data: self.execution_data,
             execution_result: result,
@@ -275,7 +281,8 @@ pub struct ExecutionArtifacts {
 pub struct ExecutedState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets<Ethereum>,
+    pub script_wallets: Wallets,
+    pub browser_wallet: Option<BrowserSigner<Ethereum>>,
     pub build_data: LinkedBuildData,
     pub execution_data: ExecutionData,
     pub execution_result: ScriptResult,
@@ -314,6 +321,7 @@ impl ExecutedState {
             args: self.args,
             script_config: self.script_config,
             script_wallets: self.script_wallets,
+            browser_wallet: self.browser_wallet,
             build_data: self.build_data,
             execution_data: self.execution_data,
             execution_result: self.execution_result,

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -229,25 +229,28 @@ pub struct ScriptArgs {
 impl ScriptArgs {
     pub async fn preprocess(self) -> Result<PreprocessedState> {
         let script_wallets = Wallets::new(self.wallets.get_multi_wallet().await?, self.evm.sender);
+        let browser_wallet = self.wallets.browser_signer::<Ethereum>().await?;
 
         let (config, mut evm_opts) = self.load_config_and_evm_opts()?;
 
         if let Some(sender) = self.maybe_load_private_key()? {
             evm_opts.sender = sender;
         } else if self.evm.sender.is_none() {
-            // If no sender was explicitly set via --sender and there's exactly one signer
-            // (e.g. from --account or --keystore), use that signer's address as the sender.
-            // This makes --account behave consistently with --private-key.
+            // If no sender was explicitly set via --sender, auto-detect it from available signers:
+            // use the sole signer's address if there's exactly one, or fall back to the browser
+            // wallet address if present.
             if let Ok(signers) = script_wallets.signers()
                 && signers.len() == 1
             {
                 evm_opts.sender = signers[0];
+            } else if let Some(signer) = browser_wallet.as_ref().map(|b| b.address()) {
+                evm_opts.sender = signer
             }
         }
 
         let script_config = ScriptConfig::new(config, evm_opts).await?;
 
-        Ok(PreprocessedState { args: self, script_config, script_wallets })
+        Ok(PreprocessedState { args: self, script_config, script_wallets, browser_wallet })
     }
 
     /// Executes the script
@@ -624,7 +627,7 @@ impl ScriptConfig {
     async fn get_runner_with_cheatcodes(
         &mut self,
         known_contracts: ContractsByArtifact,
-        script_wallets: Wallets<Ethereum>,
+        script_wallets: Wallets,
         debug: bool,
         target: ArtifactId,
     ) -> Result<ScriptRunner> {
@@ -633,7 +636,7 @@ impl ScriptConfig {
 
     async fn _get_runner(
         &mut self,
-        cheats_data: Option<(ContractsByArtifact, Wallets<Ethereum>, ArtifactId)>,
+        cheats_data: Option<(ContractsByArtifact, Wallets, ArtifactId)>,
         debug: bool,
     ) -> Result<ScriptRunner> {
         trace!("preparing script runner");

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -20,6 +20,7 @@ use foundry_cli::utils::{has_different_gas_calc, now};
 use foundry_common::{ContractData, shell};
 use foundry_evm::traces::{decode_trace_arena, render_trace_arena};
 use foundry_primitives::FoundryTransactionBuilder;
+use foundry_wallets::wallet_browser::signer::BrowserSigner;
 use futures::future::{join_all, try_join_all};
 use parking_lot::RwLock;
 use std::{
@@ -36,7 +37,8 @@ use std::{
 pub struct PreSimulationState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets<Ethereum>,
+    pub script_wallets: Wallets,
+    pub browser_wallet: Option<BrowserSigner<Ethereum>>,
     pub build_data: LinkedBuildData,
     pub execution_data: ExecutionData,
     pub execution_result: ScriptResult,
@@ -90,6 +92,7 @@ impl PreSimulationState {
             args: self.args,
             script_config: self.script_config,
             script_wallets: self.script_wallets,
+            browser_wallet: self.browser_wallet,
             build_data: self.build_data,
             execution_artifacts: self.execution_artifacts,
             transactions,
@@ -256,7 +259,8 @@ impl PreSimulationState {
 pub struct FilledTransactionsState {
     pub args: ScriptArgs,
     pub script_config: ScriptConfig,
-    pub script_wallets: Wallets<Ethereum>,
+    pub script_wallets: Wallets,
+    pub browser_wallet: Option<BrowserSigner<Ethereum>>,
     pub build_data: LinkedBuildData,
     pub execution_artifacts: ExecutionArtifacts,
     pub transactions: VecDeque<TransactionWithMetadata<Ethereum>>,
@@ -418,6 +422,7 @@ impl FilledTransactionsState {
             args: self.args,
             script_config: self.script_config,
             script_wallets: self.script_wallets,
+            browser_wallet: self.browser_wallet,
             build_data: self.build_data,
             sequence,
         })

--- a/crates/wallets/src/wallet_multi/mod.rs
+++ b/crates/wallets/src/wallet_multi/mod.rs
@@ -15,35 +15,19 @@ use serde::Serialize;
 use std::path::PathBuf;
 
 /// Container for multiple wallets.
-#[derive(Debug)]
-pub struct MultiWallet<N: Network> {
+#[derive(Debug, Default)]
+pub struct MultiWallet {
     /// Vector of wallets that require an action to be unlocked.
     /// Those are lazily unlocked on the first access of the signers.
     pending_signers: Vec<PendingSigner>,
     /// Contains unlocked signers.
     signers: AddressHashMap<WalletSigner>,
-    /// Browser signer
-    browser: Option<BrowserSigner<N>>,
 }
 
-impl<N: Network> Default for MultiWallet<N> {
-    fn default() -> Self {
-        Self {
-            pending_signers: Default::default(),
-            signers: Default::default(),
-            browser: Default::default(),
-        }
-    }
-}
-
-impl<N: Network> MultiWallet<N> {
-    pub fn new(
-        pending_signers: Vec<PendingSigner>,
-        signers: Vec<WalletSigner>,
-        browser: Option<BrowserSigner<N>>,
-    ) -> Self {
+impl MultiWallet {
+    pub fn new(pending_signers: Vec<PendingSigner>, signers: Vec<WalletSigner>) -> Self {
         let signers = signers.into_iter().map(|signer| (signer.address(), signer)).collect();
-        Self { pending_signers, signers, browser }
+        Self { pending_signers, signers }
     }
 
     fn maybe_unlock_pending(&mut self) -> Result<()> {
@@ -54,18 +38,14 @@ impl<N: Network> MultiWallet<N> {
         Ok(())
     }
 
-    pub fn signers(
-        &mut self,
-    ) -> Result<(&AddressHashMap<WalletSigner>, Option<&BrowserSigner<N>>)> {
+    pub fn signers(&mut self) -> Result<&AddressHashMap<WalletSigner>> {
         self.maybe_unlock_pending()?;
-        Ok((&self.signers, self.browser.as_ref()))
+        Ok(&self.signers)
     }
 
-    pub fn into_signers(
-        mut self,
-    ) -> Result<(AddressHashMap<WalletSigner>, Option<BrowserSigner<N>>)> {
+    pub fn into_signers(mut self) -> Result<AddressHashMap<WalletSigner>> {
         self.maybe_unlock_pending()?;
-        Ok((self.signers, self.browser))
+        Ok(self.signers)
     }
 
     pub fn add_signer(&mut self, signer: WalletSigner) {
@@ -260,10 +240,9 @@ pub struct MultiWalletOpts {
 
 impl MultiWalletOpts {
     /// Returns [MultiWallet] container configured with provided options.
-    pub async fn get_multi_wallet<N: Network>(&self) -> Result<MultiWallet<N>> {
+    pub async fn get_multi_wallet(&self) -> Result<MultiWallet> {
         let mut pending = Vec::new();
         let mut signers: Vec<WalletSigner> = Vec::new();
-        let browser = self.browser_signer().await?;
 
         if let Some(ledgers) = self.ledgers().await? {
             signers.extend(ledgers);
@@ -300,7 +279,7 @@ impl MultiWalletOpts {
             ));
         }
 
-        Ok(MultiWallet::new(pending, signers, browser))
+        Ok(MultiWallet::new(pending, signers))
     }
 
     pub fn private_keys(&self) -> Result<Option<Vec<WalletSigner>>> {


### PR DESCRIPTION
## Motivation

- Avoid leaking `Network` generic to `foundry-cheatcodes` through `Wallets`.
- Thread `browser_wallet` through the script state machine so it is available during broadcast.
