### PR TITLE
feat(evm): wire Inspector and DatabaseExt Context generics

### DIFF
--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -14,7 +14,7 @@ use foundry_evm_core::{
     backend::{FoundryJournalExt, JournaledState},
     fork::CreateFork,
 };
-use revm::context::{ContextTr, TxEnv};
+use revm::context::{Cfg, ContextTr};
 
 impl Cheatcode for activeForkCall {
     fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
@@ -415,9 +415,9 @@ fn create_fork_request<CTX: EthCheatCtx>(
 fn fork_env_op<CTX: EthCheatCtx, T: SolValue>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     f: impl FnOnce(
-        &mut dyn DatabaseExt,
-        &mut EvmEnv,
-        &mut TxEnv,
+        &mut dyn DatabaseExt<CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
+        &mut EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
+        &mut CTX::Tx,
         &mut JournaledState,
     ) -> eyre::Result<T>,
 ) -> Result {

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -113,7 +113,7 @@ pub trait CheatcodesExecutor<CTX: ContextTr> {
     fn with_fresh_nested_evm(
         &mut self,
         cheats: &mut Cheatcodes,
-        db: &mut dyn DatabaseExt,
+        db: &mut dyn DatabaseExt<CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
         evm_env: EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
         tx_env: CTX::Tx,
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
@@ -185,7 +185,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
     fn with_fresh_nested_evm(
         &mut self,
         cheats: &mut Cheatcodes,
-        db: &mut dyn DatabaseExt,
+        db: &mut dyn DatabaseExt<CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
         evm_env: EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
         tx_env: CTX::Tx,
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -79,7 +79,7 @@ pub type JournaledState = JournalInner<JournalEntry>;
 
 /// An extension trait that allows us to easily extend the `revm::Inspector` capabilities
 #[auto_impl::auto_impl(&mut)]
-pub trait DatabaseExt<Spec = SpecId, Block = BlockEnv, Tx = TxEnv>:
+pub trait DatabaseExt<BLOCK = BlockEnv, TX = TxEnv, SPEC = SpecId>:
     Database<Error = DatabaseError> + DatabaseCommit + Debug
 {
     /// Creates a new state snapshot at the current point of execution.
@@ -90,7 +90,7 @@ pub trait DatabaseExt<Spec = SpecId, Block = BlockEnv, Tx = TxEnv>:
     fn snapshot_state(
         &mut self,
         journaled_state: &JournaledState,
-        evm_env: &EvmEnv<Spec, Block>,
+        evm_env: &EvmEnv<SPEC, BLOCK>,
     ) -> U256;
 
     /// Reverts the snapshot if it exists
@@ -109,8 +109,8 @@ pub trait DatabaseExt<Spec = SpecId, Block = BlockEnv, Tx = TxEnv>:
         &mut self,
         id: U256,
         journaled_state: &JournaledState,
-        evm_env: &mut EvmEnv<Spec, Block>,
-        tx_env: &mut Tx,
+        evm_env: &mut EvmEnv<SPEC, BLOCK>,
+        tx_env: &mut TX,
         action: RevertStateSnapshotAction,
     ) -> Option<JournaledState>;
 
@@ -129,8 +129,8 @@ pub trait DatabaseExt<Spec = SpecId, Block = BlockEnv, Tx = TxEnv>:
     fn create_select_fork(
         &mut self,
         fork: CreateFork,
-        evm_env: &mut EvmEnv<Spec, Block>,
-        tx_env: &mut Tx,
+        evm_env: &mut EvmEnv<SPEC, BLOCK>,
+        tx_env: &mut TX,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<LocalForkId> {
         let id = self.create_fork(fork)?;
@@ -144,8 +144,8 @@ pub trait DatabaseExt<Spec = SpecId, Block = BlockEnv, Tx = TxEnv>:
     fn create_select_fork_at_transaction(
         &mut self,
         fork: CreateFork,
-        evm_env: &mut EvmEnv<Spec, Block>,
-        tx_env: &mut Tx,
+        evm_env: &mut EvmEnv<SPEC, BLOCK>,
+        tx_env: &mut TX,
         journaled_state: &mut JournaledState,
         transaction: B256,
     ) -> eyre::Result<LocalForkId> {
@@ -176,8 +176,8 @@ pub trait DatabaseExt<Spec = SpecId, Block = BlockEnv, Tx = TxEnv>:
     fn select_fork(
         &mut self,
         id: LocalForkId,
-        evm_env: &mut EvmEnv<Spec, Block>,
-        tx_env: &mut Tx,
+        evm_env: &mut EvmEnv<SPEC, BLOCK>,
+        tx_env: &mut TX,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()>;
 
@@ -192,8 +192,8 @@ pub trait DatabaseExt<Spec = SpecId, Block = BlockEnv, Tx = TxEnv>:
         &mut self,
         id: Option<LocalForkId>,
         block_number: u64,
-        evm_env: &mut EvmEnv<Spec, Block>,
-        tx_env: &mut Tx,
+        evm_env: &mut EvmEnv<SPEC, BLOCK>,
+        tx_env: &mut TX,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()>;
 
@@ -209,8 +209,8 @@ pub trait DatabaseExt<Spec = SpecId, Block = BlockEnv, Tx = TxEnv>:
         &mut self,
         id: Option<LocalForkId>,
         transaction: B256,
-        evm_env: &mut EvmEnv<Spec, Block>,
-        tx_env: &mut Tx,
+        evm_env: &mut EvmEnv<SPEC, BLOCK>,
+        tx_env: &mut TX,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()>;
 
@@ -219,19 +219,19 @@ pub trait DatabaseExt<Spec = SpecId, Block = BlockEnv, Tx = TxEnv>:
         &mut self,
         id: Option<LocalForkId>,
         transaction: B256,
-        evm_env: EvmEnv<Spec, Block>,
-        tx_env: Tx,
+        evm_env: EvmEnv<SPEC, BLOCK>,
+        tx_env: TX,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn EthInspectorExt,
+        inspector: &mut dyn EthInspectorExt<BLOCK, TX, SPEC>,
     ) -> eyre::Result<()>;
 
     /// Executes a given TransactionRequest, commits the new state to the DB
     fn transact_from_tx(
         &mut self,
         transaction: &TransactionRequest,
-        evm_env: EvmEnv<Spec, Block>,
+        evm_env: EvmEnv<SPEC, BLOCK>,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn EthInspectorExt,
+        inspector: &mut dyn EthInspectorExt<BLOCK, TX, SPEC>,
     ) -> eyre::Result<()>;
 
     /// Returns the `ForkId` that's currently used in the database, if fork mode is on
@@ -397,7 +397,7 @@ struct _ObjectSafe(dyn DatabaseExt);
 /// enabling direct [`DatabaseExt`] method calls with zero-copy borrow splitting.
 pub trait FoundryJournalExt<CTX: ContextTr + ?Sized>: JournalExt {
     /// The database type backing this journal.
-    type DB: DatabaseExt<<CTX::Cfg as Cfg>::Spec, CTX::Block, CTX::Tx>;
+    type DB: DatabaseExt<CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>;
 
     /// Returns mutable references to the database and journal inner state.
     fn as_db_and_inner(&mut self) -> (&mut Self::DB, &mut JournaledState);
@@ -411,7 +411,7 @@ pub trait FoundryJournalExt<CTX: ContextTr + ?Sized>: JournalExt {
 impl<DB, CTX> FoundryJournalExt<CTX> for Journal<DB, JournalEntry>
 where
     CTX: ContextTr + ?Sized,
-    DB: DatabaseExt<<CTX::Cfg as Cfg>::Spec, CTX::Block, CTX::Tx>,
+    DB: DatabaseExt<CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
 {
     type DB = DB;
 
@@ -1917,13 +1917,13 @@ impl Default for BackendInner {
 
 /// This updates the currently used env with the fork's environment
 pub(crate) fn update_current_env_with_fork_env<
-    Spec,
-    Block: FoundryBlock,
-    Tx: FoundryTransaction,
+    SPEC,
+    BLOCK: FoundryBlock,
+    TX: FoundryTransaction,
 >(
-    evm_env: &mut EvmEnv<Spec, Block>,
-    tx_env: &mut Tx,
-    fork_evm_env: EvmEnv<Spec, Block>,
+    evm_env: &mut EvmEnv<SPEC, BLOCK>,
+    tx_env: &mut TX,
+    fork_evm_env: EvmEnv<SPEC, BLOCK>,
 ) {
     tx_env.set_chain_id(Some(fork_evm_env.cfg_env.chain_id));
     *evm_env = fork_evm_env;
@@ -2004,8 +2004,8 @@ fn is_contract_in_state(evm_state: &EvmState, acc: Address) -> bool {
 }
 
 /// Updates the evm env's block with the block's data
-fn update_env_block<Spec, Block: FoundryBlock>(
-    evm_env: &mut EvmEnv<Spec, Block>,
+fn update_env_block<SPEC, BLOCK: FoundryBlock>(
+    evm_env: &mut EvmEnv<SPEC, BLOCK>,
     header: &impl BlockHeader,
 ) {
     let block_env = &mut evm_env.block_env;

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -258,7 +258,7 @@ pub trait EthCheatCtx:
         Tx = TxEnv,
         Cfg = CfgEnv,
         Journal: FoundryJournalExt<Self>,
-        Db: DatabaseExt,
+        Db: DatabaseExt<Self::Block, Self::Tx, SpecId>,
     >
 {
 }
@@ -268,7 +268,7 @@ impl<CTX> EthCheatCtx for CTX where
             Tx = TxEnv,
             Cfg = CfgEnv,
             Journal: FoundryJournalExt<Self>,
-            Db: DatabaseExt,
+            Db: DatabaseExt<Self::Block, Self::Tx, SpecId>,
         >
 {
 }

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -269,7 +269,7 @@ pub type NestedEvmClosure<'a, Block, Tx, Spec> =
 pub fn with_cloned_context<CTX: EthCheatCtx>(
     ecx: &mut CTX,
     f: impl FnOnce(
-        &mut dyn DatabaseExt,
+        &mut dyn DatabaseExt<CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
         EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
         CTX::Tx,
         JournaledState,

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -6,11 +6,16 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 use crate::constants::DEFAULT_CREATE2_DEPLOYER;
-use alloy_evm::eth::EthEvmContext;
 use alloy_primitives::{Address, map::HashMap};
 use auto_impl::auto_impl;
 use backend::DatabaseExt;
-use revm::{Inspector, inspector::NoOpInspector, interpreter::CreateInputs};
+use revm::{
+    Context, Inspector,
+    context::{BlockEnv, CfgEnv, TxEnv},
+    inspector::NoOpInspector,
+    interpreter::CreateInputs,
+    primitives::hardfork::SpecId,
+};
 use revm_inspectors::access_list::AccessListInspector;
 
 /// Map keyed by breakpoints char to their location (contract address, pc)
@@ -74,16 +79,17 @@ pub trait FoundryInspectorExt {
     }
 }
 
-/// Combined trait: `Inspector<EthEvmContext<...>>` + [`FoundryInspectorExt`].
+/// Combined trait: `Inspector<Context<...>>` + [`FoundryInspectorExt`].
 ///
 /// For generic multi-network code, use `I: FoundryInspectorExt + Inspector<CTX>` instead.
-pub trait EthInspectorExt:
-    for<'a> Inspector<EthEvmContext<&'a mut dyn DatabaseExt>> + FoundryInspectorExt
+pub trait EthInspectorExt<BLOCK = BlockEnv, TX = TxEnv, SPEC = SpecId>:
+    for<'a> Inspector<Context<BLOCK, TX, CfgEnv<SPEC>, &'a mut dyn DatabaseExt>> + FoundryInspectorExt
 {
 }
 
-impl<T> EthInspectorExt for T where
-    T: for<'a> Inspector<EthEvmContext<&'a mut dyn DatabaseExt>> + FoundryInspectorExt
+impl<BLOCK, TX, SPEC, T> EthInspectorExt<BLOCK, TX, SPEC> for T where
+    T: for<'a> Inspector<Context<BLOCK, TX, CfgEnv<SPEC>, &'a mut dyn DatabaseExt>>
+        + FoundryInspectorExt
 {
 }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -386,7 +386,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for InspectorStackInner {
     fn with_fresh_nested_evm(
         &mut self,
         cheats: &mut Cheatcodes,
-        db: &mut dyn DatabaseExt,
+        db: &mut dyn DatabaseExt<CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
         evm_env: EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
         tx_env: CTX::Tx,
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,


### PR DESCRIPTION
## Motivation

Wire Inspector and DatabaseExt context generics towards proper robust unified generic Evm types (Backend/DB/EVM).

As Backend doesn't have generics yet, the wiring was made only on traits : `DatabaseExt`, `EthInspectorExt`. Backend impl assume Eth types for now.

Consistent generics formatting and ordering (revm style).
