### PR TITLE
refactor(cheatcodes): simplify broadcastable tx creation

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -31,13 +31,12 @@ use foundry_evm_core::{
     utils::get_blob_base_fee_update_fraction_by_spec_id,
 };
 use foundry_evm_traces::TraceMode;
-use foundry_primitives::FoundryTxEnvelope;
 use itertools::Itertools;
 use rand::Rng;
 use revm::{
     Database,
     bytecode::Bytecode,
-    context::{Block, Cfg, ContextTr, JournalTr, Transaction, TxEnv, result::ExecutionResult},
+    context::{Block, Cfg, ContextTr, JournalTr, Transaction, result::ExecutionResult},
     inspector::JournalExt,
     primitives::{KECCAK_EMPTY, hardfork::SpecId},
     state::{Account, AccountStatus},
@@ -1125,7 +1124,7 @@ impl Cheatcode for broadcastRawTransactionCall {
         if ccx.state.broadcast.is_some() {
             ccx.state.broadcastable_transactions.push_back(BroadcastableTransaction {
                 rpc: ccx.ecx.db().active_fork_url(),
-                transaction: TransactionMaybeSigned::new_signed(tx)?,
+                transaction: TransactionMaybeSigned::Signed { tx, from },
             });
         }
 
@@ -1167,26 +1166,15 @@ impl Cheatcode for executeTransactionCall {
         }
 
         // Decode the RLP-encoded signed transaction.
-        let tx = FoundryTxEnvelope::decode(&mut self.rawTx.as_ref())
+        let tx = TxEnvelope::decode(&mut self.rawTx.as_ref())
             .map_err(|err| fmt_err!("failed to decode RLP-encoded transaction: {err}"))?;
 
-        // Reject unsupported transaction types.
-        // TODO: add support for OP deposit transactions.
-        if matches!(tx, FoundryTxEnvelope::Deposit(_)) {
-            return Err(fmt_err!(
-                "OP deposit transactions are not yet supported by executeTransaction"
-            ));
-        }
-        // TODO: add support for Tempo AA transactions.
-        if matches!(tx, FoundryTxEnvelope::Tempo(_)) {
-            return Err(fmt_err!("Tempo transactions are not yet supported by executeTransaction"));
-        }
-
         // Recover signer from the transaction signature.
-        let sender = tx.recover().map_err(|err| fmt_err!("failed to recover signer: {err}"))?;
+        let sender =
+            tx.recover_signer().map_err(|err| fmt_err!("failed to recover signer: {err}"))?;
 
         // Build TxEnv from the recovered transaction.
-        let tx_env = <TxEnv as FromRecoveredTx<FoundryTxEnvelope>>::from_recovered_tx(&tx, sender);
+        let tx_env = FromRecoveredTx::from_recovered_tx(&tx, sender);
 
         // Save current env for restoration after execution.
         let cached_evm_env = ccx.ecx.evm_clone();

--- a/crates/common/src/transactions.rs
+++ b/crates/common/src/transactions.rs
@@ -1,6 +1,6 @@
 //! Wrappers for transactions.
 
-use alloy_consensus::{Transaction, transaction::SignerRecoverable};
+use alloy_consensus::Transaction;
 use alloy_eips::eip7702::SignedAuthorization;
 use alloy_network::{AnyTransactionReceipt, Network, TransactionResponse};
 use alloy_primitives::{Address, Bytes, U256};
@@ -177,17 +177,6 @@ impl<N: Network> TransactionMaybeSigned<N> {
     /// Creates a new (unsigned) transaction for broadcast
     pub fn new(tx: N::TransactionRequest) -> Self {
         Self::Unsigned(tx)
-    }
-
-    /// Creates a new signed transaction for broadcast.
-    pub fn new_signed(
-        tx: N::TxEnvelope,
-    ) -> core::result::Result<Self, alloy_consensus::crypto::RecoveryError>
-    where
-        N::TxEnvelope: SignerRecoverable,
-    {
-        let from = tx.recover_signer()?;
-        Ok(Self::Signed { tx, from })
     }
 
     pub fn is_unsigned(&self) -> bool {


### PR DESCRIPTION
## Motivation

Towards `Cheatcodes` generics:

- Remove `TransactionMaybeSigned::new_signed()` helper in favor of direct struct construction to avoid double signer recovery

- Use `TxEnvelope` instead of `FoundryTxEnvelope` in `executeTransactionCall` cheatcode as it will become generic soon, allowing to remove Tempo/OP rejection checks (actually aligns on `broadcastRawTransactionCall` impl).
