### PR TITLE
chore: remove no-op `spec_id` reassignment in `Executor::clone_with_backend`

### DIFF
--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -144,8 +144,7 @@ impl Executor {
     }
 
     fn clone_with_backend(&self, backend: Backend) -> Self {
-        let mut evm_env = self.evm_env.clone();
-        evm_env.cfg_env.spec = self.spec_id();
+        let evm_env = self.evm_env.clone();
         Self {
             backend: Arc::new(backend),
             evm_env,


### PR DESCRIPTION
## Summary

Remove a no-op line in `Executor::clone_with_backend()`:

```rust
let mut evm_env = self.evm_env.clone();
evm_env.cfg_env.spec = self.spec_id(); // ← no-op
```

After cloning `self.evm_env`, `evm_env.cfg_env.spec` already equals `self.spec_id()`, which simply returns `self.evm_env.cfg_env.spec` (see [line 203-205](https://github.com/foundry-rs/foundry/blob/master/crates/evm/evm/src/executors/mod.rs#L203-L205)). The reassignment has no effect.

## Verification

- `cargo check -p foundry-evm` passes cleanly.