### PR TITLE
chore(anvil): remove deadcode + useless `Clone` bound on receipts

### DIFF
--- a/crates/anvil/core/src/eth/block.rs
+++ b/crates/anvil/core/src/eth/block.rs
@@ -47,24 +47,6 @@ where
     Block::new(header, body)
 }
 
-/// Generic helper function to create a block with any transaction type that supports encoding.
-pub fn create_typed_block<T>(
-    mut header: Header,
-    transactions: impl IntoIterator<Item = T>,
-) -> alloy_consensus::Block<T>
-where
-    T: Encodable2718,
-{
-    let transactions: Vec<_> = transactions.into_iter().collect();
-    let transactions_root = calculate_transaction_root(&transactions);
-
-    header.transactions_root = transactions_root;
-    header.ommers_hash = EMPTY_OMMER_ROOT_HASH;
-
-    let body = BlockBody { transactions, ommers: Vec::new(), withdrawals: None };
-    alloy_consensus::Block::new(header, body)
-}
-
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{

--- a/crates/anvil/src/eth/backend/info.rs
+++ b/crates/anvil/src/eth/backend/info.rs
@@ -41,7 +41,7 @@ impl<N: Network> StorageInfo<N> {
 
 impl<N: Network> StorageInfo<N>
 where
-    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log> + Clone,
+    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log>,
 {
     /// Returns the receipts of the current block
     pub fn current_receipts(&self) -> Option<Vec<N::ReceiptEnvelope>> {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2006,7 +2006,7 @@ impl<N: Network> Backend<N> {
 
 impl<N: Network> Backend<N>
 where
-    N::ReceiptEnvelope: alloy_consensus::TxReceipt<Log = alloy_primitives::Log> + Clone,
+    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log>,
 {
     /// Returns all `Log`s mined by the node that were emitted in the `block` and match the `Filter`
     fn mined_logs_for_block(&self, filter: Filter, block: Block, block_hash: B256) -> Vec<Log> {

--- a/crates/anvil/src/filter.rs
+++ b/crates/anvil/src/filter.rs
@@ -100,7 +100,7 @@ impl<N: Network> Filters<N> {
 
 impl<N: Network> Filters<N>
 where
-    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log> + Clone,
+    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log>,
 {
     pub async fn get_filter_changes(&self, id: &str) -> ResponseResult {
         {
@@ -156,7 +156,7 @@ impl<N: Network> std::fmt::Debug for EthFilter<N> {
 
 impl<N: Network> Stream for EthFilter<N>
 where
-    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log> + Clone,
+    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log>,
 {
     type Item = ResponseResult;
 
@@ -204,7 +204,7 @@ impl<N: Network> std::fmt::Debug for LogsFilter<N> {
 
 impl<N: Network> LogsFilter<N>
 where
-    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log> + Clone,
+    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log>,
 {
     /// Returns all the logs since the last time this filter was polled
     pub fn poll(&mut self, cx: &mut Context<'_>) -> Vec<Log> {

--- a/crates/anvil/src/pubsub.rs
+++ b/crates/anvil/src/pubsub.rs
@@ -37,7 +37,7 @@ impl<N: Network> std::fmt::Debug for LogsSubscription<N> {
 
 impl<N: Network> LogsSubscription<N>
 where
-    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log> + Clone,
+    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log>,
 {
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Option<EthSubscriptionResponse>> {
         loop {
@@ -115,7 +115,7 @@ impl<N: Network> std::fmt::Debug for EthSubscription<N> {
 
 impl<N: Network> EthSubscription<N>
 where
-    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log> + Clone,
+    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log>,
 {
     fn poll_response(&mut self, cx: &mut Context<'_>) -> Poll<Option<EthSubscriptionResponse>> {
         match self {
@@ -161,7 +161,7 @@ where
 
 impl<N: Network> Stream for EthSubscription<N>
 where
-    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log> + Clone,
+    N::ReceiptEnvelope: TxReceipt<Log = alloy_primitives::Log>,
 {
     type Item = serde_json::Value;
 


### PR DESCRIPTION
## Motivation

Smol clean-ups :
- remove deadcode `create_typed_block `
- useless `Clone` bound on `N::ReceiptEnvelope`