### PR TITLE
fix(npm): remove deprecated `baseUrl` compiler option

### DIFF
--- a/npm/tsconfig.json
+++ b/npm/tsconfig.json
@@ -2,7 +2,6 @@
   "schema": "https://json.schemastore.org/tsconfig.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "noEmit": true,
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
The `baseUrl` compiler option is [deprecated in TypeScript 6.0](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#deprecated-baseurl) and will be removed in TypeScript 7.0.

This was causing the npm Typecheck CI step to fail with:

> Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.

The option was unused — there are no `paths` mappings, and all imports use `node:` prefixed modules or `#` subpath imports (resolved via `package.json` `imports`).