### PR TITLE
refactor(evm): add `IntoInstructionResult` bound to `FoundryEvmFactory`

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -3,10 +3,7 @@ use crate::{
         backend::cheats::CheatsManager, error::InvalidTransactionError,
         pool::transactions::PoolTransaction,
     },
-    mem::{
-        IntoInstructionResult,
-        inspector::{AnvilInspector, InspectorTxConfig},
-    },
+    mem::inspector::{AnvilInspector, InspectorTxConfig},
 };
 use alloy_consensus::{
     Eip658Value, Transaction, TransactionEnvelope, TxReceipt,
@@ -31,7 +28,7 @@ use alloy_primitives::{Address, B256, Bytes};
 use anvil_core::eth::transaction::{
     MaybeImpersonatedTransaction, PendingTransaction, TransactionInfo,
 };
-use foundry_evm::core::env::FoundryTransaction;
+use foundry_evm::core::{env::FoundryTransaction, evm::IntoInstructionResult};
 use foundry_primitives::{FoundryReceiptEnvelope, FoundryTxEnvelope, FoundryTxType};
 use revm::{
     Database, DatabaseCommit,

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -4544,33 +4544,7 @@ pub fn is_arbitrum(chain_id: u64) -> bool {
 ///
 /// Abstracts over network-specific halt reason types (`HaltReason`, `OpHaltReason`)
 /// so that anvil code doesn't need to match on each variant directly.
-pub trait IntoInstructionResult {
-    fn into_instruction_result(self) -> InstructionResult;
-}
-
-impl IntoInstructionResult for HaltReason {
-    fn into_instruction_result(self) -> InstructionResult {
-        self.into()
-    }
-}
-
-impl IntoInstructionResult for OpHaltReason {
-    fn into_instruction_result(self) -> InstructionResult {
-        match self {
-            Self::Base(eth_h) => eth_h.into(),
-            Self::FailedDeposit => InstructionResult::Stop,
-        }
-    }
-}
-
-impl IntoInstructionResult for TempoHaltReason {
-    fn into_instruction_result(self) -> InstructionResult {
-        match self {
-            Self::Ethereum(eth_h) => eth_h.into(),
-            _ => InstructionResult::PrecompileError,
-        }
-    }
-}
+pub use foundry_evm::core::evm::IntoInstructionResult;
 
 #[cfg(test)]
 mod tests {

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -16,6 +16,7 @@ use alloy_evm::{
 use alloy_primitives::{Address, B256, Bytes, U256};
 use foundry_config::FromEvmVersion;
 use foundry_fork_db::{DatabaseError, ForkBlockEnv};
+use op_revm::OpHaltReason;
 use revm::{
     Context,
     context::{
@@ -40,11 +41,41 @@ use tempo_revm::{
     gas_params::tempo_gas_params, handler::TempoEvmHandler,
 };
 
+/// Converts a network-specific halt reason into an [`InstructionResult`].
+pub trait IntoInstructionResult {
+    fn into_instruction_result(self) -> InstructionResult;
+}
+
+impl IntoInstructionResult for HaltReason {
+    fn into_instruction_result(self) -> InstructionResult {
+        self.into()
+    }
+}
+
+impl IntoInstructionResult for OpHaltReason {
+    fn into_instruction_result(self) -> InstructionResult {
+        match self {
+            Self::Base(eth) => eth.into(),
+            Self::FailedDeposit => InstructionResult::Stop,
+        }
+    }
+}
+
+impl IntoInstructionResult for TempoHaltReason {
+    fn into_instruction_result(self) -> InstructionResult {
+        match self {
+            Self::Ethereum(eth) => eth.into(),
+            _ => InstructionResult::PrecompileError,
+        }
+    }
+}
+
 pub trait FoundryEvmFactory:
     EvmFactory<
         Spec: Into<SpecId> + FromEvmVersion + Default + Copy + Unpin + Send + 'static,
         BlockEnv: FoundryBlock + ForkBlockEnv + Default + Unpin,
         Tx: Clone + FoundryTransaction + Default,
+        HaltReason: IntoInstructionResult,
         Precompiles = PrecompilesMap,
     > + Clone
     + Debug


### PR DESCRIPTION
## Motivation
Moves `IntoInstructionResult` from anvil to `foundry-evm-core` and adds `HaltReason: IntoInstructionResult` as a bound on `FoundryEvmFactory`. This enables generic code to convert network-specific halt reasons into `InstructionResult` without being pinned to Ethereum types.