### PR TITLE
feature(evm): `CheatcodeExecutor` generic `FoundryEvmFactory`

### DIFF
--- a/crates/cheatcodes/src/base64.rs
+++ b/crates/cheatcodes/src/base64.rs
@@ -2,6 +2,7 @@ use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
 use alloy_network::Network;
 use alloy_sol_types::SolValue;
 use base64::prelude::*;
+use foundry_evm_core::evm::FoundryEvmFactory;
 
 fn encode_base64(data: impl AsRef<[u8]>) -> Result {
     Ok(BASE64_STANDARD.encode(data).abi_encode())
@@ -12,28 +13,28 @@ fn encode_base64_url(data: impl AsRef<[u8]>) -> Result {
 }
 
 impl Cheatcode for toBase64_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { data } = self;
         encode_base64(data)
     }
 }
 
 impl Cheatcode for toBase64_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { data } = self;
         encode_base64(data)
     }
 }
 
 impl Cheatcode for toBase64URL_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { data } = self;
         encode_base64_url(data)
     }
 }
 
 impl Cheatcode for toBase64URL_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { data } = self;
         encode_base64_url(data)
     }

--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -12,6 +12,7 @@ use alloy_signer_local::{
     },
 };
 use alloy_sol_types::SolValue;
+use foundry_evm_core::evm::FoundryEvmFactory;
 use k256::{
     FieldBytes, Scalar,
     ecdsa::{SigningKey, hazmat},
@@ -31,28 +32,28 @@ use ed25519_consensus::{
 const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/60'/0'/0/";
 
 impl Cheatcode for createWallet_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { walletLabel } = self;
         create_wallet(&U256::from_be_bytes(keccak256(walletLabel).0), Some(walletLabel), state)
     }
 }
 
 impl Cheatcode for createWallet_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { privateKey } = self;
         create_wallet(privateKey, None, state)
     }
 }
 
 impl Cheatcode for createWallet_2Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { privateKey, walletLabel } = self;
         create_wallet(privateKey, Some(walletLabel), state)
     }
 }
 
 impl Cheatcode for sign_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { wallet, digest } = self;
         let sig = sign(&wallet.privateKey, digest)?;
         Ok(encode_full_sig(sig))
@@ -60,7 +61,7 @@ impl Cheatcode for sign_0Call {
 }
 
 impl Cheatcode for signWithNonceUnsafeCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let pk: U256 = self.privateKey;
         let digest: B256 = self.digest;
         let nonce: U256 = self.nonce;
@@ -70,7 +71,7 @@ impl Cheatcode for signWithNonceUnsafeCall {
 }
 
 impl Cheatcode for signCompact_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { wallet, digest } = self;
         let sig = sign(&wallet.privateKey, digest)?;
         Ok(encode_compact_sig(sig))
@@ -78,35 +79,35 @@ impl Cheatcode for signCompact_0Call {
 }
 
 impl Cheatcode for deriveKey_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { mnemonic, index } = self;
         derive_key::<English>(mnemonic, DEFAULT_DERIVATION_PATH_PREFIX, *index)
     }
 }
 
 impl Cheatcode for deriveKey_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { mnemonic, derivationPath, index } = self;
         derive_key::<English>(mnemonic, derivationPath, *index)
     }
 }
 
 impl Cheatcode for deriveKey_2Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { mnemonic, index, language } = self;
         derive_key_str(mnemonic, DEFAULT_DERIVATION_PATH_PREFIX, *index, language)
     }
 }
 
 impl Cheatcode for deriveKey_3Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { mnemonic, derivationPath, index, language } = self;
         derive_key_str(mnemonic, derivationPath, *index, language)
     }
 }
 
 impl Cheatcode for rememberKeyCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { privateKey } = self;
         let wallet = parse_wallet(privateKey)?;
         let address = inject_wallet(state, wallet);
@@ -115,7 +116,7 @@ impl Cheatcode for rememberKeyCall {
 }
 
 impl Cheatcode for rememberKeys_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { mnemonic, derivationPath, count } = self;
         let wallets = derive_wallets::<English>(mnemonic, derivationPath, *count)?;
         let mut addresses = Vec::<Address>::with_capacity(wallets.len());
@@ -129,7 +130,7 @@ impl Cheatcode for rememberKeys_0Call {
 }
 
 impl Cheatcode for rememberKeys_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { mnemonic, derivationPath, language, count } = self;
         let wallets = derive_wallets_str(mnemonic, derivationPath, language, *count)?;
         let mut addresses = Vec::<Address>::with_capacity(wallets.len());
@@ -142,8 +143,8 @@ impl Cheatcode for rememberKeys_1Call {
     }
 }
 
-fn inject_wallet<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn inject_wallet<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     wallet: LocalSigner<SigningKey>,
 ) -> Address {
     let address = wallet.address();
@@ -152,7 +153,7 @@ fn inject_wallet<SPEC, BLOCK, N: Network>(
 }
 
 impl Cheatcode for sign_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { privateKey, digest } = self;
         let sig = sign(privateKey, digest)?;
         Ok(encode_full_sig(sig))
@@ -160,7 +161,7 @@ impl Cheatcode for sign_1Call {
 }
 
 impl Cheatcode for signCompact_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { privateKey, digest } = self;
         let sig = sign(privateKey, digest)?;
         Ok(encode_compact_sig(sig))
@@ -168,7 +169,7 @@ impl Cheatcode for signCompact_1Call {
 }
 
 impl Cheatcode for sign_2Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { digest } = self;
         let sig = sign_with_wallet(state, None, digest)?;
         Ok(encode_full_sig(sig))
@@ -176,7 +177,7 @@ impl Cheatcode for sign_2Call {
 }
 
 impl Cheatcode for signCompact_2Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { digest } = self;
         let sig = sign_with_wallet(state, None, digest)?;
         Ok(encode_compact_sig(sig))
@@ -184,7 +185,7 @@ impl Cheatcode for signCompact_2Call {
 }
 
 impl Cheatcode for sign_3Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { signer, digest } = self;
         let sig = sign_with_wallet(state, Some(*signer), digest)?;
         Ok(encode_full_sig(sig))
@@ -192,7 +193,7 @@ impl Cheatcode for sign_3Call {
 }
 
 impl Cheatcode for signCompact_3Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { signer, digest } = self;
         let sig = sign_with_wallet(state, Some(*signer), digest)?;
         Ok(encode_compact_sig(sig))
@@ -200,14 +201,14 @@ impl Cheatcode for signCompact_3Call {
 }
 
 impl Cheatcode for signP256Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { privateKey, digest } = self;
         sign_p256(privateKey, digest)
     }
 }
 
 impl Cheatcode for publicKeyP256Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { privateKey } = self;
         let pub_key =
             parse_private_key_p256(privateKey)?.verifying_key().as_affine().to_encoded_point(false);
@@ -219,28 +220,28 @@ impl Cheatcode for publicKeyP256Call {
 }
 
 impl Cheatcode for createEd25519KeyCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { salt } = self;
         create_ed25519_key(salt)
     }
 }
 
 impl Cheatcode for publicKeyEd25519Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { privateKey } = self;
         public_key_ed25519(privateKey)
     }
 }
 
 impl Cheatcode for signEd25519Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { namespace, message, privateKey } = self;
         sign_ed25519(namespace, message, privateKey)
     }
 }
 
 impl Cheatcode for verifyEd25519Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { signature, namespace, message, publicKey } = self;
         verify_ed25519(signature, namespace, message, publicKey)
     }
@@ -250,10 +251,10 @@ impl Cheatcode for verifyEd25519Call {
 /// coordinates, and its private key (see the 'Wallet' struct)
 ///
 /// If 'label' is set to 'Some()', assign that label to the associated ETH address in state
-fn create_wallet<SPEC, BLOCK, N: Network>(
+fn create_wallet<N: Network, F: FoundryEvmFactory>(
     private_key: &U256,
     label: Option<&str>,
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+    state: &mut Cheatcodes<N, F>,
 ) -> Result {
     let key = parse_private_key(private_key)?;
     let addr = alloy_signer::utils::secret_key_to_address(&key);
@@ -374,8 +375,8 @@ fn sign_with_nonce(
     Ok(alloy_primitives::Signature::new(r_u256, s_u256, y_parity))
 }
 
-fn sign_with_wallet<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn sign_with_wallet<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     signer: Option<Address>,
     digest: &B256,
 ) -> Result<alloy_primitives::Signature> {

--- a/crates/cheatcodes/src/env.rs
+++ b/crates/cheatcodes/src/env.rs
@@ -4,13 +4,14 @@ use crate::{Cheatcode, Cheatcodes, Error, Result, Vm::*, string};
 use alloy_dyn_abi::DynSolType;
 use alloy_network::Network;
 use alloy_sol_types::SolValue;
+use foundry_evm_core::evm::FoundryEvmFactory;
 use std::{env, sync::OnceLock};
 
 /// Stores the forge execution context for the duration of the program.
 pub static FORGE_CONTEXT: OnceLock<ForgeContext> = OnceLock::new();
 
 impl Cheatcode for setEnvCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name: key, value } = self;
         if key.is_empty() {
             Err(fmt_err!("environment variable key can't be empty"))
@@ -30,7 +31,7 @@ impl Cheatcode for setEnvCall {
 }
 
 impl Cheatcode for resolveEnvCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { input } = self;
         let resolved = foundry_config::resolve::interpolate(input)
             .map_err(|e| fmt_err!("failed to resolve env var: {e}"))?;
@@ -39,105 +40,105 @@ impl Cheatcode for resolveEnvCall {
 }
 
 impl Cheatcode for envExistsCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name } = self;
         Ok(env::var(name).is_ok().abi_encode())
     }
 }
 
 impl Cheatcode for envBool_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for envUint_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for envInt_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for envAddress_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for envBytes32_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for envString_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::String)
     }
 }
 
 impl Cheatcode for envBytes_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name } = self;
         env(name, &DynSolType::Bytes)
     }
 }
 
 impl Cheatcode for envBool_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for envUint_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for envInt_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for envAddress_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for envBytes32_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for envString_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::String)
     }
 }
 
 impl Cheatcode for envBytes_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim } = self;
         env_array(name, delim, &DynSolType::Bytes)
     }
@@ -145,7 +146,7 @@ impl Cheatcode for envBytes_1Call {
 
 // bool
 impl Cheatcode for envOr_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Bool)
     }
@@ -153,7 +154,7 @@ impl Cheatcode for envOr_0Call {
 
 // uint256
 impl Cheatcode for envOr_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Uint(256))
     }
@@ -161,7 +162,7 @@ impl Cheatcode for envOr_1Call {
 
 // int256
 impl Cheatcode for envOr_2Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Int(256))
     }
@@ -169,7 +170,7 @@ impl Cheatcode for envOr_2Call {
 
 // address
 impl Cheatcode for envOr_3Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Address)
     }
@@ -177,7 +178,7 @@ impl Cheatcode for envOr_3Call {
 
 // bytes32
 impl Cheatcode for envOr_4Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::FixedBytes(32))
     }
@@ -185,7 +186,7 @@ impl Cheatcode for envOr_4Call {
 
 // string
 impl Cheatcode for envOr_5Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::String)
     }
@@ -193,7 +194,7 @@ impl Cheatcode for envOr_5Call {
 
 // bytes
 impl Cheatcode for envOr_6Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, defaultValue } = self;
         env_default(name, defaultValue, &DynSolType::Bytes)
     }
@@ -201,7 +202,7 @@ impl Cheatcode for envOr_6Call {
 
 // bool[]
 impl Cheatcode for envOr_7Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::Bool)
     }
@@ -209,7 +210,7 @@ impl Cheatcode for envOr_7Call {
 
 // uint256[]
 impl Cheatcode for envOr_8Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::Uint(256))
     }
@@ -217,7 +218,7 @@ impl Cheatcode for envOr_8Call {
 
 // int256[]
 impl Cheatcode for envOr_9Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::Int(256))
     }
@@ -225,7 +226,7 @@ impl Cheatcode for envOr_9Call {
 
 // address[]
 impl Cheatcode for envOr_10Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::Address)
     }
@@ -233,7 +234,7 @@ impl Cheatcode for envOr_10Call {
 
 // bytes32[]
 impl Cheatcode for envOr_11Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::FixedBytes(32))
     }
@@ -241,7 +242,7 @@ impl Cheatcode for envOr_11Call {
 
 // string[]
 impl Cheatcode for envOr_12Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim, defaultValue } = self;
         env_array_default(name, delim, defaultValue, &DynSolType::String)
     }
@@ -249,7 +250,7 @@ impl Cheatcode for envOr_12Call {
 
 // bytes[]
 impl Cheatcode for envOr_13Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name, delim, defaultValue } = self;
         let default = defaultValue.clone();
         env_array_default(name, delim, &default, &DynSolType::Bytes)
@@ -257,7 +258,7 @@ impl Cheatcode for envOr_13Call {
 }
 
 impl Cheatcode for isContextCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { context } = self;
         Ok((FORGE_CONTEXT.get() == Some(context)).abi_encode())
     }

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -28,6 +28,7 @@ use foundry_evm_core::{
     backend::{DatabaseError, DatabaseExt, RevertStateSnapshotAction},
     constants::{CALLER, CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, TEST_CONTRACT_ADDRESS},
     env::FoundryContextExt,
+    evm::FoundryEvmFactory,
     utils::get_blob_base_fee_update_fraction_by_spec_id,
 };
 use foundry_evm_traces::TraceMode;
@@ -36,7 +37,7 @@ use rand::Rng;
 use revm::{
     Database,
     bytecode::Bytecode,
-    context::{Block, Cfg, ContextTr, JournalTr, Transaction, result::ExecutionResult},
+    context::{Block, Cfg, ContextTr, Host, JournalTr, Transaction, result::ExecutionResult},
     inspector::JournalExt,
     primitives::{KECCAK_EMPTY, hardfork::SpecId},
     state::{Account, AccountStatus},
@@ -246,7 +247,7 @@ impl Display for AccountStateDiffs {
 }
 
 impl Cheatcode for addrCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { privateKey } = self;
         let wallet = super::crypto::parse_wallet(privateKey)?;
         Ok(wallet.address().abi_encode())
@@ -254,9 +255,9 @@ impl Cheatcode for addrCall {
 }
 
 impl Cheatcode for getNonce_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { account } = self;
         get_nonce(ccx, account)
@@ -264,9 +265,9 @@ impl Cheatcode for getNonce_0Call {
 }
 
 impl Cheatcode for getNonce_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { wallet } = self;
         get_nonce(ccx, &wallet.addr)
@@ -274,9 +275,9 @@ impl Cheatcode for getNonce_1Call {
 }
 
 impl Cheatcode for loadCall {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { target, slot } = *self;
         ccx.ensure_not_precompile(&target)?;
@@ -319,12 +320,9 @@ impl Cheatcode for loadCall {
 }
 
 impl Cheatcode for loadAllocsCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { pathToAllocsJson } = self;
 
@@ -350,12 +348,9 @@ impl Cheatcode for loadAllocsCall {
 }
 
 impl Cheatcode for cloneAccountCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { source, target } = self;
 
@@ -370,9 +365,9 @@ impl Cheatcode for cloneAccountCall {
 }
 
 impl Cheatcode for dumpStateCall {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { pathToStateJson } = self;
         let path = Path::new(pathToStateJson);
@@ -403,7 +398,7 @@ impl Cheatcode for dumpStateCall {
 }
 
 impl Cheatcode for recordCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         state.recording_accesses = true;
         state.accesses.clear();
@@ -412,14 +407,14 @@ impl Cheatcode for recordCall {
 }
 
 impl Cheatcode for stopRecordCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         state.recording_accesses = false;
         Ok(Default::default())
     }
 }
 
 impl Cheatcode for accessesCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { target } = *self;
         let result = (
             state.accesses.reads.entry(target).or_default().as_slice(),
@@ -430,7 +425,7 @@ impl Cheatcode for accessesCall {
 }
 
 impl Cheatcode for recordLogsCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         state.recorded_logs = Some(Default::default());
         Ok(Default::default())
@@ -438,14 +433,14 @@ impl Cheatcode for recordLogsCall {
 }
 
 impl Cheatcode for getRecordedLogsCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         Ok(state.recorded_logs.replace(Default::default()).unwrap_or_default().abi_encode())
     }
 }
 
 impl Cheatcode for getRecordedLogsJsonCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         let logs = state.recorded_logs.replace(Default::default()).unwrap_or_default();
         let json_logs: Vec<_> = logs
@@ -461,7 +456,7 @@ impl Cheatcode for getRecordedLogsJsonCall {
 }
 
 impl Cheatcode for pauseGasMeteringCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         state.gas_metering.paused = true;
         Ok(Default::default())
@@ -469,7 +464,7 @@ impl Cheatcode for pauseGasMeteringCall {
 }
 
 impl Cheatcode for resumeGasMeteringCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         state.gas_metering.resume();
         Ok(Default::default())
@@ -477,7 +472,7 @@ impl Cheatcode for resumeGasMeteringCall {
 }
 
 impl Cheatcode for resetGasMeteringCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         state.gas_metering.reset();
         Ok(Default::default())
@@ -485,7 +480,7 @@ impl Cheatcode for resetGasMeteringCall {
 }
 
 impl Cheatcode for lastCallGasCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         let Some(last_call_gas) = &state.gas_metering.last_call_gas else {
             bail!("no external call was made yet");
@@ -495,9 +490,9 @@ impl Cheatcode for lastCallGasCall {
 }
 
 impl Cheatcode for getChainIdCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         Ok(U256::from(ccx.ecx.cfg().chain_id()).abi_encode())
@@ -505,9 +500,9 @@ impl Cheatcode for getChainIdCall {
 }
 
 impl Cheatcode for chainIdCall {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { newChainId } = self;
         ensure!(*newChainId <= U256::from(u64::MAX), "chain ID must be less than 2^64");
@@ -517,9 +512,9 @@ impl Cheatcode for chainIdCall {
 }
 
 impl Cheatcode for coinbaseCall {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { newCoinbase } = self;
         ccx.ecx.block_mut().set_beneficiary(*newCoinbase);
@@ -528,9 +523,9 @@ impl Cheatcode for coinbaseCall {
 }
 
 impl Cheatcode for difficultyCall {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { newDifficulty } = self;
         ensure!(
@@ -544,9 +539,9 @@ impl Cheatcode for difficultyCall {
 }
 
 impl Cheatcode for feeCall {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { newBasefee } = self;
         ensure!(*newBasefee <= U256::from(u64::MAX), "base fee must be less than 2^64");
@@ -556,9 +551,9 @@ impl Cheatcode for feeCall {
 }
 
 impl Cheatcode for prevrandao_0Call {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { newPrevrandao } = self;
         ensure!(
@@ -572,9 +567,9 @@ impl Cheatcode for prevrandao_0Call {
 }
 
 impl Cheatcode for prevrandao_1Call {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { newPrevrandao } = self;
         ensure!(
@@ -588,9 +583,9 @@ impl Cheatcode for prevrandao_1Call {
 }
 
 impl Cheatcode for blobhashesCall {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { hashes } = self;
         ensure!(
@@ -606,9 +601,9 @@ impl Cheatcode for blobhashesCall {
 }
 
 impl Cheatcode for getBlobhashesCall {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         ensure!(
@@ -621,9 +616,9 @@ impl Cheatcode for getBlobhashesCall {
 }
 
 impl Cheatcode for rollCall {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { newHeight } = self;
         ccx.ecx.block_mut().set_number(*newHeight);
@@ -632,9 +627,9 @@ impl Cheatcode for rollCall {
 }
 
 impl Cheatcode for getBlockNumberCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         Ok(ccx.ecx.block().number().abi_encode())
@@ -642,9 +637,9 @@ impl Cheatcode for getBlockNumberCall {
 }
 
 impl Cheatcode for txGasPriceCall {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { newGasPrice } = self;
         ensure!(*newGasPrice <= U256::from(u64::MAX), "gas price must be less than 2^64");
@@ -654,9 +649,9 @@ impl Cheatcode for txGasPriceCall {
 }
 
 impl Cheatcode for warpCall {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { newTimestamp } = self;
         ccx.ecx.block_mut().set_timestamp(*newTimestamp);
@@ -665,9 +660,9 @@ impl Cheatcode for warpCall {
 }
 
 impl Cheatcode for getBlockTimestampCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         Ok(ccx.ecx.block().timestamp().abi_encode())
@@ -675,9 +670,9 @@ impl Cheatcode for getBlockTimestampCall {
 }
 
 impl Cheatcode for blobBaseFeeCall {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { newBlobBaseFee } = self;
         ensure!(
@@ -696,9 +691,9 @@ impl Cheatcode for blobBaseFeeCall {
 }
 
 impl Cheatcode for getBlobBaseFeeCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         Ok(ccx.ecx.block().blob_excess_gas().unwrap_or(0).abi_encode())
@@ -706,12 +701,9 @@ impl Cheatcode for getBlobBaseFeeCall {
 }
 
 impl Cheatcode for dealCall {
-    fn apply_stateful<
-        CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { account: address, newBalance: new_balance } = *self;
         let account = journaled_account(ccx.ecx, address)?;
@@ -723,9 +715,9 @@ impl Cheatcode for dealCall {
 }
 
 impl Cheatcode for etchCall {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { target, newRuntimeBytecode } = self;
         ccx.ensure_not_precompile(target)?;
@@ -738,12 +730,9 @@ impl Cheatcode for etchCall {
 }
 
 impl Cheatcode for resetNonceCall {
-    fn apply_stateful<
-        CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { account } = self;
         let account = journaled_account(ccx.ecx, *account)?;
@@ -759,12 +748,9 @@ impl Cheatcode for resetNonceCall {
 }
 
 impl Cheatcode for setNonceCall {
-    fn apply_stateful<
-        CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { account, newNonce } = *self;
         let account = journaled_account(ccx.ecx, account)?;
@@ -781,12 +767,9 @@ impl Cheatcode for setNonceCall {
 }
 
 impl Cheatcode for setNonceUnsafeCall {
-    fn apply_stateful<
-        CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { account, newNonce } = *self;
         let account = journaled_account(ccx.ecx, account)?;
@@ -796,9 +779,9 @@ impl Cheatcode for setNonceUnsafeCall {
 }
 
 impl Cheatcode for storeCall {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { target, slot, value } = *self;
         ccx.ensure_not_precompile(&target)?;
@@ -812,9 +795,9 @@ impl Cheatcode for storeCall {
 }
 
 impl Cheatcode for coolCall {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { target } = self;
         if let Some(account) = ccx.ecx.journal_mut().evm_state_mut().get_mut(target) {
@@ -826,7 +809,7 @@ impl Cheatcode for coolCall {
 }
 
 impl Cheatcode for accessListCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { access } = self;
         let access_list = access
             .iter()
@@ -841,7 +824,7 @@ impl Cheatcode for accessListCall {
 }
 
 impl Cheatcode for noAccessListCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         // Set to empty option in order to override previous applied access list.
         if state.access_list.is_some() {
@@ -852,9 +835,9 @@ impl Cheatcode for noAccessListCall {
 }
 
 impl Cheatcode for warmSlotCall {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { target, slot } = *self;
         set_cold_slot(ccx, target, slot.into(), false);
@@ -863,9 +846,9 @@ impl Cheatcode for warmSlotCall {
 }
 
 impl Cheatcode for coolSlotCall {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { target, slot } = *self;
         set_cold_slot(ccx, target, slot.into(), true);
@@ -874,9 +857,9 @@ impl Cheatcode for coolSlotCall {
 }
 
 impl Cheatcode for readCallersCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         read_callers(ccx.state, &ccx.ecx.tx().caller(), ccx.ecx.journal().depth())
@@ -884,9 +867,9 @@ impl Cheatcode for readCallersCall {
 }
 
 impl Cheatcode for snapshotValue_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { name, value } = self;
         inner_value_snapshot(ccx, None, Some(name.clone()), value.to_string())
@@ -894,9 +877,9 @@ impl Cheatcode for snapshotValue_0Call {
 }
 
 impl Cheatcode for snapshotValue_1Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { group, name, value } = self;
         inner_value_snapshot(ccx, Some(group.clone()), Some(name.clone()), value.to_string())
@@ -904,9 +887,9 @@ impl Cheatcode for snapshotValue_1Call {
 }
 
 impl Cheatcode for snapshotGasLastCall_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { name } = self;
         let Some(last_call_gas) = &ccx.state.gas_metering.last_call_gas else {
@@ -917,9 +900,9 @@ impl Cheatcode for snapshotGasLastCall_0Call {
 }
 
 impl Cheatcode for snapshotGasLastCall_1Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { name, group } = self;
         let Some(last_call_gas) = &ccx.state.gas_metering.last_call_gas else {
@@ -935,9 +918,9 @@ impl Cheatcode for snapshotGasLastCall_1Call {
 }
 
 impl Cheatcode for startSnapshotGas_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { name } = self;
         inner_start_gas_snapshot(ccx, None, Some(name.clone()))
@@ -945,9 +928,9 @@ impl Cheatcode for startSnapshotGas_0Call {
 }
 
 impl Cheatcode for startSnapshotGas_1Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { group, name } = self;
         inner_start_gas_snapshot(ccx, Some(group.clone()), Some(name.clone()))
@@ -955,9 +938,9 @@ impl Cheatcode for startSnapshotGas_1Call {
 }
 
 impl Cheatcode for stopSnapshotGas_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         inner_stop_gas_snapshot(ccx, None, None)
@@ -965,9 +948,9 @@ impl Cheatcode for stopSnapshotGas_0Call {
 }
 
 impl Cheatcode for stopSnapshotGas_1Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { name } = self;
         inner_stop_gas_snapshot(ccx, None, Some(name.clone()))
@@ -975,9 +958,9 @@ impl Cheatcode for stopSnapshotGas_1Call {
 }
 
 impl Cheatcode for stopSnapshotGas_2Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { group, name } = self;
         inner_stop_gas_snapshot(ccx, Some(group.clone()), Some(name.clone()))
@@ -986,12 +969,9 @@ impl Cheatcode for stopSnapshotGas_2Call {
 
 // Deprecated in favor of `snapshotStateCall`
 impl Cheatcode for snapshotCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         inner_snapshot_state(ccx)
@@ -999,12 +979,9 @@ impl Cheatcode for snapshotCall {
 }
 
 impl Cheatcode for snapshotStateCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         inner_snapshot_state(ccx)
@@ -1013,12 +990,9 @@ impl Cheatcode for snapshotStateCall {
 
 // Deprecated in favor of `revertToStateCall`
 impl Cheatcode for revertToCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state(ccx, *snapshotId)
@@ -1026,12 +1000,9 @@ impl Cheatcode for revertToCall {
 }
 
 impl Cheatcode for revertToStateCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state(ccx, *snapshotId)
@@ -1040,12 +1011,9 @@ impl Cheatcode for revertToStateCall {
 
 // Deprecated in favor of `revertToStateAndDeleteCall`
 impl Cheatcode for revertToAndDeleteCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state_and_delete(ccx, *snapshotId)
@@ -1053,12 +1021,9 @@ impl Cheatcode for revertToAndDeleteCall {
 }
 
 impl Cheatcode for revertToStateAndDeleteCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state_and_delete(ccx, *snapshotId)
@@ -1067,12 +1032,9 @@ impl Cheatcode for revertToStateAndDeleteCall {
 
 // Deprecated in favor of `deleteStateSnapshotCall`
 impl Cheatcode for deleteSnapshotCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { snapshotId } = self;
         let result = ccx.ecx.db_mut().delete_state_snapshot(*snapshotId);
@@ -1081,12 +1043,9 @@ impl Cheatcode for deleteSnapshotCall {
 }
 
 impl Cheatcode for deleteStateSnapshotCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { snapshotId } = self;
         let result = ccx.ecx.db_mut().delete_state_snapshot(*snapshotId);
@@ -1096,12 +1055,9 @@ impl Cheatcode for deleteStateSnapshotCall {
 
 // Deprecated in favor of `deleteStateSnapshotsCall`
 impl Cheatcode for deleteSnapshotsCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         ccx.ecx.db_mut().delete_state_snapshots();
@@ -1110,12 +1066,9 @@ impl Cheatcode for deleteSnapshotsCall {
 }
 
 impl Cheatcode for deleteStateSnapshotsCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         ccx.ecx.db_mut().delete_state_snapshots();
@@ -1124,7 +1077,7 @@ impl Cheatcode for deleteStateSnapshotsCall {
 }
 
 impl Cheatcode for startStateDiffRecordingCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         state.recorded_account_diffs_stack = Some(Default::default());
         // Enable mapping recording to track mapping slot accesses
@@ -1134,16 +1087,16 @@ impl Cheatcode for startStateDiffRecordingCall {
 }
 
 impl Cheatcode for stopAndReturnStateDiffCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         get_state_diff(state)
     }
 }
 
 impl Cheatcode for getStateDiffCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let mut diffs = String::new();
         let state_diffs = get_recorded_state_diffs(ccx);
@@ -1156,9 +1109,9 @@ impl Cheatcode for getStateDiffCall {
 }
 
 impl Cheatcode for getStateDiffJsonCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let state_diffs = get_recorded_state_diffs(ccx);
         Ok(serde_json::to_string(&state_diffs)?.abi_encode())
@@ -1166,9 +1119,9 @@ impl Cheatcode for getStateDiffJsonCall {
 }
 
 impl Cheatcode for getStorageSlotsCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { target, variableName } = self;
 
@@ -1247,7 +1200,7 @@ impl Cheatcode for getStorageSlotsCall {
 }
 
 impl Cheatcode for getStorageAccessesCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let mut storage_accesses = Vec::new();
 
         if let Some(recorded_diffs) = &state.recorded_account_diffs_stack {
@@ -1262,22 +1215,19 @@ impl Cheatcode for getStorageAccessesCall {
 
 impl Cheatcode for broadcastRawTransactionCall {
     fn apply_full<
-        CTX: FoundryContextExt<
-                Tx: FromRecoveredTx<N::TxEnvelope>,
-                Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
-            >,
         N: Network<TxEnvelope: Decodable + SignerRecoverable>,
+        F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
     >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let tx = N::TxEnvelope::decode(&mut self.data.as_ref())
             .map_err(|err| fmt_err!("failed to decode RLP-encoded transaction: {err}"))?;
 
         let sender =
             tx.recover_signer().map_err(|err| fmt_err!("failed to recover signer: {err}"))?;
-        let tx_env = CTX::Tx::from_recovered_tx(&tx, sender);
+        let tx_env = F::Tx::from_recovered_tx(&tx, sender);
         let from = sender;
 
         executor.transact_from_tx_on_db(ccx.state, ccx.ecx, tx_env)?;
@@ -1294,12 +1244,9 @@ impl Cheatcode for broadcastRawTransactionCall {
 }
 
 impl Cheatcode for setBlockhashCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { blockNumber, blockHash } = *self;
         ensure!(blockNumber <= U256::from(u64::MAX), "blockNumber must be less than 2^64");
@@ -1316,12 +1263,12 @@ impl Cheatcode for setBlockhashCall {
 
 impl Cheatcode for executeTransactionCall {
     fn apply_full<
-        CTX: FoundryContextExt<Tx: FromRecoveredTx<N::TxEnvelope>>,
         N: Network<TxEnvelope: Decodable + SignerRecoverable>,
+        F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
     >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         use crate::env::FORGE_CONTEXT;
 
@@ -1339,7 +1286,7 @@ impl Cheatcode for executeTransactionCall {
         // Build TxEnv from the recovered transaction.
         let sender =
             tx.recover_signer().map_err(|err| fmt_err!("failed to recover signer: {err}"))?;
-        let tx_env = CTX::Tx::from_recovered_tx(&tx, sender);
+        let tx_env = F::Tx::from_recovered_tx(&tx, sender);
 
         // Save current env for restoration after execution.
         let cached_evm_env = ccx.ecx.evm_clone();
@@ -1455,10 +1402,10 @@ impl Cheatcode for executeTransactionCall {
 }
 
 impl Cheatcode for startDebugTraceRecordingCall {
-    fn apply_full<CTX: ContextTr, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             return Err(Error::from("no tracer initiated, consider adding -vvv flag"));
@@ -1485,10 +1432,10 @@ impl Cheatcode for startDebugTraceRecordingCall {
 }
 
 impl Cheatcode for stopAndReturnDebugTraceRecordingCall {
-    fn apply_full<CTX: ContextTr, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             return Err(Error::from("no tracer initiated, consider adding -vvv flag"));
@@ -1524,9 +1471,9 @@ impl Cheatcode for stopAndReturnDebugTraceRecordingCall {
 }
 
 impl Cheatcode for setEvmVersionCall {
-    fn apply_stateful<CTX: FoundryContextExt<Spec: FromEvmVersion>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory<Spec: FromEvmVersion>>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { evm } = self;
         let spec_id = evm_spec_id(
@@ -1539,28 +1486,25 @@ impl Cheatcode for setEvmVersionCall {
 }
 
 impl Cheatcode for getEvmVersionCall {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let spec = (*ccx.ecx.cfg().spec()).into();
         Ok(spec.to_string().to_lowercase().abi_encode())
     }
 }
 
-pub(super) fn get_nonce<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+pub(super) fn get_nonce<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     address: &Address,
 ) -> Result {
     let account = ccx.ecx.journal_mut().load_account(*address)?;
     Ok(account.data.info.nonce.abi_encode())
 }
 
-fn inner_snapshot_state<
-    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-    N: Network,
->(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn inner_snapshot_state<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
 ) -> Result {
     let evm_env = ccx.ecx.evm_clone();
     let (db, inner) = ccx.ecx.db_journal_inner_mut();
@@ -1568,11 +1512,8 @@ fn inner_snapshot_state<
     Ok(id.abi_encode())
 }
 
-fn inner_revert_to_state<
-    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-    N: Network,
->(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn inner_revert_to_state<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     snapshot_id: U256,
 ) -> Result {
     let mut evm_env = ccx.ecx.evm_clone();
@@ -1593,11 +1534,8 @@ fn inner_revert_to_state<
     }
 }
 
-fn inner_revert_to_state_and_delete<
-    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-    N: Network,
->(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn inner_revert_to_state_and_delete<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     snapshot_id: U256,
 ) -> Result {
     let mut evm_env = ccx.ecx.evm_clone();
@@ -1618,8 +1556,8 @@ fn inner_revert_to_state_and_delete<
     }
 }
 
-fn inner_value_snapshot<CTX: ContextTr, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn inner_value_snapshot<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     group: Option<String>,
     name: Option<String>,
     value: String,
@@ -1631,8 +1569,8 @@ fn inner_value_snapshot<CTX: ContextTr, N: Network>(
     Ok(Default::default())
 }
 
-fn inner_last_gas_snapshot<CTX: ContextTr, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn inner_last_gas_snapshot<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     group: Option<String>,
     name: Option<String>,
     value: u64,
@@ -1644,8 +1582,8 @@ fn inner_last_gas_snapshot<CTX: ContextTr, N: Network>(
     Ok(value.abi_encode())
 }
 
-fn inner_start_gas_snapshot<CTX: ContextTr, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn inner_start_gas_snapshot<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     group: Option<String>,
     name: Option<String>,
 ) -> Result {
@@ -1670,8 +1608,8 @@ fn inner_start_gas_snapshot<CTX: ContextTr, N: Network>(
     Ok(Default::default())
 }
 
-fn inner_stop_gas_snapshot<CTX: ContextTr, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn inner_stop_gas_snapshot<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     group: Option<String>,
     name: Option<String>,
 ) -> Result {
@@ -1722,8 +1660,8 @@ fn inner_stop_gas_snapshot<CTX: ContextTr, N: Network>(
 }
 
 // Derives the snapshot group and name from the provided group and name or the running contract.
-fn derive_snapshot_name<CTX: ContextTr, N: Network>(
-    ccx: &CheatsCtxt<'_, CTX, N>,
+fn derive_snapshot_name<N: Network, F: FoundryEvmFactory>(
+    ccx: &CheatsCtxt<'_, '_, N, F>,
     group: Option<String>,
     name: Option<String>,
 ) -> (String, String) {
@@ -1757,8 +1695,8 @@ fn derive_snapshot_name<CTX: ContextTr, N: Network>(
 /// - If no caller modification is active:
 ///     - caller_mode will be equal to [CallerMode::None],
 ///     - `msg.sender` and `tx.origin` will be equal to the default sender address.
-fn read_callers<SPEC, BLOCK, N: Network>(
-    state: &Cheatcodes<SPEC, BLOCK, N>,
+fn read_callers<N: Network, F: FoundryEvmFactory>(
+    state: &Cheatcodes<N, F>,
     default_sender: &Address,
     call_depth: usize,
 ) -> Result {
@@ -1811,7 +1749,7 @@ pub(super) fn ensure_loaded_account<CTX: ContextTr<Db: Database<Error = Database
 /// In the case where `stopAndReturnStateDiff` is called at a lower
 /// depth than `startStateDiffRecording`, multiple `Vec<RecordedAccountAccesses>`
 /// will be flattened, preserving the order of the accesses.
-fn get_state_diff<SPEC, BLOCK, N: Network>(state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+fn get_state_diff<N: Network, F: FoundryEvmFactory>(state: &mut Cheatcodes<N, F>) -> Result {
     let res = state
         .recorded_account_diffs_stack
         .replace(Default::default())
@@ -1840,8 +1778,8 @@ fn genesis_account(account: &Account) -> GenesisAccount {
 }
 
 /// Helper function to returns state diffs recorded for each changed account.
-fn get_recorded_state_diffs<CTX: ContextTr, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn get_recorded_state_diffs<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
 ) -> BTreeMap<Address, AccountStateDiffs> {
     let mut state_diffs: BTreeMap<Address, AccountStateDiffs> = BTreeMap::default();
 
@@ -2019,8 +1957,8 @@ const EIP1822_PROXIABLE_SLOT: &str =
     "c5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7";
 
 /// Helper function to get the contract data from the deployed code at an address.
-fn get_contract_data<'a, CTX: ContextTr, N: Network>(
-    ccx: &'a mut CheatsCtxt<'_, CTX, N>,
+fn get_contract_data<'a, N: Network, F: FoundryEvmFactory>(
+    ccx: &'a mut CheatsCtxt<'_, '_, N, F>,
     address: Address,
 ) -> Option<(&'a foundry_compilers::ArtifactId, &'a foundry_common::contracts::ContractData)> {
     // Check if we have available artifacts to match against
@@ -2062,8 +2000,8 @@ fn get_contract_data<'a, CTX: ContextTr, N: Network>(
 }
 
 /// Helper function to set / unset cold storage slot of the target address.
-fn set_cold_slot<CTX: ContextTr<Journal: JournalExt>, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn set_cold_slot<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     target: Address,
     slot: U256,
     cold: bool,

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -10,16 +10,15 @@ use alloy_provider::Provider;
 use alloy_rpc_types::Filter;
 use alloy_sol_types::SolValue;
 use foundry_common::provider::ProviderBuilder;
-use foundry_evm_core::{FoundryContextExt, backend::JournaledState, fork::CreateFork};
+use foundry_evm_core::{
+    FoundryContextExt, backend::JournaledState, evm::FoundryEvmFactory, fork::CreateFork,
+};
 use revm::context::ContextTr;
 
 impl Cheatcode for activeForkCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         ccx.ecx
@@ -31,12 +30,9 @@ impl Cheatcode for activeForkCall {
 }
 
 impl Cheatcode for createFork_0Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { urlOrAlias } = self;
         create_fork(ccx, urlOrAlias, None)
@@ -44,12 +40,9 @@ impl Cheatcode for createFork_0Call {
 }
 
 impl Cheatcode for createFork_1Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { urlOrAlias, blockNumber } = self;
         create_fork(ccx, urlOrAlias, Some(blockNumber.saturating_to()))
@@ -57,12 +50,9 @@ impl Cheatcode for createFork_1Call {
 }
 
 impl Cheatcode for createFork_2Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { urlOrAlias, txHash } = self;
         create_fork_at_transaction(ccx, urlOrAlias, txHash)
@@ -70,12 +60,9 @@ impl Cheatcode for createFork_2Call {
 }
 
 impl Cheatcode for createSelectFork_0Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { urlOrAlias } = self;
         create_select_fork(ccx, urlOrAlias, None)
@@ -83,12 +70,9 @@ impl Cheatcode for createSelectFork_0Call {
 }
 
 impl Cheatcode for createSelectFork_1Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { urlOrAlias, blockNumber } = self;
         create_select_fork(ccx, urlOrAlias, Some(blockNumber.saturating_to()))
@@ -96,12 +80,9 @@ impl Cheatcode for createSelectFork_1Call {
 }
 
 impl Cheatcode for createSelectFork_2Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { urlOrAlias, txHash } = self;
         create_select_fork_at_transaction(ccx, urlOrAlias, txHash)
@@ -109,91 +90,76 @@ impl Cheatcode for createSelectFork_2Call {
 }
 
 impl Cheatcode for rollFork_0Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { blockNumber } = self;
         persist_caller(ccx);
-        fork_env_op(ccx, |db, evm_env, _, inner| {
+        fork_env_op(ccx.ecx, |db, evm_env, _, inner| {
             db.roll_fork(None, (*blockNumber).to(), evm_env, inner)
         })
     }
 }
 
 impl Cheatcode for rollFork_1Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { txHash } = self;
         persist_caller(ccx);
-        fork_env_op(ccx, |db, evm_env, _, inner| {
+        fork_env_op(ccx.ecx, |db, evm_env, _, inner| {
             db.roll_fork_to_transaction(None, *txHash, evm_env, inner)
         })
     }
 }
 
 impl Cheatcode for rollFork_2Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { forkId, blockNumber } = self;
         persist_caller(ccx);
-        fork_env_op(ccx, |db, evm_env, _, inner| {
+        fork_env_op(ccx.ecx, |db, evm_env, _, inner| {
             db.roll_fork(Some(*forkId), (*blockNumber).to(), evm_env, inner)
         })
     }
 }
 
 impl Cheatcode for rollFork_3Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { forkId, txHash } = self;
         persist_caller(ccx);
-        fork_env_op(ccx, |db, evm_env, _, inner| {
+        fork_env_op(ccx.ecx, |db, evm_env, _, inner| {
             db.roll_fork_to_transaction(Some(*forkId), *txHash, evm_env, inner)
         })
     }
 }
 
 impl Cheatcode for selectForkCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { forkId } = self;
         persist_caller(ccx);
         check_broadcast(ccx.state)?;
-        fork_env_op(ccx, |db, evm_env, tx_env, inner| {
+        fork_env_op(ccx.ecx, |db, evm_env, tx_env, inner| {
             db.select_fork(*forkId, evm_env, tx_env, inner)
         })
     }
 }
 
 impl Cheatcode for transact_0Call {
-    fn apply_full<CTX: FoundryContextExt, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Self { txHash } = *self;
         transact(ccx, executor, txHash, None)
@@ -201,10 +167,10 @@ impl Cheatcode for transact_0Call {
 }
 
 impl Cheatcode for transact_1Call {
-    fn apply_full<CTX: FoundryContextExt, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Self { forkId, txHash } = *self;
         transact(ccx, executor, txHash, Some(forkId))
@@ -212,12 +178,9 @@ impl Cheatcode for transact_1Call {
 }
 
 impl Cheatcode for allowCheatcodesCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { account } = self;
         ccx.ecx.db_mut().allow_cheatcode_access(*account);
@@ -226,12 +189,9 @@ impl Cheatcode for allowCheatcodesCall {
 }
 
 impl Cheatcode for makePersistent_0Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { account } = self;
         ccx.ecx.db_mut().add_persistent_account(*account);
@@ -240,12 +200,9 @@ impl Cheatcode for makePersistent_0Call {
 }
 
 impl Cheatcode for makePersistent_1Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { account0, account1 } = self;
         ccx.ecx.db_mut().add_persistent_account(*account0);
@@ -255,12 +212,9 @@ impl Cheatcode for makePersistent_1Call {
 }
 
 impl Cheatcode for makePersistent_2Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { account0, account1, account2 } = self;
         ccx.ecx.db_mut().add_persistent_account(*account0);
@@ -271,12 +225,9 @@ impl Cheatcode for makePersistent_2Call {
 }
 
 impl Cheatcode for makePersistent_3Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { accounts } = self;
         for account in accounts {
@@ -287,12 +238,9 @@ impl Cheatcode for makePersistent_3Call {
 }
 
 impl Cheatcode for revokePersistent_0Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { account } = self;
         ccx.ecx.db_mut().remove_persistent_account(account);
@@ -301,12 +249,9 @@ impl Cheatcode for revokePersistent_0Call {
 }
 
 impl Cheatcode for revokePersistent_1Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { accounts } = self;
         for account in accounts {
@@ -317,12 +262,9 @@ impl Cheatcode for revokePersistent_1Call {
 }
 
 impl Cheatcode for isPersistentCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { account } = self;
         Ok(ccx.ecx.db().is_persistent(account).abi_encode())
@@ -330,12 +272,9 @@ impl Cheatcode for isPersistentCall {
 }
 
 impl Cheatcode for rpc_0Call {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { method, params } = self;
         let url =
@@ -345,7 +284,7 @@ impl Cheatcode for rpc_0Call {
 }
 
 impl Cheatcode for rpc_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { urlOrAlias, method, params } = self;
         let url = state.config.rpc_endpoint(urlOrAlias)?.url()?;
         rpc_call(&url, method, params)
@@ -353,12 +292,9 @@ impl Cheatcode for rpc_1Call {
 }
 
 impl Cheatcode for eth_getLogsCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { fromBlock, toBlock, target, topics } = self;
         let (Ok(from_block), Ok(to_block)) = (u64::try_from(fromBlock), u64::try_from(toBlock))
@@ -401,12 +337,9 @@ impl Cheatcode for eth_getLogsCall {
 }
 
 impl Cheatcode for getRawBlockHeaderCall {
-    fn apply_stateful<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { blockNumber } = self;
         let url = ccx.ecx.db().active_fork_url().ok_or_else(|| fmt_err!("no active fork"))?;
@@ -429,28 +362,22 @@ impl Cheatcode for getRawBlockHeaderCall {
 }
 
 /// Creates and then also selects the new fork
-fn create_select_fork<
-    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-    N: Network,
->(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn create_select_fork<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     url_or_alias: &str,
     block: Option<u64>,
 ) -> Result {
     check_broadcast(ccx.state)?;
 
     let fork = create_fork_request(ccx, url_or_alias, block)?;
-    fork_env_op(ccx, |db, evm_env, tx_env, inner| {
+    fork_env_op(ccx.ecx, |db, evm_env, tx_env, inner| {
         db.create_select_fork(fork, evm_env, tx_env, inner)
     })
 }
 
 /// Creates a new fork
-fn create_fork<
-    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-    N: Network,
->(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn create_fork<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     url_or_alias: &str,
     block: Option<u64>,
 ) -> Result {
@@ -460,28 +387,22 @@ fn create_fork<
 }
 
 /// Creates and then also selects the new fork at the given transaction
-fn create_select_fork_at_transaction<
-    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-    N: Network,
->(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn create_select_fork_at_transaction<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     url_or_alias: &str,
     transaction: &B256,
 ) -> Result {
     check_broadcast(ccx.state)?;
 
     let fork = create_fork_request(ccx, url_or_alias, None)?;
-    fork_env_op(ccx, |db, evm_env, tx_env, inner| {
+    fork_env_op(ccx.ecx, |db, evm_env, tx_env, inner| {
         db.create_select_fork_at_transaction(fork, evm_env, tx_env, inner, *transaction)
     })
 }
 
 /// Creates a new fork at the given transaction
-fn create_fork_at_transaction<
-    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-    N: Network,
->(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn create_fork_at_transaction<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     url_or_alias: &str,
     transaction: &B256,
 ) -> Result {
@@ -491,11 +412,8 @@ fn create_fork_at_transaction<
 }
 
 /// Creates the request object for a new fork request
-fn create_fork_request<
-    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-    N: Network,
->(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn create_fork_request<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     url_or_alias: &str,
     block: Option<u64>,
 ) -> Result<CreateFork> {
@@ -522,8 +440,8 @@ fn create_fork_request<
 /// Clones the EVM and tx environments, runs a fork operation that may modify them, then writes
 /// them back. This is the common pattern for all fork-switching cheatcodes (rollFork, selectFork,
 /// createSelectFork).
-fn fork_env_op<CTX: FoundryContextExt, T: SolValue, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn fork_env_op<CTX: FoundryContextExt, T: SolValue>(
+    ecx: &mut CTX,
     f: impl FnOnce(
         &mut CTX::Db,
         &mut EvmEnv<CTX::Spec, CTX::Block>,
@@ -531,16 +449,16 @@ fn fork_env_op<CTX: FoundryContextExt, T: SolValue, N: Network>(
         &mut JournaledState,
     ) -> eyre::Result<T>,
 ) -> Result {
-    let mut evm_env = ccx.ecx.evm_clone();
-    let mut tx_env = ccx.ecx.tx_clone();
-    let (db, inner) = ccx.ecx.db_journal_inner_mut();
+    let mut evm_env = ecx.evm_clone();
+    let mut tx_env = ecx.tx_clone();
+    let (db, inner) = ecx.db_journal_inner_mut();
     let result = f(db, &mut evm_env, &mut tx_env, inner)?;
-    ccx.ecx.set_evm(evm_env);
-    ccx.ecx.set_tx(tx_env);
+    ecx.set_evm(evm_env);
+    ecx.set_tx(tx_env);
     Ok(result.abi_encode())
 }
 
-fn check_broadcast<SPEC, BLOCK, N: Network>(state: &Cheatcodes<SPEC, BLOCK, N>) -> Result<()> {
+fn check_broadcast<N: Network, F: FoundryEvmFactory>(state: &Cheatcodes<N, F>) -> Result<()> {
     if state.broadcast.is_none() {
         Ok(())
     } else {
@@ -548,9 +466,9 @@ fn check_broadcast<SPEC, BLOCK, N: Network>(state: &Cheatcodes<SPEC, BLOCK, N>) 
     }
 }
 
-fn transact<CTX: FoundryContextExt, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
-    executor: &mut dyn CheatcodesExecutor<CTX, N>,
+fn transact<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
+    executor: &mut dyn CheatcodesExecutor<N, F>,
     transaction: B256,
     fork_id: Option<U256>,
 ) -> Result {
@@ -562,12 +480,7 @@ fn transact<CTX: FoundryContextExt, N: Network>(
 // state of caller contract is not lost when fork changes).
 // Applies to create, select and roll forks actions.
 // https://github.com/foundry-rs/foundry/issues/8004
-fn persist_caller<
-    CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-    N: Network,
->(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
-) {
+fn persist_caller<N: Network, F: FoundryEvmFactory>(ccx: &mut CheatsCtxt<'_, '_, N, F>) {
     ccx.ecx.db_mut().add_persistent_account(ccx.caller);
 }
 

--- a/crates/cheatcodes/src/evm/mapping.rs
+++ b/crates/cheatcodes/src/evm/mapping.rs
@@ -3,9 +3,10 @@ use alloy_network::Network;
 use alloy_primitives::{Address, B256};
 use alloy_sol_types::SolValue;
 use foundry_common::mapping_slots::MappingSlots;
+use foundry_evm_core::evm::FoundryEvmFactory;
 
 impl Cheatcode for startMappingRecordingCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         state.mapping_slots.get_or_insert_default();
         Ok(Default::default())
@@ -13,7 +14,7 @@ impl Cheatcode for startMappingRecordingCall {
 }
 
 impl Cheatcode for stopMappingRecordingCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         state.mapping_slots = None;
         Ok(Default::default())
@@ -21,7 +22,7 @@ impl Cheatcode for stopMappingRecordingCall {
 }
 
 impl Cheatcode for getMappingLengthCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { target, mappingSlot } = self;
         let result = slot_child(state, target, mappingSlot).map(Vec::len).unwrap_or(0);
         Ok((result as u64).abi_encode())
@@ -29,7 +30,7 @@ impl Cheatcode for getMappingLengthCall {
 }
 
 impl Cheatcode for getMappingSlotAtCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { target, mappingSlot, idx } = self;
         let result = slot_child(state, target, mappingSlot)
             .and_then(|set| set.get(idx.saturating_to::<usize>()))
@@ -40,7 +41,7 @@ impl Cheatcode for getMappingSlotAtCall {
 }
 
 impl Cheatcode for getMappingKeyAndParentOfCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { target, elementSlot: slot } = self;
         let mut found = false;
         let mut key = &B256::ZERO;
@@ -60,15 +61,15 @@ impl Cheatcode for getMappingKeyAndParentOfCall {
     }
 }
 
-fn mapping_slot<'a, SPEC, BLOCK, N: Network>(
-    state: &'a Cheatcodes<SPEC, BLOCK, N>,
+fn mapping_slot<'a, N: Network, F: FoundryEvmFactory>(
+    state: &'a Cheatcodes<N, F>,
     target: &'a Address,
 ) -> Option<&'a MappingSlots> {
     state.mapping_slots.as_ref()?.get(target)
 }
 
-fn slot_child<'a, SPEC, BLOCK, N: Network>(
-    state: &'a Cheatcodes<SPEC, BLOCK, N>,
+fn slot_child<'a, N: Network, F: FoundryEvmFactory>(
+    state: &'a Cheatcodes<N, F>,
     target: &'a Address,
     slot: &'a B256,
 ) -> Option<&'a Vec<B256>> {

--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -1,9 +1,8 @@
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, Result, Vm::*};
 use alloy_network::Network;
 use alloy_primitives::{Address, Bytes, U256};
-use foundry_evm_core::backend::DatabaseError;
+use foundry_evm_core::evm::FoundryEvmFactory;
 use revm::{
-    Database,
     bytecode::Bytecode,
     context::{ContextTr, JournalTr},
     interpreter::InstructionResult,
@@ -46,7 +45,7 @@ impl Ord for MockCallDataContext {
 }
 
 impl Cheatcode for clearMockedCallsCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         state.mocked_calls = Default::default();
         Ok(Default::default())
@@ -54,9 +53,9 @@ impl Cheatcode for clearMockedCallsCall {
 }
 
 impl Cheatcode for mockCall_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { callee, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -67,9 +66,9 @@ impl Cheatcode for mockCall_0Call {
 }
 
 impl Cheatcode for mockCall_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { callee, msgValue, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -80,9 +79,9 @@ impl Cheatcode for mockCall_1Call {
 }
 
 impl Cheatcode for mockCall_2Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { callee, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -100,9 +99,9 @@ impl Cheatcode for mockCall_2Call {
 }
 
 impl Cheatcode for mockCall_3Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { callee, msgValue, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -120,9 +119,9 @@ impl Cheatcode for mockCall_3Call {
 }
 
 impl Cheatcode for mockCalls_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { callee, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -133,9 +132,9 @@ impl Cheatcode for mockCalls_0Call {
 }
 
 impl Cheatcode for mockCalls_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { callee, msgValue, data, returnData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -146,9 +145,9 @@ impl Cheatcode for mockCalls_1Call {
 }
 
 impl Cheatcode for mockCallRevert_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { callee, data, revertData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -159,9 +158,9 @@ impl Cheatcode for mockCallRevert_0Call {
 }
 
 impl Cheatcode for mockCallRevert_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { callee, msgValue, data, revertData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -172,9 +171,9 @@ impl Cheatcode for mockCallRevert_1Call {
 }
 
 impl Cheatcode for mockCallRevert_2Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { callee, data, revertData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -192,9 +191,9 @@ impl Cheatcode for mockCallRevert_2Call {
 }
 
 impl Cheatcode for mockCallRevert_3Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { callee, msgValue, data, revertData } = self;
         let _ = make_acc_non_empty(callee, ccx)?;
@@ -212,7 +211,7 @@ impl Cheatcode for mockCallRevert_3Call {
 }
 
 impl Cheatcode for mockFunctionCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { callee, target, data } = self;
         state.mocked_functions.entry(*callee).or_default().insert(data.clone(), *target);
 
@@ -220,8 +219,8 @@ impl Cheatcode for mockFunctionCall {
     }
 }
 
-fn mock_call<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn mock_call<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     callee: &Address,
     cdata: &Bytes,
     value: Option<&U256>,
@@ -231,8 +230,8 @@ fn mock_call<SPEC, BLOCK, N: Network>(
     mock_calls(state, callee, cdata, value, std::slice::from_ref(rdata), ret_type)
 }
 
-fn mock_calls<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn mock_calls<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     callee: &Address,
     cdata: &Bytes,
     value: Option<&U256>,
@@ -250,9 +249,9 @@ fn mock_calls<SPEC, BLOCK, N: Network>(
 
 // Etches a single byte onto the account if it is empty to circumvent the `extcodesize`
 // check Solidity might perform.
-fn make_acc_non_empty<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+fn make_acc_non_empty<N: Network, F: FoundryEvmFactory>(
     callee: &Address,
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
 ) -> Result {
     let empty_bytecode = {
         let acc = ccx.ecx.journal_mut().load_account(*callee)?;

--- a/crates/cheatcodes/src/evm/prank.rs
+++ b/crates/cheatcodes/src/evm/prank.rs
@@ -1,12 +1,8 @@
 use crate::{Cheatcode, CheatsCtxt, Result, Vm::*, evm::journaled_account};
 use alloy_network::Network;
 use alloy_primitives::Address;
-use foundry_evm_core::backend::DatabaseError;
-use revm::{
-    Database,
-    context::{ContextTr, JournalTr, Transaction},
-    inspector::JournalExt,
-};
+use foundry_evm_core::evm::FoundryEvmFactory;
+use revm::context::{ContextTr, JournalTr, Transaction};
 
 /// Prank information.
 #[derive(Clone, Copy, Debug, Default)]
@@ -60,12 +56,9 @@ impl Prank {
 }
 
 impl Cheatcode for prank_0Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { msgSender } = self;
         prank(ccx, msgSender, None, true, false)
@@ -73,12 +66,9 @@ impl Cheatcode for prank_0Call {
 }
 
 impl Cheatcode for startPrank_0Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { msgSender } = self;
         prank(ccx, msgSender, None, false, false)
@@ -86,12 +76,9 @@ impl Cheatcode for startPrank_0Call {
 }
 
 impl Cheatcode for prank_1Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { msgSender, txOrigin } = self;
         prank(ccx, msgSender, Some(txOrigin), true, false)
@@ -99,12 +86,9 @@ impl Cheatcode for prank_1Call {
 }
 
 impl Cheatcode for startPrank_1Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { msgSender, txOrigin } = self;
         prank(ccx, msgSender, Some(txOrigin), false, false)
@@ -112,12 +96,9 @@ impl Cheatcode for startPrank_1Call {
 }
 
 impl Cheatcode for prank_2Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { msgSender, delegateCall } = self;
         prank(ccx, msgSender, None, true, *delegateCall)
@@ -125,12 +106,9 @@ impl Cheatcode for prank_2Call {
 }
 
 impl Cheatcode for startPrank_2Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { msgSender, delegateCall } = self;
         prank(ccx, msgSender, None, false, *delegateCall)
@@ -138,12 +116,9 @@ impl Cheatcode for startPrank_2Call {
 }
 
 impl Cheatcode for prank_3Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { msgSender, txOrigin, delegateCall } = self;
         prank(ccx, msgSender, Some(txOrigin), true, *delegateCall)
@@ -151,12 +126,9 @@ impl Cheatcode for prank_3Call {
 }
 
 impl Cheatcode for startPrank_3Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { msgSender, txOrigin, delegateCall } = self;
         prank(ccx, msgSender, Some(txOrigin), false, *delegateCall)
@@ -164,12 +136,9 @@ impl Cheatcode for startPrank_3Call {
 }
 
 impl Cheatcode for stopPrankCall {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         ccx.state.pranks.remove(&ccx.ecx.journal().depth());
@@ -177,8 +146,8 @@ impl Cheatcode for stopPrankCall {
     }
 }
 
-fn prank<CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn prank<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     new_caller: &Address,
     new_origin: Option<&Address>,
     single_call: bool,

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -13,6 +13,7 @@ use dialoguer::{Input, Password};
 use forge_script_sequence::{BroadcastReader, TransactionWithMetadata};
 use foundry_common::fs;
 use foundry_config::fs_permissions::FsAccessKind;
+use foundry_evm_core::evm::FoundryEvmFactory;
 use revm::{
     context::{Cfg, ContextTr, CreateScheme, JournalTr},
     interpreter::CreateInputs,
@@ -30,7 +31,7 @@ use std::{
 use walkdir::WalkDir;
 
 impl Cheatcode for existsCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
         Ok(path.exists().abi_encode())
@@ -38,7 +39,7 @@ impl Cheatcode for existsCall {
 }
 
 impl Cheatcode for fsMetadataCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
 
@@ -64,7 +65,7 @@ impl Cheatcode for fsMetadataCall {
 }
 
 impl Cheatcode for isDirCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
         Ok(path.is_dir().abi_encode())
@@ -72,7 +73,7 @@ impl Cheatcode for isDirCall {
 }
 
 impl Cheatcode for isFileCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
         Ok(path.is_file().abi_encode())
@@ -80,14 +81,14 @@ impl Cheatcode for isFileCall {
 }
 
 impl Cheatcode for projectRootCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         Ok(state.config.root.display().to_string().abi_encode())
     }
 }
 
 impl Cheatcode for currentFilePathCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         let artifact = state
             .config
@@ -100,7 +101,7 @@ impl Cheatcode for currentFilePathCall {
 }
 
 impl Cheatcode for unixTimeCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         let difference = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -110,7 +111,7 @@ impl Cheatcode for unixTimeCall {
 }
 
 impl Cheatcode for closeFileCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
 
@@ -121,7 +122,7 @@ impl Cheatcode for closeFileCall {
 }
 
 impl Cheatcode for copyFileCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { from, to } = self;
         let from = state.config.ensure_path_allowed(from, FsAccessKind::Read)?;
         let to = state.config.ensure_path_allowed(to, FsAccessKind::Write)?;
@@ -133,7 +134,7 @@ impl Cheatcode for copyFileCall {
 }
 
 impl Cheatcode for createDirCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path, recursive } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
         if *recursive { fs::create_dir_all(path) } else { fs::create_dir(path) }?;
@@ -142,28 +143,28 @@ impl Cheatcode for createDirCall {
 }
 
 impl Cheatcode for readDir_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path } = self;
         read_dir(state, path.as_ref(), 1, false)
     }
 }
 
 impl Cheatcode for readDir_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path, maxDepth } = self;
         read_dir(state, path.as_ref(), *maxDepth, false)
     }
 }
 
 impl Cheatcode for readDir_2Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path, maxDepth, followLinks } = self;
         read_dir(state, path.as_ref(), *maxDepth, *followLinks)
     }
 }
 
 impl Cheatcode for readFileCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
         Ok(fs::locked_read_to_string(path)?.abi_encode())
@@ -171,7 +172,7 @@ impl Cheatcode for readFileCall {
 }
 
 impl Cheatcode for readFileBinaryCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
         Ok(fs::locked_read(path)?.abi_encode())
@@ -179,7 +180,7 @@ impl Cheatcode for readFileBinaryCall {
 }
 
 impl Cheatcode for readLineCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
 
@@ -205,7 +206,7 @@ impl Cheatcode for readLineCall {
 }
 
 impl Cheatcode for readLinkCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { linkPath: path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
         let target = fs::read_link(path)?;
@@ -214,7 +215,7 @@ impl Cheatcode for readLinkCall {
 }
 
 impl Cheatcode for removeDirCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path, recursive } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
         if *recursive { fs::remove_dir_all(path) } else { fs::remove_dir(path) }?;
@@ -223,7 +224,7 @@ impl Cheatcode for removeDirCall {
 }
 
 impl Cheatcode for removeFileCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
         state.config.ensure_not_foundry_toml(&path)?;
@@ -240,21 +241,21 @@ impl Cheatcode for removeFileCall {
 }
 
 impl Cheatcode for writeFileCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path, data } = self;
         write_file(state, path.as_ref(), data.as_bytes())
     }
 }
 
 impl Cheatcode for writeFileBinaryCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path, data } = self;
         write_file(state, path.as_ref(), data)
     }
 }
 
 impl Cheatcode for writeLineCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { path, data: line } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
         state.config.ensure_not_foundry_toml(&path)?;
@@ -268,7 +269,7 @@ impl Cheatcode for writeLineCall {
 }
 
 impl Cheatcode for getArtifactPathByCodeCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { code } = self;
         let (artifact_id, _) = state
             .config
@@ -282,7 +283,7 @@ impl Cheatcode for getArtifactPathByCodeCall {
 }
 
 impl Cheatcode for getArtifactPathByDeployedCodeCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { deployedCode } = self;
         let (artifact_id, _) = state
             .config
@@ -296,24 +297,24 @@ impl Cheatcode for getArtifactPathByDeployedCodeCall {
 }
 
 impl Cheatcode for getCodeCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { artifactPath: path } = self;
         Ok(get_artifact_code(state, path, false)?.abi_encode())
     }
 }
 
 impl Cheatcode for getDeployedCodeCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { artifactPath: path } = self;
         Ok(get_artifact_code(state, path, true)?.abi_encode())
     }
 }
 
 impl Cheatcode for deployCode_0Call {
-    fn apply_full<CTX: ContextTr, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Self { artifactPath: path } = self;
         deploy_code(ccx, executor, path, None, None, None)
@@ -321,10 +322,10 @@ impl Cheatcode for deployCode_0Call {
 }
 
 impl Cheatcode for deployCode_1Call {
-    fn apply_full<CTX: ContextTr, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Self { artifactPath: path, constructorArgs: args } = self;
         deploy_code(ccx, executor, path, Some(args), None, None)
@@ -332,10 +333,10 @@ impl Cheatcode for deployCode_1Call {
 }
 
 impl Cheatcode for deployCode_2Call {
-    fn apply_full<CTX: ContextTr, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Self { artifactPath: path, value } = self;
         deploy_code(ccx, executor, path, None, Some(*value), None)
@@ -343,10 +344,10 @@ impl Cheatcode for deployCode_2Call {
 }
 
 impl Cheatcode for deployCode_3Call {
-    fn apply_full<CTX: ContextTr, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Self { artifactPath: path, constructorArgs: args, value } = self;
         deploy_code(ccx, executor, path, Some(args), Some(*value), None)
@@ -354,10 +355,10 @@ impl Cheatcode for deployCode_3Call {
 }
 
 impl Cheatcode for deployCode_4Call {
-    fn apply_full<CTX: ContextTr, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Self { artifactPath: path, salt } = self;
         deploy_code(ccx, executor, path, None, None, Some((*salt).into()))
@@ -365,10 +366,10 @@ impl Cheatcode for deployCode_4Call {
 }
 
 impl Cheatcode for deployCode_5Call {
-    fn apply_full<CTX: ContextTr, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Self { artifactPath: path, constructorArgs: args, salt } = self;
         deploy_code(ccx, executor, path, Some(args), None, Some((*salt).into()))
@@ -376,10 +377,10 @@ impl Cheatcode for deployCode_5Call {
 }
 
 impl Cheatcode for deployCode_6Call {
-    fn apply_full<CTX: ContextTr, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Self { artifactPath: path, value, salt } = self;
         deploy_code(ccx, executor, path, None, Some(*value), Some((*salt).into()))
@@ -387,10 +388,10 @@ impl Cheatcode for deployCode_6Call {
 }
 
 impl Cheatcode for deployCode_7Call {
-    fn apply_full<CTX: ContextTr, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Self { artifactPath: path, constructorArgs: args, value, salt } = self;
         deploy_code(ccx, executor, path, Some(args), Some(*value), Some((*salt).into()))
@@ -399,9 +400,9 @@ impl Cheatcode for deployCode_7Call {
 
 /// Helper function to deploy contract from artifact code.
 /// Uses CREATE2 scheme if salt specified.
-fn deploy_code<CTX: ContextTr, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
-    executor: &mut dyn CheatcodesExecutor<CTX, N>,
+fn deploy_code<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
+    executor: &mut dyn CheatcodesExecutor<N, F>,
     path: &str,
     constructor_args: Option<&Bytes>,
     value: Option<U256>,
@@ -460,8 +461,8 @@ fn deploy_code<CTX: ContextTr, N: Network>(
 /// This function is safe to use with contracts that have library dependencies.
 /// `alloy_json_abi::ContractObject` validates bytecode during JSON parsing and will
 /// reject artifacts with unlinked library placeholders.
-fn get_artifact_code<SPEC, BLOCK, N: Network>(
-    state: &Cheatcodes<SPEC, BLOCK, N>,
+fn get_artifact_code<N: Network, F: FoundryEvmFactory>(
+    state: &Cheatcodes<N, F>,
     path: &str,
     deployed: bool,
 ) -> Result<Bytes> {
@@ -602,7 +603,7 @@ fn get_artifact_code<SPEC, BLOCK, N: Network>(
 }
 
 impl Cheatcode for ffiCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { commandInput: input } = self;
 
         let output = ffi(state, input)?;
@@ -630,49 +631,49 @@ impl Cheatcode for ffiCall {
 }
 
 impl Cheatcode for tryFfiCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { commandInput: input } = self;
         ffi(state, input).map(|res| res.abi_encode())
     }
 }
 
 impl Cheatcode for promptCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { promptText: text } = self;
         prompt(state, text, prompt_input).map(|res| res.abi_encode())
     }
 }
 
 impl Cheatcode for promptSecretCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { promptText: text } = self;
         prompt(state, text, prompt_password).map(|res| res.abi_encode())
     }
 }
 
 impl Cheatcode for promptSecretUintCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { promptText: text } = self;
         parse(&prompt(state, text, prompt_password)?, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for promptAddressCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { promptText: text } = self;
         parse(&prompt(state, text, prompt_input)?, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for promptUintCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { promptText: text } = self;
         parse(&prompt(state, text, prompt_input)?, &DynSolType::Uint(256))
     }
 }
 
-pub(super) fn write_file<SPEC, BLOCK, N: Network>(
-    state: &Cheatcodes<SPEC, BLOCK, N>,
+pub(super) fn write_file<N: Network, F: FoundryEvmFactory>(
+    state: &Cheatcodes<N, F>,
     path: &Path,
     contents: &[u8],
 ) -> Result {
@@ -687,8 +688,8 @@ pub(super) fn write_file<SPEC, BLOCK, N: Network>(
     Ok(Default::default())
 }
 
-fn read_dir<SPEC, BLOCK, N: Network>(
-    state: &Cheatcodes<SPEC, BLOCK, N>,
+fn read_dir<N: Network, F: FoundryEvmFactory>(
+    state: &Cheatcodes<N, F>,
     path: &Path,
     max_depth: u64,
     follow_links: bool,
@@ -722,8 +723,8 @@ fn read_dir<SPEC, BLOCK, N: Network>(
     Ok(paths.abi_encode())
 }
 
-fn ffi<SPEC, BLOCK, N: Network>(
-    state: &Cheatcodes<SPEC, BLOCK, N>,
+fn ffi<N: Network, F: FoundryEvmFactory>(
+    state: &Cheatcodes<N, F>,
     input: &[String],
 ) -> Result<FfiResult> {
     ensure!(
@@ -765,8 +766,8 @@ fn prompt_password(prompt_text: &str) -> Result<String, dialoguer::Error> {
     Password::new().with_prompt(prompt_text).interact()
 }
 
-fn prompt<SPEC, BLOCK, N: Network>(
-    state: &Cheatcodes<SPEC, BLOCK, N>,
+fn prompt<N: Network, F: FoundryEvmFactory>(
+    state: &Cheatcodes<N, F>,
     prompt_text: &str,
     input: fn(&str) -> Result<String, dialoguer::Error>,
 ) -> Result<String> {
@@ -791,7 +792,7 @@ fn prompt<SPEC, BLOCK, N: Network>(
 }
 
 impl Cheatcode for getBroadcastCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { contractName, chainId, txType } = self;
 
         let latest_broadcast = latest_broadcast(
@@ -806,7 +807,7 @@ impl Cheatcode for getBroadcastCall {
 }
 
 impl Cheatcode for getBroadcasts_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { contractName, chainId, txType } = self;
 
         let reader = BroadcastReader::new(contractName.clone(), *chainId, &state.config.broadcast)?
@@ -827,7 +828,7 @@ impl Cheatcode for getBroadcasts_0Call {
 }
 
 impl Cheatcode for getBroadcasts_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { contractName, chainId } = self;
 
         let reader = BroadcastReader::new(contractName.clone(), *chainId, &state.config.broadcast)?;
@@ -847,9 +848,9 @@ impl Cheatcode for getBroadcasts_1Call {
 }
 
 impl Cheatcode for getDeployment_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { contractName } = self;
         let chain_id = ccx.ecx.cfg().chain_id();
@@ -866,7 +867,7 @@ impl Cheatcode for getDeployment_0Call {
 }
 
 impl Cheatcode for getDeployment_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { contractName, chainId } = self;
 
         let latest_broadcast = latest_broadcast(
@@ -881,7 +882,7 @@ impl Cheatcode for getDeployment_1Call {
 }
 
 impl Cheatcode for getDeploymentsCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { contractName, chainId } = self;
 
         let reader = BroadcastReader::new(contractName.clone(), *chainId, &state.config.broadcast)?

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -21,7 +21,7 @@ use crate::{
     utils::IgnoredTraces,
 };
 use alloy_consensus::{BlobTransactionSidecarVariant, transaction::SignerRecoverable};
-use alloy_evm::FromRecoveredTx;
+use alloy_evm::{EthEvmFactory, FromRecoveredTx};
 use alloy_network::{Ethereum, Network, TransactionBuilder};
 use alloy_primitives::{
     Address, B256, Bytes, Log, TxKind, U256, hex,
@@ -41,9 +41,7 @@ use foundry_evm_core::{
     backend::{DatabaseError, DatabaseExt, RevertDiagnostic},
     constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME},
     env::FoundryContextExt,
-    evm::{
-        IntoNestedEvm, NestedEvm, NestedEvmClosure, new_eth_evm_with_inspector, with_cloned_context,
-    },
+    evm::{FoundryEvmFactory, IntoNestedEvm, NestedEvm, NestedEvmClosure, with_cloned_context},
 };
 use foundry_evm_traces::{
     TracingInspector, TracingInspectorConfig, identifier::SignaturesIdentifier,
@@ -56,11 +54,9 @@ use rand::Rng;
 use revm::{
     Inspector,
     bytecode::opcode as op,
-    context::{
-        BlockEnv, Cfg, ContextTr, JournalTr, Transaction, TransactionType, TxEnv, result::EVMError,
-    },
+    context::{Cfg, ContextTr, Host, JournalTr, Transaction, TransactionType, result::EVMError},
     context_interface::{CreateScheme, transaction::SignedAuthorization},
-    handler::{EvmTr, FrameResult},
+    handler::FrameResult,
     inspector::JournalExt,
     interpreter::{
         CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, FrameInput, Gas,
@@ -87,21 +83,21 @@ pub mod analysis;
 pub use analysis::CheatcodeAnalysis;
 
 /// Helper trait for running nested EVM operations from inside cheatcode implementations.
-pub trait CheatcodesExecutor<CTX: ContextTr, N: Network> {
+pub trait CheatcodesExecutor<N: Network, F: FoundryEvmFactory> {
     /// Runs a closure with a nested EVM built from the current context.
     /// The inspector is assembled internally — never exposed to the caller.
     fn with_nested_evm(
         &mut self,
-        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
-        ecx: &mut CTX,
-        f: NestedEvmClosure<'_, <CTX::Cfg as Cfg>::Spec, CTX::Block, CTX::Tx>,
+        cheats: &mut Cheatcodes<N, F>,
+        ecx: &mut F::FoundryContext<'_>,
+        f: NestedEvmClosure<'_, F::Spec, F::BlockEnv, F::Tx>,
     ) -> Result<(), EVMError<DatabaseError>>;
 
     /// Replays a historical transaction on the database. Inspector is assembled internally.
     fn transact_on_db(
         &mut self,
-        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
-        ecx: &mut CTX,
+        cheats: &mut Cheatcodes<N, F>,
+        ecx: &mut F::FoundryContext<'_>,
         fork_id: Option<U256>,
         transaction: B256,
     ) -> eyre::Result<()>;
@@ -109,9 +105,9 @@ pub trait CheatcodesExecutor<CTX: ContextTr, N: Network> {
     /// Executes a `TransactionRequest` on the database. Inspector is assembled internally.
     fn transact_from_tx_on_db(
         &mut self,
-        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
-        ecx: &mut CTX,
-        tx: CTX::Tx,
+        cheats: &mut Cheatcodes<N, F>,
+        ecx: &mut F::FoundryContext<'_>,
+        tx: F::Tx,
     ) -> eyre::Result<()>;
 
     /// Runs a closure with a fresh nested EVM built from a raw database and environment.
@@ -121,11 +117,11 @@ pub trait CheatcodesExecutor<CTX: ContextTr, N: Network> {
     #[allow(clippy::type_complexity)]
     fn with_fresh_nested_evm(
         &mut self,
-        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
-        db: &mut CTX::Db,
-        evm_env: EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>,
-        f: NestedEvmClosure<'_, <CTX::Cfg as Cfg>::Spec, CTX::Block, CTX::Tx>,
-    ) -> Result<EvmEnv<<CTX::Cfg as Cfg>::Spec, CTX::Block>, EVMError<DatabaseError>>;
+        cheats: &mut Cheatcodes<N, F>,
+        db: &mut <F::FoundryContext<'_> as ContextTr>::Db,
+        evm_env: EvmEnv<F::Spec, F::BlockEnv>,
+        f: NestedEvmClosure<'_, F::Spec, F::BlockEnv, F::Tx>,
+    ) -> Result<EvmEnv<F::Spec, F::BlockEnv>, EVMError<DatabaseError>>;
 
     /// Simulates `console.log` invocation.
     fn console_log(&mut self, msg: &str);
@@ -142,10 +138,10 @@ pub trait CheatcodesExecutor<CTX: ContextTr, N: Network> {
 }
 
 /// Builds a sub-EVM from the current context and executes the given CREATE frame.
-pub(crate) fn exec_create<CTX: ContextTr, N: Network>(
-    executor: &mut dyn CheatcodesExecutor<CTX, N>,
+pub(crate) fn exec_create<N: Network, F: FoundryEvmFactory>(
+    executor: &mut dyn CheatcodesExecutor<N, F>,
     inputs: CreateInputs,
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
 ) -> std::result::Result<CreateOutcome, EVMError<DatabaseError>> {
     let mut inputs = Some(inputs);
     let mut outcome = None;
@@ -174,69 +170,67 @@ pub(crate) fn exec_create<CTX: ContextTr, N: Network>(
 struct TransparentCheatcodesExecutor;
 
 impl<
-    CTX: FoundryContextExt<
-            Spec = SpecId,
-            Block = BlockEnv,
-            Tx = TxEnv,
-            Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
-        >,
     N: Network<
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-> CheatcodesExecutor<CTX, N> for TransparentCheatcodesExecutor
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
+> CheatcodesExecutor<N, F> for TransparentCheatcodesExecutor
 where
-    CTX::Tx: FromRecoveredTx<N::TxEnvelope>,
+    F::Tx: FromRecoveredTx<N::TxEnvelope>,
 {
     fn with_nested_evm(
         &mut self,
-        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
-        ecx: &mut CTX,
-        f: NestedEvmClosure<'_, <CTX::Cfg as Cfg>::Spec, CTX::Block, CTX::Tx>,
+        cheats: &mut Cheatcodes<N, F>,
+        ecx: &mut F::FoundryContext<'_>,
+        f: NestedEvmClosure<'_, F::Spec, F::BlockEnv, F::Tx>,
     ) -> Result<(), EVMError<DatabaseError>> {
         with_cloned_context(ecx, |db, evm_env, journal_inner| {
-            let mut evm = new_eth_evm_with_inspector(db, evm_env, cheats).into_nested_evm();
+            let mut evm = F::default()
+                .create_foundry_evm_with_inspector(db, evm_env, cheats)
+                .into_nested_evm();
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
-            let sub_inner = evm.journaled_state.inner.clone();
-            let sub_evm_env = evm.ctx_ref().evm_clone();
+            let sub_inner = evm.journal_inner_mut().clone();
+            let sub_evm_env = evm.to_evm_env();
             Ok((sub_evm_env, sub_inner))
         })
     }
 
     fn with_fresh_nested_evm(
         &mut self,
-        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
-        db: &mut CTX::Db,
-        evm_env: EvmEnv<CTX::Spec, CTX::Block>,
-        f: NestedEvmClosure<'_, <CTX::Cfg as Cfg>::Spec, CTX::Block, CTX::Tx>,
-    ) -> Result<EvmEnv<CTX::Spec, CTX::Block>, EVMError<DatabaseError>> {
-        let mut evm = new_eth_evm_with_inspector(db, evm_env, cheats).into_nested_evm();
+        cheats: &mut Cheatcodes<N, F>,
+        db: &mut <F::FoundryContext<'_> as ContextTr>::Db,
+        evm_env: EvmEnv<F::Spec, F::BlockEnv>,
+        f: NestedEvmClosure<'_, F::Spec, F::BlockEnv, F::Tx>,
+    ) -> Result<EvmEnv<F::Spec, F::BlockEnv>, EVMError<DatabaseError>> {
+        let mut evm =
+            F::default().create_foundry_evm_with_inspector(db, evm_env, cheats).into_nested_evm();
         f(&mut evm)?;
-        Ok(evm.ctx_ref().evm_clone())
+        Ok(evm.to_evm_env())
     }
 
     fn transact_on_db(
         &mut self,
-        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
-        ecx: &mut CTX,
+        cheats: &mut Cheatcodes<N, F>,
+        ecx: &mut F::FoundryContext<'_>,
         fork_id: Option<U256>,
         transaction: B256,
     ) -> eyre::Result<()> {
         let evm_env = ecx.evm_clone();
         let (db, inner) = ecx.db_journal_inner_mut();
-        db.transact(fork_id, transaction, evm_env, inner, cheats)
+        F::default().db_transact(db, fork_id, transaction, evm_env, inner, cheats)
     }
 
     fn transact_from_tx_on_db(
         &mut self,
-        cheats: &mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
-        ecx: &mut CTX,
-        tx: CTX::Tx,
+        cheats: &mut Cheatcodes<N, F>,
+        ecx: &mut F::FoundryContext<'_>,
+        tx: F::Tx,
     ) -> eyre::Result<()> {
         let evm_env = ecx.evm_clone();
         let (db, inner) = ecx.db_journal_inner_mut();
-        db.transact_from_tx(tx, evm_env, inner, cheats)
+        F::default().db_transact_from_tx(db, tx, evm_env, inner, cheats)
     }
 
     fn console_log(&mut self, _msg: &str) {}
@@ -451,7 +445,7 @@ pub type BroadcastableTransactions<N> = VecDeque<BroadcastableTransaction<N>>;
 ///   cheatcode address: by default, the caller, test contract and newly deployed contracts are
 ///   allowed to execute cheatcodes
 #[derive(Clone, Debug)]
-pub struct Cheatcodes<SPEC = SpecId, BLOCK = BlockEnv, N: Network = Ethereum> {
+pub struct Cheatcodes<N: Network = Ethereum, F: FoundryEvmFactory = EthEvmFactory> {
     /// Solar compiler instance, to grant syntactic and semantic analysis capabilities
     pub analysis: Option<CheatcodeAnalysis>,
 
@@ -459,7 +453,7 @@ pub struct Cheatcodes<SPEC = SpecId, BLOCK = BlockEnv, N: Network = Ethereum> {
     ///
     /// Used in the cheatcode handler to overwrite the block environment separately from the
     /// execution block environment.
-    pub block: Option<BLOCK>,
+    pub block: Option<F::BlockEnv>,
 
     /// Currently active EIP-7702 delegations that will be consumed when building the next
     /// transaction. Set by `vm.attachDelegation()` and consumed via `.take()` during
@@ -590,7 +584,7 @@ pub struct Cheatcodes<SPEC = SpecId, BLOCK = BlockEnv, N: Network = Ethereum> {
     /// Used to determine whether the broadcasted call has dynamic gas limit.
     pub dynamic_gas_limit: bool,
     // Custom execution evm version.
-    pub execution_evm_version: Option<SPEC>,
+    pub execution_evm_version: Option<F::Spec>,
 }
 
 // This is not derived because calling this in `fn new` with `..Default::default()` creates a second
@@ -602,7 +596,7 @@ impl Default for Cheatcodes {
     }
 }
 
-impl<SPEC, BLOCK, N: Network> Cheatcodes<SPEC, BLOCK, N> {
+impl<N: Network, F: FoundryEvmFactory> Cheatcodes<N, F> {
     /// Creates a new `Cheatcodes` with the given settings.
     pub fn new(config: Arc<CheatsConfig>) -> Self {
         Self {
@@ -685,21 +679,15 @@ impl<SPEC, BLOCK, N: Network> Cheatcodes<SPEC, BLOCK, N> {
     }
 
     /// Decodes the input data and applies the cheatcode.
-    fn apply_cheatcode<
-        CTX: FoundryContextExt<
-                Spec = SPEC,
-                Block = BLOCK,
-                Tx: FromRecoveredTx<N::TxEnvelope>,
-                Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
-            >,
-    >(
+    fn apply_cheatcode(
         &mut self,
-        ecx: &mut CTX,
+        ecx: &mut F::FoundryContext<'_>,
         call: &CallInputs,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result
     where
-        SPEC: FromEvmVersion + Into<SpecId> + Clone,
+        F::Spec: FromEvmVersion + Into<SpecId> + Clone,
+        F::Tx: FromRecoveredTx<N::TxEnvelope>,
         N: Network<TxEnvelope: Decodable + SignerRecoverable>,
     {
         // decode the cheatcode call
@@ -788,21 +776,15 @@ impl<SPEC, BLOCK, N: Network> Cheatcodes<SPEC, BLOCK, N> {
         }
     }
 
-    pub fn call_with_executor<
-        CTX: FoundryContextExt<
-                Spec = SPEC,
-                Block = BLOCK,
-                Tx: FromRecoveredTx<N::TxEnvelope>,
-                Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
-            >,
-    >(
+    pub fn call_with_executor(
         &mut self,
-        ecx: &mut CTX,
+        ecx: &mut F::FoundryContext<'_>,
         call: &mut CallInputs,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Option<CallOutcome>
     where
-        SPEC: FromEvmVersion + Into<SpecId> + Copy,
+        F::Spec: FromEvmVersion + Into<SpecId> + Copy,
+        F::Tx: FromRecoveredTx<N::TxEnvelope>,
         N::TxEnvelope: Decodable + SignerRecoverable,
         N::TransactionRequest: FoundryTransactionBuilder<N>,
     {
@@ -1220,21 +1202,20 @@ impl<SPEC, BLOCK, N: Network> Cheatcodes<SPEC, BLOCK, N> {
 }
 
 impl<
-    CTX: FoundryContextExt<
-            Spec = SpecId,
-            Block = BlockEnv,
-            Tx = TxEnv,
-            Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
-        >,
     N: Network<
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-> Inspector<CTX> for Cheatcodes<CTX::Spec, CTX::Block, N>
+    F: FoundryEvmFactory,
+> Inspector<F::FoundryContext<'_>> for Cheatcodes<N, F>
 where
-    CTX::Tx: FromRecoveredTx<N::TxEnvelope>,
+    F::Tx: FromRecoveredTx<N::TxEnvelope>,
 {
-    fn initialize_interp(&mut self, interpreter: &mut Interpreter, ecx: &mut CTX) {
+    fn initialize_interp(
+        &mut self,
+        interpreter: &mut Interpreter,
+        ecx: &mut F::FoundryContext<'_>,
+    ) {
         // When the first interpreter is initialized we've circumvented the balance and gas checks,
         // so we apply our actual block data with the correct fees and all.
         if let Some(block) = self.block.take() {
@@ -1255,7 +1236,7 @@ where
         }
     }
 
-    fn step(&mut self, interpreter: &mut Interpreter, ecx: &mut CTX) {
+    fn step(&mut self, interpreter: &mut Interpreter, ecx: &mut F::FoundryContext<'_>) {
         self.pc = interpreter.bytecode.pc();
 
         if self.broadcast.is_some() {
@@ -1301,7 +1282,7 @@ where
         }
     }
 
-    fn step_end(&mut self, interpreter: &mut Interpreter, ecx: &mut CTX) {
+    fn step_end(&mut self, interpreter: &mut Interpreter, ecx: &mut F::FoundryContext<'_>) {
         if self.gas_metering.paused {
             self.meter_gas_end(interpreter);
         }
@@ -1316,7 +1297,7 @@ where
         }
     }
 
-    fn log(&mut self, _ecx: &mut CTX, log: Log) {
+    fn log(&mut self, _ecx: &mut F::FoundryContext<'_>, log: Log) {
         if !self.expected_emits.is_empty()
             && let Some(err) = expect::handle_expect_emit(self, &log, None)
         {
@@ -1330,7 +1311,12 @@ where
         record_logs(&mut self.recorded_logs, &log);
     }
 
-    fn log_full(&mut self, interpreter: &mut Interpreter, _ecx: &mut CTX, log: Log) {
+    fn log_full(
+        &mut self,
+        interpreter: &mut Interpreter,
+        _ecx: &mut F::FoundryContext<'_>,
+        log: Log,
+    ) {
         if !self.expected_emits.is_empty() {
             expect::handle_expect_emit(self, &log, Some(interpreter));
         }
@@ -1339,11 +1325,20 @@ where
         record_logs(&mut self.recorded_logs, &log);
     }
 
-    fn call(&mut self, ecx: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
+    fn call(
+        &mut self,
+        ecx: &mut F::FoundryContext<'_>,
+        inputs: &mut CallInputs,
+    ) -> Option<CallOutcome> {
         Self::call_with_executor(self, ecx, inputs, &mut TransparentCheatcodesExecutor)
     }
 
-    fn call_end(&mut self, ecx: &mut CTX, call: &CallInputs, outcome: &mut CallOutcome) {
+    fn call_end(
+        &mut self,
+        ecx: &mut F::FoundryContext<'_>,
+        call: &CallInputs,
+        outcome: &mut CallOutcome,
+    ) {
         let cheatcode_call = call.target_address == CHEATCODE_ADDRESS
             || call.target_address == HARDHAT_CONSOLE_ADDRESS;
 
@@ -1745,7 +1740,11 @@ where
         }
     }
 
-    fn create(&mut self, ecx: &mut CTX, mut input: &mut CreateInputs) -> Option<CreateOutcome> {
+    fn create(
+        &mut self,
+        ecx: &mut F::FoundryContext<'_>,
+        mut input: &mut CreateInputs,
+    ) -> Option<CreateOutcome> {
         // Apply custom execution evm version.
         if let Some(spec_id) = self.execution_evm_version {
             ecx.cfg_mut().set_spec(spec_id);
@@ -1871,7 +1870,12 @@ where
         None
     }
 
-    fn create_end(&mut self, ecx: &mut CTX, call: &CreateInputs, outcome: &mut CreateOutcome) {
+    fn create_end(
+        &mut self,
+        ecx: &mut F::FoundryContext<'_>,
+        call: &CreateInputs,
+        outcome: &mut CreateOutcome,
+    ) {
         let call = Some(call);
         let curr_depth = ecx.journal().depth();
 
@@ -2007,7 +2011,7 @@ where
     }
 }
 
-impl<SPEC, BLOCK, N: Network> InspectorExt for Cheatcodes<SPEC, BLOCK, N> {
+impl<N: Network, F: FoundryEvmFactory> InspectorExt for Cheatcodes<N, F> {
     fn should_use_create2_factory(&mut self, depth: usize, inputs: &CreateInputs) -> bool {
         if let CreateScheme::Create2 { .. } = inputs.scheme() {
             let target_depth = if let Some(prank) = &self.get_prank(depth) {
@@ -2030,7 +2034,7 @@ impl<SPEC, BLOCK, N: Network> InspectorExt for Cheatcodes<SPEC, BLOCK, N> {
     }
 }
 
-impl<SPEC, BLOCK, N: Network> Cheatcodes<SPEC, BLOCK, N> {
+impl<N: Network, F: FoundryEvmFactory> Cheatcodes<N, F> {
     #[cold]
     fn meter_gas(&mut self, interpreter: &mut Interpreter) {
         if let Some(paused_gas) = self.gas_metering.paused_frames.last() {
@@ -2047,7 +2051,7 @@ impl<SPEC, BLOCK, N: Network> Cheatcodes<SPEC, BLOCK, N> {
     }
 
     #[cold]
-    fn meter_gas_record<CTX: ContextTr>(&mut self, interpreter: &mut Interpreter, ecx: &mut CTX) {
+    fn meter_gas_record(&mut self, interpreter: &mut Interpreter, ecx: &mut F::FoundryContext<'_>) {
         if interpreter.bytecode.action.as_ref().and_then(|i| i.instruction_result()).is_none() {
             self.gas_metering.gas_records.iter_mut().for_each(|record| {
                 let curr_depth = ecx.journal().depth();
@@ -2111,10 +2115,10 @@ impl<SPEC, BLOCK, N: Network> Cheatcodes<SPEC, BLOCK, N> {
     ///   cache) from mapped source address to the target address.
     /// - generates arbitrary value and saves it in target address storage.
     #[cold]
-    fn arbitrary_storage_end<CTX: ContextTr>(
+    fn arbitrary_storage_end(
         &mut self,
         interpreter: &mut Interpreter,
-        ecx: &mut CTX,
+        ecx: &mut F::FoundryContext<'_>,
     ) {
         let (key, target_address) = if interpreter.bytecode.opcode() == op::SLOAD {
             (try_or_return!(interpreter.stack.peek(0)), interpreter.input.target_address)
@@ -2167,12 +2171,10 @@ impl<SPEC, BLOCK, N: Network> Cheatcodes<SPEC, BLOCK, N> {
     }
 
     #[cold]
-    fn record_state_diffs<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-    >(
+    fn record_state_diffs(
         &mut self,
         interpreter: &mut Interpreter,
-        ecx: &mut CTX,
+        ecx: &mut F::FoundryContext<'_>,
     ) {
         let Some(account_accesses) = &mut self.recorded_account_diffs_stack else { return };
         match interpreter.bytecode.opcode() {
@@ -2642,16 +2644,12 @@ fn cheatcode_signature(cheat: &spec::Cheatcode<'static>) -> &'static str {
 
 /// Dispatches the cheatcode call to the appropriate function.
 fn apply_dispatch<
-    CTX: FoundryContextExt<
-            Spec: FromEvmVersion,
-            Tx: FromRecoveredTx<N::TxEnvelope>,
-            Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
-        >,
     N: Network<TxEnvelope: Decodable + SignerRecoverable>,
+    F: FoundryEvmFactory<Spec: FromEvmVersion, Tx: FromRecoveredTx<N::TxEnvelope>>,
 >(
     calls: &Vm::VmCalls,
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
-    executor: &mut dyn CheatcodesExecutor<CTX, N>,
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
+    executor: &mut dyn CheatcodesExecutor<N, F>,
 ) -> Result {
     // Extract metadata for logging/deprecation via CheatcodeDef.
     macro_rules! get_cheatcode {

--- a/crates/cheatcodes/src/inspector/utils.rs
+++ b/crates/cheatcodes/src/inspector/utils.rs
@@ -1,7 +1,7 @@
 use crate::inspector::Cheatcodes;
 use alloy_network::Network;
 use alloy_primitives::{Address, Bytes, U256};
-use foundry_evm_core::{FoundryContextExt, backend::DatabaseExt};
+use foundry_evm_core::evm::FoundryEvmFactory;
 use revm::{
     context::ContextTr,
     inspector::JournalExt,
@@ -16,18 +16,15 @@ pub(crate) trait CommonCreateInput {
     fn init_code(&self) -> Bytes;
     fn scheme(&self) -> Option<CreateScheme>;
     fn set_caller(&mut self, caller: Address);
-    fn log_debug<SPEC, BLOCK, N: Network>(
+    fn log_debug<N: Network, F: FoundryEvmFactory>(
         &self,
-        cheatcode: &mut Cheatcodes<SPEC, BLOCK, N>,
+        cheatcode: &mut Cheatcodes<N, F>,
         scheme: &CreateScheme,
     );
-    fn allow_cheatcodes<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn allow_cheatcodes<N: Network, F: FoundryEvmFactory>(
         &self,
-        cheatcodes: &mut Cheatcodes<CTX::Spec, CTX::Block, N>,
-        ecx: &mut CTX,
+        cheatcodes: &mut Cheatcodes<N, F>,
+        ecx: &mut F::FoundryContext<'_>,
     ) -> Address;
 }
 
@@ -50,9 +47,9 @@ impl CommonCreateInput for &mut CreateInputs {
     fn set_caller(&mut self, caller: Address) {
         CreateInputs::set_call(self, caller);
     }
-    fn log_debug<SPEC, BLOCK, N: Network>(
+    fn log_debug<N: Network, F: FoundryEvmFactory>(
         &self,
-        cheatcode: &mut Cheatcodes<SPEC, BLOCK, N>,
+        cheatcode: &mut Cheatcodes<N, F>,
         scheme: &CreateScheme,
     ) {
         let kind = match scheme {
@@ -62,13 +59,10 @@ impl CommonCreateInput for &mut CreateInputs {
         };
         debug!(target: "cheatcodes", tx=?cheatcode.broadcastable_transactions.back().unwrap(), "broadcastable {kind}");
     }
-    fn allow_cheatcodes<
-        CTX: FoundryContextExt<Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn allow_cheatcodes<N: Network, F: FoundryEvmFactory>(
         &self,
-        cheatcodes: &mut Cheatcodes<CTX::Spec, CTX::Block, N>,
-        ecx: &mut CTX,
+        cheatcodes: &mut Cheatcodes<N, F>,
+        ecx: &mut F::FoundryContext<'_>,
     ) -> Address {
         let caller = CreateInputs::caller(self);
         let old_nonce =

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -7,6 +7,7 @@ use alloy_primitives::{Address, B256, I256, U256, hex};
 use alloy_sol_types::SolValue;
 use foundry_common::{fmt::StructDefinitions, fs};
 use foundry_config::fs_permissions::FsAccessKind;
+use foundry_evm_core::evm::FoundryEvmFactory;
 use serde_json::{Map, Value};
 use std::{
     borrow::Cow,
@@ -14,133 +15,133 @@ use std::{
 };
 
 impl Cheatcode for keyExistsCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         check_json_key_exists(json, key)
     }
 }
 
 impl Cheatcode for keyExistsJsonCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         check_json_key_exists(json, key)
     }
 }
 
 impl Cheatcode for parseJson_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json } = self;
         parse_json(json, "$", state.struct_defs())
     }
 }
 
 impl Cheatcode for parseJson_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json(json, key, state.struct_defs())
     }
 }
 
 impl Cheatcode for parseJsonUintCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for parseJsonUintArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Uint(256))))
     }
 }
 
 impl Cheatcode for parseJsonIntCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for parseJsonIntArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Int(256))))
     }
 }
 
 impl Cheatcode for parseJsonBoolCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for parseJsonBoolArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Bool)))
     }
 }
 
 impl Cheatcode for parseJsonAddressCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for parseJsonAddressArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Address)))
     }
 }
 
 impl Cheatcode for parseJsonStringCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::String)
     }
 }
 
 impl Cheatcode for parseJsonStringArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::String)))
     }
 }
 
 impl Cheatcode for parseJsonBytesCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Bytes)
     }
 }
 
 impl Cheatcode for parseJsonBytesArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::Bytes)))
     }
 }
 
 impl Cheatcode for parseJsonBytes32Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for parseJsonBytes32ArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(DynSolType::FixedBytes(32))))
     }
 }
 
 impl Cheatcode for parseJsonType_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, typeDescription } = self;
         parse_json_coerce(json, "$", &resolve_type(typeDescription, state.struct_defs())?)
             .map(|v| v.abi_encode())
@@ -148,7 +149,7 @@ impl Cheatcode for parseJsonType_0Call {
 }
 
 impl Cheatcode for parseJsonType_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key, typeDescription } = self;
         parse_json_coerce(json, key, &resolve_type(typeDescription, state.struct_defs())?)
             .map(|v| v.abi_encode())
@@ -156,7 +157,7 @@ impl Cheatcode for parseJsonType_1Call {
 }
 
 impl Cheatcode for parseJsonTypeArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key, typeDescription } = self;
         let ty = resolve_type(typeDescription, state.struct_defs())?;
         parse_json_coerce(json, key, &DynSolType::Array(Box::new(ty))).map(|v| v.abi_encode())
@@ -164,14 +165,14 @@ impl Cheatcode for parseJsonTypeArrayCall {
 }
 
 impl Cheatcode for parseJsonKeysCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, key } = self;
         parse_json_keys(json, key)
     }
 }
 
 impl Cheatcode for serializeJsonCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, value } = self;
         *state.serialized_jsons.entry(objectKey.into()).or_default() = serde_json::from_str(value)?;
         Ok(value.abi_encode())
@@ -179,56 +180,56 @@ impl Cheatcode for serializeJsonCall {
 }
 
 impl Cheatcode for serializeBool_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, (*value).into())
     }
 }
 
 impl Cheatcode for serializeUint_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, (*value).into())
     }
 }
 
 impl Cheatcode for serializeInt_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, (*value).into())
     }
 }
 
 impl Cheatcode for serializeAddress_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, (*value).into())
     }
 }
 
 impl Cheatcode for serializeBytes32_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, DynSolValue::FixedBytes(*value, 32))
     }
 }
 
 impl Cheatcode for serializeString_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, value.clone().into())
     }
 }
 
 impl Cheatcode for serializeBytes_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         serialize_json(state, objectKey, valueKey, value.to_vec().into())
     }
 }
 
 impl Cheatcode for serializeBool_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -240,7 +241,7 @@ impl Cheatcode for serializeBool_1Call {
 }
 
 impl Cheatcode for serializeUint_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -252,7 +253,7 @@ impl Cheatcode for serializeUint_1Call {
 }
 
 impl Cheatcode for serializeInt_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -264,7 +265,7 @@ impl Cheatcode for serializeInt_1Call {
 }
 
 impl Cheatcode for serializeAddress_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -276,7 +277,7 @@ impl Cheatcode for serializeAddress_1Call {
 }
 
 impl Cheatcode for serializeBytes32_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -288,7 +289,7 @@ impl Cheatcode for serializeBytes32_1Call {
 }
 
 impl Cheatcode for serializeString_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -300,7 +301,7 @@ impl Cheatcode for serializeString_1Call {
 }
 
 impl Cheatcode for serializeBytes_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, values } = self;
         serialize_json(
             state,
@@ -314,7 +315,7 @@ impl Cheatcode for serializeBytes_1Call {
 }
 
 impl Cheatcode for serializeJsonType_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { typeDescription, value } = self;
         let ty = resolve_type(typeDescription, state.struct_defs())?;
         let value = ty.abi_decode(value)?;
@@ -324,7 +325,7 @@ impl Cheatcode for serializeJsonType_0Call {
 }
 
 impl Cheatcode for serializeJsonType_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, typeDescription, value } = self;
         let ty = resolve_type(typeDescription, state.struct_defs())?;
         let value = ty.abi_decode(value)?;
@@ -333,7 +334,7 @@ impl Cheatcode for serializeJsonType_1Call {
 }
 
 impl Cheatcode for serializeUintToHexCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { objectKey, valueKey, value } = self;
         let hex = format!("0x{value:x}");
         serialize_json(state, objectKey, valueKey, hex.into())
@@ -341,7 +342,7 @@ impl Cheatcode for serializeUintToHexCall {
 }
 
 impl Cheatcode for writeJson_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, path } = self;
         let json = serde_json::from_str(json).unwrap_or_else(|_| Value::String(json.to_owned()));
         let json_string = serde_json::to_string_pretty(&json)?;
@@ -350,7 +351,7 @@ impl Cheatcode for writeJson_0Call {
 }
 
 impl Cheatcode for writeJson_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json: value, path, valueKey } = self;
 
         // Read, parse, and update the JSON object.
@@ -653,8 +654,8 @@ fn _json_value_to_token(value: &Value, defs: &StructDefinitions) -> Result<DynSo
 /// object, so that the user can use that as a value to a new invocation of the same function with a
 /// new object key. This enables the user to reuse the same function to crate arbitrarily complex
 /// object structures (JSON).
-fn serialize_json<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn serialize_json<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     object_key: &str,
     value_key: &str,
     value: DynSolValue,

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -17,12 +17,12 @@ extern crate tracing;
 
 use alloy_consensus::transaction::SignerRecoverable;
 use alloy_evm::FromRecoveredTx;
-use alloy_network::{Ethereum, Network};
+use alloy_network::Network;
 use alloy_primitives::Address;
 use alloy_rlp::Decodable;
 use foundry_config::FromEvmVersion;
-use foundry_evm_core::{FoundryContextExt, backend::DatabaseExt};
-use revm::context::{Cfg, ContextTr, JournalTr};
+use foundry_evm_core::{backend::DatabaseExt, evm::FoundryEvmFactory};
+use revm::context::{ContextTr, JournalTr};
 
 pub use Vm::ForgeContext;
 pub use config::CheatsConfig;
@@ -73,7 +73,7 @@ pub(crate) trait Cheatcode: CheatcodeDef {
     /// Applies this cheatcode to the given state.
     ///
     /// Implement this function if you don't need access to the EVM data.
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let _ = state;
         unimplemented!("{}", Self::CHEATCODE.func.id)
     }
@@ -82,12 +82,9 @@ pub(crate) trait Cheatcode: CheatcodeDef {
     ///
     /// Implement this function if you need access to the EVM data.
     #[inline(always)]
-    fn apply_stateful<
-        CTX: FoundryContextExt<Spec: FromEvmVersion, Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory<Spec: FromEvmVersion>>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         self.apply(ccx.state)
     }
@@ -97,16 +94,12 @@ pub(crate) trait Cheatcode: CheatcodeDef {
     /// Implement this function if you need access to the executor.
     #[inline(always)]
     fn apply_full<
-        CTX: FoundryContextExt<
-                Spec: FromEvmVersion,
-                Tx: FromRecoveredTx<N::TxEnvelope>,
-                Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
-            >,
         N: Network<TxEnvelope: Decodable + SignerRecoverable>,
+        F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
     >(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let _ = executor;
         self.apply_stateful(ccx)
@@ -114,19 +107,19 @@ pub(crate) trait Cheatcode: CheatcodeDef {
 }
 
 /// The cheatcode context.
-pub struct CheatsCtxt<'a, CTX: ContextTr, N: Network = Ethereum> {
+pub struct CheatsCtxt<'a, 'db, N: Network, F: FoundryEvmFactory + 'db> {
     /// The cheatcodes inspector state.
-    pub(crate) state: &'a mut Cheatcodes<<CTX::Cfg as Cfg>::Spec, CTX::Block, N>,
+    pub(crate) state: &'a mut Cheatcodes<N, F>,
     /// The EVM context.
-    pub(crate) ecx: &'a mut CTX,
+    pub(crate) ecx: &'a mut F::FoundryContext<'db>,
     /// The original `msg.sender`.
     pub(crate) caller: Address,
     /// Gas limit of the current cheatcode call.
     pub(crate) gas_limit: u64,
 }
 
-impl<CTX: ContextTr, N: Network> std::ops::Deref for CheatsCtxt<'_, CTX, N> {
-    type Target = CTX;
+impl<'a, 'db, N: Network, F: FoundryEvmFactory> std::ops::Deref for CheatsCtxt<'a, 'db, N, F> {
+    type Target = F::FoundryContext<'db>;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
@@ -134,14 +127,14 @@ impl<CTX: ContextTr, N: Network> std::ops::Deref for CheatsCtxt<'_, CTX, N> {
     }
 }
 
-impl<CTX: ContextTr, N: Network> std::ops::DerefMut for CheatsCtxt<'_, CTX, N> {
+impl<'db, N: Network, F: FoundryEvmFactory> std::ops::DerefMut for CheatsCtxt<'_, 'db, N, F> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.ecx
     }
 }
 
-impl<CTX: ContextTr, N: Network> CheatsCtxt<'_, CTX, N> {
+impl<N: Network, F: FoundryEvmFactory> CheatsCtxt<'_, '_, N, F> {
     pub(crate) fn ensure_not_precompile(&self, address: &Address) -> Result<()> {
         if self.is_precompile(address) { Err(precompile_error(address)) } else { Ok(()) }
     }

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -8,26 +8,21 @@ use alloy_rpc_types::Authorization;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolValue;
-use foundry_evm_core::backend::DatabaseError;
+use foundry_evm_core::evm::FoundryEvmFactory;
 use foundry_wallets::{WalletSigner, wallet_multi::MultiWallet};
 use parking_lot::Mutex;
 use revm::{
-    Database,
     bytecode::Bytecode,
     context::{Cfg, ContextTr, JournalTr, Transaction},
     context_interface::transaction::SignedAuthorization,
-    inspector::JournalExt,
     primitives::{KECCAK_EMPTY, hardfork::SpecId},
 };
 use std::sync::Arc;
 
 impl Cheatcode for broadcast_0Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         broadcast(ccx, None, true)
@@ -35,12 +30,9 @@ impl Cheatcode for broadcast_0Call {
 }
 
 impl Cheatcode for broadcast_1Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { signer } = self;
         broadcast(ccx, Some(signer), true)
@@ -48,12 +40,9 @@ impl Cheatcode for broadcast_1Call {
 }
 
 impl Cheatcode for broadcast_2Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { privateKey } = self;
         broadcast_key(ccx, privateKey, true)
@@ -61,9 +50,9 @@ impl Cheatcode for broadcast_2Call {
 }
 
 impl Cheatcode for attachDelegation_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { signedDelegation } = self;
         attach_delegation(ccx, signedDelegation, false)
@@ -71,9 +60,9 @@ impl Cheatcode for attachDelegation_0Call {
 }
 
 impl Cheatcode for attachDelegation_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { signedDelegation, crossChain } = self;
         attach_delegation(ccx, signedDelegation, *crossChain)
@@ -81,9 +70,9 @@ impl Cheatcode for attachDelegation_1Call {
 }
 
 impl Cheatcode for signDelegation_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { implementation, privateKey } = *self;
         sign_delegation(ccx, privateKey, implementation, None, false, false)
@@ -91,9 +80,9 @@ impl Cheatcode for signDelegation_0Call {
 }
 
 impl Cheatcode for signDelegation_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { implementation, privateKey, nonce } = *self;
         sign_delegation(ccx, privateKey, implementation, Some(nonce), false, false)
@@ -101,9 +90,9 @@ impl Cheatcode for signDelegation_1Call {
 }
 
 impl Cheatcode for signDelegation_2Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { implementation, privateKey, crossChain } = *self;
         sign_delegation(ccx, privateKey, implementation, None, crossChain, false)
@@ -111,9 +100,9 @@ impl Cheatcode for signDelegation_2Call {
 }
 
 impl Cheatcode for signAndAttachDelegation_0Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { implementation, privateKey } = *self;
         sign_delegation(ccx, privateKey, implementation, None, false, true)
@@ -121,9 +110,9 @@ impl Cheatcode for signAndAttachDelegation_0Call {
 }
 
 impl Cheatcode for signAndAttachDelegation_1Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { implementation, privateKey, nonce } = *self;
         sign_delegation(ccx, privateKey, implementation, Some(nonce), false, true)
@@ -131,9 +120,9 @@ impl Cheatcode for signAndAttachDelegation_1Call {
 }
 
 impl Cheatcode for signAndAttachDelegation_2Call {
-    fn apply_stateful<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { implementation, privateKey, crossChain } = *self;
         sign_delegation(ccx, privateKey, implementation, None, crossChain, true)
@@ -141,8 +130,8 @@ impl Cheatcode for signAndAttachDelegation_2Call {
 }
 
 /// Helper function to attach an EIP-7702 delegation.
-fn attach_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn attach_delegation<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     delegation: &SignedDelegation,
     cross_chain: bool,
 ) -> Result {
@@ -165,8 +154,8 @@ fn attach_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Net
 
 /// Helper function to sign and attach (if needed) an EIP-7702 delegation.
 /// Uses the provided nonce, otherwise retrieves and increments the nonce of the EOA.
-fn sign_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn sign_delegation<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     private_key: Uint<256, 4>,
     implementation: Address,
     nonce: Option<u64>,
@@ -238,8 +227,8 @@ fn next_delegation_nonce(
     }
 }
 
-fn write_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn write_delegation<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     auth: SignedAuthorization,
 ) -> Result<()> {
     let authority = auth.recover_authority().map_err(|e| format!("{e}"))?;
@@ -275,18 +264,18 @@ fn write_delegation<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Netw
 }
 
 impl Cheatcode for attachBlobCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { blob } = self;
         ensure!(
-            ccx.ecx.cfg().spec().into() >= SpecId::CANCUN,
+            (*ccx.ecx.cfg().spec()).into() >= SpecId::CANCUN,
             "`attachBlob` is not supported before the Cancun hard fork; \
              see EIP-4844: https://eips.ethereum.org/EIPS/eip-4844"
         );
         let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(blob);
-        let sidecar_variant = if ccx.ecx.cfg().spec().into() < SpecId::OSAKA {
+        let sidecar_variant = if (*ccx.ecx.cfg().spec()).into() < SpecId::OSAKA {
             sidecar.build_4844().map_err(|e| format!("{e}"))?.into()
         } else {
             sidecar.build_7594().map_err(|e| format!("{e}"))?.into()
@@ -297,12 +286,9 @@ impl Cheatcode for attachBlobCall {
 }
 
 impl Cheatcode for startBroadcast_0Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         broadcast(ccx, None, false)
@@ -310,12 +296,9 @@ impl Cheatcode for startBroadcast_0Call {
 }
 
 impl Cheatcode for startBroadcast_1Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { signer } = self;
         broadcast(ccx, Some(signer), false)
@@ -323,12 +306,9 @@ impl Cheatcode for startBroadcast_1Call {
 }
 
 impl Cheatcode for startBroadcast_2Call {
-    fn apply_stateful<
-        CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-        N: Network,
-    >(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { privateKey } = self;
         broadcast_key(ccx, privateKey, false)
@@ -336,9 +316,9 @@ impl Cheatcode for startBroadcast_2Call {
 }
 
 impl Cheatcode for stopBroadcastCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         let Some(broadcast) = ccx.state.broadcast.take() else {
@@ -350,9 +330,9 @@ impl Cheatcode for stopBroadcastCall {
 }
 
 impl Cheatcode for getWalletsCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let wallets = ccx.state.wallets().signers().unwrap_or_default();
         Ok(wallets.abi_encode())
@@ -429,11 +409,8 @@ impl Wallets {
 }
 
 /// Sets up broadcasting from a script using `new_origin` as the sender.
-fn broadcast<
-    CTX: ContextTr<Db: Database<Error = DatabaseError>, Journal: JournalExt>,
-    N: Network,
->(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn broadcast<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     new_origin: Option<&Address>,
     single_call: bool,
 ) -> Result {
@@ -478,11 +455,8 @@ fn broadcast<
 /// Sets up broadcasting from a script with the sender derived from `private_key`.
 /// Adds this private key to `state`'s `wallets` vector to later be used for signing
 /// if broadcast is successful.
-fn broadcast_key<
-    CTX: ContextTr<Journal: JournalExt, Db: Database<Error = DatabaseError>>,
-    N: Network,
->(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
+fn broadcast_key<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
     private_key: &U256,
     single_call: bool,
 ) -> Result {

--- a/crates/cheatcodes/src/string.rs
+++ b/crates/cheatcodes/src/string.rs
@@ -5,10 +5,11 @@ use alloy_dyn_abi::{DynSolType, DynSolValue};
 use alloy_network::Network;
 use alloy_primitives::{U256, hex};
 use alloy_sol_types::SolValue;
+use foundry_evm_core::evm::FoundryEvmFactory;
 
 // address
 impl Cheatcode for toString_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
     }
@@ -16,7 +17,7 @@ impl Cheatcode for toString_0Call {
 
 // bytes
 impl Cheatcode for toString_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
     }
@@ -24,7 +25,7 @@ impl Cheatcode for toString_1Call {
 
 // bytes32
 impl Cheatcode for toString_2Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
     }
@@ -32,7 +33,7 @@ impl Cheatcode for toString_2Call {
 
 // bool
 impl Cheatcode for toString_3Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
     }
@@ -40,7 +41,7 @@ impl Cheatcode for toString_3Call {
 
 // uint256
 impl Cheatcode for toString_4Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
     }
@@ -48,84 +49,84 @@ impl Cheatcode for toString_4Call {
 
 // int256
 impl Cheatcode for toString_5Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { value } = self;
         Ok(value.to_string().abi_encode())
     }
 }
 
 impl Cheatcode for parseBytesCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Bytes)
     }
 }
 
 impl Cheatcode for parseAddressCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for parseUintCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for parseIntCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for parseBytes32Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for parseBoolCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { stringifiedValue } = self;
         parse(stringifiedValue, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for toLowercaseCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { input } = self;
         Ok(input.to_lowercase().abi_encode())
     }
 }
 
 impl Cheatcode for toUppercaseCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { input } = self;
         Ok(input.to_uppercase().abi_encode())
     }
 }
 
 impl Cheatcode for trimCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { input } = self;
         Ok(input.trim().abi_encode())
     }
 }
 
 impl Cheatcode for replaceCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { input, from, to } = self;
         Ok(input.replace(from, to).abi_encode())
     }
 }
 
 impl Cheatcode for splitCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { input, delimiter } = self;
         let parts: Vec<&str> = input.split(delimiter).collect();
         Ok(parts.abi_encode())
@@ -133,14 +134,14 @@ impl Cheatcode for splitCall {
 }
 
 impl Cheatcode for indexOfCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { input, key } = self;
         Ok(input.find(key).map(U256::from).unwrap_or(U256::MAX).abi_encode())
     }
 }
 
 impl Cheatcode for containsCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { subject, search } = self;
         Ok(subject.contains(search).abi_encode())
     }

--- a/crates/cheatcodes/src/test.rs
+++ b/crates/cheatcodes/src/test.rs
@@ -6,7 +6,7 @@ use alloy_network::Network;
 use alloy_primitives::{Address, U256};
 use alloy_sol_types::SolValue;
 use foundry_common::version::SEMVER_VERSION;
-use foundry_evm_core::constants::MAGIC_SKIP;
+use foundry_evm_core::{constants::MAGIC_SKIP, evm::FoundryEvmFactory};
 use revm::context::{ContextTr, JournalTr};
 use std::str::FromStr;
 
@@ -16,9 +16,9 @@ pub(crate) mod expect;
 pub(crate) mod revert_handlers;
 
 impl Cheatcode for breakpoint_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { char } = self;
         breakpoint(ccx.state, &ccx.caller, char, true)
@@ -26,9 +26,9 @@ impl Cheatcode for breakpoint_0Call {
 }
 
 impl Cheatcode for breakpoint_1Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { char, value } = self;
         breakpoint(ccx.state, &ccx.caller, char, *value)
@@ -36,14 +36,14 @@ impl Cheatcode for breakpoint_1Call {
 }
 
 impl Cheatcode for getFoundryVersionCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         Ok(SEMVER_VERSION.abi_encode())
     }
 }
 
 impl Cheatcode for rpcUrlCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { rpcAlias } = self;
         let url = state.config.rpc_endpoint(rpcAlias)?.url()?.abi_encode();
         Ok(url)
@@ -51,21 +51,21 @@ impl Cheatcode for rpcUrlCall {
 }
 
 impl Cheatcode for rpcUrlsCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         state.config.rpc_urls().map(|urls| urls.abi_encode())
     }
 }
 
 impl Cheatcode for rpcUrlStructsCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         state.config.rpc_urls().map(|urls| urls.abi_encode())
     }
 }
 
 impl Cheatcode for sleepCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { duration } = self;
         let sleep_duration = std::time::Duration::from_millis(duration.saturating_to());
         std::thread::sleep(sleep_duration);
@@ -74,9 +74,9 @@ impl Cheatcode for sleepCall {
 }
 
 impl Cheatcode for skip_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { skipTest } = *self;
         if skipTest {
@@ -91,9 +91,9 @@ impl Cheatcode for skip_0Call {
 }
 
 impl Cheatcode for skip_1Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { skipTest, reason } = self;
         if *skipTest {
@@ -108,14 +108,14 @@ impl Cheatcode for skip_1Call {
 }
 
 impl Cheatcode for getChain_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { chainAlias } = self;
         get_chain(state, chainAlias)
     }
 }
 
 impl Cheatcode for getChain_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { chainId } = self;
         // Convert the chainId to a string and use the existing get_chain function
         let chain_id_str = chainId.to_string();
@@ -124,8 +124,8 @@ impl Cheatcode for getChain_1Call {
 }
 
 /// Adds or removes the given breakpoint to the state.
-fn breakpoint<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn breakpoint<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     caller: &Address,
     s: &str,
     add: bool,
@@ -146,8 +146,8 @@ fn breakpoint<SPEC, BLOCK, N: Network>(
 }
 
 /// Gets chain information for the given alias.
-fn get_chain<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn get_chain<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     chain_alias: &str,
 ) -> Result {
     // Parse the chain alias - works for both chain names and IDs

--- a/crates/cheatcodes/src/test/assert.rs
+++ b/crates/cheatcodes/src/test/assert.rs
@@ -1,16 +1,13 @@
-use crate::{CheatcodesExecutor, CheatsCtxt, Result, Vm::*};
+use crate::{CheatcodesExecutor, CheatsCtxt, FoundryEvmFactory, Result, Vm::*};
 use alloy_network::Network;
 use alloy_primitives::{I256, U256, U512};
 use foundry_evm_core::{
     abi::console::{format_units_int, format_units_uint},
-    backend::{DatabaseError, GLOBAL_FAIL_SLOT},
+    backend::GLOBAL_FAIL_SLOT,
     constants::CHEATCODE_ADDRESS,
 };
 use itertools::Itertools;
-use revm::{
-    Database,
-    context::{ContextTr, JournalTr},
-};
+use revm::context::{ContextTr, JournalTr};
 use std::{borrow::Cow, fmt};
 
 const EQ_REL_DELTA_RESOLUTION: U256 = U256::from_limbs([18, 0, 0, 0]);
@@ -191,9 +188,9 @@ impl EqRelAssertionError<I256> {
 type ComparisonResult<'a, T> = Result<(), ComparisonAssertionError<'a, T>>;
 
 #[cold]
-fn handle_assertion_result<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network, E>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
-    executor: &mut dyn CheatcodesExecutor<CTX, N>,
+fn handle_assertion_result<N: Network, F: FoundryEvmFactory, E>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
+    executor: &mut dyn CheatcodesExecutor<N, F>,
     err: E,
     error_formatter: Option<&dyn Fn(&E) -> String>,
     error_msg: Option<&str>,
@@ -207,9 +204,9 @@ fn handle_assertion_result<CTX: ContextTr<Db: Database<Error = DatabaseError>>, 
     handle_assertion_result_mono(ccx, executor, msg)
 }
 
-fn handle_assertion_result_mono<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
-    ccx: &mut CheatsCtxt<'_, CTX, N>,
-    executor: &mut dyn CheatcodesExecutor<CTX, N>,
+fn handle_assertion_result_mono<N: Network, F: FoundryEvmFactory>(
+    ccx: &mut CheatsCtxt<'_, '_, N, F>,
+    executor: &mut dyn CheatcodesExecutor<N, F>,
     msg: Cow<'_, str>,
 ) -> Result {
     if ccx.state.config.assertions_revert {
@@ -250,10 +247,10 @@ macro_rules! impl_assertions {
 
     (@impl $no_error:ident, $with_error:ident, ($($arg:ident),*), $body:expr, $error_formatter:expr) => {
         impl crate::Cheatcode for $no_error {
-            fn apply_full<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+            fn apply_full<N: Network, F: FoundryEvmFactory>(
                 &self,
-                ccx: &mut CheatsCtxt<'_, CTX, N>,
-                executor: &mut dyn CheatcodesExecutor<CTX, N>,
+                ccx: &mut CheatsCtxt<'_, '_, N, F>,
+                executor: &mut dyn CheatcodesExecutor<N, F>,
             ) -> Result {
                 let Self { $($arg),* } = self;
                 match $body {
@@ -264,10 +261,10 @@ macro_rules! impl_assertions {
         }
 
         impl crate::Cheatcode for $with_error {
-            fn apply_full<CTX: ContextTr<Db: Database<Error = DatabaseError>>, N: Network>(
+            fn apply_full<N: Network, F: FoundryEvmFactory>(
                 &self,
-                ccx: &mut CheatsCtxt<'_, CTX, N>,
-                executor: &mut dyn CheatcodesExecutor<CTX, N>,
+                ccx: &mut CheatsCtxt<'_, '_, N, F>,
+                executor: &mut dyn CheatcodesExecutor<N, F>,
             ) -> Result {
                 let Self { $($arg,)* error } = self;
                 match $body {

--- a/crates/cheatcodes/src/test/assume.rs
+++ b/crates/cheatcodes/src/test/assume.rs
@@ -1,7 +1,7 @@
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, Error, Result};
 use alloy_network::Network;
 use alloy_primitives::Address;
-use foundry_evm_core::constants::MAGIC_ASSUME;
+use foundry_evm_core::{constants::MAGIC_ASSUME, evm::FoundryEvmFactory};
 use revm::context::{ContextTr, JournalTr};
 use spec::Vm::{
     PotentialRevert, assumeCall, assumeNoRevert_0Call, assumeNoRevert_1Call, assumeNoRevert_2Call,
@@ -46,25 +46,25 @@ impl AcceptableRevertParameters {
 }
 
 impl Cheatcode for assumeCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { condition } = self;
         if *condition { Ok(Default::default()) } else { Err(Error::from(MAGIC_ASSUME)) }
     }
 }
 
 impl Cheatcode for assumeNoRevert_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         assume_no_revert(ccx.state, ccx.ecx.journal().depth(), vec![])
     }
 }
 
 impl Cheatcode for assumeNoRevert_1Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { potentialRevert } = self;
         assume_no_revert(
@@ -76,9 +76,9 @@ impl Cheatcode for assumeNoRevert_1Call {
 }
 
 impl Cheatcode for assumeNoRevert_2Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { potentialReverts } = self;
         assume_no_revert(
@@ -89,8 +89,8 @@ impl Cheatcode for assumeNoRevert_2Call {
     }
 }
 
-fn assume_no_revert<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn assume_no_revert<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     depth: usize,
     parameters: Vec<AcceptableRevertParameters>,
 ) -> Result {

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -12,6 +12,7 @@ use alloy_primitives::{
     map::{AddressHashMap, HashMap, hash_map::Entry},
 };
 use foundry_common::{abi::get_indexed_event, fmt::format_token};
+use foundry_evm_core::evm::FoundryEvmFactory;
 use foundry_evm_traces::DecodedCallLog;
 use revm::{
     context::{ContextTr, JournalTr},
@@ -164,28 +165,28 @@ impl CreateScheme {
 }
 
 impl Cheatcode for expectCall_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { callee, data } = self;
         expect_call(state, callee, data, None, None, None, 1, ExpectedCallType::NonCount)
     }
 }
 
 impl Cheatcode for expectCall_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { callee, data, count } = self;
         expect_call(state, callee, data, None, None, None, *count, ExpectedCallType::Count)
     }
 }
 
 impl Cheatcode for expectCall_2Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { callee, msgValue, data } = self;
         expect_call(state, callee, data, Some(msgValue), None, None, 1, ExpectedCallType::NonCount)
     }
 }
 
 impl Cheatcode for expectCall_3Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { callee, msgValue, data, count } = self;
         expect_call(
             state,
@@ -201,7 +202,7 @@ impl Cheatcode for expectCall_3Call {
 }
 
 impl Cheatcode for expectCall_4Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { callee, msgValue, gas, data } = self;
         expect_call(
             state,
@@ -217,7 +218,7 @@ impl Cheatcode for expectCall_4Call {
 }
 
 impl Cheatcode for expectCall_5Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { callee, msgValue, gas, data, count } = self;
         expect_call(
             state,
@@ -233,7 +234,7 @@ impl Cheatcode for expectCall_5Call {
 }
 
 impl Cheatcode for expectCallMinGas_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { callee, msgValue, minGas, data } = self;
         expect_call(
             state,
@@ -249,7 +250,7 @@ impl Cheatcode for expectCallMinGas_0Call {
 }
 
 impl Cheatcode for expectCallMinGas_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { callee, msgValue, minGas, data, count } = self;
         expect_call(
             state,
@@ -265,9 +266,9 @@ impl Cheatcode for expectCallMinGas_1Call {
 }
 
 impl Cheatcode for expectEmit_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData } = *self;
         expect_emit(
@@ -282,9 +283,9 @@ impl Cheatcode for expectEmit_0Call {
 }
 
 impl Cheatcode for expectEmit_1Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData, emitter } = *self;
         expect_emit(
@@ -299,9 +300,9 @@ impl Cheatcode for expectEmit_1Call {
 }
 
 impl Cheatcode for expectEmit_2Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], None, false, 1)
@@ -309,9 +310,9 @@ impl Cheatcode for expectEmit_2Call {
 }
 
 impl Cheatcode for expectEmit_3Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { emitter } = *self;
         expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], Some(emitter), false, 1)
@@ -319,9 +320,9 @@ impl Cheatcode for expectEmit_3Call {
 }
 
 impl Cheatcode for expectEmit_4Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData, count } = *self;
         expect_emit(
@@ -336,9 +337,9 @@ impl Cheatcode for expectEmit_4Call {
 }
 
 impl Cheatcode for expectEmit_5Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { checkTopic1, checkTopic2, checkTopic3, checkData, emitter, count } = *self;
         expect_emit(
@@ -353,9 +354,9 @@ impl Cheatcode for expectEmit_5Call {
 }
 
 impl Cheatcode for expectEmit_6Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { count } = *self;
         expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], None, false, count)
@@ -363,9 +364,9 @@ impl Cheatcode for expectEmit_6Call {
 }
 
 impl Cheatcode for expectEmit_7Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { emitter, count } = *self;
         expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], Some(emitter), false, count)
@@ -373,9 +374,9 @@ impl Cheatcode for expectEmit_7Call {
 }
 
 impl Cheatcode for expectEmitAnonymous_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { checkTopic0, checkTopic1, checkTopic2, checkTopic3, checkData } = *self;
         expect_emit(
@@ -390,9 +391,9 @@ impl Cheatcode for expectEmitAnonymous_0Call {
 }
 
 impl Cheatcode for expectEmitAnonymous_1Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { checkTopic0, checkTopic1, checkTopic2, checkTopic3, checkData, emitter } = *self;
         expect_emit(
@@ -407,9 +408,9 @@ impl Cheatcode for expectEmitAnonymous_1Call {
 }
 
 impl Cheatcode for expectEmitAnonymous_2Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], None, true, 1)
@@ -417,9 +418,9 @@ impl Cheatcode for expectEmitAnonymous_2Call {
 }
 
 impl Cheatcode for expectEmitAnonymous_3Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { emitter } = *self;
         expect_emit(ccx.state, ccx.ecx.journal().depth(), [true; 5], Some(emitter), true, 1)
@@ -427,23 +428,23 @@ impl Cheatcode for expectEmitAnonymous_3Call {
 }
 
 impl Cheatcode for expectCreateCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { bytecode, deployer } = self;
         expect_create(state, bytecode.clone(), *deployer, CreateScheme::Create)
     }
 }
 
 impl Cheatcode for expectCreate2Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { bytecode, deployer } = self;
         expect_create(state, bytecode.clone(), *deployer, CreateScheme::Create2)
     }
 }
 
 impl Cheatcode for expectRevert_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         expect_revert(ccx.state, None, ccx.ecx.journal().depth(), false, false, None, 1)
@@ -451,9 +452,9 @@ impl Cheatcode for expectRevert_0Call {
 }
 
 impl Cheatcode for expectRevert_1Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { revertData } = self;
         expect_revert(
@@ -469,9 +470,9 @@ impl Cheatcode for expectRevert_1Call {
 }
 
 impl Cheatcode for expectRevert_2Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { revertData } = self;
         expect_revert(ccx.state, Some(revertData), ccx.ecx.journal().depth(), false, false, None, 1)
@@ -479,9 +480,9 @@ impl Cheatcode for expectRevert_2Call {
 }
 
 impl Cheatcode for expectRevert_3Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { reverter } = self;
         expect_revert(ccx.state, None, ccx.ecx.journal().depth(), false, false, Some(*reverter), 1)
@@ -489,9 +490,9 @@ impl Cheatcode for expectRevert_3Call {
 }
 
 impl Cheatcode for expectRevert_4Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { revertData, reverter } = self;
         expect_revert(
@@ -507,9 +508,9 @@ impl Cheatcode for expectRevert_4Call {
 }
 
 impl Cheatcode for expectRevert_5Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { revertData, reverter } = self;
         expect_revert(
@@ -525,9 +526,9 @@ impl Cheatcode for expectRevert_5Call {
 }
 
 impl Cheatcode for expectRevert_6Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { count } = self;
         expect_revert(ccx.state, None, ccx.ecx.journal().depth(), false, false, None, *count)
@@ -535,9 +536,9 @@ impl Cheatcode for expectRevert_6Call {
 }
 
 impl Cheatcode for expectRevert_7Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { revertData, count } = self;
         expect_revert(
@@ -553,9 +554,9 @@ impl Cheatcode for expectRevert_7Call {
 }
 
 impl Cheatcode for expectRevert_8Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { revertData, count } = self;
         expect_revert(
@@ -571,9 +572,9 @@ impl Cheatcode for expectRevert_8Call {
 }
 
 impl Cheatcode for expectRevert_9Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { reverter, count } = self;
         expect_revert(
@@ -589,9 +590,9 @@ impl Cheatcode for expectRevert_9Call {
 }
 
 impl Cheatcode for expectRevert_10Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { revertData, reverter, count } = self;
         expect_revert(
@@ -607,9 +608,9 @@ impl Cheatcode for expectRevert_10Call {
 }
 
 impl Cheatcode for expectRevert_11Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { revertData, reverter, count } = self;
         expect_revert(
@@ -625,9 +626,9 @@ impl Cheatcode for expectRevert_11Call {
 }
 
 impl Cheatcode for expectPartialRevert_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { revertData } = self;
         expect_revert(
@@ -643,9 +644,9 @@ impl Cheatcode for expectPartialRevert_0Call {
 }
 
 impl Cheatcode for expectPartialRevert_1Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { revertData, reverter } = self;
         expect_revert(
@@ -661,18 +662,18 @@ impl Cheatcode for expectPartialRevert_1Call {
 }
 
 impl Cheatcode for _expectCheatcodeRevert_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         expect_revert(ccx.state, None, ccx.ecx.journal().depth(), true, false, None, 1)
     }
 }
 
 impl Cheatcode for _expectCheatcodeRevert_1Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { revertData } = self;
         expect_revert(
@@ -688,9 +689,9 @@ impl Cheatcode for _expectCheatcodeRevert_1Call {
 }
 
 impl Cheatcode for _expectCheatcodeRevert_2Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { revertData } = self;
         expect_revert(ccx.state, Some(revertData), ccx.ecx.journal().depth(), true, false, None, 1)
@@ -698,9 +699,9 @@ impl Cheatcode for _expectCheatcodeRevert_2Call {
 }
 
 impl Cheatcode for expectSafeMemoryCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { min, max } = *self;
         expect_safe_memory(ccx.state, min, max, ccx.ecx.journal().depth().try_into()?)
@@ -708,9 +709,9 @@ impl Cheatcode for expectSafeMemoryCall {
 }
 
 impl Cheatcode for stopExpectSafeMemoryCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self {} = self;
         ccx.state.allowed_mem_writes.remove(&ccx.ecx.journal().depth().try_into()?);
@@ -719,9 +720,9 @@ impl Cheatcode for stopExpectSafeMemoryCall {
 }
 
 impl Cheatcode for expectSafeMemoryCallCall {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { min, max } = *self;
         expect_safe_memory(ccx.state, min, max, (ccx.ecx.journal().depth() + 1).try_into()?)
@@ -759,8 +760,8 @@ impl RevertParameters for ExpectedRevert {
 ///   address(0xc4f3) and selector `0xd34db33f` to be made at least once. If the amount of calls is
 ///   0, the test will fail. If the call is made more than once, the test will pass.
 #[expect(clippy::too_many_arguments)] // It is what it is
-fn expect_call<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn expect_call<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     target: &Address,
     calldata: &Bytes,
     value: Option<&U256>,
@@ -826,8 +827,8 @@ fn expect_call<SPEC, BLOCK, N: Network>(
     Ok(Default::default())
 }
 
-fn expect_emit<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn expect_emit<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     depth: usize,
     checks: [bool; 5],
     address: Option<Address>,
@@ -856,8 +857,8 @@ fn expect_emit<SPEC, BLOCK, N: Network>(
     Ok(Default::default())
 }
 
-pub(crate) fn handle_expect_emit<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+pub(crate) fn handle_expect_emit<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     log: &alloy_primitives::Log,
     mut interpreter: Option<&mut Interpreter>,
 ) -> Option<&'static str> {
@@ -1095,8 +1096,8 @@ impl LogCountMap {
     }
 }
 
-fn expect_create<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn expect_create<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     bytecode: Bytes,
     deployer: Address,
     create_scheme: CreateScheme,
@@ -1107,8 +1108,8 @@ fn expect_create<SPEC, BLOCK, N: Network>(
     Ok(Default::default())
 }
 
-fn expect_revert<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn expect_revert<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     reason: Option<&[u8]>,
     depth: usize,
     cheatcode: bool,
@@ -1370,8 +1371,8 @@ fn name_mismatched_logs(
     format!("{actual_name} != expected {expected_name}")
 }
 
-fn expect_safe_memory<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn expect_safe_memory<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     start: u64,
     end: u64,
     depth: u64,

--- a/crates/cheatcodes/src/toml.rs
+++ b/crates/cheatcodes/src/toml.rs
@@ -13,18 +13,19 @@ use alloy_network::Network;
 use alloy_sol_types::SolValue;
 use foundry_common::{fmt::StructDefinitions, fs};
 use foundry_config::fs_permissions::FsAccessKind;
+use foundry_evm_core::evm::FoundryEvmFactory;
 use serde_json::Value as JsonValue;
 use toml::Value as TomlValue;
 
 impl Cheatcode for keyExistsTomlCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         check_json_key_exists(&toml_to_json_string(toml)?, key)
     }
 }
 
 impl Cheatcode for parseToml_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml } = self;
         parse_toml(
             toml,
@@ -35,7 +36,7 @@ impl Cheatcode for parseToml_0Call {
 }
 
 impl Cheatcode for parseToml_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml(
             toml,
@@ -46,105 +47,105 @@ impl Cheatcode for parseToml_1Call {
 }
 
 impl Cheatcode for parseTomlUintCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for parseTomlUintArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Uint(256))))
     }
 }
 
 impl Cheatcode for parseTomlIntCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for parseTomlIntArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Int(256))))
     }
 }
 
 impl Cheatcode for parseTomlBoolCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for parseTomlBoolArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Bool)))
     }
 }
 
 impl Cheatcode for parseTomlAddressCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for parseTomlAddressArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Address)))
     }
 }
 
 impl Cheatcode for parseTomlStringCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::String)
     }
 }
 
 impl Cheatcode for parseTomlStringArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::String)))
     }
 }
 
 impl Cheatcode for parseTomlBytesCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Bytes)
     }
 }
 
 impl Cheatcode for parseTomlBytesArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::Bytes)))
     }
 }
 
 impl Cheatcode for parseTomlBytes32Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for parseTomlBytes32ArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::FixedBytes(32))))
     }
 }
 
 impl Cheatcode for parseTomlType_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, typeDescription } = self;
         parse_toml_coerce(
             toml,
@@ -159,7 +160,7 @@ impl Cheatcode for parseTomlType_0Call {
 }
 
 impl Cheatcode for parseTomlType_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key, typeDescription } = self;
         parse_toml_coerce(
             toml,
@@ -174,7 +175,7 @@ impl Cheatcode for parseTomlType_1Call {
 }
 
 impl Cheatcode for parseTomlTypeArrayCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key, typeDescription } = self;
         let ty = resolve_type(
             typeDescription,
@@ -185,14 +186,14 @@ impl Cheatcode for parseTomlTypeArrayCall {
 }
 
 impl Cheatcode for parseTomlKeysCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { toml, key } = self;
         parse_toml_keys(toml, key)
     }
 }
 
 impl Cheatcode for writeToml_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json, path } = self;
         let value =
             serde_json::from_str(json).unwrap_or_else(|_| JsonValue::String(json.to_owned()));
@@ -203,7 +204,7 @@ impl Cheatcode for writeToml_0Call {
 }
 
 impl Cheatcode for writeToml_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { json: value, path, valueKey } = self;
 
         // Read and parse the TOML file.

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -9,7 +9,7 @@ use alloy_rlp::{Decodable, Encodable};
 use alloy_sol_types::SolValue;
 use foundry_common::{TYPE_BINDING_PREFIX, fs};
 use foundry_config::fs_permissions::FsAccessKind;
-use foundry_evm_core::{FoundryContextExt, constants::DEFAULT_CREATE2_DEPLOYER};
+use foundry_evm_core::{constants::DEFAULT_CREATE2_DEPLOYER, evm::FoundryEvmFactory};
 use foundry_evm_fuzz::strategies::BoundMutator;
 use proptest::prelude::Strategy;
 use rand::{Rng, RngCore, seq::SliceRandom};
@@ -34,7 +34,7 @@ pub struct IgnoredTraces {
 }
 
 impl Cheatcode for labelCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { account, newLabel } = self;
         state.labels.insert(*account, newLabel.clone());
         Ok(Default::default())
@@ -42,7 +42,7 @@ impl Cheatcode for labelCall {
 }
 
 impl Cheatcode for getLabelCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { account } = self;
         Ok(match state.labels.get(account) {
             Some(label) => label.abi_encode(),
@@ -52,7 +52,7 @@ impl Cheatcode for getLabelCall {
 }
 
 impl Cheatcode for computeCreateAddressCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { nonce, deployer } = self;
         ensure!(*nonce <= U256::from(u64::MAX), "nonce must be less than 2^64");
         Ok(deployer.create(nonce.to()).abi_encode())
@@ -60,28 +60,28 @@ impl Cheatcode for computeCreateAddressCall {
 }
 
 impl Cheatcode for computeCreate2Address_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { salt, initCodeHash, deployer } = self;
         Ok(deployer.create2(salt, initCodeHash).abi_encode())
     }
 }
 
 impl Cheatcode for computeCreate2Address_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { salt, initCodeHash } = self;
         Ok(DEFAULT_CREATE2_DEPLOYER.create2(salt, initCodeHash).abi_encode())
     }
 }
 
 impl Cheatcode for ensNamehashCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { name } = self;
         Ok(namehash(name).abi_encode())
     }
 }
 
 impl Cheatcode for bound_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { current, min, max } = *self;
         let Some(mutated) = U256::bound(current, min, max, state.test_runner()) else {
             bail!("cannot bound {current} in [{min}, {max}] range")
@@ -91,7 +91,7 @@ impl Cheatcode for bound_0Call {
 }
 
 impl Cheatcode for bound_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { current, min, max } = *self;
         let Some(mutated) = I256::bound(current, min, max, state.test_runner()) else {
             bail!("cannot bound {current} in [{min}, {max}] range")
@@ -101,27 +101,27 @@ impl Cheatcode for bound_1Call {
 }
 
 impl Cheatcode for randomUint_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         random_uint(state, None, None)
     }
 }
 
 impl Cheatcode for randomUint_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { min, max } = *self;
         random_uint(state, None, Some((min, max)))
     }
 }
 
 impl Cheatcode for randomUint_2Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { bits } = *self;
         random_uint(state, Some(bits), None)
     }
 }
 
 impl Cheatcode for randomAddressCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         Ok(DynSolValue::type_strategy(&DynSolType::Address)
             .new_tree(state.test_runner())
             .unwrap()
@@ -131,27 +131,27 @@ impl Cheatcode for randomAddressCall {
 }
 
 impl Cheatcode for randomInt_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         random_int(state, None)
     }
 }
 
 impl Cheatcode for randomInt_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { bits } = *self;
         random_int(state, Some(bits))
     }
 }
 
 impl Cheatcode for randomBoolCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let rand_bool: bool = state.rng().random();
         Ok(rand_bool.abi_encode())
     }
 }
 
 impl Cheatcode for randomBytesCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { len } = *self;
         ensure!(
             len <= U256::from(usize::MAX),
@@ -164,24 +164,24 @@ impl Cheatcode for randomBytesCall {
 }
 
 impl Cheatcode for randomBytes4Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let rand_u32 = state.rng().next_u32();
         Ok(B32::from(rand_u32).abi_encode())
     }
 }
 
 impl Cheatcode for randomBytes8Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let rand_u64 = state.rng().next_u64();
         Ok(B64::from(rand_u64).abi_encode())
     }
 }
 
 impl Cheatcode for pauseTracingCall {
-    fn apply_full<CTX: ContextTr, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             // No tracer -> nothing to pause
@@ -201,10 +201,10 @@ impl Cheatcode for pauseTracingCall {
 }
 
 impl Cheatcode for resumeTracingCall {
-    fn apply_full<CTX: ContextTr, N: Network>(
+    fn apply_full<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
-        executor: &mut dyn CheatcodesExecutor<CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
+        executor: &mut dyn CheatcodesExecutor<N, F>,
     ) -> Result {
         let Some(tracer) = executor.tracing_inspector() else {
             // No tracer -> nothing to unpause
@@ -224,7 +224,7 @@ impl Cheatcode for resumeTracingCall {
 }
 
 impl Cheatcode for interceptInitcodeCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self {} = self;
         if !state.intercept_next_create_call {
             state.intercept_next_create_call = true;
@@ -236,9 +236,9 @@ impl Cheatcode for interceptInitcodeCall {
 }
 
 impl Cheatcode for setArbitraryStorage_0Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { target } = self;
         ccx.state.arbitrary_storage().mark_arbitrary(target, false);
@@ -248,9 +248,9 @@ impl Cheatcode for setArbitraryStorage_0Call {
 }
 
 impl Cheatcode for setArbitraryStorage_1Call {
-    fn apply_stateful<CTX: ContextTr, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { target, overwrite } = self;
         ccx.state.arbitrary_storage().mark_arbitrary(target, *overwrite);
@@ -260,9 +260,9 @@ impl Cheatcode for setArbitraryStorage_1Call {
 }
 
 impl Cheatcode for copyStorageCall {
-    fn apply_stateful<CTX: ContextTr<Journal: JournalExt>, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { from, to } = self;
 
@@ -287,7 +287,7 @@ impl Cheatcode for copyStorageCall {
 }
 
 impl Cheatcode for sortCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { array } = self;
 
         let mut sorted_values = array.clone();
@@ -298,7 +298,7 @@ impl Cheatcode for sortCall {
 }
 
 impl Cheatcode for shuffleCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { array } = self;
 
         let mut shuffled_values = array.clone();
@@ -310,9 +310,9 @@ impl Cheatcode for shuffleCall {
 }
 
 impl Cheatcode for setSeedCall {
-    fn apply_stateful<CTX: FoundryContextExt, N: Network>(
+    fn apply_stateful<N: Network, F: FoundryEvmFactory>(
         &self,
-        ccx: &mut CheatsCtxt<'_, CTX, N>,
+        ccx: &mut CheatsCtxt<'_, '_, N, F>,
     ) -> Result {
         let Self { seed } = self;
         ccx.state.set_seed(*seed);
@@ -322,8 +322,8 @@ impl Cheatcode for setSeedCall {
 
 /// Helper to generate a random `uint` value (with given bits or bounded if specified)
 /// from type strategy.
-fn random_uint<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn random_uint<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     bits: Option<U256>,
     bounds: Option<(U256, U256)>,
 ) -> Result {
@@ -359,8 +359,8 @@ fn random_uint<SPEC, BLOCK, N: Network>(
 }
 
 /// Helper to generate a random `int` value (with given bits if specified) from type strategy.
-fn random_int<SPEC, BLOCK, N: Network>(
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+fn random_int<N: Network, F: FoundryEvmFactory>(
+    state: &mut Cheatcodes<N, F>,
     bits: Option<U256>,
 ) -> Result {
     let no_bits = bits.unwrap_or(U256::from(256));
@@ -373,7 +373,7 @@ fn random_int<SPEC, BLOCK, N: Network>(
 }
 
 impl Cheatcode for eip712HashType_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { typeNameOrDefinition } = self;
 
         let type_def = get_canonical_type_def(typeNameOrDefinition, state, None)?;
@@ -383,7 +383,7 @@ impl Cheatcode for eip712HashType_0Call {
 }
 
 impl Cheatcode for eip712HashType_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { bindingsPath, typeName } = self;
 
         let path = state.config.ensure_path_allowed(bindingsPath, FsAccessKind::Read)?;
@@ -394,7 +394,7 @@ impl Cheatcode for eip712HashType_1Call {
 }
 
 impl Cheatcode for eip712HashStruct_0Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { typeNameOrDefinition, abiEncodedData } = self;
 
         let type_def = get_canonical_type_def(typeNameOrDefinition, state, None)?;
@@ -405,7 +405,7 @@ impl Cheatcode for eip712HashStruct_0Call {
 }
 
 impl Cheatcode for eip712HashStruct_1Call {
-    fn apply<SPEC, BLOCK, N: Network>(&self, state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, state: &mut Cheatcodes<N, F>) -> Result {
         let Self { bindingsPath, typeName, abiEncodedData } = self;
 
         let path = state.config.ensure_path_allowed(bindingsPath, FsAccessKind::Read)?;
@@ -416,7 +416,7 @@ impl Cheatcode for eip712HashStruct_1Call {
 }
 
 impl Cheatcode for eip712HashTypedDataCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { jsonData } = self;
         let typed_data: TypedData = serde_json::from_str(jsonData)?;
         let digest = typed_data.eip712_signing_hash()?;
@@ -427,9 +427,9 @@ impl Cheatcode for eip712HashTypedDataCall {
 
 /// Returns EIP-712 canonical type definition from the provided string type representation or type
 /// name. If type name provided, then it looks up bindings from file generated by `forge bind-json`.
-fn get_canonical_type_def<SPEC, BLOCK, N: Network>(
+fn get_canonical_type_def<N: Network, F: FoundryEvmFactory>(
     name_or_def: &String,
-    state: &mut Cheatcodes<SPEC, BLOCK, N>,
+    state: &mut Cheatcodes<N, F>,
     path: Option<PathBuf>,
 ) -> Result<String> {
     let type_def = if name_or_def.contains('(') {
@@ -518,7 +518,7 @@ fn get_struct_hash(primary: &str, type_def: &String, abi_encoded_data: &Bytes) -
 }
 
 impl Cheatcode for toRlpCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { data } = self;
 
         let mut buf = Vec::new();
@@ -529,7 +529,7 @@ impl Cheatcode for toRlpCall {
 }
 
 impl Cheatcode for fromRlpCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { rlp } = self;
 
         let decoded: Vec<Bytes> = Vec::<Bytes>::decode(&mut rlp.as_ref())

--- a/crates/cheatcodes/src/version.rs
+++ b/crates/cheatcodes/src/version.rs
@@ -2,18 +2,19 @@ use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
 use alloy_network::Network;
 use alloy_sol_types::SolValue;
 use foundry_common::version::SEMVER_VERSION;
+use foundry_evm_core::evm::FoundryEvmFactory;
 use semver::Version;
 use std::cmp::Ordering;
 
 impl Cheatcode for foundryVersionCmpCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { version } = self;
         foundry_version_cmp(version).map(|cmp| (cmp as i8).abi_encode())
     }
 }
 
 impl Cheatcode for foundryVersionAtLeastCall {
-    fn apply<SPEC, BLOCK, N: Network>(&self, _state: &mut Cheatcodes<SPEC, BLOCK, N>) -> Result {
+    fn apply<N: Network, F: FoundryEvmFactory>(&self, _state: &mut Cheatcodes<N, F>) -> Result {
         let Self { version } = self;
         foundry_version_cmp(version).map(|cmp| cmp.is_ge().abi_encode())
     }

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -6,14 +6,14 @@ use std::{
 
 use crate::{
     FoundryBlock, FoundryContextExt, FoundryInspectorExt, FoundryTransaction,
-    backend::{DatabaseExt, JournaledState},
+    backend::{DatabaseExt, JournaledState, LocalForkId},
     constants::DEFAULT_CREATE2_DEPLOYER_CODEHASH,
 };
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_evm::{
     EthEvmFactory, Evm, EvmEnv, EvmFactory, eth::EthEvmContext, precompiles::PrecompilesMap,
 };
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use foundry_config::FromEvmVersion;
 use foundry_fork_db::{DatabaseError, ForkBlockEnv};
 use revm::{
@@ -44,11 +44,12 @@ pub trait FoundryEvmFactory:
     EvmFactory<
         Spec: Into<SpecId> + FromEvmVersion + Default + Copy + Unpin + Send + 'static,
         BlockEnv: FoundryBlock + ForkBlockEnv + Default + Unpin,
-        Tx: Clone + FoundryTransaction,
+        Tx: Clone + FoundryTransaction + Default,
         Precompiles = PrecompilesMap,
     > + Clone
     + Debug
     + Default
+    + 'static
 {
     /// Foundry Context abstraction
     type FoundryContext<'db>: FoundryContextExt<
@@ -103,6 +104,35 @@ pub trait FoundryEvmFactory:
         depth: usize,
         tx_env: Self::Tx,
     ) -> eyre::Result<ResultAndState<Self::HaltReason>>;
+
+    /// Adapter that forwards to [`DatabaseExt::transact`] with a context-typed inspector.
+    ///
+    /// Generic code only knows `FoundryInspectorExt<Self::FoundryContext<'db>>`, but
+    /// `DatabaseExt::transact` expects the hardcoded `revm::Context<…>`. Each concrete
+    /// factory resolves the type equality and forwards directly.
+    #[allow(clippy::type_complexity)]
+    fn db_transact(
+        &self,
+        db: &mut dyn DatabaseExt<Self::BlockEnv, Self::Tx, Self::Spec>,
+        id: Option<LocalForkId>,
+        transaction: B256,
+        evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
+        journaled_state: &mut JournaledState,
+        inspector: &mut dyn for<'db> FoundryInspectorExt<Self::FoundryContext<'db>>,
+    ) -> eyre::Result<()>;
+
+    /// Adapter that forwards to [`DatabaseExt::transact_from_tx`] with a context-typed inspector.
+    ///
+    /// See [`Self::db_transact`] for rationale.
+    #[allow(clippy::type_complexity)]
+    fn db_transact_from_tx(
+        &self,
+        db: &mut dyn DatabaseExt<Self::BlockEnv, Self::Tx, Self::Spec>,
+        tx_env: Self::Tx,
+        evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
+        journaled_state: &mut JournaledState,
+        inspector: &mut dyn for<'db> FoundryInspectorExt<Self::FoundryContext<'db>>,
+    ) -> eyre::Result<()>;
 }
 
 impl FoundryEvmFactory for EthEvmFactory {
@@ -130,6 +160,29 @@ impl FoundryEvmFactory for EthEvmFactory {
         let mut evm = new_eth_evm_with_inspector(db, evm_env, inspector);
         evm.journaled_state.depth = depth;
         Ok(evm.transact_raw(tx_env)?)
+    }
+
+    fn db_transact(
+        &self,
+        db: &mut dyn DatabaseExt<BlockEnv, TxEnv, SpecId>,
+        id: Option<LocalForkId>,
+        transaction: B256,
+        evm_env: EvmEnv,
+        journaled_state: &mut JournaledState,
+        inspector: &mut dyn for<'db> FoundryInspectorExt<Self::FoundryContext<'db>>,
+    ) -> eyre::Result<()> {
+        db.transact(id, transaction, evm_env, journaled_state, inspector)
+    }
+
+    fn db_transact_from_tx(
+        &self,
+        db: &mut dyn DatabaseExt<BlockEnv, TxEnv, SpecId>,
+        tx_env: TxEnv,
+        evm_env: EvmEnv,
+        journaled_state: &mut JournaledState,
+        inspector: &mut dyn for<'db> FoundryInspectorExt<Self::FoundryContext<'db>>,
+    ) -> eyre::Result<()> {
+        db.transact_from_tx(tx_env, evm_env, journaled_state, inspector)
     }
 }
 
@@ -648,6 +701,29 @@ impl FoundryEvmFactory for TempoEvmFactory {
         let mut evm = new_tempo_evm_with_inspector(db, evm_env, inspector);
         evm.journaled_state.depth = depth;
         Ok(evm.transact_raw(tx_env)?)
+    }
+
+    fn db_transact(
+        &self,
+        db: &mut dyn DatabaseExt<Self::BlockEnv, Self::Tx, Self::Spec>,
+        id: Option<LocalForkId>,
+        transaction: B256,
+        evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
+        journaled_state: &mut JournaledState,
+        inspector: &mut dyn for<'db> FoundryInspectorExt<Self::FoundryContext<'db>>,
+    ) -> eyre::Result<()> {
+        db.transact(id, transaction, evm_env, journaled_state, inspector)
+    }
+
+    fn db_transact_from_tx(
+        &self,
+        db: &mut dyn DatabaseExt<Self::BlockEnv, Self::Tx, Self::Spec>,
+        tx_env: Self::Tx,
+        evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
+        journaled_state: &mut JournaledState,
+        inspector: &mut dyn for<'db> FoundryInspectorExt<Self::FoundryContext<'db>>,
+    ) -> eyre::Result<()> {
+        db.transact_from_tx(tx_env, evm_env, journaled_state, inspector)
     }
 }
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -26,6 +26,7 @@ use foundry_evm_core::{
         DEFAULT_CREATE2_DEPLOYER_CODE, DEFAULT_CREATE2_DEPLOYER_DEPLOYER,
     },
     decode::{RevertDecoder, SkipReason},
+    evm::FoundryEvmFactory,
     utils::StateChangeset,
 };
 use foundry_evm_coverage::HitMaps;
@@ -879,7 +880,7 @@ impl From<DeployResult> for RawCallResult {
 
 /// The result of a raw call.
 #[derive(Debug)]
-pub struct RawCallResult<SPEC = SpecId, BLOCK = BlockEnv, TX = TxEnv, N: Network = Ethereum> {
+pub struct RawCallResult<N: Network = Ethereum, F: FoundryEvmFactory = EthEvmFactory> {
     /// The status of the call
     pub exit_reason: Option<InstructionResult>,
     /// Whether the call reverted or not
@@ -912,11 +913,11 @@ pub struct RawCallResult<SPEC = SpecId, BLOCK = BlockEnv, TX = TxEnv, N: Network
     /// The changeset of the state.
     pub state_changeset: StateChangeset,
     /// The `EvmEnv` after the call
-    pub evm_env: EvmEnv<SPEC, BLOCK>,
+    pub evm_env: EvmEnv<F::Spec, F::BlockEnv>,
     /// The `TxEnv` after the call
-    pub tx_env: TX,
+    pub tx_env: F::Tx,
     /// The cheatcode states after execution
-    pub cheatcodes: Option<Box<Cheatcodes<SPEC, BLOCK, N>>>,
+    pub cheatcodes: Option<Box<Cheatcodes<N, F>>>,
     /// The raw output of the execution
     pub out: Option<Output>,
     /// The chisel state
@@ -924,9 +925,7 @@ pub struct RawCallResult<SPEC = SpecId, BLOCK = BlockEnv, TX = TxEnv, N: Network
     pub reverter: Option<Address>,
 }
 
-impl<SPEC: Default + Into<SpecId> + Clone, BLOCK: Default, TX: Default, N: Network> Default
-    for RawCallResult<SPEC, BLOCK, TX, N>
-{
+impl<N: Network, F: FoundryEvmFactory> Default for RawCallResult<N, F> {
     fn default() -> Self {
         Self {
             exit_reason: None,
@@ -944,7 +943,7 @@ impl<SPEC: Default + Into<SpecId> + Clone, BLOCK: Default, TX: Default, N: Netwo
             transactions: None,
             state_changeset: HashMap::default(),
             evm_env: EvmEnv::default(),
-            tx_env: TX::default(),
+            tx_env: F::Tx::default(),
             cheatcodes: Default::default(),
             out: None,
             chisel_state: None,
@@ -1007,7 +1006,7 @@ impl RawCallResult {
     }
 }
 
-impl<SPEC, BLOCK, TX, N: Network> RawCallResult<SPEC, BLOCK, TX, N> {
+impl<N: Network, F: FoundryEvmFactory> RawCallResult<N, F> {
     /// Update provided history map with edge coverage info collected during this call.
     /// Uses AFL binning algo <https://github.com/h0mbre/Lucid/blob/3026e7323c52b30b3cf12563954ac1eaa9c6981e/src/coverage.rs#L57-L85>
     pub fn merge_edge_coverage(&mut self, history_map: &mut [u8]) -> (bool, bool) {

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -15,12 +15,9 @@ use foundry_cheatcodes::{CheatcodeAnalysis, CheatcodesExecutor, NestedEvmClosure
 use foundry_common::compile::Analysis;
 use foundry_evm_core::{
     FoundryBlock, FoundryTransaction, InspectorExt,
-    backend::{DatabaseError, DatabaseExt, JournaledState},
+    backend::{DatabaseError, JournaledState},
     env::FoundryContextExt,
-    evm::{
-        FoundryEvmFactory, IntoNestedEvm, NestedEvm, new_eth_evm_with_inspector,
-        with_cloned_context,
-    },
+    evm::{FoundryEvmFactory, IntoNestedEvm, NestedEvm, with_cloned_context},
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_networks::NetworkConfigs;
@@ -29,17 +26,15 @@ use foundry_primitives::FoundryTransactionBuilder;
 use revm::{
     Inspector,
     context::{
-        Block, BlockEnv, Cfg, ContextTr, JournalTr, Transaction, TxEnv,
+        Block, Cfg, ContextTr, JournalTr, Transaction,
         result::{EVMError, ExecutionResult, Output},
     },
     context_interface::CreateScheme,
-    handler::EvmTr,
     inspector::JournalExt,
     interpreter::{
         CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, Gas, InstructionResult,
         Interpreter, InterpreterResult,
     },
-    primitives::hardfork::SpecId,
     state::{Account, AccountStatus},
 };
 use revm_inspectors::edge_cov::EdgeCovInspector;
@@ -113,7 +108,7 @@ impl<BLOCK: Clone> Default for InspectorStackBuilder<BLOCK> {
     }
 }
 
-impl InspectorStackBuilder<BlockEnv> {
+impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
     /// Create a new inspector stack builder.
     #[inline]
     pub fn new() -> Self {
@@ -129,7 +124,7 @@ impl InspectorStackBuilder<BlockEnv> {
 
     /// Set the block environment.
     #[inline]
-    pub fn block(mut self, block: BlockEnv) -> Self {
+    pub fn block(mut self, block: BLOCK) -> Self {
         self.block = Some(block);
         self
     }
@@ -227,13 +222,10 @@ impl InspectorStackBuilder<BlockEnv> {
                 TxEnvelope: Decodable + SignerRecoverable,
                 TransactionRequest: FoundryTransactionBuilder<N>,
             >,
-        F: FoundryEvmFactory<Spec = SpecId, BlockEnv = BlockEnv, Tx = TxEnv>,
+        F: FoundryEvmFactory<BlockEnv = BLOCK, Tx: FromRecoveredTx<N::TxEnvelope>>,
     >(
         self,
-    ) -> InspectorStack<N, F>
-    where
-        F::Tx: FromRecoveredTx<N::TxEnvelope>,
-    {
+    ) -> InspectorStack<N, F> {
         let Self {
             analysis,
             block,
@@ -323,13 +315,13 @@ macro_rules! call_inspectors {
 }
 
 /// The collected results of [`InspectorStack`].
-pub struct InspectorData<SPEC, BLOCK, N: Network> {
+pub struct InspectorData<N: Network, F: FoundryEvmFactory> {
     pub logs: Vec<Log>,
     pub labels: AddressHashMap<String>,
     pub traces: Option<SparsedTraceArena>,
     pub line_coverage: Option<HitMaps>,
     pub edge_coverage: Option<Vec<u8>>,
-    pub cheatcodes: Option<Box<Cheatcodes<SPEC, BLOCK, N>>>,
+    pub cheatcodes: Option<Box<Cheatcodes<N, F>>>,
     pub chisel_state: Option<(Vec<U256>, Vec<u8>)>,
     pub reverter: Option<Address>,
 }
@@ -358,7 +350,7 @@ pub struct InnerContextData {
 #[derive(Clone, Debug)]
 pub struct InspectorStack<N: Network = Ethereum, F: FoundryEvmFactory = EthEvmFactory> {
     #[allow(clippy::type_complexity)]
-    pub cheatcodes: Option<Box<Cheatcodes<F::Spec, F::BlockEnv, N>>>,
+    pub cheatcodes: Option<Box<Cheatcodes<N, F>>>,
     pub inner: InspectorStackInner,
 }
 
@@ -399,82 +391,75 @@ pub struct InspectorStackInner {
 /// Struct keeping mutable references to both parts of [InspectorStack] and implementing
 /// [revm::Inspector]. This struct can be obtained via [InspectorStack::as_mut].
 pub struct InspectorStackRefMut<'a, N: Network = Ethereum, F: FoundryEvmFactory = EthEvmFactory> {
-    pub cheatcodes: Option<&'a mut Cheatcodes<F::Spec, F::BlockEnv, N>>,
+    pub cheatcodes: Option<&'a mut Cheatcodes<N, F>>,
     pub inner: &'a mut InspectorStackInner,
 }
 
 impl<
-    CTX: FoundryContextExt<
-            Spec = SpecId,
-            Block = BlockEnv,
-            Tx = TxEnv,
-            Db: DatabaseExt<CTX::Block, CTX::Tx, CTX::Spec>,
-        >,
     N: Network<
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-> CheatcodesExecutor<CTX, N> for InspectorStackInner
-where
-    CTX::Tx: FromRecoveredTx<N::TxEnvelope>,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
+> CheatcodesExecutor<N, F> for InspectorStackInner
 {
     fn with_nested_evm(
         &mut self,
-        cheats: &mut Cheatcodes<CTX::Spec, CTX::Block, N>,
-        ecx: &mut CTX,
-        f: NestedEvmClosure<'_, <CTX::Cfg as Cfg>::Spec, CTX::Block, CTX::Tx>,
+        cheats: &mut Cheatcodes<N, F>,
+        ecx: &mut F::FoundryContext<'_>,
+        f: NestedEvmClosure<'_, F::Spec, F::BlockEnv, F::Tx>,
     ) -> Result<(), EVMError<DatabaseError>> {
-        let mut inspector: InspectorStackRefMut<'_, N, EthEvmFactory> =
-            InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
+        let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         with_cloned_context(ecx, |db, evm_env, journal_inner| {
-            let mut evm = new_eth_evm_with_inspector(db, evm_env, &mut inspector).into_nested_evm();
+            let mut evm = F::default()
+                .create_foundry_evm_with_inspector(db, evm_env, &mut inspector)
+                .into_nested_evm();
             *evm.journal_inner_mut() = journal_inner;
             f(&mut evm)?;
-            let sub_inner = evm.journaled_state.inner.clone();
-            let sub_evm_env = evm.ctx_ref().evm_clone();
+            let sub_inner = evm.journal_inner_mut().clone();
+            let sub_evm_env = evm.to_evm_env();
             Ok((sub_evm_env, sub_inner))
         })
     }
 
     fn with_fresh_nested_evm(
         &mut self,
-        cheats: &mut Cheatcodes<CTX::Spec, CTX::Block, N>,
-        db: &mut CTX::Db,
-        evm_env: EvmEnv<CTX::Spec, CTX::Block>,
-        f: NestedEvmClosure<'_, <CTX::Cfg as Cfg>::Spec, CTX::Block, CTX::Tx>,
-    ) -> Result<EvmEnv<CTX::Spec, CTX::Block>, EVMError<DatabaseError>> {
-        let mut inspector: InspectorStackRefMut<'_, N, EthEvmFactory> =
-            InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
-        let mut evm = new_eth_evm_with_inspector(db, evm_env, &mut inspector).into_nested_evm();
+        cheats: &mut Cheatcodes<N, F>,
+        db: &mut <F::FoundryContext<'_> as ContextTr>::Db,
+        evm_env: EvmEnv<F::Spec, F::BlockEnv>,
+        f: NestedEvmClosure<'_, F::Spec, F::BlockEnv, F::Tx>,
+    ) -> Result<EvmEnv<F::Spec, F::BlockEnv>, EVMError<DatabaseError>> {
+        let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
+        let mut evm = F::default()
+            .create_foundry_evm_with_inspector(db, evm_env, &mut inspector)
+            .into_nested_evm();
         f(&mut evm)?;
-        Ok(evm.ctx_ref().evm_clone())
+        Ok(evm.to_evm_env())
     }
 
     fn transact_on_db(
         &mut self,
-        cheats: &mut Cheatcodes<CTX::Spec, CTX::Block, N>,
-        ecx: &mut CTX,
+        cheats: &mut Cheatcodes<N, F>,
+        ecx: &mut F::FoundryContext<'_>,
         fork_id: Option<U256>,
         transaction: B256,
     ) -> eyre::Result<()> {
         let evm_env = ecx.evm_clone();
-        let mut inspector: InspectorStackRefMut<'_, N, EthEvmFactory> =
-            InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
+        let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         let (db, inner) = ecx.db_journal_inner_mut();
-        db.transact(fork_id, transaction, evm_env, inner, &mut inspector)
+        F::default().db_transact(db, fork_id, transaction, evm_env, inner, &mut inspector)
     }
 
     fn transact_from_tx_on_db(
         &mut self,
-        cheats: &mut Cheatcodes<CTX::Spec, CTX::Block, N>,
-        ecx: &mut CTX,
-        tx_env: CTX::Tx,
+        cheats: &mut Cheatcodes<N, F>,
+        ecx: &mut F::FoundryContext<'_>,
+        tx_env: F::Tx,
     ) -> eyre::Result<()> {
         let evm_env = ecx.evm_clone();
-        let mut inspector: InspectorStackRefMut<'_, N, EthEvmFactory> =
-            InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
+        let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         let (db, inner) = ecx.db_journal_inner_mut();
-        db.transact_from_tx(tx_env, evm_env, inner, &mut inspector)
+        F::default().db_transact_from_tx(db, tx_env, evm_env, inner, &mut inspector)
     }
 
     fn console_log(&mut self, msg: &str) {
@@ -504,10 +489,8 @@ impl<
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-    F: FoundryEvmFactory<Spec = SpecId, BlockEnv = BlockEnv, Tx = TxEnv>,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
 > Default for InspectorStack<N, F>
-where
-    F::Tx: FromRecoveredTx<N::TxEnvelope>,
 {
     fn default() -> Self {
         Self::new()
@@ -519,10 +502,8 @@ impl<
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-    F: FoundryEvmFactory<Spec = SpecId, BlockEnv = BlockEnv, Tx = TxEnv>,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
 > InspectorStack<N, F>
-where
-    F::Tx: FromRecoveredTx<N::TxEnvelope>,
 {
     /// Creates a new inspector stack.
     ///
@@ -558,7 +539,7 @@ where
 
     /// Set the cheatcodes inspector.
     #[inline]
-    pub fn set_cheatcodes(&mut self, cheatcodes: Cheatcodes<F::Spec, F::BlockEnv, N>) {
+    pub fn set_cheatcodes(&mut self, cheatcodes: Cheatcodes<N, F>) {
         self.cheatcodes = Some(cheatcodes.into());
     }
 
@@ -652,7 +633,7 @@ where
     }
 
     /// Collects all the data gathered during inspection into a single struct.
-    pub fn collect(self) -> InspectorData<F::Spec, F::BlockEnv, N> {
+    pub fn collect(self) -> InspectorData<N, F> {
         let Self {
             mut cheatcodes,
             inner:
@@ -710,10 +691,8 @@ impl<
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-    F: FoundryEvmFactory<Spec = SpecId, BlockEnv = BlockEnv, Tx = TxEnv>,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
 > InspectorStackRefMut<'_, N, F>
-where
-    F::Tx: FromRecoveredTx<N::TxEnvelope>,
 {
     /// Adjusts the EVM data for the inner EVM context.
     /// Should be called on the top-level call of inner context (depth == 0 &&
@@ -1020,10 +999,8 @@ impl<
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-    F: FoundryEvmFactory<Spec = SpecId, BlockEnv = BlockEnv, Tx = TxEnv>,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
 > Inspector<F::FoundryContext<'_>> for InspectorStackRefMut<'_, N, F>
-where
-    F::Tx: FromRecoveredTx<N::TxEnvelope>,
 {
     fn initialize_interp(
         &mut self,
@@ -1288,10 +1265,8 @@ impl<
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-    F: FoundryEvmFactory<Spec = SpecId, BlockEnv = BlockEnv, Tx = TxEnv>,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
 > Inspector<F::FoundryContext<'_>> for InspectorStack<N, F>
-where
-    F::Tx: FromRecoveredTx<N::TxEnvelope>,
 {
     fn step(&mut self, interpreter: &mut Interpreter, ecx: &mut F::FoundryContext<'_>) {
         self.as_mut().step_inlined(interpreter, ecx)
@@ -1368,10 +1343,8 @@ impl<
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-    F: FoundryEvmFactory<Spec = SpecId, BlockEnv = BlockEnv, Tx = TxEnv>,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
 > InspectorExt for InspectorStack<N, F>
-where
-    F::Tx: FromRecoveredTx<N::TxEnvelope>,
 {
     fn should_use_create2_factory(&mut self, depth: usize, inputs: &CreateInputs) -> bool {
         self.as_mut().should_use_create2_factory(depth, inputs)


### PR DESCRIPTION
## Motivation

Make `CheatcodeExecutor` generic over `FoundryEvmFactory`.

80% of the diff is mechanical through `Cheatcode` impls, ie. wiring `Network` and `FoundryEvmFactory` to `Cheatcodes`, `CheatsCtxt` and `CheatcodeExecutor`.

Now there are 3 "workaround" methods in `FoundryEvmFactory` to handle `DatabaseExt` dyn dispatching:
- `transact_with_dyn_inspector` (should be renamed)
- `db_transact`
- `db_transact_from_tx`

They are ugly atm, but can be easily refactored  in the future, in one unique method taking a closure.

Providing `FoundryEvmFactory` to may seem kinda overkill `Cheatcodes`, but it's necessary since `Cheatcodes` has inspector impl that need to spawn evm.

Updated misc structs like `InspectorData` accordingly to handle `FoundryEvmFactory`.