### PR TITLE
fix(lint): detect unsafe casts on function returns and ternaries

### DIFF
--- a/crates/lint/src/sol/med/unsafe_typecast.rs
+++ b/crates/lint/src/sol/med/unsafe_typecast.rs
@@ -48,7 +48,7 @@ fn is_unsafe_typecast_hir(
     target_type: &hir::ElementaryType,
 ) -> bool {
     let mut source_types = Vec::<ElementaryType>::new();
-    infer_source_types(Some(&mut source_types), hir, source_expr);
+    infer_source_types(&mut source_types, hir, source_expr);
 
     if source_types.is_empty() {
         return false;
@@ -59,26 +59,10 @@ fn is_unsafe_typecast_hir(
 
 /// Infers the elementary source type(s) of an expression.
 ///
-/// This function traverses an expression tree to find the original "source" types.
-/// For cast chains, it returns the ultimate source type, not intermediate cast results.
-/// For binary operations, it collects types from both sides into the `output` vector.
-///
-/// # Returns
-/// An `Option<ElementaryType>` containing the inferred type of the expression if it can be
-/// resolved to a single source (like variables, literals, or unary expressions).
-/// Returns `None` for expressions complex expressions (like binary operations).
-fn infer_source_types(
-    mut output: Option<&mut Vec<ElementaryType>>,
-    hir: &hir::Hir<'_>,
-    expr: &hir::Expr<'_>,
-) -> Option<ElementaryType> {
-    let mut track = |ty: ElementaryType| -> Option<ElementaryType> {
-        if let Some(output) = output.as_mut() {
-            output.push(ty);
-        }
-        Some(ty)
-    };
-
+/// Traverses an expression tree to find the original "source" types and pushes them
+/// into `output`. For cast chains, finds the ultimate source type, not intermediate
+/// cast results. For binary and ternary operations, collects types from all branches.
+fn infer_source_types(output: &mut Vec<ElementaryType>, hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) {
     match &expr.kind {
         // A type cast call: `Type(val)`, or a regular function call.
         ExprKind::Call(call_expr, args, ..) => {
@@ -88,14 +72,12 @@ fn infer_source_types(
                 && let Some(inner) = args.exprs().next()
             {
                 // Recurse to find the original (inner-most) source type.
-                return infer_source_types(output, hir, inner);
+                infer_source_types(output, hir, inner);
+                return;
             }
 
             // For non-cast function calls, infer the return type from the function signature.
-            if let Some(elem_ty) = resolve_call_return_type(hir, call_expr) {
-                return track(elem_ty);
-            }
-            None
+            resolve_call_return_types(output, hir, call_expr);
         }
 
         // Identifiers (variables)
@@ -103,67 +85,106 @@ fn infer_source_types(
             if let Some(Res::Item(ItemId::Variable(var_id))) = resolutions.first() {
                 let variable = hir.variable(*var_id);
                 if let TypeKind::Elementary(elem_type) = &variable.ty.kind {
-                    return track(*elem_type);
+                    output.push(*elem_type);
                 }
             }
-            None
         }
 
         // Handle literal values
         ExprKind::Lit(hir::Lit { kind, .. }) => match kind {
-            LitKind::Str(StrKind::Hex, ..) => track(ElementaryType::Bytes),
-            LitKind::Str(..) => track(ElementaryType::String),
-            LitKind::Address(_) => track(ElementaryType::Address(false)),
-            LitKind::Bool(_) => track(ElementaryType::Bool),
+            LitKind::Str(StrKind::Hex, ..) => output.push(ElementaryType::Bytes),
+            LitKind::Str(..) => output.push(ElementaryType::String),
+            LitKind::Address(_) => output.push(ElementaryType::Address(false)),
+            LitKind::Bool(_) => output.push(ElementaryType::Bool),
             // Unnecessary to check numbers as assigning literal values that cannot fit into a type
             // throws a compiler error. Reference: <https://solang.readthedocs.io/en/latest/language/types.html>
-            _ => None,
+            _ => {}
         },
 
         // Unary operations: Recurse to find the source type of the inner expression.
         ExprKind::Unary(_, inner_expr) => infer_source_types(output, hir, inner_expr),
 
-        // Binary operations
+        // Binary operations: recurse on both sides.
         ExprKind::Binary(lhs, _, rhs) => {
-            if let Some(mut output) = output {
-                // Recurse on both sides to find and collect all source types.
-                infer_source_types(Some(&mut output), hir, lhs);
-                infer_source_types(Some(&mut output), hir, rhs);
-            }
-            None
+            infer_source_types(output, hir, lhs);
+            infer_source_types(output, hir, rhs);
         }
 
         // Ternary: check both branches.
         ExprKind::Ternary(_, true_expr, false_expr) => {
-            if let Some(mut output) = output {
-                infer_source_types(Some(&mut output), hir, true_expr);
-                infer_source_types(Some(&mut output), hir, false_expr);
-            }
-            None
+            infer_source_types(output, hir, true_expr);
+            infer_source_types(output, hir, false_expr);
         }
 
         // Complex expressions are not evaluated.
-        _ => None,
+        _ => {}
     }
 }
 
-/// Resolves the return type of a function call expression.
+/// Resolves the return type(s) of a function call expression and pushes them to `output`.
 ///
-/// For calls where the callee is a resolved function identifier, looks up the function
-/// in the HIR and returns its return type if it has exactly one elementary return value.
-fn resolve_call_return_type(
+/// Handles both direct function calls (`foo()`) and member function calls
+/// (`contract.foo()`). For overloaded functions, collects return types from all
+/// matching overloads to avoid false negatives.
+fn resolve_call_return_types(
+    output: &mut Vec<ElementaryType>,
     hir: &hir::Hir<'_>,
     call_expr: &hir::Expr<'_>,
-) -> Option<ElementaryType> {
-    // Direct function call: `foo()`
-    if let ExprKind::Ident(resolutions) = &call_expr.kind {
-        return resolve_function_return(hir, resolutions);
+) {
+    match &call_expr.kind {
+        // Direct function call: `foo()`
+        ExprKind::Ident(resolutions) => {
+            resolve_function_returns(output, hir, resolutions);
+        }
+        // Member function call: `contract.foo()`
+        ExprKind::Member(contract_expr, func_ident) => {
+            // Resolve the contract from the base expression.
+            let contract_id = match &contract_expr.kind {
+                // Variable with contract type: `myContract.foo()`
+                ExprKind::Ident([Res::Item(ItemId::Variable(var_id)), ..]) => {
+                    if let TypeKind::Custom(ItemId::Contract(cid)) = hir.variable(*var_id).ty.kind {
+                        Some(cid)
+                    } else {
+                        None
+                    }
+                }
+                // Contract type cast: `IFoo(addr).foo()`
+                ExprKind::Call(
+                    hir::Expr { kind: ExprKind::Ident([Res::Item(ItemId::Contract(cid))]), .. },
+                    ..,
+                ) => Some(*cid),
+                _ => None,
+            };
+
+            if let Some(cid) = contract_id {
+                // Find matching functions in the contract by name.
+                for item in hir.contract_item_ids(cid) {
+                    let Some(fid) = item.as_function() else { continue };
+                    let func = hir.function(fid);
+                    if func.name.is_some_and(|name| name.as_str() == func_ident.as_str())
+                        && func.returns.len() == 1
+                    {
+                        let ret_var = hir.variable(func.returns[0]);
+                        if let TypeKind::Elementary(elem_ty) = &ret_var.ty.kind {
+                            output.push(*elem_ty);
+                        }
+                    }
+                }
+            }
+        }
+        _ => {}
     }
-    None
 }
 
-/// Resolves the elementary return type from a set of function resolutions.
-fn resolve_function_return(hir: &hir::Hir<'_>, resolutions: &[Res]) -> Option<ElementaryType> {
+/// Resolves elementary return types from function resolutions.
+///
+/// For overloaded functions with multiple resolutions, collects return types from all
+/// matching overloads to avoid false negatives.
+fn resolve_function_returns(
+    output: &mut Vec<ElementaryType>,
+    hir: &hir::Hir<'_>,
+    resolutions: &[Res],
+) {
     for res in resolutions {
         if let Res::Item(ItemId::Function(func_id)) = res {
             let func = hir.function(*func_id);
@@ -171,12 +192,11 @@ fn resolve_function_return(hir: &hir::Hir<'_>, resolutions: &[Res]) -> Option<El
             if func.returns.len() == 1 {
                 let ret_var = hir.variable(func.returns[0]);
                 if let TypeKind::Elementary(elem_ty) = &ret_var.ty.kind {
-                    return Some(*elem_ty);
+                    output.push(*elem_ty);
                 }
             }
         }
     }
-    None
 }
 
 /// Checks if a type cast from source_type to target_type is unsafe.

--- a/crates/lint/src/sol/med/unsafe_typecast.rs
+++ b/crates/lint/src/sol/med/unsafe_typecast.rs
@@ -80,7 +80,7 @@ fn infer_source_types(
     };
 
     match &expr.kind {
-        // A type cast call: `Type(val)`
+        // A type cast call: `Type(val)`, or a regular function call.
         ExprKind::Call(call_expr, args, ..) => {
             // Check if the called expression is a type, which indicates a cast.
             if let ExprKind::Type(hir::Type { kind: TypeKind::Elementary(..), .. }) =
@@ -89,6 +89,11 @@ fn infer_source_types(
             {
                 // Recurse to find the original (inner-most) source type.
                 return infer_source_types(output, hir, inner);
+            }
+
+            // For non-cast function calls, infer the return type from the function signature.
+            if let Some(elem_ty) = resolve_call_return_type(hir, call_expr) {
+                return track(elem_ty);
             }
             None
         }
@@ -128,9 +133,50 @@ fn infer_source_types(
             None
         }
 
-        // Complex expressions are not evaluated
+        // Ternary: check both branches.
+        ExprKind::Ternary(_, true_expr, false_expr) => {
+            if let Some(mut output) = output {
+                infer_source_types(Some(&mut output), hir, true_expr);
+                infer_source_types(Some(&mut output), hir, false_expr);
+            }
+            None
+        }
+
+        // Complex expressions are not evaluated.
         _ => None,
     }
+}
+
+/// Resolves the return type of a function call expression.
+///
+/// For calls where the callee is a resolved function identifier, looks up the function
+/// in the HIR and returns its return type if it has exactly one elementary return value.
+fn resolve_call_return_type(
+    hir: &hir::Hir<'_>,
+    call_expr: &hir::Expr<'_>,
+) -> Option<ElementaryType> {
+    // Direct function call: `foo()`
+    if let ExprKind::Ident(resolutions) = &call_expr.kind {
+        return resolve_function_return(hir, resolutions);
+    }
+    None
+}
+
+/// Resolves the elementary return type from a set of function resolutions.
+fn resolve_function_return(hir: &hir::Hir<'_>, resolutions: &[Res]) -> Option<ElementaryType> {
+    for res in resolutions {
+        if let Res::Item(ItemId::Function(func_id)) = res {
+            let func = hir.function(*func_id);
+            // Only handle single-return functions.
+            if func.returns.len() == 1 {
+                let ret_var = hir.variable(func.returns[0]);
+                if let TypeKind::Elementary(elem_ty) = &ret_var.ty.kind {
+                    return Some(*elem_ty);
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Checks if a type cast from source_type to target_type is unsafe.

--- a/crates/lint/src/sol/med/unsafe_typecast.rs
+++ b/crates/lint/src/sol/med/unsafe_typecast.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use solar::{
     ast::{LitKind, StrKind},
+    interface::sym,
     sema::hir::{self, ElementaryType, ExprKind, ItemId, Res, TypeKind},
 };
 
@@ -22,7 +23,6 @@ impl<'hir> LateLintPass<'hir> for UnsafeTypecast {
         hir: &'hir hir::Hir<'hir>,
         expr: &'hir hir::Expr<'hir>,
     ) {
-        // Check for type cast expressions: Type(value)
         if let ExprKind::Call(call, args, _) = &expr.kind
             && let ExprKind::Type(hir::Type { kind: TypeKind::Elementary(ty), .. }) = &call.kind
             && args.len() == 1
@@ -41,7 +41,6 @@ impl<'hir> LateLintPass<'hir> for UnsafeTypecast {
     }
 }
 
-/// Determines if a typecast is potentially unsafe (could lose data or precision).
 fn is_unsafe_typecast_hir(
     hir: &hir::Hir<'_>,
     source_expr: &hir::Expr<'_>,
@@ -57,30 +56,20 @@ fn is_unsafe_typecast_hir(
     source_types.iter().any(|source_ty| is_unsafe_elementary_typecast(source_ty, target_type))
 }
 
-/// Infers the elementary source type(s) of an expression.
-///
-/// Traverses an expression tree to find the original "source" types and pushes them
-/// into `output`. For cast chains, finds the ultimate source type, not intermediate
-/// cast results. For binary and ternary operations, collects types from all branches.
 fn infer_source_types(output: &mut Vec<ElementaryType>, hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) {
     match &expr.kind {
-        // A type cast call: `Type(val)`, or a regular function call.
         ExprKind::Call(call_expr, args, ..) => {
-            // Check if the called expression is a type, which indicates a cast.
             if let ExprKind::Type(hir::Type { kind: TypeKind::Elementary(..), .. }) =
                 &call_expr.kind
                 && let Some(inner) = args.exprs().next()
             {
-                // Recurse to find the original (inner-most) source type.
                 infer_source_types(output, hir, inner);
                 return;
             }
 
-            // For non-cast function calls, infer the return type from the function signature.
-            resolve_call_return_types(output, hir, call_expr);
+            resolve_call_return_types(output, hir, call_expr, args.len());
         }
 
-        // Identifiers (variables)
         ExprKind::Ident(resolutions) => {
             if let Some(Res::Item(ItemId::Variable(var_id))) = resolutions.first() {
                 let variable = hir.variable(*var_id);
@@ -90,65 +79,79 @@ fn infer_source_types(output: &mut Vec<ElementaryType>, hir: &hir::Hir<'_>, expr
             }
         }
 
-        // Handle literal values
         ExprKind::Lit(hir::Lit { kind, .. }) => match kind {
             LitKind::Str(StrKind::Hex, ..) => output.push(ElementaryType::Bytes),
             LitKind::Str(..) => output.push(ElementaryType::String),
             LitKind::Address(_) => output.push(ElementaryType::Address(false)),
             LitKind::Bool(_) => output.push(ElementaryType::Bool),
-            // Unnecessary to check numbers as assigning literal values that cannot fit into a type
-            // throws a compiler error. Reference: <https://solang.readthedocs.io/en/latest/language/types.html>
             _ => {}
         },
 
-        // Unary operations: Recurse to find the source type of the inner expression.
         ExprKind::Unary(_, inner_expr) => infer_source_types(output, hir, inner_expr),
 
-        // Binary operations: recurse on both sides.
         ExprKind::Binary(lhs, _, rhs) => {
-            infer_source_types(output, hir, lhs);
-            infer_source_types(output, hir, rhs);
+            infer_branch_type(output, hir, lhs);
+            infer_branch_type(output, hir, rhs);
         }
 
-        // Ternary: check both branches.
         ExprKind::Ternary(_, true_expr, false_expr) => {
-            infer_source_types(output, hir, true_expr);
-            infer_source_types(output, hir, false_expr);
+            infer_branch_type(output, hir, true_expr);
+            infer_branch_type(output, hir, false_expr);
         }
 
-        // Complex expressions are not evaluated.
+        ExprKind::Member(base, member) => {
+            if let Some(elem_ty) = resolve_member_elem_type(hir, base, member) {
+                output.push(elem_ty);
+            }
+        }
+
+        ExprKind::Index(_, _) => {
+            if let Some(elem_ty) = resolve_index_elem_type(hir, expr) {
+                output.push(elem_ty);
+            }
+        }
+
         _ => {}
     }
 }
 
-/// Resolves the return type(s) of a function call expression and pushes them to `output`.
-///
-/// Handles both direct function calls (`foo()`) and member function calls
-/// (`contract.foo()`). For overloaded functions, collects return types from all
-/// matching overloads to avoid false negatives.
+fn infer_branch_type(output: &mut Vec<ElementaryType>, hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) {
+    if let ExprKind::Call(call_expr, _, ..) = &expr.kind
+        && let ExprKind::Type(hir::Type { kind: TypeKind::Elementary(ty), .. }) = &call_expr.kind
+    {
+        output.push(*ty);
+        return;
+    }
+    infer_source_types(output, hir, expr);
+}
+
 fn resolve_call_return_types(
     output: &mut Vec<ElementaryType>,
     hir: &hir::Hir<'_>,
     call_expr: &hir::Expr<'_>,
+    args_count: usize,
 ) {
     match &call_expr.kind {
-        // Direct function call: `foo()`
         ExprKind::Ident(resolutions) => {
             resolve_function_returns(output, hir, resolutions);
         }
-        // Member function call: `contract.foo()`
-        ExprKind::Member(contract_expr, func_ident) => {
-            // Resolve the contract from the base expression.
-            let contract_id = match &contract_expr.kind {
-                // Variable with contract type: `myContract.foo()`
-                ExprKind::Ident([Res::Item(ItemId::Variable(var_id)), ..]) => {
-                    if let TypeKind::Custom(ItemId::Contract(cid)) = hir.variable(*var_id).ty.kind {
-                        Some(cid)
+        ExprKind::Member(base_expr, func_ident) => {
+            let contract_id = match &base_expr.kind {
+                ExprKind::Ident(reses) => {
+                    if let Some(Res::Item(ItemId::Variable(var_id))) = reses.first() {
+                        if let TypeKind::Custom(ItemId::Contract(cid)) =
+                            hir.variable(*var_id).ty.kind
+                        {
+                            Some(cid)
+                        } else {
+                            None
+                        }
+                    } else if let Some(Res::Item(ItemId::Contract(cid))) = reses.first() {
+                        Some(*cid)
                     } else {
                         None
                     }
                 }
-                // Contract type cast: `IFoo(addr).foo()`
                 ExprKind::Call(
                     hir::Expr { kind: ExprKind::Ident([Res::Item(ItemId::Contract(cid))]), .. },
                     ..,
@@ -157,17 +160,23 @@ fn resolve_call_return_types(
             };
 
             if let Some(cid) = contract_id {
-                // Find matching functions in the contract by name.
+                let mut candidates: Vec<ElementaryType> = Vec::new();
                 for item in hir.contract_item_ids(cid) {
                     let Some(fid) = item.as_function() else { continue };
                     let func = hir.function(fid);
                     if func.name.is_some_and(|name| name.as_str() == func_ident.as_str())
+                        && func.parameters.len() == args_count
                         && func.returns.len() == 1
                     {
                         let ret_var = hir.variable(func.returns[0]);
                         if let TypeKind::Elementary(elem_ty) = &ret_var.ty.kind {
-                            output.push(*elem_ty);
+                            candidates.push(*elem_ty);
                         }
+                    }
+                }
+                if let Some(&first) = candidates.first() {
+                    if candidates.iter().all(|t| t == &first) {
+                        output.push(first);
                     }
                 }
             }
@@ -176,10 +185,6 @@ fn resolve_call_return_types(
     }
 }
 
-/// Resolves elementary return types from function resolutions.
-///
-/// For overloaded functions with multiple resolutions, collects return types from all
-/// matching overloads to avoid false negatives.
 fn resolve_function_returns(
     output: &mut Vec<ElementaryType>,
     hir: &hir::Hir<'_>,
@@ -188,7 +193,6 @@ fn resolve_function_returns(
     for res in resolutions {
         if let Res::Item(ItemId::Function(func_id)) = res {
             let func = hir.function(*func_id);
-            // Only handle single-return functions.
             if func.returns.len() == 1 {
                 let ret_var = hir.variable(func.returns[0]);
                 if let TypeKind::Elementary(elem_ty) = &ret_var.ty.kind {
@@ -199,38 +203,165 @@ fn resolve_function_returns(
     }
 }
 
-/// Checks if a type cast from source_type to target_type is unsafe.
+fn resolve_expr_type<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    expr: &hir::Expr<'_>,
+) -> Option<&'hir hir::Type<'hir>> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) => {
+            let var_id = reses.iter().find_map(|r| {
+                if let Res::Item(ItemId::Variable(vid)) = r { Some(*vid) } else { None }
+            })?;
+            Some(&hir.variable(var_id).ty)
+        }
+        ExprKind::Index(base, _) => {
+            let base_ty = resolve_expr_type(hir, base)?;
+            match &base_ty.kind {
+                TypeKind::Array(arr) => Some(&arr.element),
+                TypeKind::Mapping(m) => Some(&m.value),
+                _ => None,
+            }
+        }
+        ExprKind::Member(base, member) => {
+            let base_ty = resolve_expr_type(hir, base)?;
+            if let TypeKind::Custom(ItemId::Struct(sid)) = &base_ty.kind {
+                return hir
+                    .strukt(*sid)
+                    .fields
+                    .iter()
+                    .map(|&fid| hir.variable(fid))
+                    .find(|f| f.name.is_some_and(|n| n.as_str() == member.as_str()))
+                    .map(|f| &f.ty);
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn resolve_member_elem_type(
+    hir: &hir::Hir<'_>,
+    base: &hir::Expr<'_>,
+    member: &solar::interface::Ident,
+) -> Option<ElementaryType> {
+    let member_name = member.as_str();
+
+    if let ExprKind::Ident(reses) = &base.kind {
+        if let Some(Res::Builtin(builtin)) = reses.first() {
+            let builtin_name = builtin.name();
+
+            if builtin_name == sym::block {
+                return match member_name {
+                    "timestamp" | "number" | "basefee" | "chainid" | "gaslimit" | "prevrandao"
+                    | "difficulty" | "blobbasefee" => Some(ElementaryType::UInt(uint_size(256))),
+                    _ => None,
+                };
+            }
+
+            if builtin_name == sym::msg {
+                return match member_name {
+                    "value" | "gas" => Some(ElementaryType::UInt(uint_size(256))),
+                    "sender" => Some(ElementaryType::Address(false)),
+                    _ => None,
+                };
+            }
+
+            if builtin_name == sym::tx {
+                return match member_name {
+                    "gasprice" => Some(ElementaryType::UInt(uint_size(256))),
+                    _ => None,
+                };
+            }
+
+            return None;
+        }
+    }
+
+    let base_ty = resolve_expr_type(hir, base)?;
+
+    match member_name {
+        "balance" => {
+            if matches!(&base_ty.kind, TypeKind::Elementary(ElementaryType::Address(_))) {
+                return Some(ElementaryType::UInt(uint_size(256)));
+            }
+        }
+        "length" => match &base_ty.kind {
+            TypeKind::Array(arr) if arr.size.is_none() => {
+                return Some(ElementaryType::UInt(uint_size(256)));
+            }
+            TypeKind::Elementary(ElementaryType::Bytes) => {
+                return Some(ElementaryType::UInt(uint_size(256)));
+            }
+            TypeKind::Elementary(ElementaryType::FixedBytes(_)) => {
+                return Some(ElementaryType::UInt(uint_size(8)));
+            }
+            _ => {}
+        },
+        "selector" => {
+            if matches!(&base_ty.kind, TypeKind::Function(_)) {
+                return Some(ElementaryType::FixedBytes(fixed_bytes_size(4)));
+            }
+        }
+        _ => {}
+    }
+
+    if let TypeKind::Custom(ItemId::Struct(struct_id)) = &base_ty.kind {
+        return hir
+            .strukt(*struct_id)
+            .fields
+            .iter()
+            .map(|&field_id| hir.variable(field_id))
+            .find(|field| field.name.is_some_and(|n| n.as_str() == member_name))
+            .and_then(
+                |field| {
+                    if let TypeKind::Elementary(e) = &field.ty.kind { Some(*e) } else { None }
+                },
+            );
+    }
+
+    None
+}
+
+fn resolve_index_elem_type(
+    hir: &hir::Hir<'_>,
+    index_expr: &hir::Expr<'_>,
+) -> Option<ElementaryType> {
+    let base_ty = resolve_expr_type(hir, index_expr)?;
+    if let TypeKind::Elementary(e) = &base_ty.kind { Some(*e) } else { None }
+}
+
+fn uint_size(bits: u16) -> solar::ast::TypeSize {
+    solar::ast::TypeSize::new_int_bits(bits)
+}
+
+fn fixed_bytes_size(bytes: u8) -> solar::ast::TypeSize {
+    solar::ast::TypeSize::new_fb_bytes(bytes)
+}
+
 const fn is_unsafe_elementary_typecast(
     source_type: &ElementaryType,
     target_type: &ElementaryType,
 ) -> bool {
     match (source_type, target_type) {
-        // Numeric downcasts (smaller target size)
         (ElementaryType::UInt(source_size), ElementaryType::UInt(target_size))
         | (ElementaryType::Int(source_size), ElementaryType::Int(target_size)) => {
             source_size.bits() > target_size.bits()
         }
 
-        // Signed to unsigned conversion (potential loss of sign)
         (ElementaryType::Int(_), ElementaryType::UInt(_)) => true,
 
-        // Unsigned to signed conversion with same or smaller size
         (ElementaryType::UInt(source_size), ElementaryType::Int(target_size)) => {
             source_size.bits() >= target_size.bits()
         }
 
-        // Fixed bytes to smaller fixed bytes
         (ElementaryType::FixedBytes(source_size), ElementaryType::FixedBytes(target_size)) => {
             source_size.bytes() > target_size.bytes()
         }
 
-        // Dynamic bytes to fixed bytes (potential truncation)
         (ElementaryType::Bytes | ElementaryType::String, ElementaryType::FixedBytes(_)) => true,
 
-        // Address to smaller uint (truncation) - address is 160 bits
         (ElementaryType::Address(_), ElementaryType::UInt(target_size)) => target_size.bits() < 160,
 
-        // Address to int (sign issues)
         (ElementaryType::Address(_), ElementaryType::Int(_)) => true,
 
         _ => false,

--- a/crates/lint/testdata/UnsafeTypecast.sol
+++ b/crates/lint/testdata/UnsafeTypecast.sol
@@ -487,4 +487,137 @@ contract MemberCallRepros {
         //~^WARN: typecasts that can truncate values should be checked
     }
 }
+
+contract InnerCastInTernaryRepros {
+    function innerCastInTernaryIsSafe(bool cond, uint256 x, uint128 y) internal pure {
+        uint128 b = uint128(x);
+        //~^WARN: typecasts that can truncate values should be checked
+        uint128 a = uint128(cond ? uint128(x) : y);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+}
+
+interface IOverloadedArity {
+    function value() external view returns (uint256);
+    function value(address x) external view returns (uint128);
+}
+
+contract OverloadArityRepros {
+    function safeOverload(IOverloadedArity foo, address who) internal view {
+        uint128 a = uint128(foo.value(who));
+    }
+
+    function unsafeOverload(IOverloadedArity foo) internal view {
+        uint128 a = uint128(foo.value());
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+}
+
+interface IOverloadedSameArity {
+    function value(address x) external view returns (uint128);
+    function value(uint256 x) external view returns (uint256);
+}
+
+contract OverloadSameArityRepros {
+    function safeOverload(IOverloadedSameArity foo, address who) internal view {
+        uint128 a = uint128(foo.value(who));
+    }
+}
+
+contract GlobalRepros {
+    function blockTimestampNarrowing() internal view returns (uint32) {
+        return uint32(block.timestamp);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+
+    function msgValueNarrowing() internal view returns (uint128) {
+        return uint128(msg.value);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+
+    function arrayLengthNarrowing(uint256[] memory data) internal pure returns (uint32) {
+        return uint32(data.length);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+
+    function addressBalanceNarrowing(address who) internal view returns (uint128) {
+        return uint128(who.balance);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+}
+
+struct Position {
+    uint256 amount;
+    uint128 shares;
+}
+
+contract StructRepros {
+    function structFieldUnsafe(Position memory p) internal pure returns (uint128) {
+        return uint128(p.amount);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+
+    function structFieldSafe(Position memory p) internal pure returns (uint128) {
+        return uint128(p.shares);
+    }
+}
+
+contract IndexRepros {
+    function arrayIndexNarrowing(uint256[] memory data) internal pure returns (uint128) {
+        return uint128(data[0]);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+
+    function mappingIndexNarrowing(
+        mapping(address => uint256) storage balances,
+        address who
+    ) internal view returns (uint128) {
+        return uint128(balances[who]);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+
+    function nestedIndexNarrowing(uint256[][] memory matrix) internal pure returns (uint128) {
+        return uint128(matrix[0][0]);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+
+    function indexedStructFieldNarrowing(Position[] memory positions) internal pure returns (uint128) {
+        return uint128(positions[0].amount);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+
+    function nestedMappingNarrowing(
+        mapping(address => mapping(uint256 => uint256)) storage nested,
+        address who,
+        uint256 id
+    ) internal view returns (uint128) {
+        return uint128(nested[who][id]);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+}
+
+library MathLib {
+    function asUint256(uint128 x) internal pure returns (uint256) {
+        return x;
+    }
+}
+
+contract LibraryRepros {
+    function libraryCallUnsafe(uint128 x) internal pure returns (uint128) {
+        return uint128(MathLib.asUint256(x));
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+}
+
+contract FixedBytesRepros {
+    function fixedBytesLengthIsUint8(bytes32 b) internal pure returns (int8) {
+        return int8(b.length);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+
+    function selectorNarrowing(function() external pure fp) external pure returns (bytes2) {
+        return bytes2(fp.selector);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+}
 // forge-lint: disable-end(mixed-case-variable)

--- a/crates/lint/testdata/UnsafeTypecast.sol
+++ b/crates/lint/testdata/UnsafeTypecast.sol
@@ -470,5 +470,21 @@ contract Repros {
         uint128 a = uint128(cond ? x : y);
         //~^WARN: typecasts that can truncate values should be checked
     }
+
+    function mixedTernaryIsUnsafe(bool cond, uint128 safe, uint256 unsafe_) internal pure {
+        uint128 a = uint128(cond ? safe : unsafe_);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+}
+
+interface IReturnsUint256 {
+    function getUint256() external view returns (uint256);
+}
+
+contract MemberCallRepros {
+    function memberCallCastIsUnsafe(IReturnsUint256 foo) internal view {
+        uint128 a = uint128(foo.getUint256());
+        //~^WARN: typecasts that can truncate values should be checked
+    }
 }
 // forge-lint: disable-end(mixed-case-variable)

--- a/crates/lint/testdata/UnsafeTypecast.sol
+++ b/crates/lint/testdata/UnsafeTypecast.sol
@@ -456,5 +456,19 @@ contract Repros {
         //~^WARN: typecasts that can truncate values should be checked
         //~|WARN: typecasts that can truncate values should be checked
     }
+
+    function getUint256() internal pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function functionReturnCastIsUnsafe() internal pure {
+        uint128 a = uint128(getUint256());
+        //~^WARN: typecasts that can truncate values should be checked
+    }
+
+    function ternaryBranchesAreChecked(bool cond, uint256 x, uint256 y) internal pure {
+        uint128 a = uint128(cond ? x : y);
+        //~^WARN: typecasts that can truncate values should be checked
+    }
 }
 // forge-lint: disable-end(mixed-case-variable)

--- a/crates/lint/testdata/UnsafeTypecast.stderr
+++ b/crates/lint/testdata/UnsafeTypecast.stderr
@@ -20,7 +20,7 @@ note[multi-contract-file]: prefer having only one contract, interface or library
 LL │ interface IReturnsUint256 {
    │           ━━━━━━━━━━━━━━━
    │
-   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#multi-contract-file
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
 
 note[multi-contract-file]: prefer having only one contract, interface or library per file
    ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
@@ -28,7 +28,7 @@ note[multi-contract-file]: prefer having only one contract, interface or library
 LL │ contract MemberCallRepros {
    │          ━━━━━━━━━━━━━━━━
    │
-   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#multi-contract-file
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
 
 warning[unsafe-typecast]: typecasts that can truncate values should be checked
    ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
@@ -2324,7 +2324,7 @@ LL │         uint128 a = uint128(getUint256());
    │       // forge-lint: disable-next-line(unsafe-typecast)
    │       
    │       
-   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#unsafe-typecast
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
 
 warning[unsafe-typecast]: typecasts that can truncate values should be checked
    ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
@@ -2338,7 +2338,7 @@ LL │         uint128 a = uint128(cond ? x : y);
    │       // forge-lint: disable-next-line(unsafe-typecast)
    │       
    │       
-   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#unsafe-typecast
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
 
 warning[unsafe-typecast]: typecasts that can truncate values should be checked
    ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
@@ -2352,7 +2352,7 @@ LL │         uint128 a = uint128(cond ? safe : unsafe_);
    │       // forge-lint: disable-next-line(unsafe-typecast)
    │       
    │       
-   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#unsafe-typecast
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
 
 warning[unsafe-typecast]: typecasts that can truncate values should be checked
    ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
@@ -2366,5 +2366,5 @@ LL │         uint128 a = uint128(foo.getUint256());
    │       // forge-lint: disable-next-line(unsafe-typecast)
    │       
    │       
-   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#unsafe-typecast
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
 

--- a/crates/lint/testdata/UnsafeTypecast.stderr
+++ b/crates/lint/testdata/UnsafeTypecast.stderr
@@ -30,6 +30,94 @@ LL │ contract MemberCallRepros {
    │
    ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
 
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │ contract InnerCastInTernaryRepros {
+   │          ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │ interface IOverloadedArity {
+   │           ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │ contract OverloadArityRepros {
+   │          ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │ interface IOverloadedSameArity {
+   │           ━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │ contract OverloadSameArityRepros {
+   │          ━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │ contract GlobalRepros {
+   │          ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │ contract StructRepros {
+   │          ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │ contract IndexRepros {
+   │          ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │ library MathLib {
+   │         ━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │ contract LibraryRepros {
+   │          ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │ contract FixedBytesRepros {
+   │          ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
 warning[unsafe-typecast]: typecasts that can truncate values should be checked
    ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
    │
@@ -2363,6 +2451,230 @@ LL │         uint128 a = uint128(foo.getUint256());
    ├ note: consider disabling this lint if you're certain the cast is safe
    │       
    │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         uint128 b = uint128(x);
+   │                     ━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         uint128 a = uint128(cond ? uint128(x) : y);
+   │                                    ━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         uint128 a = uint128(foo.value());
+   │                     ━━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         return uint32(block.timestamp);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint32' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         return uint128(msg.value);
+   │                ━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         return uint32(data.length);
+   │                ━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint32' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         return uint128(who.balance);
+   │                ━━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         return uint128(p.amount);
+   │                ━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         return uint128(data[0]);
+   │                ━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         return uint128(balances[who]);
+   │                ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         return uint128(matrix[0][0]);
+   │                ━━━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         return uint128(positions[0].amount);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         return uint128(nested[who][id]);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         return uint128(MathLib.asUint256(x));
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         return int8(b.length);
+   │                ━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'int8' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         return bytes2(fp.selector);
+   │                ━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'bytes2' is safe because [explain why]
    │       // forge-lint: disable-next-line(unsafe-typecast)
    │       
    │       

--- a/crates/lint/testdata/UnsafeTypecast.stderr
+++ b/crates/lint/testdata/UnsafeTypecast.stderr
@@ -14,6 +14,22 @@ LL │ contract Repros {
    │
    ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
 
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │ interface IReturnsUint256 {
+   │           ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │ contract MemberCallRepros {
+   │          ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#multi-contract-file
+
 warning[unsafe-typecast]: typecasts that can truncate values should be checked
    ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
    │
@@ -2315,6 +2331,34 @@ warning[unsafe-typecast]: typecasts that can truncate values should be checked
    │
 LL │         uint128 a = uint128(cond ? x : y);
    │                     ━━━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         uint128 a = uint128(cond ? safe : unsafe_);
+   │                     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         uint128 a = uint128(foo.getUint256());
+   │                     ━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ├ note: consider disabling this lint if you're certain the cast is safe
    │       

--- a/crates/lint/testdata/UnsafeTypecast.stderr
+++ b/crates/lint/testdata/UnsafeTypecast.stderr
@@ -2296,3 +2296,31 @@ LL │         return uint64(uint128(int128(uint128(a)) + b));
    │       
    ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
 
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         uint128 a = uint128(getUint256());
+   │                     ━━━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#unsafe-typecast
+
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+   ╭▸ ROOT/testdata/UnsafeTypecast.sol:LL:CC
+   │
+LL │         uint128 a = uint128(cond ? x : y);
+   │                     ━━━━━━━━━━━━━━━━━━━━━
+   │
+   ├ note: consider disabling this lint if you're certain the cast is safe
+   │       
+   │       // casting to 'uint128' is safe because [explain why]
+   │       // forge-lint: disable-next-line(unsafe-typecast)
+   │       
+   │       
+   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#unsafe-typecast
+


### PR DESCRIPTION
Closes #13921

## Problem

The `unsafe-typecast` lint misses unsafe casts when the source expression is a function return value, ternary, or other complex expression. `infer_source_types` only handles `Ident`, `Lit`, type-cast `Call`, `Unary`, and `Binary` -- everything else falls through `_ => None`, which makes `source_types` empty and the lint assumes the cast is safe.

## Fix

- For non-cast function calls, resolve the callee's return type from the HIR (`Function.returns`) so casts like `uint128(getUint256())` are now flagged.
- For ternary expressions, recurse on both branches (matching the existing `Binary` pattern) so casts like `uint128(cond ? x : y)` is now flagged.

## Test cases added

- `uint128(getUint256())` -- function return value narrowing cast
- `uint128(cond ? x : y)` -- ternary with uint256 branches narrowed to uint128
