### PR TITLE
refactor(evm): CREATE2 factory redirect via Inspector frame hooks

### DIFF
--- a/crates/evm/core/src/evm/eth.rs
+++ b/crates/evm/core/src/evm/eth.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-type EthMainnetHandler<'db, I> =
+type EthEvmHandler<'db, I> =
     MainnetHandler<EthRevmEvm<'db, I>, EVMError<DatabaseError>, EthFrame<EthInterpreter>>;
 
 pub type EthRevmEvm<'db, I> = RevmEvm<
@@ -60,7 +60,7 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFa
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         self.inner.set_tx(tx);
 
-        let result = EthMainnetHandler::<I>::default().inspect_run(&mut self.inner)?;
+        let result = EthEvmHandler::<I>::default().inspect_run(&mut self.inner)?;
 
         Ok(ResultAndState::new(result, self.inner.ctx.journaled_state.inner.state.clone()))
     }
@@ -154,7 +154,7 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFa
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
-        let mut handler = EthMainnetHandler::<I>::default();
+        let mut handler = EthEvmHandler::<I>::default();
 
         // Create first frame
         let memory =
@@ -176,7 +176,7 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFa
     ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>> {
         self.set_tx(tx);
 
-        let result = EthMainnetHandler::<I>::default().inspect_run(self)?;
+        let result = EthEvmHandler::<I>::default().inspect_run(self)?;
 
         Ok(ResultAndState::new(result, self.ctx.journaled_state.inner.state.clone()))
     }

--- a/crates/evm/core/src/evm/eth.rs
+++ b/crates/evm/core/src/evm/eth.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+type EthMainnetHandler<'db, I> =
+    MainnetHandler<EthRevmEvm<'db, I>, EVMError<DatabaseError>, EthFrame<EthInterpreter>>;
+
 pub type EthRevmEvm<'db, I> = RevmEvm<
     EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>,
     I,
@@ -57,8 +60,7 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFa
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         self.inner.set_tx(tx);
 
-        let mut handler = EthFoundryHandler::<I>::default();
-        let result = handler.inspect_run(&mut self.inner)?;
+        let result = EthMainnetHandler::<I>::default().inspect_run(&mut self.inner)?;
 
         Ok(ResultAndState::new(result, self.inner.ctx.journaled_state.inner.state.clone()))
     }
@@ -152,7 +154,7 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFa
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
-        let mut handler = EthFoundryHandler::<I>::default();
+        let mut handler = EthMainnetHandler::<I>::default();
 
         // Create first frame
         let memory =
@@ -174,190 +176,12 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFa
     ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>> {
         self.set_tx(tx);
 
-        let mut handler = EthFoundryHandler::<I>::default();
-        let result = handler.inspect_run(self)?;
+        let result = EthMainnetHandler::<I>::default().inspect_run(self)?;
 
         Ok(ResultAndState::new(result, self.ctx.journaled_state.inner.state.clone()))
     }
 
     fn to_evm_env(&self) -> EvmEnv<Self::Spec, Self::Block> {
         self.ctx_ref().evm_clone()
-    }
-}
-
-pub struct EthFoundryHandler<
-    'db,
-    I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>>,
-> {
-    create2_overrides: Vec<(usize, CallInputs)>,
-    _phantom: PhantomData<(&'db mut dyn DatabaseExt<EthEvmFactory>, I)>,
-}
-
-impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>>> Default
-    for EthFoundryHandler<'db, I>
-{
-    fn default() -> Self {
-        Self { create2_overrides: Vec::new(), _phantom: PhantomData }
-    }
-}
-
-// Blanket Handler implementation for FoundryHandler, needed for implementing the InspectorHandler
-// trait.
-impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>>> Handler
-    for EthFoundryHandler<'db, I>
-{
-    type Evm = RevmEvm<
-        EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>,
-        I,
-        EthInstructions<EthInterpreter, EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>>,
-        PrecompilesMap,
-        EthFrame<EthInterpreter>,
-    >;
-    type Error = EVMError<DatabaseError>;
-    type HaltReason = HaltReason;
-}
-
-impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>>>
-    EthFoundryHandler<'db, I>
-{
-    /// Handles CREATE2 frame initialization, potentially transforming it to use the CREATE2
-    /// factory.
-    fn handle_create_frame(
-        &mut self,
-        evm: &mut <Self as Handler>::Evm,
-        init: &mut FrameInit,
-    ) -> Result<Option<FrameResult>, <Self as Handler>::Error> {
-        if let FrameInput::Create(inputs) = &init.frame_input
-            && let CreateScheme::Create2 { salt } = inputs.scheme()
-        {
-            let (ctx, inspector) = evm.ctx_inspector();
-
-            if inspector.should_use_create2_factory(ctx.journal().depth(), inputs) {
-                let gas_limit = inputs.gas_limit();
-
-                // Get CREATE2 deployer.
-                let create2_deployer = evm.inspector().create2_deployer();
-
-                // Generate call inputs for CREATE2 factory.
-                let call_inputs = get_create2_factory_call_inputs(
-                    salt,
-                    inputs,
-                    create2_deployer,
-                    evm.journal_mut(),
-                )?;
-
-                // Push data about current override to the stack.
-                self.create2_overrides.push((evm.journal().depth(), call_inputs.clone()));
-
-                // Sanity check that CREATE2 deployer exists.
-                let code_hash = evm.journal_mut().load_account(create2_deployer)?.info.code_hash;
-                if code_hash == KECCAK_EMPTY {
-                    return Ok(Some(FrameResult::Call(CallOutcome {
-                        result: InterpreterResult {
-                            result: InstructionResult::Revert,
-                            output: Bytes::from(
-                                format!("missing CREATE2 deployer: {create2_deployer}")
-                                    .into_bytes(),
-                            ),
-                            gas: Gas::new(gas_limit),
-                        },
-                        memory_offset: 0..0,
-                        was_precompile_called: false,
-                        precompile_call_logs: vec![],
-                    })));
-                } else if code_hash != DEFAULT_CREATE2_DEPLOYER_CODEHASH {
-                    return Ok(Some(FrameResult::Call(CallOutcome {
-                        result: InterpreterResult {
-                            result: InstructionResult::Revert,
-                            output: "invalid CREATE2 deployer bytecode".into(),
-                            gas: Gas::new(gas_limit),
-                        },
-                        memory_offset: 0..0,
-                        was_precompile_called: false,
-                        precompile_call_logs: vec![],
-                    })));
-                }
-
-                // Rewrite the frame init
-                init.frame_input = FrameInput::Call(Box::new(call_inputs));
-            }
-        }
-        Ok(None)
-    }
-
-    /// Transforms CREATE2 factory call results back into CREATE outcomes.
-    fn handle_create2_override(
-        &mut self,
-        evm: &mut <Self as Handler>::Evm,
-        result: FrameResult,
-    ) -> FrameResult {
-        if self.create2_overrides.last().is_some_and(|(depth, _)| *depth == evm.journal().depth()) {
-            let (_, call_inputs) = self.create2_overrides.pop().unwrap();
-            let FrameResult::Call(mut call) = result else {
-                unreachable!("create2 override should be a call frame");
-            };
-
-            // Decode address from output.
-            let address = match call.instruction_result() {
-                return_ok!() => Address::try_from(call.output().as_ref())
-                    .map_err(|_| {
-                        call.result = InterpreterResult {
-                            result: InstructionResult::Revert,
-                            output: "invalid CREATE2 factory output".into(),
-                            gas: Gas::new(call_inputs.gas_limit),
-                        };
-                    })
-                    .ok(),
-                _ => None,
-            };
-
-            FrameResult::Create(CreateOutcome { result: call.result, address })
-        } else {
-            result
-        }
-    }
-}
-
-impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>>>
-    InspectorHandler for EthFoundryHandler<'db, I>
-{
-    type IT = EthInterpreter;
-
-    fn inspect_run_exec_loop(
-        &mut self,
-        evm: &mut Self::Evm,
-        first_frame_input: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameInit,
-    ) -> Result<FrameResult, Self::Error> {
-        let res = evm.inspect_frame_init(first_frame_input)?;
-
-        if let ItemOrResult::Result(frame_result) = res {
-            return Ok(frame_result);
-        }
-
-        loop {
-            let call_or_result = evm.inspect_frame_run()?;
-
-            let result = match call_or_result {
-                ItemOrResult::Item(mut init) => {
-                    // Handle CREATE/CREATE2 frame initialization
-                    if let Some(frame_result) = self.handle_create_frame(evm, &mut init)? {
-                        return Ok(frame_result);
-                    }
-
-                    match evm.inspect_frame_init(init)? {
-                        ItemOrResult::Item(_) => continue,
-                        ItemOrResult::Result(result) => result,
-                    }
-                }
-                ItemOrResult::Result(result) => result,
-            };
-
-            // Handle CREATE2 override transformation if needed
-            let result = self.handle_create2_override(evm, result);
-
-            if let Some(result) = evm.frame_return_result(result)? {
-                return Ok(result);
-            }
-        }
     }
 }

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -1,6 +1,5 @@
 use std::{
     fmt::Debug,
-    marker::PhantomData,
     ops::{Deref, DerefMut},
 };
 
@@ -8,12 +7,10 @@ use crate::{
     FoundryBlock, FoundryContextExt, FoundryInspectorExt, FoundryTransaction,
     FromAnyRpcTransaction,
     backend::{DatabaseExt, JournaledState},
-    constants::{CALLER, DEFAULT_CREATE2_DEPLOYER_CODEHASH, TEST_CONTRACT_ADDRESS},
+    constants::{CALLER, TEST_CONTRACT_ADDRESS},
     tempo::{TEMPO_PRECOMPILE_ADDRESSES, TEMPO_TIP20_TOKENS, initialize_tempo_genesis_inner},
 };
-use alloy_consensus::{
-    SignableTransaction, Signed, constants::KECCAK_EMPTY, transaction::SignerRecoverable,
-};
+use alloy_consensus::{SignableTransaction, Signed, transaction::SignerRecoverable};
 use alloy_evm::{
     EthEvmFactory, Evm, EvmEnv, EvmFactory, FromRecoveredTx, eth::EthEvmContext,
     precompiles::PrecompilesMap,
@@ -33,21 +30,19 @@ use op_revm::{
 use revm::{
     Context, Database, Journal, MainContext,
     context::{
-        BlockEnv, CfgEnv, ContextTr, CreateScheme, Evm as RevmEvm, JournalTr, LocalContextTr,
-        TxEnv,
+        BlockEnv, CfgEnv, ContextTr, Evm as RevmEvm, JournalTr, LocalContextTr, TxEnv,
         result::{
             EVMError, ExecResultAndState, ExecutionResult, HaltReason, InvalidTransaction,
             ResultAndState,
         },
     },
     handler::{
-        EthFrame, EvmTr, FrameResult, FrameTr, Handler, ItemOrResult, instructions::EthInstructions,
+        EthFrame, EvmTr, FrameResult, Handler, MainnetHandler, instructions::EthInstructions,
     },
     inspector::{InspectorEvmTr, InspectorHandler},
     interpreter::{
-        CallInput, CallInputs, CallOutcome, CallScheme, CallValue, CreateInputs, CreateOutcome,
-        FrameInput, Gas, InstructionResult, InterpreterResult, SharedMemory,
-        interpreter::EthInterpreter, interpreter_action::FrameInit, return_ok,
+        CallInput, CallInputs, CallScheme, CallValue, CreateInputs, FrameInput, InstructionResult,
+        SharedMemory, interpreter::EthInterpreter, interpreter_action::FrameInit,
     },
     primitives::hardfork::SpecId,
     state::Bytecode,
@@ -258,7 +253,7 @@ pub fn with_cloned_context<CTX: FoundryContextExt>(
 }
 
 /// Get the call inputs for the CREATE2 factory.
-pub(crate) fn get_create2_factory_call_inputs<T: JournalTr>(
+pub fn get_create2_factory_call_inputs<T: JournalTr>(
     salt: U256,
     inputs: &CreateInputs,
     deployer: Address,

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-type OpUpstreamHandler<'db, I> = OpHandler<
+type OpEvmHandler<'db, I> = OpHandler<
     OpRevmEvm<'db, I>,
     EVMError<DatabaseError, OpTransactionError>,
     EthFrame<EthInterpreter>,
@@ -102,7 +102,7 @@ impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         self.inner.ctx().set_tx(tx);
 
-        let mut handler = OpUpstreamHandler::<I>::new();
+        let mut handler = OpEvmHandler::<I>::new();
         // Convert OpTransactionError to InvalidTransaction due to missing InvalidTxError impl
         let result = handler.inspect_run(&mut self.inner).map_err(|e| match e {
             EVMError::Transaction(tx_error) => EVMError::Transaction(match tx_error {
@@ -195,7 +195,7 @@ impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
-        let mut handler = OpUpstreamHandler::<I>::new();
+        let mut handler = OpEvmHandler::<I>::new();
 
         let memory =
             SharedMemory::new_with_buffer(self.ctx_ref().local.shared_memory_buffer().clone());
@@ -215,7 +215,7 @@ impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory
     ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>> {
         self.ctx().set_tx(tx);
 
-        let mut handler = OpUpstreamHandler::<I>::new();
+        let mut handler = OpEvmHandler::<I>::new();
         let result = handler.inspect_run(self).map_err(map_op_error)?;
 
         let result = result.map_haltreason(|h| match h {

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+type OpUpstreamHandler<'db, I> = OpHandler<
+    OpRevmEvm<'db, I>,
+    EVMError<DatabaseError, OpTransactionError>,
+    EthFrame<EthInterpreter>,
+>;
+
 pub type OpRevmEvm<'db, I> = op_revm::OpEvm<
     OpContext<&'db mut dyn DatabaseExt<OpEvmFactory>>,
     I,
@@ -8,7 +14,7 @@ pub type OpRevmEvm<'db, I> = op_revm::OpEvm<
 >;
 
 /// Optimism counterpart of [`EthFoundryEvm`]. Wraps `op_revm::OpEvm` and routes execution
-/// through [`OpFoundryHandler`] which composes [`OpHandler`] with CREATE2 factory redirect logic.
+/// through [`OpHandler`].
 pub struct OpFoundryEvm<
     'db,
     I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory>>>,
@@ -96,7 +102,7 @@ impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         self.inner.ctx().set_tx(tx);
 
-        let mut handler = OpFoundryHandler::<I>::default();
+        let mut handler = OpUpstreamHandler::<I>::new();
         // Convert OpTransactionError to InvalidTransaction due to missing InvalidTxError impl
         let result = handler.inspect_run(&mut self.inner).map_err(|e| match e {
             EVMError::Transaction(tx_error) => EVMError::Transaction(match tx_error {
@@ -189,7 +195,7 @@ impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
-        let mut handler = OpFoundryHandler::<I>::default();
+        let mut handler = OpUpstreamHandler::<I>::new();
 
         let memory =
             SharedMemory::new_with_buffer(self.ctx_ref().local.shared_memory_buffer().clone());
@@ -209,7 +215,7 @@ impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory
     ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>> {
         self.ctx().set_tx(tx);
 
-        let mut handler = OpFoundryHandler::<I>::default();
+        let mut handler = OpUpstreamHandler::<I>::new();
         let result = handler.inspect_run(self).map_err(map_op_error)?;
 
         let result = result.map_haltreason(|h| match h {
@@ -222,227 +228,5 @@ impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory
 
     fn to_evm_env(&self) -> EvmEnv<Self::Spec, Self::Block> {
         EvmEnv::new(self.ctx_ref().cfg.clone(), self.ctx_ref().block.clone())
-    }
-}
-
-/// Optimism handler that composes [`OpHandler`] with CREATE2 factory redirect logic.
-pub struct OpFoundryHandler<
-    'db,
-    I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory>>>,
-> {
-    inner: OpHandler<
-        OpRevmEvm<'db, I>,
-        EVMError<DatabaseError, OpTransactionError>,
-        EthFrame<EthInterpreter>,
-    >,
-    create2_overrides: Vec<(usize, CallInputs)>,
-}
-
-impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory>>>> Default
-    for OpFoundryHandler<'db, I>
-{
-    fn default() -> Self {
-        Self { inner: OpHandler::new(), create2_overrides: Vec::new() }
-    }
-}
-
-impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory>>>> Handler
-    for OpFoundryHandler<'db, I>
-{
-    type Evm = OpRevmEvm<'db, I>;
-    type Error = EVMError<DatabaseError, OpTransactionError>;
-    type HaltReason = OpHaltReason;
-
-    #[inline]
-    fn run(
-        &mut self,
-        evm: &mut Self::Evm,
-    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        self.inner.run(evm)
-    }
-
-    #[inline]
-    fn execution(
-        &mut self,
-        evm: &mut Self::Evm,
-        init_and_floor_gas: &revm::interpreter::InitialAndFloorGas,
-    ) -> Result<FrameResult, Self::Error> {
-        self.inner.execution(evm, init_and_floor_gas)
-    }
-
-    #[inline]
-    fn validate_env(&self, evm: &mut Self::Evm) -> Result<(), Self::Error> {
-        self.inner.validate_env(evm)
-    }
-
-    #[inline]
-    fn validate_against_state_and_deduct_caller(
-        &self,
-        evm: &mut Self::Evm,
-    ) -> Result<(), Self::Error> {
-        self.inner.validate_against_state_and_deduct_caller(evm)
-    }
-
-    #[inline]
-    fn reimburse_caller(
-        &self,
-        evm: &mut Self::Evm,
-        exec_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
-    ) -> Result<(), Self::Error> {
-        self.inner.reimburse_caller(evm, exec_result)
-    }
-
-    #[inline]
-    fn reward_beneficiary(
-        &self,
-        evm: &mut Self::Evm,
-        exec_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
-    ) -> Result<(), Self::Error> {
-        self.inner.reward_beneficiary(evm, exec_result)
-    }
-
-    #[inline]
-    fn validate_initial_tx_gas(
-        &self,
-        evm: &mut Self::Evm,
-    ) -> Result<revm::interpreter::InitialAndFloorGas, Self::Error> {
-        self.inner.validate_initial_tx_gas(evm)
-    }
-
-    #[inline]
-    fn execution_result(
-        &mut self,
-        evm: &mut Self::Evm,
-        result: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
-        result_gas: revm::context::result::ResultGas,
-    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        self.inner.execution_result(evm, result, result_gas)
-    }
-
-    #[inline]
-    fn catch_error(
-        &self,
-        evm: &mut Self::Evm,
-        error: Self::Error,
-    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        self.inner.catch_error(evm, error)
-    }
-}
-
-impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory>>>>
-    InspectorHandler for OpFoundryHandler<'db, I>
-{
-    type IT = EthInterpreter;
-
-    fn inspect_run_exec_loop(
-        &mut self,
-        evm: &mut Self::Evm,
-        first_frame_input: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameInit,
-    ) -> Result<FrameResult, Self::Error> {
-        let res = evm.inspect_frame_init(first_frame_input)?;
-
-        if let ItemOrResult::Result(frame_result) = res {
-            return Ok(frame_result);
-        }
-
-        loop {
-            let call_or_result = evm.inspect_frame_run()?;
-
-            let result = match call_or_result {
-                ItemOrResult::Item(mut init) => {
-                    // Handle CREATE/CREATE2 frame initialization
-                    if let FrameInput::Create(inputs) = &init.frame_input
-                        && let CreateScheme::Create2 { salt } = inputs.scheme()
-                    {
-                        let (ctx, inspector) = evm.ctx_inspector();
-                        if inspector.should_use_create2_factory(ctx.journal().depth(), inputs) {
-                            let gas_limit = inputs.gas_limit();
-                            let create2_deployer = inspector.create2_deployer();
-                            let call_inputs = get_create2_factory_call_inputs(
-                                salt,
-                                inputs,
-                                create2_deployer,
-                                ctx.journal_mut(),
-                            )?;
-
-                            self.create2_overrides
-                                .push((evm.ctx_ref().journal().depth(), call_inputs.clone()));
-
-                            let code_hash = evm
-                                .ctx()
-                                .journal_mut()
-                                .load_account(create2_deployer)?
-                                .info
-                                .code_hash;
-                            if code_hash == KECCAK_EMPTY {
-                                return Ok(FrameResult::Call(CallOutcome {
-                                    result: InterpreterResult {
-                                        result: InstructionResult::Revert,
-                                        output: Bytes::from(
-                                            format!("missing CREATE2 deployer: {create2_deployer}")
-                                                .into_bytes(),
-                                        ),
-                                        gas: Gas::new(gas_limit),
-                                    },
-                                    memory_offset: 0..0,
-                                    was_precompile_called: false,
-                                    precompile_call_logs: vec![],
-                                }));
-                            } else if code_hash != DEFAULT_CREATE2_DEPLOYER_CODEHASH {
-                                return Ok(FrameResult::Call(CallOutcome {
-                                    result: InterpreterResult {
-                                        result: InstructionResult::Revert,
-                                        output: "invalid CREATE2 deployer bytecode".into(),
-                                        gas: Gas::new(gas_limit),
-                                    },
-                                    memory_offset: 0..0,
-                                    was_precompile_called: false,
-                                    precompile_call_logs: vec![],
-                                }));
-                            }
-
-                            init.frame_input = FrameInput::Call(Box::new(call_inputs));
-                        }
-                    }
-
-                    match evm.inspect_frame_init(init)? {
-                        ItemOrResult::Item(_) => continue,
-                        ItemOrResult::Result(result) => result,
-                    }
-                }
-                ItemOrResult::Result(result) => result,
-            };
-
-            // Handle CREATE2 override transformation if needed
-            let result = if self
-                .create2_overrides
-                .last()
-                .is_some_and(|(depth, _)| *depth == evm.ctx_ref().journal().depth())
-            {
-                let (_, call_inputs) = self.create2_overrides.pop().unwrap();
-                let FrameResult::Call(mut call) = result else {
-                    unreachable!("create2 override should be a call frame");
-                };
-                let address = match call.instruction_result() {
-                    return_ok!() => Address::try_from(call.output().as_ref())
-                        .map_err(|_| {
-                            call.result = InterpreterResult {
-                                result: InstructionResult::Revert,
-                                output: "invalid CREATE2 factory output".into(),
-                                gas: Gas::new(call_inputs.gas_limit),
-                            };
-                        })
-                        .ok(),
-                    _ => None,
-                };
-                FrameResult::Create(CreateOutcome { result: call.result, address })
-            } else {
-                result
-            };
-
-            if let Some(result) = evm.frame_return_result(result)? {
-                return Ok(result);
-            }
-        }
     }
 }

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -4,8 +4,7 @@ use super::*;
 pub type TempoRevmEvm<'db, I> = tempo_revm::TempoEvm<&'db mut dyn DatabaseExt<TempoEvmFactory>, I>;
 
 /// Tempo counterpart of [`EthFoundryEvm`]. Wraps `tempo_revm::TempoEvm` and routes execution
-/// through [`TempoFoundryHandler`] which composes [`TempoEvmHandler`] with CREATE2 factory
-/// redirect logic.
+/// through [`TempoEvmHandler`].
 ///
 /// Uses [`TempoEvmFactory`] for construction to reuse factory setup logic, then unwraps to the
 /// raw revm EVM via `into_inner()` since the handler operates at the revm level.
@@ -130,7 +129,7 @@ impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmF
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         self.inner.set_tx(tx);
 
-        let mut handler = TempoFoundryHandler::<I>::default();
+        let mut handler = TempoEvmHandler::new();
         let result = handler.inspect_run(&mut self.inner)?;
 
         Ok(ResultAndState::new(result, self.inner.inner.ctx.journaled_state.inner.state.clone()))
@@ -214,7 +213,7 @@ impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmF
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
-        let mut handler = TempoFoundryHandler::<I>::default();
+        let mut handler = TempoEvmHandler::new();
 
         let memory =
             SharedMemory::new_with_buffer(self.ctx().local().shared_memory_buffer().clone());
@@ -234,7 +233,7 @@ impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmF
     ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>> {
         self.set_tx(tx);
 
-        let mut handler = TempoFoundryHandler::<I>::default();
+        let mut handler = TempoEvmHandler::new();
         let result = handler.inspect_run(self).map_err(map_tempo_error)?;
 
         let result = result.map_haltreason(|h| match h {
@@ -247,269 +246,5 @@ impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmF
 
     fn to_evm_env(&self) -> EvmEnv<Self::Spec, Self::Block> {
         self.ctx_ref().evm_clone()
-    }
-}
-
-/// Tempo counterpart of [`EthFoundryHandler`]. Wraps [`TempoEvmHandler`] and injects CREATE2
-/// factory redirect logic into the execution loop. Delegates all [`Handler`] methods to
-/// [`TempoEvmHandler`] for proper Tempo validation, fee collection, AA dispatch, and gas
-/// handling.
-///
-/// Will be removed when the next revm release includes bluealloy/revm#3518.
-pub struct TempoFoundryHandler<
-    'db,
-    I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>,
-> {
-    inner: TempoEvmHandler<&'db mut dyn DatabaseExt<TempoEvmFactory>, I>,
-    create2_overrides: Vec<(usize, CallInputs)>,
-}
-
-impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>> Default
-    for TempoFoundryHandler<'db, I>
-{
-    fn default() -> Self {
-        Self { inner: TempoEvmHandler::new(), create2_overrides: Vec::new() }
-    }
-}
-
-impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>> Handler
-    for TempoFoundryHandler<'db, I>
-{
-    type Evm = TempoRevmEvm<'db, I>;
-    type Error = EVMError<DatabaseError, TempoInvalidTransaction>;
-    type HaltReason = TempoHaltReason;
-
-    #[inline]
-    fn run(
-        &mut self,
-        evm: &mut Self::Evm,
-    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        self.inner.run(evm)
-    }
-
-    #[inline]
-    fn execution(
-        &mut self,
-        evm: &mut Self::Evm,
-        init_and_floor_gas: &revm::interpreter::InitialAndFloorGas,
-    ) -> Result<FrameResult, Self::Error> {
-        self.inner.execution(evm, init_and_floor_gas)
-    }
-
-    #[inline]
-    fn validate_env(&self, evm: &mut Self::Evm) -> Result<(), Self::Error> {
-        self.inner.validate_env(evm)
-    }
-
-    #[inline]
-    fn validate_against_state_and_deduct_caller(
-        &self,
-        evm: &mut Self::Evm,
-    ) -> Result<(), Self::Error> {
-        self.inner.validate_against_state_and_deduct_caller(evm)
-    }
-
-    #[inline]
-    fn reimburse_caller(
-        &self,
-        evm: &mut Self::Evm,
-        exec_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
-    ) -> Result<(), Self::Error> {
-        self.inner.reimburse_caller(evm, exec_result)
-    }
-
-    #[inline]
-    fn reward_beneficiary(
-        &self,
-        evm: &mut Self::Evm,
-        exec_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
-    ) -> Result<(), Self::Error> {
-        self.inner.reward_beneficiary(evm, exec_result)
-    }
-
-    #[inline]
-    fn validate_initial_tx_gas(
-        &self,
-        evm: &mut Self::Evm,
-    ) -> Result<revm::interpreter::InitialAndFloorGas, Self::Error> {
-        self.inner.validate_initial_tx_gas(evm)
-    }
-
-    #[inline]
-    fn execution_result(
-        &mut self,
-        evm: &mut Self::Evm,
-        result: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
-        result_gas: revm::context::result::ResultGas,
-    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        self.inner.execution_result(evm, result, result_gas)
-    }
-
-    #[inline]
-    fn catch_error(
-        &self,
-        evm: &mut Self::Evm,
-        error: Self::Error,
-    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        self.inner.catch_error(evm, error)
-    }
-}
-
-/// CREATE2 factory redirect execution loop for Tempo.
-fn create2_exec_loop<
-    'db,
-    I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>,
->(
-    create2_overrides: &mut Vec<(usize, CallInputs)>,
-    evm: &mut TempoRevmEvm<'db, I>,
-    first_frame_input: FrameInit,
-) -> Result<FrameResult, EVMError<DatabaseError, TempoInvalidTransaction>> {
-    let res = evm.inspect_frame_init(first_frame_input)?;
-
-    if let ItemOrResult::Result(frame_result) = res {
-        return Ok(frame_result);
-    }
-
-    loop {
-        let call_or_result = evm.inspect_frame_run()?;
-
-        let result = match call_or_result {
-            ItemOrResult::Item(mut init) => {
-                if let Some(frame_result) = handle_create2_frame(create2_overrides, evm, &mut init)?
-                {
-                    return Ok(frame_result);
-                }
-
-                match evm.inspect_frame_init(init)? {
-                    ItemOrResult::Item(_) => continue,
-                    ItemOrResult::Result(result) => result,
-                }
-            }
-            ItemOrResult::Result(result) => result,
-        };
-
-        let result = handle_create2_result(create2_overrides, evm, result);
-
-        if let Some(result) = evm.frame_return_result(result)? {
-            return Ok(result);
-        }
-    }
-}
-
-/// Handles CREATE2 frame initialization, potentially transforming it to use the CREATE2 factory.
-fn handle_create2_frame<
-    'db,
-    I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>,
->(
-    create2_overrides: &mut Vec<(usize, CallInputs)>,
-    evm: &mut TempoRevmEvm<'db, I>,
-    init: &mut FrameInit,
-) -> Result<Option<FrameResult>, EVMError<DatabaseError, TempoInvalidTransaction>> {
-    if let FrameInput::Create(inputs) = &init.frame_input
-        && let CreateScheme::Create2 { salt } = inputs.scheme()
-    {
-        let (ctx, inspector) = evm.ctx_inspector();
-
-        if inspector.should_use_create2_factory(ctx.journal().depth(), inputs) {
-            let gas_limit = inputs.gas_limit();
-            let create2_deployer = inspector.create2_deployer();
-            let call_inputs =
-                get_create2_factory_call_inputs(salt, inputs, create2_deployer, ctx.journal_mut())?;
-
-            create2_overrides.push((evm.journal().depth(), call_inputs.clone()));
-
-            let code_hash = evm.journal_mut().load_account(create2_deployer)?.info.code_hash;
-            if code_hash == KECCAK_EMPTY {
-                return Ok(Some(FrameResult::Call(CallOutcome {
-                    result: InterpreterResult {
-                        result: InstructionResult::Revert,
-                        output: Bytes::from(
-                            format!("missing CREATE2 deployer: {create2_deployer}").into_bytes(),
-                        ),
-                        gas: Gas::new(gas_limit),
-                    },
-                    memory_offset: 0..0,
-                    was_precompile_called: false,
-                    precompile_call_logs: vec![],
-                })));
-            } else if code_hash != DEFAULT_CREATE2_DEPLOYER_CODEHASH {
-                return Ok(Some(FrameResult::Call(CallOutcome {
-                    result: InterpreterResult {
-                        result: InstructionResult::Revert,
-                        output: "invalid CREATE2 deployer bytecode".into(),
-                        gas: Gas::new(gas_limit),
-                    },
-                    memory_offset: 0..0,
-                    was_precompile_called: false,
-                    precompile_call_logs: vec![],
-                })));
-            }
-
-            init.frame_input = FrameInput::Call(Box::new(call_inputs));
-        }
-    }
-    Ok(None)
-}
-
-/// Transforms CREATE2 factory call results back into CREATE outcomes.
-fn handle_create2_result<
-    'db,
-    I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>,
->(
-    create2_overrides: &mut Vec<(usize, CallInputs)>,
-    evm: &mut TempoRevmEvm<'db, I>,
-    result: FrameResult,
-) -> FrameResult {
-    if create2_overrides.last().is_some_and(|(depth, _)| *depth == evm.journal().depth()) {
-        let (_, call_inputs) = create2_overrides.pop().unwrap();
-        let FrameResult::Call(mut call) = result else {
-            unreachable!("create2 override should be a call frame");
-        };
-
-        let address = match call.instruction_result() {
-            return_ok!() => Address::try_from(call.output().as_ref())
-                .map_err(|_| {
-                    call.result = InterpreterResult {
-                        result: InstructionResult::Revert,
-                        output: "invalid CREATE2 factory output".into(),
-                        gas: Gas::new(call_inputs.gas_limit),
-                    };
-                })
-                .ok(),
-            _ => None,
-        };
-
-        FrameResult::Create(CreateOutcome { result: call.result, address })
-    } else {
-        result
-    }
-}
-
-impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>>
-    InspectorHandler for TempoFoundryHandler<'db, I>
-{
-    type IT = EthInterpreter;
-
-    /// Delegates to [`TempoEvmHandler::inspect_execution_with`], injecting the CREATE2 factory
-    /// redirect exec loop. AA multi-call dispatch and gas adjustments are handled by the inner
-    /// Tempo handler.
-    #[inline]
-    fn inspect_execution(
-        &mut self,
-        evm: &mut Self::Evm,
-        init_and_floor_gas: &revm::interpreter::InitialAndFloorGas,
-    ) -> Result<FrameResult, Self::Error> {
-        let overrides = &mut self.create2_overrides;
-        self.inner.inspect_execution_with(evm, init_and_floor_gas, |_handler, evm, init| {
-            create2_exec_loop(overrides, evm, init)
-        })
-    }
-
-    fn inspect_run_exec_loop(
-        &mut self,
-        evm: &mut Self::Evm,
-        first_frame_input: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameInit,
-    ) -> Result<FrameResult, Self::Error> {
-        create2_exec_loop(&mut self.create2_overrides, evm, first_frame_input)
     }
 }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -12,10 +12,12 @@ use foundry_common::compile::Analysis;
 use foundry_evm_core::{
     FoundryBlock, FoundryTransaction, InspectorExt,
     backend::{DatabaseError, DatabaseExt, JournaledState},
+    constants::DEFAULT_CREATE2_DEPLOYER_CODEHASH,
     env::FoundryContextExt,
     evm::{
         BlockEnvFor, EthEvmNetwork, EvmEnvFor, FoundryContextFor, FoundryEvmFactory,
-        FoundryEvmNetwork, IntoNestedEvm, NestedEvm, SpecFor, TxEnvFor, with_cloned_context,
+        FoundryEvmNetwork, IntoNestedEvm, NestedEvm, SpecFor, TxEnvFor,
+        get_create2_factory_call_inputs, with_cloned_context,
     },
 };
 use foundry_evm_coverage::HitMaps;
@@ -28,11 +30,13 @@ use revm::{
         result::{EVMError, ExecutionResult, Output},
     },
     context_interface::CreateScheme,
+    handler::FrameResult,
     inspector::JournalExt,
     interpreter::{
-        CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, Gas, InstructionResult,
-        Interpreter, InterpreterResult,
+        CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, FrameInput, Gas,
+        InstructionResult, Interpreter, InterpreterResult, return_ok,
     },
+    primitives::KECCAK_EMPTY,
     state::{Account, AccountStatus},
 };
 use revm_inspectors::edge_cov::EdgeCovInspector;
@@ -382,6 +386,12 @@ pub struct InspectorStackInner {
     pub top_frame_journal: AddressMap<Account>,
     /// Address that reverted the call, if any.
     pub reverter: Option<Address>,
+    /// LIFO stack tracking CREATE2 frames that were redirected to the CREATE2 factory.
+    /// Each entry records the journal depth at which the redirect occurred.
+    pub pending_create2_redirects: Vec<usize>,
+    /// Pending CREATE2 deployer validation error, deferred from `frame_start` to `create` so
+    /// it goes through the normal inspector lifecycle (tracing, etc.).
+    pub pending_create2_error: Option<CreateOutcome>,
 }
 
 /// Struct keeping mutable references to both parts of [InspectorStack] and implementing
@@ -1031,6 +1041,94 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
         );
     }
 
+    fn frame_start(
+        &mut self,
+        ecx: &mut FoundryContextFor<'_, FEN>,
+        frame_input: &mut FrameInput,
+    ) -> Option<FrameResult> {
+        if let FrameInput::Create(inputs) = frame_input
+            && let CreateScheme::Create2 { salt } = inputs.scheme()
+            && self.should_use_create2_factory(ecx.journal().depth(), inputs)
+        {
+            let gas_limit = inputs.gas_limit();
+            let create2_deployer = self.create2_deployer();
+
+            // Validate deployer before rewriting.
+            let code_hash = ecx.journal_mut().load_account(create2_deployer).ok()?.info.code_hash;
+            if code_hash == KECCAK_EMPTY {
+                // Store the revert so `create` can return it inside the normal inspector
+                // lifecycle (avoids tracing mismatch from short-circuiting in frame_start).
+                self.inner.pending_create2_error = Some(CreateOutcome {
+                    result: InterpreterResult {
+                        result: InstructionResult::Revert,
+                        output: Bytes::from(
+                            format!("missing CREATE2 deployer: {create2_deployer}").into_bytes(),
+                        ),
+                        gas: Gas::new(gas_limit),
+                    },
+                    address: None,
+                });
+                return None;
+            } else if code_hash != DEFAULT_CREATE2_DEPLOYER_CODEHASH {
+                self.inner.pending_create2_error = Some(CreateOutcome {
+                    result: InterpreterResult {
+                        result: InstructionResult::Revert,
+                        output: "invalid CREATE2 deployer bytecode".into(),
+                        gas: Gas::new(gas_limit),
+                    },
+                    address: None,
+                });
+                return None;
+            }
+
+            let call_inputs =
+                get_create2_factory_call_inputs(salt, inputs, create2_deployer, ecx.journal_mut())
+                    .ok()?;
+
+            // Record the redirect depth *after* validation succeeds.
+            self.inner.pending_create2_redirects.push(ecx.journal().depth());
+
+            // Rewrite the frame input from Create to Call.
+            *frame_input = FrameInput::Call(Box::new(call_inputs));
+        }
+
+        None
+    }
+
+    fn frame_end(
+        &mut self,
+        ecx: &mut FoundryContextFor<'_, FEN>,
+        _frame_input: &FrameInput,
+        frame_result: &mut FrameResult,
+    ) {
+        let depth = ecx.journal().depth();
+        if self.inner.pending_create2_redirects.last().copied() != Some(depth) {
+            return;
+        }
+
+        self.inner.pending_create2_redirects.pop();
+
+        let FrameResult::Call(call) = frame_result else {
+            debug_assert!(false, "pending CREATE2 redirect ended with non-call result");
+            return;
+        };
+
+        let address = match call.instruction_result() {
+            return_ok!() => Address::try_from(call.output().as_ref())
+                .map_err(|_| {
+                    call.result = InterpreterResult {
+                        result: InstructionResult::Revert,
+                        output: "invalid CREATE2 factory output".into(),
+                        gas: Gas::new(call.result.gas.limit()),
+                    };
+                })
+                .ok(),
+            _ => None,
+        };
+
+        *frame_result = FrameResult::Create(CreateOutcome { result: call.result.clone(), address });
+    }
+
     fn call(
         &mut self,
         ecx: &mut FoundryContextFor<'_, FEN>,
@@ -1178,6 +1276,12 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
             |inspector| inspector.create(ecx, create).map(Some),
         );
 
+        // If frame_start detected an invalid CREATE2 deployer, return the error here
+        // (after sub-inspectors have been notified) so tracing stays balanced.
+        if let Some(error) = self.inner.pending_create2_error.take() {
+            return Some(error);
+        }
+
         if !matches!(create.scheme(), CreateScheme::Create2 { .. })
             && self.enable_isolation
             && !self.in_inner_context
@@ -1313,6 +1417,23 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Inspector
         log: Log,
     ) {
         self.as_mut().log_full(interpreter, ecx, log)
+    }
+
+    fn frame_start(
+        &mut self,
+        context: &mut FoundryContextFor<'_, FEN>,
+        frame_input: &mut FrameInput,
+    ) -> Option<FrameResult> {
+        self.as_mut().frame_start(context, frame_input)
+    }
+
+    fn frame_end(
+        &mut self,
+        context: &mut FoundryContextFor<'_, FEN>,
+        frame_input: &FrameInput,
+        frame_result: &mut FrameResult,
+    ) {
+        self.as_mut().frame_end(context, frame_input, frame_result)
     }
 
     fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {


### PR DESCRIPTION
## Motivation

Leverage revm 37.0.0's `Inspector::{frame_start, frame_end}` hooks to handle CREATE2-to-factory-call rewriting directly in `InspectorStack`, removing the need for `EthFoundryHandler`, `OpFoundryHandler`, and `TempoFoundryHandler`.

- Add `frame_start`/`frame_end` to `InspectorStackRefMut` with CREATE2 redirect logic (rewrite `FrameInput::Create` -> `Call`, transform result back)
- Use upstream `MainnetHandler`, `OpHandler`, `TempoEvmHandler` directly
- Remove ~600 lines of duplicated handler wrapper code

The `alloy_evm::Evm` impls become now dummy, so they will be removed in a follow-up PR to keep the current one contained. 