### PR TITLE
chore(evm): clean-up `FoundryEvm` impl

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -182,7 +182,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
             let (sub_evm_env, sub_tx) = evm.to_env();
-            let sub_inner = evm.into_context().journaled_state.inner;
+            let sub_inner = evm.journaled_state.inner.clone();
             Ok(((), sub_evm_env, sub_tx, sub_inner))
         })
     }

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -110,32 +110,6 @@ pub struct FoundryEvm<'db, I: EthInspectorExt> {
         EthFrame<EthInterpreter>,
     >,
 }
-impl<'db, I: EthInspectorExt> FoundryEvm<'db, I> {
-    /// Consumes the EVM and returns the inner context.
-    pub fn into_context(self) -> EthEvmContext<&'db mut dyn DatabaseExt> {
-        self.inner.ctx
-    }
-
-    pub fn run_execution(
-        &mut self,
-        frame: FrameInput,
-    ) -> Result<FrameResult, EVMError<DatabaseError>> {
-        let mut handler = FoundryHandler::<I>::default();
-
-        // Create first frame
-        let memory =
-            SharedMemory::new_with_buffer(self.inner.ctx().local().shared_memory_buffer().clone());
-        let first_frame_input = FrameInit { depth: 0, memory, frame_input: frame };
-
-        // Run execution loop
-        let mut frame_result = handler.inspect_run_exec_loop(&mut self.inner, first_frame_input)?;
-
-        // Handle last frame result
-        handler.last_frame_result(&mut self.inner, &mut frame_result)?;
-
-        Ok(frame_result)
-    }
-}
 
 impl<'db, I: EthInspectorExt> Evm for FoundryEvm<'db, I> {
     type Precompiles = PrecompilesMap;
@@ -274,7 +248,20 @@ impl<I: EthInspectorExt> NestedEvm for FoundryEvm<'_, I> {
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
-        FoundryEvm::run_execution(self, frame)
+        let mut handler = FoundryHandler::<I>::default();
+
+        // Create first frame
+        let memory =
+            SharedMemory::new_with_buffer(self.inner.ctx().local().shared_memory_buffer().clone());
+        let first_frame_input = FrameInit { depth: 0, memory, frame_input: frame };
+
+        // Run execution loop
+        let mut frame_result = handler.inspect_run_exec_loop(&mut self.inner, first_frame_input)?;
+
+        // Handle last frame result
+        handler.last_frame_result(&mut self.inner, &mut frame_result)?;
+
+        Ok(frame_result)
     }
 
     fn transact(

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -378,7 +378,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for InspectorStackInner {
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
             let (sub_evm_env, sub_tx) = evm.to_env();
-            let sub_inner = evm.into_context().journaled_state.inner;
+            let sub_inner = evm.journaled_state.inner.clone();
             Ok(((), sub_evm_env, sub_tx, sub_inner))
         })
     }


### PR DESCRIPTION
## Motivation

Before starting to craft a Foundry `Evm` supertrait, let's simplify/clean-up existing impls.

- Remove consuming `FoundryEvm::into_context` method
- Move `FoundryEvm::run_execution` impl directly to `NestedEvm::run_execution` trait method impl

No more `impl FoundryEvm`.