### PR TITLE
feat(anvil): add `eth_getStorageValues` RPC method

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -1,5 +1,8 @@
 use crate::{eth::subscription::SubscriptionId, types::ReorgOptions};
-use alloy_primitives::{Address, B64, B256, Bytes, TxHash, U256, map::HashSet};
+use alloy_primitives::{
+    Address, B64, B256, Bytes, TxHash, U256,
+    map::{HashMap, HashSet},
+};
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag as BlockNumber, BlockOverrides, Filter, Index,
     anvil::{Forking, MineOptions},
@@ -91,6 +94,10 @@ pub enum EthRequest {
 
     #[serde(rename = "eth_getStorageAt")]
     EthGetStorageAt(Address, U256, Option<BlockId>),
+
+    /// Returns storage values for multiple accounts and slots in a single call.
+    #[serde(rename = "eth_getStorageValues")]
+    EthGetStorageValues(HashMap<Address, Vec<B256>>, Option<BlockId>),
 
     #[serde(rename = "eth_getBlockByHash")]
     EthGetBlockByHash(B256, bool),

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -916,6 +916,9 @@ impl EthApi<FoundryNetwork> {
             EthRequest::EthGetStorageAt(addr, slot, block) => {
                 self.storage_at(addr, slot, block).await.to_rpc_result()
             }
+            EthRequest::EthGetStorageValues(requests, block) => {
+                self.storage_values(requests, block).await.to_rpc_result()
+            }
             EthRequest::EthGetBlockByHash(hash, full) => {
                 if full {
                     self.block_by_hash_full(hash).await.to_rpc_result()
@@ -1505,6 +1508,47 @@ impl EthApi<FoundryNetwork> {
         }
 
         self.backend.storage_at(address, index, Some(block_request)).await
+    }
+
+    /// Returns storage values for multiple accounts and slots in a single call.
+    ///
+    /// Handler for ETH RPC call: `eth_getStorageValues`
+    pub async fn storage_values(
+        &self,
+        requests: HashMap<Address, Vec<B256>>,
+        block_number: Option<BlockId>,
+    ) -> Result<HashMap<Address, Vec<B256>>> {
+        node_info!("eth_getStorageValues");
+
+        let total_slots: usize = requests.values().map(|s| s.len()).sum();
+        if total_slots > 1024 {
+            return Err(BlockchainError::RpcError(RpcError::invalid_params(format!(
+                "total slot count {total_slots} exceeds limit 1024"
+            ))));
+        }
+
+        let block_request = self.block_request(block_number).await?;
+
+        // check if the number predates the fork, if in fork mode
+        if let BlockRequest::Number(number) = block_request
+            && let Some(fork) = self.get_fork()
+            && fork.predates_fork(number)
+        {
+            let mut result: HashMap<Address, Vec<B256>> = HashMap::default();
+            for (address, slots) in requests {
+                let mut values = Vec::with_capacity(slots.len());
+                for slot in &slots {
+                    let val = fork
+                        .storage_at(address, (*slot).into(), Some(BlockNumber::Number(number)))
+                        .await?;
+                    values.push(B256::from(val));
+                }
+                result.insert(address, values);
+            }
+            return Ok(result);
+        }
+
+        self.backend.storage_values(requests, Some(block_request)).await
     }
 
     /// Returns block with given hash.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3083,6 +3083,28 @@ where
         .await?
     }
 
+    /// Returns storage values for multiple accounts and slots in a single call.
+    pub async fn storage_values(
+        &self,
+        requests: HashMap<Address, Vec<B256>>,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
+    ) -> Result<HashMap<Address, Vec<B256>>, BlockchainError> {
+        self.with_database_at(block_request, |db, _| {
+            trace!(target: "backend", "get storage values for {} addresses", requests.len());
+            let mut result: HashMap<Address, Vec<B256>> = HashMap::default();
+            for (address, slots) in &requests {
+                let mut values = Vec::with_capacity(slots.len());
+                for slot in slots {
+                    let val = db.storage_ref(*address, (*slot).into())?;
+                    values.push(val.into());
+                }
+                result.insert(*address, values);
+            }
+            Ok(result)
+        })
+        .await?
+    }
+
     /// Returns the code of the address
     ///
     /// If the code is not present and fork mode is enabled then this will try to fetch it from the


### PR DESCRIPTION
Add `eth_getStorageValues` RPC method for batch-reading storage slots across multiple accounts in a single call.
Same as [270](https://github.com/tempoxyz/tempo-foundry/pull/270)