### PR TITLE
feat(wallets): resolve signer from Tempo wallet keystore

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -53,6 +53,7 @@ tower.workspace = true
 
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 comfy-table.workspace = true
+dirs.workspace = true
 dunce.workspace = true
 eyre.workspace = true
 itertools.workspace = true
@@ -66,6 +67,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+toml.workspace = true
 tracing.workspace = true
 url.workspace = true
 walkdir.workspace = true

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -32,6 +32,7 @@ pub mod retry;
 pub mod selectors;
 pub mod serde_helpers;
 pub mod slot_identifier;
+pub mod tempo;
 pub mod term;
 pub mod traits;
 pub mod transactions;

--- a/crates/common/src/tempo.rs
+++ b/crates/common/src/tempo.rs
@@ -1,0 +1,112 @@
+//! Tempo wallet keystore types and discovery helpers.
+//!
+//! Shared types for reading keys from the Tempo CLI wallet keystore
+//! (`$TEMPO_HOME/wallet/keys.toml`, defaulting to `~/.tempo/wallet/keys.toml`).
+//!
+//! Key discovery chain (matches `tempoxyz/wallet` `tempo-common` behavior):
+//! 1. `TEMPO_PRIVATE_KEY` env var — checked first. If set, used directly (ephemeral, no disk
+//!    access).
+//! 2. `$TEMPO_HOME/wallet/keys.toml` — read from disk. `TEMPO_HOME` defaults to `~/.tempo` if not
+//!    set.
+
+use serde::Deserialize;
+use std::path::PathBuf;
+
+/// Environment variable for an ephemeral Tempo private key.
+pub const TEMPO_PRIVATE_KEY_ENV: &str = "TEMPO_PRIVATE_KEY";
+
+/// Environment variable to override the Tempo home directory.
+pub const TEMPO_HOME_ENV: &str = "TEMPO_HOME";
+
+/// Default Tempo home directory relative to the user's home.
+pub const DEFAULT_TEMPO_HOME: &str = ".tempo";
+
+/// Relative path from Tempo home to the wallet keys file.
+pub const WALLET_KEYS_PATH: &str = "wallet/keys.toml";
+
+/// Wallet type matching `tempo-common`'s `WalletType` enum.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WalletType {
+    #[default]
+    Local,
+    Passkey,
+}
+
+/// A single key entry in `keys.toml`.
+///
+/// Mirrors the fields from `tempo-common::keys::model::KeyEntry` that are
+/// relevant for key discovery. Unknown fields (e.g. `chain_id`,
+/// `key_authorization`, `expiry`) are ignored by serde.
+#[derive(Debug, Default, Deserialize)]
+pub struct KeyEntry {
+    /// Wallet type: "local" or "passkey".
+    #[serde(default)]
+    pub wallet_type: WalletType,
+    /// Smart wallet address (the on-chain account).
+    #[serde(default)]
+    pub wallet_address: Option<String>,
+    /// Key address (the EOA derived from the private key).
+    #[serde(default)]
+    pub key_address: Option<String>,
+    /// Key private key, stored inline in keys.toml.
+    #[serde(default)]
+    pub key: Option<String>,
+}
+
+impl KeyEntry {
+    /// Whether this entry has a non-empty inline private key.
+    pub fn has_inline_key(&self) -> bool {
+        self.key.as_ref().is_some_and(|k| !k.trim().is_empty())
+    }
+}
+
+/// The top-level structure of `keys.toml`.
+#[derive(Debug, Default, Deserialize)]
+pub struct KeysFile {
+    #[serde(default)]
+    pub keys: Vec<KeyEntry>,
+}
+
+/// Resolve the Tempo home directory.
+///
+/// Uses `TEMPO_HOME` env var if set, otherwise `~/.tempo`.
+pub fn tempo_home() -> Option<PathBuf> {
+    if let Ok(home) = std::env::var(TEMPO_HOME_ENV) {
+        return Some(PathBuf::from(home));
+    }
+    dirs::home_dir().map(|h| h.join(DEFAULT_TEMPO_HOME))
+}
+
+/// Returns the path to the Tempo wallet keys file.
+pub fn tempo_keys_path() -> Option<PathBuf> {
+    tempo_home().map(|home| home.join(WALLET_KEYS_PATH))
+}
+
+/// Read and parse the Tempo wallet keys file.
+///
+/// Returns `None` if the file doesn't exist or can't be read/parsed.
+/// Errors are logged as warnings.
+pub fn read_tempo_keys_file() -> Option<KeysFile> {
+    let keys_path = tempo_keys_path()?;
+    if !keys_path.exists() {
+        trace!(?keys_path, "tempo keys file not found");
+        return None;
+    }
+
+    let contents = match std::fs::read_to_string(&keys_path) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(?keys_path, %e, "failed to read tempo keys file");
+            return None;
+        }
+    };
+
+    match toml::from_str(&contents) {
+        Ok(f) => Some(f),
+        Err(e) => {
+            warn!(?keys_path, %e, "failed to parse tempo keys file");
+            None
+        }
+    }
+}

--- a/crates/wallets/Cargo.toml
+++ b/crates/wallets/Cargo.toml
@@ -57,6 +57,8 @@ eth-keystore = "0.5.0"
 
 [dev-dependencies]
 reqwest = { workspace = true, features = ["json"] }
+tempfile.workspace = true
+toml.workspace = true
 
 [features]
 aws-kms = ["dep:alloy-signer-aws", "dep:aws-config"]

--- a/crates/wallets/src/lib.rs
+++ b/crates/wallets/src/lib.rs
@@ -18,6 +18,7 @@ pub mod utils;
 pub mod wallet_browser;
 pub mod wallet_multi;
 pub mod wallet_raw;
+pub mod wallet_tempo;
 
 pub use opts::WalletOpts;
 pub use signer::{PendingSigner, WalletSigner};

--- a/crates/wallets/src/opts.rs
+++ b/crates/wallets/src/opts.rs
@@ -1,4 +1,4 @@
-use crate::{signer::WalletSigner, utils, wallet_raw::RawWalletOpts};
+use crate::{signer::WalletSigner, utils, wallet_raw::RawWalletOpts, wallet_tempo};
 use alloy_primitives::Address;
 use clap::Parser;
 use eyre::Result;
@@ -71,6 +71,18 @@ pub struct WalletOpts {
     )]
     pub keystore_password_file: Option<String>,
 
+    /// Use a Tempo wallet.
+    ///
+    /// Resolve the signing key from the Tempo CLI wallet keystore
+    /// (`$TEMPO_HOME/wallet/keys.toml`, default `~/.tempo/wallet/keys.toml`).
+    /// The `TEMPO_PRIVATE_KEY` env var is checked first.
+    ///
+    /// Requires `--from` to specify which address to resolve.
+    ///
+    /// See: <https://docs.tempo.xyz>
+    #[arg(long, help_heading = "Wallet options - keystore")]
+    pub tempo: bool,
+
     /// Use a Ledger hardware wallet.
     #[arg(long, short, help_heading = "Wallet options - hardware wallet")]
     pub ledger: bool,
@@ -139,6 +151,11 @@ impl WalletOpts {
                 eyre::eyre!("TURNKEY_ADDRESS could not be parsed as an Ethereum address")
             })?;
             WalletSigner::from_turnkey(api_private_key, organization_id, address)?
+        } else if self.tempo {
+            let sender =
+                self.from.ok_or_else(|| eyre::eyre!("--from is required when using --tempo"))?;
+            wallet_tempo::try_resolve_tempo_signer(sender)?
+                .ok_or_else(|| eyre::eyre!("no matching key found in Tempo wallet for {sender}"))?
         } else if let Some(raw_wallet) = self.raw.signer()? {
             raw_wallet
         } else if let Some(path) = utils::maybe_get_keystore_path(
@@ -172,6 +189,7 @@ flag to set your key via:
 --aws
 --gcp
 --turnkey
+--tempo
 --trezor
 --ledger
 --browser
@@ -244,6 +262,7 @@ mod tests {
             aws: false,
             gcp: false,
             turnkey: false,
+            tempo: false,
         };
         match wallet.signer().await {
             Ok(_) => {

--- a/crates/wallets/src/wallet_tempo.rs
+++ b/crates/wallets/src/wallet_tempo.rs
@@ -1,0 +1,292 @@
+//! Tempo wallet keystore integration.
+//!
+//! Resolves a signer by matching the `--from` address against entries in the
+//! Tempo CLI wallet keystore. Types and discovery helpers are defined in
+//! [`foundry_common::tempo`].
+
+use alloy_primitives::Address;
+use alloy_signer::Signer;
+use eyre::Result;
+use foundry_common::tempo::{KeysFile, TEMPO_PRIVATE_KEY_ENV, read_tempo_keys_file};
+use std::env;
+
+use crate::{WalletSigner, utils::create_private_key_signer};
+
+/// Try to resolve a signer from the Tempo wallet keystore for the given address.
+///
+/// First checks `TEMPO_PRIVATE_KEY` env var, then reads
+/// `$TEMPO_HOME/wallet/keys.toml` (default `~/.tempo/wallet/keys.toml`) and looks
+/// for a key entry whose `wallet_address` or `key_address` matches `sender`. If a match
+/// with an inline private key is found, returns the corresponding [`WalletSigner`].
+///
+/// Read/parse errors are treated as warnings and skipped rather than
+/// failing the signer resolution.
+pub fn try_resolve_tempo_signer(sender: Address) -> Result<Option<WalletSigner>> {
+    // 1. Check TEMPO_PRIVATE_KEY env var
+    if let Ok(key) = env::var(TEMPO_PRIVATE_KEY_ENV) {
+        let key = key.trim().to_string();
+        if !key.is_empty() {
+            trace!("checking TEMPO_PRIVATE_KEY env var");
+            let signer = create_private_key_signer(&key)?;
+            if signer.address() == sender {
+                trace!("using signer from TEMPO_PRIVATE_KEY env var");
+                return Ok(Some(signer));
+            }
+            trace!(
+                derived = %signer.address(),
+                requested = %sender,
+                "TEMPO_PRIVATE_KEY address does not match requested sender"
+            );
+        }
+    }
+
+    // 2. Read $TEMPO_HOME/wallet/keys.toml
+    let Some(keys_file) = read_tempo_keys_file() else {
+        return Ok(None);
+    };
+
+    resolve_from_keys_file(&keys_file, sender)
+}
+
+/// Resolve a signer from a parsed [`KeysFile`].
+fn resolve_from_keys_file(keys_file: &KeysFile, sender: Address) -> Result<Option<WalletSigner>> {
+    let sender_lower = format!("{sender:#x}");
+
+    for entry in &keys_file.keys {
+        let wallet_match =
+            entry.wallet_address.as_deref().is_some_and(|addr| addr.to_lowercase() == sender_lower);
+        let key_match =
+            entry.key_address.as_deref().is_some_and(|addr| addr.to_lowercase() == sender_lower);
+
+        if (wallet_match || key_match) && entry.has_inline_key() {
+            let signer = create_private_key_signer(entry.key.as_ref().unwrap())?;
+            // Only return the signer if the derived address matches the requested sender.
+            // This prevents returning a signer for a different address (e.g. when
+            // wallet_address != key_address in keychain-style entries).
+            if signer.address() == sender {
+                trace!("found matching key in tempo keystore");
+                return Ok(Some(signer));
+            }
+            trace!(
+                derived = %signer.address(),
+                requested = %sender,
+                "tempo keystore entry matched but derived address differs, skipping"
+            );
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const TEST_KEY: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    const TEST_ADDR: &str = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+
+    fn resolve_from_toml(contents: &str, sender: Address) -> Result<Option<WalletSigner>> {
+        let keys_file: KeysFile = toml::from_str(contents)?;
+        resolve_from_keys_file(&keys_file, sender)
+    }
+
+    /// Write a keys.toml to a temp dir and set TEMPO_HOME to point at it.
+    /// Returns the tempdir (must be kept alive for the duration of the test).
+    fn setup_keys_toml(toml_content: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wallet_dir = dir.path().join("wallet");
+        std::fs::create_dir_all(&wallet_dir).expect("create wallet dir");
+        let keys_path = wallet_dir.join("keys.toml");
+        let mut f = std::fs::File::create(&keys_path).expect("create keys.toml");
+        f.write_all(toml_content.as_bytes()).expect("write keys.toml");
+        dir
+    }
+
+    #[test]
+    fn resolves_by_wallet_address() {
+        let toml = format!(
+            r#"[[keys]]
+wallet_address = "{TEST_ADDR}"
+key = "{TEST_KEY}"
+"#
+        );
+        let sender: Address = TEST_ADDR.parse().unwrap();
+        let signer = resolve_from_toml(&toml, sender).unwrap().unwrap();
+        assert_eq!(signer.address(), sender);
+    }
+
+    #[test]
+    fn resolves_by_key_address() {
+        let toml = format!(
+            r#"[[keys]]
+wallet_address = "0x0000000000000000000000000000000000000001"
+key_address = "{TEST_ADDR}"
+key = "{TEST_KEY}"
+"#
+        );
+        let sender: Address = TEST_ADDR.parse().unwrap();
+        let signer = resolve_from_toml(&toml, sender).unwrap().unwrap();
+        assert_eq!(signer.address(), sender);
+    }
+
+    #[test]
+    fn returns_none_when_no_match() {
+        let toml = format!(
+            r#"[[keys]]
+wallet_address = "0x1111111111111111111111111111111111111111"
+key = "{TEST_KEY}"
+"#
+        );
+        let sender: Address = "0x2222222222222222222222222222222222222222".parse().unwrap();
+        assert!(resolve_from_toml(&toml, sender).unwrap().is_none());
+    }
+
+    #[test]
+    fn skips_entry_without_key() {
+        let toml = format!(
+            r#"[[keys]]
+wallet_type = "passkey"
+wallet_address = "{TEST_ADDR}"
+key_type = "webauthn"
+"#
+        );
+        let sender: Address = TEST_ADDR.parse().unwrap();
+        assert!(resolve_from_toml(&toml, sender).unwrap().is_none());
+    }
+
+    #[test]
+    fn case_insensitive_match() {
+        let toml = format!(
+            r#"[[keys]]
+wallet_address = "0xF39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+key = "{TEST_KEY}"
+"#
+        );
+        let sender: Address = TEST_ADDR.parse().unwrap();
+        assert!(resolve_from_toml(&toml, sender).unwrap().is_some());
+    }
+
+    #[test]
+    fn empty_keystore() {
+        let sender: Address = TEST_ADDR.parse().unwrap();
+        assert!(resolve_from_toml("", sender).unwrap().is_none());
+    }
+
+    #[test]
+    fn skips_when_wallet_address_differs_from_derived_key() {
+        // wallet_address matches sender, but the private key derives to a different address.
+        // This simulates a keychain-style entry where wallet_address != key_address.
+        let other_addr = "0x0000000000000000000000000000000000000042";
+        let toml = format!(
+            r#"[[keys]]
+wallet_address = "{other_addr}"
+key_address = "{TEST_ADDR}"
+key = "{TEST_KEY}"
+"#
+        );
+        // Looking up by wallet_address (0x42) — the key derives to TEST_ADDR, not 0x42.
+        let sender: Address = other_addr.parse().unwrap();
+        assert!(resolve_from_toml(&toml, sender).unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_keys_toml_unknown_fields_ignored() {
+        let toml_str = r#"
+[[keys]]
+wallet_address = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+key = "0xsecret"
+chain_id = 4217
+key_authorization = "0xauth_data"
+expiry = 1750000000
+unknown_future_field = "should be ignored"
+
+[[keys.limits]]
+currency = "0x20c000000000000000000000b9537d11c60e8b50"
+limit = "1000"
+"#;
+        let keys_file: KeysFile = toml::from_str(toml_str).unwrap();
+        assert_eq!(keys_file.keys.len(), 1);
+        assert_eq!(keys_file.keys[0].key.as_deref(), Some("0xsecret"));
+    }
+
+    /// Integration tests that exercise the full discovery chain via env vars.
+    /// Combined into a single test to avoid parallel env var mutation.
+    #[test]
+    fn discover_from_tempo_home() {
+        let sender: Address = TEST_ADDR.parse().unwrap();
+
+        // 1. Resolves from keys.toml via TEMPO_HOME
+        {
+            let toml_content = format!(
+                r#"
+[[keys]]
+wallet_address = "{TEST_ADDR}"
+key = "{TEST_KEY}"
+chain_id = 4217
+"#
+            );
+            let dir = setup_keys_toml(&toml_content);
+
+            // SAFETY: test-only env manipulation, single-threaded within this test.
+            unsafe {
+                std::env::set_var("TEMPO_HOME", dir.path());
+                std::env::remove_var("TEMPO_PRIVATE_KEY");
+            }
+
+            let signer = try_resolve_tempo_signer(sender).unwrap().unwrap();
+            assert_eq!(signer.address(), sender);
+        }
+
+        // 2. TEMPO_PRIVATE_KEY env var takes priority over keys.toml
+        {
+            let other_key = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+            let other_addr: Address = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8".parse().unwrap();
+            let toml_content = format!(
+                r#"
+[[keys]]
+wallet_address = "{TEST_ADDR}"
+key = "{TEST_KEY}"
+"#
+            );
+            let dir = setup_keys_toml(&toml_content);
+
+            // SAFETY: test-only env manipulation, single-threaded within this test.
+            unsafe {
+                std::env::set_var("TEMPO_HOME", dir.path());
+                std::env::set_var("TEMPO_PRIVATE_KEY", other_key);
+            }
+
+            // The env var key derives to other_addr, so looking up other_addr should
+            // use the env var key (priority over keys.toml).
+            let signer = try_resolve_tempo_signer(other_addr).unwrap().unwrap();
+            assert_eq!(signer.address(), other_addr);
+        }
+
+        // 3. Skips entries without an inline key
+        {
+            let toml_content = format!(
+                r#"
+[[keys]]
+wallet_address = "{TEST_ADDR}"
+chain_id = 4217
+"#
+            );
+            let dir = setup_keys_toml(&toml_content);
+
+            // SAFETY: test-only env manipulation, single-threaded within this test.
+            unsafe {
+                std::env::set_var("TEMPO_HOME", dir.path());
+                std::env::remove_var("TEMPO_PRIVATE_KEY");
+            }
+
+            assert!(try_resolve_tempo_signer(sender).unwrap().is_none());
+        }
+
+        // Cleanup
+        unsafe {
+            std::env::remove_var("TEMPO_HOME");
+            std::env::remove_var("TEMPO_PRIVATE_KEY");
+        }
+    }
+}


### PR DESCRIPTION
## feat(wallets): resolve signer from Tempo wallet keystore

Adds automatic signer resolution from the [Tempo CLI wallet](https://docs.tempo.xyz) keystore. When `--from` is set but no explicit wallet flag is provided, Foundry looks up the address in the Tempo keystore and uses the matching private key.

### How it works

1. Checks `TEMPO_PRIVATE_KEY` env var first (ephemeral, no disk access)
2. Reads `$TEMPO_HOME/wallet/keys.toml` (default `~/.tempo/wallet/keys.toml`)
3. Matches `--from` address against `wallet_address` or `key_address` fields
4. Validates the derived signer address equals the requested sender
5. Falls back to the existing error if no match is found

### Shared types (`foundry_common::tempo`)

Introduces a `tempo` module in `foundry-common` with shared keystore types used by both the wallet signer and the MPP transport ([#13851](https://github.com/foundry-rs/foundry/pull/13851)):

- `KeyEntry` / `KeysFile` — serde models for `keys.toml`
- `WalletType` — `local` or `passkey` (for primary key selection)
- `tempo_home()` / `tempo_keys_path()` / `read_tempo_keys_file()` — discovery helpers
- `TEMPO_PRIVATE_KEY_ENV` / `TEMPO_HOME_ENV` — env var constants

### Safety

- Read/parse errors are warnings, never hard failures
- Derived address is validated against the requested sender before returning
- Keychain-style entries (where `wallet_address` differs from `key_address`) are safely skipped
- Unknown fields are ignored for forward compatibility

### Testing

```
cargo test -p foundry-wallets -- wallet_tempo
```

9 tests covering: wallet_address match, key_address match, no match, missing key, case insensitivity, empty keystore, wallet_address/key_address mismatch, unknown fields, and full discovery chain (TEMPO_HOME, env var priority, missing inline key).

Inspired by [tempoxyz/tempo-foundry](https://github.com/tempoxyz/tempo-foundry/pull/348) and [#13851](https://github.com/foundry-rs/foundry/pull/13851) (MPP key auto-discovery).
