### PR TITLE
feat(anvil): add `feePayer` to Tempo receipts

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -4026,7 +4026,10 @@ impl Backend<FoundryNetwork> {
         };
 
         // Include timestamp in receipt to avoid extra block lookups (e.g., in Otterscan API)
-        let inner = FoundryTxReceipt::with_timestamp(receipt, block.header.timestamp());
+        let mut inner = FoundryTxReceipt::with_timestamp(receipt, block.header.timestamp());
+        if self.is_tempo() {
+            inner = inner.with_fee_payer(info.from);
+        }
         Some(MinedTransactionReceipt { inner, out: info.out })
     }
 

--- a/crates/primitives/src/network/receipt.rs
+++ b/crates/primitives/src/network/receipt.rs
@@ -31,6 +31,12 @@ impl FoundryTxReceipt {
         Self(receipt)
     }
 
+    /// Adds a `feePayer` field to the receipt.
+    pub fn with_fee_payer(mut self, fee_payer: Address) -> Self {
+        self.0.other.insert("feePayer".to_string(), serde_json::to_value(fee_payer).unwrap());
+        self
+    }
+
     /// Get block timestamp from other fields if present.
     pub fn block_timestamp(&self) -> Option<u64> {
         self.0.other.get_deserialized::<u64>("blockTimestamp").transpose().ok().flatten()


### PR DESCRIPTION
Add `feePayer` field to transaction receipts when running in Tempo mode. 