### PR TITLE
ci: remove unused HTTP_ARCHIVE_URLS and WS_ARCHIVE_URLS secrets

### DIFF
--- a/.github/workflows/test-flaky.yml
+++ b/.github/workflows/test-flaky.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Test flaky tests
         env:
           SVM_TARGET_PLATFORM: linux-amd64
-          HTTP_ARCHIVE_URLS: ${{ secrets.HTTP_ARCHIVE_URLS }}
           ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: cargo nextest run --profile flaky --no-fail-fast
 

--- a/.github/workflows/test-isolate.yml
+++ b/.github/workflows/test-isolate.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Test flaky tests with isolation
         env:
           SVM_TARGET_PLATFORM: linux-amd64
-          HTTP_ARCHIVE_URLS: ${{ secrets.HTTP_ARCHIVE_URLS }}
           ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: cargo nextest run --profile flaky --features=isolate-by-default --no-fail-fast
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,8 +111,6 @@ jobs:
       - name: Test
         env:
           SVM_TARGET_PLATFORM: ${{ matrix.svm_target_platform }}
-          HTTP_ARCHIVE_URLS: ${{ secrets.HTTP_ARCHIVE_URLS }}
-          WS_ARCHIVE_URLS: ${{ secrets.WS_ARCHIVE_URLS }}
           ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
           ARBITRUM_RPC: ${{ secrets.ARBITRUM_RPC }}
           ETH_SEPOLIA_RPC: ${{ secrets.ETH_SEPOLIA_RPC }}


### PR DESCRIPTION
These env vars (`HTTP_ARCHIVE_URLS`, `WS_ARCHIVE_URLS`) are set in CI workflows but never read by any code — archive domains are hardcoded to `ethereum.reth.rs` in `crates/test-utils/src/rpc.rs`.

Prompted by: zerosnacks