### PR TITLE
fix(script): skip `deploy_create2_deployer` in tempo mode to avoid `CreateCollision`

### DIFF
--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3529,3 +3529,23 @@ contract ArbScript is Script {
         cmd.arg("script").arg(script).args(["--fork-url", rpc.as_str(), "-vvvv"]).assert_success();
     }
 );
+
+// Tests that `forge script` works in Tempo mode without CreateCollision.
+// Tempo genesis pre-deploys the Arachnid CREATE2 factory at the same address as the default
+// CREATE2 deployer, so `deploy_create2_deployer` must be skipped to avoid a collision.
+forgetest!(can_execute_script_command_with_tempo, |prj, cmd| {
+    prj.wipe();
+
+    // Initialize a Tempo project (installs forge-std, tempo-std, generates Mail template).
+    cmd.args(["init", "--network", "tempo"]).arg(prj.root()).assert_success();
+
+    // Run the generated Mail.s.sol script with a salt argument.
+    cmd.forge_fuse()
+        .arg("script")
+        .arg("script/Mail.s.sol")
+        .arg("temposalt")
+        .arg("--tempo")
+        .arg("--root")
+        .arg(prj.root())
+        .assert_success();
+});

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -50,7 +50,9 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                 self.executor.set_balance(self.evm_opts.sender, U256::MAX)?;
             }
 
-            if script_config.evm_opts.fork_url.is_none() {
+            if script_config.evm_opts.fork_url.is_none()
+                && !script_config.evm_opts.networks.is_tempo()
+            {
                 self.executor.deploy_create2_deployer()?;
             }
         }


### PR DESCRIPTION
## Motivation

Tempo genesis already deploys the Arachnid CREATE2 factory at the same address as the default CREATE2 deployer (0x4e59b448...). The existing code check in deploy_create2_deployer runs before the EVM is created, so it doesn't see the genesis-initialized bytecode, causing a CreateCollision when the CREATE transaction executes.

Skip the call entirely in non-fork Tempo mode since genesis handles it.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
