### PR TITLE
feat(evm): add `TempoLabels` inspector for TIP20 token names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5181,6 +5181,7 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
+ "tempo-precompiles",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -48,6 +48,7 @@ revm = { workspace = true, default-features = false, features = [
     "c-kzg",
 ] }
 revm-inspectors.workspace = true
+tempo-precompiles.workspace = true
 
 eyre.workspace = true
 parking_lot.workspace = true

--- a/crates/evm/evm/src/inspectors/mod.rs
+++ b/crates/evm/evm/src/inspectors/mod.rs
@@ -24,3 +24,6 @@ pub use stack::{InspectorData, InspectorStack, InspectorStackBuilder};
 
 mod revert_diagnostic;
 pub use revert_diagnostic::RevertDiagnostic;
+
+mod tempo_labels;
+pub(crate) use tempo_labels::TempoLabels;

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1,6 +1,6 @@
 use super::{
     Cheatcodes, CheatsConfig, ChiselState, CustomPrintTracer, Fuzzer, LineCoverageCollector,
-    LogCollector, RevertDiagnostic, ScriptExecutionInspector, TracingInspector,
+    LogCollector, RevertDiagnostic, ScriptExecutionInspector, TempoLabels, TracingInspector,
 };
 use alloy_evm::EvmEnv;
 use alloy_network::{Ethereum, Network};
@@ -265,6 +265,10 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
         stack.networks(networks);
         stack.set_create2_deployer(create2_deployer);
 
+        if networks.is_tempo() {
+            stack.inner.tempo_labels = Some(Box::default());
+        }
+
         // environment, must come after all of the inspectors
         if let Some(block) = block {
             stack.set_block(block);
@@ -359,6 +363,7 @@ pub struct InspectorStackInner {
     pub printer: Option<Box<CustomPrintTracer>>,
     pub revert_diag: Option<Box<RevertDiagnostic>>,
     pub script_execution_inspector: Option<Box<ScriptExecutionInspector>>,
+    pub tempo_labels: Option<Box<TempoLabels>>,
     pub tracer: Option<Box<TracingInspector>>,
 
     // FoundryInspectorExt and other internal data.
@@ -610,6 +615,7 @@ impl<SPEC, BLOCK, N: Network> InspectorStack<SPEC, BLOCK, N> {
                     line_coverage,
                     edge_coverage,
                     log_collector,
+                    tempo_labels,
                     tracer,
                     reverter,
                     ..
@@ -636,10 +642,13 @@ impl<SPEC, BLOCK, N: Network> InspectorStack<SPEC, BLOCK, N> {
 
         InspectorData {
             logs: log_collector.and_then(|logs| logs.into_captured_logs()).unwrap_or_default(),
-            labels: cheatcodes
-                .as_ref()
-                .map(|cheatcodes| cheatcodes.labels.clone())
-                .unwrap_or_default(),
+            labels: {
+                let mut labels = cheatcodes.as_ref().map(|c| c.labels.clone()).unwrap_or_default();
+                if let Some(tempo_labels) = tempo_labels {
+                    labels.extend(tempo_labels.labels);
+                }
+                labels
+            },
             traces,
             line_coverage: line_coverage.map(|line_coverage| line_coverage.finish()),
             edge_coverage: edge_coverage.map(|edge_coverage| edge_coverage.into_hitcount()),
@@ -1061,7 +1070,8 @@ impl<
                 &mut self.tracer,
                 &mut self.log_collector,
                 &mut self.printer,
-                &mut self.revert_diag
+                &mut self.revert_diag,
+                &mut self.tempo_labels
             ],
             |inspector| {
                 let mut out = None;

--- a/crates/evm/evm/src/inspectors/tempo_labels.rs
+++ b/crates/evm/evm/src/inspectors/tempo_labels.rs
@@ -1,0 +1,47 @@
+use alloy_primitives::map::AddressMap;
+use foundry_evm_core::backend::DatabaseError;
+use revm::{
+    Database, Inspector,
+    context::ContextTr,
+    inspector::JournalExt,
+    interpreter::{CallInputs, CallOutcome, interpreter::EthInterpreter},
+};
+use tempo_precompiles::tip20::is_tip20_prefix;
+
+/// Inspector that labels TIP20 token precompile addresses with their on-chain names.
+///
+/// During execution, when a call targets a TIP20 address, this inspector reads the token's
+/// name from storage and records the `address -> name` mapping. These labels are later merged
+/// into trace output for better readability.
+#[derive(Default, Clone, Debug)]
+pub struct TempoLabels {
+    pub(crate) labels: AddressMap<String>,
+}
+
+impl<CTX, D> Inspector<CTX, EthInterpreter> for TempoLabels
+where
+    D: Database<Error = DatabaseError>,
+    CTX: ContextTr<Db = D>,
+    CTX::Journal: JournalExt,
+{
+    fn call(&mut self, ctx: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
+        if is_tip20_prefix(inputs.target_address)
+            && !self.labels.contains_key(&inputs.target_address)
+        {
+            let bytes = ctx
+                .db_mut()
+                .storage(inputs.target_address, tempo_precompiles::tip20::slots::NAME)
+                .unwrap_or_default()
+                .to_be_bytes::<32>();
+            let len = bytes[31] as usize / 2; // Last byte stores length * 2 for short strings
+            let name = if len == 0 {
+                "TIP20".to_string()
+            } else {
+                String::from_utf8_lossy(&bytes[..len]).to_string()
+            };
+            self.labels.insert(inputs.target_address, name);
+        }
+
+        None
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `TempoLabels` inspector that reads TIP20 token names from storage during execution and labels them in trace output. Only enabled when `networks.is_tempo()`.

Ported from tempoxyz/tempo-foundry#142.

NOTE: we could probably add a trait here but i don't think we'll have more networks using dynamic labelling like this 