### PR TITLE
feat(forge): use network = "tempo" and add rpc_endpoints in tempo template

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2870,10 +2870,7 @@ impl BasicConfig {
         {
             table.insert("network".to_string(), toml::Value::String(network.clone()));
             if network == "tempo" {
-                table.insert(
-                    "eth_rpc_url".to_string(),
-                    toml::Value::String("tempo".to_string()),
-                );
+                table.insert("eth_rpc_url".to_string(), toml::Value::String("tempo".to_string()));
             }
         }
         let s = toml::to_string_pretty(&value)?;

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2869,6 +2869,12 @@ impl BasicConfig {
             && let toml::Value::Table(ref mut table) = value
         {
             table.insert("network".to_string(), toml::Value::String(network.clone()));
+            if network == "tempo" {
+                table.insert(
+                    "eth_rpc_url".to_string(),
+                    toml::Value::String("tempo".to_string()),
+                );
+            }
         }
         let s = toml::to_string_pretty(&value)?;
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2864,29 +2864,35 @@ impl BasicConfig {
     ///
     /// This serializes to a table with the name of the profile
     pub fn to_string_pretty(&self) -> Result<String, toml::ser::Error> {
-        let mut value = toml::Value::try_from(self)?;
+        let mut profile_body = toml::Value::try_from(self)?;
         if let Some(ref network) = self.network
-            && let toml::Value::Table(ref mut table) = value
+            && let toml::Value::Table(ref mut table) = profile_body
         {
             table.insert("network".to_string(), toml::Value::String(network.clone()));
         }
-        let s = toml::to_string_pretty(&value)?;
 
-        let rpc_endpoints = if self.network.as_deref() == Some("tempo") {
-            "\n\
-[rpc_endpoints]\n\
-tempo = \"https://rpc.tempo.xyz/\"\n\
-moderato = \"https://rpc.moderato.tempo.xyz/\"\n"
-        } else {
-            ""
-        };
+        let mut profile_section = toml::value::Table::new();
+        profile_section.insert(self.profile.to_string(), profile_body);
 
+        let mut document = toml::value::Table::new();
+        document.insert("profile".to_string(), toml::Value::Table(profile_section));
+
+        if self.network.as_deref() == Some("tempo") {
+            let mut endpoints = toml::value::Table::new();
+            endpoints.insert(
+                "tempo".to_string(),
+                toml::Value::String("https://rpc.tempo.xyz/".to_string()),
+            );
+            endpoints.insert(
+                "moderato".to_string(),
+                toml::Value::String("https://rpc.moderato.tempo.xyz/".to_string()),
+            );
+            document.insert("rpc_endpoints".to_string(), toml::Value::Table(endpoints));
+        }
+
+        let body = toml::to_string_pretty(&toml::Value::Table(document))?;
         Ok(format!(
-            "\
-[profile.{}]
-{s}{rpc_endpoints}
-# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options\n",
-            self.profile
+            "{body}\n# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options\n"
         ))
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2869,9 +2869,6 @@ impl BasicConfig {
             && let toml::Value::Table(ref mut table) = value
         {
             table.insert("network".to_string(), toml::Value::String(network.clone()));
-            if network == "tempo" {
-                table.insert("eth_rpc_url".to_string(), toml::Value::String("tempo".to_string()));
-            }
         }
         let s = toml::to_string_pretty(&value)?;
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2868,13 +2868,23 @@ impl BasicConfig {
         if let Some(ref network) = self.network
             && let toml::Value::Table(ref mut table) = value
         {
-            table.insert(network.clone(), toml::Value::Boolean(true));
+            table.insert("network".to_string(), toml::Value::String(network.clone()));
         }
         let s = toml::to_string_pretty(&value)?;
+
+        let rpc_endpoints = if self.network.as_deref() == Some("tempo") {
+            "\n\
+[rpc_endpoints]\n\
+tempo = \"https://rpc.tempo.xyz/\"\n\
+moderato = \"https://rpc.moderato.tempo.xyz/\"\n"
+        } else {
+            ""
+        };
+
         Ok(format!(
             "\
 [profile.{}]
-{s}
+{s}{rpc_endpoints}
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options\n",
             self.profile
         ))

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -916,11 +916,18 @@ Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: N
 
     assert!(prj.root().join("foundry.toml").exists());
 
-    // Verify foundry.toml contains `tempo = true` so subsequent commands auto-detect the network.
+    // Verify foundry.toml contains `network = "tempo"` so subsequent commands auto-detect the
+    // network.
     let foundry_toml = std::fs::read_to_string(prj.root().join("foundry.toml")).unwrap();
     assert!(
-        foundry_toml.contains("tempo = true"),
-        "foundry.toml should contain `tempo = true`, got:\n{foundry_toml}"
+        foundry_toml.contains("network = \"tempo\""),
+        "foundry.toml should contain `network = \"tempo\"`, got:\n{foundry_toml}"
+    );
+    assert!(
+        foundry_toml.contains("[rpc_endpoints]")
+            && foundry_toml.contains("tempo = \"https://rpc.tempo.xyz/\"")
+            && foundry_toml.contains("moderato = \"https://rpc.moderato.tempo.xyz/\""),
+        "foundry.toml should contain tempo rpc_endpoints, got:\n{foundry_toml}"
     );
 
     assert!(prj.root().join("lib/forge-std").exists());

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -924,6 +924,10 @@ Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: N
         "foundry.toml should contain `network = \"tempo\"`, got:\n{foundry_toml}"
     );
     assert!(
+        foundry_toml.contains("eth_rpc_url = \"tempo\""),
+        "foundry.toml should contain `eth_rpc_url = \"tempo\"`, got:\n{foundry_toml}"
+    );
+    assert!(
         foundry_toml.contains("[rpc_endpoints]")
             && foundry_toml.contains("tempo = \"https://rpc.tempo.xyz/\"")
             && foundry_toml.contains("moderato = \"https://rpc.moderato.tempo.xyz/\""),

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -924,10 +924,6 @@ Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: N
         "foundry.toml should contain `network = \"tempo\"`, got:\n{foundry_toml}"
     );
     assert!(
-        foundry_toml.contains("eth_rpc_url = \"tempo\""),
-        "foundry.toml should contain `eth_rpc_url = \"tempo\"`, got:\n{foundry_toml}"
-    );
-    assert!(
         foundry_toml.contains("[rpc_endpoints]")
             && foundry_toml.contains("tempo = \"https://rpc.tempo.xyz/\"")
             && foundry_toml.contains("moderato = \"https://rpc.moderato.tempo.xyz/\""),


### PR DESCRIPTION
Updates the `forge init --network tempo` template so the generated `foundry.toml` uses `network = "tempo"` instead of the legacy `tempo = true`, and ships the Tempo RPC aliases out of the box.

```toml
[profile.default]
src = "src"
out = "out"
libs = ["lib"]
network = "tempo"

[rpc_endpoints]
tempo = "https://rpc.tempo.xyz/"
moderato = "https://rpc.moderato.tempo.xyz/"
```

- `network = "tempo"` is the canonical, non-deprecated form (legacy `tempo = true` is still parsed for back-compat).
- The `tempo` and `moderato` aliases are usable immediately via `--rpc-url` / `--fork-url` after `forge init`.