### PR TITLE
test(fmt): cover erc7201 layout formatting

### DIFF
--- a/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
@@ -56,4 +56,4 @@ contract ERC7201Short layout at erc7201("s") is Base { }
 
 contract ERC7201Mid layout at erc7201("openzeppelin.med") is Base { }
 
-contract ERC7201Medium layout at erc7201("openzeppelin.storage.med") is Base { }
+contract ERC7201OverMax layout at erc7201("openzeppelin.storage.exceeds.max") is Base { }

--- a/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
@@ -51,3 +51,9 @@ contract AnotherContract is
 { }
 
 contract WithLayoutAndBase layout at 69 is Base { }
+
+contract ERC7201Short layout at erc7201("s") is Base { }
+
+contract ERC7201Mid layout at erc7201("openzeppelin.med") is Base { }
+
+contract ERC7201Medium layout at erc7201("openzeppelin.storage.med") is Base { }

--- a/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
@@ -62,3 +62,9 @@ contract AnotherContract is
 {}
 
 contract WithLayoutAndBase layout at 69 is Base {}
+
+contract ERC7201Short layout at erc7201("s") is Base {}
+
+contract ERC7201Mid layout at erc7201("openzeppelin.med") is Base {}
+
+contract ERC7201Medium layout at erc7201("openzeppelin.storage.med") is Base {}

--- a/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
@@ -67,4 +67,7 @@ contract ERC7201Short layout at erc7201("s") is Base {}
 
 contract ERC7201Mid layout at erc7201("openzeppelin.med") is Base {}
 
-contract ERC7201Medium layout at erc7201("openzeppelin.storage.med") is Base {}
+contract ERC7201OverMax layout at erc7201("openzeppelin.storage.exceeds.max")
+    is
+    Base
+{}

--- a/crates/fmt/testdata/ContractDefinition/fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/fmt.sol
@@ -57,3 +57,9 @@ contract AnotherContract is
 {}
 
 contract WithLayoutAndBase layout at 69 is Base {}
+
+contract ERC7201Short layout at erc7201("s") is Base {}
+
+contract ERC7201Mid layout at erc7201("openzeppelin.med") is Base {}
+
+contract ERC7201Medium layout at erc7201("openzeppelin.storage.med") is Base {}

--- a/crates/fmt/testdata/ContractDefinition/fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/fmt.sol
@@ -62,4 +62,7 @@ contract ERC7201Short layout at erc7201("s") is Base {}
 
 contract ERC7201Mid layout at erc7201("openzeppelin.med") is Base {}
 
-contract ERC7201Medium layout at erc7201("openzeppelin.storage.med") is Base {}
+contract ERC7201OverMax layout at erc7201("openzeppelin.storage.exceeds.max")
+    is
+    Base
+{}

--- a/crates/fmt/testdata/ContractDefinition/original.sol
+++ b/crates/fmt/testdata/ContractDefinition/original.sol
@@ -52,4 +52,4 @@ contract AnotherContract is
 contract WithLayoutAndBase layout at 69 is Base {}
 contract ERC7201Short layout at erc7201("s") is Base {}
 contract ERC7201Mid layout at erc7201("openzeppelin.med") is Base {}
-contract ERC7201Medium layout at erc7201("openzeppelin.storage.med") is Base {}
+contract ERC7201OverMax layout at erc7201("openzeppelin.storage.exceeds.max") is Base {}

--- a/crates/fmt/testdata/ContractDefinition/original.sol
+++ b/crates/fmt/testdata/ContractDefinition/original.sol
@@ -50,3 +50,6 @@ contract AnotherContract is
 { }
 
 contract WithLayoutAndBase layout at 69 is Base {}
+contract ERC7201Short layout at erc7201("s") is Base {}
+contract ERC7201Mid layout at erc7201("openzeppelin.med") is Base {}
+contract ERC7201Medium layout at erc7201("openzeppelin.storage.med") is Base {}


### PR DESCRIPTION
## Summary
- add a formatter regression fixture for `layout at erc7201("...")`
- cover the new Solidity 0.8.35 comptime builtin without changing formatter logic

## Testing
- `cargo fmt --all`
- attempted `cargo test -p forge-fmt ContractDefinition -- --exact --nocapture` but crates.io dependency fetches were rate-limited with HTTP 429 in the sandbox
