### PR TITLE
refactor(evm): remove `tx_env` param from EVM constructor helper

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1235,23 +1235,16 @@ impl Cheatcode for executeTransactionCall {
 
         let mut res = None;
         let mut cold_state = Some(cold_state);
-        let modified_tx = modified_tx_env.clone();
         let mut nested_evm_env = {
             let (db, _) = ccx.ecx.db_journal_inner_mut();
-            executor.with_fresh_nested_evm(
-                ccx.state,
-                db,
-                modified_evm_env,
-                modified_tx_env,
-                &mut |evm| {
-                    // SAFETY: closure is called exactly once by the executor.
-                    evm.journal_inner_mut().state = cold_state.take().expect("called once");
-                    // Set depth to 1 for proper trace collection.
-                    evm.journal_inner_mut().depth = 1;
-                    res = Some(evm.transact(modified_tx.clone()));
-                    Ok(())
-                },
-            )?
+            executor.with_fresh_nested_evm(ccx.state, db, modified_evm_env, &mut |evm| {
+                // SAFETY: closure is called exactly once by the executor.
+                evm.journal_inner_mut().state = cold_state.take().expect("called once");
+                // Set depth to 1 for proper trace collection.
+                evm.journal_inner_mut().depth = 1;
+                res = Some(evm.transact(modified_tx_env.clone()));
+                Ok(())
+            })?
         };
         let res = res.unwrap();
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -119,7 +119,6 @@ pub trait CheatcodesExecutor<CTX: ContextTr> {
         cheats: &mut Cheatcodes,
         db: &mut dyn DatabaseExt<CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
         evm_env: EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
-        tx_env: CTX::Tx,
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
     ) -> Result<EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>, EVMError<DatabaseError>>;
 
@@ -176,8 +175,8 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
         ecx: &mut CTX,
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
     ) -> Result<(), EVMError<DatabaseError>> {
-        with_cloned_context(ecx, |db, evm_env, tx_env, journal_inner| {
-            let mut evm = new_eth_evm_with_inspector(db, evm_env, tx_env, cheats);
+        with_cloned_context(ecx, |db, evm_env, journal_inner| {
+            let mut evm = new_eth_evm_with_inspector(db, evm_env, cheats);
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
             let sub_inner = evm.journaled_state.inner.clone();
@@ -191,10 +190,9 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
         cheats: &mut Cheatcodes,
         db: &mut dyn DatabaseExt<CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
         evm_env: EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
-        tx_env: CTX::Tx,
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
     ) -> Result<EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>, EVMError<DatabaseError>> {
-        let mut evm = new_eth_evm_with_inspector(db, evm_env, tx_env, cheats);
+        let mut evm = new_eth_evm_with_inspector(db, evm_env, cheats);
         f(&mut evm)?;
         Ok(evm.to_evm_env())
     }

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -73,12 +73,7 @@ impl<'a> CowBackend<'a> {
         // already, we reset the initialized state
         self.pending_init = Some((evm_env.cfg_env.spec, tx_env.caller, tx_env.kind));
 
-        let mut evm = crate::evm::new_eth_evm_with_inspector(
-            self,
-            evm_env.clone(),
-            tx_env.clone(),
-            inspector,
-        );
+        let mut evm = crate::evm::new_eth_evm_with_inspector(self, evm_env.clone(), inspector);
 
         let res = evm.transact(tx_env.clone()).wrap_err("EVM error")?;
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -781,12 +781,7 @@ impl Backend {
         inspector: I,
     ) -> eyre::Result<ResultAndState> {
         self.initialize(evm_env.cfg_env.spec, tx_env.caller, tx_env.kind);
-        let mut evm = crate::evm::new_eth_evm_with_inspector(
-            self,
-            evm_env.to_owned(),
-            tx_env.to_owned(),
-            inspector,
-        );
+        let mut evm = crate::evm::new_eth_evm_with_inspector(self, evm_env.to_owned(), inspector);
 
         let res = evm.transact(tx_env.clone()).wrap_err("EVM error")?;
 
@@ -1340,8 +1335,7 @@ impl DatabaseExt for Backend {
 
         let res = {
             let mut db = self.clone();
-            let mut evm =
-                new_eth_evm_with_inspector(&mut db, evm_env, tx_env.to_owned(), inspector);
+            let mut evm = new_eth_evm_with_inspector(&mut db, evm_env, inspector);
             evm.journaled_state.depth = journaled_state.depth + 1;
             evm.transact_raw(tx_env.to_owned())?
         };
@@ -2014,12 +2008,8 @@ fn commit_transaction(
         let depth = journaled_state.depth;
         let mut db = Backend::new_with_fork(fork_id, fork, journaled_state)?;
 
-        let mut evm = crate::evm::new_eth_evm_with_inspector(
-            &mut db as _,
-            evm_env.to_owned(),
-            tx_env.to_owned(),
-            inspector,
-        );
+        let mut evm =
+            crate::evm::new_eth_evm_with_inspector(&mut db as _, evm_env.to_owned(), inspector);
         // Adjust inner EVM depth to ensure that inspectors receive accurate data.
         evm.journaled_state.depth = depth + 1;
         evm.transact(tx_env.clone()).wrap_err("backend: failed committing transaction")?

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -34,14 +34,12 @@ use revm::{
 pub fn new_eth_evm_with_inspector<'db, I: EthInspectorExt>(
     db: &'db mut dyn DatabaseExt,
     evm_env: EvmEnv,
-    tx_env: TxEnv,
     inspector: I,
 ) -> FoundryEvm<'db, I> {
     let eth_evm =
         alloy_evm::EthEvmFactory::default().create_evm_with_inspector(db, evm_env, inspector);
     let mut inner = eth_evm.into_inner();
     inner.ctx.cfg.tx_chain_id_check = true;
-    inner.ctx.tx = tx_env;
 
     let mut evm = FoundryEvm { inner };
     evm.inspector().get_networks().inject_precompiles(evm.precompiles_mut());
@@ -240,7 +238,6 @@ pub fn with_cloned_context<CTX: EthCheatCtx>(
     f: impl FnOnce(
         &mut dyn DatabaseExt<CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
         EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
-        CTX::Tx,
         JournaledState,
     ) -> Result<
         (EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>, JournaledState),
@@ -248,12 +245,11 @@ pub fn with_cloned_context<CTX: EthCheatCtx>(
     >,
 ) -> Result<(), EVMError<DatabaseError>> {
     let evm_env = ecx.evm_clone();
-    let tx_env = ecx.tx_clone();
 
     let (db, journal_inner) = ecx.db_journal_inner_mut();
     let journal_inner_clone = journal_inner.clone();
 
-    let (sub_evm_env, sub_inner) = f(db, evm_env, tx_env, journal_inner_clone)?;
+    let (sub_evm_env, sub_inner) = f(db, evm_env, journal_inner_clone)?;
 
     // Write back modified state. The db borrow was released when f returned.
     ecx.set_journal_inner(sub_inner);

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -372,8 +372,8 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for InspectorStackInner {
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
     ) -> Result<(), EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
-        with_cloned_context(ecx, |db, evm_env, tx_env, journal_inner| {
-            let mut evm = new_eth_evm_with_inspector(db, evm_env, tx_env, &mut inspector);
+        with_cloned_context(ecx, |db, evm_env, journal_inner| {
+            let mut evm = new_eth_evm_with_inspector(db, evm_env, &mut inspector);
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
             let sub_inner = evm.journaled_state.inner.clone();
@@ -387,11 +387,10 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for InspectorStackInner {
         cheats: &mut Cheatcodes,
         db: &mut dyn DatabaseExt<CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
         evm_env: EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
-        tx_env: CTX::Tx,
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
     ) -> Result<EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>, EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
-        let mut evm = new_eth_evm_with_inspector(db, evm_env, tx_env, &mut inspector);
+        let mut evm = new_eth_evm_with_inspector(db, evm_env, &mut inspector);
         f(&mut evm)?;
         Ok(evm.to_evm_env())
     }
@@ -764,8 +763,7 @@ impl InspectorStackRefMut<'_> {
         let res = self.with_inspector(|mut inspector| {
             let (res, nested_env) = {
                 let (db, journal) = ecx.db_journal_inner_mut();
-                let mut evm =
-                    new_eth_evm_with_inspector(db, evm_env, tx_env.clone(), &mut inspector);
+                let mut evm = new_eth_evm_with_inspector(db, evm_env, &mut inspector);
 
                 evm.journal_inner_mut().state = {
                     let mut state = journal.state.clone();


### PR DESCRIPTION
## Motivation

Remove the `tx_env` parameter from `new_eth_evm_with_inspector`, `with_cloned_context`, and `with_fresh_nested_evm`.

Instead of setting the transaction environment at EVM construction time (where it may become stale or be set redundantly), callers now only pass the tx env directly to `evm.transact()` at execution time avoiding some clones.

This brings us closer to `EvmFactory` pattern.