### PR TITLE
feat(forge): browser wallet support for `create` subcommand

### DIFF
--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -9,7 +9,7 @@ use alloy_provider::{PendingTransactionError, Provider, ProviderBuilder as Alloy
 use alloy_signer::{Signature, Signer};
 use alloy_transport::TransportError;
 use clap::{Parser, ValueHint};
-use eyre::{Context, Result};
+use eyre::{Context, ContextCompat, Result};
 use forge_verify::{RetryArgs, VerifierArgs, VerifyArgs};
 use foundry_cli::{
     opts::{BuildOpts, EthereumOpts, EtherscanOpts, TransactionOpts},
@@ -33,10 +33,12 @@ use foundry_config::{
     },
     merge_impl_figment_convert,
 };
-use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
+use foundry_wallets::{
+    BrowserWalletOpts, TempoAccessKeyConfig, WalletSigner, wallet_browser::signer::BrowserSigner,
+};
 use serde_json::json;
 use std::{borrow::Borrow, marker::PhantomData, path::PathBuf, sync::Arc, time::Duration};
-use tempo_alloy::TempoNetwork;
+use tempo_alloy::{TempoNetwork, contracts::precompiles::DEFAULT_FEE_TOKEN};
 
 merge_impl_figment_convert!(CreateArgs, build, eth);
 
@@ -101,14 +103,29 @@ pub struct CreateArgs {
 
     #[command(flatten)]
     retry: RetryArgs,
+
+    /// Browser wallet options
+    #[command(flatten)]
+    browser: BrowserWalletOpts,
 }
 
 impl CreateArgs {
     /// Executes the command to create a contract
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(mut self) -> Result<()> {
         let (signer, tempo_access_key) = self.eth.wallet.maybe_signer().await?;
 
-        if tempo_access_key.is_some() || self.tx.tempo.is_tempo() {
+        // Resolve chain early so we can dispatch to the correct network type.
+        if self.chain_id().is_none() {
+            let config = self.load_config()?;
+            let provider = ProviderBuilder::<Ethereum>::from_config(&config)?.build()?;
+            let chain_id = provider.get_chain_id().await?;
+            self.eth.etherscan.chain = Some(chain_id.into());
+        }
+
+        if tempo_access_key.is_some()
+            || self.tx.tempo.is_tempo()
+            || self.chain_id().is_some_and(|c| c.is_tempo())
+        {
             self.run_generic::<TempoNetwork>(signer, tempo_access_key).await
         } else {
             self.run_generic::<Ethereum>(signer, None).await
@@ -185,17 +202,29 @@ impl CreateArgs {
             self.tx.tempo.key_id = Some(ak.key_address);
         }
 
-        // respect chain, if set explicitly via cmd args
-        let chain_id = if let Some(chain_id) = self.chain_id() {
-            chain_id
-        } else {
-            provider.get_chain_id().await?
-        };
-
         // Whether to broadcast the transaction or not
         let dry_run = !self.broadcast;
 
-        if self.unlocked {
+        // Launch browser signer if `--browser` flag is set
+        let browser = self.browser.run::<N>().await?;
+
+        if let Some(browser) = browser {
+            // Deploy with browser wallet
+            let deployer_address = browser.address();
+            self.deploy(
+                abi,
+                bin,
+                params,
+                provider,
+                deployer_address,
+                config.transaction_timeout,
+                id,
+                dry_run,
+                None,
+                Some(browser),
+            )
+            .await
+        } else if self.unlocked {
             // Deploy with unlocked account
             let sender = self.eth.wallet.from.expect("required");
             self.deploy(
@@ -203,11 +232,11 @@ impl CreateArgs {
                 bin,
                 params,
                 provider,
-                chain_id,
                 sender,
                 config.transaction_timeout,
                 id,
                 dry_run,
+                None,
                 None,
             )
             .await
@@ -223,12 +252,12 @@ impl CreateArgs {
                 bin,
                 params,
                 provider,
-                chain_id,
                 deployer_address,
                 config.transaction_timeout,
                 id,
                 dry_run,
                 Some((signer, ak)),
+                None,
             )
             .await
         } else {
@@ -246,20 +275,20 @@ impl CreateArgs {
                 bin,
                 params,
                 provider,
-                chain_id,
                 deployer,
                 config.transaction_timeout,
                 id,
                 dry_run,
+                None,
                 None,
             )
             .await
         }
     }
 
-    /// Returns the provided chain id, if any.
-    fn chain_id(&self) -> Option<u64> {
-        self.eth.etherscan.chain.map(|chain| chain.id())
+    /// Returns the resolved chain, if any.
+    const fn chain_id(&self) -> Option<Chain> {
+        self.eth.etherscan.chain
     }
 
     /// Ensures the verify command can be executed.
@@ -271,7 +300,6 @@ impl CreateArgs {
     async fn verify_preflight_check(
         &self,
         constructor_args: Option<String>,
-        chain: u64,
         id: &ArtifactId,
     ) -> Result<()> {
         // NOTE: this does not represent the same `VerifyArgs` that would be sent after deployment,
@@ -287,7 +315,7 @@ impl CreateArgs {
             num_of_optimizations: None,
             etherscan: EtherscanOpts {
                 key: self.eth.etherscan.key.clone(),
-                chain: Some(chain.into()),
+                chain: self.chain_id(),
             },
             rpc: Default::default(),
             flatten: false,
@@ -311,7 +339,7 @@ impl CreateArgs {
         // ETHERSCAN_API_KEY value set.
         let config = verify.load_config()?;
         verify.etherscan.key =
-            config.get_etherscan_config_with_chain(Some(chain.into()))?.map(|c| c.key);
+            config.get_etherscan_config_with_chain(self.chain_id())?.map(|c| c.key);
 
         let context = verify.resolve_context().await?;
 
@@ -327,17 +355,19 @@ impl CreateArgs {
         bin: BytecodeObject,
         args: Vec<DynSolValue>,
         provider: P,
-        chain: u64,
         deployer_address: Address,
         timeout: u64,
         id: ArtifactId,
         dry_run: bool,
         tempo_keychain: Option<(WalletSigner, TempoAccessKeyConfig)>,
+        browser_signer: Option<BrowserSigner<N>>,
     ) -> Result<()>
     where
         N::TransactionRequest: FoundryTransactionBuilder<N> + serde::Serialize,
         N::ReceiptResponse: serde::Serialize,
     {
+        let chain = self.chain_id().context("chain ID not resolved")?;
+
         let bin = bin.into_bytes().unwrap_or_default();
         if bin.is_empty() {
             eyre::bail!("no bytecode found in bin object for {}", self.contract.name)
@@ -349,20 +379,29 @@ impl CreateArgs {
 
         let is_args_empty = args.is_empty();
         let mut deployer =
-            factory.deploy_tokens(args.clone(), self.tx.tempo.fee_token).context("failed to deploy contract").map_err(|e| {
+            factory.deploy_tokens(args.clone()).context("failed to deploy contract").map_err(|e| {
                 if is_args_empty {
                     e.wrap_err("no arguments provided for contract constructor; consider --constructor-args or --constructor-args-path")
                 } else {
                     e
                 }
             })?;
-        let is_legacy = self.tx.legacy || Chain::from(chain).is_legacy();
+        let is_legacy = self.tx.legacy || chain.is_legacy();
 
         deployer.tx.set_from(deployer_address);
-        deployer.tx.set_chain_id(chain);
+        deployer.tx.set_chain_id(chain.id());
         // `to` field must be set explicitly, cannot be None.
         if deployer.tx.to().is_none() {
             deployer.tx.set_create();
+        }
+
+        // If Tempo chain fee token must be set
+        if chain.is_tempo() {
+            if let Some(fee_token) = self.tx.tempo.fee_token {
+                deployer.tx.set_fee_token(fee_token);
+            } else {
+                deployer.tx.set_fee_token(DEFAULT_FEE_TOKEN);
+            }
         }
 
         // Apply user-provided gas, fee, nonce, and Tempo options.
@@ -422,7 +461,7 @@ impl CreateArgs {
                 constructor_args = Some(hex::encode(encoded_args));
             }
 
-            self.verify_preflight_check(constructor_args.clone(), chain, &id).await?;
+            self.verify_preflight_check(constructor_args.clone(), &id).await?;
         }
 
         if dry_run {
@@ -452,7 +491,31 @@ impl CreateArgs {
         }
 
         // Deploy the actual contract
-        let (deployed_contract, receipt) = if let Some((signer, ak)) = tempo_keychain {
+        let (deployed_contract, receipt) = if let Some(browser) = browser_signer {
+            // Browser wallet signs and sends the transaction
+            let tx_hash = browser.send_transaction_via_browser(deployer.tx).await?;
+
+            // Wait for the transaction to be confirmed, then fetch the receipt.
+            provider
+                .watch_pending_transaction(alloy_provider::PendingTransactionConfig::new(tx_hash))
+                .await?
+                .await?;
+
+            let receipt = provider
+                .get_transaction_receipt(tx_hash)
+                .await?
+                .ok_or_else(|| eyre::eyre!("could not get transaction receipt for {tx_hash}"))?;
+
+            if !receipt.status() {
+                eyre::bail!("deployment transaction failed (receipt status 0): {tx_hash}");
+            }
+
+            let address = receipt
+                .contract_address()
+                .ok_or_else(|| eyre::eyre!("contract was not deployed"))?;
+
+            (address, receipt)
+        } else if let Some((signer, ak)) = tempo_keychain {
             // Tempo keychain mode: sign with access key provisioning and send raw
             let raw_tx = deployer
                 .tx
@@ -518,7 +581,7 @@ impl CreateArgs {
             no_auto_detect: false,
             use_solc: None,
             num_of_optimizations,
-            etherscan: EtherscanOpts { key: self.eth.etherscan.key(), chain: Some(chain.into()) },
+            etherscan: EtherscanOpts { key: self.eth.etherscan.key(), chain: Some(chain) },
             rpc: Default::default(),
             flatten: false,
             force: false,
@@ -681,7 +744,6 @@ impl<N: Network, P: Provider<N> + Clone> DeploymentTxFactory<N, P> {
     pub fn deploy_tokens(
         self,
         params: Vec<DynSolValue>,
-        fee_token: Option<Address>,
     ) -> Result<Deployer<N, P>, ContractDeploymentError>
     where
         N::TransactionRequest: FoundryTransactionBuilder<N>,
@@ -703,9 +765,6 @@ impl<N: Network, P: Provider<N> + Clone> DeploymentTxFactory<N, P> {
         // create the tx object. Since we're deploying a contract, `to` is `None`
         let mut tx = N::TransactionRequest::default();
         tx.set_input(data);
-        if let Some(fee_token) = fee_token {
-            tx.set_fee_token(fee_token);
-        }
         Ok(Deployer { client: self.client.clone(), tx, confs: 1, timeout: self.timeout })
     }
 }
@@ -763,7 +822,7 @@ mod tests {
             "--chain-id",
             "9999",
         ]);
-        assert_eq!(args.chain_id(), Some(9999));
+        assert_eq!(args.chain_id().map(|c| c.id()), Some(9999));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Bring browser wallet support for `forge create` subcommand

Close #12958

## Solution

- add `BrowserWalletOpts` to `CreateArgs`
- Chain-based network dispatch

## Tests

```
forge create src/Counter.sol:Counter --rpc-url https://rpc.tempo.xyz --broadcast --browser --browser-disable-open
```

Explicit `fee-token` (e.g. USDC.e):
```
forge create src/Counter.sol:Counter --rpc-url https://rpc.tempo.xyz --broadcast --browser --browser-disable-open --tempo.fee-token 0x20c000000000000000000000b9537d11c60e8b50
```