### PR TITLE
fix(ci): import `TxEnv` in EVM cheatcodes

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -36,7 +36,7 @@ use rand::Rng;
 use revm::{
     Database,
     bytecode::Bytecode,
-    context::{Block, Cfg, ContextTr, JournalTr, Transaction, result::ExecutionResult},
+    context::{Block, Cfg, ContextTr, JournalTr, Transaction, TxEnv, result::ExecutionResult},
     inspector::JournalExt,
     primitives::{KECCAK_EMPTY, hardfork::SpecId},
     state::{Account, AccountStatus},


### PR DESCRIPTION
## Summary
- import `TxEnv` in `crates/cheatcodes/src/evm.rs`
- fix the missing-type compile error introduced in the new cheatcode bounds
- unblock CI jobs that compile `foundry-cheatcodes`

## Root Cause
CI run `23733776562` failed because `crates/cheatcodes/src/evm.rs` referenced `TxEnv` in generic bounds for `broadcastRawTransactionCall` and `executeTransactionCall`, but the module did not import that type.