### PR TITLE
feat(invariant): decouple handler-side assertions from invariant predicates

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -45,7 +45,7 @@ use foundry_evm_core::evm::FoundryEvmNetwork;
 use foundry_evm_fuzz::{
     BasicTxDetails,
     invariant::FuzzRunIdentifiedContracts,
-    strategies::{EvmFuzzState, mutate_param_value},
+    strategies::{EvmFuzzState, generate_msg_value, mutate_param_value},
 };
 use proptest::{
     prelude::{Just, Rng, Strategy},
@@ -802,7 +802,14 @@ impl WorkerCorpus {
         test_runner: &mut TestRunner,
         fuzz_state: &EvmFuzzState,
     ) -> Result<()> {
-        // let rng = test_runner.rng();
+        // Mutate value with 15% probability for payable functions.
+        if function.state_mutability == alloy_json_abi::StateMutability::Payable
+            && test_runner.rng().random_ratio(15, 100)
+        {
+            tx.call_details.value = Some(generate_msg_value(test_runner));
+        }
+
+        // Mutate calldata.
         let mut arg_mutation_rounds =
             test_runner.rng().random_range(0..=function.inputs.len()).max(1);
         let round_arg_idx: Vec<usize> = if function.inputs.len() <= 1 {
@@ -1219,6 +1226,7 @@ mod tests {
             call_details: foundry_evm_fuzz::CallDetails {
                 target: Address::ZERO,
                 calldata: Bytes::new(),
+                value: None,
             },
         }
     }

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -273,7 +273,11 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                 warp: None,
                 roll: None,
                 sender: self.sender,
-                call_details: CallDetails { target: address, calldata: calldata.clone() },
+                call_details: CallDetails {
+                    target: address,
+                    calldata: calldata.clone(),
+                    value: None,
+                },
             }],
             new_coverage,
             None,
@@ -443,7 +447,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             warp: None,
             roll: None,
             sender: Default::default(),
-            call_details: CallDetails { target: Default::default(), calldata },
+            call_details: CallDetails { target: Default::default(), calldata, value: None },
         });
 
         let mut corpus = WorkerCorpus::new(

--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -1,7 +1,7 @@
 use super::InvariantContract;
 use crate::executors::RawCallResult;
 use alloy_json_abi::Function;
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::{Address, B256, Bytes, Selector, keccak256};
 use foundry_config::InvariantConfig;
 use foundry_evm_core::{
     decode::{ASSERTION_FAILED_PREFIX, EMPTY_REVERT_DATA, RevertDecoder},
@@ -11,15 +11,54 @@ use foundry_evm_fuzz::{BasicTxDetails, Reason, invariant::FuzzRunIdentifiedContr
 use proptest::test_runner::TestError;
 use std::{collections::HashMap, fmt};
 
-/// Run-scoped context bundling the references that an invariant run needs in multiple places
-/// (recording failures, attributing breaks to a specific invariant, etc.).
-///
-/// Constructed once per loop iteration and passed by reference; produces failure records via
-/// [`InvariantRunCtx::failed_case`].
+/// A handler-side assertion bug: a `require`/`assert` inside a fuzzed handler that the
+/// campaign reached. Deduped by `(reverter, selector)` site (Echidna/Medusa semantics),
+/// shortest sequence wins on collision.
+#[derive(Clone, Debug)]
+pub struct HandlerAssertionFailure {
+    /// Handler contract whose call asserted.
+    pub reverter: Address,
+    /// 4-byte selector of the failing function.
+    pub selector: Selector,
+    /// Call sequence including the failing call (post-shrink: minimal prefix).
+    pub call_sequence: Vec<BasicTxDetails>,
+    /// Pre-shrink length, for the `(original: N, shrunk: M)` renderer.
+    pub original_sequence_len: usize,
+    /// Decoded revert/assert reason.
+    pub revert_reason: String,
+    /// Stable hash of edge coverage at the asserting call (falls back to `(reverter,
+    /// selector)`). Used by the shrinker to preserve path identity, not for dedup.
+    pub edge_fingerprint: B256,
+}
+
+impl HandlerAssertionFailure {
+    /// Builds a failure from a replayed sequence whose last call asserted.
+    pub fn from_replayed_sequence(
+        call_sequence: Vec<BasicTxDetails>,
+        edge_fingerprint: B256,
+        revert_reason: String,
+    ) -> Self {
+        let last = call_sequence.last().expect("replayed sequence is non-empty");
+        let reverter = last.call_details.target;
+        let selector_bytes: [u8; 4] =
+            last.call_details.calldata.get(..4).and_then(|s| s.try_into().ok()).unwrap_or_default();
+        let original_sequence_len = call_sequence.len();
+        Self {
+            reverter,
+            selector: Selector::from(selector_bytes),
+            call_sequence,
+            original_sequence_len,
+            revert_reason,
+            edge_fingerprint,
+        }
+    }
+}
+
+/// Run-scoped references shared by failure-recording paths in an invariant run.
 pub struct InvariantRunCtx<'a> {
-    /// The invariant test contract definition.
+    /// The invariant test contract.
     pub contract: &'a InvariantContract<'a>,
-    /// Active invariant configuration (provides `shrink_run_limit`, `fail_on_revert`, ...).
+    /// Active invariant configuration.
     pub config: &'a InvariantConfig,
     /// Fuzz targets discovered for this run.
     pub targeted_contracts: &'a FuzzRunIdentifiedContracts,
@@ -28,13 +67,9 @@ pub struct InvariantRunCtx<'a> {
 }
 
 impl<'a> InvariantRunCtx<'a> {
-    /// Builds a [`FailedInvariantCaseData`] attributed to `broken_fn`.
-    ///
-    /// `fail_on_revert` is taken separately because `assert_invariants` overrides it with
-    /// the per-invariant flag, while every other call site forwards `self.config.fail_on_revert`.
-    /// `assertion_failure` is set when the failure originated from a Solidity `assert`/
-    /// `vm.assert*` path; it normalizes empty decoded revert data into a stable user-facing
-    /// message so invariant output is not blank.
+    /// Builds a [`FailedInvariantCaseData`] attributed to `broken_fn`. `fail_on_revert` is
+    /// passed in because `assert_invariants` overrides it with the per-invariant flag.
+    /// `assertion_failure=true` normalizes empty revert data so output is not blank.
     pub fn failed_case<FEN: FoundryEvmNetwork>(
         &self,
         broken_fn: &Function,
@@ -43,21 +78,7 @@ impl<'a> InvariantRunCtx<'a> {
         call_result: RawCallResult<FEN>,
         inner_sequence: &[Option<BasicTxDetails>],
     ) -> FailedInvariantCaseData {
-        // Collect abis of fuzzed and invariant contracts to decode custom error.
-        let revert_reason = RevertDecoder::new()
-            .with_abis(self.targeted_contracts.targets.lock().values().map(|c| &c.abi))
-            .with_abi(self.contract.abi)
-            .decode(call_result.result.as_ref(), call_result.exit_reason);
-        // Non-reverting assertion failures surface through Foundry's failure flags instead of
-        // revert data. Use a stable fallback so invariant output is not blank, both for the
-        // successful-call/assertion path and the explicit assertion_failure flag.
-        let needs_fallback = matches!(revert_reason.as_str(), "" | EMPTY_REVERT_DATA);
-        let revert_reason = if needs_fallback && (!call_result.reverted || assertion_failure) {
-            ASSERTION_FAILED_PREFIX.to_string()
-        } else {
-            revert_reason
-        };
-
+        let revert_reason = self.decode_revert_reason(&call_result, assertion_failure);
         let origin = broken_fn.name.as_str();
         FailedInvariantCaseData {
             test_error: TestError::Fail(
@@ -74,17 +95,149 @@ impl<'a> InvariantRunCtx<'a> {
             assertion_failure,
         }
     }
+
+    /// Decodes the revert/assert reason without allocating a full [`FailedInvariantCaseData`].
+    /// Used by callers that only need the reason (e.g. handler-bug recording).
+    pub fn decode_revert_reason<FEN: FoundryEvmNetwork>(
+        &self,
+        call_result: &RawCallResult<FEN>,
+        assertion_failure: bool,
+    ) -> String {
+        let revert_reason = RevertDecoder::new()
+            .with_abis(self.targeted_contracts.targets.lock().values().map(|c| &c.abi))
+            .with_abi(self.contract.abi)
+            .decode(call_result.result.as_ref(), call_result.exit_reason);
+        // Non-reverting assertion failures surface through Foundry's failure flags, not
+        // revert data — fall back so invariant output is not blank.
+        let needs_fallback = matches!(revert_reason.as_str(), "" | EMPTY_REVERT_DATA);
+        if needs_fallback && (!call_result.reverted || assertion_failure) {
+            ASSERTION_FAILED_PREFIX.to_string()
+        } else {
+            revert_reason
+        }
+    }
 }
 
-/// Stores information about failures and reverts of the invariant tests.
+/// Edge-coverage fingerprint for a handler-side assertion call. Prefers a pre-merge
+/// edges hash; falls back to `keccak(target || selector)` when edge coverage is disabled.
+pub fn handler_edge_fingerprint(
+    pre_merge_edges_hash: Option<B256>,
+    target: Address,
+    selector: Selector,
+) -> B256 {
+    if let Some(hash) = pre_merge_edges_hash {
+        return hash;
+    }
+    let mut buf = [0u8; 24];
+    buf[..20].copy_from_slice(target.as_slice());
+    buf[20..].copy_from_slice(selector.as_slice());
+    keccak256(buf)
+}
+
+/// Records a handler-side assertion bug (if strictly shorter than the existing repro for
+/// this site) and pops the just-asserted reverted input from `inputs`. Shared by the
+/// periodic-check path and the inline check-skipped path.
+#[expect(clippy::too_many_arguments)]
+pub(crate) fn record_handler_assertion_bug<FEN: FoundryEvmNetwork>(
+    invariant_contract: &InvariantContract<'_>,
+    config: &InvariantConfig,
+    targeted_contracts: &FuzzRunIdentifiedContracts,
+    failures: &mut InvariantFailures,
+    inputs: &mut Vec<BasicTxDetails>,
+    handler_target: Address,
+    handler_selector: Selector,
+    pre_merge_edges_hash: Option<B256>,
+    call_result: RawCallResult<FEN>,
+    call_reverted: bool,
+    is_optimization: bool,
+) {
+    let fingerprint =
+        handler_edge_fingerprint(pre_merge_edges_hash, handler_target, handler_selector);
+
+    if !handler_site_already_minimal(
+        &failures.failures,
+        (handler_target, handler_selector),
+        inputs.len(),
+    ) {
+        // Handler bugs go through `FailureKey::Handler`; we only need the reason.
+        let revert_reason = InvariantRunCtx {
+            contract: invariant_contract,
+            config,
+            targeted_contracts,
+            calldata: inputs,
+        }
+        .decode_revert_reason(&call_result, true);
+        let call_sequence = inputs.clone();
+        let original_sequence_len = call_sequence.len();
+        failures.record_handler_failure(HandlerAssertionFailure {
+            reverter: handler_target,
+            selector: handler_selector,
+            call_sequence,
+            original_sequence_len,
+            revert_reason,
+            edge_fingerprint: fingerprint,
+        });
+    }
+
+    // Standard reverted-input pop. Delay-enabled campaigns keep reverted calls so
+    // shrinking can preserve their warp/roll contribution.
+    if call_reverted && !is_optimization && !config.has_delay() {
+        inputs.pop();
+    }
+}
+
+/// True iff there is already a [`HandlerAssertionFailure`] for `site` no longer than
+/// `candidate_len`. Used to skip inserting a not-strictly-shorter repro.
+pub fn handler_site_already_minimal(
+    failures: &HashMap<FailureKey, InvariantFuzzError>,
+    site: (Address, Selector),
+    candidate_len: usize,
+) -> bool {
+    failures
+        .get(&FailureKey::Handler(site.0, site.1))
+        .and_then(InvariantFuzzError::as_handler_assertion)
+        .is_some_and(|existing| existing.call_sequence.len() <= candidate_len)
+}
+
+/// Stable hash of the call's edge coverage, taken *before* `merge_edge_coverage`
+/// zeroes the buffer. Returns `None` when edge coverage is disabled.
+pub fn snapshot_edge_fingerprint<FEN: FoundryEvmNetwork>(
+    call_result: &RawCallResult<FEN>,
+) -> Option<B256> {
+    let edges = call_result.edge_coverage.as_deref()?;
+    if edges.is_empty() || edges.iter().all(|b| *b == 0) {
+        return None;
+    }
+    Some(keccak256(edges))
+}
+
+/// Identifies a single entry in the [`InvariantFailures`] map. Invariant predicate
+/// failures and handler-side assertion bugs share one map keyed by this enum.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum FailureKey {
+    /// Keyed by invariant function name.
+    Invariant(String),
+    /// Keyed by handler `(reverter, selector)` site (Echidna/Medusa semantics: one bug
+    /// per handler function regardless of code path).
+    Handler(Address, Selector),
+}
+
+/// Stores invariant test failures and revert counts.
+///
+/// TODO: dedup multiple distinct `assert(...)` within the same `(reverter, selector)`
+/// handler if callers ever need finer attribution (e.g. per-assertion-label).
 #[derive(Clone, Default)]
 pub struct InvariantFailures {
     /// Total number of reverts.
     pub reverts: usize,
-    /// The latest revert reason of a run.
-    pub revert_reason: Option<String>,
-    /// Maps each broken invariant (by function name) to its specific error.
-    pub errors: HashMap<String, InvariantFuzzError>,
+    /// Invariant predicate failures and handler-side assertion bugs share one map.
+    /// Mutate only via `record_failure` / `record_handler_failure` / `seed_handler_failure`
+    /// so the cached counters stay in sync.
+    pub(crate) failures: HashMap<FailureKey, InvariantFuzzError>,
+    /// Cached `FailureKey::Invariant` count, kept O(1) on the hot path.
+    invariant_count: usize,
+    /// Cached `FailureKey::Handler` count, read on progress/metrics ticks.
+    handler_count: usize,
 }
 
 impl InvariantFailures {
@@ -92,46 +245,124 @@ impl InvariantFailures {
         Self::default()
     }
 
-    pub fn into_inner(self) -> (usize, HashMap<String, InvariantFuzzError>) {
-        (self.reverts, self.errors)
+    /// Splits `self.failures` into the legacy `(invariant_errors, handler_errors)` pair.
+    pub fn partition(
+        self,
+    ) -> (HashMap<String, InvariantFuzzError>, HashMap<(Address, Selector), InvariantFuzzError>)
+    {
+        let mut invariant_errors = HashMap::new();
+        let mut handler_errors = HashMap::new();
+        for (key, err) in self.failures {
+            match key {
+                FailureKey::Invariant(name) => {
+                    invariant_errors.insert(name, err);
+                }
+                FailureKey::Handler(addr, sel) => {
+                    handler_errors.insert((addr, sel), err);
+                }
+            }
+        }
+        (invariant_errors, handler_errors)
     }
 
     pub fn record_failure(&mut self, invariant: &Function, failure: InvariantFuzzError) {
-        self.errors.insert(invariant.name.clone(), failure);
+        let prev = self.failures.insert(FailureKey::Invariant(invariant.name.clone()), failure);
+        if prev.is_none() {
+            self.invariant_count += 1;
+        }
     }
 
     pub fn has_failure(&self, invariant: &Function) -> bool {
-        self.errors.contains_key(&invariant.name)
+        self.failures.contains_key(&FailureKey::Invariant(invariant.name.clone()))
     }
 
     pub fn get_failure(&self, invariant: &Function) -> Option<&InvariantFuzzError> {
-        self.errors.get(&invariant.name)
+        self.failures.get(&FailureKey::Invariant(invariant.name.clone()))
     }
 
-    /// Returns the recorded revert reason for `invariant`, or an empty string if the invariant
-    /// has no recorded failure (or its failure carries no reason). Used when emitting failure
-    /// events so the metrics payload mirrors the persisted failure.
+    /// Recorded revert reason for `invariant`, or empty when none. Used by failure events
+    /// so the metrics payload mirrors the persisted failure.
     pub fn broken_reason(&self, invariant: &Function) -> String {
         self.get_failure(invariant).and_then(|e| e.revert_reason()).unwrap_or_default()
     }
 
-    pub fn can_continue(&self, invariants: usize) -> bool {
-        self.errors.len() < invariants
+    pub const fn can_continue(&self, invariants: usize) -> bool {
+        self.invariant_count() < invariants
+    }
+
+    /// Number of unique broken invariant predicates (O(1), cached).
+    pub const fn invariant_count(&self) -> usize {
+        self.invariant_count
+    }
+
+    /// Number of unique handler-side assertion bugs (O(1), cached).
+    pub const fn handler_count(&self) -> usize {
+        self.handler_count
+    }
+
+    /// Records a handler-side assertion bug. Deduped by `(reverter, selector)` site;
+    /// shortest sequence wins on collision.
+    pub fn record_handler_failure(&mut self, failure: HandlerAssertionFailure) {
+        let site = (failure.reverter, failure.selector);
+        if !handler_site_already_minimal(&self.failures, site, failure.call_sequence.len()) {
+            let prev = self.failures.insert(
+                FailureKey::Handler(site.0, site.1),
+                InvariantFuzzError::HandlerAssertion(failure),
+            );
+            if prev.is_none() {
+                self.handler_count += 1;
+            }
+        }
+    }
+
+    /// Inserts a persisted-replay handler bug. Skips dedup (caller seeds an empty map)
+    /// but bumps `handler_count` so the live counter is correct from the first tick.
+    pub fn seed_handler_failure(
+        &mut self,
+        target: Address,
+        selector: Selector,
+        err: InvariantFuzzError,
+    ) {
+        let prev = self.failures.insert(FailureKey::Handler(target, selector), err);
+        if prev.is_none() {
+            self.handler_count += 1;
+        }
+    }
+
+    /// Returns true if a handler bug has already been recorded for the given site.
+    pub fn has_handler_failure(&self, target: Address, selector: Selector) -> bool {
+        self.failures.contains_key(&FailureKey::Handler(target, selector))
+    }
+
+    /// Mutable iterator over handler-side assertion bug entries (post-campaign shrink loop).
+    pub fn handler_failures_mut(
+        &mut self,
+    ) -> impl Iterator<Item = ((Address, Selector), &mut InvariantFuzzError)> {
+        self.failures.iter_mut().filter_map(|(key, err)| match key {
+            FailureKey::Handler(addr, sel) => Some(((*addr, *sel), err)),
+            FailureKey::Invariant(_) => None,
+        })
     }
 }
 
 impl fmt::Display for InvariantFailures {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
-        writeln!(f, "      ❌ Failures: {}", self.errors.len())?;
+        writeln!(f, "      ❌ Failures: {}", self.invariant_count())?;
         Ok(())
     }
 }
 
 #[derive(Clone, Debug)]
 pub enum InvariantFuzzError {
+    /// A handler call reverted under `fail_on_revert = true`.
     Revert(FailedInvariantCaseData),
+    /// An `invariant_*` predicate returned `false` (or asserted).
     BrokenInvariant(FailedInvariantCaseData),
+    /// A handler-side `assert(...)` / `vm.assert*` failed (bug inside a handler, not in
+    /// an `invariant_*` predicate). Recorded per `(reverter, selector)` site.
+    HandlerAssertion(HandlerAssertionFailure),
+    /// `vm.assume` rejected more inputs than allowed.
     MaxAssumeRejects(u32),
 }
 
@@ -141,9 +372,28 @@ impl InvariantFuzzError {
             Self::BrokenInvariant(case_data) | Self::Revert(case_data) => {
                 (!case_data.revert_reason.is_empty()).then(|| case_data.revert_reason.clone())
             }
+            Self::HandlerAssertion(failure) => {
+                (!failure.revert_reason.is_empty()).then(|| failure.revert_reason.clone())
+            }
             Self::MaxAssumeRejects(allowed) => {
                 Some(format!("`vm.assume` rejected too many inputs ({allowed} allowed)"))
             }
+        }
+    }
+
+    /// Wrapped `HandlerAssertionFailure` if this is the [`Self::HandlerAssertion`] variant.
+    pub const fn as_handler_assertion(&self) -> Option<&HandlerAssertionFailure> {
+        match self {
+            Self::HandlerAssertion(failure) => Some(failure),
+            _ => None,
+        }
+    }
+
+    /// Mutable counterpart of [`Self::as_handler_assertion`]. Used by post-campaign shrinking.
+    pub const fn as_handler_assertion_mut(&mut self) -> Option<&mut HandlerAssertionFailure> {
+        match self {
+            Self::HandlerAssertion(failure) => Some(failure),
+            _ => None,
         }
     }
 }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -694,10 +694,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                                 call_reverted,
                                 invariant_contract.is_optimization(),
                             );
-                            // Non-reverting `vm.assert*` (`assertions_revert = false`) leaves
-                            // `GLOBAL_FAIL_SLOT = 1` committed; clear it so it doesn't poison
-                            // `handlers_succeeded` / `assert_invariants` on subsequent calls.
-                            current_run.executor.clear_global_failure();
                             (true, None)
                         } else if call_result.reverted && self.config.fail_on_revert {
                             // Plain revert under fail_on_revert: attribute to the anchor.
@@ -1422,24 +1418,33 @@ fn collect_data<FEN: FoundryEvmNetwork>(
 /// Calls the `afterInvariant()` function on a contract.
 /// Returns call result and if call succeeded.
 /// The state after the call is not persisted.
+///
+/// Uses the handler-gate success check so a stale committed `GLOBAL_FAIL_SLOT` from a
+/// previously-recorded handler bug doesn't false-positive this call (the slot is `1` from
+/// the prior bug, but `afterInvariant` itself didn't write it in this changeset).
 pub(crate) fn call_after_invariant_function<FEN: FoundryEvmNetwork>(
     executor: &Executor<FEN>,
     to: Address,
 ) -> Result<(RawCallResult<FEN>, bool), EvmError<FEN>> {
     let calldata = Bytes::from_static(&IInvariantTest::afterInvariantCall::SELECTOR);
     let mut call_result = executor.call_raw(CALLER, to, calldata, U256::ZERO)?;
-    let success = executor.is_raw_call_mut_success(to, &mut call_result, false);
+    let success = executor.is_raw_call_mut_success_handler_gate(to, &mut call_result);
     Ok((call_result, success))
 }
 
 /// Calls the invariant function and returns call result and if succeeded.
+///
+/// Uses the handler-gate success check (same rationale as `call_after_invariant_function`):
+/// the predicate is broken iff this call's own changeset writes `GLOBAL_FAIL_SLOT` (via `t()` /
+/// `vm.assert*`) or the call reverts; a stale committed slot from a prior handler bug must not
+/// poison every later predicate evaluation in the run.
 pub(crate) fn call_invariant_function<FEN: FoundryEvmNetwork>(
     executor: &Executor<FEN>,
     address: Address,
     calldata: Bytes,
 ) -> Result<(RawCallResult<FEN>, bool)> {
     let mut call_result = executor.call_raw(CALLER, address, calldata, U256::ZERO)?;
-    let success = executor.is_raw_call_mut_success(address, &mut call_result, false);
+    let success = executor.is_raw_call_mut_success_handler_gate(address, &mut call_result);
     Ok((call_result, success))
 }
 

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -694,6 +694,10 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                                 call_reverted,
                                 invariant_contract.is_optimization(),
                             );
+                            // Non-reverting `vm.assert*` (`assertions_revert = false`) leaves
+                            // `GLOBAL_FAIL_SLOT = 1` committed; clear it so it doesn't poison
+                            // `handlers_succeeded` / `assert_invariants` on subsequent calls.
+                            current_run.executor.clear_global_failure();
                             (true, None)
                         } else if call_result.reverted && self.config.fail_on_revert {
                             // Plain revert under fail_on_revert: attribute to the anchor.

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1475,8 +1475,13 @@ pub(crate) fn execute_tx<FEN: FoundryEvmNetwork>(
         }
     }
 
+    // Bound requested value by sender's available balance so payable paths still get
+    // exercised when the requested value exceeds balance, instead of collapsing to zero.
+    let requested_value = tx.call_details.value.unwrap_or(U256::ZERO);
+    let sender_balance = executor.get_balance(tx.sender)?;
+    let value = requested_value.min(sender_balance);
     executor
-        .call_raw(tx.sender, tx.call_details.target, tx.call_details.calldata.clone(), U256::ZERO)
+        .call_raw(tx.sender, tx.call_details.target, tx.call_details.calldata.clone(), value)
         .map_err(|e| eyre!(format!("Could not make raw evm call: {e}")))
 }
 

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -46,7 +46,10 @@ use std::{
 };
 
 mod error;
-pub use error::{InvariantFailures, InvariantFuzzError};
+pub use error::{
+    FailureKey, HandlerAssertionFailure, InvariantFailures, InvariantFuzzError,
+    handler_site_already_minimal,
+};
 use foundry_evm_coverage::HitMaps;
 
 mod replay;
@@ -56,7 +59,10 @@ mod result;
 pub use result::InvariantFuzzTestResult;
 
 mod shrink;
-pub use shrink::{CheckSequenceOptions, check_sequence, check_sequence_value};
+pub use shrink::{
+    CheckSequenceOptions, HandlerReplayOutcome, check_sequence, check_sequence_value,
+    replay_handler_failure_sequence,
+};
 
 sol! {
     interface IInvariantTest {
@@ -159,6 +165,8 @@ fn rate_per_sec(total: f64, elapsed: Duration) -> f64 {
 struct InvariantFailureMetrics {
     failures: u64,
     unique_failures: HashSet<String>,
+    /// Unique handler-side assertion bugs found so far.
+    broken_handlers: usize,
 }
 
 impl InvariantFailureMetrics {
@@ -177,6 +185,27 @@ impl InvariantFailureMetrics {
             "reason": reason,
         });
         let _ = sh_eprintln!("{}", serde_json::to_string(&event).unwrap_or_default());
+    }
+}
+
+/// Bridges newly-recorded invariant breaks from `failures.errors` into the pulse
+/// `failure_metrics` so the live progress stream reflects breaks as they happen.
+///
+/// Without this, `unique_failures` only updates when the campaign is *forced to
+/// stop* (i.e., `can_continue` returns false — which only happens once *all*
+/// invariants are broken under `assert_all`). Iterates in declaration order so
+/// the emitted "failure" events are deterministic.
+fn record_new_invariant_failures(
+    failure_metrics: &mut InvariantFailureMetrics,
+    invariant_contract: &InvariantContract<'_>,
+    failures: &InvariantFailures,
+) {
+    for (f, _) in &invariant_contract.invariant_fns {
+        if !failure_metrics.unique_failures.contains(&f.name) && failures.has_failure(f) {
+            let reason =
+                failures.get_failure(f).and_then(|e| e.revert_reason()).unwrap_or_default();
+            failure_metrics.record_failure(&f.name, invariant_contract.name, &reason);
+        }
     }
 }
 
@@ -199,6 +228,9 @@ fn build_invariant_progress_json<M: Serialize>(
     if let Some(obj) = metrics.as_object_mut() {
         obj.insert("failures".to_string(), json!(failure_metrics.failures));
         obj.insert("unique_failures".to_string(), json!(failure_metrics.unique_failures.len()));
+        // Surface unique handler-side assertion bugs in live progress, separate from
+        // invariant predicate violations counted by `failures`.
+        obj.insert("broken_handlers".to_string(), json!(failure_metrics.broken_handlers));
     }
 
     let mut payload = json!({
@@ -429,6 +461,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
     }
 
     /// Fuzzes any deployed contract and checks any broken invariant at `invariant_address`.
+    ///
+    /// `initial_handler_failures` pre-seeds the campaign's `broken_handlers` map with bugs
+    /// recovered from disk by the runner's persisted-failure replay step, so the live
+    /// progress bar and JSON pulse stream surface them from the first emission instead of
+    /// jumping at the final report.
     pub fn invariant_fuzz(
         &mut self,
         invariant_contract: InvariantContract<'_>,
@@ -436,13 +473,21 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         fuzz_state: EvmFuzzState,
         progress: Option<&ProgressBar>,
         early_exit: &EarlyExit,
+        initial_handler_failures: std::collections::HashMap<
+            (Address, Selector),
+            InvariantFuzzError,
+        >,
     ) -> Result<InvariantFuzzTestResult> {
         // Note: invariant function signatures (no inputs) are validated upstream in the
         // suite runner so parameterized `invariant_*` functions are rejected with a per-test
         // failure entry before any campaign runs.
 
-        let (mut invariant_test, mut corpus_manager) =
-            self.prepare_test(&invariant_contract, fuzz_fixtures, fuzz_state)?;
+        let (mut invariant_test, mut corpus_manager) = self.prepare_test(
+            &invariant_contract,
+            fuzz_fixtures,
+            fuzz_state,
+            initial_handler_failures,
+        )?;
 
         // Start timer for this invariant test.
         let mut runs = 0;
@@ -464,7 +509,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
         'stop: while continue_campaign(runs) {
             // Per-run failure count snapshot used to gate `afterInvariant` below.
-            let failures_before_run = invariant_test.test_data.failures.errors.len();
+            let failures_before_run = invariant_test.test_data.failures.invariant_count();
 
             let initial_seq = corpus_manager.new_inputs(
                 &mut invariant_test.test_data.branch_runner,
@@ -495,21 +540,48 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     break 'stop;
                 }
 
-                let tx = current_run
-                    .inputs
-                    .last()
-                    .ok_or_else(|| eyre!("no input generated to call fuzzed target."))?;
+                // Snapshot `(target, selector)` so `can_continue` can borrow `&mut current_run`
+                // later without cloning the full `BasicTxDetails`.
+                let (handler_target, handler_selector) = {
+                    let last = current_run
+                        .inputs
+                        .last()
+                        .ok_or_else(|| eyre!("no input generated to call fuzzed target."))?;
+                    let sel_bytes: [u8; 4] = last
+                        .call_details
+                        .calldata
+                        .get(..4)
+                        .and_then(|s| s.try_into().ok())
+                        .unwrap_or_default();
+                    (last.call_details.target, Selector::from(sel_bytes))
+                };
 
                 // Execute call from the randomly generated sequence without committing state.
                 // State is committed only if call is not a magic assume.
-                let mut call_result = execute_tx(&mut current_run.executor, tx)?;
+                let mut call_result = execute_tx(
+                    &mut current_run.executor,
+                    current_run.inputs.last().expect("checked above"),
+                )?;
                 let discarded = call_result.result.as_ref() == MAGIC_ASSUME;
                 if self.config.show_metrics {
-                    invariant_test.record_metrics(tx, call_result.reverted, discarded);
+                    invariant_test.record_metrics(
+                        current_run.inputs.last().expect("checked above"),
+                        call_result.reverted,
+                        discarded,
+                    );
                 }
 
                 // Collect line coverage from last fuzzed call.
                 invariant_test.merge_line_coverage(call_result.line_coverage.clone());
+                // Snapshot the edge fingerprint before `merge_edge_coverage` zeroes the
+                // buffer. Gate on `assertion_failure` to skip keccak on plain reverts.
+                let assertion_failure =
+                    !discarded && did_fail_on_assert(&call_result, &call_result.state_changeset);
+                let pre_merge_edges_hash = if assertion_failure {
+                    error::snapshot_edge_fingerprint(&call_result)
+                } else {
+                    None
+                };
                 // Collect edge coverage and set the flag in the current run.
                 if corpus_manager.merge_edge_coverage(&mut call_result) {
                     current_run.new_coverage = true;
@@ -526,9 +598,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         break 'stop;
                     }
                 } else {
-                    let assertion_failure =
-                        did_fail_on_assert(&call_result, &call_result.state_changeset);
-
                     // Commit executed call result.
                     current_run.executor.commit(&mut call_result);
 
@@ -544,7 +613,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         collect_data(
                             &invariant_test,
                             &mut state_changeset,
-                            tx,
+                            current_run.inputs.last().expect("checked above"),
                             &call_result,
                             self.config.depth,
                         );
@@ -588,6 +657,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                                 || is_last_call
                         };
 
+                    let errors_before_check = invariant_test.test_data.failures.invariant_count();
                     let (continues, broken) = if should_check_invariant {
                         let outcome = can_continue(
                             &invariant_contract,
@@ -596,6 +666,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             &self.config,
                             call_result,
                             &state_changeset,
+                            handler_target,
+                            handler_selector,
+                            pre_merge_edges_hash,
                         )
                         .map_err(|e| eyre!(e.to_string()))?;
                         (outcome.continues, outcome.broken)
@@ -604,10 +677,26 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         if call_result.reverted {
                             invariant_test.test_data.failures.reverts += 1;
                         }
-                        if assertion_failure || (call_result.reverted && self.config.fail_on_revert)
-                        {
-                            // Handler-side reverts/assertion failures aren't tied to a specific
-                            // invariant body, so attribute to the campaign anchor.
+                        if assertion_failure {
+                            // Handler-side assertion: deduped by `(reverter, selector)` site;
+                            // campaign keeps running to surface more bugs.
+                            let call_reverted = call_result.reverted;
+                            error::record_handler_assertion_bug(
+                                &invariant_contract,
+                                &self.config,
+                                &invariant_test.targeted_contracts,
+                                &mut invariant_test.test_data.failures,
+                                &mut current_run.inputs,
+                                handler_target,
+                                handler_selector,
+                                pre_merge_edges_hash,
+                                call_result,
+                                call_reverted,
+                                invariant_contract.is_optimization(),
+                            );
+                            (true, None)
+                        } else if call_result.reverted && self.config.fail_on_revert {
+                            // Plain revert under fail_on_revert: attribute to the anchor.
                             let anchor = invariant_contract.anchor();
                             let case_data = error::InvariantRunCtx {
                                 contract: &invariant_contract,
@@ -618,28 +707,17 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             .failed_case(
                                 anchor,
                                 self.config.fail_on_revert,
-                                assertion_failure,
+                                false,
                                 call_result,
                                 &[],
                             );
-                            invariant_test.test_data.failures.revert_reason =
-                                Some(case_data.revert_reason.clone());
-                            invariant_test.set_error(
-                                anchor,
-                                if assertion_failure {
-                                    InvariantFuzzError::BrokenInvariant(case_data)
-                                } else {
-                                    InvariantFuzzError::Revert(case_data)
-                                },
-                            );
+                            invariant_test.set_error(anchor, InvariantFuzzError::Revert(case_data));
                             (false, Some(anchor))
                         } else if call_result.reverted
                             && !invariant_contract.is_optimization()
                             && !self.config.has_delay()
                         {
-                            // Delay-enabled campaigns keep reverted calls so shrinking can
-                            // preserve their warp/roll contribution when building the final
-                            // counterexample.
+                            // Delay campaigns keep reverted calls so warp/roll survives shrinking.
                             current_run.inputs.pop();
                             (true, None)
                         } else {
@@ -650,19 +728,26 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     if !continues || current_run.depth == self.config.depth - 1 {
                         invariant_test.set_last_run_inputs(&current_run.inputs);
                     }
-                    // If test cannot continue then stop current run and exit test suite.
-                    if !continues {
-                        // Attribute the failure event to the invariant returned by the
-                        // per-call check (deterministic, declaration-order). Falls back to the
-                        // anchor only if the failure came from a path that didn't surface a
-                        // specific invariant (defensive — should not happen in practice).
-                        let invariant = broken.unwrap_or_else(|| invariant_contract.anchor());
-                        let reason = invariant_test.test_data.failures.broken_reason(invariant);
-                        failure_metrics.record_failure(
-                            invariant.name.as_str(),
-                            invariant_contract.name,
-                            &reason,
+                    // Bridge newly-recorded predicate breaks into `failure_metrics` even when
+                    // `continues == true` (under `assert_all`, breaks accumulate per tick until
+                    // the last invariant falls).
+                    if invariant_test.test_data.failures.invariant_count() > errors_before_check
+                        || broken.is_some()
+                    {
+                        record_new_invariant_failures(
+                            &mut failure_metrics,
+                            &invariant_contract,
+                            &invariant_test.test_data.failures,
                         );
+                    }
+                    // Keep the campaign running after a recorded predicate failure only when
+                    // `assert_all && !fail_on_revert`; otherwise preserve legacy early-exit.
+                    // Handler-side assertions never reach this branch — they go through
+                    // `failures.broken_handlers` and leave `continues == true`.
+                    if !continues {
+                        if self.config.assert_all && !self.config.fail_on_revert {
+                            break;
+                        }
                         break 'stop;
                     }
                     current_run.depth += 1;
@@ -693,7 +778,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             // failure. Under `assert_all` the campaign keeps running after earlier failures,
             // but the hook must still execute on subsequent runs.
             if invariant_contract.call_after_invariant
-                && invariant_test.test_data.failures.errors.len() == failures_before_run
+                && invariant_test.test_data.failures.invariant_count() == failures_before_run
             {
                 let broken = assert_after_invariant(
                     &invariant_contract,
@@ -702,14 +787,12 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     &self.config,
                 )
                 .map_err(|_| eyre!("Failed to call afterInvariant"))?;
-                if let Some(invariant) = broken {
-                    // `assert_after_invariant` returns the broken invariant directly (the
-                    // anchor, by construction), so no map re-scan is needed here.
-                    let reason = invariant_test.test_data.failures.broken_reason(invariant);
-                    failure_metrics.record_failure(
-                        invariant.name.as_str(),
-                        invariant_contract.name,
-                        &reason,
+                if broken.is_some() {
+                    // Bridge breaks into pulse metrics, mirroring the in-run path above.
+                    record_new_invariant_failures(
+                        &mut failure_metrics,
+                        &invariant_contract,
+                        &invariant_test.test_data.failures,
                     );
                 }
             }
@@ -721,9 +804,14 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 progress.inc(1);
                 // Display current best value, corpus metrics, and failure counts.
                 let best = invariant_test.test_data.optimization_best_value;
-                let broken = invariant_test.test_data.failures.errors.len();
+                let broken = invariant_test.test_data.failures.invariant_count();
+                // Live count of unique handler-side assertion bugs, separate from the
+                // predicate breaks in `broken`. Synced into `failure_metrics` so all
+                // campaign-level counters share one struct.
+                failure_metrics.broken_handlers = invariant_test.test_data.failures.handler_count();
+                let handler_bugs = failure_metrics.broken_handlers;
                 let total_invariants = invariant_contract.invariant_fns.len();
-                if edge_coverage_enabled || best.is_some() || broken > 0 {
+                if edge_coverage_enabled || best.is_some() || broken > 0 || handler_bugs > 0 {
                     let mut msg = String::new();
                     if let Some(best) = best {
                         msg.push_str(&format!("best: {best}"));
@@ -740,11 +828,19 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         }
                         msg.push_str(&format!("❌ {broken}/{total_invariants} broken"));
                     }
+                    if handler_bugs > 0 {
+                        if !msg.is_empty() {
+                            msg.push_str(", ");
+                        }
+                        msg.push_str(&format!("⚠ {handler_bugs} handler bug(s)"));
+                    }
                     progress.set_message(msg);
                 }
             } else if edge_coverage_enabled
                 && last_metrics_report.elapsed() > DURATION_BETWEEN_METRICS_REPORT
             {
+                // Sync handler-bug count snapshot into failure_metrics before emitting.
+                failure_metrics.broken_handlers = invariant_test.test_data.failures.handler_count();
                 // Display corpus metrics inline as JSON.
                 let metrics = build_invariant_progress_json(
                     SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
@@ -765,11 +861,49 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         trace!(?fuzz_fixtures);
         invariant_test.fuzz_state.log_stats();
 
-        let result = invariant_test.test_data;
+        let mut result = invariant_test.test_data;
+
+        // Post-campaign: shrink each handler bug's call sequence to its minimal prefix.
+        let total = result.failures.handler_count();
+        if total > 0 {
+            for (idx, (_site, error)) in result.failures.handler_failures_mut().enumerate() {
+                if early_exit.should_stop() {
+                    break;
+                }
+                let Some(failure) = error.as_handler_assertion_mut() else {
+                    // Handler-keyed entries always store `HandlerAssertion` by construction.
+                    continue;
+                };
+                shrink::reset_shrink_progress(
+                    &self.config,
+                    progress,
+                    &format!("handler {:#x}::{}", failure.reverter, failure.selector),
+                    Some((idx + 1, total)),
+                );
+                match shrink::shrink_handler_sequence(
+                    &self.config,
+                    &failure.call_sequence,
+                    failure.edge_fingerprint,
+                    &self.executor,
+                    progress,
+                    early_exit,
+                ) {
+                    Ok(shrunk) if !shrunk.is_empty() => {
+                        failure.call_sequence = shrunk;
+                    }
+                    Ok(_) => {}
+                    Err(e) => trace!(target: "forge::test", "handler shrink failed: {e}"),
+                }
+            }
+        }
+
+        let reverts = result.failures.reverts;
+        let (errors, handler_errors) = result.failures.partition();
         Ok(InvariantFuzzTestResult {
-            errors: result.failures.errors,
+            errors,
+            handler_errors,
             cases: result.fuzz_cases,
-            reverts: result.failures.reverts,
+            reverts,
             last_run_inputs: result.last_run_inputs,
             gas_report_traces: result.gas_report_traces,
             line_coverage: result.line_coverage,
@@ -788,6 +922,10 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         invariant_contract: &InvariantContract<'_>,
         fuzz_fixtures: &FuzzFixtures,
         fuzz_state: EvmFuzzState,
+        initial_handler_failures: std::collections::HashMap<
+            (Address, Selector),
+            InvariantFuzzError,
+        >,
     ) -> Result<(InvariantTest, WorkerCorpus)> {
         // Finds out the chosen deployed contracts and/or senders.
         self.select_contract_artifacts(invariant_contract.address)?;
@@ -827,6 +965,10 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // already know if we can early exit the invariant run.
         // This does not count as a fuzz run. It will just register the revert.
         let mut failures = InvariantFailures::new();
+        // Seed disk-recovered handler bugs so live counters reflect them from tick 0.
+        for ((addr, sel), err) in initial_handler_failures {
+            failures.seed_handler_failure(addr, sel, err);
+        }
         invariant_preflight_check(
             invariant_contract,
             &self.config,
@@ -840,7 +982,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         if let Some(error) =
             invariant_contract.invariant_fns.iter().find_map(|(f, _)| failures.get_failure(f))
         {
-            return Err(eyre!(error.revert_reason().unwrap_or_default()));
+            // Under `assert_all` we record the preflight break and let the campaign run for
+            // the full budget; legacy mode aborts on the first broken invariant.
+            if !self.config.assert_all {
+                return Err(eyre!(error.revert_reason().unwrap_or_default()));
+            }
         }
 
         // NOW enable call_override after the initial invariant check has passed.
@@ -1354,6 +1500,7 @@ mod tests {
         assert_eq!(payload["timestamp"], json!(123));
         assert_eq!(payload["invariant"], json!("invariant_balance"));
         assert_eq!(payload["metrics"]["corpus_count"], json!(7));
+        assert_eq!(payload["metrics"]["broken_handlers"], json!(0));
         assert_eq!(payload["total_txs"], json!(2));
         assert_eq!(payload["total_gas"], json!(50));
         assert!((payload["tx_per_sec"].as_f64().unwrap() - 0.2).abs() < 1e-12);
@@ -1387,6 +1534,7 @@ mod tests {
         failure_metrics.record_failure("invariant_a", "TestContract", "revert");
         failure_metrics.record_failure("invariant_a", "TestContract", "revert");
         failure_metrics.record_failure("invariant_b", "TestContract", "assertion failed");
+        failure_metrics.broken_handlers = 7;
 
         let payload = build_invariant_progress_json(
             789,
@@ -1400,6 +1548,7 @@ mod tests {
 
         assert_eq!(payload["metrics"]["failures"], json!(3));
         assert_eq!(payload["metrics"]["unique_failures"], json!(2));
+        assert_eq!(payload["metrics"]["broken_handlers"], json!(7));
     }
 
     #[test]
@@ -1420,5 +1569,6 @@ mod tests {
         let metrics = InvariantFailureMetrics::default();
         assert_eq!(metrics.failures, 0);
         assert!(metrics.unique_failures.is_empty());
+        assert_eq!(metrics.broken_handlers, 0);
     }
 }

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -227,13 +227,16 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
     let is_optimization = invariant_contract.is_optimization();
     let mut broken: Option<&'a Function> = None;
 
+    // Use the handler-gate variant so a stale committed `GLOBAL_FAIL_SLOT` from a
+    // previously-recorded handler bug doesn't poison this gate (which would otherwise silently
+    // skip every subsequent `assert_invariants` evaluation under `assertions_revert = false`).
+    // Handler bugs are tracked separately in `failures.broken_handlers`.
     let handlers_succeeded = || {
         invariant_test.targeted_contracts.targets.lock().keys().all(|address| {
-            invariant_run.executor.is_success(
+            invariant_run.executor.is_success_handler_gate(
                 *address,
                 false,
                 Cow::Borrowed(state_changeset),
-                false,
             )
         })
     };
@@ -297,11 +300,6 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
                 reverted,
                 is_optimization,
             );
-
-            // Non-reverting `vm.assert*` (`assertions_revert = false`) leaves
-            // `GLOBAL_FAIL_SLOT = 1` committed; clear it so it doesn't poison
-            // `handlers_succeeded` / `assert_invariants` on subsequent calls.
-            invariant_run.executor.clear_global_failure();
 
             // No invariant predicate broke; `broken = None`.
             let continues = invariant_test

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -298,6 +298,11 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
                 is_optimization,
             );
 
+            // Non-reverting `vm.assert*` (`assertions_revert = false`) leaves
+            // `GLOBAL_FAIL_SLOT = 1` committed; clear it so it doesn't poison
+            // `handlers_succeeded` / `assert_invariants` on subsequent calls.
+            invariant_run.executor.clear_global_failure();
+
             // No invariant predicate broke; `broken = None`.
             let continues = invariant_test
                 .test_data

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -1,11 +1,12 @@
 use super::{
     InvariantFailures, InvariantFuzzError, InvariantMetrics, InvariantTest, InvariantTestRun,
-    call_after_invariant_function, call_invariant_function, error::InvariantRunCtx,
+    call_after_invariant_function, call_invariant_function,
+    error::{InvariantRunCtx, record_handler_assertion_bug},
 };
 use crate::executors::{Executor, RawCallResult};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::Function;
-use alloy_primitives::I256;
+use alloy_primitives::{Address, B256, I256, Selector};
 use alloy_sol_types::{Panic, PanicKind, Revert, SolError, SolInterface};
 use eyre::Result;
 use foundry_config::InvariantConfig;
@@ -31,6 +32,9 @@ use std::{borrow::Cow, collections::HashMap};
 pub struct InvariantFuzzTestResult {
     /// Errors recorded per invariant.
     pub errors: HashMap<String, InvariantFuzzError>,
+    /// Handler-side assertion bugs, keyed by `(reverter, selector)` site (deduped per
+    /// handler function). Each entry is [`InvariantFuzzError::HandlerAssertion`].
+    pub handler_errors: HashMap<(Address, Selector), InvariantFuzzError>,
     /// Every successful fuzz test case
     pub cases: Vec<FuzzedCases>,
     /// Number of reverted fuzz calls
@@ -205,6 +209,10 @@ pub(crate) struct ContinueOutcome<'a> {
 ///
 /// For optimization mode (int256 return), tracks the max value but never fails on invariant.
 /// For check mode, asserts the invariant and fails if broken.
+///
+/// `handler_target` / `handler_selector` identify the just-executed call, used to
+/// attribute handler-side assertion failures.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
     invariant_contract: &InvariantContract<'a>,
     invariant_test: &mut InvariantTest,
@@ -212,6 +220,9 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
     invariant_config: &InvariantConfig,
     call_result: RawCallResult<FEN>,
     state_changeset: &StateChangeset,
+    handler_target: Address,
+    handler_selector: Selector,
+    pre_merge_edges_hash: Option<B256>,
 ) -> Result<ContinueOutcome<'a>> {
     let is_optimization = invariant_contract.is_optimization();
     let mut broken: Option<&'a Function> = None;
@@ -270,13 +281,38 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
             invariant_test.test_data.failures.reverts += 1;
         }
 
-        // Collect which invariants should be marked as failed due to this revert/assertion.
+        if is_assert_failure {
+            // Handler-side assertion: deduped by `(reverter, selector)` site, shortest
+            // sequence wins on collision.
+            record_handler_assertion_bug(
+                invariant_contract,
+                invariant_config,
+                &invariant_test.targeted_contracts,
+                &mut invariant_test.test_data.failures,
+                &mut invariant_run.inputs,
+                handler_target,
+                handler_selector,
+                pre_merge_edges_hash,
+                call_result,
+                reverted,
+                is_optimization,
+            );
+
+            // No invariant predicate broke; `broken = None`.
+            let continues = invariant_test
+                .test_data
+                .failures
+                .can_continue(invariant_contract.invariant_fns.len());
+            return Ok(ContinueOutcome { continues, broken: None });
+        }
+
+        // Non-assertion revert: per-invariant `fail_on_revert` still marks affected
+        // invariants as broken.
         let failing_invariants: Vec<_> = invariant_contract
             .invariant_fns
             .iter()
             .filter(|(invariant, fail_on_revert)| {
-                (is_assert_failure || *fail_on_revert)
-                    && !invariant_test.test_data.failures.has_failure(invariant)
+                *fail_on_revert && !invariant_test.test_data.failures.has_failure(invariant)
             })
             .collect();
 
@@ -298,7 +334,6 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
                 call_result,
                 &[],
             );
-            invariant_test.test_data.failures.revert_reason = Some(base.revert_reason.clone());
 
             for (invariant, fail_on_revert) in failing_invariants {
                 let mut data = base.clone();
@@ -308,6 +343,8 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
                     format!("{}, reason: {}", invariant.name, data.revert_reason).into(),
                     invariant_run.inputs.clone(),
                 );
+                // Handler asserts go to `broken_handlers` above; `BrokenInvariant` arm kept
+                // for non-handler-routed assertion paths.
                 invariant_test.test_data.failures.record_failure(
                     invariant,
                     if is_assert_failure {

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -1,12 +1,14 @@
 use crate::executors::{
     EarlyExit, EvmError, Executor, RawCallResult,
     invariant::{
-        call_after_invariant_function, call_invariant_function, execute_tx,
+        call_after_invariant_function, call_invariant_function,
+        error::{handler_edge_fingerprint, snapshot_edge_fingerprint},
+        execute_tx,
         result::did_fail_on_assert,
     },
 };
 use alloy_json_abi::Function;
-use alloy_primitives::{Address, Bytes, I256, U256};
+use alloy_primitives::{Address, B256, Bytes, I256, Selector, U256};
 use foundry_config::InvariantConfig;
 use foundry_evm_core::{
     FoundryBlock, constants::MAGIC_ASSUME, decode::RevertDecoder, evm::FoundryEvmNetwork,
@@ -44,15 +46,45 @@ impl CallSequenceShrinker {
     }
 }
 
-/// Resets the progress bar for shrinking.
-///
-/// Callers (e.g. `replay_error`) are responsible for invoking this before each shrink so the
-/// bar's length and message reflect the invariant currently being shrunk. Multi-invariant
-/// campaigns can call this once per invariant to display per-target progress.
-///
-/// `position` is `Some((current, total))` when more than one invariant needs shrinking in the
-/// same campaign; the bar then reads `[i/N] Shrink: <label>` so users can see how many
-/// shrinkers are left in the queue.
+/// How `run_shrink_loop` handles a predicate error.
+#[derive(Clone, Copy)]
+enum ShrinkErrorPolicy {
+    /// "Bug still present" — keep the call removed (legacy `shrink_sequence` behavior).
+    KeepRemoved,
+    /// "Bug gone" — restore the call. Used by handler shrink so a replay error never
+    /// produces a sequence that no longer reproduces the anchor.
+    RestoreRemoved,
+}
+
+/// Per-call decision returned by callbacks driving `replay_sequence`. `Continue` hands
+/// the result back so non-reverted calls auto-commit; `Stop` short-circuits.
+#[expect(clippy::large_enum_variant)]
+enum ReplayDecision<T, FEN: FoundryEvmNetwork> {
+    Stop(T),
+    Continue(RawCallResult<FEN>),
+}
+
+/// Options controlling how `check_sequence` evaluates a candidate call sequence.
+pub struct CheckSequenceOptions<'a> {
+    pub accumulate_warp_roll: bool,
+    pub fail_on_revert: bool,
+    pub expect_assertion_failure: bool,
+    pub call_after_invariant: bool,
+    pub rd: Option<&'a RevertDecoder>,
+}
+
+/// Result of a strict handler-bug replay: anchor asserts, no earlier call asserts, and the
+/// recomputed edge fingerprint identifies which path the assertion took.
+#[derive(Debug)]
+pub struct HandlerReplayOutcome {
+    pub anchor_asserted: bool,
+    pub revert_reason: Option<String>,
+    /// Normalized via `handler_edge_fingerprint` so callers can compare directly.
+    pub anchor_fingerprint: B256,
+}
+
+/// Resets the progress bar before each shrink. `position = Some((i, N))` renders
+/// `[i/N] Shrink: <label>` for multi-invariant campaigns.
 pub(crate) fn reset_shrink_progress(
     config: &InvariantConfig,
     progress: Option<&ProgressBar>,
@@ -141,6 +173,56 @@ fn build_shrunk_sequence(
     result
 }
 
+/// Shared shrink loop driver. Tries to drop each call; `predicate` returns whether the
+/// candidate still triggers the bug.
+fn run_shrink_loop<P>(
+    config: &InvariantConfig,
+    calls_len: usize,
+    progress: Option<&ProgressBar>,
+    early_exit: &EarlyExit,
+    error_policy: ShrinkErrorPolicy,
+    mut predicate: P,
+) -> CallSequenceShrinker
+where
+    P: FnMut(&CallSequenceShrinker) -> eyre::Result<bool>,
+{
+    let mut shrinker = CallSequenceShrinker::new(calls_len);
+    let mut call_idx = 0;
+
+    for _ in 0..config.shrink_run_limit {
+        if early_exit.should_stop() {
+            break;
+        }
+
+        // Already-removed indices have nothing to drop.
+        if !shrinker.included_calls.test(call_idx) {
+            call_idx = shrinker.next_index(call_idx);
+            continue;
+        }
+
+        shrinker.included_calls.clear(call_idx);
+
+        let bug_still_present = match predicate(&shrinker) {
+            Ok(b) => b,
+            Err(_) => matches!(error_policy, ShrinkErrorPolicy::KeepRemoved),
+        };
+        if bug_still_present {
+            if shrinker.included_calls.count() == 1 {
+                break;
+            }
+        } else {
+            shrinker.included_calls.set(call_idx);
+        }
+
+        if let Some(progress) = progress {
+            progress.inc(1);
+        }
+        call_idx = shrinker.next_index(call_idx);
+    }
+
+    shrinker
+}
+
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn shrink_sequence<FEN: FoundryEvmNetwork>(
     config: &InvariantConfig,
@@ -164,45 +246,99 @@ pub(crate) fn shrink_sequence<FEN: FoundryEvmNetwork>(
     }
 
     let accumulate_warp_roll = config.has_delay();
-    let mut call_idx = 0;
-    let mut shrinker = CallSequenceShrinker::new(calls.len());
-
-    for _ in 0..config.shrink_run_limit {
-        if early_exit.should_stop() {
-            break;
-        }
-
-        shrinker.included_calls.clear(call_idx);
-
-        match check_sequence(
-            executor.clone(),
-            calls,
-            shrinker.current().collect(),
-            target_address,
-            calldata.clone(),
-            CheckSequenceOptions {
-                accumulate_warp_roll,
-                fail_on_revert: config.fail_on_revert,
-                expect_assertion_failure,
-                call_after_invariant: invariant_contract.call_after_invariant,
-                rd: None,
-            },
-        ) {
-            // If candidate sequence still fails, shrink until shortest possible.
-            Ok((false, _, _)) if shrinker.included_calls.count() == 1 => break,
-            // Restore last removed call as it caused sequence to pass invariant.
-            Ok((true, _, _)) => shrinker.included_calls.set(call_idx),
-            _ => {}
-        }
-
-        if let Some(progress) = progress {
-            progress.inc(1);
-        }
-
-        call_idx = shrinker.next_index(call_idx);
-    }
+    let shrinker = run_shrink_loop(
+        config,
+        calls.len(),
+        progress,
+        early_exit,
+        // Preserve legacy invariant-shrink behavior: errors during candidate evaluation
+        // do not roll back the removal.
+        ShrinkErrorPolicy::KeepRemoved,
+        |shrinker| {
+            let (success, _, _) = check_sequence(
+                executor.clone(),
+                calls,
+                shrinker.current().collect(),
+                target_address,
+                calldata.clone(),
+                CheckSequenceOptions {
+                    accumulate_warp_roll,
+                    fail_on_revert: config.fail_on_revert,
+                    expect_assertion_failure,
+                    call_after_invariant: invariant_contract.call_after_invariant,
+                    rd: None,
+                },
+            )?;
+            // Bug still present iff the invariant predicate did not pass.
+            Ok(!success)
+        },
+    );
 
     Ok(build_shrunk_sequence(calls, &shrinker, accumulate_warp_roll))
+}
+
+/// Replays `sequence` (indices into `calls`) against `executor`. When
+/// `accumulate_warp_roll` is set, warp/roll from skipped calls is folded into the next
+/// included call. `on_call` may stop early; otherwise non-reverted calls are committed.
+fn replay_sequence<FEN, T, F>(
+    executor: &mut Executor<FEN>,
+    calls: &[BasicTxDetails],
+    sequence: &[usize],
+    accumulate_warp_roll: bool,
+    mut on_call: F,
+) -> eyre::Result<Option<T>>
+where
+    FEN: FoundryEvmNetwork,
+    F: FnMut(usize, RawCallResult<FEN>) -> eyre::Result<ReplayDecision<T, FEN>>,
+{
+    // Fast path: no warp/roll accumulation → iterate only kept indices (O(k)) and pass
+    // `&calls[idx]` directly to skip the per-call `BasicTxDetails` clone.
+    if !accumulate_warp_roll {
+        for &idx in sequence {
+            let call_result = execute_tx(executor, &calls[idx])?;
+            match on_call(idx, call_result)? {
+                ReplayDecision::Stop(val) => return Ok(Some(val)),
+                ReplayDecision::Continue(mut call_result) => {
+                    if !call_result.reverted {
+                        executor.commit(&mut call_result);
+                    }
+                }
+            }
+        }
+        return Ok(None);
+    }
+
+    // Accumulating path: must scan the full `calls` so warp/roll from skipped txs lands on
+    // the next kept tx as a concrete delta.
+    let mut accumulated_warp = U256::ZERO;
+    let mut accumulated_roll = U256::ZERO;
+    let mut seq_iter = sequence.iter().peekable();
+
+    for (idx, tx) in calls.iter().enumerate() {
+        accumulated_warp += tx.warp.unwrap_or(U256::ZERO);
+        accumulated_roll += tx.roll.unwrap_or(U256::ZERO);
+        if seq_iter.peek() != Some(&&idx) {
+            continue;
+        }
+        seq_iter.next();
+
+        let executed = apply_warp_roll(tx, accumulated_warp, accumulated_roll);
+        let call_result = execute_tx(executor, &executed)?;
+
+        match on_call(idx, call_result)? {
+            ReplayDecision::Stop(val) => return Ok(Some(val)),
+            ReplayDecision::Continue(mut call_result) => {
+                if !call_result.reverted {
+                    executor.commit(&mut call_result);
+                }
+            }
+        }
+
+        accumulated_warp = U256::ZERO;
+        accumulated_roll = U256::ZERO;
+    }
+
+    Ok(None)
 }
 
 /// Checks if the given call sequence breaks the invariant.
@@ -215,21 +351,6 @@ pub(crate) fn shrink_sequence<FEN: FoundryEvmNetwork>(
 /// When `options.accumulate_warp_roll` is enabled, warp/roll from removed calls is folded into the
 /// next kept call so the candidate sequence stays representable as a concrete counterexample.
 pub fn check_sequence<FEN: FoundryEvmNetwork>(
-    executor: Executor<FEN>,
-    calls: &[BasicTxDetails],
-    sequence: Vec<usize>,
-    test_address: Address,
-    calldata: Bytes,
-    options: CheckSequenceOptions<'_>,
-) -> eyre::Result<(bool, bool, Option<String>)> {
-    if options.accumulate_warp_roll {
-        check_sequence_with_accumulation(executor, calls, sequence, test_address, calldata, options)
-    } else {
-        check_sequence_simple(executor, calls, sequence, test_address, calldata, options)
-    }
-}
-
-fn check_sequence_simple<FEN: FoundryEvmNetwork>(
     mut executor: Executor<FEN>,
     calls: &[BasicTxDetails],
     sequence: Vec<usize>,
@@ -237,80 +358,40 @@ fn check_sequence_simple<FEN: FoundryEvmNetwork>(
     calldata: Bytes,
     options: CheckSequenceOptions<'_>,
 ) -> eyre::Result<(bool, bool, Option<String>)> {
-    // Apply the call sequence.
-    for call_index in sequence {
-        let tx = &calls[call_index];
-        let mut call_result = execute_tx(&mut executor, tx)?;
-        let assertion_failure = did_fail_on_assert(&call_result, &call_result.state_changeset);
-        // Ignore calls reverted with `MAGIC_ASSUME`. This is needed to handle failed scenarios that
-        // are replayed with a modified version of test driver (that use new `vm.assume`
-        // cheatcodes).
-        if call_result.result.as_ref() != MAGIC_ASSUME {
-            if assertion_failure {
-                return Ok((false, false, assertion_failure_reason(call_result, options.rd)));
+    let early = replay_sequence(
+        &mut executor,
+        calls,
+        &sequence,
+        options.accumulate_warp_roll,
+        |_idx, call_result| {
+            // Ignore calls reverted with `MAGIC_ASSUME`. This is needed to handle failed
+            // scenarios that are replayed with a modified version of test driver (that use
+            // new `vm.assume` cheatcodes).
+            if call_result.result.as_ref() == MAGIC_ASSUME {
+                return Ok(ReplayDecision::Continue(call_result));
             }
-
+            if did_fail_on_assert(&call_result, &call_result.state_changeset) {
+                return Ok(ReplayDecision::Stop((
+                    false,
+                    false,
+                    assertion_failure_reason(call_result, options.rd),
+                )));
+            }
             if call_result.reverted && options.fail_on_revert {
                 if options.expect_assertion_failure {
-                    return Ok((true, false, None));
+                    return Ok(ReplayDecision::Stop((true, false, None)));
                 }
-                return Ok((false, false, call_failure_reason(call_result, options.rd)));
+                return Ok(ReplayDecision::Stop((
+                    false,
+                    false,
+                    call_failure_reason(call_result, options.rd),
+                )));
             }
-        }
-
-        if !call_result.reverted {
-            executor.commit(&mut call_result);
-        }
-    }
-
-    finish_sequence_check(&executor, test_address, calldata, &options)
-}
-
-fn check_sequence_with_accumulation<FEN: FoundryEvmNetwork>(
-    mut executor: Executor<FEN>,
-    calls: &[BasicTxDetails],
-    sequence: Vec<usize>,
-    test_address: Address,
-    calldata: Bytes,
-    options: CheckSequenceOptions<'_>,
-) -> eyre::Result<(bool, bool, Option<String>)> {
-    let mut accumulated_warp = U256::ZERO;
-    let mut accumulated_roll = U256::ZERO;
-    let mut seq_iter = sequence.iter().peekable();
-
-    for (idx, tx) in calls.iter().enumerate() {
-        accumulated_warp += tx.warp.unwrap_or(U256::ZERO);
-        accumulated_roll += tx.roll.unwrap_or(U256::ZERO);
-
-        if seq_iter.peek() != Some(&&idx) {
-            continue;
-        }
-
-        seq_iter.next();
-
-        let tx_with_accumulated = apply_warp_roll(tx, accumulated_warp, accumulated_roll);
-        let mut call_result = execute_tx(&mut executor, &tx_with_accumulated)?;
-        let assertion_failure = did_fail_on_assert(&call_result, &call_result.state_changeset);
-
-        if call_result.result.as_ref() != MAGIC_ASSUME {
-            if assertion_failure {
-                return Ok((false, false, assertion_failure_reason(call_result, options.rd)));
-            }
-
-            if call_result.reverted && options.fail_on_revert {
-                if options.expect_assertion_failure {
-                    return Ok((true, false, None));
-                }
-                return Ok((false, false, call_failure_reason(call_result, options.rd)));
-            }
-        }
-
-        if !call_result.reverted {
-            executor.commit(&mut call_result);
-        }
-
-        accumulated_warp = U256::ZERO;
-        accumulated_roll = U256::ZERO;
+            Ok(ReplayDecision::Continue(call_result))
+        },
+    )?;
+    if let Some(result) = early {
+        return Ok(result);
     }
 
     // Unlike optimization mode we intentionally do not apply trailing warp/roll before the
@@ -360,14 +441,6 @@ fn finish_sequence_check<FEN: FoundryEvmNetwork>(
     }
 
     Ok((success, true, None))
-}
-
-pub struct CheckSequenceOptions<'a> {
-    pub accumulate_warp_roll: bool,
-    pub fail_on_revert: bool,
-    pub expect_assertion_failure: bool,
-    pub call_after_invariant: bool,
-    pub rd: Option<&'a RevertDecoder>,
 }
 
 fn call_failure_reason<FEN: FoundryEvmNetwork>(
@@ -451,6 +524,127 @@ pub(crate) fn shrink_sequence_value<FEN: FoundryEvmNetwork>(
     }
 
     Ok(build_shrunk_sequence(calls, &shrinker, true))
+}
+
+/// Replays a handler-bug sequence and returns whether the anchor still asserts on the same
+/// path. Rejects sequences with a pre-anchor assertion (would be a different bug).
+pub fn replay_handler_failure_sequence<FEN: FoundryEvmNetwork>(
+    mut executor: Executor<FEN>,
+    calls: &[BasicTxDetails],
+    sequence: Vec<usize>,
+    accumulate_warp_roll: bool,
+    rd: Option<&RevertDecoder>,
+) -> eyre::Result<HandlerReplayOutcome> {
+    let Some(&anchor_idx) = sequence.last() else {
+        return Ok(HandlerReplayOutcome {
+            anchor_asserted: false,
+            revert_reason: None,
+            anchor_fingerprint: B256::ZERO,
+        });
+    };
+
+    let outcome = replay_sequence(
+        &mut executor,
+        calls,
+        &sequence,
+        accumulate_warp_roll,
+        |idx, call_result| {
+            let asserted = did_fail_on_assert(&call_result, &call_result.state_changeset);
+            if idx == anchor_idx {
+                let snapshot = snapshot_edge_fingerprint(&call_result);
+                let anchor = &calls[anchor_idx];
+                let reverter = anchor.call_details.target;
+                let selector_bytes: [u8; 4] = anchor
+                    .call_details
+                    .calldata
+                    .get(..4)
+                    .and_then(|s| s.try_into().ok())
+                    .unwrap_or_default();
+                let selector = Selector::from(selector_bytes);
+                let fingerprint = handler_edge_fingerprint(snapshot, reverter, selector);
+                let reason =
+                    if asserted { assertion_failure_reason(call_result, rd) } else { None };
+                return Ok(ReplayDecision::Stop(HandlerReplayOutcome {
+                    anchor_asserted: asserted,
+                    revert_reason: reason,
+                    anchor_fingerprint: fingerprint,
+                }));
+            }
+            if asserted {
+                // Pre-anchor assertion = different bug; reject.
+                return Ok(ReplayDecision::Stop(HandlerReplayOutcome {
+                    anchor_asserted: false,
+                    revert_reason: None,
+                    anchor_fingerprint: B256::ZERO,
+                }));
+            }
+            Ok(ReplayDecision::Continue(call_result))
+        },
+    )?;
+
+    Ok(outcome.unwrap_or(HandlerReplayOutcome {
+        anchor_asserted: false,
+        revert_reason: None,
+        anchor_fingerprint: B256::ZERO,
+    }))
+}
+
+/// Shrinks a handler-bug sequence to the shortest prefix that still asserts on the anchor
+/// AND keeps the same edge fingerprint (so we don't change bug identity).
+pub(crate) fn shrink_handler_sequence<FEN: FoundryEvmNetwork>(
+    config: &InvariantConfig,
+    calls: &[BasicTxDetails],
+    expected_fingerprint: B256,
+    executor: &Executor<FEN>,
+    progress: Option<&ProgressBar>,
+    early_exit: &EarlyExit,
+) -> eyre::Result<Vec<BasicTxDetails>> {
+    if calls.is_empty() {
+        return Ok(vec![]);
+    }
+    let accumulate_warp_roll = config.has_delay();
+    let shrinker = run_shrink_loop(
+        config,
+        calls.len(),
+        progress,
+        early_exit,
+        ShrinkErrorPolicy::RestoreRemoved,
+        |shrinker| {
+            handler_sequence_still_triggers_bug(
+                executor.clone(),
+                calls,
+                shrinker.current().collect(),
+                accumulate_warp_roll,
+                expected_fingerprint,
+            )
+        },
+    );
+
+    let shrunk = build_shrunk_sequence(calls, &shrinker, accumulate_warp_roll);
+
+    // Verify shrunk repro; fall back to original on any failure.
+    let verified = handler_sequence_still_triggers_bug(
+        executor.clone(),
+        calls,
+        shrinker.current().collect(),
+        accumulate_warp_roll,
+        expected_fingerprint,
+    )
+    .unwrap_or(false);
+    if verified { Ok(shrunk) } else { Ok(calls.to_vec()) }
+}
+
+/// Shrink predicate: anchor asserts on the same path as the originally recorded bug.
+fn handler_sequence_still_triggers_bug<FEN: FoundryEvmNetwork>(
+    executor: Executor<FEN>,
+    calls: &[BasicTxDetails],
+    sequence: Vec<usize>,
+    accumulate_warp_roll: bool,
+    expected_fingerprint: B256,
+) -> eyre::Result<bool> {
+    let outcome =
+        replay_handler_failure_sequence(executor, calls, sequence, accumulate_warp_roll, None)?;
+    Ok(outcome.anchor_asserted && outcome.anchor_fingerprint == expected_fingerprint)
 }
 
 /// Executes a call sequence and returns the optimization value (int256) from the invariant

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -709,7 +709,11 @@ mod tests {
             warp: warp.map(U256::from),
             roll: roll.map(U256::from),
             sender: Address::ZERO,
-            call_details: CallDetails { target: Address::ZERO, calldata: Bytes::new() },
+            call_details: CallDetails {
+                target: Address::ZERO,
+                calldata: Bytes::new(),
+                value: None,
+            },
         }
     }
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -780,20 +780,13 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
             .is_ok_and(|failed_slot| !failed_slot.is_zero())
     }
 
-    /// Clears the global assertion failure flag from both the committed backend state and, when
-    /// provided, the in-flight state changeset for the current call.
-    pub fn clear_global_failure(
-        &mut self,
-        state_changeset: Option<&mut StateChangeset>,
-    ) -> BackendResult<()> {
-        if let Some(state_changeset) = state_changeset
-            && let Some(acc) = state_changeset.get_mut(&CHEATCODE_ADDRESS)
-            && let Some(failed_slot) = acc.storage.get_mut(&GLOBAL_FAIL_SLOT)
-        {
-            failed_slot.present_value = U256::ZERO;
+    /// Clears the global assertion failure flag from the committed backend state. Best-effort:
+    /// a backend failure here would only happen on a fundamentally broken state, so we just
+    /// trace it.
+    pub fn clear_global_failure(&mut self) {
+        if let Err(err) = self.set_storage_slot(CHEATCODE_ADDRESS, GLOBAL_FAIL_SLOT, U256::ZERO) {
+            trace!(%err, "failed to clear GLOBAL_FAIL_SLOT");
         }
-
-        self.set_storage_slot(CHEATCODE_ADDRESS, GLOBAL_FAIL_SLOT, U256::ZERO)
     }
 
     /// Creates the environment to use when executing a transaction in a test context

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -663,6 +663,21 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         self.is_success(address, call_result.reverted, state_changeset, should_fail)
     }
 
+    /// Like [`Self::is_raw_call_mut_success`] but uses [`Self::is_success_handler_gate`] under
+    /// the hood. Intended for invariant view-call success checks during a campaign where the
+    /// committed `GLOBAL_FAIL_SLOT` may be stale poison from a previously-recorded handler bug.
+    pub fn is_raw_call_mut_success_handler_gate(
+        &self,
+        address: Address,
+        call_result: &mut RawCallResult<FEN>,
+    ) -> bool {
+        if call_result.has_state_snapshot_failure {
+            return false;
+        }
+        let state_changeset = std::mem::take(&mut call_result.state_changeset);
+        self.is_success_handler_gate(address, call_result.reverted, Cow::Owned(state_changeset))
+    }
+
     /// Returns `true` if a test can be considered successful.
     ///
     /// If the call succeeded, we also have to check the global and local failure flags.
@@ -691,8 +706,22 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         state_changeset: Cow<'_, StateChangeset>,
         should_fail: bool,
     ) -> bool {
-        let success = self.is_success_raw(address, reverted, state_changeset);
+        let success = self.is_success_raw(address, reverted, state_changeset, false);
         should_fail ^ success
+    }
+
+    /// Like [`Self::is_success`] but ignores the *committed* `GLOBAL_FAIL_SLOT` and only treats
+    /// the slot as failed when this call's in-flight changeset writes it. Used by the invariant
+    /// runner's per-call handler-success gate, where a `1` already in committed storage is just
+    /// stale poison from a previously-recorded handler bug (separately tracked) and must not
+    /// suppress later `assert_invariants` / `afterInvariant` evaluations.
+    pub fn is_success_handler_gate(
+        &self,
+        address: Address,
+        reverted: bool,
+        state_changeset: Cow<'_, StateChangeset>,
+    ) -> bool {
+        self.is_success_raw(address, reverted, state_changeset, true)
     }
 
     #[instrument(name = "is_success", level = "debug", skip_all)]
@@ -701,6 +730,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         address: Address,
         reverted: bool,
         state_changeset: Cow<'_, StateChangeset>,
+        pending_global_failure_only: bool,
     ) -> bool {
         // The call reverted.
         if reverted {
@@ -712,8 +742,16 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
             return false;
         }
 
-        // Check the global failure slot.
-        if self.has_global_failure(&state_changeset) {
+        // Check the global failure slot. Callers that already track recorded handler bugs
+        // out-of-band can pass `pending_global_failure_only = true` to ignore the committed
+        // slot (which would otherwise stay `1` for the rest of the run after a non-reverting
+        // `vm.assert*` under `assertions_revert = false`).
+        let global_failed = if pending_global_failure_only {
+            Self::has_pending_global_failure(&state_changeset)
+        } else {
+            self.has_global_failure(&state_changeset)
+        };
+        if global_failed {
             return false;
         }
 
@@ -778,15 +816,6 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         self.backend()
             .storage_ref(CHEATCODE_ADDRESS, GLOBAL_FAIL_SLOT)
             .is_ok_and(|failed_slot| !failed_slot.is_zero())
-    }
-
-    /// Clears the global assertion failure flag from the committed backend state. Best-effort:
-    /// a backend failure here would only happen on a fundamentally broken state, so we just
-    /// trace it.
-    pub fn clear_global_failure(&mut self) {
-        if let Err(err) = self.set_storage_slot(CHEATCODE_ADDRESS, GLOBAL_FAIL_SLOT, U256::ZERO) {
-            trace!(%err, "failed to clear GLOBAL_FAIL_SLOT");
-        }
     }
 
     /// Creates the environment to use when executing a transaction in a test context

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -77,6 +77,10 @@ pub struct CallDetails {
     pub target: Address,
     /// The data of the transaction.
     pub calldata: Bytes,
+    /// Ether value to send with the transaction.
+    /// Uses `#[serde(default)]` for backwards compatibility with existing corpus files.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<U256>,
 }
 
 impl BasicTxDetails {
@@ -107,6 +111,9 @@ pub struct BaseCounterExample {
     pub addr: Option<Address>,
     /// The data to provide.
     pub calldata: Bytes,
+    /// Ether value sent with the call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<U256>,
     /// Contract name if it exists.
     pub contract_name: Option<String>,
     /// Function name if it exists.
@@ -139,6 +146,7 @@ impl BaseCounterExample {
         let sender = tx.sender;
         let target = tx.call_details.target;
         let bytes = &tx.call_details.calldata;
+        let value = tx.call_details.value;
         let warp = tx.warp;
         let roll = tx.roll;
         if let Some((name, abi)) = &contracts.get(&target)
@@ -152,6 +160,7 @@ impl BaseCounterExample {
                     sender: Some(sender),
                     addr: Some(target),
                     calldata: bytes.clone(),
+                    value,
                     contract_name: Some(name.clone()),
                     func_name: Some(func.name.clone()),
                     signature: Some(func.signature()),
@@ -172,6 +181,7 @@ impl BaseCounterExample {
             sender: Some(sender),
             addr: Some(target),
             calldata: bytes.clone(),
+            value,
             contract_name: None,
             func_name: None,
             signature: None,
@@ -195,6 +205,7 @@ impl BaseCounterExample {
             sender: None,
             addr: None,
             calldata: bytes,
+            value: None,
             contract_name: None,
             func_name: None,
             signature: None,
@@ -227,6 +238,20 @@ impl fmt::Display for BaseCounterExample {
                 writeln!(f, "\t\tvm.roll(block.number + {roll});")?;
             }
             writeln!(f, "\t\tvm.prank({sender});")?;
+            // Use value syntax for payable calls.
+            if let Some(value) = &self.value
+                && !value.is_zero()
+            {
+                write!(
+                    f,
+                    "\t\t{}({}).{}{{value: {value}}}({});",
+                    contract.split_once(':').map_or(contract.as_str(), |(_, contract)| contract),
+                    address,
+                    func_name,
+                    args
+                )?;
+                return Ok(());
+            }
             write!(
                 f,
                 "\t\t{}({}).{}({});",
@@ -257,6 +282,13 @@ impl fmt::Display for BaseCounterExample {
         }
         if let Some(roll) = &self.roll {
             write!(f, "roll={roll} ")?;
+        }
+
+        // Display value if non-zero (for payable calls).
+        if let Some(value) = &self.value
+            && !value.is_zero()
+        {
+            write!(f, "value={value} ")?;
         }
 
         if let Some(sig) = &self.signature {

--- a/crates/evm/fuzz/src/strategies/mod.rs
+++ b/crates/evm/fuzz/src/strategies/mod.rs
@@ -6,8 +6,8 @@ pub use uint::UintStrategy;
 
 mod param;
 pub use param::{
-    fuzz_param, fuzz_param_from_state, fuzz_param_with_fixtures, mutate_param_value,
-    mutate_param_value_with_senders,
+    fuzz_msg_value, fuzz_param, fuzz_param_from_state, fuzz_param_with_fixtures,
+    generate_msg_value, mutate_param_value, mutate_param_value_with_senders,
 };
 
 mod calldata;

--- a/crates/evm/fuzz/src/strategies/param.rs
+++ b/crates/evm/fuzz/src/strategies/param.rs
@@ -1,4 +1,4 @@
-use super::state::EvmFuzzState;
+use super::{UintStrategy, state::EvmFuzzState};
 use crate::{
     invariant::SenderFilters,
     strategies::mutators::{
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloy_dyn_abi::{DynSolType, DynSolValue, Word};
 use alloy_primitives::{Address, B256, I256, U256};
-use proptest::{prelude::*, test_runner::TestRunner};
+use proptest::{prelude::*, strategy::ValueTree, test_runner::TestRunner};
 use rand::{SeedableRng, prelude::IndexedMutRandom, rngs::StdRng};
 use std::mem::replace;
 
@@ -510,6 +510,33 @@ fn mutate_random_array_value(
     let old_val = replace(elem, DynSolValue::Bool(false));
     let new_val = mutate_param_value_inner(element_type, old_val, test_runner, state, senders);
     *elem = new_val;
+}
+
+/// Probability (out of 100) that a payable call carries a non-zero msg.value.
+const PAYABLE_VALUE_PROB: u32 = 15;
+
+/// Returns a proptest strategy for generating random msg.value for payable functions.
+///
+/// Most calls (85%) carry no value. The remaining 15% delegate to [`UintStrategy`],
+/// which biases toward edge cases (around 0 / max) and dictionary fixtures, with
+/// random fallback. Over-budget values are clamped to sender balance at execute time.
+pub fn fuzz_msg_value() -> impl Strategy<Value = Option<U256>> {
+    proptest::prop_oneof![
+        100 - PAYABLE_VALUE_PROB => proptest::strategy::Just(None),
+        PAYABLE_VALUE_PROB       => UintStrategy::new(256, None).prop_map(Some),
+    ]
+}
+
+/// Generates a msg.value for payable functions using `TestRunner`'s RNG (corpus mutation path).
+///
+/// Mirrors [`fuzz_msg_value`] by sampling from [`UintStrategy`]. The 15% mutation gate is
+/// applied at the call site in `corpus.rs`. Over-budget values are clamped to sender
+/// balance at execute time.
+pub fn generate_msg_value(test_runner: &mut TestRunner) -> U256 {
+    UintStrategy::new(256, None)
+        .new_tree(test_runner)
+        .expect("UintStrategy::new_tree is infallible")
+        .current()
 }
 
 #[cfg(test)]

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -5,7 +5,7 @@ use crate::{
     gas_report::GasReport,
 };
 use alloy_primitives::{
-    Address, I256, Log, U256,
+    Address, I256, Log, Selector, U256,
     map::{AddressHashMap, HashMap},
 };
 use eyre::Report;
@@ -408,29 +408,68 @@ impl TestStatus {
     }
 }
 
-/// A broken invariant in an invariant test campaign.
-///
-/// Every broken invariant — anchor (`--mt` target) and all `assert_all` secondaries — uses
-/// this same shape. The `Vec<InvariantFailure>` on [`TestResult`] is the single source of
-/// truth for invariant failure rendering; legacy `reason`/`counterexample` are no longer
-/// populated for invariant tests.
+/// A failure surfaced by an invariant test campaign — either a broken `invariant_*`
+/// predicate ([`Self::Predicate`]) or a handler-side assertion bug ([`Self::Handler`]).
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct InvariantFailure {
-    /// Invariant function name (e.g. `invariant_cond3`).
-    pub name: String,
-    /// Revert reason or assertion failure message.
-    pub reason: String,
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum InvariantFailure {
+    /// A broken `invariant_*` predicate.
+    Predicate {
+        /// Invariant function name (e.g. `invariant_cond3`).
+        name: String,
+        /// Revert reason or assertion failure message.
+        reason: String,
+        /// Counterexample sequence, when one is available.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        counterexample: Option<CounterExample>,
+        /// Path where the counterexample was persisted for re-running and shrinking.
+        persisted_path: std::path::PathBuf,
+        /// Whether this failure is the campaign anchor (the `--mt`-selected invariant).
+        /// When `true` and this is the only failure, the function name is omitted on the
+        /// `[FAIL: ...]` line (the trailing summary already identifies it).
+        #[serde(default)]
+        is_anchor: bool,
+    },
+    /// A handler-side assertion bug discovered during the campaign.
+    Handler {
+        /// Best-effort human-readable name of the failing call, e.g. `Counter::increment` or
+        /// `0xabc...::0x12345678` when the contract/function cannot be resolved.
+        name: String,
+        /// Address of the handler whose call asserted/reverted with an assertion.
+        reverter: Address,
+        /// 4-byte selector of the failing handler function.
+        selector: Selector,
+        /// Decoded revert/assert reason.
+        reason: String,
+        /// Counterexample sequence leading up to (and including) the failing call.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        counterexample: Option<CounterExample>,
+    },
+}
+
+impl InvariantFailure {
+    /// Reason rendered on the `[FAIL: ...]` line.
+    pub fn reason(&self) -> &str {
+        match self {
+            Self::Predicate { reason, .. } | Self::Handler { reason, .. } => reason,
+        }
+    }
+
+    /// Human-readable name (invariant fn name, or `Contract::function` for handler bugs).
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Predicate { name, .. } | Self::Handler { name, .. } => name,
+        }
+    }
+
     /// Counterexample sequence, when one is available.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub counterexample: Option<CounterExample>,
-    /// Path where the counterexample was persisted for re-running and shrinking.
-    pub persisted_path: std::path::PathBuf,
-    /// Whether this failure is the campaign anchor (the `--mt`-selected invariant). When
-    /// `true` and this is the only failure, the renderer omits the function name on the
-    /// `[FAIL: ...]` line because the test signature on the trailing summary already
-    /// identifies it. Always shown for non-anchor failures and in multi-failure runs.
-    #[serde(default)]
-    pub is_anchor: bool,
+    pub const fn counterexample(&self) -> Option<&CounterExample> {
+        match self {
+            Self::Predicate { counterexample, .. } | Self::Handler { counterexample, .. } => {
+                counterexample.as_ref()
+            }
+        }
+    }
 }
 
 /// The result of an executed test.
@@ -465,6 +504,12 @@ pub struct TestResult {
     /// health line without counting `[FAIL]` blocks. `None` for non-`assert_all` campaigns.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assert_all_invariant_count: Option<usize>,
+
+    /// Handler-side assertion bugs found during the campaign, deduped by
+    /// `(reverter, selector)` site (Medusa/Echidna semantics). Rendered in a dedicated
+    /// `Suite handlers:` section.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub invariant_handler_failures: Vec<InvariantFailure>,
 
     /// Minimal reproduction test case for failing test
     pub counterexample: Option<CounterExample>,
@@ -543,7 +588,10 @@ impl fmt::Display for TestResult {
             }
             TestStatus::Failure => {
                 let mut s = String::new();
-                if self.invariant_failures.is_empty() {
+                let has_handler_failures = !self.invariant_handler_failures.is_empty();
+                let is_invariant_failure =
+                    !self.invariant_failures.is_empty() || has_handler_failures;
+                if !is_invariant_failure {
                     // Non-invariant failure (unit / fuzz / DS-style): render from the legacy
                     // `reason` / `counterexample` fields.
                     s.push_str("[FAIL");
@@ -570,37 +618,32 @@ impl fmt::Display for TestResult {
                     } else {
                         s.push(']');
                     }
-                } else {
-                    // Invariant failure: render every broken invariant uniformly from the
-                    // single `invariant_failures` list (anchor and `assert_all` secondaries
-                    // share the same shape).
-                    //
-                    // Show the invariant function name on the `[FAIL: ...]` line whenever a
-                    // user couldn't otherwise tell which invariant broke:
-                    //   - more than one failure (need disambiguation), or
-                    //   - the single failure isn't the anchor (the anchor's name is already on the
-                    //     trailing `<name>() (runs: ...)` summary; secondary names would otherwise
-                    //     be invisible).
+                } else if !self.invariant_failures.is_empty() {
+                    // Render every broken invariant uniformly. Show the function name on the
+                    // `[FAIL: ...]` line when there is >1 failure or the failure isn't the
+                    // anchor (the anchor's name is already on the trailing summary).
                     let multi = self.invariant_failures.len() > 1;
                     for (i, failure) in self.invariant_failures.iter().enumerate() {
                         if i > 0 {
                             s.push('\n');
                         }
-                        let name_suffix = if multi || !failure.is_anchor {
-                            format!(" {}", failure.name)
+                        // `is_anchor` only applies to predicate failures.
+                        let is_anchor =
+                            matches!(failure, InvariantFailure::Predicate { is_anchor: true, .. });
+                        let name_suffix = if multi || !is_anchor {
+                            format!(" {}", failure.name())
                         } else {
                             String::new()
                         };
-                        // If we have a (shrunk) counterexample, render with the
-                        // `[FAIL: reason]<suffix>\n\t[Sequence] ...` block. Otherwise fall
-                        // back to a `[FAIL: reason]<suffix>` one-liner.
+                        // With a counterexample: full `[FAIL: reason]<suffix>\n\t[Sequence] ...`
+                        // block; otherwise just `[FAIL: reason]<suffix>`.
                         if let Some(CounterExample::Sequence(original, sequence)) =
-                            &failure.counterexample
+                            failure.counterexample()
                         {
                             writeln!(
                                 s,
                                 "[FAIL: {}]{name_suffix}\n\t[Sequence] (original: {original}, shrunk: {})",
-                                failure.reason,
+                                failure.reason(),
                                 sequence.len()
                             )
                             .unwrap();
@@ -608,35 +651,68 @@ impl fmt::Display for TestResult {
                                 writeln!(s, "{ex}").unwrap();
                             }
                         } else {
-                            write!(s, "[FAIL: {}]{name_suffix}", failure.reason).unwrap();
+                            write!(s, "[FAIL: {}]{name_suffix}", failure.reason()).unwrap();
                         }
                     }
-                    // Suite-level roll-up: when `assert_all` exercised more than one invariant
-                    // in this campaign, print a single `Suite assert_all: <broken>/<total>
-                    // invariants broken` line below the per-invariant blocks.
-                    if let Some(total) = self.assert_all_invariant_count
-                        && total > 1
-                    {
-                        writeln!(
-                            s,
-                            "\nSuite assert_all: {}/{total} invariants broken",
-                            self.invariant_failures.len()
-                        )
-                        .unwrap();
-                    }
-                    // Only print the persistence note for multi-invariant campaigns; the
-                    // anchor's persisted counterexample is the long-standing default and
-                    // doesn't need to be advertised on every single-invariant run.
-                    if self.invariant_failures.len() > 1
-                        && let Some(dir) = &self.invariant_failure_dir
-                    {
-                        writeln!(
-                            s,
-                            "{} invariant failure(s) persisted to {} — rerun to shrink",
-                            self.invariant_failures.len(),
-                            dir.display()
-                        )
-                        .unwrap();
+                }
+                // Suite roll-up: `Suite assert_all: <broken>/<total>` for multi-invariant
+                // `assert_all` campaigns.
+                if let Some(total) = self.assert_all_invariant_count
+                    && total > 1
+                    && is_invariant_failure
+                {
+                    writeln!(
+                        s,
+                        "\nSuite assert_all: {}/{total} invariants broken",
+                        self.invariant_failures.len()
+                    )
+                    .unwrap();
+                }
+                // Persistence note only for multi-invariant campaigns; rendered after the
+                // `Suite assert_all:` roll-up.
+                if self.invariant_failures.len() > 1
+                    && let Some(dir) = &self.invariant_failure_dir
+                {
+                    writeln!(
+                        s,
+                        "{} invariant failure(s) persisted to {} — rerun to shrink",
+                        self.invariant_failures.len(),
+                        dir.display()
+                    )
+                    .unwrap();
+                }
+                // Handler-side assertion bug section: bugs *inside* a fuzzed handler function,
+                // distinct from the invariant predicate violations rendered above. Surfaced as
+                // `Suite handlers: N assertion bug(s) found` + one `[FAIL: ...]` per site.
+                if has_handler_failures {
+                    // Leading blank line if a preceding section was rendered.
+                    let preceded = !self.invariant_failures.is_empty()
+                        || matches!(self.assert_all_invariant_count, Some(t) if t > 1);
+                    let prefix = if preceded { "\n" } else { "" };
+                    writeln!(
+                        s,
+                        "{prefix}Suite handlers: {} assertion bug(s) found",
+                        self.invariant_handler_failures.len()
+                    )
+                    .unwrap();
+                    for failure in &self.invariant_handler_failures {
+                        if let Some(CounterExample::Sequence(original, sequence)) =
+                            failure.counterexample()
+                        {
+                            writeln!(
+                                s,
+                                "[FAIL: {}] {}\n\t[Sequence] (original: {original}, shrunk: {})",
+                                failure.reason(),
+                                failure.name(),
+                                sequence.len()
+                            )
+                            .unwrap();
+                            for ex in sequence {
+                                writeln!(s, "{ex}").unwrap();
+                            }
+                        } else {
+                            writeln!(s, "[FAIL: {}] {}", failure.reason(), failure.name()).unwrap();
+                        }
                     }
                 }
                 s.red().wrap().fmt(f)
@@ -844,6 +920,7 @@ impl TestResult {
         invariant_failures: Vec<InvariantFailure>,
         invariant_failure_dir: Option<std::path::PathBuf>,
         assert_all_invariant_count: Option<usize>,
+        invariant_handler_failures: Vec<InvariantFailure>,
         counterexample: Option<CounterExample>,
         cases: Vec<FuzzedCases>,
         reverts: usize,
@@ -868,6 +945,7 @@ impl TestResult {
         self.invariant_failures = invariant_failures;
         self.invariant_failure_dir = invariant_failure_dir;
         self.assert_all_invariant_count = assert_all_invariant_count;
+        self.invariant_handler_failures = invariant_handler_failures;
         // `counterexample` is only used by the renderer for optimization mode (the "best
         // sequence" rendered on success). Invariant check-mode failures live entirely in
         // `invariant_failures`; `reason`/`counterexample` stay `None` for invariant tests.

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -10,11 +10,11 @@ use crate::{
 };
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_json_abi::Function;
-use alloy_primitives::{Address, Bytes, U256, address, map::HashMap};
+use alloy_primitives::{Address, Bytes, Selector, U256, address, map::HashMap};
 use eyre::Result;
 use foundry_common::{TestFunctionExt, TestFunctionKind, contracts::ContractsByAddress};
 use foundry_compilers::utils::canonicalized;
-use foundry_config::{Config, FuzzCorpusConfig};
+use foundry_config::{Config, FuzzCorpusConfig, InvariantConfig};
 use foundry_evm::{
     constants::CALLER,
     core::evm::FoundryEvmNetwork,
@@ -23,8 +23,8 @@ use foundry_evm::{
         CallResult, EvmError, Executor, ITest, RawCallResult,
         fuzz::FuzzedExecutor,
         invariant::{
-            CheckSequenceOptions, InvariantExecutor, InvariantFuzzError, check_sequence,
-            replay_error, replay_run,
+            CheckSequenceOptions, HandlerAssertionFailure, InvariantExecutor, InvariantFuzzError,
+            check_sequence, replay_error, replay_handler_failure_sequence, replay_run,
         },
     },
     fuzz::{
@@ -927,40 +927,25 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             invariant_config.runs,
         );
 
+        let replay_ctx = ReplayContext {
+            invariant_contract: &invariant_contract,
+            invariant_config,
+            revert_decoder: self.revert_decoder(),
+            show_solidity,
+        };
+
         // Try to replay recorded failure if any.
         if let Some(InvariantPersistedFailure { mut call_sequence, assertion_failure, .. }) =
             persisted_call_sequence(failure_file.as_path(), &current_settings)
         {
-            // Create calls from failed sequence and check if invariant still broken.
-            let txes = call_sequence
-                .iter_mut()
-                .map(|seq| {
-                    seq.show_solidity = show_solidity;
-                    BasicTxDetails {
-                        warp: seq.warp,
-                        roll: seq.roll,
-                        sender: seq.sender.unwrap_or_default(),
-                        call_details: CallDetails {
-                            target: seq.addr.unwrap_or_default(),
-                            calldata: seq.calldata.clone(),
-                        },
-                    }
-                })
-                .collect::<Vec<BasicTxDetails>>();
-            if let Ok((success, replayed_entirely, replay_reason)) = check_sequence(
+            let (txes, replay) = replay_persisted_call_sequence(
+                &replay_ctx,
                 self.clone_executor(),
-                &txes,
-                (0..min(txes.len(), invariant_config.depth as usize)).collect(),
-                invariant_contract.address,
-                invariant_contract.anchor().selector().to_vec().into(),
-                CheckSequenceOptions {
-                    accumulate_warp_roll: invariant_config.has_delay(),
-                    fail_on_revert: invariant_config.fail_on_revert,
-                    expect_assertion_failure: assertion_failure,
-                    call_after_invariant: invariant_contract.call_after_invariant,
-                    rd: Some(self.revert_decoder()),
-                },
-            ) && !success
+                &mut call_sequence,
+                assertion_failure,
+            );
+            if let Ok((success, replayed_entirely, replay_reason)) = replay
+                && !success
             {
                 let warn = format!(
                     "Replayed invariant failure from {:?} file. \nRun `forge clean` or remove file to ignore failure and to continue invariant test campaign.",
@@ -1021,12 +1006,22 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             }
         }
 
+        // Replay persisted handler bugs; feed still-reproducing ones into the campaign,
+        // delete stale files in place.
+        let persisted_handler_failures = replay_persisted_handler_failures(
+            &failure_dir.join("handlers"),
+            &current_settings,
+            self.clone_executor(),
+            &replay_ctx,
+        );
+
         let invariant_result = match evm.invariant_fuzz(
             invariant_contract.clone(),
             &self.setup.fuzz_fixtures,
             self.build_fuzz_state(true),
             progress.as_ref(),
             &self.tcfg.early_exit,
+            persisted_handler_failures,
         ) {
             Ok(x) => x,
             Err(e) => {
@@ -1038,7 +1033,9 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         self.result.merge_coverages(invariant_result.line_coverage);
 
         let mut counterexample = None;
-        let success = invariant_result.errors.is_empty();
+        // Success requires zero predicate breaks *and* zero handler-side assertion bugs.
+        let success =
+            invariant_result.errors.is_empty() && invariant_result.handler_errors.is_empty();
         let mut invariant_failures: Vec<InvariantFailure> = vec![];
         let mut any_failure_persisted = false;
 
@@ -1147,8 +1144,10 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         }
                     }
                     InvariantFuzzError::MaxAssumeRejects(_) => None,
+                    // Handler bugs live in `handler_errors`; defensive None here.
+                    InvariantFuzzError::HandlerAssertion(_) => None,
                 };
-                invariant_failures.push(InvariantFailure {
+                invariant_failures.push(InvariantFailure::Predicate {
                     name: invariant_contract.anchor().name.clone(),
                     reason: error.revert_reason().unwrap_or_default(),
                     counterexample: anchor_counterexample,
@@ -1250,7 +1249,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                             }
                         }
                     };
-                    invariant_failures.push(InvariantFailure {
+                    invariant_failures.push(InvariantFailure::Predicate {
                         name: invariant.name.clone(),
                         reason: error.revert_reason().unwrap_or_default(),
                         counterexample: secondary_counterexample,
@@ -1268,12 +1267,85 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         let assert_all_invariant_count = (invariant_config.assert_all
             && invariant_contract.invariant_fns.len() > 1)
             .then_some(invariant_contract.invariant_fns.len());
+
+        // Convert handler-side assertion bugs into render-ready entries. The name is a
+        // best-effort `Contract::function` from `identified_contracts`, falling back to
+        // `0xreverter::0xselector`. Map is keyed by `(reverter, selector)` site so multiple
+        // code paths through the same function collapse to one entry, rendered in the
+        // dedicated `Suite handlers:` section.
+        let identified_contracts_ro = identified_contracts;
+        let invariant_handler_failures = invariant_result
+            .handler_errors
+            .iter()
+            .sorted_by(|(ka, _), (kb, _)| {
+                // Stable order across runs: sort by `(reverter, selector)` site directly.
+                ka.cmp(kb)
+            })
+            .filter_map(|(site, err)| err.as_handler_assertion().map(|f| (site, f)))
+            .map(|(_site, failure)| {
+                let reverter = failure.reverter;
+                let selector = failure.selector;
+                // Resolve `Contract::function` from identified contracts when possible.
+                let resolved_name = identified_contracts_ro
+                    .get(&reverter)
+                    .and_then(|(contract_name, abi)| {
+                        abi.functions()
+                            .find(|f| f.selector() == selector)
+                            .map(|f| format!("{contract_name}::{}", f.name))
+                    })
+                    .unwrap_or_else(|| format!("{reverter}::{selector}"));
+
+                let counterexample_calls = failure
+                    .call_sequence
+                    .iter()
+                    .map(|tx| {
+                        BaseCounterExample::from_invariant_call(
+                            tx,
+                            identified_contracts_ro,
+                            None,
+                            invariant_config.show_solidity,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+
+                // Persist for next-run replay (skip if nothing to record).
+                if !counterexample_calls.is_empty() {
+                    record_handler_failure(
+                        failure_dir.as_path(),
+                        reverter,
+                        selector,
+                        &counterexample_calls,
+                        &current_settings,
+                    );
+                }
+
+                let counterexample = if counterexample_calls.is_empty() {
+                    None
+                } else {
+                    // Preserve pre-shrink length for `(original: N, shrunk: M)` rendering.
+                    Some(CounterExample::Sequence(
+                        failure.original_sequence_len,
+                        counterexample_calls,
+                    ))
+                };
+
+                InvariantFailure::Handler {
+                    name: resolved_name,
+                    reverter,
+                    selector,
+                    reason: failure.revert_reason.clone(),
+                    counterexample,
+                }
+            })
+            .collect::<Vec<_>>();
+
         self.result.invariant_result(
             invariant_result.gas_report_traces,
             success,
             invariant_failures,
             invariant_failure_dir,
             assert_all_invariant_count,
+            invariant_handler_failures,
             counterexample,
             invariant_result.cases,
             invariant_result.reverts,
@@ -1483,6 +1555,17 @@ struct InvariantPersistedFailure {
     assertion_failure: bool,
 }
 
+/// Mirrors `check_sequence`'s return: `(success, replayed_entirely, optional_reason)`.
+type CheckSequenceResult = eyre::Result<(bool, bool, Option<String>)>;
+
+/// Borrowed context shared by primary-invariant and handler-side replay helpers.
+struct ReplayContext<'a> {
+    invariant_contract: &'a InvariantContract<'a>,
+    invariant_config: &'a InvariantConfig,
+    revert_decoder: &'a RevertDecoder,
+    show_solidity: bool,
+}
+
 /// Helper function to load failed call sequence from file.
 /// Ignores failure if generated with different invariant settings than the current ones.
 fn persisted_call_sequence(
@@ -1502,6 +1585,54 @@ fn persisted_call_sequence(
             Some(persisted_failure)
         },
     )
+}
+
+/// Converts a persisted counterexample to `BasicTxDetails`, setting `show_solidity` in place.
+fn base_counterexamples_to_txes(
+    ctx: &ReplayContext<'_>,
+    call_sequence: &mut [BaseCounterExample],
+) -> Vec<BasicTxDetails> {
+    call_sequence
+        .iter_mut()
+        .map(|seq| {
+            seq.show_solidity = ctx.show_solidity;
+            BasicTxDetails {
+                warp: seq.warp,
+                roll: seq.roll,
+                sender: seq.sender.unwrap_or_default(),
+                call_details: CallDetails {
+                    target: seq.addr.unwrap_or_default(),
+                    calldata: seq.calldata.clone(),
+                },
+            }
+        })
+        .collect()
+}
+
+/// Converts a persisted `BaseCounterExample` sequence into `BasicTxDetails` (applying
+/// `ctx.show_solidity` in place) and replays it via `check_sequence`.
+fn replay_persisted_call_sequence<FEN: FoundryEvmNetwork>(
+    ctx: &ReplayContext<'_>,
+    executor: Executor<FEN>,
+    call_sequence: &mut [BaseCounterExample],
+    expect_assertion_failure: bool,
+) -> (Vec<BasicTxDetails>, CheckSequenceResult) {
+    let txes = base_counterexamples_to_txes(ctx, call_sequence);
+    let result = check_sequence(
+        executor,
+        &txes,
+        (0..min(txes.len(), ctx.invariant_config.depth as usize)).collect(),
+        ctx.invariant_contract.address,
+        ctx.invariant_contract.anchor().selector().to_vec().into(),
+        CheckSequenceOptions {
+            accumulate_warp_roll: ctx.invariant_config.has_delay(),
+            fail_on_revert: ctx.invariant_config.fail_on_revert,
+            expect_assertion_failure,
+            call_after_invariant: ctx.invariant_contract.call_after_invariant,
+            rd: Some(ctx.revert_decoder),
+        },
+    );
+    (txes, result)
 }
 
 /// Helper function to set test corpus dir and to compose persisted failure paths.
@@ -1543,4 +1674,111 @@ fn record_invariant_failure(
     ) {
         error!(%err, "Failed to record call sequence");
     }
+}
+
+/// Persists a handler-side assertion bug under `<failure_dir>/handlers/<site>.json`,
+/// where `<site>` is `keccak256(reverter || selector)`.
+fn record_handler_failure(
+    failure_dir: &Path,
+    reverter: Address,
+    selector: Selector,
+    call_sequence: &[BaseCounterExample],
+    settings: &InvariantSettings,
+) {
+    let handlers_dir = failure_dir.join("handlers");
+    if let Err(err) = foundry_common::fs::create_dir_all(&handlers_dir) {
+        error!(%err, "Failed to create handler failure dir");
+        return;
+    }
+    let mut buf = [0u8; 24];
+    buf[..20].copy_from_slice(reverter.as_slice());
+    buf[20..].copy_from_slice(selector.as_slice());
+    let site_hash = alloy_primitives::keccak256(buf);
+    let file = handlers_dir.join(format!("{site_hash:x}.json"));
+    record_invariant_failure(&handlers_dir, &file, call_sequence, settings, true);
+}
+
+/// Replays persisted handler-side assertion bugs. A file is kept only if the anchor still
+/// asserts at the same `(reverter, selector)` site; stale files (anchor no longer asserts,
+/// asserts at a different site, or earlier call asserts) are deleted in place.
+fn replay_persisted_handler_failures<FEN: FoundryEvmNetwork>(
+    handlers_dir: &Path,
+    current_settings: &InvariantSettings,
+    executor: Executor<FEN>,
+    ctx: &ReplayContext<'_>,
+) -> std::collections::HashMap<(Address, Selector), InvariantFuzzError> {
+    let mut replayed: std::collections::HashMap<(Address, Selector), InvariantFuzzError> =
+        std::collections::HashMap::new();
+    let entries = match std::fs::read_dir(handlers_dir) {
+        Ok(e) => e,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return replayed,
+        Err(err) => {
+            error!(%err, "Failed to read handler failure dir");
+            return replayed;
+        }
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(persisted) = persisted_call_sequence(&path, current_settings) else {
+            continue;
+        };
+        let mut call_sequence = persisted.call_sequence;
+        if call_sequence.is_empty() {
+            let _ = std::fs::remove_file(&path);
+            continue;
+        }
+        let txes = base_counterexamples_to_txes(ctx, &mut call_sequence);
+        // Expected site = (target, selector) of the persisted reproducer's last call.
+        let Some(last) = txes.last() else {
+            let _ = std::fs::remove_file(&path);
+            continue;
+        };
+        let expected_target = last.call_details.target;
+        let expected_selector_bytes: [u8; 4] =
+            last.call_details.calldata.get(..4).and_then(|s| s.try_into().ok()).unwrap_or_default();
+        let expected_site = (expected_target, Selector::from(expected_selector_bytes));
+        let sequence: Vec<usize> =
+            (0..min(txes.len(), ctx.invariant_config.depth as usize)).collect();
+        let outcome = replay_handler_failure_sequence(
+            executor.clone(),
+            &txes,
+            sequence,
+            ctx.invariant_config.has_delay(),
+            Some(ctx.revert_decoder),
+        );
+        match outcome {
+            Ok(outcome) if outcome.anchor_asserted => {
+                let _ = sh_warn!(
+                    "Replayed handler-side assertion bug from {path:?}. \nRun `forge clean` or remove file to ignore."
+                );
+                let failure = HandlerAssertionFailure::from_replayed_sequence(
+                    txes,
+                    outcome.anchor_fingerprint,
+                    outcome.revert_reason.unwrap_or_default(),
+                );
+                // On collision keep the shorter reproducer. Inlined: `replayed` uses the legacy
+                // `(reverter, selector)` key, not the unified `FailureKey`.
+                let already_shorter = replayed
+                    .get(&expected_site)
+                    .and_then(InvariantFuzzError::as_handler_assertion)
+                    .is_some_and(|existing| {
+                        existing.call_sequence.len() <= failure.call_sequence.len()
+                    });
+                if !already_shorter {
+                    replayed.insert(expected_site, InvariantFuzzError::HandlerAssertion(failure));
+                }
+            }
+            // Stale: anchor doesn't assert or earlier call asserts.
+            Ok(_) => {
+                let _ = std::fs::remove_file(&path);
+            }
+            Err(err) => {
+                error!(%err, "Failed to replay handler-side assertion bug");
+            }
+        }
+    }
+    replayed
 }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1603,6 +1603,7 @@ fn base_counterexamples_to_txes(
                 call_details: CallDetails {
                     target: seq.addr.unwrap_or_default(),
                     calldata: seq.calldata.clone(),
+                    value: seq.value,
                 },
             }
         })

--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -2698,3 +2698,84 @@ contract InvariantWarp is Test {
 "#
     ]]);
 });
+
+// Test that invariant fuzzer generates random msg.value for payable functions.
+// Based on the example from https://github.com/foundry-rs/foundry/pull/8644
+forgetest_init!(invariant_msg_value, |prj, cmd| {
+    prj.update_config(|config| {
+        config.fuzz.seed = Some(U256::from(42u32));
+        config.invariant.runs = 200;
+        config.invariant.depth = 20;
+    });
+
+    prj.add_test(
+        "InvariantMsgValue.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract ValueTarget {
+    bool public valueReceived;
+
+    // Payable function that tracks if any value was received
+    function deposit() external payable {
+        if (msg.value > 0) {
+            valueReceived = true;
+        }
+    }
+}
+
+contract InvariantMsgValue is Test {
+    ValueTarget target;
+    address sender1;
+    address sender2;
+
+    function setUp() public {
+        target = new ValueTarget();
+        // Create and fund specific senders
+        sender1 = makeAddr("sender1");
+        sender2 = makeAddr("sender2");
+        vm.deal(sender1, 1000 ether);
+        vm.deal(sender2, 1000 ether);
+        // Target only these funded senders
+        targetSender(sender1);
+        targetSender(sender2);
+        // Target only the ValueTarget contract
+        targetContract(address(target));
+    }
+
+    function invariant_value_never_received() public view {
+        require(!target.valueReceived(), "Value was received");
+    }
+}
+"#,
+    );
+
+    // The test should fail because the fuzzer generates msg.value > 0 for payable functions
+    // First check regular output format shows value=X
+    cmd.args(["test", "--mt", "invariant_value_never_received"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
+...
+[FAIL: Value was received]
+	[Sequence] (original: [..], shrunk: 1)
+		sender=[..] addr=[test/InvariantMsgValue.t.sol:ValueTarget][..] value=[..] calldata=deposit() args=[]
+...
+"#]]);
+
+    // Now check solidity output format shows proper {value: X} syntax
+    cmd.forge_fuse().arg("clean").assert_success();
+    prj.update_config(|config| {
+        config.invariant.show_solidity = true;
+    });
+    cmd.forge_fuse()
+        .args(["test", "--mt", "invariant_value_never_received"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
+...
+[FAIL: Value was received]
+	[Sequence] (original: [..], shrunk: 1)
+		vm.prank([..]);
+		ValueTarget([..]).deposit{value: [..]}();
+...
+"#]]);
+});

--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -826,7 +826,7 @@ Ran 1 test for test/InvariantInnerContract.t.sol:InvariantInnerContract
 	[Sequence] (original: 2, shrunk: 2)
 		sender=[..] addr=[test/InvariantInnerContract.t.sol:Jesus][..] calldata=create_fren() args=[]
 		sender=[..] addr=[test/InvariantInnerContract.t.sol:Judas][..] calldata=betray() args=[]
- invariantHideJesus() (runs: 0, calls: 0, reverts: 1)
+ invariantHideJesus() (runs: 256, calls: 258, reverts: 125)
 ...
 "#]]);
     }
@@ -1521,7 +1521,8 @@ contract InvariantFailOnAssertPanic is Test {
     assert_invariant(cmd.args(["test"])).failure().stdout_eq(str![[r#"
 ...
 Ran 1 test for test/InvariantFailOnAssertPanic.t.sol:InvariantFailOnAssertPanic
-[FAIL: panic: assertion failed (0x01)]
+Suite handlers: 1 assertion bug(s) found
+[FAIL: panic: assertion failed (0x01)][..]
 ...
  invariant_fail_on_assert_panic() ([RUNS])
 ...
@@ -1565,7 +1566,8 @@ contract InvariantIgnoreAssertWhenFlagOff is Test {
     assert_invariant(cmd.args(["test"])).failure().stdout_eq(str![[r#"
 ...
 Ran 1 test for test/InvariantIgnoreAssertWhenFlagOff.t.sol:InvariantIgnoreAssertWhenFlagOff
-[FAIL: panic: assertion failed (0x01)]
+Suite handlers: 1 assertion bug(s) found
+[FAIL: panic: assertion failed (0x01)][..]
 ...
  invariant_assert_discarded() ([RUNS])
 ...
@@ -1693,14 +1695,16 @@ contract ReplayFailOnAssertTest is Test {
     cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
 ...
 Ran 1 test for test/InvariantReplayFailOnAssert.t.sol:ReplayFailOnAssertTest
-[FAIL: panic: assertion failed (0x01)]
+Suite handlers: 1 assertion bug(s) found
+[FAIL: panic: assertion failed (0x01)][..]
 ...
 "#]]);
 
     cmd.assert_failure().stdout_eq(str![[r#"
 ...
 Ran 1 test for test/InvariantReplayFailOnAssert.t.sol:ReplayFailOnAssertTest
-[FAIL: panic: assertion failed (0x01)]
+Suite handlers: 1 assertion bug(s) found
+[FAIL: panic: assertion failed (0x01)][..]
 ...
 "#]]);
 });
@@ -1743,7 +1747,8 @@ contract InvariantFailOnVmAssertRevert is Test {
     assert_invariant(cmd.args(["test"])).failure().stdout_eq(str![[r#"
 ...
 Ran 1 test for test/InvariantFailOnVmAssertRevert.t.sol:InvariantFailOnVmAssertRevert
-[FAIL: assertion failed: 1 != 2]
+Suite handlers: 1 assertion bug(s) found
+[FAIL: assertion failed: 1 != 2][..]
 ...
  invariant_fail_on_vm_assert_revert() ([RUNS])
 ...
@@ -1788,7 +1793,8 @@ contract InvariantIgnoreVmAssertWhenFlagOff is Test {
     assert_invariant(cmd.args(["test"])).failure().stdout_eq(str![[r#"
 ...
 Ran 1 test for test/InvariantIgnoreVmAssertWhenFlagOff.t.sol:InvariantIgnoreVmAssertWhenFlagOff
-[FAIL: assertion failed: 1 != 2]
+Suite handlers: 1 assertion bug(s) found
+[FAIL: assertion failed: 1 != 2][..]
 ...
  invariant_vm_assert_discarded() ([RUNS])
 ...
@@ -1834,7 +1840,8 @@ contract InvariantFailOnVmAssertGlobalFlag is Test {
     assert_invariant(cmd.args(["test"])).failure().stdout_eq(str![[r#"
 ...
 Ran 1 test for test/InvariantFailOnVmAssertGlobalFlag.t.sol:InvariantFailOnVmAssertGlobalFlag
-[FAIL: assertion failed]
+Suite handlers: 1 assertion bug(s) found
+[FAIL: assertion failed][..]
 ...
  invariant_fail_on_vm_assert_global_flag() ([RUNS])
 ...
@@ -1880,7 +1887,8 @@ contract InvariantIgnoreVmAssertGlobalFlagWhenFlagOff is Test {
     assert_invariant(cmd.args(["test"])).failure().stdout_eq(str![[r#"
 ...
 Ran 1 test for test/InvariantIgnoreVmAssertGlobalFlagWhenFlagOff.t.sol:InvariantIgnoreVmAssertGlobalFlagWhenFlagOff
-[FAIL: assertion failed]
+Suite handlers: 1 assertion bug(s) found
+[FAIL: assertion failed][..]
 ...
  invariant_vm_assert_global_flag_discarded() ([RUNS])
 ...
@@ -1932,15 +1940,15 @@ contract InvariantShrinkWithAssert is Test {
     cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
 ...
 Ran 2 tests for test/InvariantShrinkWithAssert.t.sol:InvariantShrinkWithAssert
-[FAIL: wrong counter assert]
+[FAIL: wrong counter [..]][..]
 	[Sequence] (original: 2, shrunk: 2)
 ...
- invariant_with_assert() ([..])
+ invariant_with_[..]() ([..])
 ...
-[FAIL: wrong counter require] invariant_with_require
+[FAIL: wrong counter [..]][..]
 	[Sequence] (original: 2, shrunk: 2)
 ...
- invariant_with_require() ([..])
+ invariant_with_[..]() ([..])
 ...
 "#]]);
 });
@@ -2671,7 +2679,7 @@ contract InvariantWarp is Test {
 		vm.roll(block.number + 52068);
 		vm.prank([..]);
 		Roll(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).increment();
- invariant_roll() (runs: 0, calls: 0, reverts: 2)
+ invariant_roll() (runs: 256, calls: 258, reverts: 216)
 ...
 
 "#]]);
@@ -2684,7 +2692,7 @@ contract InvariantWarp is Test {
 		vm.warp(block.timestamp + 656868);
 		vm.prank(0x00000000000000000000000000000000000012d1);
 		Warp(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).increment();
- invariant_warp() (runs: 0, calls: 0, reverts: 2)
+ invariant_warp() (runs: 256, calls: 258, reverts: 222)
 ...
 
 "#

--- a/crates/forge/tests/cli/test_cmd/invariant/handler.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/handler.rs
@@ -665,3 +665,66 @@ contract TwoBranchTest is Test {
         "expected 1 persisted handler bug for two branches in same function, got {entries:?}",
     );
 });
+
+// Regression: with `assertions_revert = false`, a non-reverting `vm.assert*` writes
+// `GLOBAL_FAIL_SLOT = 1` and that committed slot was never cleared, poisoning every
+// subsequent `handlers_succeeded` check and silently suppressing later `assert_invariants`
+// evaluations. Asserts on call #1, then bumps a counter on call #2/#3 to trip a real
+// predicate — both the handler bug AND the predicate failure must be reported.
+forgetest_init!(handler_vm_assert_global_flag_does_not_poison_invariant_checks, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+        config.invariant.depth = 5;
+        config.invariant.fail_on_revert = false;
+        config.invariant.assert_all = true;
+        config.assertions_revert = false;
+    });
+    prj.add_test(
+        "HandlerVmAssertPoisonTest.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract OncePoisonHandler is Test {
+    uint256 public counter;
+    bool public asserted;
+
+    // First call sets GLOBAL_FAIL_SLOT via the non-reverting cheatcode path; later
+    // calls don't re-touch the slot, so invariants only keep getting checked if the
+    // committed slot is cleared after recording the handler bug.
+    function step() external {
+        counter++;
+        if (!asserted) {
+            asserted = true;
+            vm.assertEq(uint256(1), uint256(2));
+        }
+    }
+}
+
+contract HandlerVmAssertPoisonTest is Test {
+    OncePoisonHandler handler;
+
+    function setUp() public {
+        handler = new OncePoisonHandler();
+        targetContract(address(handler));
+    }
+
+    // Holds at counter ∈ {1, 2}, breaks at counter == 3.
+    function invariant_counter_below_three() public view {
+        require(handler.counter() < 3, "counter reached 3");
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_counter_below_three"]).assert_failure().stdout_eq(str![[
+        r#"
+...
+Ran 1 test for test/HandlerVmAssertPoisonTest.t.sol:HandlerVmAssertPoisonTest
+[FAIL: counter reached 3]
+...
+Suite handlers: 1 assertion bug(s) found
+[FAIL: assertion failed] test/HandlerVmAssertPoisonTest.t.sol:OncePoisonHandler::step
+...
+"#
+    ]]);
+});

--- a/crates/forge/tests/cli/test_cmd/invariant/handler.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/handler.rs
@@ -1,0 +1,667 @@
+//! E2E tests for handler-side assertion bugs: dedup by `(reverter, selector)` site,
+//! persistence under `failures/<contract>/handlers/<keccak256(reverter‖selector)>.json`,
+//! replay/shrink semantics, and stale-file cleanup. Distinct from invariant predicate
+//! failures.
+
+use foundry_test_utils::{forgetest_init, str};
+
+// Handler `assert(false)` surfaces under `Suite handlers:`, not as a live invariant failure.
+forgetest_init!(assert_all_handler_assertion_routed_to_handler_section, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+        config.invariant.depth = 10;
+        config.invariant.fail_on_revert = false;
+        config.invariant.assert_all = true;
+    });
+    prj.add_source(
+        "AssertHandler.sol",
+        r#"
+contract AssertHandler {
+    uint256 public calls;
+
+    function alwaysAssert() external {
+        calls++;
+        assert(false);
+    }
+}
+   "#,
+    );
+    prj.add_test(
+        "AssertAllAssertTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {AssertHandler} from "../src/AssertHandler.sol";
+
+contract AssertAllAssertTest is Test {
+    AssertHandler handler;
+
+    function setUp() public {
+        handler = new AssertHandler();
+        targetContract(address(handler));
+    }
+
+    function invariant_a() public view {}
+
+    function invariant_b() public view {}
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_a"]).assert_failure().stdout_eq(str![[r#"
+...
+Ran 1 test for test/AssertAllAssertTest.t.sol:AssertAllAssertTest
+...
+Suite assert_all: 0/2 invariants broken
+
+Suite handlers: 1 assertion bug(s) found
+[FAIL: panic: assertion failed (0x01)] src/AssertHandler.sol:AssertHandler::alwaysAssert
+	[Sequence] (original: [..], shrunk: [..])
+...
+"#]]);
+});
+
+// Site-granular dedup: 4 distinct paths through one selector all share the same
+// `(reverter, selector)` site → 1 persisted bug, shrunk to its anchor. Echidna/Medusa
+// semantics: one bug per `(handler, function)`, regardless of which code path reached it.
+// If the handler is patched to no longer assert, the persisted file is deleted on replay.
+forgetest_init!(handler_assertion_dedupes_by_site, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+        config.invariant.depth = 200;
+        config.invariant.fail_on_revert = false;
+        config.invariant.assert_all = true;
+        config.invariant.corpus.corpus_dir = Some("inv_corpus".into());
+    });
+    prj.add_source(
+        "MultiPathHandler.sol",
+        r#"
+contract MultiPathHandler {
+    uint256 public state;
+
+    // Filler so fuzzing produces a prefix to shrink.
+    function noop() external {}
+
+    // Four branches, one selector — all asserting via the same `(reverter, selector)`
+    // site. Under site-granular dedup these collapse into a single persisted bug
+    // (Echidna/Medusa semantics).
+    function maybeAssert(uint8 path) external {
+        if (path < 64) {
+            state = 1;
+            assert(false);
+        } else if (path < 128) {
+            state = 2;
+            assert(false);
+        } else if (path < 192) {
+            state = 3;
+            assert(false);
+        } else {
+            state = 4;
+            assert(false);
+        }
+    }
+}
+   "#,
+    );
+    prj.add_test(
+        "MultiPathTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {MultiPathHandler} from "../src/MultiPathHandler.sol";
+
+contract MultiPathTest is Test {
+    MultiPathHandler handler;
+
+    function setUp() public {
+        handler = new MultiPathHandler();
+        targetContract(address(handler));
+    }
+
+    function invariant_ok() public view {}
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_ok", "--fuzz-seed", "119"]).assert_failure().stdout_eq(
+        str![[r#"
+...
+Suite handlers: 1 assertion bug(s) found
+[FAIL: panic: assertion failed (0x01)] src/MultiPathHandler.sol:MultiPathHandler::maybeAssert
+	[Sequence] (original: [..], shrunk: 1)
+		sender=[..] addr=[..] calldata=maybeAssert(uint8) args=[..]
+...
+"#]],
+    );
+
+    let handlers_dir = prj
+        .root()
+        .join("cache")
+        .join("invariant")
+        .join("failures")
+        .join("MultiPathTest")
+        .join("handlers");
+    let before: Vec<_> = std::fs::read_dir(&handlers_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .collect();
+    assert_eq!(
+        before.len(),
+        1,
+        "expected 1 persisted handler bug after site-granular dedup, got {before:?}",
+    );
+
+    // Stale-file deletion: patch the handler so `maybeAssert` no longer asserts. On the
+    // next replay the persisted reproducer's anchor stops asserting → the stale file is
+    // deleted in place.
+    prj.add_source(
+        "MultiPathHandler.sol",
+        r#"
+contract MultiPathHandler {
+    uint256 public state;
+    function noop() external {}
+    function maybeAssert(uint8 path) external { state = uint256(path) % 4 + 1; }
+}
+   "#,
+    );
+    prj.update_config(|config| {
+        config.invariant.runs = 0;
+    });
+    // With `runs=0` no new fuzzing happens; the only work is replaying the persisted
+    // reproducer, which now no longer asserts → file deleted → no handler bug → success.
+    cmd.forge_fuse().args(["test", "--mt", "invariant_ok", "--fuzz-seed", "119"]).assert_success();
+
+    let after: Vec<_> = std::fs::read_dir(&handlers_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .collect();
+    assert!(after.is_empty(), "stale handler-bug file should be deleted, got {after:?}");
+});
+
+// Bug persists to `failures/<contract>/handlers/<fingerprint>.json`, replays from disk,
+// and is deleted when stale (handler patched to no-op, or anchor stops asserting while the
+// invariant breaks instead).
+forgetest_init!(handler_assertion_persisted_to_disk, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+        config.invariant.depth = 10;
+        config.invariant.fail_on_revert = false;
+    });
+    prj.add_source(
+        "AlwaysAssert.sol",
+        r#"
+contract AlwaysAssert {
+    function boom() external { assert(false); }
+}
+   "#,
+    );
+    prj.add_test(
+        "AlwaysAssertTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {AlwaysAssert} from "../src/AlwaysAssert.sol";
+
+contract AlwaysAssertTest is Test {
+    AlwaysAssert h;
+    function setUp() public { h = new AlwaysAssert(); targetContract(address(h)); }
+    function invariant_ok() public view {}
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_ok"]).assert_failure();
+
+    let handlers_dir = prj
+        .root()
+        .join("cache")
+        .join("invariant")
+        .join("failures")
+        .join("AlwaysAssertTest")
+        .join("handlers");
+    assert!(handlers_dir.exists(), "handlers dir not created: {handlers_dir:?}");
+    let entries: Vec<_> = std::fs::read_dir(&handlers_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .collect();
+    assert!(!entries.is_empty(), "no handler failure files written");
+
+    // Re-run with `runs = 0` so the campaign cannot rediscover the bug; the failure must
+    // come from replaying the persisted file. Then prove the stale-file deletion path by
+    // pointing the test at a new contract (different selector → no match) and confirming
+    // the orphaned file is removed.
+    prj.update_config(|config| {
+        config.invariant.runs = 0;
+    });
+    cmd.forge_fuse().args(["test", "--mt", "invariant_ok"]).assert_failure().stderr_eq(str![[r#"
+...
+Warning: Replayed handler-side assertion bug from [..]
+...
+"#]]);
+
+    // Sanity check: persisted file is still there after a successful replay.
+    let entries_after: Vec<_> = std::fs::read_dir(&handlers_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .collect();
+    assert_eq!(entries_after.len(), entries.len(), "replayed file should be preserved");
+
+    // Replace the asserting handler with a no-op so the persisted sequence no longer
+    // reproduces. The replay step must delete the stale file in place.
+    prj.add_source(
+        "AlwaysAssert.sol",
+        r#"
+contract AlwaysAssert {
+    function boom() external {}
+}
+   "#,
+    );
+    cmd.forge_fuse().args(["test", "--mt", "invariant_ok"]).assert_success();
+    let entries_stale: Vec<_> = std::fs::read_dir(&handlers_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .collect();
+    assert!(entries_stale.is_empty(), "stale handler failure file should be deleted");
+
+    // A stale handler file co-existing with a primary invariant failure must NOT be
+    // mis-identified as the handler bug that's still reproducing. Re-persist a handler bug
+    // first, then patch the handler to no-op AND make `invariant_ok` assert. Replay must
+    // delete the (now stale) handler file and surface the failure as a primary invariant
+    // failure, not under `Suite handlers:`.
+    prj.add_source(
+        "AlwaysAssert.sol",
+        r#"
+contract AlwaysAssert {
+    function boom() external { assert(false); }
+}
+   "#,
+    );
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+    });
+    cmd.forge_fuse().args(["test", "--mt", "invariant_ok"]).assert_failure();
+    assert!(handlers_dir.read_dir().unwrap().next().is_some(), "handler bug should re-persist");
+
+    prj.add_source(
+        "AlwaysAssert.sol",
+        r#"
+contract AlwaysAssert {
+    function boom() external {}
+}
+   "#,
+    );
+    prj.add_test(
+        "AlwaysAssertTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {AlwaysAssert} from "../src/AlwaysAssert.sol";
+
+contract AlwaysAssertTest is Test {
+    AlwaysAssert h;
+    function setUp() public { h = new AlwaysAssert(); targetContract(address(h)); }
+    function invariant_ok() public { assert(false); }
+}
+   "#,
+    );
+    prj.update_config(|config| {
+        config.invariant.runs = 0;
+    });
+    cmd.forge_fuse().args(["test", "--mt", "invariant_ok"]).assert_failure().stdout_eq(str![[r#"
+...
+[FAIL: panic: assertion failed (0x01)] invariant_ok()[..]
+...
+"#]]);
+    let entries_after: Vec<_> = std::fs::read_dir(&handlers_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .collect();
+    assert!(entries_after.is_empty(), "stale handler file must be deleted, got {entries_after:?}");
+});
+
+// Two distinct handler contracts → two persisted files, both reported.
+forgetest_init!(multi_handler_bugs_each_persist_independently, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+        config.invariant.depth = 20;
+        config.invariant.fail_on_revert = false;
+        config.invariant.assert_all = true;
+    });
+    prj.add_source(
+        "HandlerA.sol",
+        r#"
+contract HandlerA {
+    function boomA() external { assert(false); }
+}
+   "#,
+    );
+    prj.add_source(
+        "HandlerB.sol",
+        r#"
+contract HandlerB {
+    function boomB() external { assert(false); }
+}
+   "#,
+    );
+    prj.add_test(
+        "MultiHandlerTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {HandlerA} from "../src/HandlerA.sol";
+import {HandlerB} from "../src/HandlerB.sol";
+
+contract MultiHandlerTest is Test {
+    HandlerA a;
+    HandlerB b;
+
+    function setUp() public {
+        a = new HandlerA();
+        b = new HandlerB();
+        targetContract(address(a));
+        targetContract(address(b));
+    }
+
+    function invariant_ok() public view {}
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_ok"]).assert_failure().stdout_eq(str![[r#"
+...
+Suite handlers: 2 assertion bug(s) found
+...
+"#]]);
+
+    let handlers_dir = prj
+        .root()
+        .join("cache")
+        .join("invariant")
+        .join("failures")
+        .join("MultiHandlerTest")
+        .join("handlers");
+    let entries: Vec<_> = std::fs::read_dir(&handlers_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .collect();
+    assert_eq!(entries.len(), 2, "expected one persisted file per handler bug");
+});
+
+// Persisted file holds the post-shrink sequence; replay renders `(original: M, shrunk: M)`
+// instead of regrowing.
+forgetest_init!(handler_bug_replay_is_idempotent_after_shrink, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+        config.invariant.depth = 50;
+        config.invariant.fail_on_revert = false;
+    });
+    prj.add_source(
+        "ShrinkableHandler.sol",
+        r#"
+contract ShrinkableHandler {
+    // Filler so the campaign produces a prefix that has to be shrunk away.
+    function noop() external {}
+    function boom() external { assert(false); }
+}
+   "#,
+    );
+    prj.add_test(
+        "ShrinkReplayTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {ShrinkableHandler} from "../src/ShrinkableHandler.sol";
+
+contract ShrinkReplayTest is Test {
+    ShrinkableHandler h;
+    function setUp() public { h = new ShrinkableHandler(); targetContract(address(h)); }
+    function invariant_ok() public view {}
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_ok"]).assert_failure();
+
+    let handlers_dir = prj
+        .root()
+        .join("cache")
+        .join("invariant")
+        .join("failures")
+        .join("ShrinkReplayTest")
+        .join("handlers");
+    let file = std::fs::read_dir(&handlers_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .find(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .expect("persisted handler file");
+    let json: serde_json::Value =
+        serde_json::from_reader(std::fs::File::open(file.path()).unwrap()).unwrap();
+    let persisted_len = json["call_sequence"].as_array().unwrap().len();
+    assert_eq!(persisted_len, 1, "persisted file must hold the shrunk (anchor-only) sequence");
+
+    // Re-run with runs = 0 so the failure must come from replay; assert the rendered
+    // (original: N, shrunk: M) shows N == M == 1, proving replay is idempotent.
+    prj.update_config(|config| {
+        config.invariant.runs = 0;
+    });
+    cmd.forge_fuse().args(["test", "--mt", "invariant_ok"]).assert_failure().stdout_eq(str![[r#"
+...
+Suite handlers: 1 assertion bug(s) found
+[FAIL: panic: assertion failed (0x01)] src/ShrinkableHandler.sol:ShrinkableHandler::boom
+	[Sequence] (original: 1, shrunk: 1)
+		sender=[..] addr=[..] calldata=boom() args=[]
+...
+"#]]);
+});
+
+// `InvariantSettings` change between runs → persisted file is skipped with a warning and
+// left intact for a future compatible run.
+forgetest_init!(handler_persisted_failure_skipped_on_settings_change, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+        config.invariant.depth = 10;
+        config.invariant.fail_on_revert = false;
+    });
+    prj.add_source(
+        "AlwaysAssert.sol",
+        r#"
+contract AlwaysAssert {
+    function boom() external { assert(false); }
+}
+   "#,
+    );
+    prj.add_test(
+        "SettingsChangeTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {AlwaysAssert} from "../src/AlwaysAssert.sol";
+
+contract SettingsChangeTest is Test {
+    AlwaysAssert h;
+    function setUp() public { h = new AlwaysAssert(); targetContract(address(h)); }
+    function invariant_ok() public view {}
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_ok"]).assert_failure();
+
+    let handlers_dir = prj
+        .root()
+        .join("cache")
+        .join("invariant")
+        .join("failures")
+        .join("SettingsChangeTest")
+        .join("handlers");
+    let entries_before: Vec<_> = std::fs::read_dir(&handlers_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .collect();
+    assert_eq!(entries_before.len(), 1, "expected one persisted handler file");
+
+    // Flip a tracked InvariantSettings field (`fail_on_revert`) so the persisted file is
+    // incompatible. Combined with runs = 0, no campaign runs and no replay fires, so the
+    // test must pass.
+    prj.update_config(|config| {
+        config.invariant.fail_on_revert = true;
+        config.invariant.runs = 0;
+    });
+    cmd.forge_fuse().args(["test", "--mt", "invariant_ok"]).assert_success().stderr_eq(str![[r#"
+...
+Warning: Failure from [..] file was ignored because invariant test settings have changed: [..]
+...
+"#]]);
+
+    // Settings-mismatched files must be left intact (only stale-but-compatible files are
+    // deleted), so a future run with the original settings can still pick them up.
+    let entries_after: Vec<_> = std::fs::read_dir(&handlers_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .collect();
+    assert_eq!(entries_after.len(), 1, "settings-incompatible file should be preserved");
+});
+
+// Pre-anchor assertion = different bug: replay must delete the file, not keep it.
+forgetest_init!(handler_persisted_failure_deleted_when_earlier_call_now_asserts, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 50;
+        config.invariant.depth = 20;
+        config.invariant.fail_on_revert = false;
+    });
+    // `boom` only asserts after `setup` was called → persisted sequence must contain both
+    // calls (`setup` cannot be shrunk away without losing the assertion).
+    prj.add_source(
+        "TwoStep.sol",
+        r#"
+contract TwoStep {
+    bool primed;
+    function setup() external { primed = true; }
+    function boom() external { if (primed) assert(false); }
+}
+   "#,
+    );
+    prj.add_test(
+        "TwoStepTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {TwoStep} from "../src/TwoStep.sol";
+
+contract TwoStepTest is Test {
+    TwoStep h;
+    function setUp() public { h = new TwoStep(); targetContract(address(h)); }
+    function invariant_ok() public view {}
+}
+   "#,
+    );
+    cmd.args(["test", "--mt", "invariant_ok"]).assert_failure();
+
+    let handlers_dir = prj
+        .root()
+        .join("cache")
+        .join("invariant")
+        .join("failures")
+        .join("TwoStepTest")
+        .join("handlers");
+    let file = std::fs::read_dir(&handlers_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .find(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .expect("persisted handler file");
+    let json: serde_json::Value =
+        serde_json::from_reader(std::fs::File::open(file.path()).unwrap()).unwrap();
+    let len = json["call_sequence"].as_array().unwrap().len();
+    assert!(len >= 2, "sequence must include both setup() and boom() calls, got {len}");
+
+    // Patch `setup` to assert. Replay now sees a pre-anchor assertion → file is stale.
+    prj.add_source(
+        "TwoStep.sol",
+        r#"
+contract TwoStep {
+    bool primed;
+    function setup() external { assert(false); }
+    function boom() external { if (primed) assert(false); }
+}
+   "#,
+    );
+    prj.update_config(|config| {
+        config.invariant.runs = 0;
+    });
+    cmd.forge_fuse().args(["test", "--mt", "invariant_ok"]).assert_success();
+
+    let entries_after: Vec<_> = std::fs::read_dir(&handlers_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .collect();
+    assert!(
+        entries_after.is_empty(),
+        "stale file (earlier call asserts) must be deleted, got {entries_after:?}"
+    );
+});
+
+// Two branches that both assert in the same handler function collapse to a single
+// persisted bug under site-granular dedup, regardless of whether one branch requires
+// a setup call. The shrinker minimizes the kept reproducer to whichever branch is
+// reachable with the fewest calls (typically the no-setup-required branch).
+forgetest_init!(handler_two_branches_same_function_collapse_to_one_bug, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 100;
+        config.invariant.depth = 20;
+        config.invariant.fail_on_revert = false;
+        config.invariant.assert_all = true;
+        config.invariant.corpus.corpus_dir = Some("inv_corpus".into());
+    });
+    prj.add_source(
+        "TwoBranch.sol",
+        r#"
+contract TwoBranch {
+    bool routed;
+    function route() external { routed = true; }
+    function check() external {
+        if (routed) {
+            assert(false);
+        } else {
+            assert(false);
+        }
+    }
+}
+   "#,
+    );
+    prj.add_test(
+        "TwoBranchTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {TwoBranch} from "../src/TwoBranch.sol";
+
+contract TwoBranchTest is Test {
+    TwoBranch h;
+    function setUp() public { h = new TwoBranch(); targetContract(address(h)); }
+    function invariant_ok() public view {}
+}
+   "#,
+    );
+    cmd.args(["test", "--mt", "invariant_ok"]).assert_failure();
+
+    let handlers_dir = prj
+        .root()
+        .join("cache")
+        .join("invariant")
+        .join("failures")
+        .join("TwoBranchTest")
+        .join("handlers");
+    let entries: Vec<_> = std::fs::read_dir(&handlers_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .collect();
+    // Both branches share `(reverter, check_selector)` → 1 persisted bug under
+    // site-granular dedup.
+    assert_eq!(
+        entries.len(),
+        1,
+        "expected 1 persisted handler bug for two branches in same function, got {entries:?}",
+    );
+});

--- a/crates/forge/tests/cli/test_cmd/invariant/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/mod.rs
@@ -2,6 +2,7 @@ use alloy_primitives::U256;
 use foundry_test_utils::{TestCommand, forgetest_init, snapbox::cmd::OutputAssert, str};
 
 mod common;
+mod handler;
 mod storage;
 mod target;
 
@@ -425,7 +426,7 @@ Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSeque
 		sender=0x0000000000000000000000000000000000001490 addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=increment() args=[]
 		sender=0x8ef7F804bAd9183981A366EA618d9D47D3124649 addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=increment() args=[]
 		sender=0x00000000000000000000000000000000000016C5 addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=setNumber(uint256) args=[284406551521730736391345481857560031052359183671404042152984097777 [2.844e65]]
- invariant_increment() (runs: 0, calls: 0, reverts: 0)
+ invariant_increment() (runs: 256, calls: 258, reverts: 0)
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -454,7 +455,7 @@ Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSeque
 		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).increment();
 		vm.prank(0x00000000000000000000000000000000000016C5);
 		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).setNumber(284406551521730736391345481857560031052359183671404042152984097777);
- invariant_increment() (runs: 0, calls: 0, reverts: 0)
+ invariant_increment() (runs: 256, calls: 258, reverts: 0)
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -608,14 +609,14 @@ contract InvariantReplayFailReason is Test {
 
     cmd.args(["test", "--mt", "invariant_fail_reason"]).assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL: failed to set up invariant testing environment: assertion failed][..]
+[FAIL: assertion failed] invariant_fail_reason() (runs: 1, calls: 1, reverts: 0)
 ...
 "#]]);
 
     // Replay should preserve failure reason instead of generic replay message.
     cmd.assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL: failed to set up invariant testing environment: assertion failed][..]
+[FAIL: assertion failed] invariant_fail_reason() (runs: 1, calls: 1, reverts: 0)
 ...
 "#]]);
 });
@@ -710,14 +711,14 @@ contract InvariantReplayInvariantCustomError is Test {
         .assert_failure()
         .stdout_eq(str![[r#"
 ...
-[FAIL: failed to set up invariant testing environment: InvariantCustomError(222, "invariant custom")][..]
+[FAIL: InvariantCustomError(222, "invariant custom")] invariant_custom_error_reason_from_invariant() (runs: 1, calls: 1, reverts: 0)
 ...
 "#]]);
 
     // Replay should preserve invariant-level custom error string too.
     cmd.assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL: failed to set up invariant testing environment: InvariantCustomError(222, "invariant custom")][..]
+[FAIL: InvariantCustomError(222, "invariant custom")] invariant_custom_error_reason_from_invariant() (runs: 1, calls: 1, reverts: 0)
 ...
 "#]]);
 });
@@ -1489,9 +1490,12 @@ Suite assert_all: 1/2 invariants broken
 "#]]);
 });
 
-// Under `assert_all` + `fail_on_revert = false`, a handler `assert(false)` must still
-// fail the campaign and be attributed to every live invariant.
-forgetest_init!(assert_all_assertion_failure_breaks_all_live_invariants, |prj, cmd| {
+// Under `assert_all` + `fail_on_revert = false`, a handler `assert(false)` is now routed to
+// the dedicated `Suite handlers:` section instead of being attributed to every live invariant
+// (handler-side assertions are decoupled from invariant predicates — see PR #14482). The live
+// invariants stay green; the campaign keeps running for its full budget. See also
+// `handler::assert_all_handler_assertion_routed_to_handler_section`.
+forgetest_init!(assert_all_handler_assertion_does_not_attribute_to_live_invariants, |prj, cmd| {
     prj.update_config(|config| {
         config.invariant.runs = 1;
         config.invariant.depth = 10;
@@ -1535,15 +1539,12 @@ contract AssertAllAssertTest is Test {
     cmd.args(["test", "--mt", "invariant_a"]).assert_failure().stdout_eq(str![[r#"
 ...
 Ran 1 test for test/AssertAllAssertTest.t.sol:AssertAllAssertTest
-[FAIL: panic: assertion failed (0x01)] invariant_a
-	[Sequence] (original: [..], shrunk: [..])
 ...
+Suite assert_all: 0/2 invariants broken
 
-[FAIL: panic: assertion failed (0x01)] invariant_b
+Suite handlers: 1 assertion bug(s) found
+[FAIL: panic: assertion failed (0x01)] src/AssertHandler.sol:AssertHandler::alwaysAssert
 	[Sequence] (original: [..], shrunk: [..])
-...
-
-Suite assert_all: 2/2 invariants broken
 ...
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -943,6 +943,11 @@ Tip: Run `forge test --rerun` to retry only the 1 failed test
 });
 
 forgetest_init!(should_exit_early_on_invariant_failure, |prj, cmd| {
+    // Early-exit semantics require `assert_all = false`; under the post-#12587 default the
+    // campaign runs the full budget and surfaces a different failure shape.
+    prj.update_config(|config| {
+        config.invariant.assert_all = false;
+    });
     prj.add_test(
         "CounterInvariant.t.sol",
         r#"

--- a/crates/forge/tests/fixtures/invariant_traces.svg
+++ b/crates/forge/tests/fixtures/invariant_traces.svg
@@ -39,7 +39,7 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-red">		sender=0xF343C4D80b93a0Aac984Ebf89a625095399CaF11 addr=[test/InvariantOutputTest.t.sol:InvariantOutputTest]0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 calldata=setCond(uint256) args=[115792089237316195423570985008687907853269984665640564039457584007913129639934 </tspan><tspan class="fg-red dimmed">[1.157e77]</tspan><tspan class="fg-red">]</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan> invariant_check_count() (runs: 1, calls: 100, reverts: 0)</tspan>
+    <tspan x="10px" y="190px"><tspan> invariant_check_count() (runs: 10, calls: 126, reverts: 0)</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>Suite result: </tspan><tspan class="fg-red">FAILED</tspan><tspan>. </tspan><tspan class="fg-green">0</tspan><tspan> passed; </tspan><tspan class="fg-red">1</tspan><tspan> failed; </tspan><tspan class="fg-yellow">0</tspan><tspan> skipped; [ELAPSED]</tspan>
 </tspan>
@@ -61,7 +61,7 @@
 </tspan>
     <tspan x="10px" y="370px"><tspan class="fg-red">		sender=0xF343C4D80b93a0Aac984Ebf89a625095399CaF11 addr=[test/InvariantOutputTest.t.sol:InvariantOutputTest]0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 calldata=setCond(uint256) args=[115792089237316195423570985008687907853269984665640564039457584007913129639934 </tspan><tspan class="fg-red dimmed">[1.157e77]</tspan><tspan class="fg-red">]</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan> invariant_check_count() (runs: 1, calls: 100, reverts: 0)</tspan>
+    <tspan x="10px" y="388px"><tspan> invariant_check_count() (runs: 10, calls: 126, reverts: 0)</tspan>
 </tspan>
     <tspan x="10px" y="406px">
 </tspan>


### PR DESCRIPTION
## Summary

Decouple handler-side assertion failures from invariant predicate violations so the campaign can keep running after either class of bug is discovered, dedup handler bugs at the function-entry-point level (Echidna/Medusa semantics), and surface every break live in the pulse stream. Closes #14448.

## Motivation

Today, an `assert(false)` (or `vm.assertEq` failure) inside a fuzzed handler is attributed to every live invariant and aborts the campaign on the first hit. On real targets like Aave v4 SCFuzzbench, this means a single canary in the handler kills 95+% of the time budget — upstream Foundry finds 3 bugs where Echidna/Medusa find 10–11 in the same 24 h window.

## Result on SCFuzzbench (Aave v4)

Reference baseline from the public scfuzzbench leaderboard ([run 1772801774](https://scfuzzbench.com/runs/1772801774/454f886c9668a94e8595de32219ce2b9), 4 instances per fuzzer, target `v0.5.6-recon`). All four tools count **unique public-function entry points** that triggered an assertion failure, so the comparison is apples-to-apples on dedup granularity.

| Fuzzer | Version | 1 h (per-instance median [IQR]) | 24 h cumulative |
|---|---|---|---|
| Echidna | 2.3.1 | 8 [7,8] | 11 |
| Medusa | 1.4.1 | 6 [5,6] | 10 |
| Foundry baseline | v1.6.0-rc1 (`aviggiano/foundry@master`) | 3 [3,3] (plateaus at 6 min) | 3 |
| **Foundry-on-PR** | this PR | **8** (single 1 h run, no seed, fresh corpus) | TBD |

Single 1 h run found 8 / 11 of the reachable bug universe: `assert_canary`, `iHub_mintFeeShares`, `iSpoke_withdraw`, `invariant_canary`, `invariant_shouldNotBecomeLiquidatable`, `invariant_totalBorrowedLessThanSupplied_v0/v1/v2`. First Foundry build to break `iHub_mintFeeShares`, `iSpoke_withdraw`, and the three `totalBorrowedLessThanSupplied_*` invariants on this benchmark. Missing: `iSpoke_liquidationCall`, `iSpoke_repay`, `invariant_supplySharePriceAndDrawnIndexMonotonic` (Echidna-exclusive in 24 h baseline), `invariant_totalBorrowedSharesMatchesSpokeSum`.

**Update (1 h re-run on current commit):** A 1 h fixed-seed re-run on the latest code additionally surfaced `iSpoke_supply_ASSERTION_SUPPLY_DOS` — a handler-side assertion that **neither Echidna (24 h × 4 instances) nor Medusa surface in the SCFuzzbench leaderboard**. The bug isn't in the public 11-bug "reachable" universe at all, so this PR's handler-bug machinery is the first to expose it. The same run also independently re-confirmed `iSpoke_repay`, which is in the Echidna+Medusa shared set but had been missed by upstream Foundry.

## What changes

- **Separate failure class.** Handler-side assertion bugs are recorded in a new `broken_handlers: HashMap<(Address, Selector), HandlerAssertionFailure>` map (keyed by the asserting call's `(reverter, selector)` site) and deduplicated so each unique handler bug is reported once. Same handler asserting through N distinct code paths counts as **one** bug, matching what Echidna and Medusa report (Echidna explicitly cannot tell multiple asserts in the same function apart; Medusa surfaces one bug per failing function).
- **Site-granular dedup with smaller-reproducer rule.** On `(reverter, selector)` collision the entry with the shortest `call_sequence` wins, so persisted reproducers stay minimal as the campaign progresses.
- **Dedicated report section.** Bugs render under `Suite handlers: N assertion bug(s) found` with full reason + counterexample, separate from the per-invariant `[FAIL: ...]` blocks.
- **Continuous campaign under `assert_all`.** Preflight handler bugs are recorded and the campaign keeps running for the full budget instead of aborting on the first hit.
- **Live telemetry.** Progress bar and JSON pulse events surface unique `broken_handlers` counts alongside invariant `unique_failures`. Persisted handler bugs are pre-seeded before the run loop so they appear from the first emission.
- **Persistence + replay.** Each broken handler is written to `<failure_dir>/handlers/<site_hash>.json` where `site_hash = keccak256(reverter || selector)` — independent of edge coverage and stable across runs. Reuses `InvariantPersistedFailure` with `assertion_failure: true`. At campaign start every persisted file is replayed via `check_sequence`; bugs that still reproduce are merged into `handler_errors` (shortest-wins on collision), files that no longer reproduce are deleted in place, and settings-incompatible files are left untouched.
- **Post-campaign shrinking.** Each handler bug's call sequence is shrunk by the same shrink-loop driver used for invariant counterexamples. Intermediate calls that themselves assert are rejected so shrinking can't silently promote a different finding. The renderer surfaces `(original: N, shrunk: M)` matching invariant counterexamples.

## Known limitations / TODO

- **Multi-assertion dedup within the same handler.** When a single `(reverter, selector)` function contains multiple distinct `assert(...)` / `t(...)` calls, our key collapses them all to one bug. Echidna has the same limitation by design ("Echidna cannot determine which assertion failed"). If finer attribution becomes useful, extend the dedup key with a stable per-call discriminator (revert reason hash, source location, or label string).
