### PR TITLE
feat(cheatcodes): generic `Cheatcodes`, `InspectorStack`, `CheatcodesExecutor`

### DIFF
--- a/crates/cheatcodes/src/base64.rs
+++ b/crates/cheatcodes/src/base64.rs
@@ -1,4 +1,5 @@
 use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
+use alloy_network::Network;
 use alloy_sol_types::SolValue;
 use base64::prelude::*;
 
@@ -11,28 +12,28 @@ fn encode_base64_url(data: impl AsRef<[u8]>) -> Result {
 }
 
 impl Cheatcode for toBase64_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { data } = self;
         encode_base64(data)
     }
 }
 
 impl Cheatcode for toBase64_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { data } = self;
         encode_base64(data)
     }
 }
 
 impl Cheatcode for toBase64URL_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { data } = self;
         encode_base64_url(data)
     }
 }
 
 impl Cheatcode for toBase64URL_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { data } = self;
         encode_base64_url(data)
     }

--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -1,6 +1,7 @@
 //! Implementations of [`Crypto`](spec::Group::Crypto) Cheatcodes.
 
 use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
+use alloy_network::Network;
 use alloy_primitives::{Address, B256, U256, keccak256};
 use alloy_signer::{Signer, SignerSync};
 use alloy_signer_local::{
@@ -30,28 +31,28 @@ use ed25519_consensus::{
 const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/60'/0'/0/";
 
 impl Cheatcode for createWallet_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { walletLabel } = self;
         create_wallet(&U256::from_be_bytes(keccak256(walletLabel).0), Some(walletLabel), state)
     }
 }
 
 impl Cheatcode for createWallet_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { privateKey } = self;
         create_wallet(privateKey, None, state)
     }
 }
 
 impl Cheatcode for createWallet_2Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { privateKey, walletLabel } = self;
         create_wallet(privateKey, Some(walletLabel), state)
     }
 }
 
 impl Cheatcode for sign_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { wallet, digest } = self;
         let sig = sign(&wallet.privateKey, digest)?;
         Ok(encode_full_sig(sig))
@@ -59,7 +60,7 @@ impl Cheatcode for sign_0Call {
 }
 
 impl Cheatcode for signWithNonceUnsafeCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let pk: U256 = self.privateKey;
         let digest: B256 = self.digest;
         let nonce: U256 = self.nonce;
@@ -69,7 +70,7 @@ impl Cheatcode for signWithNonceUnsafeCall {
 }
 
 impl Cheatcode for signCompact_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { wallet, digest } = self;
         let sig = sign(&wallet.privateKey, digest)?;
         Ok(encode_compact_sig(sig))
@@ -77,35 +78,35 @@ impl Cheatcode for signCompact_0Call {
 }
 
 impl Cheatcode for deriveKey_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { mnemonic, index } = self;
         derive_key::<English>(mnemonic, DEFAULT_DERIVATION_PATH_PREFIX, *index)
     }
 }
 
 impl Cheatcode for deriveKey_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { mnemonic, derivationPath, index } = self;
         derive_key::<English>(mnemonic, derivationPath, *index)
     }
 }
 
 impl Cheatcode for deriveKey_2Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { mnemonic, index, language } = self;
         derive_key_str(mnemonic, DEFAULT_DERIVATION_PATH_PREFIX, *index, language)
     }
 }
 
 impl Cheatcode for deriveKey_3Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { mnemonic, derivationPath, index, language } = self;
         derive_key_str(mnemonic, derivationPath, *index, language)
     }
 }
 
 impl Cheatcode for rememberKeyCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { privateKey } = self;
         let wallet = parse_wallet(privateKey)?;
         let address = inject_wallet(state, wallet);
@@ -114,7 +115,7 @@ impl Cheatcode for rememberKeyCall {
 }
 
 impl Cheatcode for rememberKeys_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { mnemonic, derivationPath, count } = self;
         let wallets = derive_wallets::<English>(mnemonic, derivationPath, *count)?;
         let mut addresses = Vec::<Address>::with_capacity(wallets.len());
@@ -128,7 +129,7 @@ impl Cheatcode for rememberKeys_0Call {
 }
 
 impl Cheatcode for rememberKeys_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { mnemonic, derivationPath, language, count } = self;
         let wallets = derive_wallets_str(mnemonic, derivationPath, language, *count)?;
         let mut addresses = Vec::<Address>::with_capacity(wallets.len());
@@ -141,14 +142,17 @@ impl Cheatcode for rememberKeys_1Call {
     }
 }
 
-fn inject_wallet(state: &mut Cheatcodes, wallet: LocalSigner<SigningKey>) -> Address {
+fn inject_wallet<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+    wallet: LocalSigner<SigningKey>,
+) -> Address {
     let address = wallet.address();
     state.wallets().add_local_signer(wallet);
     address
 }
 
 impl Cheatcode for sign_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { privateKey, digest } = self;
         let sig = sign(privateKey, digest)?;
         Ok(encode_full_sig(sig))
@@ -156,7 +160,7 @@ impl Cheatcode for sign_1Call {
 }
 
 impl Cheatcode for signCompact_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { privateKey, digest } = self;
         let sig = sign(privateKey, digest)?;
         Ok(encode_compact_sig(sig))
@@ -164,7 +168,7 @@ impl Cheatcode for signCompact_1Call {
 }
 
 impl Cheatcode for sign_2Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { digest } = self;
         let sig = sign_with_wallet(state, None, digest)?;
         Ok(encode_full_sig(sig))
@@ -172,7 +176,7 @@ impl Cheatcode for sign_2Call {
 }
 
 impl Cheatcode for signCompact_2Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { digest } = self;
         let sig = sign_with_wallet(state, None, digest)?;
         Ok(encode_compact_sig(sig))
@@ -180,7 +184,7 @@ impl Cheatcode for signCompact_2Call {
 }
 
 impl Cheatcode for sign_3Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { signer, digest } = self;
         let sig = sign_with_wallet(state, Some(*signer), digest)?;
         Ok(encode_full_sig(sig))
@@ -188,7 +192,7 @@ impl Cheatcode for sign_3Call {
 }
 
 impl Cheatcode for signCompact_3Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { signer, digest } = self;
         let sig = sign_with_wallet(state, Some(*signer), digest)?;
         Ok(encode_compact_sig(sig))
@@ -196,14 +200,14 @@ impl Cheatcode for signCompact_3Call {
 }
 
 impl Cheatcode for signP256Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { privateKey, digest } = self;
         sign_p256(privateKey, digest)
     }
 }
 
 impl Cheatcode for publicKeyP256Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { privateKey } = self;
         let pub_key =
             parse_private_key_p256(privateKey)?.verifying_key().as_affine().to_encoded_point(false);
@@ -215,28 +219,28 @@ impl Cheatcode for publicKeyP256Call {
 }
 
 impl Cheatcode for createEd25519KeyCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { salt } = self;
         create_ed25519_key(salt)
     }
 }
 
 impl Cheatcode for publicKeyEd25519Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { privateKey } = self;
         public_key_ed25519(privateKey)
     }
 }
 
 impl Cheatcode for signEd25519Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { namespace, message, privateKey } = self;
         sign_ed25519(namespace, message, privateKey)
     }
 }
 
 impl Cheatcode for verifyEd25519Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { signature, namespace, message, publicKey } = self;
         verify_ed25519(signature, namespace, message, publicKey)
     }
@@ -246,7 +250,11 @@ impl Cheatcode for verifyEd25519Call {
 /// coordinates, and its private key (see the 'Wallet' struct)
 ///
 /// If 'label' is set to 'Some()', assign that label to the associated ETH address in state
-fn create_wallet(private_key: &U256, label: Option<&str>, state: &mut Cheatcodes) -> Result {
+fn create_wallet<SPEC, BLOCK, N: Network>(
+    private_key: &U256,
+    label: Option<&str>,
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+) -> Result {
     let key = parse_private_key(private_key)?;
     let addr = alloy_signer::utils::secret_key_to_address(&key);
 
@@ -366,8 +374,8 @@ fn sign_with_nonce(
     Ok(alloy_primitives::Signature::new(r_u256, s_u256, y_parity))
 }
 
-fn sign_with_wallet(
-    state: &mut Cheatcodes,
+fn sign_with_wallet<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
     signer: Option<Address>,
     digest: &B256,
 ) -> Result<alloy_primitives::Signature> {

--- a/crates/cheatcodes/src/env.rs
+++ b/crates/cheatcodes/src/env.rs
@@ -2,6 +2,7 @@
 
 use crate::{Cheatcode, Cheatcodes, Error, Result, Vm::*, string};
 use alloy_dyn_abi::DynSolType;
+use alloy_network::Network;
 use alloy_sol_types::SolValue;
 use std::{env, sync::OnceLock};
 
@@ -9,7 +10,7 @@ use std::{env, sync::OnceLock};
 pub static FORGE_CONTEXT: OnceLock<ForgeContext> = OnceLock::new();
 
 impl Cheatcode for setEnvCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name: key, value } = self;
         if key.is_empty() {
             Err(fmt_err!("environment variable key can't be empty"))
@@ -29,7 +30,7 @@ impl Cheatcode for setEnvCall {
 }
 
 impl Cheatcode for resolveEnvCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { input } = self;
         let resolved = foundry_config::resolve::interpolate(input)
             .map_err(|e| fmt_err!("failed to resolve env var: {e}"))?;
@@ -38,105 +39,105 @@ impl Cheatcode for resolveEnvCall {
 }
 
 impl Cheatcode for envExistsCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name } = self;
         Ok(env::var(name).is_ok().abi_encode())
     }
 }
 
 impl Cheatcode for envBool_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for envUint_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for envInt_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for envAddress_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for envBytes32_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for envString_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::String)
     }
 }
 
 impl Cheatcode for envBytes_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Bytes)
     }
 }
 
 impl Cheatcode for envBool_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for envUint_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for envInt_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for envAddress_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for envBytes32_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for envString_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::String)
     }
 }
 
 impl Cheatcode for envBytes_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Bytes)
     }
@@ -144,7 +145,7 @@ impl Cheatcode for envBytes_1Call {
 
 // bool
 impl Cheatcode for envOr_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Bool)
     }
@@ -152,7 +153,7 @@ impl Cheatcode for envOr_0Call {
 
 // uint256
 impl Cheatcode for envOr_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Uint(256))
     }
@@ -160,7 +161,7 @@ impl Cheatcode for envOr_1Call {
 
 // int256
 impl Cheatcode for envOr_2Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Int(256))
     }
@@ -168,7 +169,7 @@ impl Cheatcode for envOr_2Call {
 
 // address
 impl Cheatcode for envOr_3Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Address)
     }
@@ -176,7 +177,7 @@ impl Cheatcode for envOr_3Call {
 
 // bytes32
 impl Cheatcode for envOr_4Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::FixedBytes(32))
     }
@@ -184,7 +185,7 @@ impl Cheatcode for envOr_4Call {
 
 // string
 impl Cheatcode for envOr_5Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::String)
     }
@@ -192,7 +193,7 @@ impl Cheatcode for envOr_5Call {
 
 // bytes
 impl Cheatcode for envOr_6Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Bytes)
     }
@@ -200,7 +201,7 @@ impl Cheatcode for envOr_6Call {
 
 // bool[]
 impl Cheatcode for envOr_7Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::Bool)
     }
@@ -208,7 +209,7 @@ impl Cheatcode for envOr_7Call {
 
 // uint256[]
 impl Cheatcode for envOr_8Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::Uint(256))
     }
@@ -216,7 +217,7 @@ impl Cheatcode for envOr_8Call {
 
 // int256[]
 impl Cheatcode for envOr_9Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::Int(256))
     }
@@ -224,7 +225,7 @@ impl Cheatcode for envOr_9Call {
 
 // address[]
 impl Cheatcode for envOr_10Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::Address)
     }
@@ -232,7 +233,7 @@ impl Cheatcode for envOr_10Call {
 
 // bytes32[]
 impl Cheatcode for envOr_11Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::FixedBytes(32))
     }
@@ -240,7 +241,7 @@ impl Cheatcode for envOr_11Call {
 
 // string[]
 impl Cheatcode for envOr_12Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::String)
     }
@@ -248,7 +249,7 @@ impl Cheatcode for envOr_12Call {
 
 // bytes[]
 impl Cheatcode for envOr_13Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name, delim, defaultValue } = self;
         let default = defaultValue.to_vec();
         env_array_default(name, delim, &default, &DynSolType::Bytes)
@@ -256,7 +257,7 @@ impl Cheatcode for envOr_13Call {
 }
 
 impl Cheatcode for isContextCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { context } = self;
         Ok((FORGE_CONTEXT.get() == Some(context)).abi_encode())
     }

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -4,10 +4,10 @@ use crate::{
     BroadcastableTransaction, Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Error, Result,
     Vm::*, inspector::RecordDebugStepInfo,
 };
-use alloy_consensus::{TxEnvelope, transaction::SignerRecoverable};
+use alloy_consensus::transaction::SignerRecoverable;
 use alloy_evm::FromRecoveredTx;
 use alloy_genesis::{Genesis, GenesisAccount};
-use alloy_network::eip2718::EIP4844_TX_TYPE_ID;
+use alloy_network::{Network, eip2718::EIP4844_TX_TYPE_ID};
 use alloy_primitives::{
     Address, B256, U256, hex, keccak256,
     map::{B256Map, HashMap},
@@ -36,7 +36,7 @@ use rand::Rng;
 use revm::{
     Database,
     bytecode::Bytecode,
-    context::{Block, Cfg, ContextTr, JournalTr, Transaction, TxEnv, result::ExecutionResult},
+    context::{Block, Cfg, ContextTr, JournalTr, Transaction, result::ExecutionResult},
     inspector::JournalExt,
     primitives::{KECCAK_EMPTY, hardfork::SpecId},
     state::{Account, AccountStatus},
@@ -50,7 +50,7 @@ use std::{
 
 mod record_debug_step;
 use foundry_common::fmt::format_token_raw;
-use foundry_config::evm_spec_id;
+use foundry_config::{FromEvmVersion, evm_spec_id};
 use record_debug_step::{convert_call_trace_ctx_to_debug_step, flatten_call_trace};
 use serde::Serialize;
 
@@ -246,7 +246,7 @@ impl Display for AccountStateDiffs {
 }
 
 impl Cheatcode for addrCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { privateKey } = self;
         let wallet = super::crypto::parse_wallet(privateKey)?;
         Ok(wallet.address().abi_encode())
@@ -254,9 +254,9 @@ impl Cheatcode for addrCall {
 }
 
 impl Cheatcode for getNonce_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { account } = self;
         get_nonce(ccx, account)
@@ -264,9 +264,9 @@ impl Cheatcode for getNonce_0Call {
 }
 
 impl Cheatcode for getNonce_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { wallet } = self;
         get_nonce(ccx, &wallet.addr)
@@ -274,9 +274,9 @@ impl Cheatcode for getNonce_1Call {
 }
 
 impl Cheatcode for loadCall {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { target, slot } = *self;
         ccx.ensure_not_precompile(&target)?;
@@ -319,9 +319,12 @@ impl Cheatcode for loadCall {
 }
 
 impl Cheatcode for loadAllocsCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { pathToAllocsJson } = self;
 
@@ -347,9 +350,12 @@ impl Cheatcode for loadAllocsCall {
 }
 
 impl Cheatcode for cloneAccountCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { source, target } = self;
 
@@ -364,9 +370,9 @@ impl Cheatcode for cloneAccountCall {
 }
 
 impl Cheatcode for dumpStateCall {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { pathToStateJson } = self;
         let path = Path::new(pathToStateJson);
@@ -397,7 +403,7 @@ impl Cheatcode for dumpStateCall {
 }
 
 impl Cheatcode for recordCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         state.recording_accesses = true;
         state.accesses.clear();
@@ -406,14 +412,14 @@ impl Cheatcode for recordCall {
 }
 
 impl Cheatcode for stopRecordCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         state.recording_accesses = false;
         Ok(Default::default())
     }
 }
 
 impl Cheatcode for accessesCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { target } = *self;
         let result = (
             state.accesses.reads.entry(target).or_default().as_slice(),
@@ -424,7 +430,7 @@ impl Cheatcode for accessesCall {
 }
 
 impl Cheatcode for recordLogsCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         state.recorded_logs = Some(Default::default());
         Ok(Default::default())
@@ -432,14 +438,14 @@ impl Cheatcode for recordLogsCall {
 }
 
 impl Cheatcode for getRecordedLogsCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         Ok(state.recorded_logs.replace(Default::default()).unwrap_or_default().abi_encode())
     }
 }
 
 impl Cheatcode for getRecordedLogsJsonCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         let logs = state.recorded_logs.replace(Default::default()).unwrap_or_default();
         let json_logs: Vec<_> = logs
@@ -455,7 +461,7 @@ impl Cheatcode for getRecordedLogsJsonCall {
 }
 
 impl Cheatcode for pauseGasMeteringCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         state.gas_metering.paused = true;
         Ok(Default::default())
@@ -463,7 +469,7 @@ impl Cheatcode for pauseGasMeteringCall {
 }
 
 impl Cheatcode for resumeGasMeteringCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         state.gas_metering.resume();
         Ok(Default::default())
@@ -471,7 +477,7 @@ impl Cheatcode for resumeGasMeteringCall {
 }
 
 impl Cheatcode for resetGasMeteringCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         state.gas_metering.reset();
         Ok(Default::default())
@@ -479,7 +485,7 @@ impl Cheatcode for resetGasMeteringCall {
 }
 
 impl Cheatcode for lastCallGasCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         let Some(last_call_gas) = &state.gas_metering.last_call_gas else {
             bail!("no external call was made yet");
@@ -489,14 +495,20 @@ impl Cheatcode for lastCallGasCall {
 }
 
 impl Cheatcode for getChainIdCall {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self {} = self;
         Ok(U256::from(ccx.ecx.cfg().chain_id()).abi_encode())
     }
 }
 
 impl Cheatcode for chainIdCall {
-    fn apply_stateful<CTX: FoundryContextExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { newChainId } = self;
         ensure!(*newChainId <= U256::from(u64::MAX), "chain ID must be less than 2^64");
         ccx.ecx.cfg_mut().chain_id = newChainId.to();
@@ -505,7 +517,10 @@ impl Cheatcode for chainIdCall {
 }
 
 impl Cheatcode for coinbaseCall {
-    fn apply_stateful<CTX: FoundryContextExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { newCoinbase } = self;
         ccx.ecx.block_mut().set_beneficiary(*newCoinbase);
         Ok(Default::default())
@@ -513,7 +528,10 @@ impl Cheatcode for coinbaseCall {
 }
 
 impl Cheatcode for difficultyCall {
-    fn apply_stateful<CTX: FoundryContextExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { newDifficulty } = self;
         ensure!(
             (*ccx.ecx.cfg().spec()).into() < SpecId::MERGE,
@@ -526,7 +544,10 @@ impl Cheatcode for difficultyCall {
 }
 
 impl Cheatcode for feeCall {
-    fn apply_stateful<CTX: FoundryContextExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { newBasefee } = self;
         ensure!(*newBasefee <= U256::from(u64::MAX), "base fee must be less than 2^64");
         ccx.ecx.block_mut().set_basefee(newBasefee.saturating_to());
@@ -535,7 +556,10 @@ impl Cheatcode for feeCall {
 }
 
 impl Cheatcode for prevrandao_0Call {
-    fn apply_stateful<CTX: FoundryContextExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { newPrevrandao } = self;
         ensure!(
             (*ccx.ecx.cfg().spec()).into() >= SpecId::MERGE,
@@ -548,7 +572,10 @@ impl Cheatcode for prevrandao_0Call {
 }
 
 impl Cheatcode for prevrandao_1Call {
-    fn apply_stateful<CTX: FoundryContextExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { newPrevrandao } = self;
         ensure!(
             (*ccx.ecx.cfg().spec()).into() >= SpecId::MERGE,
@@ -561,7 +588,10 @@ impl Cheatcode for prevrandao_1Call {
 }
 
 impl Cheatcode for blobhashesCall {
-    fn apply_stateful<CTX: FoundryContextExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { hashes } = self;
         ensure!(
             (*ccx.ecx.cfg().spec()).into() >= SpecId::CANCUN,
@@ -576,7 +606,10 @@ impl Cheatcode for blobhashesCall {
 }
 
 impl Cheatcode for getBlobhashesCall {
-    fn apply_stateful<CTX: FoundryContextExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self {} = self;
         ensure!(
             (*ccx.ecx.cfg().spec()).into() >= SpecId::CANCUN,
@@ -588,7 +621,10 @@ impl Cheatcode for getBlobhashesCall {
 }
 
 impl Cheatcode for rollCall {
-    fn apply_stateful<CTX: FoundryContextExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { newHeight } = self;
         ccx.ecx.block_mut().set_number(*newHeight);
         Ok(Default::default())
@@ -596,14 +632,20 @@ impl Cheatcode for rollCall {
 }
 
 impl Cheatcode for getBlockNumberCall {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self {} = self;
         Ok(ccx.ecx.block().number().abi_encode())
     }
 }
 
 impl Cheatcode for txGasPriceCall {
-    fn apply_stateful<CTX: FoundryContextExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { newGasPrice } = self;
         ensure!(*newGasPrice <= U256::from(u64::MAX), "gas price must be less than 2^64");
         ccx.ecx.tx_mut().set_gas_price(newGasPrice.saturating_to());
@@ -612,7 +654,10 @@ impl Cheatcode for txGasPriceCall {
 }
 
 impl Cheatcode for warpCall {
-    fn apply_stateful<CTX: FoundryContextExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { newTimestamp } = self;
         ccx.ecx.block_mut().set_timestamp(*newTimestamp);
         Ok(Default::default())
@@ -620,14 +665,20 @@ impl Cheatcode for warpCall {
 }
 
 impl Cheatcode for getBlockTimestampCall {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self {} = self;
         Ok(ccx.ecx.block().timestamp().abi_encode())
     }
 }
 
 impl Cheatcode for blobBaseFeeCall {
-    fn apply_stateful<CTX: FoundryContextExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { newBlobBaseFee } = self;
         ensure!(
             (*ccx.ecx.cfg().spec()).into() >= SpecId::CANCUN,
@@ -645,16 +696,22 @@ impl Cheatcode for blobBaseFeeCall {
 }
 
 impl Cheatcode for getBlobBaseFeeCall {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self {} = self;
         Ok(ccx.ecx.block().blob_excess_gas().unwrap_or(0).abi_encode())
     }
 }
 
 impl Cheatcode for dealCall {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>>(
+    fn apply_stateful<
+        CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { account: address, newBalance: new_balance } = *self;
         let account = journaled_account(ccx.ecx, address)?;
@@ -666,9 +723,9 @@ impl Cheatcode for dealCall {
 }
 
 impl Cheatcode for etchCall {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { target, newRuntimeBytecode } = self;
         ccx.ensure_not_precompile(target)?;
@@ -681,9 +738,12 @@ impl Cheatcode for etchCall {
 }
 
 impl Cheatcode for resetNonceCall {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>>(
+    fn apply_stateful<
+        CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { account } = self;
         let account = journaled_account(ccx.ecx, *account)?;
@@ -699,9 +759,12 @@ impl Cheatcode for resetNonceCall {
 }
 
 impl Cheatcode for setNonceCall {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>>(
+    fn apply_stateful<
+        CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { account, newNonce } = *self;
         let account = journaled_account(ccx.ecx, account)?;
@@ -718,9 +781,12 @@ impl Cheatcode for setNonceCall {
 }
 
 impl Cheatcode for setNonceUnsafeCall {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>>(
+    fn apply_stateful<
+        CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { account, newNonce } = *self;
         let account = journaled_account(ccx.ecx, account)?;
@@ -730,9 +796,9 @@ impl Cheatcode for setNonceUnsafeCall {
 }
 
 impl Cheatcode for storeCall {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { target, slot, value } = *self;
         ccx.ensure_not_precompile(&target)?;
@@ -746,9 +812,9 @@ impl Cheatcode for storeCall {
 }
 
 impl Cheatcode for coolCall {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { target } = self;
         if let Some(account) = ccx.ecx.journal_mut().evm_state_mut().get_mut(target) {
@@ -760,7 +826,7 @@ impl Cheatcode for coolCall {
 }
 
 impl Cheatcode for accessListCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { access } = self;
         let access_list = access
             .iter()
@@ -775,7 +841,7 @@ impl Cheatcode for accessListCall {
 }
 
 impl Cheatcode for noAccessListCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         // Set to empty option in order to override previous applied access list.
         if state.access_list.is_some() {
@@ -786,9 +852,9 @@ impl Cheatcode for noAccessListCall {
 }
 
 impl Cheatcode for warmSlotCall {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { target, slot } = *self;
         set_cold_slot(ccx, target, slot.into(), false);
@@ -797,9 +863,9 @@ impl Cheatcode for warmSlotCall {
 }
 
 impl Cheatcode for coolSlotCall {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { target, slot } = *self;
         set_cold_slot(ccx, target, slot.into(), true);
@@ -808,28 +874,40 @@ impl Cheatcode for coolSlotCall {
 }
 
 impl Cheatcode for readCallersCall {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self {} = self;
         read_callers(ccx.state, &ccx.ecx.tx().caller(), ccx.ecx.journal().depth())
     }
 }
 
 impl Cheatcode for snapshotValue_0Call {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { name, value } = self;
         inner_value_snapshot(ccx, None, Some(name.clone()), value.to_string())
     }
 }
 
 impl Cheatcode for snapshotValue_1Call {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { group, name, value } = self;
         inner_value_snapshot(ccx, Some(group.clone()), Some(name.clone()), value.to_string())
     }
 }
 
 impl Cheatcode for snapshotGasLastCall_0Call {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { name } = self;
         let Some(last_call_gas) = &ccx.state.gas_metering.last_call_gas else {
             bail!("no external call was made yet");
@@ -839,7 +917,10 @@ impl Cheatcode for snapshotGasLastCall_0Call {
 }
 
 impl Cheatcode for snapshotGasLastCall_1Call {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { name, group } = self;
         let Some(last_call_gas) = &ccx.state.gas_metering.last_call_gas else {
             bail!("no external call was made yet");
@@ -854,35 +935,50 @@ impl Cheatcode for snapshotGasLastCall_1Call {
 }
 
 impl Cheatcode for startSnapshotGas_0Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { name } = self;
         inner_start_gas_snapshot(ccx, None, Some(name.clone()))
     }
 }
 
 impl Cheatcode for startSnapshotGas_1Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { group, name } = self;
         inner_start_gas_snapshot(ccx, Some(group.clone()), Some(name.clone()))
     }
 }
 
 impl Cheatcode for stopSnapshotGas_0Call {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self {} = self;
         inner_stop_gas_snapshot(ccx, None, None)
     }
 }
 
 impl Cheatcode for stopSnapshotGas_1Call {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { name } = self;
         inner_stop_gas_snapshot(ccx, None, Some(name.clone()))
     }
 }
 
 impl Cheatcode for stopSnapshotGas_2Call {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { group, name } = self;
         inner_stop_gas_snapshot(ccx, Some(group.clone()), Some(name.clone()))
     }
@@ -890,9 +986,12 @@ impl Cheatcode for stopSnapshotGas_2Call {
 
 // Deprecated in favor of `snapshotStateCall`
 impl Cheatcode for snapshotCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self {} = self;
         inner_snapshot_state(ccx)
@@ -900,9 +999,12 @@ impl Cheatcode for snapshotCall {
 }
 
 impl Cheatcode for snapshotStateCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self {} = self;
         inner_snapshot_state(ccx)
@@ -911,9 +1013,12 @@ impl Cheatcode for snapshotStateCall {
 
 // Deprecated in favor of `revertToStateCall`
 impl Cheatcode for revertToCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state(ccx, *snapshotId)
@@ -921,9 +1026,12 @@ impl Cheatcode for revertToCall {
 }
 
 impl Cheatcode for revertToStateCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state(ccx, *snapshotId)
@@ -932,9 +1040,12 @@ impl Cheatcode for revertToStateCall {
 
 // Deprecated in favor of `revertToStateAndDeleteCall`
 impl Cheatcode for revertToAndDeleteCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state_and_delete(ccx, *snapshotId)
@@ -942,9 +1053,12 @@ impl Cheatcode for revertToAndDeleteCall {
 }
 
 impl Cheatcode for revertToStateAndDeleteCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state_and_delete(ccx, *snapshotId)
@@ -953,9 +1067,12 @@ impl Cheatcode for revertToStateAndDeleteCall {
 
 // Deprecated in favor of `deleteStateSnapshotCall`
 impl Cheatcode for deleteSnapshotCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { snapshotId } = self;
         let result = ccx.ecx.db_mut().delete_state_snapshot(*snapshotId);
@@ -964,9 +1081,12 @@ impl Cheatcode for deleteSnapshotCall {
 }
 
 impl Cheatcode for deleteStateSnapshotCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { snapshotId } = self;
         let result = ccx.ecx.db_mut().delete_state_snapshot(*snapshotId);
@@ -976,9 +1096,12 @@ impl Cheatcode for deleteStateSnapshotCall {
 
 // Deprecated in favor of `deleteStateSnapshotsCall`
 impl Cheatcode for deleteSnapshotsCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self {} = self;
         ccx.ecx.db_mut().delete_state_snapshots();
@@ -987,9 +1110,12 @@ impl Cheatcode for deleteSnapshotsCall {
 }
 
 impl Cheatcode for deleteStateSnapshotsCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self {} = self;
         ccx.ecx.db_mut().delete_state_snapshots();
@@ -998,7 +1124,7 @@ impl Cheatcode for deleteStateSnapshotsCall {
 }
 
 impl Cheatcode for startStateDiffRecordingCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         state.recorded_account_diffs_stack = Some(Default::default());
         // Enable mapping recording to track mapping slot accesses
@@ -1008,14 +1134,17 @@ impl Cheatcode for startStateDiffRecordingCall {
 }
 
 impl Cheatcode for stopAndReturnStateDiffCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         get_state_diff(state)
     }
 }
 
 impl Cheatcode for getStateDiffCall {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let mut diffs = String::new();
         let state_diffs = get_recorded_state_diffs(ccx);
         for (address, state_diffs) in state_diffs {
@@ -1027,14 +1156,20 @@ impl Cheatcode for getStateDiffCall {
 }
 
 impl Cheatcode for getStateDiffJsonCall {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let state_diffs = get_recorded_state_diffs(ccx);
         Ok(serde_json::to_string(&state_diffs)?.abi_encode())
     }
 }
 
 impl Cheatcode for getStorageSlotsCall {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { target, variableName } = self;
 
         let storage_layout = get_contract_data(ccx, *target)
@@ -1112,7 +1247,7 @@ impl Cheatcode for getStorageSlotsCall {
 }
 
 impl Cheatcode for getStorageAccessesCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let mut storage_accesses = Vec::new();
 
         if let Some(recorded_diffs) = &state.recorded_account_diffs_stack {
@@ -1127,17 +1262,23 @@ impl Cheatcode for getStorageAccessesCall {
 
 impl Cheatcode for broadcastRawTransactionCall {
     fn apply_full<
-        CTX: FoundryContextExt<Tx = TxEnv, Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        CTX: FoundryContextExt<
+                Tx: FromRecoveredTx<N::TxEnvelope>,
+                Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
+            >,
+        N: Network<TxEnvelope: Decodable + SignerRecoverable>,
     >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
-        let tx = TxEnvelope::decode(&mut self.data.as_ref())
+        let tx = N::TxEnvelope::decode(&mut self.data.as_ref())
             .map_err(|err| fmt_err!("failed to decode RLP-encoded transaction: {err}"))?;
 
-        let from = tx.recover_signer()?;
-        let tx_env = FromRecoveredTx::from_recovered_tx(&tx, from);
+        let sender =
+            tx.recover_signer().map_err(|err| fmt_err!("failed to recover signer: {err}"))?;
+        let tx_env = CTX::Tx::from_recovered_tx(&tx, sender);
+        let from = sender;
 
         executor.transact_from_tx_on_db(ccx.state, ccx.ecx, tx_env)?;
 
@@ -1153,9 +1294,12 @@ impl Cheatcode for broadcastRawTransactionCall {
 }
 
 impl Cheatcode for setBlockhashCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { blockNumber, blockHash } = *self;
         ensure!(blockNumber <= U256::from(u64::MAX), "blockNumber must be less than 2^64");
@@ -1171,10 +1315,13 @@ impl Cheatcode for setBlockhashCall {
 }
 
 impl Cheatcode for executeTransactionCall {
-    fn apply_full<CTX: FoundryContextExt<Tx = TxEnv>>(
+    fn apply_full<
+        CTX: FoundryContextExt<Tx: FromRecoveredTx<N::TxEnvelope>>,
+        N: Network<TxEnvelope: Decodable + SignerRecoverable>,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         use crate::env::FORGE_CONTEXT;
 
@@ -1186,15 +1333,13 @@ impl Cheatcode for executeTransactionCall {
         }
 
         // Decode the RLP-encoded signed transaction.
-        let tx = TxEnvelope::decode(&mut self.rawTx.as_ref())
+        let tx = N::TxEnvelope::decode(&mut self.rawTx.as_ref())
             .map_err(|err| fmt_err!("failed to decode RLP-encoded transaction: {err}"))?;
 
-        // Recover signer from the transaction signature.
+        // Build TxEnv from the recovered transaction.
         let sender =
             tx.recover_signer().map_err(|err| fmt_err!("failed to recover signer: {err}"))?;
-
-        // Build TxEnv from the recovered transaction.
-        let tx_env = FromRecoveredTx::from_recovered_tx(&tx, sender);
+        let tx_env = CTX::Tx::from_recovered_tx(&tx, sender);
 
         // Save current env for restoration after execution.
         let cached_evm_env = ccx.ecx.evm_clone();
@@ -1310,10 +1455,10 @@ impl Cheatcode for executeTransactionCall {
 }
 
 impl Cheatcode for startDebugTraceRecordingCall {
-    fn apply_full<CTX: ContextTr>(
+    fn apply_full<CTX: ContextTr, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             return Err(Error::from("no tracer initiated, consider adding -vvv flag"));
@@ -1340,10 +1485,10 @@ impl Cheatcode for startDebugTraceRecordingCall {
 }
 
 impl Cheatcode for stopAndReturnDebugTraceRecordingCall {
-    fn apply_full<CTX: ContextTr>(
+    fn apply_full<CTX: ContextTr, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             return Err(Error::from("no tracer initiated, consider adding -vvv flag"));
@@ -1379,7 +1524,10 @@ impl Cheatcode for stopAndReturnDebugTraceRecordingCall {
 }
 
 impl Cheatcode for setEvmVersionCall {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt<Spec: FromEvmVersion>, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { evm } = self;
         let spec_id = evm_spec_id(
             EvmVersion::from_str(evm)
@@ -1391,22 +1539,28 @@ impl Cheatcode for setEvmVersionCall {
 }
 
 impl Cheatcode for getEvmVersionCall {
-    fn apply_stateful<CTX: FoundryContextExt>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let spec = (*ccx.ecx.cfg().spec()).into();
         Ok(spec.to_string().to_lowercase().abi_encode())
     }
 }
 
-pub(super) fn get_nonce<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+pub(super) fn get_nonce<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     address: &Address,
 ) -> Result {
     let account = ccx.ecx.journal_mut().load_account(*address)?;
     Ok(account.data.info.nonce.abi_encode())
 }
 
-fn inner_snapshot_state<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn inner_snapshot_state<
+    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+    N: Network,
+>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
 ) -> Result {
     let evm_env = ccx.ecx.evm_clone();
     let (db, inner) = ccx.ecx.db_journal_inner_mut();
@@ -1416,8 +1570,9 @@ fn inner_snapshot_state<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::
 
 fn inner_revert_to_state<
     CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+    N: Network,
 >(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     snapshot_id: U256,
 ) -> Result {
     let mut evm_env = ccx.ecx.evm_clone();
@@ -1440,8 +1595,9 @@ fn inner_revert_to_state<
 
 fn inner_revert_to_state_and_delete<
     CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+    N: Network,
 >(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     snapshot_id: U256,
 ) -> Result {
     let mut evm_env = ccx.ecx.evm_clone();
@@ -1462,8 +1618,8 @@ fn inner_revert_to_state_and_delete<
     }
 }
 
-fn inner_value_snapshot<CTX>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn inner_value_snapshot<CTX: ContextTr, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     group: Option<String>,
     name: Option<String>,
     value: String,
@@ -1475,8 +1631,8 @@ fn inner_value_snapshot<CTX>(
     Ok(Default::default())
 }
 
-fn inner_last_gas_snapshot<CTX>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn inner_last_gas_snapshot<CTX: ContextTr, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     group: Option<String>,
     name: Option<String>,
     value: u64,
@@ -1488,8 +1644,8 @@ fn inner_last_gas_snapshot<CTX>(
     Ok(value.abi_encode())
 }
 
-fn inner_start_gas_snapshot<CTX: ContextTr>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn inner_start_gas_snapshot<CTX: ContextTr, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     group: Option<String>,
     name: Option<String>,
 ) -> Result {
@@ -1514,8 +1670,8 @@ fn inner_start_gas_snapshot<CTX: ContextTr>(
     Ok(Default::default())
 }
 
-fn inner_stop_gas_snapshot<CTX>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn inner_stop_gas_snapshot<CTX: ContextTr, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     group: Option<String>,
     name: Option<String>,
 ) -> Result {
@@ -1566,8 +1722,8 @@ fn inner_stop_gas_snapshot<CTX>(
 }
 
 // Derives the snapshot group and name from the provided group and name or the running contract.
-fn derive_snapshot_name<CTX>(
-    ccx: &CheatsCtxt<'_, CTX>,
+fn derive_snapshot_name<CTX: ContextTr, N: Network>(
+    ccx: &CheatsCtxt<'_, CTX, N>,
     group: Option<String>,
     name: Option<String>,
 ) -> (String, String) {
@@ -1601,7 +1757,11 @@ fn derive_snapshot_name<CTX>(
 /// - If no caller modification is active:
 ///     - caller_mode will be equal to [CallerMode::None],
 ///     - `msg.sender` and `tx.origin` will be equal to the default sender address.
-fn read_callers(state: &Cheatcodes, default_sender: &Address, call_depth: usize) -> Result {
+fn read_callers<SPEC, BLOCK, N: Network>(
+    state: &Cheatcodes<SPEC, BLOCK, N>,
+    default_sender: &Address,
+    call_depth: usize,
+) -> Result {
     let mut mode = CallerMode::None;
     let mut new_caller = default_sender;
     let mut new_origin = default_sender;
@@ -1651,7 +1811,7 @@ pub(super) fn ensure_loaded_account<CTX: ContextTr<Db: Database<Error = Database
 /// In the case where `stopAndReturnStateDiff` is called at a lower
 /// depth than `startStateDiffRecording`, multiple `Vec<RecordedAccountAccesses>`
 /// will be flattened, preserving the order of the accesses.
-fn get_state_diff(state: &mut Cheatcodes) -> Result {
+fn get_state_diff<SPEC, BLOCK, N: Network>(state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
     let res = state
         .recorded_account_diffs_stack
         .replace(Default::default())
@@ -1680,8 +1840,8 @@ fn genesis_account(account: &Account) -> GenesisAccount {
 }
 
 /// Helper function to returns state diffs recorded for each changed account.
-fn get_recorded_state_diffs<CTX: ContextTr>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn get_recorded_state_diffs<CTX: ContextTr, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
 ) -> BTreeMap<Address, AccountStateDiffs> {
     let mut state_diffs: BTreeMap<Address, AccountStateDiffs> = BTreeMap::default();
 
@@ -1859,8 +2019,8 @@ const EIP1822_PROXIABLE_SLOT: &str =
     "c5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7";
 
 /// Helper function to get the contract data from the deployed code at an address.
-fn get_contract_data<'a, CTX: ContextTr>(
-    ccx: &'a mut CheatsCtxt<'_, CTX>,
+fn get_contract_data<'a, CTX: ContextTr, N: Network>(
+    ccx: &'a mut CheatsCtxt<'_, CTX, N>,
     address: Address,
 ) -> Option<(&'a foundry_compilers::ArtifactId, &'a foundry_common::contracts::ContractData)> {
     // Check if we have available artifacts to match against
@@ -1902,8 +2062,8 @@ fn get_contract_data<'a, CTX: ContextTr>(
 }
 
 /// Helper function to set / unset cold storage slot of the target address.
-fn set_cold_slot<CTX: ContextTr<Journal: JournalExt>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn set_cold_slot<CTX: ContextTr<Journal: JournalExt>, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     target: Address,
     slot: U256,
     cold: bool,

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use alloy_dyn_abi::DynSolValue;
 use alloy_evm::EvmEnv;
-use alloy_network::AnyNetwork;
+use alloy_network::{AnyNetwork, Network};
 use alloy_primitives::{B256, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types::Filter;
@@ -14,9 +14,12 @@ use foundry_evm_core::{FoundryContextExt, backend::JournaledState, fork::CreateF
 use revm::context::ContextTr;
 
 impl Cheatcode for activeForkCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self {} = self;
         ccx.ecx
@@ -28,9 +31,12 @@ impl Cheatcode for activeForkCall {
 }
 
 impl Cheatcode for createFork_0Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { urlOrAlias } = self;
         create_fork(ccx, urlOrAlias, None)
@@ -38,9 +44,12 @@ impl Cheatcode for createFork_0Call {
 }
 
 impl Cheatcode for createFork_1Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { urlOrAlias, blockNumber } = self;
         create_fork(ccx, urlOrAlias, Some(blockNumber.saturating_to()))
@@ -48,9 +57,12 @@ impl Cheatcode for createFork_1Call {
 }
 
 impl Cheatcode for createFork_2Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { urlOrAlias, txHash } = self;
         create_fork_at_transaction(ccx, urlOrAlias, txHash)
@@ -58,9 +70,12 @@ impl Cheatcode for createFork_2Call {
 }
 
 impl Cheatcode for createSelectFork_0Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { urlOrAlias } = self;
         create_select_fork(ccx, urlOrAlias, None)
@@ -68,9 +83,12 @@ impl Cheatcode for createSelectFork_0Call {
 }
 
 impl Cheatcode for createSelectFork_1Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { urlOrAlias, blockNumber } = self;
         create_select_fork(ccx, urlOrAlias, Some(blockNumber.saturating_to()))
@@ -78,9 +96,12 @@ impl Cheatcode for createSelectFork_1Call {
 }
 
 impl Cheatcode for createSelectFork_2Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { urlOrAlias, txHash } = self;
         create_select_fork_at_transaction(ccx, urlOrAlias, txHash)
@@ -88,9 +109,12 @@ impl Cheatcode for createSelectFork_2Call {
 }
 
 impl Cheatcode for rollFork_0Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { blockNumber } = self;
         persist_caller(ccx);
@@ -101,9 +125,12 @@ impl Cheatcode for rollFork_0Call {
 }
 
 impl Cheatcode for rollFork_1Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { txHash } = self;
         persist_caller(ccx);
@@ -114,9 +141,12 @@ impl Cheatcode for rollFork_1Call {
 }
 
 impl Cheatcode for rollFork_2Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { forkId, blockNumber } = self;
         persist_caller(ccx);
@@ -127,9 +157,12 @@ impl Cheatcode for rollFork_2Call {
 }
 
 impl Cheatcode for rollFork_3Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { forkId, txHash } = self;
         persist_caller(ccx);
@@ -140,9 +173,12 @@ impl Cheatcode for rollFork_3Call {
 }
 
 impl Cheatcode for selectForkCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { forkId } = self;
         persist_caller(ccx);
@@ -154,10 +190,10 @@ impl Cheatcode for selectForkCall {
 }
 
 impl Cheatcode for transact_0Call {
-    fn apply_full<CTX: FoundryContextExt>(
+    fn apply_full<CTX: FoundryContextExt, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Self { txHash } = *self;
         transact(ccx, executor, txHash, None)
@@ -165,10 +201,10 @@ impl Cheatcode for transact_0Call {
 }
 
 impl Cheatcode for transact_1Call {
-    fn apply_full<CTX: FoundryContextExt>(
+    fn apply_full<CTX: FoundryContextExt, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Self { forkId, txHash } = *self;
         transact(ccx, executor, txHash, Some(forkId))
@@ -176,9 +212,12 @@ impl Cheatcode for transact_1Call {
 }
 
 impl Cheatcode for allowCheatcodesCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { account } = self;
         ccx.ecx.db_mut().allow_cheatcode_access(*account);
@@ -187,9 +226,12 @@ impl Cheatcode for allowCheatcodesCall {
 }
 
 impl Cheatcode for makePersistent_0Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { account } = self;
         ccx.ecx.db_mut().add_persistent_account(*account);
@@ -198,9 +240,12 @@ impl Cheatcode for makePersistent_0Call {
 }
 
 impl Cheatcode for makePersistent_1Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { account0, account1 } = self;
         ccx.ecx.db_mut().add_persistent_account(*account0);
@@ -210,9 +255,12 @@ impl Cheatcode for makePersistent_1Call {
 }
 
 impl Cheatcode for makePersistent_2Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { account0, account1, account2 } = self;
         ccx.ecx.db_mut().add_persistent_account(*account0);
@@ -223,9 +271,12 @@ impl Cheatcode for makePersistent_2Call {
 }
 
 impl Cheatcode for makePersistent_3Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { accounts } = self;
         for account in accounts {
@@ -236,9 +287,12 @@ impl Cheatcode for makePersistent_3Call {
 }
 
 impl Cheatcode for revokePersistent_0Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { account } = self;
         ccx.ecx.db_mut().remove_persistent_account(account);
@@ -247,9 +301,12 @@ impl Cheatcode for revokePersistent_0Call {
 }
 
 impl Cheatcode for revokePersistent_1Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { accounts } = self;
         for account in accounts {
@@ -260,9 +317,12 @@ impl Cheatcode for revokePersistent_1Call {
 }
 
 impl Cheatcode for isPersistentCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { account } = self;
         Ok(ccx.ecx.db().is_persistent(account).abi_encode())
@@ -270,9 +330,12 @@ impl Cheatcode for isPersistentCall {
 }
 
 impl Cheatcode for rpc_0Call {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { method, params } = self;
         let url =
@@ -282,7 +345,7 @@ impl Cheatcode for rpc_0Call {
 }
 
 impl Cheatcode for rpc_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { urlOrAlias, method, params } = self;
         let url = state.config.rpc_endpoint(urlOrAlias)?.url()?;
         rpc_call(&url, method, params)
@@ -290,9 +353,12 @@ impl Cheatcode for rpc_1Call {
 }
 
 impl Cheatcode for eth_getLogsCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { fromBlock, toBlock, target, topics } = self;
         let (Ok(from_block), Ok(to_block)) = (u64::try_from(fromBlock), u64::try_from(toBlock))
@@ -335,9 +401,12 @@ impl Cheatcode for eth_getLogsCall {
 }
 
 impl Cheatcode for getRawBlockHeaderCall {
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { blockNumber } = self;
         let url = ccx.ecx.db().active_fork_url().ok_or_else(|| fmt_err!("no active fork"))?;
@@ -360,8 +429,11 @@ impl Cheatcode for getRawBlockHeaderCall {
 }
 
 /// Creates and then also selects the new fork
-fn create_select_fork<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn create_select_fork<
+    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+    N: Network,
+>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     url_or_alias: &str,
     block: Option<u64>,
 ) -> Result {
@@ -374,8 +446,11 @@ fn create_select_fork<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx
 }
 
 /// Creates a new fork
-fn create_fork<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn create_fork<
+    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+    N: Network,
+>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     url_or_alias: &str,
     block: Option<u64>,
 ) -> Result {
@@ -387,8 +462,9 @@ fn create_fork<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::
 /// Creates and then also selects the new fork at the given transaction
 fn create_select_fork_at_transaction<
     CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+    N: Network,
 >(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     url_or_alias: &str,
     transaction: &B256,
 ) -> Result {
@@ -403,8 +479,9 @@ fn create_select_fork_at_transaction<
 /// Creates a new fork at the given transaction
 fn create_fork_at_transaction<
     CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+    N: Network,
 >(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     url_or_alias: &str,
     transaction: &B256,
 ) -> Result {
@@ -414,8 +491,11 @@ fn create_fork_at_transaction<
 }
 
 /// Creates the request object for a new fork request
-fn create_fork_request<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn create_fork_request<
+    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+    N: Network,
+>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     url_or_alias: &str,
     block: Option<u64>,
 ) -> Result<CreateFork> {
@@ -442,8 +522,8 @@ fn create_fork_request<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::T
 /// Clones the EVM and tx environments, runs a fork operation that may modify them, then writes
 /// them back. This is the common pattern for all fork-switching cheatcodes (rollFork, selectFork,
 /// createSelectFork).
-fn fork_env_op<CTX: FoundryContextExt, T: SolValue>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn fork_env_op<CTX: FoundryContextExt, T: SolValue, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     f: impl FnOnce(
         &mut CTX::Db,
         &mut EvmEnv<CTX::Spec, CTX::Block>,
@@ -460,7 +540,7 @@ fn fork_env_op<CTX: FoundryContextExt, T: SolValue>(
     Ok(result.abi_encode())
 }
 
-fn check_broadcast(state: &Cheatcodes) -> Result<()> {
+fn check_broadcast<SPEC, BLOCK, N: Network>(state: &Cheatcodes<SPEC, BLOCK, N>) -> Result<()> {
     if state.broadcast.is_none() {
         Ok(())
     } else {
@@ -468,9 +548,9 @@ fn check_broadcast(state: &Cheatcodes) -> Result<()> {
     }
 }
 
-fn transact<CTX: FoundryContextExt>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
-    executor: &mut dyn CheatcodesExecutor<CTX>,
+fn transact<CTX: FoundryContextExt, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
+    executor: &mut dyn CheatcodesExecutor<CTX, N>,
     transaction: B256,
     fork_id: Option<U256>,
 ) -> Result {
@@ -482,8 +562,11 @@ fn transact<CTX: FoundryContextExt>(
 // state of caller contract is not lost when fork changes).
 // Applies to create, select and roll forks actions.
 // https://github.com/foundry-rs/foundry/issues/8004
-fn persist_caller<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn persist_caller<
+    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+    N: Network,
+>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
 ) {
     ccx.ecx.db_mut().add_persistent_account(ccx.caller);
 }

--- a/crates/cheatcodes/src/evm/mapping.rs
+++ b/crates/cheatcodes/src/evm/mapping.rs
@@ -1,10 +1,11 @@
 use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
+use alloy_network::Network;
 use alloy_primitives::{Address, B256};
 use alloy_sol_types::SolValue;
 use foundry_common::mapping_slots::MappingSlots;
 
 impl Cheatcode for startMappingRecordingCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         state.mapping_slots.get_or_insert_default();
         Ok(Default::default())
@@ -12,7 +13,7 @@ impl Cheatcode for startMappingRecordingCall {
 }
 
 impl Cheatcode for stopMappingRecordingCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         state.mapping_slots = None;
         Ok(Default::default())
@@ -20,7 +21,7 @@ impl Cheatcode for stopMappingRecordingCall {
 }
 
 impl Cheatcode for getMappingLengthCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { target, mappingSlot } = self;
         let result = slot_child(state, target, mappingSlot).map(Vec::len).unwrap_or(0);
         Ok((result as u64).abi_encode())
@@ -28,7 +29,7 @@ impl Cheatcode for getMappingLengthCall {
 }
 
 impl Cheatcode for getMappingSlotAtCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { target, mappingSlot, idx } = self;
         let result = slot_child(state, target, mappingSlot)
             .and_then(|set| set.get(idx.saturating_to::<usize>()))
@@ -39,7 +40,7 @@ impl Cheatcode for getMappingSlotAtCall {
 }
 
 impl Cheatcode for getMappingKeyAndParentOfCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { target, elementSlot: slot } = self;
         let mut found = false;
         let mut key = &B256::ZERO;
@@ -59,12 +60,15 @@ impl Cheatcode for getMappingKeyAndParentOfCall {
     }
 }
 
-fn mapping_slot<'a>(state: &'a Cheatcodes, target: &'a Address) -> Option<&'a MappingSlots> {
+fn mapping_slot<'a, SPEC, BLOCK, N: Network>(
+    state: &'a Cheatcodes<SPEC, BLOCK, N>,
+    target: &'a Address,
+) -> Option<&'a MappingSlots> {
     state.mapping_slots.as_ref()?.get(target)
 }
 
-fn slot_child<'a>(
-    state: &'a Cheatcodes,
+fn slot_child<'a, SPEC, BLOCK, N: Network>(
+    state: &'a Cheatcodes<SPEC, BLOCK, N>,
     target: &'a Address,
     slot: &'a B256,
 ) -> Option<&'a Vec<B256>> {

--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -1,4 +1,5 @@
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, Result, Vm::*};
+use alloy_network::Network;
 use alloy_primitives::{Address, Bytes, U256};
 use foundry_evm_core::backend::DatabaseError;
 use revm::{
@@ -45,7 +46,7 @@ impl Ord for MockCallDataContext {
 }
 
 impl Cheatcode for clearMockedCallsCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         state.mocked_calls = Default::default();
         Ok(Default::default())
@@ -53,9 +54,9 @@ impl Cheatcode for clearMockedCallsCall {
 }
 
 impl Cheatcode for mockCall_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { callee, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -66,9 +67,9 @@ impl Cheatcode for mockCall_0Call {
 }
 
 impl Cheatcode for mockCall_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { callee, msgValue, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -79,9 +80,9 @@ impl Cheatcode for mockCall_1Call {
 }
 
 impl Cheatcode for mockCall_2Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { callee, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -99,9 +100,9 @@ impl Cheatcode for mockCall_2Call {
 }
 
 impl Cheatcode for mockCall_3Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { callee, msgValue, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -119,9 +120,9 @@ impl Cheatcode for mockCall_3Call {
 }
 
 impl Cheatcode for mockCalls_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { callee, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -132,9 +133,9 @@ impl Cheatcode for mockCalls_0Call {
 }
 
 impl Cheatcode for mockCalls_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { callee, msgValue, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -145,9 +146,9 @@ impl Cheatcode for mockCalls_1Call {
 }
 
 impl Cheatcode for mockCallRevert_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { callee, data, revertData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -158,9 +159,9 @@ impl Cheatcode for mockCallRevert_0Call {
 }
 
 impl Cheatcode for mockCallRevert_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { callee, msgValue, data, revertData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -171,9 +172,9 @@ impl Cheatcode for mockCallRevert_1Call {
 }
 
 impl Cheatcode for mockCallRevert_2Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { callee, data, revertData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -191,9 +192,9 @@ impl Cheatcode for mockCallRevert_2Call {
 }
 
 impl Cheatcode for mockCallRevert_3Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { callee, msgValue, data, revertData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -211,7 +212,7 @@ impl Cheatcode for mockCallRevert_3Call {
 }
 
 impl Cheatcode for mockFunctionCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { callee, target, data } = self;
         state.mocked_functions.entry(*callee).or_default().insert(data.clone(), *target);
 
@@ -219,8 +220,8 @@ impl Cheatcode for mockFunctionCall {
     }
 }
 
-fn mock_call(
-    state: &mut Cheatcodes,
+fn mock_call<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
     callee: &Address,
     cdata: &Bytes,
     value: Option<&U256>,
@@ -230,8 +231,8 @@ fn mock_call(
     mock_calls(state, callee, cdata, value, std::slice::from_ref(rdata), ret_type)
 }
 
-fn mock_calls(
-    state: &mut Cheatcodes,
+fn mock_calls<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
     callee: &Address,
     cdata: &Bytes,
     value: Option<&U256>,
@@ -249,9 +250,9 @@ fn mock_calls(
 
 // Etches a single byte onto the account if it is empty to circumvent the `extcodesize`
 // check Solidity might perform.
-fn make_acc_non_empty<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+fn make_acc_non_empty<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
     callee: &Address,
-    ccx: &mut CheatsCtxt<'_, CTX>,
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
 ) -> Result {
     let empty_bytecode = {
         let acc = ccx.ecx.journal_mut().load_account(*callee)?;

--- a/crates/cheatcodes/src/evm/prank.rs
+++ b/crates/cheatcodes/src/evm/prank.rs
@@ -1,4 +1,5 @@
 use crate::{Cheatcode, CheatsCtxt, Result, Vm::*, evm::journaled_account};
+use alloy_network::Network;
 use alloy_primitives::Address;
 use foundry_evm_core::backend::DatabaseError;
 use revm::{
@@ -59,9 +60,12 @@ impl Prank {
 }
 
 impl Cheatcode for prank_0Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { msgSender } = self;
         prank(ccx, msgSender, None, true, false)
@@ -69,9 +73,12 @@ impl Cheatcode for prank_0Call {
 }
 
 impl Cheatcode for startPrank_0Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { msgSender } = self;
         prank(ccx, msgSender, None, false, false)
@@ -79,9 +86,12 @@ impl Cheatcode for startPrank_0Call {
 }
 
 impl Cheatcode for prank_1Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { msgSender, txOrigin } = self;
         prank(ccx, msgSender, Some(txOrigin), true, false)
@@ -89,9 +99,12 @@ impl Cheatcode for prank_1Call {
 }
 
 impl Cheatcode for startPrank_1Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { msgSender, txOrigin } = self;
         prank(ccx, msgSender, Some(txOrigin), false, false)
@@ -99,9 +112,12 @@ impl Cheatcode for startPrank_1Call {
 }
 
 impl Cheatcode for prank_2Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { msgSender, delegateCall } = self;
         prank(ccx, msgSender, None, true, *delegateCall)
@@ -109,9 +125,12 @@ impl Cheatcode for prank_2Call {
 }
 
 impl Cheatcode for startPrank_2Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { msgSender, delegateCall } = self;
         prank(ccx, msgSender, None, false, *delegateCall)
@@ -119,9 +138,12 @@ impl Cheatcode for startPrank_2Call {
 }
 
 impl Cheatcode for prank_3Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { msgSender, txOrigin, delegateCall } = self;
         prank(ccx, msgSender, Some(txOrigin), true, *delegateCall)
@@ -129,9 +151,12 @@ impl Cheatcode for prank_3Call {
 }
 
 impl Cheatcode for startPrank_3Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { msgSender, txOrigin, delegateCall } = self;
         prank(ccx, msgSender, Some(txOrigin), false, *delegateCall)
@@ -139,9 +164,12 @@ impl Cheatcode for startPrank_3Call {
 }
 
 impl Cheatcode for stopPrankCall {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self {} = self;
         ccx.state.pranks.remove(&ccx.ecx.journal().depth());
@@ -149,8 +177,8 @@ impl Cheatcode for stopPrankCall {
     }
 }
 
-fn prank<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn prank<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     new_caller: &Address,
     new_origin: Option<&Address>,
     single_call: bool,

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -30,7 +30,7 @@ use std::{
 use walkdir::WalkDir;
 
 impl Cheatcode for existsCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
         Ok(path.exists().abi_encode())
@@ -38,7 +38,7 @@ impl Cheatcode for existsCall {
 }
 
 impl Cheatcode for fsMetadataCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
 
@@ -64,7 +64,7 @@ impl Cheatcode for fsMetadataCall {
 }
 
 impl Cheatcode for isDirCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
         Ok(path.is_dir().abi_encode())
@@ -72,7 +72,7 @@ impl Cheatcode for isDirCall {
 }
 
 impl Cheatcode for isFileCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
         Ok(path.is_file().abi_encode())
@@ -80,14 +80,14 @@ impl Cheatcode for isFileCall {
 }
 
 impl Cheatcode for projectRootCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         Ok(state.config.root.display().to_string().abi_encode())
     }
 }
 
 impl Cheatcode for currentFilePathCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         let artifact = state
             .config
@@ -100,7 +100,7 @@ impl Cheatcode for currentFilePathCall {
 }
 
 impl Cheatcode for unixTimeCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         let difference = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -110,7 +110,7 @@ impl Cheatcode for unixTimeCall {
 }
 
 impl Cheatcode for closeFileCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
 
@@ -121,7 +121,7 @@ impl Cheatcode for closeFileCall {
 }
 
 impl Cheatcode for copyFileCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { from, to } = self;
         let from = state.config.ensure_path_allowed(from, FsAccessKind::Read)?;
         let to = state.config.ensure_path_allowed(to, FsAccessKind::Write)?;
@@ -133,7 +133,7 @@ impl Cheatcode for copyFileCall {
 }
 
 impl Cheatcode for createDirCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path, recursive } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
         if *recursive { fs::create_dir_all(path) } else { fs::create_dir(path) }?;
@@ -142,28 +142,28 @@ impl Cheatcode for createDirCall {
 }
 
 impl Cheatcode for readDir_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path } = self;
         read_dir(state, path.as_ref(), 1, false)
     }
 }
 
 impl Cheatcode for readDir_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path, maxDepth } = self;
         read_dir(state, path.as_ref(), *maxDepth, false)
     }
 }
 
 impl Cheatcode for readDir_2Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path, maxDepth, followLinks } = self;
         read_dir(state, path.as_ref(), *maxDepth, *followLinks)
     }
 }
 
 impl Cheatcode for readFileCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
         Ok(fs::locked_read_to_string(path)?.abi_encode())
@@ -171,7 +171,7 @@ impl Cheatcode for readFileCall {
 }
 
 impl Cheatcode for readFileBinaryCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
         Ok(fs::locked_read(path)?.abi_encode())
@@ -179,7 +179,7 @@ impl Cheatcode for readFileBinaryCall {
 }
 
 impl Cheatcode for readLineCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
 
@@ -205,7 +205,7 @@ impl Cheatcode for readLineCall {
 }
 
 impl Cheatcode for readLinkCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { linkPath: path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
         let target = fs::read_link(path)?;
@@ -214,7 +214,7 @@ impl Cheatcode for readLinkCall {
 }
 
 impl Cheatcode for removeDirCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path, recursive } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
         if *recursive { fs::remove_dir_all(path) } else { fs::remove_dir(path) }?;
@@ -223,7 +223,7 @@ impl Cheatcode for removeDirCall {
 }
 
 impl Cheatcode for removeFileCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
         state.config.ensure_not_foundry_toml(&path)?;
@@ -240,21 +240,21 @@ impl Cheatcode for removeFileCall {
 }
 
 impl Cheatcode for writeFileCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path, data } = self;
         write_file(state, path.as_ref(), data.as_bytes())
     }
 }
 
 impl Cheatcode for writeFileBinaryCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path, data } = self;
         write_file(state, path.as_ref(), data)
     }
 }
 
 impl Cheatcode for writeLineCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { path, data: line } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
         state.config.ensure_not_foundry_toml(&path)?;
@@ -268,7 +268,7 @@ impl Cheatcode for writeLineCall {
 }
 
 impl Cheatcode for getArtifactPathByCodeCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { code } = self;
         let (artifact_id, _) = state
             .config
@@ -282,7 +282,7 @@ impl Cheatcode for getArtifactPathByCodeCall {
 }
 
 impl Cheatcode for getArtifactPathByDeployedCodeCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { deployedCode } = self;
         let (artifact_id, _) = state
             .config
@@ -296,24 +296,24 @@ impl Cheatcode for getArtifactPathByDeployedCodeCall {
 }
 
 impl Cheatcode for getCodeCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { artifactPath: path } = self;
         Ok(get_artifact_code(state, path, false)?.abi_encode())
     }
 }
 
 impl Cheatcode for getDeployedCodeCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { artifactPath: path } = self;
         Ok(get_artifact_code(state, path, true)?.abi_encode())
     }
 }
 
 impl Cheatcode for deployCode_0Call {
-    fn apply_full<CTX: ContextTr>(
+    fn apply_full<CTX: ContextTr, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Self { artifactPath: path } = self;
         deploy_code(ccx, executor, path, None, None, None)
@@ -321,10 +321,10 @@ impl Cheatcode for deployCode_0Call {
 }
 
 impl Cheatcode for deployCode_1Call {
-    fn apply_full<CTX: ContextTr>(
+    fn apply_full<CTX: ContextTr, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Self { artifactPath: path, constructorArgs: args } = self;
         deploy_code(ccx, executor, path, Some(args), None, None)
@@ -332,10 +332,10 @@ impl Cheatcode for deployCode_1Call {
 }
 
 impl Cheatcode for deployCode_2Call {
-    fn apply_full<CTX: ContextTr>(
+    fn apply_full<CTX: ContextTr, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Self { artifactPath: path, value } = self;
         deploy_code(ccx, executor, path, None, Some(*value), None)
@@ -343,10 +343,10 @@ impl Cheatcode for deployCode_2Call {
 }
 
 impl Cheatcode for deployCode_3Call {
-    fn apply_full<CTX: ContextTr>(
+    fn apply_full<CTX: ContextTr, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Self { artifactPath: path, constructorArgs: args, value } = self;
         deploy_code(ccx, executor, path, Some(args), Some(*value), None)
@@ -354,10 +354,10 @@ impl Cheatcode for deployCode_3Call {
 }
 
 impl Cheatcode for deployCode_4Call {
-    fn apply_full<CTX: ContextTr>(
+    fn apply_full<CTX: ContextTr, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Self { artifactPath: path, salt } = self;
         deploy_code(ccx, executor, path, None, None, Some((*salt).into()))
@@ -365,10 +365,10 @@ impl Cheatcode for deployCode_4Call {
 }
 
 impl Cheatcode for deployCode_5Call {
-    fn apply_full<CTX: ContextTr>(
+    fn apply_full<CTX: ContextTr, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Self { artifactPath: path, constructorArgs: args, salt } = self;
         deploy_code(ccx, executor, path, Some(args), None, Some((*salt).into()))
@@ -376,10 +376,10 @@ impl Cheatcode for deployCode_5Call {
 }
 
 impl Cheatcode for deployCode_6Call {
-    fn apply_full<CTX: ContextTr>(
+    fn apply_full<CTX: ContextTr, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Self { artifactPath: path, value, salt } = self;
         deploy_code(ccx, executor, path, None, Some(*value), Some((*salt).into()))
@@ -387,10 +387,10 @@ impl Cheatcode for deployCode_6Call {
 }
 
 impl Cheatcode for deployCode_7Call {
-    fn apply_full<CTX: ContextTr>(
+    fn apply_full<CTX: ContextTr, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Self { artifactPath: path, constructorArgs: args, value, salt } = self;
         deploy_code(ccx, executor, path, Some(args), Some(*value), Some((*salt).into()))
@@ -399,9 +399,9 @@ impl Cheatcode for deployCode_7Call {
 
 /// Helper function to deploy contract from artifact code.
 /// Uses CREATE2 scheme if salt specified.
-fn deploy_code<CTX: ContextTr>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
-    executor: &mut dyn CheatcodesExecutor<CTX>,
+fn deploy_code<CTX: ContextTr, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
+    executor: &mut dyn CheatcodesExecutor<CTX, N>,
     path: &str,
     constructor_args: Option<&Bytes>,
     value: Option<U256>,
@@ -460,7 +460,11 @@ fn deploy_code<CTX: ContextTr>(
 /// This function is safe to use with contracts that have library dependencies.
 /// `alloy_json_abi::ContractObject` validates bytecode during JSON parsing and will
 /// reject artifacts with unlinked library placeholders.
-fn get_artifact_code(state: &Cheatcodes, path: &str, deployed: bool) -> Result<Bytes> {
+fn get_artifact_code<SPEC, BLOCK, N: Network>(
+    state: &Cheatcodes<SPEC, BLOCK, N>,
+    path: &str,
+    deployed: bool,
+) -> Result<Bytes> {
     let path = if path.ends_with(".json") {
         PathBuf::from(path)
     } else {
@@ -598,7 +602,7 @@ fn get_artifact_code(state: &Cheatcodes, path: &str, deployed: bool) -> Result<B
 }
 
 impl Cheatcode for ffiCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { commandInput: input } = self;
 
         let output = ffi(state, input)?;
@@ -626,48 +630,52 @@ impl Cheatcode for ffiCall {
 }
 
 impl Cheatcode for tryFfiCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { commandInput: input } = self;
         ffi(state, input).map(|res| res.abi_encode())
     }
 }
 
 impl Cheatcode for promptCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { promptText: text } = self;
         prompt(state, text, prompt_input).map(|res| res.abi_encode())
     }
 }
 
 impl Cheatcode for promptSecretCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { promptText: text } = self;
         prompt(state, text, prompt_password).map(|res| res.abi_encode())
     }
 }
 
 impl Cheatcode for promptSecretUintCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { promptText: text } = self;
         parse(&prompt(state, text, prompt_password)?, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for promptAddressCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { promptText: text } = self;
         parse(&prompt(state, text, prompt_input)?, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for promptUintCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { promptText: text } = self;
         parse(&prompt(state, text, prompt_input)?, &DynSolType::Uint(256))
     }
 }
 
-pub(super) fn write_file(state: &Cheatcodes, path: &Path, contents: &[u8]) -> Result {
+pub(super) fn write_file<SPEC, BLOCK, N: Network>(
+    state: &Cheatcodes<SPEC, BLOCK, N>,
+    path: &Path,
+    contents: &[u8],
+) -> Result {
     let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
     // write access to foundry.toml is not allowed
     state.config.ensure_not_foundry_toml(&path)?;
@@ -679,7 +687,12 @@ pub(super) fn write_file(state: &Cheatcodes, path: &Path, contents: &[u8]) -> Re
     Ok(Default::default())
 }
 
-fn read_dir(state: &Cheatcodes, path: &Path, max_depth: u64, follow_links: bool) -> Result {
+fn read_dir<SPEC, BLOCK, N: Network>(
+    state: &Cheatcodes<SPEC, BLOCK, N>,
+    path: &Path,
+    max_depth: u64,
+    follow_links: bool,
+) -> Result {
     let root = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
     let paths: Vec<DirEntry> = WalkDir::new(root)
         .min_depth(1)
@@ -709,7 +722,10 @@ fn read_dir(state: &Cheatcodes, path: &Path, max_depth: u64, follow_links: bool)
     Ok(paths.abi_encode())
 }
 
-fn ffi(state: &Cheatcodes, input: &[String]) -> Result<FfiResult> {
+fn ffi<SPEC, BLOCK, N: Network>(
+    state: &Cheatcodes<SPEC, BLOCK, N>,
+    input: &[String],
+) -> Result<FfiResult> {
     ensure!(
         state.config.ffi,
         "FFI is disabled; add the `--ffi` flag to allow tests to call external commands"
@@ -749,8 +765,8 @@ fn prompt_password(prompt_text: &str) -> Result<String, dialoguer::Error> {
     Password::new().with_prompt(prompt_text).interact()
 }
 
-fn prompt(
-    state: &Cheatcodes,
+fn prompt<SPEC, BLOCK, N: Network>(
+    state: &Cheatcodes<SPEC, BLOCK, N>,
     prompt_text: &str,
     input: fn(&str) -> Result<String, dialoguer::Error>,
 ) -> Result<String> {
@@ -775,7 +791,7 @@ fn prompt(
 }
 
 impl Cheatcode for getBroadcastCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { contractName, chainId, txType } = self;
 
         let latest_broadcast = latest_broadcast(
@@ -790,7 +806,7 @@ impl Cheatcode for getBroadcastCall {
 }
 
 impl Cheatcode for getBroadcasts_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { contractName, chainId, txType } = self;
 
         let reader = BroadcastReader::new(contractName.clone(), *chainId, &state.config.broadcast)?
@@ -811,7 +827,7 @@ impl Cheatcode for getBroadcasts_0Call {
 }
 
 impl Cheatcode for getBroadcasts_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { contractName, chainId } = self;
 
         let reader = BroadcastReader::new(contractName.clone(), *chainId, &state.config.broadcast)?;
@@ -831,7 +847,10 @@ impl Cheatcode for getBroadcasts_1Call {
 }
 
 impl Cheatcode for getDeployment_0Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { contractName } = self;
         let chain_id = ccx.ecx.cfg().chain_id();
 
@@ -847,7 +866,7 @@ impl Cheatcode for getDeployment_0Call {
 }
 
 impl Cheatcode for getDeployment_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { contractName, chainId } = self;
 
         let latest_broadcast = latest_broadcast(
@@ -862,7 +881,7 @@ impl Cheatcode for getDeployment_1Call {
 }
 
 impl Cheatcode for getDeploymentsCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { contractName, chainId } = self;
 
         let reader = BroadcastReader::new(contractName.clone(), *chainId, &state.config.broadcast)?

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -20,18 +20,21 @@ use crate::{
     },
     utils::IgnoredTraces,
 };
-use alloy_consensus::BlobTransactionSidecarVariant;
+use alloy_consensus::{BlobTransactionSidecarVariant, transaction::SignerRecoverable};
+use alloy_evm::FromRecoveredTx;
 use alloy_network::{Ethereum, Network, TransactionBuilder};
 use alloy_primitives::{
     Address, B256, Bytes, Log, TxKind, U256, hex,
     map::{AddressHashMap, HashMap, HashSet},
 };
-use alloy_rpc_types::{AccessList, TransactionRequest};
+use alloy_rlp::Decodable;
+use alloy_rpc_types::AccessList;
 use alloy_sol_types::{SolCall, SolInterface, SolValue};
 use foundry_common::{
     SELECTOR_LEN, TransactionMaybeSigned,
     mapping_slots::{MappingSlots, step as mapping_step},
 };
+use foundry_config::FromEvmVersion;
 use foundry_evm_core::{
     Breakpoints, EvmEnv, FoundryTransaction, InspectorExt,
     abi::Vm::stopExpectSafeMemoryCall,
@@ -82,12 +85,12 @@ pub mod analysis;
 pub use analysis::CheatcodeAnalysis;
 
 /// Helper trait for running nested EVM operations from inside cheatcode implementations.
-pub trait CheatcodesExecutor<CTX: ContextTr> {
+pub trait CheatcodesExecutor<CTX: ContextTr, N: Network> {
     /// Runs a closure with a nested EVM built from the current context.
     /// The inspector is assembled internally — never exposed to the caller.
     fn with_nested_evm(
         &mut self,
-        cheats: &mut Cheatcodes,
+        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
         ecx: &mut CTX,
         f: NestedEvmClosure<'_, CTX::Tx>,
     ) -> Result<(), EVMError<DatabaseError>>;
@@ -95,7 +98,7 @@ pub trait CheatcodesExecutor<CTX: ContextTr> {
     /// Replays a historical transaction on the database. Inspector is assembled internally.
     fn transact_on_db(
         &mut self,
-        cheats: &mut Cheatcodes,
+        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
         ecx: &mut CTX,
         fork_id: Option<U256>,
         transaction: B256,
@@ -104,7 +107,7 @@ pub trait CheatcodesExecutor<CTX: ContextTr> {
     /// Executes a `TransactionRequest` on the database. Inspector is assembled internally.
     fn transact_from_tx_on_db(
         &mut self,
-        cheats: &mut Cheatcodes,
+        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
         ecx: &mut CTX,
         tx: CTX::Tx,
     ) -> eyre::Result<()>;
@@ -116,7 +119,7 @@ pub trait CheatcodesExecutor<CTX: ContextTr> {
     #[allow(clippy::type_complexity)]
     fn with_fresh_nested_evm(
         &mut self,
-        cheats: &mut Cheatcodes,
+        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
         db: &mut CTX::Db,
         evm_env: EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
         f: NestedEvmClosure<'_, CTX::Tx>,
@@ -137,10 +140,10 @@ pub trait CheatcodesExecutor<CTX: ContextTr> {
 }
 
 /// Builds a sub-EVM from the current context and executes the given CREATE frame.
-pub(crate) fn exec_create<CTX: ContextTr>(
-    executor: &mut dyn CheatcodesExecutor<CTX>,
+pub(crate) fn exec_create<CTX: ContextTr, N: Network>(
+    executor: &mut dyn CheatcodesExecutor<CTX, N>,
     inputs: CreateInputs,
-    ccx: &mut CheatsCtxt<'_, CTX>,
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
 ) -> std::result::Result<CreateOutcome, EVMError<DatabaseError>> {
     let mut inputs = Some(inputs);
     let mut outcome = None;
@@ -175,11 +178,17 @@ impl<
             Tx = TxEnv,
             Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
         >,
-> CheatcodesExecutor<CTX> for TransparentCheatcodesExecutor
+    N: Network<
+            TxEnvelope: Decodable + SignerRecoverable,
+            TransactionRequest: FoundryTransactionBuilder<N>,
+        >,
+> CheatcodesExecutor<CTX, N> for TransparentCheatcodesExecutor
+where
+    CTX::Tx: FromRecoveredTx<N::TxEnvelope>,
 {
     fn with_nested_evm(
         &mut self,
-        cheats: &mut Cheatcodes,
+        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
         ecx: &mut CTX,
         f: NestedEvmClosure<'_, CTX::Tx>,
     ) -> Result<(), EVMError<DatabaseError>> {
@@ -195,7 +204,7 @@ impl<
 
     fn with_fresh_nested_evm(
         &mut self,
-        cheats: &mut Cheatcodes,
+        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
         db: &mut CTX::Db,
         evm_env: EvmEnv<CTX::Spec, CTX::Block>,
         f: NestedEvmClosure<'_, CTX::Tx>,
@@ -207,7 +216,7 @@ impl<
 
     fn transact_on_db(
         &mut self,
-        cheats: &mut Cheatcodes,
+        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
         ecx: &mut CTX,
         fork_id: Option<U256>,
         transaction: B256,
@@ -220,7 +229,7 @@ impl<
 
     fn transact_from_tx_on_db(
         &mut self,
-        cheats: &mut Cheatcodes,
+        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
         ecx: &mut CTX,
         tx: CTX::Tx,
     ) -> eyre::Result<()> {
@@ -592,7 +601,7 @@ impl Default for Cheatcodes {
     }
 }
 
-impl Cheatcodes {
+impl<SPEC, BLOCK, N: Network> Cheatcodes<SPEC, BLOCK, N> {
     /// Creates a new `Cheatcodes` with the given settings.
     pub fn new(config: Arc<CheatsConfig>) -> Self {
         Self {
@@ -676,13 +685,22 @@ impl Cheatcodes {
 
     /// Decodes the input data and applies the cheatcode.
     fn apply_cheatcode<
-        CTX: FoundryContextExt<Tx = TxEnv, Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        CTX: FoundryContextExt<
+                Spec = SPEC,
+                Block = BLOCK,
+                Tx: FromRecoveredTx<N::TxEnvelope>,
+                Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
+            >,
     >(
         &mut self,
         ecx: &mut CTX,
         call: &CallInputs,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
-    ) -> Result {
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+    ) -> Result
+    where
+        SPEC: FromEvmVersion + Into<SpecId> + Clone,
+        N: Network<TxEnvelope: Decodable + SignerRecoverable>,
+    {
         // decode the cheatcode call
         let decoded = Vm::VmCalls::abi_decode(&call.input.bytes(ecx)).map_err(|e| {
             if let alloy_sol_types::Error::UnknownSelector { name: _, selector } = e {
@@ -771,16 +789,22 @@ impl Cheatcodes {
 
     pub fn call_with_executor<
         CTX: FoundryContextExt<
-                Spec = SpecId,
-                Tx = TxEnv,
+                Spec = SPEC,
+                Block = BLOCK,
+                Tx: FromRecoveredTx<N::TxEnvelope>,
                 Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
             >,
     >(
         &mut self,
         ecx: &mut CTX,
         call: &mut CallInputs,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
-    ) -> Option<CallOutcome> {
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+    ) -> Option<CallOutcome>
+    where
+        SPEC: FromEvmVersion + Into<SpecId> + Copy,
+        N::TxEnvelope: Decodable + SignerRecoverable,
+        N::TransactionRequest: FoundryTransactionBuilder<N>,
+    {
         // Apply custom execution evm version.
         if let Some(spec_id) = self.execution_evm_version {
             ecx.cfg_mut().set_spec(spec_id);
@@ -995,7 +1019,7 @@ impl Cheatcodes {
                     let account =
                         ecx.journal_mut().evm_state_mut().get_mut(&broadcast.new_origin).unwrap();
 
-                    let mut tx_req = TransactionRequest::default()
+                    let mut tx_req = N::TransactionRequest::default()
                         .with_from(broadcast.new_origin)
                         .with_to(call.target_address)
                         .with_value(call.transfer_value().unwrap_or_default())
@@ -1201,7 +1225,13 @@ impl<
             Tx = TxEnv,
             Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
         >,
-> Inspector<CTX> for Cheatcodes
+    N: Network<
+            TxEnvelope: Decodable + SignerRecoverable,
+            TransactionRequest: FoundryTransactionBuilder<N>,
+        >,
+> Inspector<CTX> for Cheatcodes<CTX::Spec, CTX::Block, N>
+where
+    CTX::Tx: FromRecoveredTx<N::TxEnvelope>,
 {
     fn initialize_interp(&mut self, interpreter: &mut Interpreter, ecx: &mut CTX) {
         // When the first interpreter is initialized we've circumvented the balance and gas checks,
@@ -1797,7 +1827,7 @@ impl<
                 self.broadcastable_transactions.push_back(BroadcastableTransaction {
                     rpc,
                     transaction: TransactionMaybeSigned::new(
-                        TransactionRequest::default()
+                        N::TransactionRequest::default()
                             .with_from(broadcast.new_origin)
                             .with_kind(TxKind::Create)
                             .with_value(input.value())
@@ -1976,7 +2006,7 @@ impl<
     }
 }
 
-impl InspectorExt for Cheatcodes {
+impl<SPEC, BLOCK, N: Network> InspectorExt for Cheatcodes<SPEC, BLOCK, N> {
     fn should_use_create2_factory(&mut self, depth: usize, inputs: &CreateInputs) -> bool {
         if let CreateScheme::Create2 { .. } = inputs.scheme() {
             let target_depth = if let Some(prank) = &self.get_prank(depth) {
@@ -1999,7 +2029,7 @@ impl InspectorExt for Cheatcodes {
     }
 }
 
-impl Cheatcodes {
+impl<SPEC, BLOCK, N: Network> Cheatcodes<SPEC, BLOCK, N> {
     #[cold]
     fn meter_gas(&mut self, interpreter: &mut Interpreter) {
         if let Some(paused_gas) = self.gas_metering.paused_frames.last() {
@@ -2611,11 +2641,16 @@ fn cheatcode_signature(cheat: &spec::Cheatcode<'static>) -> &'static str {
 
 /// Dispatches the cheatcode call to the appropriate function.
 fn apply_dispatch<
-    CTX: FoundryContextExt<Tx = TxEnv, Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+    CTX: FoundryContextExt<
+            Spec: FromEvmVersion,
+            Tx: FromRecoveredTx<N::TxEnvelope>,
+            Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
+        >,
+    N: Network<TxEnvelope: Decodable + SignerRecoverable>,
 >(
     calls: &Vm::VmCalls,
-    ccx: &mut CheatsCtxt<'_, CTX>,
-    executor: &mut dyn CheatcodesExecutor<CTX>,
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
+    executor: &mut dyn CheatcodesExecutor<CTX, N>,
 ) -> Result {
     // Extract metadata for logging/deprecation via CheatcodeDef.
     macro_rules! get_cheatcode {

--- a/crates/cheatcodes/src/inspector/utils.rs
+++ b/crates/cheatcodes/src/inspector/utils.rs
@@ -1,4 +1,5 @@
 use crate::inspector::Cheatcodes;
+use alloy_network::Network;
 use alloy_primitives::{Address, Bytes, U256};
 use foundry_evm_core::{FoundryContextExt, backend::DatabaseExt};
 use revm::{
@@ -15,10 +16,17 @@ pub(crate) trait CommonCreateInput {
     fn init_code(&self) -> Bytes;
     fn scheme(&self) -> Option<CreateScheme>;
     fn set_caller(&mut self, caller: Address);
-    fn log_debug(&self, cheatcode: &mut Cheatcodes, scheme: &CreateScheme);
-    fn allow_cheatcodes<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn log_debug<SPEC, BLOCK, N: Network>(
         &self,
-        cheatcodes: &mut Cheatcodes,
+        cheatcode: &mut Cheatcodes<SPEC, BLOCK, N>,
+        scheme: &CreateScheme,
+    );
+    fn allow_cheatcodes<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
+        &self,
+        cheatcodes: &mut Cheatcodes<CTX::Spec, CTX::Block, N>,
         ecx: &mut CTX,
     ) -> Address;
 }
@@ -42,7 +50,11 @@ impl CommonCreateInput for &mut CreateInputs {
     fn set_caller(&mut self, caller: Address) {
         CreateInputs::set_call(self, caller);
     }
-    fn log_debug(&self, cheatcode: &mut Cheatcodes, scheme: &CreateScheme) {
+    fn log_debug<SPEC, BLOCK, N: Network>(
+        &self,
+        cheatcode: &mut Cheatcodes<SPEC, BLOCK, N>,
+        scheme: &CreateScheme,
+    ) {
         let kind = match scheme {
             CreateScheme::Create => "create",
             CreateScheme::Create2 { .. } => "create2",
@@ -50,9 +62,12 @@ impl CommonCreateInput for &mut CreateInputs {
         };
         debug!(target: "cheatcodes", tx=?cheatcode.broadcastable_transactions.back().unwrap(), "broadcastable {kind}");
     }
-    fn allow_cheatcodes<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn allow_cheatcodes<
+        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        cheatcodes: &mut Cheatcodes,
+        cheatcodes: &mut Cheatcodes<CTX::Spec, CTX::Block, N>,
         ecx: &mut CTX,
     ) -> Address {
         let caller = CreateInputs::caller(self);

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -2,6 +2,7 @@
 
 use crate::{Cheatcode, Cheatcodes, Result, Vm::*, string};
 use alloy_dyn_abi::{DynSolType, DynSolValue, Resolver, eip712_parser::EncodeType};
+use alloy_network::Network;
 use alloy_primitives::{Address, B256, I256, U256, hex};
 use alloy_sol_types::SolValue;
 use foundry_common::{fmt::StructDefinitions, fs};
@@ -13,133 +14,133 @@ use std::{
 };
 
 impl Cheatcode for keyExistsCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         check_json_key_exists(json, key)
     }
 }
 
 impl Cheatcode for keyExistsJsonCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         check_json_key_exists(json, key)
     }
 }
 
 impl Cheatcode for parseJson_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json } = self;
         parse_json(json, "$", state.struct_defs())
     }
 }
 
 impl Cheatcode for parseJson_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json(json, key, state.struct_defs())
     }
 }
 
 impl Cheatcode for parseJsonUintCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for parseJsonUintArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Uint(256))))
     }
 }
 
 impl Cheatcode for parseJsonIntCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for parseJsonIntArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Int(256))))
     }
 }
 
 impl Cheatcode for parseJsonBoolCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for parseJsonBoolArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Bool)))
     }
 }
 
 impl Cheatcode for parseJsonAddressCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for parseJsonAddressArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Address)))
     }
 }
 
 impl Cheatcode for parseJsonStringCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::String)
     }
 }
 
 impl Cheatcode for parseJsonStringArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::String)))
     }
 }
 
 impl Cheatcode for parseJsonBytesCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Bytes)
     }
 }
 
 impl Cheatcode for parseJsonBytesArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Bytes)))
     }
 }
 
 impl Cheatcode for parseJsonBytes32Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for parseJsonBytes32ArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::FixedBytes(32))))
     }
 }
 
 impl Cheatcode for parseJsonType_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, typeDescription } = self;
         parse_json_coerce(json, "$", &resolve_type(typeDescription, state.struct_defs())?)
             .map(|v| v.abi_encode())
@@ -147,7 +148,7 @@ impl Cheatcode for parseJsonType_0Call {
 }
 
 impl Cheatcode for parseJsonType_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key, typeDescription } = self;
         parse_json_coerce(json, key, &resolve_type(typeDescription, state.struct_defs())?)
             .map(|v| v.abi_encode())
@@ -155,7 +156,7 @@ impl Cheatcode for parseJsonType_1Call {
 }
 
 impl Cheatcode for parseJsonTypeArrayCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key, typeDescription } = self;
         let ty = resolve_type(typeDescription, state.struct_defs())?;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(ty))).map(|v| v.abi_encode())
@@ -163,14 +164,14 @@ impl Cheatcode for parseJsonTypeArrayCall {
 }
 
 impl Cheatcode for parseJsonKeysCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, key } = self;
         parse_json_keys(json, key)
     }
 }
 
 impl Cheatcode for serializeJsonCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, value } = self;
         *state.serialized_jsons.entry(objectKey.into()).or_default() = serde_json::from_str(value)?;
         Ok(value.abi_encode())
@@ -178,56 +179,56 @@ impl Cheatcode for serializeJsonCall {
 }
 
 impl Cheatcode for serializeBool_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, (*value).into())
     }
 }
 
 impl Cheatcode for serializeUint_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, (*value).into())
     }
 }
 
 impl Cheatcode for serializeInt_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, (*value).into())
     }
 }
 
 impl Cheatcode for serializeAddress_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, (*value).into())
     }
 }
 
 impl Cheatcode for serializeBytes32_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, DynSolValue::FixedBytes(*value, 32))
     }
 }
 
 impl Cheatcode for serializeString_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, value.clone().into())
     }
 }
 
 impl Cheatcode for serializeBytes_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, value.to_vec().into())
     }
 }
 
 impl Cheatcode for serializeBool_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -239,7 +240,7 @@ impl Cheatcode for serializeBool_1Call {
 }
 
 impl Cheatcode for serializeUint_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -251,7 +252,7 @@ impl Cheatcode for serializeUint_1Call {
 }
 
 impl Cheatcode for serializeInt_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -263,7 +264,7 @@ impl Cheatcode for serializeInt_1Call {
 }
 
 impl Cheatcode for serializeAddress_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -275,7 +276,7 @@ impl Cheatcode for serializeAddress_1Call {
 }
 
 impl Cheatcode for serializeBytes32_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -287,7 +288,7 @@ impl Cheatcode for serializeBytes32_1Call {
 }
 
 impl Cheatcode for serializeString_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -299,7 +300,7 @@ impl Cheatcode for serializeString_1Call {
 }
 
 impl Cheatcode for serializeBytes_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -313,7 +314,7 @@ impl Cheatcode for serializeBytes_1Call {
 }
 
 impl Cheatcode for serializeJsonType_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { typeDescription, value } = self;
         let ty = resolve_type(typeDescription, state.struct_defs())?;
         let value = ty.abi_decode(value)?;
@@ -323,7 +324,7 @@ impl Cheatcode for serializeJsonType_0Call {
 }
 
 impl Cheatcode for serializeJsonType_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, typeDescription, value } = self;
         let ty = resolve_type(typeDescription, state.struct_defs())?;
         let value = ty.abi_decode(value)?;
@@ -332,7 +333,7 @@ impl Cheatcode for serializeJsonType_1Call {
 }
 
 impl Cheatcode for serializeUintToHexCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         let hex = format!("0x{value:x}");
         serialize_json(state, objectKey, valueKey, hex.into())
@@ -340,7 +341,7 @@ impl Cheatcode for serializeUintToHexCall {
 }
 
 impl Cheatcode for writeJson_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, path } = self;
         let json = serde_json::from_str(json).unwrap_or_else(|_| Value::String(json.to_owned()));
         let json_string = serde_json::to_string_pretty(&json)?;
@@ -349,7 +350,7 @@ impl Cheatcode for writeJson_0Call {
 }
 
 impl Cheatcode for writeJson_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json: value, path, valueKey } = self;
 
         // Read, parse, and update the JSON object.
@@ -652,8 +653,8 @@ fn _json_value_to_token(value: &Value, defs: &StructDefinitions) -> Result<DynSo
 /// object, so that the user can use that as a value to a new invocation of the same function with a
 /// new object key. This enables the user to reuse the same function to crate arbitrarily complex
 /// object structures (JSON).
-fn serialize_json(
-    state: &mut Cheatcodes,
+fn serialize_json<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
     object_key: &str,
     value_key: &str,
     value: DynSolValue,

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -15,9 +15,14 @@ pub extern crate foundry_cheatcodes_spec as spec;
 #[macro_use]
 extern crate tracing;
 
+use alloy_consensus::transaction::SignerRecoverable;
+use alloy_evm::FromRecoveredTx;
+use alloy_network::{Ethereum, Network};
 use alloy_primitives::Address;
+use alloy_rlp::Decodable;
+use foundry_config::FromEvmVersion;
 use foundry_evm_core::{FoundryContextExt, backend::DatabaseExt};
-use revm::context::{ContextTr, JournalTr, TxEnv};
+use revm::context::{Cfg, ContextTr, JournalTr};
 
 pub use Vm::ForgeContext;
 pub use config::CheatsConfig;
@@ -68,7 +73,7 @@ pub(crate) trait Cheatcode: CheatcodeDef {
     /// Applies this cheatcode to the given state.
     ///
     /// Implement this function if you don't need access to the EVM data.
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let _ = state;
         unimplemented!("{}", Self::CHEATCODE.func.id)
     }
@@ -77,9 +82,12 @@ pub(crate) trait Cheatcode: CheatcodeDef {
     ///
     /// Implement this function if you need access to the EVM data.
     #[inline(always)]
-    fn apply_stateful<CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>>(
+    fn apply_stateful<
+        CTX: FoundryContextExt<Spec: FromEvmVersion, Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         self.apply(ccx.state)
     }
@@ -89,11 +97,16 @@ pub(crate) trait Cheatcode: CheatcodeDef {
     /// Implement this function if you need access to the executor.
     #[inline(always)]
     fn apply_full<
-        CTX: FoundryContextExt<Tx = TxEnv, Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
+        CTX: FoundryContextExt<
+                Spec: FromEvmVersion,
+                Tx: FromRecoveredTx<N::TxEnvelope>,
+                Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
+            >,
+        N: Network<TxEnvelope: Decodable + SignerRecoverable>,
     >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let _ = executor;
         self.apply_stateful(ccx)
@@ -101,9 +114,9 @@ pub(crate) trait Cheatcode: CheatcodeDef {
 }
 
 /// The cheatcode context.
-pub struct CheatsCtxt<'a, CTX> {
+pub struct CheatsCtxt<'a, CTX: ContextTr, N: Network = Ethereum> {
     /// The cheatcodes inspector state.
-    pub(crate) state: &'a mut Cheatcodes,
+    pub(crate) state: &'a mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
     /// The EVM context.
     pub(crate) ecx: &'a mut CTX,
     /// The original `msg.sender`.
@@ -112,7 +125,7 @@ pub struct CheatsCtxt<'a, CTX> {
     pub(crate) gas_limit: u64,
 }
 
-impl<CTX> std::ops::Deref for CheatsCtxt<'_, CTX> {
+impl<CTX: ContextTr, N: Network> std::ops::Deref for CheatsCtxt<'_, CTX, N> {
     type Target = CTX;
 
     #[inline(always)]
@@ -121,14 +134,14 @@ impl<CTX> std::ops::Deref for CheatsCtxt<'_, CTX> {
     }
 }
 
-impl<CTX> std::ops::DerefMut for CheatsCtxt<'_, CTX> {
+impl<CTX: ContextTr, N: Network> std::ops::DerefMut for CheatsCtxt<'_, CTX, N> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.ecx
     }
 }
 
-impl<CTX: ContextTr> CheatsCtxt<'_, CTX> {
+impl<CTX: ContextTr, N: Network> CheatsCtxt<'_, CTX, N> {
     pub(crate) fn ensure_not_precompile(&self, address: &Address) -> Result<()> {
         if self.is_precompile(address) { Err(precompile_error(address)) } else { Ok(()) }
     }

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -2,6 +2,7 @@
 
 use crate::{Cheatcode, CheatsCtxt, Result, Vm::*, evm::journaled_account};
 use alloy_consensus::{SidecarBuilder, SimpleCoder};
+use alloy_network::Network;
 use alloy_primitives::{Address, B256, U256, Uint};
 use alloy_rpc_types::Authorization;
 use alloy_signer::SignerSync;
@@ -21,9 +22,12 @@ use revm::{
 use std::sync::Arc;
 
 impl Cheatcode for broadcast_0Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self {} = self;
         broadcast(ccx, None, true)
@@ -31,9 +35,12 @@ impl Cheatcode for broadcast_0Call {
 }
 
 impl Cheatcode for broadcast_1Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { signer } = self;
         broadcast(ccx, Some(signer), true)
@@ -41,9 +48,12 @@ impl Cheatcode for broadcast_1Call {
 }
 
 impl Cheatcode for broadcast_2Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { privateKey } = self;
         broadcast_key(ccx, privateKey, true)
@@ -51,9 +61,9 @@ impl Cheatcode for broadcast_2Call {
 }
 
 impl Cheatcode for attachDelegation_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { signedDelegation } = self;
         attach_delegation(ccx, signedDelegation, false)
@@ -61,9 +71,9 @@ impl Cheatcode for attachDelegation_0Call {
 }
 
 impl Cheatcode for attachDelegation_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { signedDelegation, crossChain } = self;
         attach_delegation(ccx, signedDelegation, *crossChain)
@@ -71,9 +81,9 @@ impl Cheatcode for attachDelegation_1Call {
 }
 
 impl Cheatcode for signDelegation_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { implementation, privateKey } = *self;
         sign_delegation(ccx, privateKey, implementation, None, false, false)
@@ -81,9 +91,9 @@ impl Cheatcode for signDelegation_0Call {
 }
 
 impl Cheatcode for signDelegation_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { implementation, privateKey, nonce } = *self;
         sign_delegation(ccx, privateKey, implementation, Some(nonce), false, false)
@@ -91,9 +101,9 @@ impl Cheatcode for signDelegation_1Call {
 }
 
 impl Cheatcode for signDelegation_2Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { implementation, privateKey, crossChain } = *self;
         sign_delegation(ccx, privateKey, implementation, None, crossChain, false)
@@ -101,9 +111,9 @@ impl Cheatcode for signDelegation_2Call {
 }
 
 impl Cheatcode for signAndAttachDelegation_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { implementation, privateKey } = *self;
         sign_delegation(ccx, privateKey, implementation, None, false, true)
@@ -111,9 +121,9 @@ impl Cheatcode for signAndAttachDelegation_0Call {
 }
 
 impl Cheatcode for signAndAttachDelegation_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { implementation, privateKey, nonce } = *self;
         sign_delegation(ccx, privateKey, implementation, Some(nonce), false, true)
@@ -121,9 +131,9 @@ impl Cheatcode for signAndAttachDelegation_1Call {
 }
 
 impl Cheatcode for signAndAttachDelegation_2Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { implementation, privateKey, crossChain } = *self;
         sign_delegation(ccx, privateKey, implementation, None, crossChain, true)
@@ -131,8 +141,8 @@ impl Cheatcode for signAndAttachDelegation_2Call {
 }
 
 /// Helper function to attach an EIP-7702 delegation.
-fn attach_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn attach_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     delegation: &SignedDelegation,
     cross_chain: bool,
 ) -> Result {
@@ -155,8 +165,8 @@ fn attach_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
 
 /// Helper function to sign and attach (if needed) an EIP-7702 delegation.
 /// Uses the provided nonce, otherwise retrieves and increments the nonce of the EOA.
-fn sign_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn sign_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     private_key: Uint<256, 4>,
     implementation: Address,
     nonce: Option<u64>,
@@ -228,8 +238,8 @@ fn next_delegation_nonce(
     }
 }
 
-fn write_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn write_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     auth: SignedAuthorization,
 ) -> Result<()> {
     let authority = auth.recover_authority().map_err(|e| format!("{e}"))?;
@@ -265,7 +275,10 @@ fn write_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
 }
 
 impl Cheatcode for attachBlobCall {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { blob } = self;
         ensure!(
             ccx.ecx.cfg().spec().into() >= SpecId::CANCUN,
@@ -284,9 +297,12 @@ impl Cheatcode for attachBlobCall {
 }
 
 impl Cheatcode for startBroadcast_0Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self {} = self;
         broadcast(ccx, None, false)
@@ -294,9 +310,12 @@ impl Cheatcode for startBroadcast_0Call {
 }
 
 impl Cheatcode for startBroadcast_1Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { signer } = self;
         broadcast(ccx, Some(signer), false)
@@ -304,9 +323,12 @@ impl Cheatcode for startBroadcast_1Call {
 }
 
 impl Cheatcode for startBroadcast_2Call {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
+    fn apply_stateful<
+        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+        N: Network,
+    >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { privateKey } = self;
         broadcast_key(ccx, privateKey, false)
@@ -314,7 +336,10 @@ impl Cheatcode for startBroadcast_2Call {
 }
 
 impl Cheatcode for stopBroadcastCall {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self {} = self;
         let Some(broadcast) = ccx.state.broadcast.take() else {
             bail!("no broadcast in progress to stop");
@@ -325,7 +350,10 @@ impl Cheatcode for stopBroadcastCall {
 }
 
 impl Cheatcode for getWalletsCall {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let wallets = ccx.state.wallets().signers().unwrap_or_default();
         Ok(wallets.abi_encode())
     }
@@ -401,8 +429,11 @@ impl Wallets {
 }
 
 /// Sets up broadcasting from a script using `new_origin` as the sender.
-fn broadcast<CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn broadcast<
+    CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>,
+    N: Network,
+>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     new_origin: Option<&Address>,
     single_call: bool,
 ) -> Result {
@@ -447,8 +478,11 @@ fn broadcast<CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: Journa
 /// Sets up broadcasting from a script with the sender derived from `private_key`.
 /// Adds this private key to `state`'s `wallets` vector to later be used for signing
 /// if broadcast is successful.
-fn broadcast_key<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
+fn broadcast_key<
+    CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
+    N: Network,
+>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
     private_key: &U256,
     single_call: bool,
 ) -> Result {

--- a/crates/cheatcodes/src/string.rs
+++ b/crates/cheatcodes/src/string.rs
@@ -2,12 +2,13 @@
 
 use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
 use alloy_dyn_abi::{DynSolType, DynSolValue};
+use alloy_network::Network;
 use alloy_primitives::{U256, hex};
 use alloy_sol_types::SolValue;
 
 // address
 impl Cheatcode for toString_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
     }
@@ -15,7 +16,7 @@ impl Cheatcode for toString_0Call {
 
 // bytes
 impl Cheatcode for toString_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
     }
@@ -23,7 +24,7 @@ impl Cheatcode for toString_1Call {
 
 // bytes32
 impl Cheatcode for toString_2Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
     }
@@ -31,7 +32,7 @@ impl Cheatcode for toString_2Call {
 
 // bool
 impl Cheatcode for toString_3Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
     }
@@ -39,7 +40,7 @@ impl Cheatcode for toString_3Call {
 
 // uint256
 impl Cheatcode for toString_4Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
     }
@@ -47,84 +48,84 @@ impl Cheatcode for toString_4Call {
 
 // int256
 impl Cheatcode for toString_5Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
     }
 }
 
 impl Cheatcode for parseBytesCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Bytes)
     }
 }
 
 impl Cheatcode for parseAddressCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for parseUintCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for parseIntCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for parseBytes32Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for parseBoolCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for toLowercaseCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { input } = self;
         Ok(input.to_lowercase().abi_encode())
     }
 }
 
 impl Cheatcode for toUppercaseCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { input } = self;
         Ok(input.to_uppercase().abi_encode())
     }
 }
 
 impl Cheatcode for trimCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { input } = self;
         Ok(input.trim().abi_encode())
     }
 }
 
 impl Cheatcode for replaceCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { input, from, to } = self;
         Ok(input.replace(from, to).abi_encode())
     }
 }
 
 impl Cheatcode for splitCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { input, delimiter } = self;
         let parts: Vec<&str> = input.split(delimiter).collect();
         Ok(parts.abi_encode())
@@ -132,14 +133,14 @@ impl Cheatcode for splitCall {
 }
 
 impl Cheatcode for indexOfCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { input, key } = self;
         Ok(input.find(key).map(U256::from).unwrap_or(U256::MAX).abi_encode())
     }
 }
 
 impl Cheatcode for containsCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { subject, search } = self;
         Ok(subject.contains(search).abi_encode())
     }

--- a/crates/cheatcodes/src/test.rs
+++ b/crates/cheatcodes/src/test.rs
@@ -2,6 +2,7 @@
 
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, Result, Vm::*};
 use alloy_chains::Chain as AlloyChain;
+use alloy_network::Network;
 use alloy_primitives::{Address, U256};
 use alloy_sol_types::SolValue;
 use foundry_common::version::SEMVER_VERSION;
@@ -15,28 +16,34 @@ pub(crate) mod expect;
 pub(crate) mod revert_handlers;
 
 impl Cheatcode for breakpoint_0Call {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { char } = self;
         breakpoint(ccx.state, &ccx.caller, char, true)
     }
 }
 
 impl Cheatcode for breakpoint_1Call {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { char, value } = self;
         breakpoint(ccx.state, &ccx.caller, char, *value)
     }
 }
 
 impl Cheatcode for getFoundryVersionCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         Ok(SEMVER_VERSION.abi_encode())
     }
 }
 
 impl Cheatcode for rpcUrlCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { rpcAlias } = self;
         let url = state.config.rpc_endpoint(rpcAlias)?.url()?.abi_encode();
         Ok(url)
@@ -44,21 +51,21 @@ impl Cheatcode for rpcUrlCall {
 }
 
 impl Cheatcode for rpcUrlsCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         state.config.rpc_urls().map(|urls| urls.abi_encode())
     }
 }
 
 impl Cheatcode for rpcUrlStructsCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         state.config.rpc_urls().map(|urls| urls.abi_encode())
     }
 }
 
 impl Cheatcode for sleepCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { duration } = self;
         let sleep_duration = std::time::Duration::from_millis(duration.saturating_to());
         std::thread::sleep(sleep_duration);
@@ -67,7 +74,10 @@ impl Cheatcode for sleepCall {
 }
 
 impl Cheatcode for skip_0Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { skipTest } = *self;
         if skipTest {
             // Skip should not work if called deeper than at test level.
@@ -81,7 +91,10 @@ impl Cheatcode for skip_0Call {
 }
 
 impl Cheatcode for skip_1Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { skipTest, reason } = self;
         if *skipTest {
             // Skip should not work if called deeper than at test level.
@@ -95,14 +108,14 @@ impl Cheatcode for skip_1Call {
 }
 
 impl Cheatcode for getChain_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { chainAlias } = self;
         get_chain(state, chainAlias)
     }
 }
 
 impl Cheatcode for getChain_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { chainId } = self;
         // Convert the chainId to a string and use the existing get_chain function
         let chain_id_str = chainId.to_string();
@@ -111,7 +124,12 @@ impl Cheatcode for getChain_1Call {
 }
 
 /// Adds or removes the given breakpoint to the state.
-fn breakpoint(state: &mut Cheatcodes, caller: &Address, s: &str, add: bool) -> Result {
+fn breakpoint<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+    caller: &Address,
+    s: &str,
+    add: bool,
+) -> Result {
     let mut chars = s.chars();
     let (Some(point), None) = (chars.next(), chars.next()) else {
         bail!("breakpoints must be exactly one character");
@@ -128,7 +146,10 @@ fn breakpoint(state: &mut Cheatcodes, caller: &Address, s: &str, add: bool) -> R
 }
 
 /// Gets chain information for the given alias.
-fn get_chain(state: &mut Cheatcodes, chain_alias: &str) -> Result {
+fn get_chain<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+    chain_alias: &str,
+) -> Result {
     // Parse the chain alias - works for both chain names and IDs
     let alloy_chain = AlloyChain::from_str(chain_alias)
         .map_err(|_| fmt_err!("invalid chain alias: {chain_alias}"))?;

--- a/crates/cheatcodes/src/test/assert.rs
+++ b/crates/cheatcodes/src/test/assert.rs
@@ -1,4 +1,5 @@
 use crate::{CheatcodesExecutor, CheatsCtxt, Result, Vm::*};
+use alloy_network::Network;
 use alloy_primitives::{I256, U256, U512};
 use foundry_evm_core::{
     abi::console::{format_units_int, format_units_uint},
@@ -190,9 +191,9 @@ impl EqRelAssertionError<I256> {
 type ComparisonResult<'a, T> = Result<(), ComparisonAssertionError<'a, T>>;
 
 #[cold]
-fn handle_assertion_result<CTX: ContextTr<Db: Database<Error = DatabaseError>>, E>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
-    executor: &mut dyn CheatcodesExecutor<CTX>,
+fn handle_assertion_result<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network, E>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
+    executor: &mut dyn CheatcodesExecutor<CTX, N>,
     err: E,
     error_formatter: Option<&dyn Fn(&E) -> String>,
     error_msg: Option<&str>,
@@ -206,9 +207,9 @@ fn handle_assertion_result<CTX: ContextTr<Db: Database<Error = DatabaseError>>, 
     handle_assertion_result_mono(ccx, executor, msg)
 }
 
-fn handle_assertion_result_mono<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
-    ccx: &mut CheatsCtxt<'_, CTX>,
-    executor: &mut dyn CheatcodesExecutor<CTX>,
+fn handle_assertion_result_mono<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    ccx: &mut CheatsCtxt<'_, CTX, N>,
+    executor: &mut dyn CheatcodesExecutor<CTX, N>,
     msg: Cow<'_, str>,
 ) -> Result {
     if ccx.state.config.assertions_revert {
@@ -249,10 +250,10 @@ macro_rules! impl_assertions {
 
     (@impl $no_error:ident, $with_error:ident, ($($arg:ident),*), $body:expr, $error_formatter:expr) => {
         impl crate::Cheatcode for $no_error {
-            fn apply_full<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+            fn apply_full<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
                 &self,
-                ccx: &mut CheatsCtxt<'_, CTX>,
-                executor: &mut dyn CheatcodesExecutor<CTX>,
+                ccx: &mut CheatsCtxt<'_, CTX, N>,
+                executor: &mut dyn CheatcodesExecutor<CTX, N>,
             ) -> Result {
                 let Self { $($arg),* } = self;
                 match $body {
@@ -263,10 +264,10 @@ macro_rules! impl_assertions {
         }
 
         impl crate::Cheatcode for $with_error {
-            fn apply_full<CTX: ContextTr<Db: Database<Error = DatabaseError>>>(
+            fn apply_full<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
                 &self,
-                ccx: &mut CheatsCtxt<'_, CTX>,
-                executor: &mut dyn CheatcodesExecutor<CTX>,
+                ccx: &mut CheatsCtxt<'_, CTX, N>,
+                executor: &mut dyn CheatcodesExecutor<CTX, N>,
             ) -> Result {
                 let Self { $($arg,)* error } = self;
                 match $body {

--- a/crates/cheatcodes/src/test/assume.rs
+++ b/crates/cheatcodes/src/test/assume.rs
@@ -1,4 +1,5 @@
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, Error, Result};
+use alloy_network::Network;
 use alloy_primitives::Address;
 use foundry_evm_core::constants::MAGIC_ASSUME;
 use revm::context::{ContextTr, JournalTr};
@@ -45,20 +46,26 @@ impl AcceptableRevertParameters {
 }
 
 impl Cheatcode for assumeCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { condition } = self;
         if *condition { Ok(Default::default()) } else { Err(Error::from(MAGIC_ASSUME)) }
     }
 }
 
 impl Cheatcode for assumeNoRevert_0Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         assume_no_revert(ccx.state, ccx.ecx.journal().depth(), vec![])
     }
 }
 
 impl Cheatcode for assumeNoRevert_1Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { potentialRevert } = self;
         assume_no_revert(
             ccx.state,
@@ -69,7 +76,10 @@ impl Cheatcode for assumeNoRevert_1Call {
 }
 
 impl Cheatcode for assumeNoRevert_2Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { potentialReverts } = self;
         assume_no_revert(
             ccx.state,
@@ -79,8 +89,8 @@ impl Cheatcode for assumeNoRevert_2Call {
     }
 }
 
-fn assume_no_revert(
-    state: &mut Cheatcodes,
+fn assume_no_revert<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
     depth: usize,
     parameters: Vec<AcceptableRevertParameters>,
 ) -> Result {

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -6,6 +6,7 @@ use std::{
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, Error, Result, Vm::*};
 use alloy_dyn_abi::{DynSolValue, EventExt};
 use alloy_json_abi::Event;
+use alloy_network::Network;
 use alloy_primitives::{
     Address, Bytes, LogData as RawLog, U256, hex,
     map::{AddressHashMap, HashMap, hash_map::Entry},
@@ -163,28 +164,28 @@ impl CreateScheme {
 }
 
 impl Cheatcode for expectCall_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { callee, data } = self;
         expect_call(state, callee, data, None, None, None, 1, ExpectedCallType::NonCount)
     }
 }
 
 impl Cheatcode for expectCall_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { callee, data, count } = self;
         expect_call(state, callee, data, None, None, None, *count, ExpectedCallType::Count)
     }
 }
 
 impl Cheatcode for expectCall_2Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { callee, msgValue, data } = self;
         expect_call(state, callee, data, Some(msgValue), None, None, 1, ExpectedCallType::NonCount)
     }
 }
 
 impl Cheatcode for expectCall_3Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { callee, msgValue, data, count } = self;
         expect_call(
             state,
@@ -200,7 +201,7 @@ impl Cheatcode for expectCall_3Call {
 }
 
 impl Cheatcode for expectCall_4Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { callee, msgValue, gas, data } = self;
         expect_call(
             state,
@@ -216,7 +217,7 @@ impl Cheatcode for expectCall_4Call {
 }
 
 impl Cheatcode for expectCall_5Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { callee, msgValue, gas, data, count } = self;
         expect_call(
             state,
@@ -232,7 +233,7 @@ impl Cheatcode for expectCall_5Call {
 }
 
 impl Cheatcode for expectCallMinGas_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { callee, msgValue, minGas, data } = self;
         expect_call(
             state,
@@ -248,7 +249,7 @@ impl Cheatcode for expectCallMinGas_0Call {
 }
 
 impl Cheatcode for expectCallMinGas_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { callee, msgValue, minGas, data, count } = self;
         expect_call(
             state,
@@ -264,7 +265,10 @@ impl Cheatcode for expectCallMinGas_1Call {
 }
 
 impl Cheatcode for expectEmit_0Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData } = *self;
         expect_emit(
             ccx.state,
@@ -278,7 +282,10 @@ impl Cheatcode for expectEmit_0Call {
 }
 
 impl Cheatcode for expectEmit_1Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData, emitter } = *self;
         expect_emit(
             ccx.state,
@@ -292,21 +299,30 @@ impl Cheatcode for expectEmit_1Call {
 }
 
 impl Cheatcode for expectEmit_2Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self {} = self;
         expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], None, false, 1)
     }
 }
 
 impl Cheatcode for expectEmit_3Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { emitter } = *self;
         expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], Some(emitter), false, 1)
     }
 }
 
 impl Cheatcode for expectEmit_4Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData, count } = *self;
         expect_emit(
             ccx.state,
@@ -320,7 +336,10 @@ impl Cheatcode for expectEmit_4Call {
 }
 
 impl Cheatcode for expectEmit_5Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData, emitter, count } = *self;
         expect_emit(
             ccx.state,
@@ -334,21 +353,30 @@ impl Cheatcode for expectEmit_5Call {
 }
 
 impl Cheatcode for expectEmit_6Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { count } = *self;
         expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], None, false, count)
     }
 }
 
 impl Cheatcode for expectEmit_7Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { emitter, count } = *self;
         expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], Some(emitter), false, count)
     }
 }
 
 impl Cheatcode for expectEmitAnonymous_0Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { checkTopic0, checkTopic1, checkTopic2, checkTopic3, checkData } = *self;
         expect_emit(
             ccx.state,
@@ -362,7 +390,10 @@ impl Cheatcode for expectEmitAnonymous_0Call {
 }
 
 impl Cheatcode for expectEmitAnonymous_1Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { checkTopic0, checkTopic1, checkTopic2, checkTopic3, checkData, emitter } = *self;
         expect_emit(
             ccx.state,
@@ -376,42 +407,54 @@ impl Cheatcode for expectEmitAnonymous_1Call {
 }
 
 impl Cheatcode for expectEmitAnonymous_2Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self {} = self;
         expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], None, true, 1)
     }
 }
 
 impl Cheatcode for expectEmitAnonymous_3Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { emitter } = *self;
         expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], Some(emitter), true, 1)
     }
 }
 
 impl Cheatcode for expectCreateCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { bytecode, deployer } = self;
         expect_create(state, bytecode.clone(), *deployer, CreateScheme::Create)
     }
 }
 
 impl Cheatcode for expectCreate2Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { bytecode, deployer } = self;
         expect_create(state, bytecode.clone(), *deployer, CreateScheme::Create2)
     }
 }
 
 impl Cheatcode for expectRevert_0Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self {} = self;
         expect_revert(ccx.state, None, ccx.ecx.journal().depth(), false, false, None, 1)
     }
 }
 
 impl Cheatcode for expectRevert_1Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { revertData } = self;
         expect_revert(
             ccx.state,
@@ -426,21 +469,30 @@ impl Cheatcode for expectRevert_1Call {
 }
 
 impl Cheatcode for expectRevert_2Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { revertData } = self;
         expect_revert(ccx.state, Some(revertData), ccx.ecx.journal().depth(), false, false, None, 1)
     }
 }
 
 impl Cheatcode for expectRevert_3Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { reverter } = self;
         expect_revert(ccx.state, None, ccx.ecx.journal().depth(), false, false, Some(*reverter), 1)
     }
 }
 
 impl Cheatcode for expectRevert_4Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { revertData, reverter } = self;
         expect_revert(
             ccx.state,
@@ -455,7 +507,10 @@ impl Cheatcode for expectRevert_4Call {
 }
 
 impl Cheatcode for expectRevert_5Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { revertData, reverter } = self;
         expect_revert(
             ccx.state,
@@ -470,14 +525,20 @@ impl Cheatcode for expectRevert_5Call {
 }
 
 impl Cheatcode for expectRevert_6Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { count } = self;
         expect_revert(ccx.state, None, ccx.ecx.journal().depth(), false, false, None, *count)
     }
 }
 
 impl Cheatcode for expectRevert_7Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { revertData, count } = self;
         expect_revert(
             ccx.state,
@@ -492,7 +553,10 @@ impl Cheatcode for expectRevert_7Call {
 }
 
 impl Cheatcode for expectRevert_8Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { revertData, count } = self;
         expect_revert(
             ccx.state,
@@ -507,7 +571,10 @@ impl Cheatcode for expectRevert_8Call {
 }
 
 impl Cheatcode for expectRevert_9Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { reverter, count } = self;
         expect_revert(
             ccx.state,
@@ -522,7 +589,10 @@ impl Cheatcode for expectRevert_9Call {
 }
 
 impl Cheatcode for expectRevert_10Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { revertData, reverter, count } = self;
         expect_revert(
             ccx.state,
@@ -537,7 +607,10 @@ impl Cheatcode for expectRevert_10Call {
 }
 
 impl Cheatcode for expectRevert_11Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { revertData, reverter, count } = self;
         expect_revert(
             ccx.state,
@@ -552,7 +625,10 @@ impl Cheatcode for expectRevert_11Call {
 }
 
 impl Cheatcode for expectPartialRevert_0Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { revertData } = self;
         expect_revert(
             ccx.state,
@@ -567,7 +643,10 @@ impl Cheatcode for expectPartialRevert_0Call {
 }
 
 impl Cheatcode for expectPartialRevert_1Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { revertData, reverter } = self;
         expect_revert(
             ccx.state,
@@ -582,13 +661,19 @@ impl Cheatcode for expectPartialRevert_1Call {
 }
 
 impl Cheatcode for _expectCheatcodeRevert_0Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         expect_revert(ccx.state, None, ccx.ecx.journal().depth(), true, false, None, 1)
     }
 }
 
 impl Cheatcode for _expectCheatcodeRevert_1Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { revertData } = self;
         expect_revert(
             ccx.state,
@@ -603,21 +688,30 @@ impl Cheatcode for _expectCheatcodeRevert_1Call {
 }
 
 impl Cheatcode for _expectCheatcodeRevert_2Call {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { revertData } = self;
         expect_revert(ccx.state, Some(revertData), ccx.ecx.journal().depth(), true, false, None, 1)
     }
 }
 
 impl Cheatcode for expectSafeMemoryCall {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { min, max } = *self;
         expect_safe_memory(ccx.state, min, max, ccx.ecx.journal().depth().try_into()?)
     }
 }
 
 impl Cheatcode for stopExpectSafeMemoryCall {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self {} = self;
         ccx.state.allowed_mem_writes.remove(&ccx.ecx.journal().depth().try_into()?);
         Ok(Default::default())
@@ -625,7 +719,10 @@ impl Cheatcode for stopExpectSafeMemoryCall {
 }
 
 impl Cheatcode for expectSafeMemoryCallCall {
-    fn apply_stateful<CTX: ContextTr>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { min, max } = *self;
         expect_safe_memory(ccx.state, min, max, (ccx.ecx.journal().depth() + 1).try_into()?)
     }
@@ -662,8 +759,8 @@ impl RevertParameters for ExpectedRevert {
 ///   address(0xc4f3) and selector `0xd34db33f` to be made at least once. If the amount of calls is
 ///   0, the test will fail. If the call is made more than once, the test will pass.
 #[expect(clippy::too_many_arguments)] // It is what it is
-fn expect_call(
-    state: &mut Cheatcodes,
+fn expect_call<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
     target: &Address,
     calldata: &Bytes,
     value: Option<&U256>,
@@ -729,8 +826,8 @@ fn expect_call(
     Ok(Default::default())
 }
 
-fn expect_emit(
-    state: &mut Cheatcodes,
+fn expect_emit<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
     depth: usize,
     checks: [bool; 5],
     address: Option<Address>,
@@ -759,8 +856,8 @@ fn expect_emit(
     Ok(Default::default())
 }
 
-pub(crate) fn handle_expect_emit(
-    state: &mut Cheatcodes,
+pub(crate) fn handle_expect_emit<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
     log: &alloy_primitives::Log,
     mut interpreter: Option<&mut Interpreter>,
 ) -> Option<&'static str> {
@@ -998,8 +1095,8 @@ impl LogCountMap {
     }
 }
 
-fn expect_create(
-    state: &mut Cheatcodes,
+fn expect_create<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
     bytecode: Bytes,
     deployer: Address,
     create_scheme: CreateScheme,
@@ -1010,8 +1107,8 @@ fn expect_create(
     Ok(Default::default())
 }
 
-fn expect_revert(
-    state: &mut Cheatcodes,
+fn expect_revert<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
     reason: Option<&[u8]>,
     depth: usize,
     cheatcode: bool,
@@ -1273,7 +1370,12 @@ fn name_mismatched_logs(
     format!("{actual_name} != expected {expected_name}")
 }
 
-fn expect_safe_memory(state: &mut Cheatcodes, start: u64, end: u64, depth: u64) -> Result {
+fn expect_safe_memory<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+    start: u64,
+    end: u64,
+    depth: u64,
+) -> Result {
     ensure!(start < end, "memory range start ({start}) is greater than end ({end})");
     #[expect(clippy::single_range_in_vec_init)] // Wanted behaviour
     let offsets = state.allowed_mem_writes.entry(depth).or_insert_with(|| vec![0..0x60]);

--- a/crates/cheatcodes/src/toml.rs
+++ b/crates/cheatcodes/src/toml.rs
@@ -9,6 +9,7 @@ use crate::{
     },
 };
 use alloy_dyn_abi::DynSolType;
+use alloy_network::Network;
 use alloy_sol_types::SolValue;
 use foundry_common::{fmt::StructDefinitions, fs};
 use foundry_config::fs_permissions::FsAccessKind;
@@ -16,14 +17,14 @@ use serde_json::Value as JsonValue;
 use toml::Value as TomlValue;
 
 impl Cheatcode for keyExistsTomlCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         check_json_key_exists(&toml_to_json_string(toml)?, key)
     }
 }
 
 impl Cheatcode for parseToml_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml } = self;
         parse_toml(
             toml,
@@ -34,7 +35,7 @@ impl Cheatcode for parseToml_0Call {
 }
 
 impl Cheatcode for parseToml_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml(
             toml,
@@ -45,105 +46,105 @@ impl Cheatcode for parseToml_1Call {
 }
 
 impl Cheatcode for parseTomlUintCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for parseTomlUintArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Uint(256))))
     }
 }
 
 impl Cheatcode for parseTomlIntCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for parseTomlIntArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Int(256))))
     }
 }
 
 impl Cheatcode for parseTomlBoolCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for parseTomlBoolArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Bool)))
     }
 }
 
 impl Cheatcode for parseTomlAddressCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for parseTomlAddressArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Address)))
     }
 }
 
 impl Cheatcode for parseTomlStringCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::String)
     }
 }
 
 impl Cheatcode for parseTomlStringArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::String)))
     }
 }
 
 impl Cheatcode for parseTomlBytesCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Bytes)
     }
 }
 
 impl Cheatcode for parseTomlBytesArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Bytes)))
     }
 }
 
 impl Cheatcode for parseTomlBytes32Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for parseTomlBytes32ArrayCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::FixedBytes(32))))
     }
 }
 
 impl Cheatcode for parseTomlType_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, typeDescription } = self;
         parse_toml_coerce(
             toml,
@@ -158,7 +159,7 @@ impl Cheatcode for parseTomlType_0Call {
 }
 
 impl Cheatcode for parseTomlType_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key, typeDescription } = self;
         parse_toml_coerce(
             toml,
@@ -173,7 +174,7 @@ impl Cheatcode for parseTomlType_1Call {
 }
 
 impl Cheatcode for parseTomlTypeArrayCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key, typeDescription } = self;
         let ty = resolve_type(
             typeDescription,
@@ -184,14 +185,14 @@ impl Cheatcode for parseTomlTypeArrayCall {
 }
 
 impl Cheatcode for parseTomlKeysCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { toml, key } = self;
         parse_toml_keys(toml, key)
     }
 }
 
 impl Cheatcode for writeToml_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json, path } = self;
         let value =
             serde_json::from_str(json).unwrap_or_else(|_| JsonValue::String(json.to_owned()));
@@ -202,7 +203,7 @@ impl Cheatcode for writeToml_0Call {
 }
 
 impl Cheatcode for writeToml_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { json: value, path, valueKey } = self;
 
         // Read and parse the TOML file.

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -3,12 +3,13 @@
 use crate::{Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Result, Vm::*};
 use alloy_dyn_abi::{DynSolType, DynSolValue, Resolver, TypedData, eip712_parser::EncodeType};
 use alloy_ens::namehash;
+use alloy_network::Network;
 use alloy_primitives::{B64, Bytes, I256, U256, aliases::B32, keccak256, map::HashMap};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_sol_types::SolValue;
 use foundry_common::{TYPE_BINDING_PREFIX, fs};
 use foundry_config::fs_permissions::FsAccessKind;
-use foundry_evm_core::constants::DEFAULT_CREATE2_DEPLOYER;
+use foundry_evm_core::{FoundryContextExt, constants::DEFAULT_CREATE2_DEPLOYER};
 use foundry_evm_fuzz::strategies::BoundMutator;
 use proptest::prelude::Strategy;
 use rand::{Rng, RngCore, seq::SliceRandom};
@@ -33,7 +34,7 @@ pub struct IgnoredTraces {
 }
 
 impl Cheatcode for labelCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { account, newLabel } = self;
         state.labels.insert(*account, newLabel.clone());
         Ok(Default::default())
@@ -41,7 +42,7 @@ impl Cheatcode for labelCall {
 }
 
 impl Cheatcode for getLabelCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { account } = self;
         Ok(match state.labels.get(account) {
             Some(label) => label.abi_encode(),
@@ -51,7 +52,7 @@ impl Cheatcode for getLabelCall {
 }
 
 impl Cheatcode for computeCreateAddressCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { nonce, deployer } = self;
         ensure!(*nonce <= U256::from(u64::MAX), "nonce must be less than 2^64");
         Ok(deployer.create(nonce.to()).abi_encode())
@@ -59,28 +60,28 @@ impl Cheatcode for computeCreateAddressCall {
 }
 
 impl Cheatcode for computeCreate2Address_0Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { salt, initCodeHash, deployer } = self;
         Ok(deployer.create2(salt, initCodeHash).abi_encode())
     }
 }
 
 impl Cheatcode for computeCreate2Address_1Call {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { salt, initCodeHash } = self;
         Ok(DEFAULT_CREATE2_DEPLOYER.create2(salt, initCodeHash).abi_encode())
     }
 }
 
 impl Cheatcode for ensNamehashCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { name } = self;
         Ok(namehash(name).abi_encode())
     }
 }
 
 impl Cheatcode for bound_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { current, min, max } = *self;
         let Some(mutated) = U256::bound(current, min, max, state.test_runner()) else {
             bail!("cannot bound {current} in [{min}, {max}] range")
@@ -90,7 +91,7 @@ impl Cheatcode for bound_0Call {
 }
 
 impl Cheatcode for bound_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { current, min, max } = *self;
         let Some(mutated) = I256::bound(current, min, max, state.test_runner()) else {
             bail!("cannot bound {current} in [{min}, {max}] range")
@@ -100,27 +101,27 @@ impl Cheatcode for bound_1Call {
 }
 
 impl Cheatcode for randomUint_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         random_uint(state, None, None)
     }
 }
 
 impl Cheatcode for randomUint_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { min, max } = *self;
         random_uint(state, None, Some((min, max)))
     }
 }
 
 impl Cheatcode for randomUint_2Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { bits } = *self;
         random_uint(state, Some(bits), None)
     }
 }
 
 impl Cheatcode for randomAddressCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         Ok(DynSolValue::type_strategy(&DynSolType::Address)
             .new_tree(state.test_runner())
             .unwrap()
@@ -130,27 +131,27 @@ impl Cheatcode for randomAddressCall {
 }
 
 impl Cheatcode for randomInt_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         random_int(state, None)
     }
 }
 
 impl Cheatcode for randomInt_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { bits } = *self;
         random_int(state, Some(bits))
     }
 }
 
 impl Cheatcode for randomBoolCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let rand_bool: bool = state.rng().random();
         Ok(rand_bool.abi_encode())
     }
 }
 
 impl Cheatcode for randomBytesCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { len } = *self;
         ensure!(
             len <= U256::from(usize::MAX),
@@ -163,24 +164,24 @@ impl Cheatcode for randomBytesCall {
 }
 
 impl Cheatcode for randomBytes4Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let rand_u32 = state.rng().next_u32();
         Ok(B32::from(rand_u32).abi_encode())
     }
 }
 
 impl Cheatcode for randomBytes8Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let rand_u64 = state.rng().next_u64();
         Ok(B64::from(rand_u64).abi_encode())
     }
 }
 
 impl Cheatcode for pauseTracingCall {
-    fn apply_full<CTX: ContextTr>(
+    fn apply_full<CTX: ContextTr, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             // No tracer -> nothing to pause
@@ -200,10 +201,10 @@ impl Cheatcode for pauseTracingCall {
 }
 
 impl Cheatcode for resumeTracingCall {
-    fn apply_full<CTX: ContextTr>(
+    fn apply_full<CTX: ContextTr, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
-        executor: &mut dyn CheatcodesExecutor<CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<CTX, N>,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             // No tracer -> nothing to unpause
@@ -223,7 +224,7 @@ impl Cheatcode for resumeTracingCall {
 }
 
 impl Cheatcode for interceptInitcodeCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self {} = self;
         if !state.intercept_next_create_call {
             state.intercept_next_create_call = true;
@@ -235,7 +236,10 @@ impl Cheatcode for interceptInitcodeCall {
 }
 
 impl Cheatcode for setArbitraryStorage_0Call {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { target } = self;
         ccx.state.arbitrary_storage().mark_arbitrary(target, false);
 
@@ -244,7 +248,10 @@ impl Cheatcode for setArbitraryStorage_0Call {
 }
 
 impl Cheatcode for setArbitraryStorage_1Call {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: ContextTr, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { target, overwrite } = self;
         ccx.state.arbitrary_storage().mark_arbitrary(target, *overwrite);
 
@@ -253,9 +260,9 @@ impl Cheatcode for setArbitraryStorage_1Call {
 }
 
 impl Cheatcode for copyStorageCall {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>>(
+    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>, N: Network>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX>,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
     ) -> Result {
         let Self { from, to } = self;
 
@@ -280,7 +287,7 @@ impl Cheatcode for copyStorageCall {
 }
 
 impl Cheatcode for sortCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { array } = self;
 
         let mut sorted_values = array.clone();
@@ -291,7 +298,7 @@ impl Cheatcode for sortCall {
 }
 
 impl Cheatcode for shuffleCall {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { array } = self;
 
         let mut shuffled_values = array.clone();
@@ -303,7 +310,10 @@ impl Cheatcode for shuffleCall {
 }
 
 impl Cheatcode for setSeedCall {
-    fn apply_stateful<CTX>(&self, ccx: &mut CheatsCtxt<'_, CTX>) -> Result {
+    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+        &self,
+        ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ) -> Result {
         let Self { seed } = self;
         ccx.state.set_seed(*seed);
         Ok(Default::default())
@@ -312,7 +322,11 @@ impl Cheatcode for setSeedCall {
 
 /// Helper to generate a random `uint` value (with given bits or bounded if specified)
 /// from type strategy.
-fn random_uint(state: &mut Cheatcodes, bits: Option<U256>, bounds: Option<(U256, U256)>) -> Result {
+fn random_uint<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+    bits: Option<U256>,
+    bounds: Option<(U256, U256)>,
+) -> Result {
     if let Some(bits) = bits {
         // Generate random with specified bits.
         ensure!(bits <= U256::from(256), "number of bits cannot exceed 256");
@@ -345,7 +359,10 @@ fn random_uint(state: &mut Cheatcodes, bits: Option<U256>, bounds: Option<(U256,
 }
 
 /// Helper to generate a random `int` value (with given bits if specified) from type strategy.
-fn random_int(state: &mut Cheatcodes, bits: Option<U256>) -> Result {
+fn random_int<SPEC, BLOCK, N: Network>(
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+    bits: Option<U256>,
+) -> Result {
     let no_bits = bits.unwrap_or(U256::from(256));
     ensure!(no_bits <= U256::from(256), "number of bits cannot exceed 256");
     Ok(DynSolValue::type_strategy(&DynSolType::Int(no_bits.to::<usize>()))
@@ -356,7 +373,7 @@ fn random_int(state: &mut Cheatcodes, bits: Option<U256>) -> Result {
 }
 
 impl Cheatcode for eip712HashType_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { typeNameOrDefinition } = self;
 
         let type_def = get_canonical_type_def(typeNameOrDefinition, state, None)?;
@@ -366,7 +383,7 @@ impl Cheatcode for eip712HashType_0Call {
 }
 
 impl Cheatcode for eip712HashType_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { bindingsPath, typeName } = self;
 
         let path = state.config.ensure_path_allowed(bindingsPath, FsAccessKind::Read)?;
@@ -377,7 +394,7 @@ impl Cheatcode for eip712HashType_1Call {
 }
 
 impl Cheatcode for eip712HashStruct_0Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { typeNameOrDefinition, abiEncodedData } = self;
 
         let type_def = get_canonical_type_def(typeNameOrDefinition, state, None)?;
@@ -388,7 +405,7 @@ impl Cheatcode for eip712HashStruct_0Call {
 }
 
 impl Cheatcode for eip712HashStruct_1Call {
-    fn apply(&self, state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { bindingsPath, typeName, abiEncodedData } = self;
 
         let path = state.config.ensure_path_allowed(bindingsPath, FsAccessKind::Read)?;
@@ -399,7 +416,7 @@ impl Cheatcode for eip712HashStruct_1Call {
 }
 
 impl Cheatcode for eip712HashTypedDataCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { jsonData } = self;
         let typed_data: TypedData = serde_json::from_str(jsonData)?;
         let digest = typed_data.eip712_signing_hash()?;
@@ -410,9 +427,9 @@ impl Cheatcode for eip712HashTypedDataCall {
 
 /// Returns EIP-712 canonical type definition from the provided string type representation or type
 /// name. If type name provided, then it looks up bindings from file generated by `forge bind-json`.
-fn get_canonical_type_def(
+fn get_canonical_type_def<SPEC, BLOCK, N: Network>(
     name_or_def: &String,
-    state: &mut Cheatcodes,
+    state: &mut Cheatcodes<SPEC, BLOCK, N>,
     path: Option<PathBuf>,
 ) -> Result<String> {
     let type_def = if name_or_def.contains('(') {
@@ -501,7 +518,7 @@ fn get_struct_hash(primary: &str, type_def: &String, abi_encoded_data: &Bytes) -
 }
 
 impl Cheatcode for toRlpCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { data } = self;
 
         let mut buf = Vec::new();
@@ -512,7 +529,7 @@ impl Cheatcode for toRlpCall {
 }
 
 impl Cheatcode for fromRlpCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { rlp } = self;
 
         let decoded: Vec<Bytes> = Vec::<Bytes>::decode(&mut rlp.as_ref())

--- a/crates/cheatcodes/src/version.rs
+++ b/crates/cheatcodes/src/version.rs
@@ -1,18 +1,19 @@
 use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
+use alloy_network::Network;
 use alloy_sol_types::SolValue;
 use foundry_common::version::SEMVER_VERSION;
 use semver::Version;
 use std::cmp::Ordering;
 
 impl Cheatcode for foundryVersionCmpCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { version } = self;
         foundry_version_cmp(version).map(|cmp| (cmp as i8).abi_encode())
     }
 }
 
 impl Cheatcode for foundryVersionAtLeastCall {
-    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
         let Self { version } = self;
         foundry_version_cmp(version).map(|cmp| cmp.is_ge().abi_encode())
     }

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -1,6 +1,9 @@
 use crate::{executors::Executor, inspectors::InspectorStackBuilder};
 use foundry_evm_core::{EvmEnv, backend::Backend};
-use revm::{context::TxEnv, primitives::hardfork::SpecId};
+use revm::{
+    context::{BlockEnv, TxEnv},
+    primitives::hardfork::SpecId,
+};
 
 /// The builder that allows to configure an evm [`Executor`] which a stack of optional
 /// [`revm::Inspector`]s, such as [`Cheatcodes`].
@@ -13,7 +16,7 @@ use revm::{context::TxEnv, primitives::hardfork::SpecId};
 #[must_use = "builders do nothing unless you call `build` on them"]
 pub struct ExecutorBuilder {
     /// The configuration used to build an `InspectorStack`.
-    stack: InspectorStackBuilder,
+    stack: InspectorStackBuilder<BlockEnv>,
     /// The gas limit.
     gas_limit: Option<u64>,
     /// The spec ID.
@@ -44,7 +47,7 @@ impl ExecutorBuilder {
     #[inline]
     pub fn inspectors(
         mut self,
-        f: impl FnOnce(InspectorStackBuilder) -> InspectorStackBuilder,
+        f: impl FnOnce(InspectorStackBuilder<BlockEnv>) -> InspectorStackBuilder<BlockEnv>,
     ) -> Self {
         self.stack = f(self.stack);
         self

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -102,7 +102,7 @@ pub struct Executor {
     /// The transaction environment.
     tx_env: TxEnv,
     /// The Revm inspector stack.
-    inspector: InspectorStack,
+    inspector: InspectorStack<SpecId, BlockEnv, Ethereum>,
     /// The gas limit for calls and deployments.
     gas_limit: u64,
     /// Whether `failed()` should be called on the test contract to determine if the test failed.
@@ -116,7 +116,7 @@ impl Executor {
         mut backend: Backend,
         evm_env: EvmEnv,
         tx_env: TxEnv,
-        inspector: InspectorStack,
+        inspector: InspectorStack<SpecId, BlockEnv, Ethereum>,
         gas_limit: u64,
         legacy_assertions: bool,
     ) -> Self {
@@ -189,12 +189,12 @@ impl Executor {
     }
 
     /// Returns a reference to the EVM inspector.
-    pub fn inspector(&self) -> &InspectorStack {
+    pub fn inspector(&self) -> &InspectorStack<SpecId, BlockEnv, Ethereum> {
         &self.inspector
     }
 
     /// Returns a mutable reference to the EVM inspector.
-    pub fn inspector_mut(&mut self) -> &mut InspectorStack {
+    pub fn inspector_mut(&mut self) -> &mut InspectorStack<SpecId, BlockEnv, Ethereum> {
         &mut self.inspector
     }
 
@@ -1078,7 +1078,7 @@ impl std::ops::DerefMut for CallResult {
 fn convert_executed_result(
     evm_env: EvmEnv,
     tx_env: TxEnv,
-    inspector: InspectorStack,
+    inspector: InspectorStack<SpecId, BlockEnv, Ethereum>,
     ResultAndState { result, state: state_changeset }: ResultAndState,
     has_state_snapshot_failure: bool,
 ) -> eyre::Result<RawCallResult> {

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -3,10 +3,12 @@ use super::{
     LogCollector, RevertDiagnostic, ScriptExecutionInspector, TracingInspector,
 };
 use alloy_evm::EvmEnv;
+use alloy_network::{Ethereum, Network};
 use alloy_primitives::{
     Address, B256, Bytes, Log, TxKind, U256,
     map::{AddressHashMap, AddressMap},
 };
+
 use foundry_cheatcodes::{CheatcodeAnalysis, CheatcodesExecutor, NestedEvmClosure, Wallets};
 use foundry_common::compile::Analysis;
 use foundry_evm_core::{
@@ -40,16 +42,16 @@ use std::{
     sync::Arc,
 };
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[must_use = "builders do nothing unless you call `build` on them"]
-pub struct InspectorStackBuilder {
+pub struct InspectorStackBuilder<BLOCK: Clone> {
     /// Solar compiler instance, to grant syntactic and semantic analysis capabilities.
     pub analysis: Option<Analysis>,
     /// The block environment.
     ///
     /// Used in the cheatcode handler to overwrite the block environment separately from the
     /// execution block environment.
-    pub block: Option<BlockEnv>,
+    pub block: Option<BLOCK>,
     /// The gas price.
     ///
     /// Used in the cheatcode handler to overwrite the gas price separately from the gas price
@@ -84,7 +86,28 @@ pub struct InspectorStackBuilder {
     pub create2_deployer: Address,
 }
 
-impl InspectorStackBuilder {
+impl<BLOCK: Clone> Default for InspectorStackBuilder<BLOCK> {
+    fn default() -> Self {
+        Self {
+            analysis: None,
+            block: None,
+            gas_price: None,
+            cheatcodes: None,
+            fuzzer: None,
+            trace_mode: TraceMode::None,
+            logs: None,
+            line_coverage: None,
+            print: None,
+            chisel_state: None,
+            enable_isolation: false,
+            networks: NetworkConfigs::default(),
+            wallets: None,
+            create2_deployer: Default::default(),
+        }
+    }
+}
+
+impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
     /// Create a new inspector stack builder.
     #[inline]
     pub fn new() -> Self {
@@ -100,7 +123,7 @@ impl InspectorStackBuilder {
 
     /// Set the block environment.
     #[inline]
-    pub fn block(mut self, block: BlockEnv) -> Self {
+    pub fn block(mut self, block: BLOCK) -> Self {
         self.block = Some(block);
         self
     }
@@ -193,7 +216,7 @@ impl InspectorStackBuilder {
     }
 
     /// Builds the stack of inspectors to use when transacting/committing on the EVM.
-    pub fn build(self) -> InspectorStack {
+    pub fn build(self) -> InspectorStack<SpecId, BLOCK, Ethereum> {
         let Self {
             analysis,
             block,
@@ -279,13 +302,13 @@ macro_rules! call_inspectors {
 }
 
 /// The collected results of [`InspectorStack`].
-pub struct InspectorData {
+pub struct InspectorData<SPEC, BLOCK, N: Network> {
     pub logs: Vec<Log>,
     pub labels: AddressHashMap<String>,
     pub traces: Option<SparsedTraceArena>,
     pub line_coverage: Option<HitMaps>,
     pub edge_coverage: Option<Vec<u8>>,
-    pub cheatcodes: Option<Box<Cheatcodes>>,
+    pub cheatcodes: Option<Box<Cheatcodes<SPEC, BLOCK, N>>>,
     pub chisel_state: Option<(Vec<U256>, Vec<u8>)>,
     pub reverter: Option<Address>,
 }
@@ -311,9 +334,9 @@ pub struct InnerContextData {
 /// us ability to create and execute separate EVM frames from inside cheatcodes while still having
 /// access to entire stack of inspectors and correctly handling traces, logs, debugging info
 /// collection, etc.
-#[derive(Clone, Debug, Default)]
-pub struct InspectorStack {
-    pub cheatcodes: Option<Box<Cheatcodes>>,
+#[derive(Clone, Debug)]
+pub struct InspectorStack<SPEC, BLOCK, N: Network = Ethereum> {
+    pub cheatcodes: Option<Box<Cheatcodes<SPEC, BLOCK, N>>>,
     pub inner: InspectorStackInner,
 }
 
@@ -352,8 +375,8 @@ pub struct InspectorStackInner {
 
 /// Struct keeping mutable references to both parts of [InspectorStack] and implementing
 /// [revm::Inspector]. This struct can be obtained via [InspectorStack::as_mut].
-pub struct InspectorStackRefMut<'a> {
-    pub cheatcodes: Option<&'a mut Cheatcodes>,
+pub struct InspectorStackRefMut<'a, SPEC, BLOCK, N: Network> {
+    pub cheatcodes: Option<&'a mut Cheatcodes<SPEC, BLOCK, N>>,
     pub inner: &'a mut InspectorStackInner,
 }
 
@@ -364,11 +387,11 @@ impl<
             Tx = TxEnv,
             Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
         >,
-> CheatcodesExecutor<CTX> for InspectorStackInner
+> CheatcodesExecutor<CTX, Ethereum> for InspectorStackInner
 {
     fn with_nested_evm(
         &mut self,
-        cheats: &mut Cheatcodes,
+        cheats: &mut Cheatcodes<SpecId, BlockEnv, Ethereum>,
         ecx: &mut CTX,
         f: NestedEvmClosure<'_, CTX::Tx>,
     ) -> Result<(), EVMError<DatabaseError>> {
@@ -385,7 +408,7 @@ impl<
 
     fn with_fresh_nested_evm(
         &mut self,
-        cheats: &mut Cheatcodes,
+        cheats: &mut Cheatcodes<SpecId, BlockEnv, Ethereum>,
         db: &mut CTX::Db,
         evm_env: EvmEnv<CTX::Spec, CTX::Block>,
         f: NestedEvmClosure<'_, CTX::Tx>,
@@ -398,7 +421,7 @@ impl<
 
     fn transact_on_db(
         &mut self,
-        cheats: &mut Cheatcodes,
+        cheats: &mut Cheatcodes<SpecId, BlockEnv, Ethereum>,
         ecx: &mut CTX,
         fork_id: Option<U256>,
         transaction: B256,
@@ -412,7 +435,7 @@ impl<
 
     fn transact_from_tx_on_db(
         &mut self,
-        cheats: &mut Cheatcodes,
+        cheats: &mut Cheatcodes<SpecId, BlockEnv, Ethereum>,
         ecx: &mut CTX,
         tx_env: CTX::Tx,
     ) -> eyre::Result<()> {
@@ -444,7 +467,13 @@ impl<
     }
 }
 
-impl InspectorStack {
+impl<SPEC, BLOCK, N: Network> Default for InspectorStack<SPEC, BLOCK, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<SPEC, BLOCK, N: Network> InspectorStack<SPEC, BLOCK, N> {
     /// Creates a new inspector stack.
     ///
     /// Note that the stack is empty by default, and you must add inspectors to it.
@@ -452,7 +481,7 @@ impl InspectorStack {
     /// with [`InspectorStack`].
     #[inline]
     pub fn new() -> Self {
-        Self::default()
+        Self { cheatcodes: None, inner: InspectorStackInner::default() }
     }
 
     /// Set the solar compiler instance.
@@ -463,7 +492,7 @@ impl InspectorStack {
 
     /// Sets the block for the relevant inspectors.
     #[inline]
-    pub fn set_block(&mut self, block: BlockEnv) {
+    pub fn set_block(&mut self, block: BLOCK) {
         if let Some(cheatcodes) = &mut self.cheatcodes {
             cheatcodes.block = Some(block);
         }
@@ -479,7 +508,7 @@ impl InspectorStack {
 
     /// Set the cheatcodes inspector.
     #[inline]
-    pub fn set_cheatcodes(&mut self, cheatcodes: Cheatcodes) {
+    pub fn set_cheatcodes(&mut self, cheatcodes: Cheatcodes<SPEC, BLOCK, N>) {
         self.cheatcodes = Some(cheatcodes.into());
     }
 
@@ -511,13 +540,13 @@ impl InspectorStack {
     /// Set whether to enable call isolation.
     #[inline]
     pub fn enable_isolation(&mut self, yes: bool) {
-        self.enable_isolation = yes;
+        self.inner.enable_isolation = yes;
     }
 
     /// Set networks with enabled features.
     #[inline]
     pub fn networks(&mut self, networks: NetworkConfigs) {
-        self.networks = networks;
+        self.inner.networks = networks;
     }
 
     /// Set the CREATE2 deployer address.
@@ -568,12 +597,12 @@ impl InspectorStack {
     }
 
     #[inline(always)]
-    fn as_mut(&mut self) -> InspectorStackRefMut<'_> {
+    fn as_mut(&mut self) -> InspectorStackRefMut<'_, SPEC, BLOCK, N> {
         InspectorStackRefMut { cheatcodes: self.cheatcodes.as_deref_mut(), inner: &mut self.inner }
     }
 
     /// Collects all the data gathered during inspection into a single struct.
-    pub fn collect(self) -> InspectorData {
+    pub fn collect(self) -> InspectorData<SPEC, BLOCK, N> {
         let Self {
             mut cheatcodes,
             inner:
@@ -622,7 +651,7 @@ impl InspectorStack {
     }
 }
 
-impl InspectorStackRefMut<'_> {
+impl InspectorStackRefMut<'_, SpecId, BlockEnv, Ethereum> {
     /// Adjusts the EVM data for the inner EVM context.
     /// Should be called on the top-level call of inner context (depth == 0 &&
     /// self.in_inner_context) Decreases sender nonce for CALLs to keep backwards compatibility
@@ -841,7 +870,7 @@ impl InspectorStackRefMut<'_> {
             }
             ExecutionResult::Halt { reason, gas: result_gas, .. } => {
                 let _ = gas.record_cost(result_gas.used());
-                (reason.into(), None, Bytes::new())
+                (InstructionResult::from(reason), None, Bytes::new())
             }
             ExecutionResult::Revert { gas: result_gas, output, .. } => {
                 let _ = gas.record_cost(result_gas.used());
@@ -853,7 +882,10 @@ impl InspectorStackRefMut<'_> {
 
     /// Moves out of references, constructs a new [`InspectorStackRefMut`] and runs the given
     /// closure with it.
-    fn with_inspector<O>(&mut self, f: impl FnOnce(InspectorStackRefMut<'_>) -> O) -> O {
+    fn with_inspector<O>(
+        &mut self,
+        f: impl FnOnce(InspectorStackRefMut<'_, SpecId, BlockEnv, Ethereum>) -> O,
+    ) -> O {
         let mut cheatcodes = self
             .cheatcodes
             .as_deref_mut()
@@ -974,7 +1006,7 @@ impl<
             Tx = TxEnv,
             Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
         >,
-> Inspector<CTX> for InspectorStackRefMut<'_>
+> Inspector<CTX> for InspectorStackRefMut<'_, SpecId, BlockEnv, Ethereum>
 {
     fn initialize_interp(&mut self, interpreter: &mut Interpreter, ecx: &mut CTX) {
         call_inspectors!(
@@ -1180,7 +1212,7 @@ impl<
     }
 }
 
-impl InspectorExt for InspectorStackRefMut<'_> {
+impl<SPEC, BLOCK, N: Network> InspectorExt for InspectorStackRefMut<'_, SPEC, BLOCK, N> {
     fn should_use_create2_factory(&mut self, depth: usize, inputs: &CreateInputs) -> bool {
         call_inspectors!(
             #[ret]
@@ -1213,7 +1245,7 @@ impl<
             Tx = TxEnv,
             Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
         >,
-> Inspector<CTX> for InspectorStack
+> Inspector<CTX> for InspectorStack<SpecId, BlockEnv, Ethereum>
 {
     fn step(&mut self, interpreter: &mut Interpreter, ecx: &mut CTX) {
         self.as_mut().step_inlined(interpreter, ecx)
@@ -1258,7 +1290,7 @@ impl<
     }
 }
 
-impl InspectorExt for InspectorStack {
+impl<SPEC, BLOCK, N: Network> InspectorExt for InspectorStack<SPEC, BLOCK, N> {
     fn should_use_create2_factory(&mut self, depth: usize, inputs: &CreateInputs) -> bool {
         self.as_mut().should_use_create2_factory(depth, inputs)
     }
@@ -1272,7 +1304,7 @@ impl InspectorExt for InspectorStack {
     }
 }
 
-impl<'a> Deref for InspectorStackRefMut<'a> {
+impl<'a, SPEC, BLOCK, N: Network> Deref for InspectorStackRefMut<'a, SPEC, BLOCK, N> {
     type Target = &'a mut InspectorStackInner;
 
     fn deref(&self) -> &Self::Target {
@@ -1280,13 +1312,13 @@ impl<'a> Deref for InspectorStackRefMut<'a> {
     }
 }
 
-impl DerefMut for InspectorStackRefMut<'_> {
+impl<SPEC, BLOCK, N: Network> DerefMut for InspectorStackRefMut<'_, SPEC, BLOCK, N> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
 
-impl Deref for InspectorStack {
+impl<SPEC, BLOCK, N: Network> Deref for InspectorStack<SPEC, BLOCK, N> {
     type Target = InspectorStackInner;
 
     fn deref(&self) -> &Self::Target {
@@ -1294,7 +1326,7 @@ impl Deref for InspectorStack {
     }
 }
 
-impl DerefMut for InspectorStack {
+impl<SPEC, BLOCK, N: Network> DerefMut for InspectorStack<SPEC, BLOCK, N> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }


### PR DESCRIPTION
## Motivation

 Generic `Cheatcodes`, `InspectorStack`, `CheatcodesExecutor`.
 
 ## Insights
 
 Some structs and impls generics are still pinned to concrete types `SpecId`, `BlockEnv`, `Ethereum` to keep this PR contained.
 
 90% of the PR is mechanical generics propagation through `Cheatcode` impls.