### PR TITLE
feat(forge-script): Tempo access key support for forge script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,6 +4365,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tempo-alloy",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -55,6 +55,7 @@ alloy-primitives.workspace = true
 alloy-eips.workspace = true
 alloy-consensus.workspace = true
 thiserror.workspace = true
+tempo-alloy.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -22,10 +22,11 @@ use foundry_common::{
 };
 use foundry_config::Config;
 use foundry_primitives::FoundryTransactionBuilder;
-use foundry_wallets::wallet_browser::signer::BrowserSigner;
+use foundry_wallets::{TempoAccessKeyConfig, WalletSigner, wallet_browser::signer::BrowserSigner};
 use futures::{FutureExt, StreamExt, future::join_all, stream::FuturesUnordered};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+use tempo_alloy::provider::TempoProviderExt;
 
 use crate::{
     ScriptArgs, ScriptConfig, build::LinkedBuildData, progress::ScriptProgress,
@@ -71,13 +72,15 @@ pub enum SendTransactionKind<'a, N: Network> {
     Raw(N::TransactionRequest, &'a EthereumWallet),
     Browser(N::TransactionRequest, &'a BrowserSigner<N>),
     Signed(N::TxEnvelope),
+    AccessKey(N::TransactionRequest, &'a WalletSigner, &'a TempoAccessKeyConfig, String),
 }
 
 impl<'a, N: Network> SendTransactionKind<'a, N>
 where
     N::TxEnvelope: From<Signed<N::UnsignedTx>>,
     N::UnsignedTx: SignableTransaction<Signature>,
-    N::TransactionRequest: FoundryTransactionBuilder<N>,
+    N::TransactionRequest:
+        FoundryTransactionBuilder<N> + Into<tempo_alloy::rpc::TempoTransactionRequest>,
 {
     /// Prepares the transaction for broadcasting by synchronizing nonce and estimating gas.
     ///
@@ -93,7 +96,11 @@ where
         estimate_via_rpc: bool,
         estimate_multiplier: u64,
     ) -> Result<()> {
-        if let Self::Raw(tx, _) | Self::Unlocked(tx) | Self::Browser(tx, _) = self {
+        if let Self::Raw(tx, _)
+        | Self::Unlocked(tx)
+        | Self::Browser(tx, _)
+        | Self::AccessKey(tx, _, _, _) = self
+        {
             if sequential_broadcast {
                 let from = tx.from().expect("no sender");
 
@@ -169,6 +176,35 @@ where
                 // Sign and send the transaction via the browser wallet
                 Ok(signer.send_transaction_via_browser(tx).await?)
             }
+            Self::AccessKey(mut tx, signer, access_key, rpc_url) => {
+                debug!("sending transaction via tempo access key: {:?}", tx);
+
+                // Check if the key needs on-chain provisioning.
+                if let Some(auth) = &access_key.key_authorization {
+                    let tempo_provider = foundry_common::provider::ProviderBuilder::<
+                        tempo_alloy::TempoNetwork,
+                    >::new(&rpc_url)
+                    .build()?;
+                    if !tempo_provider
+                        .get_keychain_key(access_key.wallet_address, access_key.key_address)
+                        .await
+                        .map(|info| info.keyId != Address::ZERO)
+                        .unwrap_or(false)
+                    {
+                        tx.set_key_authorization(auth.clone());
+                    }
+                }
+
+                let raw_tx = foundry_wallets::tempo::sign_with_access_key(
+                    tx,
+                    signer,
+                    access_key.wallet_address,
+                )
+                .await?;
+
+                let pending = provider.send_raw_transaction(&raw_tx).await?;
+                Ok(*pending.tx_hash())
+            }
         }
     }
 
@@ -202,7 +238,11 @@ pub enum SendTransactionsKind<N: Network> {
     /// Send via `eth_sendTransaction` and rely on the  `from` address being unlocked.
     Unlocked(AddressHashSet),
     /// Send a signed transaction via `eth_sendRawTransaction`, or via browser
-    Raw { eth_wallets: AddressHashMap<EthereumWallet>, browser: Option<BrowserSigner<N>> },
+    Raw {
+        eth_wallets: AddressHashMap<EthereumWallet>,
+        browser: Option<BrowserSigner<N>>,
+        access_keys: AddressHashMap<(WalletSigner, TempoAccessKeyConfig)>,
+    },
 }
 
 impl<N: Network> SendTransactionsKind<N> {
@@ -213,6 +253,7 @@ impl<N: Network> SendTransactionsKind<N> {
         &self,
         addr: &Address,
         tx: N::TransactionRequest,
+        rpc_url: &str,
     ) -> Result<SendTransactionKind<'_, N>> {
         match self {
             Self::Unlocked(unlocked) => {
@@ -221,8 +262,10 @@ impl<N: Network> SendTransactionsKind<N> {
                 }
                 Ok(SendTransactionKind::Unlocked(tx))
             }
-            Self::Raw { eth_wallets, browser } => {
-                if let Some(wallet) = eth_wallets.get(addr) {
+            Self::Raw { eth_wallets, browser, access_keys } => {
+                if let Some((signer, config)) = access_keys.get(addr) {
+                    Ok(SendTransactionKind::AccessKey(tx, signer, config, rpc_url.to_string()))
+                } else if let Some(wallet) = eth_wallets.get(addr) {
                     Ok(SendTransactionKind::Raw(tx, wallet))
                 } else if let Some(b) = browser
                     && b.address() == *addr
@@ -295,7 +338,8 @@ where
     where
         N::TxEnvelope: From<Signed<N::UnsignedTx>>,
         N::UnsignedTx: SignableTransaction<Signature>,
-        N::TransactionRequest: FoundryTransactionBuilder<N>,
+        N::TransactionRequest:
+            FoundryTransactionBuilder<N> + Into<tempo_alloy::rpc::TempoTransactionRequest>,
     {
         let required_addresses = self
             .sequence
@@ -325,11 +369,22 @@ where
                 .into_iter()
                 .chain(self.browser_wallet.as_ref().map(|b| b.address()))
                 .collect();
+
+            // For addresses without an explicit signer, try Tempo access key lookup.
+            let mut access_keys: AddressHashMap<(WalletSigner, TempoAccessKeyConfig)> =
+                AddressHashMap::default();
             let mut missing_addresses = Vec::new();
 
             for addr in &required_addresses {
                 if !signers.contains(addr) {
-                    missing_addresses.push(addr);
+                    match foundry_wallets::tempo::lookup_signer(*addr) {
+                        Ok(foundry_wallets::tempo::TempoLookup::Keychain(signer, config)) => {
+                            access_keys.insert(*addr, (signer, *config));
+                        }
+                        _ => {
+                            missing_addresses.push(addr);
+                        }
+                    }
                 }
             }
 
@@ -345,7 +400,7 @@ where
             let eth_wallets =
                 signers.into_iter().map(|(addr, signer)| (addr, signer.into())).collect();
 
-            SendTransactionsKind::Raw { eth_wallets, browser: self.browser_wallet }
+            SendTransactionsKind::Raw { eth_wallets, browser: self.browser_wallet, access_keys }
         };
 
         let progress = ScriptProgress::default();
@@ -424,7 +479,7 @@ where
                                     tx.set_max_fee_per_gas(eip1559_fees.max_fee_per_gas);
                                 }
 
-                                send_kind.for_sender(&from, tx)?
+                                send_kind.for_sender(&from, tx, sequence.rpc_url())?
                             }
                         };
 


### PR DESCRIPTION
Adds Tempo access key (keychain mode) support to `forge script`.

During broadcast, any required signer address not covered by an explicit wallet is looked up in `~/.tempo/wallet/keys.toml`. If a keychain-mode entry is found, transactions are signed with the access key and sent as a raw transaction instead of using `EthereumWallet`.