### PR TITLE
feat(anvil): add Tempo async pool validation (time bounds + fee token balance)

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -58,7 +58,7 @@ use alloy_network::{
 };
 use alloy_op_evm::OpEvmFactory;
 use alloy_primitives::{
-    Address, B256, Bloom, Bytes, TxHash, TxKind, U64, U256, address, hex, keccak256, logs_bloom,
+    Address, B256, Bloom, Bytes, TxHash, TxKind, U64, U256, hex, keccak256, logs_bloom,
     map::{AddressMap, HashMap, HashSet},
 };
 use alloy_rpc_types::{
@@ -4123,7 +4123,7 @@ impl TransactionValidator<FoundryTxEnvelope> for Backend<FoundryNetwork> {
             // Fee token balance check
             let fee_payer = tempo_tx.recover_fee_payer(address).unwrap_or(address);
             let fee_token =
-                tempo_tx.fee_token.unwrap_or(address!("20C0000000000000000000000000000000000000"));
+                tempo_tx.fee_token.unwrap_or(foundry_evm::core::tempo::PATH_USD_ADDRESS);
 
             // gas_limit * max_fee_per_gas in wei, scaled to 6-decimal token units
             let required_wei =


### PR DESCRIPTION
Add async validation checks for Tempo transactions at pool admission:

- Time bounds: reject if `valid_before` is expired/too close (< 3s buffer) or valid_after is too far in the future (> 1h)
- Fee token balance: ERC-20 `balanceOf` check on the fee payer's token balance, scaled from 18-decimal wei to 6-decimal token units
Also adds `get_fee_token_balance` helper for ERC-20 balance queries.

Follow-up: move `call()` and related methods out of the `Self: TransactionValidator` bounded impl block so `TransactionValidator` can be made generic over `N: Network`