### PR TITLE
fix(anvil): avoid panic on non-standard tx conversion

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -4455,16 +4455,30 @@ pub fn transaction_build(
     // there's no `info` yet.
     let hash = tx_hash.unwrap_or_else(|| eth_transaction.hash());
 
-    let eth_envelope = FoundryTxEnvelope::from(eth_transaction)
-        .try_into_eth()
-        .expect("non-standard transactions are handled above");
+    let envelope = match FoundryTxEnvelope::from(eth_transaction).try_into_eth() {
+        Ok(eth_envelope) => match eth_envelope {
+            TxEnvelope::Legacy(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Legacy(rehash(s, hash))),
+            TxEnvelope::Eip1559(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Eip1559(rehash(s, hash))),
+            TxEnvelope::Eip2930(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Eip2930(rehash(s, hash))),
+            TxEnvelope::Eip4844(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Eip4844(rehash(s, hash))),
+            TxEnvelope::Eip7702(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Eip7702(rehash(s, hash))),
+        },
+        Err(non_standard_tx) => {
+            error!(
+                target: "backend",
+                tx_type = non_standard_tx.ty(),
+                "encountered unhandled non-standard tx in transaction_build; falling back to unknown envelope"
+            );
 
-    let envelope = match eth_envelope {
-        TxEnvelope::Legacy(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Legacy(rehash(s, hash))),
-        TxEnvelope::Eip1559(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Eip1559(rehash(s, hash))),
-        TxEnvelope::Eip2930(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Eip2930(rehash(s, hash))),
-        TxEnvelope::Eip4844(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Eip4844(rehash(s, hash))),
-        TxEnvelope::Eip7702(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Eip7702(rehash(s, hash))),
+            AnyTxEnvelope::Unknown(UnknownTxEnvelope {
+                hash,
+                inner: UnknownTypedTransaction {
+                    ty: AnyTxType(non_standard_tx.ty()),
+                    fields: Default::default(),
+                    memo: Default::default(),
+                },
+            })
+        }
     };
 
     let tx = Transaction {


### PR DESCRIPTION
 ## Motivation
                                                                                                                                                                                      
  `transaction_build` used `try_into_eth().expect(...)` for the fallback path.                                                                                                        
  This can panic when a non-standard transaction reaches this branch (for example through future tx type additions or unexpected input), which creates a runtime crash risk in Anvil RPC transaction serialization.                                                                                                                                                      
                                                                                                                                                                                      
  ## Solution
                                                                                                                                                                                      
  Replace the `expect` with an explicit `match` on `try_into_eth()`:                                                                                                                  
                                                                                                                                                                                      
  - Keep existing behavior for standard Ethereum transaction envelopes.
  - For non-standard envelopes, avoid panic and return an `Unknown` envelope fallback.                                                                                                
  - Emit an error log with `tx_type` to preserve observability.                                                                                                                       

  This keeps normal behavior unchanged while removing a crash path.                                                                                                                   
                                                                                                                                                                                      
  ## PR Checklist                                                                                                                                                                     
                                                                                                                                                                                      
  - [ ] Added Tests                                                                                                                                                                   
  - [ ] Added Documentation
  - [ ] Breaking changes   