### PR TITLE
refactor(anvil): generalize MaybeImpersonatedTransaction From impl

### DIFF
--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -99,8 +99,8 @@ impl From<MaybeImpersonatedTransaction<Self>> for FoundryTxEnvelope {
     }
 }
 
-impl From<FoundryTxEnvelope> for MaybeImpersonatedTransaction<FoundryTxEnvelope> {
-    fn from(value: FoundryTxEnvelope) -> Self {
+impl<T> From<T> for MaybeImpersonatedTransaction<T> {
+    fn from(value: T) -> Self {
         Self::new(value)
     }
 }


### PR DESCRIPTION
Generalize `From<FoundryTxEnvelope> for MaybeImpersonatedTransaction<FoundryTxEnvelope>` to `From<T> for MaybeImpersonatedTransaction<T>`, since `MaybeImpersonatedTransaction::new` already accepts any `T`.