### PR TITLE
chore: harden Makefile & CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -61,7 +61,7 @@ jobs:
           printf '%s\n' "$GITHUB_WORKSPACE/.foundry/bin" >> "$GITHUB_PATH"
 
       - name: Build benchmark binary
-        run: cargo build --release --bin foundry-bench
+        run: cargo build --locked --release --bin foundry-bench
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo test --workspace --doc
+      - run: cargo test --workspace --doc --locked
 
   typos:
     runs-on: depot-ubuntu-latest
@@ -92,7 +92,7 @@ jobs:
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo clippy --workspace --all-targets --all-features
+      - run: cargo clippy --workspace --all-targets --all-features --locked
         env:
           RUSTFLAGS: -Dwarnings
 

--- a/.github/workflows/crate-checks.yml
+++ b/.github/workflows/crate-checks.yml
@@ -34,7 +34,7 @@ jobs:
           tool: cargo-hack
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo hack check
+      - run: cargo hack check --locked
 
   issue:
     name: Open an issue

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build documentation
-        run: cargo doc --workspace --all-features --no-deps --document-private-items
+        run: cargo doc --workspace --all-features --no-deps --document-private-items --locked
         env:
           RUSTDOCFLAGS: --cfg docsrs -D warnings --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options
       - name: Setup Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
         shell: bash
         run: |
           set -eo pipefail
-          flags=(--target $TARGET --profile $RUST_PROFILE --bins
+          flags=(--locked --target $TARGET --profile $RUST_PROFILE --bins
             --no-default-features --features "$RUST_FEATURES")
 
           # `jemalloc` is not fully supported on MSVC or aarch64 Linux.

--- a/.github/workflows/test-flaky.yml
+++ b/.github/workflows/test-flaky.yml
@@ -50,7 +50,7 @@ jobs:
           ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
           ARBITRUM_RPC: ${{ secrets.ARBITRUM_RPC }}
           ETH_SEPOLIA_RPC: ${{ secrets.ETH_SEPOLIA_RPC }}
-        run: cargo nextest run --profile flaky --no-fail-fast
+        run: cargo nextest run --locked --profile flaky --no-fail-fast
 
   # If any of the jobs fail, this will create a normal-priority issue to signal so.
   issue:

--- a/.github/workflows/test-isolate.yml
+++ b/.github/workflows/test-isolate.yml
@@ -54,7 +54,7 @@ jobs:
           ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
           ARBITRUM_RPC: ${{ secrets.ARBITRUM_RPC }}
           ETH_SEPOLIA_RPC: ${{ secrets.ETH_SEPOLIA_RPC }}
-        run: cargo nextest run --profile flaky --features=isolate-by-default --no-fail-fast
+        run: cargo nextest run --locked --profile flaky --features=isolate-by-default --no-fail-fast
 
   # If nextest fails, create a high-priority issue for isolation failures.
   issue-isolate:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,4 +121,4 @@ jobs:
           ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
           ARBITRUM_RPC: ${{ secrets.ARBITRUM_RPC }}
           ETH_SEPOLIA_RPC: ${{ secrets.ETH_SEPOLIA_RPC }}
-        run: cargo nextest run ${{ matrix.flags }}
+        run: cargo nextest run --locked ${{ matrix.flags }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -380,7 +380,6 @@ alloy-signer-local = { version = "2.0.0", default-features = false }
 alloy-signer-trezor = { version = "2.0.0", default-features = false }
 alloy-signer-turnkey = { version = "2.0.0", default-features = false }
 alloy-transport = { version = "2.0.0", default-features = false }
-alloy-transport-http = { version = "2.0.0", default-features = false }
 alloy-transport-ipc = { version = "2.0.0", default-features = false }
 alloy-transport-ws = { version = "2.0.0", default-features = false }
 alloy-hardforks = { version = "0.4.7", default-features = false }
@@ -618,3 +617,6 @@ solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/sola
 solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }
 solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }
 solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }
+
+[workspace.metadata.cargo-shear]
+ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ help: ## Display this help.
 
 .PHONY: build
 build: ## Build the project.
-	cargo build --features "$(FEATURES)" --profile "$(PROFILE)"
+	cargo build --locked --features "$(FEATURES)" --profile "$(PROFILE)"
 
 .PHONY: build-docker
 build-docker: ## Build the docker image.
@@ -47,17 +47,17 @@ build-docker: ## Build the docker image.
 ## is unstable (https://github.com/taiki-e/cargo-llvm-cov/issues/2).
 .PHONY: test-coverage
 test-coverage:
-	cargo +nightly llvm-cov --no-report nextest -E 'kind(test) & !test(/\b(issue|ext_integration|flaky_)/)' && \
-	cargo +nightly llvm-cov --no-report --doc && \
+	cargo +nightly llvm-cov --no-report nextest --locked -E 'kind(test) & !test(/\b(issue|ext_integration|flaky_)/)' && \
+	cargo +nightly llvm-cov --no-report --doc --locked && \
 	cargo +nightly llvm-cov report --doctests --open
 
 .PHONY: test-unit
 test-unit: ## Run unit tests.
-	cargo nextest run -E 'kind(test) & !test(/\b(issue|ext_integration|flaky_)/)'
+	cargo nextest run --workspace --locked -E 'kind(test) & !test(/\b(issue|ext_integration|flaky_)/)'
 
 .PHONY: test-doc
 test-doc: ## Run doc tests.
-	cargo test --doc --workspace
+	cargo test --doc --workspace --locked
 
 .PHONY: test
 test: ## Run all tests.
@@ -77,6 +77,7 @@ lint-clippy: ## Run clippy on the codebase.
 	--workspace \
 	--all-targets \
 	--all-features \
+	--locked \
 	-- -D warnings
 
 .PHONY: lint-clippy-fix
@@ -85,6 +86,7 @@ lint-clippy-fix: ## Run clippy on the codebase and fix warnings.
 	--workspace \
 	--all-targets \
 	--all-features \
+	--locked \
 	--fix \
 	--allow-dirty \
 	--allow-staged \
@@ -104,7 +106,23 @@ lint: ## Run all linters.
 	$(MAKE) lint-clippy && \
 	$(MAKE) lint-typos
 
+##@ Documentation
+
+.PHONY: doc
+doc: ## Build the documentation.
+	RUSTDOCFLAGS="--cfg docsrs -D warnings -Zunstable-options --show-type-layout --generate-link-to-definition" \
+	cargo +nightly doc \
+	--workspace \
+	--all-features \
+	--document-private-items \
+	--no-deps \
+	--locked
+
 ##@ Other
+
+.PHONY: lock
+lock: ## Update the Cargo.lock file with the current dependencies.
+	cargo fetch
 
 .PHONY: clean
 clean: ## Clean the project.
@@ -112,13 +130,22 @@ clean: ## Clean the project.
 
 .PHONY: deny
 deny: ## Perform a `cargo` deny check.
-	cargo deny --all-features check all
+	cargo deny --locked --all-features check all
+
+.PHONY: check
+check: ## Run a feature check on all crates and binaries.
+	cargo hack check --locked --feature-powerset --depth 1
+
+.PHONY: shear
+shear: ## Run `cargo shear` to check for unused dependencies.
+	cargo shear --locked
 
 .PHONY: pr
 pr: ## Run all checks and tests.
 	$(MAKE) deny && \
 	$(MAKE) lint && \
-	$(MAKE) test
+	$(MAKE) test && \
+	$(MAKE) doc
 
 # dprint formatting commands
 .PHONY: dprint-fmt


### PR DESCRIPTION
Hardens Makefile to always use `--locked` to prevent accidental pulls of new dependency versions when the lockfile is stale. If you run into a stale lockfile run `make lock`, this runs `cargo fetch` rather than `cargo update`.