### PR TITLE
refactor(evm): `NestedEvm` based on revm's `Evm` instead of alloy-evm

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1242,7 +1242,7 @@ impl Cheatcode for executeTransactionCall {
                 evm.journal_inner_mut().state = cold_state.take().expect("called once");
                 // Set depth to 1 for proper trace collection.
                 evm.journal_inner_mut().depth = 1;
-                res = Some(evm.transact(modified_tx_env.clone()));
+                res = Some(evm.transact_raw(modified_tx_env.clone()));
                 Ok(())
             })?
         };

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -38,7 +38,7 @@ use foundry_evm_core::{
     backend::{DatabaseError, DatabaseExt, RevertDiagnostic},
     constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME},
     env::FoundryContextExt,
-    evm::{NestedEvm, NestedEvmClosure, new_eth_evm_with_inspector, with_cloned_context},
+    evm::{NestedEvm, NestedEvmClosure, new_revm_with_inspector, with_cloned_context},
 };
 use foundry_evm_traces::{
     TracingInspector, TracingInspectorConfig, identifier::SignaturesIdentifier,
@@ -176,7 +176,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
     ) -> Result<(), EVMError<DatabaseError>> {
         with_cloned_context(ecx, |db, evm_env, journal_inner| {
-            let mut evm = new_eth_evm_with_inspector(db, evm_env, cheats);
+            let mut evm = new_revm_with_inspector(db, evm_env, cheats);
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
             let sub_inner = evm.journaled_state.inner.clone();
@@ -192,7 +192,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
         evm_env: EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
     ) -> Result<EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>, EVMError<DatabaseError>> {
-        let mut evm = new_eth_evm_with_inspector(db, evm_env, cheats);
+        let mut evm = new_revm_with_inspector(db, evm_env, cheats);
         f(&mut evm)?;
         Ok(evm.to_evm_env())
     }

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -31,6 +31,19 @@ use revm::{
     primitives::hardfork::SpecId,
 };
 
+pub fn new_revm_with_inspector<'db, I: EthInspectorExt>(
+    db: &'db mut dyn DatabaseExt,
+    evm_env: EvmEnv,
+    inspector: I,
+) -> EthRevmEvm<'db, I> {
+    let mut revm = alloy_evm::EthEvmFactory::default()
+        .create_evm_with_inspector(db, evm_env, inspector)
+        .into_inner();
+    revm.ctx.cfg.tx_chain_id_check = true;
+    revm.inspector.get_networks().inject_precompiles(&mut revm.precompiles);
+    revm
+}
+
 pub fn new_eth_evm_with_inspector<'db, I: EthInspectorExt>(
     db: &'db mut dyn DatabaseExt,
     evm_env: EvmEnv,
@@ -67,15 +80,16 @@ fn get_create2_factory_call_inputs(
     }
 }
 
+type EthRevmEvm<'db, I> = RevmEvm<
+    EthEvmContext<&'db mut dyn DatabaseExt>,
+    I,
+    EthInstructions<EthInterpreter, EthEvmContext<&'db mut dyn DatabaseExt>>,
+    PrecompilesMap,
+    EthFrame<EthInterpreter>,
+>;
+
 pub struct FoundryEvm<'db, I: EthInspectorExt> {
-    #[allow(clippy::type_complexity)]
-    inner: RevmEvm<
-        EthEvmContext<&'db mut dyn DatabaseExt>,
-        I,
-        EthInstructions<EthInterpreter, EthEvmContext<&'db mut dyn DatabaseExt>>,
-        PrecompilesMap,
-        EthFrame<EthInterpreter>,
-    >,
+    inner: EthRevmEvm<'db, I>,
 }
 
 impl<'db, I: EthInspectorExt> Evm for FoundryEvm<'db, I> {
@@ -176,7 +190,7 @@ pub trait NestedEvm {
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>>;
 
     /// Executes a full transaction with the given tx env.
-    fn transact(
+    fn transact_raw(
         &mut self,
         tx: Self::Tx,
     ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>>;
@@ -185,13 +199,13 @@ pub trait NestedEvm {
     fn to_evm_env(self) -> EvmEnv<Self::Spec, Self::Block>;
 }
 
-impl<I: EthInspectorExt> NestedEvm for FoundryEvm<'_, I> {
+impl<'db, I: EthInspectorExt> NestedEvm for EthRevmEvm<'db, I> {
     type Tx = TxEnv;
     type Block = BlockEnv;
     type Spec = SpecId;
 
     fn journal_inner_mut(&mut self) -> &mut JournaledState {
-        &mut self.inner.ctx.journaled_state.inner
+        &mut self.ctx_mut().journaled_state.inner
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
@@ -199,27 +213,33 @@ impl<I: EthInspectorExt> NestedEvm for FoundryEvm<'_, I> {
 
         // Create first frame
         let memory =
-            SharedMemory::new_with_buffer(self.inner.ctx().local().shared_memory_buffer().clone());
+            SharedMemory::new_with_buffer(self.ctx().local().shared_memory_buffer().clone());
         let first_frame_input = FrameInit { depth: 0, memory, frame_input: frame };
 
         // Run execution loop
-        let mut frame_result = handler.inspect_run_exec_loop(&mut self.inner, first_frame_input)?;
+        let mut frame_result = handler.inspect_run_exec_loop(self, first_frame_input)?;
 
         // Handle last frame result
-        handler.last_frame_result(&mut self.inner, &mut frame_result)?;
+        handler.last_frame_result(self, &mut frame_result)?;
 
         Ok(frame_result)
     }
 
-    fn transact(
+    fn transact_raw(
         &mut self,
         tx: TxEnv,
     ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>> {
-        Evm::transact_raw(self, tx)
+        self.set_tx(tx);
+
+        let mut handler = FoundryHandler::<I>::default();
+        let result = handler.inspect_run(self)?;
+
+        Ok(ResultAndState::new(result, self.ctx.journaled_state.inner.state.clone()))
     }
 
     fn to_evm_env(self) -> EvmEnv {
-        Evm::finish(self).1
+        let Context { block, cfg, .. } = self.ctx;
+        EvmEnv::new(cfg, block)
     }
 }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -15,7 +15,7 @@ use foundry_evm_core::{
     FoundryBlock, FoundryInspectorExt, FoundryTransaction,
     backend::{DatabaseError, DatabaseExt, JournaledState},
     env::FoundryContextExt,
-    evm::{NestedEvm, new_eth_evm_with_inspector, with_cloned_context},
+    evm::{NestedEvm, new_revm_with_inspector, with_cloned_context},
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_networks::NetworkConfigs;
@@ -366,7 +366,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for InspectorStackInner {
     ) -> Result<(), EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         with_cloned_context(ecx, |db, evm_env, journal_inner| {
-            let mut evm = new_eth_evm_with_inspector(db, evm_env, &mut inspector);
+            let mut evm = new_revm_with_inspector(db, evm_env, &mut inspector);
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
             let sub_inner = evm.journaled_state.inner.clone();
@@ -383,7 +383,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for InspectorStackInner {
         f: NestedEvmClosure<'_, CTX::Block, CTX::Tx, <CTX::Cfg as Cfg>::Spec>,
     ) -> Result<EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>, EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
-        let mut evm = new_eth_evm_with_inspector(db, evm_env, &mut inspector);
+        let mut evm = new_revm_with_inspector(db, evm_env, &mut inspector);
         f(&mut evm)?;
         Ok(evm.to_evm_env())
     }
@@ -735,7 +735,7 @@ impl InspectorStackRefMut<'_> {
         let res = self.with_inspector(|mut inspector| {
             let (res, nested_env) = {
                 let (db, journal) = ecx.db_journal_inner_mut();
-                let mut evm = new_eth_evm_with_inspector(db, evm_env, &mut inspector);
+                let mut evm = new_revm_with_inspector(db, evm_env, &mut inspector);
 
                 evm.journal_inner_mut().state = {
                     let mut state = journal.state.clone();
@@ -759,7 +759,7 @@ impl InspectorStackRefMut<'_> {
                 // set depth to 1 to make sure traces are collected correctly
                 evm.journal_inner_mut().depth = 1;
 
-                let res = evm.transact(tx_env);
+                let res = evm.transact_raw(tx_env);
                 let nested_evm_env = evm.to_evm_env();
                 (res, nested_evm_env)
             };


### PR DESCRIPTION
## Motivation
Decouple the NestedEvm trait from the `alloy-evm::Evm` abstraction by implementing it directly on the underlying revm Evm type. This removes an unnecessary layer of indirection all NestedEvm methods were just delegating to the inner revm Evm.

Key changes:
- Extract `EthRevmEvm` type alias for the concrete revm Evm type, making clippy happy
- Add `new_revm_with_inspector()` that returns the raw revm Evm directly (vs `new_eth_evm_with_inspector()` which wraps it in `FoundryEvm`)
- Rename `NestedEvm::transact()` to `transact_raw()` to avoid name collision with revm's `ExecuteEvm::transact()` now that the trait is implemented on the revm type directly
- Update all call sites (cheatcodes, inspector stack) to use the raw revm Evm for nested execution contexts
