### PR TITLE
perf(evm): make `NestedEvm::to_evm_env` consuming to avoid useless clone

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1234,10 +1234,9 @@ impl Cheatcode for executeTransactionCall {
         };
 
         let mut res = None;
-        let mut nested_env = None;
         let mut cold_state = Some(cold_state);
         let modified_tx = modified_tx_env.clone();
-        {
+        let mut nested_evm_env = {
             let (db, _) = ccx.ecx.db_journal_inner_mut();
             executor.with_fresh_nested_evm(
                 ccx.state,
@@ -1250,12 +1249,11 @@ impl Cheatcode for executeTransactionCall {
                     // Set depth to 1 for proper trace collection.
                     evm.journal_inner_mut().depth = 1;
                     res = Some(evm.transact(modified_tx.clone()));
-                    nested_env = Some(evm.to_evm_env());
                     Ok(())
                 },
-            )?;
-        }
-        let (res, mut nested_evm_env) = (res.unwrap(), nested_env.unwrap());
+            )?
+        };
+        let res = res.unwrap();
 
         // Restore env, preserving cheatcode cfg/block changes from the nested EVM
         // but restoring the original tx and basefee (which we zeroed for the nested call)

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -115,6 +115,8 @@ pub trait CheatcodesExecutor<CTX: ContextTr> {
     /// Runs a closure with a fresh nested EVM built from a raw database and environment.
     /// Unlike `with_nested_evm`, this does NOT clone from `ecx` and does NOT write back.
     /// The caller is responsible for state merging. Used by `executeTransactionCall`.
+    /// Returns the final EVM environment after the closure runs (consumed without cloning).
+    #[allow(clippy::type_complexity)]
     fn with_fresh_nested_evm(
         &mut self,
         cheats: &mut Cheatcodes,
@@ -122,7 +124,7 @@ pub trait CheatcodesExecutor<CTX: ContextTr> {
         evm_env: EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
         tx_env: CTX::Tx,
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
-    ) -> Result<(), EVMError<DatabaseError>>;
+    ) -> Result<EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>, EVMError<DatabaseError>>;
 
     /// Simulates `console.log` invocation.
     fn console_log(&mut self, cheats: &mut Cheatcodes, msg: &str);
@@ -181,8 +183,8 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
             let mut evm = new_eth_evm_with_inspector(db, evm_env, tx_env, cheats);
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
-            let sub_evm_env = evm.to_evm_env();
             let sub_inner = evm.journaled_state.inner.clone();
+            let sub_evm_env = evm.to_evm_env();
             Ok((sub_evm_env, sub_inner))
         })
     }
@@ -194,9 +196,10 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
         evm_env: EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
         tx_env: CTX::Tx,
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
-    ) -> Result<(), EVMError<DatabaseError>> {
+    ) -> Result<EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>, EVMError<DatabaseError>> {
         let mut evm = new_eth_evm_with_inspector(db, evm_env, tx_env, cheats);
-        f(&mut evm)
+        f(&mut evm)?;
+        Ok(evm.to_evm_env())
     }
 
     fn transact_on_db(

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -15,8 +15,8 @@ use foundry_fork_db::DatabaseError;
 use revm::{
     Context,
     context::{
-        BlockEnv, Cfg, CfgEnv, ContextTr, CreateScheme, Evm as RevmEvm, JournalTr, LocalContextTr,
-        TxEnv,
+        BlockEnv, Cfg, CfgEnv, ContextSetters, ContextTr, CreateScheme, Evm as RevmEvm, JournalTr,
+        LocalContextTr, TxEnv,
         result::{EVMError, ExecResultAndState, ExecutionResult, HaltReason, ResultAndState},
     },
     handler::{
@@ -118,7 +118,7 @@ impl<'db, I: EthInspectorExt> Evm for FoundryEvm<'db, I> {
         &mut self,
         tx: Self::Tx,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        self.inner.ctx.tx = tx;
+        self.inner.set_tx(tx);
 
         let mut handler = FoundryHandler::<I>::default();
         let result = handler.inspect_run(&mut self.inner)?;
@@ -184,7 +184,7 @@ pub trait NestedEvm {
     ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>>;
 
     /// Returns a snapshot of the current EVM environment (cfg + block).
-    fn to_evm_env(&self) -> EvmEnv<Self::Spec, Self::Block>;
+    fn to_evm_env(self) -> EvmEnv<Self::Spec, Self::Block>;
 }
 
 impl<I: EthInspectorExt> NestedEvm for FoundryEvm<'_, I> {
@@ -220,8 +220,8 @@ impl<I: EthInspectorExt> NestedEvm for FoundryEvm<'_, I> {
         Evm::transact_raw(self, tx)
     }
 
-    fn to_evm_env(&self) -> EvmEnv {
-        EvmEnv { cfg_env: self.inner.ctx.cfg.clone(), block_env: self.inner.ctx.block.clone() }
+    fn to_evm_env(self) -> EvmEnv {
+        Evm::finish(self).1
     }
 }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -376,8 +376,8 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for InspectorStackInner {
             let mut evm = new_eth_evm_with_inspector(db, evm_env, tx_env, &mut inspector);
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
-            let sub_evm_env = evm.to_evm_env();
             let sub_inner = evm.journaled_state.inner.clone();
+            let sub_evm_env = evm.to_evm_env();
             Ok((sub_evm_env, sub_inner))
         })
     }
@@ -389,10 +389,11 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for InspectorStackInner {
         evm_env: EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
         tx_env: CTX::Tx,
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
-    ) -> Result<(), EVMError<DatabaseError>> {
+    ) -> Result<EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>, EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         let mut evm = new_eth_evm_with_inspector(db, evm_env, tx_env, &mut inspector);
-        f(&mut evm)
+        f(&mut evm)?;
+        Ok(evm.to_evm_env())
     }
 
     fn transact_on_db(


### PR DESCRIPTION
## Motivation

Change `to_evm_env(&self)` to `to_evm_env(self)` so the implementation can use `Evm::finish()` to destructure the EVM without an extra clone of `cfg_env` and `block_env`.

Update `with_fresh_nested_evm` to return `EvmEnv` after consuming the EVM post-closure, so callers no longer need to capture the env inside a `NestedEvmClosure` (which only has `&mut dyn NestedEvm` and cannot call a consuming method). Fix the `sub_inner` / `sub_evm_env` ordering in `with_nested_evm` impls so the journal is cloned before `to_evm_env` consumes the EVM.