### PR TITLE
fix(cast): remove duplicate 0x prefix in sign-auth output

### DIFF
--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -689,7 +689,7 @@ impl WalletSubcommands {
                         )?;
                     } else {
                         sh_println!(
-                            "Successfully signed!\n   Nonce: {}\n   Chain ID: {}\n   Address: {}\n   Signature: 0x{}",
+                            "Successfully signed!\n   Nonce: {}\n   Chain ID: {}\n   Address: {}\n   Signature: {}",
                             nonce,
                             chain_id,
                             wallet.address(),


### PR DESCRIPTION
`hex::encode_prefixed` already returns a string with `0x` prefix, so having `0x{}` in the format string resulted in double prefix like `0x0xf85a...`.

Before:
Signature: 0x0xf85a01800194
After:
Signature: 0xf85a01800194