### PR TITLE
feat(evm): auto-detect Tempo network on Anvil

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5248,6 +5248,7 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-serde 2.0.0-rc.0",
  "alloy-sol-types",
+ "anvil",
  "auto_impl",
  "eyre",
  "foundry-cheatcodes-spec",

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -81,4 +81,5 @@ alloy-op-evm.workspace = true
 alloy-serde.workspace = true
 op-alloy-consensus.workspace = true
 op-alloy-rpc-types.workspace = true
+anvil.workspace = true
 foundry-test-utils.workspace = true

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -462,6 +462,68 @@ mod tests {
     use super::*;
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn infer_network_default_anvil_selects_ethereum() {
+        let (_api, handle) = anvil::spawn(anvil::NodeConfig::test()).await;
+
+        let config = Config::figment();
+        let mut evm_opts = config.extract::<EvmOpts>().unwrap();
+        evm_opts.fork_url = Some(handle.http_endpoint());
+        assert_eq!(evm_opts.networks, NetworkConfigs::default());
+
+        evm_opts.infer_network_from_fork().await;
+
+        // Plain anvil (chain id 31337) without tempo flag -> Ethereum (no network flags set).
+        assert!(!evm_opts.networks.is_tempo());
+        assert!(!evm_opts.networks.is_optimism());
+        assert!(!evm_opts.networks.is_celo());
+        assert_eq!(evm_opts.networks, NetworkConfigs::default());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn infer_network_tempo_anvil_via_node_info() {
+        let (_api, handle) = anvil::spawn(anvil::NodeConfig::test_tempo()).await;
+
+        let config = Config::figment();
+        let mut evm_opts = config.extract::<EvmOpts>().unwrap();
+        evm_opts.fork_url = Some(handle.http_endpoint());
+        // Networks not set -> should query anvil_nodeInfo to discover tempo.
+        assert_eq!(evm_opts.networks, NetworkConfigs::default());
+
+        evm_opts.infer_network_from_fork().await;
+
+        assert!(evm_opts.networks.is_tempo(), "should detect tempo via anvil_nodeInfo");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn infer_network_tempo_anvil_skips_rpc_when_already_set() {
+        // Use a URL that would fail if any RPC call were attempted (connection refused).
+        // This proves the early-return guard prevents all network requests.
+        let config = Config::figment();
+        let mut evm_opts = config.extract::<EvmOpts>().unwrap();
+        evm_opts.fork_url = Some("http://127.0.0.1:1".to_string());
+        // Explicitly set tempo before calling infer (simulates --tempo CLI flag).
+        evm_opts.networks = NetworkConfigs::with_tempo();
+
+        evm_opts.infer_network_from_fork().await;
+
+        // Should still be tempo, the early-return guard skips the RPC call.
+        assert!(evm_opts.networks.is_tempo());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flaky_infer_network_tempo_moderato_rpc() {
+        let config = Config::figment();
+        let mut evm_opts = config.extract::<EvmOpts>().unwrap();
+        evm_opts.fork_url = Some("https://rpc.moderato.tempo.xyz".to_string());
+        assert_eq!(evm_opts.networks, NetworkConfigs::default());
+
+        evm_opts.infer_network_from_fork().await;
+
+        // Tempo Moderato has a known Tempo chain ID -> should be inferred via with_chain_id.
+        assert!(evm_opts.networks.is_tempo(), "should detect tempo from Moderato chain ID");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_fork_pins_block_number_from_env() {
         let endpoint = foundry_test_utils::rpc::next_http_rpc_endpoint();
 

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -4,11 +4,12 @@ use crate::{
     fork::CreateFork,
     utils::{apply_chain_and_block_specific_env_changes, block_env_from_header},
 };
+use alloy_chains::NamedChain;
 use alloy_consensus::BlockHeader;
 use alloy_network::{AnyNetwork, BlockResponse, Network};
 use alloy_primitives::{Address, B256, BlockNumber, ChainId, U256};
 use alloy_provider::{Provider, RootProvider};
-use alloy_rpc_types::BlockNumberOrTag;
+use alloy_rpc_types::{BlockNumberOrTag, anvil::NodeInfo};
 use eyre::WrapErr;
 use foundry_common::{ALCHEMY_FREE_TIER_CUPS, NON_ARCHIVE_NODE_WARNING, provider::ProviderBuilder};
 use foundry_config::{Chain, Config, GasLimit};
@@ -142,7 +143,17 @@ impl EvmOpts {
             && let Ok(provider) = self.fork_provider_with_url::<AnyNetwork>(fork_url)
             && let Ok(chain_id) = provider.get_chain_id().await
         {
-            self.networks = self.networks.with_chain_id(chain_id);
+            // If Anvil's chain, request anvil_nodeInfo to determine if the network is Tempo.
+            if chain_id == NamedChain::AnvilHardhat as u64 {
+                if let Ok(node_info) =
+                    provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), ()).await
+                    && node_info.network.is_some_and(|network| network == "tempo")
+                {
+                    self.networks = NetworkConfigs::with_tempo();
+                }
+            } else {
+                self.networks = self.networks.with_chain_id(chain_id);
+            }
         }
     }
 


### PR DESCRIPTION
## Motivation

 #14258 follow-up, given @0xrusowsky's suggestion:
 - Add Tempo network auto-detection on `EvmOpts::infer_network_from_fork` when run against Anvil via `NodeInfo`.
 
`--tempo`, `--tempo.fee-token` flags remains to shortcut `NodeInfo` request.