### PR TITLE
refactor(anvil): delete `AnvilBlockExecutorFactory`

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -1,4 +1,4 @@
-use crate::{eth::backend::cheats::CheatsManager, mem::inspector::AnvilInspector};
+use crate::eth::backend::cheats::CheatsManager;
 use alloy_consensus::{Eip658Value, Transaction, TransactionEnvelope, transaction::Either};
 use alloy_eips::{
     Encodable2718, eip2935, eip4788,
@@ -281,21 +281,6 @@ where
 
     fn receipts(&self) -> &[FoundryReceiptEnvelope] {
         &self.receipts
-    }
-}
-
-pub struct AnvilBlockExecutorFactory;
-
-impl AnvilBlockExecutorFactory {
-    pub fn create_executor<DB>(
-        evm: EitherEvm<DB, AnvilInspector, PrecompilesMap>,
-        parent_hash: B256,
-        spec_id: SpecId,
-    ) -> AnvilBlockExecutor<EitherEvm<DB, AnvilInspector, PrecompilesMap>>
-    where
-        DB: StateDB,
-    {
-        AnvilBlockExecutor::new(evm, parent_hash, spec_id)
     }
 }
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         backend::{
             cheats::{CheatEcrecover, CheatsManager},
             db::{AnvilCacheDB, Db, MaybeFullDatabase, SerializableState, StateDb},
-            executor::{AnvilBlockExecutorFactory, build_tx_env_for_pending},
+            executor::{AnvilBlockExecutor, build_tx_env_for_pending},
             fork::ClientFork,
             genesis::GenesisConfig,
             mem::{
@@ -2249,9 +2249,8 @@ where
                     });
                 }
 
-                // 4. Create executor via AnvilBlockExecutorFactory
-                let mut executor =
-                    AnvilBlockExecutorFactory::create_executor(evm, best_hash, spec_id);
+                // 4. Create executor
+                let mut executor = AnvilBlockExecutor::new(evm, best_hash, spec_id);
                 executor.apply_pre_execution_changes().expect("pre-execution changes failed");
 
                 // 5. Per-tx loop
@@ -2671,7 +2670,7 @@ where
             });
         }
 
-        let mut executor = AnvilBlockExecutorFactory::create_executor(evm, parent_hash, spec_id);
+        let mut executor = AnvilBlockExecutor::new(evm, parent_hash, spec_id);
         executor.apply_pre_execution_changes().expect("pre-execution changes failed");
 
         let mut transaction_infos: Vec<TransactionInfo> = Vec::new();
@@ -3263,11 +3262,8 @@ where
                 });
             }
 
-            let mut replay_executor = AnvilBlockExecutorFactory::create_executor(
-                evm_replay,
-                block.header.parent_hash,
-                spec_id,
-            );
+            let mut replay_executor =
+                AnvilBlockExecutor::new(evm_replay, block.header.parent_hash, spec_id);
             replay_executor.apply_pre_execution_changes().expect("pre-execution changes failed");
 
             let blob_params = self.blob_params();


### PR DESCRIPTION
## Summary

- Delete `AnvilBlockExecutorFactory` — it was a namespace wrapper that just called `AnvilBlockExecutor::new()`
- Replace all 3 call sites with direct `AnvilBlockExecutor::new(evm, ctx)`
- Remove now-unused `AnvilInspector` import from `executor.rs`