### PR TITLE
fix(benches): add repos + extra args support to prevent blocking errors

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,14 +30,14 @@ env:
     ithacaxyz/account:v0.5.7,
     vectorized/solady:v0.1.26 --nmc 'LifebuoyTest|LibBitTest|Base58Test',
     aave/aave-v4:v0.5.11,
-    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75,
+    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75 --nmc 'TickMathTestTest',
     sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
 
   ISOLATE_TEST_REPOS: >-
     ithacaxyz/account:v0.5.7 --nmc SimulateExecuteTest,
     vectorized/solady:v0.1.26 --nmc 'SafeTransferLibTest|LifebuoyTest|LibBitTest|Base58Test',
     aave/aave-v4:v0.5.11,
-    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75,
+    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75 --nmc 'TickMathTestTest',
     sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
 
   BUILD_REPOS: >-

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -109,7 +109,7 @@ jobs:
           VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
           REPOS: ${{ github.event.inputs.repos || env.TEST_REPOS }}
         run: |
-          ./target/release/foundry-bench --output-dir ./benches --force-install --verbose \
+          ./target/release/foundry-bench --output-dir ./benches --force-install \
             --versions "$VERSIONS" \
             --repos "$REPOS" \
             --benchmarks forge_test,forge_fuzz_test \
@@ -121,7 +121,7 @@ jobs:
           VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
           REPOS: ${{ github.event.inputs.repos || env.ISOLATE_TEST_REPOS }}
         run: |
-          ./target/release/foundry-bench --output-dir ./benches --force-install --verbose \
+          ./target/release/foundry-bench --output-dir ./benches --force-install \
             --versions "$VERSIONS" \
             --repos "$REPOS" \
             --benchmarks forge_isolate_test \
@@ -133,7 +133,7 @@ jobs:
           VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
           REPOS: ${{ github.event.inputs.repos || env.BUILD_REPOS }}
         run: |
-          ./target/release/foundry-bench --output-dir ./benches --force-install --verbose \
+          ./target/release/foundry-bench --output-dir ./benches --force-install \
             --versions "$VERSIONS" \
             --repos "$REPOS" \
             --benchmarks forge_build_no_cache,forge_build_with_cache \
@@ -145,7 +145,7 @@ jobs:
           VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
           REPOS: ${{ github.event.inputs.repos || env.COVERAGE_REPOS }}
         run: |
-          ./target/release/foundry-bench --output-dir ./benches --force-install --verbose \
+          ./target/release/foundry-bench --output-dir ./benches --force-install \
             --versions "$VERSIONS" \
             --repos "$REPOS" \
             --benchmarks forge_coverage \

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,15 +15,44 @@ on:
         type: string
         default: "stable,nightly"
       repos:
-        description: "Comma-separated list of repos to benchmark (e.g., ithacaxyz/account:main,Vectorized/solady)"
+        description: "Comma-separated repos to benchmark. Each entry: org/repo[:rev][ <extra args>] (e.g. vectorized/solady:v0.1.26 --nmc BrokenTest)"
         required: false
         type: string
-        default: "ithacaxyz/account:v0.3.2,Vectorized/solady:v0.1.22"
+        default: "ithacaxyz/account:v0.3.2,vectorized/solady:v0.1.22"
 
 env:
-  ITHACAXYZ_ACCOUNT: "ithacaxyz/account:v0.3.2"
-  VECTORIZED_SOLADY: "Vectorized/solady:v0.1.22"
-  DEFAULT_REPOS: "ithacaxyz/account:v0.3.2,Vectorized/solady:v0.1.22"
+  # Repos to benchmark per step. Each comma-separated entry has the form
+  #   org/repo[:rev][ <extra args>]
+  # where anything after the first whitespace is appended to every benchmark
+  # command for that repo (use this to skip a broken test contract via e.g.
+  # `--nmc BrokenTest`, so a single failing test does not fail the whole CI).
+  TEST_REPOS: >-
+    ithacaxyz/account:v0.5.7,
+    vectorized/solady:v0.1.26 --nmc 'LifebuoyTest|LibBitTest|Base58Test',
+    aave/aave-v4:v0.5.11,
+    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75,
+    sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
+
+  ISOLATE_TEST_REPOS: >-
+    ithacaxyz/account:v0.5.7 --nmc SimulateExecuteTest,
+    vectorized/solady:v0.1.26 --nmc 'SafeTransferLibTest|LifebuoyTest|LibBitTest|Base58Test',
+    aave/aave-v4:v0.5.11,
+    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75,
+    sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
+
+  BUILD_REPOS: >-
+    ithacaxyz/account:v0.5.7,
+    vectorized/solady:v0.1.26,
+    aave/aave-v4:v0.5.11,
+    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75,
+    sparkdotfi/spark-psm:v1.0.0
+
+  COVERAGE_REPOS: >-
+    ithacaxyz/account:v0.5.7,
+    aave/aave-v4:v0.5.11,
+    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75,
+    sparkdotfi/spark-psm:v1.0.0
+
   RUSTC_WRAPPER: "sccache"
 
 jobs:
@@ -78,9 +107,9 @@ jobs:
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
           VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
-          REPOS: ${{ github.event.inputs.repos || env.DEFAULT_REPOS }}
+          REPOS: ${{ github.event.inputs.repos || env.TEST_REPOS }}
         run: |
-          ./target/release/foundry-bench --output-dir ./benches --force-install \
+          ./target/release/foundry-bench --output-dir ./benches --force-install --verbose \
             --versions "$VERSIONS" \
             --repos "$REPOS" \
             --benchmarks forge_test,forge_fuzz_test \
@@ -90,9 +119,9 @@ jobs:
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
           VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
-          REPOS: ${{ github.event.inputs.repos || env.VECTORIZED_SOLADY }}
+          REPOS: ${{ github.event.inputs.repos || env.ISOLATE_TEST_REPOS }}
         run: |
-          ./target/release/foundry-bench --output-dir ./benches --force-install \
+          ./target/release/foundry-bench --output-dir ./benches --force-install --verbose \
             --versions "$VERSIONS" \
             --repos "$REPOS" \
             --benchmarks forge_isolate_test \
@@ -102,9 +131,9 @@ jobs:
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
           VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
-          REPOS: ${{ github.event.inputs.repos || env.DEFAULT_REPOS }}
+          REPOS: ${{ github.event.inputs.repos || env.BUILD_REPOS }}
         run: |
-          ./target/release/foundry-bench --output-dir ./benches --force-install \
+          ./target/release/foundry-bench --output-dir ./benches --force-install --verbose \
             --versions "$VERSIONS" \
             --repos "$REPOS" \
             --benchmarks forge_build_no_cache,forge_build_with_cache \
@@ -114,10 +143,11 @@ jobs:
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
           VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
+          REPOS: ${{ github.event.inputs.repos || env.COVERAGE_REPOS }}
         run: |
-          ./target/release/foundry-bench --output-dir ./benches --force-install \
+          ./target/release/foundry-bench --output-dir ./benches --force-install --verbose \
             --versions "$VERSIONS" \
-            --repos ${{ env.ITHACAXYZ_ACCOUNT }} \
+            --repos "$REPOS" \
             --benchmarks forge_coverage \
             --output-file forge_coverage_bench.md
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,10 +15,10 @@ on:
         type: string
         default: "stable,nightly"
       repos:
-        description: "Comma-separated repos to benchmark. Each entry: org/repo[:rev][ <extra args>] (e.g. vectorized/solady:v0.1.26 --nmc BrokenTest)"
+        description: "Comma-separated repos to benchmark. Each entry: org/repo[:rev][ <extra args>] (e.g. vectorized/solady:v0.1.26 --nmc BrokenTest). Leave empty to use the per-benchmark default repo lists."
         required: false
         type: string
-        default: "ithacaxyz/account:v0.3.2,vectorized/solady:v0.1.22"
+        default: ""
 
 env:
   # Repos to benchmark per step. Each comma-separated entry has the form

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -24,46 +24,53 @@ pub struct RepoConfig {
     pub org: String,
     pub repo: String,
     pub rev: String,
+    /// Optional extra arguments appended to every benchmark command for this
+    /// repo (e.g. `--nmc BrokenTest` to skip a broken test contract).
+    pub extra_args: Option<String>,
 }
 
 impl FromStr for RepoConfig {
     type Err = eyre::Error;
 
+    /// Parse a repo spec of the form `org/repo[:rev][ <extra args...>]`.
+    ///
+    /// Anything after the first whitespace is treated as extra arguments
+    /// appended to every benchmark command for this repo.
     fn from_str(spec: &str) -> Result<Self> {
-        // Split by ':' first to separate repo path from optional rev
-        let parts: Vec<&str> = spec.splitn(2, ':').collect();
-        let repo_path = parts[0];
-        let custom_rev = parts.get(1).copied();
+        let spec = spec.trim();
+        // Anything after the first whitespace is per-repo extra args.
+        let (head, extra_args) = match spec.split_once(char::is_whitespace) {
+            Some((head, rest)) => (head, Some(rest.trim().to_string())),
+            None => (spec, None),
+        };
 
-        // Now split the repo path by '/'
-        let path_parts: Vec<&str> = repo_path.split('/').collect();
-        if path_parts.len() != 2 {
-            eyre::bail!("Invalid repo format '{}'. Expected 'org/repo' or 'org/repo:rev'", spec);
-        }
+        let (repo_path, custom_rev) = match head.split_once(':') {
+            Some((path, rev)) => (path, Some(rev)),
+            None => (head, None),
+        };
 
-        let org = path_parts[0];
-        let repo = path_parts[1];
+        let (org, repo) = repo_path.split_once('/').ok_or_else(|| {
+            eyre::eyre!("Invalid repo format '{spec}'. Expected 'org/repo' or 'org/repo:rev'")
+        })?;
 
-        // Try to find this repo in BENCHMARK_REPOS to get the full config
-        let existing_config = BENCHMARK_REPOS.iter().find(|r| r.org == org && r.repo == repo);
-
-        let config = if let Some(existing) = existing_config {
-            // Use existing config but allow custom rev to override
-            let mut config = existing.clone();
-            if let Some(rev) = custom_rev {
-                config.rev = rev.to_string();
-            }
-            config
-        } else {
-            // Create new config with custom rev or default
-            // Name should follow the format: org-repo (with hyphen)
-            Self {
+        // Inherit defaults from BENCHMARK_REPOS when available, otherwise build
+        // a fresh config. Custom rev / extra args always override.
+        let mut config = BENCHMARK_REPOS
+            .iter()
+            .find(|r| r.org == org && r.repo == repo)
+            .cloned()
+            .unwrap_or_else(|| Self {
                 name: format!("{org}-{repo}"),
                 org: org.to_string(),
                 repo: repo.to_string(),
-                rev: custom_rev.unwrap_or("main").to_string(),
-            }
-        };
+                rev: "main".to_string(),
+                extra_args: None,
+            });
+
+        if let Some(rev) = custom_rev {
+            config.rev = rev.to_string();
+        }
+        config.extra_args = extra_args;
 
         let _ = sh_println!("Parsed repo spec '{spec}' -> {config:?}");
         Ok(config)
@@ -78,12 +85,14 @@ pub fn default_benchmark_repos() -> Vec<RepoConfig> {
             org: "ithacaxyz".to_string(),
             repo: "account".to_string(),
             rev: "main".to_string(),
+            extra_args: None,
         },
         RepoConfig {
             name: "solady".to_string(),
             org: "Vectorized".to_string(),
             repo: "solady".to_string(),
             rev: "main".to_string(),
+            extra_args: None,
         },
     ]
 }
@@ -113,6 +122,8 @@ pub struct BenchmarkProject {
     pub name: String,
     pub temp_project: TempProject,
     pub root_path: PathBuf,
+    /// Optional extra arguments appended to every benchmark command.
+    pub extra_args: Option<String>,
 }
 
 impl BenchmarkProject {
@@ -159,7 +170,20 @@ impl BenchmarkProject {
         Self::install_npm_dependencies(&root_path)?;
 
         sh_println!("  ✅ Project {} setup complete at {}", config.name, root);
-        Ok(Self { name: config.name.clone(), root_path, temp_project })
+        Ok(Self {
+            name: config.name.clone(),
+            root_path,
+            temp_project,
+            extra_args: config.extra_args.clone(),
+        })
+    }
+
+    /// Append `self.extra_args` to a benchmark shell command, if any.
+    fn cmd(&self, base: &str) -> String {
+        match self.extra_args.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+            Some(extra) => format!("{base} {extra}"),
+            None => base.to_string(),
+        }
     }
 
     /// Install npm dependencies if package.json exists
@@ -286,7 +310,7 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_test",
             version,
-            "forge test",
+            &self.cmd("forge test"),
             runs,
             Some("forge build"),
             None,
@@ -305,7 +329,7 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_build_with_cache",
             version,
-            "FOUNDRY_LINT_LINT_ON_BUILD=false forge build",
+            &self.cmd("FOUNDRY_LINT_LINT_ON_BUILD=false forge build"),
             runs,
             None,
             Some("forge build"),
@@ -325,7 +349,7 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_build_no_cache",
             version,
-            "FOUNDRY_LINT_LINT_ON_BUILD=false forge build",
+            &self.cmd("FOUNDRY_LINT_LINT_ON_BUILD=false forge build"),
             runs,
             Some("forge clean"),
             None,
@@ -345,7 +369,7 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_fuzz_test",
             version,
-            r#"forge test --match-test "test[^(]*\([^)]+\)""#,
+            &self.cmd(r#"forge test --match-test "test[^(]*\([^)]+\)""#),
             runs,
             Some("forge build"),
             None,
@@ -366,7 +390,7 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_coverage",
             version,
-            "forge coverage --ir-minimum",
+            &self.cmd("forge coverage --ir-minimum"),
             runs,
             None,
             None,
@@ -386,7 +410,7 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_isolate_test",
             version,
-            "forge test --isolate",
+            &self.cmd("forge test --isolate"),
             runs,
             Some("forge build"),
             None,

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -48,8 +48,16 @@ struct Cli {
     #[clap(long, value_delimiter = ',')]
     benchmarks: Option<Vec<String>>,
 
-    /// Run only on specific repositories (comma-separated in org/repo[:rev] format:
-    /// ithacaxyz/account,Vectorized/solady:main,foundry-rs/foundry:v1.0.0)
+    /// Comma-separated list of repositories to benchmark.
+    ///
+    /// Each entry has the form `org/repo[:rev][ <extra args...>]`. Anything
+    /// after the first whitespace is appended to every benchmark command for
+    /// that repo (handy to skip a broken test contract via e.g.
+    /// `--nmc BrokenTest`).
+    ///
+    /// Examples:
+    ///   `ithacaxyz/account:v0.5.7`
+    ///   `vectorized/solady:v0.1.26 --nmc 'LifebuoyTest|LibBitTest'`
     #[clap(long, value_delimiter = ',')]
     repos: Option<Vec<String>>,
 }


### PR DESCRIPTION
## Motivation

Add more repos to benchmark:
- aave/aave-v4
- uniswap/v4-core
- sparkdotfi/spark-psm

All pinned to a tag or commit.

Added extra args forwarding to exclude falling tests in order to complete benchmarking.

All tested locally (cmd-by-cmd), see preliminary output: https://gist.github.com/mablr/eb1e07e0244c5cf5cff0c0443beb17f8 