### PR TITLE
feat(anvil): extract base eth errors from `TempoInvalidTransaction`

### DIFF
--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -188,9 +188,12 @@ where
 {
     fn from(err: EVMError<T, TempoInvalidTransaction>) -> Self {
         match err {
-            EVMError::Transaction(err) => {
-                Self::Message(format!("tempo transaction error: {err:?}"))
-            }
+            EVMError::Transaction(err) => match err {
+                TempoInvalidTransaction::EthInvalidTransaction(err) => {
+                    InvalidTransactionError::from(err).into()
+                }
+                err => Self::Message(format!("tempo transaction error: {err}")),
+            },
             EVMError::Header(err) => match err {
                 InvalidHeader::ExcessBlobGasNotSet => Self::ExcessBlobGasNotSet,
                 InvalidHeader::PrevrandaoNotSet => Self::PrevrandaoNotSet,

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -593,7 +593,10 @@ fn map_tempo_error(e: EVMError<DatabaseError, TempoInvalidTransaction>) -> EVMEr
         EVMError::Database(db) => EVMError::Database(db),
         EVMError::Header(h) => EVMError::Header(h),
         EVMError::Custom(s) => EVMError::Custom(s),
-        EVMError::Transaction(t) => EVMError::Custom(format!("tempo transaction error: {t:?}")),
+        EVMError::Transaction(t) => match t {
+            TempoInvalidTransaction::EthInvalidTransaction(eth) => EVMError::Transaction(eth),
+            t => EVMError::Custom(format!("tempo transaction error: {t}")),
+        },
     }
 }
 


### PR DESCRIPTION
Extract base eth errors from `TempoInvalidTransaction::EthInvalidTransaction` instead of stringifying them. Matches the `OpTransactionError::Base` pattern.