### PR TITLE
refactor(anvil): make Backend serialization methods generic over Network

### DIFF
--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -8,6 +8,7 @@ use std::{
 
 use alloy_consensus::{BlockBody, Header};
 use alloy_eips::eip4895::Withdrawals;
+use alloy_network::Network;
 use alloy_primitives::{
     Address, B256, Bytes, U256, keccak256,
     map::{AddressMap, HashMap},
@@ -21,7 +22,7 @@ use foundry_common::errors::FsPathError;
 use foundry_evm::backend::{
     BlockchainDb, DatabaseError, DatabaseResult, MemDb, RevertStateSnapshotAction, StateSnapshot,
 };
-use foundry_primitives::{FoundryNetwork, FoundryReceiptEnvelope, FoundryTxEnvelope};
+use foundry_primitives::{FoundryReceiptEnvelope, FoundryTxEnvelope};
 use revm::{
     Database, DatabaseCommit,
     bytecode::Bytecode,
@@ -705,8 +706,10 @@ pub struct SerializableTransaction {
     pub block_number: u64,
 }
 
-impl From<MinedTransaction<FoundryNetwork>> for SerializableTransaction {
-    fn from(transaction: MinedTransaction<FoundryNetwork>) -> Self {
+impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> From<MinedTransaction<N>>
+    for SerializableTransaction
+{
+    fn from(transaction: MinedTransaction<N>) -> Self {
         Self {
             info: transaction.info,
             receipt: transaction.receipt,
@@ -716,7 +719,9 @@ impl From<MinedTransaction<FoundryNetwork>> for SerializableTransaction {
     }
 }
 
-impl From<SerializableTransaction> for MinedTransaction<FoundryNetwork> {
+impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> From<SerializableTransaction>
+    for MinedTransaction<N>
+{
     fn from(transaction: SerializableTransaction) -> Self {
         Self {
             info: transaction.info,

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3271,7 +3271,7 @@ where
     }
 }
 
-impl Backend<FoundryNetwork> {
+impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
     /// Get the current state.
     pub async fn serialized_state(
         &self,
@@ -3420,7 +3420,9 @@ impl Backend<FoundryNetwork> {
 
         self.load_state(state).await
     }
+}
 
+impl Backend<FoundryNetwork> {
     /// Simulates the payload by executing the calls in request.
     pub async fn simulate(
         &self,

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -32,7 +32,9 @@ use foundry_evm::{
     backend::MemDb,
     traces::{CallKind, ParityTraceBuilder, TracingInspectorConfig},
 };
-use foundry_primitives::{FoundryNetwork, FoundryTxEnvelope};
+#[cfg(test)]
+use foundry_primitives::FoundryNetwork;
+use foundry_primitives::{FoundryReceiptEnvelope, FoundryTxEnvelope};
 use parking_lot::RwLock;
 use revm::{context::Block as RevmBlock, primitives::hardfork::SpecId};
 use std::{collections::VecDeque, fmt, path::PathBuf, sync::Arc, time::Duration};
@@ -443,19 +445,15 @@ impl<N: Network> BlockchainStorage<N> {
     }
 }
 
-impl BlockchainStorage<FoundryNetwork> {
+impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> BlockchainStorage<N> {
     pub fn serialized_transactions(&self) -> Vec<SerializableTransaction> {
-        self.transactions
-            .values()
-            .map(|tx: &MinedTransaction<FoundryNetwork>| tx.clone().into())
-            .collect()
+        self.transactions.values().map(|tx: &MinedTransaction<N>| tx.clone().into()).collect()
     }
 
     /// Deserialize and add all transactions data to the backend storage
     pub fn load_transactions(&mut self, serializable_transactions: Vec<SerializableTransaction>) {
         for serializable_transaction in &serializable_transactions {
-            let transaction: MinedTransaction<FoundryNetwork> =
-                serializable_transaction.clone().into();
+            let transaction: MinedTransaction<N> = serializable_transaction.clone().into();
             self.transactions.insert(transaction.info.transaction_hash, transaction);
         }
     }


### PR DESCRIPTION
Make `From` impls between `MinedTransaction<N>` and `SerializableTransaction` generic over `N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>`. Lift `BlockchainStorage` serialization methods and Backend serialization methods (`serialized_state`, `dump_state`, `load_state`, `load_state_bytes`) from `impl Backend<FoundryNetwork>` to `impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N>`.