### PR TITLE
feat(anvil): support multiple `--fork-url` values for load balancing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,6 +1232,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.23",
+ "url",
  "yansi",
 ]
 

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -99,6 +99,7 @@ tempfile.workspace = true
 itertools.workspace = true
 rand_08.workspace = true
 eyre.workspace = true
+url.workspace = true
 ethereum_ssz.workspace = true
 
 # cli

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -260,7 +260,7 @@ impl NodeArgs {
                 _ => self
                     .evm
                     .fork_url
-                    .as_ref()
+                    .first()
                     .and_then(|f| f.block)
                     .map(|num| ForkChoice::Block(num as i128)),
             })
@@ -270,7 +270,11 @@ impl NodeArgs {
             .fork_request_retries(self.evm.fork_request_retries)
             .fork_retry_backoff(self.evm.fork_retry_backoff.map(Duration::from_millis))
             .fork_compute_units_per_second(compute_units_per_second)
-            .with_eth_rpc_url(self.evm.fork_url.map(|fork| fork.url))
+            .with_eth_rpc_url(if self.evm.fork_url.is_empty() {
+                None
+            } else {
+                Some(self.evm.fork_url.into_iter().map(|f| f.url).collect::<Vec<_>>())
+            })
             .with_base_fee(self.evm.block_base_fee_per_gas)
             .disable_min_priority_fee(self.evm.disable_min_priority_fee)
             .with_no_storage_caching(self.evm.no_storage_caching)
@@ -433,7 +437,7 @@ pub struct AnvilEvmArgs {
         value_name = "URL",
         help_heading = "Fork config"
     )]
-    pub fork_url: Option<ForkUrl>,
+    pub fork_url: Vec<ForkUrl>,
 
     /// Headers to use for the rpc client, e.g. "User-Agent: test-agent"
     ///
@@ -441,21 +445,20 @@ pub struct AnvilEvmArgs {
     #[arg(
         long = "fork-header",
         value_name = "HEADERS",
-        help_heading = "Fork config",
-        requires = "fork_url"
+        help_heading = "Fork config"
     )]
     pub fork_headers: Vec<String>,
 
     /// Timeout in ms for requests sent to remote JSON-RPC server in forking mode.
     ///
     /// Default value 45000
-    #[arg(id = "timeout", long = "timeout", help_heading = "Fork config", requires = "fork_url")]
+    #[arg(id = "timeout", long = "timeout", help_heading = "Fork config")]
     pub fork_request_timeout: Option<u64>,
 
     /// Number of retry requests for spurious networks (timed out requests)
     ///
     /// Default value 5
-    #[arg(id = "retries", long = "retries", help_heading = "Fork config", requires = "fork_url")]
+    #[arg(id = "retries", long = "retries", help_heading = "Fork config")]
     pub fork_request_retries: Option<u32>,
 
     /// Fetch state from a specific block number over a remote endpoint.
@@ -465,7 +468,6 @@ pub struct AnvilEvmArgs {
     /// See --fork-url.
     #[arg(
         long,
-        requires = "fork_url",
         value_name = "BLOCK",
         help_heading = "Fork config",
         allow_hyphen_values = true
@@ -477,7 +479,6 @@ pub struct AnvilEvmArgs {
     /// See --fork-url.
     #[arg(
         long,
-        requires = "fork_url",
         value_name = "TRANSACTION",
         help_heading = "Fork config",
         conflicts_with = "fork_block_number"
@@ -487,7 +488,7 @@ pub struct AnvilEvmArgs {
     /// Initial retry backoff on encountering errors.
     ///
     /// See --fork-url.
-    #[arg(long, requires = "fork_url", value_name = "BACKOFF", help_heading = "Fork config")]
+    #[arg(long, value_name = "BACKOFF", help_heading = "Fork config")]
     pub fork_retry_backoff: Option<u64>,
 
     /// Specify chain id to skip fetching it from remote endpoint. This enables offline-start mode.
@@ -498,8 +499,7 @@ pub struct AnvilEvmArgs {
     #[arg(
         long,
         help_heading = "Fork config",
-        value_name = "CHAIN",
-        requires = "fork_block_number"
+        value_name = "CHAIN"
     )]
     pub fork_chain_id: Option<Chain>,
 
@@ -510,7 +510,6 @@ pub struct AnvilEvmArgs {
     /// See also --fork-url and <https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second>
     #[arg(
         long,
-        requires = "fork_url",
         alias = "cups",
         value_name = "CUPS",
         help_heading = "Fork config"
@@ -524,7 +523,6 @@ pub struct AnvilEvmArgs {
     /// See also --fork-url and <https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second>
     #[arg(
         long,
-        requires = "fork_url",
         value_name = "NO_RATE_LIMITS",
         help_heading = "Fork config",
         visible_alias = "no-rpc-rate-limit"
@@ -538,7 +536,7 @@ pub struct AnvilEvmArgs {
     /// This flag overrides the project's configuration file.
     ///
     /// See --fork-url.
-    #[arg(long, requires = "fork_url", help_heading = "Fork config")]
+    #[arg(long, help_heading = "Fork config")]
     pub no_storage_caching: bool,
 
     /// The block gas limit.
@@ -632,11 +630,12 @@ pub struct AnvilEvmArgs {
 /// Does nothing if the fork-url is not a configured alias.
 impl AnvilEvmArgs {
     pub fn resolve_rpc_alias(&mut self) {
-        if let Some(fork_url) = &self.fork_url
-            && let Ok(config) = Config::load_with_providers(FigmentProviders::Anvil)
-            && let Some(Ok(url)) = config.get_rpc_url_with_alias(&fork_url.url)
-        {
-            self.fork_url = Some(ForkUrl { url: url.to_string(), block: fork_url.block });
+        if let Ok(config) = Config::load_with_providers(FigmentProviders::Anvil) {
+            for fork_url in &mut self.fork_url {
+                if let Some(Ok(url)) = config.get_rpc_url_with_alias(&fork_url.url) {
+                    fork_url.url = url.to_string();
+                }
+            }
         }
     }
 }

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -134,8 +134,8 @@ pub struct NodeConfig {
     pub port: u16,
     /// maximum number of transactions in a block
     pub max_transactions: usize,
-    /// url of the rpc server that should be used for any rpc calls
-    pub eth_rpc_url: Option<String>,
+    /// urls of the rpc server that should be used for any rpc calls
+    pub eth_rpc_url: Option<Vec<String>>,
     /// pins the block number or transaction hash for the state fork
     pub fork_choice: Option<ForkChoice>,
     /// headers to use with `eth_rpc_url`
@@ -857,8 +857,8 @@ impl NodeConfig {
 
     /// Sets the `eth_rpc_url` to use when forking
     #[must_use]
-    pub fn with_eth_rpc_url<U: Into<String>>(mut self, eth_rpc_url: Option<U>) -> Self {
-        self.eth_rpc_url = eth_rpc_url.map(Into::into);
+    pub fn with_eth_rpc_url(mut self, eth_rpc_url: Option<Vec<String>>) -> Self {
+        self.eth_rpc_url = eth_rpc_url;
         self
     }
 
@@ -1142,8 +1142,8 @@ impl NodeConfig {
         );
 
         let (db, fork): (Arc<TokioRwLock<Box<dyn Db>>>, Option<ClientFork>) =
-            if let Some(eth_rpc_url) = self.eth_rpc_url.clone() {
-                self.setup_fork_db(eth_rpc_url, &mut evm_env, &fees).await?
+            if let Some(eth_rpc_urls) = self.eth_rpc_url.clone() {
+                self.setup_fork_db(eth_rpc_urls, &mut evm_env, &fees).await?
             } else {
                 (Arc::new(TokioRwLock::new(Box::<MemDb>::default())), None)
             };
@@ -1223,11 +1223,11 @@ impl NodeConfig {
     ///  - mutating some members of `self`
     pub async fn setup_fork_db(
         &mut self,
-        eth_rpc_url: String,
+        eth_rpc_urls: Vec<String>,
         evm_env: &mut EvmEnv,
         fees: &FeeManager,
     ) -> Result<(Arc<TokioRwLock<Box<dyn Db>>>, Option<ClientFork>)> {
-        let (db, config) = self.setup_fork_db_config(eth_rpc_url, evm_env, fees).await?;
+        let (db, config) = self.setup_fork_db_config(eth_rpc_urls, evm_env, fees).await?;
         let db: Arc<TokioRwLock<Box<dyn Db>>> = Arc::new(TokioRwLock::new(Box::new(db)));
         let fork = ClientFork::new(config, Arc::clone(&db));
         Ok((db, Some(fork)))
@@ -1240,18 +1240,25 @@ impl NodeConfig {
     ///  - mutating some members of `self`
     pub async fn setup_fork_db_config(
         &mut self,
-        eth_rpc_url: String,
+        eth_rpc_urls: Vec<String>,
         evm_env: &mut EvmEnv,
         fees: &FeeManager,
     ) -> Result<(ForkedDatabase<AnyNetwork>, ClientForkConfig)> {
-        debug!(target: "node", ?eth_rpc_url, "setting up fork db");
+        let primary_url = eth_rpc_urls.first().expect("at least one fork URL required").clone();
+        let additional_urls: Vec<url::Url> = eth_rpc_urls[1..]
+            .iter()
+            .filter_map(|u| url::Url::parse(u).ok())
+            .collect();
+
+        debug!(target: "node", ?primary_url, additional_count = additional_urls.len(), "setting up fork db");
         let provider = Arc::new(
-            ProviderBuilder::new(&eth_rpc_url)
+            ProviderBuilder::new(&primary_url)
                 .timeout(self.fork_request_timeout)
                 .initial_backoff(self.fork_retry_backoff.as_millis() as u64)
                 .compute_units_per_second(self.compute_units_per_second)
                 .max_retry(self.fork_request_retries)
                 .headers(self.fork_headers.clone())
+                .additional_urls(additional_urls)
                 .build()
                 .wrap_err("failed to establish provider to fork url")?,
         );
@@ -1399,7 +1406,7 @@ latest block number: {latest_block}"
             self.networks,
         );
 
-        let meta = BlockchainDbMeta::new(evm_env.block_env.clone(), eth_rpc_url.clone());
+        let meta = BlockchainDbMeta::new(evm_env.block_env.clone(), primary_url.clone());
         let block_chain_db = if self.fork_chain_id.is_some() {
             BlockchainDb::new_skip_check(meta, self.block_cache_path(fork_block_number))
         } else {
@@ -1415,8 +1422,10 @@ latest block number: {latest_block}"
         )
         .await;
 
+        let additional_rpc_urls: Vec<String> = eth_rpc_urls[1..].to_vec();
         let config = ClientForkConfig {
-            eth_rpc_url,
+            eth_rpc_url: primary_url,
+            additional_rpc_urls,
             block_number: fork_block_number,
             block_hash,
             transaction_hash: self.fork_choice.and_then(|fc| fc.transaction_hash()),

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -634,6 +634,8 @@ impl ClientFork {
 #[derive(Clone, Debug)]
 pub struct ClientForkConfig<N: Network = AnyNetwork> {
     pub eth_rpc_url: String,
+    /// Additional RPC URLs for load balancing
+    pub additional_rpc_urls: Vec<String>,
     /// The block number of the forked block
     pub block_number: u64,
     /// The hash of the forked block
@@ -672,16 +674,22 @@ impl<N: Network> ClientForkConfig<N> {
     ///
     /// This will fail if no new provider could be established (erroneous URL)
     fn update_url(&mut self, url: String) -> Result<(), BlockchainError> {
-        // let interval = self.provider.get_interval();
+        let mut builder = ProviderBuilder::<N>::new(url.as_str())
+            .timeout(self.timeout)
+            .max_retry(self.retries)
+            .initial_backoff(self.backoff.as_millis() as u64)
+            .compute_units_per_second(self.compute_units_per_second);
+
+        if !self.additional_rpc_urls.is_empty() {
+            let additional: Vec<url::Url> = self.additional_rpc_urls.iter()
+                .filter_map(|u| url::Url::parse(u).ok())
+                .collect();
+            builder = builder.additional_urls(additional);
+        }
+
         self.provider = Arc::new(
-            ProviderBuilder::<N>::new(url.as_str())
-                .timeout(self.timeout)
-                // .timeout_retry(self.retries)
-                .max_retry(self.retries)
-                .initial_backoff(self.backoff.as_millis() as u64)
-                .compute_units_per_second(self.compute_units_per_second)
-                .build()
-                .map_err(|e| BlockchainError::InvalidUrl(format!("{url}: {e}")))?, /* .interval(interval), */
+            builder.build()
+                .map_err(|e| BlockchainError::InvalidUrl(format!("{url}: {e}")))?,
         );
         trace!(target: "fork", "Updated rpc url  {}", url);
         self.eth_rpc_url = url;

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2055,7 +2055,7 @@ impl<N: Network> Backend<N> {
                     // `setup_fork_db_config`
                     node_config.base_fee.take();
 
-                    node_config.setup_fork_db_config(eth_rpc_url, &mut evm_env, &self.fees).await?
+                    node_config.setup_fork_db_config(vec![eth_rpc_url], &mut evm_env, &self.fees).await?
                 };
 
                 *self.db.write().await = Box::new(db);
@@ -2085,14 +2085,14 @@ impl<N: Network> Backend<N> {
             // update all settings related to the forked block
             {
                 if let Some(fork_url) = forking.json_rpc_url {
-                    self.reset_block_number(fork_url, fork_block_number).await?;
+                    self.reset_block_number(vec![fork_url], fork_block_number).await?;
                 } else {
                     // If rpc url is unspecified, then update the fork with the new block number and
                     // existing rpc url, this updates the cache path
                     {
-                        let maybe_fork_url = { self.node_config.read().await.eth_rpc_url.clone() };
-                        if let Some(fork_url) = maybe_fork_url {
-                            self.reset_block_number(fork_url, fork_block_number).await?;
+                        let maybe_fork_urls = { self.node_config.read().await.eth_rpc_url.clone() };
+                        if let Some(fork_urls) = maybe_fork_urls {
+                            self.reset_block_number(fork_urls, fork_block_number).await?;
                         }
                     }
 
@@ -2199,7 +2199,7 @@ impl<N: Network> Backend<N> {
 
     async fn reset_block_number(
         &self,
-        fork_url: String,
+        fork_urls: Vec<String>,
         fork_block_number: u64,
     ) -> Result<(), BlockchainError> {
         let mut node_config = self.node_config.write().await;
@@ -2207,7 +2207,7 @@ impl<N: Network> Backend<N> {
 
         let mut evm_env = self.evm_env.read().clone();
         let (forked_db, client_fork_config) =
-            node_config.setup_fork_db_config(fork_url, &mut evm_env, &self.fees).await?;
+            node_config.setup_fork_db_config(fork_urls, &mut evm_env, &self.fees).await?;
 
         *self.db.write().await = Box::new(forked_db);
         let fork = ClientFork::new(client_fork_config, Arc::clone(&self.db));

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -407,7 +407,7 @@ async fn test_timestamp_interval() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_can_set_storage_bsc_fork() {
     let (api, handle) =
-        spawn(NodeConfig::test().with_eth_rpc_url(Some("https://bsc-dataseed.binance.org/"))).await;
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(vec!["https://bsc-dataseed.binance.org/".to_string()]))).await;
     let provider = handle.http_provider();
 
     let busd_addr = address!("0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56");
@@ -492,7 +492,7 @@ async fn can_get_metadata() {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_metadata_on_fork() {
     let (api, handle) =
-        spawn(NodeConfig::test().with_eth_rpc_url(Some("https://bsc-dataseed.binance.org/"))).await;
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(vec!["https://bsc-dataseed.binance.org/".to_string()]))).await;
     let provider = handle.http_provider();
 
     let metadata = api.anvil_metadata().await.unwrap();
@@ -521,7 +521,7 @@ async fn can_get_metadata_on_fork() {
 #[tokio::test(flavor = "multi_thread")]
 async fn metadata_changes_on_reset() {
     let (api, _) =
-        spawn(NodeConfig::test().with_eth_rpc_url(Some("https://bsc-dataseed.binance.org/"))).await;
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(vec!["https://bsc-dataseed.binance.org/".to_string()]))).await;
 
     let metadata = api.anvil_metadata().await.unwrap();
     let instance_id = metadata.instance_id;

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -476,7 +476,7 @@ async fn can_send_tx_sync() {
 #[ignore = "no debug_"]
 async fn can_get_code_by_hash() {
     let (api, _) =
-        spawn(NodeConfig::test().with_eth_rpc_url(Some(rpc::next_http_archive_rpc_url()))).await;
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(vec![rpc::next_http_archive_rpc_url()]))).await;
 
     // The code hash for DEFAULT_CREATE2_DEPLOYER_RUNTIME_CODE
     let code_hash = b256!("2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989");

--- a/crates/anvil/tests/it/eip4844.rs
+++ b/crates/anvil/tests/it/eip4844.rs
@@ -50,7 +50,7 @@ async fn can_send_eip4844_transaction() {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_send_eip4844_transaction_fork() {
     let node_config = NodeConfig::test()
-        .with_eth_rpc_url(Some(rpc::next_http_archive_rpc_url()))
+        .with_eth_rpc_url(Some(vec![rpc::next_http_archive_rpc_url()]))
         .with_fork_block_number(Some(23432306u64))
         .with_hardfork(Some(EthereumHardfork::Cancun.into()));
     let (api, handle) = spawn(node_config).await;
@@ -77,7 +77,7 @@ async fn can_send_eip4844_transaction_fork() {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_send_eip4844_transaction_eth_send_transaction() {
     let node_config = NodeConfig::test()
-        .with_eth_rpc_url(Some(rpc::next_http_archive_rpc_url()))
+        .with_eth_rpc_url(Some(vec![rpc::next_http_archive_rpc_url()]))
         .with_fork_block_number(Some(23552208u64))
         .with_hardfork(Some(EthereumHardfork::Cancun.into()));
     let (api, handle) = spawn(node_config).await;

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -60,14 +60,14 @@ impl LocalFork {
         let (origin_api, origin_handle) = spawn(origin).await;
 
         let (fork_api, fork_handle) =
-            spawn(fork.with_eth_rpc_url(Some(origin_handle.http_endpoint()))).await;
+            spawn(fork.with_eth_rpc_url(Some(vec![origin_handle.http_endpoint()]))).await;
         Self { origin_api, origin_handle, fork_api, fork_handle }
     }
 }
 
 pub fn fork_config() -> NodeConfig {
     NodeConfig::test()
-        .with_eth_rpc_url(Some(rpc::next_http_archive_rpc_url()))
+        .with_eth_rpc_url(Some(vec![rpc::next_http_archive_rpc_url()]))
         .with_fork_block_number(Some(BLOCK_NUMBER))
 }
 
@@ -218,7 +218,7 @@ async fn test_fork_optimism_with_transaction_hash() {
             .unwrap();
     let (api, _handle) = spawn(
         NodeConfig::test()
-            .with_eth_rpc_url(Some(rpc::next_rpc_endpoint(NamedChain::Optimism)))
+            .with_eth_rpc_url(Some(vec![rpc::next_rpc_endpoint(NamedChain::Optimism)]))
             .with_fork_transaction_hash(Some(fork_tx_hash)),
     )
     .await;
@@ -509,7 +509,7 @@ async fn can_reset_properly() {
     assert_eq!(origin_nonce, origin_provider.get_transaction_count(account).await.unwrap());
 
     let (fork_api, fork_handle) =
-        spawn(NodeConfig::test().with_eth_rpc_url(Some(origin_handle.http_endpoint()))).await;
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(vec![origin_handle.http_endpoint()]))).await;
 
     let fork_provider = fork_handle.http_provider();
     let fork_tx_provider = http_provider(&fork_handle.http_endpoint());
@@ -541,7 +541,7 @@ async fn can_reset_properly() {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_reset_fork_to_new_fork() {
     let eth_rpc_url = next_rpc_endpoint(NamedChain::Mainnet);
-    let (api, handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(eth_rpc_url))).await;
+    let (api, handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(vec![eth_rpc_url]))).await;
     let provider = handle.http_provider();
 
     let op = address!("0xC0d3c0d3c0D3c0D3C0d3C0D3C0D3c0d3c0d30007"); // L2CrossDomainMessenger - Dead on mainnet.
@@ -836,7 +836,7 @@ async fn test_fork_init_blob_base_fee_with_explicit_base_fee() {
     let fork_block_number = 24_127_158u64;
     let (default_api, _) = spawn(
         NodeConfig::test()
-            .with_eth_rpc_url(Some(fork_rpc_url.clone()))
+            .with_eth_rpc_url(Some(vec![fork_rpc_url.clone()]))
             .with_fork_block_number(Some(fork_block_number)),
     )
     .await;
@@ -850,7 +850,7 @@ async fn test_fork_init_blob_base_fee_with_explicit_base_fee() {
         .unwrap();
     let (explicit_api, _) = spawn(
         NodeConfig::test()
-            .with_eth_rpc_url(Some(fork_rpc_url))
+            .with_eth_rpc_url(Some(vec![fork_rpc_url]))
             .with_fork_block_number(Some(fork_block_number))
             .with_base_fee(Some(explicit_base_fee)),
     )
@@ -866,7 +866,7 @@ async fn test_fork_init_blob_base_fee_with_explicit_base_fee() {
 #[tokio::test(flavor = "multi_thread")]
 async fn flaky_test_reset_fork_on_new_blocks() {
     let (api, handle) =
-        spawn(NodeConfig::test().with_eth_rpc_url(Some(rpc::next_http_archive_rpc_url()))).await;
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(vec![rpc::next_http_archive_rpc_url()]))).await;
 
     let anvil_provider = handle.http_provider();
     let endpoint = next_http_rpc_endpoint();
@@ -1179,7 +1179,7 @@ async fn test_fork_reset_moonbeam() {
     crate::init_tracing();
     let (api, handle) = spawn(
         fork_config()
-            .with_eth_rpc_url(Some("https://rpc.api.moonbeam.network".to_string()))
+            .with_eth_rpc_url(Some(vec!["https://rpc.api.moonbeam.network".to_string()]))
             .with_fork_block_number(None::<u64>),
     )
     .await;
@@ -1242,7 +1242,7 @@ async fn flaky_test_arbitrum_fork_dev_balance() {
     let (api, handle) = spawn(
         fork_config()
             .with_fork_block_number(None::<u64>)
-            .with_eth_rpc_url(Some(next_rpc_endpoint(NamedChain::Arbitrum))),
+            .with_eth_rpc_url(Some(vec![next_rpc_endpoint(NamedChain::Arbitrum)])),
     )
     .await;
 
@@ -1261,7 +1261,7 @@ async fn flaky_test_arb_fork_mining() {
     let (api, _handle) = spawn(
         fork_config()
             .with_fork_block_number(Some(fork_block_number))
-            .with_eth_rpc_url(Some(fork_rpc)),
+            .with_eth_rpc_url(Some(vec![fork_rpc])),
     )
     .await;
 
@@ -1281,7 +1281,7 @@ async fn flaky_test_arbitrum_fork_block_number() {
     let (_, handle) = spawn(
         fork_config()
             .with_fork_block_number(None::<u64>)
-            .with_eth_rpc_url(Some(next_rpc_endpoint(NamedChain::Arbitrum))),
+            .with_eth_rpc_url(Some(vec![next_rpc_endpoint(NamedChain::Arbitrum)])),
     )
     .await;
     let provider = handle.http_provider();
@@ -1293,7 +1293,7 @@ async fn flaky_test_arbitrum_fork_block_number() {
     let (api, _) = spawn(
         fork_config()
             .with_fork_block_number(Some(initial_block_number))
-            .with_eth_rpc_url(Some(next_rpc_endpoint(NamedChain::Arbitrum))),
+            .with_eth_rpc_url(Some(vec![next_rpc_endpoint(NamedChain::Arbitrum)])),
     )
     .await;
     let block_number = api.block_number().unwrap().to::<u64>();
@@ -1334,7 +1334,7 @@ async fn test_base_fork_gas_limit() {
     let (api, handle) = spawn(
         fork_config()
             .with_fork_block_number(None::<u64>)
-            .with_eth_rpc_url(Some(next_rpc_endpoint(NamedChain::Base))),
+            .with_eth_rpc_url(Some(vec![next_rpc_endpoint(NamedChain::Base)])),
     )
     .await;
 
@@ -1384,7 +1384,7 @@ async fn test_immutable_fork_transaction_hash() {
         fork_config()
             .with_blocktime(Some(Duration::from_millis(500)))
             .with_fork_transaction_hash(Some(fork_tx_hash))
-            .with_eth_rpc_url(Some("https://immutable-zkevm.drpc.org".to_string())),
+            .with_eth_rpc_url(Some(vec!["https://immutable-zkevm.drpc.org".to_string()])),
     )
     .await;
 
@@ -1983,4 +1983,37 @@ async fn test_config_with_osaka_hardfork_with_precompile_factory() {
         &expected_precompiles,
         &expected_system_contracts,
     );
+}
+
+// Test that anvil can fork using multiple RPC URLs for load balancing.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_multi_rpc_load_balance() {
+    // Spawn two independent origin nodes with the same initial state
+    let (origin_api_1, origin_handle_1) = spawn(NodeConfig::test()).await;
+    let (origin_api_2, origin_handle_2) = spawn(NodeConfig::test()).await;
+
+    // Mine a block on both so they have state at block 1
+    origin_api_1.mine_one().await;
+    origin_api_2.mine_one().await;
+
+    // Get a dev wallet address from the first origin
+    let accounts_1 = origin_handle_1.dev_wallets().collect::<Vec<_>>();
+    let signer_addr = accounts_1[0].address();
+
+    // Fork from both origin nodes using multi-URL
+    let (fork_api, _fork_handle) = spawn(
+        NodeConfig::test().with_eth_rpc_url(Some(vec![
+            origin_handle_1.http_endpoint(),
+            origin_handle_2.http_endpoint(),
+        ]))
+    )
+    .await;
+
+    // Verify the fork works — can read balance
+    let balance = fork_api.balance(signer_addr, None).await.unwrap();
+    assert!(balance > U256::ZERO, "should read balance through load-balanced fork");
+
+    // Verify block number is correct
+    let block_num = fork_api.block_number().unwrap();
+    assert_eq!(block_num, U256::from(1), "fork should be at block 1");
 }

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -14,7 +14,7 @@ use foundry_test_utils::rpc;
 async fn test_fork_simulate_v1() {
     crate::init_tracing();
     let (api, _) =
-        spawn(NodeConfig::test().with_eth_rpc_url(Some(rpc::next_http_archive_rpc_url()))).await;
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(vec![rpc::next_http_archive_rpc_url()]))).await;
     let block_overrides =
         Some(BlockOverrides { base_fee: Some(U256::from(9)), ..Default::default() });
     let account_override =

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -229,7 +229,7 @@ async fn can_preserve_historical_states_between_dump_and_load() {
 async fn test_fork_load_state() {
     let (api, handle) = spawn(
         NodeConfig::test()
-            .with_eth_rpc_url(Some(next_http_archive_rpc_url()))
+            .with_eth_rpc_url(Some(vec![next_http_archive_rpc_url()]))
             .with_fork_block_number(Some(21070682u64)),
     )
     .await;
@@ -257,7 +257,7 @@ async fn test_fork_load_state() {
 
     let (api, handle) = spawn(
         NodeConfig::test()
-            .with_eth_rpc_url(Some(next_http_archive_rpc_url()))
+            .with_eth_rpc_url(Some(vec![next_http_archive_rpc_url()]))
             .with_fork_block_number(Some(21070686u64)) // Forked chain has moved forward
             .with_init_state(Some(serialized_state)),
     )
@@ -316,7 +316,7 @@ async fn test_fork_load_state() {
 async fn test_fork_load_state_with_greater_state_block() {
     let (api, _handle) = spawn(
         NodeConfig::test()
-            .with_eth_rpc_url(Some(next_http_archive_rpc_url()))
+            .with_eth_rpc_url(Some(vec![next_http_archive_rpc_url()]))
             .with_fork_block_number(Some(21070682u64)),
     )
     .await;
@@ -331,7 +331,7 @@ async fn test_fork_load_state_with_greater_state_block() {
 
     let (api, _handle) = spawn(
         NodeConfig::test()
-            .with_eth_rpc_url(Some(next_http_archive_rpc_url()))
+            .with_eth_rpc_url(Some(vec![next_http_archive_rpc_url()]))
             .with_fork_block_number(Some(21070682u64)) // Forked chain has moved forward
             .with_init_state(Some(serialized_state)),
     )

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3757,7 +3757,7 @@ forgetest_async!(flaky_cast_run_impersonated_tx, |_prj, cmd| {
     let (_api, handle) = anvil::spawn(
         NodeConfig::test()
             .with_auto_impersonate(true)
-            .with_eth_rpc_url(Some("https://sepolia.base.org")),
+            .with_eth_rpc_url(Some(vec!["https://sepolia.base.org".to_string()])),
     )
     .await;
 

--- a/crates/common/src/provider/load_balanced_transport.rs
+++ b/crates/common/src/provider/load_balanced_transport.rs
@@ -1,0 +1,152 @@
+//! Load-balanced transport that distributes requests across multiple [`RuntimeTransport`]
+//! instances using atomic round-robin selection.
+//!
+//! The [`LoadBalancedTransport`] sits between the `RetryBackoffLayer` and multiple
+//! [`RuntimeTransport`] instances. When a request fails and the retry layer retries, it calls
+//! this transport again — which round-robins to the next backend, providing free failover.
+
+use crate::provider::runtime_transport::RuntimeTransport;
+use alloy_json_rpc::{RequestPacket, ResponsePacket};
+use alloy_transport::{TransportError, TransportFut};
+use std::{
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::{Context, Poll},
+};
+use tower::Service;
+
+/// A [`tower::Service`] that wraps multiple [`RuntimeTransport`] instances and distributes
+/// requests across them using atomic round-robin selection.
+///
+/// # Panics
+///
+/// The constructor panics if `backends` is empty.
+#[derive(Clone, Debug)]
+pub struct LoadBalancedTransport {
+    /// The underlying transports.
+    backends: Vec<RuntimeTransport>,
+    /// Atomic counter used for round-robin backend selection.
+    next: Arc<AtomicUsize>,
+}
+
+impl LoadBalancedTransport {
+    /// Creates a new [`LoadBalancedTransport`] from the given backends.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `backends` is empty.
+    pub fn new(backends: Vec<RuntimeTransport>) -> Self {
+        assert!(!backends.is_empty(), "LoadBalancedTransport requires at least one backend");
+        Self { backends, next: Arc::new(AtomicUsize::new(0)) }
+    }
+
+    /// Returns the number of backends.
+    pub fn len(&self) -> usize {
+        self.backends.len()
+    }
+
+    /// Returns `true` if there are no backends.
+    ///
+    /// Note: this is always `false` for a successfully constructed [`LoadBalancedTransport`]
+    /// because the constructor panics on empty input.
+    pub fn is_empty(&self) -> bool {
+        self.backends.is_empty()
+    }
+
+    /// Selects the next backend using atomic round-robin and returns a reference to it.
+    pub fn next_backend(&self) -> &RuntimeTransport {
+        let idx = self.next.fetch_add(1, Ordering::Relaxed) % self.backends.len();
+        &self.backends[idx]
+    }
+}
+
+impl fmt::Display for LoadBalancedTransport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "LoadBalancedTransport({} backends)", self.backends.len())
+    }
+}
+
+impl Service<RequestPacket> for LoadBalancedTransport {
+    type Response = ResponsePacket;
+    type Error = TransportError;
+    type Future = TransportFut<'static>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: RequestPacket) -> Self::Future {
+        self.next_backend().request(req)
+    }
+}
+
+impl Service<RequestPacket> for &LoadBalancedTransport {
+    type Response = ResponsePacket;
+    type Error = TransportError;
+    type Future = TransportFut<'static>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: RequestPacket) -> Self::Future {
+        self.next_backend().request(req)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::runtime_transport::RuntimeTransportBuilder;
+    use url::Url;
+
+    fn make_transport(url: &str) -> RuntimeTransport {
+        RuntimeTransportBuilder::new(Url::parse(url).unwrap()).build()
+    }
+
+    #[test]
+    fn round_robin_selection() {
+        let t = LoadBalancedTransport::new(vec![
+            make_transport("http://localhost:8545"),
+            make_transport("http://localhost:8546"),
+            make_transport("http://localhost:8547"),
+        ]);
+
+        // The counter starts at 0; each call to next_backend increments it.
+        // We verify the counter advances by checking that three successive calls
+        // wrap back around to the first backend on the fourth call.
+        assert_eq!(t.next.load(Ordering::Relaxed), 0);
+        let _ = t.next_backend(); // idx 0, counter → 1
+        assert_eq!(t.next.load(Ordering::Relaxed), 1);
+        let _ = t.next_backend(); // idx 1, counter → 2
+        assert_eq!(t.next.load(Ordering::Relaxed), 2);
+        let _ = t.next_backend(); // idx 2, counter → 3
+        assert_eq!(t.next.load(Ordering::Relaxed), 3);
+
+        // Fourth call wraps: 3 % 3 == 0 → first backend again
+        let _ = t.next_backend(); // idx 0, counter → 4
+        assert_eq!(t.next.load(Ordering::Relaxed), 4);
+    }
+
+    #[test]
+    fn single_backend() {
+        let t = LoadBalancedTransport::new(vec![make_transport("http://localhost:8545")]);
+        assert_eq!(t.len(), 1);
+        assert!(!t.is_empty());
+
+        // Every call must select index 0 (counter % 1 == 0 always).
+        for i in 1..=5u64 {
+            let _ = t.next_backend();
+            assert_eq!(t.next.load(Ordering::Relaxed) as u64, i);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "LoadBalancedTransport requires at least one backend")]
+    fn empty_backends_panics() {
+        let _ = LoadBalancedTransport::new(vec![]);
+    }
+}

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -1,11 +1,16 @@
 //! Provider-related instantiation and usage utilities.
 
 pub mod curl_transport;
+pub mod load_balanced_transport;
 pub mod runtime_transport;
 
 use crate::{
     ALCHEMY_FREE_TIER_CUPS, REQUEST_TIMEOUT,
-    provider::{curl_transport::CurlTransport, runtime_transport::RuntimeTransportBuilder},
+    provider::{
+        curl_transport::CurlTransport,
+        load_balanced_transport::LoadBalancedTransport,
+        runtime_transport::RuntimeTransportBuilder,
+    },
 };
 use alloy_chains::NamedChain;
 use alloy_network::{Network, NetworkWallet};
@@ -90,6 +95,8 @@ pub struct ProviderBuilder<N: Network = AnyNetwork> {
     /// JWT Secret
     jwt: Option<String>,
     headers: Vec<String>,
+    /// Additional URLs for load balancing.
+    additional_urls: Vec<Url>,
     is_local: bool,
     /// Whether to accept invalid certificates.
     accept_invalid_certs: bool,
@@ -147,6 +154,7 @@ impl<N: Network> ProviderBuilder<N> {
             compute_units_per_second: ALCHEMY_FREE_TIER_CUPS,
             jwt: None,
             headers: vec![],
+            additional_urls: vec![],
             is_local,
             accept_invalid_certs: false,
             no_proxy: false,
@@ -278,6 +286,12 @@ impl<N: Network> ProviderBuilder<N> {
         self
     }
 
+    /// Sets additional URLs for load balancing.
+    pub fn additional_urls(mut self, urls: Vec<Url>) -> Self {
+        self.additional_urls = urls;
+        self
+    }
+
     /// Sets whether to accept invalid certificates.
     pub fn accept_invalid_certs(mut self, accept_invalid_certs: bool) -> Self {
         self.accept_invalid_certs = accept_invalid_certs;
@@ -313,6 +327,7 @@ impl<N: Network> ProviderBuilder<N> {
             compute_units_per_second,
             jwt,
             headers,
+            additional_urls,
             is_local,
             accept_invalid_certs,
             no_proxy,
@@ -335,14 +350,28 @@ impl<N: Network> ProviderBuilder<N> {
             return Ok(provider);
         }
 
-        let transport = RuntimeTransportBuilder::new(url)
-            .with_timeout(timeout)
-            .with_headers(headers)
-            .with_jwt(jwt)
-            .accept_invalid_certs(accept_invalid_certs)
-            .no_proxy(no_proxy)
-            .build();
-        let client = ClientBuilder::default().layer(retry_layer).transport(transport, is_local);
+        let make_runtime_transport = |u: Url| {
+            RuntimeTransportBuilder::new(u)
+                .with_timeout(timeout)
+                .with_headers(headers.clone())
+                .with_jwt(jwt.clone())
+                .accept_invalid_certs(accept_invalid_certs)
+                .no_proxy(no_proxy)
+                .build()
+        };
+
+        let client = if additional_urls.is_empty() {
+            let transport = make_runtime_transport(url);
+            ClientBuilder::default().layer(retry_layer).transport(transport, is_local)
+        } else {
+            let mut backends = Vec::with_capacity(1 + additional_urls.len());
+            backends.push(make_runtime_transport(url));
+            for u in additional_urls {
+                backends.push(make_runtime_transport(u));
+            }
+            let transport = LoadBalancedTransport::new(backends);
+            ClientBuilder::default().layer(retry_layer).transport(transport, is_local)
+        };
 
         if !is_local {
             client.set_poll_interval(
@@ -381,6 +410,7 @@ impl<N: Network> ProviderBuilder<N> {
             compute_units_per_second,
             jwt,
             headers,
+            additional_urls,
             is_local,
             accept_invalid_certs,
             no_proxy,
@@ -405,15 +435,28 @@ impl<N: Network> ProviderBuilder<N> {
             return Ok(provider);
         }
 
-        let transport = RuntimeTransportBuilder::new(url)
-            .with_timeout(timeout)
-            .with_headers(headers)
-            .with_jwt(jwt)
-            .accept_invalid_certs(accept_invalid_certs)
-            .no_proxy(no_proxy)
-            .build();
+        let make_runtime_transport = |u: Url| {
+            RuntimeTransportBuilder::new(u)
+                .with_timeout(timeout)
+                .with_headers(headers.clone())
+                .with_jwt(jwt.clone())
+                .accept_invalid_certs(accept_invalid_certs)
+                .no_proxy(no_proxy)
+                .build()
+        };
 
-        let client = ClientBuilder::default().layer(retry_layer).transport(transport, is_local);
+        let client = if additional_urls.is_empty() {
+            let transport = make_runtime_transport(url);
+            ClientBuilder::default().layer(retry_layer).transport(transport, is_local)
+        } else {
+            let mut backends = Vec::with_capacity(1 + additional_urls.len());
+            backends.push(make_runtime_transport(url));
+            for u in additional_urls {
+                backends.push(make_runtime_transport(u));
+            }
+            let transport = LoadBalancedTransport::new(backends);
+            ClientBuilder::default().layer(retry_layer).transport(transport, is_local)
+        };
 
         if !is_local {
             client.set_poll_interval(

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -192,7 +192,7 @@ contract DeployScript is Script {
 
     let deploy_contract = deploy_script.display().to_string() + ":DeployScript";
 
-    let node_config = NodeConfig::test().with_eth_rpc_url(Some(rpc::next_http_archive_rpc_url()));
+    let node_config = NodeConfig::test().with_eth_rpc_url(Some(vec![rpc::next_http_archive_rpc_url()]));
     let (_api, handle) = spawn(node_config).await;
     let dev = handle.dev_accounts().next().unwrap();
     cmd.set_current_dir(prj.root());
@@ -291,7 +291,7 @@ contract DeployScript is Script {
 
     let deploy_contract = deploy_script.display().to_string() + ":DeployScript";
 
-    let node_config = NodeConfig::test().with_eth_rpc_url(Some(rpc::next_http_archive_rpc_url()));
+    let node_config = NodeConfig::test().with_eth_rpc_url(Some(vec![rpc::next_http_archive_rpc_url()]));
     let (_api, handle) = spawn(node_config).await;
     let private_key =
         "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string();
@@ -507,7 +507,7 @@ contract DeployScript is Script {
 
     let deploy_contract = deploy_script.display().to_string() + ":DeployScript";
 
-    let node_config = NodeConfig::test().with_eth_rpc_url(Some(rpc::next_http_archive_rpc_url()));
+    let node_config = NodeConfig::test().with_eth_rpc_url(Some(vec![rpc::next_http_archive_rpc_url()]));
     let (_api, handle) = spawn(node_config).await;
     let private_key =
         "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string();


### PR DESCRIPTION
## Summary

- Allow `--fork-url` to be specified multiple times for load balancing across RPC endpoints
- Requests are distributed using round-robin via a new `LoadBalancedTransport`
- Failed requests automatically failover to the next backend through the existing `RetryBackoffLayer`
- Single `--fork-url` behavior is completely unchanged

## Motivation

When forking with public or rate-limited RPC providers, heavy workloads (automation scripts, many unique address/slot queries) frequently hit rate limits (HTTP 429), causing timeouts. Existing mitigations (`--retries`, `--compute-units-per-second`) only slow down requests — they don't increase throughput. Distributing load across multiple providers effectively multiplies the available rate limit budget.

## Usage

```bash
anvil --fork-url https://rpc1.example.com --fork-url https://rpc2.example.com
```

## Changes

- **`LoadBalancedTransport`** (`crates/common/src/provider/load_balanced_transport.rs`): New `tower::Service<RequestPacket>` that wraps multiple `RuntimeTransport` backends with atomic round-robin dispatch
- **`ProviderBuilder`** (`crates/common/src/provider/mod.rs`): Extended with `additional_urls()` to create `LoadBalancedTransport` when multiple URLs provided
- **CLI** (`crates/anvil/src/cmd.rs`): `--fork-url` accepts multiple values (`Vec<ForkUrl>`)
- **Config** (`crates/anvil/src/config.rs`): `NodeConfig.eth_rpc_url` is now `Option<Vec<String>>`
- **Fork backend** (`crates/anvil/src/eth/backend/fork.rs`): `ClientForkConfig` stores additional URLs

## Test plan

- [x] Unit tests for `LoadBalancedTransport` (round-robin, single backend, empty panics)
- [x] All existing provider tests pass (9/9)
- [x] Integration test: fork through two local Anvil nodes with load balancing
- [x] Clean compilation across anvil, cast, forge test crates
- [ ] Manual testing with multiple real RPC endpoints

Closes #14265