### PR TITLE
ci(tempo): run testnet on PRs

### DIFF
--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -59,30 +59,30 @@ jobs:
           cargo build --profile dev --locked -p forge -p cast -p anvil -p chisel
           echo "${{ github.workspace }}/target/debug" >> "$GITHUB_PATH"
 
-      - name: Run Tempo check on devnet
-        if: |
-          github.event_name == 'pull_request' ||
-          github.event.inputs.network == 'devnet' ||
-          github.event.inputs.network == 'all'
-        env:
-          ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
-          SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
-        run: |
-          if [ "$SCRIPTS" = "check" ] || [ "$SCRIPTS" = "both" ]; then
-            ./.github/scripts/tempo-check.sh
-          fi
-          if [ "$SCRIPTS" = "deploy" ] || [ "$SCRIPTS" = "both" ]; then
-            ./.github/scripts/tempo-deploy.sh
-          fi
+      # - name: Run Tempo check on devnet
+      #   if: |
+      #     github.event_name == 'pull_request' ||
+      #     github.event.inputs.network == 'devnet' ||
+      #     github.event.inputs.network == 'all'
+      #   env:
+      #     ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
+      #     SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
+      #   run: |
+      #     if [ "$SCRIPTS" = "check" ] || [ "$SCRIPTS" = "both" ]; then
+      #       ./.github/scripts/tempo-check.sh
+      #     fi
+      #     if [ "$SCRIPTS" = "deploy" ] || [ "$SCRIPTS" = "both" ]; then
+      #       ./.github/scripts/tempo-deploy.sh
+      #     fi
 
-      - name: Run Tempo wallet tests on devnet
-        if: |
-          github.event_name == 'pull_request' ||
-          github.event.inputs.network == 'devnet' ||
-          github.event.inputs.network == 'all'
-        env:
-          ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
-        run: ./.github/scripts/tempo-wallet.sh
+      # - name: Run Tempo wallet tests on devnet
+      #   if: |
+      #     github.event_name == 'pull_request' ||
+      #     github.event.inputs.network == 'devnet' ||
+      #     github.event.inputs.network == 'all'
+      #   env:
+      #     ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
+      #   run: ./.github/scripts/tempo-wallet.sh
 
       - name: Run Tempo check on testnet
         if: |

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -59,34 +59,34 @@ jobs:
           cargo build --profile dev --locked -p forge -p cast -p anvil -p chisel
           echo "${{ github.workspace }}/target/debug" >> "$GITHUB_PATH"
 
-      # TODO(upstream): re-enable when flaky devnet faucet is fixed
-      # - name: Run Tempo check on devnet
-      #   if: |
-      #     github.event_name == 'pull_request' ||
-      #     github.event.inputs.network == 'devnet' ||
-      #     github.event.inputs.network == 'all'
-      #   env:
-      #     ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
-      #     SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
-      #   run: |
-      #     if [ "$SCRIPTS" = "check" ] || [ "$SCRIPTS" = "both" ]; then
-      #       ./.github/scripts/tempo-check.sh
-      #     fi
-      #     if [ "$SCRIPTS" = "deploy" ] || [ "$SCRIPTS" = "both" ]; then
-      #       ./.github/scripts/tempo-deploy.sh
-      #     fi
+      - name: Run Tempo check on devnet
+        if: |
+          github.event_name == 'pull_request' ||
+          github.event.inputs.network == 'devnet' ||
+          github.event.inputs.network == 'all'
+        env:
+          ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
+          SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
+        run: |
+          if [ "$SCRIPTS" = "check" ] || [ "$SCRIPTS" = "both" ]; then
+            ./.github/scripts/tempo-check.sh
+          fi
+          if [ "$SCRIPTS" = "deploy" ] || [ "$SCRIPTS" = "both" ]; then
+            ./.github/scripts/tempo-deploy.sh
+          fi
 
-      # - name: Run Tempo wallet tests on devnet
-      #   if: |
-      #     github.event_name == 'pull_request' ||
-      #     github.event.inputs.network == 'devnet' ||
-      #     github.event.inputs.network == 'all'
-      #   env:
-      #     ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
-      #   run: ./.github/scripts/tempo-wallet.sh
+      - name: Run Tempo wallet tests on devnet
+        if: |
+          github.event_name == 'pull_request' ||
+          github.event.inputs.network == 'devnet' ||
+          github.event.inputs.network == 'all'
+        env:
+          ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
+        run: ./.github/scripts/tempo-wallet.sh
 
       - name: Run Tempo check on testnet
         if: |
+          github.event_name == 'pull_request' ||
           github.event.inputs.network == 'testnet' ||
           github.event.inputs.network == 'all'
         env:

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -59,6 +59,7 @@ jobs:
           cargo build --profile dev --locked -p forge -p cast -p anvil -p chisel
           echo "${{ github.workspace }}/target/debug" >> "$GITHUB_PATH"
 
+      # TODO: re-enable once devnet is up and stable
       # - name: Run Tempo check on devnet
       #   if: |
       #     github.event_name == 'pull_request' ||
@@ -75,6 +76,7 @@ jobs:
       #       ./.github/scripts/tempo-deploy.sh
       #     fi
 
+      # TODO: re-enable once devnet is up and stable
       # - name: Run Tempo wallet tests on devnet
       #   if: |
       #     github.event_name == 'pull_request' ||


### PR DESCRIPTION
## Motivation

In [ci-tempo.yml](https://github.com/foundry-rs/foundry/blob/master/.github/workflows/ci-tempo.yml), the testnet and mainnet steps gate solely on `github.event.inputs.network`, which is only populated for `workflow_dispatch` runs. As a result, on PRs (e.g. https://github.com/foundry-rs/foundry/actions/runs/25039986722/job/73340587511?pr=14445) those steps are skipped — only the build runs.

## Changes

- Run the testnet check step on `pull_request` events (in addition to matching `workflow_dispatch` inputs).
- Refresh the TODO comment on the still-disabled devnet steps to clarify they remain off pending devnet stabilization.
- Mainnet remains gated to manual `workflow_dispatch` only.