### PR TITLE
Improve checkout failure reporting

### DIFF
--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -494,9 +494,15 @@ impl Installer<'_> {
         let res = self.git.root(path).checkout(recurse, &tag);
         if let Err(mut e) = res {
             // remove dependency on failed checkout
-            fs::remove_dir_all(path)?;
+            let cleanup_err = fs::remove_dir_all(path).err();
             if e.to_string().contains("did not match any file(s) known to git") {
                 e = eyre::eyre!("Tag: \"{tag}\" not found for repo \"{url}\"!")
+            }
+            if let Some(cleanup_err) = cleanup_err {
+                return Err(eyre::eyre!(
+                    "{e}\nAdditionally failed to clean up dependency directory {}: {cleanup_err}",
+                    path.display()
+                ));
             }
             return Err(e);
         }


### PR DESCRIPTION
 ## Motivation
                                                                                                                                                                                      
  `forge install` runs a checkout and then cleans up the dependency directory on failure.                                                                                             
  Previously, cleanup used `remove_dir_all(path)?`, so a cleanup error could overwrite the original checkout error and hide the real failure reason (including invalid tag/branch cases).                                                                                                                                                                             
                                                                                                                                                                                      
  ## Solution                                                                                                                                                                         
                                                                                                                                                                                      
  Keep the original checkout error as the primary failure signal, preserve the existing user-friendly `tag not found` rewrite, and capture cleanup failure separately.                
  If cleanup also fails, return a combined error with the dependency path and cleanup failure details, so debugging keeps the root cause and gains actionable cleanup context.        

  ## PR Checklist                                                                                                                                                                     
                                                                                                                                                                                      
  - [ ] Added Tests                                                                                                                                                                   
  - [ ] Added Documentation                                                                                                                                                           
  - [ ] Breaking changes