### PR TITLE
fix(cheatcodes): reject nested debug trace recording

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1246,6 +1246,10 @@ impl Cheatcode for startDebugTraceRecordingCall {
             return Err(Error::from("no tracer initiated, consider adding -vvv flag"));
         };
 
+        if ccx.state.record_debug_steps_info.is_some() {
+            bail!("debug trace recording was already started");
+        }
+
         let mut info = RecordDebugStepInfo {
             // will be updated later
             start_node_idx: 0,

--- a/testdata/default/cheats/RecordDebugTrace.t.sol
+++ b/testdata/default/cheats/RecordDebugTrace.t.sol
@@ -85,14 +85,16 @@ contract RecordDebugTraceTest is Test {
         for (uint256 i = 0; i < steps.length; i++) {
             Vm.DebugStep memory step = steps[i];
             if (
-                step.opcode == 0x52 /*MSTORE*/ && step.stack[0] == testContract.memPtr() // MSTORE offset
+                step.opcode == 0x52 /*MSTORE*/
+                    && step.stack[0] == testContract.memPtr() // MSTORE offset
                     && step.stack[1] == testContract.expectedValueInMemory() // MSTORE val
             ) {
                 mstoreCalled = true;
             }
 
             if (
-                step.opcode == 0x51 /*MLOAD*/ && step.stack[0] == testContract.memPtr() // MLOAD offset
+                step.opcode == 0x51 /*MLOAD*/
+                    && step.stack[0] == testContract.memPtr() // MLOAD offset
                     && step.memoryInput.length == 32 // MLOAD should always load 32 bytes
                     && uint256(bytes32(step.memoryInput)) == testContract.expectedValueInMemory() // MLOAD value
             ) {

--- a/testdata/default/cheats/RecordDebugTrace.t.sol
+++ b/testdata/default/cheats/RecordDebugTrace.t.sol
@@ -85,16 +85,14 @@ contract RecordDebugTraceTest is Test {
         for (uint256 i = 0; i < steps.length; i++) {
             Vm.DebugStep memory step = steps[i];
             if (
-                step.opcode == 0x52 /*MSTORE*/
-                    && step.stack[0] == testContract.memPtr() // MSTORE offset
+                step.opcode == 0x52 /*MSTORE*/ && step.stack[0] == testContract.memPtr() // MSTORE offset
                     && step.stack[1] == testContract.expectedValueInMemory() // MSTORE val
             ) {
                 mstoreCalled = true;
             }
 
             if (
-                step.opcode == 0x51 /*MLOAD*/
-                    && step.stack[0] == testContract.memPtr() // MLOAD offset
+                step.opcode == 0x51 /*MLOAD*/ && step.stack[0] == testContract.memPtr() // MLOAD offset
                     && step.memoryInput.length == 32 // MLOAD should always load 32 bytes
                     && uint256(bytes32(step.memoryInput)) == testContract.expectedValueInMemory() // MLOAD value
             ) {
@@ -161,5 +159,20 @@ contract RecordDebugTraceTest is Test {
             }
         }
         assertTrue(isOOG, "should OOG");
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testCannotRestartDebugTraceRecordingWhileActive() public {
+        MStoreAndMLoadCaller testContract = new MStoreAndMLoadCaller();
+
+        vm.startDebugTraceRecording();
+
+        vm.expectRevert("vm.startDebugTraceRecording: debug trace recording was already started");
+        vm.startDebugTraceRecording();
+
+        testContract.storeAndLoadValueFromMemory();
+
+        Vm.DebugStep[] memory steps = vm.stopAndReturnDebugTraceRecording();
+        assertGt(steps.length, 0, "first recording should remain active after failed restart");
     }
 }


### PR DESCRIPTION
## Motivation

`startDebugTraceRecording` currently overwrites the saved tracer config each time it is called. If recording is started twice before `stopAndReturnDebugTraceRecording`, the final restore uses the overwritten config instead of the original one, which can leak debug tracing settings across later execution.

## Solution

Reject repeated `startDebugTraceRecording` calls while a recording session is already active, and add a regression test that verifies the second start reverts while the first recording remains usable.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes