### PR TITLE
fix(ci): aave v4 pinned on latest

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,27 +29,27 @@ env:
   TEST_REPOS: >-
     ithacaxyz/account:v0.5.7,
     vectorized/solady:v0.1.26 --nmc 'LifebuoyTest|LibBitTest|Base58Test',
-    aave/aave-v4:v0.5.11,
+    aave/aave-v4:af1f0f2ba323ac6fbaaee3abf6be060c78e22d35,
     uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75 --nmc 'TickMathTestTest',
     sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
 
   ISOLATE_TEST_REPOS: >-
     ithacaxyz/account:v0.5.7 --nmc SimulateExecuteTest,
     vectorized/solady:v0.1.26 --nmc 'SafeTransferLibTest|LifebuoyTest|LibBitTest|Base58Test',
-    aave/aave-v4:v0.5.11,
+    aave/aave-v4:af1f0f2ba323ac6fbaaee3abf6be060c78e22d35,
     uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75 --nmc 'TickMathTestTest',
     sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
 
   BUILD_REPOS: >-
     ithacaxyz/account:v0.5.7,
     vectorized/solady:v0.1.26,
-    aave/aave-v4:v0.5.11,
+    aave/aave-v4:af1f0f2ba323ac6fbaaee3abf6be060c78e22d35,
     uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75,
     sparkdotfi/spark-psm:v1.0.0
 
   COVERAGE_REPOS: >-
     ithacaxyz/account:v0.5.7,
-    aave/aave-v4:v0.5.11,
+    aave/aave-v4:af1f0f2ba323ac6fbaaee3abf6be060c78e22d35,
     uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75,
     sparkdotfi/spark-psm:v1.0.0
 


### PR DESCRIPTION
## Motivation

#14470 Follow-up

Fix benchmark CI by bumping `aave/aave-v4` to latest commit on master https://github.com/aave/aave-v4/commit/af1f0f2ba323ac6fbaaee3abf6be060c78e22d35

See associated workflow: https://github.com/foundry-rs/foundry/actions/runs/25018563273 