### PR TITLE
refactor(evm): `FuzzedExecutor` generic

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -35,24 +35,29 @@
 //!   entries since it doesn't matter as long as the corpus eventually syncs across all workers
 
 use crate::executors::{Executor, RawCallResult, invariant::execute_tx};
+use alloy_consensus::transaction::SignerRecoverable;
 use alloy_dyn_abi::JsonAbiExt;
-use alloy_evm::EthEvmFactory;
+use alloy_evm::FromRecoveredTx;
 use alloy_json_abi::Function;
-use alloy_network::Ethereum;
+use alloy_network::{AnyRpcTransaction, Network};
 use alloy_primitives::Bytes;
+use alloy_rlp::Decodable;
 use eyre::{Result, eyre};
 use foundry_config::FuzzCorpusConfig;
+use foundry_evm_core::{TryAnyToTxEnv, evm::FoundryEvmFactory};
 use foundry_evm_fuzz::{
     BasicTxDetails,
     invariant::FuzzRunIdentifiedContracts,
     strategies::{EvmFuzzState, mutate_param_value},
 };
+use foundry_primitives::FoundryTransactionBuilder;
 use proptest::{
     prelude::{Just, Rng, Strategy},
     prop_oneof,
     strategy::{BoxedStrategy, ValueTree},
     test_runner::TestRunner,
 };
+use revm::primitives::hardfork::SpecId;
 use serde::Serialize;
 use std::{
     fmt,
@@ -273,15 +278,23 @@ pub struct WorkerCorpus {
 }
 
 impl WorkerCorpus {
-    pub fn new(
+    pub fn new<N, F>(
         id: usize,
         config: FuzzCorpusConfig,
         tx_generator: BoxedStrategy<BasicTxDetails>,
         // Only required by master worker (id = 0) to replay existing corpus.
-        executor: Option<&Executor<Ethereum, EthEvmFactory>>,
+        executor: Option<&Executor<N, F>>,
         fuzzed_function: Option<&Function>,
         fuzzed_contracts: Option<&FuzzRunIdentifiedContracts>,
-    ) -> Result<Self> {
+    ) -> Result<Self>
+    where
+        N: Network<
+                TxEnvelope: Decodable + SignerRecoverable,
+                TransactionRequest: FoundryTransactionBuilder<N>,
+            >,
+        F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+        AnyRpcTransaction: TryAnyToTxEnv<F::Tx>,
+    {
         let mutation_generator = prop_oneof![
             Just(MutationType::Splice),
             Just(MutationType::Repeat),
@@ -443,7 +456,10 @@ impl WorkerCorpus {
     }
 
     /// Collects coverage from call result and updates metrics.
-    pub fn merge_edge_coverage(&mut self, call_result: &mut RawCallResult) -> bool {
+    pub fn merge_edge_coverage<N: Network, F: FoundryEvmFactory>(
+        &mut self,
+        call_result: &mut RawCallResult<N, F>,
+    ) -> bool {
         if !self.config.collect_edge_coverage() {
             return false;
         }
@@ -761,12 +777,20 @@ impl WorkerCorpus {
     /// Syncs and calibrates the in memory corpus and updates the history_map if new coverage is
     /// found from the corpus findings of other workers.
     #[instrument(skip_all)]
-    fn calibrate(
+    fn calibrate<N, F>(
         &mut self,
-        executor: &Executor<Ethereum, EthEvmFactory>,
+        executor: &Executor<N, F>,
         fuzzed_function: Option<&Function>,
         fuzzed_contracts: Option<&FuzzRunIdentifiedContracts>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        N: Network<
+                TxEnvelope: Decodable + SignerRecoverable,
+                TransactionRequest: FoundryTransactionBuilder<N>,
+            >,
+        F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+        AnyRpcTransaction: TryAnyToTxEnv<F::Tx>,
+    {
         let Some(worker_dir) = &self.worker_dir else {
             return Ok(());
         };
@@ -974,14 +998,22 @@ impl WorkerCorpus {
 
     /// Syncs the workers in_memory_corpus and history_map with the findings from other workers.
     #[instrument(skip_all)]
-    pub fn sync(
+    pub fn sync<N, F>(
         &mut self,
         num_workers: usize,
-        executor: &Executor<Ethereum, EthEvmFactory>,
+        executor: &Executor<N, F>,
         fuzzed_function: Option<&Function>,
         fuzzed_contracts: Option<&FuzzRunIdentifiedContracts>,
         global_corpus_metrics: &GlobalCorpusMetrics,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        N: Network<
+                TxEnvelope: Decodable + SignerRecoverable,
+                TransactionRequest: FoundryTransactionBuilder<N>,
+            >,
+        F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+        AnyRpcTransaction: TryAnyToTxEnv<F::Tx>,
+    {
         trace!(target: "corpus", "syncing");
 
         self.sync_metrics(global_corpus_metrics);

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -2,18 +2,21 @@ use crate::executors::{
     DURATION_BETWEEN_METRICS_REPORT, EarlyExit, Executor, FuzzTestTimer, RawCallResult,
     corpus::{GlobalCorpusMetrics, WorkerCorpus},
 };
+use alloy_consensus::transaction::SignerRecoverable;
 use alloy_dyn_abi::JsonAbiExt;
-use alloy_evm::EthEvmFactory;
+use alloy_evm::FromRecoveredTx;
 use alloy_json_abi::Function;
-use alloy_network::Ethereum;
+use alloy_network::{AnyRpcTransaction, Network};
 use alloy_primitives::{Address, Bytes, Log, U256, keccak256, map::HashMap};
+use alloy_rlp::Decodable;
 use eyre::Result;
 use foundry_common::sh_println;
 use foundry_config::FuzzConfig;
 use foundry_evm_core::{
-    Breakpoints,
+    Breakpoints, TryAnyToTxEnv,
     constants::{CHEATCODE_ADDRESS, MAGIC_ASSUME},
     decode::{RevertDecoder, SkipReason},
+    evm::FoundryEvmFactory,
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::{
@@ -22,12 +25,14 @@ use foundry_evm_fuzz::{
     strategies::{EvmFuzzState, fuzz_calldata, fuzz_calldata_from_state},
 };
 use foundry_evm_traces::SparsedTraceArena;
+use foundry_primitives::FoundryTransactionBuilder;
 use indicatif::ProgressBar;
 use proptest::{
     strategy::Strategy,
     test_runner::{RngAlgorithm, TestCaseError, TestRng, TestRunner},
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use revm::primitives::hardfork::SpecId;
 use serde_json::json;
 use std::{
     sync::{
@@ -47,8 +52,7 @@ const SYNC_INTERVAL: u32 = 1000;
 /// This is mainly to reduce the overall number of rayon jobs.
 const MIN_RUNS_PER_WORKER: u32 = 64;
 
-#[derive(Default)]
-struct WorkerState {
+struct WorkerState<N: Network, F: FoundryEvmFactory> {
     /// Worker identifier
     id: usize,
     /// First fuzz case this worker encountered (with global run number)
@@ -56,7 +60,7 @@ struct WorkerState {
     /// Gas usage for all cases this worker ran
     gas_by_case: Vec<(u64, u64)>,
     /// Counterexample if this worker found one
-    counterexample: (Bytes, RawCallResult),
+    counterexample: (Bytes, RawCallResult<N, F>),
     /// Traces collected by this worker
     ///
     /// Stores up to `max_traces_to_collect` which is `config.gas_report_samples / num_workers`
@@ -81,9 +85,23 @@ struct WorkerState {
     failed_corpus_replays: usize,
 }
 
-impl WorkerState {
+impl<N: Network, F: FoundryEvmFactory> WorkerState<N, F> {
     fn new(worker_id: usize) -> Self {
-        Self { id: worker_id, ..Default::default() }
+        Self {
+            id: worker_id,
+            first_case: None,
+            gas_by_case: Vec::new(),
+            counterexample: (Bytes::new(), RawCallResult::default()),
+            traces: Vec::new(),
+            breakpoints: None,
+            coverage: None,
+            logs: Vec::new(),
+            deprecated_cheatcodes: HashMap::default(),
+            runs: 0,
+            failure: None,
+            last_run_timestamp: 0,
+            failed_corpus_replays: 0,
+        }
     }
 }
 
@@ -160,9 +178,9 @@ impl SharedFuzzState {
 /// After instantiation, calling `fuzz` will proceed to hammer the deployed smart contract with
 /// inputs, until it finds a counterexample. The provided [`TestRunner`] contains all the
 /// configuration which can be overridden via [environment variables](proptest::test_runner::Config)
-pub struct FuzzedExecutor {
+pub struct FuzzedExecutor<N: Network, F: FoundryEvmFactory> {
     /// The EVM executor.
-    executor_f: Executor<Ethereum, EthEvmFactory>,
+    executor_f: Executor<N, F>,
     /// The fuzzer
     runner: TestRunner,
     /// The account that calls tests.
@@ -175,10 +193,18 @@ pub struct FuzzedExecutor {
     num_workers: usize,
 }
 
-impl FuzzedExecutor {
+impl<N, F> FuzzedExecutor<N, F>
+where
+    N: Network<
+            TxEnvelope: Decodable + SignerRecoverable,
+            TransactionRequest: FoundryTransactionBuilder<N>,
+        >,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+    AnyRpcTransaction: TryAnyToTxEnv<F::Tx>,
+{
     /// Instantiates a fuzzed executor given a testrunner
     pub fn new(
-        executor: Executor<Ethereum, EthEvmFactory>,
+        executor: Executor<N, F>,
         runner: TestRunner,
         sender: Address,
         config: FuzzConfig,
@@ -239,11 +265,11 @@ impl FuzzedExecutor {
     /// or a `CounterExampleOutcome`
     fn single_fuzz(
         &self,
-        executor: &Executor<Ethereum, EthEvmFactory>,
+        executor: &Executor<N, F>,
         address: Address,
         calldata: Bytes,
         coverage_metrics: &mut WorkerCorpus,
-    ) -> Result<FuzzOutcome, TestCaseError> {
+    ) -> Result<FuzzOutcome<N, F>, TestCaseError> {
         let mut call = executor
             .call_raw(self.sender, address, calldata.clone(), U256::ZERO)
             .map_err(|e| TestCaseError::fail(e.to_string()))?;
@@ -301,7 +327,7 @@ impl FuzzedExecutor {
     /// Aggregates the results from all workers
     fn aggregate_results(
         &self,
-        mut workers: Vec<WorkerState>,
+        mut workers: Vec<WorkerState<N, F>>,
         func: &Function,
         shared_state: &SharedFuzzState,
     ) -> FuzzTestResult {
@@ -405,7 +431,7 @@ impl FuzzedExecutor {
         rd: &RevertDecoder,
         shared_state: &SharedFuzzState,
         progress: Option<&ProgressBar>,
-    ) -> Result<WorkerState> {
+    ) -> Result<WorkerState<N, F>> {
         // Prepare
         let dictionary_weight = self.config.dictionary.dictionary_weight.min(100);
         let strategy = proptest::prop_oneof![

--- a/crates/evm/evm/src/executors/fuzz/types.rs
+++ b/crates/evm/evm/src/executors/fuzz/types.rs
@@ -1,6 +1,7 @@
 use crate::executors::RawCallResult;
+use alloy_network::Network;
 use alloy_primitives::{Bytes, Log, map::HashMap};
-use foundry_evm_core::Breakpoints;
+use foundry_evm_core::{Breakpoints, evm::FoundryEvmFactory};
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::FuzzCase;
 use foundry_evm_traces::SparsedTraceArena;
@@ -25,9 +26,9 @@ pub struct CaseOutcome {
 
 /// Returned by a single fuzz when a counterexample has been discovered
 #[derive(Debug)]
-pub struct CounterExampleOutcome {
+pub struct CounterExampleOutcome<N: Network, F: FoundryEvmFactory> {
     /// Minimal reproduction test case for failing test.
-    pub counterexample: (Bytes, RawCallResult),
+    pub counterexample: (Bytes, RawCallResult<N, F>),
     /// The status of the call.
     pub exit_reason: Option<InstructionResult>,
     /// Breakpoints char pc map.
@@ -37,7 +38,7 @@ pub struct CounterExampleOutcome {
 /// Outcome of a single fuzz
 #[derive(Debug)]
 #[expect(clippy::large_enum_variant)]
-pub enum FuzzOutcome {
+pub enum FuzzOutcome<N: Network, F: FoundryEvmFactory> {
     Case(CaseOutcome),
-    CounterExample(CounterExampleOutcome),
+    CounterExample(CounterExampleOutcome<N, F>),
 }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -5,9 +5,11 @@ use crate::{
     },
     inspectors::Fuzzer,
 };
-use alloy_evm::EthEvmFactory;
-use alloy_network::Ethereum;
+use alloy_consensus::transaction::SignerRecoverable;
+use alloy_evm::{EthEvmFactory, FromRecoveredTx};
+use alloy_network::{AnyRpcTransaction, Ethereum, Network};
 use alloy_primitives::{Address, Bytes, FixedBytes, I256, Selector, U256, map::AddressMap};
+use alloy_rlp::Decodable;
 use alloy_sol_types::{SolCall, sol};
 use eyre::{ContextCompat, Result, eyre};
 use foundry_common::{
@@ -17,9 +19,11 @@ use foundry_common::{
 };
 use foundry_config::InvariantConfig;
 use foundry_evm_core::{
+    FoundryBlock, TryAnyToTxEnv,
     constants::{
         CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME,
     },
+    evm::FoundryEvmFactory,
     precompiles::PRECOMPILES,
 };
 use foundry_evm_fuzz::{
@@ -31,11 +35,12 @@ use foundry_evm_fuzz::{
     strategies::{EvmFuzzState, invariant_strat, override_call_strat},
 };
 use foundry_evm_traces::{CallTraceArena, SparsedTraceArena};
+use foundry_primitives::FoundryTransactionBuilder;
 use indicatif::ProgressBar;
 use parking_lot::RwLock;
 use proptest::{strategy::Strategy, test_runner::TestRunner};
 use result::{assert_after_invariant, assert_invariants, can_continue};
-use revm::state::Account;
+use revm::{context::Block, primitives::hardfork::SpecId, state::Account};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
@@ -1102,17 +1107,27 @@ pub(crate) fn call_invariant_function(
 
 /// Executes a fuzz call and returns the result.
 /// Applies any block timestamp (warp) and block number (roll) adjustments before the call.
-pub(crate) fn execute_tx(
-    executor: &mut Executor<Ethereum, EthEvmFactory>,
+pub(crate) fn execute_tx<N, F>(
+    executor: &mut Executor<N, F>,
     tx: &BasicTxDetails,
-) -> Result<RawCallResult> {
+) -> Result<RawCallResult<N, F>>
+where
+    N: Network<
+            TxEnvelope: Decodable + SignerRecoverable,
+            TransactionRequest: FoundryTransactionBuilder<N>,
+        >,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+    AnyRpcTransaction: TryAnyToTxEnv<F::Tx>,
+{
     let warp = tx.warp.unwrap_or_default();
     let roll = tx.roll.unwrap_or_default();
 
     if warp > 0 || roll > 0 {
         // Apply pre-call block adjustments to the executor's env.
-        executor.evm_env_mut().block_env.timestamp += warp;
-        executor.evm_env_mut().block_env.number += roll;
+        let ts = executor.evm_env().block_env.timestamp();
+        let num = executor.evm_env().block_env.number();
+        executor.evm_env_mut().block_env.set_timestamp(ts + warp);
+        executor.evm_env_mut().block_env.set_number(num + roll);
 
         // Also update the inspector's cheatcodes.block if set.
         // The inspector's block may override the env during interpreter initialization,
@@ -1120,8 +1135,10 @@ pub(crate) fn execute_tx(
         let block_env = executor.evm_env().block_env.clone();
         if let Some(cheatcodes) = executor.inspector_mut().cheatcodes.as_mut() {
             if let Some(block) = cheatcodes.block.as_mut() {
-                block.timestamp += warp;
-                block.number += roll;
+                let bts = block.timestamp();
+                let bnum = block.number();
+                block.set_timestamp(bts + warp);
+                block.set_number(bnum + roll);
             } else {
                 cheatcodes.block = Some(block_env);
             }


### PR DESCRIPTION
## Motivation
Makes `FuzzedExecutor<N, F>` generic over `Network` and `FoundryEvmFactory`. Also generifies `WorkerCorpus` methods, `CounterExampleOutcome`, `FuzzOutcome`, `WorkerState`, and `execute_tx`.