### PR TITLE
fix(ci): handle stale branches in bump-tempo workflow

### DIFF
--- a/.github/workflows/bump-tempo.yml
+++ b/.github/workflows/bump-tempo.yml
@@ -34,15 +34,22 @@ jobs:
         run: |
           BRANCH_NAME="deps/bump-tempo-${LATEST_REV:0:7}"
 
+          # Skip if a PR already exists for this branch
+          EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number')
+          if [[ -n "$EXISTING_PR" ]]; then
+            echo "PR #${EXISTING_PR} already exists for ${BRANCH_NAME}, skipping."
+            exit 0
+          fi
+
           # Configure git
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Create and push branch
+          # Create and push branch (force-push in case a stale branch exists from a prior failed run)
           git checkout -b "$BRANCH_NAME"
           git add Cargo.toml Cargo.lock
           git commit -m "chore(deps): bump tempo dependencies to ${LATEST_REV:0:7}"
-          git push origin "$BRANCH_NAME"
+          git push --force-with-lease origin "$BRANCH_NAME"
 
           # Create PR
           gh pr create \


### PR DESCRIPTION
The `bump-tempo.yml` workflow has been failing daily since April 16 because:

1. The branch name `deps/bump-tempo-{rev}` is deterministic based on the latest tempo commit
2. When tempo's main hasn't changed between runs, the workflow tries to push to an already-existing remote branch
3. `git push` fails with `non-fast-forward` since the branch was created from a different base commit

**Fix:**
- Check for an existing open PR before doing any git work — skip if one already exists
- Use `--force-with-lease` on push to handle stale orphan branches from prior failed runs (where push succeeded but PR creation failed)

Also deleted 3 orphan branches left behind by the failed runs: `deps/bump-tempo-6f4f5cc`, `deps/bump-tempo-786c8ce`, `deps/bump-tempo-fb6ce83`.

Prompted by: zerosnacks