### PR TITLE
fix(ext): bump forge-std commit in external integration tests

### DIFF
--- a/crates/forge/tests/cli/ext_integration.rs
+++ b/crates/forge/tests/cli/ext_integration.rs
@@ -6,7 +6,7 @@ use foundry_test_utils::util::ExtTester;
 // <https://github.com/foundry-rs/forge-std>
 #[test]
 fn forge_std() {
-    ExtTester::new("foundry-rs", "forge-std", "b69e66b0ff79924d487d49bf7fb47c9ec326acba")
+    ExtTester::new("foundry-rs", "forge-std", "8987040ede9553cea20c95ad40d0455930f9c8e0")
         // Skip fork tests.
         .args(["--nmc", "Fork"])
         .verbosity(2)


### PR DESCRIPTION
Aims to resolve https://github.com/foundry-rs/foundry/actions/runs/25096368257/job/73555748907

There are other outdated ext integration test commit revs, updating this in a separate PR