### PR TITLE
fix: remove `network: tempo` from Tempo template

### DIFF
--- a/crates/forge/assets/tempo/workflowTemplate.yml
+++ b/crates/forge/assets/tempo/workflowTemplate.yml
@@ -23,7 +23,6 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
-          network: tempo
 
       - name: Show Forge version
         run: forge --version


### PR DESCRIPTION
Remove `network: tempo` from template, no longer needed