### PR TITLE
feat(evm): add tmp `TempoFoundryEvm` wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1158,7 +1158,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2956,7 +2956,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3109,7 +3109,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3884,7 +3884,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4189,7 +4189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6094,7 +6094,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6471,7 +6471,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7341,7 +7341,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8486,7 +8486,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8524,9 +8524,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9683,7 +9683,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9742,7 +9742,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10446,7 +10446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10973,13 +10973,13 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b364dab518df5e0ac7859faa24d52e591e5b48fa"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#032d608de0b3d0cfc41506a113f394f8420b00c9"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11004,7 +11004,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b364dab518df5e0ac7859faa24d52e591e5b48fa"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#032d608de0b3d0cfc41506a113f394f8420b00c9"
 dependencies = [
  "alloy-eips 2.0.0-rc.0",
  "alloy-evm",
@@ -11023,7 +11023,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b364dab518df5e0ac7859faa24d52e591e5b48fa"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#032d608de0b3d0cfc41506a113f394f8420b00c9"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11039,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b364dab518df5e0ac7859faa24d52e591e5b48fa"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#032d608de0b3d0cfc41506a113f394f8420b00c9"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11050,7 +11050,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b364dab518df5e0ac7859faa24d52e591e5b48fa"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#032d608de0b3d0cfc41506a113f394f8420b00c9"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11077,7 +11077,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b364dab518df5e0ac7859faa24d52e591e5b48fa"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#032d608de0b3d0cfc41506a113f394f8420b00c9"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11096,7 +11096,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b364dab518df5e0ac7859faa24d52e591e5b48fa"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#032d608de0b3d0cfc41506a113f394f8420b00c9"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11107,7 +11107,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b364dab518df5e0ac7859faa24d52e591e5b48fa"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#032d608de0b3d0cfc41506a113f394f8420b00c9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0-rc.0",
@@ -11131,7 +11131,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b364dab518df5e0ac7859faa24d52e591e5b48fa"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#032d608de0b3d0cfc41506a113f394f8420b00c9"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11166,7 +11166,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11176,7 +11176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12353,7 +12353,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12503,7 +12503,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -58,6 +58,7 @@ op-revm.workspace = true
 tempo-revm.workspace = true
 tempo-chainspec.workspace = true
 tempo-contracts.workspace = true
+tempo-evm.workspace = true
 tempo-precompiles.workspace = true
 
 auto_impl.workspace = true
@@ -77,4 +78,3 @@ alloy-op-evm.workspace = true
 alloy-serde.workspace = true
 op-alloy-consensus.workspace = true
 foundry-test-utils.workspace = true
-tempo-evm.workspace = true

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -31,6 +31,12 @@ use revm::{
     },
     primitives::hardfork::SpecId,
 };
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_evm::evm::TempoEvmFactory;
+use tempo_revm::{
+    TempoBlockEnv, TempoHaltReason, TempoInvalidTransaction, TempoTxEnv, evm::TempoContext,
+    gas_params::tempo_gas_params, handler::TempoEvmHandler,
+};
 
 /// Marker trait for [`EvmFactory`] implementations compatible with Foundry's EVM infrastructure.
 ///
@@ -445,5 +451,439 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt>>> Inspe
                 return Ok(result);
             }
         }
+    }
+}
+
+// Will be removed when the next revm release includes bluealloy/revm#3518.
+type TempoRevmEvm<'db, I> = tempo_revm::TempoEvm<&'db mut dyn DatabaseExt, I>;
+
+/// Tempo counterpart of [`FoundryEvm`]. Wraps `tempo_revm::TempoEvm` and routes execution
+/// through [`TempoFoundryHandler`] which composes [`TempoEvmHandler`] with CREATE2 factory
+/// redirect logic.
+///
+/// Uses [`TempoEvmFactory`] for construction to reuse factory setup logic, then unwraps to the
+/// raw revm EVM via `into_inner()` since the handler operates at the revm level.
+pub struct TempoFoundryEvm<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt>>> {
+    pub inner: TempoRevmEvm<'db, I>,
+}
+
+/// Creates a new Tempo EVM instance with an inspector, analogous to
+/// [`new_eth_evm_with_inspector`].
+///
+/// Delegates to [`TempoFoundryEvmFactory`].
+pub fn new_tempo_evm_with_inspector<
+    'db,
+    I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt>>,
+>(
+    db: &'db mut dyn DatabaseExt,
+    evm_env: EvmEnv<TempoHardfork, TempoBlockEnv>,
+    inspector: I,
+) -> TempoFoundryEvm<'db, I> {
+    TempoFoundryEvmFactory.create_tempo_evm_with_inspector(db, evm_env, inspector)
+}
+
+/// Factory for creating [`TempoFoundryEvm`] instances. Wraps [`TempoEvmFactory`] and applies
+/// Foundry-specific setup (gas params, chain ID check, network precompile injection).
+///
+/// When `Executor` becomes generic over `EvmFactory`, this factory will be used directly
+/// instead of the [`new_tempo_evm_with_inspector`] free function.
+#[derive(Debug, Default, Clone)]
+pub struct TempoFoundryEvmFactory;
+
+impl TempoFoundryEvmFactory {
+    /// Creates a new Tempo EVM with an inspector, applying TIP-1000 gas params and injecting
+    /// network precompiles.
+    pub fn create_tempo_evm_with_inspector<
+        'db,
+        I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt>>,
+    >(
+        &self,
+        db: &'db mut dyn DatabaseExt,
+        mut evm_env: EvmEnv<TempoHardfork, TempoBlockEnv>,
+        inspector: I,
+    ) -> TempoFoundryEvm<'db, I> {
+        evm_env.cfg_env.gas_params = tempo_gas_params(evm_env.cfg_env.spec);
+        evm_env.cfg_env.tx_chain_id_check = true;
+
+        let tempo_evm =
+            TempoEvmFactory::default().create_evm_with_inspector(db, evm_env, inspector);
+        let inner = tempo_evm.into_inner();
+
+        let mut evm = TempoFoundryEvm { inner };
+        let networks = Evm::inspector(&evm).get_networks();
+        networks.inject_precompiles(evm.precompiles_mut());
+        evm
+    }
+}
+
+impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt>>> Evm
+    for TempoFoundryEvm<'db, I>
+{
+    type Precompiles = PrecompilesMap;
+    type Inspector = I;
+    type DB = &'db mut dyn DatabaseExt;
+    type Error = EVMError<DatabaseError, TempoInvalidTransaction>;
+    type HaltReason = TempoHaltReason;
+    type Spec = TempoHardfork;
+    type Tx = TempoTxEnv;
+    type BlockEnv = TempoBlockEnv;
+
+    fn block(&self) -> &TempoBlockEnv {
+        &self.inner.block
+    }
+
+    fn chain_id(&self) -> u64 {
+        self.inner.ctx.cfg.chain_id
+    }
+
+    fn components(&self) -> (&Self::DB, &Self::Inspector, &Self::Precompiles) {
+        let evm = &self.inner.inner;
+        (&evm.ctx.journaled_state.database, &evm.inspector, &evm.precompiles)
+    }
+
+    fn components_mut(&mut self) -> (&mut Self::DB, &mut Self::Inspector, &mut Self::Precompiles) {
+        let evm = &mut self.inner.inner;
+        (&mut evm.ctx.journaled_state.database, &mut evm.inspector, &mut evm.precompiles)
+    }
+
+    fn set_inspector_enabled(&mut self, _enabled: bool) {
+        unimplemented!("TempoFoundryEvm is always inspecting")
+    }
+
+    fn transact_raw(
+        &mut self,
+        tx: Self::Tx,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+        self.inner.set_tx(tx);
+
+        let mut handler = TempoFoundryHandler::<I>::default();
+        let result = handler.inspect_run(&mut self.inner)?;
+
+        Ok(ResultAndState::new(result, self.inner.inner.ctx.journaled_state.inner.state.clone()))
+    }
+
+    fn transact_system_call(
+        &mut self,
+        _caller: Address,
+        _contract: Address,
+        _data: Bytes,
+    ) -> Result<ExecResultAndState<ExecutionResult<Self::HaltReason>>, Self::Error> {
+        unimplemented!()
+    }
+
+    fn finish(self) -> (Self::DB, EvmEnv<Self::Spec, Self::BlockEnv>)
+    where
+        Self: Sized,
+    {
+        let revm_evm = self.inner.inner;
+        let Context { block: block_env, cfg: cfg_env, journaled_state, .. } = revm_evm.ctx;
+        (journaled_state.database, EvmEnv { block_env, cfg_env })
+    }
+}
+
+/// Maps a Tempo [`EVMError`] to the common `EVMError<DatabaseError>` used by [`NestedEvm`].
+///
+/// This exists because [`NestedEvm`] currently uses Eth-typed errors. When `NestedEvm` gains
+/// an associated `Error` type, this mapping can be removed.
+fn map_tempo_error(e: EVMError<DatabaseError, TempoInvalidTransaction>) -> EVMError<DatabaseError> {
+    match e {
+        EVMError::Database(db) => EVMError::Database(db),
+        EVMError::Header(h) => EVMError::Header(h),
+        EVMError::Custom(s) => EVMError::Custom(s),
+        EVMError::Transaction(t) => EVMError::Custom(format!("tempo transaction error: {t:?}")),
+    }
+}
+
+impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt>>> NestedEvm
+    for TempoRevmEvm<'db, I>
+{
+    type Tx = TempoTxEnv;
+
+    fn journal_inner_mut(&mut self) -> &mut JournaledState {
+        &mut self.ctx_mut().journaled_state.inner
+    }
+
+    fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
+        let mut handler = TempoFoundryHandler::<I>::default();
+
+        let memory =
+            SharedMemory::new_with_buffer(self.ctx().local().shared_memory_buffer().clone());
+        let first_frame_input = FrameInit { depth: 0, memory, frame_input: frame };
+
+        let mut frame_result =
+            handler.inspect_run_exec_loop(self, first_frame_input).map_err(map_tempo_error)?;
+
+        handler.last_frame_result(self, &mut frame_result).map_err(map_tempo_error)?;
+
+        Ok(frame_result)
+    }
+
+    fn transact_raw(
+        &mut self,
+        tx: Self::Tx,
+    ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>> {
+        self.set_tx(tx);
+
+        let mut handler = TempoFoundryHandler::<I>::default();
+        let result = handler.inspect_run(self).map_err(map_tempo_error)?;
+
+        let result = result.map_haltreason(|h| match h {
+            TempoHaltReason::Ethereum(eth) => eth,
+            _ => HaltReason::PrecompileError,
+        });
+
+        Ok(ResultAndState::new(result, self.ctx.journaled_state.inner.state.clone()))
+    }
+}
+
+/// Tempo counterpart of [`FoundryHandler`]. Wraps [`TempoEvmHandler`] and injects CREATE2
+/// factory redirect logic into the execution loop. Delegates all [`Handler`] methods to
+/// [`TempoEvmHandler`] for proper Tempo validation, fee collection, AA dispatch, and gas
+/// handling.
+///
+/// Will be removed when the next revm release includes bluealloy/revm#3518.
+pub struct TempoFoundryHandler<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt>>>
+{
+    inner: TempoEvmHandler<&'db mut dyn DatabaseExt, I>,
+    create2_overrides: Vec<(usize, CallInputs)>,
+}
+
+impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt>>> Default
+    for TempoFoundryHandler<'db, I>
+{
+    fn default() -> Self {
+        Self { inner: TempoEvmHandler::new(), create2_overrides: Vec::new() }
+    }
+}
+
+impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt>>> Handler
+    for TempoFoundryHandler<'db, I>
+{
+    type Evm = TempoRevmEvm<'db, I>;
+    type Error = EVMError<DatabaseError, TempoInvalidTransaction>;
+    type HaltReason = TempoHaltReason;
+
+    #[inline]
+    fn run(
+        &mut self,
+        evm: &mut Self::Evm,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        self.inner.run(evm)
+    }
+
+    #[inline]
+    fn execution(
+        &mut self,
+        evm: &mut Self::Evm,
+        init_and_floor_gas: &revm::interpreter::InitialAndFloorGas,
+    ) -> Result<FrameResult, Self::Error> {
+        self.inner.execution(evm, init_and_floor_gas)
+    }
+
+    #[inline]
+    fn validate_env(&self, evm: &mut Self::Evm) -> Result<(), Self::Error> {
+        self.inner.validate_env(evm)
+    }
+
+    #[inline]
+    fn validate_against_state_and_deduct_caller(
+        &self,
+        evm: &mut Self::Evm,
+    ) -> Result<(), Self::Error> {
+        self.inner.validate_against_state_and_deduct_caller(evm)
+    }
+
+    #[inline]
+    fn reimburse_caller(
+        &self,
+        evm: &mut Self::Evm,
+        exec_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+    ) -> Result<(), Self::Error> {
+        self.inner.reimburse_caller(evm, exec_result)
+    }
+
+    #[inline]
+    fn reward_beneficiary(
+        &self,
+        evm: &mut Self::Evm,
+        exec_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+    ) -> Result<(), Self::Error> {
+        self.inner.reward_beneficiary(evm, exec_result)
+    }
+
+    #[inline]
+    fn validate_initial_tx_gas(
+        &self,
+        evm: &mut Self::Evm,
+    ) -> Result<revm::interpreter::InitialAndFloorGas, Self::Error> {
+        self.inner.validate_initial_tx_gas(evm)
+    }
+
+    #[inline]
+    fn execution_result(
+        &mut self,
+        evm: &mut Self::Evm,
+        result: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+        result_gas: revm::context::result::ResultGas,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        self.inner.execution_result(evm, result, result_gas)
+    }
+
+    #[inline]
+    fn catch_error(
+        &self,
+        evm: &mut Self::Evm,
+        error: Self::Error,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        self.inner.catch_error(evm, error)
+    }
+}
+
+/// CREATE2 factory redirect execution loop for Tempo.
+fn create2_exec_loop<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt>>>(
+    create2_overrides: &mut Vec<(usize, CallInputs)>,
+    evm: &mut TempoRevmEvm<'db, I>,
+    first_frame_input: FrameInit,
+) -> Result<FrameResult, EVMError<DatabaseError, TempoInvalidTransaction>> {
+    let res = evm.inspect_frame_init(first_frame_input)?;
+
+    if let ItemOrResult::Result(frame_result) = res {
+        return Ok(frame_result);
+    }
+
+    loop {
+        let call_or_result = evm.inspect_frame_run()?;
+
+        let result = match call_or_result {
+            ItemOrResult::Item(mut init) => {
+                if let Some(frame_result) = handle_create2_frame(create2_overrides, evm, &mut init)?
+                {
+                    return Ok(frame_result);
+                }
+
+                match evm.inspect_frame_init(init)? {
+                    ItemOrResult::Item(_) => continue,
+                    ItemOrResult::Result(result) => result,
+                }
+            }
+            ItemOrResult::Result(result) => result,
+        };
+
+        let result = handle_create2_result(create2_overrides, evm, result);
+
+        if let Some(result) = evm.frame_return_result(result)? {
+            return Ok(result);
+        }
+    }
+}
+
+/// Handles CREATE2 frame initialization, potentially transforming it to use the CREATE2 factory.
+fn handle_create2_frame<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt>>>(
+    create2_overrides: &mut Vec<(usize, CallInputs)>,
+    evm: &mut TempoRevmEvm<'db, I>,
+    init: &mut FrameInit,
+) -> Result<Option<FrameResult>, EVMError<DatabaseError, TempoInvalidTransaction>> {
+    if let FrameInput::Create(inputs) = &init.frame_input
+        && let CreateScheme::Create2 { salt } = inputs.scheme()
+    {
+        let (ctx, inspector) = evm.ctx_inspector();
+
+        if inspector.should_use_create2_factory(ctx.journal().depth(), inputs) {
+            let gas_limit = inputs.gas_limit();
+            let create2_deployer = evm.inspector().create2_deployer();
+            let call_inputs = get_create2_factory_call_inputs(salt, inputs, create2_deployer);
+
+            create2_overrides.push((evm.journal().depth(), call_inputs.clone()));
+
+            let code_hash = evm.journal_mut().load_account(create2_deployer)?.info.code_hash;
+            if code_hash == KECCAK_EMPTY {
+                return Ok(Some(FrameResult::Call(CallOutcome {
+                    result: InterpreterResult {
+                        result: InstructionResult::Revert,
+                        output: Bytes::from(
+                            format!("missing CREATE2 deployer: {create2_deployer}").into_bytes(),
+                        ),
+                        gas: Gas::new(gas_limit),
+                    },
+                    memory_offset: 0..0,
+                    was_precompile_called: false,
+                    precompile_call_logs: vec![],
+                })));
+            } else if code_hash != DEFAULT_CREATE2_DEPLOYER_CODEHASH {
+                return Ok(Some(FrameResult::Call(CallOutcome {
+                    result: InterpreterResult {
+                        result: InstructionResult::Revert,
+                        output: "invalid CREATE2 deployer bytecode".into(),
+                        gas: Gas::new(gas_limit),
+                    },
+                    memory_offset: 0..0,
+                    was_precompile_called: false,
+                    precompile_call_logs: vec![],
+                })));
+            }
+
+            init.frame_input = FrameInput::Call(Box::new(call_inputs));
+        }
+    }
+    Ok(None)
+}
+
+/// Transforms CREATE2 factory call results back into CREATE outcomes.
+fn handle_create2_result<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt>>>(
+    create2_overrides: &mut Vec<(usize, CallInputs)>,
+    evm: &mut TempoRevmEvm<'db, I>,
+    result: FrameResult,
+) -> FrameResult {
+    if create2_overrides.last().is_some_and(|(depth, _)| *depth == evm.journal().depth()) {
+        let (_, call_inputs) = create2_overrides.pop().unwrap();
+        let FrameResult::Call(mut call) = result else {
+            unreachable!("create2 override should be a call frame");
+        };
+
+        let address = match call.instruction_result() {
+            return_ok!() => Address::try_from(call.output().as_ref())
+                .map_err(|_| {
+                    call.result = InterpreterResult {
+                        result: InstructionResult::Revert,
+                        output: "invalid CREATE2 factory output".into(),
+                        gas: Gas::new(call_inputs.gas_limit),
+                    };
+                })
+                .ok(),
+            _ => None,
+        };
+
+        FrameResult::Create(CreateOutcome { result: call.result, address })
+    } else {
+        result
+    }
+}
+
+impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt>>> InspectorHandler
+    for TempoFoundryHandler<'db, I>
+{
+    type IT = EthInterpreter;
+
+    /// Delegates to [`TempoEvmHandler::inspect_execution_with`], injecting the CREATE2 factory
+    /// redirect exec loop. AA multi-call dispatch and gas adjustments are handled by the inner
+    /// Tempo handler.
+    #[inline]
+    fn inspect_execution(
+        &mut self,
+        evm: &mut Self::Evm,
+        init_and_floor_gas: &revm::interpreter::InitialAndFloorGas,
+    ) -> Result<FrameResult, Self::Error> {
+        let overrides = &mut self.create2_overrides;
+        self.inner.inspect_execution_with(evm, init_and_floor_gas, |_handler, evm, init| {
+            create2_exec_loop(overrides, evm, init)
+        })
+    }
+
+    fn inspect_run_exec_loop(
+        &mut self,
+        evm: &mut Self::Evm,
+        first_frame_input: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameInit,
+    ) -> Result<FrameResult, Self::Error> {
+        create2_exec_loop(&mut self.create2_overrides, evm, first_frame_input)
     }
 }


### PR DESCRIPTION
## Summary

Adds `TempoFoundryEvm`, `TempoFoundryHandler`, and `new_tempo_evm_with_inspector()` as Tempo counterparts to the existing Eth types. This lets Tempo use the CREATE2 factory redirect handler.

Temporary. All of this gets deleted when the next revm release includes [bluealloy/revm#3518](https://github.com/bluealloy/revm/pull/3518) and CREATE2 moves to a simple inspector.