### PR TITLE
perf(evm): remove `EvmEnv`/`TxEnv` cloning in DBs & `CheatcodesExecutor` impls

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1120,7 +1120,7 @@ impl Cheatcode for broadcastRawTransactionCall {
         let from = tx.recover_signer()?;
         let tx_env = FromRecoveredTx::from_recovered_tx(&tx, from);
 
-        executor.transact_from_tx_on_db(ccx.state, ccx.ecx, &tx_env)?;
+        executor.transact_from_tx_on_db(ccx.state, ccx.ecx, tx_env)?;
 
         if ccx.state.broadcast.is_some() {
             ccx.state.broadcastable_transactions.push_back(BroadcastableTransaction {

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -106,7 +106,7 @@ pub trait CheatcodesExecutor<CTX: ContextTr> {
         &mut self,
         cheats: &mut Cheatcodes,
         ecx: &mut CTX,
-        tx: &CTX::Tx,
+        tx: CTX::Tx,
     ) -> eyre::Result<()>;
 
     /// Runs a closure with a fresh nested EVM built from a raw database and environment.
@@ -214,7 +214,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
         &mut self,
         cheats: &mut Cheatcodes,
         ecx: &mut CTX,
-        tx: &CTX::Tx,
+        tx: CTX::Tx,
     ) -> eyre::Result<()> {
         let evm_env = ecx.evm_clone();
         let (db, inner) = ecx.db_journal_inner_mut();

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -77,8 +77,8 @@ impl<'a> CowBackend<'a> {
 
         let res = evm.transact(tx_env.clone()).wrap_err("EVM error")?;
 
-        *evm_env = EvmEnv::new(evm.cfg.clone(), evm.block.clone());
         *tx_env = evm.tx.clone();
+        *evm_env = evm.finish().1;
 
         Ok(res)
     }
@@ -197,7 +197,7 @@ impl DatabaseExt for CowBackend<'_> {
 
     fn transact_from_tx(
         &mut self,
-        tx_env: &TxEnv,
+        tx_env: TxEnv,
         evm_env: EvmEnv,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn for<'db> FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt>>,

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -223,7 +223,7 @@ pub trait DatabaseExt<BLOCK = BlockEnv, TX = TxEnv, SPEC = SpecId>:
     /// Executes a given TransactionRequest, commits the new state to the DB
     fn transact_from_tx(
         &mut self,
-        tx_env: &TX,
+        tx_env: TX,
         evm_env: EvmEnv<SPEC, BLOCK>,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn for<'db> FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt>>,
@@ -783,8 +783,8 @@ where
 
         let res = evm.transact(tx_env.clone()).wrap_err("EVM error")?;
 
-        *evm_env = EvmEnv::new(evm.cfg.clone(), evm.block.clone());
         *tx_env = evm.tx.clone();
+        *evm_env = evm.finish().1;
 
         Ok(res)
     }
@@ -1333,7 +1333,7 @@ where
 
     fn transact_from_tx(
         &mut self,
-        tx_env: &TxEnv,
+        tx_env: TxEnv,
         evm_env: EvmEnv,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn for<'db> FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt>>,
@@ -1346,7 +1346,7 @@ where
             let mut db = self.clone();
             let mut evm = new_eth_evm_with_inspector(&mut db, evm_env, inspector);
             evm.journaled_state.depth = journaled_state.depth + 1;
-            evm.transact_raw(tx_env.to_owned())?
+            evm.transact_raw(tx_env)?
         };
 
         self.commit(res.state);

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -407,7 +407,7 @@ impl<CTX: EthCheatCtx> CheatcodesExecutor<CTX> for InspectorStackInner {
         &mut self,
         cheats: &mut Cheatcodes,
         ecx: &mut CTX,
-        tx_env: &CTX::Tx,
+        tx_env: CTX::Tx,
     ) -> eyre::Result<()> {
         let evm_env = ecx.evm_clone();
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };


### PR DESCRIPTION
## Motivation

Memory optimization:

- Change `CheatcodesExecutor::{transact_from_tx,transact_from_tx_on_db}` to accept tx by value instead of by reference that requires to be cloned.

- Fix `evm_env` update after transact to use consuming `evm.finish().1` instead of cloning and manually reconstructing `EvmEnv` from cfg/block fields.
