### PR TITLE
fix: fix tempo CLI arg constraints for valid-before/valid-after

### DIFF
--- a/crates/cli/src/opts/tempo.rs
+++ b/crates/cli/src/opts/tempo.rs
@@ -61,14 +61,14 @@ pub struct TempoOpts {
     ///
     /// The transaction is only valid before this unix timestamp.
     /// Requires `--tempo.expiring-nonce`.
-    #[arg(long = "tempo.valid-before")]
+    #[arg(long = "tempo.valid-before", requires = "expiring_nonce")]
     pub valid_before: Option<u64>,
 
     /// Lower bound timestamp for Tempo expiring nonce transactions.
     ///
     /// The transaction is only valid after this unix timestamp.
     /// Requires `--tempo.expiring-nonce`.
-    #[arg(long = "tempo.valid-after")]
+    #[arg(long = "tempo.valid-after", requires = "expiring_nonce")]
     pub valid_after: Option<u64>,
 }
 


### PR DESCRIPTION
comments said these flags require `--tempo.expiring-nonce`, but clap didn't enforce it. you could pass `--tempo.valid-before` alone and get a transaction with a time window but no expiring nonce setup. fixed, two lines.