### PR TITLE
ci: split MPP e2e into its own workflow

### DIFF
--- a/.github/workflows/ci-mpp.yml
+++ b/.github/workflows/ci-mpp.yml
@@ -17,7 +17,7 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
-  mpp-e2e:
+  mpp-check:
     runs-on: depot-ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/ci-mpp.yml
+++ b/.github/workflows/ci-mpp.yml
@@ -1,0 +1,55 @@
+name: CI MPP
+
+permissions: {}
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: "sccache"
+
+jobs:
+  mpp-e2e:
+    runs-on: depot-ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      # Checkout the repository
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+        with:
+          toolchain: stable
+
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+
+      # Build and install binaries
+      - name: Build and install Foundry binaries
+        run: |
+          cargo build --profile dev --locked -p forge -p cast -p anvil -p chisel
+          echo "${{ github.workspace }}/target/debug" >> "$GITHUB_PATH"
+
+      - name: Run MPP e2e test
+        env:
+          TEMPO_KEYS_TOML_B64: ${{ secrets.TEMPO_KEYS_TOML_B64 }}
+          MPP_API_KEY: ${{ secrets.MPP_API_KEY }}
+          MPP_DEPOSIT: "1000000"
+        run: |
+          if [ -z "${TEMPO_KEYS_TOML_B64:-}" ]; then
+            echo "::warning::TEMPO_KEYS_TOML_B64 secret not set, skipping MPP e2e"
+            exit 0
+          fi
+          mkdir -p ~/.tempo/wallet
+          echo "$TEMPO_KEYS_TOML_B64" | tr -d '[:space:]' | base64 -d > ~/.tempo/wallet/keys.toml
+          ./.github/scripts/tempo-mpp.sh "$(which cast | xargs dirname)"

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -59,21 +59,6 @@ jobs:
           cargo build --profile dev --locked -p forge -p cast -p anvil -p chisel
           echo "${{ github.workspace }}/target/debug" >> "$GITHUB_PATH"
 
-      - name: Run MPP e2e test
-        if: github.event_name == 'push' || github.event_name == 'pull_request'
-        env:
-          TEMPO_KEYS_TOML_B64: ${{ secrets.TEMPO_KEYS_TOML_B64 }}
-          MPP_API_KEY: ${{ secrets.MPP_API_KEY }}
-          MPP_DEPOSIT: "1000000"
-        run: |
-          if [ -z "${TEMPO_KEYS_TOML_B64:-}" ]; then
-            echo "::warning::TEMPO_KEYS_TOML_B64 secret not set, skipping MPP e2e"
-            exit 0
-          fi
-          mkdir -p ~/.tempo/wallet
-          echo "$TEMPO_KEYS_TOML_B64" | tr -d '[:space:]' | base64 -d > ~/.tempo/wallet/keys.toml
-          ./.github/scripts/tempo-mpp.sh "$(which cast | xargs dirname)"
-
       # TODO(upstream): re-enable when flaky devnet faucet is fixed
       # - name: Run Tempo check on devnet
       #   if: |

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -36,7 +36,7 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
-  sanity-check:
+  tempo-check:
     runs-on: depot-ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
Moves the `Run MPP e2e test` step out of `ci-tempo.yml` and into a new standalone `ci-mpp.yml` workflow.

Motivation: the MPP RPC has been returning transient HTTP 402 "Payment verification failed" errors (e.g. https://github.com/foundry-rs/foundry/actions/runs/24991029126/job/73176371269?pr=14445), which currently fails the entire Tempo CI workflow and blocks unrelated PRs.

With this split:
- `CI Tempo` (`ci-tempo.yml`) no longer depends on the MPP service.
- `CI MPP` (`ci-mpp.yml`) runs the MPP e2e test independently and can be made non-required / re-run in isolation when the upstream service is flaky.

No script or test logic is changed; `./.github/scripts/tempo-mpp.sh` is invoked from the new workflow with the same env (`TEMPO_KEYS_TOML_B64`, `MPP_API_KEY`, `MPP_DEPOSIT`).