### PR TITLE
feat(tempo): bump tempo rev and integrate TempoAddressExt trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1218,7 +1218,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3021,7 +3021,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3174,7 +3174,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3958,7 +3958,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4263,7 +4263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5248,6 +5248,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-precompiles",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6565,7 +6566,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6579,15 +6580,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -7480,7 +7472,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7701,7 +7693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.17.0",
+ "hashbrown 0.16.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -8451,7 +8443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8464,7 +8456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8633,7 +8625,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10000,7 +9992,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10059,7 +10051,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10762,7 +10754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10830,7 +10822,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "itoa",
  "normalize-path",
  "once_map",
@@ -10842,7 +10834,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -10865,7 +10857,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11175,7 +11167,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
@@ -11289,13 +11281,13 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=39b9262#39b92627745eb1b0dbb99650d990ef9168376ded"
+source = "git+https://github.com/tempoxyz/tempo?rev=04a29a5#04a29a572a9f9e7bc7363e081c3cde4e11f29097"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11321,7 +11313,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.5.3"
-source = "git+https://github.com/tempoxyz/tempo?rev=39b9262#39b92627745eb1b0dbb99650d990ef9168376ded"
+source = "git+https://github.com/tempoxyz/tempo?rev=04a29a5#04a29a572a9f9e7bc7363e081c3cde4e11f29097"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-evm",
@@ -11340,7 +11332,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.5.3"
-source = "git+https://github.com/tempoxyz/tempo?rev=39b9262#39b92627745eb1b0dbb99650d990ef9168376ded"
+source = "git+https://github.com/tempoxyz/tempo?rev=04a29a5#04a29a572a9f9e7bc7363e081c3cde4e11f29097"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11356,7 +11348,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=39b9262#39b92627745eb1b0dbb99650d990ef9168376ded"
+source = "git+https://github.com/tempoxyz/tempo?rev=04a29a5#04a29a572a9f9e7bc7363e081c3cde4e11f29097"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11367,7 +11359,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.5.3"
-source = "git+https://github.com/tempoxyz/tempo?rev=39b9262#39b92627745eb1b0dbb99650d990ef9168376ded"
+source = "git+https://github.com/tempoxyz/tempo?rev=04a29a5#04a29a572a9f9e7bc7363e081c3cde4e11f29097"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11394,7 +11386,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.5.3"
-source = "git+https://github.com/tempoxyz/tempo?rev=39b9262#39b92627745eb1b0dbb99650d990ef9168376ded"
+source = "git+https://github.com/tempoxyz/tempo?rev=04a29a5#04a29a572a9f9e7bc7363e081c3cde4e11f29097"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11414,7 +11406,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.5.3"
-source = "git+https://github.com/tempoxyz/tempo?rev=39b9262#39b92627745eb1b0dbb99650d990ef9168376ded"
+source = "git+https://github.com/tempoxyz/tempo?rev=04a29a5#04a29a572a9f9e7bc7363e081c3cde4e11f29097"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11425,7 +11417,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=39b9262#39b92627745eb1b0dbb99650d990ef9168376ded"
+source = "git+https://github.com/tempoxyz/tempo?rev=04a29a5#04a29a572a9f9e7bc7363e081c3cde4e11f29097"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -11456,7 +11448,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.5.3"
-source = "git+https://github.com/tempoxyz/tempo?rev=39b9262#39b92627745eb1b0dbb99650d990ef9168376ded"
+source = "git+https://github.com/tempoxyz/tempo?rev=04a29a5#04a29a572a9f9e7bc7363e081c3cde4e11f29097"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11493,7 +11485,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11503,7 +11495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12720,7 +12712,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12870,7 +12862,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -513,15 +513,15 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "310c9a1f3fe485fa9c7a8
     "client",
     "reqwest-rustls-tls",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "39b9262", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "39b9262", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "04a29a5", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "04a29a5", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "39b9262", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "39b9262", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "39b9262", default-features = false, features = ["serde"] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "39b9262" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "39b9262" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "04a29a5", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "04a29a5", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "04a29a5", default-features = false, features = ["serde"] }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "04a29a5" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "04a29a5" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -608,9 +608,9 @@ alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = 
 # foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-fork-db", rev = "b139c57c2b54bc06a9e4c9783941f5bbd4bd3a1f" }
 
 ## tempo — unify crates.io versions (pulled by mpp) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "39b9262" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "39b9262" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "39b9262" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "04a29a5" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "04a29a5" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "04a29a5" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -48,6 +48,7 @@ revm = { workspace = true, default-features = false, features = [
 ] }
 revm-inspectors.workspace = true
 tempo-precompiles.workspace = true
+tempo-primitives.workspace = true
 
 eyre.workspace = true
 parking_lot.workspace = true

--- a/crates/evm/evm/src/inspectors/tempo_labels.rs
+++ b/crates/evm/evm/src/inspectors/tempo_labels.rs
@@ -6,7 +6,7 @@ use revm::{
     inspector::JournalExt,
     interpreter::{CallInputs, CallOutcome, interpreter::EthInterpreter},
 };
-use tempo_precompiles::tip20::is_tip20_prefix;
+use tempo_primitives::TempoAddressExt;
 
 /// Inspector that labels TIP20 token precompile addresses with their on-chain names.
 ///
@@ -25,7 +25,7 @@ where
     CTX::Journal: JournalExt,
 {
     fn call(&mut self, ctx: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
-        if is_tip20_prefix(inputs.target_address)
+        if inputs.target_address.is_tip20()
             && !self.labels.contains_key(&inputs.target_address)
         {
             let bytes = ctx


### PR DESCRIPTION
Bumps tempo dependency from `39b9262` to `04a29a5` ([tempoxyz/tempo#3637](https://github.com/tempoxyz/tempo/pull/3637)) and migrates `foundry-evm` to use the new `TempoAddressExt` trait.

## Changes

- `Cargo.toml`: bump all tempo crate revs `39b9262` → `04a29a5`
- `crates/evm/evm/Cargo.toml`: add `tempo-primitives` dep
- `crates/evm/evm/src/inspectors/tempo_labels.rs`: replace `is_tip20_prefix(addr)` → `addr.is_tip20()` via `TempoAddressExt`

> **Note:** Blocked on [tempoxyz/tempo#3637](https://github.com/tempoxyz/tempo/pull/3637) being merged — once merged, rev should be updated to the merge commit on main.

Prompted by: rusowsky