### PR TITLE
refactor(evm): `TracingExecutor` generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4740,6 +4740,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-evm",
  "alloy-json-abi",
+ "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -6,7 +6,8 @@ use crate::{
     tx::{CastTxBuilder, SenderKind},
 };
 use alloy_ens::NameOrAddress;
-use alloy_network::{AnyNetwork, Network, TransactionBuilder};
+use alloy_evm::EthEvmFactory;
+use alloy_network::{AnyNetwork, Ethereum, Network, TransactionBuilder};
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, hex, map::HashMap};
 use alloy_provider::Provider;
 use alloy_rpc_types::{
@@ -299,7 +300,11 @@ impl CallArgs {
 
             let create2_deployer = evm_opts.create2_deployer;
             let (mut evm_env, tx_env, fork, chain, networks) =
-                TracingExecutor::get_fork_material(&mut config, evm_opts).await?;
+                TracingExecutor::<Ethereum, EthEvmFactory>::get_fork_material(
+                    &mut config,
+                    evm_opts,
+                )
+                .await?;
 
             // modify settings that usually set in eth_call
             evm_env.cfg_env.disable_block_gas_limit = true;
@@ -324,7 +329,7 @@ impl CallArgs {
                     InternalTraceMode::None
                 })
                 .with_state_changes(shell::verbosity() > 4);
-            let mut executor = TracingExecutor::new(
+            let mut executor = TracingExecutor::<Ethereum, EthEvmFactory>::new(
                 (evm_env, tx_env),
                 fork,
                 evm_version,

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -169,7 +169,7 @@ impl RunArgs {
         let (block, (mut evm_env, tx_env, fork, chain, networks)) = tokio::try_join!(
             // fetch the block the transaction was mined in
             provider.get_block(tx_block_number.into()).full().into_future().map_err(Into::into),
-            TracingExecutor::get_fork_material(&mut config, evm_opts)
+            TracingExecutor::<Ethereum, EthEvmFactory>::get_fork_material(&mut config, evm_opts)
         )?;
 
         let mut evm_version = self.evm_version;
@@ -211,7 +211,7 @@ impl RunArgs {
                 InternalTraceMode::None
             })
             .with_state_changes(shell::verbosity() > 4);
-        let mut executor = TracingExecutor::new(
+        let mut executor = TracingExecutor::<Ethereum, EthEvmFactory>::new(
             (evm_env.clone(), tx_env),
             fork,
             evm_version,

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -1,29 +1,39 @@
 use crate::executors::{Executor, ExecutorBuilder};
-use alloy_evm::{EthEvmFactory, EvmEnv};
-use alloy_network::Ethereum;
+use alloy_consensus::transaction::SignerRecoverable;
+use alloy_evm::FromRecoveredTx;
+use alloy_network::{AnyRpcTransaction, Network};
 use alloy_primitives::{Address, U256, map::HashMap};
+use alloy_rlp::Decodable;
 use alloy_rpc_types::state::StateOverride;
 use eyre::Context;
 use foundry_compilers::artifacts::EvmVersion;
 use foundry_config::{Chain, Config, evm_spec_id};
-use foundry_evm_core::{backend::Backend, fork::CreateFork, opts::EvmOpts};
+use foundry_evm_core::{
+    EvmEnv, TryAnyToTxEnv, backend::Backend, evm::FoundryEvmFactory, fork::CreateFork,
+    opts::EvmOpts,
+};
 use foundry_evm_networks::NetworkConfigs;
 use foundry_evm_traces::TraceMode;
-use revm::{
-    context::{Transaction, TxEnv},
-    primitives::hardfork::SpecId,
-    state::Bytecode,
-};
+use foundry_primitives::FoundryTransactionBuilder;
+use revm::{context::Transaction, primitives::hardfork::SpecId, state::Bytecode};
 use std::ops::{Deref, DerefMut};
 
 /// A default executor with tracing enabled
-pub struct TracingExecutor {
-    executor: Executor<Ethereum, EthEvmFactory>,
+pub struct TracingExecutor<N: Network, F: FoundryEvmFactory> {
+    executor: Executor<N, F>,
 }
 
-impl TracingExecutor {
+impl<N, F> TracingExecutor<N, F>
+where
+    N: Network<
+            TxEnvelope: Decodable + SignerRecoverable,
+            TransactionRequest: FoundryTransactionBuilder<N>,
+        >,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+    AnyRpcTransaction: TryAnyToTxEnv<F::Tx>,
+{
     pub fn new(
-        env: (EvmEnv, TxEnv),
+        env: (EvmEnv<F::Spec, F::BlockEnv>, F::Tx),
         fork: CreateFork,
         version: Option<EvmVersion>,
         trace_mode: TraceMode,
@@ -38,7 +48,7 @@ impl TracingExecutor {
             .inspectors(|stack| {
                 stack.trace_mode(trace_mode).networks(networks).create2_deployer(create2_deployer)
             })
-            .spec_id(evm_spec_id(version.unwrap_or_default()))
+            .spec_id(evm_spec_id::<F::Spec>(version.unwrap_or_default()))
             .build(env.0, env.1, db);
 
         // Apply the state overrides.
@@ -74,7 +84,7 @@ impl TracingExecutor {
     }
 
     /// Returns the spec id of the executor
-    pub fn spec_id(&self) -> SpecId {
+    pub fn spec_id(&self) -> F::Spec {
         self.executor.spec_id()
     }
 
@@ -82,11 +92,12 @@ impl TracingExecutor {
     pub async fn get_fork_material(
         config: &mut Config,
         mut evm_opts: EvmOpts,
-    ) -> eyre::Result<(EvmEnv, TxEnv, CreateFork, Chain, NetworkConfigs)> {
+    ) -> eyre::Result<(EvmEnv<F::Spec, F::BlockEnv>, F::Tx, CreateFork, Chain, NetworkConfigs)>
+    {
         evm_opts.fork_url = Some(config.get_rpc_url_or_localhost_http()?.into_owned());
         evm_opts.fork_block_number = config.fork_block_number;
 
-        let (evm_env, tx_env, fork_block) = evm_opts.env::<_, _, TxEnv>().await?;
+        let (evm_env, tx_env, fork_block) = evm_opts.env::<F::Spec, F::BlockEnv, F::Tx>().await?;
 
         let fork = evm_opts.get_fork(config, evm_env.cfg_env.chain_id, fork_block).unwrap();
         let networks = evm_opts.networks.with_chain_id(evm_env.cfg_env.chain_id);
@@ -97,15 +108,23 @@ impl TracingExecutor {
     }
 }
 
-impl Deref for TracingExecutor {
-    type Target = Executor<Ethereum, EthEvmFactory>;
+impl<N, F> Deref for TracingExecutor<N, F>
+where
+    N: Network,
+    F: FoundryEvmFactory,
+{
+    type Target = Executor<N, F>;
 
     fn deref(&self) -> &Self::Target {
         &self.executor
     }
 }
 
-impl DerefMut for TracingExecutor {
+impl<N, F> DerefMut for TracingExecutor<N, F>
+where
+    N: Network,
+    F: FoundryEvmFactory,
+{
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.executor
     }

--- a/crates/verify/Cargo.toml
+++ b/crates/verify/Cargo.toml
@@ -33,6 +33,7 @@ foundry-compilers.workspace = true
 foundry-block-explorers = { workspace = true, features = ["foundry-compilers"] }
 revm.workspace = true
 alloy-evm = { workspace = true, features = ["rpc"] }
+alloy-network.workspace = true
 
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 reqwest = { workspace = true, features = ["json"] }

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -1,6 +1,7 @@
 use crate::{bytecode::VerifyBytecodeArgs, types::VerificationType};
 use alloy_dyn_abi::DynSolValue;
-use alloy_evm::EvmEnv;
+use alloy_evm::{EthEvmFactory, EvmEnv};
+use alloy_network::Ethereum;
 use alloy_primitives::{Address, Bytes, TxKind};
 use alloy_provider::{
     Provider,
@@ -268,15 +269,16 @@ pub async fn get_tracing_executor(
     fork_blk_num: u64,
     evm_version: EvmVersion,
     evm_opts: EvmOpts,
-) -> Result<(EvmEnv, TxEnv, TracingExecutor)> {
+) -> Result<(EvmEnv, TxEnv, TracingExecutor<Ethereum, EthEvmFactory>)> {
     fork_config.fork_block_number = Some(fork_blk_num);
     fork_config.evm_version = evm_version;
 
     let create2_deployer = evm_opts.create2_deployer;
     let (evm_env, tx_env, fork, _chain, networks) =
-        TracingExecutor::get_fork_material(fork_config, evm_opts).await?;
+        TracingExecutor::<Ethereum, EthEvmFactory>::get_fork_material(fork_config, evm_opts)
+            .await?;
 
-    let executor = TracingExecutor::new(
+    let executor = TracingExecutor::<Ethereum, EthEvmFactory>::new(
         (evm_env.clone(), tx_env.clone()),
         fork,
         Some(fork_config.evm_version),
@@ -297,7 +299,7 @@ pub fn configure_env_block(evm_env: &mut EvmEnv, block: &AnyRpcBlock, config: Ne
 }
 
 pub fn deploy_contract(
-    executor: &mut TracingExecutor,
+    executor: &mut TracingExecutor<Ethereum, EthEvmFactory>,
     evm_env: &EvmEnv,
     tx_env: &TxEnv,
     spec_id: SpecId,
@@ -350,7 +352,7 @@ pub fn deploy_contract(
 }
 
 pub async fn get_runtime_codes(
-    executor: &mut TracingExecutor,
+    executor: &mut TracingExecutor<Ethereum, EthEvmFactory>,
     provider: &impl Provider<AnyNetwork>,
     address: Address,
     fork_address: Address,


### PR DESCRIPTION
## Motivation
Makes `TracingExecutor<N, F>` generic over `Network` and `FoundryEvmFactory`, consistent with `Executor<N, F>`. Also makes `EvmOpts::get_fork` generic over `SPEC` and `BLOCK`.

Stacked on #14101.