### PR TITLE
chore(mpp): add built-in rpc url mapping

### DIFF
--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -186,6 +186,9 @@ impl CheatsConfig {
     pub fn rpc_endpoint(&self, url_or_alias: &str) -> Result<ResolvedRpcEndpoint> {
         if let Some(endpoint) = self.rpc_endpoints.get(url_or_alias) {
             Ok(endpoint.clone().try_resolve())
+        } else if let Some(builtin_url) = foundry_config::builtin_rpc_url(url_or_alias) {
+            let url = RpcEndpointUrl::Url(builtin_url.to_string());
+            Ok(RpcEndpoint::new(url).resolve())
         } else {
             // check if it's a URL or a path to an existing file to an ipc socket
             if url_or_alias.starts_with("http") ||

--- a/crates/config/src/endpoints.rs
+++ b/crates/config/src/endpoints.rs
@@ -453,6 +453,18 @@ impl DerefMut for ResolvedRpcEndpoints {
     }
 }
 
+/// Returns the URL for a built-in RPC alias, if one exists.
+///
+/// Built-in aliases act as fallbacks: they are only used when the alias has **not** been
+/// defined by the user in `[rpc_endpoints]` or resolved via MESC.
+pub fn builtin_rpc_url(alias: &str) -> Option<&'static str> {
+    match alias {
+        "tempo" => Some("https://rpc.mpp.tempo.xyz"),
+        "moderato" => Some("https://rpc.mpp.moderato.tempo.xyz"),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -59,6 +59,7 @@ pub use utils::*;
 mod endpoints;
 pub use endpoints::{
     ResolvedRpcEndpoint, ResolvedRpcEndpoints, RpcEndpoint, RpcEndpointUrl, RpcEndpoints,
+    builtin_rpc_url,
 };
 
 mod etherscan;
@@ -1527,6 +1528,10 @@ impl Config {
 
         if let Some(mesc_url) = self.get_rpc_url_from_mesc(maybe_alias) {
             return Some(Ok(Cow::Owned(mesc_url)));
+        }
+
+        if let Some(builtin) = crate::endpoints::builtin_rpc_url(maybe_alias) {
+            return Some(Ok(Cow::Borrowed(builtin)));
         }
 
         None


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

To allow `cast bn -r tempo` to work

```
$ cast bn -r tempo
$ 15106072
```

```
$ MPP_API_KEY=<secret> cast bn -r moderato
$ 13205373
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Ported from: https://github.com/tempoxyz/tempo-foundry/blob/e95b51a3f845d8453622ed8ebbbb27fe8721b057/crates/config/src/endpoints.rs#L460