### PR TITLE
fix(cast): use FoundryNetwork for RPC provider in `cast run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2703,6 +2703,7 @@ dependencies = [
  "foundry-config",
  "foundry-debugger",
  "foundry-evm",
+ "foundry-primitives",
  "foundry-test-utils",
  "foundry-wallets",
  "futures",

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -28,6 +28,7 @@ foundry-compilers.workspace = true
 foundry-config.workspace = true
 foundry-debugger.workspace = true
 foundry-evm.workspace = true
+foundry-primitives.workspace = true
 foundry-wallets.workspace = true
 forge-fmt.workspace = true
 

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -5,7 +5,7 @@ use crate::{
 use alloy_consensus::{BlockHeader, Transaction, transaction::SignerRecoverable};
 
 use alloy_evm::FromRecoveredTx;
-use alloy_network::{BlockResponse, TransactionResponse};
+use alloy_network::{BlockResponse, Network, TransactionResponse};
 use alloy_primitives::{
     Address, Bytes, U256,
     map::{AddressSet, HashMap},
@@ -38,6 +38,7 @@ use foundry_evm::{
     opts::EvmOpts,
     traces::{InternalTraceMode, TraceMode, Traces},
 };
+use foundry_primitives::FoundryNetwork;
 use futures::TryFutureExt;
 use revm::{DatabaseRef, context::Block};
 
@@ -138,13 +139,26 @@ impl RunArgs {
         evm_opts.infer_network_from_fork().await;
 
         if evm_opts.networks.is_tempo() {
-            self.run_with_evm::<TempoEvmNetwork>().await
+            self.run_with_provider::<TempoEvmNetwork, <TempoEvmNetwork as FoundryEvmNetwork>::Network>().await
+        } else if evm_opts.networks.is_optimism() {
+            // OP Stack chains include deposit transactions (type 0x7e) that the
+            // `Ethereum` network type cannot deserialize. Use `FoundryNetwork` as the
+            // provider network, which supports all transaction types.
+            self.run_with_provider::<EthEvmNetwork, FoundryNetwork>().await
         } else {
-            self.run_with_evm::<EthEvmNetwork>().await
+            self.run_with_provider::<EthEvmNetwork, <EthEvmNetwork as FoundryEvmNetwork>::Network>().await
         }
     }
 
-    async fn run_with_evm<FEN: FoundryEvmNetwork>(self) -> Result<()> {
+    async fn run_with_provider<FEN, N>(self) -> Result<()>
+    where
+        FEN: FoundryEvmNetwork,
+        N: Network,
+        N::TransactionResponse: TransactionResponse + AsRef<N::TxEnvelope>,
+        N::TxEnvelope: SignerRecoverable,
+        N::BlockResponse: BlockResponse<Header: BlockHeader>,
+        TxEnvFor<FEN>: FromRecoveredTx<N::TxEnvelope>,
+    {
         let figment = self.rpc.clone().into_figment(self.with_local_artifacts).merge(&self);
         let evm_opts = figment.extract::<EvmOpts>()?;
         let mut config = Config::from_provider(figment)?.sanitized();
@@ -157,7 +171,7 @@ impl RunArgs {
         let compute_units_per_second =
             if self.no_rate_limit { Some(u64::MAX) } else { self.compute_units_per_second };
 
-        let provider = ProviderBuilder::<FEN::Network>::from_config(&config)?
+        let provider = ProviderBuilder::<N>::from_config(&config)?
             .compute_units_per_second_opt(compute_units_per_second)
             .build()?;
 
@@ -217,7 +231,7 @@ impl RunArgs {
                     evm_version = Some(EvmVersion::Prague);
                 }
             }
-            apply_chain_and_block_specific_env_changes::<FEN::Network, _, _>(
+            apply_chain_and_block_specific_env_changes::<N, _, _>(
                 &mut evm_env,
                 block,
                 config.networks,


### PR DESCRIPTION
## Summary

Fixes `cast run` failing on OP Stack chains (Base, Optimism) with:
```
Error: deserialization error: data did not match any variant of untagged enum BlockTransactions
```

Observed in nightly CI:
- [test-isolate #24165199365](https://github.com/foundry-rs/foundry/actions/runs/24165199365/job/70525144906)
- [test-flaky #24167870879](https://github.com/foundry-rs/foundry/actions/runs/24167870879/job/70533196654)
- Tracked in [#14208](https://github.com/foundry-rs/foundry/issues/14208)

## Motivation

The generic `FoundryEvmNetwork` refactor ([#14121](https://github.com/foundry-rs/foundry/pull/14121)) changed `cast run` from using `AnyNetwork` to dispatching via `FEN::Network`. Non-Tempo chains use `EthEvmNetwork` whose `Network = Ethereum`, which cannot deserialize OP deposit transactions (type `0x7e`). When `cast run` fetches a full block from Base or Optimism, the block contains deposit transactions that `Ethereum`'s `TxEnvelope` can't parse.

## Changes

Decouples the RPC provider network type from the EVM factory by making `run_with_provider` generic over both `FEN` (EVM factory) and `N` (provider network). The dispatch in `run()` detects OP Stack chains early via `is_optimism()` and uses `FoundryNetwork` as the provider network.

- `crates/cast/src/cmd/run.rs`: Rename `run_with_evm` → `run_with_provider<FEN, N>`, add OP detection branch
- `crates/cast/Cargo.toml`: Add `foundry-primitives` dependency

## Testing

- Full workspace `cargo check` passes
- Fixes `flaky_osaka_can_run_p256_precompile` (Base) and `flaky_test_non_mainnet_traces` (Optimism)

Prompted by: zerosnacks