### PR TITLE
fix(anvil): pre-check Tempo valid_after before execution

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -25,7 +25,7 @@ use alloy_evm::{
         receipt_builder::{ReceiptBuilder, ReceiptBuilderCtx},
     },
 };
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use anvil_core::eth::transaction::{
     MaybeImpersonatedTransaction, PendingTransaction, TransactionInfo,
 };
@@ -346,8 +346,10 @@ pub fn execute_pool_transactions<B>(
     ) -> Result<(), InvalidTransactionError>,
 ) -> ExecutedPoolTransactions<B::Transaction>
 where
-    B: BlockExecutor<Evm: Evm<DB: Database + Debug, Inspector = AnvilInspector>>,
-    B::Transaction: Transaction + Encodable2718 + Clone,
+    B: BlockExecutor<
+            Transaction = FoundryTxEnvelope,
+            Evm: Evm<DB: Database + Debug, Inspector = AnvilInspector>,
+        >,
     B::Receipt: TxReceipt,
     <B::Result as TxResult>::HaltReason: Clone + IntoInstructionResult,
     <B::Evm as Evm>::Tx: FromTxWithEncoded<B::Transaction> + FoundryTransaction,
@@ -364,6 +366,16 @@ where
     for pool_tx in pool_transactions {
         let pending = &pool_tx.pending_transaction;
         let sender = *pending.sender();
+        let block_timestamp = executor.evm().block().timestamp();
+
+        if let FoundryTxEnvelope::Tempo(aa_tx) = pending.transaction.as_ref()
+            && let Some(valid_after) = aa_tx.tx().valid_after
+            && U256::from(valid_after.get()) > block_timestamp
+        {
+            trace!(target: "backend", "[{:?}] transaction not valid yet, will retry later", pool_tx.hash());
+            not_yet_valid.push(pool_tx.clone());
+            continue;
+        }
 
         let account = match executor.evm_mut().db_mut().basic(sender).map(|a| a.unwrap_or_default())
         {
@@ -471,11 +483,7 @@ where
                 transactions.push(pending.transaction.clone());
             }
             Err(err) => {
-                let err_str = err.to_string();
-                if err_str.contains("not valid yet") {
-                    trace!(target: "backend", "[{:?}] transaction not valid yet, will retry later", pool_tx.hash());
-                    not_yet_valid.push(pool_tx.clone());
-                } else if err.as_validation().is_some() {
+                if err.as_validation().is_some() {
                     warn!(target: "backend", "Skipping invalid tx [{:?}]: {}", pool_tx.hash(), err);
                     invalid.push(pool_tx.clone());
                 } else {

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -793,8 +793,10 @@ async fn test_tempo_aa_valid_after_future() {
     let current_time = block.header.timestamp;
     let valid_after = current_time + 5;
     let valid_before = current_time + 60;
+    let transfer_amount = U256::from(50_000);
+    let recipient_balance_before = token.balanceOf(recipient).call().await.unwrap();
 
-    let transfer_call = token.transfer(recipient, U256::from(50_000));
+    let transfer_call = token.transfer(recipient, transfer_amount);
     let calldata: Bytes = transfer_call.calldata().clone();
 
     let tempo_tx = TempoTransaction {
@@ -824,14 +826,23 @@ async fn test_tempo_aa_valid_after_future() {
     envelope.encode_2718(&mut encoded);
 
     // Transaction enters pool but is not yet valid
-    let tx_hash = provider.send_raw_transaction(&encoded).await.unwrap();
+    let pending = provider.send_raw_transaction(&encoded).await.unwrap();
+    let tx_hash = *pending.tx_hash();
+
+    api.mine_one().await;
+    let receipt = provider.get_transaction_receipt(tx_hash).await.unwrap();
+    assert!(receipt.is_none(), "Transaction should not be mined before valid_after");
+    let recipient_balance = token.balanceOf(recipient).call().await.unwrap();
+    assert_eq!(recipient_balance, recipient_balance_before);
 
     // Advance time past valid_after
     api.evm_set_next_block_timestamp(valid_after + 1).unwrap();
     api.mine_one().await;
 
-    let receipt = tx_hash.get_receipt().await.unwrap();
+    let receipt = pending.get_receipt().await.unwrap();
     assert!(receipt.status(), "Transaction should succeed after valid_after time");
+    let recipient_balance = token.balanceOf(recipient).call().await.unwrap();
+    assert_eq!(recipient_balance, recipient_balance_before + transfer_amount);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Motivation

Mined transaction traces currently pass the receipt's cumulative gas value into the geth trace builders. For transactions after the first one in a block, that makes trace `gas`/`gasUsed` fields reflect the block running total instead of the transaction's own gas usage.

## Solution

Use the per-transaction `TransactionInfo::gas_used` value when building geth call and structlog traces for mined transactions.