### PR TITLE
refactor(evm): remove useless `tx_env` on `DatabaseExt::transact`

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -222,9 +222,8 @@ where
         transaction: B256,
     ) -> eyre::Result<()> {
         let evm_env = ecx.evm_clone();
-        let tx_env = ecx.tx_clone();
         let (db, inner) = ecx.db_journal_inner_mut();
-        db.transact(fork_id, transaction, evm_env, tx_env, inner, cheats)
+        db.transact(fork_id, transaction, evm_env, inner, cheats)
     }
 
     fn transact_from_tx_on_db(

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -188,11 +188,10 @@ impl DatabaseExt for CowBackend<'_> {
         id: Option<LocalForkId>,
         transaction: B256,
         evm_env: EvmEnv,
-        tx_env: TxEnv,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn for<'db> FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt>>,
     ) -> eyre::Result<()> {
-        self.backend_mut().transact(id, transaction, evm_env, tx_env, journaled_state, inspector)
+        self.backend_mut().transact(id, transaction, evm_env, journaled_state, inspector)
     }
 
     fn transact_from_tx(

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -215,7 +215,6 @@ pub trait DatabaseExt<BLOCK = BlockEnv, TX = TxEnv, SPEC = SpecId>:
         id: Option<LocalForkId>,
         transaction: B256,
         evm_env: EvmEnv<SPEC, BLOCK>,
-        tx_env: TX,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn for<'db> FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt>>,
     ) -> eyre::Result<()>;
@@ -1311,7 +1310,6 @@ where
         maybe_id: Option<LocalForkId>,
         transaction: B256,
         mut evm_env: EvmEnv,
-        mut tx_env: TxEnv,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn for<'db> FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt>>,
     ) -> eyre::Result<()> {
@@ -1324,6 +1322,7 @@ where
             let fork = self.inner.get_fork_by_id_mut(id)?;
             fork.backend().get_transaction(transaction)?
         };
+        let tx_env = tx.try_any_to_tx_env()?;
 
         // This is a bit ambiguous because the user wants to transact an arbitrary transaction in
         // the current context, but we're assuming the user wants to transact the transaction as it
@@ -1337,9 +1336,8 @@ where
 
         let fork = self.inner.get_fork_by_id_mut(id)?;
         commit_transaction(
-            &tx,
-            &mut evm_env,
-            &mut tx_env,
+            evm_env,
+            tx_env,
             journaled_state,
             fork,
             &fork_id,
@@ -2028,9 +2026,8 @@ fn update_env_block<SPEC, BLOCK: FoundryBlock>(
 /// state, with an inspector.
 #[allow(clippy::too_many_arguments)]
 fn commit_transaction<N: Network>(
-    tx: &N::TransactionResponse,
-    evm_env: &mut EvmEnv,
-    tx_env: &mut TxEnv,
+    evm_env: EvmEnv,
+    tx_env: TxEnv,
     journaled_state: &mut JournaledState,
     fork: &mut Fork<N>,
     fork_id: &ForkId,
@@ -2040,8 +2037,6 @@ fn commit_transaction<N: Network>(
 where
     N::TransactionResponse: TryAnyToTxEnv<TxEnv>,
 {
-    *tx_env = tx.try_any_to_tx_env()?;
-
     let now = Instant::now();
     let res = {
         let fork = fork.clone();
@@ -2049,11 +2044,10 @@ where
         let depth = journaled_state.depth;
         let mut db = Backend::new_with_fork(fork_id, fork, journaled_state)?;
 
-        let mut evm =
-            crate::evm::new_eth_evm_with_inspector(&mut db as _, evm_env.to_owned(), inspector);
+        let mut evm = crate::evm::new_eth_evm_with_inspector(&mut db as _, evm_env, inspector);
         // Adjust inner EVM depth to ensure that inspectors receive accurate data.
         evm.journaled_state.depth = depth + 1;
-        evm.transact(tx_env.clone()).wrap_err("backend: failed committing transaction")?
+        evm.transact(tx_env).wrap_err("backend: failed committing transaction")?
     };
     trace!(elapsed = ?now.elapsed(), "transacted transaction");
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -427,10 +427,9 @@ impl<
         transaction: B256,
     ) -> eyre::Result<()> {
         let evm_env = ecx.evm_clone();
-        let tx_env = ecx.tx_clone();
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         let (db, inner) = ecx.db_journal_inner_mut();
-        db.transact(fork_id, transaction, evm_env, tx_env, inner, &mut inspector)
+        db.transact(fork_id, transaction, evm_env, inner, &mut inspector)
     }
 
     fn transact_from_tx_on_db(


### PR DESCRIPTION
## Motivation

Simplification of `DatabaseExt` and `CheatcodesExecutor`:

- remove useless `tx_env` args
- `commit_transaction` now gets owned `evm_env`/`tx_env` which prevents cloning.