### PR TITLE
fix(ci): mark flaky Arbitrum RPC-dependent tests

### DIFF
--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1255,7 +1255,7 @@ async fn flaky_test_arbitrum_fork_dev_balance() {
 
 // <https://github.com/foundry-rs/foundry/issues/9152>
 #[tokio::test(flavor = "multi_thread")]
-async fn test_arb_fork_mining() {
+async fn flaky_test_arb_fork_mining() {
     let fork_block_number = 394274860u64;
     let fork_rpc = next_rpc_endpoint(NamedChain::Arbitrum);
     let (api, _handle) = spawn(

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -465,7 +465,7 @@ mod tests {
     // `apply_chain_and_block_specific_env_changes`. The fork block number returned
     // by `env()` must be the actual L2 block number, not the remapped L1 value.
     #[tokio::test(flavor = "multi_thread")]
-    async fn get_fork_uses_l2_block_number_on_arbitrum() {
+    async fn flaky_get_fork_uses_l2_block_number_on_arbitrum() {
         let endpoint =
             foundry_test_utils::rpc::next_rpc_endpoint(foundry_config::NamedChain::Arbitrum);
 

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -20,8 +20,9 @@ mod spec;
 mod table;
 mod trace;
 
-// Run `forge test` on `/testdata`.
-forgetest!(testdata, |_prj, cmd| {
+/// Sets up a [`TestCommand`] to run `forge test` on the `/testdata` directory with RPC
+/// endpoints written to a `.env` file.
+fn setup_testdata_cmd(cmd: &mut TestCommand) {
     let testdata =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../testdata").canonicalize().unwrap();
     cmd.current_dir(&testdata);
@@ -30,17 +31,30 @@ forgetest!(testdata, |_prj, cmd| {
     for (name, endpoint) in rpc_endpoints().iter() {
         if let Some(url) = endpoint.endpoint.as_url() {
             let key = format!("RPC_{}", name.to_uppercase());
-            // cmd.env(&key, url);
             writeln!(dotenv, "{key}={url}").unwrap();
         }
     }
     drop(dotenv);
+}
+
+/// Contracts excluded from the main `testdata` run because they depend on flaky external RPCs.
+/// These are run separately by the `flaky_testdata` test below.
+/// Format: pipe-separated regex alternation, e.g. `"Foo|Bar|Baz"`.
+const FLAKY_TESTDATA_CONTRACTS: &str = "Issue4640Test";
+
+// Run `forge test` on `/testdata`.
+forgetest!(testdata, |_prj, cmd| {
+    setup_testdata_cmd(&mut cmd);
 
     let mut args = vec!["test"];
+    let nmc_isolate = format!(
+        "--nmc=(LastCallGasDefaultTest|MockFunctionTest|WithSeed|StateDiff|GetStorageSlotsTest|RecordAccount|{FLAKY_TESTDATA_CONTRACTS})",
+    );
+    let nmc_default = format!("--nmc=({FLAKY_TESTDATA_CONTRACTS})");
     if cfg!(feature = "isolate-by-default") {
-        args.push(
-            "--nmc=(LastCallGasDefaultTest|MockFunctionTest|WithSeed|StateDiff|GetStorageSlotsTest|RecordAccount)",
-        );
+        args.push(&nmc_isolate);
+    } else {
+        args.push(&nmc_default);
     }
 
     let orig_assert = cmd.args(args).assert();
@@ -64,6 +78,14 @@ forgetest!(testdata, |_prj, cmd| {
     }
 
     orig_assert.success();
+});
+
+// Run flaky testdata contracts excluded from the main `testdata` test above.
+// Picked up by the nightly `test-flaky` workflow via `cargo nextest run --profile flaky`.
+forgetest!(flaky_testdata, |_prj, cmd| {
+    setup_testdata_cmd(&mut cmd);
+    let mc = format!("--mc=({FLAKY_TESTDATA_CONTRACTS})");
+    cmd.args(["test", &mc]).assert_success();
 });
 
 // tests that test filters are handled correctly


### PR DESCRIPTION
## Summary

Mark Arbitrum-dependent tests as flaky so they stop breaking regular CI.

## Motivation

These tests depend on external Arbitrum RPC availability and fail intermittently (e.g. [this run](https://github.com/foundry-rs/foundry/actions/runs/23850196243/job/69527939969)):

- `anvil::fork::test_arb_fork_mining`
- `foundry_evm_core::opts::get_fork_uses_l2_block_number_on_arbitrum`
- `testdata::Issue4640Test::testArbitrumBlockNumber`

## Changes

- Rename `test_arb_fork_mining` → `flaky_test_arb_fork_mining`
- Rename `get_fork_uses_l2_block_number_on_arbitrum` → `flaky_get_fork_uses_l2_block_number_on_arbitrum`
- Extract `setup_testdata_cmd()` helper for shared testdata setup
- Add `FLAKY_TESTDATA_CONTRACTS` const (pipe-separated regex) to centralize which Solidity contracts are excluded from the main `testdata` run
- Add `flaky_testdata` test that runs only the excluded contracts, picked up by the nightly `test-flaky` workflow

Adding a new flaky testdata contract is now a one-line change to the const.

Prompted by: zerosnacks