### PR TITLE
lint: add post-increment-decrement gas lint

### DIFF
--- a/crates/lint/src/sol/gas/increment.rs
+++ b/crates/lint/src/sol/gas/increment.rs
@@ -1,0 +1,23 @@
+use super::PostIncrementDecrement;
+use crate::{
+    linter::{EarlyLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::ast::{Expr, ExprKind, UnOpKind};
+
+declare_forge_lint!(
+    POST_INCREMENT_DECREMENT,
+    Severity::Gas,
+    "post-increment-decrement",
+    "use pre-increment/decrement instead of post-increment/decrement"
+);
+
+impl<'ast> EarlyLintPass<'ast> for PostIncrementDecrement {
+    fn check_expr(&mut self, ctx: &LintContext, expr: &'ast Expr<'ast>) {
+        if let ExprKind::Unary(op, _) = &expr.kind
+            && matches!(op.kind, UnOpKind::PostInc | UnOpKind::PostDec)
+        {
+            ctx.emit(&POST_INCREMENT_DECREMENT, expr.span);
+        }
+    }
+}

--- a/crates/lint/src/sol/gas/mod.rs
+++ b/crates/lint/src/sol/gas/mod.rs
@@ -1,8 +1,15 @@
 use crate::sol::{EarlyLintPass, LateLintPass, SolLint};
 
 mod custom_errors;
+mod increment;
 mod keccak;
+
 use custom_errors::CUSTOM_ERRORS;
+use increment::POST_INCREMENT_DECREMENT;
 use keccak::ASM_KECCAK256;
 
-register_lints!((CustomErrors, early, (CUSTOM_ERRORS)), (AsmKeccak256, late, (ASM_KECCAK256)));
+register_lints!(
+    (CustomErrors, early, (CUSTOM_ERRORS)),
+    (AsmKeccak256, late, (ASM_KECCAK256)),
+    (PostIncrementDecrement, early, (POST_INCREMENT_DECREMENT))
+);

--- a/crates/lint/testdata/PostIncrementDecrement.sol
+++ b/crates/lint/testdata/PostIncrementDecrement.sol
@@ -1,0 +1,34 @@
+//@compile-flags: --severity gas
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+contract PostIncrementDecrement {
+    // should trigger - in for loop
+    function bad(uint256[] memory arr) public pure {
+        for (uint256 i = 0; i < arr.length; i++) { //~NOTE: use pre-increment/decrement instead of post-increment/decrement
+        }
+    }
+
+    // should trigger - decrement in for loop
+    function badDec(uint256[] memory arr) public pure {
+        for (uint256 i = arr.length; i > 0; i--) { //~NOTE: use pre-increment/decrement instead of post-increment/decrement
+        }
+    }
+
+    // should trigger - standalone post-increment
+    function badStandalone() public pure returns (uint256 i) {
+        i++; //~NOTE: use pre-increment/decrement instead of post-increment/decrement
+    }
+
+    // should not trigger - pre-increment
+    function good(uint256[] memory arr) public pure {
+        for (uint256 i = 0; i < arr.length; ++i) {
+        }
+    }
+
+    // should not trigger - pre-decrement
+    function alsoGood(uint256[] memory arr) public pure {
+        for (uint256 i = arr.length; i > 0; --i) {
+        }
+    }
+}

--- a/crates/lint/testdata/PostIncrementDecrement.stderr
+++ b/crates/lint/testdata/PostIncrementDecrement.stderr
@@ -1,0 +1,24 @@
+note[post-increment-decrement]: use pre-increment/decrement instead of post-increment/decrement
+   ╭▸ ROOT/testdata/PostIncrementDecrement.sol:LL:CC
+   │
+LL │         for (uint256 i = 0; i < arr.length; i++) {
+   │                                             ━━━
+   │
+   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#post-increment-decrement
+
+note[post-increment-decrement]: use pre-increment/decrement instead of post-increment/decrement
+   ╭▸ ROOT/testdata/PostIncrementDecrement.sol:LL:CC
+   │
+LL │         for (uint256 i = arr.length; i > 0; i--) {
+   │                                             ━━━
+   │
+   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#post-increment-decrement
+
+note[post-increment-decrement]: use pre-increment/decrement instead of post-increment/decrement
+   ╭▸ ROOT/testdata/PostIncrementDecrement.sol:LL:CC
+   │
+LL │         i++;
+   │         ━━━
+   │
+   ╰ help: https://book.getfoundry.sh/reference/forge/forge-lint#post-increment-decrement
+


### PR DESCRIPTION
## What this PR does
Adds a new `post-increment-decrement` lint rule in the `gas` category that flags
`i++` and `i--` when used in for loop update expressions, suggesting `++i` and
`--i` instead.

## Why
Post-increment (`i++`) and post-decrement (`i--`) return the value before
modification, requiring an extra copy operation under the hood. In for loop
update expressions the return value is always discarded, so the copy is
pure overhead. Pre-increment (`++i`) skips the copy entirely.

The lint is intentionally scoped to for loop update expressions only. Outside
of loops, `i++` vs `++i` is a semantic choice the developer may have made
deliberately.

## Changes
- `crates/lint/src/sol/gas/increment.rs`: new `EarlyLintPass` implementation
- `crates/lint/src/sol/gas/mod.rs`: registered the new lint
- `crates/lint/testdata/PostIncrementDecrement.sol`: test cases covering
  triggering and non-triggering patterns
- `crates/lint/testdata/PostIncrementDecrement.stderr`: blessed test output