### PR TITLE
fix(evm): update alloy-chains + `TempoDevnet` handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
+checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -113,12 +113,9 @@ pub fn init_progress(len: u64, label: &str) -> indicatif::ProgressBar {
 /// True if the network calculates gas costs differently.
 pub fn has_different_gas_calc(chain_id: u64) -> bool {
     let chain = Chain::from(chain_id);
-    // Is either Tempo | TempoModerato | TempoTestnet | TempoDevnet
-    if chain.is_tempo() || chain.id() == 31318 {
-        return true;
-    }
     if let Some(chain) = chain.named() {
-        return chain.is_arbitrum()
+        return chain.is_tempo()
+            || chain.is_arbitrum()
             || chain.is_elastic()
             || matches!(
                 chain,


### PR DESCRIPTION
## Motivation

Update alloy-chains to `0.2.34`, to handle properly `TempoDevnet`.

Necessary for Tempo CI.