### PR TITLE
fix(forge): adjust gas assertion `CounterWithFallback`

### DIFF
--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3016,7 +3016,7 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
   {
     "contract": "test/FallbackWithCalldataTest.sol:CounterWithFallback",
     "deployment": {
-      "gas": 132471,
+      "gas": 132459,
       "size": 396
     },
     "functions": {


### PR DESCRIPTION

## Motivation

Close #14457
Close #14464

Fix `flaky_gas_report_fallback_with_calldata` test

Failure on `can_bind_e2e` is simply a timeout. 