### PR TITLE
feat(anvil): add Tempo transaction pool validation

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -4076,10 +4076,30 @@ impl TransactionValidator<FoundryTxEnvelope> for Backend<FoundryNetwork> {
             }
         }
 
-        // Nonce validation
+        // Reject native value transfers on Tempo networks
+        if self.is_tempo() && !tx.value().is_zero() {
+            warn!(target: "backend", "[{:?}] native value transfer not allowed in Tempo mode", tx.hash());
+            return Err(InvalidTransactionError::TempoNativeValueTransfer);
+        }
+
+        // Tempo AA: cap authorization list size
+        if let FoundryTxEnvelope::Tempo(aa_tx) = tx.as_ref() {
+            const MAX_TEMPO_AUTHORIZATIONS: usize = 16;
+            let auth_count = aa_tx.tx().tempo_authorization_list.len();
+            if auth_count > MAX_TEMPO_AUTHORIZATIONS {
+                warn!(target: "backend", "[{:?}] Tempo tx has too many authorizations: {}", tx.hash(), auth_count);
+                return Err(InvalidTransactionError::TempoTooManyAuthorizations {
+                    count: auth_count,
+                    max: MAX_TEMPO_AUTHORIZATIONS,
+                });
+            }
+        }
+
+        // Nonce validation — skip for deposits (L1→L2) and Tempo txs (2D nonce system)
         let is_deposit_tx = matches!(pending.transaction.as_ref(), FoundryTxEnvelope::Deposit(_));
+        let is_tempo_tx = matches!(pending.transaction.as_ref(), FoundryTxEnvelope::Tempo(_));
         let nonce = tx.nonce();
-        if nonce < account.nonce && !is_deposit_tx {
+        if nonce < account.nonce && !is_deposit_tx && !is_tempo_tx {
             debug!(target: "backend", "[{:?}] nonce too low", tx.hash());
             return Err(InvalidTransactionError::NonceTooLow);
         }
@@ -4202,6 +4222,10 @@ impl TransactionValidator<FoundryTxEnvelope> for Backend<FoundryNetwork> {
                         debug!(target: "backend", "[{:?}] insufficient balance={}, required={} account={:?}", tx.hash(), account.balance + U256::from(deposit_tx.mint), value, *pending.sender());
                         return Err(InvalidTransactionError::InsufficientFunds);
                     }
+                }
+                FoundryTxEnvelope::Tempo(_) => {
+                    // Tempo AA transactions pay gas with fee tokens, not ETH.
+                    // Fee token balance is validated in validate_pool_transaction (async).
                 }
                 _ => {
                     // check sufficient funds: `gas * price + value`

--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -2,7 +2,7 @@
 
 use alloy_consensus::crypto::RecoveryError;
 use alloy_evm::overrides::StateOverrideError;
-use alloy_primitives::{B256, Bytes, SignatureError, TxHash};
+use alloy_primitives::{B256, Bytes, SignatureError, TxHash, U256};
 use alloy_rpc_types::BlockNumberOrTag;
 use alloy_signer::Error as SignerError;
 use alloy_transport::TransportError;
@@ -355,6 +355,21 @@ pub enum InvalidTransactionError {
     /// Missing enveloped transaction
     #[error("missing enveloped transaction")]
     MissingEnvelopedTx,
+    /// Native ETH value transfers are not allowed in Tempo mode
+    #[error("native value transfer not allowed in Tempo mode")]
+    TempoNativeValueTransfer,
+    /// Tempo transaction valid_before is expired or too close to current time
+    #[error("Tempo tx valid_before ({valid_before}) must be > current time + 3s ({min_allowed})")]
+    TempoValidBeforeExpired { valid_before: u64, min_allowed: u64 },
+    /// Tempo transaction valid_after is too far in the future
+    #[error("Tempo tx valid_after ({valid_after}) must be <= current time + 1h ({max_allowed})")]
+    TempoValidAfterTooFar { valid_after: u64, max_allowed: u64 },
+    /// Tempo transaction has too many authorizations
+    #[error("Tempo tx has too many authorizations ({count}), max allowed is {max}")]
+    TempoTooManyAuthorizations { count: usize, max: usize },
+    /// Tempo transaction fee payer has insufficient fee token balance
+    #[error("insufficient fee token balance: have {balance}, need {required}")]
+    TempoInsufficientFeeTokenBalance { balance: U256, required: U256 },
 }
 
 impl From<InvalidTransaction> for InvalidTransactionError {


### PR DESCRIPTION
Add pool validation rules for Tempo transactions, matching the deposit tx pattern:

- Skip sequential nonce check; Tempo uses a 2D nonce system
- Reject native ETH value transfers on Tempo networks
- Cap authorization list at 16 entries
- Skip ETH balance check; fees paid in tokens, validated async