### PR TITLE
revert: "BroadcastableTransaction network-agnostic" (#13849)

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -2,23 +2,20 @@
 
 use crate::{
     BroadcastableTransaction, Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Error,
-    EthCheatCtx, Result,
-    Vm::*,
-    inspector::{BroadcastKind, RecordDebugStepInfo},
+    EthCheatCtx, Result, Vm::*, inspector::RecordDebugStepInfo,
 };
-use alloy_consensus::{
-    Transaction as TransactionTrait, TxEnvelope, transaction::SignerRecoverable,
-};
+use alloy_consensus::{TxEnvelope, transaction::SignerRecoverable};
 use alloy_evm::{EvmEnv, FromRecoveredTx};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_network::eip2718::EIP4844_TX_TYPE_ID;
 use alloy_primitives::{
-    Address, B256, Bytes, U256, hex, keccak256,
+    Address, B256, U256, hex, keccak256,
     map::{B256Map, HashMap},
 };
 use alloy_rlp::Decodable;
 use alloy_sol_types::SolValue;
 use foundry_common::{
+    TransactionMaybeSigned,
     fs::{read_json_file, write_json_file},
     slot_identifier::{
         ENCODING_BYTES, ENCODING_DYN_ARRAY, ENCODING_INPLACE, ENCODING_MAPPING, SlotIdentifier,
@@ -1132,13 +1129,7 @@ impl Cheatcode for broadcastRawTransactionCall {
         if ccx.state.broadcast.is_some() {
             ccx.state.broadcastable_transactions.push_back(BroadcastableTransaction {
                 rpc: ccx.ecx.db().active_fork_url(),
-                from,
-                to: Some(tx.kind()),
-                value: tx.value(),
-                input: tx.input().clone(),
-                nonce: tx.nonce(),
-                gas: Some(tx.gas_limit()),
-                kind: BroadcastKind::Signed(Bytes::copy_from_slice(&self.data)),
+                transaction: TransactionMaybeSigned::new_signed(tx)?,
             });
         }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -21,14 +21,18 @@ use crate::{
     utils::IgnoredTraces,
 };
 use alloy_consensus::BlobTransactionSidecarVariant;
+use alloy_network::{Ethereum, Network};
 use alloy_primitives::{
     Address, B256, Bytes, Log, TxKind, U256, hex,
     map::{AddressHashMap, HashMap, HashSet},
 };
-use alloy_rpc_types::AccessList;
+use alloy_rpc_types::{
+    AccessList,
+    request::{TransactionInput, TransactionRequest},
+};
 use alloy_sol_types::{SolCall, SolInterface, SolValue};
 use foundry_common::{
-    SELECTOR_LEN,
+    SELECTOR_LEN, TransactionMaybeSigned,
     mapping_slots::{MappingSlots, step as mapping_step},
 };
 use foundry_evm_core::{
@@ -42,6 +46,7 @@ use foundry_evm_core::{
 use foundry_evm_traces::{
     TracingInspector, TracingInspectorConfig, identifier::SignaturesIdentifier,
 };
+use foundry_primitives::FoundryTransactionBuilder;
 use foundry_wallets::wallet_multi::MultiWallet;
 use itertools::Itertools;
 use proptest::test_runner::{RngAlgorithm, TestRng, TestRunner};
@@ -252,49 +257,12 @@ impl TestContext {
 }
 
 /// Helps collecting transactions from different forks.
-///
-/// This type is intentionally network-agnostic — it stores raw EVM data (from, to, value, input,
-/// etc.) without requiring a `Network` type parameter. Conversion to network-specific types
-/// (e.g. `TransactionRequest`, `TxEnvelope`) happens later in the script layer.
 #[derive(Clone, Debug)]
-pub struct BroadcastableTransaction {
+pub struct BroadcastableTransaction<N: Network = Ethereum> {
     /// The optional RPC URL.
     pub rpc: Option<String>,
-    /// Sender address.
-    pub from: Address,
-    /// Recipient (None for contract creation).
-    pub to: Option<TxKind>,
-    /// Ether value.
-    pub value: U256,
-    /// Calldata or init code.
-    pub input: Bytes,
-    /// Sender nonce.
-    pub nonce: u64,
-    /// Gas limit, if explicitly set.
-    pub gas: Option<u64>,
-    /// Whether this transaction was pre-signed or needs signing.
-    pub kind: BroadcastKind,
-}
-
-/// Distinguishes between unsigned transactions (from `startBroadcast`) that need signing, and
-/// pre-signed transactions (from `broadcastRawTransaction`) that carry raw RLP-encoded bytes.
-#[derive(Clone, Debug)]
-pub enum BroadcastKind {
-    /// Unsigned transaction collected during `startBroadcast`. Needs signing before broadcast.
-    Unsigned {
-        chain_id: Option<u64>,
-        blob_sidecar: Option<BlobTransactionSidecarVariant>,
-        authorization_list: Option<Vec<SignedAuthorization>>,
-    },
-    /// Pre-signed transaction from `broadcastRawTransaction`. Contains raw RLP-encoded bytes.
-    Signed(Bytes),
-}
-
-impl BroadcastKind {
-    /// Creates an unsigned broadcast with no chain-specific fields set.
-    pub fn unsigned() -> Self {
-        Self::Unsigned { chain_id: None, blob_sidecar: None, authorization_list: None }
-    }
+    /// The transaction to broadcast.
+    pub transaction: TransactionMaybeSigned<N>,
 }
 
 #[derive(Clone, Debug, Copy)]
@@ -1005,36 +973,45 @@ impl Cheatcodes {
                         });
                     }
 
-                    let input = call.input.bytes(ecx);
+                    let input = TransactionInput::new(call.input.bytes(ecx));
                     let chain_id = ecx.cfg().chain_id();
                     let rpc = ecx.db().active_fork_url();
                     let account =
                         ecx.journal_mut().evm_state_mut().get_mut(&broadcast.new_origin).unwrap();
 
-                    let blob_sidecar = self.active_blob_sidecar.take();
-                    let active_delegations = std::mem::take(&mut self.active_delegations);
+                    let mut tx_req = TransactionRequest {
+                        from: Some(broadcast.new_origin),
+                        to: Some(TxKind::from(Some(call.target_address))),
+                        value: call.transfer_value(),
+                        input,
+                        nonce: Some(account.info.nonce),
+                        chain_id: Some(chain_id),
+                        gas: if is_fixed_gas_limit { Some(call.gas_limit) } else { None },
+                        ..Default::default()
+                    };
 
-                    // Ensure blob and delegation are not set for the same tx.
-                    if blob_sidecar.is_some() && !active_delegations.is_empty() {
-                        let msg = "both delegation and blob are active; `attachBlob` and `attachDelegation` are not compatible";
-                        return Some(CallOutcome {
-                            result: InterpreterResult {
-                                result: InstructionResult::Revert,
-                                output: Error::encode(msg),
-                                gas,
-                            },
-                            memory_offset: call.return_memory_offset.clone(),
-                            was_precompile_called: false,
-                            precompile_call_logs: vec![],
-                        });
+                    let active_delegations = std::mem::take(&mut self.active_delegations);
+                    // Set active blob sidecar, if any.
+                    if let Some(blob_sidecar) = self.active_blob_sidecar.take() {
+                        // Ensure blob and delegation are not set for the same tx.
+                        if !active_delegations.is_empty() {
+                            let msg = "both delegation and blob are active; `attachBlob` and `attachDelegation` are not compatible";
+                            return Some(CallOutcome {
+                                result: InterpreterResult {
+                                    result: InstructionResult::Revert,
+                                    output: Error::encode(msg),
+                                    gas,
+                                },
+                                memory_offset: call.return_memory_offset.clone(),
+                                was_precompile_called: false,
+                                precompile_call_logs: vec![],
+                            });
+                        }
+                        tx_req.set_blob_sidecar(blob_sidecar);
                     }
 
-                    // Capture nonce before delegation bump (delegations increment the
-                    // account nonce but the transaction itself uses the pre-bump nonce).
-                    let nonce = account.info.nonce;
-
                     // Apply active EIP-7702 delegations, if any.
-                    let authorization_list = if !active_delegations.is_empty() {
+                    if !active_delegations.is_empty() {
                         for auth in &active_delegations {
                             let Ok(authority) = auth.recover_authority() else {
                                 continue;
@@ -1045,24 +1022,12 @@ impl Cheatcodes {
                                 account.info.nonce += 1;
                             }
                         }
-                        Some(active_delegations)
-                    } else {
-                        None
-                    };
+                        tx_req.authorization_list = Some(active_delegations);
+                    }
 
                     self.broadcastable_transactions.push_back(BroadcastableTransaction {
                         rpc,
-                        from: broadcast.new_origin,
-                        to: Some(TxKind::from(Some(call.target_address))),
-                        value: call.transfer_value().unwrap_or_default(),
-                        input,
-                        nonce,
-                        gas: if is_fixed_gas_limit { Some(call.gas_limit) } else { None },
-                        kind: BroadcastKind::Unsigned {
-                            chain_id: Some(chain_id),
-                            blob_sidecar,
-                            authorization_list,
-                        },
+                        transaction: TransactionMaybeSigned::new(tx_req),
                     });
                     debug!(target: "cheatcodes", tx=?self.broadcastable_transactions.back().unwrap(), "broadcastable call");
 
@@ -1807,13 +1772,14 @@ impl<CTX: EthCheatCtx> Inspector<CTX> for Cheatcodes {
                 let account = &ecx.journal().evm_state()[&broadcast.new_origin];
                 self.broadcastable_transactions.push_back(BroadcastableTransaction {
                     rpc,
-                    from: broadcast.new_origin,
-                    to: None,
-                    value: input.value(),
-                    input: input.init_code(),
-                    nonce: account.info.nonce,
-                    gas: None,
-                    kind: BroadcastKind::unsigned(),
+                    transaction: TransactionMaybeSigned::new(TransactionRequest {
+                        from: Some(broadcast.new_origin),
+                        to: None,
+                        value: Some(input.value()),
+                        input: TransactionInput::new(input.init_code()),
+                        nonce: Some(account.info.nonce),
+                        ..Default::default()
+                    }),
                 });
 
                 input.log_debug(self, &input.scheme().unwrap_or(CreateScheme::Create));

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -24,8 +24,7 @@ pub use config::CheatsConfig;
 pub use error::{Error, ErrorKind, Result};
 pub use foundry_evm_core::{EthCheatCtx, evm::NestedEvmClosure};
 pub use inspector::{
-    BroadcastKind, BroadcastableTransaction, BroadcastableTransactions, Cheatcodes,
-    CheatcodesExecutor,
+    BroadcastableTransaction, BroadcastableTransactions, Cheatcodes, CheatcodesExecutor,
 };
 pub use spec::{CheatcodeDef, Vm};
 

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -12,6 +12,7 @@ use alloy_primitives::{
     map::{HashMap, HashSet},
 };
 use alloy_provider::Provider;
+use alloy_rpc_types::TransactionInput;
 use eyre::{OptionExt, Result};
 use foundry_cheatcodes::Wallets;
 use foundry_cli::utils::{ensure_clean_constructor, needs_setup};
@@ -195,8 +196,8 @@ impl PreExecutionState {
                 && self.args.evm.sender.is_none()
             {
                 for tx in txs {
-                    if tx.to.is_none() {
-                        let sender = tx.from;
+                    if tx.transaction.to().is_none() {
+                        let sender = tx.transaction.from().expect("no sender");
                         if let Some(ns) = new_sender {
                             if sender != ns {
                                 sh_warn!(
@@ -294,7 +295,16 @@ impl ExecutedState {
 
         let decoder = self.build_trace_decoder(&self.build_data.known_contracts).await?;
 
-        let txs = self.execution_result.transactions.clone().unwrap_or_default();
+        let mut txs = self.execution_result.transactions.clone().unwrap_or_default();
+
+        // Ensure that unsigned transactions have both `data` and `input` populated to avoid
+        // issues with eth_estimateGas and eth_sendTransaction requests.
+        for tx in &mut txs {
+            if let Some(req) = tx.transaction.as_unsigned_mut() {
+                req.input =
+                    TransactionInput::maybe_both(std::mem::take(&mut req.input).into_input());
+            }
+        }
         let rpc_data = RpcData::from_transactions(&txs);
 
         if rpc_data.is_multi_chain() {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -458,7 +458,12 @@ impl ScriptArgs {
         };
 
         for (data, to) in result.transactions.iter().flat_map(|txes| {
-            txes.iter().filter_map(|tx| (tx.input.len() > max_size).then_some((&tx.input, tx.to)))
+            txes.iter().filter_map(|tx| {
+                tx.transaction
+                    .input()
+                    .filter(|data| data.len() > max_size)
+                    .map(|data| (data, tx.transaction.to()))
+            })
         }) {
             let mut offset = 0;
 

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -2,8 +2,10 @@ use super::{ScriptConfig, ScriptResult};
 use crate::build::ScriptPredeployLibraries;
 use alloy_eips::eip7702::SignedAuthorization;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_rpc_types::TransactionRequest;
 use eyre::Result;
-use foundry_cheatcodes::{BroadcastKind, BroadcastableTransaction};
+use foundry_cheatcodes::BroadcastableTransaction;
+use foundry_common::TransactionMaybeSigned;
 use foundry_config::Config;
 use foundry_evm::{
     constants::CALLER,
@@ -72,13 +74,12 @@ impl ScriptRunner {
 
                 library_transactions.push_back(BroadcastableTransaction {
                     rpc: self.evm_opts.fork_url.clone(),
-                    from: self.evm_opts.sender,
-                    to: None,
-                    value: U256::ZERO,
-                    input: code.clone(),
-                    nonce: sender_nonce + library_transactions.len() as u64,
-                    gas: None,
-                    kind: BroadcastKind::unsigned(),
+                    transaction: TransactionMaybeSigned::new(TransactionRequest {
+                        from: Some(self.evm_opts.sender),
+                        input: code.clone().into(),
+                        nonce: Some(sender_nonce + library_transactions.len() as u64),
+                        ..Default::default()
+                    }),
                 })
             }),
             ScriptPredeployLibraries::Create2(libraries, salt) => {
@@ -106,17 +107,13 @@ impl ScriptRunner {
 
                     library_transactions.push_back(BroadcastableTransaction {
                         rpc: self.evm_opts.fork_url.clone(),
-                        from: self.evm_opts.sender,
-                        to: Some(TxKind::Call(create2_deployer)),
-                        value: U256::ZERO,
-                        input: calldata.into(),
-                        nonce: sender_nonce + library_transactions.len() as u64,
-                        gas: None,
-                        kind: BroadcastKind::Unsigned {
-                            chain_id: None,
-                            blob_sidecar: None,
-                            authorization_list: None,
-                        },
+                        transaction: TransactionMaybeSigned::new(TransactionRequest {
+                            from: Some(self.evm_opts.sender),
+                            input: calldata.into(),
+                            nonce: Some(sender_nonce + library_transactions.len() as u64),
+                            to: Some(TxKind::Call(create2_deployer)),
+                            ..Default::default()
+                        }),
                     });
                 }
 

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -10,16 +10,14 @@ use crate::{
     sequence::get_commit_hash,
 };
 use alloy_chains::NamedChain;
-use alloy_consensus::TxEnvelope;
-use alloy_network::{Ethereum, Network, TransactionBuilder, eip2718::Decodable2718};
+use alloy_network::{Ethereum, Network, TransactionBuilder};
 use alloy_primitives::{Address, TxKind, U256, map::HashMap, utils::format_units};
-use alloy_rpc_types::request::{TransactionInput, TransactionRequest};
 use dialoguer::Confirm;
 use eyre::{Context, Result};
 use forge_script_sequence::{ScriptSequence, TransactionWithMetadata};
-use foundry_cheatcodes::{BroadcastKind, BroadcastableTransaction, Wallets};
+use foundry_cheatcodes::Wallets;
 use foundry_cli::utils::{has_different_gas_calc, now};
-use foundry_common::{ContractData, TransactionMaybeSigned, shell};
+use foundry_common::{ContractData, shell};
 use foundry_evm::traces::{decode_trace_arena, render_trace_arena};
 use foundry_primitives::FoundryTransactionBuilder;
 use foundry_wallets::wallet_browser::signer::BrowserSigner;
@@ -63,13 +61,12 @@ impl PreSimulationState {
             .unwrap_or_default()
             .into_iter()
             .map(|tx| {
-                let rpc = tx.rpc.clone().expect("missing broadcastable tx rpc url");
-                let sender = tx.from;
-                let nonce = tx.nonce;
-                let to = tx.to;
+                let rpc = tx.rpc.expect("missing broadcastable tx rpc url");
+                let sender = tx.transaction.from().expect("all transactions should have a sender");
+                let nonce = tx.transaction.nonce().expect("all transactions should have a nonce");
+                let to = tx.transaction.to();
 
-                let maybe_signed = into_maybe_signed(tx);
-                let mut builder = ScriptTransactionBuilder::new(maybe_signed, rpc);
+                let mut builder = ScriptTransactionBuilder::new(tx.transaction, rpc);
 
                 if let Some(TxKind::Call(_)) = to {
                     builder.set_call(
@@ -477,36 +474,5 @@ impl FilledTransactionsState {
             commit,
         };
         Ok(sequence)
-    }
-}
-
-/// Converts a network-agnostic [`BroadcastableTransaction`] into a
-/// [`TransactionMaybeSigned<Ethereum>`] for use in the script pipeline.
-fn into_maybe_signed(tx: BroadcastableTransaction) -> TransactionMaybeSigned<Ethereum> {
-    match tx.kind {
-        BroadcastKind::Unsigned { chain_id, blob_sidecar, authorization_list } => {
-            let mut req = TransactionRequest {
-                from: Some(tx.from),
-                to: tx.to,
-                value: Some(tx.value),
-                input: TransactionInput::maybe_both(Some(tx.input)),
-                nonce: Some(tx.nonce),
-                chain_id,
-                gas: tx.gas,
-                ..Default::default()
-            };
-            if let Some(sidecar) = blob_sidecar {
-                req.set_blob_sidecar(sidecar);
-            }
-            if let Some(auths) = authorization_list {
-                req.authorization_list = Some(auths);
-            }
-            TransactionMaybeSigned::Unsigned(req)
-        }
-        BroadcastKind::Signed(raw) => {
-            let envelope = TxEnvelope::decode_2718(&mut raw.as_ref())
-                .expect("failed to decode pre-signed transaction");
-            TransactionMaybeSigned::Signed { tx: envelope, from: tx.from }
-        }
     }
 }


### PR DESCRIPTION
## Summary

Reverts #13849. Threading `N: Network` through cheatcodes appears unavoidable, let's re evaluate this