### PR TITLE
fix(evm): enforce tx gas limits in `executeTransaction`

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1134,8 +1134,8 @@ impl Cheatcode for executeTransactionCall {
         ccx.ecx.cfg_mut().limit_contract_initcode_size =
             Some(revm::primitives::eip3860::MAX_INITCODE_SIZE);
 
-        // Enforce any network-specific per-tx gas limit cap for realistic simulation.
-        if let Some(cap) = <EvmFactoryFor<FEN>>::execute_tx_gas_limit_cap(ccx.ecx.cfg().spec()) {
+        // Enforce the canonical per-tx gas limit cap, if any, for realistic simulation.
+        if let Some(cap) = <EvmFactoryFor<FEN>>::tx_gas_limit_cap(ccx.ecx.cfg().spec()) {
             ccx.ecx.cfg_mut().tx_gas_limit_cap = Some(cap);
         }
 

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -28,7 +28,7 @@ use foundry_evm_core::{
     backend::{DatabaseError, DatabaseExt, RevertStateSnapshotAction},
     constants::{CALLER, CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, TEST_CONTRACT_ADDRESS},
     env::FoundryContextExt,
-    evm::{FoundryEvmNetwork, TxEnvFor, TxEnvelopeFor},
+    evm::{EvmFactoryFor, FoundryEvmFactory, FoundryEvmNetwork, TxEnvFor, TxEnvelopeFor},
     utils::get_blob_base_fee_update_fraction_by_spec_id,
 };
 use foundry_evm_traces::TraceMode;
@@ -1134,6 +1134,11 @@ impl Cheatcode for executeTransactionCall {
         ccx.ecx.cfg_mut().limit_contract_initcode_size =
             Some(revm::primitives::eip3860::MAX_INITCODE_SIZE);
 
+        // Enforce any network-specific per-tx gas limit cap for realistic simulation.
+        if let Some(cap) = <EvmFactoryFor<FEN>>::execute_tx_gas_limit_cap(ccx.ecx.cfg().spec()) {
+            ccx.ecx.cfg_mut().tx_gas_limit_cap = Some(cap);
+        }
+
         // Snapshot the modified env for EVM construction.
         let modified_evm_env = ccx.ecx.evm_clone();
         let modified_tx_env = ccx.ecx.tx_clone();
@@ -1180,6 +1185,7 @@ impl Cheatcode for executeTransactionCall {
         nested_evm_env.cfg_env.disable_nonce_check = cached_evm_env.cfg_env.disable_nonce_check;
         nested_evm_env.cfg_env.limit_contract_initcode_size =
             cached_evm_env.cfg_env.limit_contract_initcode_size;
+        nested_evm_env.cfg_env.tx_gas_limit_cap = cached_evm_env.cfg_env.tx_gas_limit_cap;
         ccx.ecx.set_evm(nested_evm_env);
         ccx.ecx.set_tx(cached_tx_env);
 

--- a/crates/evm/core/src/evm/eth.rs
+++ b/crates/evm/core/src/evm/eth.rs
@@ -138,6 +138,10 @@ impl FoundryEvmFactory for EthEvmFactory {
     ) -> Box<dyn NestedEvm<Spec = SpecId, Block = BlockEnv, Tx = TxEnv> + 'db> {
         Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_nested_evm())
     }
+
+    fn tx_gas_limit_cap(spec: &SpecId) -> Option<u64> {
+        spec.is_enabled_in(SpecId::OSAKA).then_some(revm::primitives::eip7825::TX_GAS_LIMIT_CAP)
+    }
 }
 
 impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>>> NestedEvm

--- a/crates/evm/core/src/evm/eth.rs
+++ b/crates/evm/core/src/evm/eth.rs
@@ -1,4 +1,5 @@
 use super::*;
+use revm::primitives::eip7825::TX_GAS_LIMIT_CAP;
 
 pub type EthRevmEvm<'db, I> = RevmEvm<
     EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>,
@@ -140,7 +141,7 @@ impl FoundryEvmFactory for EthEvmFactory {
     }
 
     fn tx_gas_limit_cap(spec: &SpecId) -> Option<u64> {
-        spec.is_enabled_in(SpecId::OSAKA).then_some(revm::primitives::eip7825::TX_GAS_LIMIT_CAP)
+        spec.is_enabled_in(SpecId::OSAKA).then_some(TX_GAS_LIMIT_CAP)
     }
 }
 

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -184,11 +184,11 @@ pub trait FoundryEvmFactory:
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> Box<dyn NestedEvm<Spec = Self::Spec, Block = Self::BlockEnv, Tx = Self::Tx> + 'db>;
 
-    /// Returns the per-tx gas limit cap to enforce during `executeTransaction`.
+    /// Returns the canonical per-tx gas limit cap for the given spec, if any.
     ///
-    /// Returns `None` for networks with no extra cap (default).
+    /// Returns `None` for networks with no explicit cap (default).
     /// Networks with tx gas caps must override so `executeTransaction` mirrors production checks.
-    fn execute_tx_gas_limit_cap(_spec: &Self::Spec) -> Option<u64> {
+    fn tx_gas_limit_cap(_spec: &Self::Spec) -> Option<u64> {
         None
     }
 }

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -183,6 +183,14 @@ pub trait FoundryEvmFactory:
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> Box<dyn NestedEvm<Spec = Self::Spec, Block = Self::BlockEnv, Tx = Self::Tx> + 'db>;
+
+    /// Returns the per-tx gas limit cap to enforce during `executeTransaction`.
+    ///
+    /// Returns `None` for networks with no extra cap (default).
+    /// Networks with tx gas caps must override so `executeTransaction` mirrors production checks.
+    fn execute_tx_gas_limit_cap(_spec: &Self::Spec) -> Option<u64> {
+        None
+    }
 }
 
 /// Trait for converting a Foundry EVM wrapper into its inner `NestedEvm` implementation.

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -54,6 +54,12 @@ impl FoundryEvmFactory for OpEvmFactory {
     ) -> Box<dyn NestedEvm<Spec = OpSpecId, Block = BlockEnv, Tx = OpTx> + 'db> {
         Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_nested_evm())
     }
+
+    fn tx_gas_limit_cap(spec: &OpSpecId) -> Option<u64> {
+        spec.into_eth_spec()
+            .is_enabled_in(SpecId::OSAKA)
+            .then_some(revm::primitives::eip7825::TX_GAS_LIMIT_CAP)
+    }
 }
 
 impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory>>>> Evm

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -1,4 +1,5 @@
 use super::*;
+use revm::primitives::eip7825::TX_GAS_LIMIT_CAP;
 
 pub type OpRevmEvm<'db, I> = op_revm::OpEvm<
     OpContext<&'db mut dyn DatabaseExt<OpEvmFactory>>,
@@ -56,9 +57,7 @@ impl FoundryEvmFactory for OpEvmFactory {
     }
 
     fn tx_gas_limit_cap(spec: &OpSpecId) -> Option<u64> {
-        spec.into_eth_spec()
-            .is_enabled_in(SpecId::OSAKA)
-            .then_some(revm::primitives::eip7825::TX_GAS_LIMIT_CAP)
+        spec.into_eth_spec().is_enabled_in(SpecId::OSAKA).then_some(TX_GAS_LIMIT_CAP)
     }
 }
 

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -85,6 +85,10 @@ impl FoundryEvmFactory for TempoEvmFactory {
     {
         Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_nested_evm())
     }
+
+    fn execute_tx_gas_limit_cap(spec: &TempoHardfork) -> Option<u64> {
+        spec.tx_gas_limit_cap()
+    }
 }
 
 impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>> Evm

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -86,7 +86,7 @@ impl FoundryEvmFactory for TempoEvmFactory {
         Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_nested_evm())
     }
 
-    fn execute_tx_gas_limit_cap(spec: &TempoHardfork) -> Option<u64> {
+    fn tx_gas_limit_cap(spec: &TempoHardfork) -> Option<u64> {
         spec.tx_gas_limit_cap()
     }
 }


### PR DESCRIPTION
this PR makes the `executeTransaction` cheatcode enforce network-specific tx gas limits, by extending `trait FoundryEvmFactory` with `fn tx_gas_limit_cap()`

## PR Checklist

- [ ] Added Tests
- [X] Added Documentation
- [ ] Breaking changes
