### PR TITLE
feat: add OWS (Open Wallet Standard) as wallet signer

### DIFF
--- a/crates/wallets/src/error.rs
+++ b/crates/wallets/src/error.rs
@@ -72,4 +72,8 @@ impl WalletSignerError {
     pub fn browser_unsupported() -> Self {
         Self::UnsupportedSigner("Browser Wallet")
     }
+
+    pub fn ows_unsupported() -> Self {
+        Self::UnsupportedSigner("OWS")
+    }
 }

--- a/crates/wallets/src/opts.rs
+++ b/crates/wallets/src/opts.rs
@@ -102,6 +102,15 @@ pub struct WalletOpts {
     /// See: <https://docs.turnkey.com/getting-started/quickstart>
     #[arg(long, help_heading = "Wallet options - remote", hide = !cfg!(feature = "turnkey"))]
     pub turnkey: bool,
+
+    /// Use an OWS (Open Wallet Standard) encrypted vault.
+    ///
+    /// Provide the wallet name or UUID. The key is decrypted from the vault
+    /// only during signing, then wiped from memory.
+    ///
+    /// See: <https://openwallet.sh>
+    #[arg(long, help_heading = "Wallet options - keystore", value_name = "WALLET", hide = !cfg!(feature = "ows"))]
+    pub ows: Option<String>,
 }
 
 impl WalletOpts {
@@ -148,6 +157,8 @@ impl WalletOpts {
                 eyre::eyre!("TURNKEY_ADDRESS could not be parsed as an Ethereum address")
             })?;
             WalletSigner::from_turnkey(api_private_key, organization_id, address)?
+        } else if let Some(ref wallet_name) = self.ows {
+            WalletSigner::from_ows(wallet_name)?
         } else if let Some(raw_wallet) = self.raw.signer()? {
             raw_wallet
         } else if let Some(path) = utils::maybe_get_keystore_path(
@@ -273,6 +284,7 @@ mod tests {
             aws: false,
             gcp: false,
             turnkey: false,
+            ows: None,
         };
         match wallet.signer().await {
             Ok(_) => {

--- a/crates/wallets/src/signer.rs
+++ b/crates/wallets/src/signer.rs
@@ -150,6 +150,33 @@ impl WalletSigner {
         }
     }
 
+    pub fn from_ows(wallet_name: &str) -> Result<Self> {
+        #[cfg(feature = "ows")]
+        {
+            let key_bytes = ows_lib::decrypt_signing_key(
+                wallet_name,
+                ows_core::ChainType::Evm,
+                "",
+                None,
+                None,
+            )
+            .map_err(|e| {
+                WalletSignerError::Io(std::io::Error::other(format!("OWS decrypt: {e}")))
+            })?;
+            let signer = PrivateKeySigner::from_slice(key_bytes.expose())
+                .map_err(|e| {
+                    WalletSignerError::Io(std::io::Error::other(format!("invalid OWS key: {e}")))
+                })?;
+            Ok(Self::Local(signer))
+        }
+
+        #[cfg(not(feature = "ows"))]
+        {
+            let _ = wallet_name;
+            Err(WalletSignerError::ows_unsupported())
+        }
+    }
+
     pub fn from_private_key(private_key: &B256) -> Result<Self> {
         Ok(Self::Local(PrivateKeySigner::from_bytes(private_key)?))
     }


### PR DESCRIPTION
## Summary

Adds `--ows <WALLET>` flag for loading signers from an [OWS](https://openwallet.sh) encrypted vault, alongside the existing `--ledger`, `--trezor`, `--aws`, `--gcp`, and `--turnkey` options. Feature-gated behind `ows`.

## Usage

```bash
# Before: Foundry-specific keystore or raw key
cast send <TO> --value 1ether --account my-wallet
cast send <TO> --value 1ether --private-key 0x...

# After: OWS encrypted vault (same vault as Solana CLI, Tempo, etc.)
cast send <TO> --value 1ether --ows my-wallet
forge script Deploy.s.sol --ows my-wallet
```

One wallet created with `ows wallet create` works in cast, forge, solana, tempo, polymarket — every tool.

## Changes

| File | What |
|------|------|
| `crates/wallets/src/opts.rs` | Added `--ows` flag, resolution in `maybe_signer()` |
| `crates/wallets/src/signer.rs` | Added `WalletSigner::from_ows()` |
| `crates/wallets/src/error.rs` | Added `ows_unsupported()` helper |

Feature-gated: `--features ows`. Follows the same pattern as `--aws`, `--gcp`, `--turnkey`.

## How it works

OWS decrypts the EVM signing key from the vault (AES-256-GCM, scrypt KDF) and wraps it as a `PrivateKeySigner`. The key is only in memory during signing, then wiped. No plaintext on disk.

## Dependencies

Would require adding `ows-lib` and `ows-core` as optional dependencies to `foundry-wallets`.