### PR TITLE
fix(lint): catch divide-before-multiply on rhs of multiplication

### DIFF
--- a/crates/lint/src/sol/med/div_mul.rs
+++ b/crates/lint/src/sol/med/div_mul.rs
@@ -17,8 +17,9 @@ declare_forge_lint!(
 
 impl<'ast> EarlyLintPass<'ast> for DivideBeforeMultiply {
     fn check_expr(&mut self, ctx: &LintContext, expr: &'ast Expr<'ast>) {
-        if let ExprKind::Binary(left_expr, BinOp { kind: BinOpKind::Mul, .. }, _) = &expr.kind
-            && contains_division(left_expr)
+        if let ExprKind::Binary(left_expr, BinOp { kind: BinOpKind::Mul, .. }, right_expr) =
+            &expr.kind
+            && (contains_division(left_expr) || contains_division(right_expr))
         {
             ctx.emit(&DIVIDE_BEFORE_MULTIPLY, expr.span);
         }


### PR DESCRIPTION
## Summary

The `divide-before-multiply` lint only walked the **left** operand of a multiplication, so `x * (y / z)` was missed. Bind the right-hand `Binary` operand and emit when either side contains a division.

## Test plan

- `cargo check -p forge-lint`