### PR TITLE
fix(anvil): handle BlockTransactions::Uncle without panic

### DIFF
--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -383,8 +383,7 @@ impl<N: Network> ClientFork<N> {
                         return self.transaction_by_hash(*tx_hash).await;
                     }
                 }
-                // TODO(evalir): Is it possible to reach this case? Should we support it
-                BlockTransactions::Uncle => panic!("Uncles not supported"),
+                BlockTransactions::Uncle => {}
             }
         }
         Ok(None)
@@ -408,8 +407,7 @@ impl<N: Network> ClientFork<N> {
                         return self.transaction_by_hash(*tx_hash).await;
                     }
                 }
-                // TODO(evalir): Is it possible to reach this case? Should we support it
-                BlockTransactions::Uncle => panic!("Uncles not supported"),
+                BlockTransactions::Uncle => {}
             }
         }
         Ok(None)


### PR DESCRIPTION
Panics in RPC server are not acceptable. When `BlockTransactions::Uncle` is encountered, return `Ok(None)` instead of crashing.

This variant appears due to alloy deserialization quirk (alloy-rs/alloy#805) and other anvil handlers already handle it gracefully (api.rs returns 0 for tx count).

Introduced in 51632c475 (#13647).
Related: #8822 (similar panic fix in Otterscan).