### PR TITLE
fix: enable `anvil` feature for `alloy-rpc-types` in `foundry-evm-core`

### DIFF
--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -36,7 +36,7 @@ alloy-primitives = { workspace = true, features = [
 alloy-provider.workspace = true
 alloy-network.workspace = true
 alloy-consensus.workspace = true
-alloy-rpc-types.workspace = true
+alloy-rpc-types = { workspace = true, features = ["anvil"] }
 alloy-sol-types.workspace = true
 alloy-rlp.workspace = true
 foundry-fork-db.workspace = true


### PR DESCRIPTION
The nightly `cargo hack check` CI ([#14303](https://github.com/foundry-rs/foundry/issues/14303)) fails because `foundry-evm-core` imports `alloy_rpc_types::anvil::NodeInfo` but does not enable the `anvil` feature on `alloy-rpc-types`. This works in the full workspace build due to feature unification (the `anvil` crate enables it), but fails when checking the crate in isolation.

Adds `features = ["anvil"]` to the `alloy-rpc-types` dependency in `crates/evm/core/Cargo.toml`.

Closes #14303

Prompted by: zerosnacks