### PR TITLE
fix(cli): restore short flag for `--rpc-url`

### DIFF
--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3977,7 +3977,7 @@ Error: Failed to estimate gas: server returned an error response: error code 3: 
 
 // <https://basescan.org/block/30558838>
 casttest!(estimate_base_da, |_prj, cmd| {
-    cmd.args(["da-estimate", "30558838", "--rpc-url", "https://mainnet.base.org/"])
+    cmd.args(["da-estimate", "30558838", "-r", "https://mainnet.base.org/"])
         .assert_success()
         .stdout_eq(str![[r#"
 Estimated data availability size for block 30558838 with 225 transactions: 52916546100

--- a/crates/cli/src/opts/evm.rs
+++ b/crates/cli/src/opts/evm.rs
@@ -48,21 +48,21 @@ pub struct EvmArgs {
     /// Fetch state from a specific block number over a remote endpoint.
     ///
     /// See --rpc-url.
-    #[arg(long, requires = "url", value_name = "BLOCK")]
+    #[arg(long, requires = "rpc_url", value_name = "BLOCK")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fork_block_number: Option<u64>,
 
     /// Number of retries.
     ///
     /// See --rpc-url.
-    #[arg(long, requires = "url", value_name = "RETRIES")]
+    #[arg(long, requires = "rpc_url", value_name = "RETRIES")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fork_retries: Option<u32>,
 
     /// Initial retry backoff on encountering errors.
     ///
     /// See --rpc-url.
-    #[arg(long, requires = "url", value_name = "BACKOFF")]
+    #[arg(long, requires = "rpc_url", value_name = "BACKOFF")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fork_retry_backoff: Option<u64>,
 

--- a/crates/cli/src/opts/rpc_common.rs
+++ b/crates/cli/src/opts/rpc_common.rs
@@ -20,7 +20,7 @@ use std::borrow::Cow;
 #[derive(Clone, Debug, Default, Serialize, Parser)]
 pub struct RpcCommonOpts {
     /// The RPC endpoint.
-    #[arg(short, visible_alias = "fork-url", env = "ETH_RPC_URL")]
+    #[arg(short, long, visible_alias = "fork-url", env = "ETH_RPC_URL")]
     #[serde(rename = "eth_rpc_url", skip_serializing_if = "Option::is_none")]
     pub rpc_url: Option<String>,
 

--- a/crates/cli/src/opts/rpc_common.rs
+++ b/crates/cli/src/opts/rpc_common.rs
@@ -20,9 +20,9 @@ use std::borrow::Cow;
 #[derive(Clone, Debug, Default, Serialize, Parser)]
 pub struct RpcCommonOpts {
     /// The RPC endpoint.
-    #[arg(long = "rpc-url", visible_alias = "fork-url", env = "ETH_RPC_URL")]
+    #[arg(short, visible_alias = "fork-url", env = "ETH_RPC_URL")]
     #[serde(rename = "eth_rpc_url", skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub rpc_url: Option<String>,
 
     /// Allow insecure RPC connections (accept invalid HTTPS certificates).
     ///
@@ -80,7 +80,7 @@ impl figment::Provider for RpcCommonOpts {
 impl RpcCommonOpts {
     /// Returns the RPC endpoint URL, resolving from CLI args or config.
     pub fn url<'a>(&'a self, config: Option<&'a Config>) -> Result<Option<Cow<'a, str>>> {
-        let url = match (self.url.as_deref(), config) {
+        let url = match (self.rpc_url.as_deref(), config) {
             (Some(url), _) => Some(Cow::Borrowed(url)),
             (None, Some(config)) => config.get_rpc_url().transpose()?,
             (None, None) => None,

--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -55,7 +55,6 @@ pub struct CoverageArgs {
     /// If not specified, the report will be stored in the root of the project.
     #[arg(
         long,
-        short,
         value_hint = ValueHint::FilePath,
         value_name = "PATH"
     )]

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3201,7 +3201,7 @@ contract CounterScript is Script {
 error: the following required arguments were not provided:
   --broadcast
 
-Usage: [..] script --broadcast --verify --rpc-url <URL> <PATH> [ARGS]...
+Usage: [..] script --broadcast --verify --rpc-url <RPC_URL> <PATH> [ARGS]...
 
 For more information, try '--help'.
 


### PR DESCRIPTION
## Motivation

Restore short flag for `--rpc-url`, regression from #14224.

Restored `estimate_base_da` test to use short flag.