### PR TITLE
ci: remove softprops/action-gh-release dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-    ignore:
-      - dependency-name: "softprops/action-gh-release"
 
   - package-ecosystem: "cargo"
     directory: "/"


### PR DESCRIPTION
The ignore rule was added in #13528 because dependabot kept bumping to v2.5.0, which had a draft→finalize race in matrix jobs causing `Too many retries` during releases.

That race was fixed in v2.5.2 ([#746](https://github.com/softprops/action-gh-release/pull/746), [#745](https://github.com/softprops/action-gh-release/pull/745)). We're already on v2.6.1, so the ignore rule is no longer needed — dependabot can resume bumping this action.

Prompted by: zerosnacks