### PR TITLE
fix(cheatcodes): correct gas record filter on stopGasSnapshot

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1464,7 +1464,7 @@ fn inner_stop_gas_snapshot<FEN: FoundryEvmNetwork>(
         ccx.state
             .gas_metering
             .gas_records
-            .retain(|record| record.group != group && record.name != name);
+            .retain(|record| record.group != group || record.name != name);
 
         // Clear last snapshot cache if we have an exact match.
         if let Some((snapshot_group, snapshot_name)) = &ccx.state.gas_metering.active_gas_snapshot


### PR DESCRIPTION
## Summary

`stopGasSnapshot` removes the finished snapshot from `gas_records`. The predicate must **keep** every record except the one whose **group and name** both match the stopped snapshot.

The previous condition used `&&`, so a record was kept only when **both** the group and name differed from the target. That incorrectly removed other snapshots that only matched on group or only on name.

## Test plan

- `cargo test -p cheatcodes` or `cargo check -p cheatcodes`