### PR TITLE
chore(cheatcodes): relax `DatabaseExt` bounds to `Database<Error =  DatabaseError>`

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -25,7 +25,7 @@ use foundry_common::{
 use foundry_compilers::artifacts::EvmVersion;
 use foundry_evm_core::{
     FoundryBlock, FoundryTransaction,
-    backend::{DatabaseExt, RevertStateSnapshotAction},
+    backend::{DatabaseError, DatabaseExt, RevertStateSnapshotAction},
     constants::{CALLER, CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, TEST_CONTRACT_ADDRESS},
     env::FoundryContextExt,
     utils::get_blob_base_fee_update_fraction_by_spec_id,
@@ -35,6 +35,7 @@ use foundry_primitives::FoundryTxEnvelope;
 use itertools::Itertools;
 use rand::Rng;
 use revm::{
+    Database,
     bytecode::Bytecode,
     context::{Block, Cfg, ContextTr, JournalTr, Transaction, TxEnv, result::ExecutionResult},
     inspector::JournalExt,
@@ -254,7 +255,7 @@ impl Cheatcode for addrCall {
 }
 
 impl Cheatcode for getNonce_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -264,7 +265,7 @@ impl Cheatcode for getNonce_0Call {
 }
 
 impl Cheatcode for getNonce_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -274,7 +275,7 @@ impl Cheatcode for getNonce_1Call {
 }
 
 impl Cheatcode for loadCall {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -652,7 +653,7 @@ impl Cheatcode for getBlobBaseFeeCall {
 }
 
 impl Cheatcode for dealCall {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -666,7 +667,7 @@ impl Cheatcode for dealCall {
 }
 
 impl Cheatcode for etchCall {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -681,7 +682,7 @@ impl Cheatcode for etchCall {
 }
 
 impl Cheatcode for resetNonceCall {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -699,7 +700,7 @@ impl Cheatcode for resetNonceCall {
 }
 
 impl Cheatcode for setNonceCall {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -718,7 +719,7 @@ impl Cheatcode for setNonceCall {
 }
 
 impl Cheatcode for setNonceUnsafeCall {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -730,7 +731,7 @@ impl Cheatcode for setNonceUnsafeCall {
 }
 
 impl Cheatcode for storeCall {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -935,12 +936,13 @@ impl Cheatcode for revertToStateAndDeleteCall {
 
 // Deprecated in favor of `deleteStateSnapshotCall`
 impl Cheatcode for deleteSnapshotCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
         let Self { snapshotId } = self;
-        inner_delete_state_snapshot(ccx, *snapshotId)
+        let result = ccx.ecx.db_mut().delete_state_snapshot(*snapshotId);
+        Ok(result.abi_encode())
     }
 }
 
@@ -950,7 +952,8 @@ impl Cheatcode for deleteStateSnapshotCall {
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
         let Self { snapshotId } = self;
-        inner_delete_state_snapshot(ccx, *snapshotId)
+        let result = ccx.ecx.db_mut().delete_state_snapshot(*snapshotId);
+        Ok(result.abi_encode())
     }
 }
 
@@ -961,7 +964,8 @@ impl Cheatcode for deleteSnapshotsCall {
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
         let Self {} = self;
-        inner_delete_state_snapshots(ccx)
+        ccx.ecx.db_mut().delete_state_snapshots();
+        Ok(Default::default())
     }
 }
 
@@ -971,7 +975,8 @@ impl Cheatcode for deleteStateSnapshotsCall {
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
         let Self {} = self;
-        inner_delete_state_snapshots(ccx)
+        ccx.ecx.db_mut().delete_state_snapshots();
+        Ok(Default::default())
     }
 }
 
@@ -993,10 +998,7 @@ impl Cheatcode for stopAndReturnStateDiffCall {
 }
 
 impl Cheatcode for getStateDiffCall {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
-        &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-    ) -> Result {
+    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let mut diffs = String::new();
         let state_diffs = get_recorded_state_diffs(ccx);
         for (address, state_diffs) in state_diffs {
@@ -1008,20 +1010,14 @@ impl Cheatcode for getStateDiffCall {
 }
 
 impl Cheatcode for getStateDiffJsonCall {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
-        &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-    ) -> Result {
+    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let state_diffs = get_recorded_state_diffs(ccx);
         Ok(serde_json::to_string(&state_diffs)?.abi_encode())
     }
 }
 
 impl Cheatcode for getStorageSlotsCall {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
-        &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-    ) -> Result {
+    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
         let Self { target, variableName } = self;
 
         let storage_layout = get_contract_data(ccx, *target)
@@ -1393,7 +1389,7 @@ impl Cheatcode for getEvmVersionCall {
     }
 }
 
-pub(super) fn get_nonce<CTX: ContextTr<Db: DatabaseExt>>(
+pub(super) fn get_nonce<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     address: &Address,
 ) -> Result {
@@ -1452,21 +1448,6 @@ fn inner_revert_to_state_and_delete<CTX: EthCheatCtx>(
     } else {
         Ok(false.abi_encode())
     }
-}
-
-fn inner_delete_state_snapshot<CTX: ContextTr<Db: DatabaseExt>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
-    snapshot_id: U256,
-) -> Result {
-    let result = ccx.ecx.db_mut().delete_state_snapshot(snapshot_id);
-    Ok(result.abi_encode())
-}
-
-fn inner_delete_state_snapshots<CTX: ContextTr<Db: DatabaseExt>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
-) -> Result {
-    ccx.ecx.db_mut().delete_state_snapshots();
-    Ok(Default::default())
 }
 
 fn inner_value_snapshot<CTX>(
@@ -1632,7 +1613,9 @@ fn read_callers(state: &Cheatcodes, default_sender: &Address, call_depth: usize)
 }
 
 /// Ensures the `Account` is loaded and touched.
-pub(super) fn journaled_account<CTX: ContextTr<Db: DatabaseExt, Journal: JournalExt>>(
+pub(super) fn journaled_account<
+    CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>,
+>(
     ecx: &mut CTX,
     addr: Address,
 ) -> Result<&mut Account> {
@@ -1640,7 +1623,7 @@ pub(super) fn journaled_account<CTX: ContextTr<Db: DatabaseExt, Journal: Journal
     Ok(ecx.journal_mut().evm_state_mut().get_mut(&addr).expect("account is loaded"))
 }
 
-pub(super) fn ensure_loaded_account<CTX: ContextTr<Db: DatabaseExt>>(
+pub(super) fn ensure_loaded_account<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
     ecx: &mut CTX,
     addr: Address,
 ) -> Result<()> {
@@ -1685,7 +1668,7 @@ fn genesis_account(account: &Account) -> GenesisAccount {
 }
 
 /// Helper function to returns state diffs recorded for each changed account.
-fn get_recorded_state_diffs<CTX: ContextTr<Db: DatabaseExt>>(
+fn get_recorded_state_diffs<CTX: ContextTr>(
     ccx: &mut CheatsCtxt<'_, CTX>,
 ) -> BTreeMap<Address, AccountStateDiffs> {
     let mut state_diffs: BTreeMap<Address, AccountStateDiffs> = BTreeMap::default();
@@ -1864,7 +1847,7 @@ const EIP1822_PROXIABLE_SLOT: &str =
     "c5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7";
 
 /// Helper function to get the contract data from the deployed code at an address.
-fn get_contract_data<'a, CTX: ContextTr<Db: DatabaseExt>>(
+fn get_contract_data<'a, CTX: ContextTr>(
     ccx: &'a mut CheatsCtxt<'_, CTX>,
     address: Address,
 ) -> Option<(&'a foundry_compilers::ArtifactId, &'a foundry_common::contracts::ContractData)> {

--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -1,7 +1,8 @@
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, Result, Vm::*};
 use alloy_primitives::{Address, Bytes, U256};
-use foundry_evm_core::backend::DatabaseExt;
+use foundry_evm_core::backend::DatabaseError;
 use revm::{
+    Database,
     bytecode::Bytecode,
     context::{ContextTr, JournalTr},
     interpreter::InstructionResult,
@@ -52,7 +53,7 @@ impl Cheatcode for clearMockedCallsCall {
 }
 
 impl Cheatcode for mockCall_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -65,7 +66,7 @@ impl Cheatcode for mockCall_0Call {
 }
 
 impl Cheatcode for mockCall_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -78,7 +79,7 @@ impl Cheatcode for mockCall_1Call {
 }
 
 impl Cheatcode for mockCall_2Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -98,7 +99,7 @@ impl Cheatcode for mockCall_2Call {
 }
 
 impl Cheatcode for mockCall_3Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -118,7 +119,7 @@ impl Cheatcode for mockCall_3Call {
 }
 
 impl Cheatcode for mockCalls_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -131,7 +132,7 @@ impl Cheatcode for mockCalls_0Call {
 }
 
 impl Cheatcode for mockCalls_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -144,7 +145,7 @@ impl Cheatcode for mockCalls_1Call {
 }
 
 impl Cheatcode for mockCallRevert_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -157,7 +158,7 @@ impl Cheatcode for mockCallRevert_0Call {
 }
 
 impl Cheatcode for mockCallRevert_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -170,7 +171,7 @@ impl Cheatcode for mockCallRevert_1Call {
 }
 
 impl Cheatcode for mockCallRevert_2Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -190,7 +191,7 @@ impl Cheatcode for mockCallRevert_2Call {
 }
 
 impl Cheatcode for mockCallRevert_3Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -248,7 +249,7 @@ fn mock_calls(
 
 // Etches a single byte onto the account if it is empty to circumvent the `extcodesize`
 // check Solidity might perform.
-fn make_acc_non_empty<CTX: ContextTr<Db: DatabaseExt>>(
+fn make_acc_non_empty<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
     callee: &Address,
     ccx: &mut CheatsCtxt<'_, CTX>,
 ) -> Result {

--- a/crates/cheatcodes/src/evm/prank.rs
+++ b/crates/cheatcodes/src/evm/prank.rs
@@ -1,7 +1,8 @@
 use crate::{Cheatcode, CheatsCtxt, Result, Vm::*, evm::journaled_account};
 use alloy_primitives::Address;
-use foundry_evm_core::backend::DatabaseExt;
+use foundry_evm_core::backend::DatabaseError;
 use revm::{
+    Database,
     context::{ContextTr, JournalTr, Transaction},
     inspector::JournalExt,
 };
@@ -58,7 +59,7 @@ impl Prank {
 }
 
 impl Cheatcode for prank_0Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -68,7 +69,7 @@ impl Cheatcode for prank_0Call {
 }
 
 impl Cheatcode for startPrank_0Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -78,7 +79,7 @@ impl Cheatcode for startPrank_0Call {
 }
 
 impl Cheatcode for prank_1Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -88,7 +89,7 @@ impl Cheatcode for prank_1Call {
 }
 
 impl Cheatcode for startPrank_1Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -98,7 +99,7 @@ impl Cheatcode for startPrank_1Call {
 }
 
 impl Cheatcode for prank_2Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -108,7 +109,7 @@ impl Cheatcode for prank_2Call {
 }
 
 impl Cheatcode for startPrank_2Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -118,7 +119,7 @@ impl Cheatcode for startPrank_2Call {
 }
 
 impl Cheatcode for prank_3Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -128,7 +129,7 @@ impl Cheatcode for prank_3Call {
 }
 
 impl Cheatcode for startPrank_3Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -138,7 +139,7 @@ impl Cheatcode for startPrank_3Call {
 }
 
 impl Cheatcode for stopPrankCall {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -148,7 +149,7 @@ impl Cheatcode for stopPrankCall {
     }
 }
 
-fn prank<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+fn prank<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     new_caller: &Address,
     new_origin: Option<&Address>,

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -7,10 +7,11 @@ use alloy_rpc_types::Authorization;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolValue;
-use foundry_evm_core::backend::DatabaseExt;
+use foundry_evm_core::backend::DatabaseError;
 use foundry_wallets::{WalletSigner, wallet_multi::MultiWallet};
 use parking_lot::Mutex;
 use revm::{
+    Database,
     bytecode::Bytecode,
     context::{Cfg, ContextTr, JournalTr, Transaction},
     context_interface::transaction::SignedAuthorization,
@@ -20,7 +21,7 @@ use revm::{
 use std::sync::Arc;
 
 impl Cheatcode for broadcast_0Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -30,7 +31,7 @@ impl Cheatcode for broadcast_0Call {
 }
 
 impl Cheatcode for broadcast_1Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -40,7 +41,7 @@ impl Cheatcode for broadcast_1Call {
 }
 
 impl Cheatcode for broadcast_2Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -50,7 +51,7 @@ impl Cheatcode for broadcast_2Call {
 }
 
 impl Cheatcode for attachDelegation_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -60,7 +61,7 @@ impl Cheatcode for attachDelegation_0Call {
 }
 
 impl Cheatcode for attachDelegation_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -70,7 +71,7 @@ impl Cheatcode for attachDelegation_1Call {
 }
 
 impl Cheatcode for signDelegation_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -80,7 +81,7 @@ impl Cheatcode for signDelegation_0Call {
 }
 
 impl Cheatcode for signDelegation_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -90,7 +91,7 @@ impl Cheatcode for signDelegation_1Call {
 }
 
 impl Cheatcode for signDelegation_2Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -100,7 +101,7 @@ impl Cheatcode for signDelegation_2Call {
 }
 
 impl Cheatcode for signAndAttachDelegation_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -110,7 +111,7 @@ impl Cheatcode for signAndAttachDelegation_0Call {
 }
 
 impl Cheatcode for signAndAttachDelegation_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -120,7 +121,7 @@ impl Cheatcode for signAndAttachDelegation_1Call {
 }
 
 impl Cheatcode for signAndAttachDelegation_2Call {
-    fn apply_stateful<CTX: ContextTr<Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -130,7 +131,7 @@ impl Cheatcode for signAndAttachDelegation_2Call {
 }
 
 /// Helper function to attach an EIP-7702 delegation.
-fn attach_delegation<CTX: ContextTr<Db: DatabaseExt>>(
+fn attach_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     delegation: &SignedDelegation,
     cross_chain: bool,
@@ -154,7 +155,7 @@ fn attach_delegation<CTX: ContextTr<Db: DatabaseExt>>(
 
 /// Helper function to sign and attach (if needed) an EIP-7702 delegation.
 /// Uses the provided nonce, otherwise retrieves and increments the nonce of the EOA.
-fn sign_delegation<CTX: ContextTr<Db: DatabaseExt>>(
+fn sign_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     private_key: Uint<256, 4>,
     implementation: Address,
@@ -227,7 +228,7 @@ fn next_delegation_nonce(
     }
 }
 
-fn write_delegation<CTX: ContextTr<Db: DatabaseExt>>(
+fn write_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     auth: SignedAuthorization,
 ) -> Result<()> {
@@ -283,7 +284,7 @@ impl Cheatcode for attachBlobCall {
 }
 
 impl Cheatcode for startBroadcast_0Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -293,7 +294,7 @@ impl Cheatcode for startBroadcast_0Call {
 }
 
 impl Cheatcode for startBroadcast_1Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -303,7 +304,7 @@ impl Cheatcode for startBroadcast_1Call {
 }
 
 impl Cheatcode for startBroadcast_2Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
         &self,
         ccx: &mut CheatsCtxt<'_, CTX>,
     ) -> Result {
@@ -400,7 +401,7 @@ impl Wallets {
 }
 
 /// Sets up broadcasting from a script using `new_origin` as the sender.
-fn broadcast<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+fn broadcast<CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     new_origin: Option<&Address>,
     single_call: bool,
@@ -446,7 +447,7 @@ fn broadcast<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
 /// Sets up broadcasting from a script with the sender derived from `private_key`.
 /// Adds this private key to `state`'s `wallets` vector to later be used for signing
 /// if broadcast is successful.
-fn broadcast_key<CTX: ContextTr<Journal: JournalExt, Db: DatabaseExt>>(
+fn broadcast_key<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     private_key: &U256,
     single_call: bool,

--- a/crates/cheatcodes/src/test/assert.rs
+++ b/crates/cheatcodes/src/test/assert.rs
@@ -2,11 +2,14 @@ use crate::{CheatcodesExecutor, CheatsCtxt, EthCheatCtx, Result, Vm::*};
 use alloy_primitives::{I256, U256, U512};
 use foundry_evm_core::{
     abi::console::{format_units_int, format_units_uint},
-    backend::{DatabaseExt, GLOBAL_FAIL_SLOT},
+    backend::{DatabaseError, GLOBAL_FAIL_SLOT},
     constants::CHEATCODE_ADDRESS,
 };
 use itertools::Itertools;
-use revm::context::{ContextTr, JournalTr};
+use revm::{
+    Database,
+    context::{ContextTr, JournalTr},
+};
 use std::{borrow::Cow, fmt};
 
 const EQ_REL_DELTA_RESOLUTION: U256 = U256::from_limbs([18, 0, 0, 0]);
@@ -187,7 +190,7 @@ impl EqRelAssertionError<I256> {
 type ComparisonResult<'a, T> = Result<(), ComparisonAssertionError<'a, T>>;
 
 #[cold]
-fn handle_assertion_result<CTX: ContextTr<Db: DatabaseExt>, E>(
+fn handle_assertion_result<CTX: ContextTr<Db: Database<Error = DatabaseError>>, E>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     executor: &mut dyn CheatcodesExecutor<CTX>,
     err: E,
@@ -203,7 +206,7 @@ fn handle_assertion_result<CTX: ContextTr<Db: DatabaseExt>, E>(
     handle_assertion_result_mono(ccx, executor, msg)
 }
 
-fn handle_assertion_result_mono<CTX: ContextTr<Db: DatabaseExt>>(
+fn handle_assertion_result_mono<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
     ccx: &mut CheatsCtxt<'_, CTX>,
     executor: &mut dyn CheatcodesExecutor<CTX>,
     msg: Cow<'_, str>,


### PR DESCRIPTION
## Motivation

Towards generic `ContextTr`/`Network` through `Cheatcodes`.

Let's relax `DatabaseExt` bounds to `Database<Error =  DatabaseError>` where it's possible. Making them context/network agnostic.

