### PR TITLE
ci: partition crate-checks into 3 parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,14 @@ jobs:
         run: ./.github/scripts/format.sh --check
 
   crate-checks:
+    name: crate-checks (${{ matrix.partition }}/${{ matrix.total_partitions }})
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2, 3]
+        total_partitions: [3]
     permissions:
       contents: read
     steps:
@@ -146,7 +152,10 @@ jobs:
           tool: cargo-hack
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
-      - run: cargo hack check
+        with:
+          cache-on-failure: true
+          key: crate-checks-${{ matrix.partition }}-of-${{ matrix.total_partitions }}
+      - run: cargo hack check --workspace --partition ${{ matrix.partition }}/${{ matrix.total_partitions }}
 
   deny:
     uses: tempoxyz/ci/.github/workflows/deny.yml@268b3ce142717ff86c58fbbcc3abc3f109f0fb8d # main


### PR DESCRIPTION
Split `crate-checks` into 3 parallel matrix jobs using `cargo hack check --workspace --partition M/N`, matching the pattern used by [reth](https://github.com/paradigmxyz/reth/blob/main/.github/workflows/lint.yml).

## Motivation

`crate-checks` runs `cargo hack check` sequentially across all 36 workspace crates. On fork PRs (which get no sccache or rust-cache), this takes ~16 min. Partitioning into 3 parallel jobs cuts wall-clock time by ~3x.

## Changes

- Split into 3 matrix partitions via `cargo hack check --workspace --partition 1/3`
- Add `fail-fast: false` so one failing partition doesn't cancel the others
- Add `cache-on-failure: true` to rust-cache so failed runs still populate cache
- Add partition-specific rust-cache key to avoid save races between matrix legs

Prompted by: zerosnacks