### PR TITLE
fix(config): validate `optimizer_runs` does not exceed u32::MAX

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -858,14 +858,14 @@ impl Config {
         config.normalize_hardfork_settings().map_err(ExtractConfigError::new)?;
 
         // Validate optimizer_runs does not exceed u32::MAX (Solidity compiler limit)
-        if let Some(runs) = config.optimizer_runs {
-            if runs > u32::MAX as usize {
-                return Err(ExtractConfigError::new(Error::from(format!(
-                    "`optimizer_runs` value {} exceeds maximum allowed value of {}",
-                    runs,
-                    u32::MAX
-                ))));
-            }
+        if let Some(runs) = config.optimizer_runs
+            && runs > u32::MAX as usize
+        {
+            return Err(ExtractConfigError::new(Error::from(format!(
+                "`optimizer_runs` value {} exceeds maximum allowed value of {}",
+                runs,
+                u32::MAX
+            ))));
         }
 
         Ok(config)

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -857,6 +857,17 @@ impl Config {
         config.normalize_optimizer_settings();
         config.normalize_hardfork_settings().map_err(ExtractConfigError::new)?;
 
+        // Validate optimizer_runs does not exceed u32::MAX (Solidity compiler limit)
+        if let Some(runs) = config.optimizer_runs {
+            if runs > u32::MAX as usize {
+                return Err(ExtractConfigError::new(Error::from(format!(
+                    "`optimizer_runs` value {} exceeds maximum allowed value of {}",
+                    runs,
+                    u32::MAX
+                ))));
+            }
+        }
+
         Ok(config)
     }
 


### PR DESCRIPTION
Added validation in config loading to reject `optimizer_runs` values exceeding `u32::MAX`. The Solidity compiler expects this parameter as u32, and the doc comment at line 271 already documents this limit. Now the config fails early with a clear error instead of causing undefined behavior at compile time.