### PR TITLE
fix: get_proof returns stale fork data after local state mutation at fork block

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2150,7 +2150,7 @@ impl EthApi<FoundryNetwork> {
         // delegate the call.
         if let BlockRequest::Number(number) = block_request
             && let Some(fork) = self.get_fork()
-            && fork.predates_fork_inclusive(number)
+            && fork.predates_fork(number)
         {
             return Ok(fork.get_proof(address, keys, Some(number.into())).await?);
         }


### PR DESCRIPTION
get_proof uses predates_fork_inclusive(number) so at the exact fork block it delegates to the remote fork backend, butget_balance/get_account/get_code use the strict predates_fork and return locally-stored values. After set_balance/set_code at the fork block, eth_getBalance returns the local value while eth_getProof still returns the remote pre-mutation proof — they disagree about the same address at the same block.

