### PR TITLE
refactor(evm): remove `EvmEnv` from `get_fork`

### DIFF
--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -206,7 +206,7 @@ impl SessionSource {
             None => {
                 let fork = self.config.evm_opts.get_fork(
                     &self.config.foundry_config,
-                    &evm_env,
+                    evm_env.cfg_env.chain_id,
                     fork_block,
                 );
                 let backend = Backend::spawn(fork)?;

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -2130,7 +2130,11 @@ mod tests {
     use foundry_common::provider::get_http_provider;
     use foundry_config::{Config, NamedChain};
     use foundry_fork_db::cache::{BlockchainDb, BlockchainDbMeta};
-    use revm::{context::TxEnv, database::DatabaseRef};
+    use revm::{
+        context::{BlockEnv, TxEnv},
+        database::DatabaseRef,
+        primitives::hardfork::SpecId,
+    };
 
     #[tokio::test(flavor = "multi_thread")]
     async fn can_read_write_cache() {
@@ -2143,9 +2147,10 @@ mod tests {
         evm_opts.fork_url = Some(endpoint.to_string());
         evm_opts.fork_block_number = Some(block_num);
 
-        let (evm_env, _, fork_block) = evm_opts.env::<_, _, TxEnv>().await.unwrap();
+        let (evm_env, _, fork_block) = evm_opts.env::<SpecId, BlockEnv, TxEnv>().await.unwrap();
 
-        let fork = evm_opts.get_fork(&Config::default(), &evm_env, fork_block).unwrap();
+        let fork =
+            evm_opts.get_fork(&Config::default(), evm_env.cfg_env.chain_id, fork_block).unwrap();
 
         let backend = Backend::<Ethereum>::spawn(Some(fork)).unwrap();
 

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -309,11 +309,11 @@ impl EvmOpts {
     pub fn get_fork(
         &self,
         config: &Config,
-        evm_env: &EvmEnv,
+        chain_id: u64,
         fork_block_number: Option<BlockNumber>,
     ) -> Option<CreateFork> {
         let url = self.fork_url.clone()?;
-        let enable_caching = config.enable_caching(&url, evm_env.cfg_env.chain_id);
+        let enable_caching = config.enable_caching(&url, chain_id);
 
         // Pin fork_block_number to the block that was already fetched in env, so subsequent
         // fork operations use the same block. This prevents inconsistencies when forking at
@@ -450,7 +450,8 @@ mod tests {
         assert!(resolved_block > 0, "should have resolved to a real block number");
 
         // Create the fork - this should pin the block number
-        let fork = evm_opts.get_fork(&Config::default(), &evm_env, fork_block).unwrap();
+        let fork =
+            evm_opts.get_fork(&Config::default(), evm_env.cfg_env.chain_id, fork_block).unwrap();
 
         // The fork's evm_opts should now have fork_block_number set to the resolved block
         assert_eq!(
@@ -487,7 +488,9 @@ mod tests {
         );
 
         // Verify get_fork pins to the correct L2 block number
-        let fork = evm_opts.get_fork(&Config::default(), &evm_env, Some(fork_block)).unwrap();
+        let fork = evm_opts
+            .get_fork(&Config::default(), evm_env.cfg_env.chain_id, Some(fork_block))
+            .unwrap();
         assert_eq!(
             fork.evm_opts.fork_block_number,
             Some(fork_block),
@@ -505,9 +508,10 @@ mod tests {
         // Set an explicit block number
         evm_opts.fork_block_number = Some(12345678);
 
-        let (evm_env, _, fork_block) = evm_opts.env::<SpecId, _, TxEnv>().await.unwrap();
+        let (evm_env, _, fork_block) = evm_opts.env::<SpecId, BlockEnv, TxEnv>().await.unwrap();
 
-        let fork = evm_opts.get_fork(&Config::default(), &evm_env, fork_block).unwrap();
+        let fork =
+            evm_opts.get_fork(&Config::default(), evm_env.cfg_env.chain_id, fork_block).unwrap();
 
         // Should preserve the explicit block number, not override it
         assert_eq!(

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -88,7 +88,7 @@ impl TracingExecutor {
 
         let (evm_env, tx_env, fork_block) = evm_opts.env::<_, _, TxEnv>().await?;
 
-        let fork = evm_opts.get_fork(config, &evm_env, fork_block).unwrap();
+        let fork = evm_opts.get_fork(config, evm_env.cfg_env.chain_id, fork_block).unwrap();
         let networks = evm_opts.networks.with_chain_id(evm_env.cfg_env.chain_id);
         config.labels.extend(networks.precompiles_label());
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -345,7 +345,7 @@ impl TestArgs {
             .initial_balance(evm_opts.initial_balance)
             .evm_spec(config.evm_spec_id())
             .sender(evm_opts.sender)
-            .with_fork(evm_opts.get_fork(&config, &evm_env, fork_block))
+            .with_fork(evm_opts.get_fork(&config, evm_env.cfg_env.chain_id, fork_block))
             .enable_isolation(evm_opts.isolate)
             .networks(evm_opts.networks)
             .fail_fast(self.fail_fast)

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -644,7 +644,8 @@ impl ScriptConfig {
             match self.backends.get(fork_url) {
                 Some(db) => db.clone(),
                 None => {
-                    let fork = self.evm_opts.get_fork(&self.config, &evm_env, fork_block);
+                    let fork =
+                        self.evm_opts.get_fork(&self.config, evm_env.cfg_env.chain_id, fork_block);
                     let backend = Backend::spawn(fork)?;
                     self.backends.insert(fork_url.clone(), backend.clone());
                     backend


### PR DESCRIPTION
## Motivation
`EvmOpts::get_fork` only uses `evm_env.cfg_env.chain_id`. Passing `chain_id: u64` directly removes the dependency on concrete `EvmEnv` types, which unblocks generic `TracingExecutor<N, F>`.