### PR TITLE
feat(script): add --rpc-timeout flag to forge script

### DIFF
--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, sync::Arc, time::Duration};
 use alloy_chains::{Chain, NamedChain};
 use alloy_consensus::{SignableTransaction, Signed};
 use alloy_eips::{BlockId, eip2718::Encodable2718};
-use alloy_network::{EthereumWallet, Network, ReceiptResponse, TransactionBuilder};
+use alloy_network::{AnyNetwork, EthereumWallet, Network, ReceiptResponse, TransactionBuilder};
 use alloy_primitives::{
     Address, TxHash,
     map::{AddressHashMap, AddressHashSet},
@@ -15,11 +15,7 @@ use eyre::{Context, Result, bail};
 use forge_verify::provider::VerificationProviderType;
 use foundry_cheatcodes::Wallets;
 use foundry_cli::utils::{has_batch_support, has_different_gas_calc};
-use foundry_common::{
-    TransactionMaybeSigned,
-    provider::{ProviderBuilder, try_get_http_provider},
-    shell,
-};
+use foundry_common::{TransactionMaybeSigned, shell};
 use foundry_config::Config;
 use foundry_primitives::FoundryTransactionBuilder;
 use foundry_wallets::wallet_browser::signer::BrowserSigner;
@@ -29,7 +25,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     ScriptArgs, ScriptConfig, build::LinkedBuildData, progress::ScriptProgress,
-    sequence::ScriptSequenceKind, verify::BroadcastedState,
+    providers::build_script_provider, sequence::ScriptSequenceKind, verify::BroadcastedState,
 };
 
 pub async fn estimate_gas<N: Network, P: Provider<N>>(
@@ -55,9 +51,10 @@ where
 pub async fn next_nonce(
     caller: Address,
     provider_url: &str,
+    config: &Config,
     block_number: Option<u64>,
 ) -> eyre::Result<u64> {
-    let provider = try_get_http_provider(provider_url)
+    let provider = build_script_provider::<AnyNetwork>(provider_url, config)
         .wrap_err_with(|| format!("bad fork_url provider: {provider_url}"))?;
 
     let block_id = block_number.map_or(BlockId::latest(), BlockId::number);
@@ -260,22 +257,26 @@ where
     pub async fn wait_for_pending(mut self) -> Result<Self> {
         let progress = ScriptProgress::default();
         let progress_ref = &progress;
+        let config = self.script_config.config.clone();
         let futs = self
             .sequence
             .sequences_mut()
             .iter_mut()
             .enumerate()
-            .map(|(sequence_idx, sequence)| async move {
-                let rpc_url = sequence.rpc_url();
-                let provider = Arc::new(ProviderBuilder::new(rpc_url).build()?);
-                progress_ref
-                    .wait_for_pending(
-                        sequence_idx,
-                        sequence,
-                        &provider,
-                        self.script_config.config.transaction_timeout,
-                    )
-                    .await
+            .map(|(sequence_idx, sequence)| {
+                let config = config.clone();
+                async move {
+                    let rpc_url = sequence.rpc_url();
+                    let provider = Arc::new(build_script_provider(rpc_url, &config)?);
+                    progress_ref
+                        .wait_for_pending(
+                            sequence_idx,
+                            sequence,
+                            &provider,
+                            config.transaction_timeout,
+                        )
+                        .await
+                }
             })
             .collect::<Vec<_>>();
 
@@ -353,7 +354,8 @@ where
         for i in 0..self.sequence.sequences().len() {
             let mut sequence = self.sequence.sequences_mut().get_mut(i).unwrap();
 
-            let provider = Arc::new(ProviderBuilder::new(sequence.rpc_url()).build()?);
+            let provider =
+                Arc::new(build_script_provider(sequence.rpc_url(), &self.script_config.config)?);
             let already_broadcasted = sequence.receipts.len();
 
             let seq_progress = progress.get_sequence_progress(i, sequence);

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -1,6 +1,7 @@
 use crate::{
     ScriptArgs, ScriptConfig, broadcast::BundledState, execute::LinkedState,
-    multi_sequence::MultiChainSequence, sequence::ScriptSequenceKind,
+    multi_sequence::MultiChainSequence, providers::build_script_provider,
+    sequence::ScriptSequenceKind,
 };
 use alloy_network::{AnyNetwork, Ethereum};
 use alloy_primitives::{B256, Bytes};
@@ -8,9 +9,7 @@ use alloy_provider::Provider;
 use eyre::{OptionExt, Result};
 use forge_script_sequence::ScriptSequence;
 use foundry_cheatcodes::Wallets;
-use foundry_common::{
-    ContractData, ContractsByArtifact, compile::ProjectCompiler, provider::ProviderBuilder,
-};
+use foundry_common::{ContractData, ContractsByArtifact, compile::ProjectCompiler};
 use foundry_compilers::{
     ArtifactId, ProjectCompileOutput,
     artifacts::{BytecodeObject, Libraries},
@@ -44,7 +43,7 @@ impl BuildData {
     pub async fn link(self, script_config: &ScriptConfig) -> Result<LinkedBuildData> {
         let create2_deployer = script_config.evm_opts.create2_deployer;
         let can_use_create2 = if let Some(fork_url) = &script_config.evm_opts.fork_url {
-            let provider = ProviderBuilder::<AnyNetwork>::new(fork_url).build()?;
+            let provider = build_script_provider::<AnyNetwork>(fork_url, &script_config.config)?;
             let deployer_code = provider.get_code_at(create2_deployer).await?;
 
             !deployer_code.is_empty()
@@ -265,7 +264,10 @@ impl CompiledState {
             None
         } else {
             let fork_url = self.script_config.evm_opts.fork_url.clone().ok_or_eyre("Missing --fork-url field, if you were trying to broadcast a multi-chain sequence, please use --multi flag")?;
-            let provider = Arc::new(ProviderBuilder::<AnyNetwork>::new(&fork_url).build()?);
+            let provider = Arc::new(build_script_provider::<AnyNetwork>(
+                &fork_url,
+                &self.script_config.config,
+            )?);
             Some(provider.get_chain_id().await?)
         };
 

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -1,4 +1,6 @@
-use super::{JsonResult, NestedValue, ScriptResult, runner::ScriptRunner};
+use super::{
+    JsonResult, NestedValue, ScriptResult, providers::build_script_provider, runner::ScriptRunner,
+};
 use crate::{
     ScriptArgs, ScriptConfig,
     build::{CompiledState, LinkedBuildData},
@@ -18,9 +20,8 @@ use foundry_cli::utils::{ensure_clean_constructor, needs_setup};
 use foundry_common::{
     ContractsByArtifact,
     fmt::{format_token, format_token_raw},
-    provider::ProviderBuilder,
 };
-use foundry_config::NamedChain;
+use foundry_config::{Config, NamedChain};
 use foundry_debugger::Debugger;
 use foundry_evm::{
     decode::decode_console_logs,
@@ -240,9 +241,9 @@ impl RpcData {
     }
 
     /// Checks if all RPCs support EIP-3855. Prints a warning if not.
-    async fn check_shanghai_support(&self) -> Result<()> {
+    async fn check_shanghai_support(&self, config: &Config) -> Result<()> {
         let chain_ids = self.total_rpcs.iter().map(|rpc| async move {
-            let provider = ProviderBuilder::<AnyNetwork>::new(rpc).build().ok()?;
+            let provider = build_script_provider::<AnyNetwork>(rpc, config).ok()?;
             let id = provider.get_chain_id().await.ok()?;
             NamedChain::try_from(id).ok()
         });
@@ -305,7 +306,7 @@ impl ExecutedState {
                 )
             }
         }
-        rpc_data.check_shanghai_support().await?;
+        rpc_data.check_shanghai_support(&self.script_config.config).await?;
 
         Ok(PreSimulationState {
             args: self.args,

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -210,6 +210,14 @@ pub struct ScriptArgs {
     #[arg(long, env = "ETH_TIMEOUT")]
     pub timeout: Option<u64>,
 
+    /// Timeout for RPC requests in seconds.
+    ///
+    /// The specified timeout will be used to override the default timeout for RPC requests.
+    ///
+    /// Default value: 45
+    #[arg(long, env = "ETH_RPC_TIMEOUT")]
+    pub rpc_timeout: Option<u64>,
+
     #[command(flatten)]
     pub build: BuildOpts,
 
@@ -527,6 +535,10 @@ impl Provider for ScriptArgs {
             dict.insert("transaction_timeout".to_string(), timeout.into());
         }
 
+        if let Some(rpc_timeout) = self.rpc_timeout {
+            dict.insert("eth_rpc_timeout".to_string(), rpc_timeout.into());
+        }
+
         Ok(Map::from([(Config::selected_profile(), dict)]))
     }
 }
@@ -595,7 +607,7 @@ pub struct ScriptConfig {
 impl ScriptConfig {
     pub async fn new(config: Config, evm_opts: EvmOpts) -> Result<Self> {
         let sender_nonce = if let Some(fork_url) = evm_opts.fork_url.as_ref() {
-            next_nonce(evm_opts.sender, fork_url, evm_opts.fork_block_number).await?
+            next_nonce(evm_opts.sender, fork_url, &config, evm_opts.fork_block_number).await?
         } else {
             // dapptools compatibility
             1
@@ -606,7 +618,7 @@ impl ScriptConfig {
 
     pub async fn update_sender(&mut self, sender: Address) -> Result<()> {
         self.sender_nonce = if let Some(fork_url) = self.evm_opts.fork_url.as_ref() {
-            next_nonce(sender, fork_url, None).await?
+            next_nonce(sender, fork_url, &self.config, None).await?
         } else {
             // dapptools compatibility
             1
@@ -947,6 +959,13 @@ mod tests {
         assert_eq!(etherscan, Some("etherscan_api_key".to_string()));
         let etherscan = config.get_etherscan_api_key(None);
         assert_eq!(etherscan, Some("etherscan_api_key".to_string()));
+    }
+
+    #[test]
+    fn can_merge_script_rpc_timeout() {
+        let args = ScriptArgs::parse_from(["foundry-cli", "Contract.sol", "--rpc-timeout", "90"]);
+        let config = args.load_config().unwrap();
+        assert_eq!(config.eth_rpc_timeout, Some(90));
     }
 
     // <https://github.com/foundry-rs/foundry/issues/5923>

--- a/crates/script/src/providers.rs
+++ b/crates/script/src/providers.rs
@@ -1,10 +1,24 @@
-use alloy_network::Ethereum;
+use alloy_network::{Ethereum, Network};
 use alloy_primitives::map::{HashMap, hash_map::Entry};
 use alloy_provider::{Provider, RootProvider, utils::Eip1559Estimation};
 use eyre::{Result, WrapErr};
 use foundry_common::provider::ProviderBuilder;
-use foundry_config::Chain;
-use std::{ops::Deref, sync::Arc};
+use foundry_config::{Chain, Config};
+use std::{ops::Deref, sync::Arc, time::Duration};
+
+/// Helper function to build a provider for script with a potential RPC timeout.
+pub fn build_script_provider<N: Network>(
+    rpc_url: &str,
+    config: &Config,
+) -> Result<RootProvider<N>> {
+    let mut builder = ProviderBuilder::new(rpc_url);
+
+    if let Some(rpc_timeout) = config.eth_rpc_timeout {
+        builder = builder.timeout(Duration::from_secs(rpc_timeout));
+    }
+
+    builder.build()
+}
 
 /// Contains a map of RPC urls to single instances of [`ProviderInfo`].
 #[derive(Default)]
@@ -17,12 +31,13 @@ impl ProvidersManager {
     pub async fn get_or_init_provider(
         &mut self,
         rpc: &str,
+        config: &Config,
         is_legacy: bool,
     ) -> Result<&ProviderInfo> {
         Ok(match self.inner.entry(rpc.to_string()) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
-                let info = ProviderInfo::new(rpc, is_legacy).await?;
+                let info = ProviderInfo::new(rpc, config, is_legacy).await?;
                 entry.insert(info)
             }
         })
@@ -53,8 +68,8 @@ pub enum GasPrice {
 }
 
 impl ProviderInfo {
-    pub async fn new(rpc: &str, mut is_legacy: bool) -> Result<Self> {
-        let provider = Arc::new(ProviderBuilder::new(rpc).build()?);
+    pub async fn new(rpc: &str, config: &Config, mut is_legacy: bool) -> Result<Self> {
+        let provider = Arc::new(build_script_provider(rpc, config)?);
         let chain = provider.get_chain_id().await?;
 
         if let Some(chain) = Chain::from(chain).named() {

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -295,7 +295,9 @@ impl FilledTransactionsState {
 
         while let Some(mut tx) = txes_iter.next() {
             let tx_rpc = tx.rpc.to_owned();
-            let provider_info = manager.get_or_init_provider(&tx.rpc, self.args.legacy).await?;
+            let provider_info = manager
+                .get_or_init_provider(&tx.rpc, &self.script_config.config, self.args.legacy)
+                .await?;
 
             if let Some(tx) = tx.tx_mut().as_unsigned_mut() {
                 // Handles chain specific requirements for unsigned transactions.


### PR DESCRIPTION
### **Summary**
This PR adds a configurable `--rpc-timeout` flag and `ETH_RPC_TIMEOUT` environment variable to `forge script`. It replaces the previously hardcoded 45-second timeout for RPC requests, allowing users to handle slow or congested networks more effectively.

### **Changes**
- Added `rpc_timeout` field to `ScriptArgs` in `crates/script/src/lib.rs`.
- Introduced `build_script_provider` in `crates/script/src/providers.rs` to centralize provider creation with timeout support.
- Updated `ProvidersManager` and `ProviderInfo` to correctly propagate the RPC timeout from the user's configuration.
- Refactored `broadcast.rs`, `build.rs`, `execute.rs`, and `simulate.rs` to use the new provider logic for all RPC interactions (nonce fetching, simulation, and broadcasting).
- Added a unit test `can_merge_script_rpc_timeout` to verify the flag correctly merges into the project configuration.

### **Related Issues**
Closes #9303

### **Checklist**
- [x] I have run `cargo test -p forge-script` and all tests passed.
- [x] I have run `cargo +nightly fmt -p forge-script`.
- [x] I have followed the [contribution guidelines](https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md).