### PR TITLE
ci(npm): use OIDC trusted publishing, remove NPM_TOKEN

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -151,9 +151,6 @@ jobs:
         id: release-version
         working-directory: ./npm
         env:
-          PROVENANCE: true
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_REGISTRY_URL: ${{ env.NPM_REGISTRY_URL }}
           ARTIFACT_DIR: ${{ steps.paths.outputs.artifact_dir }}
         run: |
@@ -224,8 +221,6 @@ jobs:
           PROVENANCE: true
           VERSION_NAME: ${{ steps.release-version.outputs.RELEASE_VERSION }}
           RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -249,8 +244,6 @@ jobs:
     name: Publish Meta Package
     runs-on: ubuntu-latest
     env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       RELEASE_VERSION: ${{ needs.publish-arch.outputs.RELEASE_VERSION }}
     steps:
       - name: Checkout
@@ -286,6 +279,4 @@ jobs:
           PROVENANCE: true
           VERSION_NAME: ${{ env.RELEASE_VERSION }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-          NPM_TOKEN: ${{ env.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
           NPM_REGISTRY_URL: ${{ env.NPM_REGISTRY_URL }}

--- a/npm/scripts/publish.mjs
+++ b/npm/scripts/publish.mjs
@@ -7,17 +7,12 @@ import { colors } from '#const.mjs'
 
 const REGISTRY_URL = Bun.env.NPM_REGISTRY_URL || 'https://registry.npmjs.org'
 
-const NPM_TOKEN = Bun.env.NPM_TOKEN
-if (!NPM_TOKEN) throw new Error('NPM_TOKEN is required')
-
 main().catch(error => {
   console.error(error)
   process.exit(1)
 })
 
 async function main() {
-  const npmToken = Bun.env.NPM_TOKEN
-  if (!npmToken) throw new Error('NPM_TOKEN is required')
 
   const inputPath = Bun.argv[2]
   if (!inputPath) throw new Error('Package path is required')
@@ -114,11 +109,6 @@ async function setPackageVersion(packagePath, version) {
   console.info(colors.green, 'Setting package version:', version)
   const result = await Bun.$`npm version ${version} --allow-same-version --no-git-tag-version`
     .cwd(packagePath)
-    .env({
-      ...Bun.env,
-      ...process.env,
-      NPM_TOKEN
-    })
     .quiet()
     .nothrow()
 


### PR DESCRIPTION
Use npm OIDC trusted publishing instead of long-lived tokens for npm publishing.

## Changes

- Remove all `NPM_TOKEN` / `NODE_AUTH_TOKEN` env vars from `npm.yml`
- Remove token guard in `publish.mjs` — npm CLI auto-authenticates via OIDC when `id-token: write` permission is set (already present)
- Remove token passthrough in `setPackageVersion` env

The workflow already had the required `id-token: write` permission and `NPM_CONFIG_PROVENANCE: true`. With npm CLI >=11.5.1 on Node 24, OIDC auth is automatic.

## Prerequisites

Each `@foundry-rs/*` package must have a trusted publisher configured on npmjs.com:
- Repository: `foundry-rs/foundry`
- Workflow filename: `npm.yml`

## Migration

Set up the trusted publishers on npmjs.com first, then merge this PR. Old tokens can be revoked after verifying a successful publish.

Prompted by: zerosnacks