### PR TITLE
fix(anvil): auto-detect seconds vs milliseconds in evm_setTime

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -477,15 +477,18 @@ impl<N: Network> EthApi<N> {
     /// Sets the specific timestamp and returns the number of seconds between the given timestamp
     /// and the current time.
     ///
+    /// The `timestamp` is a JavaScript-style millisecond timestamp for Ganache compatibility.
+    ///
     /// Handler for RPC call: `evm_setTime`
     pub fn evm_set_time(&self, timestamp: u64) -> Result<u64> {
         node_info!("evm_setTime");
+        let timestamp_secs = Duration::from_millis(timestamp).as_secs();
         let now = self.backend.time().current_call_timestamp();
-        self.backend.time().reset(timestamp);
+        self.backend.time().reset(timestamp_secs);
 
         // number of seconds between the given timestamp and the current time.
-        let offset = timestamp.saturating_sub(now);
-        Ok(Duration::from_millis(offset).as_secs())
+        let offset = timestamp_secs.saturating_sub(now);
+        Ok(offset)
     }
 
     /// Set the next block gas limit

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -477,17 +477,18 @@ impl<N: Network> EthApi<N> {
     /// Sets the specific timestamp and returns the number of seconds between the given timestamp
     /// and the current time.
     ///
-    /// The `timestamp` is a JavaScript-style millisecond timestamp for Ganache compatibility.
+    /// The `timestamp` is in seconds. Note that the `evm_setTime` JSON-RPC method accepts a
+    /// JavaScript-style millisecond timestamp for Ganache compatibility; the RPC handler converts
+    /// it to seconds before calling this function.
     ///
     /// Handler for RPC call: `evm_setTime`
     pub fn evm_set_time(&self, timestamp: u64) -> Result<u64> {
         node_info!("evm_setTime");
-        let timestamp_secs = Duration::from_millis(timestamp).as_secs();
         let now = self.backend.time().current_call_timestamp();
-        self.backend.time().reset(timestamp_secs);
+        self.backend.time().reset(timestamp);
 
         // number of seconds between the given timestamp and the current time.
-        let offset = timestamp_secs.saturating_sub(now);
+        let offset = timestamp.saturating_sub(now);
         Ok(offset)
     }
 
@@ -1758,7 +1759,9 @@ impl EthApi<FoundryNetwork> {
                         "The timestamp is too big",
                     ));
                 }
-                let time = timestamp.to::<u64>();
+                // evm_setTime accepts a JavaScript-style millisecond timestamp for Ganache
+                // compatibility, convert to seconds before passing to the handler.
+                let time = Duration::from_millis(timestamp.to::<u64>()).as_secs();
                 self.evm_set_time(time).to_rpc_result()
             }
             EthRequest::EvmSetBlockGasLimit(gas_limit) => {

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -477,9 +477,9 @@ impl<N: Network> EthApi<N> {
     /// Sets the specific timestamp and returns the number of seconds between the given timestamp
     /// and the current time.
     ///
-    /// The `timestamp` is in seconds. Note that the `evm_setTime` JSON-RPC method accepts a
-    /// JavaScript-style millisecond timestamp for Ganache compatibility; the RPC handler converts
-    /// it to seconds before calling this function.
+    /// The `timestamp` is in seconds. The `evm_setTime` JSON-RPC method accepts both seconds and
+    /// milliseconds (values above 1e12 are treated as milliseconds); the RPC handler normalises
+    /// the input to seconds before calling this function.
     ///
     /// Handler for RPC call: `evm_setTime`
     pub fn evm_set_time(&self, timestamp: u64) -> Result<u64> {
@@ -1759,9 +1759,12 @@ impl EthApi<FoundryNetwork> {
                         "The timestamp is too big",
                     ));
                 }
-                // evm_setTime accepts a JavaScript-style millisecond timestamp for Ganache
-                // compatibility, convert to seconds before passing to the handler.
-                let time = Duration::from_millis(timestamp.to::<u64>()).as_secs();
+                // evm_setTime accepts either seconds or milliseconds for Ganache compatibility.
+                // Timestamps above 1e12 are interpreted as milliseconds and converted to
+                // seconds; below that threshold they are treated as seconds directly.
+                let raw = timestamp.to::<u64>();
+                let time =
+                    if raw > 1_000_000_000_000 { Duration::from_millis(raw).as_secs() } else { raw };
                 self.evm_set_time(time).to_rpc_result()
             }
             EthRequest::EvmSetBlockGasLimit(gas_limit) => {

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1763,8 +1763,11 @@ impl EthApi<FoundryNetwork> {
                 // Timestamps above 1e12 are interpreted as milliseconds and converted to
                 // seconds; below that threshold they are treated as seconds directly.
                 let raw = timestamp.to::<u64>();
-                let time =
-                    if raw > 1_000_000_000_000 { Duration::from_millis(raw).as_secs() } else { raw };
+                let time = if raw > 1_000_000_000_000 {
+                    Duration::from_millis(raw).as_secs()
+                } else {
+                    raw
+                };
                 self.evm_set_time(time).to_rpc_result()
             }
             EthRequest::EvmSetBlockGasLimit(gas_limit) => {


### PR DESCRIPTION
Fixes the unit mismatch in `evm_setTime` without breaking the RPC interface.

## Motivation

`evm_setTime` is [documented in Ganache](https://ganache.pages.dev/) as accepting a **JavaScript-style millisecond timestamp** and returning the offset in **seconds**. The current code subtracts `current_call_timestamp()` (seconds) directly from the raw input, then wraps the result in `Duration::from_millis(offset).as_secs()` — treating an already-seconds offset as milliseconds and dividing by 1000.

This is an alternative to #14244 which changed the input semantics from milliseconds to seconds — a breaking change for Ganache-compatible callers.

## Changes

- Move the millis-to-seconds conversion to the **RPC dispatch layer**, keeping the internal `evm_set_time()` API in seconds (matching existing tests and `evm_set_next_block_timestamp`)
- Auto-detect whether the caller passed seconds or milliseconds: values above `1e12` are treated as milliseconds and converted; values at or below are treated as seconds directly
- Compute the return offset in seconds without the erroneous `Duration::from_millis` wrapping
- Updated doc comments to clarify input handling

## Testing

```bash
# Seconds input (no conversion needed)
cast rpc evm_setTime $(($(date +%s) + 60)) --rpc-url http://localhost:8545
# -> returns ~60

# Milliseconds input (Ganache compat, auto-detected and converted)
cast rpc evm_setTime $(($(date +%s) * 1000 + 60000)) --rpc-url http://localhost:8545
# -> returns ~60
```

`cargo test -p anvil --test it -- anvil_api::test_evm_set_time` — 2/2 pass.

Co-Authored-By: cui <1579517+cuiweixie@users.noreply.github.com>
Co-Authored-By: zerosnacks <95942363+zerosnacks@users.noreply.github.com>

Prompted by: zerosnacks