### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mattsse @grandizzy @zerosnacks @0xrusowsky @mablr @figtracer @stevencartavia
+* @danipopes @mattsse @grandizzy @zerosnacks @onbjerg @0xrusowsky @mablr @figtracer @stevencartavia


### PR DESCRIPTION
Adds @mablr / @figtracer & @stevencartavia as co-reviewers

For the other contributors, if you prefer to not be included in the CODEOWNERS please open a PR to remove yourself or ping me to remove you and I'll create a PR