### PR TITLE
chore(evm): import `PATH_USD_ADDRESS` from `tempo-contracts`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,7 +2496,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2958,7 +2958,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3111,7 +3111,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3895,7 +3895,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4200,7 +4200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6105,7 +6105,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6482,7 +6482,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7352,7 +7352,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8361,7 +8361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8374,7 +8374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8497,7 +8497,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8535,9 +8535,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9694,7 +9694,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9753,7 +9753,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10525,7 +10525,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -10560,7 +10560,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.0",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -10984,13 +10984,13 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b156d95b5b880fd772a3a6ee4b2dcc2bc56e982f"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#55f1885a66009cc45fb3d7b2524765401bb64c72"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11015,7 +11015,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b156d95b5b880fd772a3a6ee4b2dcc2bc56e982f"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#55f1885a66009cc45fb3d7b2524765401bb64c72"
 dependencies = [
  "alloy-eips 2.0.0-rc.0",
  "alloy-evm",
@@ -11034,7 +11034,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b156d95b5b880fd772a3a6ee4b2dcc2bc56e982f"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#55f1885a66009cc45fb3d7b2524765401bb64c72"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11050,7 +11050,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b156d95b5b880fd772a3a6ee4b2dcc2bc56e982f"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#55f1885a66009cc45fb3d7b2524765401bb64c72"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11061,7 +11061,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b156d95b5b880fd772a3a6ee4b2dcc2bc56e982f"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#55f1885a66009cc45fb3d7b2524765401bb64c72"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11088,7 +11088,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b156d95b5b880fd772a3a6ee4b2dcc2bc56e982f"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#55f1885a66009cc45fb3d7b2524765401bb64c72"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11107,7 +11107,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b156d95b5b880fd772a3a6ee4b2dcc2bc56e982f"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#55f1885a66009cc45fb3d7b2524765401bb64c72"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11118,7 +11118,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b156d95b5b880fd772a3a6ee4b2dcc2bc56e982f"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#55f1885a66009cc45fb3d7b2524765401bb64c72"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0-rc.0",
@@ -11142,7 +11142,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#b156d95b5b880fd772a3a6ee4b2dcc2bc56e982f"
+source = "git+https://github.com/tempoxyz/tempo?branch=alloy-2.0#55f1885a66009cc45fb3d7b2524765401bb64c72"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11177,7 +11177,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11187,7 +11187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12364,7 +12364,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12514,7 +12514,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -33,14 +33,9 @@ use tempo_precompiles::{
 
 use crate::backend::Backend;
 
-/// PathUSD token address.
-pub const PATH_USD_ADDRESS: Address = address!("20C0000000000000000000000000000000000000");
-/// AlphaUSD token address.
-pub const ALPHA_USD_ADDRESS: Address = address!("20C0000000000000000000000000000000000001");
-/// BetaUSD token address.
-pub const BETA_USD_ADDRESS: Address = address!("20C0000000000000000000000000000000000002");
-/// ThetaUSD token address.
-pub const THETA_USD_ADDRESS: Address = address!("20C0000000000000000000000000000000000003");
+pub use tempo_contracts::precompiles::{
+    ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, PATH_USD_ADDRESS, THETA_USD_ADDRESS,
+};
 
 /// All well-known TIP20 fee token addresses on Tempo networks.
 pub const TEMPO_TIP20_TOKENS: &[Address] =


### PR DESCRIPTION
## Summary

Import `PATH_USD_ADDRESS` from `tempo_contracts::precompiles` instead of redefining it.