### PR TITLE
chore(evm): remove useless bounds on `Backend`

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -814,10 +814,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: &mut TxEnvFor<FEN>,
         inspector: I,
-    ) -> eyre::Result<ResultAndState<HaltReasonFor<FEN>>>
-    where
-        Self: DatabaseExt<FEN::EvmFactory>,
-    {
+    ) -> eyre::Result<ResultAndState<HaltReasonFor<FEN>>> {
         self.initialize(evm_env.cfg_env.spec, tx_env.caller(), tx_env.kind());
         let mut evm = FEN::EvmFactory::default().create_foundry_evm_with_inspector(
             self,

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -676,7 +676,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
                 None => {
                     let fork =
                         self.evm_opts.get_fork(&self.config, evm_env.cfg_env.chain_id, fork_block);
-                    let backend = Backend::<FEN>::spawn(fork)?;
+                    let backend = Backend::spawn(fork)?;
                     self.backends.insert(fork_url.clone(), backend.clone());
                     backend
                 }


### PR DESCRIPTION
## Motivation

Smol clean-up: remove useless bounds on `Backend`