### PR TITLE
fix(fmt): swap valid_before/valid_after in TempoTransaction pretty print

### DIFF
--- a/crates/common/fmt/src/ui.rs
+++ b/crates/common/fmt/src/ui.rs
@@ -519,8 +519,8 @@ validAfter           {}",
             self.nonce_key.pretty(),
             self.nonce.pretty(),
             self.fee_payer_signature.pretty(),
-            self.valid_after.pretty(),
             self.valid_before.pretty(),
+            self.valid_after.pretty(),
         )
     }
 }


### PR DESCRIPTION
The format string labels were swapped with their values - validBefore was showing valid_after and vice versa.

Introduced in #13631