### PR TITLE
perf(evm): avoid hot-path clones in fuzz and replay

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -381,9 +381,8 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             result.breakpoints = last_run_worker.breakpoints.clone();
         }
 
-        if !self.config.show_logs {
-            result.logs = workers[last_run_worker_idx].logs.clone();
-        }
+        let last_run_logs = (!self.config.show_logs)
+            .then(|| std::mem::take(&mut workers[last_run_worker_idx].logs));
 
         for mut worker in workers {
             result.gas_by_case.append(&mut worker.gas_by_case);
@@ -393,6 +392,10 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             result.gas_report_traces.extend(worker.traces.into_iter().map(|t| t.arena));
             HitMaps::merge_opt(&mut result.line_coverage, worker.coverage);
             result.deprecated_cheatcodes.extend(worker.deprecated_cheatcodes);
+        }
+
+        if let Some(logs) = last_run_logs {
+            result.logs = logs;
         }
 
         if let Some(reason) = &result.reason
@@ -605,8 +608,9 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                         } else {
                             rd.maybe_decode(&outcome.1.result, status)
                         };
-                        worker.logs.extend(outcome.1.logs.clone());
-                        worker.counterexample = outcome;
+                        let (calldata, mut call) = outcome;
+                        worker.logs.extend(std::mem::take(&mut call.logs));
+                        worker.counterexample = (calldata, call);
                         worker.failure = Some(TestCaseError::fail(reason.unwrap_or_default()));
                         shared_state.try_claim_failure(worker_id);
                         break 'stop;

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -489,7 +489,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 }
 
                 // Collect line coverage from last fuzzed call.
-                invariant_test.merge_line_coverage(call_result.line_coverage.clone());
+                invariant_test.merge_line_coverage(call_result.line_coverage.take());
                 // Collect edge coverage and set the flag in the current run.
                 if corpus_manager.merge_edge_coverage(&mut call_result) {
                     current_run.new_coverage = true;

--- a/crates/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/evm/evm/src/executors/invariant/replay.rs
@@ -41,9 +41,9 @@ pub fn replay_run<FEN: FoundryEvmNetwork>(
     // Replay each call from the sequence, collect logs, traces and coverage.
     for tx in inputs {
         let mut call_result = execute_tx(&mut executor, tx)?;
-        logs.extend(call_result.logs.clone());
+        logs.extend(std::mem::take(&mut call_result.logs));
         traces.push((TraceKind::Execution, call_result.traces.clone().unwrap()));
-        HitMaps::merge_opt(line_coverage, call_result.line_coverage.clone());
+        HitMaps::merge_opt(line_coverage, call_result.line_coverage.take());
 
         // Commit state changes to persist across calls in the sequence.
         executor.commit(&mut call_result);
@@ -66,13 +66,13 @@ pub fn replay_run<FEN: FoundryEvmNetwork>(
     // Checking after each call doesn't add valuable info for passing scenario
     // (invariant call result is always success) nor for failed scenarios
     // (invariant call result is always success until the last call that breaks it).
-    let (invariant_result, invariant_success) = call_invariant_function(
+    let (mut invariant_result, invariant_success) = call_invariant_function(
         &executor,
         invariant_contract.address,
         invariant_contract.invariant_function.abi_encode_input(&[])?.into(),
     )?;
-    traces.push((TraceKind::Execution, invariant_result.traces.clone().unwrap()));
-    logs.extend(invariant_result.logs);
+    traces.push((TraceKind::Execution, invariant_result.traces.take().unwrap()));
+    logs.extend(std::mem::take(&mut invariant_result.logs));
     deprecated_cheatcodes.extend(
         invariant_result
             .cheatcodes
@@ -82,10 +82,10 @@ pub fn replay_run<FEN: FoundryEvmNetwork>(
 
     // Collect after invariant logs and traces.
     if invariant_contract.call_after_invariant && invariant_success {
-        let (after_invariant_result, _) =
+        let (mut after_invariant_result, _) =
             call_after_invariant_function(&executor, invariant_contract.address)?;
-        traces.push((TraceKind::Execution, after_invariant_result.traces.clone().unwrap()));
-        logs.extend(after_invariant_result.logs);
+        traces.push((TraceKind::Execution, after_invariant_result.traces.take().unwrap()));
+        logs.extend(std::mem::take(&mut after_invariant_result.logs));
     }
 
     Ok(counterexample_sequence)


### PR DESCRIPTION
## Motivation

Invariant replay and fuzz execution still clone logs and line coverage in hot paths even when the source value is immediately consumed or discarded afterward. That keeps avoidable allocations on per-call paths and on the last-run log handoff.

## Solution

- Move replay logs and line coverage out of `RawCallResult` with `std::mem::take` / `Option::take` where the value is consumed once.
- Move invariant and after-invariant replay logs and traces directly into the collected output.
- Reuse owned logs in fuzz counterexample handling and last-run aggregation instead of cloning them.
- Keep the trace clones that still have two real owners (`result.traces` and counterexample/replay outputs), so the change stays ownership-only and behavior-preserving.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes