### PR TITLE
chore: add `id` attributes to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -25,30 +25,25 @@ body:
     validations:
       required: true
   - type: checkboxes
-    id: up-to-date
     attributes:
       label: Have you ensured that all of these are up to date?
       options:
         - label: Foundry
         - label: Foundryup
   - type: input
-    id: foundry-version
     attributes:
       label: What version of Foundry are you on?
       placeholder: "Run forge --version and paste the output here"
   - type: input
-    id: foundryup-version
     attributes:
       label: What version of Foundryup are you on?
       placeholder: "Run foundryup --version and paste the output here"
   - type: input
-    id: command
     attributes:
       label: What command(s) is the bug in?
       description: Leave empty if not relevant
       placeholder: "For example: forge test"
   - type: dropdown
-    id: operating-system
     attributes:
       label: Operating System
       description: What operating system are you on?

--- a/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
@@ -32,7 +32,6 @@ body:
     validations:
       required: true
   - type: textarea
-    id: additional-context
     attributes:
       label: Additional context
       description: Add any other context to the feature (like screenshots, resources)


### PR DESCRIPTION
Adds `id` attributes to all form fields in issue templates so that URLs can prefill fields via query parameters (e.g. `?template=BUG-FORM.yml&component=Forge&description=...`).

See [GitHub docs on query params for issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys).

Co-Authored-By: 0xrusowsky <90208954+0xrusowsky@users.noreply.github.com>

Prompted by: rusowsky