### PR TITLE
chore(clippy): remove `literal_string_with_formatting_args` allow, no longer required

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,6 @@ significant_drop_tightening = "allow"
 too_long_first_doc_paragraph = "allow"
 
 # Specific allows.
-# until <https://github.com/rust-lang/rust-clippy/issues/13885> is fixed
-literal_string_with_formatting_args = "allow"
 result_large_err = "allow"
 
 [workspace.lints.rust]


### PR DESCRIPTION
The upstream clippy false-positive bug ([rust-lang/rust-clippy#13885](https://github.com/rust-lang/rust-clippy/issues/13885)) was fixed in [rust-lang/rust-clippy#13953](https://github.com/rust-lang/rust-clippy/pull/13953) (merged Feb 2025). The workaround is no longer needed.

Prompted by: zerosnacks