### PR TITLE
fix(foundryup): use $HOME instead of $XDG_CONFIG_HOME for default install path

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -5,8 +5,7 @@ set -eo pipefail
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
 FOUNDRYUP_INSTALLER_VERSION="1.6.1"
 
-BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
-FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}
+FOUNDRY_DIR=${FOUNDRY_DIR:-"$HOME/.foundry"}
 FOUNDRY_VERSIONS_DIR="$FOUNDRY_DIR/versions"
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"

--- a/foundryup/install
+++ b/foundryup/install
@@ -3,8 +3,7 @@ set -eo pipefail
 
 echo "Installing foundryup..."
 
-BASE_DIR="${XDG_CONFIG_HOME:-$HOME}"
-FOUNDRY_DIR="${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}"
+FOUNDRY_DIR="${FOUNDRY_DIR:-"$HOME/.foundry"}"
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 


### PR DESCRIPTION
## Motivation

Fixes #14153

`foundryup` and `install` both use `XDG_CONFIG_HOME` as the base directory for `FOUNDRY_DIR`:

```bash
BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}
```

On systems where `XDG_CONFIG_HOME` is explicitly set (e.g. Ubuntu 24.04), this resolves to `~/.config/.foundry`, which doesn't exist and causes installation to fail:

```
cp: cannot create regular file '/home/user/.config/.foundry/bin/forge': No such file or directory
```

## Solution

Use `$HOME` directly as the base path in both `foundryup/foundryup` and `foundryup/install`, removing the `BASE_DIR` variable:

```bash
FOUNDRY_DIR=${FOUNDRY_DIR:-"$HOME/.foundry"}
```

This ensures the install path is always `~/.foundry` regardless of `XDG_CONFIG_HOME`, maintaining backward compatibility with all existing installations. Users who need a custom path can still override via `FOUNDRY_DIR`.

> **Note:** Proper XDG Base Directory support (e.g. `~/.config/foundry/`) would require a migration strategy for existing users and should be handled in a separate issue.

## PR Checklist
- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes