### PR TITLE
fix(anvil): return error for eth_getLogs with unknown blockHash instead of empty

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2371,7 +2371,7 @@ where
             return Ok(fork.logs(&filter).await?);
         }
 
-        Ok(Vec::new())
+        Err(BlockchainError::UnknownBlock)
     }
 
     /// Returns the logs that match the filter in the given range of blocks

--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -73,6 +73,8 @@ pub enum BlockchainError {
     BlockOutOfRange(u64, u64),
     #[error("Resource not found")]
     BlockNotFound,
+    #[error("unknown block")]
+    UnknownBlock,
     /// Thrown when a requested transaction is not found
     #[error("transaction not found")]
     TransactionNotFound,
@@ -647,6 +649,11 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                 BlockchainError::FilterNotFound => RpcError {
                     code: ErrorCode::ServerError(-32000),
                     message: "filter not found".into(),
+                    data: None,
+                },
+                err @ BlockchainError::UnknownBlock => RpcError {
+                    code: ErrorCode::ServerError(-32000),
+                    message: err.to_string().into(),
                     data: None,
                 },
             }

--- a/crates/anvil/tests/it/logs.rs
+++ b/crates/anvil/tests/it/logs.rs
@@ -10,6 +10,7 @@ use alloy_provider::Provider;
 use alloy_rpc_types::{BlockNumberOrTag, Filter};
 use anvil::{NodeConfig, spawn};
 use futures::StreamExt;
+use std::str::FromStr;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_past_events() {
@@ -194,4 +195,21 @@ async fn watch_events() {
             .hash;
         assert_eq!(log.1.block_hash.unwrap(), hash);
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_logs_unknown_block_hash_returns_error() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let unknown_hash =
+        B256::from_str("0x0000000000000000000000000000000000000000000000000000000000000001")
+            .unwrap();
+    let filter = Filter::new().at_block_hash(unknown_hash);
+
+    let err = provider.get_logs(&filter).await.unwrap_err();
+    assert!(
+        err.to_string().contains("unknown block"),
+        "expected `unknown block` in error, got: {err}"
+    );
 }


### PR DESCRIPTION
Return a JSON-RPC error (-32000 "unknown block") when eth_getLogs is called with a blockHash that doesn't resolve to a known block, instead of silently returning an empty array. This aligns with how geth and other clients behave:

```
$ curl -s -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000001"}],"id":1}'  $RPC_URL

{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"unknown block"}}

$ curl -s -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}' $RPC_URL

{"jsonrpc":"2.0","id":1,"result":"Geth/v1.17.2-stable-be4dc0c4/linux-arm64/go1.26.1"}
```

See also https://github.com/paradigmxyz/reth/issues/7371

Code written with Claude.
