### PR TITLE
chore: group dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      actions-weekly:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "cargo"
     directory: "/"
@@ -14,6 +19,11 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
+    groups:
+      cargo-weekly:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "npm"
     directory: "/npm"
@@ -22,3 +32,8 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
+    groups:
+      npm-weekly:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Group minor and patch version updates per ecosystem into single PRs to reduce PR noise. Major version bumps still get individual PRs for careful review.

**Before:** up to 15 PRs/week (5 per ecosystem)
**After:** up to 6 PRs/week (1 grouped + 1 major per ecosystem, worst case)

Currently there are 7 open dependabot PRs that could have been 3.