### PR TITLE
fix(forge): remember last test path in forge test --watch

### DIFF
--- a/crates/forge/src/cmd/watch.rs
+++ b/crates/forge/src/cmd/watch.rs
@@ -340,8 +340,9 @@ pub async fn watch_test(args: TestArgs) -> Result<()> {
                 return;
             }
 
-            if changed_sol_test_files.is_empty() {
-                // Reuse the old test files if a non-test file was changed.
+            if !changed_sol_test_files.is_empty() {
+                *last_test_files.lock() = changed_sol_test_files.clone();
+            } else {
                 let last = last_test_files.lock();
                 if last.is_empty() {
                     return;


### PR DESCRIPTION
## Summary

`watch_test` keeps a `last_test_files` cache so that when a non-test Solidity file changes, it can still pass `--match-path` for the most recently touched test file. That cache was never populated when a single test file changed, so the fallback stayed empty and the watcher skipped reconfiguration.

Persist the detected test path when exactly one `.t.sol` file changes.

## Test plan

- Manual: `forge test --watch`, edit a test file then a src file; expect tests to rerun with the prior test path filter.
- `cargo check -p forge`