### PR TITLE
chore(evm): remove useless `Spec: From<SpecId>` bounds

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -24,7 +24,7 @@ use revm::{
     context::{Block, BlockEnv, CfgEnv, ContextTr, JournalInner, Transaction},
     context_interface::{journaled_state::account::JournaledAccountTr, result::ResultAndState},
     database::{CacheDB, DatabaseRef, EmptyDB},
-    primitives::{AddressMap, HashMap as Map, KECCAK_EMPTY, Log, hardfork::SpecId},
+    primitives::{AddressMap, HashMap as Map, KECCAK_EMPTY, Log},
     state::{Account, AccountInfo, EvmState, EvmStorageSlot},
 };
 use std::{
@@ -792,7 +792,6 @@ impl<N: Network, F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>> Backe
     ) -> eyre::Result<ResultAndState<F::HaltReason>>
     where
         Self: DatabaseExt<F::BlockEnv, F::Tx, F::Spec>,
-        F::Spec: From<SpecId>,
     {
         self.initialize(evm_env.cfg_env.spec, tx_env.caller(), tx_env.kind());
         let mut evm =

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -5,10 +5,7 @@ use alloy_network::Network;
 use alloy_rlp::Decodable;
 use foundry_evm_core::{EvmEnv, backend::Backend, evm::FoundryEvmFactory};
 use foundry_primitives::FoundryTransactionBuilder;
-use revm::{
-    context::{Block, Transaction},
-    primitives::hardfork::SpecId,
-};
+use revm::context::{Block, Transaction};
 use std::marker::PhantomData;
 
 /// The builder that allows to configure an evm [`Executor`] which a stack of optional
@@ -57,7 +54,7 @@ where
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
 {
     /// Modify the inspector stack.
     #[inline]

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -57,7 +57,6 @@ use proptest::{
     strategy::{BoxedStrategy, ValueTree},
     test_runner::TestRunner,
 };
-use revm::primitives::hardfork::SpecId;
 use serde::Serialize;
 use std::{
     fmt,
@@ -292,7 +291,7 @@ impl WorkerCorpus {
                 TxEnvelope: Decodable + SignerRecoverable,
                 TransactionRequest: FoundryTransactionBuilder<N>,
             >,
-        F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+        F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
     {
         let mutation_generator = prop_oneof![
             Just(MutationType::Splice),
@@ -787,7 +786,7 @@ impl WorkerCorpus {
                 TxEnvelope: Decodable + SignerRecoverable,
                 TransactionRequest: FoundryTransactionBuilder<N>,
             >,
-        F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+        F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
     {
         let Some(worker_dir) = &self.worker_dir else {
             return Ok(());
@@ -1009,7 +1008,7 @@ impl WorkerCorpus {
                 TxEnvelope: Decodable + SignerRecoverable,
                 TransactionRequest: FoundryTransactionBuilder<N>,
             >,
-        F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+        F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
     {
         trace!(target: "corpus", "syncing");
 

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -32,7 +32,6 @@ use proptest::{
     test_runner::{RngAlgorithm, TestCaseError, TestRng, TestRunner},
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use revm::primitives::hardfork::SpecId;
 use serde_json::json;
 use std::{
     sync::{
@@ -199,7 +198,7 @@ where
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
 {
     /// Instantiates a fuzzed executor given a testrunner
     pub fn new(

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -40,7 +40,7 @@ use indicatif::ProgressBar;
 use parking_lot::RwLock;
 use proptest::{strategy::Strategy, test_runner::TestRunner};
 use result::{assert_after_invariant, assert_invariants, can_continue};
-use revm::{context::Block, primitives::hardfork::SpecId, state::Account};
+use revm::{context::Block, state::Account};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
@@ -1116,7 +1116,7 @@ where
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
 {
     let warp = tx.warp.unwrap_or_default();
     let roll = tx.roll.unwrap_or_default();

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -43,7 +43,6 @@ use revm::{
     },
     database::{DatabaseCommit, DatabaseRef},
     interpreter::{InstructionResult, return_ok},
-    primitives::hardfork::SpecId,
 };
 use std::{
     borrow::Cow,
@@ -120,7 +119,7 @@ where
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
 {
     /// Creates a new `Executor` with the given arguments.
     #[inline]

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -14,7 +14,7 @@ use foundry_evm_core::{
 use foundry_evm_networks::NetworkConfigs;
 use foundry_evm_traces::TraceMode;
 use foundry_primitives::FoundryTransactionBuilder;
-use revm::{context::Transaction, primitives::hardfork::SpecId, state::Bytecode};
+use revm::{context::Transaction, state::Bytecode};
 use std::ops::{Deref, DerefMut};
 
 /// A default executor with tracing enabled
@@ -28,7 +28,7 @@ where
             TxEnvelope: Decodable + SignerRecoverable,
             TransactionRequest: FoundryTransactionBuilder<N>,
         >,
-    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>, Spec: From<SpecId>>,
+    F: FoundryEvmFactory<Tx: FromRecoveredTx<N::TxEnvelope>>,
 {
     pub fn new(
         env: (EvmEnv<F::Spec, F::BlockEnv>, F::Tx),


### PR DESCRIPTION
## Motivation

Remove useless `Spec: From<SpecId>` bounds everywhere.