### PR TITLE
feat(anvil): handle `not-yet-valid` transactions during mining

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -301,6 +301,9 @@ pub struct ExecutedPoolTransactions<T> {
     pub included: Vec<Arc<PoolTransaction<T>>>,
     /// Transactions that failed validation.
     pub invalid: Vec<Arc<PoolTransaction<T>>>,
+    /// Transactions skipped because they're not yet valid (e.g., valid_after in the future).
+    /// These remain in the pool and should be retried later.
+    pub not_yet_valid: Vec<Arc<PoolTransaction<T>>>,
     /// Per-transaction execution info.
     pub tx_info: Vec<TransactionInfo>,
     /// The raw pending transactions that were included (in order).
@@ -347,6 +350,7 @@ where
 
     let mut included = Vec::new();
     let mut invalid = Vec::new();
+    let mut not_yet_valid = Vec::new();
     let mut tx_info: Vec<TransactionInfo> = Vec::new();
     let mut transactions = Vec::new();
     let mut blob_gas_used = 0u64;
@@ -463,12 +467,21 @@ where
                 transactions.push(pending.transaction.clone());
             }
             Err(err) => {
-                trace!(target: "backend", ?err, "tx execution error, skipping {:?}", pool_tx.hash());
+                let err_str = err.to_string();
+                if err_str.contains("not valid yet") {
+                    trace!(target: "backend", "[{:?}] transaction not valid yet, will retry later", pool_tx.hash());
+                    not_yet_valid.push(pool_tx.clone());
+                } else if err.as_validation().is_some() {
+                    warn!(target: "backend", "Skipping invalid tx [{:?}]: {}", pool_tx.hash(), err);
+                    invalid.push(pool_tx.clone());
+                } else {
+                    trace!(target: "backend", ?err, "tx execution error, skipping {:?}", pool_tx.hash());
+                }
             }
         }
     }
 
-    ExecutedPoolTransactions { included, invalid, tx_info, txs: transactions }
+    ExecutedPoolTransactions { included, invalid, not_yet_valid, tx_info, txs: transactions }
 }
 
 /// Builds the EVM transaction env from a pending pool transaction.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2436,7 +2436,7 @@ where
                 self.states.write().insert(best_hash, db);
             }
 
-            let (block_info, included, invalid, block_hash) = {
+            let (block_info, included, invalid, not_yet_valid, block_hash) = {
                 let mut db = self.db.write().await;
 
                 // finally set the next block timestamp, this is done just before execution, because
@@ -2490,6 +2490,7 @@ where
 
                 let included = pool_result.included;
                 let invalid = pool_result.invalid;
+                let not_yet_valid = pool_result.not_yet_valid;
                 let transaction_infos = pool_result.tx_info;
                 let transactions = pool_result.txs;
 
@@ -2539,7 +2540,7 @@ where
                 let block_hash = block_info.block.header.hash_slow();
                 db.insert_block_hash(U256::from(block_info.block.header.number()), block_hash);
 
-                (block_info, included, invalid, block_hash)
+                (block_info, included, invalid, not_yet_valid, block_hash)
             };
 
             // create the new block with the current timestamp
@@ -2616,7 +2617,7 @@ where
                 node_info!("    Block Time: {:?}\n", timestamp.to_rfc2822());
             }
 
-            let outcome = MinedBlockOutcome { block_number, included, invalid };
+            let outcome = MinedBlockOutcome { block_number, included, invalid, not_yet_valid };
 
             (outcome, header, block_hash)
         };

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -525,6 +525,9 @@ pub struct MinedBlockOutcome<T> {
     /// All transactions that were attempted to be included but were invalid at the time of
     /// execution
     pub invalid: Vec<Arc<PoolTransaction<T>>>,
+    /// Transactions skipped because they're not yet valid (e.g., valid_after in the future).
+    /// These remain in the pool and should be retried later.
+    pub not_yet_valid: Vec<Arc<PoolTransaction<T>>>,
 }
 
 impl<T> Clone for MinedBlockOutcome<T> {
@@ -533,6 +536,7 @@ impl<T> Clone for MinedBlockOutcome<T> {
             block_number: self.block_number,
             included: self.included.clone(),
             invalid: self.invalid.clone(),
+            not_yet_valid: self.not_yet_valid.clone(),
         }
     }
 }
@@ -543,6 +547,7 @@ impl<T> fmt::Debug for MinedBlockOutcome<T> {
             .field("block_number", &self.block_number)
             .field("included", &self.included.len())
             .field("invalid", &self.invalid.len())
+            .field("not_yet_valid", &self.not_yet_valid.len())
             .finish()
     }
 }

--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -180,8 +180,8 @@ impl<T: Transaction> Pool<T> {
     /// Invoked when a set of transactions ([Self::ready_transactions()]) was executed.
     ///
     /// This will remove the transactions from the pool.
-    pub fn on_mined_block(&self, outcome: MinedBlockOutcome<T>) -> PruneResult<T> {
-        let MinedBlockOutcome { block_number, included, invalid } = outcome;
+    pub fn on_mined_block(self: &Arc<Self>, outcome: MinedBlockOutcome<T>) -> PruneResult<T> {
+        let MinedBlockOutcome { block_number, included, invalid, not_yet_valid } = outcome;
 
         // remove invalid transactions from the pool
         self.remove_invalid(invalid.into_iter().map(|tx| tx.hash()).collect());
@@ -190,6 +190,21 @@ impl<T: Transaction> Pool<T> {
         let res = self
             .prune_markers(block_number, included.into_iter().flat_map(|tx| tx.provides.clone()));
         trace!(target: "txpool", "pruned transaction markers {:?}", res);
+
+        // Re-notify the miner about not-yet-valid transactions so they'll be retried.
+        // Delay by 1 second to let time advance before the next mining attempt.
+        if !not_yet_valid.is_empty() {
+            let tx_hashes: Vec<_> = not_yet_valid.iter().map(|tx| tx.hash()).collect();
+            let pool = Arc::clone(self);
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                for hash in tx_hashes {
+                    trace!(target: "txpool", "re-notifying for not-yet-valid tx: {:?}", hash);
+                    pool.notify_listener(hash);
+                }
+            });
+        }
+
         res
     }
 


### PR DESCRIPTION
Tempo transactions with a `valid_after` timestamp in the future are now kept in the pool and retried after a 1-second delay instead of being silently dropped. Also pushes EVM validation errors (e.g. `NonceTooLow`) to the invalid list so they get removed from the pool instead of persisting forever.