### PR TITLE
refactor(evm): remove useless Eth/Tempo EVM wrapper structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5308,7 +5308,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-alloy",
- "tempo-chainspec",
  "tempo-contracts",
  "tempo-evm",
  "tempo-precompiles",

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -59,7 +59,6 @@ op-alloy-network.workspace = true
 op-revm.workspace = true
 tempo-revm.workspace = true
 tempo-alloy.workspace = true
-tempo-chainspec.workspace = true
 tempo-contracts.workspace = true
 tempo-evm.workspace = true
 tempo-precompiles.workspace = true

--- a/crates/evm/core/src/evm/eth.rs
+++ b/crates/evm/core/src/evm/eth.rs
@@ -1,111 +1,43 @@
-use super::*;
+use alloy_evm::{
+    EthEvm, EthEvmFactory, Evm, EvmEnv, EvmFactory, eth::EthEvmContext, precompiles::PrecompilesMap,
+};
+use foundry_fork_db::DatabaseError;
+use revm::{
+    context::{
+        BlockEnv, ContextTr, Evm as RevmEvm, LocalContextTr, TxEnv,
+        result::{EVMError, ResultAndState},
+    },
+    handler::{
+        EthFrame, EvmTr, FrameResult, Handler, MainnetHandler, instructions::EthInstructions,
+    },
+    inspector::InspectorHandler,
+    interpreter::{
+        FrameInput, SharedMemory, interpreter::EthInterpreter, interpreter_action::FrameInit,
+    },
+    primitives::hardfork::SpecId,
+};
 
-type EthEvmHandler<'db, I> =
-    MainnetHandler<EthRevmEvm<'db, I>, EVMError<DatabaseError>, EthFrame<EthInterpreter>>;
+use crate::{
+    FoundryContextExt, FoundryInspectorExt,
+    backend::{DatabaseExt, JournaledState},
+    evm::{FoundryEvmFactory, NestedEvm},
+};
+
+type EthEvmHandler<'db, I> = MainnetHandler<EthRevmEvm<'db, I>, EVMError<DatabaseError>, EthFrame>;
 
 pub type EthRevmEvm<'db, I> = RevmEvm<
     EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>,
     I,
     EthInstructions<EthInterpreter, EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>>,
     PrecompilesMap,
-    EthFrame<EthInterpreter>,
+    EthFrame,
 >;
-
-pub struct EthFoundryEvm<
-    'db,
-    I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>>,
-> {
-    pub inner: EthRevmEvm<'db, I>,
-}
-
-impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>>> Evm
-    for EthFoundryEvm<'db, I>
-{
-    type Precompiles = PrecompilesMap;
-    type Inspector = I;
-    type DB = &'db mut dyn DatabaseExt<EthEvmFactory>;
-    type Error = EVMError<DatabaseError>;
-    type HaltReason = HaltReason;
-    type Spec = SpecId;
-    type Tx = TxEnv;
-    type BlockEnv = BlockEnv;
-
-    fn block(&self) -> &BlockEnv {
-        &self.inner.block
-    }
-
-    fn chain_id(&self) -> u64 {
-        self.inner.ctx.cfg.chain_id
-    }
-
-    fn components(&self) -> (&Self::DB, &Self::Inspector, &Self::Precompiles) {
-        (&self.inner.ctx.journaled_state.database, &self.inner.inspector, &self.inner.precompiles)
-    }
-
-    fn components_mut(&mut self) -> (&mut Self::DB, &mut Self::Inspector, &mut Self::Precompiles) {
-        (
-            &mut self.inner.ctx.journaled_state.database,
-            &mut self.inner.inspector,
-            &mut self.inner.precompiles,
-        )
-    }
-
-    fn set_inspector_enabled(&mut self, _enabled: bool) {
-        unimplemented!("FoundryEvm is always inspecting")
-    }
-
-    fn transact_raw(
-        &mut self,
-        tx: Self::Tx,
-    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        self.inner.set_tx(tx);
-
-        let result = EthEvmHandler::<I>::default().inspect_run(&mut self.inner)?;
-
-        Ok(ResultAndState::new(result, self.inner.ctx.journaled_state.inner.state.clone()))
-    }
-
-    fn transact_system_call(
-        &mut self,
-        _caller: Address,
-        _contract: Address,
-        _data: Bytes,
-    ) -> Result<ExecResultAndState<ExecutionResult>, Self::Error> {
-        unimplemented!()
-    }
-
-    fn finish(self) -> (Self::DB, EvmEnv<Self::Spec>)
-    where
-        Self: Sized,
-    {
-        let Context { block: block_env, cfg: cfg_env, journaled_state, .. } = self.inner.ctx;
-
-        (journaled_state.database, EvmEnv { block_env, cfg_env })
-    }
-}
-
-impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>>> Deref
-    for EthFoundryEvm<'db, I>
-{
-    type Target = EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner.ctx
-    }
-}
-
-impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFactory>>>> DerefMut
-    for EthFoundryEvm<'db, I>
-{
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner.ctx
-    }
-}
 
 impl FoundryEvmFactory for EthEvmFactory {
     type FoundryContext<'db> = EthEvmContext<&'db mut dyn DatabaseExt<Self>>;
 
-    type FoundryEvm<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>> = EthFoundryEvm<'db, I>;
+    type FoundryEvm<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>> =
+        EthEvm<&'db mut dyn DatabaseExt<Self>, I, Self::Precompiles>;
 
     fn create_foundry_evm_with_inspector<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>>(
         &self,
@@ -113,13 +45,10 @@ impl FoundryEvmFactory for EthEvmFactory {
         evm_env: EvmEnv,
         inspector: I,
     ) -> Self::FoundryEvm<'db, I> {
-        let eth_evm = Self::default().create_evm_with_inspector(db, evm_env, inspector);
-        let mut inner = eth_evm.into_inner();
-        inner.ctx.cfg.tx_chain_id_check = true;
-
-        let mut evm = EthFoundryEvm { inner };
-        evm.inspector().get_networks().inject_precompiles(evm.precompiles_mut());
-        evm
+        let mut eth_evm = Self::default().create_evm_with_inspector(db, evm_env, inspector);
+        eth_evm.cfg.tx_chain_id_check = true;
+        eth_evm.inspector().get_networks().inject_precompiles(eth_evm.precompiles_mut());
+        eth_evm
     }
 
     fn create_foundry_nested_evm<'db>(
@@ -128,7 +57,7 @@ impl FoundryEvmFactory for EthEvmFactory {
         evm_env: EvmEnv,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> Box<dyn NestedEvm<Spec = SpecId, Block = BlockEnv, Tx = TxEnv> + 'db> {
-        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).inner)
+        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_inner())
     }
 }
 
@@ -148,7 +77,7 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFa
 
         // Create first frame
         let memory =
-            SharedMemory::new_with_buffer(self.ctx().local().shared_memory_buffer().clone());
+            SharedMemory::new_with_buffer(self.ctx_ref().local().shared_memory_buffer().clone());
         let first_frame_input = FrameInit { depth: 0, memory, frame_input: frame };
 
         // Run execution loop
@@ -160,10 +89,7 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFa
         Ok(frame_result)
     }
 
-    fn transact_raw(
-        &mut self,
-        tx: Self::Tx,
-    ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>> {
+    fn transact_raw(&mut self, tx: Self::Tx) -> Result<ResultAndState, EVMError<DatabaseError>> {
         self.set_tx(tx);
 
         let result = EthEvmHandler::<I>::default().inspect_run(self)?;

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -1,64 +1,39 @@
-use std::{
-    fmt::Debug,
-    ops::{Deref, DerefMut},
-};
+use std::{fmt::Debug, ops::Deref};
 
 use crate::{
     FoundryBlock, FoundryContextExt, FoundryInspectorExt, FoundryTransaction,
     FromAnyRpcTransaction,
     backend::{DatabaseExt, JournaledState},
-    constants::{CALLER, TEST_CONTRACT_ADDRESS},
-    tempo::{TEMPO_PRECOMPILE_ADDRESSES, TEMPO_TIP20_TOKENS, initialize_tempo_genesis_inner},
 };
 use alloy_consensus::{SignableTransaction, Signed, transaction::SignerRecoverable};
 use alloy_evm::{
-    EthEvmFactory, Evm, EvmEnv, EvmFactory, FromRecoveredTx, eth::EthEvmContext,
-    precompiles::PrecompilesMap,
+    EthEvmFactory, Evm, EvmEnv, EvmFactory, FromRecoveredTx, precompiles::PrecompilesMap,
 };
 use alloy_network::{Ethereum, Network};
-use alloy_op_evm::{OpEvmFactory, OpTx};
-use alloy_primitives::{Address, Bytes, Signature, U256};
+use alloy_op_evm::OpEvmFactory;
+use alloy_primitives::{Address, Signature, U256};
 use alloy_rlp::Decodable;
 use foundry_common::{FoundryReceiptResponse, FoundryTransactionBuilder, fmt::UIfmt};
 use foundry_config::FromEvmVersion;
 use foundry_fork_db::{DatabaseError, ForkBlockEnv};
 use op_alloy_network::Optimism;
-use op_revm::{
-    L1BlockInfo, OpEvm, OpHaltReason, OpSpecId, OpTransaction, handler::OpHandler,
-    precompiles::OpPrecompiles, transaction::error::OpTransactionError,
-};
+use op_revm::OpHaltReason;
 use revm::{
-    Context, Database, Journal, MainContext,
+    Database,
     context::{
-        BlockEnv, CfgEnv, ContextTr, Evm as RevmEvm, JournalTr, LocalContextTr, TxEnv,
-        result::{
-            EVMError, ExecResultAndState, ExecutionResult, HaltReason, InvalidTransaction,
-            ResultAndState,
-        },
+        JournalTr,
+        result::{EVMError, HaltReason, ResultAndState},
     },
-    handler::{
-        EthFrame, EvmTr, FrameResult, Handler, MainnetHandler, instructions::EthInstructions,
-    },
-    inspector::{InspectorEvmTr, InspectorHandler},
+    handler::FrameResult,
     interpreter::{
         CallInput, CallInputs, CallScheme, CallValue, CreateInputs, FrameInput, InstructionResult,
-        SharedMemory, interpreter::EthInterpreter, interpreter_action::FrameInit,
     },
     primitives::hardfork::SpecId,
-    state::Bytecode,
 };
 use serde::{Deserialize, Serialize};
 use tempo_alloy::TempoNetwork;
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::evm::TempoEvmFactory;
-use tempo_precompiles::storage::StorageCtx;
-use tempo_revm::{
-    TempoBlockEnv, TempoHaltReason, TempoInvalidTransaction, TempoTxEnv, evm::TempoContext,
-    gas_params::tempo_gas_params, handler::TempoEvmHandler,
-};
-
-// Modified revm's OpContext with `OpTx`
-pub type OpContext<DB> = Context<BlockEnv, OpTx, CfgEnv<OpSpecId>, DB, Journal<DB>, L1BlockInfo>;
+use tempo_revm::TempoHaltReason;
 
 pub mod eth;
 pub mod op;

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -1,10 +1,40 @@
-use super::*;
+use std::ops::{Deref, DerefMut};
 
-type OpEvmHandler<'db, I> = OpHandler<
-    OpRevmEvm<'db, I>,
-    EVMError<DatabaseError, OpTransactionError>,
-    EthFrame<EthInterpreter>,
->;
+use alloy_evm::{Evm, EvmEnv, precompiles::PrecompilesMap};
+use alloy_op_evm::{OpEvmFactory, OpTx};
+use alloy_primitives::{Address, Bytes};
+use foundry_fork_db::DatabaseError;
+use op_revm::{
+    L1BlockInfo, OpEvm, OpHaltReason, OpSpecId, OpTransaction, OpTransactionError,
+    handler::OpHandler, precompiles::OpPrecompiles,
+};
+use revm::{
+    Context, Journal, MainContext,
+    context::{
+        BlockEnv, CfgEnv, ContextTr, LocalContextTr,
+        result::{
+            EVMError, ExecResultAndState, ExecutionResult, HaltReason, InvalidTransaction,
+            ResultAndState,
+        },
+    },
+    handler::{EthFrame, EvmTr, FrameResult, Handler, instructions::EthInstructions},
+    inspector::{InspectorEvmTr, InspectorHandler},
+    interpreter::{
+        FrameInput, SharedMemory, interpreter::EthInterpreter, interpreter_action::FrameInit,
+    },
+};
+
+use crate::{
+    FoundryContextExt, FoundryInspectorExt,
+    backend::{DatabaseExt, JournaledState},
+    evm::{FoundryEvmFactory, NestedEvm},
+};
+
+// Modified revm's OpContext with `OpTx`
+pub type OpContext<DB> = Context<BlockEnv, OpTx, CfgEnv<OpSpecId>, DB, Journal<DB>, L1BlockInfo>;
+
+type OpEvmHandler<'db, I> =
+    OpHandler<OpRevmEvm<'db, I>, EVMError<DatabaseError, OpTransactionError>, EthFrame>;
 
 pub type OpRevmEvm<'db, I> = op_revm::OpEvm<
     OpContext<&'db mut dyn DatabaseExt<OpEvmFactory>>,
@@ -188,7 +218,7 @@ impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory
         let mut handler = OpEvmHandler::<I>::new();
 
         let memory =
-            SharedMemory::new_with_buffer(self.ctx_ref().local.shared_memory_buffer().clone());
+            SharedMemory::new_with_buffer(self.ctx_ref().local().shared_memory_buffer().clone());
         let first_frame_input = FrameInit { depth: 0, memory, frame_input: frame };
 
         let mut frame_result =
@@ -217,6 +247,6 @@ impl<'db, I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory
     }
 
     fn to_evm_env(&self) -> EvmEnv<Self::Spec, Self::Block> {
-        EvmEnv::new(self.ctx_ref().cfg.clone(), self.ctx_ref().block.clone())
+        self.ctx_ref().evm_clone()
     }
 }

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -43,8 +43,8 @@ pub type OpRevmEvm<'db, I> = op_revm::OpEvm<
     PrecompilesMap,
 >;
 
-/// Optimism counterpart of [`EthFoundryEvm`]. Wraps `op_revm::OpEvm` and routes execution
-/// through [`OpHandler`].
+/// Wraps [`op_revm::OpEvm`] and routes execution through [`OpHandler`].
+/// It uses foundry's custom [`OpContext`] as op-revm's one is not compatible with [`OpTx`].
 pub struct OpFoundryEvm<
     'db,
     I: FoundryInspectorExt<OpContext<&'db mut dyn DatabaseExt<OpEvmFactory>>>,

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -1,21 +1,36 @@
-use super::*;
+use alloy_evm::{Evm, EvmEnv, EvmFactory};
+use alloy_primitives::Bytes;
+use foundry_evm_hardforks::TempoHardfork;
+use foundry_fork_db::DatabaseError;
+use revm::{
+    context::{
+        ContextTr, LocalContextTr,
+        result::{EVMError, HaltReason, ResultAndState},
+    },
+    handler::{EvmTr, FrameResult, Handler},
+    inspector::InspectorHandler,
+    interpreter::{FrameInput, SharedMemory, interpreter_action::FrameInit},
+    state::Bytecode,
+};
+use tempo_evm::{TempoBlockEnv, TempoEvmFactory, TempoHaltReason, evm::TempoEvm};
+use tempo_precompiles::storage::StorageCtx;
+use tempo_revm::{
+    TempoInvalidTransaction, TempoTxEnv, evm::TempoContext, gas_params::tempo_gas_params,
+    handler::TempoEvmHandler,
+};
+
+use crate::{
+    FoundryContextExt, FoundryInspectorExt,
+    backend::{DatabaseExt, JournaledState},
+    constants::{CALLER, TEST_CONTRACT_ADDRESS},
+    evm::{FoundryEvmFactory, NestedEvm},
+    tempo::{TEMPO_PRECOMPILE_ADDRESSES, TEMPO_TIP20_TOKENS, initialize_tempo_genesis_inner},
+};
 
 // Will be removed when the next revm release includes bluealloy/revm#3518.
 pub type TempoRevmEvm<'db, I> = tempo_revm::TempoEvm<&'db mut dyn DatabaseExt<TempoEvmFactory>, I>;
 
-/// Tempo counterpart of [`EthFoundryEvm`]. Wraps `tempo_revm::TempoEvm` and routes execution
-/// through [`TempoEvmHandler`].
-///
-/// Uses [`TempoEvmFactory`] for construction to reuse factory setup logic, then unwraps to the
-/// raw revm EVM via `into_inner()` since the handler operates at the revm level.
-pub struct TempoFoundryEvm<
-    'db,
-    I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>,
-> {
-    pub inner: TempoRevmEvm<'db, I>,
-}
-
-/// Initialize Tempo precompiles and contracts for a newly created [`TempoFoundryEvm`].
+/// Initialize Tempo precompiles and contracts for a newly created EVM.
 ///
 /// In non-fork mode, runs full genesis initialization (precompile sentinel bytecode,
 /// TIP20 fee tokens, standard contracts) via [`StorageCtx::enter_evm`].
@@ -27,10 +42,10 @@ pub(crate) fn initialize_tempo_evm<
     'db,
     I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>,
 >(
-    evm: &mut TempoFoundryEvm<'db, I>,
+    evm: &mut TempoEvm<&'db mut dyn DatabaseExt<TempoEvmFactory>, I>,
     is_forked: bool,
 ) {
-    let ctx = &mut evm.inner.inner.ctx;
+    let ctx = evm.ctx_mut();
     StorageCtx::enter_evm(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx, || {
         if is_forked {
             // In fork mode, warm up precompile accounts to avoid repeated RPC fetches.
@@ -52,7 +67,7 @@ impl FoundryEvmFactory for TempoEvmFactory {
     type FoundryContext<'db> = TempoContext<&'db mut dyn DatabaseExt<Self>>;
 
     type FoundryEvm<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>> =
-        TempoFoundryEvm<'db, I>;
+        TempoEvm<&'db mut dyn DatabaseExt<Self>, I>;
 
     fn create_foundry_evm_with_inspector<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>>(
         &self,
@@ -62,20 +77,18 @@ impl FoundryEvmFactory for TempoEvmFactory {
     ) -> Self::FoundryEvm<'db, I> {
         let is_forked = db.is_forked_mode();
         let spec = *evm_env.spec_id();
-        let tempo_evm = Self::default().create_evm_with_inspector(db, evm_env, inspector);
-        let mut inner = tempo_evm.into_inner();
-        inner.ctx.cfg.gas_params = tempo_gas_params(spec);
-        inner.ctx.cfg.tx_chain_id_check = true;
-        if inner.ctx.cfg.tx_gas_limit_cap.is_none() {
-            inner.ctx.cfg.tx_gas_limit_cap = spec.tx_gas_limit_cap();
+        let mut tempo_evm = Self::default().create_evm_with_inspector(db, evm_env, inspector);
+        tempo_evm.cfg.gas_params = tempo_gas_params(spec);
+        tempo_evm.cfg.tx_chain_id_check = true;
+        if tempo_evm.cfg.tx_gas_limit_cap.is_none() {
+            tempo_evm.cfg.tx_gas_limit_cap = spec.tx_gas_limit_cap();
         }
 
-        let mut evm = TempoFoundryEvm { inner };
-        let networks = Evm::inspector(&evm).get_networks();
-        networks.inject_precompiles(evm.precompiles_mut());
+        let networks = tempo_evm.inspector().get_networks();
+        networks.inject_precompiles(tempo_evm.precompiles_mut());
 
-        initialize_tempo_evm(&mut evm, is_forked);
-        evm
+        initialize_tempo_evm(&mut tempo_evm, is_forked);
+        tempo_evm
     }
 
     fn create_foundry_nested_evm<'db>(
@@ -85,90 +98,7 @@ impl FoundryEvmFactory for TempoEvmFactory {
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> Box<dyn NestedEvm<Spec = TempoHardfork, Block = TempoBlockEnv, Tx = TempoTxEnv> + 'db>
     {
-        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).inner)
-    }
-}
-
-impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>> Evm
-    for TempoFoundryEvm<'db, I>
-{
-    type Precompiles = PrecompilesMap;
-    type Inspector = I;
-    type DB = &'db mut dyn DatabaseExt<TempoEvmFactory>;
-    type Error = EVMError<DatabaseError, TempoInvalidTransaction>;
-    type HaltReason = TempoHaltReason;
-    type Spec = TempoHardfork;
-    type Tx = TempoTxEnv;
-    type BlockEnv = TempoBlockEnv;
-
-    fn block(&self) -> &TempoBlockEnv {
-        &self.inner.block
-    }
-
-    fn chain_id(&self) -> u64 {
-        self.inner.ctx.cfg.chain_id
-    }
-
-    fn components(&self) -> (&Self::DB, &Self::Inspector, &Self::Precompiles) {
-        let evm = &self.inner.inner;
-        (&evm.ctx.journaled_state.database, &evm.inspector, &evm.precompiles)
-    }
-
-    fn components_mut(&mut self) -> (&mut Self::DB, &mut Self::Inspector, &mut Self::Precompiles) {
-        let evm = &mut self.inner.inner;
-        (&mut evm.ctx.journaled_state.database, &mut evm.inspector, &mut evm.precompiles)
-    }
-
-    fn set_inspector_enabled(&mut self, _enabled: bool) {
-        unimplemented!("TempoFoundryEvm is always inspecting")
-    }
-
-    fn transact_raw(
-        &mut self,
-        tx: Self::Tx,
-    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        self.inner.set_tx(tx);
-
-        let mut handler = TempoEvmHandler::new();
-        let result = handler.inspect_run(&mut self.inner)?;
-
-        Ok(ResultAndState::new(result, self.inner.inner.ctx.journaled_state.inner.state.clone()))
-    }
-
-    fn transact_system_call(
-        &mut self,
-        _caller: Address,
-        _contract: Address,
-        _data: Bytes,
-    ) -> Result<ExecResultAndState<ExecutionResult<Self::HaltReason>>, Self::Error> {
-        unimplemented!()
-    }
-
-    fn finish(self) -> (Self::DB, EvmEnv<Self::Spec, Self::BlockEnv>)
-    where
-        Self: Sized,
-    {
-        let revm_evm = self.inner.inner;
-        let Context { block: block_env, cfg: cfg_env, journaled_state, .. } = revm_evm.ctx;
-        (journaled_state.database, EvmEnv { block_env, cfg_env })
-    }
-}
-
-impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>> Deref
-    for TempoFoundryEvm<'db, I>
-{
-    type Target = TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner.ctx
-    }
-}
-
-impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>> DerefMut
-    for TempoFoundryEvm<'db, I>
-{
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner.ctx
+        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_inner())
     }
 }
 
@@ -206,7 +136,7 @@ impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmF
         let mut handler = TempoEvmHandler::new();
 
         let memory =
-            SharedMemory::new_with_buffer(self.ctx().local().shared_memory_buffer().clone());
+            SharedMemory::new_with_buffer(self.ctx_ref().local().shared_memory_buffer().clone());
         let first_frame_input = FrameInit { depth: 0, memory, frame_input: frame };
 
         let mut frame_result =
@@ -217,10 +147,7 @@ impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmF
         Ok(frame_result)
     }
 
-    fn transact_raw(
-        &mut self,
-        tx: Self::Tx,
-    ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>> {
+    fn transact_raw(&mut self, tx: Self::Tx) -> Result<ResultAndState, EVMError<DatabaseError>> {
         self.set_tx(tx);
 
         let mut handler = TempoEvmHandler::new();


### PR DESCRIPTION

## Motivation

#14344 #14346 follow-up

Remove `EthFoundryEvm` and `TempoFoundryEvm` wrapper structs that manually reimplemented the `Evm` to use former `FoundryHandler`.

Also cleans up imports across eth.rs, tempo.rs, op.rs, and mod.rs, and fixes minor API updates (`ctx() -> ctx_ref()`, `evm_clone()`).

I haven't removed yet OP's wrapper as OpContext/OpEvm are currently messed-up upstream due to `OpTx`

Less code !😎
