### PR TITLE
feat(evm): `ForkedDatabase` and `Fork` generic over `BlockEnv`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2285,16 +2285,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "zeroize",
 ]
 
@@ -2494,7 +2494,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2771,7 +2771,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2956,7 +2956,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3109,7 +3109,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3344,7 +3344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -3427,6 +3427,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -3597,7 +3606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "fiat-crypto",
  "rustc_version 0.4.1",
@@ -3884,7 +3893,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4189,7 +4198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5341,12 +5350,10 @@ dependencies = [
 
 [[package]]
 name = "foundry-fork-db"
-version = "0.23.0"
-source = "git+https://github.com/foundry-rs/foundry-fork-db?branch=alloy-2.0#2b1077a45f70e2d70c544124ed0a06596cdc36c6"
+version = "0.24.1"
+source = "git+https://github.com/foundry-rs/foundry-fork-db?branch=main#767dcd5e6e773dde1dd10faef677bb9291cc4bf7"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-hardforks",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -5356,6 +5363,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
+ "tempo-revm",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6025,9 +6033,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -6040,7 +6048,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -6094,7 +6101,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6471,7 +6478,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6632,9 +6639,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "797146bb2677299a1eb6b7b50a890f4c361b29ef967addf5b2fa45dae1bb6d7d"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -6700,7 +6707,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -7341,7 +7348,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8090,7 +8097,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -8350,7 +8357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8363,7 +8370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8486,7 +8493,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8524,9 +8531,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9683,7 +9690,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9742,7 +9749,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10197,7 +10204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -10209,7 +10216,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -10221,7 +10228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -10514,7 +10521,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -10549,7 +10556,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.0",
  "bumpalo",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -10973,7 +10980,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11166,7 +11173,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11176,7 +11183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11500,7 +11507,7 @@ dependencies = [
  "indexmap 2.13.0",
  "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -11509,7 +11516,7 @@ version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -12220,9 +12227,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "7dc0882f7b5bb01ae8c5215a1230832694481c1a4be062fd410e12ea3da5b631"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12233,9 +12240,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "19280959e2844181895ef62f065c63e0ca07ece4771b53d89bfdb967d97cbf05"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12243,9 +12250,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "75973d3066e01d035dbedaad2864c398df42f8dd7b1ea057c35b8407c015b537"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12253,9 +12260,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "91af5e4be765819e0bcfee7322c14374dc821e35e72fa663a830bbc7dc199eac"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -12266,9 +12273,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
 dependencies = [
  "unicode-ident",
 ]
@@ -12353,7 +12360,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12393,9 +12400,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "749466a37ee189057f54748b200186b59a03417a117267baf3fd89cecc9fb837"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12503,7 +12510,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12875,9 +12882,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,7 @@ foundry-compilers = { version = "0.19.14", default-features = false, features = 
     "rustls",
     "svm-solc",
 ] }
-foundry-fork-db = "0.23"
+foundry-fork-db = "0.24.1"
 solang-parser = { version = "=0.3.9", package = "foundry-solang-parser" }
 solar = { package = "solar-compiler", version = "=0.1.8", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false, features = [
@@ -524,7 +524,7 @@ alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = 
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors.git", branch = "alloy-2.0" }
 
 ## foundry
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-fork-db", branch = "alloy-2.0" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-fork-db", branch = "main" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -16,7 +16,7 @@ use alloy_primitives::{Address, B256, TxKind, U256, keccak256, uint};
 use alloy_rpc_types::BlockNumberOrTag;
 use eyre::Context;
 use foundry_common::{SYSTEM_TRANSACTION_TYPE, is_known_system_sender};
-pub use foundry_fork_db::{BlockchainDb, SharedBackend, cache::BlockchainDbMeta};
+pub use foundry_fork_db::{BlockchainDb, ForkBlockEnv, SharedBackend, cache::BlockchainDbMeta};
 use itertools::Itertools;
 use revm::{
     Database, DatabaseCommit, JournalEntry,
@@ -49,7 +49,7 @@ mod snapshot;
 pub use snapshot::{BackendStateSnapshot, RevertStateSnapshotAction, StateSnapshot};
 
 // A `revm::Database` that is used in forking mode
-type ForkDB<N> = CacheDB<SharedBackend<N>>;
+type ForkDB<N, B> = CacheDB<SharedBackend<N, B>>;
 
 /// Represents a numeric `ForkId` valid only for the existence of the `Backend`.
 ///
@@ -690,12 +690,12 @@ where
     }
 
     /// Returns the currently active `ForkDB`, if any
-    pub fn active_fork_db(&self) -> Option<&ForkDB<N>> {
+    pub fn active_fork_db(&self) -> Option<&ForkDB<N, BlockEnv>> {
         self.active_fork().map(|f| &f.db)
     }
 
     /// Returns the currently active `ForkDB`, if any
-    pub fn active_fork_db_mut(&mut self) -> Option<&mut ForkDB<N>> {
+    pub fn active_fork_db_mut(&mut self) -> Option<&mut ForkDB<N, BlockEnv>> {
         self.active_fork_mut().map(|f| &mut f.db)
     }
 
@@ -1621,14 +1621,14 @@ pub enum BackendDatabaseSnapshot<N: Network> {
 
 /// Represents a fork
 #[derive(Clone, Debug)]
-pub struct Fork<N: Network> {
-    db: ForkDB<N>,
+pub struct Fork<N: Network, B: ForkBlockEnv = BlockEnv> {
+    db: ForkDB<N, B>,
     journaled_state: JournaledState,
 }
 
-impl<N: Network> Fork<N> {
+impl<N: Network, B: ForkBlockEnv> Fork<N, B> {
     /// Returns a reference to the underlying [`SharedBackend`].
-    pub fn backend(&self) -> &SharedBackend<N> {
+    pub fn backend(&self) -> &SharedBackend<N, B> {
         &self.db.db
     }
 
@@ -1680,7 +1680,7 @@ pub struct BackendInner<N: Network, F: FoundryEvmFactory = EthEvmFactory> {
     pub created_forks: HashMap<ForkId, ForkLookupIndex>,
     /// Holds all created fork databases
     // Note: data is stored in an `Option` so we can remove it without reshuffling
-    pub forks: Vec<Option<Fork<N>>>,
+    pub forks: Vec<Option<Fork<N, F::BlockEnv>>>,
     /// Contains state snapshots made at a certain point
     pub state_snapshots:
         StateSnapshots<BackendStateSnapshot<BackendDatabaseSnapshot<N>, F::Spec, F::BlockEnv>>,
@@ -1728,51 +1728,51 @@ impl<N: Network, F: FoundryEvmFactory> BackendInner<N, F> {
 
     /// Returns the underlying fork mapped to the index
     #[track_caller]
-    fn get_fork(&self, idx: ForkLookupIndex) -> &Fork<N> {
+    fn get_fork(&self, idx: ForkLookupIndex) -> &Fork<N, F::BlockEnv> {
         debug_assert!(idx < self.forks.len(), "fork lookup index must exist");
         self.forks[idx].as_ref().unwrap()
     }
 
     /// Returns the underlying fork mapped to the index
     #[track_caller]
-    fn get_fork_mut(&mut self, idx: ForkLookupIndex) -> &mut Fork<N> {
+    fn get_fork_mut(&mut self, idx: ForkLookupIndex) -> &mut Fork<N, F::BlockEnv> {
         debug_assert!(idx < self.forks.len(), "fork lookup index must exist");
         self.forks[idx].as_mut().unwrap()
     }
 
     /// Returns the underlying fork corresponding to the id
     #[track_caller]
-    fn get_fork_by_id_mut(&mut self, id: LocalForkId) -> eyre::Result<&mut Fork<N>> {
+    fn get_fork_by_id_mut(&mut self, id: LocalForkId) -> eyre::Result<&mut Fork<N, F::BlockEnv>> {
         let idx = self.ensure_fork_index_by_local_id(id)?;
         Ok(self.get_fork_mut(idx))
     }
 
     /// Returns the underlying fork corresponding to the id
     #[track_caller]
-    fn get_fork_by_id(&self, id: LocalForkId) -> eyre::Result<&Fork<N>> {
+    fn get_fork_by_id(&self, id: LocalForkId) -> eyre::Result<&Fork<N, F::BlockEnv>> {
         let idx = self.ensure_fork_index_by_local_id(id)?;
         Ok(self.get_fork(idx))
     }
 
     /// Removes the fork
-    fn take_fork(&mut self, idx: ForkLookupIndex) -> Fork<N> {
+    fn take_fork(&mut self, idx: ForkLookupIndex) -> Fork<N, F::BlockEnv> {
         debug_assert!(idx < self.forks.len(), "fork lookup index must exist");
         self.forks[idx].take().unwrap()
     }
 
-    fn set_fork(&mut self, idx: ForkLookupIndex, fork: Fork<N>) {
+    fn set_fork(&mut self, idx: ForkLookupIndex, fork: Fork<N, F::BlockEnv>) {
         self.forks[idx] = Some(fork)
     }
 
     /// Returns an iterator over Forks
-    pub fn forks_iter(&self) -> impl Iterator<Item = (LocalForkId, &Fork<N>)> + '_ {
+    pub fn forks_iter(&self) -> impl Iterator<Item = (LocalForkId, &Fork<N, F::BlockEnv>)> + '_ {
         self.issued_local_fork_ids
             .iter()
             .map(|(id, fork_id)| (*id, self.get_fork(self.created_forks[fork_id])))
     }
 
     /// Returns a mutable iterator over all Forks
-    pub fn forks_iter_mut(&mut self) -> impl Iterator<Item = &mut Fork<N>> + '_ {
+    pub fn forks_iter_mut(&mut self) -> impl Iterator<Item = &mut Fork<N, F::BlockEnv>> + '_ {
         self.forks.iter_mut().filter_map(|f| f.as_mut())
     }
 
@@ -1782,7 +1782,7 @@ impl<N: Network, F: FoundryEvmFactory> BackendInner<N, F> {
         id: LocalForkId,
         fork_id: ForkId,
         idx: ForkLookupIndex,
-        fork: Fork<N>,
+        fork: Fork<N, F::BlockEnv>,
     ) {
         self.created_forks.insert(fork_id.clone(), idx);
         self.issued_local_fork_ids.insert(id, fork_id);
@@ -1794,7 +1794,7 @@ impl<N: Network, F: FoundryEvmFactory> BackendInner<N, F> {
         &mut self,
         id: LocalForkId,
         fork_id: ForkId,
-        db: ForkDB<N>,
+        db: ForkDB<N, F::BlockEnv>,
         journaled_state: JournaledState,
     ) -> ForkLookupIndex {
         let idx = self.forks.len();
@@ -1810,7 +1810,7 @@ impl<N: Network, F: FoundryEvmFactory> BackendInner<N, F> {
         &mut self,
         id: LocalForkId,
         new_fork_id: ForkId,
-        backend: SharedBackend<N>,
+        backend: SharedBackend<N, F::BlockEnv>,
     ) -> eyre::Result<ForkLookupIndex> {
         let fork_id = self.ensure_fork_id(id)?;
         let idx = self.ensure_fork_index(fork_id)?;
@@ -1835,7 +1835,7 @@ impl<N: Network, F: FoundryEvmFactory> BackendInner<N, F> {
     pub fn insert_new_fork(
         &mut self,
         fork_id: ForkId,
-        db: ForkDB<N>,
+        db: ForkDB<N, F::BlockEnv>,
         journaled_state: JournaledState,
     ) -> (LocalForkId, ForkLookupIndex) {
         let idx = self.forks.len();
@@ -1944,10 +1944,10 @@ fn merge_journaled_state_data(
 }
 
 /// Clones the account data from the `active` db into the `ForkDB`
-fn merge_db_account_data<ExtDB: DatabaseRef, N: Network>(
+fn merge_db_account_data<ExtDB: DatabaseRef, N: Network, B: ForkBlockEnv>(
     addr: Address,
     active: &CacheDB<ExtDB>,
-    fork_db: &mut ForkDB<N>,
+    fork_db: &mut ForkDB<N, B>,
 ) {
     trace!(?addr, "merging database data");
 

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -12,7 +12,7 @@ use crate::{
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_evm::{Evm, EvmEnv, EvmFactory, eth::EthEvmContext, precompiles::PrecompilesMap};
 use alloy_primitives::{Address, Bytes, U256};
-use foundry_fork_db::DatabaseError;
+use foundry_fork_db::{DatabaseError, ForkBlockEnv};
 use revm::{
     Context,
     context::{
@@ -44,7 +44,7 @@ use tempo_revm::{
 /// [`PrecompilesMap`] as the precompile provider, enabling use across the backend and cheatcode
 /// layers without depending on a concrete EVM type.
 pub trait FoundryEvmFactory:
-    EvmFactory<Spec: Into<SpecId>, BlockEnv: Default, Precompiles = PrecompilesMap>
+    EvmFactory<Spec: Into<SpecId>, BlockEnv: ForkBlockEnv + Default, Precompiles = PrecompilesMap>
     + Clone
     + Debug
     + Default
@@ -52,8 +52,11 @@ pub trait FoundryEvmFactory:
 }
 
 impl<
-    F: EvmFactory<Spec: Into<SpecId>, BlockEnv: Default, Precompiles = PrecompilesMap>
-        + Clone
+    F: EvmFactory<
+            Spec: Into<SpecId>,
+            BlockEnv: ForkBlockEnv + Default,
+            Precompiles = PrecompilesMap,
+        > + Clone
         + Debug
         + Default,
 > FoundryEvmFactory for F

--- a/crates/evm/core/src/fork/database.rs
+++ b/crates/evm/core/src/fork/database.rs
@@ -7,11 +7,12 @@ use crate::{
 use alloy_network::Network;
 use alloy_primitives::{Address, B256, U256};
 use alloy_rpc_types::BlockId;
-use foundry_fork_db::{BlockchainDb, DatabaseError, SharedBackend};
+use foundry_fork_db::{BlockchainDb, DatabaseError, ForkBlockEnv, SharedBackend};
 use parking_lot::Mutex;
 use revm::{
     Database, DatabaseCommit,
     bytecode::Bytecode,
+    context::BlockEnv,
     database::{CacheDB, DatabaseRef},
     primitives::AddressMap,
     state::{Account, AccountInfo},
@@ -25,28 +26,28 @@ use std::sync::Arc;
 /// This database uses the `backend` for read and the `db` for write operations. But note the
 /// `backend` will also write (missing) data to the `db` in the background
 #[derive(Clone, Debug)]
-pub struct ForkedDatabase<N: Network> {
+pub struct ForkedDatabase<N: Network, B: ForkBlockEnv = BlockEnv> {
     /// Responsible for fetching missing data.
     ///
     /// This is responsible for getting data.
-    backend: SharedBackend<N>,
+    backend: SharedBackend<N, B>,
     /// Cached Database layer, ensures that changes are not written to the database that
     /// exclusively stores the state of the remote client.
     ///
     /// This separates Read/Write operations
     ///   - reads from the `SharedBackend as DatabaseRef` writes to the internal cache storage.
-    cache_db: CacheDB<SharedBackend<N>>,
+    cache_db: CacheDB<SharedBackend<N, B>>,
     /// Contains all the data already fetched.
     ///
     /// This exclusively stores the _unchanged_ remote client state.
-    db: BlockchainDb,
+    db: BlockchainDb<B>,
     /// Holds the state snapshots of a blockchain.
-    state_snapshots: Arc<Mutex<StateSnapshots<ForkDbStateSnapshot<N>>>>,
+    state_snapshots: Arc<Mutex<StateSnapshots<ForkDbStateSnapshot<N, B>>>>,
 }
 
-impl<N: Network> ForkedDatabase<N> {
+impl<N: Network, B: ForkBlockEnv> ForkedDatabase<N, B> {
     /// Creates a new instance of this DB
-    pub fn new(backend: SharedBackend<N>, db: BlockchainDb) -> Self {
+    pub fn new(backend: SharedBackend<N, B>, db: BlockchainDb<B>) -> Self {
         Self {
             cache_db: CacheDB::new(backend.clone()),
             backend,
@@ -55,15 +56,15 @@ impl<N: Network> ForkedDatabase<N> {
         }
     }
 
-    pub fn database(&self) -> &CacheDB<SharedBackend<N>> {
+    pub fn database(&self) -> &CacheDB<SharedBackend<N, B>> {
         &self.cache_db
     }
 
-    pub fn database_mut(&mut self) -> &mut CacheDB<SharedBackend<N>> {
+    pub fn database_mut(&mut self) -> &mut CacheDB<SharedBackend<N, B>> {
         &mut self.cache_db
     }
 
-    pub fn state_snapshots(&self) -> &Arc<Mutex<StateSnapshots<ForkDbStateSnapshot<N>>>> {
+    pub fn state_snapshots(&self) -> &Arc<Mutex<StateSnapshots<ForkDbStateSnapshot<N, B>>>> {
         &self.state_snapshots
     }
 
@@ -91,11 +92,11 @@ impl<N: Network> ForkedDatabase<N> {
     }
 
     /// Returns the database that holds the remote state
-    pub fn inner(&self) -> &BlockchainDb {
+    pub fn inner(&self) -> &BlockchainDb<B> {
         &self.db
     }
 
-    pub fn create_state_snapshot(&self) -> ForkDbStateSnapshot<N> {
+    pub fn create_state_snapshot(&self) -> ForkDbStateSnapshot<N, B> {
         let db = self.db.db();
         let state_snapshot = StateSnapshot {
             accounts: db.accounts.read().clone(),
@@ -152,7 +153,7 @@ impl<N: Network> ForkedDatabase<N> {
     }
 }
 
-impl<N: Network> Database for ForkedDatabase<N> {
+impl<N: Network, B: ForkBlockEnv> Database for ForkedDatabase<N, B> {
     type Error = DatabaseError;
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
@@ -175,7 +176,7 @@ impl<N: Network> Database for ForkedDatabase<N> {
     }
 }
 
-impl<N: Network> DatabaseRef for ForkedDatabase<N> {
+impl<N: Network, B: ForkBlockEnv> DatabaseRef for ForkedDatabase<N, B> {
     type Error = DatabaseError;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
@@ -195,7 +196,7 @@ impl<N: Network> DatabaseRef for ForkedDatabase<N> {
     }
 }
 
-impl<N: Network> DatabaseCommit for ForkedDatabase<N> {
+impl<N: Network, B: ForkBlockEnv> DatabaseCommit for ForkedDatabase<N, B> {
     fn commit(&mut self, changes: AddressMap<Account>) {
         self.database_mut().commit(changes)
     }
@@ -205,12 +206,12 @@ impl<N: Network> DatabaseCommit for ForkedDatabase<N> {
 ///
 /// This mimics `revm::CacheDB`
 #[derive(Clone, Debug)]
-pub struct ForkDbStateSnapshot<N: Network> {
-    pub local: CacheDB<SharedBackend<N>>,
+pub struct ForkDbStateSnapshot<N: Network, B: ForkBlockEnv = BlockEnv> {
+    pub local: CacheDB<SharedBackend<N, B>>,
     pub state_snapshot: StateSnapshot,
 }
 
-impl<N: Network> ForkDbStateSnapshot<N> {
+impl<N: Network, B: ForkBlockEnv> ForkDbStateSnapshot<N, B> {
     fn get_storage(&self, address: Address, index: U256) -> Option<U256> {
         self.local
             .cache
@@ -224,7 +225,7 @@ impl<N: Network> ForkDbStateSnapshot<N> {
 // This `DatabaseRef` implementation works similar to `CacheDB` which prioritizes modified elements,
 // and uses another db as fallback
 // We prioritize stored changed accounts/storage
-impl<N: Network> DatabaseRef for ForkDbStateSnapshot<N> {
+impl<N: Network, B: ForkBlockEnv> DatabaseRef for ForkDbStateSnapshot<N, B> {
     type Error = DatabaseError;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
@@ -281,7 +282,7 @@ mod tests {
     async fn fork_db_insert_basic_default() {
         let rpc = foundry_test_utils::rpc::next_http_rpc_endpoint();
         let provider = get_http_provider(rpc.clone());
-        let meta = BlockchainDbMeta::new(Default::default(), rpc);
+        let meta = BlockchainDbMeta::new(BlockEnv::default(), rpc);
 
         let db = BlockchainDb::new(meta, None);
 


### PR DESCRIPTION
## Motivation

Towards generic `Backend` over both `Network` and `EvmFactory` 

- Bumped `foundry-fork-db` to main, to get `BlockEnv` generic on `SharedBackend`, `BlockchainDb`
- `ForkedDatabase` and `Fork` now generic over `BlockEnv`
- wired to `EvmFactory::BlockEnv` in `BackendInner`
- added `ForkBlockEnv` bound to `FoundryEvmFactory`