### PR TITLE
feat(anvil): auto-fill gas fields for Tempo AA transactions

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3406,7 +3406,10 @@ impl EthApi<FoundryNetwork> {
             }
             if matches!(
                 tx_type,
-                FoundryTxType::Eip1559 | FoundryTxType::Eip4844 | FoundryTxType::Eip7702
+                FoundryTxType::Eip1559
+                    | FoundryTxType::Eip4844
+                    | FoundryTxType::Eip7702
+                    | FoundryTxType::Tempo
             ) {
                 request
                     .max_fee_per_gas()


### PR DESCRIPTION
Auto-fill `maxFeePerGas` and `maxPriorityFeePerGas` for Tempo AA transactions in `build_tx_request()`, matching the existing behavior for EIP-1559/4844/7702 tx types.