### PR TITLE
refactor(anvil): add `is_tempo()` helper to `FoundryTxEnvelope`

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -110,7 +110,7 @@ use foundry_primitives::{
     FoundryTxReceipt, get_deposit_tx_parts,
 };
 use futures::channel::mpsc::{UnboundedSender, unbounded};
-use op_alloy_consensus::DEPOSIT_TX_TYPE_ID;
+use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpTransaction as OpTransactionTrait};
 use op_revm::{OpContext, OpHaltReason, OpSpecId, OpTransaction};
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use revm::{
@@ -1138,7 +1138,7 @@ impl<N: Network> Backend<N> {
             + Inspector<TempoContext<WrapDatabaseRef<&'db DB>>>,
         WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
     {
-        if matches!(tx, FoundryTxEnvelope::Tempo(_)) {
+        if tx.is_tempo() {
             let tx_env: TempoTxEnv =
                 FromTxWithEncoded::from_encoded_tx(tx, sender, tx.encoded_2718().into());
             let base = tx_env.inner.clone();
@@ -4187,8 +4187,8 @@ impl TransactionValidator<FoundryTxEnvelope> for Backend<FoundryNetwork> {
         }
 
         // Nonce validation — skip for deposits (L1→L2) and Tempo txs (2D nonce system)
-        let is_deposit_tx = matches!(pending.transaction.as_ref(), FoundryTxEnvelope::Deposit(_));
-        let is_tempo_tx = matches!(pending.transaction.as_ref(), FoundryTxEnvelope::Tempo(_));
+        let is_deposit_tx = pending.transaction.as_ref().is_deposit();
+        let is_tempo_tx = pending.transaction.as_ref().is_tempo();
         let nonce = tx.nonce();
         if nonce < account.nonce && !is_deposit_tx && !is_tempo_tx {
             debug!(target: "backend", "[{:?}] nonce too low", tx.hash());

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -106,6 +106,11 @@ impl FoundryTxEnvelope {
         }
     }
 
+    /// Returns `true` if this is a Tempo transaction.
+    pub fn is_tempo(&self) -> bool {
+        matches!(self, Self::Tempo(_))
+    }
+
     /// Recovers the Ethereum address which was used to sign the transaction.
     pub fn recover(&self) -> Result<Address, RecoveryError> {
         Ok(match self {


### PR DESCRIPTION
Add `is_tempo()` method on `FoundryTxEnvelope`. Replace bare `matches!` variant checks with the type-level helpers for both Tempo and Deposit.

- Add `pub fn is_tempo()` to `FoundryTxEnvelope`
- Import `OpTransaction as OpTransactionTrait` to use `is_deposit()`
- Replace all `matches!(…, FoundryTxEnvelope::Tempo(_))` and `matches!(…, FoundryTxEnvelope::Deposit(_))` with `.is_tempo()` / `.is_deposit()`