### PR TITLE
refactor(cast): direct `block_env` access -> trait methods

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -34,7 +34,7 @@ use foundry_config::{
     },
 };
 use foundry_evm::{
-    core::evm::EthEvmNetwork,
+    core::{FoundryBlock, evm::EthEvmNetwork},
     executors::TracingExecutor,
     opts::EvmOpts,
     traces::{InternalTraceMode, TraceMode},
@@ -305,15 +305,15 @@ impl CallArgs {
             // modify settings that usually set in eth_call
             evm_env.cfg_env.disable_block_gas_limit = true;
             evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
-            evm_env.block_env.gas_limit = u64::MAX;
+            evm_env.block_env.set_gas_limit(u64::MAX);
 
             // Apply the block overrides.
             if let Some(block_overrides) = block_overrides {
                 if let Some(number) = block_overrides.number {
-                    evm_env.block_env.number = number.to();
+                    evm_env.block_env.set_number(number.to());
                 }
                 if let Some(time) = block_overrides.time {
-                    evm_env.block_env.timestamp = U256::from(time);
+                    evm_env.block_env.set_timestamp(U256::from(time));
                 }
             }
 

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -28,13 +28,16 @@ use foundry_config::{
     },
 };
 use foundry_evm::{
-    core::evm::EthEvmNetwork,
+    core::{FoundryBlock, evm::EthEvmNetwork},
     executors::{EvmError, Executor, TracingExecutor},
     opts::EvmOpts,
     traces::{InternalTraceMode, TraceMode, Traces},
 };
 use futures::TryFutureExt;
-use revm::{DatabaseRef, context::TxEnv};
+use revm::{
+    DatabaseRef,
+    context::{Block, TxEnv},
+};
 
 /// CLI arguments for `cast run`.
 #[derive(Clone, Debug, Parser)]
@@ -184,7 +187,7 @@ impl RunArgs {
         }
 
         evm_env.cfg_env.limit_contract_code_size = None;
-        evm_env.block_env.number = U256::from(tx_block_number);
+        evm_env.block_env.set_number(U256::from(tx_block_number));
 
         if let Some(block) = &block {
             evm_env.block_env = block_env_from_header(&block.header);
@@ -266,7 +269,7 @@ impl RunArgs {
                                 format!(
                                     "Failed to execute transaction: {:?} in block {}",
                                     tx.tx_hash(),
-                                    evm_env.block_env.number
+                                    evm_env.block_env.number()
                                 )
                             },
                         )?;
@@ -283,7 +286,7 @@ impl RunArgs {
                                         format!(
                                             "Failed to deploy transaction: {:?} in block {}",
                                             tx.tx_hash(),
-                                            evm_env.block_env.number
+                                            evm_env.block_env.number()
                                         )
                                     });
                                 }


### PR DESCRIPTION
## Motivation
Prep for generic `cast run`/`cast call`. Replaces direct `block_env` field access with `FoundryBlock`/`Block` trait methods so the code is network-agnostic.