### PR TITLE
feat(config): add built-in RPC endpoint aliases as fallbacks

### DIFF
--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -176,6 +176,9 @@ impl CheatsConfig {
     pub fn rpc_endpoint(&self, url_or_alias: &str) -> Result<ResolvedRpcEndpoint> {
         if let Some(endpoint) = self.rpc_endpoints.get(url_or_alias) {
             Ok(endpoint.clone().try_resolve())
+        } else if let Some(builtin_url) = foundry_config::builtin_rpc_url(url_or_alias) {
+            let url = RpcEndpointUrl::Url(builtin_url.to_string());
+            Ok(RpcEndpoint::new(url).resolve())
         } else {
             // check if it's a URL or a path to an existing file to an ipc socket
             if url_or_alias.starts_with("http") ||

--- a/crates/config/src/endpoints.rs
+++ b/crates/config/src/endpoints.rs
@@ -453,9 +453,28 @@ impl DerefMut for ResolvedRpcEndpoints {
     }
 }
 
+/// Returns the URL for a built-in RPC alias, if one exists.
+///
+/// Built-in aliases act as fallbacks: they are only used when the alias has **not** been
+/// defined by the user in `[rpc_endpoints]` or resolved via MESC.
+pub fn builtin_rpc_url(alias: &str) -> Option<&'static str> {
+    match alias {
+        "tempo" => Some("https://rpc.mpp.tempo.xyz"),
+        "moderato" => Some("https://rpc.mpp.moderato.tempo.xyz"),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn builtin_rpc_aliases() {
+        assert_eq!(builtin_rpc_url("tempo"), Some("https://rpc.mpp.tempo.xyz"));
+        assert_eq!(builtin_rpc_url("moderato"), Some("https://rpc.mpp.moderato.tempo.xyz"));
+        assert_eq!(builtin_rpc_url("mainnet"), None);
+    }
 
     #[test]
     fn serde_rpc_config() {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -59,6 +59,7 @@ pub use utils::*;
 mod endpoints;
 pub use endpoints::{
     ResolvedRpcEndpoint, ResolvedRpcEndpoints, RpcEndpoint, RpcEndpointUrl, RpcEndpoints,
+    builtin_rpc_url,
 };
 
 mod etherscan;
@@ -1504,6 +1505,10 @@ impl Config {
 
         if let Some(mesc_url) = self.get_rpc_url_from_mesc(maybe_alias) {
             return Some(Ok(Cow::Owned(mesc_url)));
+        }
+
+        if let Some(builtin_url) = endpoints::builtin_rpc_url(maybe_alias) {
+            return Some(Ok(Cow::Borrowed(builtin_url)));
         }
 
         None
@@ -3456,6 +3461,57 @@ mod tests {
 
             config.eth_rpc_url = Some("optimism".to_string());
             assert_eq!("https://example.com/", config.get_rpc_url_or_localhost_http().unwrap());
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_resolve_builtin_rpc_alias() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+            "#,
+            )?;
+
+            let mut config = Config::load().unwrap();
+
+            // builtin alias resolves when no user-defined endpoint exists
+            config.eth_rpc_url = Some("tempo".to_string());
+            assert_eq!("https://rpc.mpp.tempo.xyz", config.get_rpc_url().unwrap().unwrap());
+
+            config.eth_rpc_url = Some("moderato".to_string());
+            assert_eq!(
+                "https://rpc.mpp.moderato.tempo.xyz",
+                config.get_rpc_url().unwrap().unwrap()
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_resolve_builtin_rpc_alias_user_override() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                [rpc_endpoints]
+                tempo = "https://my-custom-rpc.example.com/"
+            "#,
+            )?;
+
+            let mut config = Config::load().unwrap();
+
+            // user-defined endpoint takes precedence over builtin
+            config.eth_rpc_url = Some("tempo".to_string());
+            assert_eq!(
+                "https://my-custom-rpc.example.com/",
+                config.get_rpc_url().unwrap().unwrap()
+            );
 
             Ok(())
         })


### PR DESCRIPTION
Add built-in RPC URL aliases that act as fallbacks. If an alias like `tempo` has not been user-defined in `[rpc_endpoints]` (or resolved via MESC), we check an internal list of built-in aliases.

## Aliases

- `tempo` → `https://rpc.mpp.tempo.xyz`
- `moderato` → `https://rpc.mpp.moderato.tempo.xyz`

## Resolution order

1. User-defined `[rpc_endpoints]` in `foundry.toml`
2. MESC
3. **Built-in aliases** (new)

Works everywhere: `--rpc-url`, `--fork-url`, `vm.createFork()`, `vm.createSelectFork()`.

## Changes

- `crates/config/src/endpoints.rs`: added `builtin_rpc_url()`
- `crates/config/src/lib.rs`: wired into `get_rpc_url_with_alias()`, re-exported
- `crates/cheatcodes/src/config.rs`: wired into `CheatsConfig::rpc_endpoint()`

## Testing

```
cargo test -p foundry-config -- test_resolve_builtin_rpc_alias builtin_rpc_aliases
```

Co-Authored-By: onbjerg <8862627+onbjerg@users.noreply.github.com>

Prompted by: onbjerg