### PR TITLE
Addresses scfuzzbench/scfuzzbench#112.

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -144,11 +144,21 @@ impl InvariantThroughputMetrics {
     }
 }
 
+/// Converts a cumulative campaign total into an average per-second rate.
+///
+/// Returns `0.0` during the initial zero-elapsed startup window to avoid
+/// dividing by zero while progress reporting is warming up.
 fn rate_per_sec(total: f64, elapsed: Duration) -> f64 {
     let elapsed_secs = elapsed.as_secs_f64();
     if elapsed_secs > 0.0 { total / elapsed_secs } else { 0.0 }
 }
 
+/// Builds the machine-readable invariant progress payload emitted during a
+/// campaign.
+///
+/// This keeps the existing corpus progress metrics together with cumulative and
+/// derived throughput fields so downstream benchmark tooling can consume a
+/// single JSON event shape.
 fn build_invariant_progress_json<M: Serialize>(
     timestamp_secs: u64,
     invariant_name: &str,

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1154,56 +1154,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn invariant_progress_json_includes_throughput_fields() {
-        let mut throughput = InvariantThroughputMetrics::default();
-        throughput.record_call(20);
-        throughput.record_call(30);
-
-        let payload = build_invariant_progress_json(
-            123,
-            "invariant_balance",
-            &json!({ "corpus_count": 7 }),
-            Some(I256::try_from(42).unwrap()),
-            throughput,
-            Duration::from_secs(10),
-        );
-
-        assert_eq!(payload["timestamp"], json!(123));
-        assert_eq!(payload["invariant"], json!("invariant_balance"));
-        assert_eq!(payload["metrics"]["corpus_count"], json!(7));
-        assert_eq!(payload["total_txs"], json!(2));
-        assert_eq!(payload["total_gas"], json!(50));
-        assert!((payload["tx_per_sec"].as_f64().unwrap() - 0.2).abs() < 1e-12);
-        assert!((payload["gas_per_sec"].as_f64().unwrap() - 5.0).abs() < 1e-12);
-        assert_eq!(payload["optimization_best"], json!("42"));
-    }
-
-    #[test]
-    fn invariant_progress_json_zero_elapsed_reports_zero_rates() {
-        let mut throughput = InvariantThroughputMetrics::default();
-        throughput.record_call(21_000);
-
-        let payload = build_invariant_progress_json(
-            456,
-            "invariant_zero_elapsed",
-            &json!({ "corpus_count": 1 }),
-            None,
-            throughput,
-            Duration::ZERO,
-        );
-
-        assert_eq!(payload["tx_per_sec"], json!(0.0));
-        assert_eq!(payload["gas_per_sec"], json!(0.0));
-        assert!(payload.get("optimization_best").is_none());
-    }
-}
-
 /// Collects data from call for fuzzing. However, it first verifies that the sender is not an EOA
 /// before inserting it into the dictionary. Otherwise, we flood the dictionary with
 /// randomly generated addresses.
@@ -1303,4 +1253,54 @@ pub(crate) fn execute_tx<FEN: FoundryEvmNetwork>(
     executor
         .call_raw(tx.sender, tx.call_details.target, tx.call_details.calldata.clone(), U256::ZERO)
         .map_err(|e| eyre!(format!("Could not make raw evm call: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn invariant_progress_json_includes_throughput_fields() {
+        let mut throughput = InvariantThroughputMetrics::default();
+        throughput.record_call(20);
+        throughput.record_call(30);
+
+        let payload = build_invariant_progress_json(
+            123,
+            "invariant_balance",
+            &json!({ "corpus_count": 7 }),
+            Some(I256::try_from(42).unwrap()),
+            throughput,
+            Duration::from_secs(10),
+        );
+
+        assert_eq!(payload["timestamp"], json!(123));
+        assert_eq!(payload["invariant"], json!("invariant_balance"));
+        assert_eq!(payload["metrics"]["corpus_count"], json!(7));
+        assert_eq!(payload["total_txs"], json!(2));
+        assert_eq!(payload["total_gas"], json!(50));
+        assert!((payload["tx_per_sec"].as_f64().unwrap() - 0.2).abs() < 1e-12);
+        assert!((payload["gas_per_sec"].as_f64().unwrap() - 5.0).abs() < 1e-12);
+        assert_eq!(payload["optimization_best"], json!("42"));
+    }
+
+    #[test]
+    fn invariant_progress_json_zero_elapsed_reports_zero_rates() {
+        let mut throughput = InvariantThroughputMetrics::default();
+        throughput.record_call(21_000);
+
+        let payload = build_invariant_progress_json(
+            456,
+            "invariant_zero_elapsed",
+            &json!({ "corpus_count": 1 }),
+            None,
+            throughput,
+            Duration::ZERO,
+        );
+
+        assert_eq!(payload["tx_per_sec"], json!(0.0));
+        assert_eq!(payload["gas_per_sec"], json!(0.0));
+        assert!(payload.get("optimization_best").is_none());
+    }
 }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -41,7 +41,7 @@ use serde_json::json;
 use std::{
     collections::{HashMap as Map, btree_map::Entry},
     sync::Arc,
-    time::{Instant, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 mod error;
@@ -120,6 +120,58 @@ pub struct InvariantMetrics {
     pub reverts: usize,
     // Count of fuzzed selector discards (through assume cheatcodes).
     pub discards: usize,
+}
+
+/// Campaign-level throughput metrics for invariant progress reporting.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct InvariantThroughputMetrics {
+    total_txs: u64,
+    total_gas: u64,
+}
+
+impl InvariantThroughputMetrics {
+    fn record_call(&mut self, gas_used: u64) {
+        self.total_txs += 1;
+        self.total_gas += gas_used;
+    }
+
+    fn tx_per_sec(self, elapsed: Duration) -> f64 {
+        rate_per_sec(self.total_txs as f64, elapsed)
+    }
+
+    fn gas_per_sec(self, elapsed: Duration) -> f64 {
+        rate_per_sec(self.total_gas as f64, elapsed)
+    }
+}
+
+fn rate_per_sec(total: f64, elapsed: Duration) -> f64 {
+    let elapsed_secs = elapsed.as_secs_f64();
+    if elapsed_secs > 0.0 { total / elapsed_secs } else { 0.0 }
+}
+
+fn build_invariant_progress_json<M: Serialize>(
+    timestamp_secs: u64,
+    invariant_name: &str,
+    corpus_metrics: &M,
+    optimization_best: Option<I256>,
+    throughput: InvariantThroughputMetrics,
+    elapsed: Duration,
+) -> serde_json::Value {
+    let mut payload = json!({
+        "timestamp": timestamp_secs,
+        "invariant": invariant_name,
+        "metrics": corpus_metrics,
+        "total_txs": throughput.total_txs,
+        "total_gas": throughput.total_gas,
+        "tx_per_sec": throughput.tx_per_sec(elapsed),
+        "gas_per_sec": throughput.gas_per_sec(elapsed),
+    });
+
+    if let Some(best) = optimization_best {
+        payload["optimization_best"] = json!(best.to_string());
+    }
+
+    payload
 }
 
 /// Contains data collected during invariant test runs.
@@ -370,6 +422,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let mut runs = 0;
         let timer = FuzzTestTimer::new(self.config.timeout);
         let mut last_metrics_report = Instant::now();
+        let campaign_start = Instant::now();
+        let mut throughput = InvariantThroughputMetrics::default();
         let continue_campaign = |runs: u32| {
             if early_exit.should_stop() {
                 return false;
@@ -478,6 +532,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     current_run
                         .fuzz_runs
                         .push(FuzzCase { gas: call_result.gas_used, stipend: call_result.stipend });
+                    throughput.record_call(call_result.gas_used);
 
                     // Determine if test can continue or should exit.
                     // Check invariants based on check_interval to improve deep run performance.
@@ -608,16 +663,14 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 && last_metrics_report.elapsed() > DURATION_BETWEEN_METRICS_REPORT
             {
                 // Display corpus metrics inline as JSON.
-                let mut metrics = json!({
-                    "timestamp": SystemTime::now()
-                        .duration_since(UNIX_EPOCH)?
-                        .as_secs(),
-                    "invariant": invariant_contract.invariant_function.name,
-                    "metrics": &corpus_manager.metrics,
-                });
-                if let Some(best) = invariant_test.test_data.optimization_best_value {
-                    metrics["optimization_best"] = json!(best.to_string());
-                }
+                let metrics = build_invariant_progress_json(
+                    SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
+                    &invariant_contract.invariant_function.name,
+                    &corpus_manager.metrics,
+                    invariant_test.test_data.optimization_best_value,
+                    throughput,
+                    campaign_start.elapsed(),
+                );
                 let _ = sh_println!("{}", serde_json::to_string(&metrics)?);
                 last_metrics_report = Instant::now();
             }
@@ -1085,6 +1138,56 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             self.select_contracts_and_senders(invariant_address)?;
         let targets = targeted_contracts.targets.lock();
         Ok(InvariantSettings::new(&targets, &sender_filters, self.config.fail_on_revert))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn invariant_progress_json_includes_throughput_fields() {
+        let mut throughput = InvariantThroughputMetrics::default();
+        throughput.record_call(20);
+        throughput.record_call(30);
+
+        let payload = build_invariant_progress_json(
+            123,
+            "invariant_balance",
+            &json!({ "corpus_count": 7 }),
+            Some(I256::try_from(42).unwrap()),
+            throughput,
+            Duration::from_secs(10),
+        );
+
+        assert_eq!(payload["timestamp"], json!(123));
+        assert_eq!(payload["invariant"], json!("invariant_balance"));
+        assert_eq!(payload["metrics"]["corpus_count"], json!(7));
+        assert_eq!(payload["total_txs"], json!(2));
+        assert_eq!(payload["total_gas"], json!(50));
+        assert!((payload["tx_per_sec"].as_f64().unwrap() - 0.2).abs() < 1e-12);
+        assert!((payload["gas_per_sec"].as_f64().unwrap() - 5.0).abs() < 1e-12);
+        assert_eq!(payload["optimization_best"], json!("42"));
+    }
+
+    #[test]
+    fn invariant_progress_json_zero_elapsed_reports_zero_rates() {
+        let mut throughput = InvariantThroughputMetrics::default();
+        throughput.record_call(21_000);
+
+        let payload = build_invariant_progress_json(
+            456,
+            "invariant_zero_elapsed",
+            &json!({ "corpus_count": 1 }),
+            None,
+            throughput,
+            Duration::ZERO,
+        );
+
+        assert_eq!(payload["tx_per_sec"], json!(0.0));
+        assert_eq!(payload["gas_per_sec"], json!(0.0));
+        assert!(payload.get("optimization_best").is_none());
     }
 }
 


### PR DESCRIPTION
This closes issue #13575 
cc @mattsse 

  ## Summary

  This PR ports and narrows the original approach from #13898 onto current `master`.

  The issue is that Foundry's invariant progress JSON currently exposes corpus/coverage-
  style metrics, but does not expose throughput data. As a result, downstream benchmark
  tooling such as `scfuzzbench` cannot recover Foundry `tx/s` and `gas/s` samples, so the
  corresponding throughput time-series charts remain blank for Foundry runs.

  This PR extends the existing invariant progress JSON output with campaign-level throughput
  fields:
  - `total_txs`
  - `total_gas`
  - `tx_per_sec`
  - `gas_per_sec`

  ## What This PR Changes

  ### 1. Track campaign-level throughput during invariant runs

  This PR introduces a small invariant-local throughput accumulator that records:
  - the total number of executed calls in the campaign
  - the total gas consumed by those calls

  The accumulator is updated only for non-discard calls, which keeps the semantics aligned
  with real executed work and avoids counting `vm.assume` rejections as throughput.

  ### 2. Extend the existing invariant progress JSON event

  The existing machine-readable invariant progress payload is extended to include:
  - `total_txs`
  - `total_gas`
  - `tx_per_sec`
  - `gas_per_sec`

  This keeps throughput data in the same JSON event shape already emitted for invariant
  progress, instead of introducing a separate reporting path.

  ### 3. Include cumulative and derived throughput fields

  Issue #112 specifically asks for `tx/s` and `gas/s`, so this PR includes `tx_per_sec` and
  `gas_per_sec` directly.

  It also includes `total_txs` and `total_gas` because they are the underlying cumulative
  measurements from which the rates are derived. This makes the JSON output more robust for
  downstream consumers, which can either use the reported rates directly or recompute them

  This PR adds focused tests covering:
  - the presence and correctness of the new throughput fields
  - zero-elapsed handling, which must safely report `0.0` rates instead of dividing by zero
  - preservation of the existing optional `optimization_best` field behavior

  ## How This Addresses scfuzzbench/scfuzzbench#112

  `scfuzzbench` generates `tx/s` and `gas/s` time-series charts by parsing machine-readable
  throughput samples from fuzzer logs.

  This PR makes Foundry emit those throughput values as part of its invariant progress JSON,
  so Foundry runs can produce the same throughput samples expected by the benchmark
  pipeline.

  ## Scope

  This PR is intentionally limited to invariant progress JSON output.

  It does not change:
  - the final human-readable invariant test report line
  - snapshot formatting or parsing
  - the invariant selector metrics table
  - unrelated invariant reporting or metrics behavior

  ## Test Plan

  - [x] Add focused unit tests for invariant progress JSON throughput fields
  - [x] Add zero-elapsed coverage for safe rate calculation
  - [x] `cargo test -p foundry-evm invariant_progress_json --lib`