### PR TITLE
ci: add affected-crate detection to skip unchanged tests

### DIFF
--- a/.affected.toml
+++ b/.affected.toml
@@ -1,0 +1,4 @@
+ignore = ["*.md", "docs/**", ".github/**", "LICENSE*", "*.txt", "*.yml", "*.yaml", "testdata/**"]
+
+[test]
+cargo = "cargo nextest run -p {package}"

--- a/.github/workflows/affected-test.yml
+++ b/.github/workflows/affected-test.yml
@@ -1,0 +1,86 @@
+# Experimental: Run tests only for crates affected by a PR.
+# Foundry currently uses a custom matrices.py to build test matrices — this
+# workflow uses the Cargo dependency graph to test only what changed.
+#
+# Tool: https://github.com/Rani367/affected
+
+name: Affected Tests (experimental)
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  detect:
+    name: Detect affected crates
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.affected.outputs.matrix }}
+      has_affected: ${{ steps.affected.outputs.has_affected }}
+      count: ${{ steps.affected.outputs.count }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: Rani367/setup-affected@750ce2e1ff1be73b511666ea7ddc9a76b4dd80f2 # v1
+
+      - name: Detect affected crates
+        id: affected
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: affected ci --merge-base "origin/${BASE_REF:-master}"
+
+      - name: Summary
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          AFFECTED_COUNT: ${{ steps.affected.outputs.count }}
+        run: |
+          {
+            echo "### Affected Crates (${AFFECTED_COUNT})"
+            echo ""
+            affected list --merge-base "origin/${BASE_REF:-master}" --explain
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  test:
+    name: "test / ${{ matrix.package }}"
+    needs: detect
+    if: needs.detect.outputs.has_affected == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix: ${{ fromJson(needs.detect.outputs.matrix) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-on-failure: true
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@d858f8113943481093e02986a7586a4819a3bfd6 # v2
+        with:
+          tool: cargo-nextest
+
+      - name: "Test ${{ matrix.package }}"
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: cargo nextest run -p "$PACKAGE"


### PR DESCRIPTION
## Problem

This repo has **36 crates** in its Cargo workspace. The current CI uses a custom `matrices.py` to partition tests, but it doesn't filter *which* crates need testing based on what changed.

I analyzed the last 15 commits on `master`:

| Commit | Message | Affected | Total | Reduction |
|--------|---------|----------|-------|-----------|
| `e2b2529` | feat(evm): make Executor generic | 9 | 36 | **75%** |
| `f4a6885` | clippy: warn on redundant_else | 25 | 36 | **31%** |
| `179b8f7` | feat(evm): add Tempo precompile | 29 | 36 | **19%** |

Example — an EVM change affects 9 of 36 crates with full dependency chains:

```
9 affected package(s) (base: HEAD~1, 1 files changed):

  ● foundry-evm      (directly changed)
  ● forge             (depends on: forge → foundry-evm)
  ● anvil             (depends on: anvil → foundry-evm)
  ● cast              (depends on: cast → foundry-evm)
  ...
  (27 crates NOT affected)
```

## What this PR adds

- **`.affected.toml`** — config file (ignores docs/markdown/CI/testdata files)
- **`.github/workflows/affected-test.yml`** — experimental workflow that:
  1. Detects affected crates via `affected ci`
  2. Creates a dynamic GitHub Actions matrix
  3. Runs `cargo nextest run -p <crate>` per affected crate

This complements `matrices.py` by narrowing **which** crates enter the matrix, rather than partitioning all 36.

**This runs alongside existing CI — it does NOT replace anything.**

## What `affected` is

[`affected`](https://github.com/Rani367/affected) — single 5MB Rust binary, zero config, MIT licensed. Auto-detects Cargo workspaces. Has a [GitHub Action](https://github.com/Rani367/setup-affected) and [PR comment bot](https://github.com/Rani367/affected-pr-comment).