### PR TITLE
fix(evm): preserve CREATE2 redirect state across isolated transactions

### DIFF
--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -898,12 +898,17 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
             .map(|cheats| core::mem::replace(cheats, Cheatcodes::new(cheats.config.clone())));
         let mut inner = std::mem::take(self.inner);
 
+        // Save pending CREATE2 redirects so frame_end in the nested EVM doesn't consume them.
+        // These belong to the outer EVM's frame lifecycle and must be restored after.
+        let saved_create2_redirects = std::mem::take(&mut inner.pending_create2_redirects);
+
         let out = f(InspectorStackRefMut { cheatcodes: cheatcodes.as_mut(), inner: &mut inner });
 
         if let Some(cheats) = self.cheatcodes.as_deref_mut() {
             *cheats = cheatcodes.unwrap();
         }
 
+        inner.pending_create2_redirects = saved_create2_redirects;
         *self.inner = inner;
 
         out
@@ -1187,17 +1192,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
             }
         }
 
-        // Skip isolation for calls that are actually CREATE2 redirects (rewritten by
-        // frame_start). These should execute in the current context so frame_end can
-        // transform the result back to a CreateOutcome.
-        let is_create2_redirect =
-            self.inner.pending_create2_redirects.last().copied() == Some(ecx.journal().depth());
-
-        if self.enable_isolation
-            && !self.in_inner_context
-            && ecx.journal().depth() == 1
-            && !is_create2_redirect
-        {
+        if self.enable_isolation && !self.in_inner_context && ecx.journal().depth() == 1 {
             match call.scheme {
                 // Isolate CALLs
                 CallScheme::Call => {


### PR DESCRIPTION
## Summary

Fixes [#14362](https://github.com/foundry-rs/foundry/issues/14362). Follow-up to [#14360](https://github.com/foundry-rs/foundry/pull/14360) which skipped isolation for CREATE2 factory redirects but broke broadcast nonce accounting (`nonce too low` errors).

## Root Cause

`with_inspector` does `mem::take` on the inner inspector state, moving `pending_create2_redirects` into the nested EVM. The nested `frame_end` consumes the redirect entry, so when control returns, the outer `frame_end` skips the `Call → Create` conversion.

The previous fix skipped isolation entirely for these calls, but the cheatcodes inspector relies on `transact_inner` to manage broadcast nonces when isolation is enabled.

## Fix

Save and restore `pending_create2_redirects` around `with_inspector`. Reverts the skip-isolation approach from #14360.

**Net diff vs pre-#14360 master**: +5 lines in `with_inspector`, no changes to the `call` hook.

Prompted by: zerosnacks

Co-Authored-By: zerosnacks <95942363+zerosnacks@users.noreply.github.com>