### PR TITLE
chore(deny): remove deprecated repos from whitelist

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -100,10 +100,7 @@ unknown-git = "deny"
 allow-git = [
     "https://github.com/alloy-rs/alloy",
     "https://github.com/alloy-rs/evm",
-    "https://github.com/foundry-rs/compilers",
-    "https://github.com/foundry-rs/foundry-fork-db",
     "https://github.com/foundry-rs/foundry-core",
-    "https://github.com/foundry-rs/optimism",
     "https://github.com/paradigmxyz/revm-inspectors",
     "https://github.com/paradigmxyz/solar",
     "https://github.com/bluealloy/revm",


### PR DESCRIPTION
## Motivation

Remove deprecated repos from whitelist

- foundry-fork-db (moved to [foundry-core](https://github.com/foundry-rs/foundry-core))
- foundry-compilers (moved to [foundry-core](https://github.com/foundry-rs/foundry-core))
- optimism (useless since Alloy 2.0 bump on upstream)