### PR TITLE
chore(cli): make `Git` impl more robust

### DIFF
--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -706,19 +706,54 @@ ignore them in the `.gitignore` file."
             .map(|url| Some(url.trim().to_string()))
     }
 
-    pub fn cmd(self) -> Command {
+    /// Returns the fetch URL of the given remote, or `None` if it doesn't exist.
+    pub fn remote_url(self, name: &str) -> Option<String> {
+        self.cmd().args(["remote", "get-url", name]).get_stdout_lossy().ok()
+    }
+
+    /// Sets the branch for a submodule.
+    pub fn set_submodule_branch(self, rel_path: &Path, branch: &str) -> Result<()> {
+        self.cmd().args(["submodule", "set-branch", "-b", branch]).arg(rel_path).exec().map(drop)
+    }
+
+    /// Returns remote branch names as a newline-separated string.
+    pub fn remote_branches(self) -> Result<String> {
+        self.cmd().args(["branch", "-r"]).get_stdout_lossy()
+    }
+
+    /// Fetches a branch from origin and checks out a local tracking branch at the given path.
+    pub fn fetch_and_checkout_branch(self, at: &Path, branch: &str) -> Result<()> {
+        self.cmd_at(at).args(["fetch", "origin", branch]).exec().map_err(|e| {
+            eyre::eyre!(
+                "Could not fetch latest changes for branch {branch} in submodule at {}: {e}",
+                at.display()
+            )
+        })?;
+        self.cmd_at(at)
+            .args(["checkout", "-B", branch, &format!("origin/{branch}")])
+            .exec()
+            .map_err(|e| {
+                eyre::eyre!(
+                    "Could not checkout and track origin/{branch} for submodule at {}: {e}",
+                    at.display()
+                )
+            })?;
+        Ok(())
+    }
+
+    fn cmd(self) -> Command {
         let mut cmd = Self::cmd_no_root();
         cmd.current_dir(self.root);
         cmd
     }
 
-    pub fn cmd_at(self, path: &Path) -> Command {
+    fn cmd_at(self, path: &Path) -> Command {
         let mut cmd = Self::cmd_no_root();
         cmd.current_dir(path);
         cmd
     }
 
-    pub fn cmd_no_root() -> Command {
+    fn cmd_no_root() -> Command {
         let mut cmd = Command::new("git");
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
         cmd

--- a/crates/forge/src/cmd/doc/mod.rs
+++ b/crates/forge/src/cmd/doc/mod.rs
@@ -4,10 +4,10 @@ use eyre::Result;
 use forge_doc::{
     ContractInheritance, Deployments, DocBuilder, GitSource, InferInlineHyperlinks, Inheritdoc,
 };
-use foundry_cli::opts::GH_REPO_PREFIX_REGEX;
+use foundry_cli::{opts::GH_REPO_PREFIX_REGEX, utils::Git};
 use foundry_common::compile::ProjectCompiler;
 use foundry_config::{Config, load_config_with_root};
-use std::{path::PathBuf, process::Command};
+use std::path::PathBuf;
 
 mod server;
 use server::Server;
@@ -78,23 +78,19 @@ impl DocArgs {
         if let Some(out) = self.out {
             doc_config.out = out;
         }
-        if doc_config.repository.is_none() {
-            // Attempt to read repo from git
-            if let Ok(output) = Command::new("git").args(["remote", "get-url", "origin"]).output()
-                && !output.stdout.is_empty()
-            {
-                let remote = String::from_utf8(output.stdout)?.trim().to_owned();
-                if let Some(captures) = GH_REPO_PREFIX_REGEX.captures(&remote) {
-                    let brand = captures.name("brand").unwrap().as_str();
-                    let tld = captures.name("tld").unwrap().as_str();
-                    let project = GH_REPO_PREFIX_REGEX.replace(&remote, "");
-                    doc_config.repository =
-                        Some(format!("https://{brand}.{tld}/{}", project.trim_end_matches(".git")));
-                }
-            }
+        // Attempt to read repo URL from git
+        if doc_config.repository.is_none()
+            && let Some(remote) = Git::new(root).remote_url("origin")
+            && let Some(captures) = GH_REPO_PREFIX_REGEX.captures(&remote)
+        {
+            let brand = captures.name("brand").unwrap().as_str();
+            let tld = captures.name("tld").unwrap().as_str();
+            let project = GH_REPO_PREFIX_REGEX.replace(&remote, "");
+            doc_config.repository =
+                Some(format!("https://{brand}.{tld}/{}", project.trim_end_matches(".git")));
         }
 
-        let commit = foundry_cli::utils::Git::new(root).commit_hash(false, "HEAD").ok();
+        let commit = Git::new(root).commit_hash(false, "HEAD").ok();
 
         let mut builder = DocBuilder::new(
             root.clone(),

--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -3,7 +3,7 @@ use clap::{Parser, ValueHint};
 use eyre::{Context, Result};
 use foundry_cli::{
     opts::Dependency,
-    utils::{CommandUtils, Git, LoadConfig},
+    utils::{Git, LoadConfig},
 };
 use foundry_common::fs;
 use foundry_config::{Config, impl_figment_convert_basic};
@@ -189,10 +189,7 @@ impl DependencyInstallOpts {
                         && dep_id.as_ref().is_some_and(|id| id.is_branch())
                     {
                         // always work with relative paths when directly modifying submodules
-                        git.cmd()
-                            .args(["submodule", "set-branch", "-b", tag_or_branch])
-                            .arg(rel_path)
-                            .exec()?;
+                        git.set_submodule_branch(rel_path, tag_or_branch)?;
 
                         let rev = git.get_rev(tag_or_branch, &path)?;
 
@@ -574,7 +571,7 @@ impl Installer<'_> {
 
     fn match_branch(self, tag: &str, path: &Path) -> Result<Option<String>> {
         // fetch remote branches and check for tag
-        let output = self.git.root(path).cmd().args(["branch", "-r"]).get_stdout_lossy()?;
+        let output = self.git.root(path).remote_branches()?;
 
         let mut candidates = output
             .lines()

--- a/crates/forge/src/cmd/update.rs
+++ b/crates/forge/src/cmd/update.rs
@@ -126,7 +126,7 @@ impl UpdateArgs {
             let name = dep_id.name();
 
             // Fetch and checkout the latest commit from the remote branch
-            git.fetch_and_checkout_branch(path, name)?;
+            git.fetch_and_checkout_branch(&submodule_path, name)?;
 
             // Now get the updated revision after syncing with origin
             let (updated_rev, _) = git.current_rev_branch(&submodule_path)?;

--- a/crates/forge/src/cmd/update.rs
+++ b/crates/forge/src/cmd/update.rs
@@ -4,10 +4,10 @@ use clap::{Parser, ValueHint};
 use eyre::{Context, Result};
 use foundry_cli::{
     opts::Dependency,
-    utils::{CommandUtils, Git, LoadConfig},
+    utils::{Git, LoadConfig},
 };
 use foundry_config::{Config, impl_figment_convert_basic};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use yansi::Paint;
 
 /// CLI arguments for `forge update`.
@@ -126,7 +126,7 @@ impl UpdateArgs {
             let name = dep_id.name();
 
             // Fetch and checkout the latest commit from the remote branch
-            Self::fetch_and_checkout_branch(&git, &submodule_path, name)?;
+            git.fetch_and_checkout_branch(path, name)?;
 
             // Now get the updated revision after syncing with origin
             let (updated_rev, _) = git.current_rev_branch(&submodule_path)?;
@@ -194,29 +194,6 @@ impl UpdateArgs {
                 None
             })
             .collect()
-    }
-
-    /// Fetches and checks out the latest version of a branch from origin
-    fn fetch_and_checkout_branch(git: &Git<'_>, path: &Path, branch: &str) -> Result<()> {
-        // Fetch the latest changes from origin for the branch
-        git.cmd_at(path).args(["fetch", "origin", branch]).exec().wrap_err(format!(
-            "Could not fetch latest changes for branch {} in submodule at {}",
-            branch,
-            path.display()
-        ))?;
-
-        // Checkout and track the remote branch to ensure we have the latest commit
-        // Using checkout -B ensures the local branch tracks origin/branch
-        git.cmd_at(path)
-            .args(["checkout", "-B", branch, &format!("origin/{branch}")])
-            .exec()
-            .wrap_err(format!(
-                "Could not checkout and track origin/{} for submodule at {}",
-                branch,
-                path.display()
-            ))?;
-
-        Ok(())
     }
 }
 


### PR DESCRIPTION
## Motivation

Initially, I intended to replace the `git` command usage with the `gix` library (as suggested in https://github.com/foundry-rs/foundry/issues/13501). However, it doesn’t address all the requirements, and the `git` binary will still be necessary (refer to https://github.com/foundry-rs/foundry/commit/6bb4ea90686673879779dbce63c3b75f776b6240). This approach introduces an additional layer of abstraction without providing substantial benefits.

However I extracted here some clean-ups making `foundry_cli::utils::Git` a bit more elegant and robust:
- some dedup
- made methods spawning git command private