### PR TITLE
fix(cast): `batch-send` handling by clearing `to`/`value` fields

### DIFF
--- a/crates/cast/src/cmd/batch_send.rs
+++ b/crates/cast/src/cmd/batch_send.rs
@@ -9,8 +9,8 @@ use crate::{
     cmd::send::cast_send,
     tx::{self, CastTxBuilder, CastTxSender, SendTxOpts},
 };
-use alloy_network::{EthereumWallet, TransactionBuilder};
-use alloy_primitives::{Bytes, U256};
+use alloy_network::EthereumWallet;
+use alloy_primitives::Bytes;
 use alloy_provider::{Provider, ProviderBuilder as AlloyProviderBuilder};
 use alloy_signer::Signer;
 use clap::Parser;
@@ -119,9 +119,7 @@ impl BatchSendArgs {
         let builder = builder.with_to(first_call_to.map(Into::into)).await?;
 
         // Use empty sig/args since we're using calls directly
-        let mut builder = builder.with_code_sig_and_args(None, None, vec![]).await?;
-        builder.tx.clear_kind();
-        builder.tx.set_value(U256::ZERO);
+        let builder = builder.with_code_sig_and_args(None, None, vec![]).await?;
 
         let timeout = send_tx.timeout.unwrap_or(config.transaction_timeout);
 

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -484,6 +484,11 @@ where
         let sender = sender.into();
         self.prepare(&sender);
 
+        // For batch transactions with calls, clear `to` and `value` so the node correctly
+        // identifies this as an AA batch transaction. The `calls` field determines the actual
+        // targets. If `to` is set, `build_aa()` would add a spurious extra call.
+        self.tx.clear_batch_to();
+
         // resolve
         let tx_nonce = self.resolve_nonce(sender.address(), fill).await?;
         self.resolve_auth(&sender, tx_nonce).await?;

--- a/crates/common/src/transactions/builder.rs
+++ b/crates/common/src/transactions/builder.rs
@@ -249,6 +249,14 @@ pub trait FoundryTransactionBuilder<N: Network>: TransactionBuilder<N> {
     /// No-op for non-Tempo networks.
     fn convert_create_to_call(&mut self) {}
 
+    /// Clears the `to` and `value` fields for batch transactions that use `calls`.
+    ///
+    /// In Tempo AA batch transactions, targets are specified in the `calls` field, not in `to`.
+    /// If `to` is set, `build_aa()` would add a spurious extra call. Must be called after
+    /// `prepare()` sets `kind`/`to` but before gas estimation.
+    /// No-op for non-Tempo networks.
+    fn clear_batch_to(&mut self) {}
+
     /// Signs the transaction using an access key (keychain mode).
     ///
     /// If `key_authorization` is provided and the key is not yet provisioned on-chain,
@@ -437,6 +445,13 @@ impl FoundryTransactionBuilder<TempoNetwork> for <TempoNetwork as Network>::Tran
             self.inner.input = Default::default();
             self.inner.value = None;
             self.inner.to = None;
+        }
+    }
+
+    fn clear_batch_to(&mut self) {
+        if !self.calls.is_empty() {
+            self.inner.to = None;
+            self.inner.value = None;
         }
     }
 


### PR DESCRIPTION
## Motivation

Fix `cast batch-send` Tempo CI tests, by clearing systematically `to`/`value` fields.

https://github.com/tempoxyz/tempo-foundry/blob/e95b51a3f845d8453622ed8ebbbb27fe8721b057/.github/scripts/tempo-check.sh#L527-L540
