### PR TITLE
refactor(evm): make `InspectorStackBuilder::build()` generic

### DIFF
--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -216,7 +216,7 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
     }
 
     /// Builds the stack of inspectors to use when transacting/committing on the EVM.
-    pub fn build(self) -> InspectorStack<SpecId, BLOCK, Ethereum> {
+    pub fn build<SPEC, N: Network>(self) -> InspectorStack<SPEC, BLOCK, N> {
         let Self {
             analysis,
             block,


### PR DESCRIPTION
## Summary

Makes `InspectorStackBuilder::build()` generic over `<SPEC, N: Network>` instead of hardcoding `SpecId` and `Ethereum`. All callers infer the types from context, so no call sites change.

Prerequisite for threading `EvmFactory` through `Executor`/`ExecutorBuilder`.