### PR TITLE
chore: bump foundry-compilers to 0.20.0, foundry-block-explorers to 0.23.0, foundry-fork-db to 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -2393,6 +2393,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,7 +2579,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2772,7 +2781,7 @@ dependencies = [
  "foundry-block-explorers",
  "foundry-cli",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "foundry-debugger",
  "foundry-evm",
@@ -2879,7 +2888,7 @@ dependencies = [
  "forge-fmt",
  "foundry-cli",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "foundry-evm",
  "foundry-solang-parser",
@@ -2947,7 +2956,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -3034,7 +3043,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3187,7 +3196,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3650,6 +3659,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3950,8 +3968,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -3972,7 +4000,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4277,7 +4305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4613,7 +4641,7 @@ dependencies = [
  "foundry-block-explorers",
  "foundry-cli",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "foundry-debugger",
  "foundry-evm",
@@ -4669,7 +4697,7 @@ dependencies = [
  "eyre",
  "forge-fmt",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "foundry-solang-parser",
  "itertools 0.14.0",
@@ -4704,7 +4732,7 @@ version = "1.6.0"
 dependencies = [
  "eyre",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "heck",
  "rayon",
@@ -4736,7 +4764,7 @@ dependencies = [
  "foundry-cheatcodes",
  "foundry-cli",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "foundry-debugger",
  "foundry-evm",
@@ -4768,7 +4796,7 @@ dependencies = [
  "alloy-primitives",
  "eyre",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "revm-inspectors",
  "serde",
@@ -4808,7 +4836,7 @@ dependencies = [
  "foundry-block-explorers",
  "foundry-cli",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "foundry-evm",
  "foundry-evm-networks",
@@ -4846,7 +4874,7 @@ dependencies = [
  "color-eyre",
  "eyre",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-test-utils",
  "once_cell",
  "rayon",
@@ -4863,7 +4891,7 @@ dependencies = [
  "alloy-chains",
  "alloy-json-abi",
  "alloy-primitives",
- "foundry-compilers",
+ "foundry-compilers 0.19.14",
  "reqwest 0.12.28",
  "semver 1.0.28",
  "serde",
@@ -4899,7 +4927,7 @@ dependencies = [
  "forge-script-sequence",
  "foundry-cheatcodes-spec",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "foundry-evm-core",
  "foundry-evm-fuzz",
@@ -4960,7 +4988,7 @@ dependencies = [
  "eyre",
  "foundry-cli-markdown",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "foundry-evm",
  "foundry-evm-networks",
@@ -5032,7 +5060,7 @@ dependencies = [
  "flate2",
  "foundry-block-explorers",
  "foundry-common-fmt",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "foundry-wallets",
  "futures",
@@ -5101,8 +5129,35 @@ dependencies = [
  "auto_impl",
  "derive_more",
  "dyn-clone",
- "foundry-compilers-artifacts",
- "foundry-compilers-core",
+ "foundry-compilers-artifacts 0.19.14",
+ "foundry-compilers-core 0.19.14",
+ "itertools 0.14.0",
+ "path-slash",
+ "rayon",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+ "solar-compiler",
+ "svm-rs",
+ "thiserror 2.0.18",
+ "tracing",
+ "winnow 0.7.15",
+ "yansi",
+]
+
+[[package]]
+name = "foundry-compilers"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a46823427db611c6b97506ee8f26b4424058366abcc9a97ac5c4c3419798518"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "auto_impl",
+ "derive_more",
+ "dyn-clone",
+ "foundry-compilers-artifacts 0.20.0",
+ "foundry-compilers-core 0.20.0",
  "fs_extra",
  "itertools 0.14.0",
  "path-slash",
@@ -5111,7 +5166,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "solar-compiler",
  "svm-rs",
  "svm-rs-builds",
@@ -5128,8 +5183,18 @@ version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93ec96df20055211f4e46b5a61fa479b2ea7d1ce0659818e0359afadfcded8d2"
 dependencies = [
- "foundry-compilers-artifacts-solc",
- "foundry-compilers-artifacts-vyper",
+ "foundry-compilers-artifacts-solc 0.19.14",
+ "foundry-compilers-artifacts-vyper 0.19.14",
+]
+
+[[package]]
+name = "foundry-compilers-artifacts"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c29c6a49e82684909549e8e3a63a9dea4c92dfeb1b5b3a5e3ad683db42324ac3"
+dependencies = [
+ "foundry-compilers-artifacts-solc 0.20.0",
+ "foundry-compilers-artifacts-vyper 0.20.0",
 ]
 
 [[package]]
@@ -5140,7 +5205,28 @@ checksum = "f8a206e475b5dd1a77dc33cd917cde4846148f5136729a24edb3a16ab431b90a"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
- "foundry-compilers-core",
+ "foundry-compilers-core 0.19.14",
+ "memchr",
+ "path-slash",
+ "rayon",
+ "regex",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "yansi",
+]
+
+[[package]]
+name = "foundry-compilers-artifacts-solc"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d3e554932001133f433473b3bdb37c74b4a648750ab61cd7966e7db0ead16d"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "foundry-compilers-core 0.20.0",
  "memchr",
  "path-slash",
  "rayon",
@@ -5161,9 +5247,23 @@ checksum = "f74883db8036522fa21d0853c21ac318e165ec88e141f1ef1d6f7b4dfa841ff7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
- "foundry-compilers-artifacts-solc",
- "foundry-compilers-core",
+ "foundry-compilers-artifacts-solc 0.19.14",
+ "foundry-compilers-core 0.19.14",
  "path-slash",
+ "semver 1.0.28",
+ "serde",
+]
+
+[[package]]
+name = "foundry-compilers-artifacts-vyper"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583168b6df6b73cc3de8d205a922dca58a9c0b4c2774f6b115b3ff7e79d23900"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "foundry-compilers-artifacts-solc 0.20.0",
+ "foundry-compilers-core 0.20.0",
  "semver 1.0.28",
  "serde",
 ]
@@ -5176,6 +5276,24 @@ checksum = "2ab384daeaea5c33cad8c3c094a1eb6f98e70922e18380c660980c74c19e362b"
 dependencies = [
  "alloy-primitives",
  "cfg-if",
+ "dunce",
+ "path-slash",
+ "regex",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "foundry-compilers-core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f80dd5d9f3ed065e412ecef2da3904ea21708d53f79fac29a3547c10ae947f"
+dependencies = [
+ "alloy-primitives",
  "dunce",
  "fs_extra",
  "path-slash",
@@ -5203,7 +5321,7 @@ dependencies = [
  "eyre",
  "figment2",
  "foundry-block-explorers",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-evm-hardforks",
  "foundry-evm-networks",
  "glob",
@@ -5239,7 +5357,7 @@ dependencies = [
  "crossterm",
  "eyre",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-evm-core",
  "foundry-evm-traces",
  "ratatui",
@@ -5261,7 +5379,7 @@ dependencies = [
  "eyre",
  "foundry-cheatcodes",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "foundry-evm-core",
  "foundry-evm-coverage",
@@ -5357,7 +5475,7 @@ dependencies = [
  "alloy-primitives",
  "eyre",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-evm-core",
  "rayon",
  "revm",
@@ -5375,7 +5493,7 @@ dependencies = [
  "alloy-primitives",
  "eyre",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "foundry-evm-core",
  "foundry-evm-coverage",
@@ -5399,7 +5517,7 @@ dependencies = [
  "alloy-hardforks",
  "alloy-op-hardforks",
  "alloy-rpc-types",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "op-revm",
  "revm",
  "serde",
@@ -5438,7 +5556,7 @@ dependencies = [
  "eyre",
  "foundry-block-explorers",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "foundry-evm-core",
  "foundry-linking",
@@ -5486,7 +5604,7 @@ name = "foundry-linking"
 version = "1.6.0"
 dependencies = [
  "alloy-primitives",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "rayon",
  "semver 1.0.28",
  "thiserror 2.0.18",
@@ -5554,7 +5672,7 @@ dependencies = [
  "fd-lock",
  "foundry-block-explorers",
  "foundry-common",
- "foundry-compilers",
+ "foundry-compilers 0.20.0",
  "foundry-config",
  "idna_adapter",
  "parking_lot",
@@ -6161,6 +6279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6606,7 +6733,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7553,7 +7680,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7774,7 +7901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -8536,7 +8663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8705,7 +8832,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9966,7 +10093,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10025,7 +10152,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10518,6 +10645,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10796,7 +10934,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -10831,7 +10969,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11255,7 +11393,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11462,7 +11600,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11472,7 +11610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12323,7 +12461,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -12718,7 +12856,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12868,7 +13006,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,7 +2579,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3043,7 +3043,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3196,7 +3196,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4000,7 +4000,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4305,7 +4305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5506,6 +5506,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "zstd",
 ]
 
 [[package]]
@@ -6642,7 +6643,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7589,7 +7590,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8572,7 +8573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8741,7 +8742,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10002,7 +10003,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10061,7 +10062,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10843,7 +10844,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -10878,7 +10879,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11302,7 +11303,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11509,7 +11510,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11519,7 +11520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12765,7 +12766,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12915,7 +12916,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
  "foundry-block-explorers",
  "foundry-cli",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "foundry-debugger",
  "foundry-evm",
@@ -2888,7 +2888,7 @@ dependencies = [
  "forge-fmt",
  "foundry-cli",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "foundry-evm",
  "foundry-solang-parser",
@@ -4641,7 +4641,7 @@ dependencies = [
  "foundry-block-explorers",
  "foundry-cli",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "foundry-debugger",
  "foundry-evm",
@@ -4697,7 +4697,7 @@ dependencies = [
  "eyre",
  "forge-fmt",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "foundry-solang-parser",
  "itertools 0.14.0",
@@ -4732,7 +4732,7 @@ version = "1.6.0"
 dependencies = [
  "eyre",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "heck",
  "rayon",
@@ -4764,7 +4764,7 @@ dependencies = [
  "foundry-cheatcodes",
  "foundry-cli",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "foundry-debugger",
  "foundry-evm",
@@ -4796,7 +4796,7 @@ dependencies = [
  "alloy-primitives",
  "eyre",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "revm-inspectors",
  "serde",
@@ -4836,7 +4836,7 @@ dependencies = [
  "foundry-block-explorers",
  "foundry-cli",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "foundry-evm",
  "foundry-evm-networks",
@@ -4874,7 +4874,7 @@ dependencies = [
  "color-eyre",
  "eyre",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-test-utils",
  "once_cell",
  "rayon",
@@ -4884,15 +4884,15 @@ dependencies = [
 
 [[package]]
 name = "foundry-block-explorers"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff814624bb21bfe43b70fb736ab39527b405d04cdc94d90b7e182fba28b25ec7"
+checksum = "c41211d5c69c92070d2e2174eff99ffb259d0d568d2e4f789d2a7251b4416ccd"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
  "alloy-primitives",
- "foundry-compilers 0.19.14",
- "reqwest 0.12.28",
+ "foundry-compilers",
+ "reqwest 0.13.2",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -4927,7 +4927,7 @@ dependencies = [
  "forge-script-sequence",
  "foundry-cheatcodes-spec",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "foundry-evm-core",
  "foundry-evm-fuzz",
@@ -4988,7 +4988,7 @@ dependencies = [
  "eyre",
  "foundry-cli-markdown",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "foundry-evm",
  "foundry-evm-networks",
@@ -5060,7 +5060,7 @@ dependencies = [
  "flate2",
  "foundry-block-explorers",
  "foundry-common-fmt",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "foundry-wallets",
  "futures",
@@ -5120,33 +5120,6 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.19.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e639f98fe54d1cc0011a4bdb2eb1d838b379c9f004991ae7555a4cc09e8da32a"
-dependencies = [
- "alloy-json-abi",
- "alloy-primitives",
- "auto_impl",
- "derive_more",
- "dyn-clone",
- "foundry-compilers-artifacts 0.19.14",
- "foundry-compilers-core 0.19.14",
- "itertools 0.14.0",
- "path-slash",
- "rayon",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "solar-compiler",
- "svm-rs",
- "thiserror 2.0.18",
- "tracing",
- "winnow 0.7.15",
- "yansi",
-]
-
-[[package]]
-name = "foundry-compilers"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a46823427db611c6b97506ee8f26b4424058366abcc9a97ac5c4c3419798518"
@@ -5156,8 +5129,8 @@ dependencies = [
  "auto_impl",
  "derive_more",
  "dyn-clone",
- "foundry-compilers-artifacts 0.20.0",
- "foundry-compilers-core 0.20.0",
+ "foundry-compilers-artifacts",
+ "foundry-compilers-core",
  "fs_extra",
  "itertools 0.14.0",
  "path-slash",
@@ -5179,43 +5152,12 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts"
-version = "0.19.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ec96df20055211f4e46b5a61fa479b2ea7d1ce0659818e0359afadfcded8d2"
-dependencies = [
- "foundry-compilers-artifacts-solc 0.19.14",
- "foundry-compilers-artifacts-vyper 0.19.14",
-]
-
-[[package]]
-name = "foundry-compilers-artifacts"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c29c6a49e82684909549e8e3a63a9dea4c92dfeb1b5b3a5e3ad683db42324ac3"
 dependencies = [
- "foundry-compilers-artifacts-solc 0.20.0",
- "foundry-compilers-artifacts-vyper 0.20.0",
-]
-
-[[package]]
-name = "foundry-compilers-artifacts-solc"
-version = "0.19.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a206e475b5dd1a77dc33cd917cde4846148f5136729a24edb3a16ab431b90a"
-dependencies = [
- "alloy-json-abi",
- "alloy-primitives",
- "foundry-compilers-core 0.19.14",
- "memchr",
- "path-slash",
- "rayon",
- "regex",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
- "yansi",
+ "foundry-compilers-artifacts-solc",
+ "foundry-compilers-artifacts-vyper",
 ]
 
 [[package]]
@@ -5226,7 +5168,7 @@ checksum = "02d3e554932001133f433473b3bdb37c74b4a648750ab61cd7966e7db0ead16d"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
- "foundry-compilers-core 0.20.0",
+ "foundry-compilers-core",
  "memchr",
  "path-slash",
  "rayon",
@@ -5241,50 +5183,16 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
-version = "0.19.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f74883db8036522fa21d0853c21ac318e165ec88e141f1ef1d6f7b4dfa841ff7"
-dependencies = [
- "alloy-json-abi",
- "alloy-primitives",
- "foundry-compilers-artifacts-solc 0.19.14",
- "foundry-compilers-core 0.19.14",
- "path-slash",
- "semver 1.0.28",
- "serde",
-]
-
-[[package]]
-name = "foundry-compilers-artifacts-vyper"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583168b6df6b73cc3de8d205a922dca58a9c0b4c2774f6b115b3ff7e79d23900"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
- "foundry-compilers-artifacts-solc 0.20.0",
- "foundry-compilers-core 0.20.0",
+ "foundry-compilers-artifacts-solc",
+ "foundry-compilers-core",
  "semver 1.0.28",
  "serde",
-]
-
-[[package]]
-name = "foundry-compilers-core"
-version = "0.19.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab384daeaea5c33cad8c3c094a1eb6f98e70922e18380c660980c74c19e362b"
-dependencies = [
- "alloy-primitives",
- "cfg-if",
- "dunce",
- "path-slash",
- "regex",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "walkdir",
- "xxhash-rust",
 ]
 
 [[package]]
@@ -5321,7 +5229,7 @@ dependencies = [
  "eyre",
  "figment2",
  "foundry-block-explorers",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-evm-hardforks",
  "foundry-evm-networks",
  "glob",
@@ -5357,7 +5265,7 @@ dependencies = [
  "crossterm",
  "eyre",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-evm-core",
  "foundry-evm-traces",
  "ratatui",
@@ -5379,7 +5287,7 @@ dependencies = [
  "eyre",
  "foundry-cheatcodes",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "foundry-evm-core",
  "foundry-evm-coverage",
@@ -5475,7 +5383,7 @@ dependencies = [
  "alloy-primitives",
  "eyre",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-evm-core",
  "rayon",
  "revm",
@@ -5493,7 +5401,7 @@ dependencies = [
  "alloy-primitives",
  "eyre",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "foundry-evm-core",
  "foundry-evm-coverage",
@@ -5517,7 +5425,7 @@ dependencies = [
  "alloy-hardforks",
  "alloy-op-hardforks",
  "alloy-rpc-types",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "op-revm",
  "revm",
  "serde",
@@ -5556,7 +5464,7 @@ dependencies = [
  "eyre",
  "foundry-block-explorers",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "foundry-evm-core",
  "foundry-linking",
@@ -5604,7 +5512,7 @@ name = "foundry-linking"
 version = "1.6.0"
 dependencies = [
  "alloy-primitives",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "rayon",
  "semver 1.0.28",
  "thiserror 2.0.18",
@@ -5672,7 +5580,7 @@ dependencies = [
  "fd-lock",
  "foundry-block-explorers",
  "foundry-common",
- "foundry-compilers 0.20.0",
+ "foundry-compilers",
  "foundry-config",
  "idna_adapter",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5488,8 +5488,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-fork-db"
-version = "0.25.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=2f90eb86d4549fa15a8cc2d99bfc1039bc083977#2f90eb86d4549fa15a8cc2d99bfc1039bc083977"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce9e91abb900e4ab5346d06b97c3784ae6ed4fc44b9fa22d3dc712b7e21be9"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -348,7 +348,7 @@ foundry-compilers = { version = "0.20.0", default-features = false, features = [
     "rustls",
     "svm-solc",
 ] }
-foundry-fork-db = "0.26.0"
+foundry-fork-db = { version = "0.26.0", features = ["zstd"] }
 solang-parser = { version = "=0.3.9", package = "foundry-solang-parser" }
 solar = { package = "solar-compiler", version = "=0.1.8", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -348,7 +348,7 @@ foundry-compilers = { version = "0.20.0", default-features = false, features = [
     "rustls",
     "svm-solc",
 ] }
-foundry-fork-db = "0.25.0"
+foundry-fork-db = "0.26.0"
 solang-parser = { version = "=0.3.9", package = "foundry-solang-parser" }
 solar = { package = "solar-compiler", version = "=0.1.8", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false, features = [
@@ -604,7 +604,7 @@ alloy-op-evm = { git = "https://github.com/ethereum-optimism/optimism", rev = "4
 alloy-op-hardforks = { git = "https://github.com/ethereum-optimism/optimism", rev = "42f5117c2e7de0614cd3b96f274d0a3078f9701c" }
 
 ## foundry-fork-db
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "2f90eb86d4549fa15a8cc2d99bfc1039bc083977" }
+# foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "2f90eb86d4549fa15a8cc2d99bfc1039bc083977" }
 
 ## tempo — unify crates.io versions (pulled by mpp) with git rev
 tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,7 +343,7 @@ foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives" }
 
 # solc & compilation utilities
-foundry-block-explorers = { version = "0.22.0", default-features = false }
+foundry-block-explorers = { version = "0.23.0", default-features = false }
 foundry-compilers = { version = "0.20.0", default-features = false, features = [
     "rustls",
     "svm-solc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -344,7 +344,7 @@ foundry-primitives = { path = "crates/primitives" }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.22.0", default-features = false }
-foundry-compilers = { version = "0.19.14", default-features = false, features = [
+foundry-compilers = { version = "0.20.0", default-features = false, features = [
     "rustls",
     "svm-solc",
 ] }

--- a/crates/verify/src/etherscan/flatten.rs
+++ b/crates/verify/src/etherscan/flatten.rs
@@ -89,7 +89,7 @@ impl EtherscanFlattenedSource {
         if out.errors.iter().any(|e| e.is_error()) {
             let mut o = AggregatedCompilerOutput::<SolcCompiler>::default();
             o.extend(version, RawBuildInfo::new(&input, &out, false)?, "default", out);
-            let diags = o.diagnostics(&[], &[], Default::default());
+            let diags = o.diagnostics(&[], &[], Default::default(), Default::default());
 
             eyre::bail!(
                 "\


### PR DESCRIPTION
### Changes

- Bump `foundry-compilers` from `0.19.14` to `0.20.0`
- Bump `foundry-block-explorers` from `0.22.0` to `0.23.0` (to align with new compilers version)
- Bump `foundry-fork-db` from `0.25.0` to `0.26.0` (remove git override, enable `zstd` feature)
- Update `diagnostics()` call in `crates/verify/src/etherscan/flatten.rs` to pass the new `compiler_severity_filter` argument added in compilers 0.20.0