### PR TITLE
chore(clippy): remove stale octal_escapes allow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,6 @@ significant_drop_tightening = "allow"
 too_long_first_doc_paragraph = "allow"
 
 # Specific allows.
-octal_escapes = "allow"
 # until <https://github.com/rust-lang/rust-clippy/issues/13885> is fixed
 literal_string_with_formatting_args = "allow"
 result_large_err = "allow"


### PR DESCRIPTION
Remove `octal_escapes = "allow"` from workspace clippy lints.

No `.rs` file in the codebase contains an ambiguous octal escape sequence (`\0` followed by a digit). The allow was added during lint consolidation in [#14084](https://github.com/foundry-rs/foundry/pull/14084) but is unnecessary — clippy passes clean without it.

Prompted by: zerosnacks