### PR TITLE
feat(anvil): add Tempo EVM execution path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,8 +1223,10 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tempo-chainspec",
+ "tempo-evm",
  "tempo-precompiles",
  "tempo-primitives",
+ "tempo-revm",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5406,6 +5408,7 @@ dependencies = [
  "serde_json",
  "tempo-alloy",
  "tempo-primitives",
+ "tempo-revm",
 ]
 
 [[package]]

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -32,6 +32,8 @@ foundry-primitives.workspace = true
 tempo-chainspec.workspace = true
 tempo-primitives.workspace = true
 tempo-precompiles.workspace = true
+tempo-evm.workspace = true
+tempo-revm.workspace = true
 
 # alloy
 alloy-evm = { workspace = true, features = ["call-util"] }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -136,6 +136,11 @@ use std::{
     time::Duration,
 };
 use storage::{Blockchain, DEFAULT_HISTORY_LIMIT, MinedTransaction};
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_evm::evm::TempoEvmFactory;
+use tempo_revm::{
+    TempoBlockEnv, TempoHaltReason, TempoTxEnv, evm::TempoContext, gas_params::tempo_gas_params,
+};
 use tokio::sync::RwLock as AsyncRwLock;
 
 pub mod cache;
@@ -474,6 +479,11 @@ impl<N: Network> Backend<N> {
     /// Returns true if op-stack deposits are active
     pub fn is_optimism(&self) -> bool {
         self.networks.is_optimism()
+    }
+
+    /// Returns true if Tempo network mode is active
+    pub fn is_tempo(&self) -> bool {
+        self.networks.is_tempo()
     }
 
     /// Returns the precompiles for the current spec.
@@ -1061,7 +1071,8 @@ impl<N: Network> Backend<N> {
     where
         DB: DatabaseRef + ?Sized,
         I: Inspector<EthEvmContext<WrapDatabaseRef<&'db DB>>>
-            + Inspector<OpContext<WrapDatabaseRef<&'db DB>>>,
+            + Inspector<OpContext<WrapDatabaseRef<&'db DB>>>
+            + Inspector<TempoContext<WrapDatabaseRef<&'db DB>>>,
         WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
     {
         if self.is_optimism() {
@@ -1076,6 +1087,30 @@ impl<N: Network> Backend<N> {
             );
             self.inject_precompiles(evm.precompiles_mut());
             Ok(evm.transact(tx_env)?)
+        } else if self.is_tempo() {
+            let hardfork = TempoHardfork::from(evm_env.cfg_env.spec);
+            let tempo_env = EvmEnv::new(
+                evm_env
+                    .cfg_env
+                    .clone()
+                    .with_spec_and_gas_params(hardfork, tempo_gas_params(hardfork)),
+                TempoBlockEnv { inner: evm_env.block_env.clone(), timestamp_millis_part: 0 },
+            );
+            let mut evm = TempoEvmFactory::default().create_evm_with_inspector(
+                WrapDatabaseRef(db),
+                tempo_env,
+                inspector,
+            );
+            self.inject_precompiles(evm.precompiles_mut());
+            let tempo_tx = TempoTxEnv::from(tx_env.base);
+            let result = evm.transact(tempo_tx)?;
+            Ok(ResultAndState {
+                result: result.result.map_haltreason(|h| match h {
+                    TempoHaltReason::Ethereum(eth) => OpHaltReason::Base(eth),
+                    _ => OpHaltReason::Base(HaltReason::PrecompileError),
+                }),
+                state: result.state,
+            })
         } else {
             let mut evm = EthEvmFactory::default().create_evm_with_inspector(
                 WrapDatabaseRef(db),
@@ -1119,6 +1154,31 @@ impl<N: Network> Backend<N> {
                 evm_env.block_env.clone(),
             );
             let mut evm = OpEvmFactory::default().create_evm_with_inspector(db, op_env, inspector);
+            self.inject_precompiles(evm.precompiles_mut());
+            let mut executor = AnvilBlockExecutor::new(evm, parent_hash, spec_id);
+            executor.apply_pre_execution_changes().expect("pre-execution changes failed");
+            let pool_result = execute_pool_transactions(
+                &mut executor,
+                pool_transactions,
+                gas_config,
+                inspector_tx_config,
+                self.cheats(),
+                validator,
+            );
+            let (evm, block_result) = executor.finish().expect("executor finish failed");
+            drop(evm);
+            (pool_result, block_result)
+        } else if self.is_tempo() {
+            let hardfork = TempoHardfork::from(evm_env.cfg_env.spec);
+            let tempo_env = EvmEnv::new(
+                evm_env
+                    .cfg_env
+                    .clone()
+                    .with_spec_and_gas_params(hardfork, tempo_gas_params(hardfork)),
+                TempoBlockEnv { inner: evm_env.block_env.clone(), timestamp_millis_part: 0 },
+            );
+            let mut evm =
+                TempoEvmFactory::default().create_evm_with_inspector(db, tempo_env, inspector);
             self.inject_precompiles(evm.precompiles_mut());
             let mut executor = AnvilBlockExecutor::new(evm, parent_hash, spec_id);
             executor.apply_pre_execution_changes().expect("pre-execution changes failed");
@@ -3020,6 +3080,7 @@ where
     where
         for<'a> I: Inspector<EthEvmContext<WrapDatabaseRef<&'a CacheDB<Box<&'a StateDb>>>>>
             + Inspector<OpContext<WrapDatabaseRef<&'a CacheDB<Box<&'a StateDb>>>>>
+            + Inspector<TempoContext<WrapDatabaseRef<&'a CacheDB<Box<&'a StateDb>>>>>
             + 'a,
         for<'a> F:
             FnOnce(ResultAndState<OpHaltReason>, CacheDB<Box<&'a StateDb>>, I, TxEnv, EvmEnv) -> T,
@@ -4287,6 +4348,15 @@ impl IntoInstructionResult for OpHaltReason {
         match self {
             Self::Base(eth_h) => eth_h.into(),
             Self::FailedDeposit => InstructionResult::Stop,
+        }
+    }
+}
+
+impl IntoInstructionResult for TempoHaltReason {
+    fn into_instruction_result(self) -> InstructionResult {
+        match self {
+            Self::Ethereum(eth_h) => eth_h.into(),
+            _ => InstructionResult::PrecompileError,
         }
     }
 }

--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -18,6 +18,7 @@ use revm::{
     interpreter::InstructionResult,
 };
 use serde::Serialize;
+use tempo_revm::TempoInvalidTransaction;
 use tokio::time::Duration;
 
 pub(crate) type Result<T> = std::result::Result<T, BlockchainError>;
@@ -171,6 +172,25 @@ where
                 }
                 OpTransactionError::MissingEnvelopedTx => Self::InvalidTransaction(err.into()),
             },
+            EVMError::Header(err) => match err {
+                InvalidHeader::ExcessBlobGasNotSet => Self::ExcessBlobGasNotSet,
+                InvalidHeader::PrevrandaoNotSet => Self::PrevrandaoNotSet,
+            },
+            EVMError::Database(err) => err.into(),
+            EVMError::Custom(err) => Self::Message(err),
+        }
+    }
+}
+
+impl<T> From<EVMError<T, TempoInvalidTransaction>> for BlockchainError
+where
+    T: Into<Self>,
+{
+    fn from(err: EVMError<T, TempoInvalidTransaction>) -> Self {
+        match err {
+            EVMError::Transaction(err) => {
+                Self::Message(format!("tempo transaction error: {err:?}"))
+            }
             EVMError::Header(err) => match err {
                 InvalidHeader::ExcessBlobGasNotSet => Self::ExcessBlobGasNotSet,
                 InvalidHeader::PrevrandaoNotSet => Self::PrevrandaoNotSet,

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -32,3 +32,4 @@ serde = { version = "1.0", features = ["derive"] }
 derive_more.workspace = true
 tempo-primitives.workspace = true
 tempo-alloy.workspace = true
+tempo-revm.workspace = true

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -15,6 +15,7 @@ use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpTransaction as OpTransactionTrait
 use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
 use revm::context::TxEnv;
 use tempo_primitives::{AASigned, TempoTransaction};
+use tempo_revm::TempoTxEnv;
 
 //
 /// Container type for signed, typed transactions.
@@ -232,6 +233,36 @@ impl FromRecoveredTx<FoundryTxEnvelope> for OpTransaction<TxEnv> {
 }
 
 impl FromTxWithEncoded<FoundryTxEnvelope> for TxEnv {
+    fn from_encoded_tx(tx: &FoundryTxEnvelope, sender: Address, _encoded: Bytes) -> Self {
+        Self::from_recovered_tx(tx, sender)
+    }
+}
+
+impl FromRecoveredTx<FoundryTxEnvelope> for TempoTxEnv {
+    fn from_recovered_tx(tx: &FoundryTxEnvelope, caller: Address) -> Self {
+        match tx {
+            FoundryTxEnvelope::Legacy(signed_tx) => {
+                Self::from(TxEnv::from_recovered_tx(signed_tx, caller))
+            }
+            FoundryTxEnvelope::Eip2930(signed_tx) => {
+                Self::from(TxEnv::from_recovered_tx(signed_tx, caller))
+            }
+            FoundryTxEnvelope::Eip1559(signed_tx) => {
+                Self::from(TxEnv::from_recovered_tx(signed_tx, caller))
+            }
+            FoundryTxEnvelope::Eip4844(signed_tx) => {
+                Self::from(TxEnv::from_recovered_tx(signed_tx, caller))
+            }
+            FoundryTxEnvelope::Eip7702(signed_tx) => {
+                Self::from(TxEnv::from_recovered_tx(signed_tx, caller))
+            }
+            FoundryTxEnvelope::Deposit(_) => unreachable!("Deposit tx in Tempo context"),
+            FoundryTxEnvelope::Tempo(aa_signed) => Self::from_recovered_tx(aa_signed, caller),
+        }
+    }
+}
+
+impl FromTxWithEncoded<FoundryTxEnvelope> for TempoTxEnv {
     fn from_encoded_tx(tx: &FoundryTxEnvelope, sender: Address, _encoded: Bytes) -> Self {
         Self::from_recovered_tx(tx, sender)
     }


### PR DESCRIPTION
Add Tempo EVM execution support to anvil's backend.

- Implement `FromRecoveredTx<FoundryTxEnvelope>` and `FromTxWithEncoded<FoundryTxEnvelope>` for `TempoTxEnv`
- Add `else if is_tempo()` branches in `transact_with_inspector_ref` and `execute_with_block_executor` using `TempoEvmFactory`
- Add `From<EVMError<T, TempoInvalidTransaction>>` for `BlockchainError`
- Add `IntoInstructionResult` for `TempoHaltReason`