### PR TITLE
refactor(evm): `FoundryEvmFactory` network-generic

### DIFF
--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -2,22 +2,22 @@
 
 use super::BackendError;
 use crate::{
-    FoundryInspectorExt,
+    FoundryContextExt, FoundryInspectorExt,
     backend::{
         Backend, DatabaseExt, JournaledState, LocalForkId, RevertStateSnapshotAction,
         diagnostic::RevertDiagnostic,
     },
+    evm::{FoundryEvmFactory, transact_with_factory},
     fork::{CreateFork, ForkId},
 };
-use alloy_evm::{Evm, EvmEnv, eth::EthEvmContext};
+use alloy_evm::{EthEvmFactory, EvmEnv, eth::EthEvmContext};
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{Address, B256, TxKind, U256};
-use eyre::WrapErr;
 use foundry_fork_db::DatabaseError;
 use revm::{
     Database, DatabaseCommit,
     bytecode::Bytecode,
-    context::TxEnv,
+    context::{Transaction, TxEnv},
     context_interface::result::ResultAndState,
     database::DatabaseRef,
     primitives::{AddressMap, hardfork::SpecId},
@@ -69,18 +69,26 @@ impl<'a> CowBackend<'a> {
         tx_env: &mut TxEnv,
         inspector: I,
     ) -> eyre::Result<ResultAndState> {
+        self.inspect_with_factory(evm_env, tx_env, inspector, &EthEvmFactory::default())
+    }
+
+    /// Like [`inspect`](Self::inspect), but uses the given factory to construct the EVM.
+    pub fn inspect_with_factory<F: FoundryEvmFactory, I>(
+        &mut self,
+        evm_env: &mut EvmEnv<F::Spec, F::BlockEnv>,
+        tx_env: &mut F::Tx,
+        inspector: I,
+        factory: &F,
+    ) -> eyre::Result<ResultAndState>
+    where
+        I: for<'db> FoundryInspectorExt<F::Context<&'db mut dyn DatabaseExt>>,
+        for<'db> F::Context<&'db mut dyn DatabaseExt>: FoundryContextExt,
+    {
         // this is a new call to inspect with a new env, so even if we've cloned the backend
         // already, we reset the initialized state
-        self.pending_init = Some((evm_env.cfg_env.spec, tx_env.caller, tx_env.kind));
+        self.pending_init = Some((evm_env.cfg_env.spec.into(), tx_env.caller(), tx_env.kind()));
 
-        let mut evm = crate::evm::new_eth_evm_with_inspector(self, evm_env.clone(), inspector);
-
-        let res = evm.transact(tx_env.clone()).wrap_err("EVM error")?;
-
-        *tx_env = evm.tx.clone();
-        *evm_env = evm.finish().1;
-
-        Ok(res)
+        transact_with_factory(self, evm_env, tx_env, inspector, factory)
     }
 
     /// Returns whether there was a state snapshot failure in the backend.

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1,9 +1,9 @@
 //! Foundry's main executor backend abstraction and implementation.
 
 use crate::{
-    FoundryBlock, FoundryInspectorExt, FoundryTransaction, TryAnyToTxEnv,
+    FoundryBlock, FoundryContextExt, FoundryInspectorExt, FoundryTransaction, TryAnyToTxEnv,
     constants::{CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, TEST_CONTRACT_ADDRESS},
-    evm::{FoundryEvmFactory, new_eth_evm_with_inspector},
+    evm::{FoundryEvmFactory, new_eth_evm_with_inspector, transact_with_factory},
     fork::{CreateFork, ForkId, MultiFork},
     state_snapshot::StateSnapshots,
     utils::get_blob_base_fee_update_fraction,
@@ -21,7 +21,7 @@ use itertools::Itertools;
 use revm::{
     Database, DatabaseCommit, JournalEntry,
     bytecode::Bytecode,
-    context::{BlockEnv, CfgEnv, JournalInner, TxEnv},
+    context::{BlockEnv, CfgEnv, JournalInner, Transaction, TxEnv},
     context_interface::{journaled_state::account::JournaledAccountTr, result::ResultAndState},
     database::{CacheDB, DatabaseRef, EmptyDB},
     primitives::{AddressMap, HashMap as Map, KECCAK_EMPTY, Log, hardfork::SpecId},
@@ -781,15 +781,23 @@ where
         tx_env: &mut TxEnv,
         inspector: I,
     ) -> eyre::Result<ResultAndState> {
-        self.initialize(evm_env.cfg_env.spec, tx_env.caller, tx_env.kind);
-        let mut evm = crate::evm::new_eth_evm_with_inspector(self, evm_env.to_owned(), inspector);
+        self.inspect_with_factory(evm_env, tx_env, inspector, &EthEvmFactory::default())
+    }
 
-        let res = evm.transact(tx_env.clone()).wrap_err("EVM error")?;
-
-        *tx_env = evm.tx.clone();
-        *evm_env = evm.finish().1;
-
-        Ok(res)
+    /// Like [`inspect`](Self::inspect), but uses the given factory to construct the EVM.
+    pub fn inspect_with_factory<F: FoundryEvmFactory, I>(
+        &mut self,
+        evm_env: &mut EvmEnv<F::Spec, F::BlockEnv>,
+        tx_env: &mut F::Tx,
+        inspector: I,
+        factory: &F,
+    ) -> eyre::Result<ResultAndState>
+    where
+        I: for<'db> FoundryInspectorExt<F::Context<&'db mut dyn DatabaseExt>>,
+        for<'db> F::Context<&'db mut dyn DatabaseExt>: FoundryContextExt,
+    {
+        self.initialize(evm_env.cfg_env.spec.into(), tx_env.caller(), tx_env.kind());
+        transact_with_factory(self, evm_env, tx_env, inspector, factory)
     }
 
     /// Returns true if the address is a precompile

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -10,14 +10,18 @@ use crate::{
     constants::DEFAULT_CREATE2_DEPLOYER_CODEHASH,
 };
 use alloy_consensus::constants::KECCAK_EMPTY;
-use alloy_evm::{Evm, EvmEnv, EvmFactory, eth::EthEvmContext, precompiles::PrecompilesMap};
+use alloy_evm::{
+    Evm, EvmEnv, EvmFactory, IntoTxEnv,
+    eth::{EthEvmContext, EthEvmFactory},
+    precompiles::PrecompilesMap,
+};
 use alloy_primitives::{Address, Bytes, U256};
 use foundry_fork_db::{DatabaseError, ForkBlockEnv};
 use revm::{
     Context,
     context::{
         BlockEnv, CfgEnv, ContextTr, CreateScheme, Evm as RevmEvm, JournalTr, LocalContextTr,
-        TxEnv,
+        Transaction, TxEnv,
         result::{EVMError, ExecResultAndState, ExecutionResult, HaltReason, ResultAndState},
     },
     handler::{
@@ -38,29 +42,95 @@ use tempo_revm::{
     gas_params::tempo_gas_params, handler::TempoEvmHandler,
 };
 
-/// Marker trait for [`EvmFactory`] implementations compatible with Foundry's EVM infrastructure.
+/// Factory for constructing a Foundry-wrapped EVM with custom handler logic (CREATE2 factory
+/// redirect) and network precompile injection.
 ///
-/// Requires a spec type convertible to [`SpecId`], a defaultable block environment, and
-/// [`PrecompilesMap`] as the precompile provider, enabling use across the backend and cheatcode
-/// layers without depending on a concrete EVM type.
+/// This is the central abstraction for network-generic EVM construction in Foundry. Each
+/// network (Ethereum, Tempo, etc.) implements this trait. It extends [`EvmFactory`] so that
+/// the raw alloy factory is also available (e.g. for precompile queries in [`BackendInner`]).
+///
+/// [`BackendInner`]: crate::backend::BackendInner
 pub trait FoundryEvmFactory:
-    EvmFactory<Spec: Into<SpecId>, BlockEnv: ForkBlockEnv + Default, Precompiles = PrecompilesMap>
-    + Clone
+    EvmFactory<
+        Spec: Into<SpecId>,
+        BlockEnv: ForkBlockEnv + Default,
+        Tx: Clone + IntoTxEnv<Self::Tx> + Transaction,
+        Precompiles = PrecompilesMap,
+    > + Clone
     + Debug
     + Default
 {
+    /// The Foundry-wrapped EVM type produced by this factory.
+    type FoundryEvm<'db, I>: Evm<
+            DB = &'db mut dyn DatabaseExt,
+            Tx = Self::Tx,
+            BlockEnv = Self::BlockEnv,
+            Spec = Self::Spec,
+            HaltReason = HaltReason,
+        > + Deref<Target: ContextTr<Tx = Self::Tx>>
+    where
+        I: FoundryInspectorExt<Self::Context<&'db mut dyn DatabaseExt>>,
+        Self::Context<&'db mut dyn DatabaseExt>: FoundryContextExt,
+        Self: 'db;
+
+    /// Creates a Foundry-wrapped EVM with the given inspector.
+    fn create_evm_with_inspector<'db, I>(
+        &self,
+        db: &'db mut dyn DatabaseExt,
+        evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
+        inspector: I,
+    ) -> Self::FoundryEvm<'db, I>
+    where
+        I: FoundryInspectorExt<Self::Context<&'db mut dyn DatabaseExt>>,
+        Self::Context<&'db mut dyn DatabaseExt>: FoundryContextExt;
 }
 
-impl<
-    F: EvmFactory<
-            Spec: Into<SpecId>,
-            BlockEnv: ForkBlockEnv + Default,
-            Precompiles = PrecompilesMap,
-        > + Clone
-        + Debug
-        + Default,
-> FoundryEvmFactory for F
+impl FoundryEvmFactory for EthEvmFactory {
+    type FoundryEvm<'db, I>
+        = FoundryEvm<'db, I>
+    where
+        I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt>>;
+
+    fn create_evm_with_inspector<'db, I>(
+        &self,
+        db: &'db mut dyn DatabaseExt,
+        evm_env: EvmEnv,
+        inspector: I,
+    ) -> Self::FoundryEvm<'db, I>
+    where
+        I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt>>,
+    {
+        new_eth_evm_with_inspector(db, evm_env, inspector)
+    }
+}
+
+/// Builds an EVM using the given factory, executes a transaction, and writes back the
+/// modified tx env and `EvmEnv`.
+///
+/// Shared by [`Backend::inspect_with_factory`] and [`CowBackend::inspect_with_factory`].
+///
+/// [`Backend::inspect_with_factory`]: crate::backend::Backend::inspect_with_factory
+/// [`CowBackend::inspect_with_factory`]: crate::backend::CowBackend::inspect_with_factory
+pub fn transact_with_factory<F: FoundryEvmFactory, I>(
+    db: &mut dyn DatabaseExt,
+    evm_env: &mut EvmEnv<F::Spec, F::BlockEnv>,
+    tx_env: &mut F::Tx,
+    inspector: I,
+    factory: &F,
+) -> eyre::Result<ResultAndState>
+where
+    I: for<'db> FoundryInspectorExt<F::Context<&'db mut dyn DatabaseExt>>,
+    for<'db> F::Context<&'db mut dyn DatabaseExt>: FoundryContextExt,
 {
+    let mut evm =
+        FoundryEvmFactory::create_evm_with_inspector(factory, db, evm_env.clone(), inspector);
+
+    let res = evm.transact(tx_env.clone()).map_err(|e| eyre::eyre!("EVM error; {e}"))?;
+
+    *tx_env = evm.tx().clone();
+    *evm_env = evm.finish().1;
+
+    Ok(res)
 }
 
 pub fn new_eth_evm_with_inspector<
@@ -72,7 +142,7 @@ pub fn new_eth_evm_with_inspector<
     inspector: I,
 ) -> FoundryEvm<'db, I> {
     let eth_evm =
-        alloy_evm::EthEvmFactory::default().create_evm_with_inspector(db, evm_env, inspector);
+        EvmFactory::create_evm_with_inspector(&EthEvmFactory::default(), db, evm_env, inspector);
     let mut inner = eth_evm.into_inner();
     inner.ctx.cfg.tx_chain_id_check = true;
 


### PR DESCRIPTION
## Summary

Expands `FoundryEvmFactory` from a marker trait into the central abstraction for network-generic EVM construction.