### PR TITLE
chore(cast): remove redundant batch-mktx clearing

### DIFF
--- a/crates/cast/src/cmd/batch_mktx.rs
+++ b/crates/cast/src/cmd/batch_mktx.rs
@@ -10,7 +10,7 @@ use crate::{
 use alloy_consensus::SignableTransaction;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_network::{EthereumWallet, TransactionBuilder};
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, Bytes};
 use alloy_provider::Provider;
 use alloy_signer::Signer;
 use clap::Parser;
@@ -115,9 +115,7 @@ impl BatchMakeTxArgs {
         // Set dummy "to" from first call
         let first_call_to = call_specs.first().map(|s| s.to);
         let builder = builder.with_to(first_call_to.map(Into::into)).await?;
-        let mut tx_builder = builder.with_code_sig_and_args(None, None, vec![]).await?;
-        tx_builder.tx.clear_kind();
-        tx_builder.tx.set_value(U256::ZERO);
+        let tx_builder = builder.with_code_sig_and_args(None, None, vec![]).await?;
 
         if raw_unsigned {
             if eth.wallet.from.is_none() && !has_nonce {


### PR DESCRIPTION
Remove manual `clear_kind()` / `set_value(U256::ZERO)` in `batch_mktx.rs`, made redundant by `clear_batch_to()` added in #14250.