### PR TITLE
refactor(evm): remove `IntoNestedEvm` helper trait

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -40,8 +40,7 @@ use foundry_evm_core::{
     env::FoundryContextExt,
     evm::{
         BlockEnvFor, EthEvmNetwork, FoundryContextFor, FoundryEvmFactory, FoundryEvmNetwork,
-        IntoNestedEvm, NestedEvm, NestedEvmClosure, SpecFor, TransactionRequestFor, TxEnvFor,
-        with_cloned_context,
+        NestedEvmClosure, SpecFor, TransactionRequestFor, TxEnvFor, with_cloned_context,
     },
 };
 use foundry_evm_traces::{
@@ -176,11 +175,9 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for TransparentCheatcodesEx
         f: NestedEvmClosure<'_, SpecFor<FEN>, BlockEnvFor<FEN>, TxEnvFor<FEN>>,
     ) -> Result<(), EVMError<DatabaseError>> {
         with_cloned_context(ecx, |db, evm_env, journal_inner| {
-            let mut evm = FEN::EvmFactory::default()
-                .create_foundry_evm_with_inspector(db, evm_env, cheats)
-                .into_nested_evm();
+            let mut evm = FEN::EvmFactory::default().create_foundry_nested_evm(db, evm_env, cheats);
             *evm.journal_inner_mut() = journal_inner;
-            f(&mut evm)?;
+            f(&mut *evm)?;
             let sub_inner = evm.journal_inner_mut().clone();
             let sub_evm_env = evm.to_evm_env();
             Ok((sub_evm_env, sub_inner))
@@ -194,10 +191,8 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for TransparentCheatcodesEx
         evm_env: EvmEnv<SpecFor<FEN>, BlockEnvFor<FEN>>,
         f: NestedEvmClosure<'_, SpecFor<FEN>, BlockEnvFor<FEN>, TxEnvFor<FEN>>,
     ) -> Result<EvmEnv<SpecFor<FEN>, BlockEnvFor<FEN>>, EVMError<DatabaseError>> {
-        let mut evm = FEN::EvmFactory::default()
-            .create_foundry_evm_with_inspector(db, evm_env, cheats)
-            .into_nested_evm();
-        f(&mut evm)?;
+        let mut evm = FEN::EvmFactory::default().create_foundry_nested_evm(db, evm_env, cheats);
+        f(&mut *evm)?;
         Ok(evm.to_evm_env())
     }
 

--- a/crates/evm/core/src/evm/eth.rs
+++ b/crates/evm/core/src/evm/eth.rs
@@ -102,16 +102,6 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFa
     }
 }
 
-impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>>>
-    IntoNestedEvm<SpecId, BlockEnv, TxEnv> for EthFoundryEvm<'db, I>
-{
-    type Inner = EthRevmEvm<'db, I>;
-
-    fn into_nested_evm(self) -> Self::Inner {
-        self.inner
-    }
-}
-
 impl FoundryEvmFactory for EthEvmFactory {
     type FoundryContext<'db> = EthEvmContext<&'db mut dyn DatabaseExt<Self>>;
 
@@ -138,7 +128,7 @@ impl FoundryEvmFactory for EthEvmFactory {
         evm_env: EvmEnv,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> Box<dyn NestedEvm<Spec = SpecId, Block = BlockEnv, Tx = TxEnv> + 'db> {
-        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_nested_evm())
+        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).inner)
     }
 }
 

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -154,7 +154,6 @@ pub trait FoundryEvmFactory:
             Spec = Self::Spec,
             HaltReason = Self::HaltReason,
         > + Deref<Target = Self::FoundryContext<'db>>
-        + IntoNestedEvm<Self::Spec, Self::BlockEnv, Self::Tx>
     where
         Self: 'db;
 
@@ -178,18 +177,6 @@ pub trait FoundryEvmFactory:
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> Box<dyn NestedEvm<Spec = Self::Spec, Block = Self::BlockEnv, Tx = Self::Tx> + 'db>;
-}
-
-/// Trait for converting a Foundry EVM wrapper into its inner `NestedEvm` implementation.
-///
-/// Both [`EthFoundryEvm`] and [`TempoFoundryEvm`] wrap an inner revm EVM that implements
-/// [`NestedEvm`]. This trait provides a uniform way to unwrap them.
-pub trait IntoNestedEvm<SPEC, BLOCK, TX> {
-    /// The inner type that implements [`NestedEvm`].
-    type Inner: NestedEvm<Spec = SPEC, Block = BLOCK, Tx = TX>;
-
-    /// Consumes the wrapper, returning the inner revm EVM.
-    fn into_nested_evm(self) -> Self::Inner;
 }
 
 /// Object-safe trait exposing the operations that cheatcode nested EVM closures need.

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -58,7 +58,7 @@ impl FoundryEvmFactory for OpEvmFactory {
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> Box<dyn NestedEvm<Spec = OpSpecId, Block = BlockEnv, Tx = OpTx> + 'db> {
-        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_nested_evm())
+        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).inner)
     }
 }
 
@@ -159,16 +159,6 @@ impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner.0.ctx
-    }
-}
-
-impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory>>>>
-    IntoNestedEvm<OpSpecId, BlockEnv, OpTx> for OpFoundryEvm<'db, I>
-{
-    type Inner = OpRevmEvm<'db, I>;
-
-    fn into_nested_evm(self) -> Self::Inner {
-        self.inner
     }
 }
 

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -85,7 +85,7 @@ impl FoundryEvmFactory for TempoEvmFactory {
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> Box<dyn NestedEvm<Spec = TempoHardfork, Block = TempoBlockEnv, Tx = TempoTxEnv> + 'db>
     {
-        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_nested_evm())
+        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).inner)
     }
 }
 
@@ -169,16 +169,6 @@ impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmF
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner.ctx
-    }
-}
-
-impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>>
-    IntoNestedEvm<TempoHardfork, TempoBlockEnv, TempoTxEnv> for TempoFoundryEvm<'db, I>
-{
-    type Inner = TempoRevmEvm<'db, I>;
-
-    fn into_nested_evm(self) -> Self::Inner {
-        self.inner
     }
 }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -16,8 +16,7 @@ use foundry_evm_core::{
     env::FoundryContextExt,
     evm::{
         BlockEnvFor, EthEvmNetwork, EvmEnvFor, FoundryContextFor, FoundryEvmFactory,
-        FoundryEvmNetwork, IntoNestedEvm, NestedEvm, SpecFor, TxEnvFor,
-        get_create2_factory_call_inputs, with_cloned_context,
+        FoundryEvmNetwork, SpecFor, TxEnvFor, get_create2_factory_call_inputs, with_cloned_context,
     },
 };
 use foundry_evm_coverage::HitMaps;
@@ -410,11 +409,10 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for InspectorStackInner {
     ) -> Result<(), EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         with_cloned_context(ecx, |db, evm_env, journal_inner| {
-            let mut evm = FEN::EvmFactory::default()
-                .create_foundry_evm_with_inspector(db, evm_env, &mut inspector)
-                .into_nested_evm();
+            let mut evm =
+                FEN::EvmFactory::default().create_foundry_nested_evm(db, evm_env, &mut inspector);
             *evm.journal_inner_mut() = journal_inner;
-            f(&mut evm)?;
+            f(&mut *evm)?;
             let sub_inner = evm.journal_inner_mut().clone();
             let sub_evm_env = evm.to_evm_env();
             Ok((sub_evm_env, sub_inner))
@@ -429,10 +427,9 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for InspectorStackInner {
         f: NestedEvmClosure<'_, SpecFor<FEN>, BlockEnvFor<FEN>, TxEnvFor<FEN>>,
     ) -> Result<EvmEnvFor<FEN>, EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
-        let mut evm = FEN::EvmFactory::default()
-            .create_foundry_evm_with_inspector(db, evm_env, &mut inspector)
-            .into_nested_evm();
-        f(&mut evm)?;
+        let mut evm =
+            FEN::EvmFactory::default().create_foundry_nested_evm(db, evm_env, &mut inspector);
+        f(&mut *evm)?;
         Ok(evm.to_evm_env())
     }
 
@@ -790,9 +787,11 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
         let res = self.with_inspector(|mut inspector| {
             let (res, nested_env) = {
                 let (db, journal) = ecx.db_journal_inner_mut();
-                let mut evm = FEN::EvmFactory::default()
-                    .create_foundry_evm_with_inspector(db, evm_env, &mut inspector)
-                    .into_nested_evm();
+                let mut evm = FEN::EvmFactory::default().create_foundry_nested_evm(
+                    db,
+                    evm_env,
+                    &mut inspector,
+                );
 
                 evm.journal_inner_mut().state = {
                     let mut state = journal.state.clone();


### PR DESCRIPTION
## Motivation

Smol simplification:

- remove `IntoNestedEvm` helper trait
- always use `FoundryEvmFactory::create_foundry_nested_evm` method.