### PR TITLE
refactor(anvil): make beacon handlers generic over Network

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -622,6 +622,33 @@ impl<N: Network> EthApi<N> {
     pub fn storage_info(&self) -> StorageInfo<N> {
         StorageInfo::new(Arc::clone(&self.backend))
     }
+
+    /// Handler for RPC call: `anvil_getBlobByHash`
+    pub fn anvil_get_blob_by_versioned_hash(
+        &self,
+        hash: B256,
+    ) -> Result<Option<alloy_consensus::Blob>> {
+        node_info!("anvil_getBlobByHash");
+        Ok(self.backend.get_blob_by_versioned_hash(hash)?)
+    }
+
+    /// Handler for RPC call: `anvil_getBlobsByBlockId`
+    pub fn anvil_get_blobs_by_block_id(
+        &self,
+        block_id: impl Into<BlockId>,
+        versioned_hashes: Vec<B256>,
+    ) -> Result<Option<Vec<Blob>>> {
+        node_info!("anvil_getBlobsByBlockId");
+        Ok(self.backend.get_blobs_by_block_id(block_id, versioned_hashes)?)
+    }
+
+    /// Returns the genesis time for the Beacon chain
+    ///
+    /// Handler for Beacon API call: `GET /eth/v1/beacon/genesis`
+    pub fn anvil_get_genesis_time(&self) -> Result<u64> {
+        node_info!("anvil_getGenesisTime");
+        Ok(self.backend.genesis_time())
+    }
 }
 
 // == impl EthApi anvil endpoints ==
@@ -2097,37 +2124,10 @@ impl EthApi<FoundryNetwork> {
         Ok(FillTransaction { raw, tx })
     }
 
-    /// Handler for RPC call: `anvil_getBlobByHash`
-    pub fn anvil_get_blob_by_versioned_hash(
-        &self,
-        hash: B256,
-    ) -> Result<Option<alloy_consensus::Blob>> {
-        node_info!("anvil_getBlobByHash");
-        Ok(self.backend.get_blob_by_versioned_hash(hash)?)
-    }
-
     /// Handler for RPC call: `anvil_getBlobsByTransactionHash`
     pub fn anvil_get_blob_by_tx_hash(&self, hash: B256) -> Result<Option<Vec<Blob>>> {
         node_info!("anvil_getBlobsByTransactionHash");
         Ok(self.backend.get_blob_by_tx_hash(hash)?)
-    }
-
-    /// Handler for RPC call: `anvil_getBlobsByBlockId`
-    pub fn anvil_get_blobs_by_block_id(
-        &self,
-        block_id: impl Into<BlockId>,
-        versioned_hashes: Vec<B256>,
-    ) -> Result<Option<Vec<Blob>>> {
-        node_info!("anvil_getBlobsByBlockId");
-        Ok(self.backend.get_blobs_by_block_id(block_id, versioned_hashes)?)
-    }
-
-    /// Returns the genesis time for the Beacon chain
-    ///
-    /// Handler for Beacon API call: `GET /eth/v1/beacon/genesis`
-    pub fn anvil_get_genesis_time(&self) -> Result<u64> {
-        node_info!("anvil_getGenesisTime");
-        Ok(self.backend.genesis_time())
     }
 
     /// Get transaction by its hash.

--- a/crates/anvil/src/server/beacon/handlers.rs
+++ b/crates/anvil/src/server/beacon/handlers.rs
@@ -1,6 +1,7 @@
 use super::{error::BeaconError, utils::must_be_ssz};
 use crate::eth::EthApi;
 use alloy_eips::BlockId;
+use alloy_network::Network;
 use alloy_primitives::{B256, aliases::B32};
 use alloy_rpc_types_beacon::{
     genesis::{GenesisData, GenesisResponse},
@@ -12,7 +13,6 @@ use axum::{
     http::HeaderMap,
     response::{IntoResponse, Response},
 };
-use foundry_primitives::FoundryNetwork;
 use ssz::Encode;
 use std::{collections::HashMap, str::FromStr as _};
 
@@ -21,8 +21,8 @@ use std::{collections::HashMap, str::FromStr as _};
 /// This endpoint is deprecated. Use `GET /eth/v1/beacon/blobs/{block_id}` instead.
 ///
 /// GET /eth/v1/beacon/blob_sidecars/{block_id}
-pub async fn handle_get_blob_sidecars(
-    State(_api): State<EthApi<FoundryNetwork>>,
+pub async fn handle_get_blob_sidecars<N: Network>(
+    State(_api): State<EthApi<N>>,
     Path(_block_id): Path<String>,
     Query(_params): Query<HashMap<String, String>>,
 ) -> Response {
@@ -33,9 +33,9 @@ pub async fn handle_get_blob_sidecars(
 /// Handles incoming Beacon API requests for blobs
 ///
 /// GET /eth/v1/beacon/blobs/{block_id}
-pub async fn handle_get_blobs(
+pub async fn handle_get_blobs<N: Network>(
     headers: HeaderMap,
-    State(api): State<EthApi<FoundryNetwork>>,
+    State(api): State<EthApi<N>>,
     Path(block_id): Path<String>,
     Query(versioned_hashes): Query<HashMap<String, String>>,
 ) -> Response {
@@ -94,7 +94,7 @@ pub async fn handle_get_blobs(
 /// Only returns the `genesis_time`, other fields are set to zero.
 ///
 /// GET /eth/v1/beacon/genesis
-pub async fn handle_get_genesis(State(api): State<EthApi<FoundryNetwork>>) -> Response {
+pub async fn handle_get_genesis<N: Network>(State(api): State<EthApi<N>>) -> Response {
     match api.anvil_get_genesis_time() {
         Ok(genesis_time) => Json(GenesisResponse {
             data: GenesisData {

--- a/crates/anvil/src/server/beacon/mod.rs
+++ b/crates/anvil/src/server/beacon/mod.rs
@@ -3,17 +3,20 @@
 use axum::{Router, routing::get};
 
 use crate::eth::EthApi;
-use foundry_primitives::FoundryNetwork;
+use alloy_network::Network;
 
 mod error;
 mod handlers;
 mod utils;
 
 /// Configures an [`axum::Router`] that handles Beacon REST API calls.
-pub fn router(api: EthApi<FoundryNetwork>) -> Router {
+pub fn router<N: Network>(api: EthApi<N>) -> Router {
     Router::new()
-        .route("/eth/v1/beacon/blob_sidecars/{block_id}", get(handlers::handle_get_blob_sidecars))
-        .route("/eth/v1/beacon/blobs/{block_id}", get(handlers::handle_get_blobs))
-        .route("/eth/v1/beacon/genesis", get(handlers::handle_get_genesis))
+        .route(
+            "/eth/v1/beacon/blob_sidecars/{block_id}",
+            get(handlers::handle_get_blob_sidecars::<N>),
+        )
+        .route("/eth/v1/beacon/blobs/{block_id}", get(handlers::handle_get_blobs::<N>))
+        .route("/eth/v1/beacon/genesis", get(handlers::handle_get_genesis::<N>))
         .with_state(api)
 }


### PR DESCRIPTION
Make beacon API handlers (`handle_get_blob_sidecars`, `handle_get_blobs`, `handle_get_genesis`) and `beacon::router` generic over `N: Network`.