### PR TITLE
cheatcodes: mark copyStorage and setArbitraryStorage as Unsafe

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -3758,7 +3758,7 @@
       },
       "group": "utilities",
       "status": "stable",
-      "safety": "safe"
+      "safety": "unsafe"
     },
     {
       "func": {
@@ -9868,7 +9868,7 @@
       },
       "group": "utilities",
       "status": "stable",
-      "safety": "safe"
+      "safety": "unsafe"
     },
     {
       "func": {
@@ -9888,7 +9888,7 @@
       },
       "group": "utilities",
       "status": "stable",
-      "safety": "safe"
+      "safety": "unsafe"
     },
     {
       "func": {

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2968,16 +2968,16 @@ interface Vm {
     function resumeTracing() external view;
 
     /// Utility cheatcode to copy storage of `from` contract to another `to` contract.
-    #[cheatcode(group = Utilities)]
+    #[cheatcode(group = Utilities, safety = Unsafe)]
     function copyStorage(address from, address to) external;
 
     /// Utility cheatcode to set arbitrary storage for given target address.
-    #[cheatcode(group = Utilities)]
+    #[cheatcode(group = Utilities, safety = Unsafe)]
     function setArbitraryStorage(address target) external;
 
     /// Utility cheatcode to set arbitrary storage for given target address and overwrite
     /// any storage slots that have been previously set.
-    #[cheatcode(group = Utilities)]
+    #[cheatcode(group = Utilities, safety = Unsafe)]
     function setArbitraryStorage(address target, bool overwrite) external;
 
     /// Sorts an array in ascending order.


### PR DESCRIPTION
## What this PR does
Adds `safety = Unsafe` to `copyStorage` and `setArbitraryStorage` (both overloads)
in `crates/cheatcodes/spec/src/vm.rs`.

## Why
Both cheatcodes are in the `Utilities` group, which defaults to `Safety::Safe`.
Neither had an explicit safety override, so both were silently inheriting `Safe`.

This is incorrect:
- `copyStorage` directly overwrites EVM journal state by copying entire storage from
  one address to another, the same category of mutation as `store` and `etch`,
  both of which are explicitly marked `Unsafe`.
- `setArbitraryStorage` intercepts every subsequent SLOAD on the marked address and
  returns a random value. Non-deterministic storage reads in a script context are
  exactly what `Unsafe` is meant to flag.

`interceptInitcode` in the same group has similar impact and was explicitly marked
`safety = Unsafe`, suggesting these two were simply missed.

## Changes
- `crates/cheatcodes/spec/src/vm.rs`: added `safety = Unsafe` to `copyStorage`,
  `setArbitraryStorage(address)` and `setArbitraryStorage(address, bool)`
- Updated `assets/cheatcodes.json` via `cargo cheats`