### PR TITLE
fix(anvil): refetch full fork blocks with missing tx cache

### DIFF
--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -442,10 +442,10 @@ impl<N: Network> ClientFork<N> {
         &self,
         hash: B256,
     ) -> Result<Option<N::BlockResponse>, TransportError> {
-        if let Some(block) = self.storage_read().blocks.get(&hash).cloned() {
-            if let Some(block) = self.convert_to_full_block(block) {
-                return Ok(Some(block));
-            }
+        if let Some(block) = self.storage_read().blocks.get(&hash).cloned()
+            && let Some(block) = self.convert_to_full_block(block)
+        {
+            return Ok(Some(block));
         }
         self.fetch_full_block(hash).await
     }
@@ -481,10 +481,9 @@ impl<N: Network> ClientFork<N> {
             .get(&block_number)
             .copied()
             .and_then(|hash| self.storage_read().blocks.get(&hash).cloned())
+            && let Some(block) = self.convert_to_full_block(block)
         {
-            if let Some(block) = self.convert_to_full_block(block) {
-                return Ok(Some(block));
-            }
+            return Ok(Some(block));
         }
 
         self.fetch_full_block(block_number).await

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -443,7 +443,9 @@ impl<N: Network> ClientFork<N> {
         hash: B256,
     ) -> Result<Option<N::BlockResponse>, TransportError> {
         if let Some(block) = self.storage_read().blocks.get(&hash).cloned() {
-            return Ok(Some(self.convert_to_full_block(block)));
+            if let Some(block) = self.convert_to_full_block(block) {
+                return Ok(Some(block));
+            }
         }
         self.fetch_full_block(hash).await
     }
@@ -480,7 +482,9 @@ impl<N: Network> ClientFork<N> {
             .copied()
             .and_then(|hash| self.storage_read().blocks.get(&hash).cloned())
         {
-            return Ok(Some(self.convert_to_full_block(block)));
+            if let Some(block) = self.convert_to_full_block(block) {
+                return Ok(Some(block));
+            }
         }
 
         self.fetch_full_block(block_number).await
@@ -509,15 +513,15 @@ impl<N: Network> ClientFork<N> {
     }
 
     /// Converts a block of hashes into a full block
-    fn convert_to_full_block(&self, mut block: N::BlockResponse) -> N::BlockResponse {
+    fn convert_to_full_block(&self, mut block: N::BlockResponse) -> Option<N::BlockResponse> {
         let storage = self.storage.read();
         let transactions = block
             .transactions()
             .hashes()
-            .filter_map(|hash| storage.transactions.get(&hash).cloned())
-            .collect();
+            .map(|hash| storage.transactions.get(&hash).cloned())
+            .collect::<Option<Vec<_>>>()?;
         *block.transactions_mut() = BlockTransactions::Full(transactions);
-        block
+        Some(block)
     }
 }
 

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1449,6 +1449,31 @@ async fn test_immutable_fork_transaction_hash() {
     }
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_block_by_number_full_refetches_missing_cached_transactions() {
+    let (api, _) = spawn(fork_config()).await;
+
+    let block =
+        api.block_by_number_full(BlockNumberOrTag::Number(BLOCK_NUMBER)).await.unwrap().unwrap();
+    let block_txs = block.transactions.as_transactions().unwrap();
+    let original_len = block_txs.len();
+    let missing_hash = *block_txs[0].tx_hash();
+
+    let fork = api.backend.get_fork().unwrap();
+    {
+        let mut storage = fork.storage.write();
+        assert!(storage.transactions.remove(&missing_hash).is_some());
+    }
+
+    let refreshed =
+        api.block_by_number_full(BlockNumberOrTag::Number(BLOCK_NUMBER)).await.unwrap().unwrap();
+    let refreshed_txs = refreshed.transactions.as_transactions().unwrap();
+
+    assert_eq!(refreshed_txs.len(), original_len);
+    assert_eq!(refreshed_txs[0].tx_hash(), &missing_hash);
+    assert!(fork.storage.read().transactions.contains_key(&missing_hash));
+}
+
 // <https://github.com/foundry-rs/foundry/issues/4700>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_query_at_fork_block() {


### PR DESCRIPTION
## Motivation

Cached fork blocks can lose one or more stored transaction payloads while still keeping the block shell. When `block_by_hash_full` or `block_by_number_full` reconstructs that stale cache entry, RPC consumers receive an incomplete full block instead of a refetched upstream response.

## Solution

Return `None` from full-block reconstruction when any cached transaction is missing, then fall back to `fetch_full_block(...)` so the fork cache is repaired from upstream data. Add an integration test that removes one cached transaction and asserts the next full-block read refetches and restores it.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes