### PR TITLE
refactor(anvil): make `PendingTransaction` generic over tx type

### DIFF
--- a/crates/anvil/core/src/eth/block.rs
+++ b/crates/anvil/core/src/eth/block.rs
@@ -4,13 +4,13 @@ use alloy_consensus::{
 };
 use alloy_eips::eip2718::Encodable2718;
 use alloy_network::Network;
-use foundry_primitives::FoundryNetwork;
+use foundry_primitives::{FoundryNetwork, FoundryTxEnvelope};
 use std::fmt::Debug;
 
 use crate::eth::transaction::MaybeImpersonatedTransaction;
 
 /// Type alias for Ethereum Block with Anvil's transaction type
-pub type Block = alloy_consensus::Block<MaybeImpersonatedTransaction>;
+pub type Block = alloy_consensus::Block<MaybeImpersonatedTransaction<FoundryTxEnvelope>>;
 
 /// Anvil's concrete block info type.
 pub type BlockInfo = TypedBlockInfo<FoundryNetwork>;
@@ -29,7 +29,7 @@ pub struct TypedBlockInfo<N: Network> {
 /// `MaybeImpersonatedTransaction`.
 pub fn create_block<T>(mut header: Header, transactions: impl IntoIterator<Item = T>) -> Block
 where
-    T: Into<MaybeImpersonatedTransaction>,
+    T: Into<MaybeImpersonatedTransaction<FoundryTxEnvelope>>,
 {
     let transactions: Vec<_> = transactions.into_iter().map(Into::into).collect();
     let transactions_root = calculate_transaction_root(&transactions);

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -20,7 +20,7 @@ use std::ops::Deref;
 /// This is a helper that carries the `impersonated` sender so that the right hash
 /// can be created.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct MaybeImpersonatedTransaction<T = FoundryTxEnvelope> {
+pub struct MaybeImpersonatedTransaction<T> {
     transaction: T,
     impersonated_sender: Option<Address>,
 }
@@ -93,13 +93,13 @@ impl<T: Encodable> Encodable for MaybeImpersonatedTransaction<T> {
     }
 }
 
-impl From<MaybeImpersonatedTransaction> for FoundryTxEnvelope {
-    fn from(value: MaybeImpersonatedTransaction) -> Self {
+impl From<MaybeImpersonatedTransaction<Self>> for FoundryTxEnvelope {
+    fn from(value: MaybeImpersonatedTransaction<Self>) -> Self {
         value.transaction
     }
 }
 
-impl From<FoundryTxEnvelope> for MaybeImpersonatedTransaction {
+impl From<FoundryTxEnvelope> for MaybeImpersonatedTransaction<FoundryTxEnvelope> {
     fn from(value: FoundryTxEnvelope) -> Self {
         Self::new(value)
     }
@@ -127,7 +127,7 @@ impl<T> Deref for MaybeImpersonatedTransaction<T> {
 
 /// Queued transaction
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PendingTransaction<T = FoundryTxEnvelope> {
+pub struct PendingTransaction<T> {
     /// The actual transaction
     pub transaction: MaybeImpersonatedTransaction<T>,
     /// the recovered sender of this transaction

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -47,6 +47,7 @@ use foundry_evm::{
         get_blob_base_fee_update_fraction,
     },
 };
+use foundry_primitives::FoundryTxEnvelope;
 use itertools::Itertools;
 use op_revm::OpTransaction;
 use parking_lot::RwLock;
@@ -1450,7 +1451,7 @@ latest block number: {latest_block}"
 async fn derive_block_and_transactions(
     fork_choice: &ForkChoice,
     provider: &Arc<RetryProvider>,
-) -> eyre::Result<(BlockNumber, Option<Vec<PoolTransaction>>)> {
+) -> eyre::Result<(BlockNumber, Option<Vec<PoolTransaction<FoundryTxEnvelope>>>)> {
     match fork_choice {
         ForkChoice::Block(block_number) => {
             let block_number = *block_number;

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -685,7 +685,10 @@ impl EthApi<FoundryNetwork> {
         self.backend.revert_state_snapshot(id).await
     }
 
-    async fn block_request(&self, block_number: Option<BlockId>) -> Result<BlockRequest> {
+    async fn block_request(
+        &self,
+        block_number: Option<BlockId>,
+    ) -> Result<BlockRequest<FoundryTxEnvelope>> {
         let block_request = match block_number {
             Some(BlockId::Number(BlockNumber::Pending)) => {
                 let pending_txs = self.pool.ready_transactions().collect();
@@ -2919,7 +2922,8 @@ impl EthApi<FoundryNetwork> {
             // address -> cumulative nonce
             let mut nonces: HashMap<Address, u64> = HashMap::default();
 
-            let mut txs: HashMap<u64, Vec<Arc<PoolTransaction>>> = HashMap::default();
+            let mut txs: HashMap<u64, Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>> =
+                HashMap::default();
             for pair in pairs {
                 let (tx_data, block_index) = pair;
 
@@ -3085,7 +3089,7 @@ impl EthApi<FoundryNetwork> {
         node_info!("txpool_inspect");
         let mut inspect = TxpoolInspect::default();
 
-        fn convert(tx: Arc<PoolTransaction>) -> TxpoolInspectSummary {
+        fn convert(tx: Arc<PoolTransaction<FoundryTxEnvelope>>) -> TxpoolInspectSummary {
             let tx = &tx.pending_transaction.transaction;
             let to = tx.to();
             let gas_price = tx.max_fee_per_gas();
@@ -3122,7 +3126,7 @@ impl EthApi<FoundryNetwork> {
     pub async fn txpool_content(&self) -> Result<TxpoolContent<AnyRpcTransaction>> {
         node_info!("txpool_content");
         let mut content = TxpoolContent::<AnyRpcTransaction>::default();
-        fn convert(tx: Arc<PoolTransaction>) -> Result<AnyRpcTransaction> {
+        fn convert(tx: Arc<PoolTransaction<FoundryTxEnvelope>>) -> Result<AnyRpcTransaction> {
             let from = *tx.pending_transaction.sender();
             let tx = transaction_build(
                 Some(tx.hash()),
@@ -3419,7 +3423,7 @@ impl EthApi<FoundryNetwork> {
     /// Adds the given transaction to the pool
     fn add_pending_transaction(
         &self,
-        pending_transaction: PendingTransaction,
+        pending_transaction: PendingTransaction<FoundryTxEnvelope>,
         requires: Vec<TxMarker>,
         provides: Vec<TxMarker>,
     ) -> Result<TxHash> {

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -667,7 +667,7 @@ where
 #[serde(untagged)]
 pub enum SerializableTransactionType {
     TypedTransaction(FoundryTxEnvelope),
-    MaybeImpersonatedTransaction(MaybeImpersonatedTransaction),
+    MaybeImpersonatedTransaction(MaybeImpersonatedTransaction<FoundryTxEnvelope>),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -699,13 +699,13 @@ impl From<SerializableBlock> for Block {
     }
 }
 
-impl From<MaybeImpersonatedTransaction> for SerializableTransactionType {
-    fn from(transaction: MaybeImpersonatedTransaction) -> Self {
+impl From<MaybeImpersonatedTransaction<FoundryTxEnvelope>> for SerializableTransactionType {
+    fn from(transaction: MaybeImpersonatedTransaction<FoundryTxEnvelope>) -> Self {
         Self::MaybeImpersonatedTransaction(transaction)
     }
 }
 
-impl From<SerializableTransactionType> for MaybeImpersonatedTransaction {
+impl From<SerializableTransactionType> for MaybeImpersonatedTransaction<FoundryTxEnvelope> {
     fn from(transaction: SerializableTransactionType) -> Self {
         match transaction {
             SerializableTransactionType::TypedTransaction(tx) => Self::new(tx),

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -312,7 +312,7 @@ impl AnvilBlockExecutorFactory {
 /// Builds the per-tx `OpTransaction<TxEnv>` from a pending transaction, replicating the logic
 /// from `TransactionExecutor::env_for`.
 pub fn build_tx_env_for_pending(
-    tx: &PendingTransaction,
+    tx: &PendingTransaction<FoundryTxEnvelope>,
     cheats: &CheatsManager,
     networks: NetworkConfigs,
     _evm_env: &EvmEnv,

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -26,7 +26,7 @@ use alloy_rpc_types::{
 };
 use alloy_transport::TransportError;
 use foundry_common::provider::{ProviderBuilder, RetryProvider};
-use foundry_primitives::FoundryTxReceipt;
+use foundry_primitives::{FoundryTxEnvelope, FoundryTxReceipt};
 use parking_lot::{
     RawRwLock, RwLock,
     lock_api::{RwLockReadGuard, RwLockWriteGuard},
@@ -664,7 +664,7 @@ pub struct ClientForkConfig<N: Network = AnyNetwork> {
     /// total difficulty of the chain until this block
     pub total_difficulty: U256,
     /// Transactions to force include in the forked chain
-    pub force_transactions: Option<Vec<PoolTransaction>>,
+    pub force_transactions: Option<Vec<PoolTransaction<FoundryTxEnvelope>>>,
 }
 
 impl<N: Network> ClientForkConfig<N> {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -156,7 +156,7 @@ pub const MIN_CREATE_GAS: u128 = 53000;
 pub type State = foundry_evm::utils::StateChangeset;
 
 /// A block request, which includes the Pool Transactions if it's Pending
-pub enum BlockRequest<T = FoundryTxEnvelope> {
+pub enum BlockRequest<T> {
     Pending(Vec<Arc<PoolTransaction<T>>>),
     Number(u64),
 }
@@ -1959,7 +1959,7 @@ impl<N: Network> Backend<N> {
     /// executes the transactions without writing to the underlying database
     pub async fn inspect_tx(
         &self,
-        tx: Arc<PoolTransaction>,
+        tx: Arc<PoolTransaction<FoundryTxEnvelope>>,
     ) -> Result<
         (InstructionResult, Option<Output>, u64, State, Vec<revm::primitives::Log>),
         BlockchainError,
@@ -2129,7 +2129,7 @@ where
 // Mining methods — generic over N: Network, with Foundry-associated-type bounds for now.
 impl<N: Network> Backend<N>
 where
-    Self: TransactionValidator,
+    Self: TransactionValidator<FoundryTxEnvelope>,
     N: Network<TxEnvelope = FoundryTxEnvelope, ReceiptEnvelope = FoundryReceiptEnvelope>,
 {
     /// Mines a new block and stores it.
@@ -2138,15 +2138,15 @@ where
     /// provide.
     pub async fn mine_block(
         &self,
-        pool_transactions: Vec<Arc<PoolTransaction>>,
-    ) -> MinedBlockOutcome {
+        pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
+    ) -> MinedBlockOutcome<FoundryTxEnvelope> {
         self.do_mine_block(pool_transactions).await
     }
 
     async fn do_mine_block(
         &self,
-        pool_transactions: Vec<Arc<PoolTransaction>>,
-    ) -> MinedBlockOutcome {
+        pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
+    ) -> MinedBlockOutcome<FoundryTxEnvelope> {
         let _mining_guard = self.mining.lock().await;
         trace!(target: "backend", "creating new block with {} transactions", pool_transactions.len());
 
@@ -2253,8 +2253,8 @@ where
                 executor.apply_pre_execution_changes().expect("pre-execution changes failed");
 
                 // 5. Per-tx loop
-                let mut included: Vec<Arc<PoolTransaction>> = Vec::new();
-                let mut invalid: Vec<Arc<PoolTransaction>> = Vec::new();
+                let mut included: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>> = Vec::new();
+                let mut invalid: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>> = Vec::new();
                 let mut transaction_infos: Vec<TransactionInfo> = Vec::new();
                 let mut transactions = Vec::new();
                 let mut bloom = Bloom::default();
@@ -2602,7 +2602,7 @@ where
     pub async fn reorg(
         &self,
         depth: u64,
-        tx_pairs: HashMap<u64, Vec<Arc<PoolTransaction>>>,
+        tx_pairs: HashMap<u64, Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>>,
         common_block: Block,
     ) -> Result<(), BlockchainError> {
         self.rollback(common_block).await?;
@@ -2624,7 +2624,10 @@ where
     /// Creates the pending block
     ///
     /// This will execute all transaction in the order they come but will not mine the block
-    pub async fn pending_block(&self, pool_transactions: Vec<Arc<PoolTransaction>>) -> BlockInfo {
+    pub async fn pending_block(
+        &self,
+        pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
+    ) -> BlockInfo {
         self.with_pending_block(pool_transactions, |_, block| block).await
     }
 
@@ -2633,7 +2636,7 @@ where
     /// This will execute all transaction in the order they come but will not mine the block
     pub async fn with_pending_block<F, T>(
         &self,
-        pool_transactions: Vec<Arc<PoolTransaction>>,
+        pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
         f: F,
     ) -> T
     where
@@ -2895,7 +2898,7 @@ where
         &self,
         request: WithOtherFields<TransactionRequest>,
         fee_details: FeeDetails,
-        block_request: Option<BlockRequest>,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
         overrides: EvmOverrides,
     ) -> Result<(InstructionResult, Option<Output>, u128, State), BlockchainError> {
         self.with_database_at(block_request, |state, mut block| {
@@ -2919,7 +2922,7 @@ where
         &self,
         request: WithOtherFields<TransactionRequest>,
         fee_details: FeeDetails,
-        block_request: Option<BlockRequest>,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
         opts: GethDebugTracingCallOptions,
     ) -> Result<GethTrace, BlockchainError> {
         let GethDebugTracingCallOptions {
@@ -3066,7 +3069,7 @@ where
     /// Helper function to execute a closure with the database at a specific block
     pub async fn with_database_at<F, T>(
         &self,
-        block_request: Option<BlockRequest>,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
         f: F,
     ) -> Result<T, BlockchainError>
     where
@@ -3123,7 +3126,7 @@ where
         &self,
         address: Address,
         index: U256,
-        block_request: Option<BlockRequest>,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
     ) -> Result<B256, BlockchainError> {
         self.with_database_at(block_request, |db, _| {
             trace!(target: "backend", "get storage for {:?} at {:?}", address, index);
@@ -3140,7 +3143,7 @@ where
     pub async fn get_code(
         &self,
         address: Address,
-        block_request: Option<BlockRequest>,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
     ) -> Result<Bytes, BlockchainError> {
         self.with_database_at(block_request, |db, _| self.get_code_with_state(&db, address)).await?
     }
@@ -3151,7 +3154,7 @@ where
     pub async fn get_balance(
         &self,
         address: Address,
-        block_request: Option<BlockRequest>,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
     ) -> Result<U256, BlockchainError> {
         self.with_database_at(block_request, |db, _| self.get_balance_with_state(db, address))
             .await?
@@ -3160,7 +3163,7 @@ where
     pub async fn get_account_at_block(
         &self,
         address: Address,
-        block_request: Option<BlockRequest>,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
     ) -> Result<TrieAccount, BlockchainError> {
         self.with_database_at(block_request, |block_db, _| {
             let db = block_db.maybe_as_full_db().ok_or(BlockchainError::DataUnavailable)?;
@@ -3180,7 +3183,7 @@ where
     pub async fn get_nonce(
         &self,
         address: Address,
-        block_request: BlockRequest,
+        block_request: BlockRequest<FoundryTxEnvelope>,
     ) -> Result<u64, BlockchainError> {
         if let BlockRequest::Pending(pool_transactions) = &block_request
             && let Some(value) = get_pool_transactions_nonce(pool_transactions, address)
@@ -3230,7 +3233,8 @@ where
             .position(|tx| tx.hash() == hash)
             .expect("transaction not found in block");
 
-        let pool_txs: Vec<Arc<PoolTransaction>> = block.body.transactions[..index]
+        let pool_txs: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>> = block.body.transactions
+            [..index]
             .iter()
             .map(|tx| {
                 let pending_tx =
@@ -3448,7 +3452,7 @@ where
         &self,
         address: Address,
         keys: Vec<B256>,
-        block_request: Option<BlockRequest>,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
     ) -> Result<AccountProof, BlockchainError> {
         let block_number = block_request.as_ref().map(|r| r.block_number());
 
@@ -3730,7 +3734,7 @@ impl Backend<FoundryNetwork> {
     pub async fn simulate(
         &self,
         request: SimulatePayload,
-        block_request: Option<BlockRequest>,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
     ) -> Result<Vec<SimulatedBlock<AnyRpcBlock>>, BlockchainError> {
         self.with_database_at(block_request, |state, mut block_env| {
             let SimulatePayload {
@@ -4207,7 +4211,7 @@ impl Backend<FoundryNetwork> {
 
 /// Get max nonce from transaction pool by address.
 fn get_pool_transactions_nonce(
-    pool_transactions: &[Arc<PoolTransaction>],
+    pool_transactions: &[Arc<PoolTransaction<FoundryTxEnvelope>>],
     address: Address,
 ) -> Option<u64> {
     if let Some(highest_nonce) = pool_transactions
@@ -4223,10 +4227,10 @@ fn get_pool_transactions_nonce(
 }
 
 #[async_trait::async_trait]
-impl TransactionValidator for Backend<FoundryNetwork> {
+impl TransactionValidator<FoundryTxEnvelope> for Backend<FoundryNetwork> {
     async fn validate_pool_transaction(
         &self,
-        tx: &PendingTransaction,
+        tx: &PendingTransaction<FoundryTxEnvelope>,
     ) -> Result<(), BlockchainError> {
         let address = *tx.sender();
         let account = self.get_account(address).await?;
@@ -4236,7 +4240,7 @@ impl TransactionValidator for Backend<FoundryNetwork> {
 
     fn validate_pool_transaction_for(
         &self,
-        pending: &PendingTransaction,
+        pending: &PendingTransaction<FoundryTxEnvelope>,
         account: &AccountInfo,
         env: &Env,
     ) -> Result<(), InvalidTransactionError> {
@@ -4407,7 +4411,7 @@ impl TransactionValidator for Backend<FoundryNetwork> {
 
     fn validate_for(
         &self,
-        tx: &PendingTransaction,
+        tx: &PendingTransaction<FoundryTxEnvelope>,
         account: &AccountInfo,
         env: &Env,
     ) -> Result<(), InvalidTransactionError> {
@@ -4422,7 +4426,7 @@ impl TransactionValidator for Backend<FoundryNetwork> {
 /// Creates a `AnyRpcTransaction` as it's expected for the `eth` RPC api from storage data
 pub fn transaction_build(
     tx_hash: Option<B256>,
-    eth_transaction: MaybeImpersonatedTransaction,
+    eth_transaction: MaybeImpersonatedTransaction<FoundryTxEnvelope>,
     block: Option<&Block>,
     info: Option<TransactionInfo>,
     base_fee: Option<u64>,

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -305,7 +305,8 @@ impl<N: Network> BlockchainStorage<N> {
             requests_hash: is_prague.then_some(EMPTY_REQUESTS_HASH),
             ..Default::default()
         };
-        let block = create_block(header, Vec::<MaybeImpersonatedTransaction>::new());
+        let block =
+            create_block(header, Vec::<MaybeImpersonatedTransaction<FoundryTxEnvelope>>::new());
         let genesis_hash = block.header.hash_slow();
         let best_hash = genesis_hash;
         let best_number = genesis_number;
@@ -521,7 +522,7 @@ impl<N: Network> Blockchain<N> {
 }
 
 /// Represents the outcome of mining a new block
-pub struct MinedBlockOutcome<T = FoundryTxEnvelope> {
+pub struct MinedBlockOutcome<T> {
     /// The block that was mined
     pub block_number: u64,
     /// All transactions included in the block
@@ -724,7 +725,7 @@ mod tests {
 
         let header = Header { gas_limit: 123456, ..Default::default() };
         let bytes_first = &mut &hex::decode("f86b02843b9aca00830186a094d3e8763675e4c425df46cc3b5c0f6cbdac39604687038d7ea4c68000802ba00eb96ca19e8a77102767a41fc85a36afd5c61ccb09911cec5d3e86e193d9c5aea03a456401896b1b6055311536bf00a718568c744d8c1f9df59879e8350220ca18").unwrap()[..];
-        let tx: MaybeImpersonatedTransaction =
+        let tx: MaybeImpersonatedTransaction<FoundryTxEnvelope> =
             FoundryTxEnvelope::decode(&mut &bytes_first[..]).unwrap().into();
         let block = create_block(header.clone(), vec![tx.clone()]);
         let block_hash = block.header.hash_slow();

--- a/crates/anvil/src/eth/backend/validate.rs
+++ b/crates/anvil/src/eth/backend/validate.rs
@@ -5,12 +5,11 @@ use crate::eth::{
     error::{BlockchainError, InvalidTransactionError},
 };
 use anvil_core::eth::transaction::PendingTransaction;
-use foundry_primitives::FoundryTxEnvelope;
 use revm::state::AccountInfo;
 
 /// A trait for validating transactions
 #[async_trait::async_trait]
-pub trait TransactionValidator<T = FoundryTxEnvelope> {
+pub trait TransactionValidator<T> {
     /// Validates the transaction's validity when it comes to nonce, payment
     ///
     /// This is intended to be checked before the transaction makes it into the pool and whether it

--- a/crates/anvil/src/eth/miner.rs
+++ b/crates/anvil/src/eth/miner.rs
@@ -2,7 +2,6 @@
 
 use crate::eth::pool::{Pool, transactions::PoolTransaction};
 use alloy_primitives::TxHash;
-use foundry_primitives::FoundryTxEnvelope;
 use futures::{
     channel::mpsc::Receiver,
     stream::{Fuse, StreamExt},
@@ -17,7 +16,7 @@ use std::{
 };
 use tokio::time::{Interval, MissedTickBehavior};
 
-pub struct Miner<T = FoundryTxEnvelope> {
+pub struct Miner<T> {
     /// The mode this miner currently operates in
     mode: Arc<RwLock<MiningMode>>,
     /// used for task wake up when the mining mode was forcefully changed

--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -40,7 +40,6 @@ use alloy_consensus::Transaction;
 use alloy_primitives::{Address, TxHash};
 use alloy_rpc_types::txpool::TxpoolStatus;
 use anvil_core::eth::transaction::PendingTransaction;
-use foundry_primitives::FoundryTxEnvelope;
 use futures::channel::mpsc::{Receiver, Sender, channel};
 use parking_lot::{Mutex, RwLock};
 use std::{collections::VecDeque, fmt, sync::Arc};
@@ -48,7 +47,7 @@ use std::{collections::VecDeque, fmt, sync::Arc};
 pub mod transactions;
 
 /// Transaction pool that performs validation.
-pub struct Pool<T = FoundryTxEnvelope> {
+pub struct Pool<T> {
     /// processes all pending transactions
     inner: RwLock<PoolInner<T>>,
     /// listeners for new ready transactions
@@ -226,7 +225,7 @@ impl<T: Transaction> Pool<T> {
 ///
 /// Contains all transactions that are ready to be executed
 #[derive(Debug)]
-struct PoolInner<T = FoundryTxEnvelope> {
+struct PoolInner<T> {
     ready_transactions: ReadyTransactions<T>,
     pending_transactions: PendingTransactions<T>,
 }
@@ -434,7 +433,7 @@ impl<T: Transaction> PoolInner<T> {
 }
 
 /// Represents the outcome of a prune
-pub struct PruneResult<T = FoundryTxEnvelope> {
+pub struct PruneResult<T> {
     /// a list of added transactions that a pruned marker satisfied
     pub promoted: Vec<AddedTransaction<T>>,
     /// all transactions that  failed to be promoted and now are discarded
@@ -463,7 +462,7 @@ impl<T> fmt::Debug for PruneResult<T> {
 }
 
 #[derive(Clone, Debug)]
-pub struct ReadyTransaction<T = FoundryTxEnvelope> {
+pub struct ReadyTransaction<T> {
     /// the hash of the submitted transaction
     hash: TxHash,
     /// transactions promoted to the ready queue
@@ -486,7 +485,7 @@ impl<T> ReadyTransaction<T> {
 }
 
 #[derive(Clone, Debug)]
-pub enum AddedTransaction<T = FoundryTxEnvelope> {
+pub enum AddedTransaction<T> {
     /// transaction was successfully added and being processed
     Ready(ReadyTransaction<T>),
     /// Transaction was successfully added but not yet queued for processing

--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -73,7 +73,7 @@ pub struct TransactionPriority(pub u128);
 
 /// Internal Transaction type
 #[derive(Clone, PartialEq, Eq)]
-pub struct PoolTransaction<T = FoundryTxEnvelope> {
+pub struct PoolTransaction<T> {
     /// the pending eth transaction
     pub pending_transaction: PendingTransaction<T>,
     /// Markers required by the transaction
@@ -128,7 +128,7 @@ impl<T: fmt::Debug> fmt::Debug for PoolTransaction<T> {
     }
 }
 
-impl TryFrom<AnyRpcTransaction> for PoolTransaction {
+impl TryFrom<AnyRpcTransaction> for PoolTransaction<FoundryTxEnvelope> {
     type Error = eyre::Error;
     fn try_from(value: AnyRpcTransaction) -> Result<Self, Self::Error> {
         let typed_transaction = FoundryTxEnvelope::try_from(value)?;
@@ -146,7 +146,7 @@ impl TryFrom<AnyRpcTransaction> for PoolTransaction {
 ///
 /// Keeps a set of transactions that are waiting for other transactions
 #[derive(Clone, Debug)]
-pub struct PendingTransactions<T = FoundryTxEnvelope> {
+pub struct PendingTransactions<T> {
     /// markers that aren't yet provided by any transaction
     required_markers: HashMap<TxMarker, HashSet<TxHash>>,
     /// mapping of the markers of a transaction to the hash of the transaction
@@ -289,7 +289,7 @@ impl<T: Transaction> PendingTransactions<T> {
 
 /// A transaction in the pool
 #[derive(Clone)]
-pub struct PendingPoolTransaction<T = FoundryTxEnvelope> {
+pub struct PendingPoolTransaction<T> {
     pub transaction: Arc<PoolTransaction<T>>,
     /// markers required and have not been satisfied yet by other transactions in the pool
     pub missing_markers: HashSet<TxMarker>,
@@ -337,7 +337,7 @@ impl<T: fmt::Debug> fmt::Debug for PendingPoolTransaction<T> {
     }
 }
 
-pub struct TransactionsIterator<T = FoundryTxEnvelope> {
+pub struct TransactionsIterator<T> {
     all: HashMap<TxHash, ReadyTransaction<T>>,
     awaiting: HashMap<TxHash, (usize, PoolTransactionRef<T>)>,
     independent: BTreeSet<PoolTransactionRef<T>>,
@@ -394,7 +394,7 @@ impl<T> Iterator for TransactionsIterator<T> {
 
 /// transactions that are ready to be included in a block.
 #[derive(Clone, Debug)]
-pub struct ReadyTransactions<T = FoundryTxEnvelope> {
+pub struct ReadyTransactions<T> {
     /// keeps track of transactions inserted in the pool
     ///
     /// this way we can determine when transactions where submitted to the pool
@@ -704,7 +704,7 @@ impl<T: Transaction> ReadyTransactions<T> {
 
 /// A reference to a transaction in the pool
 #[derive(Debug)]
-pub struct PoolTransactionRef<T = FoundryTxEnvelope> {
+pub struct PoolTransactionRef<T> {
     /// actual transaction
     pub transaction: Arc<PoolTransaction<T>>,
     /// identifier used to internally compare the transaction in the pool
@@ -741,7 +741,7 @@ impl<T> Ord for PoolTransactionRef<T> {
 }
 
 #[derive(Debug)]
-pub struct ReadyTransaction<T = FoundryTxEnvelope> {
+pub struct ReadyTransaction<T> {
     /// ref to the actual transaction
     pub transaction: PoolTransactionRef<T>,
     /// tracks the transactions that get unlocked by this transaction

--- a/crates/anvil/src/service.rs
+++ b/crates/anvil/src/service.rs
@@ -45,7 +45,7 @@ pub struct NodeService<N: Network> {
 
 impl<N: Network> NodeService<N>
 where
-    Backend<N>: TransactionValidator,
+    Backend<N>: TransactionValidator<N::TxEnvelope>,
     N: Network<TxEnvelope = FoundryTxEnvelope, ReceiptEnvelope = FoundryReceiptEnvelope>,
 {
     pub fn new(
@@ -70,7 +70,7 @@ where
 
 impl<N: Network> Future for NodeService<N>
 where
-    Backend<N>: TransactionValidator,
+    Backend<N>: TransactionValidator<N::TxEnvelope>,
     N: Network<TxEnvelope = FoundryTxEnvelope, ReceiptEnvelope = FoundryReceiptEnvelope>,
 {
     type Output = NodeResult<()>;
@@ -126,7 +126,7 @@ struct BlockProducer<N: Network> {
 
 impl<N: Network> BlockProducer<N>
 where
-    Backend<N>: TransactionValidator,
+    Backend<N>: TransactionValidator<N::TxEnvelope>,
     N: Network<TxEnvelope = FoundryTxEnvelope, ReceiptEnvelope = FoundryReceiptEnvelope>,
 {
     fn new(backend: Arc<Backend<N>>) -> Self {
@@ -136,10 +136,10 @@ where
 
 impl<N: Network> Stream for BlockProducer<N>
 where
-    Backend<N>: TransactionValidator + Send + Sync + 'static,
+    Backend<N>: TransactionValidator<N::TxEnvelope> + Send + Sync + 'static,
     N: Network<TxEnvelope = FoundryTxEnvelope, ReceiptEnvelope = FoundryReceiptEnvelope> + 'static,
 {
-    type Item = MinedBlockOutcome;
+    type Item = MinedBlockOutcome<N::TxEnvelope>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let pin = self.get_mut();


### PR DESCRIPTION
`PendingTransaction` was hardcoded to `FoundryTxEnvelope`, blocking custom networks from flowing their transactions through the pool into `mine_block`.