### PR TITLE
fix(anvil): downgrade "Already imported" log from warn to debug

### DIFF
--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -329,7 +329,7 @@ impl<T: Transaction> PoolInner<T> {
         tx: PoolTransaction<T>,
     ) -> Result<AddedTransaction<T>, PoolError> {
         if self.contains(&tx.hash()) {
-            warn!(target: "txpool", "[{:?}] Already imported", tx.hash());
+            debug!(target: "txpool", "[{:?}] Already imported", tx.hash());
             return Err(PoolError::AlreadyImported(tx.hash()));
         }
 


### PR DESCRIPTION
Downgrade the "Already imported" transaction pool log from `warn` to `debug` level. Duplicate transaction submissions are normal in distributed systems (frontend retries, multi-node forwarding) and should not trigger warnings.

follow-up of https://github.com/foundry-rs/foundry/pull/13911