### PR TITLE
feat: SanitizerCoverage support for coverage-guided fuzzing of native Rust code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5214,6 +5214,7 @@ dependencies = [
  "foundry-evm-fuzz",
  "foundry-evm-hardforks",
  "foundry-evm-networks",
+ "foundry-evm-sancov",
  "foundry-evm-traces",
  "indicatif",
  "parking_lot",
@@ -5365,6 +5366,10 @@ dependencies = [
  "revm",
  "serde",
 ]
+
+[[package]]
+name = "foundry-evm-sancov"
+version = "1.6.0"
 
 [[package]]
 name = "foundry-evm-traces"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,12 @@ inherits = "release"
 lto = "fat"
 codegen-units = 1
 
+[profile.fuzz]
+inherits = "release"
+lto = "thin"
+strip = "none"
+debug = "line-tables-only"
+
 # Speed up tests and dev build.
 [profile.dev.package]
 # Solc and artifacts.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/evm/coverage/",
     "crates/evm/evm/",
     "crates/evm/fuzz/",
+    "crates/evm/sancov/",
     "crates/evm/hardforks/",
     "crates/evm/traces/",
     "crates/fmt/",
@@ -327,6 +328,7 @@ foundry-evm-coverage = { path = "crates/evm/coverage" }
 foundry-evm-hardforks = { path = "crates/evm/hardforks" }
 foundry-evm-networks = { path = "crates/evm/networks" }
 foundry-evm-fuzz = { path = "crates/evm/fuzz" }
+foundry-evm-sancov = { path = "crates/evm/sancov" }
 foundry-evm-traces = { path = "crates/evm/traces" }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils" }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -143,6 +143,16 @@ impl FuzzCorpusConfig {
         self.corpus_dir.is_some() || self.show_edge_coverage || self.sancov_edges
     }
 
+    /// Whether the EVM `EdgeCovInspector` should be enabled.
+    ///
+    /// Disabled when sancov edge coverage is active — sancov provides the
+    /// coverage signal and EVM hits from the Solidity handler would dilute it.
+    /// Trace-cmp-only mode keeps EVM edges enabled since trace-cmp only
+    /// contributes dictionary entries, not edge coverage.
+    pub const fn collect_evm_edge_coverage(&self) -> bool {
+        !self.sancov_edges && (self.corpus_dir.is_some() || self.show_edge_coverage)
+    }
+
     /// Whether sancov edge coverage collection is enabled.
     pub const fn collect_sancov_edges(&self) -> bool {
         self.sancov_edges

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -122,6 +122,13 @@ pub struct FuzzCorpusConfig {
     pub corpus_min_size: usize,
     /// Whether to collect and display edge coverage metrics.
     pub show_edge_coverage: bool,
+    /// Whether to collect edge coverage from native Rust crates compiled with
+    /// SanitizerCoverage instrumentation (e.g. precompile implementations).
+    /// Requires building forge with a `RUSTC_WRAPPER` that injects sancov flags.
+    pub sancov_edges: bool,
+    /// Whether to capture comparison operands from sancov-instrumented crates
+    /// and inject them into the fuzz dictionary. Independent of `sancov_edges`.
+    pub sancov_trace_cmp: bool,
 }
 
 impl FuzzCorpusConfig {
@@ -131,9 +138,24 @@ impl FuzzCorpusConfig {
         }
     }
 
-    /// Whether edge coverage should be collected and displayed.
+    /// Whether any edge coverage (EVM or sancov) should be collected.
     pub const fn collect_edge_coverage(&self) -> bool {
-        self.corpus_dir.is_some() || self.show_edge_coverage
+        self.corpus_dir.is_some() || self.show_edge_coverage || self.sancov_edges
+    }
+
+    /// Whether sancov edge coverage collection is enabled.
+    pub const fn collect_sancov_edges(&self) -> bool {
+        self.sancov_edges
+    }
+
+    /// Whether sancov trace-cmp capture is enabled.
+    pub const fn collect_sancov_trace_cmp(&self) -> bool {
+        self.sancov_trace_cmp
+    }
+
+    /// Whether either sancov coverage mode is active.
+    pub const fn sancov_active(&self) -> bool {
+        self.sancov_edges || self.sancov_trace_cmp
     }
 
     /// Whether coverage guided fuzzing is enabled.
@@ -150,6 +172,8 @@ impl Default for FuzzCorpusConfig {
             corpus_min_mutations: 5,
             corpus_min_size: 0,
             show_edge_coverage: false,
+            sancov_edges: false,
+            sancov_trace_cmp: false,
         }
     }
 }

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -21,6 +21,7 @@ foundry-config.workspace = true
 foundry-evm-core.workspace = true
 foundry-evm-coverage.workspace = true
 foundry-evm-fuzz.workspace = true
+foundry-evm-sancov.workspace = true
 foundry-evm-hardforks.workspace = true
 foundry-evm-networks.workspace = true
 foundry-evm-traces.workspace = true

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -372,8 +372,8 @@ impl WorkerCorpus {
                 for tx in &tx_seq {
                     if Self::can_replay_tx(tx, fuzzed_function, fuzzed_contracts) {
                         let mut call_result = execute_tx(&mut executor, tx)?;
-                        let (new_coverage, is_edge) =
-                            call_result.merge_all_coverage(&mut history_map, &mut sancov_history_map);
+                        let (new_coverage, is_edge) = call_result
+                            .merge_all_coverage(&mut history_map, &mut sancov_history_map);
                         if new_coverage {
                             metrics.update_seen(is_edge);
                         }
@@ -895,8 +895,8 @@ impl WorkerCorpus {
                 let mut call_result = execute_tx(&mut executor, tx)?;
 
                 // Check if this provides new coverage.
-                let (new_coverage, is_edge) =
-                    call_result.merge_all_coverage(&mut self.history_map, &mut self.sancov_history_map);
+                let (new_coverage, is_edge) = call_result
+                    .merge_all_coverage(&mut self.history_map, &mut self.sancov_history_map);
 
                 if new_coverage {
                     self.metrics.update_seen(is_edge);

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -257,6 +257,8 @@ pub struct WorkerCorpus {
     in_memory_corpus: Vec<CorpusEntry>,
     /// History of binned hitcount of edges seen during fuzzing
     history_map: Vec<u8>,
+    /// History of binned hitcount of sancov (native Rust) edges seen during fuzzing
+    sancov_history_map: Vec<u8>,
     /// Number of failed replays from initial corpus
     pub(crate) failed_replays: usize,
     /// Worker Metrics
@@ -318,6 +320,7 @@ impl WorkerCorpus {
 
         let mut in_memory_corpus = vec![];
         let mut history_map = vec![0u8; COVERAGE_MAP_SIZE];
+        let mut sancov_history_map = vec![0u8; COVERAGE_MAP_SIZE];
         let mut metrics = CorpusMetrics::default();
         let mut failed_replays = 0;
         let mut optimization_best_value = None;
@@ -370,7 +373,7 @@ impl WorkerCorpus {
                     if Self::can_replay_tx(tx, fuzzed_function, fuzzed_contracts) {
                         let mut call_result = execute_tx(&mut executor, tx)?;
                         let (new_coverage, is_edge) =
-                            call_result.merge_edge_coverage(&mut history_map);
+                            call_result.merge_all_coverage(&mut history_map, &mut sancov_history_map);
                         if new_coverage {
                             metrics.update_seen(is_edge);
                         }
@@ -408,6 +411,7 @@ impl WorkerCorpus {
             id,
             in_memory_corpus,
             history_map,
+            sancov_history_map,
             failed_replays,
             metrics,
             tx_generator,
@@ -546,7 +550,7 @@ impl WorkerCorpus {
         }
     }
 
-    /// Collects coverage from call result and updates metrics.
+    /// Collects EVM and sancov coverage from call result and updates metrics.
     pub fn merge_edge_coverage<FEN: FoundryEvmNetwork>(
         &mut self,
         call_result: &mut RawCallResult<FEN>,
@@ -555,7 +559,8 @@ impl WorkerCorpus {
             return false;
         }
 
-        let (new_coverage, is_edge) = call_result.merge_edge_coverage(&mut self.history_map);
+        let (new_coverage, is_edge) =
+            call_result.merge_all_coverage(&mut self.history_map, &mut self.sancov_history_map);
         if new_coverage {
             self.metrics.update_seen(is_edge);
         }
@@ -891,7 +896,7 @@ impl WorkerCorpus {
 
                 // Check if this provides new coverage.
                 let (new_coverage, is_edge) =
-                    call_result.merge_edge_coverage(&mut self.history_map);
+                    call_result.merge_all_coverage(&mut self.history_map, &mut self.sancov_history_map);
 
                 if new_coverage {
                     self.metrics.update_seen(is_edge);
@@ -1251,6 +1256,7 @@ mod tests {
             current_mutated: Some(seed_uuid),
             failed_replays: 0,
             history_map: vec![0u8; COVERAGE_MAP_SIZE],
+            sancov_history_map: vec![0u8; COVERAGE_MAP_SIZE],
             metrics: CorpusMetrics::default(),
             new_entry_indices: Default::default(),
             last_sync_timestamp: 0,
@@ -1360,6 +1366,7 @@ mod tests {
             current_mutated: None,
             failed_replays: 0,
             history_map: vec![0u8; COVERAGE_MAP_SIZE],
+            sancov_history_map: vec![0u8; COVERAGE_MAP_SIZE],
             metrics: CorpusMetrics::default(),
             new_entry_indices: Default::default(),
             last_sync_timestamp: 0,

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1193,6 +1193,13 @@ fn collect_data<FEN: FoundryEvmNetwork>(
         run_depth,
     );
 
+    // Inject typed sancov trace-cmp operands into the fuzz dictionary.
+    if let Some(cmp_values) = &call_result.sancov_cmp_values {
+        invariant_test.fuzz_state.collect_typed_cmp_values(
+            cmp_values.iter().map(|s| (s.width, alloy_primitives::B256::from(s.value))),
+        );
+    }
+
     // Re-add changes
     if let Some(changed) = sender_changeset {
         state_changeset.insert(tx.sender, changed);

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -9,6 +9,7 @@
 use crate::inspectors::{
     Cheatcodes, InspectorData, InspectorStack, cheatcodes::BroadcastableTransactions,
 };
+use sancov::SancovGuard;
 use alloy_dyn_abi::{DynSolValue, FunctionExt, JsonAbiExt};
 use alloy_json_abi::Function;
 use alloy_primitives::{
@@ -61,6 +62,7 @@ pub mod invariant;
 pub use invariant::InvariantExecutor;
 
 mod corpus;
+mod sancov;
 mod trace;
 
 pub use trace::TracingExecutor;
@@ -541,15 +543,29 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         mut tx_env: TxEnvFor<FEN>,
     ) -> eyre::Result<RawCallResult<FEN>> {
         let mut stack = self.inspector().clone();
+        let sancov_edges = stack.inner.sancov_edges;
+        let sancov_trace_cmp = stack.inner.sancov_trace_cmp;
+        let sancov_active = sancov_edges || sancov_trace_cmp;
         let mut backend = CowBackend::new_borrowed(self.backend());
-        let result = backend.inspect(&mut evm_env, &mut tx_env, &mut stack)?;
-        convert_executed_result(
+        let result = {
+            let _guard =
+                sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
+            backend.inspect(&mut evm_env, &mut tx_env, &mut stack)?
+        };
+        let mut result = convert_executed_result(
             evm_env,
             tx_env,
             stack,
             result,
             backend.has_state_snapshot_failure(),
-        )
+        )?;
+        if sancov_edges {
+            SancovGuard::append_edges_into(&mut result);
+        }
+        if sancov_trace_cmp {
+            SancovGuard::drain_cmp_into(&mut result);
+        }
+        Ok(result)
     }
 
     /// Execute the transaction configured in `tx_env`.
@@ -560,8 +576,15 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         mut tx_env: TxEnvFor<FEN>,
     ) -> eyre::Result<RawCallResult<FEN>> {
         let mut stack = self.inspector().clone();
+        let sancov_edges = stack.inner.sancov_edges;
+        let sancov_trace_cmp = stack.inner.sancov_trace_cmp;
+        let sancov_active = sancov_edges || sancov_trace_cmp;
         let backend = self.backend_mut();
-        let result = backend.inspect(&mut evm_env, &mut tx_env, &mut stack)?;
+        let result = {
+            let _guard =
+                sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
+            backend.inspect(&mut evm_env, &mut tx_env, &mut stack)?
+        };
         let mut result = convert_executed_result(
             evm_env,
             tx_env,
@@ -569,6 +592,12 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
             result,
             backend.has_state_snapshot_failure(),
         )?;
+        if sancov_edges {
+            SancovGuard::append_edges_into(&mut result);
+        }
+        if sancov_trace_cmp {
+            SancovGuard::drain_cmp_into(&mut result);
+        }
         self.commit(&mut result);
         Ok(result)
     }
@@ -934,6 +963,11 @@ pub struct RawCallResult<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     pub line_coverage: Option<HitMaps>,
     /// The edge coverage info collected during the call
     pub edge_coverage: Option<Vec<u8>>,
+    /// Sancov edge coverage from instrumented native Rust crates (e.g. precompiles).
+    /// Tracked separately from EVM edge coverage to avoid ID-space collisions.
+    pub sancov_coverage: Option<Vec<u8>>,
+    /// Comparison operands captured via sancov trace-cmp callbacks.
+    pub sancov_cmp_values: Option<Vec<foundry_evm_sancov::CmpSample>>,
     /// Scripted transactions generated from this call
     pub transactions: Option<BroadcastableTransactions<FEN::Network>>,
     /// The changeset of the state.
@@ -966,6 +1000,8 @@ impl<FEN: FoundryEvmNetwork> Default for RawCallResult<FEN> {
             traces: None,
             line_coverage: None,
             edge_coverage: None,
+            sancov_coverage: None,
+            sancov_cmp_values: None,
             transactions: None,
             state_changeset: HashMap::default(),
             evm_env: EvmEnv::default(),
@@ -1074,6 +1110,54 @@ impl<FEN: FoundryEvmNetwork> RawCallResult<FEN> {
         }
         (new_coverage, is_edge)
     }
+
+    /// Update provided history map with sancov coverage info collected during this call.
+    /// Same AFL binning algo as [`Self::merge_edge_coverage`].
+    pub fn merge_sancov_coverage(&mut self, history_map: &mut Vec<u8>) -> (bool, bool) {
+        let mut new_coverage = false;
+        let mut is_edge = false;
+        if let Some(x) = &mut self.sancov_coverage {
+            if history_map.len() < x.len() {
+                history_map.resize(x.len(), 0);
+            }
+            for (curr, hist) in std::iter::zip(x.iter_mut(), history_map.iter_mut()) {
+                if *curr > 0 {
+                    let bucket = match *curr {
+                        0 => 0,
+                        1 => 1,
+                        2 => 2,
+                        3 => 4,
+                        4..=7 => 8,
+                        8..=15 => 16,
+                        16..=31 => 32,
+                        32..=127 => 64,
+                        128..=255 => 128,
+                    };
+                    if *hist < bucket {
+                        if *hist == 0 {
+                            is_edge = true;
+                        }
+                        *hist = bucket;
+                        new_coverage = true;
+                    }
+                    *curr = 0;
+                }
+            }
+        }
+        (new_coverage, is_edge)
+    }
+
+    /// Merge both EVM and sancov coverage into their respective history maps.
+    /// Returns `(new_coverage, is_edge)` — true if either domain produced new coverage.
+    pub fn merge_all_coverage(
+        &mut self,
+        evm_history: &mut [u8],
+        sancov_history: &mut Vec<u8>,
+    ) -> (bool, bool) {
+        let (new_evm, edge_evm) = self.merge_edge_coverage(evm_history);
+        let (new_san, edge_san) = self.merge_sancov_coverage(sancov_history);
+        (new_evm || new_san, edge_evm || edge_san)
+    }
 }
 
 /// The result of a call.
@@ -1162,6 +1246,8 @@ fn convert_executed_result<FEN: FoundryEvmNetwork>(
         traces,
         line_coverage,
         edge_coverage,
+        sancov_coverage: None,
+        sancov_cmp_values: None,
         transactions,
         state_changeset,
         evm_env,

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -9,7 +9,6 @@
 use crate::inspectors::{
     Cheatcodes, InspectorData, InspectorStack, cheatcodes::BroadcastableTransactions,
 };
-use sancov::SancovGuard;
 use alloy_dyn_abi::{DynSolValue, FunctionExt, JsonAbiExt};
 use alloy_json_abi::Function;
 use alloy_primitives::{
@@ -43,6 +42,7 @@ use revm::{
     database::{DatabaseCommit, DatabaseRef},
     interpreter::{InstructionResult, return_ok},
 };
+use sancov::SancovGuard;
 use std::{
     borrow::Cow,
     sync::{
@@ -548,8 +548,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         let sancov_active = sancov_edges || sancov_trace_cmp;
         let mut backend = CowBackend::new_borrowed(self.backend());
         let result = {
-            let _guard =
-                sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
+            let _guard = sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
             backend.inspect(&mut evm_env, &mut tx_env, &mut stack)?
         };
         let mut result = convert_executed_result(
@@ -581,8 +580,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         let sancov_active = sancov_edges || sancov_trace_cmp;
         let backend = self.backend_mut();
         let result = {
-            let _guard =
-                sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
+            let _guard = sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
             backend.inspect(&mut evm_env, &mut tx_env, &mut stack)?
         };
         let mut result = convert_executed_result(

--- a/crates/evm/evm/src/executors/sancov.rs
+++ b/crates/evm/evm/src/executors/sancov.rs
@@ -1,0 +1,70 @@
+use super::RawCallResult;
+use foundry_evm_core::evm::FoundryEvmNetwork;
+
+const SANCOV_BUFFER_CAPACITY: usize = 65536;
+
+/// RAII guard that activates sancov coverage collection for the duration of an EVM call.
+///
+/// Allocates a thread-local scratch buffer for sancov hits and sets it as the active coverage map.
+/// After execution, sancov hits are appended to the call result separately from EVM edge coverage.
+pub(super) struct SancovGuard {
+    collect_edges: bool,
+}
+
+thread_local! {
+    static SANCOV_BUFFER: std::cell::RefCell<Vec<u8>> =
+        std::cell::RefCell::new(vec![0u8; SANCOV_BUFFER_CAPACITY]);
+}
+
+impl SancovGuard {
+    pub(super) fn new(collect_edges: bool, collect_trace_cmp: bool) -> Self {
+        if collect_edges {
+            SANCOV_BUFFER.with(|buf| {
+                let mut buf = buf.borrow_mut();
+                buf.fill(0);
+                let ptr = buf.as_mut_ptr();
+                let len = buf.len();
+                foundry_evm_sancov::set_coverage_map(ptr, len);
+            });
+        }
+        if collect_trace_cmp {
+            foundry_evm_sancov::clear_cmp_operands();
+        }
+        Self { collect_edges }
+    }
+
+    /// Populate the result's sancov coverage buffer with edge hits.
+    pub(super) fn append_edges_into<FEN: FoundryEvmNetwork>(result: &mut RawCallResult<FEN>) {
+        let sancov_used = foundry_evm_sancov::sancov_edge_count();
+        if sancov_used == 0 {
+            return;
+        }
+
+        SANCOV_BUFFER.with(|buf| {
+            let buf = buf.borrow();
+            let sancov_slice = &buf[..sancov_used.min(buf.len())];
+
+            if !sancov_slice.iter().any(|&b| b > 0) {
+                return;
+            }
+
+            result.sancov_coverage = Some(sancov_slice.to_vec());
+        });
+    }
+
+    /// Drain captured comparison operands and attach them to the result for dictionary injection.
+    pub(super) fn drain_cmp_into<FEN: FoundryEvmNetwork>(result: &mut RawCallResult<FEN>) {
+        let cmp_values = foundry_evm_sancov::drain_cmp_operands();
+        if !cmp_values.is_empty() {
+            result.sancov_cmp_values = Some(cmp_values);
+        }
+    }
+}
+
+impl Drop for SancovGuard {
+    fn drop(&mut self) {
+        if self.collect_edges {
+            foundry_evm_sancov::clear_coverage_map();
+        }
+    }
+}

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -369,6 +369,10 @@ pub struct InspectorStackInner {
     pub tracer: Option<Box<TracingInspector>>,
 
     // FoundryInspectorExt and other internal data.
+    /// Whether to collect sancov edge coverage from instrumented native crates.
+    pub sancov_edges: bool,
+    /// Whether to capture sancov trace-cmp operands for dictionary injection.
+    pub sancov_trace_cmp: bool,
     pub enable_isolation: bool,
     pub networks: NetworkConfigs,
     pub create2_deployer: Address,
@@ -533,6 +537,18 @@ impl<FEN: FoundryEvmNetwork> InspectorStack<FEN> {
     pub fn collect_edge_coverage(&mut self, yes: bool) {
         // TODO: configurable edge size?
         self.edge_coverage = yes.then(EdgeCovInspector::new).map(Into::into);
+    }
+
+    /// Set whether to collect sancov edge coverage from instrumented native crates.
+    #[inline]
+    pub const fn collect_sancov_edges(&mut self, yes: bool) {
+        self.inner.sancov_edges = yes;
+    }
+
+    /// Set whether to capture sancov trace-cmp operands for dictionary injection.
+    #[inline]
+    pub const fn collect_sancov_trace_cmp(&mut self, yes: bool) {
+        self.inner.sancov_trace_cmp = yes;
     }
 
     /// Set whether to enable call isolation.

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -115,6 +115,17 @@ impl EvmFuzzState {
         }
     }
 
+    /// Collects typed trace-cmp operands from sancov-instrumented code.
+    /// Values are inserted into both persistent state values (survive reverts) and typed
+    /// sample buckets (for ABI-aware mutation).
+    pub fn collect_typed_cmp_values(&self, values: impl IntoIterator<Item = (u8, B256)>) {
+        let mut dict = self.inner.write();
+        for (width, value) in values {
+            dict.insert_persistent_value(value);
+            dict.insert_typed_cmp_value(width, value);
+        }
+    }
+
     /// Removes all newly added entries from the dictionary.
     ///
     /// Should be called between fuzz/invariant runs to avoid accumulating data derived from fuzz
@@ -141,6 +152,9 @@ impl EvmFuzzState {
 
 // We're using `IndexSet` to have a stable element order when restoring persisted state, as well as
 // for performance when iterating over the sets.
+/// Maximum number of persistent values from sancov trace-cmp.
+const MAX_PERSISTENT_VALUES: usize = 2048;
+
 pub struct FuzzDictionary {
     /// Collected state values.
     state_values: B256IndexSet,
@@ -164,6 +178,8 @@ pub struct FuzzDictionary {
     /// Set to `true` on first call to `seed_samples()`. Before seeding, `samples()` checks both
     /// maps separately. After seeding, literals are merged in, so only `sample_values` is checked.
     samples_seeded: bool,
+    /// Persistent values from sancov trace-cmp that survive `revert()` across runs.
+    persistent_values: B256IndexSet,
 
     misses: usize,
     hits: usize,
@@ -174,6 +190,7 @@ impl fmt::Debug for FuzzDictionary {
         f.debug_struct("FuzzDictionary")
             .field("state_values", &self.state_values.len())
             .field("addresses", &self.addresses)
+            .field("persistent_values", &self.persistent_values.len())
             .finish()
     }
 }
@@ -196,6 +213,7 @@ impl FuzzDictionary {
             db_addresses: Default::default(),
             sample_values: Default::default(),
             literal_values: Default::default(),
+            persistent_values: Default::default(),
             misses: Default::default(),
             hits: Default::default(),
         };
@@ -419,6 +437,50 @@ impl FuzzDictionary {
             *counter += 1;
         }
         insert
+    }
+
+    /// Insert a persistent value that survives `revert()` across invariant runs.
+    /// Used for trace-cmp operands that should compound over time.
+    fn insert_persistent_value(&mut self, value: B256) {
+        if self.persistent_values.len() >= MAX_PERSISTENT_VALUES {
+            return;
+        }
+        if self.persistent_values.insert(value) && self.state_values.insert(value) {
+            self.db_state_values += 1;
+        }
+    }
+
+    /// Insert a typed trace-cmp value into the `sample_values` map.
+    /// Maps sancov width to `DynSolType` buckets and promotes to larger types.
+    fn insert_typed_cmp_value(&mut self, width: u8, value: B256) {
+        if !self.samples_seeded {
+            self.seed_samples();
+        }
+
+        const MAX_TYPED_CMP_PER_BUCKET: usize = 1024;
+
+        let native_type = match width {
+            8 => DynSolType::Uint(8),
+            16 => DynSolType::Uint(16),
+            32 => DynSolType::Uint(32),
+            64 => DynSolType::Uint(64),
+            _ => DynSolType::Uint(256),
+        };
+
+        let insert = |map: &mut HashMap<DynSolType, B256IndexSet>, ty: DynSolType, val: B256| {
+            let bucket = map.entry(ty).or_default();
+            if bucket.len() < MAX_TYPED_CMP_PER_BUCKET {
+                bucket.insert(val);
+            }
+        };
+
+        insert(&mut self.sample_values, native_type, value);
+
+        if width <= 64 {
+            insert(&mut self.sample_values, DynSolType::Uint(128), value);
+            insert(&mut self.sample_values, DynSolType::Uint(256), value);
+            insert(&mut self.sample_values, DynSolType::Int(256), value);
+        }
     }
 
     fn insert_value_u256(&mut self, value: U256) -> bool {

--- a/crates/evm/sancov/Cargo.toml
+++ b/crates/evm/sancov/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "foundry-evm-sancov"
+description = "SanitizerCoverage callbacks for coverage-guided fuzzing of native Rust code"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true

--- a/crates/evm/sancov/README.md
+++ b/crates/evm/sancov/README.md
@@ -1,0 +1,48 @@
+# foundry-evm-sancov
+
+SanitizerCoverage callbacks for coverage-guided fuzzing of native Rust code (precompiles, revm internals, etc.).
+
+When forge is built with a `RUSTC_WRAPPER` that injects sancov flags for target crates, the fuzzer uses native code edge coverage to guide mutation. Comparison operands from instrumented code are also captured and injected into the fuzz dictionary.
+
+## Config
+
+```toml
+[invariant]
+sancov_edges = true
+sancov_trace_cmp = true
+corpus_dir = "corpus/invariant"
+```
+
+When `sancov_edges` is enabled, the EVM `EdgeCovInspector` is automatically disabled — sancov replaces EVM bytecode coverage as the guidance signal.
+
+## Build
+
+Create a `RUSTC_WRAPPER` that injects sancov flags for the crate(s) you want to instrument:
+
+```bash
+#!/usr/bin/env bash
+RUSTC="$1"; shift
+CRATE_NAME=""
+PREV=""
+for arg in "$@"; do
+    [ "$PREV" = "--crate-name" ] && CRATE_NAME="$arg" && break
+    PREV="$arg"
+done
+
+if [ "$CRATE_NAME" = "your_target_crate" ]; then
+    exec "$RUSTC" "$@" \
+        -Cpasses=sancov-module \
+        -Cllvm-args=-sanitizer-coverage-level=3 \
+        -Cllvm-args=-sanitizer-coverage-trace-pc-guard \
+        -Cllvm-args=-sanitizer-coverage-trace-compares
+else
+    exec "$RUSTC" "$@"
+fi
+```
+
+Then build:
+
+```bash
+RUSTC_WRAPPER=./sancov-wrapper.sh cargo build --profile fuzz --bin forge
+```
+

--- a/crates/evm/sancov/src/lib.rs
+++ b/crates/evm/sancov/src/lib.rs
@@ -1,0 +1,258 @@
+//! SanitizerCoverage callbacks for coverage-guided fuzzing of native Rust code.
+//!
+//! Provides LLVM SanitizerCoverage callbacks and a coverage map that can be set
+//! by the fuzzing executor to collect edge coverage from instrumented Rust
+//! crates (e.g. precompile implementations compiled with `-Cpasses=sancov-module`).
+//!
+//! Additionally provides trace-cmp callbacks that capture comparison operands
+//! and surface them to the fuzzer's dictionary, enabling it to solve comparison
+//! guards (balance checks, overflow guards, etc.).
+//!
+//! Only crates compiled with sancov instrumentation (via a `RUSTC_WRAPPER`)
+//! will trigger these callbacks — no runtime filtering needed.
+
+use std::sync::atomic::{AtomicPtr, AtomicU32, AtomicUsize, Ordering};
+
+static COVERAGE_MAP_PTR: AtomicPtr<u8> = AtomicPtr::new(std::ptr::null_mut());
+static COVERAGE_MAP_LEN: AtomicUsize = AtomicUsize::new(0);
+
+/// Point the coverage map at the given buffer. Subsequent `__sanitizer_cov_trace_pc_guard`
+/// calls will record hits into this buffer.
+pub fn set_coverage_map(ptr: *mut u8, len: usize) {
+    COVERAGE_MAP_PTR.store(ptr, Ordering::Release);
+    COVERAGE_MAP_LEN.store(len, Ordering::Release);
+}
+
+/// Deactivate the coverage map.
+pub fn clear_coverage_map() {
+    COVERAGE_MAP_PTR.store(std::ptr::null_mut(), Ordering::Release);
+    COVERAGE_MAP_LEN.store(0, Ordering::Release);
+}
+
+/// Whether a coverage map is currently active.
+pub fn is_active() -> bool {
+    !COVERAGE_MAP_PTR.load(Ordering::Relaxed).is_null()
+}
+
+static NEXT_SANCOV_IDX: AtomicUsize = AtomicUsize::new(0);
+
+static GUARD_LOOKUP: std::sync::RwLock<Vec<usize>> = std::sync::RwLock::new(Vec::new());
+
+const UNASSIGNED: usize = usize::MAX;
+
+/// Record a hit for the given guard ID into the active coverage map.
+#[inline(always)]
+pub fn record_hit(guard_id: u32) {
+    let ptr = COVERAGE_MAP_PTR.load(Ordering::Relaxed);
+    if ptr.is_null() {
+        return;
+    }
+    let len = COVERAGE_MAP_LEN.load(Ordering::Relaxed);
+    if len == 0 {
+        return;
+    }
+
+    let gid = guard_id as usize;
+
+    // Fast path: read lock, check if already assigned.
+    let idx = {
+        let lookup = GUARD_LOOKUP.read().unwrap();
+        (gid < lookup.len() && lookup[gid] != UNASSIGNED).then(|| lookup[gid])
+    };
+
+    let idx = idx.unwrap_or_else(|| {
+        // Slow path: write lock, assign new index (double-check after acquiring).
+        let mut lookup = GUARD_LOOKUP.write().unwrap();
+        if gid >= lookup.len() {
+            lookup.resize(gid + 1, UNASSIGNED);
+        }
+        if lookup[gid] == UNASSIGNED {
+            lookup[gid] = NEXT_SANCOV_IDX.fetch_add(1, Ordering::Relaxed);
+        }
+        lookup[gid]
+    });
+
+    if idx >= len {
+        return;
+    }
+    unsafe {
+        let slot = ptr.add(idx);
+        *slot = (*slot).wrapping_add(1);
+    }
+}
+
+/// Number of unique sancov edges discovered so far.
+pub fn sancov_edge_count() -> usize {
+    NEXT_SANCOV_IDX.load(Ordering::Relaxed)
+}
+
+static GUARD_COUNTER: AtomicU32 = AtomicU32::new(1);
+
+/// # Safety
+///
+/// Called by the LLVM SanitizerCoverage runtime at startup. `[start, stop)` must be a valid
+/// range of mutable `u32` guard slots allocated by the compiler for the current DSO.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __sanitizer_cov_trace_pc_guard_init(mut start: *mut u32, stop: *mut u32) {
+    while start < stop {
+        let id = GUARD_COUNTER.fetch_add(1, Ordering::Relaxed);
+        unsafe {
+            *start = id;
+            start = start.add(1);
+        }
+    }
+}
+
+/// # Safety
+///
+/// Called by the LLVM SanitizerCoverage runtime at every instrumented CFG edge.
+/// `guard` must point to a valid `u32` guard slot initialized by
+/// `__sanitizer_cov_trace_pc_guard_init`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __sanitizer_cov_trace_pc_guard(guard: *mut u32) {
+    let id = unsafe { *guard };
+    if id == 0 {
+        return;
+    }
+    record_hit(id);
+}
+
+// ---------------------------------------------------------------------------
+// Trace-cmp: capture comparison operands from instrumented code
+// ---------------------------------------------------------------------------
+
+const MAX_CMP_OPERANDS: usize = 512;
+
+/// A single comparison operand captured by a trace-cmp callback.
+#[derive(Clone, Copy, Debug)]
+pub struct CmpSample {
+    /// Bit-width of the original comparison (8, 16, 32, or 64).
+    pub width: u8,
+    /// The operand value, right-aligned in a 32-byte buffer.
+    pub value: [u8; 32],
+}
+
+thread_local! {
+    static CMP_OPERANDS: std::cell::RefCell<Vec<CmpSample>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+#[inline(always)]
+fn record_cmp(width: u8, arg1: u64, arg2: u64) {
+    if !is_active() {
+        return;
+    }
+    if arg1 == 0 && arg2 == 0 {
+        return;
+    }
+    CMP_OPERANDS.with(|ops| {
+        let mut ops = ops.borrow_mut();
+        if ops.len() >= MAX_CMP_OPERANDS {
+            return;
+        }
+        if arg1 != 0 {
+            let mut buf = [0u8; 32];
+            buf[24..].copy_from_slice(&arg1.to_be_bytes());
+            ops.push(CmpSample { width, value: buf });
+        }
+        if arg2 != 0 && arg2 != arg1 {
+            let mut buf = [0u8; 32];
+            buf[24..].copy_from_slice(&arg2.to_be_bytes());
+            ops.push(CmpSample { width, value: buf });
+        }
+    });
+}
+
+/// Drain all captured comparison operands from the current thread.
+pub fn drain_cmp_operands() -> Vec<CmpSample> {
+    CMP_OPERANDS.with(|ops| {
+        let mut ops = ops.borrow_mut();
+        std::mem::take(&mut *ops)
+    })
+}
+
+/// Clear all captured comparison operands on the current thread.
+pub fn clear_cmp_operands() {
+    CMP_OPERANDS.with(|ops| ops.borrow_mut().clear());
+}
+
+/// # Safety
+///
+/// Called by LLVM SanitizerCoverage at 1-byte comparison instructions.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __sanitizer_cov_trace_cmp1(arg1: u8, arg2: u8) {
+    record_cmp(8, arg1 as u64, arg2 as u64);
+}
+
+/// # Safety
+///
+/// Called by LLVM SanitizerCoverage at 2-byte comparison instructions.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __sanitizer_cov_trace_cmp2(arg1: u16, arg2: u16) {
+    record_cmp(16, arg1 as u64, arg2 as u64);
+}
+
+/// # Safety
+///
+/// Called by LLVM SanitizerCoverage at 4-byte comparison instructions.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __sanitizer_cov_trace_cmp4(arg1: u32, arg2: u32) {
+    record_cmp(32, arg1 as u64, arg2 as u64);
+}
+
+/// # Safety
+///
+/// Called by LLVM SanitizerCoverage at 8-byte comparison instructions.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __sanitizer_cov_trace_cmp8(arg1: u64, arg2: u64) {
+    record_cmp(64, arg1, arg2);
+}
+
+/// # Safety
+///
+/// Called by LLVM SanitizerCoverage at 1-byte constant comparison instructions.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __sanitizer_cov_trace_const_cmp1(arg1: u8, arg2: u8) {
+    record_cmp(8, arg1 as u64, arg2 as u64);
+}
+
+/// # Safety
+///
+/// Called by LLVM SanitizerCoverage at 2-byte constant comparison instructions.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __sanitizer_cov_trace_const_cmp2(arg1: u16, arg2: u16) {
+    record_cmp(16, arg1 as u64, arg2 as u64);
+}
+
+/// # Safety
+///
+/// Called by LLVM SanitizerCoverage at 4-byte constant comparison instructions.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __sanitizer_cov_trace_const_cmp4(arg1: u32, arg2: u32) {
+    record_cmp(32, arg1 as u64, arg2 as u64);
+}
+
+/// # Safety
+///
+/// Called by LLVM SanitizerCoverage at 8-byte constant comparison instructions.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __sanitizer_cov_trace_const_cmp8(arg1: u64, arg2: u64) {
+    record_cmp(64, arg1, arg2);
+}
+
+/// # Safety
+///
+/// Called by LLVM SanitizerCoverage before switch statements.
+/// `cases[0]` is the number of cases, `cases[1]` is bit-width of `val`,
+/// `cases[2..]` are the case constants.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __sanitizer_cov_trace_switch(val: u64, cases: *const u64) {
+    if !is_active() || cases.is_null() {
+        return;
+    }
+    let n = unsafe { *cases } as usize;
+    for i in 0..n.min(16) {
+        let case_val = unsafe { *cases.add(2 + i) };
+        record_cmp(64, val, case_val);
+    }
+}

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1055,9 +1055,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         // Enable edge coverage if running with coverage guided fuzzing or with edge coverage
         // metrics (useful for benchmarking the fuzzer).
         executor.inspector_mut().collect_edge_coverage(fuzz_config.corpus.collect_edge_coverage());
-        executor
-            .inspector_mut()
-            .collect_sancov_edges(fuzz_config.corpus.collect_sancov_edges());
+        executor.inspector_mut().collect_sancov_edges(fuzz_config.corpus.collect_sancov_edges());
         executor
             .inspector_mut()
             .collect_sancov_trace_cmp(fuzz_config.corpus.collect_sancov_trace_cmp());

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -738,6 +738,12 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         executor
             .inspector_mut()
             .collect_edge_coverage(invariant_config.corpus.collect_edge_coverage());
+        executor
+            .inspector_mut()
+            .collect_sancov_edges(invariant_config.corpus.collect_sancov_edges());
+        executor
+            .inspector_mut()
+            .collect_sancov_trace_cmp(invariant_config.corpus.collect_sancov_trace_cmp());
         let mut config = invariant_config.clone();
         let (failure_dir, failure_file) = test_paths(
             &mut config.corpus,
@@ -1049,6 +1055,12 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         // Enable edge coverage if running with coverage guided fuzzing or with edge coverage
         // metrics (useful for benchmarking the fuzzer).
         executor.inspector_mut().collect_edge_coverage(fuzz_config.corpus.collect_edge_coverage());
+        executor
+            .inspector_mut()
+            .collect_sancov_edges(fuzz_config.corpus.collect_sancov_edges());
+        executor
+            .inspector_mut()
+            .collect_sancov_trace_cmp(fuzz_config.corpus.collect_sancov_trace_cmp());
         // Load persisted counterexample, if any.
         let persisted_failure =
             foundry_common::fs::read_json_file::<BaseCounterExample>(failure_file.as_path()).ok();

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -737,7 +737,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         // metrics (useful for benchmarking the fuzzer).
         executor
             .inspector_mut()
-            .collect_edge_coverage(invariant_config.corpus.collect_edge_coverage());
+            .collect_edge_coverage(invariant_config.corpus.collect_evm_edge_coverage());
         executor
             .inspector_mut()
             .collect_sancov_edges(invariant_config.corpus.collect_sancov_edges());
@@ -1054,7 +1054,9 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         let mut executor = self.executor.into_owned();
         // Enable edge coverage if running with coverage guided fuzzing or with edge coverage
         // metrics (useful for benchmarking the fuzzer).
-        executor.inspector_mut().collect_edge_coverage(fuzz_config.corpus.collect_edge_coverage());
+        executor
+            .inspector_mut()
+            .collect_edge_coverage(fuzz_config.corpus.collect_evm_edge_coverage());
         executor.inspector_mut().collect_sancov_edges(fuzz_config.corpus.collect_sancov_edges());
         executor
             .inspector_mut()

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -195,6 +195,8 @@ corpus_gzip = true
 corpus_min_mutations = 5
 corpus_min_size = 0
 show_edge_coverage = false
+sancov_edges = false
+sancov_trace_cmp = false
 failure_persist_dir = "cache/fuzz"
 show_logs = false
 
@@ -216,6 +218,8 @@ corpus_gzip = true
 corpus_min_mutations = 5
 corpus_min_size = 0
 show_edge_coverage = false
+sancov_edges = false
+sancov_trace_cmp = false
 failure_persist_dir = "cache/invariant"
 show_metrics = true
 show_solidity = false
@@ -1278,6 +1282,8 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "corpus_min_mutations": 5,
     "corpus_min_size": 0,
     "show_edge_coverage": false,
+    "sancov_edges": false,
+    "sancov_trace_cmp": false,
     "failure_persist_dir": "cache/fuzz",
     "show_logs": false,
     "timeout": null
@@ -1301,6 +1307,8 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "corpus_min_mutations": 5,
     "corpus_min_size": 0,
     "show_edge_coverage": false,
+    "sancov_edges": false,
+    "sancov_trace_cmp": false,
     "failure_persist_dir": "cache/invariant",
     "show_metrics": true,
     "timeout": null,


### PR DESCRIPTION
## Summary

Adds sancov-based coverage feedback for native Rust code (precompiles, revm internals, etc.) during fuzz/invariant campaigns. When forge is built with a `RUSTC_WRAPPER` that injects sancov flags for target crates, the fuzzer uses native code edge coverage alongside EVM coverage to guide mutation.

## Motivation

Forge's fuzzer is coverage-guided for EVM bytecode, but native Rust code (precompiles, interpreter hot paths) is a black box. This means the fuzzer can't discover new paths through native implementations. By hooking LLVM SanitizerCoverage callbacks and feeding hits back into the corpus, we get coverage-guided fuzzing for arbitrary Rust crates compiled into forge.

## Changes

- `crates/evm/sancov`: new crate — `__sanitizer_cov_trace_pc_guard` + `trace_cmp*` callbacks, shared coverage map, `CmpSample` type
- `executors/sancov.rs`: RAII `SancovGuard` managing coverage map lifecycle per EVM call
- `RawCallResult`: `sancov_coverage` and `sancov_cmp_values` fields (separate from EVM edge coverage)
- `merge_sancov_coverage`/`merge_all_coverage` on `RawCallResult` — AFL-style binning into a dedicated history map
- `WorkerCorpus`: `sancov_history_map` tracked independently
- `FuzzDictionary`: `persistent_values` (survive reverts) + `insert_typed_cmp_value` for ABI-aware mutation
- `FuzzCorpusConfig`: `sancov_edges` / `sancov_trace_cmp` config bools (default `false`)
- `InspectorStackInner`: corresponding flags, wired from `runner.rs`

## Usage

Users are responsible for the instrumented build:

1. Write a `RUSTC_WRAPPER` that injects `-Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Cllvm-args=-sanitizer-coverage-trace-compares` for their target crate(s)
2. Build forge with that wrapper (e.g. `RUSTC_WRAPPER=./my-wrapper.sh cargo build --profile fuzz --bin forge`)
3. Set in `foundry.toml`:
```toml
[invariant]
sancov_edges = true
sancov_trace_cmp = true
corpus_dir = "corpus/invariant"
```

Zero impact when not enabled — callbacks compile to no-ops (no instrumented crate triggers them), config defaults to `false`.

## Testing

```
cargo check -p foundry-evm-sancov -p foundry-evm -p foundry-config -p forge
cargo clippy -p foundry-evm-sancov -p foundry-evm -p foundry-config -p forge
cargo test -p foundry-evm --lib -- corpus  # 4/4 pass
cargo test -p foundry-evm-fuzz             # 18/18 pass
```

Prompted by: georgen