### PR TITLE
refactor(verify): make verify-bytecode network-agnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,6 +4422,7 @@ dependencies = [
  "foundry-config",
  "foundry-evm",
  "foundry-evm-networks",
+ "foundry-primitives",
  "foundry-test-utils",
  "futures",
  "itertools 0.14.0",

--- a/crates/verify/Cargo.toml
+++ b/crates/verify/Cargo.toml
@@ -19,6 +19,7 @@ foundry-cli.workspace = true
 foundry-common.workspace = true
 foundry-evm.workspace = true
 foundry-evm-networks.workspace = true
+foundry-primitives.workspace = true
 serde_json.workspace = true
 alloy-consensus.workspace = true
 alloy-json-abi.workspace = true

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -7,18 +7,16 @@ use crate::{
     },
     verify::VerifierArgs,
 };
-use alloy_consensus::BlockHeader;
+use alloy_consensus::{BlockHeader, Transaction as _};
 use alloy_evm::{FromRecoveredTx, rpc::TryIntoTxEnv};
 use alloy_primitives::{Address, Bytes, TxKind, U256, hex};
 use alloy_provider::{
     Provider,
     ext::TraceApi,
-    network::{
-        AnyTxEnvelope, TransactionBuilder, TransactionResponse, primitives::BlockTransactions,
-    },
+    network::{AnyNetwork, TransactionBuilder, TransactionResponse, primitives::BlockTransactions},
 };
 use alloy_rpc_types::{
-    BlockId, BlockNumberOrTag, TransactionInput, TransactionRequest, TransactionTrait,
+    BlockId, BlockNumberOrTag, TransactionInput, TransactionRequest,
     trace::parity::{Action, CreateAction, CreateOutput, TraceOutput},
 };
 use clap::{Parser, ValueHint};
@@ -31,6 +29,7 @@ use foundry_common::{SYSTEM_TRANSACTION_TYPE, is_known_system_sender, shell};
 use foundry_compilers::{artifacts::EvmVersion, info::ContractInfo};
 use foundry_config::{Config, figment, impl_figment_convert};
 use foundry_evm::{constants::DEFAULT_CREATE2_DEPLOYER, executors::EvmError};
+use foundry_primitives::{FoundryTransactionRequest, FoundryTxEnvelope};
 use revm::{context::TxEnv, state::AccountInfo};
 use std::path::PathBuf;
 
@@ -250,7 +249,7 @@ impl VerifyBytecodeArgs {
                 .into_create();
 
             if let Some(ref block) = genesis_block {
-                configure_env_block(&mut evm_env, block, config.networks);
+                configure_env_block::<AnyNetwork>(&mut evm_env, block, config.networks);
                 gen_tx_req.max_fee_per_gas = block.header.base_fee_per_gas().map(|g| g as u128);
                 gen_tx_req.gas = Some(block.header.gas_limit());
                 gen_tx_req.gas_price = block.header.base_fee_per_gas().map(|g| g as u128);
@@ -334,10 +333,10 @@ impl VerifyBytecodeArgs {
         };
 
         let creation_block = transaction.block_number;
-        let mut transaction: TransactionRequest = match transaction.inner.inner.inner() {
-            AnyTxEnvelope::Ethereum(tx) => tx.clone().into(),
-            AnyTxEnvelope::Unknown(_) => unreachable!("Unknown transaction type"),
-        };
+        let envelope = FoundryTxEnvelope::try_from(transaction)
+            .map_err(|e| eyre::eyre!("unsupported transaction type: {e}"))?;
+        let req: FoundryTransactionRequest = envelope.into();
+        let mut transaction: TransactionRequest = req.into_inner();
 
         // Extract creation code from creation tx input.
         let maybe_creation_code = if receipt.to.is_none()
@@ -470,7 +469,7 @@ impl VerifyBytecodeArgs {
             transaction.set_nonce(prev_block_nonce);
 
             if let Some(ref block) = block {
-                configure_env_block(&mut evm_env, block, config.networks);
+                configure_env_block::<AnyNetwork>(&mut evm_env, block, config.networks);
 
                 let BlockTransactions::Full(ref txs) = block.transactions else {
                     return Err(eyre::eyre!("Could not get block txs"));

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -4,7 +4,7 @@ use alloy_evm::EvmEnv;
 use alloy_primitives::{Address, Bytes, TxKind};
 use alloy_provider::{
     Provider,
-    network::{AnyNetwork, AnyRpcBlock},
+    network::{BlockResponse, Network},
 };
 use alloy_rpc_types::BlockId;
 use clap::ValueEnum;
@@ -289,11 +289,15 @@ pub async fn get_tracing_executor(
     Ok((evm_env, tx_env, executor))
 }
 
-pub fn configure_env_block(evm_env: &mut EvmEnv, block: &AnyRpcBlock, config: NetworkConfigs) {
+pub fn configure_env_block<N: Network>(
+    evm_env: &mut EvmEnv,
+    block: &N::BlockResponse,
+    config: NetworkConfigs,
+) {
     let number = evm_env.block_env.number;
-    evm_env.block_env = block_env_from_header(&block.header);
+    evm_env.block_env = block_env_from_header(block.header());
     evm_env.block_env.number = number;
-    apply_chain_and_block_specific_env_changes::<AnyNetwork>(evm_env, block, config);
+    apply_chain_and_block_specific_env_changes::<N>(evm_env, block, config);
 }
 
 pub fn deploy_contract(
@@ -349,9 +353,9 @@ pub fn deploy_contract(
     }
 }
 
-pub async fn get_runtime_codes(
+pub async fn get_runtime_codes<N: Network>(
     executor: &mut TracingExecutor,
-    provider: &impl Provider<AnyNetwork>,
+    provider: &impl Provider<N>,
     address: Address,
     fork_address: Address,
     block: Option<u64>,


### PR DESCRIPTION
Make `configure_env_block` and `get_runtime_codes` generic over `N: Network` instead of hardcoding `AnyNetwork`.

Replace the `AnyTxEnvelope::Ethereum` match in `verify-bytecode` with the full `FoundryTxEnvelope` conversion path, which preserves all transaction fields and handles OP deposit transactions instead of panicking on non-Ethereum transaction types.