### PR TITLE
fix: accept 0x-prefixed value inputs

### DIFF
--- a/crates/cast/src/call_spec.rs
+++ b/crates/cast/src/call_spec.rs
@@ -146,7 +146,8 @@ impl FromStr for CallSpec {
 fn parse_ether_or_wei(s: &str) -> Result<U256> {
     // Use alloy's DynSolType coercion which handles "1ether", "1gwei", "1000" etc.
     if s.starts_with("0x") {
-        U256::from_str_radix(s, 16).map_err(|e| eyre!("Invalid hex value '{}': {}", s, e))
+        U256::from_str_radix(s.strip_prefix("0x").unwrap_or(s), 16)
+            .map_err(|e| eyre!("Invalid hex value '{}': {}", s, e))
     } else {
         alloy_dyn_abi::DynSolType::coerce_str(&alloy_dyn_abi::DynSolType::Uint(256), s)
             .wrap_err_with(|| format!("Invalid value '{s}'"))?
@@ -178,6 +179,11 @@ mod tests {
         let spec = CallSpec::parse("0x1234567890123456789012345678901234567890:1ether").unwrap();
         assert_eq!(spec.value, parse_ether_or_wei("1ether").unwrap());
         assert!(spec.sig.is_none());
+    }
+
+    #[test]
+    fn test_parse_hex_value() {
+        assert_eq!(parse_ether_or_wei("0x10").unwrap(), U256::from(16));
     }
 
     #[test]

--- a/crates/cast/src/call_spec.rs
+++ b/crates/cast/src/call_spec.rs
@@ -145,9 +145,8 @@ impl FromStr for CallSpec {
 /// Parse a value string that can be in ether notation (e.g., "0.1ether") or raw wei.
 fn parse_ether_or_wei(s: &str) -> Result<U256> {
     // Use alloy's DynSolType coercion which handles "1ether", "1gwei", "1000" etc.
-    if s.starts_with("0x") {
-        U256::from_str_radix(s.strip_prefix("0x").unwrap_or(s), 16)
-            .map_err(|e| eyre!("Invalid hex value '{}': {}", s, e))
+    if s.starts_with("0x") || s.starts_with("0X") {
+        U256::from_str(s).map_err(|e| eyre!("Invalid hex value '{}': {}", s, e))
     } else {
         alloy_dyn_abi::DynSolType::coerce_str(&alloy_dyn_abi::DynSolType::Uint(256), s)
             .wrap_err_with(|| format!("Invalid value '{s}'"))?
@@ -184,6 +183,7 @@ mod tests {
     #[test]
     fn test_parse_hex_value() {
         assert_eq!(parse_ether_or_wei("0x10").unwrap(), U256::from(16));
+        assert_eq!(parse_ether_or_wei("0X10").unwrap(), U256::from(16));
     }
 
     #[test]

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -129,8 +129,8 @@ where
 /// If the string represents an untagged amount (e.g. "100") then
 /// it is interpreted as wei.
 pub fn parse_ether_value(value: &str) -> Result<U256> {
-    Ok(if value.starts_with("0x") {
-        U256::from_str_radix(value.strip_prefix("0x").unwrap_or(value), 16)?
+    Ok(if value.starts_with("0x") || value.starts_with("0X") {
+        U256::from_str(value)?
     } else {
         alloy_dyn_abi::DynSolType::coerce_str(&alloy_dyn_abi::DynSolType::Uint(256), value)?
             .as_uint()
@@ -847,6 +847,11 @@ mod tests {
     #[test]
     fn parse_ether_value_accepts_hex_prefixed_wei() {
         assert_eq!(parse_ether_value("0x10").unwrap(), U256::from(16));
+        assert_eq!(parse_ether_value("0X10").unwrap(), U256::from(16));
+        assert_eq!(parse_ether_value("0x12").unwrap(), U256::from(0x12));
+        assert_eq!(parse_ether_value("0xff").unwrap(), U256::from(0xff));
+        assert_eq!(parse_ether_value("100").unwrap(), U256::from(100));
+        assert_eq!(parse_ether_value("1ether").unwrap(), U256::from(1000000000000000000u128));
     }
 
     // loads .env from cwd and project dir, See [`find_project_root()`]

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -130,7 +130,7 @@ where
 /// it is interpreted as wei.
 pub fn parse_ether_value(value: &str) -> Result<U256> {
     Ok(if value.starts_with("0x") {
-        U256::from_str_radix(value, 16)?
+        U256::from_str_radix(value.strip_prefix("0x").unwrap_or(value), 16)?
     } else {
         alloy_dyn_abi::DynSolType::coerce_str(&alloy_dyn_abi::DynSolType::Uint(256), value)?
             .as_uint()
@@ -842,6 +842,11 @@ mod tests {
         assert!(p.is_sol());
         let p = Path::new("contracts/Greeter.sol");
         assert!(!p.is_sol_test());
+    }
+
+    #[test]
+    fn parse_ether_value_accepts_hex_prefixed_wei() {
+        assert_eq!(parse_ether_value("0x10").unwrap(), U256::from(16));
     }
 
     // loads .env from cwd and project dir, See [`find_project_root()`]


### PR DESCRIPTION
Fixes #14403.

## Summary

Fix `parse_ether_value` and `parse_ether_or_wei` to correctly handle `0x`-prefixed hex strings (e.g. `--value 0x12`).

## Problem

```
cast call --value 0x12 ...
error: invalid value '0x12' for '--value <VALUE>': digit 33 is out of range for base 16
```

The previous code passed the full `0x`-prefixed string to `U256::from_str_radix(value, 16)`, which treats the `x` as an invalid hex digit.

## Fix

Use `U256::from_str(value)` which natively handles the `0x`/`0X` prefix — it [strips the prefix and delegates to `from_str_radix` with base 16 internally](https://github.com/recmo/uint/blob/main/src/string.rs#L225-L241).

Also adds `0X` prefix support and expands regression tests to cover hex, decimal, and ether-tagged values.