### PR TITLE
feat: add missing Tempo precompile addresses

### DIFF
--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -37,6 +37,12 @@ pub use tempo_contracts::precompiles::{
     ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, PATH_USD_ADDRESS, THETA_USD_ADDRESS,
 };
 
+// TODO: remove once we can re-export from tempo_precompiles instead.
+pub const SIGNATURE_VERIFIER_ADDRESS: Address =
+    address!("0x5165300000000000000000000000000000000000");
+pub const ADDRESS_REGISTRY_ADDRESS: Address =
+    address!("0xFDC0000000000000000000000000000000000000");
+
 /// All well-known TIP20 fee token addresses on Tempo networks.
 pub const TEMPO_TIP20_TOKENS: &[Address] =
     &[PATH_USD_ADDRESS, ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, THETA_USD_ADDRESS];
@@ -227,6 +233,8 @@ pub fn initialize_tempo_genesis(
             VALIDATOR_CONFIG_ADDRESS,
             VALIDATOR_CONFIG_V2_ADDRESS,
             ACCOUNT_KEYCHAIN_ADDRESS,
+            SIGNATURE_VERIFIER_ADDRESS,
+            ADDRESS_REGISTRY_ADDRESS,
         ] {
             ctx.set_code(precompile, sentinel.clone())?;
         }

--- a/crates/evm/evm/src/tempo.rs
+++ b/crates/evm/evm/src/tempo.rs
@@ -5,7 +5,10 @@ use alloy_primitives::{Address, Bytes, U256};
 use foundry_evm_core::{
     backend::DatabaseError,
     constants::{CALLER, TEST_CONTRACT_ADDRESS},
-    tempo::{TEMPO_TIP20_TOKENS, TempoStorageProvider, initialize_tempo_genesis},
+    tempo::{
+        ADDRESS_REGISTRY_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, TEMPO_TIP20_TOKENS,
+        TempoStorageProvider, initialize_tempo_genesis,
+    },
 };
 use foundry_evm_hardforks::FoundryHardfork;
 use revm::state::{AccountInfo, Bytecode};
@@ -79,6 +82,8 @@ pub fn warm_tempo_precompile_accounts(
         VALIDATOR_CONFIG_ADDRESS,
         VALIDATOR_CONFIG_V2_ADDRESS,
         ACCOUNT_KEYCHAIN_ADDRESS,
+        SIGNATURE_VERIFIER_ADDRESS,
+        ADDRESS_REGISTRY_ADDRESS,
     ];
 
     for addr in precompile_addresses.iter().chain(TEMPO_TIP20_TOKENS.iter()) {


### PR DESCRIPTION
Add `SIGNATURE_VERIFIER_ADDRESS` and `ADDRESS_REGISTRY_ADDRESS` to the genesis sentinel list for both anvil and forge. 

- These 2 should be re-exported when available on the alloy-2.0 branch or in a bump