### PR TITLE
fix(anvil): guard deposit tx parsing in Tempo mode

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1412,8 +1412,8 @@ impl<N: Network> Backend<N> {
             evm_env.cfg_env.disable_base_fee = true;
         }
 
-        // Deposit transaction? (not supported in Tempo mode)
-        if !self.is_tempo()
+        // Deposit transaction? (only valid when op-stack deposits are active)
+        if self.ensure_op_deposits_active().is_ok()
             && let Ok(deposit) = get_deposit_tx_parts(&other)
         {
             tx_env.deposit = deposit;

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1412,8 +1412,10 @@ impl<N: Network> Backend<N> {
             evm_env.cfg_env.disable_base_fee = true;
         }
 
-        // Deposit transaction?
-        if let Ok(deposit) = get_deposit_tx_parts(&other) {
+        // Deposit transaction? (not supported in Tempo mode)
+        if !self.is_tempo()
+            && let Ok(deposit) = get_deposit_tx_parts(&other)
+        {
             tx_env.deposit = deposit;
         }
 


### PR DESCRIPTION
Skip `get_deposit_tx_parts()` in `build_call_env()` when running in Tempo mode.