### PR TITLE
chore(cli): remove unused `TryFrom<Result<RawCallResult>>` on `TraceResult`

### DIFF
--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -310,7 +310,7 @@ impl RunArgs {
 
             if let Some(to) = Transaction::to(&tx) {
                 trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");
-                TraceResult::try_from(executor.transact_with_env(evm_env, tx_env))?
+                TraceResult::from(executor.transact_with_env(evm_env, tx_env)?)
             } else {
                 trace!(tx=?tx.tx_hash(), "executing create transaction");
                 TraceResult::try_from(executor.deploy_with_env(evm_env, tx_env, None))?

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -274,17 +274,6 @@ impl From<RawCallResult> for TraceResult {
     }
 }
 
-impl TryFrom<Result<RawCallResult>> for TraceResult {
-    type Error = EvmError;
-
-    fn try_from(value: Result<RawCallResult>) -> Result<Self, Self::Error> {
-        match value {
-            Ok(result) => Ok(Self::from(result)),
-            Err(err) => Err(EvmError::from(err)),
-        }
-    }
-}
-
 pub async fn print_traces(
     result: &mut TraceResult,
     decoder: &CallTraceDecoder,


### PR DESCRIPTION
## Motivation
Removes an unused `TryFrom<Result<RawCallResult>>` impl on `TraceResult` that wrapped `eyre::Report` into `EvmError::Eyre`. No call sites use this pattern — the `transact_with_env` result is unwrapped with `?` before conversion.