### PR TITLE
fix(anvil): honor max on-disk state limit as inclusive cap

### DIFF
--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -170,7 +170,7 @@ impl InMemoryBlockStates {
         }
 
         // enforce on disk limit and purge the oldest state cached on disk
-        while !self.is_memory_only() && self.oldest_on_disk.len() >= self.max_on_disk_limit {
+        while !self.is_memory_only() && self.oldest_on_disk.len() > self.max_on_disk_limit {
             // evict the oldest block
             if let Some(hash) = self.oldest_on_disk.pop_front() {
                 self.on_disk_states.remove(&hash);


### PR DESCRIPTION
## Summary

`InMemoryBlockStates::enforce_limits` documents `max_on_disk_limit` as the maximum number of states kept on disk. The on-disk eviction loop used `oldest_on_disk.len() >= max_on_disk_limit`, which removed an entry as soon as the count **reached** the limit, so the cache could hold at most **N−1** entries.

Evict only when the length is **strictly greater** than the limit so up to **N** states may remain, matching the documented semantics.

## Test plan

- `cargo check -p anvil`