### PR TITLE
refactor(anvil): generalize PoolTransaction TryFrom impl

### DIFF
--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -1,12 +1,16 @@
 use crate::eth::{error::PoolError, util::hex_fmt_many};
-use alloy_consensus::{Transaction, Typed2718};
+use alloy_consensus::{
+    Transaction, Typed2718,
+    crypto::RecoveryError,
+    transaction::{SignerRecoverable, TxHashRef},
+};
 use alloy_network::AnyRpcTransaction;
 use alloy_primitives::{
     Address, TxHash,
     map::{HashMap, HashSet},
 };
+use alloy_rlp::Encodable;
 use anvil_core::eth::transaction::PendingTransaction;
-use foundry_primitives::FoundryTxEnvelope;
 use parking_lot::RwLock;
 use std::{cmp::Ordering, collections::BTreeSet, fmt, str::FromStr, sync::Arc, time::Instant};
 
@@ -128,10 +132,15 @@ impl<T: fmt::Debug> fmt::Debug for PoolTransaction<T> {
     }
 }
 
-impl TryFrom<AnyRpcTransaction> for PoolTransaction<FoundryTxEnvelope> {
+impl<T> TryFrom<AnyRpcTransaction> for PoolTransaction<T>
+where
+    T: SignerRecoverable + TxHashRef + Encodable + TryFrom<AnyRpcTransaction>,
+    <T as TryFrom<AnyRpcTransaction>>::Error: Into<eyre::Error>,
+    RecoveryError: Into<eyre::Error>,
+{
     type Error = eyre::Error;
     fn try_from(value: AnyRpcTransaction) -> Result<Self, Self::Error> {
-        let typed_transaction = FoundryTxEnvelope::try_from(value)?;
+        let typed_transaction = T::try_from(value).map_err(Into::into)?;
         let pending_transaction = PendingTransaction::new(typed_transaction)?;
         Ok(Self {
             pending_transaction,


### PR DESCRIPTION
Generalize `TryFrom<AnyRpcTransaction>` from `PoolTransaction<FoundryTxEnvelope>` to `PoolTransaction<T>` for any transaction type that supports signer recovery and conversion from `AnyRpcTransaction`.