### PR TITLE
feat(evm): make `BackendStateSnapshot` generic over Spec and Block types

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -586,7 +586,7 @@ where
     /// Returns all snapshots created in this backend
     pub fn state_snapshots(
         &self,
-    ) -> &StateSnapshots<BackendStateSnapshot<BackendDatabaseSnapshot<N>>> {
+    ) -> &StateSnapshots<BackendStateSnapshot<BackendDatabaseSnapshot<N>, SpecId, BlockEnv>> {
         &self.inner.state_snapshots
     }
 
@@ -1682,7 +1682,8 @@ pub struct BackendInner<N: Network> {
     // Note: data is stored in an `Option` so we can remove it without reshuffling
     pub forks: Vec<Option<Fork<N>>>,
     /// Contains state snapshots made at a certain point
-    pub state_snapshots: StateSnapshots<BackendStateSnapshot<BackendDatabaseSnapshot<N>>>,
+    pub state_snapshots:
+        StateSnapshots<BackendStateSnapshot<BackendDatabaseSnapshot<N>, SpecId, BlockEnv>>,
     /// Tracks whether there was a failure in a snapshot that was reverted
     ///
     /// The Test contract contains a bool variable that is set to true when an `assert` function

--- a/crates/evm/core/src/backend/snapshot.rs
+++ b/crates/evm/core/src/backend/snapshot.rs
@@ -17,17 +17,17 @@ pub struct StateSnapshot {
 
 /// Represents a state snapshot taken during evm execution
 #[derive(Clone, Debug)]
-pub struct BackendStateSnapshot<T> {
+pub struct BackendStateSnapshot<T, SPEC, BLOCK> {
     pub db: T,
     /// The journaled_state state at a specific point
     pub journaled_state: JournaledState,
     /// Contains the evm env at the time of the snapshot
-    pub snap_evm_env: EvmEnv,
+    pub snap_evm_env: EvmEnv<SPEC, BLOCK>,
 }
 
-impl<T> BackendStateSnapshot<T> {
+impl<T, SPEC, BLOCK> BackendStateSnapshot<T, SPEC, BLOCK> {
     /// Takes a new state snapshot.
-    pub fn new(db: T, journaled_state: JournaledState, evm_env: EvmEnv) -> Self {
+    pub fn new(db: T, journaled_state: JournaledState, evm_env: EvmEnv<SPEC, BLOCK>) -> Self {
         Self { db, journaled_state, snap_evm_env: evm_env }
     }
 


### PR DESCRIPTION
## Motivation

Towards `Backend` generic over `ContextTr` and `Network`, make `BackendStateSnapshot` generic over `Spec` and `Block` types.
