### PR TITLE
refactor(anvil): extract `build_block_info` helper

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2435,6 +2435,56 @@ where
         self.do_mine_block(pool_transactions).await
     }
 
+    /// Builds a [`BlockInfo`] from the EVM environment, execution results, and transactions.
+    fn build_block_info(
+        evm_env: &EvmEnv,
+        parent_hash: B256,
+        number: u64,
+        state_root: B256,
+        block_result: BlockExecutionResult<FoundryReceiptEnvelope>,
+        transactions: Vec<MaybeImpersonatedTransaction<FoundryTxEnvelope>>,
+        transaction_infos: Vec<TransactionInfo>,
+    ) -> BlockInfo<N> {
+        let spec_id = *evm_env.spec_id();
+        let is_shanghai = spec_id >= SpecId::SHANGHAI;
+        let is_cancun = spec_id >= SpecId::CANCUN;
+        let is_prague = spec_id >= SpecId::PRAGUE;
+
+        let receipts_root = calculate_receipt_root(&block_result.receipts);
+        let cumulative_blob_gas_used = is_cancun.then_some(block_result.blob_gas_used);
+        let bloom = block_result.receipts.iter().fold(Bloom::default(), |mut b, r| {
+            b.accrue_bloom(r.logs_bloom());
+            b
+        });
+
+        let header = Header {
+            parent_hash,
+            ommers_hash: Default::default(),
+            beneficiary: evm_env.block_env.beneficiary,
+            state_root,
+            transactions_root: Default::default(),
+            receipts_root,
+            logs_bloom: bloom,
+            difficulty: evm_env.block_env.difficulty,
+            number,
+            gas_limit: evm_env.block_env.gas_limit,
+            gas_used: block_result.gas_used,
+            timestamp: evm_env.block_env.timestamp.saturating_to(),
+            extra_data: Default::default(),
+            mix_hash: evm_env.block_env.prevrandao.unwrap_or_default(),
+            nonce: Default::default(),
+            base_fee_per_gas: (spec_id >= SpecId::LONDON).then_some(evm_env.block_env.basefee),
+            parent_beacon_block_root: is_cancun.then_some(Default::default()),
+            blob_gas_used: cumulative_blob_gas_used,
+            excess_blob_gas: if is_cancun { evm_env.block_env.blob_excess_gas() } else { None },
+            withdrawals_root: is_shanghai.then_some(EMPTY_WITHDRAWALS),
+            requests_hash: is_prague.then_some(EMPTY_REQUESTS_HASH),
+        };
+
+        let block = create_block(header, transactions);
+        BlockInfo { block, transactions: transaction_infos, receipts: block_result.receipts }
+    }
+
     async fn do_mine_block(
         &self,
         pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
@@ -2489,17 +2539,6 @@ where
                 evm_env.block_env.timestamp = U256::from(self.time.next_timestamp());
 
                 let spec_id = *evm_env.spec_id();
-                let is_shanghai = spec_id >= SpecId::SHANGHAI;
-                let is_cancun = spec_id >= SpecId::CANCUN;
-                let is_prague = spec_id >= SpecId::PRAGUE;
-                let gas_limit = evm_env.block_env.gas_limit;
-                let difficulty = evm_env.block_env.difficulty;
-                let mix_hash = evm_env.block_env.prevrandao;
-                let beneficiary = evm_env.block_env.beneficiary;
-                let timestamp = evm_env.block_env.timestamp;
-                let base_fee = (spec_id >= SpecId::LONDON).then_some(evm_env.block_env.basefee);
-                let excess_blob_gas =
-                    if is_cancun { evm_env.block_env.blob_excess_gas() } else { None };
 
                 let inspector_tx_config = self.inspector_tx_config();
                 let gas_config = self.pool_tx_gas_config(&evm_env);
@@ -2520,50 +2559,17 @@ where
                 let included = pool_result.included;
                 let invalid = pool_result.invalid;
                 let not_yet_valid = pool_result.not_yet_valid;
-                let transaction_infos = pool_result.tx_info;
-                let transactions = pool_result.txs;
 
                 let state_root = db.maybe_state_root().unwrap_or_default();
-
-                // 7. Build block header
-                let receipts_root = calculate_receipt_root(&block_result.receipts);
-                let cumulative_gas_used = block_result.gas_used;
-                let cumulative_blob_gas_used = is_cancun.then_some(block_result.blob_gas_used);
-                let bloom = block_result.receipts.iter().fold(Bloom::default(), |mut b, r| {
-                    b.accrue_bloom(r.logs_bloom());
-                    b
-                });
-
-                let header = Header {
-                    parent_hash: best_hash,
-                    ommers_hash: Default::default(),
-                    beneficiary,
+                let block_info = Self::build_block_info(
+                    &evm_env,
+                    best_hash,
+                    block_number,
                     state_root,
-                    transactions_root: Default::default(),
-                    receipts_root,
-                    logs_bloom: bloom,
-                    difficulty,
-                    number: block_number,
-                    gas_limit,
-                    gas_used: cumulative_gas_used,
-                    timestamp: timestamp.saturating_to(),
-                    extra_data: Default::default(),
-                    mix_hash: mix_hash.unwrap_or_default(),
-                    nonce: Default::default(),
-                    base_fee_per_gas: base_fee,
-                    parent_beacon_block_root: is_cancun.then_some(Default::default()),
-                    blob_gas_used: cumulative_blob_gas_used,
-                    excess_blob_gas,
-                    withdrawals_root: is_shanghai.then_some(EMPTY_WITHDRAWALS),
-                    requests_hash: is_prague.then_some(EMPTY_REQUESTS_HASH),
-                };
-
-                let block = create_block(header, transactions);
-                let block_info: BlockInfo<N> = BlockInfo {
-                    block,
-                    transactions: transaction_infos,
-                    receipts: block_result.receipts,
-                };
+                    block_result,
+                    pool_result.txs,
+                    pool_result.tx_info,
+                );
 
                 // update the new blockhash in the db itself
                 let block_hash = block_info.block.header.hash_slow();
@@ -2731,16 +2737,6 @@ where
         let parent_hash = self.blockchain.storage.read().best_hash;
 
         let spec_id = *evm_env.spec_id();
-        let is_shanghai = spec_id >= SpecId::SHANGHAI;
-        let is_cancun = spec_id >= SpecId::CANCUN;
-        let is_prague = spec_id >= SpecId::PRAGUE;
-        let gas_limit = evm_env.block_env.gas_limit;
-        let difficulty = evm_env.block_env.difficulty;
-        let mix_hash = evm_env.block_env.prevrandao;
-        let beneficiary = evm_env.block_env.beneficiary;
-        let timestamp = evm_env.block_env.timestamp;
-        let base_fee = (spec_id >= SpecId::LONDON).then_some(evm_env.block_env.basefee);
-        let excess_blob_gas = if is_cancun { evm_env.block_env.blob_excess_gas() } else { None };
 
         let inspector_tx_config = self.inspector_tx_config();
         let gas_config = self.pool_tx_gas_config(&evm_env);
@@ -2756,49 +2752,20 @@ where
             &|pending, account| self.validate_pool_transaction_for(pending, account, &evm_env),
         );
 
-        let transaction_infos = pool_result.tx_info;
-        let transactions = pool_result.txs;
-
         // Extract inner CacheDB (which implements MaybeFullDatabase)
         let cache_db = cache_db.0;
 
         let state_root = cache_db.maybe_state_root().unwrap_or_default();
-
-        let receipts_root = calculate_receipt_root(&block_result.receipts);
-        let cumulative_gas_used = block_result.gas_used;
-        let cumulative_blob_gas_used = is_cancun.then_some(block_result.blob_gas_used);
-        let bloom = block_result.receipts.iter().fold(Bloom::default(), |mut b, r| {
-            b.accrue_bloom(r.logs_bloom());
-            b
-        });
-
-        let header = Header {
+        let block_number = evm_env.block_env.number.saturating_to();
+        let block_info = Self::build_block_info(
+            &evm_env,
             parent_hash,
-            ommers_hash: Default::default(),
-            beneficiary,
+            block_number,
             state_root,
-            transactions_root: Default::default(),
-            receipts_root,
-            logs_bloom: bloom,
-            difficulty,
-            number: evm_env.block_env.number.saturating_to(),
-            gas_limit,
-            gas_used: cumulative_gas_used,
-            timestamp: timestamp.saturating_to(),
-            extra_data: Default::default(),
-            mix_hash: mix_hash.unwrap_or_default(),
-            nonce: Default::default(),
-            base_fee_per_gas: base_fee,
-            parent_beacon_block_root: is_cancun.then_some(Default::default()),
-            blob_gas_used: cumulative_blob_gas_used,
-            excess_blob_gas,
-            withdrawals_root: is_shanghai.then_some(EMPTY_WITHDRAWALS),
-            requests_hash: is_prague.then_some(EMPTY_REQUESTS_HASH),
-        };
-
-        let block = create_block(header, transactions);
-        let block_info =
-            BlockInfo { block, transactions: transaction_infos, receipts: block_result.receipts };
+            block_result,
+            pool_result.txs,
+            pool_result.tx_info,
+        );
 
         f(Box::new(cache_db), block_info)
     }


### PR DESCRIPTION
Extract the duplicated header construction, receipt/bloom computation, and `BlockInfo` assembly from `do_mine_block` and `with_pending_block` into a shared `build_block_info` method.