### PR TITLE
chore(evm): remove `new_revm_with_inspector` helper

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -38,7 +38,7 @@ use foundry_evm_core::{
     backend::{DatabaseError, DatabaseExt, RevertDiagnostic},
     constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME},
     env::FoundryContextExt,
-    evm::{NestedEvm, NestedEvmClosure, new_revm_with_inspector, with_cloned_context},
+    evm::{NestedEvm, NestedEvmClosure, new_eth_evm_with_inspector, with_cloned_context},
 };
 use foundry_evm_traces::{
     TracingInspector, TracingInspectorConfig, identifier::SignaturesIdentifier,
@@ -185,7 +185,7 @@ impl<
         f: NestedEvmClosure<'_, CTX::Tx>,
     ) -> Result<(), EVMError<DatabaseError>> {
         with_cloned_context(ecx, |db, evm_env, journal_inner| {
-            let mut evm = new_revm_with_inspector(db, evm_env, cheats);
+            let mut evm = new_eth_evm_with_inspector(db, evm_env, cheats).inner;
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
             let sub_inner = evm.journaled_state.inner.clone();
@@ -201,7 +201,7 @@ impl<
         evm_env: EvmEnv<CTX::Spec, CTX::Block>,
         f: NestedEvmClosure<'_, CTX::Tx>,
     ) -> Result<EvmEnv<CTX::Spec, CTX::Block>, EVMError<DatabaseError>> {
-        let mut evm = new_revm_with_inspector(db, evm_env, cheats);
+        let mut evm = new_eth_evm_with_inspector(db, evm_env, cheats).inner;
         f(&mut evm)?;
         Ok(evm.ctx_ref().evm_clone())
     }

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -31,22 +31,6 @@ use revm::{
     primitives::hardfork::SpecId,
 };
 
-pub fn new_revm_with_inspector<
-    'db,
-    I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt>>,
->(
-    db: &'db mut dyn DatabaseExt,
-    evm_env: EvmEnv,
-    inspector: I,
-) -> EthRevmEvm<'db, I> {
-    let mut revm = alloy_evm::EthEvmFactory::default()
-        .create_evm_with_inspector(db, evm_env, inspector)
-        .into_inner();
-    revm.ctx.cfg.tx_chain_id_check = true;
-    revm.inspector.get_networks().inject_precompiles(&mut revm.precompiles);
-    revm
-}
-
 pub fn new_eth_evm_with_inspector<
     'db,
     I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt>>,
@@ -95,7 +79,7 @@ type EthRevmEvm<'db, I> = RevmEvm<
 >;
 
 pub struct FoundryEvm<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt>>> {
-    inner: EthRevmEvm<'db, I>,
+    pub inner: EthRevmEvm<'db, I>,
 }
 
 impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt>>> Evm

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -13,7 +13,7 @@ use foundry_evm_core::{
     FoundryBlock, FoundryTransaction, InspectorExt,
     backend::{DatabaseError, DatabaseExt, JournaledState},
     env::FoundryContextExt,
-    evm::{NestedEvm, new_revm_with_inspector, with_cloned_context},
+    evm::{NestedEvm, new_eth_evm_with_inspector, with_cloned_context},
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_networks::NetworkConfigs;
@@ -374,7 +374,7 @@ impl<
     ) -> Result<(), EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         with_cloned_context(ecx, |db, evm_env, journal_inner| {
-            let mut evm = new_revm_with_inspector(db, evm_env, &mut inspector);
+            let mut evm = new_eth_evm_with_inspector(db, evm_env, &mut inspector).inner;
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
             let sub_inner = evm.journaled_state.inner.clone();
@@ -391,7 +391,7 @@ impl<
         f: NestedEvmClosure<'_, CTX::Tx>,
     ) -> Result<EvmEnv<CTX::Spec, CTX::Block>, EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
-        let mut evm = new_revm_with_inspector(db, evm_env, &mut inspector);
+        let mut evm = new_eth_evm_with_inspector(db, evm_env, &mut inspector).inner;
         f(&mut evm)?;
         Ok(evm.ctx_ref().evm_clone())
     }
@@ -760,7 +760,7 @@ impl InspectorStackRefMut<'_> {
         let res = self.with_inspector(|mut inspector| {
             let (res, nested_env) = {
                 let (db, journal) = ecx.db_journal_inner_mut();
-                let mut evm = new_revm_with_inspector(db, evm_env, &mut inspector);
+                let mut evm = new_eth_evm_with_inspector(db, evm_env, &mut inspector).inner;
 
                 evm.journal_inner_mut().state = {
                     let mut state = journal.state.clone();


### PR DESCRIPTION
## Motivation

As `alloy_evm::Evm` impls Eth/Op/Tempo now have `into_inner()` method to get underlying revm's `Evm`. We can  remove `new_revm_with_inspector` helper.

When evm factory is going to be introduced we'll simply call `into_inner()` and then operate with `NestedEvm` trait impl.
