### PR TITLE
cast: route RPC tracing through cast run --trace

### DIFF
--- a/.github/workflows/docker-fork.yml
+++ b/.github/workflows/docker-fork.yml
@@ -20,6 +20,7 @@ on:
         type: string
   push:
     branches:
+      - main
       - master
 
 permissions:
@@ -59,6 +60,10 @@ jobs:
             TAG="${{ inputs.image_tag }}"
             PROFILE="${{ inputs.rust_profile }}"
             FEATURES="${{ inputs.rust_features }}"
+          elif [[ "${GITHUB_REF_NAME}" == "main" || "${GITHUB_REF_NAME}" == "master" ]]; then
+            TAG="latest"
+            PROFILE="${DEFAULT_RUST_PROFILE}"
+            FEATURES="${DEFAULT_RUST_FEATURES}"
           else
             TAG="${GITHUB_REF_NAME}"
             PROFILE="${DEFAULT_RUST_PROFILE}"

--- a/.github/workflows/docker-fork.yml
+++ b/.github/workflows/docker-fork.yml
@@ -29,7 +29,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
   DEFAULT_RUST_PROFILE: dist
   DEFAULT_RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer
 
@@ -71,10 +70,12 @@ jobs:
           fi
 
           TAG_SAFE="${TAG//\//-}"
+          IMAGE_NAME="$(printf '%s' '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
           {
             printf 'tag=%s\n' "$TAG_SAFE"
             printf 'profile=%s\n' "$PROFILE"
             printf 'features=%s\n' "$FEATURES"
+            printf 'image_name=%s\n' "$IMAGE_NAME"
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and push image
@@ -85,8 +86,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.tag }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ steps.vars.outputs.image_name }}:${{ steps.vars.outputs.tag }}
+            ${{ env.REGISTRY }}/${{ steps.vars.outputs.image_name }}:sha-${{ github.sha }}
           build-args: |
             RUST_PROFILE=${{ steps.vars.outputs.profile }}
             RUST_FEATURES=${{ steps.vars.outputs.features }}

--- a/.github/workflows/docker-fork.yml
+++ b/.github/workflows/docker-fork.yml
@@ -1,0 +1,89 @@
+name: docker-fork
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Docker tag to publish
+        required: true
+        default: custom
+        type: string
+      rust_profile:
+        description: Cargo profile passed to Dockerfile
+        required: true
+        default: dist
+        type: string
+      rust_features:
+        description: Comma-separated feature list passed to Dockerfile
+        required: true
+        default: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer
+        type: string
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  DEFAULT_RUST_PROFILE: dist
+  DEFAULT_RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer
+
+jobs:
+  docker:
+    name: build and push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve build inputs
+        id: vars
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ inputs.image_tag }}"
+            PROFILE="${{ inputs.rust_profile }}"
+            FEATURES="${{ inputs.rust_features }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+            PROFILE="${DEFAULT_RUST_PROFILE}"
+            FEATURES="${DEFAULT_RUST_FEATURES}"
+          fi
+
+          TAG_SAFE="${TAG//\//-}"
+          {
+            printf 'tag=%s\n' "$TAG_SAFE"
+            printf 'profile=%s\n' "$PROFILE"
+            printf 'features=%s\n' "$FEATURES"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          build-args: |
+            RUST_PROFILE=${{ steps.vars.outputs.profile }}
+            RUST_FEATURES=${{ steps.vars.outputs.features }}
+            TAG_NAME=${{ steps.vars.outputs.tag }}
+            VERGEN_GIT_SHA=${{ github.sha }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2598,6 +2613,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,9 +3383,12 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
+ "brotli",
  "compression-core",
  "flate2",
  "memchr",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -5400,6 +5439,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",
+ "alloy-rpc-types",
  "alloy-sol-types",
  "async-trait",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -474,7 +474,7 @@ rand = "0.9"
 rand_08 = { package = "rand", version = "0.8" }
 rayon = "1"
 regex = { version = "1", default-features = false }
-reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "gzip", "brotli", "zstd", "deflate"] }
 rustls = "0.23"
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/cast/src/cmd/mod.rs
+++ b/crates/cast/src/cmd/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod miner;
 pub mod mktx;
 pub mod rpc;
 pub mod run;
+mod run_trace;
 pub mod send;
 pub mod storage;
 pub mod tip20;

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -2,12 +2,13 @@ use crate::{
     debug::handle_traces,
     utils::{apply_chain_and_block_specific_env_changes, block_env_from_header},
 };
+use super::run_trace::RunTraceArgs;
+use alloy_chains::Chain;
 use alloy_consensus::{BlockHeader, Transaction, transaction::SignerRecoverable};
 
-use alloy_evm::FromRecoveredTx;
-use alloy_network::{BlockResponse, TransactionResponse};
+use alloy_network::{AnyNetwork, BlockResponse, TransactionResponse};
 use alloy_primitives::{
-    Address, Bytes, U256,
+    Address, Bytes, TxHash, U256,
     map::{AddressSet, HashMap},
 };
 use alloy_provider::Provider;
@@ -25,13 +26,13 @@ use foundry_compilers::artifacts::EvmVersion;
 use foundry_config::{
     Config,
     figment::{
-        self, Metadata, Profile,
+        self, Figment, Metadata, Profile,
         value::{Dict, Map},
     },
 };
 use foundry_evm::{
     core::{
-        FoundryBlock as _,
+        FoundryBlock as _, FromAnyRpcTransaction,
         evm::{EthEvmNetwork, FoundryEvmNetwork, OpEvmNetwork, TempoEvmNetwork, TxEnvFor},
     },
     executors::{EvmError, Executor, TracingExecutor},
@@ -48,8 +49,14 @@ pub struct RunArgs {
     /// The transaction hash.
     tx_hash: String,
 
+    /// Use `debug_traceTransaction` instead of local block replay.
+    ///
+    /// This makes `cast run` use the RPC trace path instead of local replay.
+    #[arg(long)]
+    trace: bool,
+
     /// Opens the transaction in the debugger.
-    #[arg(long, short)]
+    #[arg(long, short, conflicts_with = "trace")]
     debug: bool,
 
     /// Whether to identify internal functions in traces.
@@ -71,7 +78,7 @@ pub struct RunArgs {
     quick: bool,
 
     /// Whether to replay system transactions.
-    #[arg(long, alias = "sys")]
+    #[arg(long, alias = "sys", conflicts_with = "trace")]
     replay_system_txes: bool,
 
     /// Disables the labels in the traces.
@@ -94,6 +101,7 @@ pub struct RunArgs {
     ///
     /// Overrides the version specified in the config.
     #[arg(long)]
+    #[arg(conflicts_with = "trace")]
     evm_version: Option<EvmVersion>,
 
     /// Use current project artifacts for trace decoding.
@@ -101,12 +109,103 @@ pub struct RunArgs {
     pub with_local_artifacts: bool,
 
     /// Disable block gas limit check.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "trace")]
     pub disable_block_gas_limit: bool,
 
     /// Enable the tx gas limit checks as imposed by Osaka (EIP-7825).
-    #[arg(long)]
+    #[arg(long, conflicts_with = "trace")]
     pub enable_tx_gas_limit: bool,
+
+    /// Print gas and storage profiler summaries.
+    #[arg(long, requires = "trace")]
+    profile: bool,
+
+    /// Disable storage hot-slot profiling.
+    #[arg(long, requires = "trace")]
+    no_storage_profile: bool,
+
+    /// Fetch pre/post storage values with prestateTracer diff mode.
+    #[arg(long, requires = "trace")]
+    storage_values: bool,
+
+    /// Include full memory snapshots in the opcode trace for deeper internal argument decoding.
+    ///
+    /// This can make debug_traceTransaction responses very large; some RPCs reject large traces.
+    #[arg(long, alias = "full-memory", requires = "trace")]
+    enable_memory: bool,
+
+    /// Read/write raw RPC trace responses at this path.
+    #[arg(long, requires = "trace")]
+    raw_rpc_cache: Option<std::path::PathBuf>,
+
+    /// Local JSON file containing the callTracer response.
+    ///
+    /// Accepts either the raw tracer result object or a full JSON-RPC response envelope.
+    #[arg(long, requires = "trace")]
+    call_trace_json: Option<std::path::PathBuf>,
+
+    /// Local JSON file containing the default struct logger response.
+    ///
+    /// Accepts either the raw tracer result object or a full JSON-RPC response envelope.
+    #[arg(long, requires = "trace")]
+    struct_trace_json: Option<std::path::PathBuf>,
+
+    /// Local JSON file containing the prestateTracer diff response.
+    ///
+    /// Accepts either the raw tracer result object or a full JSON-RPC response envelope.
+    #[arg(long, requires = "trace")]
+    storage_values_json: Option<std::path::PathBuf>,
+
+    /// Local JSON file containing `eth_getTransactionByHash` result for this tx.
+    ///
+    /// Accepts either the raw result object or a full JSON-RPC response envelope.
+    #[arg(long, requires = "trace")]
+    tx_json: Option<std::path::PathBuf>,
+
+    /// Local JSON file containing `eth_getTransactionReceipt` result for this tx.
+    ///
+    /// Accepts either the raw result object or a full JSON-RPC response envelope.
+    #[arg(long, requires = "trace")]
+    receipt_json: Option<std::path::PathBuf>,
+
+    /// Local JSON file containing `eth_getBlockByNumber(..., false)` result for this tx's block.
+    ///
+    /// Accepts either the raw result object or a full JSON-RPC response envelope.
+    #[arg(long, requires = "trace")]
+    block_json: Option<std::path::PathBuf>,
+
+    /// Disable the automatic raw RPC trace cache.
+    #[arg(long, requires = "trace")]
+    no_rpc_trace_cache: bool,
+
+    /// Ignore any existing raw RPC trace cache and overwrite it.
+    #[arg(long, requires = "trace")]
+    refresh_rpc_trace_cache: bool,
+
+    /// Allow decoded output even when local bytecode matching is incomplete.
+    #[arg(long, requires = "trace")]
+    allow_bytecode_mismatch: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ReplayTxArgs {
+    pub tx_hash: TxHash,
+    pub debug: bool,
+    pub decode_internal: bool,
+    pub trace_printer: bool,
+    pub quick: bool,
+    pub replay_system_txes: bool,
+    pub evm_version: Option<EvmVersion>,
+    pub compute_units_per_second: Option<u64>,
+    pub disable_block_gas_limit: bool,
+    pub enable_tx_gas_limit: bool,
+}
+
+pub(crate) struct ReplayTxResult {
+    pub config: Config,
+    pub result: TraceResult,
+    pub contracts_bytecode: HashMap<Address, Bytes>,
+    pub chain: Chain,
 }
 
 impl RunArgs {
@@ -116,236 +215,332 @@ impl RunArgs {
     ///
     /// Note: This executes the transaction(s) as is: Cheatcodes are disabled
     pub async fn run(self) -> Result<()> {
-        let figment = self.rpc.clone().into_figment(self.with_local_artifacts).merge(&self);
-        let mut evm_opts = figment.extract::<EvmOpts>()?;
-
-        // Auto-detect network from fork chain ID when not explicitly configured.
-        evm_opts.infer_network_from_fork().await;
-
-        if evm_opts.networks.is_tempo() {
-            self.run_with_evm::<TempoEvmNetwork>().await
-        } else if evm_opts.networks.is_optimism() {
-            self.run_with_evm::<OpEvmNetwork>().await
-        } else {
-            self.run_with_evm::<EthEvmNetwork>().await
+        if self.trace {
+            return RunTraceArgs {
+                tx_hash: Some(self.tx_hash),
+                decode_internal: self.decode_internal,
+                trace_depth: self.trace_depth,
+                trace_printer: self.trace_printer,
+                quick: self.quick,
+                disable_labels: self.disable_labels,
+                label: self.label,
+                with_local_artifacts: self.with_local_artifacts,
+                profile: self.profile,
+                no_storage_profile: self.no_storage_profile,
+                storage_values: self.storage_values,
+                enable_memory: self.enable_memory,
+                raw_rpc_cache: self.raw_rpc_cache,
+                call_trace_json: self.call_trace_json,
+                struct_trace_json: self.struct_trace_json,
+                storage_values_json: self.storage_values_json,
+                tx_json: self.tx_json,
+                receipt_json: self.receipt_json,
+                block_json: self.block_json,
+                no_rpc_trace_cache: self.no_rpc_trace_cache,
+                refresh_rpc_trace_cache: self.refresh_rpc_trace_cache,
+                allow_bytecode_mismatch: self.allow_bytecode_mismatch,
+                rpc: self.rpc,
+            }
+            .run()
+            .await;
         }
-    }
-
-    async fn run_with_evm<FEN: FoundryEvmNetwork>(self) -> Result<()> {
-        let figment = self.rpc.clone().into_figment(self.with_local_artifacts).merge(&self);
-        let evm_opts = figment.extract::<EvmOpts>()?;
-        let mut config = Config::from_provider(figment)?.sanitized();
-
-        let label = self.label;
-        let with_local_artifacts = self.with_local_artifacts;
-        let debug = self.debug;
-        let decode_internal = self.decode_internal;
-        let disable_labels = self.disable_labels;
-        let compute_units_per_second = if self.rpc.common.no_rpc_rate_limit {
-            Some(u64::MAX)
-        } else {
-            self.rpc.common.compute_units_per_second
-        };
-
-        let provider = ProviderBuilder::<FEN::Network>::from_config(&config)?
-            .compute_units_per_second_opt(compute_units_per_second)
-            .build()?;
 
         let tx_hash = self.tx_hash.parse().wrap_err("invalid tx hash")?;
-        let tx = provider
-            .get_transaction_by_hash(tx_hash)
-            .await
-            .wrap_err_with(|| format!("tx not found: {tx_hash:?}"))?
-            .ok_or_else(|| eyre::eyre!("tx not found: {:?}", tx_hash))?;
-
-        // check if the tx is a system transaction
-        if !self.replay_system_txes
-            && (is_known_system_sender(tx.from())
-                || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE))
-        {
-            return Err(eyre::eyre!(
-                "{:?} is a system transaction.\nReplaying system transactions is currently not supported.",
-                tx.tx_hash()
-            ));
-        }
-
-        let tx_block_number = tx
-            .block_number()
-            .ok_or_else(|| eyre::eyre!("tx may still be pending: {:?}", tx_hash))?;
-
-        // we need to fork off the parent block
-        config.fork_block_number = Some(tx_block_number - 1);
-
-        let create2_deployer = evm_opts.create2_deployer;
-        let (block, (mut evm_env, tx_env, fork, chain, networks)) = tokio::try_join!(
-            // fetch the block the transaction was mined in
-            provider.get_block(tx_block_number.into()).full().into_future().map_err(Into::into),
-            TracingExecutor::<FEN>::get_fork_material(&mut config, evm_opts)
-        )?;
-
-        let mut evm_version = self.evm_version;
-
-        evm_env.cfg_env.disable_block_gas_limit = self.disable_block_gas_limit;
-
-        // By default do not enforce transaction gas limits imposed by Osaka (EIP-7825).
-        // Users can opt-in to enable these limits by setting `enable_tx_gas_limit` to true.
-        if !self.enable_tx_gas_limit {
-            evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
-        }
-
-        evm_env.cfg_env.limit_contract_code_size = None;
-        evm_env.block_env.set_number(U256::from(tx_block_number));
-
-        if let Some(block) = &block {
-            evm_env.block_env = block_env_from_header(block.header());
-
-            // Resolve the correct spec for the block using the same approach as reth: walk
-            // known chain activation conditions to find the latest active fork. Falls back
-            // to a blob-gas heuristic for unknown chains.
-            if evm_version.is_none() {
-                if let Some(hardfork) = FoundryHardfork::from_chain_and_timestamp(
-                    evm_env.cfg_env.chain_id,
-                    block.header().timestamp(),
-                ) {
-                    evm_env.cfg_env.set_spec_and_mainnet_gas_params(hardfork.into());
-                } else if block.header().excess_blob_gas().is_some() {
-                    // TODO: add glamsterdam header field checks in the future
-                    evm_version = Some(EvmVersion::Cancun);
-                }
-            }
-            apply_chain_and_block_specific_env_changes::<FEN::Network, _, _>(
-                &mut evm_env,
-                block,
-                config.networks,
-            );
-        }
-
-        let trace_mode = TraceMode::Call
-            .with_debug(self.debug)
-            .with_decode_internal(if self.decode_internal {
-                InternalTraceMode::Full
-            } else {
-                InternalTraceMode::None
-            })
-            .with_state_changes(shell::verbosity() > 4);
-        let mut executor = TracingExecutor::<FEN>::new(
-            (evm_env.clone(), tx_env),
-            fork,
-            evm_version,
-            trace_mode,
-            networks,
-            create2_deployer,
-            None,
-        )?;
-
-        evm_env.cfg_env.set_spec_and_mainnet_gas_params(executor.spec_id());
-
-        // Set the state to the moment right before the transaction
-        if !self.quick {
-            if !shell::is_json() {
-                sh_println!("Executing previous transactions from the block.")?;
-            }
-
-            if let Some(block) = block {
-                let pb = init_progress(block.transactions().len() as u64, "tx");
-                pb.set_position(0);
-
-                let BlockTransactions::Full(ref txs) = *block.transactions() else {
-                    return Err(eyre::eyre!("Could not get block txs"));
-                };
-
-                for (index, tx) in txs.iter().enumerate() {
-                    // Replay system transactions only if running with `sys` option.
-                    // System transactions such as on L2s don't contain any pricing info so it
-                    // could cause reverts.
-                    if !self.replay_system_txes
-                        && (is_known_system_sender(tx.from())
-                            || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE))
-                    {
-                        pb.set_position((index + 1) as u64);
-                        continue;
-                    }
-                    if tx.tx_hash() == tx_hash {
-                        break;
-                    }
-
-                    let tx_env = TxEnvFor::<FEN>::from_recovered_tx(tx.as_ref(), tx.from());
-
-                    evm_env.cfg_env.disable_balance_check = true;
-
-                    if let Some(to) = Transaction::to(tx) {
-                        trace!(tx=?tx.tx_hash(),?to, "executing previous call transaction");
-                        executor.transact_with_env(evm_env.clone(), tx_env.clone()).wrap_err_with(
-                            || {
-                                format!(
-                                    "Failed to execute transaction: {:?} in block {}",
-                                    tx.tx_hash(),
-                                    evm_env.block_env.number()
-                                )
-                            },
-                        )?;
-                    } else {
-                        trace!(tx=?tx.tx_hash(), "executing previous create transaction");
-                        if let Err(error) =
-                            executor.deploy_with_env(evm_env.clone(), tx_env.clone(), None)
-                        {
-                            match error {
-                                // Reverted transactions should be skipped
-                                EvmError::Execution(_) => (),
-                                error => {
-                                    return Err(error).wrap_err_with(|| {
-                                        format!(
-                                            "Failed to deploy transaction: {:?} in block {}",
-                                            tx.tx_hash(),
-                                            evm_env.block_env.number()
-                                        )
-                                    });
-                                }
-                            }
-                        }
-                    }
-
-                    pb.set_position((index + 1) as u64);
-                }
-            }
-        }
-
-        // Execute our transaction
-        let result = {
-            executor.set_trace_printer(self.trace_printer);
-
-            let tx_env = TxEnvFor::<FEN>::from_recovered_tx(tx.as_ref(), tx.from());
-
-            if tx.as_ref().recover_signer().is_ok_and(|signer| signer != tx.from()) {
-                evm_env.cfg_env.disable_balance_check = true;
-            }
-
-            if let Some(to) = Transaction::to(&tx) {
-                trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");
-                TraceResult::from(executor.transact_with_env(evm_env, tx_env)?)
-            } else {
-                trace!(tx=?tx.tx_hash(), "executing create transaction");
-                TraceResult::try_from(executor.deploy_with_env(evm_env, tx_env, None))?
-            }
-        };
-
-        let contracts_bytecode = fetch_contracts_bytecode_from_trace(&executor, &result)?;
-        handle_traces(
-            result,
-            &config,
-            chain,
-            &contracts_bytecode,
-            label,
-            with_local_artifacts,
-            debug,
-            decode_internal,
-            disable_labels,
-            self.trace_depth,
+        let figment = self.rpc.clone().into_figment(self.with_local_artifacts).merge(&self);
+        let replay = replay_transaction(
+            figment,
+            ReplayTxArgs {
+                tx_hash,
+                debug: self.debug,
+                decode_internal: self.decode_internal,
+                trace_printer: self.trace_printer,
+                quick: self.quick,
+                replay_system_txes: self.replay_system_txes,
+                evm_version: self.evm_version,
+                compute_units_per_second: if self.rpc.common.no_rpc_rate_limit {
+                    Some(u64::MAX)
+                } else {
+                    self.rpc.common.compute_units_per_second
+                },
+                disable_block_gas_limit: self.disable_block_gas_limit,
+                enable_tx_gas_limit: self.enable_tx_gas_limit,
+            },
         )
         .await?;
 
-        Ok(())
+        handle_traces(
+            replay.result,
+            &replay.config,
+            replay.chain,
+            &replay.contracts_bytecode,
+            self.label,
+            self.with_local_artifacts,
+            self.debug,
+            self.decode_internal,
+            self.disable_labels,
+            self.trace_depth,
+        )
+        .await
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RunArgs;
+    use clap::Parser;
+
+    #[test]
+    fn run_trace_accepts_trace_flags() {
+        let args = RunArgs::try_parse_from([
+            "run",
+            "0xdeadbeef",
+            "--trace",
+            "--profile",
+            "--storage-values",
+            "--raw-rpc-cache",
+            "/tmp/trace.json",
+        ])
+        .unwrap();
+
+        assert!(args.trace);
+        assert!(args.profile);
+        assert!(args.storage_values);
+        assert_eq!(
+            args.raw_rpc_cache.as_deref(),
+            Some(std::path::Path::new("/tmp/trace.json"))
+        );
+    }
+
+    #[test]
+    fn run_profile_requires_trace() {
+        assert!(RunArgs::try_parse_from(["run", "0xdeadbeef", "--profile"]).is_err());
+    }
+
+    #[test]
+    fn run_debug_conflicts_with_trace() {
+        assert!(RunArgs::try_parse_from(["run", "0xdeadbeef", "--trace", "--debug"]).is_err());
+    }
+}
+
+pub(crate) async fn replay_transaction(
+    figment: Figment,
+    args: ReplayTxArgs,
+) -> Result<ReplayTxResult> {
+    let mut evm_opts = figment.extract::<EvmOpts>()?;
+
+    // Auto-detect network from fork chain ID when not explicitly configured.
+    evm_opts.infer_network_from_fork().await;
+
+    let config = Config::from_provider(figment)?.sanitized();
+    if evm_opts.networks.is_tempo() {
+        replay_transaction_with_evm::<TempoEvmNetwork>(config, evm_opts, args).await
+    } else if evm_opts.networks.is_optimism() {
+        replay_transaction_with_evm::<OpEvmNetwork>(config, evm_opts, args).await
+    } else {
+        replay_transaction_with_evm::<EthEvmNetwork>(config, evm_opts, args).await
+    }
+}
+
+async fn replay_transaction_with_evm<FEN: FoundryEvmNetwork>(
+    mut config: Config,
+    evm_opts: EvmOpts,
+    args: ReplayTxArgs,
+) -> Result<ReplayTxResult> {
+    let provider = ProviderBuilder::<AnyNetwork>::from_config(&config)?
+        .compute_units_per_second_opt(args.compute_units_per_second)
+        .build()?;
+
+    let tx_hash = args.tx_hash;
+    let tx = provider
+        .get_transaction_by_hash(tx_hash)
+        .await
+        .wrap_err_with(|| format!("tx not found: {tx_hash:?}"))?
+        .ok_or_else(|| eyre::eyre!("tx not found: {:?}", tx_hash))?;
+
+    // check if the tx is a system transaction
+    if !args.replay_system_txes
+        && (is_known_system_sender(tx.from())
+            || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE))
+    {
+        return Err(eyre::eyre!(
+            "{:?} is a system transaction.\nReplaying system transactions is currently not supported.",
+            tx.tx_hash()
+        ));
+    }
+
+    let tx_block_number =
+        tx.block_number().ok_or_else(|| eyre::eyre!("tx may still be pending: {:?}", tx_hash))?;
+
+    // we need to fork off the parent block
+    config.fork_block_number = Some(tx_block_number - 1);
+
+    let create2_deployer = evm_opts.create2_deployer;
+    let (block, (mut evm_env, tx_env, fork, chain, networks)) = tokio::try_join!(
+        provider.get_block(tx_block_number.into()).full().into_future().map_err(Into::into),
+        TracingExecutor::<FEN>::get_fork_material(&mut config, evm_opts)
+    )?;
+
+    let mut evm_version = args.evm_version;
+
+    evm_env.cfg_env.disable_block_gas_limit = args.disable_block_gas_limit;
+
+    // By default do not enforce transaction gas limits imposed by Osaka (EIP-7825).
+    // Users can opt-in to enable these limits by setting `enable_tx_gas_limit` to true.
+    if !args.enable_tx_gas_limit {
+        evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+    }
+
+    evm_env.cfg_env.limit_contract_code_size = None;
+    evm_env.block_env.set_number(U256::from(tx_block_number));
+
+    if let Some(block) = &block {
+        evm_env.block_env = block_env_from_header(block.header());
+
+        // Resolve the correct spec for the block using the same approach as reth: walk
+        // known chain activation conditions to find the latest active fork. Falls back
+        // to a blob-gas heuristic for unknown chains.
+        if evm_version.is_none() {
+            if let Some(hardfork) = FoundryHardfork::from_chain_and_timestamp(
+                evm_env.cfg_env.chain_id,
+                block.header().timestamp(),
+            ) {
+                evm_env.cfg_env.set_spec_and_mainnet_gas_params(hardfork.into());
+            } else if block.header().excess_blob_gas().is_some() {
+                // TODO: add glamsterdam header field checks in the future
+                evm_version = Some(EvmVersion::Cancun);
+            }
+        }
+        apply_chain_and_block_specific_env_changes::<AnyNetwork, _, _>(
+            &mut evm_env,
+            block,
+            config.networks,
+        );
+    }
+
+    let trace_mode = TraceMode::Call
+        .with_debug(args.debug)
+        .with_decode_internal(if args.decode_internal {
+            InternalTraceMode::Full
+        } else {
+            InternalTraceMode::None
+        })
+        .with_state_changes(shell::verbosity() > 4);
+    let mut executor = TracingExecutor::<FEN>::new(
+        (evm_env.clone(), tx_env),
+        fork,
+        evm_version,
+        trace_mode,
+        networks,
+        create2_deployer,
+        None,
+    )?;
+
+    evm_env.cfg_env.set_spec_and_mainnet_gas_params(executor.spec_id());
+
+    // Set the state to the moment right before the transaction
+    if !args.quick {
+        if !shell::is_json() {
+            sh_println!("Executing previous transactions from the block.")?;
+        }
+
+        if let Some(block) = block {
+            let pb = init_progress(block.transactions().len() as u64, "tx");
+            pb.set_position(0);
+
+            let BlockTransactions::Full(ref txs) = *block.transactions() else {
+                return Err(eyre::eyre!("Could not get block txs"));
+            };
+
+            for (index, tx) in txs.iter().enumerate() {
+                // Replay system transactions only if running with `sys` option.
+                // System transactions such as on L2s don't contain any pricing info so it
+                // could cause reverts.
+                if !args.replay_system_txes
+                    && (is_known_system_sender(tx.from())
+                        || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE))
+                {
+                    pb.set_position((index + 1) as u64);
+                    continue;
+                }
+                if tx.tx_hash() == tx_hash {
+                    break;
+                }
+
+                let tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(tx).wrap_err_with(|| {
+                    format!(
+                        "Failed to convert transaction {:?} into the local EVM transaction format",
+                        tx.tx_hash()
+                    )
+                })?;
+
+                evm_env.cfg_env.disable_balance_check = true;
+
+                if let Some(to) = tx.to() {
+                    trace!(tx=?tx.tx_hash(),?to, "executing previous call transaction");
+                    executor.transact_with_env(evm_env.clone(), tx_env.clone()).wrap_err_with(
+                        || {
+                            format!(
+                                "Failed to execute transaction: {:?} in block {}",
+                                tx.tx_hash(),
+                                evm_env.block_env.number()
+                            )
+                        },
+                    )?;
+                } else {
+                    trace!(tx=?tx.tx_hash(), "executing previous create transaction");
+                    if let Err(error) =
+                        executor.deploy_with_env(evm_env.clone(), tx_env.clone(), None)
+                    {
+                        match error {
+                            // Reverted transactions should be skipped
+                            EvmError::Execution(_) => (),
+                            error => {
+                                return Err(error).wrap_err_with(|| {
+                                    format!(
+                                        "Failed to deploy transaction: {:?} in block {}",
+                                        tx.tx_hash(),
+                                        evm_env.block_env.number()
+                                    )
+                                });
+                            }
+                        }
+                    }
+                }
+
+                pb.set_position((index + 1) as u64);
+            }
+        }
+    }
+
+    let result = {
+        executor.set_trace_printer(args.trace_printer);
+
+        let tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(&tx).wrap_err_with(|| {
+            format!(
+                "Failed to convert transaction {:?} into the local EVM transaction format",
+                tx.tx_hash()
+            )
+        })?;
+
+        if tx
+            .as_envelope()
+            .and_then(|envelope| envelope.recover_signer().ok())
+            .is_some_and(|signer| signer != tx.from())
+        {
+            evm_env.cfg_env.disable_balance_check = true;
+        }
+
+        if let Some(to) = tx.to() {
+            trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");
+            TraceResult::from(executor.transact_with_env(evm_env, tx_env)?)
+        } else {
+            trace!(tx=?tx.tx_hash(), "executing create transaction");
+            TraceResult::try_from(executor.deploy_with_env(evm_env, tx_env, None))?
+        }
+    };
+
+    let contracts_bytecode = fetch_contracts_bytecode_from_trace(&executor, &result)?;
+    Ok(ReplayTxResult { config, result, contracts_bytecode, chain })
 }
 
 pub fn fetch_contracts_bytecode_from_trace<FEN: FoundryEvmNetwork>(

--- a/crates/cast/src/cmd/run_trace.rs
+++ b/crates/cast/src/cmd/run_trace.rs
@@ -1,0 +1,1020 @@
+use super::run::{ReplayTxArgs, replay_transaction};
+use crate::debug::prepare_trace_decoder;
+use alloy_chains::Chain;
+use alloy_network::Network;
+use alloy_primitives::{Address, Bytes, TxHash, map::HashMap};
+use alloy_provider::{Provider, ext::DebugApi};
+use alloy_rpc_types::{
+    BlockId, BlockNumberOrTag,
+    trace::geth::{
+        CallConfig, GethDebugTracingOptions, GethDefaultTracingOptions, GethTrace, PreStateConfig,
+    },
+};
+use clap::Parser;
+use eyre::{Context, Result};
+use foundry_cli::{
+    opts::RpcOpts,
+    utils::{self, TraceResult, print_traces},
+};
+use foundry_common::{shell, stdin};
+use foundry_config::Config;
+use foundry_evm::traces::{
+    TraceKind,
+    rpc_profile::{RpcTraceProfiles, profile_arena},
+    rpc_trace::{
+        build_rpc_trace_arena, finalize_rpc_trace_arena, graft_local_replay_onto_call_tracer,
+    },
+};
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{
+    borrow::Cow,
+    fs::File,
+    io::{BufReader, BufWriter},
+    path::{Path, PathBuf},
+};
+
+/// Internal arguments for `cast run --trace`.
+#[derive(Clone, Debug, Parser)]
+pub struct RunTraceArgs {
+    /// The transaction hash.
+    ///
+    /// Reads from stdin when omitted.
+    pub(crate) tx_hash: Option<String>,
+
+    /// Whether to identify internal functions in traces.
+    #[arg(long)]
+    pub(crate) decode_internal: bool,
+
+    /// Defines the depth of a trace.
+    #[arg(long)]
+    pub(crate) trace_depth: Option<usize>,
+
+    /// Print opcode-level lines in the trace.
+    #[arg(long, short)]
+    pub(crate) trace_printer: bool,
+
+    /// Skip optional metadata lookups for faster decoded terminal output.
+    ///
+    /// This avoids `eth_getTransactionByHash`, `eth_getTransactionReceipt`, and
+    /// `eth_getBlockByNumber` when they are not needed for rendering. JSON output, local artifact
+    /// decoding, and explicit raw RPC cache paths still fetch the required metadata.
+    #[arg(long)]
+    pub(crate) quick: bool,
+
+    /// Disables labels in the traces.
+    #[arg(long, default_value_t = false)]
+    pub(crate) disable_labels: bool,
+
+    /// Label addresses in the trace.
+    ///
+    /// Example: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth
+    #[arg(long, short)]
+    pub(crate) label: Vec<String>,
+
+    /// Use current project artifacts for trace decoding.
+    #[arg(long, visible_alias = "la")]
+    pub(crate) with_local_artifacts: bool,
+
+    /// Print gas and storage profiler summaries.
+    #[arg(long)]
+    pub(crate) profile: bool,
+
+    /// Disable storage hot-slot profiling.
+    #[arg(long)]
+    pub(crate) no_storage_profile: bool,
+
+    /// Fetch pre/post storage values with prestateTracer diff mode.
+    #[arg(long)]
+    pub(crate) storage_values: bool,
+
+    /// Include full memory snapshots in the opcode trace for deeper internal argument decoding.
+    ///
+    /// This can make debug_traceTransaction responses very large; some RPCs reject large traces.
+    #[arg(long, alias = "full-memory")]
+    pub(crate) enable_memory: bool,
+
+    /// Read/write raw RPC trace responses at this path.
+    #[arg(long)]
+    pub(crate) raw_rpc_cache: Option<PathBuf>,
+
+    /// Local JSON file containing the callTracer response.
+    ///
+    /// Accepts either the raw tracer result object or a full JSON-RPC response envelope.
+    #[arg(long)]
+    pub(crate) call_trace_json: Option<PathBuf>,
+
+    /// Local JSON file containing the default struct logger response.
+    ///
+    /// Accepts either the raw tracer result object or a full JSON-RPC response envelope.
+    #[arg(long)]
+    pub(crate) struct_trace_json: Option<PathBuf>,
+
+    /// Local JSON file containing the prestateTracer diff response.
+    ///
+    /// Accepts either the raw tracer result object or a full JSON-RPC response envelope.
+    #[arg(long)]
+    pub(crate) storage_values_json: Option<PathBuf>,
+
+    /// Local JSON file containing `eth_getTransactionByHash` result for this tx.
+    ///
+    /// Accepts either the raw result object or a full JSON-RPC response envelope.
+    #[arg(long)]
+    pub(crate) tx_json: Option<PathBuf>,
+
+    /// Local JSON file containing `eth_getTransactionReceipt` result for this tx.
+    ///
+    /// Accepts either the raw result object or a full JSON-RPC response envelope.
+    #[arg(long)]
+    pub(crate) receipt_json: Option<PathBuf>,
+
+    /// Local JSON file containing `eth_getBlockByNumber(..., false)` result for this tx's block.
+    ///
+    /// Accepts either the raw result object or a full JSON-RPC response envelope.
+    #[arg(long)]
+    pub(crate) block_json: Option<PathBuf>,
+
+    /// Disable the automatic raw RPC trace cache.
+    #[arg(long)]
+    pub(crate) no_rpc_trace_cache: bool,
+
+    /// Ignore any existing raw RPC trace cache and overwrite it.
+    #[arg(long)]
+    pub(crate) refresh_rpc_trace_cache: bool,
+
+    /// Allow decoded output even when local bytecode matching is incomplete.
+    #[arg(long)]
+    pub(crate) allow_bytecode_mismatch: bool,
+
+    #[command(flatten)]
+    pub(crate) rpc: RpcOpts,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawRpcTraceCache {
+    chain_id: u64,
+    tx: Value,
+    receipt: Value,
+    block: Value,
+    #[serde(default)]
+    call_trace: Option<GethTrace>,
+    #[serde(default)]
+    call_trace_warning: Option<String>,
+    #[serde(default)]
+    struct_trace: Option<GethTrace>,
+    #[serde(default)]
+    struct_trace_warning: Option<String>,
+    storage_values: Option<GethTrace>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum JsonFileInput<T> {
+    Raw(T),
+    RpcSuccess { result: T },
+    RpcError { error: Value },
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct MetadataFetchPlan {
+    tx: bool,
+    receipt: bool,
+    block: bool,
+    automatic_cache: bool,
+}
+
+impl RunTraceArgs {
+    pub async fn run(self) -> Result<()> {
+        let config =
+            Config::from_provider(self.rpc.clone().into_figment(self.with_local_artifacts))?
+                .sanitized();
+        let provider = utils::get_provider(&config)?;
+        let tx_hash: TxHash =
+            stdin::unwrap_line(self.tx_hash.clone())?.parse().wrap_err("invalid tx hash")?;
+
+        let raw = self.load_or_fetch_raw_traces(&provider, tx_hash).await?;
+        let mut warnings = Vec::new();
+        if let Some(warning) = raw.call_trace_warning.clone() {
+            warnings.push(warning);
+        }
+        if let Some(warning) = raw.struct_trace_warning.clone() {
+            warnings.push(warning);
+        }
+
+        let (mut result, mut mode_warnings, contracts_bytecode) = if let (
+            Some(call_trace),
+            Some(struct_trace),
+        ) =
+            (raw.call_trace.clone(), raw.struct_trace.clone())
+        {
+            let call_frame = call_trace.try_into_call_frame().map_err(|_| {
+                eyre::eyre!("debug_traceTransaction callTracer returned an unexpected shape")
+            })?;
+            let default_frame = struct_trace.try_into_default_frame().map_err(|_| {
+                eyre::eyre!("debug_traceTransaction default tracer returned an unexpected shape")
+            })?;
+
+            let receipt_gas = gas_used_from_receipt(&raw.receipt).unwrap_or(default_frame.gas);
+            let mut converted =
+                build_rpc_trace_arena(&call_frame, &default_frame, self.trace_printer);
+            let mut warnings = Vec::new();
+            warnings.append(&mut converted.warnings);
+            finalize_rpc_trace_arena(&mut converted.arena.arena, receipt_gas, &mut warnings);
+            if !raw.receipt.is_null() && receipt_gas != default_frame.gas {
+                warnings.push(format!(
+                    "receipt gasUsed ({receipt_gas}) differs from structLogger gas ({})",
+                    default_frame.gas
+                ));
+            }
+
+            let result = TraceResult {
+                success: !default_frame.failed,
+                traces: Some(vec![(TraceKind::Execution, converted.arena)]),
+                gas_used: receipt_gas,
+            };
+            let contracts_bytecode = if self.with_local_artifacts {
+                fetch_contracts_bytecode(&provider, &result, block_number_from_tx(&raw.tx)).await
+            } else {
+                HashMap::default()
+            };
+            (result, warnings, contracts_bytecode)
+        } else if let Some(call_trace) = raw.call_trace.clone() {
+            let replay = self.replay_transaction_locally(tx_hash).await?;
+            let local_execution = execution_trace(&replay.result)
+                .ok_or_else(|| eyre::eyre!("local replay did not produce an execution trace"))?;
+            let call_frame = call_trace.try_into_call_frame().map_err(|_| {
+                eyre::eyre!("debug_traceTransaction callTracer returned an unexpected shape")
+            })?;
+
+            if let Some(mut converted) =
+                graft_local_replay_onto_call_tracer(&call_frame, &local_execution.arena)
+            {
+                let receipt_gas = gas_used_from_receipt(&raw.receipt)
+                    .unwrap_or(converted.arena.nodes()[0].trace.gas_used);
+                let mut warnings = Vec::new();
+                warnings.append(&mut converted.warnings);
+                warnings.push(
+                    "using remote callTracer as the call skeleton and local cast run replay for opcode steps".to_string(),
+                );
+                finalize_rpc_trace_arena(&mut converted.arena.arena, receipt_gas, &mut warnings);
+                if receipt_gas != replay.result.gas_used {
+                    warnings.push(format!(
+                        "receipt gasUsed ({receipt_gas}) differs from local replay gas ({})",
+                        replay.result.gas_used
+                    ));
+                }
+                let success = converted.arena.nodes()[0].trace.success;
+                let result = TraceResult {
+                    success,
+                    traces: Some(vec![(TraceKind::Execution, converted.arena)]),
+                    gas_used: receipt_gas,
+                };
+                let contracts_bytecode = if self.with_local_artifacts {
+                    replay.contracts_bytecode
+                } else {
+                    HashMap::default()
+                };
+                (result, warnings, contracts_bytecode)
+            } else {
+                let mut warnings = vec![
+                    "callTracer could not be aligned with local replay; using pure local replay"
+                        .to_string(),
+                ];
+                if let Some(receipt_gas) = gas_used_from_receipt(&raw.receipt)
+                    && receipt_gas != replay.result.gas_used
+                {
+                    warnings.push(format!(
+                        "receipt gasUsed ({receipt_gas}) differs from local replay gas ({})",
+                        replay.result.gas_used
+                    ));
+                }
+                let contracts_bytecode = if self.with_local_artifacts {
+                    replay.contracts_bytecode
+                } else {
+                    HashMap::default()
+                };
+                (replay.result, warnings, contracts_bytecode)
+            }
+        } else {
+            let replay = self.replay_transaction_locally(tx_hash).await?;
+            let mut warnings =
+                vec!["callTracer was unavailable; using pure local cast run replay".to_string()];
+            if let Some(receipt_gas) = gas_used_from_receipt(&raw.receipt)
+                && receipt_gas != replay.result.gas_used
+            {
+                warnings.push(format!(
+                    "receipt gasUsed ({receipt_gas}) differs from local replay gas ({})",
+                    replay.result.gas_used
+                ));
+            }
+            let contracts_bytecode = if self.with_local_artifacts {
+                replay.contracts_bytecode
+            } else {
+                HashMap::default()
+            };
+            (replay.result, warnings, contracts_bytecode)
+        };
+        warnings.append(&mut mode_warnings);
+
+        if self.allow_bytecode_mismatch {
+            warnings.push(
+                "--allow-bytecode-mismatch is accepted for compatibility; unmatched local bytecode is already decoded conservatively".to_string(),
+            );
+        }
+        if self.storage_values && raw.storage_values.is_none() {
+            warnings.push(
+                "--storage-values was requested but no prestateTracer response was available"
+                    .to_string(),
+            );
+        }
+        if self.quick && raw.receipt.is_null() {
+            warnings.push(
+                "--quick skips receipt lookup; gasUsed may differ from the mined receipt"
+                    .to_string(),
+            );
+        }
+
+        let prepared = prepare_trace_decoder(
+            &result,
+            &config,
+            Chain::from(raw.chain_id),
+            &contracts_bytecode,
+            self.label,
+            self.with_local_artifacts,
+            self.decode_internal,
+            self.disable_labels,
+        )
+        .await?;
+
+        warnings.sort();
+        warnings.dedup();
+
+        print_traces(
+            &mut result,
+            &prepared.decoder,
+            shell::verbosity() > 0,
+            shell::verbosity() > 4,
+            self.trace_depth,
+        )
+        .await?;
+
+        if shell::is_json() {
+            for warning in warnings {
+                sh_warn!("{warning}")?;
+            }
+            return Ok(());
+        }
+
+        if self.profile {
+            let arena = &result.traces.as_ref().unwrap()[0].1.arena;
+            let profiles = profile_arena(arena, !self.no_storage_profile);
+            print_profiles(&profiles)?;
+        }
+
+        for warning in warnings {
+            sh_warn!("{warning}")?;
+        }
+
+        Ok(())
+    }
+
+    async fn replay_transaction_locally(
+        &self,
+        tx_hash: TxHash,
+    ) -> Result<super::run::ReplayTxResult> {
+        replay_transaction(
+            self.rpc.clone().into_figment(self.with_local_artifacts),
+            ReplayTxArgs {
+                tx_hash,
+                debug: false,
+                decode_internal: self.decode_internal,
+                trace_printer: self.trace_printer,
+                quick: false,
+                replay_system_txes: false,
+                evm_version: None,
+                compute_units_per_second: if self.rpc.common.no_rpc_rate_limit {
+                    Some(u64::MAX)
+                } else {
+                    self.rpc.common.compute_units_per_second
+                },
+                disable_block_gas_limit: false,
+                enable_tx_gas_limit: false,
+            },
+        )
+        .await
+    }
+
+    fn struct_logger_options(&self) -> GethDebugTracingOptions {
+        GethDebugTracingOptions {
+            config: GethDefaultTracingOptions::default()
+                .with_disable_stack(false)
+                .with_disable_storage(true)
+                .with_enable_memory(self.enable_memory)
+                .with_enable_return_data(false),
+            ..Default::default()
+        }
+    }
+
+    async fn fetch_call_trace<P, N>(
+        &self,
+        provider: &P,
+        tx_hash: TxHash,
+    ) -> (Option<GethTrace>, Option<String>)
+    where
+        P: Provider<N>,
+        N: Network,
+    {
+        match provider
+            .debug_trace_transaction(
+                tx_hash,
+                GethDebugTracingOptions::call_tracer(CallConfig::default().with_log()),
+            )
+            .await
+        {
+            Ok(trace) => (Some(trace), None),
+            Err(err) => (None, Some(format!("debug_traceTransaction callTracer failed: {err}"))),
+        }
+    }
+
+    async fn fetch_struct_trace<P, N>(
+        &self,
+        provider: &P,
+        tx_hash: TxHash,
+    ) -> (Option<GethTrace>, Option<String>)
+    where
+        P: Provider<N>,
+        N: Network,
+    {
+        match provider.debug_trace_transaction(tx_hash, self.struct_logger_options()).await {
+            Ok(trace) => (Some(trace), None),
+            Err(err) if is_trace_response_too_big(&err) => (
+                None,
+                Some(
+                    "debug_traceTransaction default struct logger exceeded provider limits; falling back to local replay for opcode steps".to_string(),
+                ),
+            ),
+            Err(err) => (
+                None,
+                Some(format!("debug_traceTransaction default struct logger failed: {err}")),
+            ),
+        }
+    }
+
+    async fn fetch_storage_values<P, N>(&self, provider: &P, tx_hash: TxHash) -> Result<GethTrace>
+    where
+        P: Provider<N>,
+        N: Network,
+    {
+        provider
+            .debug_trace_transaction(
+                tx_hash,
+                GethDebugTracingOptions::prestate_tracer(PreStateConfig {
+                    diff_mode: Some(true),
+                    disable_storage: Some(false),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .wrap_err("debug_traceTransaction prestateTracer failed")
+    }
+
+    async fn load_or_fetch_raw_traces<P, N>(
+        &self,
+        provider: &P,
+        tx_hash: TxHash,
+    ) -> Result<RawRpcTraceCache>
+    where
+        P: Provider<N>,
+        N: Network,
+    {
+        if self.has_explicit_local_json_inputs() {
+            return self.load_from_explicit_local_json(provider, tx_hash).await;
+        }
+
+        if let Some(path) = self.raw_rpc_cache.as_ref()
+            && !self.refresh_rpc_trace_cache
+            && path.exists()
+        {
+            return read_json_file(path)
+                .wrap_err_with(|| format!("failed to parse raw RPC cache {}", path.display()));
+        }
+
+        let chain_id = provider.get_chain_id().await?;
+        let fetch_plan = self.metadata_fetch_plan();
+        let tx = if fetch_plan.tx {
+            let tx: Option<Value> =
+                provider.raw_request(Cow::Borrowed("eth_getTransactionByHash"), (tx_hash,)).await?;
+            tx.ok_or_else(|| eyre::eyre!("tx not found: {tx_hash:?}"))?
+        } else {
+            Value::Null
+        };
+        let block_number = if fetch_plan.tx {
+            Some(
+                block_number_from_tx(&tx)
+                    .ok_or_else(|| eyre::eyre!("tx may still be pending: {tx_hash:?}"))?,
+            )
+        } else {
+            None
+        };
+
+        let cache_path = self.raw_rpc_cache.clone().or_else(|| {
+            if fetch_plan.automatic_cache {
+                block_number
+                    .and_then(|number| self.automatic_raw_rpc_cache_path(chain_id, number, tx_hash))
+            } else {
+                None
+            }
+        });
+        if let Some(path) = cache_path.as_ref()
+            && !self.refresh_rpc_trace_cache
+            && path.exists()
+        {
+            return read_json_file(path)
+                .wrap_err_with(|| format!("failed to parse raw RPC cache {}", path.display()));
+        }
+
+        let receipt = if fetch_plan.receipt {
+            let receipt: Option<Value> = provider
+                .raw_request(Cow::Borrowed("eth_getTransactionReceipt"), (tx_hash,))
+                .await?;
+            receipt.ok_or_else(|| eyre::eyre!("receipt not found for tx: {tx_hash:?}"))?
+        } else {
+            Value::Null
+        };
+        let block = if fetch_plan.block {
+            let block_number =
+                block_number.ok_or_else(|| eyre::eyre!("missing tx metadata for block lookup"))?;
+            let block_number_hex = format!("0x{block_number:x}");
+            let block: Option<Value> = provider
+                .raw_request(Cow::Borrowed("eth_getBlockByNumber"), (block_number_hex, false))
+                .await?;
+            block.ok_or_else(|| eyre::eyre!("block not found for tx: {tx_hash:?}"))?
+        } else {
+            Value::Null
+        };
+
+        let (call_trace, call_trace_warning) = self.fetch_call_trace(provider, tx_hash).await;
+        let (struct_trace, struct_trace_warning) = self.fetch_struct_trace(provider, tx_hash).await;
+
+        let storage_values = if self.storage_values {
+            Some(self.fetch_storage_values(provider, tx_hash).await?)
+        } else {
+            None
+        };
+
+        let raw = RawRpcTraceCache {
+            chain_id,
+            tx,
+            receipt,
+            block,
+            call_trace,
+            call_trace_warning,
+            struct_trace,
+            struct_trace_warning,
+            storage_values,
+        };
+
+        if let Some(path) = cache_path {
+            write_raw_rpc_cache(&path, &raw)?;
+        }
+
+        Ok(raw)
+    }
+
+    fn has_explicit_local_json_inputs(&self) -> bool {
+        self.call_trace_json.is_some()
+            || self.struct_trace_json.is_some()
+            || self.storage_values_json.is_some()
+            || self.tx_json.is_some()
+            || self.receipt_json.is_some()
+            || self.block_json.is_some()
+    }
+
+    async fn load_from_explicit_local_json<P, N>(
+        &self,
+        provider: &P,
+        tx_hash: TxHash,
+    ) -> Result<RawRpcTraceCache>
+    where
+        P: Provider<N>,
+        N: Network,
+    {
+        let chain_id = provider.get_chain_id().await?;
+        let fetch_plan = self.metadata_fetch_plan();
+
+        let tx: Value = if let Some(path) = self.tx_json.as_ref() {
+            read_json_file(path)
+                .wrap_err_with(|| format!("failed to parse tx JSON {}", path.display()))?
+        } else if fetch_plan.tx {
+            let tx: Option<Value> =
+                provider.raw_request(Cow::Borrowed("eth_getTransactionByHash"), (tx_hash,)).await?;
+            tx.ok_or_else(|| eyre::eyre!("tx not found: {tx_hash:?}"))?
+        } else {
+            Value::Null
+        };
+
+        let block_number = if !tx.is_null() {
+            Some(
+                block_number_from_tx(&tx)
+                    .ok_or_else(|| eyre::eyre!("tx may still be pending: {tx_hash:?}"))?,
+            )
+        } else {
+            None
+        };
+
+        let receipt: Value = if let Some(path) = self.receipt_json.as_ref() {
+            read_json_file(path)
+                .wrap_err_with(|| format!("failed to parse receipt JSON {}", path.display()))?
+        } else if fetch_plan.receipt {
+            let receipt: Option<Value> = provider
+                .raw_request(Cow::Borrowed("eth_getTransactionReceipt"), (tx_hash,))
+                .await?;
+            receipt.ok_or_else(|| eyre::eyre!("receipt not found for tx: {tx_hash:?}"))?
+        } else {
+            Value::Null
+        };
+
+        let block: Value = if let Some(path) = self.block_json.as_ref() {
+            read_json_file(path)
+                .wrap_err_with(|| format!("failed to parse block JSON {}", path.display()))?
+        } else if fetch_plan.block {
+            let block_number =
+                block_number.ok_or_else(|| eyre::eyre!("missing tx metadata for block lookup"))?;
+            let block_number_hex = format!("0x{block_number:x}");
+            let block: Option<Value> = provider
+                .raw_request(Cow::Borrowed("eth_getBlockByNumber"), (block_number_hex, false))
+                .await?;
+            block.ok_or_else(|| eyre::eyre!("block not found for tx: {tx_hash:?}"))?
+        } else {
+            Value::Null
+        };
+
+        let (call_trace, call_trace_warning) = if let Some(path) = self.call_trace_json.as_ref() {
+            (
+                Some(read_json_file(path).wrap_err_with(|| {
+                    format!("failed to parse call trace JSON {}", path.display())
+                })?),
+                None,
+            )
+        } else {
+            self.fetch_call_trace(provider, tx_hash).await
+        };
+
+        let (struct_trace, struct_trace_warning) =
+            if let Some(path) = self.struct_trace_json.as_ref() {
+                (
+                    Some(read_json_file(path).wrap_err_with(|| {
+                        format!("failed to parse struct trace JSON {}", path.display())
+                    })?),
+                    None,
+                )
+            } else {
+                self.fetch_struct_trace(provider, tx_hash).await
+            };
+
+        let storage_values = if let Some(path) = self.storage_values_json.as_ref() {
+            Some(read_json_file(path).wrap_err_with(|| {
+                format!("failed to parse storage values JSON {}", path.display())
+            })?)
+        } else if self.storage_values {
+            Some(self.fetch_storage_values(provider, tx_hash).await?)
+        } else {
+            None
+        };
+
+        let raw = RawRpcTraceCache {
+            chain_id,
+            tx,
+            receipt,
+            block,
+            call_trace,
+            call_trace_warning,
+            struct_trace,
+            struct_trace_warning,
+            storage_values,
+        };
+
+        let cache_path = self.raw_rpc_cache.clone().or_else(|| {
+            if fetch_plan.automatic_cache {
+                block_number
+                    .and_then(|number| self.automatic_raw_rpc_cache_path(chain_id, number, tx_hash))
+            } else {
+                None
+            }
+        });
+        if let Some(path) = cache_path {
+            write_raw_rpc_cache(&path, &raw)?;
+        }
+
+        Ok(raw)
+    }
+
+    fn metadata_fetch_plan(&self) -> MetadataFetchPlan {
+        let automatic_cache = !self.no_rpc_trace_cache && !self.quick;
+        let persistent_cache = self.raw_rpc_cache.is_some();
+        let json_output = shell::is_json();
+
+        MetadataFetchPlan {
+            tx: self.with_local_artifacts || json_output || persistent_cache || automatic_cache,
+            receipt: json_output || !self.quick || persistent_cache,
+            block: json_output || persistent_cache,
+            automatic_cache,
+        }
+    }
+
+    fn automatic_raw_rpc_cache_path(
+        &self,
+        chain_id: u64,
+        block_number: u64,
+        tx_hash: TxHash,
+    ) -> Option<PathBuf> {
+        if self.no_rpc_trace_cache || self.quick {
+            return None;
+        }
+
+        Config::foundry_block_cache_dir(chain_id, block_number).map(|dir| {
+            dir.join("trace-rpc").join(format!(
+                "{}-{}.json",
+                tx_hash,
+                raw_rpc_cache_tracer_key(self.storage_values, self.enable_memory)
+            ))
+        })
+    }
+}
+
+fn raw_rpc_cache_tracer_key(storage_values: bool, enable_memory: bool) -> &'static str {
+    match (storage_values, enable_memory) {
+        (false, false) => "call-struct-v1",
+        (false, true) => "call-struct-memory-v1",
+        (true, false) => "call-struct-prestate-diff-v1",
+        (true, true) => "call-struct-memory-prestate-diff-v1",
+    }
+}
+
+fn is_trace_response_too_big(err: &impl std::fmt::Display) -> bool {
+    let msg = err.to_string();
+    (msg.contains("-32008") && msg.to_ascii_lowercase().contains("too big"))
+        || msg.contains("Exceeded max limit")
+}
+
+fn write_raw_rpc_cache(path: &Path, raw: &RawRpcTraceCache) -> Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).wrap_err_with(|| {
+            format!("failed to create raw RPC cache directory {}", parent.display())
+        })?;
+    }
+    let file = File::create(path)
+        .wrap_err_with(|| format!("failed to write raw RPC cache {}", path.display()))?;
+    serde_json::to_writer_pretty(BufWriter::new(file), raw)
+        .wrap_err_with(|| format!("failed to serialize raw RPC cache {}", path.display()))?;
+    Ok(())
+}
+
+fn read_json_file<T>(path: &Path) -> Result<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let file = File::open(path).wrap_err_with(|| format!("failed to read {}", path.display()))?;
+    let reader = BufReader::new(file);
+    match serde_json::from_reader::<_, JsonFileInput<T>>(reader)
+        .wrap_err_with(|| format!("failed to parse {}", path.display()))?
+    {
+        JsonFileInput::Raw(value) | JsonFileInput::RpcSuccess { result: value } => Ok(value),
+        JsonFileInput::RpcError { error } => {
+            eyre::bail!("{} contains a JSON-RPC error response: {error}", path.display())
+        }
+    }
+}
+
+fn execution_trace(result: &TraceResult) -> Option<&foundry_evm::traces::SparsedTraceArena> {
+    result.traces.as_ref()?.iter().find_map(|(kind, arena)| kind.is_execution().then_some(arena))
+}
+
+async fn fetch_contracts_bytecode<P, N>(
+    provider: &P,
+    result: &TraceResult,
+    block_number: Option<u64>,
+) -> HashMap<Address, Bytes>
+where
+    P: Provider<N>,
+    N: Network,
+{
+    let mut bytecodes = HashMap::default();
+    let block_id = block_number.map(|number| BlockId::Number(BlockNumberOrTag::Number(number)));
+    let Some(traces) = result.traces.as_ref() else {
+        return bytecodes;
+    };
+
+    let mut addresses = Vec::new();
+    for address in traces.iter().flat_map(|(_, arena)| arena.trace_addresses()) {
+        if address.is_zero() || bytecodes.contains_key(&address) {
+            continue;
+        }
+        bytecodes.insert(address, Bytes::new());
+        addresses.push(address);
+    }
+    bytecodes.clear();
+
+    let mut requests = futures::stream::iter(addresses.into_iter().map(|address| {
+        let block_id = block_id;
+        async move {
+            let mut code_req = provider.get_code_at(address);
+            if let Some(block_id) = block_id {
+                code_req = code_req.block_id(block_id);
+            }
+            (address, code_req.await)
+        }
+    }))
+    .buffer_unordered(16);
+
+    while let Some((address, result)) = requests.next().await {
+        match result {
+            Ok(code) if !code.is_empty() => {
+                bytecodes.insert(address, code);
+            }
+            Ok(_) => {}
+            Err(err) => {
+                let _ = sh_warn!("failed to fetch bytecode for {address}: {err}");
+            }
+        }
+    }
+
+    bytecodes
+}
+
+fn gas_used_from_receipt(receipt: &Value) -> Option<u64> {
+    quantity_to_u64(receipt.get("gasUsed")?)
+}
+
+fn block_number_from_tx(tx: &Value) -> Option<u64> {
+    quantity_to_u64(tx.get("blockNumber")?)
+}
+
+fn quantity_to_u64(value: &Value) -> Option<u64> {
+    let raw = value.as_str()?.strip_prefix("0x").unwrap_or(value.as_str()?);
+    u64::from_str_radix(raw, 16).ok()
+}
+
+fn print_profiles(profiles: &RpcTraceProfiles) -> Result<()> {
+    sh_println!("\nGas by function:")?;
+    for function in profiles.functions.iter().take(25) {
+        sh_println!(
+            "{:>12} gas  {:>12} self  {:>8} calls  {}::{}",
+            function.inclusive_gas,
+            function.self_gas,
+            function.call_count,
+            function.contract_name,
+            function.function_name
+        )?;
+    }
+
+    sh_println!("\nGas by opcode:")?;
+    for opcode in profiles.opcodes.iter().take(25) {
+        sh_println!("{:>12} gas  {:>8} hits  {}", opcode.gas_used, opcode.count, opcode.opcode)?;
+    }
+
+    if !profiles.storage_slots.is_empty() {
+        sh_println!("\nMost touched storage slots:")?;
+        for slot in profiles.storage_slots.iter().take(25) {
+            sh_println!(
+                "{:>8} touches  {:>8} reads  {:>8} writes  {:>12} gas  {}:{}",
+                slot.touches,
+                slot.reads,
+                slot.writes,
+                slot.gas_used,
+                slot.storage_address,
+                slot.slot
+            )?;
+        }
+    }
+
+    if !profiles.transient_storage_slots.is_empty() {
+        sh_println!("\nMost touched transient storage slots:")?;
+        for slot in profiles.transient_storage_slots.iter().take(25) {
+            sh_println!(
+                "{:>8} touches  {:>8} reads  {:>8} writes  {:>12} gas  {}:{}",
+                slot.touches,
+                slot.reads,
+                slot.writes,
+                slot.gas_used,
+                slot.storage_address,
+                slot.slot
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn automatic_cache_path_uses_tracer_shape() {
+        let tx_hash: TxHash =
+            "0x296fccbf5246af0dbd964fdaf698d8c16f1841159385116818c345deea92fb76".parse().unwrap();
+
+        let without_storage =
+            run_trace_args(false, false).automatic_raw_rpc_cache_path(4153, 123, tx_hash).unwrap();
+        assert_eq!(
+            without_storage.file_name().unwrap().to_str().unwrap(),
+            "0x296fccbf5246af0dbd964fdaf698d8c16f1841159385116818c345deea92fb76-call-struct-v1.json"
+        );
+
+        let with_storage =
+            run_trace_args(true, false).automatic_raw_rpc_cache_path(4153, 123, tx_hash).unwrap();
+        assert_eq!(
+            with_storage.file_name().unwrap().to_str().unwrap(),
+            "0x296fccbf5246af0dbd964fdaf698d8c16f1841159385116818c345deea92fb76-call-struct-prestate-diff-v1.json"
+        );
+
+        let with_memory = run_trace_args(false, false)
+            .with_memory()
+            .automatic_raw_rpc_cache_path(4153, 123, tx_hash)
+            .unwrap();
+        assert_eq!(
+            with_memory.file_name().unwrap().to_str().unwrap(),
+            "0x296fccbf5246af0dbd964fdaf698d8c16f1841159385116818c345deea92fb76-call-struct-memory-v1.json"
+        );
+    }
+
+    #[test]
+    fn automatic_cache_can_be_disabled() {
+        let tx_hash: TxHash =
+            "0x296fccbf5246af0dbd964fdaf698d8c16f1841159385116818c345deea92fb76".parse().unwrap();
+        assert!(
+            run_trace_args(false, true).automatic_raw_rpc_cache_path(4153, 123, tx_hash).is_none()
+        );
+    }
+
+    #[test]
+    fn quick_mode_skips_automatic_cache_and_optional_metadata() {
+        let args = run_trace_args(false, false).with_quick();
+        let tx_hash: TxHash =
+            "0x296fccbf5246af0dbd964fdaf698d8c16f1841159385116818c345deea92fb76".parse().unwrap();
+
+        assert!(args.automatic_raw_rpc_cache_path(4153, 123, tx_hash).is_none());
+        assert_eq!(
+            args.metadata_fetch_plan(),
+            MetadataFetchPlan { tx: false, receipt: false, block: false, automatic_cache: false }
+        );
+    }
+
+    #[test]
+    fn detects_oversized_trace_errors() {
+        assert!(is_trace_response_too_big(
+            &"server returned an error response: error code -32008: Response is too big, data: \"Exceeded max limit of 167772160\""
+        ));
+        assert!(!is_trace_response_too_big(&"execution reverted"));
+    }
+
+    fn run_trace_args(storage_values: bool, no_rpc_trace_cache: bool) -> RunTraceArgs {
+        RunTraceArgs {
+            tx_hash: None,
+            decode_internal: false,
+            trace_depth: None,
+            trace_printer: false,
+            quick: false,
+            disable_labels: false,
+            label: Vec::new(),
+            with_local_artifacts: false,
+            profile: false,
+            no_storage_profile: false,
+            storage_values,
+            enable_memory: false,
+            raw_rpc_cache: None,
+            call_trace_json: None,
+            struct_trace_json: None,
+            storage_values_json: None,
+            tx_json: None,
+            receipt_json: None,
+            block_json: None,
+            no_rpc_trace_cache,
+            refresh_rpc_trace_cache: false,
+            allow_bytecode_mismatch: false,
+            rpc: RpcOpts::default(),
+        }
+    }
+
+    trait RunTraceArgsTestExt {
+        fn with_memory(self) -> Self;
+        fn with_quick(self) -> Self;
+    }
+
+    impl RunTraceArgsTestExt for RunTraceArgs {
+        fn with_memory(mut self) -> Self {
+            self.enable_memory = true;
+            self
+        }
+
+        fn with_quick(mut self) -> Self {
+            self.quick = true;
+            self
+        }
+    }
+}

--- a/crates/cast/src/cmd/run_trace.rs
+++ b/crates/cast/src/cmd/run_trace.rs
@@ -25,6 +25,7 @@ use foundry_evm::traces::{
         build_rpc_trace_arena, finalize_rpc_trace_arena, graft_local_replay_onto_call_tracer,
     },
 };
+use foundry_evm::{hardforks::FoundryHardfork, revm::primitives::hardfork::SpecId};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -202,6 +203,7 @@ impl RunTraceArgs {
         if let Some(warning) = raw.struct_trace_warning.clone() {
             warnings.push(warning);
         }
+        let refund_quotient = self.rpc_refund_quotient(&provider, &raw).await?;
 
         let (mut result, mut mode_warnings, contracts_bytecode) = if let (
             Some(call_trace),
@@ -217,8 +219,12 @@ impl RunTraceArgs {
             })?;
 
             let receipt_gas = gas_used_from_receipt(&raw.receipt).unwrap_or(default_frame.gas);
-            let mut converted =
-                build_rpc_trace_arena(&call_frame, &default_frame, self.trace_printer);
+            let mut converted = build_rpc_trace_arena(
+                &call_frame,
+                &default_frame,
+                self.trace_printer,
+                refund_quotient,
+            );
             let mut warnings = Vec::new();
             warnings.append(&mut converted.warnings);
             finalize_rpc_trace_arena(&mut converted.arena.arena, receipt_gas, &mut warnings);
@@ -742,6 +748,45 @@ impl RunTraceArgs {
             ))
         })
     }
+
+    async fn rpc_refund_quotient<P, N>(&self, provider: &P, raw: &RawRpcTraceCache) -> Result<u64>
+    where
+        P: Provider<N>,
+        N: Network,
+    {
+        let Some(timestamp) = self.rpc_trace_block_timestamp(provider, raw).await? else {
+            return Ok(5);
+        };
+        let Some(hardfork) = FoundryHardfork::from_chain_and_timestamp(raw.chain_id, timestamp)
+        else {
+            return Ok(5);
+        };
+
+        Ok(if is_post_london_spec(hardfork.into()) { 5 } else { 2 })
+    }
+
+    async fn rpc_trace_block_timestamp<P, N>(
+        &self,
+        provider: &P,
+        raw: &RawRpcTraceCache,
+    ) -> Result<Option<u64>>
+    where
+        P: Provider<N>,
+        N: Network,
+    {
+        if let Some(timestamp) = block_timestamp_from_block(&raw.block) {
+            return Ok(Some(timestamp));
+        }
+
+        let Some(block_number) = block_number_from_tx(&raw.tx) else {
+            return Ok(None);
+        };
+        let block_number_hex = format!("0x{block_number:x}");
+        let block: Option<Value> = provider
+            .raw_request(Cow::Borrowed("eth_getBlockByNumber"), (block_number_hex, false))
+            .await?;
+        Ok(block.as_ref().and_then(block_timestamp_from_block))
+    }
 }
 
 fn raw_rpc_cache_tracer_key(storage_values: bool, enable_memory: bool) -> &'static str {
@@ -852,6 +897,14 @@ fn gas_used_from_receipt(receipt: &Value) -> Option<u64> {
 
 fn block_number_from_tx(tx: &Value) -> Option<u64> {
     quantity_to_u64(tx.get("blockNumber")?)
+}
+
+fn block_timestamp_from_block(block: &Value) -> Option<u64> {
+    quantity_to_u64(block.get("timestamp")?)
+}
+
+fn is_post_london_spec(spec_id: SpecId) -> bool {
+    (spec_id as u8) >= (SpecId::LONDON as u8)
 }
 
 fn quantity_to_u64(value: &Value) -> Option<u64> {

--- a/crates/cast/src/debug.rs
+++ b/crates/cast/src/debug.rs
@@ -1,16 +1,67 @@
 use std::str::FromStr;
 
 use alloy_chains::Chain;
-use alloy_primitives::{Address, Bytes, map::HashMap};
+use alloy_primitives::{Address, B256, Bytes, Selector, keccak256, map::HashMap};
 use foundry_cli::utils::{TraceResult, print_traces};
 use foundry_common::{ContractsByArtifact, compile::ProjectCompiler, shell};
 use foundry_config::Config;
 use foundry_debugger::Debugger;
 use foundry_evm::traces::{
-    CallTraceDecoderBuilder, DebugTraceIdentifier,
+    CallTraceDecoder, CallTraceDecoderBuilder, DebugTraceIdentifier,
     debug::ContractSources,
     identifier::{SignaturesIdentifier, TraceIdentifiers},
 };
+
+pub(crate) struct PreparedTraceDecoder {
+    pub decoder: CallTraceDecoder,
+    pub sources: ContractSources,
+}
+
+fn build_selector_candidates(contracts: &ContractsByArtifact) -> HashMap<Selector, Vec<String>> {
+    let mut selector_candidates = HashMap::default();
+    for (id, contract) in contracts.iter() {
+        for function in contract.abi.functions() {
+            selector_candidates
+                .entry(function.selector())
+                .or_insert_with(Vec::new)
+                .push(id.name.clone());
+        }
+    }
+    for candidates in selector_candidates.values_mut() {
+        candidates.sort();
+        candidates.dedup();
+    }
+    selector_candidates
+}
+
+fn build_exact_runtime_candidates(
+    contracts: &ContractsByArtifact,
+    contracts_bytecode: &HashMap<Address, Bytes>,
+) -> HashMap<Address, Vec<String>> {
+    let mut local_runtime_hashes: HashMap<B256, Vec<String>> = HashMap::default();
+    for (id, contract) in contracts.iter() {
+        let Some(runtime) = contract.deployed_bytecode() else { continue };
+        local_runtime_hashes
+            .entry(keccak256(runtime))
+            .or_insert_with(Vec::new)
+            .push(id.name.clone());
+    }
+    for candidates in local_runtime_hashes.values_mut() {
+        candidates.sort();
+        candidates.dedup();
+    }
+
+    let mut exact_runtime_candidates = HashMap::default();
+    for (address, runtime) in contracts_bytecode {
+        if runtime.is_empty() {
+            continue;
+        }
+        if let Some(candidates) = local_runtime_hashes.get(&keccak256(runtime)) {
+            exact_runtime_candidates.insert(*address, candidates.clone());
+        }
+    }
+    exact_runtime_candidates
+}
 
 /// labels the traces, conditionally prints them or opens the debugger
 #[expect(clippy::too_many_arguments)]
@@ -26,20 +77,71 @@ pub(crate) async fn handle_traces(
     disable_label: bool,
     trace_depth: Option<usize>,
 ) -> eyre::Result<()> {
-    let (known_contracts, mut sources) = if with_local_artifacts {
-        let _ = sh_println!("Compiling project to generate artifacts");
-        let project = config.project()?;
-        let compiler = ProjectCompiler::new();
-        let output = compiler.compile(&project)?;
-        (
-            Some(ContractsByArtifact::new(
+    let PreparedTraceDecoder { decoder, sources } = prepare_trace_decoder(
+        &result,
+        config,
+        chain,
+        contracts_bytecode,
+        labels,
+        with_local_artifacts,
+        debug || decode_internal,
+        disable_label,
+    )
+    .await?;
+
+    if debug {
+        let mut debugger = Debugger::builder()
+            .traces(result.traces.expect("missing traces"))
+            .decoder(&decoder)
+            .sources(sources)
+            .build();
+        debugger.try_run_tui()?;
+        return Ok(());
+    }
+
+    print_traces(
+        &mut result,
+        &decoder,
+        shell::verbosity() > 0,
+        shell::verbosity() > 4,
+        trace_depth,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[expect(clippy::too_many_arguments)]
+pub(crate) async fn prepare_trace_decoder(
+    result: &TraceResult,
+    config: &Config,
+    chain: Chain,
+    contracts_bytecode: &HashMap<Address, Bytes>,
+    labels: Vec<String>,
+    with_local_artifacts: bool,
+    decode_internal: bool,
+    disable_label: bool,
+) -> eyre::Result<PreparedTraceDecoder> {
+    let (known_contracts, selector_candidates, exact_runtime_candidates, mut sources) =
+        if with_local_artifacts {
+            if !shell::is_json() {
+                let _ = sh_println!("Compiling project to generate artifacts");
+            }
+            let project = config.project()?;
+            let compiler = ProjectCompiler::new();
+            let output = compiler.compile(&project)?;
+            let known_contracts = ContractsByArtifact::new(
                 output.artifact_ids().map(|(id, artifact)| (id, artifact.clone().into())),
-            )),
-            ContractSources::from_project_output(&output, project.root(), None)?,
-        )
-    } else {
-        (None, ContractSources::default())
-    };
+            );
+            (
+                Some(known_contracts.clone()),
+                build_selector_candidates(&known_contracts),
+                build_exact_runtime_candidates(&known_contracts, contracts_bytecode),
+                ContractSources::from_project_output(&output, project.root(), None)?,
+            )
+        } else {
+            (None, HashMap::default(), HashMap::default(), ContractSources::default())
+        };
 
     let labels = labels.iter().filter_map(|label_str| {
         let mut iter = label_str.split(':');
@@ -66,36 +168,21 @@ pub(crate) async fn handle_traces(
 
     let mut decoder = builder.build();
 
-    for (_, trace) in result.traces.as_deref_mut().unwrap_or_default() {
+    for (_, trace) in result.traces.as_deref().unwrap_or_default() {
         decoder.identify(trace, &mut identifier);
     }
 
-    if decode_internal || debug {
+    if decode_internal {
         if let Some(ref etherscan_identifier) = identifier.external {
             sources.merge(etherscan_identifier.get_compiled_contracts().await?);
         }
 
-        if debug {
-            let mut debugger = Debugger::builder()
-                .traces(result.traces.expect("missing traces"))
-                .decoder(&decoder)
-                .sources(sources)
-                .build();
-            debugger.try_run_tui()?;
-            return Ok(());
-        }
-
-        decoder.debug_identifier = Some(DebugTraceIdentifier::new(sources));
+        decoder.debug_identifier = Some(
+            DebugTraceIdentifier::new(sources.clone())
+                .with_selector_candidates(selector_candidates)
+                .with_exact_runtime_candidates(exact_runtime_candidates),
+        );
     }
 
-    print_traces(
-        &mut result,
-        &decoder,
-        shell::verbosity() > 0,
-        shell::verbosity() > 4,
-        trace_depth,
-    )
-    .await?;
-
-    Ok(())
+    Ok(PreparedTraceDecoder { decoder, sources })
 }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -18,7 +18,7 @@ use foundry_test_utils::{
     str,
     util::OutputExt,
 };
-use serde_json::json;
+use serde_json::{Value, json};
 use std::{fs, path::Path, str::FromStr};
 
 #[macro_use]
@@ -4745,6 +4745,37 @@ Transaction successfully executed.
 "#]]);
     }
 );
+
+casttest!(
+    #[ignore = "requires RISE_RPC_URL with debug_traceTransaction support"]
+    run_trace_rise_smoke,
+    |_prj, cmd| {
+        let rpc = std::env::var("RISE_RPC_URL").expect("set RISE_RPC_URL");
+        let mut args = vec![
+            "run".to_string(),
+            "0x296fccbf5246af0dbd964fdaf698d8c16f1841159385116818c345deea92fb76".to_string(),
+            "--trace".to_string(),
+            "--rpc-url".to_string(),
+            rpc,
+            "--profile".to_string(),
+            "--json".to_string(),
+        ];
+        if let Ok(cache) = std::env::var("RISE_TRACE_RPC_CACHE") {
+            args.push("--raw-rpc-cache".to_string());
+            args.push(cache);
+        }
+
+        let output = cmd.args(args).assert_success().get_output().stdout_lossy();
+        let value: Value = serde_json::from_str(&output).expect("run --trace emits json");
+
+        assert!(value.get("schemaVersion").is_none());
+        assert!(value.get("chainId").is_none());
+        assert!(value.get("profiles").is_none());
+        assert!(value.get("warnings").is_none());
+        assert_eq!(value["arena"][0]["trace"]["gas_used"], 1_331_363);
+    }
+);
+
 casttest!(keccak_stdin_bytes, |_prj, cmd| {
     cmd.args(["keccak"]).stdin("0x12").assert_success().stdout_eq(str![[r#"
 0x5fa2358263196dbbf23d1ca7a509451f7a2f64c15837bfbb81298b1e3e24e4fa

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -176,7 +176,11 @@ impl RuntimeTransport {
     pub fn reqwest_client(&self) -> Result<reqwest::Client, RuntimeTransportError> {
         let mut client_builder = reqwest::Client::builder()
             .timeout(self.timeout)
-            .danger_accept_invalid_certs(self.accept_invalid_certs);
+            .danger_accept_invalid_certs(self.accept_invalid_certs)
+            .gzip(true)
+            .brotli(true)
+            .zstd(true)
+            .deflate(true);
 
         // Disable automatic proxy detection if requested. This helps in sandboxed environments
         // (e.g., Cursor IDE sandbox, macOS App Sandbox) where system proxy detection via

--- a/crates/evm/core/src/ic.rs
+++ b/crates/evm/core/src/ic.rs
@@ -31,6 +31,11 @@ impl PcIcMap {
     pub fn get(&self, pc: u32) -> Option<u32> {
         self.inner.get(&pc).copied()
     }
+
+    /// Iterate over the PC-IC pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&u32, &u32)> {
+        self.inner.iter()
+    }
 }
 
 /// Map from instruction counter to program counter.

--- a/crates/evm/core/src/ic.rs
+++ b/crates/evm/core/src/ic.rs
@@ -9,12 +9,15 @@ use serde::Serialize;
 #[serde(transparent)]
 pub struct PcIcMap {
     inner: FxHashMap<u32, u32>,
+    #[serde(skip)]
+    sorted_pcs: Vec<u32>,
 }
 
 impl PcIcMap {
     /// Creates a new `PcIcMap` for the given code.
     pub fn new(code: &[u8]) -> Self {
-        Self { inner: make_map::<true>(code) }
+        let sorted_pcs = InstIter::new(code).with_pc().map(|(pc, _)| pc as u32).collect::<Vec<_>>();
+        Self { inner: make_map::<true>(code), sorted_pcs }
     }
 
     /// Returns the length of the map.
@@ -32,9 +35,31 @@ impl PcIcMap {
         self.inner.get(&pc).copied()
     }
 
+    /// Returns the instruction counter for the largest program counter that does not exceed `pc`.
+    pub fn get_nearest(&self, pc: u32) -> Option<u32> {
+        let idx = self.sorted_pcs.partition_point(|mapped_pc| *mapped_pc <= pc);
+        (idx > 0).then(|| self.get(self.sorted_pcs[idx - 1])).flatten()
+    }
+
     /// Iterate over the PC-IC pairs.
     pub fn iter(&self) -> impl Iterator<Item = (&u32, &u32)> {
         self.inner.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PcIcMap;
+
+    #[test]
+    fn nearest_pc_lookup_uses_preceding_instruction() {
+        let map = PcIcMap::new(&[0x60, 0xaa, 0x5b, 0x00]);
+
+        assert_eq!(map.get(0), Some(0));
+        assert_eq!(map.get_nearest(1), Some(0));
+        assert_eq!(map.get_nearest(2), Some(1));
+        assert_eq!(map.get_nearest(3), Some(2));
+        assert_eq!(map.get_nearest(u32::MAX), Some(2));
     }
 }
 

--- a/crates/evm/traces/Cargo.toml
+++ b/crates/evm/traces/Cargo.toml
@@ -29,6 +29,7 @@ alloy-primitives = { workspace = true, features = [
     "arbitrary",
     "rlp",
 ] }
+alloy-rpc-types = { workspace = true, features = ["trace"] }
 alloy-sol-types.workspace = true
 revm-inspectors.workspace = true
 

--- a/crates/evm/traces/src/debug/mod.rs
+++ b/crates/evm/traces/src/debug/mod.rs
@@ -2,9 +2,9 @@ mod sources;
 use crate::CallTraceNode;
 use alloy_dyn_abi::{
     DynSolType, DynSolValue, Specifier,
-    parser::{Parameters, Storage},
+    parser::{ParameterSpecifier, Parameters, Storage},
 };
-use alloy_primitives::U256;
+use alloy_primitives::{Address, Selector, U256, map::HashMap};
 use foundry_common::fmt::format_token;
 use foundry_compilers::artifacts::sourcemap::{Jump, SourceElement};
 use revm::bytecode::opcode::OpCode;
@@ -15,11 +15,49 @@ pub use sources::{ArtifactData, ContractSources, SourceData};
 pub struct DebugTraceIdentifier {
     /// Source map of contract sources
     contracts_sources: ContractSources,
+    /// Selector -> candidate contract names from the local artifacts.
+    selector_candidates: HashMap<Selector, Vec<String>>,
+    /// Exact runtime-bytecode matches for traced addresses.
+    exact_runtime_candidates: HashMap<Address, Vec<String>>,
 }
 
 impl DebugTraceIdentifier {
-    pub const fn new(contracts_sources: ContractSources) -> Self {
-        Self { contracts_sources }
+    pub fn new(contracts_sources: ContractSources) -> Self {
+        Self {
+            contracts_sources,
+            selector_candidates: HashMap::default(),
+            exact_runtime_candidates: HashMap::default(),
+        }
+    }
+
+    pub fn with_selector_candidates(
+        mut self,
+        selector_candidates: HashMap<Selector, Vec<String>>,
+    ) -> Self {
+        self.selector_candidates = selector_candidates;
+        self
+    }
+
+    pub fn with_exact_runtime_candidates(
+        mut self,
+        exact_runtime_candidates: HashMap<Address, Vec<String>>,
+    ) -> Self {
+        self.exact_runtime_candidates = exact_runtime_candidates;
+        self
+    }
+
+    pub fn has_exact_runtime_match(&self, address: Address) -> bool {
+        self.exact_runtime_candidates.contains_key(&address)
+    }
+
+    pub fn preferred_contract_name(
+        &self,
+        node: &CallTraceNode,
+        identified_contract_name: Option<&str>,
+    ) -> Option<String> {
+        self.exact_runtime_contract_name(node, identified_contract_name)
+            .or_else(|| identified_contract_name.map(str::to_string))
+            .or_else(|| self.infer_contract_name(node))
     }
 
     /// Identifies internal function invocations in a given [CallTraceNode].
@@ -27,6 +65,106 @@ impl DebugTraceIdentifier {
     /// Accepts the node itself and identified name of the contract which node corresponds to.
     pub fn identify_node_steps(&self, node: &mut CallTraceNode, contract_name: &str) {
         DebugStepsWalker::new(node, &self.contracts_sources, contract_name).walk();
+    }
+
+    fn exact_runtime_contract_name(
+        &self,
+        node: &CallTraceNode,
+        identified_contract_name: Option<&str>,
+    ) -> Option<String> {
+        let candidates = self.exact_runtime_candidates.get(&node.trace.address)?;
+
+        if let Some(identified_contract_name) = identified_contract_name
+            && candidates.iter().any(|candidate| candidate == identified_contract_name)
+        {
+            return Some(identified_contract_name.to_string());
+        }
+
+        if candidates.len() == 1 {
+            return Some(candidates[0].clone());
+        }
+
+        self.infer_contract_name_from_candidates(node, candidates.iter().map(String::as_str))
+    }
+
+    /// Best-effort inference for frames whose runtime bytecode did not match a local artifact.
+    ///
+    /// This samples program counters from the frame and looks for the contract whose source maps
+    /// cover the most steps, biasing toward contracts that also contain the externally-decoded
+    /// function name. This lets `run --trace` recover inherited/library internals even when the
+    /// deployed bytecode is not an exact local match.
+    pub fn infer_contract_name(&self, node: &CallTraceNode) -> Option<String> {
+        self.infer_contract_name_from_candidates(
+            node,
+            self.contracts_sources.entries().map(|(contract_name, _, _)| contract_name),
+        )
+    }
+
+    fn infer_contract_name_from_candidates<'a>(
+        &self,
+        node: &CallTraceNode,
+        contract_names: impl IntoIterator<Item = &'a str>,
+    ) -> Option<String> {
+        if node.trace.steps.is_empty() {
+            return None;
+        }
+
+        let function_name = external_function_name(node);
+        let selector_candidates =
+            node.selector().and_then(|selector| self.selector_candidates.get(&selector));
+        let sampled_pcs = sample_step_pcs(&node.trace.steps, 16);
+        let init_code = node.trace.kind.is_any_create();
+        let mut best_match: Option<(usize, usize, &str)> = None;
+        let contract_names: Vec<&str> = contract_names.into_iter().collect();
+
+        for (contract_name, _, source) in self.contracts_sources.entries() {
+            if !contract_names.is_empty() && !contract_names.contains(&contract_name) {
+                continue;
+            }
+            if let Some(selector_candidates) = selector_candidates
+                && !selector_candidates.iter().any(|candidate| candidate == contract_name)
+            {
+                continue;
+            }
+            if is_non_runtime_source(&source.path) {
+                continue;
+            }
+
+            let mut mapped_steps = 0usize;
+            let mut function_hits = 0usize;
+
+            for pc in &sampled_pcs {
+                let Some((source_element, mapped_source)) = self
+                    .contracts_sources
+                    .find_source_mapping(contract_name, *pc as u32, init_code)
+                else {
+                    continue;
+                };
+                mapped_steps += 1;
+
+                if let Some(function_name) = function_name
+                    && source_span(
+                        &mapped_source.source,
+                        source_element.offset() as usize,
+                        source_element.length() as usize,
+                    )
+                    .is_some_and(|(source_part, _)| source_part.contains(function_name))
+                {
+                    function_hits += 1;
+                }
+            }
+
+            if mapped_steps == 0 {
+                continue;
+            }
+
+            let current = (function_hits, mapped_steps, contract_name);
+            if best_match.is_none_or(|best| current > best) {
+                best_match = Some(current);
+            }
+        }
+
+        best_match.map(|(_, _, contract_name)| contract_name.to_string())
     }
 }
 
@@ -211,6 +349,45 @@ fn parse_function_from_loc(source: &SourceData, loc: &SourceElement) -> Option<S
     Some(format!("{contract_name}::{function_name}"))
 }
 
+fn external_function_name(node: &CallTraceNode) -> Option<&str> {
+    let signature = node.trace.decoded.as_deref()?.call_data.as_ref()?.signature.as_str();
+    let name = signature.split_once('(').map(|(name, _)| name).unwrap_or(signature);
+    if name.is_empty() || name == "fallback" || name.starts_with("0x") {
+        return None;
+    }
+    Some(name)
+}
+
+fn sample_step_pcs(steps: &[CallTraceStep], max_samples: usize) -> Vec<usize> {
+    if steps.is_empty() {
+        return Vec::new();
+    }
+    if steps.len() <= max_samples {
+        return steps.iter().map(|step| step.pc).collect();
+    }
+
+    let last = steps.len() - 1;
+    let mut pcs = Vec::with_capacity(max_samples);
+    for idx in 0..max_samples {
+        let step_idx = idx * last / (max_samples - 1);
+        let pc = steps[step_idx].pc;
+        if pcs.last().copied() != Some(pc) {
+            pcs.push(pc);
+        }
+    }
+    pcs
+}
+
+fn is_non_runtime_source(path: &std::path::Path) -> bool {
+    path.components().any(|component| {
+        let component = component.as_os_str().to_string_lossy();
+        matches!(
+            component.as_ref(),
+            "test" | "tests" | "script" | "scripts" | "benchmark" | "benchmarks"
+        )
+    })
+}
+
 fn source_span(source: &str, start: usize, len: usize) -> Option<(&str, usize)> {
     let end = start.checked_add(len)?;
 
@@ -240,45 +417,86 @@ fn try_decode_args_from_step(args: &Parameters<'_>, step: &CallTraceStep) -> Opt
         return Some(vec![]);
     }
 
-    let types = params.iter().map(|p| p.resolve().ok().map(|t| (t, p.storage))).collect::<Vec<_>>();
-
     let stack = step.stack.as_ref()?;
 
-    if stack.len() < types.len() {
+    if stack.len() < params.len() {
         return None;
     }
 
-    let inputs = &stack[stack.len() - types.len()..];
+    let inputs = &stack[stack.len() - params.len()..];
 
     let decoded = inputs
         .iter()
-        .zip(types.iter())
-        .map(|(input, type_and_storage)| {
-            type_and_storage
-                .as_ref()
-                .and_then(|(type_, storage)| {
-                    match (type_, storage) {
+        .zip(params.iter())
+        .map(|(input, param)| {
+            if param.storage.is_none() && is_user_defined_type(param.ty.span()) {
+                return format_unresolved_arg(param, input);
+            }
+
+            param
+                .resolve()
+                .ok()
+                .and_then(|type_| {
+                    match (type_, param.storage) {
                         // HACK: alloy parser treats user-defined types as uint8: https://github.com/alloy-rs/core/pull/386
                         //
                         // filter out `uint8` params which are marked as storage or memory as this
                         // is not possible in Solidity and means that type is user-defined
                         (DynSolType::Uint(8), Some(Storage::Memory | Storage::Storage)) => None,
-                        (_, Some(Storage::Memory)) => decode_from_memory(
-                            type_,
+                        (type_, Some(Storage::Memory)) => decode_from_memory(
+                            &type_,
                             step.memory.as_ref()?.as_bytes(),
                             input.try_into().ok()?,
                         ),
                         // Read other types from stack
-                        _ => type_.abi_decode(&input.to_be_bytes::<32>()).ok(),
+                        (type_, _) => type_.abi_decode(&input.to_be_bytes::<32>()).ok(),
                     }
                 })
                 .as_ref()
                 .map(format_token)
-                .unwrap_or_else(|| "<unknown>".to_string())
+                .unwrap_or_else(|| format_unresolved_arg(param, input))
         })
         .collect();
 
     Some(decoded)
+}
+
+fn format_unresolved_arg(param: &ParameterSpecifier<'_>, input: &U256) -> String {
+    let raw = format_stack_word(input);
+    let ty = param.ty.span();
+
+    match param.storage {
+        Some(Storage::Storage) => format!("{ty} storage@{raw}"),
+        Some(Storage::Memory) => format!("{ty} memory@{raw}"),
+        Some(Storage::Calldata) => format!("{ty} calldata@{raw}"),
+        None if is_user_defined_type(ty) || param.resolve().is_err() => format!("{ty}.wrap({raw})"),
+        None => raw,
+    }
+}
+
+fn format_stack_word(input: &U256) -> String {
+    format!("0x{input:064x}")
+}
+
+fn is_user_defined_type(ty: &str) -> bool {
+    let root = ty.split('[').next().unwrap_or(ty);
+    if root.starts_with('(') {
+        return false;
+    }
+
+    if matches!(root, "address" | "bool" | "string" | "bytes" | "function" | "uint" | "int") {
+        return false;
+    }
+
+    if let Some(size) = root.strip_prefix("bytes") {
+        return size.parse::<u16>().is_err();
+    }
+    let numeric_size = root.strip_prefix("uint").or_else(|| root.strip_prefix("int"));
+    if let Some(size) = numeric_size {
+        return size.parse::<u16>().is_err();
+    }
+
+    true
 }
 
 /// Decodes given [DynSolType] from memory.
@@ -332,12 +550,67 @@ fn decode_from_memory(ty: &DynSolType, memory: &[u8], location: usize) -> Option
 
 #[cfg(test)]
 mod tests {
-    use super::source_span;
+    use super::{source_span, try_decode_args_from_step};
+    use alloy_dyn_abi::parser::Parameters;
+    use alloy_primitives::U256;
+    use revm::bytecode::opcode::OpCode;
+    use revm_inspectors::tracing::types::CallTraceStep;
 
     #[test]
     fn source_span_returns_none_for_invalid_ranges() {
         assert_eq!(source_span("abcdef", 2, 3), Some(("cde", 5)));
         assert_eq!(source_span("abcdef", 7, 1), None);
         assert_eq!(source_span("abcdef", usize::MAX, 1), None);
+    }
+
+    #[test]
+    fn unresolved_udvt_args_fall_back_to_wrapped_stack_word() {
+        let slot = U256::from_be_slice(&[0x11; 32]);
+        let args = Parameters::parse("(TransientSlot.BooleanSlot slot, bool value)").unwrap();
+        let step = CallTraceStep {
+            stack: Some(vec![slot, U256::from(1)].into_boxed_slice()),
+            ..empty_step()
+        };
+
+        let decoded = try_decode_args_from_step(&args, &step).unwrap();
+        assert_eq!(
+            decoded,
+            vec![format!("TransientSlot.BooleanSlot.wrap(0x{:064x})", slot), "true".to_string(),]
+        );
+    }
+
+    #[test]
+    fn unresolved_storage_args_fall_back_to_typed_slot_pointer() {
+        let slot = U256::from(0x1234);
+        let args = Parameters::parse("(PerpsMarketStorage storage self, uint16 marketId)").unwrap();
+        let step = CallTraceStep {
+            stack: Some(vec![slot, U256::from(4)].into_boxed_slice()),
+            ..empty_step()
+        };
+
+        let decoded = try_decode_args_from_step(&args, &step).unwrap();
+        assert_eq!(
+            decoded,
+            vec![format!("PerpsMarketStorage storage@0x{:064x}", slot), "4".to_string()]
+        );
+    }
+
+    fn empty_step() -> CallTraceStep {
+        CallTraceStep {
+            pc: 0,
+            op: OpCode::STOP,
+            stack: None,
+            push_stack: None,
+            memory: None,
+            returndata: Default::default(),
+            gas_remaining: 0,
+            gas_refund_counter: 0,
+            gas_used: 0,
+            gas_cost: 0,
+            storage_change: None,
+            status: None,
+            immediate_bytes: None,
+            decoded: None,
+        }
     }
 }

--- a/crates/evm/traces/src/debug/sources.rs
+++ b/crates/evm/traces/src/debug/sources.rs
@@ -310,9 +310,5 @@ impl ContractSources {
 }
 
 fn nearest_instruction_counter(pc_ic_map: &PcIcMap, pc: u32) -> Option<u32> {
-    pc_ic_map
-        .iter()
-        .filter_map(|(mapped_pc, ic)| (*mapped_pc <= pc).then_some((*mapped_pc, *ic)))
-        .max_by_key(|(mapped_pc, _)| *mapped_pc)
-        .map(|(_, ic)| ic)
+    pc_ic_map.get_nearest(pc)
 }

--- a/crates/evm/traces/src/debug/sources.rs
+++ b/crates/evm/traces/src/debug/sources.rs
@@ -284,7 +284,8 @@ impl ContractSources {
                 } else {
                     artifact.pc_ic_map_runtime.as_ref()
                 }?;
-                let ic = pc_ic_map.get(pc)?;
+                let ic =
+                    pc_ic_map.get(pc).or_else(|| nearest_instruction_counter(pc_ic_map, pc))?;
 
                 source_map.get(ic as usize)
             } else {
@@ -306,4 +307,12 @@ impl ContractSources {
                 })
         })
     }
+}
+
+fn nearest_instruction_counter(pc_ic_map: &PcIcMap, pc: u32) -> Option<u32> {
+    pc_ic_map
+        .iter()
+        .filter_map(|(mapped_pc, ic)| (*mapped_pc <= pc).then_some((*mapped_pc, *ic)))
+        .max_by_key(|(mapped_pc, _)| *mapped_pc)
+        .map(|(_, ic)| ic)
 }

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -427,10 +427,25 @@ impl CallTraceDecoder {
                 log.decoded = Some(Box::new(self.decode_event(&log.raw_log).await));
             }
 
-            if let Some(debug) = self.debug_identifier.as_ref()
-                && let Some(identified) = self.contracts.get(&node.trace.address)
-            {
-                debug.identify_node_steps(node, get_contract_name(identified))
+            if let Some(debug) = self.debug_identifier.as_ref() {
+                let identified_contract_name = self
+                    .contracts
+                    .get(&node.trace.address)
+                    .map(|identified| get_contract_name(identified.as_str()));
+                let contract_name = debug.preferred_contract_name(node, identified_contract_name);
+
+                if let Some(contract_name) = contract_name {
+                    if let Some(decoded) = node.trace.decoded.as_mut()
+                        && (decoded.label.is_none()
+                            || (debug.has_exact_runtime_match(node.trace.address)
+                                && identified_contract_name.is_some_and(|identified| {
+                                    decoded.label.as_deref() == Some(identified)
+                                })))
+                    {
+                        decoded.label = Some(contract_name.clone());
+                    }
+                    debug.identify_node_steps(node, &contract_name);
+                }
             }
         }
     }

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -54,6 +54,9 @@ pub mod folded_stack_trace;
 
 pub mod backtrace;
 
+pub mod rpc_profile;
+pub mod rpc_trace;
+
 pub type Traces = Vec<(TraceKind, SparsedTraceArena)>;
 
 /// Trace arena keeping track of ignored trace items.

--- a/crates/evm/traces/src/rpc_profile.rs
+++ b/crates/evm/traces/src/rpc_profile.rs
@@ -1,0 +1,459 @@
+//! Profilers for RPC-backed traces.
+
+use crate::{CallKind, CallTraceArena, CallTraceNode, DecodedTraceStep};
+use alloy_primitives::{Address, B256, U256, map::HashMap};
+use revm::bytecode::opcode::OpCode;
+use revm_inspectors::tracing::types::CallTraceStep;
+use serde::{Deserialize, Serialize};
+
+/// Profile sections emitted by `cast run --trace`.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcTraceProfiles {
+    pub functions: Vec<FunctionProfile>,
+    pub source_ranges: Vec<SourceRangeProfile>,
+    pub opcodes: Vec<OpcodeProfile>,
+    pub storage_slots: Vec<StorageSlotProfile>,
+    pub transient_storage_slots: Vec<StorageSlotProfile>,
+}
+
+/// Gas attributed to an external or decoded internal function.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FunctionProfile {
+    pub contract_name: String,
+    pub function_name: String,
+    pub source_path: Option<String>,
+    pub start_line: Option<u64>,
+    pub end_line: Option<u64>,
+    pub inclusive_gas: u64,
+    pub self_gas: u64,
+    pub op_count: u64,
+    pub call_count: u64,
+}
+
+/// Placeholder for future source-range attribution.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceRangeProfile {
+    pub source_path: Option<String>,
+    pub start_line: Option<u64>,
+    pub end_line: Option<u64>,
+    pub gas_used: u64,
+    pub op_count: u64,
+}
+
+/// Gas/count by opcode.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpcodeProfile {
+    pub opcode: String,
+    pub count: u64,
+    pub gas_used: u64,
+}
+
+/// Access counts and gas for a storage slot.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageSlotProfile {
+    pub storage_address: Address,
+    pub code_address: Address,
+    pub slot: B256,
+    pub reads: u64,
+    pub writes: u64,
+    pub touches: u64,
+    pub gas_used: u64,
+    pub first_touch: Option<StorageTouch>,
+    pub last_touch: Option<StorageTouch>,
+    pub functions: Vec<String>,
+}
+
+/// Location of a storage touch.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageTouch {
+    pub call_id: usize,
+    pub contract_name: String,
+    pub function_name: String,
+    pub pc: usize,
+    pub op: String,
+}
+
+/// Builds all `cast run --trace` profiles from a decoded arena.
+pub fn profile_arena(arena: &CallTraceArena, include_storage: bool) -> RpcTraceProfiles {
+    let mut profiles = RpcTraceProfiles::default();
+    profiles.functions = profile_functions(arena);
+    profiles.opcodes = profile_opcodes(arena);
+
+    if include_storage {
+        let (storage, transient) = profile_storage(arena);
+        profiles.storage_slots = storage;
+        profiles.transient_storage_slots = transient;
+    }
+
+    profiles
+}
+
+fn profile_functions(arena: &CallTraceArena) -> Vec<FunctionProfile> {
+    let mut map: HashMap<(String, String), FunctionProfile> = HashMap::default();
+
+    for node in arena.nodes() {
+        let contract = contract_name(node);
+        let function = function_name(node);
+        let child_gas = node
+            .children
+            .iter()
+            .filter_map(|idx| arena.nodes().get(*idx))
+            .map(|child| child.trace.gas_used)
+            .sum::<u64>();
+        upsert_function(
+            &mut map,
+            contract,
+            function,
+            node.trace.gas_used,
+            node.trace.gas_used.saturating_sub(child_gas),
+            node.trace.steps.len() as u64,
+        );
+
+        for (step_idx, step) in node.trace.steps.iter().enumerate() {
+            let Some(decoded) = &step.decoded else { continue };
+            let DecodedTraceStep::InternalCall(call, end_idx) = &**decoded else { continue };
+            let gas = node
+                .trace
+                .steps
+                .get(*end_idx)
+                .map(|end| gas_between_steps(step, end))
+                .unwrap_or_default();
+            let (contract, function) = call
+                .func_name
+                .split_once("::")
+                .map(|(contract, function)| (contract.to_string(), function.to_string()))
+                .unwrap_or_else(|| (contract_name(node), call.func_name.clone()));
+            let op_count = end_idx.saturating_sub(step_idx) as u64;
+            upsert_function(&mut map, contract, function, gas, gas, op_count);
+        }
+    }
+
+    let mut functions = map.into_values().collect::<Vec<_>>();
+    functions.sort_by(|a, b| {
+        b.inclusive_gas
+            .cmp(&a.inclusive_gas)
+            .then_with(|| a.contract_name.cmp(&b.contract_name))
+            .then_with(|| a.function_name.cmp(&b.function_name))
+    });
+    functions
+}
+
+fn gas_between_steps(start: &CallTraceStep, end: &CallTraceStep) -> u64 {
+    let remaining_delta = start.gas_remaining.saturating_sub(end.gas_remaining);
+    if remaining_delta == 0 { end.gas_used.saturating_sub(start.gas_used) } else { remaining_delta }
+}
+
+fn upsert_function(
+    map: &mut HashMap<(String, String), FunctionProfile>,
+    contract_name: String,
+    function_name: String,
+    inclusive_gas: u64,
+    self_gas: u64,
+    op_count: u64,
+) {
+    let entry = map
+        .entry((contract_name.clone(), function_name.clone()))
+        .or_insert_with(|| FunctionProfile { contract_name, function_name, ..Default::default() });
+    entry.inclusive_gas = entry.inclusive_gas.saturating_add(inclusive_gas);
+    entry.self_gas = entry.self_gas.saturating_add(self_gas);
+    entry.op_count = entry.op_count.saturating_add(op_count);
+    entry.call_count = entry.call_count.saturating_add(1);
+}
+
+fn profile_opcodes(arena: &CallTraceArena) -> Vec<OpcodeProfile> {
+    let mut map: HashMap<String, OpcodeProfile> = HashMap::default();
+    for step in arena.nodes().iter().flat_map(|node| &node.trace.steps) {
+        let opcode = step.op.as_str().to_string();
+        let entry = map
+            .entry(opcode.clone())
+            .or_insert_with(|| OpcodeProfile { opcode, ..Default::default() });
+        entry.count += 1;
+        entry.gas_used = entry.gas_used.saturating_add(step.gas_cost);
+    }
+    let mut opcodes = map.into_values().collect::<Vec<_>>();
+    opcodes.sort_by(|a, b| b.gas_used.cmp(&a.gas_used).then_with(|| a.opcode.cmp(&b.opcode)));
+    opcodes
+}
+
+fn profile_storage(arena: &CallTraceArena) -> (Vec<StorageSlotProfile>, Vec<StorageSlotProfile>) {
+    let mut storage: HashMap<(Address, B256), StorageSlotProfile> = HashMap::default();
+    let mut transient: HashMap<(Address, B256), StorageSlotProfile> = HashMap::default();
+
+    for node in arena.nodes() {
+        let storage_address = storage_address(node);
+        let code_address = node.trace.address;
+        for step in &node.trace.steps {
+            let Some(slot) = storage_slot(step.op, step.stack.as_deref()) else {
+                continue;
+            };
+            let is_transient = matches!(step.op, OpCode::TLOAD | OpCode::TSTORE);
+            let target = if is_transient { &mut transient } else { &mut storage };
+            let entry = target.entry((storage_address, slot)).or_insert_with(|| {
+                StorageSlotProfile { storage_address, code_address, slot, ..Default::default() }
+            });
+
+            let touch = StorageTouch {
+                call_id: node.idx,
+                contract_name: contract_name(node),
+                function_name: function_name(node),
+                pc: step.pc,
+                op: step.op.as_str().to_string(),
+            };
+
+            match step.op {
+                OpCode::SLOAD | OpCode::TLOAD => entry.reads += 1,
+                OpCode::SSTORE | OpCode::TSTORE => entry.writes += 1,
+                _ => {}
+            }
+            entry.touches += 1;
+            entry.gas_used = entry.gas_used.saturating_add(step.gas_cost);
+            if entry.first_touch.is_none() {
+                entry.first_touch = Some(touch.clone());
+            }
+            entry.last_touch = Some(touch.clone());
+            entry.functions.push(format!("{}::{}", touch.contract_name, touch.function_name));
+        }
+    }
+
+    (finalize_storage(storage), finalize_storage(transient))
+}
+
+fn finalize_storage(map: HashMap<(Address, B256), StorageSlotProfile>) -> Vec<StorageSlotProfile> {
+    let mut slots = map
+        .into_values()
+        .map(|mut slot| {
+            slot.functions.sort();
+            slot.functions.dedup();
+            slot
+        })
+        .collect::<Vec<_>>();
+    slots.sort_by(|a, b| {
+        b.touches
+            .cmp(&a.touches)
+            .then_with(|| b.gas_used.cmp(&a.gas_used))
+            .then_with(|| a.storage_address.cmp(&b.storage_address))
+            .then_with(|| a.slot.cmp(&b.slot))
+    });
+    slots
+}
+
+fn storage_slot(op: OpCode, stack: Option<&[U256]>) -> Option<B256> {
+    if !matches!(op, OpCode::SLOAD | OpCode::SSTORE | OpCode::TLOAD | OpCode::TSTORE) {
+        return None;
+    }
+    let slot = *stack?.last()?;
+    Some(B256::from(slot.to_be_bytes::<32>()))
+}
+
+fn storage_address(node: &CallTraceNode) -> Address {
+    if matches!(node.trace.kind, CallKind::DelegateCall | CallKind::CallCode) {
+        node.trace.caller
+    } else {
+        node.trace.address
+    }
+}
+
+fn contract_name(node: &CallTraceNode) -> String {
+    node.trace
+        .decoded
+        .as_deref()
+        .and_then(|decoded| decoded.label.clone())
+        .unwrap_or_else(|| node.trace.address.to_string())
+}
+
+fn function_name(node: &CallTraceNode) -> String {
+    node.trace
+        .decoded
+        .as_deref()
+        .and_then(|decoded| decoded.call_data.as_ref())
+        .map(|call_data| {
+            call_data
+                .signature
+                .split_once('(')
+                .map(|(name, _)| name)
+                .unwrap_or(&call_data.signature)
+                .to_string()
+        })
+        .unwrap_or_else(|| {
+            node.selector()
+                .map(|selector| format!("{selector:?}"))
+                .unwrap_or_else(|| "<fallback>".to_string())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CallTrace;
+    use alloy_primitives::{address, bytes};
+
+    #[test]
+    fn extracts_sload_and_sstore_slots() {
+        let slot = U256::from(0x1234);
+        assert_eq!(
+            storage_slot(OpCode::SLOAD, Some(&[slot])),
+            Some(B256::from(slot.to_be_bytes::<32>()))
+        );
+        assert_eq!(
+            storage_slot(OpCode::SSTORE, Some(&[U256::from(1), slot])),
+            Some(B256::from(slot.to_be_bytes::<32>()))
+        );
+        assert_eq!(
+            storage_slot(OpCode::TLOAD, Some(&[slot])),
+            Some(B256::from(slot.to_be_bytes::<32>()))
+        );
+        assert_eq!(
+            storage_slot(OpCode::TSTORE, Some(&[U256::from(1), slot])),
+            Some(B256::from(slot.to_be_bytes::<32>()))
+        );
+    }
+
+    #[test]
+    fn ranks_hot_storage_slots() {
+        let addr = address!("0000000000000000000000000000000000000001");
+        let mut arena = CallTraceArena::default();
+        arena.nodes_mut()[0].trace = CallTrace {
+            address: addr,
+            success: true,
+            steps: vec![
+                CallTraceStep {
+                    op: OpCode::SLOAD,
+                    stack: Some(vec![U256::from(1)].into_boxed_slice()),
+                    gas_cost: 2100,
+                    ..empty_step()
+                },
+                CallTraceStep {
+                    op: OpCode::SSTORE,
+                    stack: Some(vec![U256::from(2), U256::from(1)].into_boxed_slice()),
+                    gas_cost: 5000,
+                    ..empty_step()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let profiles = profile_arena(&arena, true);
+        assert_eq!(profiles.storage_slots.len(), 1);
+        assert_eq!(profiles.storage_slots[0].reads, 1);
+        assert_eq!(profiles.storage_slots[0].writes, 1);
+        assert_eq!(profiles.storage_slots[0].gas_used, 7100);
+    }
+
+    #[test]
+    fn separates_delegatecall_code_and_storage_addresses() {
+        let proxy = address!("0000000000000000000000000000000000000001");
+        let implementation = address!("0000000000000000000000000000000000000002");
+        let mut arena = CallTraceArena::default();
+        arena.nodes_mut()[0].trace = CallTrace {
+            caller: proxy,
+            address: implementation,
+            kind: CallKind::DelegateCall,
+            success: true,
+            steps: vec![CallTraceStep {
+                op: OpCode::SLOAD,
+                stack: Some(vec![U256::from(1)].into_boxed_slice()),
+                gas_cost: 2100,
+                ..empty_step()
+            }],
+            ..Default::default()
+        };
+
+        let profiles = profile_arena(&arena, true);
+        assert_eq!(profiles.storage_slots.len(), 1);
+        assert_eq!(profiles.storage_slots[0].storage_address, proxy);
+        assert_eq!(profiles.storage_slots[0].code_address, implementation);
+    }
+
+    #[test]
+    fn reports_transient_storage_separately() {
+        let addr = address!("0000000000000000000000000000000000000001");
+        let mut arena = CallTraceArena::default();
+        arena.nodes_mut()[0].trace = CallTrace {
+            address: addr,
+            success: true,
+            steps: vec![
+                CallTraceStep {
+                    op: OpCode::TLOAD,
+                    stack: Some(vec![U256::from(1)].into_boxed_slice()),
+                    gas_cost: 100,
+                    ..empty_step()
+                },
+                CallTraceStep {
+                    op: OpCode::TSTORE,
+                    stack: Some(vec![U256::from(2), U256::from(1)].into_boxed_slice()),
+                    gas_cost: 100,
+                    ..empty_step()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let profiles = profile_arena(&arena, true);
+        assert!(profiles.storage_slots.is_empty());
+        assert_eq!(profiles.transient_storage_slots.len(), 1);
+        assert_eq!(profiles.transient_storage_slots[0].reads, 1);
+        assert_eq!(profiles.transient_storage_slots[0].writes, 1);
+    }
+
+    #[test]
+    fn aggregates_external_function_gas() {
+        let root_addr = address!("0000000000000000000000000000000000000001");
+        let child_addr = address!("0000000000000000000000000000000000000002");
+        let mut arena = CallTraceArena::default();
+        arena.nodes_mut()[0].children = vec![1];
+        arena.nodes_mut()[0].trace = CallTrace {
+            address: root_addr,
+            data: bytes!("aaaaaaaa"),
+            gas_used: 100,
+            steps: vec![empty_step(), empty_step()],
+            ..Default::default()
+        };
+        arena.nodes_mut().push(CallTraceNode {
+            parent: Some(0),
+            idx: 1,
+            trace: CallTrace {
+                address: child_addr,
+                data: bytes!("bbbbbbbb"),
+                gas_used: 30,
+                steps: vec![empty_step()],
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let profiles = profile_arena(&arena, false);
+        let root = profiles
+            .functions
+            .iter()
+            .find(|function| function.contract_name == root_addr.to_string())
+            .expect("root profile exists");
+        assert_eq!(root.inclusive_gas, 100);
+        assert_eq!(root.self_gas, 70);
+        assert_eq!(root.op_count, 2);
+    }
+
+    fn empty_step() -> CallTraceStep {
+        CallTraceStep {
+            pc: 0,
+            op: OpCode::STOP,
+            stack: None,
+            push_stack: None,
+            memory: None,
+            returndata: Default::default(),
+            gas_remaining: 0,
+            gas_refund_counter: 0,
+            gas_used: 0,
+            gas_cost: 0,
+            storage_change: None,
+            status: None,
+            immediate_bytes: None,
+            decoded: None,
+        }
+    }
+}

--- a/crates/evm/traces/src/rpc_trace.rs
+++ b/crates/evm/traces/src/rpc_trace.rs
@@ -1,0 +1,1006 @@
+//! Helpers for reconstructing Foundry trace data from `debug_traceTransaction` RPC responses.
+
+use crate::{
+    CallKind, CallLog, CallTrace, CallTraceArena, CallTraceNode, DecodedTraceStep,
+    SparsedTraceArena, TraceMemberOrder,
+};
+use alloy_primitives::{Address, Bytes, LogData, U256};
+use alloy_rpc_types::trace::geth::{CallFrame, DefaultFrame, StructLog};
+use revm::{
+    bytecode::opcode::{self, OpCode},
+    interpreter::InstructionResult,
+};
+use revm_inspectors::tracing::types::CallTraceStep;
+use serde::{Deserialize, Serialize};
+
+/// Result of converting RPC traces into Foundry's trace arena.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcTraceArena {
+    pub arena: SparsedTraceArena,
+    pub warnings: Vec<String>,
+}
+
+/// JSON-friendly representation of a decoded trace.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcJsonTrace {
+    pub root_call_id: usize,
+    pub calls: Vec<RpcJsonCall>,
+}
+
+/// JSON-friendly call frame derived from a decoded Foundry trace node.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcJsonCall {
+    pub id: usize,
+    pub parent_id: Option<usize>,
+    pub depth: usize,
+    #[serde(rename = "type")]
+    pub call_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contract_name: Option<String>,
+    pub from: Address,
+    pub to: Address,
+    pub code_address: Address,
+    pub storage_address: Address,
+    pub value: U256,
+    pub input: Bytes,
+    pub output: Bytes,
+    pub selector: Option<String>,
+    pub signature: Option<String>,
+    pub gas: u64,
+    pub gas_used: u64,
+    pub success: bool,
+    pub children: Vec<usize>,
+    pub internal_frames: Vec<RpcJsonInternalFrame>,
+}
+
+/// JSON-friendly internal function frame.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcJsonInternalFrame {
+    pub function_name: String,
+    pub start_step: usize,
+    pub end_step: usize,
+    pub gas_used: u64,
+}
+
+/// Converts geth's call tracer and struct logger outputs into a Foundry trace arena.
+pub fn build_rpc_trace_arena(
+    call_frame: &CallFrame,
+    default_frame: &DefaultFrame,
+    trace_printer: bool,
+) -> RpcTraceArena {
+    let mut arena = CallTraceArena::default();
+    let mut warnings = Vec::new();
+    let root_idx = push_call_frame(&mut arena, None, call_frame, 0);
+    debug_assert_eq!(root_idx, 0);
+
+    assign_struct_logs(&mut arena, &default_frame.struct_logs, trace_printer, &mut warnings);
+    append_unvisited_children(&mut arena);
+    append_call_logs(&mut arena, call_frame);
+
+    RpcTraceArena { arena: SparsedTraceArena { arena, ignored: Default::default() }, warnings }
+}
+
+/// Builds a hybrid arena using the remote call tracer for the call tree and a local replay for
+/// opcode steps and ordering.
+pub fn graft_local_replay_onto_call_tracer(
+    call_frame: &CallFrame,
+    local: &CallTraceArena,
+) -> Option<RpcTraceArena> {
+    if local.nodes().is_empty() {
+        return None;
+    }
+
+    let mut merged = build_rpc_trace_arena(call_frame, &DefaultFrame::default(), false);
+    if !nodes_match_relaxed(&merged.arena.arena.nodes()[0], &local.nodes()[0]) {
+        push_unique_warning(
+            &mut merged.warnings,
+            "callTracer root diverged from local replay; falling back to pure local replay"
+                .to_string(),
+        );
+        return None;
+    }
+    if !nodes_match_exact(&merged.arena.arena.nodes()[0], &local.nodes()[0]) {
+        push_unique_warning(
+            &mut merged.warnings,
+            "callTracer root differed slightly from local replay; preserving remote call metadata while grafting local opcode steps".to_string(),
+        );
+    }
+
+    graft_local_node(0, 0, &mut merged.arena.arena, local, &mut merged.warnings);
+    Some(merged)
+}
+
+/// Normalizes and validates an RPC-derived trace arena against the transaction receipt.
+pub fn finalize_rpc_trace_arena(
+    arena: &mut CallTraceArena,
+    receipt_gas_used: u64,
+    warnings: &mut Vec<String>,
+) {
+    if let Some(root) = arena.nodes_mut().first_mut()
+        && root.trace.gas_used != receipt_gas_used
+    {
+        push_unique_warning(
+            warnings,
+            format!(
+                "root callTracer gasUsed ({}) differs from receipt gasUsed ({receipt_gas_used}); using receipt gas for root trace",
+                root.trace.gas_used
+            ),
+        );
+        root.trace.gas_used = receipt_gas_used;
+    }
+
+    validate_trace_arena(arena, warnings);
+}
+
+/// Converts a decoded Foundry arena into the stable JSON trace shape used by `cast run --trace`.
+pub fn json_trace_from_arena(arena: &CallTraceArena) -> RpcJsonTrace {
+    let calls = arena.nodes().iter().map(json_call_from_node).collect();
+    RpcJsonTrace { root_call_id: 0, calls }
+}
+
+fn json_call_from_node(node: &CallTraceNode) -> RpcJsonCall {
+    let signature = node
+        .trace
+        .decoded
+        .as_deref()
+        .and_then(|decoded| decoded.call_data.as_ref())
+        .map(|call_data| call_data.signature.clone());
+    let selector = node.selector().map(|selector| format!("{selector:?}"));
+    let internal_frames = node
+        .trace
+        .steps
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, step)| {
+            let DecodedTraceStep::InternalCall(call, end_step) = &**step.decoded.as_ref()? else {
+                return None;
+            };
+            Some(RpcJsonInternalFrame {
+                function_name: call.func_name.clone(),
+                start_step: idx,
+                end_step: *end_step,
+                gas_used: node
+                    .trace
+                    .steps
+                    .get(*end_step)
+                    .map(|end| gas_between_steps(step, end))
+                    .unwrap_or_default(),
+            })
+        })
+        .collect();
+
+    RpcJsonCall {
+        id: node.idx,
+        parent_id: node.parent,
+        depth: node.trace.depth,
+        call_type: node.trace.kind.to_string(),
+        contract_name: node.trace.decoded.as_deref().and_then(|decoded| decoded.label.clone()),
+        from: node.trace.caller,
+        to: node.trace.address,
+        code_address: node.trace.address,
+        storage_address: storage_address(node),
+        value: node.trace.value,
+        input: node.trace.data.clone(),
+        output: node.trace.output.clone(),
+        selector,
+        signature,
+        gas: node.trace.gas_limit,
+        gas_used: node.trace.gas_used,
+        success: node.trace.success,
+        children: node.children.clone(),
+        internal_frames,
+    }
+}
+
+fn gas_between_steps(start: &CallTraceStep, end: &CallTraceStep) -> u64 {
+    end.gas_used.saturating_sub(start.gas_used)
+}
+
+fn graft_local_node(
+    remote_idx: usize,
+    local_idx: usize,
+    remote: &mut CallTraceArena,
+    local: &CallTraceArena,
+    warnings: &mut Vec<String>,
+) {
+    let remote_children = remote.nodes()[remote_idx].children.clone();
+    let remote_logs = remote.nodes()[remote_idx].logs.clone();
+    let local_node = local.nodes()[local_idx].clone();
+
+    let child_matches = match_child_nodes(
+        remote_idx,
+        &remote_children,
+        local,
+        &local_node.children,
+        remote,
+        warnings,
+    );
+    let mut ordered_remote_children = Vec::with_capacity(remote_children.len());
+    let mut matched_remote_children = Vec::with_capacity(child_matches.len());
+    let mut local_pos_to_remote_pos = vec![None; local_node.children.len()];
+    let mut matched_remote_mask = vec![false; remote_children.len()];
+
+    for (local_pos, remote_pos, local_child_idx) in &child_matches {
+        local_pos_to_remote_pos[*local_pos] = Some(ordered_remote_children.len());
+        ordered_remote_children.push(remote_children[*remote_pos]);
+        matched_remote_children.push((remote_children[*remote_pos], *local_child_idx));
+        matched_remote_mask[*remote_pos] = true;
+    }
+    for (remote_pos, remote_child_idx) in remote_children.iter().copied().enumerate() {
+        if !matched_remote_mask[remote_pos] {
+            ordered_remote_children.push(remote_child_idx);
+        }
+    }
+
+    let remote_node = &mut remote.nodes_mut()[remote_idx];
+    remote_node.children = ordered_remote_children;
+    remote_node.trace.steps = local_node.trace.steps.clone();
+    remote_node.logs = local_node.logs.clone();
+    if remote_logs.len() > remote_node.logs.len() {
+        remote_node.logs.extend(remote_logs[remote_node.logs.len()..].iter().cloned());
+        push_unique_warning(
+            warnings,
+            format!(
+                "node {remote_idx} had {} extra callTracer logs not seen in local replay; appended them after local ordering",
+                remote_logs.len() - local_node.logs.len()
+            ),
+        );
+    }
+
+    let mut ordering = Vec::with_capacity(
+        local_node.ordering.len()
+            + remote_node.children.len().saturating_sub(child_matches.len())
+            + remote_node.logs.len().saturating_sub(local_node.logs.len()),
+    );
+    for item in &local_node.ordering {
+        match item {
+            TraceMemberOrder::Step(step_idx) => ordering.push(TraceMemberOrder::Step(*step_idx)),
+            TraceMemberOrder::Log(log_idx) => {
+                if *log_idx < remote_node.logs.len() {
+                    ordering.push(TraceMemberOrder::Log(*log_idx));
+                } else {
+                    push_unique_warning(
+                        warnings,
+                        format!("node {remote_idx} local replay referenced missing log {log_idx}"),
+                    );
+                }
+            }
+            TraceMemberOrder::Call(local_child_pos) => {
+                if let Some(remote_child_pos) =
+                    local_pos_to_remote_pos.get(*local_child_pos).and_then(|pos| *pos)
+                {
+                    ordering.push(TraceMemberOrder::Call(remote_child_pos));
+                } else {
+                    push_unique_warning(
+                        warnings,
+                        format!(
+                            "node {remote_idx} had a local child at position {local_child_pos} that was not present in callTracer"
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    for remote_child_pos in child_matches.len()..remote_node.children.len() {
+        ordering.push(TraceMemberOrder::Call(remote_child_pos));
+    }
+    for remote_log_pos in local_node.logs.len()..remote_node.logs.len() {
+        ordering.push(TraceMemberOrder::Log(remote_log_pos));
+    }
+    remote_node.ordering = ordering;
+
+    for (remote_child_idx, local_child_idx) in matched_remote_children {
+        graft_local_node(remote_child_idx, local_child_idx, remote, local, warnings);
+    }
+}
+
+fn match_child_nodes(
+    remote_parent_idx: usize,
+    remote_children: &[usize],
+    local: &CallTraceArena,
+    local_children: &[usize],
+    remote: &CallTraceArena,
+    warnings: &mut Vec<String>,
+) -> Vec<(usize, usize, usize)> {
+    let mut matches = Vec::new();
+    let mut claimed_remote = vec![false; remote_children.len()];
+
+    for (local_pos, local_child_idx) in local_children.iter().copied().enumerate() {
+        let local_child = &local.nodes()[local_child_idx];
+        let mut match_pos = find_matching_child(
+            remote_children,
+            &claimed_remote,
+            remote,
+            local_child,
+            nodes_match_exact,
+        );
+        if match_pos.is_none() {
+            match_pos = find_matching_child(
+                remote_children,
+                &claimed_remote,
+                remote,
+                local_child,
+                nodes_match_relaxed,
+            );
+        }
+        if match_pos.is_none()
+            && local_pos < remote_children.len()
+            && !claimed_remote[local_pos]
+            && nodes_match_shallow(&remote.nodes()[remote_children[local_pos]], local_child)
+        {
+            match_pos = Some(local_pos);
+        }
+
+        if let Some(remote_pos) = match_pos {
+            claimed_remote[remote_pos] = true;
+            matches.push((local_pos, remote_pos, local_child_idx));
+        } else {
+            push_unique_warning(
+                warnings,
+                format!(
+                    "node {remote_parent_idx} local child at position {local_pos} could not be matched to a callTracer child"
+                ),
+            );
+        }
+    }
+
+    if remote_children.len() != local_children.len() {
+        push_unique_warning(
+            warnings,
+            format!(
+                "node {remote_parent_idx} child count differed between callTracer ({}) and local replay ({})",
+                remote_children.len(),
+                local_children.len()
+            ),
+        );
+    }
+
+    matches
+}
+
+fn find_matching_child(
+    remote_children: &[usize],
+    claimed_remote: &[bool],
+    remote: &CallTraceArena,
+    local_child: &CallTraceNode,
+    predicate: fn(&CallTraceNode, &CallTraceNode) -> bool,
+) -> Option<usize> {
+    remote_children
+        .iter()
+        .enumerate()
+        .find(|(remote_pos, remote_child_idx)| {
+            !claimed_remote[*remote_pos]
+                && predicate(&remote.nodes()[**remote_child_idx], local_child)
+        })
+        .map(|(remote_pos, _)| remote_pos)
+}
+
+fn nodes_match_exact(remote: &CallTraceNode, local: &CallTraceNode) -> bool {
+    remote.trace.kind == local.trace.kind
+        && remote.trace.caller == local.trace.caller
+        && remote.trace.address == local.trace.address
+        && remote.trace.value == local.trace.value
+        && remote.trace.data == local.trace.data
+}
+
+fn nodes_match_relaxed(remote: &CallTraceNode, local: &CallTraceNode) -> bool {
+    nodes_match_shallow(remote, local)
+        && (remote.trace.kind.is_any_create() || remote.selector() == local.selector())
+}
+
+fn nodes_match_shallow(remote: &CallTraceNode, local: &CallTraceNode) -> bool {
+    remote.trace.kind == local.trace.kind
+        && remote.trace.caller == local.trace.caller
+        && remote.trace.address == local.trace.address
+        && remote.trace.value == local.trace.value
+}
+
+fn push_call_frame(
+    arena: &mut CallTraceArena,
+    parent: Option<usize>,
+    frame: &CallFrame,
+    depth: usize,
+) -> usize {
+    let idx = if depth == 0 {
+        0
+    } else {
+        let idx = arena.nodes().len();
+        arena.nodes_mut().push(CallTraceNode { parent, idx, ..Default::default() });
+        if let Some(parent_idx) = parent {
+            arena.nodes_mut()[parent_idx].children.push(idx);
+        }
+        idx
+    };
+
+    let success = frame.error.is_none() && frame.revert_reason.is_none();
+    let kind = parse_call_kind(&frame.typ);
+    let trace = CallTrace {
+        depth,
+        success,
+        caller: frame.from,
+        address: frame.to.unwrap_or_default(),
+        kind,
+        value: frame.value.unwrap_or_default(),
+        data: frame.input.clone(),
+        output: frame.output.clone().unwrap_or_default(),
+        gas_used: frame.gas_used.saturating_to::<u64>(),
+        gas_limit: frame.gas.saturating_to::<u64>(),
+        status: Some(if success { InstructionResult::Return } else { InstructionResult::Revert }),
+        ..Default::default()
+    };
+    arena.nodes_mut()[idx].trace = trace;
+
+    for child in &frame.calls {
+        push_call_frame(arena, Some(idx), child, depth + 1);
+    }
+
+    idx
+}
+
+fn assign_struct_logs(
+    arena: &mut CallTraceArena,
+    logs: &[StructLog],
+    trace_printer: bool,
+    warnings: &mut Vec<String>,
+) {
+    if logs.is_empty() {
+        return;
+    }
+
+    let depth_offset = usize::from(logs[0].depth > 0);
+    let mut active = vec![0usize];
+    let mut next_child = vec![0usize; arena.nodes().len()];
+    let mut initial_gas = vec![None::<u64>; arena.nodes().len()];
+
+    for log in logs {
+        let call_depth = (log.depth as usize).saturating_sub(depth_offset);
+
+        if active.len() > call_depth + 1 {
+            active.truncate(call_depth + 1);
+        }
+
+        while active.len() <= call_depth {
+            let parent_idx = *active.last().unwrap_or(&0);
+            let child_pos = next_child[parent_idx];
+            let Some(child_idx) = arena.nodes()[parent_idx].children.get(child_pos).copied() else {
+                push_unique_warning(
+                    warnings,
+                    format!(
+                        "opcode depth {} had no matching callTracer child under node {}",
+                        log.depth, parent_idx
+                    ),
+                );
+                break;
+            };
+            arena.nodes_mut()[parent_idx].ordering.push(TraceMemberOrder::Call(child_pos));
+            next_child[parent_idx] += 1;
+            active.push(child_idx);
+        }
+
+        let node_idx = active.get(call_depth).copied().unwrap_or_else(|| *active.last().unwrap());
+        let entry_gas = initial_gas[node_idx].get_or_insert(log.gas);
+        let gas_used =
+            rpc_step_gas_used(*entry_gas, log.gas, log.refund_counter.unwrap_or_default());
+        let step = struct_log_to_step(log, trace_printer, warnings, gas_used);
+        let step_idx = arena.nodes()[node_idx].trace.steps.len();
+        let node = &mut arena.nodes_mut()[node_idx];
+        node.trace.steps.push(step);
+        node.ordering.push(TraceMemberOrder::Step(step_idx));
+    }
+}
+
+fn rpc_step_gas_used(initial_gas: u64, gas_remaining: u64, refund_counter: u64) -> u64 {
+    let spent = initial_gas.saturating_sub(gas_remaining);
+
+    // RPC struct logs do not expose the active hardfork, so use the post-London refund cap that
+    // matches modern chains and Foundry's local replay for current transactions.
+    spent.saturating_sub(refund_counter.min(spent / 5))
+}
+
+fn validate_trace_arena(arena: &CallTraceArena, warnings: &mut Vec<String>) {
+    for node in arena.nodes() {
+        let mut prev_step_gas_used = None;
+
+        for (step_idx, step) in node.trace.steps.iter().enumerate() {
+            if let Some(prev) = prev_step_gas_used
+                && step.gas_used < prev
+            {
+                push_unique_warning(
+                    warnings,
+                    format!(
+                        "node {} step {} gasUsed ({}) decreased from previous step gasUsed ({prev})",
+                        node.idx, step_idx, step.gas_used
+                    ),
+                );
+            }
+
+            if step.gas_used > node.trace.gas_used {
+                push_unique_warning(
+                    warnings,
+                    format!(
+                        "node {} step {} gasUsed ({}) exceeds enclosing call gasUsed ({})",
+                        node.idx, step_idx, step.gas_used, node.trace.gas_used
+                    ),
+                );
+            }
+
+            if let Some(decoded) = &step.decoded
+                && let DecodedTraceStep::InternalCall(call, end_idx) = &**decoded
+            {
+                let Some(end_step) = node.trace.steps.get(*end_idx) else {
+                    push_unique_warning(
+                        warnings,
+                        format!(
+                            "node {} internal frame '{}' has out-of-bounds end step {}",
+                            node.idx, call.func_name, end_idx
+                        ),
+                    );
+                    prev_step_gas_used = Some(step.gas_used);
+                    continue;
+                };
+
+                let frame_gas_used = gas_between_steps(step, end_step);
+                if frame_gas_used > node.trace.gas_used {
+                    push_unique_warning(
+                        warnings,
+                        format!(
+                            "node {} internal frame '{}' gasUsed ({frame_gas_used}) exceeds enclosing call gasUsed ({})",
+                            node.idx, call.func_name, node.trace.gas_used
+                        ),
+                    );
+                }
+            }
+
+            prev_step_gas_used = Some(step.gas_used);
+        }
+    }
+}
+
+fn append_unvisited_children(arena: &mut CallTraceArena) {
+    for idx in 0..arena.nodes().len() {
+        let existing_calls = arena.nodes()[idx]
+            .ordering
+            .iter()
+            .filter_map(|item| match item {
+                TraceMemberOrder::Call(child_pos) => Some(*child_pos),
+                _ => None,
+            })
+            .max()
+            .map_or(0, |max| max + 1);
+        let child_count = arena.nodes()[idx].children.len();
+        for child_pos in existing_calls..child_count {
+            arena.nodes_mut()[idx].ordering.push(TraceMemberOrder::Call(child_pos));
+        }
+    }
+}
+
+fn append_call_logs(arena: &mut CallTraceArena, root: &CallFrame) {
+    fn walk(arena: &mut CallTraceArena, frame: &CallFrame, idx: usize) {
+        for log_frame in &frame.logs {
+            let raw = log_frame.clone().into_log();
+            let log_idx = arena.nodes()[idx].logs.len();
+            let mut log = CallLog {
+                address: raw.address,
+                raw_log: LogData::new_unchecked(raw.data.topics().to_vec(), raw.data.data),
+                decoded: None,
+                position: log_frame.position.unwrap_or_default(),
+                index: log_frame.index.unwrap_or_default(),
+            };
+            log.position = log_frame.position.unwrap_or(log.position);
+            log.index = log_frame.index.unwrap_or(log.index);
+            let node = &mut arena.nodes_mut()[idx];
+            node.logs.push(log);
+            node.ordering.push(TraceMemberOrder::Log(log_idx));
+        }
+
+        let children = arena.nodes()[idx].children.clone();
+        for (child_frame, child_idx) in frame.calls.iter().zip(children) {
+            walk(arena, child_frame, child_idx);
+        }
+    }
+
+    walk(arena, root, 0);
+}
+
+fn struct_log_to_step(
+    log: &StructLog,
+    trace_printer: bool,
+    warnings: &mut Vec<String>,
+    gas_used: u64,
+) -> CallTraceStep {
+    let op = opcode_from_name(log.opcode()).unwrap_or_else(|| {
+        push_unique_warning(warnings, format!("unsupported opcode in RPC trace: {}", log.opcode()));
+        OpCode::STOP
+    });
+    CallTraceStep {
+        pc: log.pc as usize,
+        op,
+        stack: log.stack.clone().map(Vec::into_boxed_slice),
+        push_stack: None,
+        memory: None,
+        returndata: log.return_data.clone().unwrap_or_default(),
+        gas_remaining: log.gas,
+        gas_refund_counter: log.refund_counter.unwrap_or_default(),
+        gas_used,
+        gas_cost: log.gas_cost,
+        storage_change: None,
+        status: log.error.as_ref().map(|_| InstructionResult::Revert),
+        immediate_bytes: None,
+        decoded: trace_printer.then(|| {
+            Box::new(DecodedTraceStep::Line(format!(
+                "pc={} op={} gas={} gasCost={}",
+                log.pc,
+                log.opcode(),
+                log.gas,
+                log.gas_cost
+            )))
+        }),
+    }
+}
+
+fn push_unique_warning(warnings: &mut Vec<String>, warning: String) {
+    if !warnings.iter().any(|existing| existing == &warning) {
+        warnings.push(warning);
+    }
+}
+
+fn parse_call_kind(kind: &str) -> CallKind {
+    match kind.to_ascii_uppercase().as_str() {
+        "STATICCALL" => CallKind::StaticCall,
+        "CALLCODE" => CallKind::CallCode,
+        "DELEGATECALL" => CallKind::DelegateCall,
+        "AUTHCALL" => CallKind::AuthCall,
+        "CREATE" => CallKind::Create,
+        "CREATE2" => CallKind::Create2,
+        _ => CallKind::Call,
+    }
+}
+
+fn storage_address(node: &CallTraceNode) -> Address {
+    if node.trace.kind.is_delegate() { node.trace.caller } else { node.trace.address }
+}
+
+fn opcode_from_name(name: &str) -> Option<OpCode> {
+    if let Some(rest) = name.strip_prefix("PUSH") {
+        let n: u8 = rest.parse().ok()?;
+        return match n {
+            0 => OpCode::new(opcode::PUSH0),
+            1..=32 => OpCode::new(opcode::PUSH1 + n - 1),
+            _ => None,
+        };
+    }
+    if let Some(rest) = name.strip_prefix("DUP") {
+        let n: u8 = rest.parse().ok()?;
+        return (1..=16).contains(&n).then(|| OpCode::new(opcode::DUP1 + n - 1)).flatten();
+    }
+    if let Some(rest) = name.strip_prefix("SWAP") {
+        let n: u8 = rest.parse().ok()?;
+        return (1..=16).contains(&n).then(|| OpCode::new(opcode::SWAP1 + n - 1)).flatten();
+    }
+    if let Some(rest) = name.strip_prefix("LOG") {
+        let n: u8 = rest.parse().ok()?;
+        return (0..=4).contains(&n).then(|| OpCode::new(opcode::LOG0 + n)).flatten();
+    }
+
+    let raw = match name {
+        "STOP" => opcode::STOP,
+        "ADD" => opcode::ADD,
+        "MUL" => opcode::MUL,
+        "SUB" => opcode::SUB,
+        "DIV" => opcode::DIV,
+        "SDIV" => opcode::SDIV,
+        "MOD" => opcode::MOD,
+        "SMOD" => opcode::SMOD,
+        "ADDMOD" => opcode::ADDMOD,
+        "MULMOD" => opcode::MULMOD,
+        "EXP" => opcode::EXP,
+        "SIGNEXTEND" => opcode::SIGNEXTEND,
+        "LT" => opcode::LT,
+        "GT" => opcode::GT,
+        "SLT" => opcode::SLT,
+        "SGT" => opcode::SGT,
+        "EQ" => opcode::EQ,
+        "ISZERO" => opcode::ISZERO,
+        "AND" => opcode::AND,
+        "OR" => opcode::OR,
+        "XOR" => opcode::XOR,
+        "NOT" => opcode::NOT,
+        "BYTE" => opcode::BYTE,
+        "SHL" => opcode::SHL,
+        "SHR" => opcode::SHR,
+        "SAR" => opcode::SAR,
+        "KECCAK256" | "SHA3" => opcode::KECCAK256,
+        "ADDRESS" => opcode::ADDRESS,
+        "BALANCE" => opcode::BALANCE,
+        "ORIGIN" => opcode::ORIGIN,
+        "CALLER" => opcode::CALLER,
+        "CALLVALUE" => opcode::CALLVALUE,
+        "CALLDATALOAD" => opcode::CALLDATALOAD,
+        "CALLDATASIZE" => opcode::CALLDATASIZE,
+        "CALLDATACOPY" => opcode::CALLDATACOPY,
+        "CODESIZE" => opcode::CODESIZE,
+        "CODECOPY" => opcode::CODECOPY,
+        "GASPRICE" => opcode::GASPRICE,
+        "EXTCODESIZE" => opcode::EXTCODESIZE,
+        "EXTCODECOPY" => opcode::EXTCODECOPY,
+        "RETURNDATASIZE" => opcode::RETURNDATASIZE,
+        "RETURNDATACOPY" => opcode::RETURNDATACOPY,
+        "EXTCODEHASH" => opcode::EXTCODEHASH,
+        "BLOCKHASH" => opcode::BLOCKHASH,
+        "COINBASE" => opcode::COINBASE,
+        "TIMESTAMP" => opcode::TIMESTAMP,
+        "NUMBER" => opcode::NUMBER,
+        "PREVRANDAO" | "DIFFICULTY" => opcode::DIFFICULTY,
+        "GASLIMIT" => opcode::GASLIMIT,
+        "CHAINID" => opcode::CHAINID,
+        "SELFBALANCE" => opcode::SELFBALANCE,
+        "BASEFEE" => opcode::BASEFEE,
+        "BLOBHASH" => opcode::BLOBHASH,
+        "BLOBBASEFEE" => opcode::BLOBBASEFEE,
+        "POP" => opcode::POP,
+        "MLOAD" => opcode::MLOAD,
+        "MSTORE" => opcode::MSTORE,
+        "MSTORE8" => opcode::MSTORE8,
+        "SLOAD" => opcode::SLOAD,
+        "SSTORE" => opcode::SSTORE,
+        "JUMP" => opcode::JUMP,
+        "JUMPI" => opcode::JUMPI,
+        "PC" => opcode::PC,
+        "MSIZE" => opcode::MSIZE,
+        "GAS" => opcode::GAS,
+        "JUMPDEST" => opcode::JUMPDEST,
+        "TLOAD" => opcode::TLOAD,
+        "TSTORE" => opcode::TSTORE,
+        "MCOPY" => opcode::MCOPY,
+        "CREATE" => opcode::CREATE,
+        "CALL" => opcode::CALL,
+        "CALLCODE" => opcode::CALLCODE,
+        "RETURN" => opcode::RETURN,
+        "DELEGATECALL" => opcode::DELEGATECALL,
+        "CREATE2" => opcode::CREATE2,
+        "STATICCALL" => opcode::STATICCALL,
+        "REVERT" => opcode::REVERT,
+        "INVALID" => opcode::INVALID,
+        "SELFDESTRUCT" => opcode::SELFDESTRUCT,
+        _ => return None,
+    };
+    OpCode::new(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{address, bytes};
+    use revm_inspectors::tracing::types::DecodedInternalCall;
+    use std::borrow::Cow;
+
+    #[test]
+    fn converts_call_frame_to_arena() {
+        let child = CallFrame {
+            typ: "STATICCALL".to_string(),
+            from: address!("0000000000000000000000000000000000000002"),
+            to: Some(address!("0000000000000000000000000000000000000003")),
+            input: bytes!("12345678"),
+            gas_used: U256::from(7),
+            ..Default::default()
+        };
+        let root = CallFrame {
+            typ: "CALL".to_string(),
+            from: address!("0000000000000000000000000000000000000001"),
+            to: Some(address!("0000000000000000000000000000000000000002")),
+            input: bytes!("abcdef01"),
+            gas_used: U256::from(11),
+            calls: vec![child],
+            ..Default::default()
+        };
+
+        let converted = build_rpc_trace_arena(&root, &DefaultFrame::default(), false);
+        let nodes = converted.arena.nodes();
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0].children, vec![1]);
+        assert_eq!(nodes[1].trace.kind, CallKind::StaticCall);
+    }
+
+    #[test]
+    fn parses_dynamic_opcode_names() {
+        assert_eq!(opcode_from_name("PUSH0"), Some(OpCode::PUSH0));
+        assert_eq!(opcode_from_name("PUSH32"), Some(OpCode::PUSH32));
+        assert_eq!(opcode_from_name("DUP16"), Some(OpCode::DUP16));
+        assert_eq!(opcode_from_name("SWAP16"), Some(OpCode::SWAP16));
+        assert_eq!(opcode_from_name("LOG4"), Some(OpCode::LOG4));
+    }
+
+    #[test]
+    fn parses_struct_logs_into_steps_and_json() {
+        let root = CallFrame {
+            typ: "CALL".to_string(),
+            from: address!("0000000000000000000000000000000000000001"),
+            to: Some(address!("0000000000000000000000000000000000000002")),
+            gas_used: U256::from(3),
+            ..Default::default()
+        };
+        let frame = DefaultFrame {
+            gas: 3,
+            struct_logs: vec![
+                StructLog {
+                    pc: 42,
+                    op: Cow::Borrowed("SLOAD"),
+                    gas: 100,
+                    gas_cost: 2100,
+                    depth: 1,
+                    stack: Some(vec![U256::from(7)]),
+                    ..Default::default()
+                },
+                StructLog {
+                    pc: 43,
+                    op: Cow::Borrowed("JUMPDEST"),
+                    gas: 80,
+                    gas_cost: 1,
+                    depth: 1,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let converted = build_rpc_trace_arena(&root, &frame, true);
+        assert!(converted.warnings.is_empty());
+        assert_eq!(converted.arena.nodes()[0].trace.steps.len(), 2);
+        assert_eq!(converted.arena.nodes()[0].trace.steps[0].op, OpCode::SLOAD);
+        assert_eq!(converted.arena.nodes()[0].trace.steps[0].gas_used, 0);
+        assert_eq!(converted.arena.nodes()[0].trace.steps[1].gas_used, 20);
+
+        let json = serde_json::to_value(json_trace_from_arena(&converted.arena.arena))
+            .expect("trace json serializes");
+        assert_eq!(json["rootCallId"], 0);
+        assert_eq!(json["calls"][0]["gasUsed"], 3);
+    }
+
+    #[test]
+    fn finalizes_root_gas_from_receipt() {
+        let root = CallFrame {
+            typ: "CALL".to_string(),
+            from: address!("0000000000000000000000000000000000000001"),
+            to: Some(address!("0000000000000000000000000000000000000002")),
+            gas_used: U256::from(11),
+            ..Default::default()
+        };
+
+        let mut converted = build_rpc_trace_arena(&root, &DefaultFrame::default(), false);
+        let mut warnings = converted.warnings.clone();
+        finalize_rpc_trace_arena(&mut converted.arena.arena, 7, &mut warnings);
+
+        assert_eq!(converted.arena.nodes()[0].trace.gas_used, 7);
+        assert!(warnings.iter().any(|warning| {
+            warning.contains("root callTracer gasUsed (11) differs from receipt gasUsed (7)")
+        }));
+    }
+
+    #[test]
+    fn warns_when_internal_frame_exceeds_enclosing_call_gas() {
+        let root = CallFrame {
+            typ: "CALL".to_string(),
+            from: address!("0000000000000000000000000000000000000001"),
+            to: Some(address!("0000000000000000000000000000000000000002")),
+            gas_used: U256::from(5),
+            ..Default::default()
+        };
+        let frame = DefaultFrame {
+            struct_logs: vec![
+                StructLog {
+                    pc: 1,
+                    op: Cow::Borrowed("PUSH1"),
+                    gas: 100,
+                    gas_cost: 3,
+                    depth: 1,
+                    ..Default::default()
+                },
+                StructLog {
+                    pc: 2,
+                    op: Cow::Borrowed("STOP"),
+                    gas: 80,
+                    gas_cost: 0,
+                    depth: 1,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let mut converted = build_rpc_trace_arena(&root, &frame, false);
+        let node = &mut converted.arena.nodes_mut()[0];
+        node.trace.steps[0].decoded = Some(Box::new(DecodedTraceStep::InternalCall(
+            DecodedInternalCall { func_name: "foo".to_string(), args: None, return_data: None },
+            1,
+        )));
+
+        let mut warnings = converted.warnings.clone();
+        finalize_rpc_trace_arena(&mut converted.arena.arena, 5, &mut warnings);
+
+        assert!(warnings.iter().any(|warning| {
+            warning.contains("internal frame 'foo' gasUsed (20) exceeds enclosing call gasUsed (5)")
+        }));
+    }
+
+    #[test]
+    fn grafts_local_steps_onto_remote_call_tree() {
+        let child_a = CallFrame {
+            typ: "CALL".to_string(),
+            from: address!("0000000000000000000000000000000000000002"),
+            to: Some(address!("0000000000000000000000000000000000000003")),
+            input: bytes!("aaaaaaaa"),
+            gas_used: U256::from(7),
+            ..Default::default()
+        };
+        let child_b = CallFrame {
+            typ: "CALL".to_string(),
+            from: address!("0000000000000000000000000000000000000002"),
+            to: Some(address!("0000000000000000000000000000000000000004")),
+            input: bytes!("bbbbbbbb"),
+            gas_used: U256::from(5),
+            ..Default::default()
+        };
+        let root = CallFrame {
+            typ: "CALL".to_string(),
+            from: address!("0000000000000000000000000000000000000001"),
+            to: Some(address!("0000000000000000000000000000000000000002")),
+            input: bytes!("abcdef01"),
+            gas_used: U256::from(11),
+            calls: vec![child_a.clone(), child_b.clone()],
+            ..Default::default()
+        };
+
+        let mut local = build_rpc_trace_arena(&root, &DefaultFrame::default(), false).arena.arena;
+        local.nodes_mut()[0].children.swap(0, 1);
+        local.nodes_mut()[0].trace.steps.push(CallTraceStep {
+            pc: 1,
+            op: OpCode::JUMP,
+            stack: None,
+            push_stack: None,
+            memory: None,
+            returndata: Bytes::new(),
+            gas_remaining: 0,
+            gas_refund_counter: 0,
+            gas_used: 3,
+            gas_cost: 0,
+            storage_change: None,
+            status: None,
+            immediate_bytes: None,
+            decoded: None,
+        });
+        local.nodes_mut()[0].ordering =
+            vec![TraceMemberOrder::Step(0), TraceMemberOrder::Call(0), TraceMemberOrder::Call(1)];
+
+        let merged = graft_local_replay_onto_call_tracer(&root, &local).expect("root matches");
+        let root_node = &merged.arena.nodes()[0];
+        assert_eq!(root_node.children, vec![2, 1]);
+        assert_eq!(root_node.trace.steps.len(), 1);
+        assert_eq!(root_node.ordering[0], TraceMemberOrder::Step(0));
+    }
+
+    #[test]
+    fn rejects_graft_when_root_mismatches() {
+        let remote = CallFrame {
+            typ: "CALL".to_string(),
+            from: address!("0000000000000000000000000000000000000001"),
+            to: Some(address!("0000000000000000000000000000000000000002")),
+            input: bytes!("abcdef01"),
+            ..Default::default()
+        };
+        let local_root = CallFrame {
+            typ: "CALL".to_string(),
+            from: address!("0000000000000000000000000000000000000001"),
+            to: Some(address!("0000000000000000000000000000000000000009")),
+            input: bytes!("abcdef01"),
+            ..Default::default()
+        };
+        let local = build_rpc_trace_arena(&local_root, &DefaultFrame::default(), false).arena.arena;
+
+        assert!(graft_local_replay_onto_call_tracer(&remote, &local).is_none());
+    }
+}

--- a/crates/evm/traces/src/rpc_trace.rs
+++ b/crates/evm/traces/src/rpc_trace.rs
@@ -71,13 +71,20 @@ pub fn build_rpc_trace_arena(
     call_frame: &CallFrame,
     default_frame: &DefaultFrame,
     trace_printer: bool,
+    refund_quotient: u64,
 ) -> RpcTraceArena {
     let mut arena = CallTraceArena::default();
     let mut warnings = Vec::new();
     let root_idx = push_call_frame(&mut arena, None, call_frame, 0);
     debug_assert_eq!(root_idx, 0);
 
-    assign_struct_logs(&mut arena, &default_frame.struct_logs, trace_printer, &mut warnings);
+    assign_struct_logs(
+        &mut arena,
+        &default_frame.struct_logs,
+        trace_printer,
+        refund_quotient,
+        &mut warnings,
+    );
     append_unvisited_children(&mut arena);
     append_call_logs(&mut arena, call_frame);
 
@@ -94,7 +101,7 @@ pub fn graft_local_replay_onto_call_tracer(
         return None;
     }
 
-    let mut merged = build_rpc_trace_arena(call_frame, &DefaultFrame::default(), false);
+    let mut merged = build_rpc_trace_arena(call_frame, &DefaultFrame::default(), false, 5);
     if !nodes_match_relaxed(&merged.arena.arena.nodes()[0], &local.nodes()[0]) {
         push_unique_warning(
             &mut merged.warnings,
@@ -197,7 +204,8 @@ fn json_call_from_node(node: &CallTraceNode) -> RpcJsonCall {
 }
 
 fn gas_between_steps(start: &CallTraceStep, end: &CallTraceStep) -> u64 {
-    end.gas_used.saturating_sub(start.gas_used)
+    let remaining_delta = start.gas_remaining.saturating_sub(end.gas_remaining);
+    if remaining_delta == 0 { end.gas_used.saturating_sub(start.gas_used) } else { remaining_delta }
 }
 
 fn graft_local_node(
@@ -446,6 +454,7 @@ fn assign_struct_logs(
     arena: &mut CallTraceArena,
     logs: &[StructLog],
     trace_printer: bool,
+    refund_quotient: u64,
     warnings: &mut Vec<String>,
 ) {
     if logs.is_empty() {
@@ -484,8 +493,12 @@ fn assign_struct_logs(
 
         let node_idx = active.get(call_depth).copied().unwrap_or_else(|| *active.last().unwrap());
         let entry_gas = initial_gas[node_idx].get_or_insert(log.gas);
-        let gas_used =
-            rpc_step_gas_used(*entry_gas, log.gas, log.refund_counter.unwrap_or_default());
+        let gas_used = rpc_step_gas_used(
+            *entry_gas,
+            log.gas,
+            log.refund_counter.unwrap_or_default(),
+            refund_quotient,
+        );
         let step = struct_log_to_step(log, trace_printer, warnings, gas_used);
         let step_idx = arena.nodes()[node_idx].trace.steps.len();
         let node = &mut arena.nodes_mut()[node_idx];
@@ -494,12 +507,15 @@ fn assign_struct_logs(
     }
 }
 
-fn rpc_step_gas_used(initial_gas: u64, gas_remaining: u64, refund_counter: u64) -> u64 {
+fn rpc_step_gas_used(
+    initial_gas: u64,
+    gas_remaining: u64,
+    refund_counter: u64,
+    refund_quotient: u64,
+) -> u64 {
     let spent = initial_gas.saturating_sub(gas_remaining);
-
-    // RPC struct logs do not expose the active hardfork, so use the post-London refund cap that
-    // matches modern chains and Foundry's local replay for current transactions.
-    spent.saturating_sub(refund_counter.min(spent / 5))
+    let refund_quotient = refund_quotient.max(1);
+    spent.saturating_sub(refund_counter.min(spent / refund_quotient))
 }
 
 fn validate_trace_arena(arena: &CallTraceArena, warnings: &mut Vec<String>) {
@@ -662,7 +678,11 @@ fn parse_call_kind(kind: &str) -> CallKind {
 }
 
 fn storage_address(node: &CallTraceNode) -> Address {
-    if node.trace.kind.is_delegate() { node.trace.caller } else { node.trace.address }
+    if matches!(node.trace.kind, CallKind::DelegateCall | CallKind::CallCode) {
+        node.trace.caller
+    } else {
+        node.trace.address
+    }
 }
 
 fn opcode_from_name(name: &str) -> Option<OpCode> {
@@ -799,7 +819,7 @@ mod tests {
             ..Default::default()
         };
 
-        let converted = build_rpc_trace_arena(&root, &DefaultFrame::default(), false);
+        let converted = build_rpc_trace_arena(&root, &DefaultFrame::default(), false, 5);
         let nodes = converted.arena.nodes();
         assert_eq!(nodes.len(), 2);
         assert_eq!(nodes[0].children, vec![1]);
@@ -848,7 +868,7 @@ mod tests {
             ..Default::default()
         };
 
-        let converted = build_rpc_trace_arena(&root, &frame, true);
+        let converted = build_rpc_trace_arena(&root, &frame, true, 5);
         assert!(converted.warnings.is_empty());
         assert_eq!(converted.arena.nodes()[0].trace.steps.len(), 2);
         assert_eq!(converted.arena.nodes()[0].trace.steps[0].op, OpCode::SLOAD);
@@ -871,7 +891,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut converted = build_rpc_trace_arena(&root, &DefaultFrame::default(), false);
+        let mut converted = build_rpc_trace_arena(&root, &DefaultFrame::default(), false, 5);
         let mut warnings = converted.warnings.clone();
         finalize_rpc_trace_arena(&mut converted.arena.arena, 7, &mut warnings);
 
@@ -912,7 +932,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut converted = build_rpc_trace_arena(&root, &frame, false);
+        let mut converted = build_rpc_trace_arena(&root, &frame, false, 5);
         let node = &mut converted.arena.nodes_mut()[0];
         node.trace.steps[0].decoded = Some(Box::new(DecodedTraceStep::InternalCall(
             DecodedInternalCall { func_name: "foo".to_string(), args: None, return_data: None },
@@ -925,6 +945,65 @@ mod tests {
         assert!(warnings.iter().any(|warning| {
             warning.contains("internal frame 'foo' gasUsed (20) exceeds enclosing call gasUsed (5)")
         }));
+    }
+
+    #[test]
+    fn gas_between_steps_prefers_gas_remaining_delta() {
+        let start = CallTraceStep {
+            pc: 0,
+            op: OpCode::STOP,
+            stack: None,
+            push_stack: None,
+            memory: None,
+            returndata: Bytes::new(),
+            gas_remaining: 100,
+            gas_refund_counter: 0,
+            gas_used: 10,
+            gas_cost: 0,
+            storage_change: None,
+            status: None,
+            immediate_bytes: None,
+            decoded: None,
+        };
+        let end = CallTraceStep {
+            pc: 1,
+            op: OpCode::STOP,
+            stack: None,
+            push_stack: None,
+            memory: None,
+            returndata: Bytes::new(),
+            gas_remaining: 73,
+            gas_refund_counter: 0,
+            gas_used: 999,
+            gas_cost: 0,
+            storage_change: None,
+            status: None,
+            immediate_bytes: None,
+            decoded: None,
+        };
+
+        assert_eq!(gas_between_steps(&start, &end), 27);
+    }
+
+    #[test]
+    fn rpc_step_gas_used_respects_pre_london_refund_cap() {
+        assert_eq!(rpc_step_gas_used(100, 40, 50, 5), 48);
+        assert_eq!(rpc_step_gas_used(100, 40, 50, 2), 30);
+    }
+
+    #[test]
+    fn storage_address_uses_caller_for_callcode() {
+        let node = CallTraceNode {
+            trace: CallTrace {
+                caller: address!("0000000000000000000000000000000000000001"),
+                address: address!("0000000000000000000000000000000000000002"),
+                kind: CallKind::CallCode,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert_eq!(storage_address(&node), node.trace.caller);
     }
 
     #[test]
@@ -955,7 +1034,8 @@ mod tests {
             ..Default::default()
         };
 
-        let mut local = build_rpc_trace_arena(&root, &DefaultFrame::default(), false).arena.arena;
+        let mut local =
+            build_rpc_trace_arena(&root, &DefaultFrame::default(), false, 5).arena.arena;
         local.nodes_mut()[0].children.swap(0, 1);
         local.nodes_mut()[0].trace.steps.push(CallTraceStep {
             pc: 1,
@@ -999,7 +1079,8 @@ mod tests {
             input: bytes!("abcdef01"),
             ..Default::default()
         };
-        let local = build_rpc_trace_arena(&local_root, &DefaultFrame::default(), false).arena.arena;
+        let local =
+            build_rpc_trace_arena(&local_root, &DefaultFrame::default(), false, 5).arena.arena;
 
         assert!(graft_local_replay_onto_call_tracer(&remote, &local).is_none());
     }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         identifier::SignaturesIdentifier,
     },
 };
-use alloy_primitives::U256;
+use alloy_primitives::{Selector, U256, map::HashMap};
 use chrono::Utc;
 use clap::{Parser, ValueHint};
 use eyre::{Context, OptionExt, Result, bail};
@@ -20,7 +20,9 @@ use foundry_cli::{
     opts::{BuildOpts, EvmArgs, GlobalArgs},
     utils::{self, LoadConfig},
 };
-use foundry_common::{EmptyTestFilter, TestFunctionExt, compile::ProjectCompiler, fs, shell};
+use foundry_common::{
+    ContractsByArtifact, EmptyTestFilter, TestFunctionExt, compile::ProjectCompiler, fs, shell,
+};
 use foundry_compilers::{
     ProjectCompileOutput,
     artifacts::{Libraries, output_selection::OutputSelection},
@@ -65,6 +67,23 @@ use crate::{result::TestKind, traces::render_trace_arena_inner};
 pub use filter::FilterArgs;
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
 use summary::{TestSummaryReport, format_invariant_metrics_table};
+
+fn build_selector_candidates(contracts: &ContractsByArtifact) -> HashMap<Selector, Vec<String>> {
+    let mut selector_candidates = HashMap::default();
+    for (id, contract) in contracts.iter() {
+        for function in contract.abi.functions() {
+            selector_candidates
+                .entry(function.selector())
+                .or_insert_with(Vec::new)
+                .push(id.name.clone());
+        }
+    }
+    for candidates in selector_candidates.values_mut() {
+        candidates.sort();
+        candidates.dedup();
+    }
+    selector_candidates
+}
 
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::merge_impl_figment_convert!(TestArgs, build, evm);
@@ -620,7 +639,10 @@ impl TestArgs {
         if self.decode_internal {
             let sources =
                 ContractSources::from_project_output(output, &config.root, Some(&libraries))?;
-            builder = builder.with_debug_identifier(DebugTraceIdentifier::new(sources));
+            builder = builder.with_debug_identifier(
+                DebugTraceIdentifier::new(sources)
+                    .with_selector_candidates(build_selector_candidates(&known_contracts)),
+            );
         }
         let mut decoder = builder.build();
 


### PR DESCRIPTION
## Summary
- route the RPC tracing path through `cast run --trace`

## Testing
- cargo test -p cast run_trace_accepts_trace_flags --quiet