### PR TITLE
refactor(anvil): encapsulate per-tx inspector lifecycle in `finish_transaction`

### DIFF
--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -58,11 +58,7 @@ impl AnvilInspector {
         }
         self.print_logs();
 
-        let traces = self
-            .tracer
-            .take()
-            .map(|t| t.into_traces().into_nodes())
-            .unwrap_or_default();
+        let traces = self.tracer.take().map(|t| t.into_traces().into_nodes()).unwrap_or_default();
 
         // Reinstall tracer for next tx.
         let tracing_config = if config.enable_steps_tracing {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2749,10 +2749,8 @@ where
 
                     executor.commit_transaction(result).expect("commit failed");
 
-                    let traces = executor
-                        .evm_mut()
-                        .inspector_mut()
-                        .finish_transaction(&inspector_tx_config);
+                    let traces =
+                        executor.evm_mut().inspector_mut().finish_transaction(&inspector_tx_config);
 
                     if is_cancun {
                         cumulative_blob_gas_used =


### PR DESCRIPTION
Extract the repeated ~20-line drain-and-reset block from 3 locations in the block mining loop into `AnvilInspector::finish_transaction()`.

The method prints traces/logs, drains the tracer into `Vec<CallTraceNode>`, and reinstalls a fresh tracer + log collector for the next transaction.

Introduces `InspectorTxConfig` to carry the print/tracing settings, replacing direct field access into the inspector internals. This encapsulation is a prerequisite for extracting the per-tx execution loop into a generic helper.