### PR TITLE
chore(tempo): bump rev + use extension traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1218,7 +1218,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1282,11 +1282,11 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-alloy",
  "tempo-chainspec",
  "tempo-evm",
  "tempo-precompiles",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-primitives",
  "tempo-revm",
  "thiserror 2.0.18",
  "tokio",
@@ -2781,9 +2781,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
- "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-alloy",
+ "tempo-contracts",
+ "tempo-primitives",
  "tokio",
  "tracing",
  "yansi",
@@ -3021,7 +3021,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3174,7 +3174,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3958,7 +3958,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4263,7 +4263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4621,7 +4621,7 @@ dependencies = [
  "strum",
  "svm-rs",
  "tempfile",
- "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-alloy",
  "thiserror 2.0.18",
  "tokio",
  "toml_edit 0.24.1+spec-1.1.0",
@@ -4726,8 +4726,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-alloy",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4954,6 +4954,7 @@ dependencies = [
  "strsim",
  "strum",
  "tempfile",
+ "tempo-primitives",
  "tikv-jemallocator",
  "tokio",
  "tracing",
@@ -5023,8 +5024,8 @@ dependencies = [
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-alloy",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",
  "toml",
@@ -5055,7 +5056,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-alloy",
  "yansi",
 ]
 
@@ -5248,6 +5249,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-precompiles",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5307,8 +5309,8 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
- "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-alloy",
+ "tempo-contracts",
  "tempo-evm",
  "tempo-precompiles",
  "tempo-revm",
@@ -5420,7 +5422,7 @@ dependencies = [
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-contracts",
  "tempo-precompiles",
  "tokio",
  "tracing",
@@ -5492,8 +5494,8 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-alloy",
+ "tempo-primitives",
  "tempo-revm",
 ]
 
@@ -5570,7 +5572,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",
  "toml",
@@ -6565,7 +6567,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7342,8 +7344,8 @@ dependencies = [
  "serde_json",
  "serde_json_canonicalizer",
  "sha2 0.10.9",
- "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=6f4f5cc)",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=6f4f5cc)",
+ "tempo-alloy",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "time",
  "uuid 1.23.1",
@@ -7480,7 +7482,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8633,7 +8635,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10000,7 +10002,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10059,7 +10061,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10762,7 +10764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11289,33 +11291,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "tempo-alloy"
-version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6f4f5cc#6f4f5cca86a0f2aea8a863dee4b06430866ff9e5"
-dependencies = [
- "alloy-consensus",
- "alloy-contract",
- "alloy-eips 2.0.0",
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
- "alloy-signer-local",
- "alloy-sol-types",
- "alloy-transport",
- "async-trait",
- "dashmap",
- "derive_more",
- "futures",
- "serde",
- "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=6f4f5cc)",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=6f4f5cc)",
- "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11340,8 +11316,8 @@ dependencies = [
  "futures",
  "serde",
  "tempo-chainspec",
- "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-contracts",
+ "tempo-primitives",
  "tracing",
 ]
 
@@ -11361,7 +11337,7 @@ dependencies = [
  "reth-network-peers",
  "serde",
  "serde_json",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-primitives",
 ]
 
 [[package]]
@@ -11377,18 +11353,7 @@ dependencies = [
  "reth-ethereum-consensus",
  "reth-primitives-traits 0.3.0",
  "tempo-chainspec",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
-]
-
-[[package]]
-name = "tempo-contracts"
-version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6f4f5cc#6f4f5cca86a0f2aea8a863dee4b06430866ff9e5"
-dependencies = [
- "alloy-contract",
- "alloy-primitives",
- "alloy-sol-types",
- "serde",
+ "tempo-primitives",
 ]
 
 [[package]]
@@ -11422,8 +11387,8 @@ dependencies = [
  "reth-revm",
  "tempo-chainspec",
  "tempo-consensus",
- "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-contracts",
+ "tempo-primitives",
  "tempo-revm",
  "thiserror 2.0.18",
  "tracing",
@@ -11442,9 +11407,9 @@ dependencies = [
  "revm",
  "scoped-tls",
  "tempo-chainspec",
- "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-contracts",
  "tempo-precompiles-macros",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -11463,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6f4f5cc#6f4f5cca86a0f2aea8a863dee4b06430866ff9e5"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb9#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -11488,36 +11453,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=6f4f5cc)",
-]
-
-[[package]]
-name = "tempo-primitives"
-version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb9#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
-dependencies = [
- "alloy-consensus",
- "alloy-eips 2.0.0",
- "alloy-network",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
- "aws-lc-rs",
- "base64 0.22.1",
- "derive_more",
- "ed25519-consensus",
- "once_cell",
- "p256",
- "reth-codecs 0.3.0",
- "reth-ethereum-primitives",
- "reth-primitives-traits 0.3.0",
- "reth-rpc-convert",
- "revm",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-contracts",
 ]
 
 [[package]]
@@ -11536,9 +11472,9 @@ dependencies = [
  "revm",
  "serde",
  "tempo-chainspec",
- "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-contracts",
  "tempo-precompiles",
- "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -11560,7 +11496,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11570,7 +11506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12787,7 +12723,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12937,7 +12873,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,11 +1282,11 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
+ "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "tempo-chainspec",
  "tempo-evm",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "tempo-revm",
  "thiserror 2.0.18",
  "tokio",
@@ -2781,9 +2781,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "tokio",
  "tracing",
  "yansi",
@@ -4621,7 +4621,7 @@ dependencies = [
  "strum",
  "svm-rs",
  "tempfile",
- "tempo-alloy",
+ "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "thiserror 2.0.18",
  "tokio",
  "toml_edit 0.24.1+spec-1.1.0",
@@ -4726,8 +4726,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5023,8 +5023,8 @@ dependencies = [
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "thiserror 2.0.18",
  "tokio",
  "toml",
@@ -5055,7 +5055,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "tempo-alloy",
+ "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "yansi",
 ]
 
@@ -5307,8 +5307,8 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy",
- "tempo-contracts",
+ "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "tempo-evm",
  "tempo-precompiles",
  "tempo-revm",
@@ -5420,7 +5420,7 @@ dependencies = [
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-contracts",
+ "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "tempo-precompiles",
  "tokio",
  "tracing",
@@ -5492,8 +5492,8 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "tempo-revm",
 ]
 
@@ -5570,7 +5570,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
- "tempo-primitives",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "thiserror 2.0.18",
  "tokio",
  "toml",
@@ -7342,8 +7342,8 @@ dependencies = [
  "serde_json",
  "serde_json_canonicalizer",
  "sha2 0.10.9",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=6f4f5cc)",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=6f4f5cc)",
  "thiserror 2.0.18",
  "time",
  "uuid 1.23.1",
@@ -11313,15 +11313,42 @@ dependencies = [
  "derive_more",
  "futures",
  "serde",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=6f4f5cc)",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=6f4f5cc)",
+ "tracing",
+]
+
+[[package]]
+name = "tempo-alloy"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb9#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-eips 2.0.0",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-serde 2.0.0",
+ "alloy-signer-local",
+ "alloy-sol-types",
+ "alloy-transport",
+ "async-trait",
+ "dashmap",
+ "derive_more",
+ "futures",
+ "serde",
+ "tempo-chainspec",
+ "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "tracing",
 ]
 
 [[package]]
 name = "tempo-chainspec"
 version = "1.5.3"
-source = "git+https://github.com/tempoxyz/tempo?rev=6f4f5cc#6f4f5cca86a0f2aea8a863dee4b06430866ff9e5"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb9#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-evm",
@@ -11334,13 +11361,13 @@ dependencies = [
  "reth-network-peers",
  "serde",
  "serde_json",
- "tempo-primitives",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
 ]
 
 [[package]]
 name = "tempo-consensus"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6f4f5cc#6f4f5cca86a0f2aea8a863dee4b06430866ff9e5"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb9#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11350,7 +11377,7 @@ dependencies = [
  "reth-ethereum-consensus",
  "reth-primitives-traits 0.3.0",
  "tempo-chainspec",
- "tempo-primitives",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
 ]
 
 [[package]]
@@ -11365,9 +11392,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempo-contracts"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb9#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+]
+
+[[package]]
 name = "tempo-evm"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6f4f5cc#6f4f5cca86a0f2aea8a863dee4b06430866ff9e5"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb9#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11384,8 +11422,8 @@ dependencies = [
  "reth-revm",
  "tempo-chainspec",
  "tempo-consensus",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "tempo-revm",
  "thiserror 2.0.18",
  "tracing",
@@ -11394,7 +11432,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6f4f5cc#6f4f5cca86a0f2aea8a863dee4b06430866ff9e5"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb9#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11404,9 +11442,9 @@ dependencies = [
  "revm",
  "scoped-tls",
  "tempo-chainspec",
- "tempo-contracts",
+ "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "tempo-precompiles-macros",
- "tempo-primitives",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -11414,7 +11452,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6f4f5cc#6f4f5cca86a0f2aea8a863dee4b06430866ff9e5"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb9#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11450,13 +11488,42 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-contracts",
+ "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=6f4f5cc)",
+]
+
+[[package]]
+name = "tempo-primitives"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb9#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips 2.0.0",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-serde 2.0.0",
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "derive_more",
+ "ed25519-consensus",
+ "once_cell",
+ "p256",
+ "reth-codecs 0.3.0",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits 0.3.0",
+ "reth-rpc-convert",
+ "revm",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
 ]
 
 [[package]]
 name = "tempo-revm"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6f4f5cc#6f4f5cca86a0f2aea8a863dee4b06430866ff9e5"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb9#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11469,9 +11536,9 @@ dependencies = [
  "revm",
  "serde",
  "tempo-chainspec",
- "tempo-contracts",
+ "tempo-contracts 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.6.0 (git+https://github.com/tempoxyz/tempo?rev=bb08bb9)",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -516,6 +516,7 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "310c9a1f3fe485fa9c7a8
 tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9", default-features = false }
 tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9", default-features = false, features = [
     "serde",
+    "reth-codec",
 ] }
 tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9", default-features = false }
 tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9", default-features = false }
@@ -608,9 +609,9 @@ alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = 
 # foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-fork-db", rev = "b139c57c2b54bc06a9e4c9783941f5bbd4bd3a1f" }
 
 ## tempo — unify crates.io versions (pulled by mpp) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "6f4f5cc" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "6f4f5cc" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "6f4f5cc" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -513,15 +513,15 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "310c9a1f3fe485fa9c7a8
     "client",
     "reqwest-rustls-tls",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "6f4f5cc", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "6f4f5cc", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "6f4f5cc", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "6f4f5cc", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "6f4f5cc", default-features = false, features = ["serde"] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "6f4f5cc" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "6f4f5cc" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9", default-features = false, features = ["serde"] }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb9" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -1,7 +1,7 @@
 use alloy_ens::NameOrAddress;
 use alloy_network::EthereumWallet;
 use alloy_primitives::{Address, U256, hex, keccak256};
-use alloy_provider::{Provider, ProviderBuilder as AlloyProviderBuilder};
+use alloy_provider::ProviderBuilder as AlloyProviderBuilder;
 use alloy_signer::Signer;
 use alloy_sol_types::SolCall;
 use chrono::DateTime;
@@ -582,7 +582,7 @@ async fn run_authorize(
     let config = send_tx.eth.load_config()?;
     let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
 
-    let calldata = if is_hardfork_active(&provider, TempoHardfork::T3).await {
+    let calldata = if provider.is_hardfork_active(TempoHardfork::T3).await.unwrap_or(true) {
         // T3+ authorizeKey(address,SignatureType,KeyRestrictions)
         let restrictions = KeyRestrictions {
             expiry,
@@ -632,7 +632,7 @@ async fn run_remaining_limit(
     let config = rpc.load_config()?;
     let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
 
-    let remaining: U256 = if is_hardfork_active(&provider, TempoHardfork::T3).await {
+    let remaining: U256 = if provider.is_hardfork_active(TempoHardfork::T3).await.unwrap_or(true) {
         provider.get_keychain_remaining_limit(wallet_address, key_address, token).await?
     } else {
         // Pre-T3: use the legacy getRemainingLimit(address,address,address)
@@ -691,22 +691,6 @@ async fn run_remove_scope(
     let calldata =
         IAccountKeychain::removeAllowedCallsCall { keyId: key_address, target }.abi_encode();
     send_keychain_tx(calldata, tx_opts, &send_tx).await
-}
-
-/// Returns `true` when the connected Tempo chain has the given hardfork active.
-async fn is_hardfork_active<P: Provider<TempoNetwork>>(
-    provider: &P,
-    hardfork: TempoHardfork,
-) -> bool {
-    let Ok(chain_id) = provider.get_chain_id().await else { return true };
-    let block_ts = provider
-        .get_block(Default::default())
-        .await
-        .ok()
-        .flatten()
-        .map(|b| b.header.inner.inner.inner.timestamp)
-        .unwrap_or(0);
-    TempoHardfork::from_chain_and_timestamp(chain_id, block_ts).is_none_or(|h| h >= hardfork)
 }
 
 /// Shared helper to send a keychain precompile transaction.

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -582,7 +582,7 @@ async fn run_authorize(
     let config = send_tx.eth.load_config()?;
     let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
 
-    let calldata = if provider.is_hardfork_active(TempoHardfork::T3).await.unwrap_or(true) {
+    let calldata = if provider.is_hardfork_active(TempoHardfork::T3).await? {
         // T3+ authorizeKey(address,SignatureType,KeyRestrictions)
         let restrictions = KeyRestrictions {
             expiry,
@@ -632,7 +632,7 @@ async fn run_remaining_limit(
     let config = rpc.load_config()?;
     let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
 
-    let remaining: U256 = if provider.is_hardfork_active(TempoHardfork::T3).await.unwrap_or(true) {
+    let remaining: U256 = if provider.is_hardfork_active(TempoHardfork::T3).await? {
         provider.get_keychain_remaining_limit(wallet_address, key_address, token).await?
     } else {
         // Pre-T3: use the legacy getRemainingLimit(address,address,address)

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -1,7 +1,7 @@
 use alloy_ens::NameOrAddress;
 use alloy_network::EthereumWallet;
 use alloy_primitives::{Address, U256, hex, keccak256};
-use alloy_provider::ProviderBuilder as AlloyProviderBuilder;
+use alloy_provider::{Provider, ProviderBuilder as AlloyProviderBuilder};
 use alloy_signer::Signer;
 use alloy_sol_types::SolCall;
 use chrono::DateTime;

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,6 +21,8 @@ foundry-evm.workspace = true
 foundry-evm-networks.workspace = true
 foundry-wallets.workspace = true
 
+tempo-primitives.workspace = true
+
 foundry-compilers.workspace = true
 solar.workspace = true
 

--- a/crates/cli/src/utils/tempo.rs
+++ b/crates/cli/src/utils/tempo.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
-use alloy_primitives::{Address, hex};
+use alloy_primitives::Address;
+use tempo_primitives::TempoAddressExt;
 
 /// Parses a fee token address.
 pub fn parse_fee_token_address(address_or_id: &str) -> eyre::Result<Address> {
@@ -9,7 +10,7 @@ pub fn parse_fee_token_address(address_or_id: &str) -> eyre::Result<Address> {
 
 fn token_id_to_address(token_id: u64) -> Address {
     let mut address_bytes = [0u8; 20];
-    address_bytes[..12].copy_from_slice(&hex!("20C000000000000000000000"));
+    address_bytes[..12].copy_from_slice(&Address::TIP20_PREFIX);
     address_bytes[12..20].copy_from_slice(&token_id.to_be_bytes());
     Address::from(address_bytes)
 }

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -48,6 +48,7 @@ revm = { workspace = true, default-features = false, features = [
 ] }
 revm-inspectors.workspace = true
 tempo-precompiles.workspace = true
+tempo-primitives.workspace = true
 
 eyre.workspace = true
 parking_lot.workspace = true

--- a/crates/evm/evm/src/inspectors/tempo_labels.rs
+++ b/crates/evm/evm/src/inspectors/tempo_labels.rs
@@ -6,7 +6,7 @@ use revm::{
     inspector::JournalExt,
     interpreter::{CallInputs, CallOutcome, interpreter::EthInterpreter},
 };
-use tempo_precompiles::tip20::is_tip20_prefix;
+use tempo_primitives::TempoAddressExt;
 
 /// Inspector that labels TIP20 token precompile addresses with their on-chain names.
 ///
@@ -25,7 +25,7 @@ where
     CTX::Journal: JournalExt,
 {
     fn call(&mut self, ctx: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
-        if is_tip20_prefix(inputs.target_address)
+        if inputs.target_address.is_tip20()
             && !self.labels.contains_key(&inputs.target_address)
         {
             let bytes = ctx

--- a/crates/evm/evm/src/inspectors/tempo_labels.rs
+++ b/crates/evm/evm/src/inspectors/tempo_labels.rs
@@ -25,9 +25,7 @@ where
     CTX::Journal: JournalExt,
 {
     fn call(&mut self, ctx: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
-        if inputs.target_address.is_tip20()
-            && !self.labels.contains_key(&inputs.target_address)
-        {
+        if inputs.target_address.is_tip20() && !self.labels.contains_key(&inputs.target_address) {
             let bytes = ctx
                 .db_mut()
                 .storage(inputs.target_address, tempo_precompiles::tip20::slots::NAME)


### PR DESCRIPTION
Bumps tempo crates from `6f4f5cc` to `bb08bb9` (latest `main`) and adopts the new `TempoProviderExt` and `TempoAddressExt` traits across the codebase.

- Replace local `is_hardfork_active` helper with `TempoProviderExt::is_hardfork_active()`, which queries `tempo_forkSchedule` RPC directly instead of manually fetching chain ID + block timestamp
- Use `addr.is_tip20()` instead of standalone `is_tip20_prefix()` in `TempoLabels` inspector
- Use `Address::TIP20_PREFIX` instead of hardcoded hex bytes in fee token address parsing

Prompted by: rusowsky