### PR TITLE
fix(wallets): add gas limit margin to handle WebAuthn/P256 signing

### DIFF
--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -23,6 +23,7 @@ use foundry_common::{
     fmt::{UIfmt, UIfmtReceiptExt},
     provider::{ProviderBuilder, RetryProviderWithSigner},
     shell,
+    tempo::TEMPO_BROWSER_GAS_BUFFER,
 };
 #[doc(hidden)]
 pub use foundry_config::{Chain, utils::*};
@@ -591,7 +592,16 @@ where
     }
 
     if tx.gas_limit().is_none() {
-        tx.set_gas_limit(provider.estimate_gas(tx.clone()).await?);
+        let mut estimated = provider.estimate_gas(tx.clone()).await?;
+
+        // Browser wallets may sign with P256/WebAuthn instead of secp256k1, which
+        // costs more gas for signature verification on Tempo chains. Add a
+        // conservative buffer since we can't determine the signature type beforehand.
+        if chain.is_tempo() {
+            estimated += TEMPO_BROWSER_GAS_BUFFER;
+        }
+
+        tx.set_gas_limit(estimated);
     }
 
     Ok(())

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -13,6 +13,7 @@ use foundry_common::{
     FoundryTransactionBuilder,
     fmt::{UIfmt, UIfmtReceiptExt},
     provider::ProviderBuilder,
+    tempo::TEMPO_BROWSER_GAS_BUFFER,
 };
 use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
 use tempo_alloy::TempoNetwork;
@@ -258,7 +259,18 @@ impl SendTxArgs {
         // Case 2:
         // Browser wallet signs and sends the transaction in one step.
         } else if let Some(browser) = browser {
-            let (tx_request, _) = builder.build(browser.address()).await?;
+            let chain = builder.chain();
+            let (mut tx_request, _) = builder.build(browser.address()).await?;
+
+            // Browser wallets may sign with P256/WebAuthn instead of secp256k1, which
+            // costs more gas for signature verification on Tempo chains. Add a
+            // conservative buffer since we can't determine the signature type beforehand.
+            if chain.is_tempo()
+                && let Some(gas) = tx_request.gas_limit()
+            {
+                tx_request.set_gas_limit(gas + TEMPO_BROWSER_GAS_BUFFER);
+            }
+
             let tx_hash = browser.send_transaction_via_browser(tx_request).await?;
 
             let cast = CastTxSender::new(&provider);

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -398,6 +398,13 @@ pub struct CastTxBuilder<N: Network, P, S> {
     state: S,
 }
 
+impl<N: Network, P, S> CastTxBuilder<N, P, S> {
+    /// Returns the resolved chain for this builder.
+    pub const fn chain(&self) -> Chain {
+        self.chain
+    }
+}
+
 impl<N: Network, P: Provider<N>> CastTxBuilder<N, P, InitState>
 where
     N::TransactionRequest: FoundryTransactionBuilder<N>,

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -2,3 +2,14 @@
 
 mod keystore;
 pub use keystore::*;
+
+/// Conservative gas buffer for browser wallet transactions on Tempo chains.
+///
+/// Browser wallets may sign with P256 or WebAuthn instead of secp256k1, which costs more gas
+/// for signature verification. Since we can't determine the signature type before signing,
+/// we add the worst-case (WebAuthn) overhead:
+///   - P256: +5,000 gas (P256 precompile cost minus ecrecover savings)
+///   - WebAuthn: ~6,500 gas (P256 cost + calldata for webauthn_data)
+///
+/// See <https://github.com/tempoxyz/tempo/blob/6ebf1a8/crates/revm/src/handler.rs#L108-L124>
+pub const TEMPO_BROWSER_GAS_BUFFER: u64 = 7_000;

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -21,6 +21,7 @@ use foundry_common::{
     fmt::parse_tokens,
     provider::ProviderBuilder,
     shell,
+    tempo::TEMPO_BROWSER_GAS_BUFFER,
 };
 use foundry_compilers::{
     ArtifactId, artifacts::BytecodeObject, info::ContractInfo, utils::canonicalize,
@@ -433,7 +434,16 @@ impl CreateArgs {
         }
 
         if self.tx.gas_limit.is_none() {
-            deployer.tx.set_gas_limit(provider.estimate_gas(deployer.tx.clone()).await?);
+            let mut estimated = provider.estimate_gas(deployer.tx.clone()).await?;
+
+            // Browser wallets may sign with P256/WebAuthn instead of secp256k1, which
+            // costs more gas for signature verification on Tempo chains. Add a
+            // conservative buffer since we can't determine the signature type beforehand.
+            if browser_signer.is_some() && chain.is_tempo() {
+                estimated += TEMPO_BROWSER_GAS_BUFFER;
+            }
+
+            deployer.tx.set_gas_limit(estimated);
         }
 
         if is_legacy {


### PR DESCRIPTION
## Motivation

Add gas limit margin for to handle WebAuthn/P256 signing.

See https://github.com/tempoxyz/tempo/blob/6ebf1a8/crates/revm/src/handler.rs#L108-L124

s/o @zerosnacks and @0xrusowsky for their help in identifying the problem.

## Tests
```
cast erc20 transfer 0x20c0000000000000000000000000000000000000 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 10 --rpc-url 'https://rpc.presto.tempo.xyz/' --browser --tempo.fee-token 0x20c00000000000000000000014f22ca97301eb73
```
```
cast send 0x20c0000000000000000000000000000000000000 "transfer(address, uint256)" 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 10 --rpc-url 'https://rpc.presto.tempo.xyz' --browser --tempo.fee-token 0x20c00000000000000000000014f22ca97301eb73
```
```
forge create src/Counter.sol:Counter --rpc-url https://rpc.tempo.xyz --broadcast --browser --browser-disable-open --tempo.fee-token 0x20c00000000000000000000014f22ca97301eb73
```