### PR TITLE
chore: fix rustls-webpki vulnerability and clean up stale deny.toml entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9125,9 +9125,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -7,8 +7,6 @@ yanked = "warn"
 ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
     "RUSTSEC-2024-0436",
-    # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
-    "RUSTSEC-2025-0141",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
 bumped rustls-webpki 0.103.9 → 0.103.10 to resolve RUSTSEC-2026-0049
 removed stale RUSTSEC-2025-0141 ignore (bincode no longer in dep tree)
 cargo deny check should pass clean now
 
 fix ci failure in https://github.com/foundry-rs/foundry/pull/13872