### PR TITLE
feat(cast): add `ISO 4217` validation for `TIP-20`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,6 +2721,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tempo-alloy",
+ "tempo-contracts",
  "tempo-primitives",
  "tokio",
  "tracing",

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -57,6 +57,7 @@ alloy-transport.workspace = true
 alloy-ens = { workspace = true, features = ["provider"] }
 alloy-eips.workspace = true
 tempo-alloy.workspace = true
+tempo-contracts.workspace = true
 tempo-primitives.workspace = true
 alloy-evm.workspace = true
 

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -2,6 +2,8 @@ use alloy_primitives::Address;
 use alloy_provider::Provider;
 use tempo_alloy::{TempoNetwork, provider::TempoProviderExt};
 
+pub use tempo_contracts::precompiles::is_iso4217_currency;
+
 /// Checks whether an access key is already provisioned on-chain.
 ///
 /// Queries the AccountKeychain precompile's `getKey` function. A key is considered
@@ -16,4 +18,27 @@ pub async fn is_key_provisioned<P: Provider<TempoNetwork>>(
         Ok(info) => info.keyId != Address::ZERO,
         Err(_) => false,
     }
+}
+
+/// Returns a warning message for non-ISO 4217 currency codes used in TIP-20 token creation.
+pub fn iso4217_warning_message(currency: &str) -> String {
+    let hyperlink = |url: &str| format!("\x1b]8;;{url}\x1b\\{url}\x1b]8;;\x1b\\");
+    let tip20_docs = hyperlink("https://docs.tempo.xyz/protocol/tip20/overview");
+    let iso_docs = hyperlink("https://www.iso.org/iso-4217-currency-codes.html");
+
+    format!(
+        "\"{currency}\" is not a recognized ISO 4217 currency code.\n\
+         \n\
+         If the token you are trying to deploy is a fiat-backed stablecoin, Tempo strongly\n\
+         recommends that the currency code field be the ISO-4217 currency code of the fiat\n\
+         currency your token tracks (e.g. \"USD\", \"EUR\", \"GBP\").\n\
+         \n\
+         The currency field is IMMUTABLE after token creation and affects fee payment\n\
+         eligibility, DEX routing, and quote token pairing. Only \"USD\"-denominated tokens\n\
+         can be used to pay transaction fees on Tempo.\n\
+         \n\
+         Learn more:\n  \
+         - Tempo TIP-20 docs: {tip20_docs}\n  \
+         - ISO 4217 standard: {iso_docs}"
+    )
 }


### PR DESCRIPTION
## Motivation
Adds ISO 4217 currency code validation infrastructure for TIP-20 token creation. Re-exports `is_iso4217_currency` from `tempo-contracts` and adds `iso4217_warning_message()` for user-facing validation prompts.

Towards https://github.com/foundry-rs/foundry/pull/14160