### PR TITLE
feat(config): add experimental SSA CFG section

### DIFF
--- a/crates/config/src/experimental.rs
+++ b/crates/config/src/experimental.rs
@@ -1,0 +1,29 @@
+//! Experimental Solidity compiler configuration.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExperimentalConfig {
+    /// Enable Solidity's experimental SSA CFG backend.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub via_ssa_cfg: Option<bool>,
+}
+
+impl ExperimentalConfig {
+    pub const fn is_empty(&self) -> bool {
+        self.via_ssa_cfg.is_none()
+    }
+
+    pub fn extend_solc_cli_args(&self, extra_args: &mut Vec<String>) {
+        if self.via_ssa_cfg == Some(true) {
+            Self::push_arg(extra_args, "--experimental");
+            Self::push_arg(extra_args, "--via-ssa-cfg");
+        }
+    }
+
+    fn push_arg(extra_args: &mut Vec<String>, arg: &str) {
+        if !extra_args.iter().any(|existing| existing == arg) {
+            extra_args.push(arg.to_string());
+        }
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -113,6 +113,9 @@ pub use invariant::InvariantConfig;
 mod inline;
 pub use inline::{InlineConfig, InlineConfigError, NatSpec};
 
+mod experimental;
+pub use experimental::ExperimentalConfig;
+
 pub mod soldeer;
 use soldeer::{SoldeerConfig, SoldeerDependencyConfig};
 
@@ -446,6 +449,9 @@ pub struct Config {
     /// If set to true, changes compilation pipeline to go through the Yul intermediate
     /// representation.
     pub via_ir: bool,
+    /// Experimental Solidity compiler configuration.
+    #[serde(default, skip_serializing_if = "ExperimentalConfig::is_empty")]
+    pub experimental: ExperimentalConfig,
     /// Whether to include the AST as JSON in the compiler output.
     pub ast: bool,
     /// RPC storage caching settings determines what chains and endpoints to cache
@@ -1772,8 +1778,10 @@ impl Config {
             settings = settings.with_ast();
         }
 
-        let cli_settings =
-            CliSettings { extra_args: self.extra_args.clone(), ..Default::default() };
+        let mut extra_args = self.extra_args.clone();
+        self.experimental.extend_solc_cli_args(&mut extra_args);
+
+        let cli_settings = CliSettings { extra_args, ..Default::default() };
 
         Ok(SolcSettings { settings, cli_settings })
     }
@@ -2614,6 +2622,7 @@ impl Default for Config {
             deny: DenyLevel::Never,
             deny_warnings: false,
             via_ir: false,
+            experimental: Default::default(),
             ast: false,
             rpc_storage_caching: Default::default(),
             rpc_endpoints: Default::default(),
@@ -5243,6 +5252,36 @@ mod tests {
 
             Ok(())
         });
+    }
+
+    #[test]
+    fn test_parse_experimental() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default.experimental]
+                via_ssa_cfg = true
+            "#,
+            )?;
+
+            let config = Config::load().unwrap();
+            assert_eq!(config.experimental, ExperimentalConfig { via_ssa_cfg: Some(true) });
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_experimental_via_ssa_cfg_extends_solc_extra_args() {
+        let config = Config {
+            extra_args: vec!["--experimental".to_string()],
+            experimental: ExperimentalConfig { via_ssa_cfg: Some(true) },
+            ..Config::default()
+        };
+
+        let settings = config.solc_settings().unwrap();
+        assert_eq!(settings.cli_settings.extra_args, vec!["--experimental", "--via-ssa-cfg"]);
     }
 
     #[test]

--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -29,6 +29,9 @@ const SETTINGS_OVERRIDES_KEYS: &[&str] =
 /// causing the default serialization to produce an empty dict.
 const VYPER_KEYS: &[&str] = &["optimize", "path", "experimental_codegen"];
 
+/// Allowed keys for nested experimental config.
+const EXPERIMENTAL_KEYS: &[&str] = &["via_ssa_cfg"];
+
 /// Allowed keys for DocConfig.
 /// Required because DocConfig uses `skip_serializing_if = "Option::is_none"` on some fields
 /// (`repository`, `path`), whose defaults are `None` and thus excluded from serialization.
@@ -269,6 +272,8 @@ impl<P: Provider> WarningsProvider<P> {
             // so the default serialization produces an empty dict. Use explicit keys instead.
             let allowed_keys: BTreeSet<String> = if key == "vyper" {
                 VYPER_KEYS.iter().map(|s| s.to_string()).collect()
+            } else if key == "experimental" {
+                EXPERIMENTAL_KEYS.iter().map(|s| s.to_string()).collect()
             } else if key == "doc" {
                 DOC_KEYS.iter().map(|s| s.to_string()).collect()
             } else {

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -7,8 +7,8 @@ use foundry_compilers::{
     solc::Solc,
 };
 use foundry_config::{
-    CompilationRestrictions, Config, FsPermissions, FuzzConfig, FuzzCorpusConfig, InvariantConfig,
-    SettingsOverrides, SolcReq,
+    CompilationRestrictions, Config, ExperimentalConfig, FsPermissions, FuzzConfig,
+    FuzzCorpusConfig, InvariantConfig, SettingsOverrides, SolcReq,
     cache::{CachedChains, CachedEndpoints, StorageCachingConfig},
     filter::GlobMatcher,
     fs_permissions::{FsAccessPermission, PathPermission},
@@ -342,6 +342,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         deny: foundry_config::DenyLevel::Never,
         deny_warnings: false,
         via_ir: true,
+        experimental: ExperimentalConfig { via_ssa_cfg: Some(true) },
         ast: false,
         rpc_storage_caching: StorageCachingConfig {
             chains: CachedChains::None,


### PR DESCRIPTION
## Summary
- add a nested `[profile.default.experimental]` config section
- expose the experimental SSA CFG backend as `via_ssa_cfg = true`
- thread that setting through Foundry's existing `solc` extra-args path as `--experimental --via-ssa-cfg`
- add parsing and config coverage for the new section

## Testing
- `cargo fmt --all`
- attempted `cargo test -p foundry-config test_parse_experimental -- --exact --nocapture`
- attempted `cargo test -p foundry-config test_experimental_via_ssa_cfg_extends_solc_extra_args -- --exact --nocapture`
- both targeted tests were blocked by crates.io dependency fetches being rate-limited with HTTP 429 in the sandbox
