### PR TITLE
feat: make asm-keccak a default feature in all binaries

### DIFF
--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -124,8 +124,8 @@ op-alloy-rpc-types.workspace = true
 tempo-alloy.workspace = true
 
 [features]
-default = ["cli", "jemalloc"]
-asm-keccak = ["alloy-primitives/asm-keccak"]
+default = ["cli", "jemalloc", "asm-keccak"]
+asm-keccak = ["alloy-primitives/asm-keccak", "revm/asm-keccak"]
 jemalloc = ["foundry-cli/jemalloc"]
 mimalloc = ["foundry-cli/mimalloc"]
 tracy-allocator = ["foundry-cli/tracy-allocator"]

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -99,8 +99,8 @@ anvil.workspace = true
 foundry-test-utils.workspace = true
 
 [features]
-default = ["jemalloc"]
-asm-keccak = ["alloy-primitives/asm-keccak"]
+default = ["jemalloc", "asm-keccak"]
+asm-keccak = ["alloy-primitives/asm-keccak", "revm/asm-keccak"]
 jemalloc = ["foundry-cli/jemalloc"]
 mimalloc = ["foundry-cli/mimalloc"]
 tracy-allocator = ["foundry-cli/tracy-allocator"]

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -65,7 +65,7 @@ foundry-test-utils.workspace = true
 rexpect = "0.6"
 
 [features]
-default = ["jemalloc"]
+default = ["jemalloc", "asm-keccak"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 jemalloc = ["foundry-cli/jemalloc"]
 mimalloc = ["foundry-cli/mimalloc"]

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -117,8 +117,8 @@ tempfile.workspace = true
 alloy-signer-local.workspace = true
 
 [features]
-default = ["jemalloc"]
-asm-keccak = ["alloy-primitives/asm-keccak"]
+default = ["jemalloc", "asm-keccak"]
+asm-keccak = ["alloy-primitives/asm-keccak", "revm/asm-keccak"]
 jemalloc = ["foundry-cli/jemalloc"]
 mimalloc = ["foundry-cli/mimalloc"]
 tracy-allocator = ["foundry-cli/tracy-allocator"]


### PR DESCRIPTION
Makes `asm-keccak` a default feature in all four binary crates (forge, anvil, cast, chisel), matching reth's approach where production binaries enable assembly-optimized keccak256 out-of-the-box.

Also forwards `revm/asm-keccak` where revm is a direct dependency (forge, anvil, cast) so the EVM executor also uses the fast path.

Since `asm-keccak` is now a default, it's removed from the explicit feature lists in the Makefile and CI workflows (`release.yml`, `docker-publish.yml`).