### PR TITLE
ci: add missing ARBITRUM_RPC and ETH_SEPOLIA_RPC secrets to flaky/isolate workflows

### DIFF
--- a/.github/workflows/test-flaky.yml
+++ b/.github/workflows/test-flaky.yml
@@ -43,6 +43,8 @@ jobs:
           SVM_TARGET_PLATFORM: linux-amd64
           HTTP_ARCHIVE_URLS: ${{ secrets.HTTP_ARCHIVE_URLS }}
           ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          ARBITRUM_RPC: ${{ secrets.ARBITRUM_RPC }}
+          ETH_SEPOLIA_RPC: ${{ secrets.ETH_SEPOLIA_RPC }}
         run: cargo nextest run --profile flaky --no-fail-fast
 
   # If any of the jobs fail, this will create a normal-priority issue to signal so.

--- a/.github/workflows/test-isolate.yml
+++ b/.github/workflows/test-isolate.yml
@@ -47,6 +47,8 @@ jobs:
           SVM_TARGET_PLATFORM: linux-amd64
           HTTP_ARCHIVE_URLS: ${{ secrets.HTTP_ARCHIVE_URLS }}
           ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          ARBITRUM_RPC: ${{ secrets.ARBITRUM_RPC }}
+          ETH_SEPOLIA_RPC: ${{ secrets.ETH_SEPOLIA_RPC }}
         run: cargo nextest run --profile flaky --features=isolate-by-default --no-fail-fast
 
   # If nextest fails, create a high-priority issue for isolation failures.


### PR DESCRIPTION
The `test-flaky.yml` and `test-isolate.yml` workflows were missing `ARBITRUM_RPC` and `ETH_SEPOLIA_RPC` env vars that `test.yml` already sets. Without these, `crates/test-utils/src/rpc.rs` falls through to the public DRPC fallback for Arbitrum and Sepolia tests, causing flaky failures from rate-limited public endpoints.

Prompted by: zerosnacks