### PR TITLE
fix(cheatcodes): retain only exact stopSnapshotGas record

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1705,7 +1705,7 @@ fn inner_stop_gas_snapshot<CTX: ContextTr, N: Network>(
         ccx.state
             .gas_metering
             .gas_records
-            .retain(|record| record.group != group && record.name != name);
+            .retain(|record| record.group != group || record.name != name);
 
         // Clear last snapshot cache if we have an exact match.
         if let Some((snapshot_group, snapshot_name)) = &ccx.state.gas_metering.active_gas_snapshot


### PR DESCRIPTION
Fix stopSnapshotGas cleanup so it removes only the exact (group, name) record, keeping snapshots that only share the same group or the same name and avoiding accidental data loss in larger snapshot suites.