### PR TITLE
refactor(cheatcodes): `BroadcastableTransaction` network-agnostic

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -2,20 +2,23 @@
 
 use crate::{
     BroadcastableTransaction, Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Error,
-    EthCheatCtx, Result, Vm::*, inspector::RecordDebugStepInfo,
+    EthCheatCtx, Result,
+    Vm::*,
+    inspector::{BroadcastKind, RecordDebugStepInfo},
 };
-use alloy_consensus::TxEnvelope;
+use alloy_consensus::{
+    Transaction as TransactionTrait, TxEnvelope, transaction::SignerRecoverable,
+};
 use alloy_evm::{EvmEnv, FromRecoveredTx};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_network::eip2718::EIP4844_TX_TYPE_ID;
 use alloy_primitives::{
-    Address, B256, U256, hex, keccak256,
+    Address, B256, Bytes, U256, hex, keccak256,
     map::{B256Map, HashMap},
 };
 use alloy_rlp::Decodable;
 use alloy_sol_types::SolValue;
 use foundry_common::{
-    TransactionMaybeSigned,
     fs::{read_json_file, write_json_file},
     slot_identifier::{
         ENCODING_BYTES, ENCODING_DYN_ARRAY, ENCODING_INPLACE, ENCODING_MAPPING, SlotIdentifier,
@@ -1124,9 +1127,16 @@ impl Cheatcode for broadcastRawTransactionCall {
         executor.transact_from_tx_on_db(ccx.state, ccx.ecx, &tx.clone().into())?;
 
         if ccx.state.broadcast.is_some() {
+            let from = tx.recover_signer()?;
             ccx.state.broadcastable_transactions.push_back(BroadcastableTransaction {
                 rpc: ccx.ecx.db().active_fork_url(),
-                transaction: TransactionMaybeSigned::new_signed(tx)?,
+                from,
+                to: Some(tx.kind()),
+                value: tx.value(),
+                input: tx.input().clone(),
+                nonce: tx.nonce(),
+                gas: Some(tx.gas_limit()),
+                kind: BroadcastKind::Signed(Bytes::copy_from_slice(&self.data)),
             });
         }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -21,18 +21,14 @@ use crate::{
     utils::IgnoredTraces,
 };
 use alloy_consensus::BlobTransactionSidecarVariant;
-use alloy_network::{Ethereum, Network};
 use alloy_primitives::{
     Address, B256, Bytes, Log, TxKind, U256, hex,
     map::{AddressHashMap, HashMap, HashSet},
 };
-use alloy_rpc_types::{
-    AccessList,
-    request::{TransactionInput, TransactionRequest},
-};
+use alloy_rpc_types::{AccessList, TransactionRequest};
 use alloy_sol_types::{SolCall, SolInterface, SolValue};
 use foundry_common::{
-    SELECTOR_LEN, TransactionMaybeSigned,
+    SELECTOR_LEN,
     mapping_slots::{MappingSlots, step as mapping_step},
 };
 use foundry_evm_core::{
@@ -46,7 +42,6 @@ use foundry_evm_core::{
 use foundry_evm_traces::{
     TracingInspector, TracingInspectorConfig, identifier::SignaturesIdentifier,
 };
-use foundry_primitives::FoundryTransactionBuilder;
 use foundry_wallets::wallet_multi::MultiWallet;
 use itertools::Itertools;
 use proptest::test_runner::{RngAlgorithm, TestRng, TestRunner};
@@ -257,12 +252,49 @@ impl TestContext {
 }
 
 /// Helps collecting transactions from different forks.
+///
+/// This type is intentionally network-agnostic — it stores raw EVM data (from, to, value, input,
+/// etc.) without requiring a `Network` type parameter. Conversion to network-specific types
+/// (e.g. `TransactionRequest`, `TxEnvelope`) happens later in the script layer.
 #[derive(Clone, Debug)]
-pub struct BroadcastableTransaction<N: Network = Ethereum> {
+pub struct BroadcastableTransaction {
     /// The optional RPC URL.
     pub rpc: Option<String>,
-    /// The transaction to broadcast.
-    pub transaction: TransactionMaybeSigned<N>,
+    /// Sender address.
+    pub from: Address,
+    /// Recipient (None for contract creation).
+    pub to: Option<TxKind>,
+    /// Ether value.
+    pub value: U256,
+    /// Calldata or init code.
+    pub input: Bytes,
+    /// Sender nonce.
+    pub nonce: u64,
+    /// Gas limit, if explicitly set.
+    pub gas: Option<u64>,
+    /// Whether this transaction was pre-signed or needs signing.
+    pub kind: BroadcastKind,
+}
+
+/// Distinguishes between unsigned transactions (from `startBroadcast`) that need signing, and
+/// pre-signed transactions (from `broadcastRawTransaction`) that carry raw RLP-encoded bytes.
+#[derive(Clone, Debug)]
+pub enum BroadcastKind {
+    /// Unsigned transaction collected during `startBroadcast`. Needs signing before broadcast.
+    Unsigned {
+        chain_id: Option<u64>,
+        blob_sidecar: Option<BlobTransactionSidecarVariant>,
+        authorization_list: Option<Vec<SignedAuthorization>>,
+    },
+    /// Pre-signed transaction from `broadcastRawTransaction`. Contains raw RLP-encoded bytes.
+    Signed(Bytes),
+}
+
+impl BroadcastKind {
+    /// Creates an unsigned broadcast with no chain-specific fields set.
+    pub fn unsigned() -> Self {
+        Self::Unsigned { chain_id: None, blob_sidecar: None, authorization_list: None }
+    }
 }
 
 #[derive(Clone, Debug, Copy)]
@@ -973,45 +1005,36 @@ impl Cheatcodes {
                         });
                     }
 
-                    let input = TransactionInput::new(call.input.bytes(ecx));
+                    let input = call.input.bytes(ecx);
                     let chain_id = ecx.cfg().chain_id();
                     let rpc = ecx.db().active_fork_url();
                     let account =
                         ecx.journal_mut().evm_state_mut().get_mut(&broadcast.new_origin).unwrap();
 
-                    let mut tx_req = TransactionRequest {
-                        from: Some(broadcast.new_origin),
-                        to: Some(TxKind::from(Some(call.target_address))),
-                        value: call.transfer_value(),
-                        input,
-                        nonce: Some(account.info.nonce),
-                        chain_id: Some(chain_id),
-                        gas: if is_fixed_gas_limit { Some(call.gas_limit) } else { None },
-                        ..Default::default()
-                    };
-
+                    let blob_sidecar = self.active_blob_sidecar.take();
                     let active_delegations = std::mem::take(&mut self.active_delegations);
-                    // Set active blob sidecar, if any.
-                    if let Some(blob_sidecar) = self.active_blob_sidecar.take() {
-                        // Ensure blob and delegation are not set for the same tx.
-                        if !active_delegations.is_empty() {
-                            let msg = "both delegation and blob are active; `attachBlob` and `attachDelegation` are not compatible";
-                            return Some(CallOutcome {
-                                result: InterpreterResult {
-                                    result: InstructionResult::Revert,
-                                    output: Error::encode(msg),
-                                    gas,
-                                },
-                                memory_offset: call.return_memory_offset.clone(),
-                                was_precompile_called: false,
-                                precompile_call_logs: vec![],
-                            });
-                        }
-                        tx_req.set_blob_sidecar(blob_sidecar);
+
+                    // Ensure blob and delegation are not set for the same tx.
+                    if blob_sidecar.is_some() && !active_delegations.is_empty() {
+                        let msg = "both delegation and blob are active; `attachBlob` and `attachDelegation` are not compatible";
+                        return Some(CallOutcome {
+                            result: InterpreterResult {
+                                result: InstructionResult::Revert,
+                                output: Error::encode(msg),
+                                gas,
+                            },
+                            memory_offset: call.return_memory_offset.clone(),
+                            was_precompile_called: false,
+                            precompile_call_logs: vec![],
+                        });
                     }
 
+                    // Capture nonce before delegation bump (delegations increment the
+                    // account nonce but the transaction itself uses the pre-bump nonce).
+                    let nonce = account.info.nonce;
+
                     // Apply active EIP-7702 delegations, if any.
-                    if !active_delegations.is_empty() {
+                    let authorization_list = if !active_delegations.is_empty() {
                         for auth in &active_delegations {
                             let Ok(authority) = auth.recover_authority() else {
                                 continue;
@@ -1022,12 +1045,24 @@ impl Cheatcodes {
                                 account.info.nonce += 1;
                             }
                         }
-                        tx_req.authorization_list = Some(active_delegations);
-                    }
+                        Some(active_delegations)
+                    } else {
+                        None
+                    };
 
                     self.broadcastable_transactions.push_back(BroadcastableTransaction {
                         rpc,
-                        transaction: TransactionMaybeSigned::new(tx_req),
+                        from: broadcast.new_origin,
+                        to: Some(TxKind::from(Some(call.target_address))),
+                        value: call.transfer_value().unwrap_or_default(),
+                        input,
+                        nonce,
+                        gas: if is_fixed_gas_limit { Some(call.gas_limit) } else { None },
+                        kind: BroadcastKind::Unsigned {
+                            chain_id: Some(chain_id),
+                            blob_sidecar,
+                            authorization_list,
+                        },
                     });
                     debug!(target: "cheatcodes", tx=?self.broadcastable_transactions.back().unwrap(), "broadcastable call");
 
@@ -1772,14 +1807,13 @@ impl<CTX: EthCheatCtx> Inspector<CTX> for Cheatcodes {
                 let account = &ecx.journal().evm_state()[&broadcast.new_origin];
                 self.broadcastable_transactions.push_back(BroadcastableTransaction {
                     rpc,
-                    transaction: TransactionMaybeSigned::new(TransactionRequest {
-                        from: Some(broadcast.new_origin),
-                        to: None,
-                        value: Some(input.value()),
-                        input: TransactionInput::new(input.init_code()),
-                        nonce: Some(account.info.nonce),
-                        ..Default::default()
-                    }),
+                    from: broadcast.new_origin,
+                    to: None,
+                    value: input.value(),
+                    input: input.init_code(),
+                    nonce: account.info.nonce,
+                    gas: None,
+                    kind: BroadcastKind::unsigned(),
                 });
 
                 input.log_debug(self, &input.scheme().unwrap_or(CreateScheme::Create));

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -24,7 +24,8 @@ pub use config::CheatsConfig;
 pub use error::{Error, ErrorKind, Result};
 pub use foundry_evm_core::{EthCheatCtx, evm::EthNestedEvmClosure};
 pub use inspector::{
-    BroadcastableTransaction, BroadcastableTransactions, Cheatcodes, CheatcodesExecutor,
+    BroadcastKind, BroadcastableTransaction, BroadcastableTransactions, Cheatcodes,
+    CheatcodesExecutor,
 };
 pub use spec::{CheatcodeDef, Vm};
 

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -12,7 +12,6 @@ use alloy_primitives::{
     map::{HashMap, HashSet},
 };
 use alloy_provider::Provider;
-use alloy_rpc_types::TransactionInput;
 use eyre::{OptionExt, Result};
 use foundry_cheatcodes::Wallets;
 use foundry_cli::utils::{ensure_clean_constructor, needs_setup};
@@ -196,8 +195,8 @@ impl PreExecutionState {
                 && self.args.evm.sender.is_none()
             {
                 for tx in txs {
-                    if tx.transaction.to().is_none() {
-                        let sender = tx.transaction.from().expect("no sender");
+                    if tx.to.is_none() {
+                        let sender = tx.from;
                         if let Some(ns) = new_sender {
                             if sender != ns {
                                 sh_warn!(
@@ -295,16 +294,7 @@ impl ExecutedState {
 
         let decoder = self.build_trace_decoder(&self.build_data.known_contracts).await?;
 
-        let mut txs = self.execution_result.transactions.clone().unwrap_or_default();
-
-        // Ensure that unsigned transactions have both `data` and `input` populated to avoid
-        // issues with eth_estimateGas and eth_sendTransaction requests.
-        for tx in &mut txs {
-            if let Some(req) = tx.transaction.as_unsigned_mut() {
-                req.input =
-                    TransactionInput::maybe_both(std::mem::take(&mut req.input).into_input());
-            }
-        }
+        let txs = self.execution_result.transactions.clone().unwrap_or_default();
         let rpc_data = RpcData::from_transactions(&txs);
 
         if rpc_data.is_multi_chain() {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -458,12 +458,7 @@ impl ScriptArgs {
         };
 
         for (data, to) in result.transactions.iter().flat_map(|txes| {
-            txes.iter().filter_map(|tx| {
-                tx.transaction
-                    .input()
-                    .filter(|data| data.len() > max_size)
-                    .map(|data| (data, tx.transaction.to()))
-            })
+            txes.iter().filter_map(|tx| (tx.input.len() > max_size).then_some((&tx.input, tx.to)))
         }) {
             let mut offset = 0;
 

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -2,10 +2,8 @@ use super::{ScriptConfig, ScriptResult};
 use crate::build::ScriptPredeployLibraries;
 use alloy_eips::eip7702::SignedAuthorization;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
-use alloy_rpc_types::TransactionRequest;
 use eyre::Result;
-use foundry_cheatcodes::BroadcastableTransaction;
-use foundry_common::TransactionMaybeSigned;
+use foundry_cheatcodes::{BroadcastKind, BroadcastableTransaction};
 use foundry_config::Config;
 use foundry_evm::{
     constants::CALLER,
@@ -74,12 +72,13 @@ impl ScriptRunner {
 
                 library_transactions.push_back(BroadcastableTransaction {
                     rpc: self.evm_opts.fork_url.clone(),
-                    transaction: TransactionMaybeSigned::new(TransactionRequest {
-                        from: Some(self.evm_opts.sender),
-                        input: code.clone().into(),
-                        nonce: Some(sender_nonce + library_transactions.len() as u64),
-                        ..Default::default()
-                    }),
+                    from: self.evm_opts.sender,
+                    to: None,
+                    value: U256::ZERO,
+                    input: code.clone(),
+                    nonce: sender_nonce + library_transactions.len() as u64,
+                    gas: None,
+                    kind: BroadcastKind::unsigned(),
                 })
             }),
             ScriptPredeployLibraries::Create2(libraries, salt) => {
@@ -107,13 +106,17 @@ impl ScriptRunner {
 
                     library_transactions.push_back(BroadcastableTransaction {
                         rpc: self.evm_opts.fork_url.clone(),
-                        transaction: TransactionMaybeSigned::new(TransactionRequest {
-                            from: Some(self.evm_opts.sender),
-                            input: calldata.into(),
-                            nonce: Some(sender_nonce + library_transactions.len() as u64),
-                            to: Some(TxKind::Call(create2_deployer)),
-                            ..Default::default()
-                        }),
+                        from: self.evm_opts.sender,
+                        to: Some(TxKind::Call(create2_deployer)),
+                        value: U256::ZERO,
+                        input: calldata.into(),
+                        nonce: sender_nonce + library_transactions.len() as u64,
+                        gas: None,
+                        kind: BroadcastKind::Unsigned {
+                            chain_id: None,
+                            blob_sidecar: None,
+                            authorization_list: None,
+                        },
                     });
                 }
 

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -10,14 +10,16 @@ use crate::{
     sequence::get_commit_hash,
 };
 use alloy_chains::NamedChain;
-use alloy_network::{Ethereum, Network, TransactionBuilder};
+use alloy_consensus::TxEnvelope;
+use alloy_network::{Ethereum, Network, TransactionBuilder, eip2718::Decodable2718};
 use alloy_primitives::{Address, TxKind, U256, map::HashMap, utils::format_units};
+use alloy_rpc_types::request::{TransactionInput, TransactionRequest};
 use dialoguer::Confirm;
 use eyre::{Context, Result};
 use forge_script_sequence::{ScriptSequence, TransactionWithMetadata};
-use foundry_cheatcodes::Wallets;
+use foundry_cheatcodes::{BroadcastKind, BroadcastableTransaction, Wallets};
 use foundry_cli::utils::{has_different_gas_calc, now};
-use foundry_common::{ContractData, shell};
+use foundry_common::{ContractData, TransactionMaybeSigned, shell};
 use foundry_evm::traces::{decode_trace_arena, render_trace_arena};
 use foundry_primitives::FoundryTransactionBuilder;
 use foundry_wallets::wallet_browser::signer::BrowserSigner;
@@ -61,12 +63,13 @@ impl PreSimulationState {
             .unwrap_or_default()
             .into_iter()
             .map(|tx| {
-                let rpc = tx.rpc.expect("missing broadcastable tx rpc url");
-                let sender = tx.transaction.from().expect("all transactions should have a sender");
-                let nonce = tx.transaction.nonce().expect("all transactions should have a nonce");
-                let to = tx.transaction.to();
+                let rpc = tx.rpc.clone().expect("missing broadcastable tx rpc url");
+                let sender = tx.from;
+                let nonce = tx.nonce;
+                let to = tx.to;
 
-                let mut builder = ScriptTransactionBuilder::new(tx.transaction, rpc);
+                let maybe_signed = into_maybe_signed(tx);
+                let mut builder = ScriptTransactionBuilder::new(maybe_signed, rpc);
 
                 if let Some(TxKind::Call(_)) = to {
                     builder.set_call(
@@ -474,5 +477,36 @@ impl FilledTransactionsState {
             commit,
         };
         Ok(sequence)
+    }
+}
+
+/// Converts a network-agnostic [`BroadcastableTransaction`] into a
+/// [`TransactionMaybeSigned<Ethereum>`] for use in the script pipeline.
+fn into_maybe_signed(tx: BroadcastableTransaction) -> TransactionMaybeSigned<Ethereum> {
+    match tx.kind {
+        BroadcastKind::Unsigned { chain_id, blob_sidecar, authorization_list } => {
+            let mut req = TransactionRequest {
+                from: Some(tx.from),
+                to: tx.to,
+                value: Some(tx.value),
+                input: TransactionInput::maybe_both(Some(tx.input)),
+                nonce: Some(tx.nonce),
+                chain_id,
+                gas: tx.gas,
+                ..Default::default()
+            };
+            if let Some(sidecar) = blob_sidecar {
+                req.set_blob_sidecar(sidecar);
+            }
+            if let Some(auths) = authorization_list {
+                req.authorization_list = Some(auths);
+            }
+            TransactionMaybeSigned::Unsigned(req)
+        }
+        BroadcastKind::Signed(raw) => {
+            let envelope = TxEnvelope::decode_2718(&mut raw.as_ref())
+                .expect("failed to decode pre-signed transaction");
+            TransactionMaybeSigned::Signed { tx: envelope, from: tx.from }
+        }
     }
 }


### PR DESCRIPTION
Remove the `Network` type parameter from `BroadcastableTransaction` by storing raw EVM data (from, to, value, input, nonce, gas) as primitive fields instead of wrapping `TransactionMaybeSigned<N>`.

This prevents the `Network` generic from leaking through `Cheatcodes`, `RawCallResult`, and `ScriptResult`. The conversion to network-specific types (`TransactionMaybeSigned<Ethereum>`) now happens in the script layer (`simulate.rs`) at the point where transactions are handed off to `ScriptTransactionBuilder`.

This will need a follow-up to take care of making this `into_maybe_signed()` generic.
