### PR TITLE
fix: rename misleading `should_fail` variable in `handle_expect_emit`

### DIFF
--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -863,7 +863,7 @@ pub(crate) fn handle_expect_emit<SPEC, BLOCK, N: Network>(
 ) -> Option<&'static str> {
     // This function returns an optional string indicating a failure reason.
     // If the string is `Some`, it indicates that the expectation failed with the provided reason.
-    let mut should_fail = None;
+    let mut failure_reason = None;
 
     // Fill or check the expected emits.
     // We expect for emit checks to be filled as they're declared (from oldest to newest),
@@ -876,7 +876,7 @@ pub(crate) fn handle_expect_emit<SPEC, BLOCK, N: Network>(
     // This allows a contract to arbitrarily emit more events than expected (additive behavior),
     // as long as all the previous events were matched in the order they were expected to be.
     if state.expected_emits.iter().all(|(expected, _)| expected.found) {
-        return should_fail;
+        return failure_reason;
     }
 
     // Check count=0 expectations against this log - fail immediately if violated
@@ -897,10 +897,10 @@ pub(crate) fn handle_expect_emit<SPEC, BLOCK, N: Network>(
                     interpreter.gas,
                 ));
             } else {
-                should_fail = Some("log emitted but expected 0 times");
+                failure_reason = Some("log emitted but expected 0 times");
             }
 
-            return should_fail;
+            return failure_reason;
         }
     }
 
@@ -925,7 +925,7 @@ pub(crate) fn handle_expect_emit<SPEC, BLOCK, N: Network>(
     if !should_fill_logs
         && state.expected_emits.iter().all(|(emit, _)| emit.found || emit.count == 0)
     {
-        return should_fail;
+        return failure_reason;
     }
 
     let (mut event_to_fill_or_check, mut count_map) = state
@@ -949,10 +949,10 @@ pub(crate) fn handle_expect_emit<SPEC, BLOCK, N: Network>(
                 interpreter.gas,
             ));
         } else {
-            should_fail = Some("use vm.expectEmitAnonymous to match anonymous events");
+            failure_reason = Some("use vm.expectEmitAnonymous to match anonymous events");
         }
 
-        return should_fail;
+        return failure_reason;
     };
 
     // Increment/set `count` for `log.address` and `log.data`
@@ -1029,7 +1029,7 @@ pub(crate) fn handle_expect_emit<SPEC, BLOCK, N: Network>(
         state.expected_emits.push_front((event_to_fill_or_check, count_map));
     }
 
-    should_fail
+    failure_reason
 }
 
 /// Handles expected emits specified by the `expectEmit` cheatcodes.


### PR DESCRIPTION


`handle_expect_emit()` returns an `Option<&'static str>` that carries a failure reason, but the local variable storing that value was named `should_fail`.

that name reads like a boolean flag and is also inconsistent with the surrounding comment and with other `should_fail` usages in the codebase, where it represents an actual `bool`.



