### PR TITLE
fix(anvil): return second offset from evm_setTime

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -485,7 +485,7 @@ impl<N: Network> EthApi<N> {
 
         // number of seconds between the given timestamp and the current time.
         let offset = timestamp.saturating_sub(now);
-        Ok(Duration::from_millis(offset).as_secs())
+        Ok(offset)
     }
 
     /// Set the next block gas limit


### PR DESCRIPTION
## Summary

`evm_setTime` documents that it returns the number of **seconds** between the requested timestamp and the current time. The offset was computed in seconds, but `Duration::from_millis(offset).as_secs()` incorrectly interpreted that value as milliseconds, dividing the returned offset by 1000.

Return the offset directly.

## Test plan

- `cargo check -p anvil` (optional: full `make pr` per CONTRIBUTING.md)