### PR TITLE
fix(tests): restore env vars after config tests

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -867,6 +867,28 @@ mod tests {
     use super::*;
     use std::{env, net::Ipv4Addr};
 
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = env::var_os(key);
+            unsafe { env::set_var(key, value) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => unsafe { env::set_var(self.key, value) },
+                None => unsafe { env::remove_var(self.key) },
+            }
+        }
+    }
+
     #[test]
     fn test_parse_fork_url() {
         let fork: ForkUrl = "http://localhost:8545@1000000".parse().unwrap();
@@ -1002,11 +1024,11 @@ mod tests {
             ["::1", "1.1.1.1", "2.2.2.2"].map(|ip| ip.parse::<IpAddr>().unwrap()).to_vec()
         );
 
-        unsafe { env::set_var("ANVIL_IP_ADDR", "1.1.1.1") };
+        let _anvil_ip_addr = EnvGuard::set("ANVIL_IP_ADDR", "1.1.1.1");
         let args = NodeArgs::parse_from(["anvil"]);
         assert_eq!(args.host, vec!["1.1.1.1".parse::<IpAddr>().unwrap()]);
 
-        unsafe { env::set_var("ANVIL_IP_ADDR", "::1,1.1.1.1,2.2.2.2") };
+        let _anvil_ip_addr = EnvGuard::set("ANVIL_IP_ADDR", "::1,1.1.1.1,2.2.2.2");
         let args = NodeArgs::parse_from(["anvil"]);
         assert_eq!(
             args.host,

--- a/crates/cast/src/cmd/storage.rs
+++ b/crates/cast/src/cmd/storage.rs
@@ -395,19 +395,36 @@ const fn is_storage_layout_empty(storage_layout: &Option<StorageLayout>) -> bool
 mod tests {
     use super::*;
 
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
     #[test]
     fn parse_storage_etherscan_api_key() {
         let args =
             StorageArgs::parse_from(["foundry-cli", "addr.eth", "--etherscan-api-key", "dummykey"]);
         assert_eq!(args.etherscan.key(), Some("dummykey".to_string()));
 
-        unsafe {
-            std::env::set_var("ETHERSCAN_API_KEY", "FXY");
-        }
+        let _etherscan_key = EnvGuard::set("ETHERSCAN_API_KEY", "FXY");
         let config = args.load_config().unwrap();
-        unsafe {
-            std::env::remove_var("ETHERSCAN_API_KEY");
-        }
         assert_eq!(config.etherscan_api_key, Some("dummykey".to_string()));
 
         let key = config.get_etherscan_api_key(None).unwrap();

--- a/crates/common/src/provider/mpp/keys.rs
+++ b/crates/common/src/provider/mpp/keys.rs
@@ -133,6 +133,34 @@ mod tests {
         (dir, keys_path)
     }
 
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::remove_var(key) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
     #[test]
     fn discover_from_tempo_home_keys_toml() {
         let key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
@@ -147,15 +175,11 @@ chain_id = 4217
         );
         let (dir, _) = setup_keys_toml(&toml_content);
 
-        unsafe {
-            std::env::set_var("TEMPO_HOME", dir.path());
-            std::env::remove_var("TEMPO_PRIVATE_KEY");
-        }
+        let _tempo_home = EnvGuard::set("TEMPO_HOME", dir.path());
+        let _tempo_private_key = EnvGuard::remove("TEMPO_PRIVATE_KEY");
 
         let discovered = discover_mpp_key();
         assert_eq!(discovered.as_deref(), Some(key));
-
-        unsafe { std::env::remove_var("TEMPO_HOME") };
     }
 
     #[test]
@@ -171,33 +195,22 @@ key = "{file_key}"
         );
         let (dir, _) = setup_keys_toml(&toml_content);
 
-        unsafe {
-            std::env::set_var("TEMPO_HOME", dir.path());
-            std::env::set_var("TEMPO_PRIVATE_KEY", env_key);
-        }
+        let _tempo_home = EnvGuard::set("TEMPO_HOME", dir.path());
+        let _tempo_private_key = EnvGuard::set("TEMPO_PRIVATE_KEY", env_key);
 
         let discovered = discover_mpp_key();
         assert_eq!(discovered.as_deref(), Some(env_key));
-
-        unsafe {
-            std::env::remove_var("TEMPO_HOME");
-            std::env::remove_var("TEMPO_PRIVATE_KEY");
-        }
     }
 
     #[test]
     fn discover_returns_none_when_no_keys() {
         let (dir, _) = setup_keys_toml("");
 
-        unsafe {
-            std::env::set_var("TEMPO_HOME", dir.path());
-            std::env::remove_var("TEMPO_PRIVATE_KEY");
-        }
+        let _tempo_home = EnvGuard::set("TEMPO_HOME", dir.path());
+        let _tempo_private_key = EnvGuard::remove("TEMPO_PRIVATE_KEY");
 
         let discovered = discover_mpp_key();
         assert!(discovered.is_none());
-
-        unsafe { std::env::remove_var("TEMPO_HOME") };
     }
 
     #[test]
@@ -217,15 +230,11 @@ chain_id = 4217
         );
         let (dir, _) = setup_keys_toml(&toml_content);
 
-        unsafe {
-            std::env::set_var("TEMPO_HOME", dir.path());
-            std::env::remove_var("TEMPO_PRIVATE_KEY");
-        }
+        let _tempo_home = EnvGuard::set("TEMPO_HOME", dir.path());
+        let _tempo_private_key = EnvGuard::remove("TEMPO_PRIVATE_KEY");
 
         let discovered = discover_mpp_key();
         assert_eq!(discovered.as_deref(), Some(key));
-
-        unsafe { std::env::remove_var("TEMPO_HOME") };
     }
 
     #[test]
@@ -362,10 +371,8 @@ chain_id = 42431
 "#
         );
         let (dir, _) = setup_keys_toml(&toml_content);
-        unsafe {
-            std::env::set_var("TEMPO_HOME", dir.path());
-            std::env::remove_var("TEMPO_PRIVATE_KEY");
-        }
+        let _tempo_home = EnvGuard::set("TEMPO_HOME", dir.path());
+        let _tempo_private_key = EnvGuard::remove("TEMPO_PRIVATE_KEY");
 
         // Filter by testnet chain_id → returns testnet key (even though mainnet is first)
         let config =
@@ -403,7 +410,7 @@ chain_id = 4217
 "#
         );
         let (dir2, _) = setup_keys_toml(&toml_mixed);
-        unsafe { std::env::set_var("TEMPO_HOME", dir2.path()) };
+        let _tempo_home2 = EnvGuard::set("TEMPO_HOME", dir2.path());
 
         let config =
             discover_mpp_config(DiscoverOptions { chain_id: Some(4217), ..Default::default() });
@@ -412,8 +419,6 @@ chain_id = 4217
             testnet_key,
             "passkey should win over local within the same chain_id"
         );
-
-        unsafe { std::env::remove_var("TEMPO_HOME") };
     }
 
     #[test]

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -674,6 +674,34 @@ mod tests {
         },
     };
 
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::remove_var(key) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
     #[derive(Clone, Debug)]
     struct MockPaymentProvider;
 
@@ -873,10 +901,8 @@ mod tests {
 
         let (base_url, handle) = spawn_server(app).await;
 
-        unsafe {
-            std::env::set_var("TEMPO_HOME", "/nonexistent/path");
-            std::env::remove_var("TEMPO_PRIVATE_KEY");
-        }
+        let _tempo_home = EnvGuard::set("TEMPO_HOME", "/nonexistent/path");
+        let _tempo_private_key = EnvGuard::remove("TEMPO_PRIVATE_KEY");
 
         let transport = RuntimeTransportBuilder::new(Url::parse(&base_url).unwrap()).build();
         let err = transport.request(test_request()).await.unwrap_err();
@@ -888,7 +914,6 @@ mod tests {
         );
 
         handle.abort();
-        unsafe { std::env::remove_var("TEMPO_HOME") };
     }
 
     #[test]

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -29,6 +29,28 @@ use std::{
     thread,
 };
 
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
 const DEFAULT_CONFIG: &str = r#"[profile.default]
 src = "src"
 test = "test"
@@ -567,15 +589,10 @@ forgetest_init!(can_get_evm_opts, |prj, _cmd| {
     assert_eq!(config.eth_rpc_url, Some(url.to_string()));
     assert!(config.ffi);
 
-    unsafe {
-        std::env::set_var("FOUNDRY_ETH_RPC_URL", url);
-    }
+    let _rpc_url = EnvGuard::set("FOUNDRY_ETH_RPC_URL", url);
     let figment = Config::figment_with_root(prj.root()).merge(("debug", false));
     let evm_opts: EvmOpts = figment.extract().unwrap();
     assert_eq!(evm_opts.fork_url, Some(url.to_string()));
-    unsafe {
-        std::env::remove_var("FOUNDRY_ETH_RPC_URL");
-    }
 });
 
 // checks that we can set various config values

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -827,6 +827,28 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
     #[test]
     fn can_parse_sig() {
         let sig = "0x522bb704000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfFFb92266";
@@ -975,9 +997,7 @@ mod tests {
 
         assert!(err.downcast::<UnresolvedEnvVarError>().is_ok());
 
-        unsafe {
-            std::env::set_var("_CAN_EXTRACT_RPC_ALIAS", "123456");
-        }
+        let _rpc_alias = EnvGuard::set("_CAN_EXTRACT_RPC_ALIAS", "123456");
         let (config, evm_opts) = args.load_config_and_evm_opts().unwrap();
         assert_eq!(config.eth_rpc_url, Some("polygonAmoy".to_string()));
         assert_eq!(
@@ -1017,12 +1037,8 @@ mod tests {
 
         assert!(err.downcast::<UnresolvedEnvVarError>().is_ok());
 
-        unsafe {
-            std::env::set_var("_EXTRACT_RPC_ALIAS", "123456");
-        }
-        unsafe {
-            std::env::set_var("_ETHERSCAN_API_KEY", "etherscan_api_key");
-        }
+        let _rpc_alias = EnvGuard::set("_EXTRACT_RPC_ALIAS", "123456");
+        let _etherscan_key = EnvGuard::set("_ETHERSCAN_API_KEY", "etherscan_api_key");
         let (config, evm_opts) = args.load_config_and_evm_opts().unwrap();
         assert_eq!(config.eth_rpc_url, Some("amoy".to_string()));
         assert_eq!(
@@ -1064,12 +1080,8 @@ mod tests {
 
         assert!(err.downcast::<UnresolvedEnvVarError>().is_ok());
 
-        unsafe {
-            std::env::set_var("_SOLE_EXTRACT_RPC_ALIAS", "123456");
-        }
-        unsafe {
-            std::env::set_var("_SOLE_ETHERSCAN_API_KEY", "etherscan_api_key");
-        }
+        let _rpc_alias = EnvGuard::set("_SOLE_EXTRACT_RPC_ALIAS", "123456");
+        let _etherscan_key = EnvGuard::set("_SOLE_ETHERSCAN_API_KEY", "etherscan_api_key");
         let (config, evm_opts) = args.load_config_and_evm_opts().unwrap();
         assert_eq!(
             evm_opts.fork_url,


### PR DESCRIPTION
## Motivation

Several tests mutate process environment variables directly. If a test panics or runs near another env-sensitive test, those mutations can leak and create order-dependent failures.

## Solution

Add small scoped environment guards in the affected test modules and replace raw `set_var`/`remove_var` cleanup with drop-based restoration of the previous value.