### PR TITLE
chore(ci): mark flaky tests: `evm_version_normalization`, `test_clone_contract_with_relative_import`

### DIFF
--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -154,7 +154,7 @@ assembly {
 });
 
 // Issue #5051, #8978: Test EVM version normalization.
-repl_test!(evm_version_normalization, "--use 0.7.6 --evm-version london", |repl| {
+repl_test!(flaky_evm_version_normalization, "--use 0.7.6 --evm-version london", |repl| {
     repl.sendln("uint x;\nx");
     repl.expect("Decimal: 0");
 });

--- a/crates/forge/src/cmd/clone.rs
+++ b/crates/forge/src/cmd/clone.rs
@@ -1149,7 +1149,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_clone_contract_with_relative_import() {
+    async fn flaky_test_clone_contract_with_relative_import() {
         let address = "0x3a23F943181408EAC424116Af7b7790c94Cb97a5".parse().unwrap();
         one_test_case(address, false).await
     }


### PR DESCRIPTION
Both tests fail intermittently due to network issues (`429 Too Many Requests` from `raw.githubusercontent.com` when downloading solc).

Failure: https://github.com/foundry-rs/foundry/actions/runs/23593333044/job/68703697579

- `chisel::it repl::evm_version_normalization` — timed out because `--use 0.7.6` solc download was rate-limited
- `forge cmd::clone::tests::test_clone_contract_with_relative_import` — explicitly errored with `429 Too Many Requests` for `solc-v0.8.7`

Flaky tests are run every night to catch regressions