### PR TITLE
perf(fuzz): eagerly seed AST literals and remove per-iteration OnceLock blocking

### DIFF
--- a/crates/evm/fuzz/src/strategies/literals.rs
+++ b/crates/evm/fuzz/src/strategies/literals.rs
@@ -57,9 +57,14 @@ impl LiteralsDictionary {
         Self { maps }
     }
 
-    /// Returns a reference to the `LiteralMaps`.
+    /// Returns a reference to the `LiteralMaps`, blocking until ready.
     pub fn get(&self) -> &LiteralMaps {
         self.maps.wait()
+    }
+
+    /// Returns a reference to the `LiteralMaps` if already initialized, without blocking.
+    pub fn try_get(&self) -> Option<&LiteralMaps> {
+        self.maps.get()
     }
 
     /// Test-only helper to seed the dictionary with literal values.

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -67,6 +67,10 @@ impl EvmFuzzState {
         dictionary.insert_db_values(accs);
         if let Some(literals) = literals {
             dictionary.literal_values = literals.clone();
+            // Block once here to merge all AST literals into `sample_values`.
+            // This ensures literals are always available during fuzzing without
+            // needing to touch the OnceLock on the per-iteration hot path.
+            dictionary.seed_samples();
         }
 
         Self {
@@ -226,14 +230,31 @@ impl FuzzDictionary {
         self.insert_value(B256::ZERO);
     }
 
-    /// Seeds `sample_values` with all words from the [`LiteralsDictionary`].
-    /// Should only be called once per dictionary lifetime.
-    #[cold]
+    /// Seeds `sample_values` with all words from the [`LiteralsDictionary`], blocking until ready.
+    /// Called once during `EvmFuzzState::new` so the per-iteration hot path never touches
+    /// the `OnceLock`.
     fn seed_samples(&mut self) {
+        if self.samples_seeded {
+            return;
+        }
         trace!("seeding `sample_values` from literal dictionary");
         self.sample_values
             .extend(self.literal_values.get().words.iter().map(|(k, v)| (k.clone(), v.clone())));
         self.samples_seeded = true;
+    }
+
+    /// Non-blocking variant: seeds `sample_values` only if literals are already available.
+    /// Used by write-path methods that may be called before `seed_samples`.
+    fn try_seed_samples(&mut self) {
+        if self.samples_seeded {
+            return;
+        }
+        if let Some(maps) = self.literal_values.try_get() {
+            trace!("seeding `sample_values` from literal dictionary (non-blocking)");
+            self.sample_values
+                .extend(maps.words.iter().map(|(k, v)| (k.clone(), v.clone())));
+            self.samples_seeded = true;
+        }
     }
 
     /// Insert values from initial db state into fuzz dictionary.
@@ -407,9 +428,7 @@ impl FuzzDictionary {
             && slot_info.decode(value).is_some()
         {
             trace!(?slot_info, "inserting typed storage value");
-            if !self.samples_seeded {
-                self.seed_samples();
-            }
+            self.try_seed_samples();
             self.sample_values.entry(slot_info.slot_type.dyn_sol_type).or_default().insert(value);
         } else {
             self.insert_value_u256(value.into());
@@ -453,9 +472,7 @@ impl FuzzDictionary {
     /// Insert a typed trace-cmp value into the `sample_values` map.
     /// Maps sancov width to `DynSolType` buckets and promotes to larger types.
     fn insert_typed_cmp_value(&mut self, width: u8, value: B256) {
-        if !self.samples_seeded {
-            self.seed_samples();
-        }
+        self.try_seed_samples();
 
         const MAX_TYPED_CMP_PER_BUCKET: usize = 1024;
 
@@ -503,9 +520,7 @@ impl FuzzDictionary {
         sample_values: impl IntoIterator<Item = DynSolValue>,
         limit: u32,
     ) {
-        if !self.samples_seeded {
-            self.seed_samples();
-        }
+        self.try_seed_samples();
         for sample in sample_values {
             if let (Some(sample_type), Some(sample_value)) = (sample.as_type(), sample.as_word()) {
                 if let Some(values) = self.sample_values.get_mut(&sample_type) {
@@ -534,27 +549,26 @@ impl FuzzDictionary {
         self.state_values.is_empty()
     }
 
-    /// Returns sample values for a given type, checking both runtime samples and literals.
+    /// Returns sample values for a given type.
     ///
-    /// Before `seed_samples()` is called, checks both `literal_values` and `sample_values`
-    /// separately. After seeding, all literal values are merged into `sample_values`.
+    /// After `seed_samples()` is called in `EvmFuzzState::new`, all AST literals are
+    /// merged into `sample_values`, so this is just a single hash-map lookup with no
+    /// `OnceLock` access on the hot path.
     #[inline]
     pub fn samples(&self, param_type: &DynSolType) -> Option<&B256IndexSet> {
-        // If not seeded yet, return literals
-        if !self.samples_seeded {
-            return self.literal_values.get().words.get(param_type);
-        }
-
         self.sample_values.get(param_type)
     }
 
-    /// Returns the collected literal strings, triggering initialization if needed.
+    /// Returns the collected literal strings.
+    ///
+    /// After `seed_samples()` has been called, the `OnceLock` is already initialized
+    /// so `get()` returns immediately without blocking.
     #[inline]
     pub fn ast_strings(&self) -> &IndexSet<String> {
         &self.literal_values.get().strings
     }
 
-    /// Returns the collected literal bytes (hex strings), triggering initialization if needed.
+    /// Returns the collected literal bytes (hex strings).
     #[inline]
     pub fn ast_bytes(&self) -> &IndexSet<Bytes> {
         &self.literal_values.get().bytes
@@ -586,5 +600,7 @@ impl FuzzDictionary {
     /// Test-only helper to seed the dictionary with literal values.
     pub(crate) fn seed_literals(&mut self, map: super::LiteralMaps) {
         self.literal_values.set(map);
+        self.samples_seeded = false;
+        self.seed_samples();
     }
 }


### PR DESCRIPTION
## Summary

Addresses a suspected ~21% wall-time regression on numeric-heavy fuzz suites (e.g. Solady) introduced by the ast-seeded dictionary feature (#12015). See [benchmark gist](https://gist.github.com/figtracer/9ef6187a1316b181bc16fab9789a9eff).

## Root cause analysis

`FuzzDictionary::samples()` called `OnceLock::wait()` on **every fuzz iteration**, and returned only AST literals (ignoring `sample_values`) until a write operation triggered lazy seeding. For numeric-heavy suites like Solady:

1. **Startup cliff**: The background literal-collector thread may not have finished, so `wait()` blocks the first iterations.
2. **Changed distribution**: ~20% of numeric args were pulled from AST literal buckets instead of generic state words, hitting deeper/slower EVM execution paths.
3. **Per-iteration overhead**: Even after init, `wait()` performs an atomic check on every `samples()` call.

## Fix

- **Block once** in `EvmFuzzState::new()` to merge all AST literals into `sample_values` before any fuzz iteration runs.
- `samples()` is now a plain `HashMap::get()` — no `OnceLock` access on the hot path.
- Add non-blocking `try_seed_samples()` for write-path callers (`insert_storage_value`, `insert_sample_values`, `insert_typed_cmp_value`).
- Add `LiteralsDictionary::try_get()` for non-blocking `OnceLock` access.

## Quality

No degradation — AST literals are still fully present in the sample pool. The merged `sample_values` map is actually **richer** (AST literals + runtime values) than the pre-seeded path which returned only AST literals.

## Status

**Not yet verified with benchmarks.** Based on code analysis of the hot path.