### PR TITLE
feat(tracing): add --compact-labels flag to hide addresses when label is available

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -100,6 +100,11 @@ pub struct CallArgs {
     #[arg(long, default_value_t = false, requires = "trace")]
     disable_labels: bool,
 
+    /// Hides addresses in trace parameters when a label is available.
+    /// Can only be set with `--trace`.
+    #[arg(long, default_value_t = false, requires = "trace")]
+    compact_labels: bool,
+
     /// Opens an interactive debugger.
     /// Can only be used with `--trace`.
     #[arg(long, requires = "trace")]
@@ -252,6 +257,7 @@ impl CallArgs {
             data,
             with_local_artifacts,
             disable_labels,
+            compact_labels,
             wallet,
             ..
         } = self;
@@ -402,6 +408,7 @@ impl CallArgs {
                 debug,
                 decode_internal,
                 disable_labels,
+                compact_labels,
                 None,
             )
             .await?;

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -70,6 +70,10 @@ pub struct RunArgs {
     #[arg(long, default_value_t = false)]
     disable_labels: bool,
 
+    /// Hides addresses in trace parameters when a label is available.
+    #[arg(long, default_value_t = false)]
+    compact_labels: bool,
+
     /// Label addresses in the trace.
     ///
     /// Example: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth
@@ -133,6 +137,7 @@ impl RunArgs {
         let debug = self.debug;
         let decode_internal = self.decode_internal;
         let disable_labels = self.disable_labels;
+        let compact_labels = self.compact_labels;
         let compute_units_per_second =
             if self.no_rate_limit { Some(u64::MAX) } else { self.compute_units_per_second };
 
@@ -326,6 +331,7 @@ impl RunArgs {
             debug,
             decode_internal,
             disable_labels,
+            compact_labels,
             self.trace_depth,
         )
         .await?;

--- a/crates/cast/src/debug.rs
+++ b/crates/cast/src/debug.rs
@@ -24,6 +24,7 @@ pub(crate) async fn handle_traces(
     debug: bool,
     decode_internal: bool,
     disable_label: bool,
+    compact_labels: bool,
     trace_depth: Option<usize>,
 ) -> eyre::Result<()> {
     let (known_contracts, mut sources) = if with_local_artifacts {
@@ -56,7 +57,8 @@ pub(crate) async fn handle_traces(
     let mut builder = CallTraceDecoderBuilder::new()
         .with_labels(labels.chain(config_labels))
         .with_signature_identifier(SignaturesIdentifier::from_config(config)?)
-        .with_label_disabled(disable_label);
+        .with_label_disabled(disable_label)
+        .with_compact_labels(compact_labels);
     let mut identifier = TraceIdentifiers::new().with_external(config, Some(chain))?;
     if let Some(contracts) = &known_contracts {
         builder = builder.with_known_contracts(contracts);

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -94,6 +94,13 @@ impl CallTraceDecoderBuilder {
         self
     }
 
+    /// Hides addresses in trace parameters when a label is available.
+    #[inline]
+    pub fn with_compact_labels(mut self, compact: bool) -> Self {
+        self.decoder.compact_labels = compact;
+        self
+    }
+
     /// Sets the debug identifier for the decoder.
     #[inline]
     pub fn with_debug_identifier(mut self, identifier: DebugTraceIdentifier) -> Self {
@@ -151,6 +158,9 @@ pub struct CallTraceDecoder {
 
     /// Disable showing of labels.
     pub disable_labels: bool,
+
+    /// Hide addresses when a label is available, showing only the label.
+    pub compact_labels: bool,
 }
 
 impl CallTraceDecoder {
@@ -216,6 +226,7 @@ impl CallTraceDecoder {
             debug_identifier: None,
 
             disable_labels: false,
+            compact_labels: false,
         }
     }
 
@@ -798,6 +809,9 @@ impl CallTraceDecoder {
         if let DynSolValue::Address(addr) = value
             && let Some(label) = self.labels.get(addr)
         {
+            if self.compact_labels {
+                return label.clone();
+            }
             return format!("{label}: [{addr}]");
         }
         format_token(value)

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -193,6 +193,10 @@ pub struct TestArgs {
     #[arg(long, help_heading = "Display options")]
     pub disable_labels: bool,
 
+    /// Hides addresses in trace parameters when a label is available.
+    #[arg(long, help_heading = "Display options")]
+    pub compact_labels: bool,
+
     #[command(flatten)]
     filter: FilterArgs,
 
@@ -550,6 +554,7 @@ impl TestArgs {
         let mut builder = CallTraceDecoderBuilder::new()
             .with_known_contracts(&known_contracts)
             .with_label_disabled(self.disable_labels)
+            .with_compact_labels(self.compact_labels)
             .with_verbosity(verbosity);
         // Signatures are of no value for gas reports.
         if !self.gas_report {

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -343,6 +343,7 @@ impl ExecutedState {
                 &self.script_config.config,
             )?)
             .with_label_disabled(self.args.disable_labels)
+            .with_compact_labels(self.args.compact_labels)
             .build();
 
         let mut identifier = TraceIdentifiers::new().with_local(known_contracts).with_external(

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -186,6 +186,10 @@ pub struct ScriptArgs {
     #[arg(long)]
     pub disable_labels: bool,
 
+    /// Hides addresses in trace parameters when a label is available.
+    #[arg(long)]
+    pub compact_labels: bool,
+
     /// The Etherscan (or equivalent) API key
     #[arg(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
     pub etherscan_api_key: Option<String>,


### PR DESCRIPTION
When an address appears as a parameter in a decoded trace and has a label,
it renders as `LabelName: [0xAddr]`. The new `--compact-labels` flag shows
only the label name.

Available in `cast run`, `cast call`, `forge test`, and `forge script`.
Mirrors the existing `--disable-labels` pattern.

Closes #3381