### PR TITLE
fix(cast): add MegaETH system sender to known system senders

### DIFF
--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -42,6 +42,10 @@ pub const OPTIMISM_SYSTEM_ADDRESS: Address = address!("0xdeaddeaddeaddeaddeaddea
 /// The system address, the sender of the first transaction in every block:
 pub const MONAD_SYSTEM_ADDRESS: Address = address!("0x6f49a8F621353f12378d0046E7d7e4b9B249DC9e");
 
+/// MegaETH system sender, the sender of the second transaction in every block.
+/// These are legacy (type 0) transactions with `gasPrice=0` despite a non-zero basefee.
+pub const MEGAETH_SYSTEM_ADDRESS: Address = address!("0xa887dcb9d5f39ef79272801d05abdf707cfbbd1d");
+
 /// Transaction identifier of System transaction types
 pub const SYSTEM_TRANSACTION_TYPE: u8 = 126;
 
@@ -55,10 +59,17 @@ pub const TYPE_BINDING_PREFIX: &str = "string constant schema_";
 ///
 /// Transactions from these senders usually don't have a any fee information OR set absurdly high fees that exceed the gas limit (See: <https://github.com/foundry-rs/foundry/pull/10608>)
 ///
-/// See: [ARBITRUM_SENDER], [OPTIMISM_SYSTEM_ADDRESS], [MONAD_SYSTEM_ADDRESS] and [Address::ZERO]
+/// See: [ARBITRUM_SENDER], [OPTIMISM_SYSTEM_ADDRESS], [MONAD_SYSTEM_ADDRESS],
+/// [MEGAETH_SYSTEM_ADDRESS] and [Address::ZERO]
 pub fn is_known_system_sender(sender: Address) -> bool {
-    [ARBITRUM_SENDER, OPTIMISM_SYSTEM_ADDRESS, MONAD_SYSTEM_ADDRESS, Address::ZERO]
-        .contains(&sender)
+    [
+        ARBITRUM_SENDER,
+        OPTIMISM_SYSTEM_ADDRESS,
+        MONAD_SYSTEM_ADDRESS,
+        MEGAETH_SYSTEM_ADDRESS,
+        Address::ZERO,
+    ]
+    .contains(&sender)
 }
 
 pub fn is_impersonated_tx(tx: &AnyTxEnvelope) -> bool {


### PR DESCRIPTION
MegaETH includes a system transaction (legacy type 0, `gasPrice=0`) as the second tx in every block from `0xa887dcb9d5f39ef79272801d05abdf707cfbbd1d`. This causes `cast run` to fail with `gas price is less than basefee` when replaying prior transactions, because revm validates the zero gas price against the block's non-zero `baseFeePerGas` (1000000).

Same pattern as #10608 — adds the MegaETH system sender to `is_known_system_sender()` so these txs are skipped during replay.

Example failing tx: `cast run 0x3775b355f222b27271b06819fb357696d4c72e0d366b4bb43b8d142aa27a8525 --rpc-url https://mainnet.megaeth.com/rpc`

Prompted by: georgen