### PR TITLE
ci: prefer direct-key credentials for MPP e2e

### DIFF
--- a/.github/scripts/tempo-mpp.sh
+++ b/.github/scripts/tempo-mpp.sh
@@ -28,7 +28,9 @@ else
   ANVIL="anvil"
   CHISEL="chisel"
 fi
-export MPP_DEPOSIT=100000
+export MPP_DEPOSIT="${MPP_DEPOSIT:-100000}"
+TEMPO_AUTO_FUND="${TEMPO_AUTO_FUND:-0}"
+TEMPO_AUTO_FUND_ATTEMPTS="${TEMPO_AUTO_FUND_ATTEMPTS:-3}"
 MIN_BALANCE="${MPP_MIN_BALANCE:-$((MPP_DEPOSIT + 50000))}"
 RPC_MPP="https://rpc.mpp.moderato.tempo.xyz"
 RPC="https://rpc.moderato.tempo.xyz"
@@ -63,12 +65,28 @@ fi
 echo "Wallet: $WALLET"
 echo "RPC:    $RPC_MPP"
 echo ""
+WALLET_LOWER=$(printf '%s' "$WALLET" | tr '[:upper:]' '[:lower:]')
 
 # 1. Check balance before
 echo "=== 1. Balance BEFORE ==="
 BEFORE=$("$CAST" erc20 balance "$TOKEN" "$WALLET" --rpc-url "$RPC")
 echo "$BEFORE"
 BEFORE_RAW=$(echo "$BEFORE" | awk '{print $1}')
+
+if [ "$BEFORE_RAW" -lt "$MIN_BALANCE" ] && [ "$TEMPO_AUTO_FUND" = "1" ]; then
+  echo "Balance below threshold, requesting faucet funds for $WALLET_LOWER"
+  ATTEMPT=0
+  while [ "$BEFORE_RAW" -lt "$MIN_BALANCE" ] && [ "$ATTEMPT" -lt "$TEMPO_AUTO_FUND_ATTEMPTS" ]; do
+    ATTEMPT=$((ATTEMPT + 1))
+    echo "Faucet attempt $ATTEMPT/$TEMPO_AUTO_FUND_ATTEMPTS"
+    "$CAST" rpc tempo_fundAddress "$WALLET_LOWER" --rpc-url "$RPC" >/dev/null
+    sleep 2
+    BEFORE=$("$CAST" erc20 balance "$TOKEN" "$WALLET" --rpc-url "$RPC")
+    echo "$BEFORE"
+    BEFORE_RAW=$(echo "$BEFORE" | awk '{print $1}')
+  done
+fi
+
 if [ "$BEFORE_RAW" -lt "$MIN_BALANCE" ]; then
   echo "ERROR: Wallet balance too low for MPP e2e. Need at least $MIN_BALANCE units of $TOKEN, got $BEFORE_RAW. Refill the CI wallet."
   exit 1

--- a/.github/scripts/tempo-mpp.sh
+++ b/.github/scripts/tempo-mpp.sh
@@ -2,7 +2,7 @@
 # MPP (Machine Payments Protocol) end-to-end test script
 #
 # Prerequisites:
-#   - Tempo wallet configured: `tempo wallet login`
+#   - Either `TEMPO_PRIVATE_KEY` is set, or Tempo wallet is configured: `tempo wallet login`
 #   - Wallet funded with TEMPO on moderato testnet
 #   - Foundry binaries built: `cargo build --bin cast --bin forge --bin anvil --bin chisel`
 #
@@ -50,13 +50,15 @@ if ! command -v "$CHISEL" &>/dev/null; then
   exit 1
 fi
 
-# Discover wallet address from keys.toml
 KEYS_FILE="${TEMPO_HOME:-$HOME/.tempo}/wallet/keys.toml"
-if [ ! -f "$KEYS_FILE" ]; then
-  echo "ERROR: Tempo wallet not configured. Run: tempo wallet login"
+if [ -n "${TEMPO_PRIVATE_KEY:-}" ]; then
+  WALLET=$("$CAST" wallet address --private-key "$TEMPO_PRIVATE_KEY")
+elif [ -f "$KEYS_FILE" ]; then
+  WALLET=$(grep -m1 'wallet_address' "$KEYS_FILE" | sed 's/.*= *"\(.*\)"/\1/')
+else
+  echo "ERROR: Set TEMPO_PRIVATE_KEY or configure Tempo wallet with: tempo wallet login"
   exit 1
 fi
-WALLET=$(grep -m1 'wallet_address' "$KEYS_FILE" | sed 's/.*= *"\(.*\)"/\1/')
 echo "Wallet: $WALLET"
 echo "RPC:    $RPC_MPP"
 echo ""

--- a/.github/scripts/tempo-mpp.sh
+++ b/.github/scripts/tempo-mpp.sh
@@ -29,6 +29,7 @@ else
   CHISEL="chisel"
 fi
 export MPP_DEPOSIT=100000
+MIN_BALANCE="${MPP_MIN_BALANCE:-$((MPP_DEPOSIT + 50000))}"
 RPC_MPP="https://rpc.mpp.moderato.tempo.xyz"
 RPC="https://rpc.moderato.tempo.xyz"
 TOKEN="0x20c0000000000000000000000000000000000000"  # TEMPO TIP-20
@@ -67,6 +68,11 @@ echo ""
 echo "=== 1. Balance BEFORE ==="
 BEFORE=$("$CAST" erc20 balance "$TOKEN" "$WALLET" --rpc-url "$RPC")
 echo "$BEFORE"
+BEFORE_RAW=$(echo "$BEFORE" | awk '{print $1}')
+if [ "$BEFORE_RAW" -lt "$MIN_BALANCE" ]; then
+  echo "ERROR: Wallet balance too low for MPP e2e. Need at least $MIN_BALANCE units of $TOKEN, got $BEFORE_RAW. Refill the CI wallet."
+  exit 1
+fi
 
 # 2. Call block-number through MPP-gated endpoint
 echo ""
@@ -85,7 +91,6 @@ echo "=== 3. Balance AFTER ==="
 AFTER=$("$CAST" erc20 balance "$TOKEN" "$WALLET" --rpc-url "$RPC")
 echo "$AFTER"
 
-BEFORE_RAW=$(echo "$BEFORE" | awk '{print $1}')
 AFTER_RAW=$(echo "$AFTER" | awk '{print $1}')
 SPENT=$((BEFORE_RAW - AFTER_RAW))
 echo "Spent: $SPENT units (channel deposit + gas)"

--- a/.github/workflows/ci-mpp.yml
+++ b/.github/workflows/ci-mpp.yml
@@ -45,7 +45,7 @@ jobs:
           TEMPO_PRIVATE_KEY: ${{ secrets.TEMPO_PRIVATE_KEY }}
           TEMPO_KEYS_TOML_B64: ${{ secrets.TEMPO_KEYS_TOML_B64 }}
           MPP_API_KEY: ${{ secrets.MPP_API_KEY }}
-          MPP_DEPOSIT: "1000000"
+          MPP_DEPOSIT: "100000"
         run: |
           if [ -n "${TEMPO_PRIVATE_KEY:-}" ]; then
             echo "::notice::Using TEMPO_PRIVATE_KEY for MPP e2e"

--- a/.github/workflows/ci-mpp.yml
+++ b/.github/workflows/ci-mpp.yml
@@ -42,14 +42,18 @@ jobs:
 
       - name: Run MPP e2e test
         env:
+          TEMPO_PRIVATE_KEY: ${{ secrets.TEMPO_PRIVATE_KEY }}
           TEMPO_KEYS_TOML_B64: ${{ secrets.TEMPO_KEYS_TOML_B64 }}
           MPP_API_KEY: ${{ secrets.MPP_API_KEY }}
           MPP_DEPOSIT: "1000000"
         run: |
-          if [ -z "${TEMPO_KEYS_TOML_B64:-}" ]; then
-            echo "::warning::TEMPO_KEYS_TOML_B64 secret not set, skipping MPP e2e"
+          if [ -n "${TEMPO_PRIVATE_KEY:-}" ]; then
+            echo "::notice::Using TEMPO_PRIVATE_KEY for MPP e2e"
+          elif [ -n "${TEMPO_KEYS_TOML_B64:-}" ]; then
+            mkdir -p ~/.tempo/wallet
+            echo "$TEMPO_KEYS_TOML_B64" | tr -d '[:space:]' | base64 -d > ~/.tempo/wallet/keys.toml
+          else
+            echo "::warning::TEMPO_PRIVATE_KEY or TEMPO_KEYS_TOML_B64 secret not set, skipping MPP e2e"
             exit 0
           fi
-          mkdir -p ~/.tempo/wallet
-          echo "$TEMPO_KEYS_TOML_B64" | tr -d '[:space:]' | base64 -d > ~/.tempo/wallet/keys.toml
           ./.github/scripts/tempo-mpp.sh "$(which cast | xargs dirname)"

--- a/.github/workflows/ci-mpp.yml
+++ b/.github/workflows/ci-mpp.yml
@@ -45,7 +45,8 @@ jobs:
           TEMPO_PRIVATE_KEY: ${{ secrets.TEMPO_PRIVATE_KEY }}
           TEMPO_KEYS_TOML_B64: ${{ secrets.TEMPO_KEYS_TOML_B64 }}
           MPP_API_KEY: ${{ secrets.MPP_API_KEY }}
-          MPP_DEPOSIT: "100000"
+          MPP_DEPOSIT: "1000000"
+          TEMPO_AUTO_FUND: "1"
         run: |
           if [ -n "${TEMPO_PRIVATE_KEY:-}" ]; then
             echo "::notice::Using TEMPO_PRIVATE_KEY for MPP e2e"

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -13,6 +13,7 @@ use mpp::{
         parse_www_authenticate_all,
     },
 };
+use reqwest::header::HeaderMap;
 use reqwest::StatusCode;
 use std::{
     collections::HashMap,
@@ -40,6 +41,28 @@ const MPP_RETRY_TIMEOUT: Duration = Duration::from_secs(120);
 /// Resolve the deposit amount from `MPP_DEPOSIT` env var or the default.
 fn default_deposit() -> u128 {
     std::env::var("MPP_DEPOSIT").ok().and_then(|s| s.parse().ok()).unwrap_or(DEFAULT_DEPOSIT)
+}
+
+fn format_http_diagnostics(headers: &HeaderMap) -> String {
+    const DIAGNOSTIC_HEADERS: &[&str] = &[
+        "x-request-id",
+        "cf-ray",
+        "server",
+        "report-to",
+        "nel",
+    ];
+
+    let pairs: Vec<String> = DIAGNOSTIC_HEADERS
+        .iter()
+        .filter_map(|name| headers.get(*name).and_then(|value| value.to_str().ok().map(|v| (*name, v))))
+        .map(|(name, value)| format!("{name}: {value}"))
+        .collect();
+
+    if pairs.is_empty() {
+        String::new()
+    } else {
+        format!("\n\nHTTP diagnostics:\n{}", pairs.join("\n"))
+    }
 }
 
 /// Process-wide payment serialization locks, keyed by origin URL.
@@ -295,6 +318,7 @@ where
 
         // Retry 402 → handle specific recoverable errors before giving up.
         if retry_resp.status() == StatusCode::PAYMENT_REQUIRED {
+            let diagnostics = format_http_diagnostics(retry_resp.headers());
             let retry_body = retry_resp.bytes().await.map_err(TransportErrorKind::custom)?;
             let retry_text = String::from_utf8_lossy(&retry_body);
 
@@ -369,7 +393,7 @@ where
             self.provider.rollback_pending();
             return Err(TransportErrorKind::http_error(
                 StatusCode::PAYMENT_REQUIRED.as_u16(),
-                retry_text.into_owned(),
+                format!("{}{}", retry_text, diagnostics),
             ));
         }
 
@@ -467,7 +491,10 @@ where
 
         if www_auth_values.is_empty() {
             return Err(TransportErrorKind::custom(std::io::Error::other(
-                "402 response missing WWW-Authenticate header",
+                format!(
+                    "402 response missing WWW-Authenticate header{}",
+                    format_http_diagnostics(resp.headers())
+                ),
             )));
         }
 
@@ -505,6 +532,7 @@ where
     async fn handle_response(resp: reqwest::Response) -> TransportResult<ResponsePacket> {
         let status = resp.status();
         debug!(%status, "received response from MPP transport");
+        let diagnostics = format_http_diagnostics(resp.headers());
 
         let body = resp.bytes().await.map_err(TransportErrorKind::custom)?;
 
@@ -517,7 +545,7 @@ where
         if !status.is_success() {
             return Err(TransportErrorKind::http_error(
                 status.as_u16(),
-                String::from_utf8_lossy(&body).into_owned(),
+                format!("{}{}", String::from_utf8_lossy(&body), diagnostics),
             ));
         }
 

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -13,8 +13,7 @@ use mpp::{
         parse_www_authenticate_all,
     },
 };
-use reqwest::StatusCode;
-use reqwest::header::HeaderMap;
+use reqwest::{StatusCode, header::HeaderMap};
 use std::{
     collections::HashMap,
     fmt,

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -13,8 +13,8 @@ use mpp::{
         parse_www_authenticate_all,
     },
 };
-use reqwest::header::HeaderMap;
 use reqwest::StatusCode;
+use reqwest::header::HeaderMap;
 use std::{
     collections::HashMap,
     fmt,
@@ -44,17 +44,13 @@ fn default_deposit() -> u128 {
 }
 
 fn format_http_diagnostics(headers: &HeaderMap) -> String {
-    const DIAGNOSTIC_HEADERS: &[&str] = &[
-        "x-request-id",
-        "cf-ray",
-        "server",
-        "report-to",
-        "nel",
-    ];
+    const DIAGNOSTIC_HEADERS: &[&str] = &["x-request-id", "cf-ray", "server", "report-to", "nel"];
 
     let pairs: Vec<String> = DIAGNOSTIC_HEADERS
         .iter()
-        .filter_map(|name| headers.get(*name).and_then(|value| value.to_str().ok().map(|v| (*name, v))))
+        .filter_map(|name| {
+            headers.get(*name).and_then(|value| value.to_str().ok().map(|v| (*name, v)))
+        })
         .map(|(name, value)| format!("{name}: {value}"))
         .collect();
 
@@ -393,7 +389,7 @@ where
             self.provider.rollback_pending();
             return Err(TransportErrorKind::http_error(
                 StatusCode::PAYMENT_REQUIRED.as_u16(),
-                format!("{}{}", retry_text, diagnostics),
+                format!("{retry_text}{diagnostics}"),
             ));
         }
 
@@ -490,12 +486,10 @@ where
             .collect();
 
         if www_auth_values.is_empty() {
-            return Err(TransportErrorKind::custom(std::io::Error::other(
-                format!(
-                    "402 response missing WWW-Authenticate header{}",
-                    format_http_diagnostics(resp.headers())
-                ),
-            )));
+            return Err(TransportErrorKind::custom(std::io::Error::other(format!(
+                "402 response missing WWW-Authenticate header{}",
+                format_http_diagnostics(resp.headers())
+            ))));
         }
 
         let challenges: Vec<_> = parse_www_authenticate_all(www_auth_values)
@@ -545,7 +539,7 @@ where
         if !status.is_success() {
             return Err(TransportErrorKind::http_error(
                 status.as_u16(),
-                format!("{}{}", String::from_utf8_lossy(&body), diagnostics),
+                format!("{}{diagnostics}", String::from_utf8_lossy(&body)),
             ));
         }
 

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -2969,7 +2969,7 @@ contract ScrollForkTest is Test {
     }
 );
 
-// Test that only provider is included in failed fork error.
+// Test that failed fork errors still surface the provider hostname.
 forgetest_init!(test_display_provider_on_error, |prj, cmd| {
     prj.add_test(
         "ForkTest.t.sol",
@@ -2987,8 +2987,8 @@ contract ForkTest is Test {
     cmd.args(["test", "--mt", "test_fork_err_message"]).assert_failure().stdout_eq(str![[r#"
 ...
 Ran 1 test for test/ForkTest.t.sol:ForkTest
-[FAIL: vm.createSelectFork: could not instantiate forked environment with provider eth-mainnet.g.alchemy.com; [..]] test_fork_err_message() ([GAS])
-Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+[FAIL: vm.createSelectFork: could not instantiate forked environment with provider eth-mainnet.g.alchemy.com; HTTP error 401 with body: Must be authenticated!
+
 ...
 
 "#]]);


### PR DESCRIPTION
## Summary
- allow the MPP e2e script to run from `TEMPO_PRIVATE_KEY` without requiring `keys.toml`
- prefer a direct-key secret in `CI MPP`, while keeping `TEMPO_KEYS_TOML_B64` as a fallback during migration

## Why
The current MPP CI path depends on Tempo wallet keystore material and access-key provisioning. That is more fragile than a funded direct key because it can fail on expired access keys, missing keychain state, or chain-id mismatches in `key_authorization`.

Foundry already supports direct-key mode internally via `TEMPO_PRIVATE_KEY`; this change lets the CI script and workflow use that path directly.