### PR TITLE
feat: add gas/s and tx/s throughput metrics to invariant test output

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -121,6 +121,8 @@ pub struct InvariantMetrics {
     pub reverts: usize,
     // Count of fuzzed selector discards (through assume cheatcodes).
     pub discards: usize,
+    // Cumulative gas used by this selector.
+    pub gas: u64,
 }
 
 /// Contains data collected during invariant test runs.
@@ -223,13 +225,20 @@ impl InvariantTest {
     /// Update metrics for a fuzzed selector, extracted from tx details.
     /// Always increments number of calls; discarded runs (through assume cheatcodes) are tracked
     /// separated from reverts.
-    fn record_metrics(&mut self, tx_details: &BasicTxDetails, reverted: bool, discarded: bool) {
+    fn record_metrics(
+        &mut self,
+        tx_details: &BasicTxDetails,
+        gas_used: u64,
+        reverted: bool,
+        discarded: bool,
+    ) {
         if let Some(metric_key) =
             self.targeted_contracts.targets.lock().fuzzed_metric_key(tx_details)
         {
             let test_metrics = &mut self.test_data.metrics;
             let invariant_metrics = test_metrics.entry(metric_key).or_default();
             invariant_metrics.calls += 1;
+            invariant_metrics.gas += gas_used;
             if discarded {
                 invariant_metrics.discards += 1;
             } else if reverted {
@@ -365,6 +374,9 @@ impl<'a> InvariantExecutor<'a> {
         let mut runs = 0;
         let timer = FuzzTestTimer::new(self.config.timeout);
         let mut last_metrics_report = Instant::now();
+        let campaign_start = Instant::now();
+        let mut total_txs: u64 = 0;
+        let mut total_gas: u64 = 0;
         let continue_campaign = |runs: u32| {
             if early_exit.should_stop() {
                 return false;
@@ -416,7 +428,12 @@ impl<'a> InvariantExecutor<'a> {
                 let mut call_result = execute_tx(&mut current_run.executor, tx)?;
                 let discarded = call_result.result.as_ref() == MAGIC_ASSUME;
                 if self.config.show_metrics {
-                    invariant_test.record_metrics(tx, call_result.reverted, discarded);
+                    invariant_test.record_metrics(
+                        tx,
+                        call_result.gas_used,
+                        call_result.reverted,
+                        discarded,
+                    );
                 }
 
                 // Collect line coverage from last fuzzed call.
@@ -473,6 +490,8 @@ impl<'a> InvariantExecutor<'a> {
                     current_run
                         .fuzz_runs
                         .push(FuzzCase { gas: call_result.gas_used, stipend: call_result.stipend });
+                    total_txs += 1;
+                    total_gas += call_result.gas_used;
 
                     // Determine if test can continue or should exit.
                     // Check invariants based on check_interval to improve deep run performance.
@@ -576,12 +595,17 @@ impl<'a> InvariantExecutor<'a> {
                 && last_metrics_report.elapsed() > DURATION_BETWEEN_METRICS_REPORT
             {
                 // Display metrics inline if corpus dir set.
+                let elapsed_secs = campaign_start.elapsed().as_secs_f64();
                 let metrics = json!({
                     "timestamp": SystemTime::now()
                         .duration_since(UNIX_EPOCH)?
                         .as_secs(),
                     "invariant": invariant_contract.invariant_function.name,
                     "metrics": &corpus_manager.metrics,
+                    "total_txs": total_txs,
+                    "total_gas": total_gas,
+                    "tx_per_sec": if elapsed_secs > 0.0 { total_txs as f64 / elapsed_secs } else { 0.0 },
+                    "gas_per_sec": if elapsed_secs > 0.0 { total_gas as f64 / elapsed_secs } else { 0.0 },
                 });
                 let _ = sh_println!("{}", serde_json::to_string(&metrics)?);
                 last_metrics_report = Instant::now();
@@ -602,6 +626,8 @@ impl<'a> InvariantExecutor<'a> {
             gas_report_traces: result.gas_report_traces,
             line_coverage: result.line_coverage,
             metrics: result.metrics,
+            total_gas,
+            elapsed: campaign_start.elapsed(),
             failed_corpus_replays: corpus_manager.failed_replays,
             optimization_best_value: result.optimization_best_value,
             optimization_best_sequence: result.optimization_best_sequence,

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -14,7 +14,7 @@ use foundry_evm_fuzz::{
     invariant::{FuzzRunIdentifiedContracts, InvariantContract},
 };
 use revm_inspectors::tracing::CallTraceArena;
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::HashMap, time::Duration};
 
 /// The outcome of an invariant fuzz test
 #[derive(Debug)]
@@ -33,6 +33,10 @@ pub struct InvariantFuzzTestResult {
     pub line_coverage: Option<HitMaps>,
     /// Fuzzed selectors metrics collected during the invariant test runs.
     pub metrics: HashMap<String, InvariantMetrics>,
+    /// Total gas consumed across all transactions in the campaign.
+    pub total_gas: u64,
+    /// Wall-clock duration of the campaign.
+    pub elapsed: Duration,
     /// Number of failed replays from persisted corpus.
     pub failed_corpus_replays: usize,
     /// For optimization mode (int256 return): the best (maximum) value achieved.

--- a/crates/forge/src/cmd/snapshot.rs
+++ b/crates/forge/src/cmd/snapshot.rs
@@ -22,7 +22,7 @@ use yansi::Paint;
 /// A regex that matches a basic snapshot entry like
 /// `Test:testDeposit() (gas: 58804)`
 pub static RE_BASIC_SNAPSHOT_ENTRY: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?P<file>(.*?)):(?P<sig>(\w+)\s*\((.*?)\))\s*\(((gas:)?\s*(?P<gas>\d+)|(runs:\s*(?P<runs>\d+),\s*μ:\s*(?P<avg>\d+),\s*~:\s*(?P<med>\d+))|(runs:\s*(?P<invruns>\d+),\s*calls:\s*(?P<calls>\d+),\s*reverts:\s*(?P<reverts>\d+)))\)").unwrap()
+    Regex::new(r"(?P<file>(.*?)):(?P<sig>(\w+)\s*\((.*?)\))\s*\(((gas:)?\s*(?P<gas>\d+)|(runs:\s*(?P<runs>\d+),\s*μ:\s*(?P<avg>\d+),\s*~:\s*(?P<med>\d+))|(runs:\s*(?P<invruns>\d+),\s*calls:\s*(?P<calls>\d+),\s*reverts:\s*(?P<reverts>\d+)(?:,\s*gas/s:\s*\d+,\s*tx/s:\s*\d+)?))\)").unwrap()
 });
 
 /// CLI arguments for `forge snapshot`.
@@ -217,7 +217,7 @@ impl GasSnapshotConfig {
 ///   `<signature>(gas:? 40181)` for normal tests
 ///   `<signature>(runs: 256, μ: 40181, ~: 40181)` for fuzz tests
 ///   `<signature>(runs: 256, calls: 40181, reverts: 40181)` for invariant tests
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GasSnapshotEntry {
     pub contract_name: String,
     pub signature: String,
@@ -271,6 +271,8 @@ impl FromStr for GasSnapshotEntry {
                                         metrics: HashMap::default(),
                                         failed_corpus_replays: 0,
                                         optimization_best_value: None,
+                                        total_gas: 0,
+                                        elapsed_secs: 0.0,
                                     },
                                 })
                         }
@@ -343,7 +345,7 @@ fn build_gas_snapshot_table(tests: &[SuiteTestResult]) -> Table {
 }
 
 /// A Gas snapshot entry diff.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GasSnapshotDiff {
     pub signature: String,
     pub source_gas_used: TestKindReport,
@@ -613,7 +615,7 @@ mod tests {
 
     #[test]
     fn can_parse_invariant_gas_snapshot_entry() {
-        let s = "Test:deposit() (runs: 256, calls: 100, reverts: 200)";
+        let s = "Test:deposit() (runs: 256, calls: 100, reverts: 200, gas/s: 5000000, tx/s: 500)";
         let entry = GasSnapshotEntry::from_str(s).unwrap();
         assert_eq!(
             entry,
@@ -627,6 +629,8 @@ mod tests {
                     metrics: HashMap::default(),
                     failed_corpus_replays: 0,
                     optimization_best_value: None,
+                    total_gas: 0,
+                    elapsed_secs: 0.0,
                 }
             }
         );
@@ -634,7 +638,7 @@ mod tests {
 
     #[test]
     fn can_parse_invariant_gas_snapshot_entry2() {
-        let s = "ERC20Invariants:invariantBalanceSum() (runs: 256, calls: 3840, reverts: 2388)";
+        let s = "ERC20Invariants:invariantBalanceSum() (runs: 256, calls: 3840, reverts: 2388, gas/s: 1000000, tx/s: 768)";
         let entry = GasSnapshotEntry::from_str(s).unwrap();
         assert_eq!(
             entry,
@@ -648,6 +652,8 @@ mod tests {
                     metrics: HashMap::default(),
                     failed_corpus_replays: 0,
                     optimization_best_value: None,
+                    total_gas: 0,
+                    elapsed_secs: 0.0,
                 }
             }
         );

--- a/crates/forge/src/cmd/test/summary.rs
+++ b/crates/forge/src/cmd/test/summary.rs
@@ -126,17 +126,17 @@ impl TestSummaryReport {
 
 /// Helper function to create the invariant metrics table.
 ///
-/// ╭-----------------------+----------------+-------+---------+----------╮
-/// | Contract              | Selector       | Calls | Reverts | Discards |
-/// +=====================================================================+
-/// | AnotherCounterHandler | doWork         | 7451  | 123     | 4941     |
-/// |-----------------------+----------------+-------+---------+----------|
-/// | AnotherCounterHandler | doWorkThing    | 7279  | 137     | 4849     |
-/// |-----------------------+----------------+-------+---------+----------|
-/// | CounterHandler        | doAnotherThing | 7302  | 150     | 4794     |
-/// |-----------------------+----------------+-------+---------+----------|
-/// | CounterHandler        | doSomething    | 7382  | 160     |4794      |
-/// ╰-----------------------+----------------+-------+---------+----------╯
+/// ╭-----------------------+----------------+-------+---------+----------+----------╮
+/// | Contract              | Selector       | Calls | Reverts | Discards | Gas      |
+/// +========================================================================--------+
+/// | AnotherCounterHandler | doWork         | 7451  | 123     | 4941     | 12345678 |
+/// |-----------------------+----------------+-------+---------+----------+----------|
+/// | AnotherCounterHandler | doWorkThing    | 7279  | 137     | 4849     | 11234567 |
+/// |-----------------------+----------------+-------+---------+----------+----------|
+/// | CounterHandler        | doAnotherThing | 7302  | 150     | 4794     | 10234567 |
+/// |-----------------------+----------------+-------+---------+----------+----------|
+/// | CounterHandler        | doSomething    | 7382  | 160     | 4794     | 10345678 |
+/// ╰-----------------------+----------------+-------+---------+----------+----------╯
 pub(crate) fn format_invariant_metrics_table(
     test_metrics: &HashMap<String, InvariantMetrics>,
 ) -> Table {
@@ -153,6 +153,7 @@ pub(crate) fn format_invariant_metrics_table(
         Cell::new("Calls").fg(Color::Green),
         Cell::new("Reverts").fg(Color::Red),
         Cell::new("Discards").fg(Color::Yellow),
+        Cell::new("Gas").fg(Color::Cyan),
     ]);
 
     for name in test_metrics.keys().sorted() {
@@ -182,9 +183,16 @@ pub(crate) fn format_invariant_metrics_table(
                     Color::White
                 });
 
+                let gas_cell = Cell::new(metrics.gas).fg(if metrics.gas > 0 {
+                    Color::Cyan
+                } else {
+                    Color::White
+                });
+
                 row.add_cell(calls_cell);
                 row.add_cell(reverts_cell);
                 row.add_cell(discards_cell);
+                row.add_cell(gas_cell);
             }
 
             table.add_row(row);
@@ -204,11 +212,11 @@ mod tests {
         let mut test_metrics = HashMap::new();
         test_metrics.insert(
             "SystemConfig.setGasLimit".to_string(),
-            InvariantMetrics { calls: 10, reverts: 1, discards: 1 },
+            InvariantMetrics { calls: 10, reverts: 1, discards: 1, gas: 100000 },
         );
         test_metrics.insert(
             "src/universal/Proxy.sol:Proxy.changeAdmin".to_string(),
-            InvariantMetrics { calls: 20, reverts: 2, discards: 2 },
+            InvariantMetrics { calls: 20, reverts: 2, discards: 2, gas: 200000 },
         );
         let table = format_invariant_metrics_table(&test_metrics);
         assert_eq!(table.row_count(), 2);
@@ -219,6 +227,7 @@ mod tests {
         assert_eq!(first_row_content.next().unwrap().content(), "10");
         assert_eq!(first_row_content.next().unwrap().content(), "1");
         assert_eq!(first_row_content.next().unwrap().content(), "1");
+        assert_eq!(first_row_content.next().unwrap().content(), "100000");
 
         let mut second_row_content = table.row(1).unwrap().cell_iter();
         assert_eq!(second_row_content.next().unwrap().content(), "Proxy");
@@ -226,5 +235,6 @@ mod tests {
         assert_eq!(second_row_content.next().unwrap().content(), "20");
         assert_eq!(second_row_content.next().unwrap().content(), "2");
         assert_eq!(second_row_content.next().unwrap().content(), "2");
+        assert_eq!(second_row_content.next().unwrap().content(), "200000");
     }
 }

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -671,6 +671,8 @@ impl TestResult {
             metrics: HashMap::default(),
             failed_corpus_replays: 0,
             optimization_best_value: None,
+            total_gas: 0,
+            elapsed_secs: 0.0,
         };
         self.status = TestStatus::Skipped;
         self.reason = reason.0;
@@ -690,6 +692,8 @@ impl TestResult {
             metrics: HashMap::default(),
             failed_corpus_replays: 0,
             optimization_best_value: None,
+            total_gas: 0,
+            elapsed_secs: 0.0,
         };
         self.status = TestStatus::Failure;
         self.reason = if replayed_entirely {
@@ -709,6 +713,8 @@ impl TestResult {
             metrics: HashMap::default(),
             failed_corpus_replays: 0,
             optimization_best_value: None,
+            total_gas: 0,
+            elapsed_secs: 0.0,
         };
         self.status = TestStatus::Failure;
         self.reason = Some(format!("failed to set up invariant testing environment: {e}"));
@@ -727,6 +733,8 @@ impl TestResult {
         metrics: Map<String, InvariantMetrics>,
         failed_corpus_replays: usize,
         optimization_best_value: Option<I256>,
+        total_gas: u64,
+        elapsed_secs: f64,
     ) {
         self.kind = TestKind::Invariant {
             runs: cases.len(),
@@ -735,6 +743,8 @@ impl TestResult {
             metrics,
             failed_corpus_replays,
             optimization_best_value,
+            total_gas,
+            elapsed_secs,
         };
         // For optimization mode (Some value), always succeed. For check mode (None), use success.
         self.status = if optimization_best_value.is_some() || success {
@@ -796,7 +806,7 @@ impl TestResult {
 }
 
 /// Data report by a test.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TestKindReport {
     Unit {
         gas: u64,
@@ -815,6 +825,10 @@ pub enum TestKindReport {
         failed_corpus_replays: usize,
         /// For optimization mode (int256 return): the best value achieved. None = check mode.
         optimization_best_value: Option<I256>,
+        /// Total gas consumed across all transactions in the campaign.
+        total_gas: u64,
+        /// Wall-clock elapsed time of the campaign in seconds.
+        elapsed_secs: f64,
     },
     Table {
         runs: usize,
@@ -846,17 +860,29 @@ impl fmt::Display for TestKindReport {
                 metrics: _,
                 failed_corpus_replays,
                 optimization_best_value,
+                total_gas,
+                elapsed_secs,
             } => {
+                let tx_per_sec =
+                    if *elapsed_secs > 0.0 { *calls as f64 / elapsed_secs } else { 0.0 };
+                let gas_per_sec =
+                    if *elapsed_secs > 0.0 { *total_gas as f64 / elapsed_secs } else { 0.0 };
                 // If optimization_best_value is Some, this is optimization mode.
                 if let Some(best_value) = optimization_best_value {
-                    write!(f, "(best: {best_value}, runs: {runs}, calls: {calls})")
+                    write!(
+                        f,
+                        "(best: {best_value}, runs: {runs}, calls: {calls}, gas/s: {gas_per_sec:.0}, tx/s: {tx_per_sec:.0})"
+                    )
                 } else if *failed_corpus_replays != 0 {
                     write!(
                         f,
-                        "(runs: {runs}, calls: {calls}, reverts: {reverts}, failed corpus replays: {failed_corpus_replays})"
+                        "(runs: {runs}, calls: {calls}, reverts: {reverts}, gas/s: {gas_per_sec:.0}, tx/s: {tx_per_sec:.0}, failed corpus replays: {failed_corpus_replays})"
                     )
                 } else {
-                    write!(f, "(runs: {runs}, calls: {calls}, reverts: {reverts})")
+                    write!(
+                        f,
+                        "(runs: {runs}, calls: {calls}, reverts: {reverts}, gas/s: {gas_per_sec:.0}, tx/s: {tx_per_sec:.0})"
+                    )
                 }
             }
             Self::Table { runs, mean_gas, median_gas } => {
@@ -902,6 +928,10 @@ pub enum TestKind {
         failed_corpus_replays: usize,
         /// For optimization mode (int256 return): the best value achieved. None = check mode.
         optimization_best_value: Option<I256>,
+        /// Total gas consumed across all transactions in the campaign.
+        total_gas: u64,
+        /// Wall-clock elapsed time of the campaign in seconds.
+        elapsed_secs: f64,
     },
     /// A table test.
     Table { runs: usize, mean_gas: u64, median_gas: u64 },
@@ -943,6 +973,8 @@ impl TestKind {
                 metrics: _,
                 failed_corpus_replays,
                 optimization_best_value,
+                total_gas,
+                elapsed_secs,
             } => TestKindReport::Invariant {
                 runs: *runs,
                 calls: *calls,
@@ -950,6 +982,8 @@ impl TestKind {
                 metrics: HashMap::default(),
                 failed_corpus_replays: *failed_corpus_replays,
                 optimization_best_value: *optimization_best_value,
+                total_gas: *total_gas,
+                elapsed_secs: *elapsed_secs,
             },
             Self::Table { runs, mean_gas, median_gas } => {
                 TestKindReport::Table { runs: *runs, mean_gas: *mean_gas, median_gas: *median_gas }
@@ -1003,5 +1037,90 @@ impl TestSetup {
 
     pub fn merge_coverages(&mut self, other_coverage: Option<HitMaps>) {
         HitMaps::merge_opt(&mut self.coverage, other_coverage);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn invariant_report_display_includes_throughput() {
+        let report = TestKindReport::Invariant {
+            runs: 10,
+            calls: 5000,
+            reverts: 100,
+            metrics: HashMap::default(),
+            failed_corpus_replays: 0,
+            optimization_best_value: None,
+            total_gas: 50_000_000,
+            elapsed_secs: 10.0,
+        };
+        let output = format!("{report}");
+        // tx/s = 5000 / 10.0 = 500
+        // gas/s = 50_000_000 / 10.0 = 5_000_000
+        assert!(output.contains("gas/s: 5000000"), "expected gas/s in output: {output}");
+        assert!(output.contains("tx/s: 500"), "expected tx/s in output: {output}");
+        assert!(output.contains("runs: 10"));
+        assert!(output.contains("calls: 5000"));
+        assert!(output.contains("reverts: 100"));
+    }
+
+    #[test]
+    fn invariant_report_display_zero_elapsed() {
+        let report = TestKindReport::Invariant {
+            runs: 1,
+            calls: 100,
+            reverts: 0,
+            metrics: HashMap::default(),
+            failed_corpus_replays: 0,
+            optimization_best_value: None,
+            total_gas: 1_000_000,
+            elapsed_secs: 0.0,
+        };
+        let output = format!("{report}");
+        // Should not panic and should show 0 for rates
+        assert!(output.contains("gas/s: 0"), "expected gas/s: 0 in output: {output}");
+        assert!(output.contains("tx/s: 0"), "expected tx/s: 0 in output: {output}");
+    }
+
+    #[test]
+    fn invariant_report_display_optimization_mode() {
+        let report = TestKindReport::Invariant {
+            runs: 5,
+            calls: 2500,
+            reverts: 0,
+            metrics: HashMap::default(),
+            failed_corpus_replays: 0,
+            optimization_best_value: Some(I256::try_from(42).unwrap()),
+            total_gas: 25_000_000,
+            elapsed_secs: 5.0,
+        };
+        let output = format!("{report}");
+        assert!(output.contains("best: 42"), "expected best value in output: {output}");
+        assert!(output.contains("gas/s: 5000000"), "expected gas/s in output: {output}");
+        assert!(output.contains("tx/s: 500"), "expected tx/s in output: {output}");
+    }
+
+    #[test]
+    fn invariant_report_display_failed_corpus_replays() {
+        let report = TestKindReport::Invariant {
+            runs: 10,
+            calls: 1000,
+            reverts: 50,
+            metrics: HashMap::default(),
+            failed_corpus_replays: 3,
+            optimization_best_value: None,
+            total_gas: 10_000_000,
+            elapsed_secs: 2.0,
+        };
+        let output = format!("{report}");
+        assert!(
+            output.contains("failed corpus replays: 3"),
+            "expected failed corpus replays in output: {output}"
+        );
+        assert!(output.contains("gas/s: 5000000"), "expected gas/s in output: {output}");
+        assert!(output.contains("tx/s: 500"), "expected tx/s in output: {output}");
     }
 }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -989,6 +989,8 @@ impl<'a> FunctionRunner<'a> {
             invariant_result.metrics,
             invariant_result.failed_corpus_replays,
             invariant_result.optimization_best_value,
+            invariant_result.total_gas,
+            invariant_result.elapsed.as_secs_f64(),
         );
         self.result
     }

--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -820,7 +820,7 @@ Ran 1 test for test/InvariantInnerContract.t.sol:InvariantInnerContract
 	[Sequence] (original: 2, shrunk: 2)
 		sender=[..] addr=[test/InvariantInnerContract.t.sol:Jesus][..] calldata=create_fren() args=[]
 		sender=[..] addr=[test/InvariantInnerContract.t.sol:Judas][..] calldata=betray() args=[]
- invariantHideJesus() (runs: 0, calls: 0, reverts: 1)
+ invariantHideJesus() (runs: 0, calls: 0, reverts: 1, gas/s: 0, tx/s: 0)
 ...
 "#]]);
     }
@@ -1678,7 +1678,7 @@ Ran 1 test for test/InvariantWarpAndRoll.t.sol:InvariantWarpAndRoll
 		sender=[..] addr=[test/InvariantWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=20609 roll=27086 calldata=setNumber(uint256) args=[26717227324157985679793128079000084308648530834088529513797156275625002 [2.671e70]]
 		sender=[..] addr=[test/InvariantWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=409368 roll=24864 calldata=increment() args=[]
 		sender=[..] addr=[test/InvariantWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=218105 roll=17834 calldata=setNumber(uint256) args=[24752675372815722001736610830 [2.475e28]]
- invariant_warp() (runs: 0, calls: 0, reverts: 0)
+ invariant_warp() (runs: 0, calls: 0, reverts: 0, gas/s: 0, tx/s: 0)
 ...
 
 "#]]);
@@ -1709,7 +1709,7 @@ Ran 1 test for test/InvariantWarpAndRoll.t.sol:InvariantWarpAndRoll
 		vm.roll(block.number + 24864);
 		vm.prank([..]);
 		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).increment();
- invariant_roll() (runs: 0, calls: 0, reverts: 0)
+ invariant_roll() (runs: 0, calls: 0, reverts: 0, gas/s: 0, tx/s: 0)
 ...
 
 "#]]);
@@ -1762,7 +1762,7 @@ Ran 1 test for test/HandlerWarpAndRoll.t.sol:HandlerWarpAndRoll
 		sender=[..] addr=[test/HandlerWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=198040 roll=60259 calldata=increment() args=[]
 		sender=[..] addr=[test/HandlerWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=20609 roll=27086 calldata=setNumber(uint256) args=[26717227324157985679793128079000084308648530834088529513797156275625002 [2.671e70]]
 		sender=[..] addr=[test/HandlerWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=409368 roll=24864 calldata=increment() args=[]
- invariant_handler() (runs: 0, calls: 0, reverts: 1)
+ invariant_handler() (runs: 0, calls: 0, reverts: 1, gas/s: 0, tx/s: 0)
 
 ...
 
@@ -1812,7 +1812,7 @@ contract InvariantReplayStateTest is Test {
     // match the "after" value from the previous call, proving state persists.
     cmd.args(["test", "-vvv"]).assert_success().stdout_eq(str![[r#"
 ...
-[PASS] invariant_counter_increases() (runs: 1, calls: 5, reverts: 0)
+[PASS] invariant_counter_increases() (runs: 1, calls: 5, reverts: 0, gas/s: [..], tx/s: [..])
 ...
 Logs:
   before: 0 after: 1

--- a/crates/forge/tests/cli/test_cmd/invariant/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/mod.rs
@@ -7,7 +7,7 @@ mod target;
 
 fn assert_invariant(cmd: &mut TestCommand) -> OutputAssert {
     cmd.assert_with(&[
-        ("[RUNS]", r"runs: \d+, calls: \d+, reverts: \d+"),
+        ("[RUNS]", r"runs: \d+, calls: \d+, reverts: \d+, gas/s: \d+, tx/s: \d+"),
         ("[SEQUENCE]", r"\[Sequence\].*(\n\t\t.*)*"),
         ("[STATS]", r"╭[\s\S]*?╰.*"),
     ])
@@ -71,7 +71,7 @@ contract AssumeTest is Test {
 
     cmd.assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL: `vm.assume` rejected too many inputs (10 allowed)] invariant_assume() (runs: 0, calls: 0, reverts: 0)
+[FAIL: `vm.assume` rejected too many inputs (10 allowed)] invariant_assume() (runs: 0, calls: 0, reverts: 0, gas/s: 0, tx/s: 0)
 ...
 "#]]);
 });
@@ -122,7 +122,7 @@ contract BalanceAssumeTest is Test {
 
     cmd.args(["test", "--mt", "invariant_balance"]).assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL: `vm.assume` rejected too many inputs (10 allowed)] invariant_balance() (runs: 2, calls: 1000, reverts: 0)
+[FAIL: `vm.assume` rejected too many inputs (10 allowed)] invariant_balance() (runs: 2, calls: 1000, reverts: 0, gas/s: [..], tx/s: [..])
 ...
 "#]]);
 });
@@ -153,7 +153,7 @@ contract NoSelectorTest is Test {
 
     cmd.args(["test", "--mt", "invariant_panic"]).assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL: failed to set up invariant testing environment: No contracts to fuzz.] invariant_panic() (runs: 0, calls: 0, reverts: 0)
+[FAIL: failed to set up invariant testing environment: No contracts to fuzz.] invariant_panic() (runs: 0, calls: 0, reverts: 0, gas/s: 0, tx/s: 0)
 ...
 "#]]);
 });
@@ -209,33 +209,33 @@ contract AnotherCounterHandler is Test {
 
     cmd.args(["test", "--mt", "invariant_"]).assert_success().stdout_eq(str![[r#"
 ...
-[PASS] invariant_counter() (runs: 10, calls: 5000, reverts: [..])
+[PASS] invariant_counter() (runs: 10, calls: 5000, reverts: [..], gas/s: [..], tx/s: [..])
 
-╭-----------------------+----------------+-------+---------+----------╮
-| Contract              | Selector       | Calls | Reverts | Discards |
-+=====================================================================+
-| AnotherCounterHandler | doWork         | [..]  | [..]    | [..]     |
-|-----------------------+----------------+-------+---------+----------|
-| AnotherCounterHandler | doWorkThing    | [..]  | [..]    | [..]     |
-|-----------------------+----------------+-------+---------+----------|
-| CounterHandler        | doAnotherThing | [..]  | [..]    | [..]     |
-|-----------------------+----------------+-------+---------+----------|
-| CounterHandler        | doSomething    | [..]  | [..]    | [..]     |
-╰-----------------------+----------------+-------+---------+----------╯
+╭-----------------------+----------------+-------+---------+----------+------╮
+| Contract              | Selector       | Calls | Reverts | Discards | Gas  |
++============================================================================+
+| AnotherCounterHandler | doWork         | [..]  | [..]    | [..]     | [..] |
+|-----------------------+----------------+-------+---------+----------+------|
+| AnotherCounterHandler | doWorkThing    | [..]  | [..]    | [..]     | [..] |
+|-----------------------+----------------+-------+---------+----------+------|
+| CounterHandler        | doAnotherThing | [..]  | [..]    | [..]     | [..] |
+|-----------------------+----------------+-------+---------+----------+------|
+| CounterHandler        | doSomething    | [..]  | [..]    | [..]     | [..] |
+╰-----------------------+----------------+-------+---------+----------+------╯
 
-[PASS] invariant_counter2() (runs: 10, calls: 5000, reverts: [..])
+[PASS] invariant_counter2() (runs: 10, calls: 5000, reverts: [..], gas/s: [..], tx/s: [..])
 
-╭-----------------------+----------------+-------+---------+----------╮
-| Contract              | Selector       | Calls | Reverts | Discards |
-+=====================================================================+
-| AnotherCounterHandler | doWork         | [..]  | [..]    | [..]     |
-|-----------------------+----------------+-------+---------+----------|
-| AnotherCounterHandler | doWorkThing    | [..]  | [..]    | [..]     |
-|-----------------------+----------------+-------+---------+----------|
-| CounterHandler        | doAnotherThing | [..]  | [..]    | [..]     |
-|-----------------------+----------------+-------+---------+----------|
-| CounterHandler        | doSomething    | [..]  | [..]    | [..]     |
-╰-----------------------+----------------+-------+---------+----------╯
+╭-----------------------+----------------+-------+---------+----------+------╮
+| Contract              | Selector       | Calls | Reverts | Discards | Gas  |
++============================================================================+
+| AnotherCounterHandler | doWork         | [..]  | [..]    | [..]     | [..] |
+|-----------------------+----------------+-------+---------+----------+------|
+| AnotherCounterHandler | doWorkThing    | [..]  | [..]    | [..]     | [..] |
+|-----------------------+----------------+-------+---------+----------+------|
+| CounterHandler        | doAnotherThing | [..]  | [..]    | [..]     | [..] |
+|-----------------------+----------------+-------+---------+----------+------|
+| CounterHandler        | doSomething    | [..]  | [..]    | [..]     | [..] |
+╰-----------------------+----------------+-------+---------+----------+------╯
 
 Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
@@ -285,13 +285,13 @@ contract TimeoutTest is Test {
 Compiler run successful!
 
 Ran 1 test for test/TimeoutTest.t.sol:TimeoutTest
-[PASS] invariant_counter_timeout() (runs: 0, calls: 0, reverts: 0)
+[PASS] invariant_counter_timeout() (runs: 0, calls: 0, reverts: 0, gas/s: 0, tx/s: 0)
 
-╭----------------+-----------+-------+---------+----------╮
-| Contract       | Selector  | Calls | Reverts | Discards |
-+=========================================================+
-| TimeoutHandler | increment | [..]  | [..]    | [..]     |
-╰----------------+-----------+-------+---------+----------╯
+╭----------------+-----------+-------+---------+----------+------╮
+| Contract       | Selector  | Calls | Reverts | Discards | Gas  |
++=================================================================+
+| TimeoutHandler | increment | [..]  | [..]    | [..]     | [..] |
+╰----------------+-----------+-------+---------+----------+------╯
 
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
@@ -425,7 +425,7 @@ Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSeque
 		sender=0x00000000000000000000000000000000000014aD addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=increment() args=[]
 		sender=0x8ef7F804bAd9183981A366EA618d9D47D3124649 addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=increment() args=[]
 		sender=0x00000000000000000000000000000000000016Ac addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=setNumber(uint256) args=[284406551521730736391345481857560031052359183671404042152984097777 [2.844e65]]
- invariant_increment() (runs: 0, calls: 0, reverts: 0)
+ invariant_increment() (runs: 0, calls: 0, reverts: 0, gas/s: 0, tx/s: 0)
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -454,7 +454,7 @@ Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSeque
 		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).increment();
 		vm.prank(0x00000000000000000000000000000000000016Ac);
 		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).setNumber(284406551521730736391345481857560031052359183671404042152984097777);
- invariant_increment() (runs: 0, calls: 0, reverts: 0)
+ invariant_increment() (runs: 0, calls: 0, reverts: 0, gas/s: 0, tx/s: 0)
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -479,7 +479,7 @@ Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSeque
 		sender=0x00000000000000000000000000000000000014aD addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=increment() args=[]
 		sender=0x8ef7F804bAd9183981A366EA618d9D47D3124649 addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=increment() args=[]
 		sender=0x00000000000000000000000000000000000016Ac addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=setNumber(uint256) args=[284406551521730736391345481857560031052359183671404042152984097777 [2.844e65]]
- invariant_increment() (runs: 1, calls: 1, reverts: 1)
+ invariant_increment() (runs: 1, calls: 1, reverts: 1, gas/s: [..], tx/s: [..])
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -577,7 +577,7 @@ Warning: Failure from "[..]/invariant/failures/OwnableTest/invariant_never_owner
 "#]])
     .stdout_eq(str![[r#"
 ...
-[PASS] invariant_never_owner() (runs: 5, calls: 25, reverts: 0)
+[PASS] invariant_never_owner() (runs: 5, calls: 25, reverts: 0, gas/s: [..], tx/s: [..])
 ...
 "#]]);
 });
@@ -611,7 +611,7 @@ contract InvariantTest is Test {
 
     cmd.args(["test", "--mt", "invariant_check_count"]).assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL: failed to set up invariant testing environment: No contracts to fuzz.] invariant_check_count() (runs: 0, calls: 0, reverts: 0)
+[FAIL: failed to set up invariant testing environment: No contracts to fuzz.] invariant_check_count() (runs: 0, calls: 0, reverts: 0, gas/s: 0, tx/s: 0)
 ...
 "#]]);
 
@@ -640,7 +640,7 @@ contract InvariantTest is Test {
     cmd.forge_fuse().args(["test", "--mt", "invariant_check_count"]).assert_success().stdout_eq(
         str![[r#"
 ...
-[PASS] invariant_check_count() (runs: 5, calls: 25, reverts: 0)
+[PASS] invariant_check_count() (runs: 5, calls: 25, reverts: 0, gas/s: [..], tx/s: [..])
 ...
 "#]],
     );
@@ -716,7 +716,7 @@ contract InvariantTargetTest is Test {
 Compiler run successful!
 
 Ran 4 tests for test/InvariantTargetTest.t.sol:InvariantTargetTest
-[PASS] invariant_considered_target() (runs: 10, calls: 1000, reverts: 0)
+[PASS] invariant_considered_target() (runs: 10, calls: 1000, reverts: 0, gas/s: [..], tx/s: [..])
 
 ╭---------------------+----------+-------+---------+----------╮
 | Contract            | Selector | Calls | Reverts | Discards |
@@ -724,7 +724,7 @@ Ran 4 tests for test/InvariantTargetTest.t.sol:InvariantTargetTest
 | InvariantTargetTest | foo      | 1000  | 0       | 0        |
 ╰---------------------+----------+-------+---------+----------╯
 
-[PASS] invariant_foo_called() (runs: 10, calls: 1000, reverts: 0)
+[PASS] invariant_foo_called() (runs: 10, calls: 1000, reverts: 0, gas/s: [..], tx/s: [..])
 
 ╭---------------------+----------+-------+---------+----------╮
 | Contract            | Selector | Calls | Reverts | Discards |
@@ -732,7 +732,7 @@ Ran 4 tests for test/InvariantTargetTest.t.sol:InvariantTargetTest
 | InvariantTargetTest | foo      | 1000  | 0       | 0        |
 ╰---------------------+----------+-------+---------+----------╯
 
-[PASS] invariant_setUp_considered_target() (runs: 10, calls: 1000, reverts: 0)
+[PASS] invariant_setUp_considered_target() (runs: 10, calls: 1000, reverts: 0, gas/s: [..], tx/s: [..])
 
 ╭---------------------+----------+-------+---------+----------╮
 | Contract            | Selector | Calls | Reverts | Discards |
@@ -740,7 +740,7 @@ Ran 4 tests for test/InvariantTargetTest.t.sol:InvariantTargetTest
 | InvariantTargetTest | foo      | 1000  | 0       | 0        |
 ╰---------------------+----------+-------+---------+----------╯
 
-[PASS] invariant_testSanity_considered_target() (runs: 10, calls: 1000, reverts: 0)
+[PASS] invariant_testSanity_considered_target() (runs: 10, calls: 1000, reverts: 0, gas/s: [..], tx/s: [..])
 
 ╭---------------------+----------+-------+---------+----------╮
 | Contract            | Selector | Calls | Reverts | Discards |
@@ -838,7 +838,7 @@ contract InvariantTargetExcludeTest is Test {
 Compiler run successful!
 
 Ran 1 test for test/InvariantTargetTest.t.sol:InvariantTargetIncludeTest
-[PASS] invariant_include() (runs: 10, calls: 1000, reverts: 0)
+[PASS] invariant_include() (runs: 10, calls: 1000, reverts: 0, gas/s: [..], tx/s: [..])
 
 ╭----------------------------+----------------+-------+---------+----------╮
 | Contract                   | Selector       | Calls | Reverts | Discards |
@@ -859,7 +859,7 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 No files changed, compilation skipped
 
 Ran 1 test for test/InvariantTargetTest.t.sol:InvariantTargetExcludeTest
-[PASS] invariant_exclude() (runs: 10, calls: 1000, reverts: 0)
+[PASS] invariant_exclude() (runs: 10, calls: 1000, reverts: 0, gas/s: [..], tx/s: [..])
 
 ╭----------------------------+----------------+-------+---------+----------╮
 | Contract                   | Selector       | Calls | Reverts | Discards |
@@ -883,7 +883,7 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 No files changed, compilation skipped
 
 Ran 1 test for test/InvariantTargetTest.t.sol:InvariantTargetIncludeTest
-[PASS] invariant_include() (runs: 10, calls: 1000, reverts: 0)
+[PASS] invariant_include() (runs: 10, calls: 1000, reverts: 0, gas/s: [..], tx/s: [..])
 
 | Contract                   | Selector       | Calls | Reverts | Discards |
 |----------------------------|----------------|-------|---------|----------|
@@ -903,7 +903,7 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 No files changed, compilation skipped
 
 Ran 1 test for test/InvariantTargetTest.t.sol:InvariantTargetExcludeTest
-[PASS] invariant_exclude() (runs: 10, calls: 1000, reverts: 0)
+[PASS] invariant_exclude() (runs: 10, calls: 1000, reverts: 0, gas/s: [..], tx/s: [..])
 
 | Contract                   | Selector       | Calls | Reverts | Discards |
 |----------------------------|----------------|-------|---------|----------|
@@ -1039,7 +1039,7 @@ contract CheckIntervalTest is Test {
 
     cmd.args(["test", "--mt", "invariant_counter"]).assert_success().stdout_eq(str![[r#"
 ...
-[PASS] invariant_counter_multiple_of_depth() (runs: 5, calls: 50, reverts: 0)
+[PASS] invariant_counter_multiple_of_depth() (runs: 5, calls: 50, reverts: 0, gas/s: [..], tx/s: [..])
 ...
 "#]]);
 });
@@ -1130,7 +1130,7 @@ contract CheckIntervalTest is Test {
 
     cmd.args(["test", "--mt", "invariant_counter"]).assert_success().stdout_eq(str![[r#"
 ...
-[PASS] invariant_counter_multiple_of_five() (runs: 1, calls: 20, reverts: 0)
+[PASS] invariant_counter_multiple_of_five() (runs: 1, calls: 20, reverts: 0, gas/s: [..], tx/s: [..])
 ...
 "#]]);
 });
@@ -1172,7 +1172,7 @@ contract CheckIntervalInlineTest is Test {
     cmd.args(["test", "--mt", "invariant_only_last_checked"]).assert_success().stdout_eq(str![[
         r#"
 ...
-[PASS] invariant_only_last_checked() (runs: 1, calls: 10, reverts: 0)
+[PASS] invariant_only_last_checked() (runs: 1, calls: 10, reverts: 0, gas/s: [..], tx/s: [..])
 ...
 "#
     ]]);

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -955,14 +955,14 @@ contract CounterTest is Test {
 Compiler run successful!
 
 Ran 1 test for test/CounterInvariant.t.sol:CounterTest
-[FAIL: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0)
+[FAIL: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0, gas/s: 0, tx/s: 0)
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
 
 Failing tests:
 Encountered 1 failing test in test/CounterInvariant.t.sol:CounterTest
-[FAIL: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0)
+[FAIL: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0, gas/s: 0, tx/s: 0)
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -2103,8 +2103,8 @@ forgetest_init!(skip_output, |prj, cmd| {
     cmd.arg("test").assert_success().stdout_eq(str![[r#"
 ...
 Ran 6 tests for src/Counter.t.sol:Skips
-[SKIP] invariant_skipInvariant() (runs: 1, calls: 1, reverts: 1)
-[SKIP: invariant] invariant_skipInvariantReason() (runs: 1, calls: 1, reverts: 1)
+[SKIP] invariant_skipInvariant() (runs: 1, calls: 1, reverts: 1, gas/s: [..], tx/s: [..])
+[SKIP: invariant] invariant_skipInvariantReason() (runs: 1, calls: 1, reverts: 1, gas/s: [..], tx/s: [..])
 [SKIP] test_skipFuzz(uint256) (runs: 0, [AVG_GAS])
 [SKIP: fuzz] test_skipFuzzReason(uint256) (runs: 0, [AVG_GAS])
 [SKIP] test_skipUnit() ([GAS])
@@ -4451,8 +4451,8 @@ contract ZeroRuns is Test {
     cmd.args(["test"]).assert_success().stdout_eq(str![[r#"
 ...
 Ran 3 tests for test/ZeroRuns.t.sol:ZeroRuns
-[PASS] invariant_zeroDepth() (runs: 256, calls: 0, reverts: 0)
-[PASS] invariant_zeroRuns() (runs: 0, calls: 0, reverts: 0)
+[PASS] invariant_zeroDepth() (runs: 256, calls: 0, reverts: 0, gas/s: [..], tx/s: [..])
+[PASS] invariant_zeroRuns() (runs: 0, calls: 0, reverts: 0, gas/s: 0, tx/s: 0)
 [PASS] test_fuzzZeroRuns(uint256) (runs: 0, [AVG_GAS])
 Suite result: ok. 3 passed; 0 failed; 0 skipped; [ELAPSED]
 


### PR DESCRIPTION
## Summary

- Add throughput metrics (`gas/s`, `tx/s`) to invariant test output for benchmarking tools like scfuzzbench
- Track cumulative gas and elapsed time during invariant campaigns
- Add `gas` field to `InvariantMetrics` for per-selector gas tracking in the metrics table
- Extend inline JSON progress logging with `total_txs`, `total_gas`, `tx_per_sec`, `gas_per_sec`
- Display `gas/s` and `tx/s` in the human-readable test report line
- Update snapshot parsing regex to handle new format

## Example output

```
Ran 2 tests for test/Vault.invariant.t.sol:VaultInvariantTest
[PASS] invariant_depositWithdrawAccounting() (runs: 20, calls: 2000, reverts: 0, gas/s: 1054698686, tx/s: 15399)

╭--------------+----------+-------+---------+----------+----------╮
| Contract     | Selector | Calls | Reverts | Discards | Gas      |
+=================================================================+
| VaultHandler | deposit  | 1041  | 0       | 0        | 65616418 |
|--------------+----------+-------+---------+----------+----------|
| VaultHandler | withdraw | 959   | 0       | 0        | 71370771 |
╰--------------+----------+-------+---------+----------+----------╯

[PASS] invariant_solvency() (runs: 20, calls: 2000, reverts: 0, gas/s: 1171893077, tx/s: 17092)

╭--------------+----------+-------+---------+----------+----------╮
| Contract     | Selector | Calls | Reverts | Discards | Gas      |
+=================================================================+
| VaultHandler | deposit  | 1041  | 0       | 0        | 65559742 |
|--------------+----------+-------+---------+----------+----------|
| VaultHandler | withdraw | 959   | 0       | 0        | 71566351 |
╰--------------+----------+-------+---------+----------+----------╯

Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 140.49ms (265.67ms CPU time)
```

Closes #13575

## Test plan

- [x] Unit tests for `TestKindReport::Invariant` display (normal, zero elapsed, optimization mode, failed corpus replays)
- [x] Unit test for metrics table with Gas column
- [x] Snapshot parsing tests updated for new format
- [x] Integration test snapshots updated across all invariant test files
- [x] `cargo build -p forge` passes
- [x] `cargo test -p forge --lib` passes (36 tests)