### PR TITLE
refactor(evm): delegate to alloy's `EthEvmFactory` in `new_evm_with_inspector`

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -356,7 +356,7 @@ pub fn build_tx_env_for_pending(
 }
 
 /// Creates a database with given database and inspector.
-pub fn new_evm_with_inspector<DB, I>(
+pub fn new_eth_evm_with_inspector<DB, I>(
     db: DB,
     env: &Env,
     inspector: I,

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1,6 +1,6 @@
 //! In-memory blockchain backend.
 use self::state::trie_storage;
-use super::executor::new_evm_with_inspector;
+use super::executor::new_eth_evm_with_inspector;
 use crate::{
     ForkChoice, NodeConfig, PrecompileFactory,
     config::PruneStateHistoryConfig,
@@ -1005,7 +1005,7 @@ impl<N: Network> Backend<N> {
     }
 
     /// Creates an EVM instance with optionally injected precompiles.
-    fn new_evm_with_inspector_ref<'db, I, DB>(
+    fn new_eth_evm_with_inspector_ref<'db, I, DB>(
         &self,
         db: &'db DB,
         env: &Env,
@@ -1017,7 +1017,7 @@ impl<N: Network> Backend<N> {
             + Inspector<OpContext<WrapDatabaseRef<&'db DB>>>,
         WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
     {
-        let mut evm = new_evm_with_inspector(WrapDatabaseRef(db), env, inspector);
+        let mut evm = new_eth_evm_with_inspector(WrapDatabaseRef(db), env, inspector);
         self.env.read().networks.inject_precompiles(evm.precompiles_mut());
 
         if let Some(factory) = &self.precompile_factory {
@@ -1161,7 +1161,7 @@ impl<N: Network> Backend<N> {
         let mut inspector = self.build_inspector();
 
         let env = self.build_call_env(request, fee_details, block_env);
-        let mut evm = self.new_evm_with_inspector_ref(state, &env, &mut inspector);
+        let mut evm = self.new_eth_evm_with_inspector_ref(state, &env, &mut inspector);
         let ResultAndState { result, state } = evm.transact(env.tx)?;
         let (exit_reason, gas_used, out) = match result {
             ExecutionResult::Success { reason, gas_used, output, .. } => {
@@ -1195,7 +1195,7 @@ impl<N: Network> Backend<N> {
             AccessListInspector::new(request.access_list.clone().unwrap_or_default());
 
         let env = self.build_call_env(request, fee_details, block_env);
-        let mut evm = self.new_evm_with_inspector_ref(state, &env, &mut inspector);
+        let mut evm = self.new_eth_evm_with_inspector_ref(state, &env, &mut inspector);
         let ResultAndState { result, state: _ } = evm.transact(env.tx)?;
         let (exit_reason, gas_used, out) = match result {
             ExecutionResult::Success { reason, gas_used, output, .. } => {
@@ -1458,7 +1458,7 @@ impl<N: Network> Backend<N> {
             }
 
             // Execute the transaction with the inspector
-            let mut evm = self.new_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
+            let mut evm = self.new_eth_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
             let result = evm.transact(tx_env.clone()).ok()?;
 
             // Build TraceResults from the inspector and execution result
@@ -1976,7 +1976,7 @@ impl<N: Network> Backend<N> {
 
         let db = self.db.read().await;
         let mut inspector = self.build_inspector();
-        let mut evm = self.new_evm_with_inspector_ref(&**db, &env, &mut inspector);
+        let mut evm = self.new_eth_evm_with_inspector_ref(&**db, &env, &mut inspector);
         let ResultAndState { result, state } = evm.transact(env.tx)?;
         let (exit_reason, gas_used, out, logs) = match result {
             ExecutionResult::Success { reason, gas_used, logs, output, .. } => {
@@ -2228,7 +2228,7 @@ where
 
                 // 2. Create EVM
                 let env_struct = Env::new(env.evm_env.clone(), Default::default(), env.networks);
-                let mut evm = new_evm_with_inspector(&mut **db, &env_struct, inspector);
+                let mut evm = new_eth_evm_with_inspector(&mut **db, &env_struct, inspector);
 
                 // 3. Inject precompiles (once, before the tx loop)
                 env.networks.inject_precompiles(evm.precompiles_mut());
@@ -2675,7 +2675,7 @@ where
         }
 
         let env_struct = Env::new(env.evm_env.clone(), Default::default(), env.networks);
-        let mut evm = new_evm_with_inspector(&mut cache_db, &env_struct, inspector);
+        let mut evm = new_eth_evm_with_inspector(&mut cache_db, &env_struct, inspector);
 
         env.networks.inject_precompiles(evm.precompiles_mut());
         if let Some(factory) = &self.precompile_factory {
@@ -2954,8 +2954,11 @@ where
                             );
 
                             let env = self.build_call_env(request, fee_details, block);
-                            let mut evm =
-                                self.new_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
+                            let mut evm = self.new_eth_evm_with_inspector_ref(
+                                &cache_db,
+                                &env,
+                                &mut inspector,
+                            );
                             let ResultAndState { result, state: _ } = evm.transact(env.tx)?;
 
                             drop(evm);
@@ -2984,8 +2987,11 @@ where
                             );
 
                             let env = self.build_call_env(request, fee_details, block);
-                            let mut evm =
-                                self.new_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
+                            let mut evm = self.new_eth_evm_with_inspector_ref(
+                                &cache_db,
+                                &env,
+                                &mut inspector,
+                            );
                             let result = evm.transact(env.tx)?;
 
                             drop(evm);
@@ -3017,7 +3023,7 @@ where
 
                         let env = self.build_call_env(request, fee_details, block.clone());
                         let mut evm =
-                            self.new_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
+                            self.new_eth_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
                         let result = evm.transact(env.tx.clone())?;
                         let res = evm
                             .inspector_mut()
@@ -3035,7 +3041,7 @@ where
                 .with_tracing_config(TracingInspectorConfig::from_geth_config(&config));
 
             let env = self.build_call_env(request, fee_details, block);
-            let mut evm = self.new_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
+            let mut evm = self.new_eth_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
             let ResultAndState { result, state: _ } = evm.transact(env.tx)?;
 
             let (exit_reason, gas_used, out) = match result {
@@ -3274,7 +3280,7 @@ where
 
             let env_struct = Env::new(env.evm_env.clone(), Default::default(), env.networks);
             let mut evm_replay =
-                new_evm_with_inspector(&mut cache_db, &env_struct, inspector_replay);
+                new_eth_evm_with_inspector(&mut cache_db, &env_struct, inspector_replay);
 
             env.networks.inject_precompiles(evm_replay.precompiles_mut());
             if let Some(factory) = &self.precompile_factory {
@@ -3395,7 +3401,7 @@ where
                 tx_env.enveloped_tx = Some(target_tx.transaction.encoded_2718().into());
             }
 
-            let mut evm = self.new_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
+            let mut evm = self.new_eth_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
 
             let result = evm
                 .transact(tx_env.clone())
@@ -3794,7 +3800,7 @@ impl Backend<FoundryNetwork> {
                         // prepare inspector to capture transfer inside the evm so they are
                         // recorded and included in logs
                         inspector = inspector.with_transfers();
-                        let mut evm= self.new_evm_with_inspector_ref(
+                        let mut evm= self.new_eth_evm_with_inspector_ref(
                             &cache_db,
                             &env,
                             &mut inspector,
@@ -3803,7 +3809,7 @@ impl Backend<FoundryNetwork> {
                         trace!(target: "backend", env=?env.evm_env, spec=?env.evm_env.spec_id(),"simulate evm env");
                         evm.transact(env.tx)?
                     } else {
-                        let mut evm = self.new_evm_with_inspector_ref(
+                        let mut evm = self.new_eth_evm_with_inspector_ref(
                             &cache_db,
                             &env,
                             &mut inspector,

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -37,7 +37,7 @@ use foundry_evm_core::{
     backend::{DatabaseError, DatabaseExt, FoundryJournalExt, RevertDiagnostic},
     constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME},
     env::FoundryContextExt,
-    evm::{NestedEvm, NestedEvmClosure, new_evm_with_inspector, with_cloned_context},
+    evm::{NestedEvm, NestedEvmClosure, new_eth_evm_with_inspector, with_cloned_context},
 };
 use foundry_evm_traces::{
     TracingInspector, TracingInspectorConfig, identifier::SignaturesIdentifier,
@@ -173,7 +173,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
     ) -> Result<(), EVMError<DatabaseError>> {
         with_cloned_context(ecx, |db, evm_env, tx_env, journal_inner| {
-            let mut evm = new_evm_with_inspector(db, evm_env, tx_env, cheats);
+            let mut evm = new_eth_evm_with_inspector(db, evm_env, tx_env, cheats);
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
             let sub_evm_env = evm.to_evm_env();
@@ -190,7 +190,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
         tx_env: CTX::Tx,
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
     ) -> Result<(), EVMError<DatabaseError>> {
-        let mut evm = new_evm_with_inspector(db, evm_env, tx_env, cheats);
+        let mut evm = new_eth_evm_with_inspector(db, evm_env, tx_env, cheats);
         f(&mut evm)
     }
 

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -74,8 +74,12 @@ impl<'a> CowBackend<'a> {
         // already, we reset the initialized state
         self.pending_init = Some((evm_env.cfg_env.spec, tx_env.caller, tx_env.kind));
 
-        let mut evm =
-            crate::evm::new_evm_with_inspector(self, evm_env.clone(), tx_env.clone(), inspector);
+        let mut evm = crate::evm::new_eth_evm_with_inspector(
+            self,
+            evm_env.clone(),
+            tx_env.clone(),
+            inspector,
+        );
 
         let res = evm.transact(tx_env.clone()).wrap_err("EVM error")?;
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -3,7 +3,7 @@
 use crate::{
     EthInspectorExt, FoundryBlock, FoundryTransaction,
     constants::{CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, TEST_CONTRACT_ADDRESS},
-    evm::new_evm_with_inspector,
+    evm::new_eth_evm_with_inspector,
     fork::{CreateFork, ForkId, MultiFork},
     state_snapshot::StateSnapshots,
     utils::get_blob_base_fee_update_fraction,
@@ -815,7 +815,7 @@ impl Backend {
         inspector: I,
     ) -> eyre::Result<ResultAndState> {
         self.initialize(evm_env.cfg_env.spec, tx_env.caller, tx_env.kind);
-        let mut evm = crate::evm::new_evm_with_inspector(
+        let mut evm = crate::evm::new_eth_evm_with_inspector(
             self,
             evm_env.to_owned(),
             tx_env.to_owned(),
@@ -1376,7 +1376,8 @@ impl DatabaseExt for Backend {
 
         let res = {
             let mut db = self.clone();
-            let mut evm = new_evm_with_inspector(&mut db, evm_env, tx_env.to_owned(), inspector);
+            let mut evm =
+                new_eth_evm_with_inspector(&mut db, evm_env, tx_env.to_owned(), inspector);
             evm.journaled_state.depth = journaled_state.depth + 1;
             evm.transact(tx_env)?
         };
@@ -2049,7 +2050,7 @@ fn commit_transaction(
         let depth = journaled_state.depth;
         let mut db = Backend::new_with_fork(fork_id, fork, journaled_state)?;
 
-        let mut evm = crate::evm::new_evm_with_inspector(
+        let mut evm = crate::evm::new_eth_evm_with_inspector(
             &mut db as _,
             evm_env.to_owned(),
             tx_env.to_owned(),

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -9,19 +9,18 @@ use crate::{
     constants::DEFAULT_CREATE2_DEPLOYER_CODEHASH,
 };
 use alloy_consensus::constants::KECCAK_EMPTY;
-use alloy_evm::{Evm, EvmEnv, eth::EthEvmContext, precompiles::PrecompilesMap};
+use alloy_evm::{Evm, EvmEnv, EvmFactory, eth::EthEvmContext, precompiles::PrecompilesMap};
 use alloy_primitives::{Address, Bytes, U256};
 use foundry_fork_db::DatabaseError;
 use revm::{
-    Context, Journal,
+    Context,
     context::{
-        BlockEnv, Cfg, CfgEnv, ContextTr, CreateScheme, Evm as RevmEvm, JournalTr, LocalContext,
-        LocalContextTr, TxEnv,
+        BlockEnv, Cfg, CfgEnv, ContextTr, CreateScheme, Evm as RevmEvm, JournalTr, LocalContextTr,
+        TxEnv,
         result::{EVMError, ExecResultAndState, ExecutionResult, HaltReason, ResultAndState},
     },
     handler::{
-        EthFrame, EthPrecompiles, EvmTr, FrameResult, FrameTr, Handler, ItemOrResult,
-        instructions::EthInstructions,
+        EthFrame, EvmTr, FrameResult, FrameTr, Handler, ItemOrResult, instructions::EthInstructions,
     },
     inspector::{InspectorEvmTr, InspectorHandler},
     interpreter::{
@@ -29,54 +28,24 @@ use revm::{
         FrameInput, Gas, InstructionResult, InterpreterResult, SharedMemory,
         interpreter::EthInterpreter, interpreter_action::FrameInit, return_ok,
     },
-    precompile::{PrecompileSpecId, Precompiles},
     primitives::hardfork::SpecId,
 };
 
-pub fn new_evm_with_inspector<'db, I: EthInspectorExt>(
+pub fn new_eth_evm_with_inspector<'db, I: EthInspectorExt>(
     db: &'db mut dyn DatabaseExt,
     evm_env: EvmEnv,
     tx_env: TxEnv,
     inspector: I,
 ) -> FoundryEvm<'db, I> {
-    let mut ctx = EthEvmContext {
-        journaled_state: {
-            let mut journal = Journal::new(db);
-            journal.set_spec_id(evm_env.cfg_env.spec);
-            journal
-        },
-        block: evm_env.block_env,
-        cfg: evm_env.cfg_env,
-        tx: tx_env,
-        chain: (),
-        local: LocalContext::default(),
-        error: Ok(()),
-    };
-    ctx.cfg.tx_chain_id_check = true;
-    let spec = ctx.cfg.spec;
+    let eth_evm =
+        alloy_evm::EthEvmFactory::default().create_evm_with_inspector(db, evm_env, inspector);
+    let mut inner = eth_evm.into_inner();
+    inner.ctx.cfg.tx_chain_id_check = true;
+    inner.ctx.tx = tx_env;
 
-    let mut evm = FoundryEvm {
-        inner: RevmEvm::new_with_inspector(
-            ctx,
-            inspector,
-            EthInstructions::default(),
-            get_precompiles(spec),
-        ),
-    };
-
+    let mut evm = FoundryEvm { inner };
     evm.inspector().get_networks().inject_precompiles(evm.precompiles_mut());
     evm
-}
-
-/// Get the precompiles for the given spec.
-fn get_precompiles(spec: SpecId) -> PrecompilesMap {
-    PrecompilesMap::from_static(
-        EthPrecompiles {
-            precompiles: Precompiles::new(PrecompileSpecId::from_spec_id(spec)),
-            spec,
-        }
-        .precompiles,
-    )
 }
 
 /// Get the call inputs for the CREATE2 factory.

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -17,7 +17,7 @@ use foundry_evm_core::{
     FoundryBlock, FoundryInspectorExt, FoundryTransaction,
     backend::{DatabaseError, DatabaseExt, FoundryJournalExt, JournaledState},
     env::FoundryContextExt,
-    evm::{NestedEvm, new_evm_with_inspector, with_cloned_context},
+    evm::{NestedEvm, new_eth_evm_with_inspector, with_cloned_context},
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_networks::NetworkConfigs;
@@ -374,7 +374,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for InspectorStackInner {
     ) -> Result<(), EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         with_cloned_context(ecx, |db, evm_env, tx_env, journal_inner| {
-            let mut evm = new_evm_with_inspector(db, evm_env, tx_env, &mut inspector);
+            let mut evm = new_eth_evm_with_inspector(db, evm_env, tx_env, &mut inspector);
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
             let sub_evm_env = evm.to_evm_env();
@@ -392,7 +392,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for InspectorStackInner {
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
     ) -> Result<(), EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
-        let mut evm = new_evm_with_inspector(db, evm_env, tx_env, &mut inspector);
+        let mut evm = new_eth_evm_with_inspector(db, evm_env, tx_env, &mut inspector);
         f(&mut evm)
     }
 
@@ -764,7 +764,8 @@ impl InspectorStackRefMut<'_> {
         let res = self.with_inspector(|mut inspector| {
             let (res, nested_env) = {
                 let (db, journal) = ecx.journal_mut().as_db_and_inner();
-                let mut evm = new_evm_with_inspector(db, evm_env, tx_env.clone(), &mut inspector);
+                let mut evm =
+                    new_eth_evm_with_inspector(db, evm_env, tx_env.clone(), &mut inspector);
 
                 evm.journal_inner_mut().state = {
                     let mut state = journal.state.clone();


### PR DESCRIPTION
Refactor `new_evm_with_inspector` to delegate EVM construction to `alloy_evm::EthEvmFactory` instead of manually building the `EthEvmContext`. Removes the `get_precompiles` helper since alloy's builder derives precompiles from the spec. Network-specific precompiles are still injected on top.

Renames to `new_eth_evm_with_inspector` to clarify it's Ethereum-specific.