### PR TITLE
chore(evm): rename `FoundryStorageProvider` to `TempoStorageProvider`

### DIFF
--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -41,11 +41,9 @@ pub use tempo_contracts::precompiles::{
 pub const TEMPO_TIP20_TOKENS: &[Address] =
     &[PATH_USD_ADDRESS, ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, THETA_USD_ADDRESS];
 
-/// Storage provider adapter for Foundry's backend to work with Tempo precompiles.
-///
-/// This wraps Foundry's backend to implement the `PrecompileStorageProvider` trait,
-/// enabling use of canonical Tempo initialization logic.
-pub struct FoundryStorageProvider<'a> {
+/// Storage provider adapter that wraps Foundry's `Backend` to implement Tempo's
+/// [`PrecompileStorageProvider`] trait for precompile initialization.
+pub struct TempoStorageProvider<'a> {
     backend: &'a mut Backend,
     chain_id: u64,
     timestamp: U256,
@@ -57,7 +55,7 @@ pub struct FoundryStorageProvider<'a> {
     hardfork: TempoHardfork,
 }
 
-impl<'a> FoundryStorageProvider<'a> {
+impl<'a> TempoStorageProvider<'a> {
     pub fn new(
         backend: &'a mut Backend,
         chain_id: u64,
@@ -79,7 +77,7 @@ impl<'a> FoundryStorageProvider<'a> {
     }
 }
 
-impl PrecompileStorageProvider for FoundryStorageProvider<'_> {
+impl PrecompileStorageProvider for TempoStorageProvider<'_> {
     fn spec(&self) -> TempoHardfork {
         self.hardfork
     }


### PR DESCRIPTION
## Summary

Renames `FoundryStorageProvider` to `TempoStorageProvider` since it's Tempo-specific (lives in `tempo.rs`, holds `TempoHardfork`, implements Tempo's `PrecompileStorageProvider`).