### PR TITLE
fix(traces): use max instead of min for verbosity trace mode

### DIFF
--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -372,7 +372,7 @@ impl TraceMode {
             3..=4 => std::cmp::max(self, Self::Call),
             // Enable step recording for backtraces when verbosity is 5 or higher.
             // We need to ensure we're recording JUMP AND JUMPDEST steps.
-            _ => std::cmp::min(self, Self::Steps),
+            _ => std::cmp::max(self, Self::Steps),
         }
     }
 


### PR DESCRIPTION
`min` was incorrectly lowering trace mode instead of raising it.

Before:
_ => std::cmp::min(self, Self::Steps) // Debug → Steps (wrong)

After:
_ => std::cmp::max(self, Self::Steps) // Debug stays Debug (correct)