### PR TITLE
fix(config): warn instead of erroring on unknown FOUNDRY_PROFILE

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -847,12 +847,15 @@ impl Config {
         // Check if the selected profile exists.
         if config.profiles.contains(&selected_profile) {
             config.profile = selected_profile;
-        } else if strict_profile {
-            return Err(ExtractConfigError::new(Error::from(format!(
-                "selected profile `{selected_profile}` does not exist"
-            ))));
         } else {
-            // Fall back to default profile for nested lib configs.
+            // Fall back to the default profile. In strict mode (top-level loads), emit a warning
+            // so users are informed when an unknown profile (e.g. via `FOUNDRY_PROFILE`) is
+            // selected; the silent fallback is reserved for nested lib configs.
+            if strict_profile {
+                config.warnings.push(Warning::UnknownProfile {
+                    profile: selected_profile.to_string(),
+                });
+            }
             config.profile = Self::DEFAULT_PROFILE;
         }
 
@@ -7024,9 +7027,9 @@ mod tests {
         });
     }
 
-    // Test for issue #12844: FOUNDRY_PROFILE=nonexistent should fail
+    // Test for issue #12844: FOUNDRY_PROFILE=nonexistent should warn and fall back to default.
     #[test]
-    fn fails_on_unknown_profile() {
+    fn warns_on_unknown_profile() {
         figment::Jail::expect_with(|jail| {
             jail.create_file(
                 "foundry.toml",
@@ -7037,11 +7040,15 @@ mod tests {
             )?;
 
             jail.set_env("FOUNDRY_PROFILE", "nonexistent");
-            let err = Config::load().expect_err("expected unknown profile to fail");
-            let err_msg = err.to_string();
+            let cfg = Config::load().expect("expected unknown profile to fall back to default");
+            assert_eq!(cfg.profile, Config::DEFAULT_PROFILE);
             assert!(
-                err_msg.contains("selected profile `nonexistent` does not exist"),
-                "Expected error about nonexistent profile, got: {err_msg}"
+                cfg.warnings.iter().any(|w| matches!(
+                    w,
+                    crate::Warning::UnknownProfile { profile } if profile == "nonexistent"
+                )),
+                "Expected UnknownProfile warning, got: {:?}",
+                cfg.warnings
             );
 
             Ok(())

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -852,9 +852,9 @@ impl Config {
             // so users are informed when an unknown profile (e.g. via `FOUNDRY_PROFILE`) is
             // selected; the silent fallback is reserved for nested lib configs.
             if strict_profile {
-                config.warnings.push(Warning::UnknownProfile {
-                    profile: selected_profile.to_string(),
-                });
+                config
+                    .warnings
+                    .push(Warning::UnknownProfile { profile: selected_profile.to_string() });
             }
             config.profile = Self::DEFAULT_PROFILE;
         }

--- a/crates/config/src/warning.rs
+++ b/crates/config/src/warning.rs
@@ -64,6 +64,12 @@ pub enum Warning {
         /// The config file where the key was found
         source: String,
     },
+    /// The selected profile (via `FOUNDRY_PROFILE` or otherwise) does not exist in the config.
+    /// Falls back to the default profile.
+    UnknownProfile {
+        /// The selected profile that does not exist
+        profile: String,
+    },
 }
 
 impl fmt::Display for Warning {
@@ -115,6 +121,12 @@ impl fmt::Display for Warning {
                 write!(
                     f,
                     "Found unknown `{key}` config key in section `{section}` defined in {source}."
+                )
+            }
+            Self::UnknownProfile { profile } => {
+                write!(
+                    f,
+                    "Selected profile `{profile}` does not exist; falling back to the default profile."
                 )
             }
         }


### PR DESCRIPTION
## Motivation

Currently, setting `FOUNDRY_PROFILE` to a profile that isn't defined in `foundry.toml` aborts the command with:

```
Error: failed to extract foundry config:
foundry config error: selected profile `ci` does not exist
```

This is annoying when an env-driven `FOUNDRY_PROFILE=ci` is set globally but a particular project only defines `[profile.default]`.

## Solution

Treat an unknown selected profile as a warning instead of a fatal error: fall back to the `default` profile and emit a new `Warning::UnknownProfile` so users are still informed.

```
FOUNDRY_PROFILE=ci forge fmt
Warning: Selected profile `ci` does not exist; falling back to the default profile.
```

The lenient behaviour for nested lib configs (`from_figment_fallback`) is preserved as-is.

## Notes

- New variant: `Warning::UnknownProfile { profile }`.
- Updated test `fails_on_unknown_profile` -> `warns_on_unknown_profile`.