### PR TITLE
feat(evm): `ExecutorBuilder` generic

### DIFF
--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -215,7 +215,7 @@ impl SessionSource {
             }
         };
 
-        let executor = ExecutorBuilder::new()
+        let executor = ExecutorBuilder::default()
             .inspectors(|stack| {
                 stack
                     .logs(self.config.foundry_config.live_logs)

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -1,11 +1,12 @@
 use crate::{executors::Executor, inspectors::InspectorStackBuilder};
-use alloy_evm::EthEvmFactory;
-use alloy_network::Ethereum;
-use foundry_evm_core::{EvmEnv, backend::Backend};
-use revm::{
-    context::{BlockEnv, TxEnv},
-    primitives::hardfork::SpecId,
-};
+use alloy_consensus::transaction::SignerRecoverable;
+use alloy_evm::FromRecoveredTx;
+use alloy_network::{AnyNetwork, AnyRpcTransaction, Network};
+use alloy_rlp::Decodable;
+use foundry_evm_core::{EvmEnv, TryAnyToTxEnv, backend::Backend, evm::FoundryEvmFactory};
+use foundry_primitives::FoundryTransactionBuilder;
+use revm::context::{Block, Transaction};
+use std::marker::PhantomData;
 
 /// The builder that allows to configure an evm [`Executor`] which a stack of optional
 /// [`revm::Inspector`]s, such as [`Cheatcodes`].
@@ -16,40 +17,52 @@ use revm::{
 /// [`InspectorStack`]: super::InspectorStack
 #[derive(Debug, Clone)]
 #[must_use = "builders do nothing unless you call `build` on them"]
-pub struct ExecutorBuilder {
+pub struct ExecutorBuilder<N: Network, F: FoundryEvmFactory> {
     /// The configuration used to build an `InspectorStack`.
-    stack: InspectorStackBuilder<BlockEnv>,
+    stack: InspectorStackBuilder<F::BlockEnv>,
     /// The gas limit.
     gas_limit: Option<u64>,
-    /// The spec ID.
-    spec_id: SpecId,
+    /// The spec.
+    spec: F::Spec,
     legacy_assertions: bool,
+    _network: PhantomData<N>,
 }
 
-impl Default for ExecutorBuilder {
+impl<N, F> Default for ExecutorBuilder<N, F>
+where
+    N: Network<
+            TxEnvelope: Decodable + SignerRecoverable,
+            TransactionRequest: FoundryTransactionBuilder<N>,
+        >,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
+    AnyRpcTransaction: TryAnyToTxEnv<F::Tx>,
+{
     #[inline]
     fn default() -> Self {
         Self {
             stack: InspectorStackBuilder::new(),
             gas_limit: None,
-            spec_id: SpecId::default(),
+            spec: Default::default(),
             legacy_assertions: false,
+            _network: PhantomData,
         }
     }
 }
 
-impl ExecutorBuilder {
-    /// Create a new executor builder.
-    #[inline]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
+impl<N, F> ExecutorBuilder<N, F>
+where
+    N: Network<
+            TxEnvelope: Decodable + SignerRecoverable,
+            TransactionRequest: FoundryTransactionBuilder<N>,
+        >,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
+    AnyRpcTransaction: TryAnyToTxEnv<F::Tx>,
+{
     /// Modify the inspector stack.
     #[inline]
     pub fn inspectors(
         mut self,
-        f: impl FnOnce(InspectorStackBuilder<BlockEnv>) -> InspectorStackBuilder<BlockEnv>,
+        f: impl FnOnce(InspectorStackBuilder<F::BlockEnv>) -> InspectorStackBuilder<F::BlockEnv>,
     ) -> Self {
         self.stack = f(self.stack);
         self
@@ -57,8 +70,8 @@ impl ExecutorBuilder {
 
     /// Sets the EVM spec to use.
     #[inline]
-    pub fn spec_id(mut self, spec: SpecId) -> Self {
-        self.spec_id = spec;
+    pub fn spec_id(mut self, spec: F::Spec) -> Self {
+        self.spec = spec;
         self
     }
 
@@ -80,19 +93,19 @@ impl ExecutorBuilder {
     #[inline]
     pub fn build(
         self,
-        mut evm_env: EvmEnv,
-        tx_env: TxEnv,
-        db: Backend,
-    ) -> Executor<Ethereum, EthEvmFactory> {
-        let Self { mut stack, gas_limit, spec_id, legacy_assertions } = self;
+        mut evm_env: EvmEnv<F::Spec, F::BlockEnv>,
+        tx_env: F::Tx,
+        db: Backend<AnyNetwork, F>,
+    ) -> Executor<N, F> {
+        let Self { mut stack, gas_limit, spec, legacy_assertions, .. } = self;
         if stack.block.is_none() {
             stack.block = Some(evm_env.block_env.clone());
         }
         if stack.gas_price.is_none() {
-            stack.gas_price = Some(tx_env.gas_price);
+            stack.gas_price = Some(tx_env.gas_price());
         }
-        let gas_limit = gas_limit.unwrap_or(evm_env.block_env.gas_limit);
-        evm_env.cfg_env.set_spec(spec_id);
+        let gas_limit = gas_limit.unwrap_or(evm_env.block_env.gas_limit());
+        evm_env.cfg_env.set_spec(spec);
         Executor::new(db, evm_env, tx_env, stack.build(), gas_limit, legacy_assertions)
     }
 }

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -34,7 +34,7 @@ impl TracingExecutor {
         let db = Backend::spawn(Some(fork))?;
         // configures a bare version of the evm executor: no cheatcode and log_collector inspector
         // is enabled, tracing will be enabled only for the targeted transaction
-        let mut executor = ExecutorBuilder::new()
+        let mut executor = ExecutorBuilder::default()
             .inspectors(|stack| {
                 stack.trace_mode(trace_mode).networks(networks).create2_deployer(create2_deployer)
             })

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -377,7 +377,7 @@ impl TestRunnerConfig {
             Some(known_contracts),
             Some(artifact_id.clone()),
         ));
-        ExecutorBuilder::new()
+        ExecutorBuilder::default()
             .inspectors(|stack| {
                 stack
                     .logs(self.config.live_logs)

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -658,7 +658,7 @@ impl ScriptConfig {
         };
 
         // We need to enable tracing to decode contract names: local or external.
-        let mut builder = ExecutorBuilder::new()
+        let mut builder = ExecutorBuilder::default()
             .inspectors(|stack| {
                 stack
                     .logs(self.config.live_logs)


### PR DESCRIPTION
## Summary

Makes `ExecutorBuilder` generic.

Next step is removing concrete types from `Executor` too.