### PR TITLE
fix(cast): add browser wallet support for erc20 commands

### DIFF
--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -3,13 +3,13 @@ use std::{str::FromStr, time::Duration};
 use crate::{
     cmd::send::{cast_send, cast_send_with_access_key},
     format_uint_exp,
-    tx::{SendTxOpts, TxParams},
+    tx::{CastTxSender, SendTxOpts, TxParams},
 };
 use alloy_consensus::{SignableTransaction, Signed};
 use alloy_eips::BlockId;
 use alloy_ens::NameOrAddress;
-use alloy_network::{Ethereum, EthereumWallet, Network};
-use alloy_primitives::U256;
+use alloy_network::{Ethereum, EthereumWallet, Network, TransactionBuilder};
+use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, fillers::RecommendedFillers};
 use alloy_signer::Signature;
 use alloy_sol_types::sol;
@@ -300,7 +300,11 @@ impl Erc20Subcommand {
         };
 
         let is_tempo = self.erc20_opts().is_some_and(|erc20| erc20.tempo.is_tempo())
-            || tempo_access_key.is_some();
+            || tempo_access_key.is_some()
+            || {
+                let config = self.rpc_opts().load_config()?;
+                get_chain(config.chain, &get_provider(&config)?).await?.is_tempo()
+            };
 
         if is_tempo {
             self.run_generic::<TempoNetwork>(signer, tempo_access_key).await
@@ -356,6 +360,25 @@ impl Erc20Subcommand {
                         timeout,
                     )
                     .await?
+                } else if let Some(browser) = $send_tx.browser.run::<N>().await? {
+                    let $provider = ProviderBuilder::<N>::from_config(&config)?.build()?;
+                    if let Some(interval) = $send_tx.poll_interval {
+                        $provider.client().set_poll_interval(Duration::from_secs(interval));
+                    }
+                    let $erc20 = IERC20::new($token.resolve(&$provider).await?, &$provider);
+                    let mut tx = { $build_tx }.into_transaction_request();
+                    let chain = get_chain(config.chain, &$provider).await?;
+                    $tx_opts.apply::<N>(&mut tx, chain.is_legacy());
+                    fill_tx(&$provider, &mut tx, browser.address(), chain).await?;
+                    let tx_hash = browser.send_transaction_via_browser(tx).await?;
+                    CastTxSender::new(&$provider)
+                        .print_tx_result(
+                            tx_hash,
+                            $send_tx.cast_async,
+                            $send_tx.confirmations,
+                            timeout,
+                        )
+                        .await?
                 } else {
                     let signer = pre_resolved_signer.unwrap_or($send_tx.eth.wallet.signer().await?);
                     let $provider = build_provider_with_signer::<N>(&$send_tx, signer)?;
@@ -502,4 +525,47 @@ impl Erc20Subcommand {
         };
         Ok(())
     }
+}
+
+/// Fills from, chain_id, nonce, fees, and gas limit on a transaction request for the browser
+/// wallet path. Mirrors the filling logic in the shared tx builder but operates on a
+/// pre-built transaction request from the sol! macro rather than through the builder pipeline.
+/// Only fills fields that haven't already been set by the user.
+async fn fill_tx<N: Network, P: Provider<N>>(
+    provider: &P,
+    tx: &mut N::TransactionRequest,
+    from: Address,
+    chain: Chain,
+) -> eyre::Result<()>
+where
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+{
+    tx.set_from(from);
+    tx.set_chain_id(chain.id());
+
+    if tx.nonce().is_none() {
+        tx.set_nonce(provider.get_transaction_count(from).await?);
+    }
+
+    let legacy = chain.is_legacy();
+
+    if legacy {
+        if tx.gas_price().is_none() {
+            tx.set_gas_price(provider.get_gas_price().await?);
+        }
+    } else if tx.max_fee_per_gas().is_none() || tx.max_priority_fee_per_gas().is_none() {
+        let estimate = provider.estimate_eip1559_fees().await?;
+        if tx.max_fee_per_gas().is_none() {
+            tx.set_max_fee_per_gas(estimate.max_fee_per_gas);
+        }
+        if tx.max_priority_fee_per_gas().is_none() {
+            tx.set_max_priority_fee_per_gas(estimate.max_priority_fee_per_gas);
+        }
+    }
+
+    if tx.gas_limit().is_none() {
+        tx.set_gas_limit(provider.estimate_gas(tx.clone()).await?);
+    }
+
+    Ok(())
 }

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -296,7 +296,8 @@ impl Erc20Subcommand {
         &self,
         tempo_access_key: &Option<TempoAccessKeyConfig>,
     ) -> eyre::Result<bool> {
-        if self.erc20_opts().is_some_and(|erc20| erc20.tempo.is_tempo()) || tempo_access_key.is_some()
+        if self.erc20_opts().is_some_and(|erc20| erc20.tempo.is_tempo())
+            || tempo_access_key.is_some()
         {
             return Ok(true);
         }

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -282,6 +282,33 @@ impl Erc20Subcommand {
         }
     }
 
+    const fn uses_browser_send(&self) -> bool {
+        match self {
+            Self::Transfer { send_tx, .. }
+            | Self::Approve { send_tx, .. }
+            | Self::Mint { send_tx, .. }
+            | Self::Burn { send_tx, .. } => send_tx.browser.browser,
+            _ => false,
+        }
+    }
+
+    async fn should_use_tempo_network(
+        &self,
+        tempo_access_key: &Option<TempoAccessKeyConfig>,
+    ) -> eyre::Result<bool> {
+        if self.erc20_opts().is_some_and(|erc20| erc20.tempo.is_tempo()) || tempo_access_key.is_some()
+        {
+            return Ok(true);
+        }
+
+        if self.uses_browser_send() {
+            let config = self.rpc_opts().load_config()?;
+            return Ok(get_chain(config.chain, &get_provider(&config)?).await?.is_tempo());
+        }
+
+        Ok(false)
+    }
+
     pub async fn run(self) -> eyre::Result<()> {
         // Resolve the signer once for state-changing variants.
         let (signer, tempo_access_key) = match &self {
@@ -300,12 +327,7 @@ impl Erc20Subcommand {
             _ => (None, None),
         };
 
-        let is_tempo = self.erc20_opts().is_some_and(|erc20| erc20.tempo.is_tempo())
-            || tempo_access_key.is_some()
-            || {
-                let config = self.rpc_opts().load_config()?;
-                get_chain(config.chain, &get_provider(&config)?).await?.is_tempo()
-            };
+        let is_tempo = self.should_use_tempo_network(&tempo_access_key).await?;
 
         if is_tempo {
             self.run_generic::<TempoNetwork>(signer, tempo_access_key).await

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -28,6 +28,7 @@ use foundry_common::{
 pub use foundry_config::{Chain, utils::*};
 use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
 use tempo_alloy::TempoNetwork;
+use tempo_contracts::precompiles::PATH_USD_ADDRESS;
 
 sol! {
     #[sol(rpc)]
@@ -369,6 +370,9 @@ impl Erc20Subcommand {
                     let mut tx = { $build_tx }.into_transaction_request();
                     let chain = get_chain(config.chain, &$provider).await?;
                     $tx_opts.apply::<N>(&mut tx, chain.is_legacy());
+                    if chain.is_tempo() && tx.fee_token().is_none() {
+                        tx.set_fee_token(PATH_USD_ADDRESS);
+                    }
                     fill_tx(&$provider, &mut tx, browser.address(), chain).await?;
                     let tx_hash = browser.send_transaction_via_browser(tx).await?;
                     CastTxSender::new(&$provider)


### PR DESCRIPTION
## Summary
- add a browser-wallet branch to the erc20 command flow so `cast erc20 ... --browser` uses the browser signer instead of falling through to local signer handling
- preserve the existing transaction filling behavior for browser-submitted ERC20 transactions by filling only missing fields before dispatch
- leave Tempo fee-token browser signing behavior unchanged; MetaMask/viem still rejects custom Tempo tx type `0x76`

## Notes
- Plain Tempo browser flow reaches the wallet path correctly, but MetaMask may still block submission if the connected wallet lacks gas funds on Tempo.
- Tempo fee-token browser signing remains unsupported in MetaMask because viem rejects custom envelope type `0x76`.