### PR TITLE
chore(deny): ignore RUSTSEC-2026-0097

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,8 @@ ignore = [
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
     "RUSTSEC-2025-0141",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand is unsound with a custom logger
+    "RUSTSEC-2026-0097",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
## Summary
- add `RUSTSEC-2026-0097` to the cargo-deny advisory ignore list
- mirror the existing Tempo handling for the same `rand` advisory

## Why
Latest `master` fails `cargo deny --all-features check advisories` due to `RUSTSEC-2026-0097` on `rand 0.8.5`.

This change is a targeted cargo-deny unblock that acknowledges the advisory without changing the dependency graph.

## Impact
- restores a passing advisory check for this newly reported RustSec entry
- keeps the change limited to `deny.toml`

## Validation
- `cargo deny --all-features check advisories`

Note: the check still emits pre-existing warnings for a yanked `fastrand 2.4.0` and a stale ignored advisory entry for `RUSTSEC-2025-0141`, but the advisories check exits successfully with this change.