### PR TITLE
fix(anvil): gate EIP-7825 tx gas cap on configured limit

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -378,7 +378,7 @@ where
         }
 
         // Osaka EIP-7825 tx gas limit cap check
-        if gas_config.tx_gas_limit_cap.is_none()
+        if gas_config.tx_gas_limit_cap.is_some()
             && pending.transaction.gas_limit() > gas_config.tx_gas_limit_cap_resolved
         {
             trace!(target: "backend", tx_gas_limit = %pending.transaction.gas_limit(), ?pool_tx, "transaction gas limit exhausting, skipping transaction");


### PR DESCRIPTION
## Summary

In `execute_pool_transactions`, the EIP-7825 (Osaka) per-transaction gas limit check must only run when `tx_gas_limit_cap` is set. The condition incorrectly used `is_none()`, so the comparison against `tx_gas_limit_cap_resolved` ran when **no** cap was configured.

## Test plan

- `cargo check -p anvil`