### PR TITLE
refactor(evm): fold `tx_gas_limit_cap` logic in `FoundryEvmFactory`

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -28,7 +28,7 @@ use foundry_evm_core::{
     backend::{DatabaseError, DatabaseExt, RevertStateSnapshotAction},
     constants::{CALLER, CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, TEST_CONTRACT_ADDRESS},
     env::FoundryContextExt,
-    evm::{EvmFactoryFor, FoundryEvmFactory, FoundryEvmNetwork, TxEnvFor, TxEnvelopeFor},
+    evm::{FoundryEvmNetwork, TxEnvFor, TxEnvelopeFor},
     utils::get_blob_base_fee_update_fraction_by_spec_id,
 };
 use foundry_evm_traces::TraceMode;
@@ -1134,10 +1134,10 @@ impl Cheatcode for executeTransactionCall {
         ccx.ecx.cfg_mut().limit_contract_initcode_size =
             Some(revm::primitives::eip3860::MAX_INITCODE_SIZE);
 
-        // Enforce the canonical per-tx gas limit cap, if any, for realistic simulation.
-        if let Some(cap) = <EvmFactoryFor<FEN>>::tx_gas_limit_cap(ccx.ecx.cfg().spec()) {
-            ccx.ecx.cfg_mut().tx_gas_limit_cap = Some(cap);
-        }
+        // Reset the tx gas limit cap so revm applies the spec-defined default (EIP-7825).
+        // Normal test execution sets `Some(u64::MAX)` to disable the cap; clearing it here
+        // lets the nested EVM enforce the real network limit for realistic simulation.
+        ccx.ecx.cfg_mut().tx_gas_limit_cap = None;
 
         // Snapshot the modified env for EVM construction.
         let modified_evm_env = ccx.ecx.evm_clone();

--- a/crates/evm/core/src/evm/eth.rs
+++ b/crates/evm/core/src/evm/eth.rs
@@ -1,5 +1,4 @@
 use super::*;
-use revm::primitives::eip7825::TX_GAS_LIMIT_CAP;
 
 pub type EthRevmEvm<'db, I> = RevmEvm<
     EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>,
@@ -138,10 +137,6 @@ impl FoundryEvmFactory for EthEvmFactory {
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> Box<dyn NestedEvm<Spec = SpecId, Block = BlockEnv, Tx = TxEnv> + 'db> {
         Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_nested_evm())
-    }
-
-    fn tx_gas_limit_cap(spec: &SpecId) -> Option<u64> {
-        spec.is_enabled_in(SpecId::OSAKA).then_some(TX_GAS_LIMIT_CAP)
     }
 }
 

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -183,14 +183,6 @@ pub trait FoundryEvmFactory:
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> Box<dyn NestedEvm<Spec = Self::Spec, Block = Self::BlockEnv, Tx = Self::Tx> + 'db>;
-
-    /// Returns the canonical per-tx gas limit cap for the given spec, if any.
-    ///
-    /// Returns `None` for networks with no explicit cap (default).
-    /// Networks with tx gas caps must override so `executeTransaction` mirrors production checks.
-    fn tx_gas_limit_cap(_spec: &Self::Spec) -> Option<u64> {
-        None
-    }
 }
 
 /// Trait for converting a Foundry EVM wrapper into its inner `NestedEvm` implementation.

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -1,5 +1,4 @@
 use super::*;
-use revm::primitives::eip7825::TX_GAS_LIMIT_CAP;
 
 pub type OpRevmEvm<'db, I> = op_revm::OpEvm<
     OpContext<&'db mut dyn DatabaseExt<OpEvmFactory>>,
@@ -54,10 +53,6 @@ impl FoundryEvmFactory for OpEvmFactory {
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> Box<dyn NestedEvm<Spec = OpSpecId, Block = BlockEnv, Tx = OpTx> + 'db> {
         Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_nested_evm())
-    }
-
-    fn tx_gas_limit_cap(spec: &OpSpecId) -> Option<u64> {
-        spec.into_eth_spec().is_enabled_in(SpecId::OSAKA).then_some(TX_GAS_LIMIT_CAP)
     }
 }
 

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -67,6 +67,9 @@ impl FoundryEvmFactory for TempoEvmFactory {
         let mut inner = tempo_evm.into_inner();
         inner.ctx.cfg.gas_params = tempo_gas_params(spec);
         inner.ctx.cfg.tx_chain_id_check = true;
+        if inner.ctx.cfg.tx_gas_limit_cap.is_none() {
+            inner.ctx.cfg.tx_gas_limit_cap = spec.tx_gas_limit_cap();
+        }
 
         let mut evm = TempoFoundryEvm { inner };
         let networks = Evm::inspector(&evm).get_networks();

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -85,10 +85,6 @@ impl FoundryEvmFactory for TempoEvmFactory {
     {
         Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_nested_evm())
     }
-
-    fn tx_gas_limit_cap(spec: &TempoHardfork) -> Option<u64> {
-        spec.tx_gas_limit_cap()
-    }
 }
 
 impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>> Evm


### PR DESCRIPTION
## Motivation

#14318 follow-up

- fold systematically `tx_gas_limit_cap` logic in `FoundryEvmFactory::create_foundry_evm_with_inspector`
- remove `FoundryEvmFactory::tx_gas_limit_cap`

Tested on tempo CI (in `tips/ref-impls`), all green ✅:
```
FOUNDRY_PROFILE=tempo_ci $FOUNDRY_BUILD_TARGET/forge test -vvv
```