### PR TITLE
fix(cli): always insert numeric chain_id in EtherscanOpts::dict()

### DIFF
--- a/crates/cli/src/opts/rpc.rs
+++ b/crates/cli/src/opts/rpc.rs
@@ -1,5 +1,4 @@
 use crate::opts::{ChainValueParser, RpcCommonOpts};
-use alloy_chains::ChainKind;
 use clap::Parser;
 use eyre::Result;
 use foundry_config::{
@@ -158,11 +157,7 @@ impl EtherscanOpts {
         }
 
         if let Some(chain) = self.chain {
-            if let ChainKind::Id(id) = chain.kind() {
-                dict.insert("chain_id".into(), (*id).into());
-            } else {
-                dict.insert("chain_id".into(), chain.to_string().into());
-            }
+            dict.insert("chain_id".into(), chain.id().into());
         }
         dict
     }
@@ -214,5 +209,20 @@ mod tests {
         let args: EtherscanOpts =
             EtherscanOpts::parse_from(["foundry-cli", "--etherscan-api-key", ""]);
         assert!(!args.has_key());
+    }
+
+    // <https://github.com/foundry-rs/foundry/issues/14314>
+    #[test]
+    fn named_chain_dict_inserts_numeric_id() {
+        // Chain 9745 is recognized as NamedChain::Plasma by alloy-chains.
+        // Previously, dict() would insert chain_id as the string "plasma",
+        // causing deserialization failure when EvmOpts expects u64.
+        let args: EtherscanOpts =
+            EtherscanOpts::parse_from(["foundry-cli", "--chain", "9745"]);
+        let dict = args.dict();
+        let chain_id = dict.get("chain_id").expect("chain_id should be present");
+        // Must deserialize as u64, not fail with "found string, expected u64".
+        let id: u64 = chain_id.deserialize().expect("chain_id should deserialize as u64");
+        assert_eq!(id, 9745);
     }
 }

--- a/crates/cli/src/opts/rpc.rs
+++ b/crates/cli/src/opts/rpc.rs
@@ -217,11 +217,9 @@ mod tests {
         // Chain 9745 is recognized as NamedChain::Plasma by alloy-chains.
         // Previously, dict() would insert chain_id as the string "plasma",
         // causing deserialization failure when EvmOpts expects u64.
-        let args: EtherscanOpts =
-            EtherscanOpts::parse_from(["foundry-cli", "--chain", "9745"]);
+        let args = EtherscanOpts::parse_from(["foundry-cli", "--chain", "9745"]);
         let dict = args.dict();
         let chain_id = dict.get("chain_id").expect("chain_id should be present");
-        // Must deserialize as u64, not fail with "found string, expected u64".
         let id: u64 = chain_id.deserialize().expect("chain_id should deserialize as u64");
         assert_eq!(id, 9745);
     }


### PR DESCRIPTION
## Motivation

Closes #14314.

`forge verify-bytecode --chain 9745` crashes with `invalid type: found string "plasma", expected u64` because `EtherscanOpts::dict()` inserts a named chain string into the figment Dict, which later fails to deserialize into `EvmOpts::Env::chain_id: Option<u64>`.

The root cause: `Chain::from_id(9745)` normalizes to `ChainKind::Named(Plasma)`, then `dict()` branches on `ChainKind::Id` vs `Named` — inserting the string `"plasma"` for the named case.

## Solution

Always insert `chain.id()` (the numeric u64) regardless of whether the chain is named or not. This is a one-line fix that removes the `ChainKind` match entirely.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

Prompted by: zerosnacks