### PR TITLE
fix: rename misleading fallback binding in infer_var_expr

### DIFF
--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -955,7 +955,7 @@ impl Type {
                     Ok(None)
                 }
             }
-            ty => Ok(Self::ethabi(ty, intermediate)),
+            other_expr => Ok(Self::ethabi(other_expr, intermediate)),
         };
         // re-run everything with the resolved variable in case we're accessing a builtin member
         // for example array or bytes length etc


### PR DESCRIPTION


In `infer_var_expr`, the fallback `match` binding is named `ty` even though it is a `pt::Expression`, not a type. A few lines later, `ty` is used for the actual inferred `DynSolType`, which makes the flow harder to follow.
