### PR TITLE
feat(config): `network` key in `foundry.toml`

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1920,6 +1920,7 @@ impl Config {
             out: self.out,
             libs: self.libs,
             remappings: self.remappings,
+            network: self.networks.active_network_name().map(String::from),
         }
     }
 
@@ -2766,6 +2767,9 @@ pub struct BasicConfig {
     /// `Remappings` to use for this repo
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub remappings: Vec<RelativeRemapping>,
+    /// The active non-Ethereum network (e.g. `"tempo"`).
+    #[serde(skip)]
+    pub network: Option<String>,
 }
 
 impl BasicConfig {
@@ -2773,7 +2777,10 @@ impl BasicConfig {
     ///
     /// This serializes to a table with the name of the profile
     pub fn to_string_pretty(&self) -> Result<String, toml::ser::Error> {
-        let s = toml::to_string_pretty(self)?;
+        let mut s = toml::to_string_pretty(self)?;
+        if let Some(ref network) = self.network {
+            s.push_str(&format!("{network} = true\n"));
+        }
         Ok(format!(
             "\
 [profile.{}]
@@ -4285,6 +4292,7 @@ mod tests {
                     out: "myout".into(),
                     libs: default.libs.clone(),
                     remappings: default.remappings.clone(),
+                    network: None,
                 }
             );
             jail.set_env("FOUNDRY_PROFILE", r"other");
@@ -4297,6 +4305,7 @@ mod tests {
                     out: "myout".into(),
                     libs: default.libs.clone(),
                     remappings: default.remappings,
+                    network: None,
                 }
             );
             Ok(())
@@ -4918,7 +4927,8 @@ mod tests {
                     src: "src".into(),
                     out: "out".into(),
                     libs: vec!["lib".into()],
-                    remappings: vec![]
+                    remappings: vec![],
+                    network: None,
                 }
             )
         );

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2777,10 +2777,13 @@ impl BasicConfig {
     ///
     /// This serializes to a table with the name of the profile
     pub fn to_string_pretty(&self) -> Result<String, toml::ser::Error> {
-        let mut s = toml::to_string_pretty(self)?;
-        if let Some(ref network) = self.network {
-            s.push_str(&format!("{network} = true\n"));
+        let mut value = toml::Value::try_from(self)?;
+        if let Some(ref network) = self.network
+            && let toml::Value::Table(ref mut table) = value
+        {
+            table.insert(network.clone(), toml::Value::Boolean(true));
         }
+        let s = toml::to_string_pretty(&value)?;
         Ok(format!(
             "\
 [profile.{}]

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -29,6 +29,7 @@ foundry-common.workspace = true
 foundry-compilers.workspace = true
 foundry-config.workspace = true
 foundry-evm.workspace = true
+foundry-evm-networks.workspace = true
 foundry-linking.workspace = true
 
 comfy-table.workspace = true
@@ -104,7 +105,6 @@ quick-junit = "0.5.2"
 [dev-dependencies]
 alloy-hardforks.workspace = true
 anvil.workspace = true
-foundry-evm-networks.workspace = true
 forge-script-sequence.workspace = true
 foundry-test-utils.workspace = true
 

--- a/crates/forge/src/cmd/init.rs
+++ b/crates/forge/src/cmd/init.rs
@@ -5,6 +5,7 @@ use foundry_cli::{opts::NetworkVariant, utils::Git};
 use foundry_common::fs;
 use foundry_compilers::artifacts::remappings::Remapping;
 use foundry_config::Config;
+use foundry_evm_networks::NetworkConfigs;
 use std::path::{Path, PathBuf};
 use yansi::Paint;
 
@@ -230,6 +231,9 @@ impl InitArgs {
             // write foundry.toml, if it doesn't exist already
             let dest = root.join(Config::FILE_NAME);
             let mut config = Config::load_with_root(&root)?;
+            if tempo {
+                config.networks = NetworkConfigs::with_tempo();
+            }
             if !dest.exists() {
                 fs::write(dest, config.clone().into_basic().to_string_pretty()?)?;
             }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -915,6 +915,14 @@ Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: N
     ]]);
 
     assert!(prj.root().join("foundry.toml").exists());
+
+    // Verify foundry.toml contains `tempo = true` so subsequent commands auto-detect the network.
+    let foundry_toml = std::fs::read_to_string(prj.root().join("foundry.toml")).unwrap();
+    assert!(
+        foundry_toml.contains("tempo = true"),
+        "foundry.toml should contain `tempo = true`, got:\n{foundry_toml}"
+    );
+
     assert!(prj.root().join("lib/forge-std").exists());
     assert!(prj.root().join("lib/tempo-std").exists());
 
@@ -931,6 +939,27 @@ Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: N
     assert!(prj.root().join(".github").join("workflows").join("test.yml").exists());
 
     assert!(prj.root().join("README.md").exists());
+});
+
+// checks that `forge init --network tempo` correctly setup network key in config
+forgetest!(can_execute_test_and_script_with_default_tempo_config, |prj, cmd| {
+    prj.wipe();
+
+    // Initialize a Tempo project.
+    cmd.args(["init", "--network", "tempo"]).arg(prj.root()).assert_success();
+
+    // Run tests, Tempo EVM selection is made by reading foundry.toml config
+    cmd.forge_fuse().arg("test").arg("--root").arg(prj.root()).assert_success();
+
+    // Same for script, re-enable after https://github.com/foundry-rs/foundry/pull/14336
+    // cmd.forge_fuse()
+    //     .arg("script")
+    //     .arg("script/Mail.s.sol")
+    //     .arg("temposalt")
+    //     .arg("--tempo")
+    //     .arg("--root")
+    //     .arg(prj.root())
+    //     .assert_success();
 });
 
 // checks that clone works with raw src containing `node_modules`

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -951,15 +951,15 @@ forgetest!(can_execute_test_and_script_with_default_tempo_config, |prj, cmd| {
     // Run tests, Tempo EVM selection is made by reading foundry.toml config
     cmd.forge_fuse().arg("test").arg("--root").arg(prj.root()).assert_success();
 
-    // Same for script, re-enable after https://github.com/foundry-rs/foundry/pull/14336
-    // cmd.forge_fuse()
-    //     .arg("script")
-    //     .arg("script/Mail.s.sol")
-    //     .arg("temposalt")
-    //     .arg("--tempo")
-    //     .arg("--root")
-    //     .arg(prj.root())
-    //     .assert_success();
+    // Same for script
+    cmd.forge_fuse()
+        .arg("script")
+        .arg("script/Mail.s.sol")
+        .arg("temposalt")
+        .arg("--tempo")
+        .arg("--root")
+        .arg(prj.root())
+        .assert_success();
 });
 
 // checks that clone works with raw src containing `node_modules`


### PR DESCRIPTION
## Motivation

Write tempo network variant to config when initializing a Foundry project:
```
forge init -n tempo mail
```

So that subsequent test/script commands can automatically select the right network/evm without requiring `--tempo` flag.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes (i believe no, as network field is optional)
