### PR TITLE
test(cli): add regression tests for Tempo CLI capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4591,6 +4591,7 @@ dependencies = [
  "strsim",
  "strum",
  "tempfile",
+ "tempo-alloy",
  "tikv-jemallocator",
  "tokio",
  "tracing",

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -4939,3 +4939,80 @@ Error: Invalid hex calldata '0X1': odd number of digits
 
 "#]]);
 });
+
+// Test that --tempo.print-sponsor-hash computes and prints the sponsor hash then exits
+casttest!(cast_mktx_tempo_print_sponsor_hash, |_prj, cmd| {
+    let output = cmd
+        .args([
+            "mktx",
+            "--from",
+            "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+            "--private-key",
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "--chain",
+            "1",
+            "--nonce",
+            "0",
+            "--gas-limit",
+            "21000",
+            "--gas-price",
+            "10000000000",
+            "--priority-gas-price",
+            "1000000000",
+            "--tempo.print-sponsor-hash",
+            "--tempo.fee-token",
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000001",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    // Should output a 0x-prefixed 32-byte hash (66 chars)
+    assert!(output.starts_with("0x"), "expected 0x prefix, got: {output}");
+    assert_eq!(output.len(), 66, "expected 66-char hash, got {}: {output}", output.len());
+});
+
+// Test that --tempo.expiring-nonce with --tempo.valid-before successfully constructs a transaction
+casttest!(cast_mktx_tempo_expiring_nonce, |_prj, cmd| {
+    cmd.args([
+        "mktx",
+        "--private-key",
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "--chain",
+        "1",
+        "--nonce",
+        "0",
+        "--gas-limit",
+        "21000",
+        "--gas-price",
+        "10000000000",
+        "--priority-gas-price",
+        "1000000000",
+        "--tempo.expiring-nonce",
+        "--tempo.valid-before",
+        "99999999999",
+        "--tempo.fee-token",
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000001",
+    ])
+    .assert_success();
+});
+
+// Test that --tempo.expiring-nonce without --tempo.valid-before fails with a clap error
+casttest!(cast_mktx_tempo_expiring_nonce_requires_valid_before, |_prj, cmd| {
+    cmd.args([
+        "mktx",
+        "--private-key",
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "--chain",
+        "1",
+        "--nonce",
+        "0",
+        "--tempo.expiring-nonce",
+        "0x0000000000000000000000000000000000000001",
+    ])
+    .assert_failure();
+});

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -64,6 +64,7 @@ tracing-tracy = { version = "0.11", optional = true, features = ["demangle"] }
 
 [dev-dependencies]
 tempfile.workspace = true
+tempo-alloy.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { workspace = true, optional = true }

--- a/crates/cli/src/opts/tempo.rs
+++ b/crates/cli/src/opts/tempo.rs
@@ -135,3 +135,102 @@ impl TempoOpts {
 fn parse_signature(s: &str) -> Result<Signature, String> {
     Signature::from_str(s).map_err(|e| format!("invalid signature: {e}"))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempo_alloy::TempoNetwork;
+
+    /// Helper: creates a default TempoNetwork transaction request.
+    fn default_tempo_tx() -> <TempoNetwork as Network>::TransactionRequest {
+        Default::default()
+    }
+
+    /// Helper: a valid 65-byte signature for testing.
+    fn test_signature() -> Signature {
+        Signature::from_str(
+            "f2dd00eac33840c04b6fc8a5ec8c4a47eff63575c2bc7312ecb269383de0c668\
+             045309c423484c8d097df306e690c653f8e1ec92f7f6f45d1f517027771c3e80\
+             1c",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_apply_expiring_nonce() {
+        let opts = TempoOpts {
+            expiring_nonce: true,
+            valid_before: Some(1000),
+            sequence_key: Some(U256::from(5)),
+            ..Default::default()
+        };
+        let mut tx = default_tempo_tx();
+        opts.apply::<TempoNetwork>(&mut tx, Some(42));
+
+        // Expiring nonce overrides both passed-in nonce and sequence_key
+        assert_eq!(tx.nonce(), Some(0));
+        assert_eq!(tx.nonce_key(), Some(U256::MAX));
+    }
+
+    #[test]
+    fn test_apply_fee_token_sequence_key_and_key_id() {
+        let fee_addr = Address::with_last_byte(0xAA);
+        let key_addr = Address::with_last_byte(0xBB);
+        let opts = TempoOpts {
+            fee_token: Some(fee_addr),
+            sequence_key: Some(U256::from(7)),
+            key_id: Some(key_addr),
+            ..Default::default()
+        };
+        let mut tx = default_tempo_tx();
+        opts.apply::<TempoNetwork>(&mut tx, Some(10));
+
+        assert_eq!(tx.fee_token(), Some(fee_addr));
+        assert_eq!(tx.nonce(), Some(10));
+        assert_eq!(tx.nonce_key(), Some(U256::from(7)));
+        assert_eq!(tx.key_id(), Some(key_addr));
+    }
+
+    #[test]
+    fn test_apply_validity_window() {
+        let opts = TempoOpts {
+            valid_before: Some(2000),
+            valid_after: Some(1000),
+            ..Default::default()
+        };
+        let mut tx = default_tempo_tx();
+        opts.apply::<TempoNetwork>(&mut tx, None);
+
+        assert_eq!(tx.valid_before(), Some(2000));
+        assert_eq!(tx.valid_after(), Some(1000));
+    }
+
+    #[test]
+    fn test_apply_sponsor_forces_aa() {
+        let sig = test_signature();
+
+        // Case 1: sponsor_signature without sequence_key forces nonce_key to ZERO
+        let opts = TempoOpts { sponsor_signature: Some(sig), ..Default::default() };
+        let mut tx = default_tempo_tx();
+        opts.apply::<TempoNetwork>(&mut tx, None);
+        assert_eq!(tx.nonce_key(), Some(U256::ZERO));
+        assert_eq!(tx.fee_payer_signature(), Some(sig));
+
+        // Case 2: print_sponsor_hash without sequence_key also forces nonce_key to ZERO
+        let opts = TempoOpts { print_sponsor_hash: true, ..Default::default() };
+        let mut tx = default_tempo_tx();
+        opts.apply::<TempoNetwork>(&mut tx, None);
+        assert_eq!(tx.nonce_key(), Some(U256::ZERO));
+
+        // Case 3: sponsor_signature with sequence_key preserves existing nonce_key
+        let opts = TempoOpts {
+            sponsor_signature: Some(sig),
+            sequence_key: Some(U256::from(5)),
+            ..Default::default()
+        };
+        let mut tx = default_tempo_tx();
+        opts.apply::<TempoNetwork>(&mut tx, None);
+        assert_eq!(tx.nonce_key(), Some(U256::from(5)));
+        assert_eq!(tx.fee_payer_signature(), Some(sig));
+    }
+}

--- a/crates/cli/src/opts/tempo.rs
+++ b/crates/cli/src/opts/tempo.rs
@@ -193,11 +193,8 @@ mod tests {
 
     #[test]
     fn test_apply_validity_window() {
-        let opts = TempoOpts {
-            valid_before: Some(2000),
-            valid_after: Some(1000),
-            ..Default::default()
-        };
+        let opts =
+            TempoOpts { valid_before: Some(2000), valid_after: Some(1000), ..Default::default() };
         let mut tx = default_tempo_tx();
         opts.apply::<TempoNetwork>(&mut tx, None);
 

--- a/crates/cli/src/opts/tempo.rs
+++ b/crates/cli/src/opts/tempo.rs
@@ -61,14 +61,14 @@ pub struct TempoOpts {
     ///
     /// The transaction is only valid before this unix timestamp.
     /// Requires `--tempo.expiring-nonce`.
-    #[arg(long = "tempo.valid-before")]
+    #[arg(long = "tempo.valid-before", requires = "expiring_nonce")]
     pub valid_before: Option<u64>,
 
     /// Lower bound timestamp for Tempo expiring nonce transactions.
     ///
     /// The transaction is only valid after this unix timestamp.
     /// Requires `--tempo.expiring-nonce`.
-    #[arg(long = "tempo.valid-after")]
+    #[arg(long = "tempo.valid-after", requires = "expiring_nonce")]
     pub valid_after: Option<u64>,
 }
 


### PR DESCRIPTION
The newer Tempo flags (`--tempo.sponsor-sig`, `--tempo.print-sponsor-hash`, `--tempo.expiring-nonce`,` --tempo.valid-before/after,` `--tempo.seq`, `--tempo.key-id`) had basically zero test coverage beyond the raw block/tx queries. Added 4 unit tests for TempoOpts::apply() covering expiring nonce overrides, fee token + sequence key + key id, validity windows, and the sponsor-forces-AA logic. Also added 3 CLI integration tests for `cast mktx` — print-sponsor-hash early exit, expiring nonce success path, and the clap constraint requiring `--tempo.valid-before`. Also includes the prior fix for the missing `requires` constraint on valid-before/valid-after args.