### PR TITLE
refactor(evm): remove useless `Tx` arg on `DatabaseExt::revert_state`

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1409,18 +1409,17 @@ fn inner_revert_to_state<CTX: EthCheatCtx>(
     snapshot_id: U256,
 ) -> Result {
     let mut evm_env = ccx.ecx.evm_clone();
-    let mut tx_env = ccx.ecx.tx_clone();
+    let caller = ccx.ecx.caller();
     let (db, inner) = ccx.ecx.db_journal_inner_mut();
     if let Some(restored) = db.revert_state(
         snapshot_id,
         inner,
         &mut evm_env,
-        &mut tx_env,
+        caller,
         RevertStateSnapshotAction::RevertKeep,
     ) {
         *inner = restored;
         ccx.ecx.set_evm(evm_env);
-        ccx.ecx.set_tx(tx_env);
         Ok(true.abi_encode())
     } else {
         Ok(false.abi_encode())
@@ -1432,18 +1431,17 @@ fn inner_revert_to_state_and_delete<CTX: EthCheatCtx>(
     snapshot_id: U256,
 ) -> Result {
     let mut evm_env = ccx.ecx.evm_clone();
-    let mut tx_env = ccx.ecx.tx_clone();
+    let caller = ccx.ecx.caller();
     let (db, inner) = ccx.ecx.db_journal_inner_mut();
     if let Some(restored) = db.revert_state(
         snapshot_id,
         inner,
         &mut evm_env,
-        &mut tx_env,
+        caller,
         RevertStateSnapshotAction::RevertRemove,
     ) {
         *inner = restored;
         ccx.ecx.set_evm(evm_env);
-        ccx.ecx.set_tx(tx_env);
         Ok(true.abi_encode())
     } else {
         Ok(false.abi_encode())

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -121,10 +121,10 @@ impl DatabaseExt for CowBackend<'_> {
         id: U256,
         journaled_state: &JournaledState,
         evm_env: &mut EvmEnv,
-        tx_env: &mut TxEnv,
+        caller: Address,
         action: RevertStateSnapshotAction,
     ) -> Option<JournaledState> {
-        self.backend_mut().revert_state(id, journaled_state, evm_env, tx_env, action)
+        self.backend_mut().revert_state(id, journaled_state, evm_env, caller, action)
     }
 
     fn delete_state_snapshot(&mut self, id: U256) -> bool {

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -107,7 +107,7 @@ pub trait DatabaseExt<BLOCK = BlockEnv, TX = TxEnv, SPEC = SpecId>:
         id: U256,
         journaled_state: &JournaledState,
         evm_env: &mut EvmEnv<SPEC, BLOCK>,
-        tx_env: &mut TX,
+        caller: Address,
         action: RevertStateSnapshotAction,
     ) -> Option<JournaledState>;
 
@@ -955,7 +955,7 @@ where
         id: U256,
         current_state: &JournaledState,
         evm_env: &mut EvmEnv,
-        tx_env: &mut TxEnv,
+        caller: Address,
         action: RevertStateSnapshotAction,
     ) -> Option<JournaledState> {
         trace!(?id, "revert snapshot");
@@ -987,7 +987,6 @@ where
                     // there might be the case where the snapshot was created during `setUp` with
                     // another caller, so we need to ensure the caller account is present in the
                     // journaled state and database
-                    let caller = tx_env.caller;
                     journaled_state.state.entry(caller).or_insert_with(|| {
                         let caller_account = current_state
                             .state
@@ -1006,7 +1005,7 @@ where
                 }
             }
 
-            update_current_env_with_fork_env(evm_env, tx_env, snap_evm_env);
+            *evm_env = snap_evm_env;
             trace!(target: "backend", "Reverted snapshot {}", id);
 
             Some(journaled_state)
@@ -1185,7 +1184,8 @@ where
 
         self.active_fork_ids = Some((id, idx));
         // Update current environment with environment of newly selected fork.
-        update_current_env_with_fork_env(evm_env, tx_env, fork_evm_env);
+        tx_env.set_chain_id(Some(fork_evm_env.cfg_env.chain_id));
+        *evm_env = fork_evm_env;
 
         Ok(())
     }
@@ -1902,20 +1902,6 @@ impl<N: Network> Default for BackendInner<N> {
             ]),
         }
     }
-}
-
-/// This updates the currently used env with the fork's environment
-pub(crate) fn update_current_env_with_fork_env<
-    SPEC,
-    BLOCK: FoundryBlock,
-    TX: FoundryTransaction,
->(
-    evm_env: &mut EvmEnv<SPEC, BLOCK>,
-    tx_env: &mut TX,
-    fork_evm_env: EvmEnv<SPEC, BLOCK>,
-) {
-    tx_env.set_chain_id(Some(fork_evm_env.cfg_env.chain_id));
-    *evm_env = fork_evm_env;
 }
 
 /// Clones the data of the given `accounts` from the `active` database into the `fork_db`


### PR DESCRIPTION
## Motivation

In the same vein as #13955, removing useless `Tx` arg on `DatabaseExt::revert_state`, to simply use `caller` `Address`.

Removed `update_current_env_with_fork_env` helper (now useless).