### PR TITLE
chore: pin to foundry-wallets release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5558,7 +5558,8 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d6c92dfcb41be26fbc1de21221a5bfc6bdd93245#d6c92dfcb41be26fbc1de21221a5bfc6bdd93245"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f2cc1ff7ea002addf41bd9c5785cd34f6a7b9658998c50035cc860ffebc3a9"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -355,7 +355,7 @@ svm = { package = "svm-rs", version = "0.5", default-features = false, features 
 ] }
 
 ## foundry-core
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "d6c92dfcb41be26fbc1de21221a5bfc6bdd93245", default-features = false }
+foundry-wallets = { version = "0.1.0", default-features = false }
 
 ## alloy
 alloy-consensus = { version = "2.0.1", default-features = false }


### PR DESCRIPTION
Pins to the latest (and first!) release of https://crates.io/crates/foundry-wallets