### PR TITLE
perf(evm): remove unnecessary clones in do_call_end/do_create_end

### DIFF
--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -637,7 +637,7 @@ impl InspectorStackRefMut<'_> {
         ecx: &mut CTX,
         inputs: &CallInputs,
         outcome: &mut CallOutcome,
-    ) -> CallOutcome {
+    ) {
         let result = outcome.result.result;
         call_inspectors!(
             #[ret]
@@ -657,7 +657,7 @@ impl InspectorStackRefMut<'_> {
                 let different = outcome.result.result != result
                     || (outcome.result.result == InstructionResult::Revert
                         && outcome.output() != previous_outcome.output());
-                different.then_some(outcome.clone())
+                different.then_some(())
             },
         );
 
@@ -665,8 +665,6 @@ impl InspectorStackRefMut<'_> {
         if result.is_revert() && self.reverter.is_none() {
             self.reverter = Some(inputs.target_address);
         }
-
-        outcome.clone()
     }
 
     fn do_create_end<CTX: EthCheatCtx>(
@@ -674,7 +672,7 @@ impl InspectorStackRefMut<'_> {
         ecx: &mut CTX,
         call: &CreateInputs,
         outcome: &mut CreateOutcome,
-    ) -> CreateOutcome {
+    ) {
         let result = outcome.result.result;
         call_inspectors!(
             #[ret]
@@ -688,11 +686,9 @@ impl InspectorStackRefMut<'_> {
                 let different = outcome.result.result != result
                     || (outcome.result.result == InstructionResult::Revert
                         && outcome.output() != previous_outcome.output());
-                different.then_some(outcome.clone())
+                different.then_some(())
             },
         );
-
-        outcome.clone()
     }
 
     fn transact_inner<CTX: EthCheatCtx>(


### PR DESCRIPTION
Both methods returned `CallOutcome/CreateOutcome` but all callers discarded the return value — the outcome is already mutated in-place via &mut.

Removes the final `outcome.clone()` and changes the early-return from `then_some(outcome.clone())` to `then(|| ())`, eliminating up to 2 clones per call/create end hook invocation.