### PR TITLE
fix(ci): adapt to `TransactionMaybeSigned::to()` return type change

### DIFF
--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -196,7 +196,7 @@ impl PreExecutionState {
                 && self.args.evm.sender.is_none()
             {
                 for tx in txs {
-                    if tx.transaction.to().is_none_or(|kind| kind.is_create()) {
+                    if tx.transaction.to().is_none() {
                         let sender = tx.transaction.from().expect("no sender");
                         if let Some(ns) = new_sender {
                             if sender != ns {


### PR DESCRIPTION
Fixes master build broken by semantic merge conflict between #13895 and #13894.

#13895 changed `TransactionMaybeSigned::to()` from `Option<TxKind>` to `Option<Address>`. #13894 merged 4 minutes later without rebasing and introduced `.is_create()` on the result — which doesn't exist on `Address`.

Since `.to()` now returns `Option<Address>`, `None` already means create — `.is_none()` is the correct check.

Co-Authored-By: zerosnacks <95942363+zerosnacks@users.noreply.github.com>

Prompted by: zerosnacks