### PR TITLE
fix: remove erroneous `const` from `sanitize_remappings`

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1067,6 +1067,7 @@ impl Config {
     /// Cleans up any duplicate `Remapping` and sorts them
     ///
     /// On windows this will convert any `\` in the remapping path into a `/`
+    #[allow(clippy::missing_const_for_fn)]
     pub fn sanitize_remappings(&mut self) {
         #[cfg(target_os = "windows")]
         {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1067,7 +1067,7 @@ impl Config {
     /// Cleans up any duplicate `Remapping` and sorts them
     ///
     /// On windows this will convert any `\` in the remapping path into a `/`
-    pub const fn sanitize_remappings(&mut self) {
+    pub fn sanitize_remappings(&mut self) {
         #[cfg(target_os = "windows")]
         {
             // force `/` in remappings on windows


### PR DESCRIPTION
## Summary

Remove incorrect `const` qualifier from `Config::sanitize_remappings`.

## Motivation

The daily `test-isolate` workflow fails on Windows because `sanitize_remappings` is marked `const fn` but calls `iter_mut().for_each()`, which is not const-stable. This method only runs on Windows (`#[cfg(target_os = "windows")]`) and mutates heap-allocated `Vec` contents, so it cannot be `const`.

## Changes

- Removed `const` from `pub const fn sanitize_remappings(&mut self)` in `crates/config/src/lib.rs`

## Testing

`cargo check -p foundry-config` passes. The method is only called at runtime (`Config::canonic`), never in a const context.

Closes #14305

Prompted by: zerosnacks