### PR TITLE
clippy: enable `useless_let_if_seq` (manual)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ unnested_or_patterns = "warn"
 unused_peekable = "warn"
 unused_rounding = "warn"
 use_self = "warn"
+useless_let_if_seq = "warn"
 while_float = "warn"
 zero_sized_map_values = "warn"
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2378,12 +2378,12 @@ where
 
         // get the range that predates the fork if any
         if let Some(fork) = self.get_fork() {
-            let mut to_on_fork = to;
-
-            if !fork.predates_fork(to) {
+            let to_on_fork = if fork.predates_fork(to) {
+                to
+            } else {
                 // adjust the ranges
-                to_on_fork = fork.block_number();
-            }
+                fork.block_number()
+            };
 
             if fork.predates_fork_inclusive(from) {
                 // this data is only available on the forked client

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -605,14 +605,15 @@ impl<N: Network> MinedTransaction<N> {
                     CallKind::Create2 => OperationType::OpCreate2,
                     _ => return None,
                 };
-                let mut from = node.trace.caller;
-                let mut to = node.trace.address;
-                let mut value = node.trace.value;
-                if node.is_selfdestruct() {
-                    from = node.trace.address;
-                    to = node.trace.selfdestruct_refund_target.unwrap_or_default();
-                    value = node.trace.selfdestruct_transferred_value.unwrap_or_default();
-                }
+                let (from, to, value) = if node.is_selfdestruct() {
+                    (
+                        node.trace.address,
+                        node.trace.selfdestruct_refund_target.unwrap_or_default(),
+                        node.trace.selfdestruct_transferred_value.unwrap_or_default(),
+                    )
+                } else {
+                    (node.trace.caller, node.trace.address, node.trace.value)
+                };
                 Some(InternalOperation { r#type, from, to, value })
             })
             .collect()

--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -124,11 +124,11 @@ impl<T> Pool<T> {
         };
         trace!(target: "txpool", "Dropped transactions: {:?}", removed.iter().map(|tx| tx.hash()).collect::<Vec<_>>());
 
-        let mut dropped = None;
-        if !removed.is_empty() {
-            dropped = removed.into_iter().find(|t| *t.pending_transaction.hash() == tx);
+        if removed.is_empty() {
+            None
+        } else {
+            removed.into_iter().find(|t| *t.pending_transaction.hash() == tx)
         }
-        dropped
     }
 
     /// Notifies listeners if the transaction was added to the ready queue.

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -155,11 +155,9 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
         }
 
         let res = call.await?;
-        let mut decoded = vec![];
-
-        if let Some(func) = func {
+        let decoded = if let Some(func) = func {
             // decode args into tokens
-            decoded = match func.abi_decode_output(res.as_ref()) {
+            match func.abi_decode_output(res.as_ref()) {
                 Ok(decoded) => decoded,
                 Err(err) => {
                     // ensure the address is a contract
@@ -185,8 +183,10 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
                         "could not decode output; did you specify the wrong function return data type?"
                     );
                 }
-            };
-        }
+            }
+        } else {
+            vec![]
+        };
 
         // handle case when return type is not specified
         Ok(if decoded.is_empty() {

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -912,21 +912,23 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             }
 
             if curr_depth >= prank.depth && call.caller == prank.prank_caller {
-                let mut prank_applied = false;
-
                 // At the target depth we set `msg.sender`
-                if curr_depth == prank.depth {
+                let prank_applied = if curr_depth == prank.depth {
                     // Ensure new caller is loaded and touched
                     let _ = journaled_account(ecx, prank.new_caller);
                     call.caller = prank.new_caller;
-                    prank_applied = true;
-                }
+                    true
+                } else {
+                    false
+                };
 
                 // At the target depth, or deeper, we set `tx.origin`
-                if let Some(new_origin) = prank.new_origin {
+                let prank_applied = if let Some(new_origin) = prank.new_origin {
                     ecx.tx_mut().set_caller(new_origin);
-                    prank_applied = true;
-                }
+                    true
+                } else {
+                    prank_applied
+                };
 
                 // If prank applied for first time, then update
                 if prank_applied && let Some(applied_prank) = prank.first_time_applied() {
@@ -1060,19 +1062,12 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
         if let Some(recorded_account_diffs_stack) = &mut self.recorded_account_diffs_stack {
             // Determine if account is "initialized," ie, it has a non-zero balance, a non-zero
             // nonce, a non-zero KECCAK_EMPTY codehash, or non-empty code
-            let initialized;
-            let old_balance;
-            let old_nonce;
-
-            if let Ok(acc) = ecx.journal_mut().load_account(call.target_address) {
-                initialized = acc.data.info.exists();
-                old_balance = acc.data.info.balance;
-                old_nonce = acc.data.info.nonce;
-            } else {
-                initialized = false;
-                old_balance = U256::ZERO;
-                old_nonce = 0;
-            }
+            let (initialized, old_balance, old_nonce) =
+                if let Ok(acc) = ecx.journal_mut().load_account(call.target_address) {
+                    (acc.data.info.exists(), acc.data.info.balance, acc.data.info.nonce)
+                } else {
+                    (false, U256::ZERO, 0)
+                };
 
             let kind = match call.scheme {
                 CallScheme::Call => crate::Vm::AccountAccessKind::Call,
@@ -1743,21 +1738,23 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             && curr_depth >= prank.depth
             && input.caller() == prank.prank_caller
         {
-            let mut prank_applied = false;
-
             // At the target depth we set `msg.sender`
-            if curr_depth == prank.depth {
+            let prank_applied = if curr_depth == prank.depth {
                 // Ensure new caller is loaded and touched
                 let _ = journaled_account(ecx, prank.new_caller);
                 input.set_caller(prank.new_caller);
-                prank_applied = true;
-            }
+                true
+            } else {
+                false
+            };
 
             // At the target depth, or deeper, we set `tx.origin`
-            if let Some(new_origin) = prank.new_origin {
+            let prank_applied = if let Some(new_origin) = prank.new_origin {
                 ecx.tx_mut().set_caller(new_origin);
-                prank_applied = true;
-            }
+                true
+            } else {
+                prank_applied
+            };
 
             // If prank applied for first time, then update
             if prank_applied && let Some(applied_prank) = prank.first_time_applied() {
@@ -2214,13 +2211,14 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
 
                 // Try to include present value for informational purposes, otherwise assume
                 // it's not set (zero value)
-                let mut present_value = U256::ZERO;
                 // Try to load the account and the slot's present value
-                if ecx.journal_mut().load_account(address).is_ok()
+                let present_value = if ecx.journal_mut().load_account(address).is_ok()
                     && let Some(previous) = ecx.sload(address, key)
                 {
-                    present_value = previous.data;
-                }
+                    previous.data
+                } else {
+                    U256::ZERO
+                };
                 let access = crate::Vm::StorageAccess {
                     account: interpreter.input.target_address,
                     slot: key.into(),
@@ -2241,12 +2239,13 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                 let address = interpreter.input.target_address;
                 // Try to load the account and the slot's previous value, otherwise, assume it's
                 // not set (zero value)
-                let mut previous_value = U256::ZERO;
-                if ecx.journal_mut().load_account(address).is_ok()
+                let previous_value = if ecx.journal_mut().load_account(address).is_ok()
                     && let Some(previous) = ecx.sload(address, key)
                 {
-                    previous_value = previous.data;
-                }
+                    previous.data
+                } else {
+                    U256::ZERO
+                };
 
                 let access = crate::Vm::StorageAccess {
                     account: address,
@@ -2272,18 +2271,12 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                 };
                 let address =
                     Address::from_word(B256::from(try_or_return!(interpreter.stack.peek(0))));
-                let initialized;
-                let balance;
-                let nonce;
-                if let Ok(acc) = ecx.journal_mut().load_account(address) {
-                    initialized = acc.data.info.exists();
-                    balance = acc.data.info.balance;
-                    nonce = acc.data.info.nonce;
-                } else {
-                    initialized = false;
-                    balance = U256::ZERO;
-                    nonce = 0;
-                }
+                let (initialized, balance, nonce) =
+                    if let Ok(acc) = ecx.journal_mut().load_account(address) {
+                        (acc.data.info.exists(), acc.data.info.balance, acc.data.info.nonce)
+                    } else {
+                        (false, U256::ZERO, 0)
+                    };
                 let curr_depth =
                     ecx.journal().depth().try_into().expect("journaled state depth exceeds u64");
                 let account_access = crate::Vm::AccountAccess {

--- a/crates/config/src/inline/natspec.rs
+++ b/crates/config/src/inline/natspec.rs
@@ -58,14 +58,15 @@ impl NatSpec {
                 warn!(?abs_path, %contract, "could not parse natspec with solar");
             }
 
-            let mut used_solc = false;
-            if !used_solar
+            let used_solc = if !used_solar
                 && let Some(ast) = &artifact.ast
                 && let Some(node) = solc.contract_root_node(&ast.nodes, &contract)
             {
                 solc.parse(&mut natspecs, &contract, node, true);
-                used_solc = true;
-            }
+                true
+            } else {
+                false
+            };
 
             if !used_solar && !used_solc {
                 warn!(?abs_path, %contract, "could not parse natspec");

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -267,8 +267,7 @@ impl RemappingsProvider<'_> {
         // if the configured _src_ directory is set to something that
         // `Remapping::find_many` doesn't classify as a src directory (src, contracts,
         // lib), then we need to manually add a remapping here
-        let mut src_remapping = None;
-        if ![Path::new("src"), Path::new("contracts"), Path::new("lib")]
+        let src_remapping = if ![Path::new("src"), Path::new("contracts"), Path::new("lib")]
             .contains(&config.src.as_path())
             && let Some(name) = lib.file_name().and_then(|s| s.to_str())
         {
@@ -280,8 +279,10 @@ impl RemappingsProvider<'_> {
             if !r.path.ends_with('/') {
                 r.path.push('/')
             }
-            src_remapping = Some(r);
-        }
+            Some(r)
+        } else {
+            None
+        };
 
         // Eventually, we could set context for remappings at this location,
         // taking into account the OS platform. We'll need to be able to handle nested

--- a/crates/doc/src/preprocessor/infer_hyperlinks.rs
+++ b/crates/doc/src/preprocessor/infer_hyperlinks.rs
@@ -262,11 +262,7 @@ impl<'a> InlineLink<'a> {
     }
 
     const fn exact_identifier(&self) -> &str {
-        let mut name = self.identifier;
-        if let Some(part) = self.part {
-            name = part;
-        }
-        name
+        if let Some(part) = self.part { part } else { self.identifier }
     }
 
     /// Returns the content of the matched link.

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -196,10 +196,8 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         config: FuzzConfig,
         persisted_failure: Option<BaseCounterExample>,
     ) -> Self {
-        let mut max_workers = Ord::max(1, config.runs / MIN_RUNS_PER_WORKER);
-        if config.runs == 0 {
-            max_workers = 0;
-        }
+        let max_workers =
+            if config.runs == 0 { 0 } else { Ord::max(1, config.runs / MIN_RUNS_PER_WORKER) };
         let num_workers = Ord::min(rayon::current_num_threads(), max_workers as usize);
         Self { executor_f: executor, runner, sender, config, persisted_failure, num_workers }
     }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1165,18 +1165,16 @@ fn collect_data<FEN: FoundryEvmNetwork>(
     run_depth: u32,
 ) {
     // Verify it has no code.
-    let mut has_code = false;
-    if let Some(Some(code)) =
+    let has_code = if let Some(Some(code)) =
         state_changeset.get(&tx.sender).map(|account| account.info.code.as_ref())
     {
-        has_code = !code.is_empty();
-    }
+        !code.is_empty()
+    } else {
+        false
+    };
 
     // We keep the nonce changes to apply later.
-    let mut sender_changeset = None;
-    if !has_code {
-        sender_changeset = state_changeset.remove(&tx.sender);
-    }
+    let sender_changeset = if has_code { None } else { state_changeset.remove(&tx.sender) };
 
     // Collect values from fuzzed call result and add them to fuzz dictionary.
     invariant_test.fuzz_state.collect_values_from_call(

--- a/crates/fmt/src/state/common.rs
+++ b/crates/fmt/src/state/common.rs
@@ -243,11 +243,12 @@ impl<'ast> State<'_, 'ast> {
         self.print_inside_parens(|state| {
             let span = get_span(&values[0]);
             state.s.cbox(state.ind);
-            let mut skip_break = true;
-            if state.peek_comment_before(span.hi()).is_some() {
+            let skip_break = if state.peek_comment_before(span.hi()).is_some() {
                 state.hardbreak();
-                skip_break = false;
-            }
+                false
+            } else {
+                true
+            };
 
             state.print_comments(span.lo(), CommentConfig::skip_ws().mixed_prev_space());
             print(state, &values[0]);
@@ -657,14 +658,15 @@ impl<'ast> State<'_, 'ast> {
             print(self, stmt);
 
             let is_disabled = self.inline_config.is_disabled(get_block_span(stmt));
-            let mut next_enabled = false;
-            let mut next_lo = None;
-            if !is_last {
+            let (next_enabled, next_lo) = if is_last {
+                (false, None)
+            } else {
                 let next_span = get_block_span(&block[i + 1]);
-                next_enabled = !self.inline_config.is_disabled(next_span);
-                next_lo =
-                    self.peek_comment_before(next_span.lo()).is_none().then_some(next_span.lo());
-            }
+                (
+                    !self.inline_config.is_disabled(next_span),
+                    self.peek_comment_before(next_span.lo()).is_none().then_some(next_span.lo()),
+                )
+            };
 
             // when this stmt and the next one are enabled, break normally (except if last stmt)
             if !is_disabled
@@ -760,10 +762,7 @@ impl<'ast> State<'_, 'ast> {
         if has_braces {
             self.word("{");
         }
-        let mut offset = 0;
-        if let BlockFormat::NoBraces(Some(off)) = block_format {
-            offset = off;
-        }
+        let offset = if let BlockFormat::NoBraces(Some(off)) = block_format { off } else { 0 };
         self.print_comments(
             pos_hi,
             self.cmnt_config().offset(offset).mixed_no_break().mixed_prev_space().mixed_post_nbsp(),

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -699,16 +699,17 @@ impl<'ast> State<'_, 'ast> {
                 for cmnt in inner_cmnts.into_iter().rev() {
                     self.comments.push_front(cmnt);
                 }
-                let mut enabled = false;
-                if !self.handle_span(span, false) {
+                let enabled = if self.handle_span(span, false) {
+                    false
+                } else {
                     if !self.is_bol_or_only_ind() {
                         self.space();
                     }
                     self.ibox(0);
                     print_fn(self);
                     self.cursor.advance_to(span.hi(), true);
-                    enabled = true;
-                }
+                    true
+                };
                 // Print subsequent comments.
                 for cmnt in post_cmnts {
                     let Some(cmnt) = self.handle_comment(cmnt, false) else {
@@ -1566,14 +1567,15 @@ impl<'ast> State<'_, 'ast> {
                 }
 
                 // Trailing comment handling.
-                let mut is_trailing = false;
-                if let Some(style) = self.print_comments(
+                let is_trailing = if let Some(style) = self.print_comments(
                     span.hi(),
                     CommentConfig::skip_ws().mixed_no_break().mixed_prev_space(),
                 ) {
                     skip_break = true;
-                    is_trailing = style.is_trailing();
-                }
+                    style.is_trailing()
+                } else {
+                    false
+                };
 
                 // Adjust indentation and line breaks.
                 match (skip_break, end.is_some()) {

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -505,10 +505,11 @@ impl TestArgs {
         let num_filtered = runner.matching_test_functions(filter).count();
 
         if num_filtered == 0 {
-            let mut total_tests = num_filtered;
-            if !filter.is_empty() {
-                total_tests = runner.matching_test_functions(&EmptyTestFilter::default()).count();
-            }
+            let total_tests = if filter.is_empty() {
+                num_filtered
+            } else {
+                runner.matching_test_functions(&EmptyTestFilter::default()).count()
+            };
             if total_tests == 0 {
                 sh_println!(
                     "No tests found in project! Forge looks for functions that start with `test`"

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -246,11 +246,11 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         progress: Option<&TestsProgress>,
     ) -> SuiteResult {
         let identifier = artifact_id.identifier();
-        let mut span_name = identifier.as_str();
-
-        if !enabled!(tracing::Level::TRACE) {
-            span_name = get_contract_name(&identifier);
-        }
+        let span_name = if enabled!(tracing::Level::TRACE) {
+            identifier.as_str()
+        } else {
+            get_contract_name(&identifier)
+        };
         let span = debug_span!("suite", name = %span_name);
         let span_local = span.clone();
         let _guard = span_local.enter();

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -201,14 +201,14 @@ async fn verify_contracts<FEN: FoundryEvmNetwork>(
 
         for (receipt, tx) in sequence.receipts.iter_mut().zip(sequence.transactions.iter()) {
             // create2 hash offset
-            let mut offset = 0;
-
-            if tx.is_create2()
+            let offset = if tx.is_create2()
                 && let Some(contract_address) = tx.contract_address
             {
                 receipt.set_contract_address(contract_address);
-                offset = 32;
-            }
+                32
+            } else {
+                0
+            };
 
             // Verify contract created directly from the transaction
             if let (Some(address), Some(data)) = (receipt.contract_address(), tx.tx().input()) {


### PR DESCRIPTION
Enable `clippy::useless_let_if_seq` workspace-wide.

Replaces `let mut x = default; if cond { x = value; }` with `let x = if cond { value } else { default };` — 24 findings fixed across 16 files.

Prompted by: zerosnacks