### PR TITLE
fix(config): disable proxy detection in Etherscan client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5238,6 +5238,7 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
+ "reqwest 0.12.28",
  "semver 1.0.28",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5238,7 +5238,7 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "semver 1.0.28",
  "serde",
  "serde_json",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -37,6 +37,7 @@ mesc.workspace = true
 unit-prefix = "0.5.2"
 rayon.workspace = true
 regex.workspace = true
+reqwest = { version = "0.12", default-features = false }
 semver = { workspace = true, features = ["serde"] }
 serde_json.workspace = true
 serde.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -37,7 +37,7 @@ mesc.workspace = true
 unit-prefix = "0.5.2"
 rayon.workspace = true
 regex.workspace = true
-reqwest = { version = "0.12", default-features = false }
+reqwest.workspace = true
 semver = { workspace = true, features = ["serde"] }
 serde_json.workspace = true
 serde.workspace = true

--- a/crates/config/src/etherscan.rs
+++ b/crates/config/src/etherscan.rs
@@ -307,7 +307,13 @@ impl ResolvedEtherscanConfig {
             }
         }
 
+        // Disable automatic proxy detection. In sandboxed environments (e.g., Cursor IDE,
+        // macOS App Sandbox), reqwest's system proxy lookup via SCDynamicStore can crash
+        // when the API returns NULL. See: https://github.com/foundry-rs/foundry/issues/12733
+        let http_client = reqwest::Client::builder().no_proxy().build()?;
+
         let mut client_builder = foundry_block_explorers::Client::builder()
+            .with_client(http_client)
             .with_api_key(api_key)
             .with_cache(cache, Duration::from_secs(24 * 60 * 60));
         if let Some(ref browser_url) = browser_url {


### PR DESCRIPTION
`foundry-block-explorers` defaults to `reqwest::Client::default()`, which triggers system proxy lookup via `SCDynamicStore` and crashes under macOS App Sandbox / Cursor IDE. Build a `reqwest::Client` with `no_proxy()` and pass it through `with_client`, Note: `foundry-block-explorers` pins `reqwest = "0.12"`, so `foundry-config` picks up the same version to keep `Client` types compatible.