### PR TITLE
fix(anvil): use <= for pending pool replacement underprice check

### DIFF
--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -276,7 +276,7 @@ impl<T: Transaction> PendingTransactions<T> {
             .and_then(|hash| self.waiting_queue.get(hash))
         {
             // check if underpriced
-            if tx.transaction.max_fee_per_gas() < replace.transaction.max_fee_per_gas() {
+            if tx.transaction.max_fee_per_gas() <= replace.transaction.max_fee_per_gas() {
                 warn!(target: "txpool", "pending replacement transaction underpriced [{:?}]", tx.transaction.hash());
                 return Err(PoolError::ReplacementUnderpriced(tx.transaction.hash()));
             }


### PR DESCRIPTION
## Summary

`PendingTransactions::add_transaction` compared replacement fees with `<`, while `replaced_transactions()` already rejects when the new tx’s `max_fee_per_gas` is **`<=`** the existing one (see `transactions.rs` lines 685–688: the ready-queue branch uses `<=` against `to_remove.max_fee_per_gas()`).

Use `<=` for the waiting-queue path so replacement rules match the ready path.

## Test plan

- `cargo test -p anvil` (or `cargo check -p anvil`)