### PR TITLE
fix(anvil): skip missing transactions in `mined_parity_trace_block`

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -757,7 +757,9 @@ impl<N: Network> Backend<N> {
         let mut traces = vec![];
         let storage = self.blockchain.storage.read();
         for tx in block.body.transactions {
-            traces.extend(storage.transactions.get(&tx.hash())?.parity_traces());
+            if let Some(mined_tx) = storage.transactions.get(&tx.hash()) {
+                traces.extend(mined_tx.parity_traces());
+            }
         }
         Some(traces)
     }


### PR DESCRIPTION
Changed `mined_parity_trace_block` to skip transactions without stored traces instead of returning `None` for the entire block. Previously, a single missing tx trace would discard all collected traces, breaking tools like otterscan that depend on parity trace data.