### PR TITLE
refactor(anvil): pass `from` explicitly into `transaction_build`

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2503,8 +2503,14 @@ impl EthApi<FoundryNetwork> {
 
         let raw = tx.encoded_2718().into();
 
-        let mut tx =
-            transaction_build(None, MaybeImpersonatedTransaction::new(tx), None, None, None);
+        let mut tx = transaction_build(
+            None,
+            None,
+            MaybeImpersonatedTransaction::new(tx),
+            None,
+            None,
+            None,
+        );
 
         // Set the correct `from` address (overrides the recovered zero address from dummy
         // signature)
@@ -2529,20 +2535,14 @@ impl EthApi<FoundryNetwork> {
         node_info!("eth_getTransactionByHash");
         let mut tx = self.pool.get_transaction(hash).map(|pending| {
             let from = *pending.sender();
-            let tx = transaction_build(
+            transaction_build(
                 Some(*pending.hash()),
+                Some(from),
                 pending.transaction,
                 None,
                 None,
                 Some(self.backend.base_fee()),
-            );
-
-            let WithOtherFields { inner: mut tx, other } = tx.0;
-            // we set the from field here explicitly to the set sender of the pending transaction,
-            // in case the transaction is impersonated.
-            tx.inner = Recovered::new_unchecked(tx.inner.into_inner(), from);
-
-            AnyRpcTransaction(WithOtherFields { inner: tx, other })
+            )
         });
         if tx.is_none() {
             tx = self.backend.transaction_by_hash(hash).await?
@@ -2571,19 +2571,14 @@ impl EthApi<FoundryNetwork> {
             {
                 let tx = transaction_build(
                     Some(*pending_tx.pending_transaction.hash()),
+                    Some(*pending_tx.pending_transaction.sender()),
                     pending_tx.pending_transaction.transaction.clone(),
                     None,
                     None,
                     Some(self.backend.base_fee()),
                 );
 
-                let WithOtherFields { inner: mut tx, other } = tx.0;
-                // we set the from field here explicitly to the set sender of the pending
-                // transaction, in case the transaction is impersonated.
-                let from = *pending_tx.pending_transaction.sender();
-                tx.inner = Recovered::new_unchecked(tx.inner.into_inner(), from);
-
-                return Ok(Some(AnyRpcTransaction(WithOtherFields { inner: tx, other })));
+                return Ok(Some(tx));
             }
         }
 
@@ -3258,19 +3253,12 @@ impl EthApi<FoundryNetwork> {
             let from = *tx.pending_transaction.sender();
             let tx = transaction_build(
                 Some(tx.hash()),
+                Some(from),
                 tx.pending_transaction.transaction.clone(),
                 None,
                 None,
                 None,
             );
-
-            let WithOtherFields { inner: mut tx, other } = tx.0;
-
-            // we set the from field here explicitly to the set sender of the pending transaction,
-            // in case the transaction is impersonated.
-            tx.inner = Recovered::new_unchecked(tx.inner.into_inner(), from);
-
-            let tx = AnyRpcTransaction(WithOtherFields { inner: tx, other });
 
             Ok(tx)
         }
@@ -3424,6 +3412,7 @@ impl EthApi<FoundryNetwork> {
 
             let tx = transaction_build(
                 Some(info.transaction_hash),
+                Some(info.from),
                 tx,
                 Some(&block),
                 Some(info),

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2503,14 +2503,8 @@ impl EthApi<FoundryNetwork> {
 
         let raw = tx.encoded_2718().into();
 
-        let mut tx = transaction_build(
-            None,
-            None,
-            MaybeImpersonatedTransaction::new(tx),
-            None,
-            None,
-            None,
-        );
+        let mut tx =
+            transaction_build(None, MaybeImpersonatedTransaction::new(tx), None, None, None, None);
 
         // Set the correct `from` address (overrides the recovered zero address from dummy
         // signature)
@@ -2537,8 +2531,8 @@ impl EthApi<FoundryNetwork> {
             let from = *pending.sender();
             transaction_build(
                 Some(*pending.hash()),
-                Some(from),
                 pending.transaction,
+                Some(from),
                 None,
                 None,
                 Some(self.backend.base_fee()),
@@ -2571,8 +2565,8 @@ impl EthApi<FoundryNetwork> {
             {
                 let tx = transaction_build(
                     Some(*pending_tx.pending_transaction.hash()),
-                    Some(*pending_tx.pending_transaction.sender()),
                     pending_tx.pending_transaction.transaction.clone(),
+                    Some(*pending_tx.pending_transaction.sender()),
                     None,
                     None,
                     Some(self.backend.base_fee()),
@@ -3253,8 +3247,8 @@ impl EthApi<FoundryNetwork> {
             let from = *tx.pending_transaction.sender();
             let tx = transaction_build(
                 Some(tx.hash()),
-                Some(from),
                 tx.pending_transaction.transaction.clone(),
+                Some(from),
                 None,
                 None,
                 None,
@@ -3412,8 +3406,8 @@ impl EthApi<FoundryNetwork> {
 
             let tx = transaction_build(
                 Some(info.transaction_hash),
-                Some(info.from),
                 tx,
+                Some(info.from),
                 Some(&block),
                 Some(info),
                 Some(base_fee),

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -980,7 +980,9 @@ impl<N: Network> Backend<N> {
             let info = storage.transactions.get(&hash)?.info.clone();
             let tx = block.body.transactions.get(info.transaction_index as usize)?.clone();
 
-            let tx = transaction_build(Some(hash), tx, Some(block), Some(info), base_fee);
+            let from = info.from;
+            let tx =
+                transaction_build(Some(hash), Some(from), tx, Some(block), Some(info), base_fee);
             transactions.push(tx);
         }
         Some(transactions)
@@ -1685,6 +1687,7 @@ impl<N: Network> Backend<N> {
 
         Some(transaction_build(
             Some(info.transaction_hash),
+            Some(info.from),
             tx,
             Some(&block),
             Some(info),
@@ -1723,6 +1726,7 @@ impl<N: Network> Backend<N> {
 
         Some(transaction_build(
             Some(info.transaction_hash),
+            Some(info.from),
             tx,
             Some(&block),
             Some(info),
@@ -4095,6 +4099,7 @@ impl Backend<FoundryNetwork> {
                     let tx_hash = tx.hash();
                     let rpc_tx = transaction_build(
                         None,
+                        Some(from),
                         MaybeImpersonatedTransaction::impersonated(tx, from),
                         None,
                         None,
@@ -4621,11 +4626,19 @@ where
 /// Creates a `AnyRpcTransaction` as it's expected for the `eth` RPC api from storage data
 pub fn transaction_build(
     tx_hash: Option<B256>,
+    from: Option<Address>,
     eth_transaction: MaybeImpersonatedTransaction<FoundryTxEnvelope>,
     block: Option<&Block>,
     info: Option<TransactionInfo>,
     base_fee: Option<u64>,
 ) -> AnyRpcTransaction {
+    // If a specific hash was provided we reuse it; otherwise compute it.
+    // This is important for impersonated transactions since they all use the
+    // `BYPASS_SIGNATURE` which would result in different hashes
+    // Note: for impersonated transactions this only concerns pending transactions because
+    // there's no `info` yet.
+    let hash = tx_hash.unwrap_or_else(|| eth_transaction.hash());
+
     #[cfg(feature = "optimism")]
     if let FoundryTxEnvelope::Deposit(deposit_tx) = eth_transaction.as_ref() {
         let dep_tx = deposit_tx;
@@ -4648,10 +4661,7 @@ pub fn transaction_build(
                     memo: Default::default(),
                 };
 
-                let envelope = AnyTxEnvelope::Unknown(UnknownTxEnvelope {
-                    hash: eth_transaction.hash(),
-                    inner,
-                });
+                let envelope = AnyTxEnvelope::Unknown(UnknownTxEnvelope { hash, inner });
 
                 let tx = Transaction {
                     inner: Recovered::new_unchecked(envelope, deposit_tx.from),
@@ -4673,7 +4683,7 @@ pub fn transaction_build(
     }
 
     if let FoundryTxEnvelope::Tempo(tempo_tx) = eth_transaction.as_ref() {
-        let from = eth_transaction.recover().unwrap_or_default();
+        let from = from.unwrap_or_else(|| eth_transaction.recover().unwrap_or_default());
         let ser = serde_json::to_value(tempo_tx).expect("could not serialize Tempo transaction");
         let maybe_tempo_fields = OtherFields::try_from(ser);
 
@@ -4685,10 +4695,7 @@ pub fn transaction_build(
                     memo: Default::default(),
                 };
 
-                let envelope = AnyTxEnvelope::Unknown(UnknownTxEnvelope {
-                    hash: eth_transaction.hash(),
-                    inner,
-                });
+                let envelope = AnyTxEnvelope::Unknown(UnknownTxEnvelope { hash, inner });
 
                 let tx = Transaction {
                     inner: Recovered::new_unchecked(envelope, from),
@@ -4707,15 +4714,8 @@ pub fn transaction_build(
         }
     }
 
-    let from = eth_transaction.recover().unwrap_or_default();
+    let from = from.unwrap_or_else(|| eth_transaction.recover().unwrap_or_default());
     let effective_gas_price = eth_transaction.effective_gas_price(base_fee);
-
-    // if a specific hash was provided we update the transaction's hash
-    // This is important for impersonated transactions since they all use the
-    // `BYPASS_SIGNATURE` which would result in different hashes
-    // Note: for impersonated transactions this only concerns pending transactions because
-    // there's no `info` yet.
-    let hash = tx_hash.unwrap_or_else(|| eth_transaction.hash());
 
     let eth_envelope = FoundryTxEnvelope::from(eth_transaction)
         .try_into_eth()

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -980,9 +980,14 @@ impl<N: Network> Backend<N> {
             let info = storage.transactions.get(&hash)?.info.clone();
             let tx = block.body.transactions.get(info.transaction_index as usize)?.clone();
 
-            let from = info.from;
-            let tx =
-                transaction_build(Some(hash), Some(from), tx, Some(block), Some(info), base_fee);
+            let tx = transaction_build(
+                Some(hash),
+                tx,
+                Some(info.from),
+                Some(block),
+                Some(info),
+                base_fee,
+            );
             transactions.push(tx);
         }
         Some(transactions)
@@ -1687,8 +1692,8 @@ impl<N: Network> Backend<N> {
 
         Some(transaction_build(
             Some(info.transaction_hash),
-            Some(info.from),
             tx,
+            Some(info.from),
             Some(&block),
             Some(info),
             block.header.base_fee_per_gas(),
@@ -1726,8 +1731,8 @@ impl<N: Network> Backend<N> {
 
         Some(transaction_build(
             Some(info.transaction_hash),
-            Some(info.from),
             tx,
+            Some(info.from),
             Some(&block),
             Some(info),
             block.header.base_fee_per_gas(),
@@ -4099,8 +4104,8 @@ impl Backend<FoundryNetwork> {
                     let tx_hash = tx.hash();
                     let rpc_tx = transaction_build(
                         None,
-                        Some(from),
                         MaybeImpersonatedTransaction::impersonated(tx, from),
+                        Some(from),
                         None,
                         None,
                         Some(block_env.basefee),
@@ -4626,8 +4631,8 @@ where
 /// Creates a `AnyRpcTransaction` as it's expected for the `eth` RPC api from storage data
 pub fn transaction_build(
     tx_hash: Option<B256>,
-    from: Option<Address>,
     eth_transaction: MaybeImpersonatedTransaction<FoundryTxEnvelope>,
+    from: Option<Address>,
     block: Option<&Block>,
     info: Option<TransactionInfo>,
     base_fee: Option<u64>,

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -710,6 +710,56 @@ async fn can_get_pending_transaction() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn impersonated_transaction_keeps_from_in_rpc_responses() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let from = Address::random();
+    let to = handle.dev_wallets().next().unwrap().address();
+    api.anvil_set_balance(from, U256::from(1_000_000_000_000_000_000u128)).await.unwrap();
+    api.anvil_impersonate_account(from).await.unwrap();
+
+    let tx = TransactionRequest::default()
+        .from(from)
+        .to(to)
+        .value(U256::from(1337))
+        .with_gas_limit(21_000);
+    let tx = WithOtherFields::new(tx);
+    let pending = provider.send_transaction(tx).await.unwrap();
+
+    let pending_block = provider.get_block(BlockId::pending()).full().await.unwrap().unwrap();
+    let pending_txs = pending_block.transactions.as_transactions().unwrap();
+    assert_eq!(pending_txs.len(), 1);
+    assert_eq!(pending_txs[0].from(), from);
+
+    api.mine_one().await;
+
+    let mined = provider.get_transaction_by_hash(*pending.tx_hash()).await.unwrap().unwrap();
+    assert_eq!(mined.from(), from);
+
+    let mined_block = provider.get_block(BlockId::latest()).full().await.unwrap().unwrap();
+    let mined_txs = mined_block.transactions.as_transactions().unwrap();
+    assert_eq!(mined_txs.len(), 1);
+    assert_eq!(mined_txs[0].from(), from);
+
+    let tx_by_block_hash = api
+        .transaction_by_block_hash_and_index(mined_block.header.hash, 0.into())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(tx_by_block_hash.from(), from);
+
+    let tx_by_block_number = api
+        .transaction_by_block_number_and_index(BlockNumberOrTag::Latest, 0.into())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(tx_by_block_number.from(), from);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_listen_full_pending_transaction() {
     let (api, handle) = spawn(NodeConfig::test()).await;
 


### PR DESCRIPTION
Currently `transaction_build` recovers `from` from the signature, but impersonated transactions use a bypass signature whose recovery returns the zero address. Four callers worked around this by post-patching with `Recovered::new_unchecked` afterwards. Making `from` an explicit `Option<Address>` parameter drops those four patches, and the Tempo path picks up the same impersonation fix along the way.