### PR TITLE
refactor(script): dedup gas currency symbol lookup

### DIFF
--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -1,5 +1,6 @@
 use std::{cmp::Ordering, sync::Arc, time::Duration};
 
+use crate::gas_currency_symbol;
 use alloy_chains::Chain;
 use alloy_consensus::{SignableTransaction, Signed};
 use alloy_eips::{BlockId, eip2718::Encodable2718};
@@ -629,7 +630,7 @@ where
                 .and_then(|avg| format_units(avg, 9).ok())
                 .unwrap_or_else(|| "N/A".to_string());
 
-            let token_symbol = crate::gas_currency_symbol(sequence.chain);
+            let token_symbol = gas_currency_symbol(sequence.chain);
             seq_progress.inner.write().set_status(&format!(
                 "Total Paid: {} {} ({} gas * avg {} gwei)\n",
                 paid.trim_end_matches('0'),

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, sync::Arc, time::Duration};
 
-use alloy_chains::{Chain, NamedChain};
+use alloy_chains::Chain;
 use alloy_consensus::{SignableTransaction, Signed};
 use alloy_eips::{BlockId, eip2718::Encodable2718};
 use alloy_network::{EthereumWallet, Network, ReceiptResponse, TransactionBuilder};
@@ -629,10 +629,7 @@ where
                 .and_then(|avg| format_units(avg, 9).ok())
                 .unwrap_or_else(|| "N/A".to_string());
 
-            let token_symbol = NamedChain::try_from(sequence.chain)
-                .unwrap_or_default()
-                .native_currency_symbol()
-                .unwrap_or("ETH");
+            let token_symbol = crate::gas_currency_symbol(sequence.chain);
             seq_progress.inner.write().set_status(&format!(
                 "Total Paid: {} {} ({} gas * avg {} gwei)\n",
                 paid.trim_end_matches('0'),

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -71,6 +71,17 @@ mod simulate;
 mod transaction;
 mod verify;
 
+/// Returns the native currency symbol for gas display on a given chain.
+///
+/// All EVM chains use the same 18-decimal internal representation for gas pricing,
+/// so only the symbol changes (e.g. "ETH" vs "USDC" on Tempo).
+fn gas_currency_symbol(chain_id: u64) -> &'static str {
+    foundry_config::NamedChain::try_from(chain_id)
+        .unwrap_or_default()
+        .native_currency_symbol()
+        .unwrap_or("ETH")
+}
+
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::merge_impl_figment_convert!(ScriptArgs, build, evm);
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -74,7 +74,7 @@ mod verify;
 /// Returns the native currency symbol for gas display on a given chain.
 ///
 /// All EVM chains use the same 18-decimal internal representation for gas pricing,
-/// so only the symbol changes (e.g. "ETH" vs "USDC" on Tempo).
+/// so only the symbol changes (e.g. "ETH" vs "USD" on Tempo).
 fn gas_currency_symbol(chain_id: u64) -> &'static str {
     foundry_config::NamedChain::try_from(chain_id)
         .unwrap_or_default()

--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -1,3 +1,4 @@
+use crate::gas_currency_symbol;
 use alloy_chains::Chain;
 use alloy_network::{Network, ReceiptResponse};
 use alloy_primitives::{Address, TxHash, U256, utils::format_units};
@@ -176,7 +177,7 @@ pub fn format_receipt<N: Network>(
                     .unwrap_or_else(|_| "N/A".into());
                 let gas_price =
                     format_units(U256::from(gas_price), 9).unwrap_or_else(|_| "N/A".into());
-                let token_symbol = crate::gas_currency_symbol(chain.id());
+                let token_symbol = gas_currency_symbol(chain.id());
                 format!(
                     "Paid: {} {} ({gas_used} gas * {} gwei)",
                     paid.trim_end_matches('0'),

--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -1,4 +1,4 @@
-use alloy_chains::{Chain, NamedChain};
+use alloy_chains::Chain;
 use alloy_network::{Network, ReceiptResponse};
 use alloy_primitives::{Address, TxHash, U256, utils::format_units};
 use alloy_provider::{
@@ -176,10 +176,7 @@ pub fn format_receipt<N: Network>(
                     .unwrap_or_else(|_| "N/A".into());
                 let gas_price =
                     format_units(U256::from(gas_price), 9).unwrap_or_else(|_| "N/A".into());
-                let token_symbol = NamedChain::try_from(chain)
-                    .unwrap_or_default()
-                    .native_currency_symbol()
-                    .unwrap_or("ETH");
+                let token_symbol = crate::gas_currency_symbol(chain.id());
                 format!(
                     "Paid: {} {} ({gas_used} gas * {} gwei)",
                     paid.trim_end_matches('0'),

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -7,9 +7,9 @@ use crate::{
     broadcast::{BundledState, estimate_gas},
     build::LinkedBuildData,
     execute::{ExecutionArtifacts, ExecutionData},
+    gas_currency_symbol,
     sequence::get_commit_hash,
 };
-use alloy_chains::NamedChain;
 use alloy_network::{Ethereum, Network, TransactionBuilder};
 use alloy_primitives::{Address, U256, map::HashMap, utils::format_units};
 use dialoguer::Confirm;
@@ -360,11 +360,7 @@ impl FilledTransactionsState {
             for (rpc, total_gas) in total_gas_per_rpc {
                 let provider_info = manager.get(&rpc).expect("provider is set.");
 
-                // Get the native token symbol for the chain using NamedChain
-                let token_symbol = NamedChain::try_from(provider_info.chain)
-                    .unwrap_or_default()
-                    .native_currency_symbol()
-                    .unwrap_or("ETH");
+                let token_symbol = gas_currency_symbol(provider_info.chain);
 
                 // We don't store it in the transactions, since we want the most updated value.
                 // Right before broadcasting.


### PR DESCRIPTION
While testing Tempo compatibility, found that `forge script` displays "ETH" as the gas currency on Tempo (chain 4217), which uses USDC as its gas token.

The fix is upstream in alloy-rs/chains#266, which adds `native_currency_symbol()` for Tempo chains. Once that lands and alloy-chains is bumped, the existing `.unwrap_or("ETH")` fallback will correctly resolve to "USDC".

This PR deduplicates the symbol lookup (repeated in simulate.rs, receipts.rs, broadcast.rs) into a shared `gas_currency_symbol()` helper to keep things clean.

Also found a separate issue — gas price estimates are inflated on Tempo (~41000 gwei vs actual 20 gwei). Filed as https://github.com/foundry-rs/foundry/issues/13885
