### PR TITLE
fix(forge): update Mail templates for createToken salt parameter

### DIFF
--- a/crates/forge/assets/tempo/MailTemplate.s.sol
+++ b/crates/forge/assets/tempo/MailTemplate.s.sol
@@ -11,13 +11,16 @@ import {Mail} from "../src/Mail.sol";
 contract MailScript is Script {
     function setUp() public {}
 
-    function run() public {
+    function run(string memory salt) public {
         vm.startBroadcast();
 
-        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdTokens.ALPHA_USD_ADDRESS);
+        address feeToken = vm.envOr("TEMPO_FEE_TOKEN", StdTokens.ALPHA_USD_ADDRESS);
+        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(feeToken);
 
-        ITIP20 token =
-            ITIP20(StdPrecompiles.TIP20_FACTORY.createToken("testUSD", "tUSD", "USD", StdTokens.PATH_USD, msg.sender));
+        ITIP20 token = ITIP20(
+            StdPrecompiles.TIP20_FACTORY
+                .createToken("testUSD", "tUSD", "USD", StdTokens.PATH_USD, msg.sender, keccak256(bytes(salt)))
+        );
 
         ITIP20RolesAuth(address(token)).grantRole(token.ISSUER_ROLE(), msg.sender);
 

--- a/crates/forge/assets/tempo/MailTemplate.t.sol
+++ b/crates/forge/assets/tempo/MailTemplate.t.sol
@@ -16,10 +16,12 @@ contract MailTest is Test {
     address public constant BOB = address(0x70997970C51812dc3A010C7d01b50e0d17dc79C8);
 
     function setUp() public {
-        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdTokens.ALPHA_USD_ADDRESS);
+        address feeToken = vm.envOr("TEMPO_FEE_TOKEN", StdTokens.ALPHA_USD_ADDRESS);
+        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(feeToken);
 
         token = ITIP20(
-            StdPrecompiles.TIP20_FACTORY.createToken("testUSD", "tUSD", "USD", StdTokens.PATH_USD, address(this))
+            StdPrecompiles.TIP20_FACTORY
+                .createToken("testUSD", "tUSD", "USD", StdTokens.PATH_USD, address(this), bytes32(0))
         );
 
         ITIP20RolesAuth(address(token)).grantRole(token.ISSUER_ROLE(), address(this));


### PR DESCRIPTION
## Motivation

Towards Tempo integration tests upstreaming

- Add bytes32 salt parameter to createToken calls (tempo-std v0.1.5)
- Change Mail.s.sol run() to accept string salt for deterministic deploys
- Use vm.envOr for TEMPO_FEE_TOKEN in both templates
