### PR TITLE
refactor(chisel): migrate to solar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,15 +1670,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii-canvas"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2890,7 +2881,6 @@ dependencies = [
  "foundry-compilers",
  "foundry-config",
  "foundry-evm",
- "foundry-solang-parser",
  "foundry-test-utils",
  "itertools 0.14.0",
  "reqwest 0.13.2",
@@ -4185,15 +4175,6 @@ dependencies = [
  "pest_derive",
  "quick-xml 0.39.2",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "ena"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -5553,20 +5534,6 @@ dependencies = [
  "tempo-alloy",
  "tempo-primitives",
  "tempo-revm",
-]
-
-[[package]]
-name = "foundry-solang-parser"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9645e75b89f977423690f3b4bfd8d84825e5fdabd7803cbce6d4a2c4d54972b4"
-dependencies = [
- "itertools 0.14.0",
- "lalrpop",
- "lalrpop-util",
- "phf 0.11.3",
- "thiserror 2.0.18",
- "unicode-xid",
 ]
 
 [[package]]
@@ -6932,37 +6899,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
-dependencies = [
- "ascii-canvas",
- "bit-set",
- "ena",
- "itertools 0.14.0",
- "lalrpop-util",
- "petgraph",
- "regex",
- "regex-syntax",
- "sha3",
- "string_cache 0.8.9",
- "term",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
-dependencies = [
- "regex-automata",
- "rustversion",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8143,16 +8079,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
-dependencies = [
- "fixedbitset",
- "indexmap 2.14.0",
-]
-
-[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8168,7 +8094,6 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -8178,7 +8103,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
+ "phf_macros",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -8221,19 +8146,6 @@ checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
  "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -11013,18 +10925,6 @@ checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.11.3",
- "precomputed-hash",
-]
-
-[[package]]
-name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
@@ -11500,15 +11400,6 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
-]
-
-[[package]]
-name = "term"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12830,7 +12721,7 @@ checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
- "string_cache 0.9.0",
+ "string_cache",
  "string_cache_codegen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,9 +174,6 @@ foundry-compilers.opt-level = 3
 serde_json.opt-level = 3
 serde.opt-level = 3
 
-foundry-solang-parser.opt-level = 3
-lalrpop-util.opt-level = 3
-
 solar-compiler.opt-level = 3
 solar-ast.opt-level = 3
 solar-data-structures.opt-level = 3
@@ -349,7 +346,6 @@ foundry-compilers = { version = "0.20.0", default-features = false, features = [
     "svm-solc",
 ] }
 foundry-fork-db = { version = "0.26.0", features = ["zstd"] }
-solang-parser = { version = "=0.3.9", package = "foundry-solang-parser" }
 solar = { package = "solar-compiler", version = "=0.1.8", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false, features = [
     "rustls",

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -49,7 +49,6 @@ itertools.workspace = true
 semver.workspace = true
 serde_json.workspace = true
 serde.workspace = true
-solang-parser.workspace = true
 time = { version = "0.3", features = ["formatting"] }
 yansi.workspace = true
 tracing.workspace = true

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -16,7 +16,10 @@ use solar::{
     ast::{BinOpKind, ElementaryType, FunctionKind, LitKind, StateMutability, StrKind, UnOpKind},
     interface::Symbol,
     sema::{
-        hir::{self, Visibility},
+        hir::{
+            ContractId, Event, Expr, ExprKind, Function, ItemId, Res, StmtKind, Type as HirType,
+            TypeKind, Visibility,
+        },
         ty::{Gcx, Ty, TyKind},
     },
 };
@@ -142,10 +145,10 @@ impl SessionSource {
             // and pull out the first call argument.
             let block = out.run_func_body();
             let last = block.last()?;
-            let hir::StmtKind::DeclSingle(vid) = last.kind else { return None };
+            let StmtKind::DeclSingle(vid) = last.kind else { return None };
             let var = gcx.hir.variable(vid);
             let init = var.initializer?;
-            let hir::ExprKind::Call(_callee, args, _) = &init.kind else { return None };
+            let ExprKind::Call(_callee, args, _) = &init.kind else { return None };
             let inner_expr = args.exprs().next()?;
 
             // If the call is `func()` returning a single value, prefer the function return type.
@@ -247,13 +250,13 @@ fn lookup_named_variable_type(gcx: Gcx<'_>, name: &str) -> Option<DynSolType> {
     let body = hir.function(run_fid).body?;
     for stmt in body.stmts {
         match stmt.kind {
-            hir::StmtKind::DeclSingle(vid) => {
+            StmtKind::DeclSingle(vid) => {
                 let var = hir.variable(vid);
                 if var.name.map(|n| n.as_str() == name).unwrap_or(false) {
                     return solar_ty_to_dyn(gcx, gcx.type_of_item(vid.into()));
                 }
             }
-            hir::StmtKind::DeclMulti(vids, _) => {
+            StmtKind::DeclMulti(vids, _) => {
                 for vid in vids.iter().flatten() {
                     let var = hir.variable(*vid);
                     if var.name.map(|n| n.as_str() == name).unwrap_or(false) {
@@ -371,7 +374,7 @@ fn format_token(token: DynSolValue) -> String {
 
 /// Formats an [`hir::Event`] into an inspection message.
 // TODO: Verbosity option
-fn format_event_definition(gcx: Gcx<'_>, event: &hir::Event<'_>) -> Result<String> {
+fn format_event_definition(gcx: Gcx<'_>, event: &Event<'_>) -> Result<String> {
     let event_name = event.name.as_str().to_string();
     let inputs = event
         .parameters
@@ -454,15 +457,15 @@ enum Type {
 
 impl Type {
     /// Convert a [`hir::Expr`] to a [`Type`].
-    fn from_expr(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> Option<Self> {
+    fn from_expr(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<Self> {
         match &expr.kind {
             // Elementary type expression: `uint256`, `address`, etc.
-            hir::ExprKind::Type(ty) => Self::from_hir_ty(gcx, ty),
+            ExprKind::Type(ty) => Self::from_hir_ty(gcx, ty),
 
             // `type(T)` expression. Modelled like a call to a builtin `type` function so that
             // member access (e.g. `type(C).name` or `type(uint256).max`) can be resolved by
             // [`Self::map_special`].
-            hir::ExprKind::TypeCall(ty) => {
+            ExprKind::TypeCall(ty) => {
                 let inner = Self::from_hir_ty(gcx, ty);
                 Some(Self::Function(
                     Box::new(Self::Custom(vec![Symbol::intern("type")])),
@@ -472,11 +475,11 @@ impl Type {
             }
 
             // Resolved identifier: `foo`.
-            hir::ExprKind::Ident(reses) => {
+            ExprKind::Ident(reses) => {
                 let res = reses.first()?;
                 match *res {
-                    hir::Res::Item(item) => match item {
-                        hir::ItemId::Variable(vid) => {
+                    Res::Item(item) => match item {
+                        ItemId::Variable(vid) => {
                             let var = gcx.hir.variable(vid);
                             let name = var.name?.name;
                             // Try the resolved solar type first.
@@ -487,16 +490,16 @@ impl Type {
                                 Some(Self::Custom(vec![name]))
                             }
                         }
-                        hir::ItemId::Function(fid) => {
+                        ItemId::Function(fid) => {
                             let func = gcx.hir.function(fid);
                             let name = func.name?.name;
                             Some(Self::Custom(vec![name]))
                         }
-                        hir::ItemId::Contract(cid) => {
+                        ItemId::Contract(cid) => {
                             let c = gcx.hir.contract(cid);
                             Some(Self::Custom(vec![c.name.name]))
                         }
-                        hir::ItemId::Struct(sid) => {
+                        ItemId::Struct(sid) => {
                             // Struct constructor: produces a value of the struct type, which we
                             // model as a tuple of field types.
                             let fields = gcx.struct_field_types(sid);
@@ -506,35 +509,35 @@ impl Type {
                                 .collect();
                             Some(Self::Tuple(parts))
                         }
-                        hir::ItemId::Enum(eid) => {
+                        ItemId::Enum(eid) => {
                             let e = gcx.hir.enumm(eid);
                             Some(Self::Custom(vec![e.name.name]))
                         }
-                        hir::ItemId::Udvt(uid) => {
+                        ItemId::Udvt(uid) => {
                             let u = gcx.hir.udvt(uid);
                             Some(Self::Custom(vec![u.name.name]))
                         }
-                        hir::ItemId::Error(eid) => {
+                        ItemId::Error(eid) => {
                             let e = gcx.hir.error(eid);
                             Some(Self::Custom(vec![e.name.name]))
                         }
-                        hir::ItemId::Event(eid) => {
+                        ItemId::Event(eid) => {
                             let e = gcx.hir.event(eid);
                             Some(Self::Custom(vec![e.name.name]))
                         }
                     },
-                    hir::Res::Builtin(b) => Some(Self::Custom(vec![b.name()])),
-                    hir::Res::Namespace(_) | hir::Res::Err(_) => None,
+                    Res::Builtin(b) => Some(Self::Custom(vec![b.name()])),
+                    Res::Namespace(_) | Res::Err(_) => None,
                 }
             }
 
             // Index/access: `arr[i]`, `MyType[]`.
-            hir::ExprKind::Index(base, idx) => Self::from_expr(gcx, base).map(|ty| {
+            ExprKind::Index(base, idx) => Self::from_expr(gcx, base).map(|ty| {
                 let boxed = Box::new(ty);
                 let num =
                     idx.and_then(|e| parse_number_literal(e)).and_then(|n| usize::try_from(n).ok());
                 match &base.kind {
-                    hir::ExprKind::Type(_) | hir::ExprKind::TypeCall(_) => {
+                    ExprKind::Type(_) | ExprKind::TypeCall(_) => {
                         if let Some(num) = num {
                             Self::FixedArray(boxed, num)
                         } else {
@@ -546,40 +549,40 @@ impl Type {
             }),
 
             // Slice expression: `arr[a:b]`.
-            hir::ExprKind::Slice(base, _, _) => Self::from_expr(gcx, base),
+            ExprKind::Slice(base, _, _) => Self::from_expr(gcx, base),
 
             // Array literal `[a, b, c]`.
-            hir::ExprKind::Array(values) => values
+            ExprKind::Array(values) => values
                 .first()
                 .and_then(|e| Self::from_expr(gcx, e))
                 .map(|ty| Self::FixedArray(Box::new(ty), values.len())),
 
             // Tuple expression `(a, b, c)`.
-            hir::ExprKind::Tuple(items) => Some(Self::Tuple(
+            ExprKind::Tuple(items) => Some(Self::Tuple(
                 items.iter().map(|opt| opt.and_then(|e| Self::from_expr(gcx, e))).collect(),
             )),
 
             // Member access `lhs.rhs`.
-            hir::ExprKind::Member(lhs, ident) => {
+            ExprKind::Member(lhs, ident) => {
                 Self::from_expr(gcx, lhs).map(|lhs| Self::Access(Box::new(lhs), ident.name))
             }
 
             // `new T`.
-            hir::ExprKind::New(ty) => Self::from_hir_ty(gcx, ty),
+            ExprKind::New(ty) => Self::from_hir_ty(gcx, ty),
 
             // `payable(addr)`.
-            hir::ExprKind::Payable(_) => Some(Self::Builtin(DynSolType::Address)),
+            ExprKind::Payable(_) => Some(Self::Builtin(DynSolType::Address)),
 
             // Ternary: prefer truthy branch's type, fall back to else branch.
-            hir::ExprKind::Ternary(_, t, e) => {
+            ExprKind::Ternary(_, t, e) => {
                 Self::from_expr(gcx, t).or_else(|| Self::from_expr(gcx, e))
             }
 
             // Delete expression has no usable type.
-            hir::ExprKind::Delete(_) => None,
+            ExprKind::Delete(_) => None,
 
             // Literals.
-            hir::ExprKind::Lit(lit) => match &lit.kind {
+            ExprKind::Lit(lit) => match &lit.kind {
                 LitKind::Address(_) => Some(Self::Builtin(DynSolType::Address)),
                 LitKind::Bool(_) => Some(Self::Builtin(DynSolType::Bool)),
                 LitKind::Str(kind, _, _) => match kind {
@@ -593,7 +596,7 @@ impl Type {
             },
 
             // Unary operations.
-            hir::ExprKind::Unary(op, inner) => match op.kind {
+            ExprKind::Unary(op, inner) => match op.kind {
                 UnOpKind::Neg => Self::from_expr(gcx, inner).map(Self::invert_int),
                 UnOpKind::Not => Some(Self::Builtin(DynSolType::Bool)),
                 UnOpKind::BitNot
@@ -604,7 +607,7 @@ impl Type {
             },
 
             // Binary operations.
-            hir::ExprKind::Binary(lhs, op, rhs) => match op.kind {
+            ExprKind::Binary(lhs, op, rhs) => match op.kind {
                 BinOpKind::Lt
                 | BinOpKind::Le
                 | BinOpKind::Gt
@@ -636,23 +639,23 @@ impl Type {
             },
 
             // Assignments: type of the lhs.
-            hir::ExprKind::Assign(lhs, _, _) => Self::from_expr(gcx, lhs),
+            ExprKind::Assign(lhs, _, _) => Self::from_expr(gcx, lhs),
 
             // Function call.
-            hir::ExprKind::Call(callee, args, _named) => Self::from_expr(gcx, callee).map(|name| {
+            ExprKind::Call(callee, args, _named) => Self::from_expr(gcx, callee).map(|name| {
                 let args = args.exprs().map(|e| Self::from_expr(gcx, e)).collect();
                 Self::Function(Box::new(name), args, vec![])
             }),
 
-            hir::ExprKind::Err(_) => None,
+            ExprKind::Err(_) => None,
         }
     }
 
     /// Convert a [`hir::Type`] to a [`Type`].
-    fn from_hir_ty(gcx: Gcx<'_>, ty: &hir::Type<'_>) -> Option<Self> {
+    fn from_hir_ty(gcx: Gcx<'_>, ty: &HirType<'_>) -> Option<Self> {
         match &ty.kind {
-            hir::TypeKind::Elementary(et) => Some(Self::Builtin(elementary_to_dyn(*et)?)),
-            hir::TypeKind::Array(arr) => {
+            TypeKind::Elementary(et) => Some(Self::Builtin(elementary_to_dyn(*et)?)),
+            TypeKind::Array(arr) => {
                 let elem = Self::from_hir_ty(gcx, &arr.element)?;
                 if let Some(size) = arr.size {
                     let n = parse_number_literal(size).and_then(|n| usize::try_from(n).ok());
@@ -665,7 +668,7 @@ impl Type {
                     Some(Self::Array(Box::new(elem)))
                 }
             }
-            hir::TypeKind::Function(f) => {
+            TypeKind::Function(f) => {
                 let params = f
                     .parameters
                     .iter()
@@ -688,25 +691,25 @@ impl Type {
                     returns,
                 ))
             }
-            hir::TypeKind::Mapping(m) => Self::from_hir_ty(gcx, &m.value),
-            hir::TypeKind::Custom(item) => {
+            TypeKind::Mapping(m) => Self::from_hir_ty(gcx, &m.value),
+            TypeKind::Custom(item) => {
                 // User-defined type names always become `Custom([name])` here, mirroring the
                 // legacy pt-based engine where custom names came in via `Variable(name)` rather
                 // than the elementary `from_type` path. Conversion to a concrete `DynSolType`
                 // (e.g. struct → tuple, udvt → underlying) happens later in `try_as_ethabi`.
                 let name = match *item {
-                    hir::ItemId::Contract(id) => gcx.hir.contract(id).name.name,
-                    hir::ItemId::Struct(id) => gcx.hir.strukt(id).name.name,
-                    hir::ItemId::Enum(id) => gcx.hir.enumm(id).name.name,
-                    hir::ItemId::Udvt(id) => gcx.hir.udvt(id).name.name,
-                    hir::ItemId::Error(id) => gcx.hir.error(id).name.name,
-                    hir::ItemId::Event(id) => gcx.hir.event(id).name.name,
-                    hir::ItemId::Function(id) => gcx.hir.function(id).name?.name,
-                    hir::ItemId::Variable(id) => gcx.hir.variable(id).name?.name,
+                    ItemId::Contract(id) => gcx.hir.contract(id).name.name,
+                    ItemId::Struct(id) => gcx.hir.strukt(id).name.name,
+                    ItemId::Enum(id) => gcx.hir.enumm(id).name.name,
+                    ItemId::Udvt(id) => gcx.hir.udvt(id).name.name,
+                    ItemId::Error(id) => gcx.hir.error(id).name.name,
+                    ItemId::Event(id) => gcx.hir.event(id).name.name,
+                    ItemId::Function(id) => gcx.hir.function(id).name?.name,
+                    ItemId::Variable(id) => gcx.hir.variable(id).name?.name,
                 };
                 Some(Self::Custom(vec![name]))
             }
-            hir::TypeKind::Err(_) => {
+            TypeKind::Err(_) => {
                 // Best-effort fallback: when name resolution failed, recover the textual name
                 // from the source span so the inference engine can still treat it as a custom
                 // type (e.g., `type(C).name` where contract `C` does not exist).
@@ -871,7 +874,7 @@ impl Type {
     fn infer_custom_type(
         gcx: Gcx<'_>,
         custom_type: &mut Vec<Symbol>,
-        contract_id: Option<hir::ContractId>,
+        contract_id: Option<ContractId>,
     ) -> Result<Option<DynSolType>> {
         if let Some(last) = custom_type.last()
             && (last.as_str() == "this" || last.as_str() == "super")
@@ -917,7 +920,7 @@ impl Type {
                 let ret_id = func.returns[0];
                 let ret_var = hir.variable(ret_id);
                 // If the return type is a custom (user-defined) type, recurse on the same contract.
-                if let hir::TypeKind::Custom(_) = &ret_var.ty.kind
+                if let TypeKind::Custom(_) = &ret_var.ty.kind
                     && let Some(t) = Self::from_hir_ty(gcx, &ret_var.ty)
                 {
                     return Ok(t.try_as_ethabi(true, Some(gcx)));
@@ -952,7 +955,7 @@ impl Type {
 
             // Struct?
             if let Some(sid) = contract.items.iter().find_map(|i| {
-                if let hir::ItemId::Struct(sid) = i
+                if let ItemId::Struct(sid) = i
                     && hir.strukt(*sid).name.as_str() == cur
                 {
                     Some(*sid)
@@ -1006,7 +1009,7 @@ impl Type {
     /// Infers the type from a variable's HIR type.
     fn infer_var_ty(
         gcx: Gcx<'_>,
-        ty: &hir::Type<'_>,
+        ty: &HirType<'_>,
         custom_type: &mut Vec<Symbol>,
     ) -> Result<Option<DynSolType>> {
         let res: Option<DynSolType> = if let Some(t) = Self::from_hir_ty(gcx, ty) {
@@ -1063,21 +1066,21 @@ impl Type {
     }
 
     /// Equivalent to `Type::from_expr` + `Type::map_special` + `Type::try_as_ethabi`.
-    fn ethabi(gcx: Gcx<'_>, expr: &hir::Expr<'_>, lookup: bool) -> Option<DynSolType> {
+    fn ethabi(gcx: Gcx<'_>, expr: &Expr<'_>, lookup: bool) -> Option<DynSolType> {
         Self::from_expr(gcx, expr)
             .map(Self::map_special)
             .and_then(|ty| ty.try_as_ethabi(lookup, Some(gcx)))
     }
 
     /// Get the return type of a function call expression.
-    fn get_function_return_type<'a>(gcx: Gcx<'_>, expr: &'a hir::Expr<'a>) -> Option<DynSolType> {
-        let hir::ExprKind::Call(callee, _, _) = &expr.kind else { return None };
-        let hir::ExprKind::Member(obj, fn_ident) = &callee.kind else { return None };
+    fn get_function_return_type<'a>(gcx: Gcx<'_>, expr: &'a Expr<'a>) -> Option<DynSolType> {
+        let ExprKind::Call(callee, _, _) = &expr.kind else { return None };
+        let ExprKind::Member(obj, fn_ident) = &callee.kind else { return None };
         // The receiver should be a variable holding a contract.
-        let hir::ExprKind::Ident(reses) = &obj.kind else { return None };
+        let ExprKind::Ident(reses) = &obj.kind else { return None };
         let res = reses.first()?;
         let var_id = match res {
-            hir::Res::Item(hir::ItemId::Variable(vid)) => *vid,
+            Res::Item(ItemId::Variable(vid)) => *vid,
             _ => return None,
         };
         let var_ty = gcx.type_of_item(var_id.into()).peel_refs();
@@ -1170,7 +1173,7 @@ impl Type {
 ///
 /// Ref: <https://docs.soliditylang.org/en/latest/types.html#function-types>
 #[inline]
-fn func_members(func: &hir::Function<'_>, custom_type: &[Symbol]) -> Option<DynSolType> {
+fn func_members(func: &Function<'_>, custom_type: &[Symbol]) -> Option<DynSolType> {
     if !matches!(func.kind, FunctionKind::Function) {
         return None;
     }
@@ -1186,18 +1189,18 @@ fn func_members(func: &hir::Function<'_>, custom_type: &[Symbol]) -> Option<DynS
 
 /// Whether execution should continue after inspecting this expression.
 #[inline]
-fn should_continue(expr: &hir::Expr<'_>) -> bool {
+fn should_continue(expr: &Expr<'_>) -> bool {
     match &expr.kind {
         // assignments and compound assignments
-        hir::ExprKind::Assign(_, _, _) => true,
+        ExprKind::Assign(_, _, _) => true,
         // ++/-- pre/post operations
-        hir::ExprKind::Unary(op, _) => matches!(
+        ExprKind::Unary(op, _) => matches!(
             op.kind,
             UnOpKind::PreInc | UnOpKind::PreDec | UnOpKind::PostInc | UnOpKind::PostDec
         ),
         // Array.pop()
-        hir::ExprKind::Call(callee, _, _) => match &callee.kind {
-            hir::ExprKind::Member(_, ident) => ident.as_str() == "pop",
+        ExprKind::Call(callee, _, _) => match &callee.kind {
+            ExprKind::Member(_, ident) => ident.as_str() == "pop",
             _ => false,
         },
         _ => false,
@@ -1216,9 +1219,9 @@ fn types_to_parameters(
 /// is not a numeric literal.
 ///
 /// SubDenominations are already applied to numeric literals in solar's HIR.
-const fn parse_number_literal(expr: &hir::Expr<'_>) -> Option<U256> {
+const fn parse_number_literal(expr: &Expr<'_>) -> Option<U256> {
     match &expr.kind {
-        hir::ExprKind::Lit(lit) => match &lit.kind {
+        ExprKind::Lit(lit) => match &lit.kind {
             LitKind::Number(n) => Some(*n),
             _ => None,
         },
@@ -1675,7 +1678,7 @@ mod tests {
             let body = hir.function(run_fid).body?;
             let last = body.last()?;
             let expr = match last.kind {
-                hir::StmtKind::Expr(e) => e,
+                StmtKind::Expr(e) => e,
                 _ => return None,
             };
             Type::ethabi(gcx, expr, true)

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -152,11 +152,11 @@ impl SessionSource {
             let inner_expr = args.exprs().next()?;
 
             // If the call is `func()` returning a single value, prefer the function return type.
-            if let Some(ty) = Type::get_function_return_type(gcx, inner_expr) {
+            if let Some(ty) = get_function_return_type(gcx, inner_expr) {
                 return Some((should_continue(inner_expr), ty));
             }
 
-            let ty = Type::ethabi(gcx, inner_expr, true)?;
+            let ty = expr_to_dyn(gcx, inner_expr, true)?;
             Some((should_continue(inner_expr), ty))
         });
 
@@ -428,745 +428,586 @@ fn format_event_definition(gcx: Gcx<'_>, event: &Event<'_>) -> Result<String> {
 // [soli](https://github.com/jpopesculian/soli)
 // =============================================
 
-#[derive(Clone, Debug, PartialEq)]
-enum Type {
-    /// (type)
-    Builtin(DynSolType),
+/// Converts an [`Expr`] directly to a [`DynSolType`] for ABI inspection.
+///
+/// `lookup` controls whether user-defined type names are resolved via the HIR.
+fn expr_to_dyn(gcx: Gcx<'_>, expr: &Expr<'_>, lookup: bool) -> Option<DynSolType> {
+    match &expr.kind {
+        // Elementary type expression: `uint256`, `address`, etc.
+        ExprKind::Type(ty) => hir_ty_to_dyn(gcx, ty),
 
-    /// (type)
-    Array(Box<Self>),
+        // `type(T)`: only meaningful as the lhs of a member access.
+        ExprKind::TypeCall(_) => None,
 
-    /// (type, length)
-    FixedArray(Box<Self>, usize),
+        // Literals.
+        ExprKind::Lit(lit) => match &lit.kind {
+            LitKind::Address(_) => Some(DynSolType::Address),
+            LitKind::Bool(_) => Some(DynSolType::Bool),
+            LitKind::Str(kind, _, _) => match kind {
+                StrKind::Hex => Some(DynSolType::Bytes),
+                StrKind::Str | StrKind::Unicode => Some(DynSolType::String),
+            },
+            LitKind::Number(_) | LitKind::Rational(_) => Some(DynSolType::Uint(256)),
+            LitKind::Err(_) => None,
+        },
 
-    /// (type, index)
-    ArrayIndex(Box<Self>, Option<usize>),
+        // Resolved identifier: `foo`.
+        ExprKind::Ident(reses) => {
+            let res = reses.first()?;
+            match *res {
+                Res::Item(ItemId::Variable(vid)) => {
+                    solar_ty_to_dyn(gcx, gcx.type_of_item(vid.into()))
+                }
+                Res::Item(ItemId::Struct(sid)) => {
+                    // Struct reference used as a constructor produces a tuple of field types.
+                    Some(DynSolType::Tuple(
+                        gcx.struct_field_types(sid)
+                            .iter()
+                            .filter_map(|&t| solar_ty_to_dyn(gcx, t))
+                            .collect(),
+                    ))
+                }
+                // Other items and builtins: handled by enclosing Call/Member expressions.
+                _ => None,
+            }
+        }
 
-    /// (types)
-    Tuple(Vec<Option<Self>>),
+        // Index/access: `arr[i]`, `MyType[]`, `MyType[N]`.
+        ExprKind::Index(base, idx) => {
+            let base_ty = expr_to_dyn(gcx, base, lookup)?;
+            let num =
+                idx.and_then(|e| parse_number_literal(e)).and_then(|n| usize::try_from(n).ok());
+            match &base.kind {
+                // Type-level indexing builds an array type expression.
+                ExprKind::Type(_) | ExprKind::TypeCall(_) => {
+                    if let Some(n) = num {
+                        Some(DynSolType::FixedArray(Box::new(base_ty), n))
+                    } else {
+                        Some(DynSolType::Array(Box::new(base_ty)))
+                    }
+                }
+                // Runtime indexing returns the element type.
+                _ => match base_ty {
+                    DynSolType::Array(inner) | DynSolType::FixedArray(inner, _) => Some(*inner),
+                    DynSolType::Bytes | DynSolType::String | DynSolType::FixedBytes(_) => {
+                        Some(DynSolType::FixedBytes(1))
+                    }
+                    other => Some(other),
+                },
+            }
+        }
 
-    /// (name, params, returns)
-    Function(Box<Self>, Vec<Option<Self>>, Vec<Option<Self>>),
+        // Slice: same type as the base.
+        ExprKind::Slice(base, _, _) => expr_to_dyn(gcx, base, lookup),
 
-    /// (lhs, rhs)
-    Access(Box<Self>, Symbol),
+        // Array literal `[a, b, c]`.
+        ExprKind::Array(values) => values
+            .first()
+            .and_then(|e| expr_to_dyn(gcx, e, lookup))
+            .map(|ty| DynSolType::FixedArray(Box::new(ty), values.len())),
 
-    /// (types)
-    Custom(Vec<Symbol>),
+        // Tuple expression `(a, b, c)`.
+        ExprKind::Tuple(items) => Some(DynSolType::Tuple(
+            items.iter().filter_map(|opt| opt.and_then(|e| expr_to_dyn(gcx, e, lookup))).collect(),
+        )),
+
+        // Member access `lhs.member`.
+        ExprKind::Member(_, _) => resolve_member(gcx, expr, lookup),
+
+        // Function/constructor call.
+        ExprKind::Call(_, _, _) => resolve_call(gcx, expr, lookup),
+
+        // `new T`: produces a value of type T.
+        ExprKind::New(ty) => hir_ty_to_dyn(gcx, ty),
+
+        // `payable(addr)`.
+        ExprKind::Payable(_) => Some(DynSolType::Address),
+
+        // Ternary: prefer truthy branch's type, fall back to else branch.
+        ExprKind::Ternary(_, t, e) => {
+            expr_to_dyn(gcx, t, lookup).or_else(|| expr_to_dyn(gcx, e, lookup))
+        }
+
+        // Delete has no return type.
+        ExprKind::Delete(_) => None,
+
+        // Unary operations.
+        ExprKind::Unary(op, inner) => match op.kind {
+            UnOpKind::Neg => expr_to_dyn(gcx, inner, lookup).map(|ty| match ty {
+                DynSolType::Uint(n) => DynSolType::Int(n),
+                DynSolType::Int(n) => DynSolType::Uint(n),
+                x => x,
+            }),
+            UnOpKind::Not => Some(DynSolType::Bool),
+            UnOpKind::BitNot
+            | UnOpKind::PreInc
+            | UnOpKind::PreDec
+            | UnOpKind::PostInc
+            | UnOpKind::PostDec => expr_to_dyn(gcx, inner, lookup),
+        },
+
+        // Binary operations.
+        ExprKind::Binary(lhs, op, rhs) => match op.kind {
+            BinOpKind::Lt
+            | BinOpKind::Le
+            | BinOpKind::Gt
+            | BinOpKind::Ge
+            | BinOpKind::Eq
+            | BinOpKind::Ne
+            | BinOpKind::And
+            | BinOpKind::Or => Some(DynSolType::Bool),
+            BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul | BinOpKind::Div => {
+                match (expr_to_dyn(gcx, lhs, false), expr_to_dyn(gcx, rhs, false)) {
+                    (Some(DynSolType::Int(_) | DynSolType::Uint(_)), Some(DynSolType::Int(_)))
+                    | (Some(DynSolType::Int(_)), Some(DynSolType::Uint(_))) => {
+                        Some(DynSolType::Int(256))
+                    }
+                    _ => Some(DynSolType::Uint(256)),
+                }
+            }
+            BinOpKind::Rem
+            | BinOpKind::Pow
+            | BinOpKind::BitAnd
+            | BinOpKind::BitOr
+            | BinOpKind::BitXor
+            | BinOpKind::Shl
+            | BinOpKind::Shr
+            | BinOpKind::Sar => Some(DynSolType::Uint(256)),
+        },
+
+        // Assignments: type of the lhs.
+        ExprKind::Assign(lhs, _, _) => expr_to_dyn(gcx, lhs, lookup),
+
+        ExprKind::Err(_) => None,
+    }
 }
 
-impl Type {
-    /// Convert a [`hir::Expr`] to a [`Type`].
-    fn from_expr(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<Self> {
-        match &expr.kind {
-            // Elementary type expression: `uint256`, `address`, etc.
-            ExprKind::Type(ty) => Self::from_hir_ty(gcx, ty),
-
-            // `type(T)` expression. Modelled like a call to a builtin `type` function so that
-            // member access (e.g. `type(C).name` or `type(uint256).max`) can be resolved by
-            // [`Self::map_special`].
-            ExprKind::TypeCall(ty) => {
-                let inner = Self::from_hir_ty(gcx, ty);
-                Some(Self::Function(
-                    Box::new(Self::Custom(vec![Symbol::intern("type")])),
-                    vec![inner],
-                    vec![],
-                ))
-            }
-
-            // Resolved identifier: `foo`.
-            ExprKind::Ident(reses) => {
-                let res = reses.first()?;
-                match *res {
-                    Res::Item(item) => match item {
-                        ItemId::Variable(vid) => {
-                            let var = gcx.hir.variable(vid);
-                            let name = var.name?.name;
-                            // Try the resolved solar type first.
-                            let ty = gcx.type_of_item(vid.into());
-                            if let Some(dyn_ty) = solar_ty_to_dyn(gcx, ty) {
-                                Some(Self::Builtin(dyn_ty))
-                            } else {
-                                Some(Self::Custom(vec![name]))
-                            }
-                        }
-                        ItemId::Function(fid) => {
-                            let func = gcx.hir.function(fid);
-                            let name = func.name?.name;
-                            Some(Self::Custom(vec![name]))
-                        }
-                        ItemId::Contract(cid) => {
-                            let c = gcx.hir.contract(cid);
-                            Some(Self::Custom(vec![c.name.name]))
-                        }
-                        ItemId::Struct(sid) => {
-                            // Struct constructor: produces a value of the struct type, which we
-                            // model as a tuple of field types.
-                            let fields = gcx.struct_field_types(sid);
-                            let parts = fields
-                                .iter()
-                                .map(|&t| solar_ty_to_dyn(gcx, t).map(Self::Builtin))
-                                .collect();
-                            Some(Self::Tuple(parts))
-                        }
-                        ItemId::Enum(eid) => {
-                            let e = gcx.hir.enumm(eid);
-                            Some(Self::Custom(vec![e.name.name]))
-                        }
-                        ItemId::Udvt(uid) => {
-                            let u = gcx.hir.udvt(uid);
-                            Some(Self::Custom(vec![u.name.name]))
-                        }
-                        ItemId::Error(eid) => {
-                            let e = gcx.hir.error(eid);
-                            Some(Self::Custom(vec![e.name.name]))
-                        }
-                        ItemId::Event(eid) => {
-                            let e = gcx.hir.event(eid);
-                            Some(Self::Custom(vec![e.name.name]))
-                        }
-                    },
-                    Res::Builtin(b) => Some(Self::Custom(vec![b.name()])),
-                    Res::Namespace(_) | Res::Err(_) => None,
-                }
-            }
-
-            // Index/access: `arr[i]`, `MyType[]`.
-            ExprKind::Index(base, idx) => Self::from_expr(gcx, base).map(|ty| {
-                let boxed = Box::new(ty);
-                let num =
-                    idx.and_then(|e| parse_number_literal(e)).and_then(|n| usize::try_from(n).ok());
-                match &base.kind {
-                    ExprKind::Type(_) | ExprKind::TypeCall(_) => {
-                        if let Some(num) = num {
-                            Self::FixedArray(boxed, num)
-                        } else {
-                            Self::Array(boxed)
-                        }
-                    }
-                    _ => Self::ArrayIndex(boxed, num),
-                }
-            }),
-
-            // Slice expression: `arr[a:b]`.
-            ExprKind::Slice(base, _, _) => Self::from_expr(gcx, base),
-
-            // Array literal `[a, b, c]`.
-            ExprKind::Array(values) => values
-                .first()
-                .and_then(|e| Self::from_expr(gcx, e))
-                .map(|ty| Self::FixedArray(Box::new(ty), values.len())),
-
-            // Tuple expression `(a, b, c)`.
-            ExprKind::Tuple(items) => Some(Self::Tuple(
-                items.iter().map(|opt| opt.and_then(|e| Self::from_expr(gcx, e))).collect(),
-            )),
-
-            // Member access `lhs.rhs`.
-            ExprKind::Member(lhs, ident) => {
-                Self::from_expr(gcx, lhs).map(|lhs| Self::Access(Box::new(lhs), ident.name))
-            }
-
-            // `new T`.
-            ExprKind::New(ty) => Self::from_hir_ty(gcx, ty),
-
-            // `payable(addr)`.
-            ExprKind::Payable(_) => Some(Self::Builtin(DynSolType::Address)),
-
-            // Ternary: prefer truthy branch's type, fall back to else branch.
-            ExprKind::Ternary(_, t, e) => {
-                Self::from_expr(gcx, t).or_else(|| Self::from_expr(gcx, e))
-            }
-
-            // Delete expression has no usable type.
-            ExprKind::Delete(_) => None,
-
-            // Literals.
-            ExprKind::Lit(lit) => match &lit.kind {
-                LitKind::Address(_) => Some(Self::Builtin(DynSolType::Address)),
-                LitKind::Bool(_) => Some(Self::Builtin(DynSolType::Bool)),
-                LitKind::Str(kind, _, _) => match kind {
-                    StrKind::Hex => Some(Self::Builtin(DynSolType::Bytes)),
-                    StrKind::Str | StrKind::Unicode => Some(Self::Builtin(DynSolType::String)),
-                },
-                LitKind::Number(_) | LitKind::Rational(_) => {
-                    Some(Self::Builtin(DynSolType::Uint(256)))
-                }
-                LitKind::Err(_) => None,
-            },
-
-            // Unary operations.
-            ExprKind::Unary(op, inner) => match op.kind {
-                UnOpKind::Neg => Self::from_expr(gcx, inner).map(Self::invert_int),
-                UnOpKind::Not => Some(Self::Builtin(DynSolType::Bool)),
-                UnOpKind::BitNot
-                | UnOpKind::PreInc
-                | UnOpKind::PreDec
-                | UnOpKind::PostInc
-                | UnOpKind::PostDec => Self::from_expr(gcx, inner),
-            },
-
-            // Binary operations.
-            ExprKind::Binary(lhs, op, rhs) => match op.kind {
-                BinOpKind::Lt
-                | BinOpKind::Le
-                | BinOpKind::Gt
-                | BinOpKind::Ge
-                | BinOpKind::Eq
-                | BinOpKind::Ne
-                | BinOpKind::And
-                | BinOpKind::Or => Some(Self::Builtin(DynSolType::Bool)),
-                BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul | BinOpKind::Div => {
-                    match (Self::ethabi(gcx, lhs, false), Self::ethabi(gcx, rhs, false)) {
-                        (
-                            Some(DynSolType::Int(_) | DynSolType::Uint(_)),
-                            Some(DynSolType::Int(_)),
-                        )
-                        | (Some(DynSolType::Int(_)), Some(DynSolType::Uint(_))) => {
-                            Some(Self::Builtin(DynSolType::Int(256)))
-                        }
-                        _ => Some(Self::Builtin(DynSolType::Uint(256))),
-                    }
-                }
-                BinOpKind::Rem
-                | BinOpKind::Pow
-                | BinOpKind::BitAnd
-                | BinOpKind::BitOr
-                | BinOpKind::BitXor
-                | BinOpKind::Shl
-                | BinOpKind::Shr
-                | BinOpKind::Sar => Some(Self::Builtin(DynSolType::Uint(256))),
-            },
-
-            // Assignments: type of the lhs.
-            ExprKind::Assign(lhs, _, _) => Self::from_expr(gcx, lhs),
-
-            // Function call.
-            ExprKind::Call(callee, args, _named) => Self::from_expr(gcx, callee).map(|name| {
-                let args = args.exprs().map(|e| Self::from_expr(gcx, e)).collect();
-                Self::Function(Box::new(name), args, vec![])
-            }),
-
-            ExprKind::Err(_) => None,
-        }
-    }
-
-    /// Convert a [`hir::Type`] to a [`Type`].
-    fn from_hir_ty(gcx: Gcx<'_>, ty: &HirType<'_>) -> Option<Self> {
-        match &ty.kind {
-            TypeKind::Elementary(et) => Some(Self::Builtin(elementary_to_dyn(*et)?)),
-            TypeKind::Array(arr) => {
-                let elem = Self::from_hir_ty(gcx, &arr.element)?;
-                if let Some(size) = arr.size {
-                    let n = parse_number_literal(size).and_then(|n| usize::try_from(n).ok());
-                    if let Some(n) = n {
-                        Some(Self::FixedArray(Box::new(elem), n))
-                    } else {
-                        Some(Self::Array(Box::new(elem)))
-                    }
+/// Converts a [`HirType`] to a [`DynSolType`].
+fn hir_ty_to_dyn(gcx: Gcx<'_>, ty: &HirType<'_>) -> Option<DynSolType> {
+    match &ty.kind {
+        TypeKind::Elementary(et) => elementary_to_dyn(*et),
+        TypeKind::Array(arr) => {
+            let elem = hir_ty_to_dyn(gcx, &arr.element)?;
+            if let Some(size) = arr.size {
+                let n = parse_number_literal(size).and_then(|n| usize::try_from(n).ok());
+                if let Some(n) = n {
+                    Some(DynSolType::FixedArray(Box::new(elem), n))
                 } else {
-                    Some(Self::Array(Box::new(elem)))
+                    Some(DynSolType::Array(Box::new(elem)))
                 }
-            }
-            TypeKind::Function(f) => {
-                let params = f
-                    .parameters
-                    .iter()
-                    .map(|&pid| {
-                        let var = gcx.hir.variable(pid);
-                        Self::from_hir_ty(gcx, &var.ty)
-                    })
-                    .collect();
-                let returns = f
-                    .returns
-                    .iter()
-                    .map(|&pid| {
-                        let var = gcx.hir.variable(pid);
-                        Self::from_hir_ty(gcx, &var.ty)
-                    })
-                    .collect();
-                Some(Self::Function(
-                    Box::new(Self::Custom(vec![Symbol::intern("__fn_type__")])),
-                    params,
-                    returns,
-                ))
-            }
-            TypeKind::Mapping(m) => Self::from_hir_ty(gcx, &m.value),
-            TypeKind::Custom(item) => {
-                // User-defined type names always become `Custom([name])` here, mirroring the
-                // legacy pt-based engine where custom names came in via `Variable(name)` rather
-                // than the elementary `from_type` path. Conversion to a concrete `DynSolType`
-                // (e.g. struct → tuple, udvt → underlying) happens later in `try_as_ethabi`.
-                let name = match *item {
-                    ItemId::Contract(id) => gcx.hir.contract(id).name.name,
-                    ItemId::Struct(id) => gcx.hir.strukt(id).name.name,
-                    ItemId::Enum(id) => gcx.hir.enumm(id).name.name,
-                    ItemId::Udvt(id) => gcx.hir.udvt(id).name.name,
-                    ItemId::Error(id) => gcx.hir.error(id).name.name,
-                    ItemId::Event(id) => gcx.hir.event(id).name.name,
-                    ItemId::Function(id) => gcx.hir.function(id).name?.name,
-                    ItemId::Variable(id) => gcx.hir.variable(id).name?.name,
-                };
-                Some(Self::Custom(vec![name]))
-            }
-            TypeKind::Err(_) => {
-                // Best-effort fallback: when name resolution failed, recover the textual name
-                // from the source span so the inference engine can still treat it as a custom
-                // type (e.g., `type(C).name` where contract `C` does not exist).
-                let snippet = gcx.sess.source_map().span_to_snippet(ty.span).ok()?;
-                let name = snippet.trim();
-                if name.is_empty() { None } else { Some(Self::Custom(vec![Symbol::intern(name)])) }
+            } else {
+                Some(DynSolType::Array(Box::new(elem)))
             }
         }
+        TypeKind::Function(f) => match f.returns.len() {
+            0 => None,
+            1 => {
+                let var = gcx.hir.variable(f.returns[0]);
+                hir_ty_to_dyn(gcx, &var.ty)
+            }
+            _ => Some(DynSolType::Tuple(
+                f.returns
+                    .iter()
+                    .filter_map(|&pid| hir_ty_to_dyn(gcx, &gcx.hir.variable(pid).ty))
+                    .collect(),
+            )),
+        },
+        TypeKind::Mapping(m) => hir_ty_to_dyn(gcx, &m.value),
+        TypeKind::Custom(item) => solar_ty_to_dyn(gcx, gcx.type_of_item(*item)),
+        TypeKind::Err(_) => None,
+    }
+}
+
+/// Resolves a member-access expression (`lhs.member`) to its [`DynSolType`].
+///
+/// `expr` must be `ExprKind::Member`.
+fn resolve_member(gcx: Gcx<'_>, expr: &Expr<'_>, lookup: bool) -> Option<DynSolType> {
+    let ExprKind::Member(lhs, ident) = &expr.kind else { return None };
+    let member = ident.name;
+
+    // `type(T).member` — type introspection.
+    if let ExprKind::TypeCall(ty) = &lhs.kind {
+        return match member.as_str() {
+            "name" => Some(DynSolType::String),
+            "creationCode" | "runtimeCode" => Some(DynSolType::Bytes),
+            "interfaceId" => Some(DynSolType::FixedBytes(4)),
+            // Only valid for integer types; custom types (enums) fall back to Uint(256).
+            "min" | "max" => match &ty.kind {
+                TypeKind::Elementary(et) => elementary_to_dyn(*et),
+                _ => Some(DynSolType::Uint(256)),
+            },
+            _ => None,
+        };
     }
 
-    /// Handle special expressions like
-    /// [global variables](https://docs.soliditylang.org/en/latest/cheatsheet.html#global-variables).
-    fn map_special(self) -> Self {
-        if !matches!(self, Self::Function(_, _, _) | Self::Access(_, _) | Self::Custom(_)) {
-            return self;
-        }
+    // Built-in namespace identifier: `block.timestamp`, `msg.sender`, `abi.encode`, etc.
+    if let ExprKind::Ident(reses) = &lhs.kind
+        && let Some(Res::Builtin(b)) = reses.first()
+        && let Some(ty) = builtin_member(b.name().as_str(), member.as_str())
+    {
+        return Some(ty);
+    }
 
-        let mut types: Vec<Symbol> = Vec::with_capacity(5);
-        let mut args = None;
-        self.recurse(&mut types, &mut args);
+    // Elementary type used as a namespace: `address.balance`, `bytes.concat`, etc.
+    if let ExprKind::Type(ty) = &lhs.kind
+        && let TypeKind::Elementary(et) = &ty.kind
+    {
+        return match et {
+            ElementaryType::Address(_) => match member.as_str() {
+                "balance" => Some(DynSolType::Uint(256)),
+                "code" => Some(DynSolType::Bytes),
+                "codehash" => Some(DynSolType::FixedBytes(32)),
+                "send" => Some(DynSolType::Bool),
+                _ => None,
+            },
+            ElementaryType::Bytes => match member.as_str() {
+                "concat" => Some(DynSolType::Bytes),
+                _ => None,
+            },
+            ElementaryType::String => match member.as_str() {
+                "concat" => Some(DynSolType::String),
+                _ => None,
+            },
+            _ => None,
+        };
+    }
 
-        let len = types.len();
-        if len == 0 {
-            return self;
-        }
+    // Members on a resolved DynSolType (`.length`, `.pop`, `.selector`, `.address`).
+    if let Some(lhs_ty) = expr_to_dyn(gcx, lhs, lookup)
+        && let Some(ty) = dyn_member(&lhs_ty, member.as_str())
+    {
+        return Some(ty);
+    }
 
-        // Type members, like array, bytes etc
-        #[expect(clippy::single_match)]
-        #[allow(clippy::collapsible_match)]
-        match &self {
-            Self::Access(inner, access) => {
-                if let Some(ty) = inner.as_ref().clone().try_as_ethabi(false, None) {
-                    // Array / bytes members
-                    let ty = Self::Builtin(ty);
-                    match access.as_str() {
-                        "length" if ty.is_dynamic() || ty.is_array() || ty.is_fixed_bytes() => {
-                            return Self::Builtin(DynSolType::Uint(256));
+    // HIR lookup for user-defined type members.
+    if lookup && let Some(mut chain) = expr_name_chain(gcx, lhs) {
+        chain.insert(0, member);
+        return infer_custom_type(gcx, &mut chain, None).ok().flatten();
+    }
+
+    None
+}
+
+/// Returns the type of `builtin_ns.member` for built-in global namespaces.
+fn builtin_member(builtin: &str, member: &str) -> Option<DynSolType> {
+    match builtin {
+        "block" => match member {
+            "coinbase" => Some(DynSolType::Address),
+            "timestamp" | "difficulty" | "prevrandao" | "number" | "gaslimit" | "chainid"
+            | "basefee" | "blobbasefee" => Some(DynSolType::Uint(256)),
+            _ => None,
+        },
+        "msg" => match member {
+            "sender" => Some(DynSolType::Address),
+            "gas" | "value" => Some(DynSolType::Uint(256)),
+            "data" => Some(DynSolType::Bytes),
+            "sig" => Some(DynSolType::FixedBytes(4)),
+            _ => None,
+        },
+        "tx" => match member {
+            "origin" => Some(DynSolType::Address),
+            "gasprice" => Some(DynSolType::Uint(256)),
+            _ => None,
+        },
+        "address" => match member {
+            "balance" => Some(DynSolType::Uint(256)),
+            "code" => Some(DynSolType::Bytes),
+            "codehash" => Some(DynSolType::FixedBytes(32)),
+            "send" => Some(DynSolType::Bool),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Returns the type of `ty.member` for a known [`DynSolType`].
+fn dyn_member(ty: &DynSolType, member: &str) -> Option<DynSolType> {
+    match member {
+        "length" => match ty {
+            DynSolType::Array(_)
+            | DynSolType::FixedArray(_, _)
+            | DynSolType::Bytes
+            | DynSolType::String
+            | DynSolType::FixedBytes(_) => Some(DynSolType::Uint(256)),
+            _ => None,
+        },
+        "pop" => match ty {
+            DynSolType::Array(inner) => Some(*inner.clone()),
+            _ => None,
+        },
+        // Address members.
+        "balance" => match ty {
+            DynSolType::Address => Some(DynSolType::Uint(256)),
+            _ => None,
+        },
+        "code" => match ty {
+            DynSolType::Address => Some(DynSolType::Bytes),
+            _ => None,
+        },
+        "codehash" => match ty {
+            DynSolType::Address => Some(DynSolType::FixedBytes(32)),
+            _ => None,
+        },
+        "send" => match ty {
+            DynSolType::Address => Some(DynSolType::Bool),
+            _ => None,
+        },
+        // External function members.
+        "selector" => Some(DynSolType::FixedBytes(4)),
+        "address" => Some(DynSolType::Address),
+        _ => None,
+    }
+}
+
+/// Resolves a call expression to its return [`DynSolType`].
+///
+/// `expr` must be `ExprKind::Call`.
+fn resolve_call(gcx: Gcx<'_>, expr: &Expr<'_>, lookup: bool) -> Option<DynSolType> {
+    let ExprKind::Call(callee, args, _named) = &expr.kind else { return None };
+
+    // Type cast: `uint256(x)`, `address(y)`, etc.
+    if let ExprKind::Type(ty) = &callee.kind {
+        return hir_ty_to_dyn(gcx, ty);
+    }
+
+    // Member call: `ns.method(...)`.
+    if let ExprKind::Member(lhs, method) = &callee.kind
+        && let ExprKind::Ident(reses) = &lhs.kind
+        && let Some(Res::Builtin(b)) = reses.first()
+    {
+        match b.name().as_str() {
+            "abi" => {
+                return match method.as_str() {
+                    "decode" => {
+                        let last = args.exprs().last()?;
+                        match expr_to_dyn(gcx, last, false)? {
+                            DynSolType::Tuple(tys) => Some(DynSolType::Tuple(tys)),
+                            ty => Some(DynSolType::Tuple(vec![ty])),
                         }
-                        "pop" if ty.is_dynamic_array() => return ty,
-                        _ => {}
                     }
-                }
+                    s if s.starts_with("encode") => Some(DynSolType::Bytes),
+                    _ => None,
+                };
             }
+            "string" if method.as_str() == "concat" => return Some(DynSolType::String),
+            "bytes" if method.as_str() == "concat" => return Some(DynSolType::Bytes),
             _ => {}
         }
+    }
 
-        let this = {
-            let name = types.last().unwrap().as_str();
-            match len {
-                0 => unreachable!(),
-                1 => match name {
+    // Simple identifier call: built-in global functions and HIR function calls.
+    if let ExprKind::Ident(reses) = &callee.kind {
+        match reses.first() {
+            Some(Res::Builtin(b)) => {
+                return match b.name().as_str() {
                     "gasleft" | "addmod" | "mulmod" => Some(DynSolType::Uint(256)),
                     "keccak256" | "sha256" | "blockhash" => Some(DynSolType::FixedBytes(32)),
                     "ripemd160" => Some(DynSolType::FixedBytes(20)),
                     "ecrecover" => Some(DynSolType::Address),
                     _ => None,
-                },
-                2 => {
-                    let access = types.first().unwrap().as_str();
-                    match name {
-                        "block" => match access {
-                            "coinbase" => Some(DynSolType::Address),
-                            "timestamp" | "difficulty" | "prevrandao" | "number" | "gaslimit"
-                            | "chainid" | "basefee" | "blobbasefee" => Some(DynSolType::Uint(256)),
-                            _ => None,
-                        },
-                        "msg" => match access {
-                            "sender" => Some(DynSolType::Address),
-                            "gas" => Some(DynSolType::Uint(256)),
-                            "value" => Some(DynSolType::Uint(256)),
-                            "data" => Some(DynSolType::Bytes),
-                            "sig" => Some(DynSolType::FixedBytes(4)),
-                            _ => None,
-                        },
-                        "tx" => match access {
-                            "origin" => Some(DynSolType::Address),
-                            "gasprice" => Some(DynSolType::Uint(256)),
-                            _ => None,
-                        },
-                        "abi" => match access {
-                            "decode" => {
-                                // args = Some([Bytes(_), Tuple(args)])
-                                let mut args = args.unwrap();
-                                let last = args.pop().unwrap();
-                                match last {
-                                    Some(ty) => {
-                                        return match ty {
-                                            Self::Tuple(_) => ty,
-                                            ty => Self::Tuple(vec![Some(ty)]),
-                                        };
-                                    }
-                                    None => None,
-                                }
-                            }
-                            s if s.starts_with("encode") => Some(DynSolType::Bytes),
-                            _ => None,
-                        },
-                        "address" => match access {
-                            "balance" => Some(DynSolType::Uint(256)),
-                            "code" => Some(DynSolType::Bytes),
-                            "codehash" => Some(DynSolType::FixedBytes(32)),
-                            "send" => Some(DynSolType::Bool),
-                            _ => None,
-                        },
-                        "type" => match access {
-                            "name" => Some(DynSolType::String),
-                            "creationCode" | "runtimeCode" => Some(DynSolType::Bytes),
-                            "interfaceId" => Some(DynSolType::FixedBytes(4)),
-                            "min" | "max" => Some(
-                                // Either a builtin or an enum
-                                (|| args?.pop()??.into_builtin())()
-                                    .unwrap_or(DynSolType::Uint(256)),
-                            ),
-                            _ => None,
-                        },
-                        "string" => match access {
-                            "concat" => Some(DynSolType::String),
-                            _ => None,
-                        },
-                        "bytes" => match access {
-                            "concat" => Some(DynSolType::Bytes),
-                            _ => None,
-                        },
-                        _ => None,
-                    }
-                }
-                _ => None,
+                };
             }
-        };
-
-        this.map(Self::Builtin).unwrap_or_else(|| match types.last().unwrap().as_str() {
-            "this" | "super" => Self::Custom(types),
-            _ => match self {
-                Self::Custom(_) | Self::Access(_, _) => Self::Custom(types),
-                Self::Function(_, _, _) => self,
-                _ => unreachable!(),
-            },
-        })
-    }
-
-    /// Recurses over itself, appending all the idents and function arguments in the order that they
-    /// are found.
-    fn recurse(&self, types: &mut Vec<Symbol>, args: &mut Option<Vec<Option<Self>>>) {
-        match self {
-            Self::Builtin(ty) => types.push(Symbol::intern(&ty.to_string())),
-            Self::Custom(tys) => types.extend(tys.iter().copied()),
-            Self::Access(expr, name) => {
-                types.push(*name);
-                expr.recurse(types, args);
-            }
-            Self::Function(fn_name, fn_args, _fn_ret) => {
-                if args.is_none() && !fn_args.is_empty() {
-                    *args = Some(fn_args.clone());
+            Some(Res::Item(ItemId::Function(fid))) if lookup => {
+                let func = gcx.hir.function(*fid);
+                if !matches!(func.state_mutability, StateMutability::View | StateMutability::Pure) {
+                    return None;
                 }
-                fn_name.recurse(types, args);
+                let ret_id = *func.returns.first()?;
+                return solar_ty_to_dyn(gcx, gcx.type_of_item(ret_id.into()));
             }
             _ => {}
         }
     }
 
-    /// Infers a custom type's true type by recursing through the HIR.
-    fn infer_custom_type(
-        gcx: Gcx<'_>,
-        custom_type: &mut Vec<Symbol>,
-        contract_id: Option<ContractId>,
-    ) -> Result<Option<DynSolType>> {
-        if let Some(last) = custom_type.last()
-            && (last.as_str() == "this" || last.as_str() == "super")
-        {
-            custom_type.pop();
+    // Fall back to the callee's resolved type.
+    expr_to_dyn(gcx, callee, lookup)
+}
+
+/// Extracts a name chain from a member-access expression tree for HIR lookup.
+///
+/// The chain is ordered outermost-first so `a.b.c` produces `["c", "b", "a"]` with the root
+/// identifier at the back. This matches the convention expected by [`infer_custom_type`].
+fn expr_name_chain(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<Vec<Symbol>> {
+    match &expr.kind {
+        ExprKind::Ident(reses) => {
+            let res = reses.first()?;
+            let name = match *res {
+                Res::Item(ItemId::Variable(vid)) => gcx.hir.variable(vid).name?.name,
+                Res::Item(ItemId::Function(fid)) => gcx.hir.function(fid).name?.name,
+                Res::Item(ItemId::Contract(cid)) => gcx.hir.contract(cid).name.name,
+                Res::Builtin(b) => b.name(),
+                _ => return None,
+            };
+            Some(vec![name])
         }
-        if custom_type.is_empty() {
-            return Ok(None);
+        ExprKind::Member(lhs, ident) => {
+            let mut chain = expr_name_chain(gcx, lhs)?;
+            chain.insert(0, ident.name);
+            Some(chain)
         }
+        _ => None,
+    }
+}
 
-        // If a contract exists with the given name, check its definitions for a match.
-        // Otherwise look in the `run`.
-        if let Some(cid) = contract_id {
-            let hir = &gcx.hir;
-            let contract = hir.contract(cid);
-
-            let cur_name = *custom_type.last().unwrap();
-            let cur = cur_name.as_str();
-
-            // Function?
-            if let Some(fid) = contract.functions().find(|&f| {
-                hir.function(f).name.as_ref().map(|n| n.as_str() == cur).unwrap_or(false)
-            }) {
-                let func = hir.function(fid);
-                if let res @ Some(_) = func_members(func, custom_type) {
-                    return Ok(res);
-                }
-
-                if func.returns.is_empty() {
-                    eyre::bail!(
-                        "This call expression does not return any values to inspect. Insert as statement."
-                    )
-                }
-
-                // Check if our final function call alters the state. If it does, we bail so that it
-                // will be inserted normally without inspecting.
-                let sm = func.state_mutability;
-                if !matches!(sm, StateMutability::View | StateMutability::Pure) {
-                    eyre::bail!("This function mutates state. Insert as a statement.")
-                }
-
-                // Resolve the return type.
-                let ret_id = func.returns[0];
-                let ret_var = hir.variable(ret_id);
-                // If the return type is a custom (user-defined) type, recurse on the same contract.
-                if let TypeKind::Custom(_) = &ret_var.ty.kind
-                    && let Some(t) = Self::from_hir_ty(gcx, &ret_var.ty)
-                {
-                    return Ok(t.try_as_ethabi(true, Some(gcx)));
-                }
-                return Ok(solar_ty_to_dyn(gcx, gcx.type_of_item(ret_id.into())));
-            }
-
-            // Variable?
-            if let Some(vid) = contract.variables().find(|&v| {
-                hir.variable(v).name.as_ref().map(|n| n.as_str() == cur).unwrap_or(false)
-            }) {
-                let var = hir.variable(vid);
-                if let Some(ty) = solar_ty_to_dyn(gcx, gcx.type_of_item(vid.into())) {
-                    // Check if there are remaining members to access.
-                    custom_type.pop();
-                    if custom_type.is_empty() {
-                        return Ok(Some(ty));
-                    }
-                    // Try to use the resolved type for member-access lookups.
-                    let access = Self::Access(
-                        Box::new(Self::Builtin(ty.clone())),
-                        custom_type.drain(..).next().unwrap_or(Symbol::DUMMY),
-                    );
-                    if let Some(mapped) = access.map_special().try_as_ethabi(true, Some(gcx)) {
-                        return Ok(Some(mapped));
-                    }
-                    return Ok(Some(ty));
-                }
-                // Fall back to the type expression.
-                return Self::infer_var_ty(gcx, &var.ty, custom_type);
-            }
-
-            // Struct?
-            if let Some(sid) = contract.items.iter().find_map(|i| {
-                if let ItemId::Struct(sid) = i
-                    && hir.strukt(*sid).name.as_str() == cur
-                {
-                    Some(*sid)
-                } else {
-                    None
-                }
-            }) {
-                let inner = gcx
-                    .struct_field_types(sid)
-                    .iter()
-                    .map(|&t| {
-                        solar_ty_to_dyn(gcx, t)
-                            .ok_or_else(|| eyre::eyre!("Struct `{cur}` has invalid fields"))
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-                return Ok(Some(DynSolType::Tuple(inner)));
-            }
-
-            eyre::bail!(
-                "Could not find any definition in contract \"{}\" for type: {custom_type:?}",
-                contract.name.as_str()
-            )
-        }
-        // Check if the custom type is a variable or function within the REPL contract first.
-        let repl_id = gcx
-            .hir
-            .contracts_enumerated()
-            .find_map(|(cid, c)| (c.name.as_str() == "REPL").then_some(cid));
-        if let Some(repl_id) = repl_id
-            && let Ok(res) = Self::infer_custom_type(gcx, custom_type, Some(repl_id))
-        {
-            return Ok(res);
-        }
-
-        // Check if the first element of the custom type is a known contract.
-        let last_name = *custom_type.last().unwrap();
-        let last = last_name.as_str();
-        let contract_match = gcx
-            .hir
-            .contracts_enumerated()
-            .find_map(|(cid, c)| (c.name.as_str() == last).then_some(cid));
-        if let Some(cid) = contract_match {
-            custom_type.pop();
-            return Self::infer_custom_type(gcx, custom_type, Some(cid));
-        }
-
-        // Otherwise gracefully give up.
-        Ok(None)
+/// Infers a custom type's true type by recursing through the HIR.
+///
+/// `custom_type` is a name chain ordered outermost-first (root at back). This is mutated during
+/// resolution. `contract_id` narrows the search to a specific contract scope.
+fn infer_custom_type(
+    gcx: Gcx<'_>,
+    custom_type: &mut Vec<Symbol>,
+    contract_id: Option<ContractId>,
+) -> Result<Option<DynSolType>> {
+    if let Some(last) = custom_type.last()
+        && (last.as_str() == "this" || last.as_str() == "super")
+    {
+        custom_type.pop();
+    }
+    if custom_type.is_empty() {
+        return Ok(None);
     }
 
-    /// Infers the type from a variable's HIR type.
-    fn infer_var_ty(
-        gcx: Gcx<'_>,
-        ty: &HirType<'_>,
-        custom_type: &mut Vec<Symbol>,
-    ) -> Result<Option<DynSolType>> {
-        let res: Option<DynSolType> = if let Some(t) = Self::from_hir_ty(gcx, ty) {
-            t.try_as_ethabi(true, Some(gcx))
-        } else {
-            None
-        };
-        match res {
-            Some(ty) => {
-                let access = Self::Access(
-                    Box::new(Self::Builtin(ty.clone())),
-                    custom_type.drain(..).next().unwrap_or(Symbol::DUMMY),
-                );
-                if let Some(mapped) = access.map_special().try_as_ethabi(true, Some(gcx)) {
-                    Ok(Some(mapped))
-                } else {
-                    Ok(Some(ty))
-                }
-            }
-            None => Ok(None),
-        }
-    }
-
-    /// Attempt to convert this type into a [`DynSolType`].
-    ///
-    /// `lookup` controls whether [`Self::Custom`] entries should be resolved via the HIR.
-    fn try_as_ethabi(self, lookup: bool, gcx: Option<Gcx<'_>>) -> Option<DynSolType> {
-        match self {
-            Self::Builtin(ty) => Some(ty),
-            Self::Tuple(types) => Some(DynSolType::Tuple(types_to_parameters(types, lookup, gcx))),
-            Self::Array(inner) => match *inner {
-                ty @ Self::Custom(_) => ty.try_as_ethabi(lookup, gcx),
-                _ => {
-                    inner.try_as_ethabi(lookup, gcx).map(|inner| DynSolType::Array(Box::new(inner)))
-                }
-            },
-            Self::FixedArray(inner, size) => match *inner {
-                ty @ Self::Custom(_) => ty.try_as_ethabi(lookup, gcx),
-                _ => inner
-                    .try_as_ethabi(lookup, gcx)
-                    .map(|inner| DynSolType::FixedArray(Box::new(inner), size)),
-            },
-            ty @ Self::ArrayIndex(_, _) => ty.into_array_index(lookup, gcx),
-            Self::Function(ty, _, _) => ty.try_as_ethabi(lookup, gcx),
-            // should have been mapped to `Custom` in previous steps
-            Self::Access(_, _) => None,
-            Self::Custom(mut types) => {
-                if !lookup {
-                    return None;
-                }
-                gcx.and_then(|gcx| Self::infer_custom_type(gcx, &mut types, None).ok().flatten())
-            }
-        }
-    }
-
-    /// Equivalent to `Type::from_expr` + `Type::map_special` + `Type::try_as_ethabi`.
-    fn ethabi(gcx: Gcx<'_>, expr: &Expr<'_>, lookup: bool) -> Option<DynSolType> {
-        Self::from_expr(gcx, expr)
-            .map(Self::map_special)
-            .and_then(|ty| ty.try_as_ethabi(lookup, Some(gcx)))
-    }
-
-    /// Get the return type of a function call expression.
-    fn get_function_return_type<'a>(gcx: Gcx<'_>, expr: &'a Expr<'a>) -> Option<DynSolType> {
-        let ExprKind::Call(callee, _, _) = &expr.kind else { return None };
-        let ExprKind::Member(obj, fn_ident) = &callee.kind else { return None };
-        // The receiver should be a variable holding a contract.
-        let ExprKind::Ident(reses) = &obj.kind else { return None };
-        let res = reses.first()?;
-        let var_id = match res {
-            Res::Item(ItemId::Variable(vid)) => *vid,
-            _ => return None,
-        };
-        let var_ty = gcx.type_of_item(var_id.into()).peel_refs();
-        let cid = match var_ty.kind {
-            TyKind::Contract(cid) => cid,
-            _ => return None,
-        };
-
+    if let Some(cid) = contract_id {
         let hir = &gcx.hir;
         let contract = hir.contract(cid);
-        let fid = contract.functions().find(|&f| {
-            hir.function(f).name.as_ref().map(|n| n.as_str()) == Some(fn_ident.as_str())
-        })?;
-        let func = hir.function(fid);
-        let ret_id = *func.returns.first()?;
-        solar_ty_to_dyn(gcx, gcx.type_of_item(ret_id.into()))
-    }
 
-    /// Inverts Int to Uint and vice-versa.
-    fn invert_int(self) -> Self {
-        match self {
-            Self::Builtin(DynSolType::Uint(n)) => Self::Builtin(DynSolType::Int(n)),
-            Self::Builtin(DynSolType::Int(n)) => Self::Builtin(DynSolType::Uint(n)),
-            x => x,
-        }
-    }
+        let cur_name = *custom_type.last().unwrap();
+        let cur = cur_name.as_str();
 
-    /// Returns the `DynSolType` contained by `Type::Builtin`.
-    #[inline]
-    fn into_builtin(self) -> Option<DynSolType> {
-        match self {
-            Self::Builtin(ty) => Some(ty),
-            _ => None,
-        }
-    }
-
-    /// Returns the resulting `DynSolType` of indexing self.
-    fn into_array_index(self, lookup: bool, gcx: Option<Gcx<'_>>) -> Option<DynSolType> {
-        match self {
-            Self::Array(inner) | Self::FixedArray(inner, _) | Self::ArrayIndex(inner, _) => {
-                match inner.try_as_ethabi(lookup, gcx) {
-                    Some(DynSolType::Array(inner) | DynSolType::FixedArray(inner, _)) => {
-                        Some(*inner)
-                    }
-                    Some(DynSolType::Bytes | DynSolType::String | DynSolType::FixedBytes(_)) => {
-                        Some(DynSolType::FixedBytes(1))
-                    }
-                    ty => ty,
-                }
+        // Function?
+        if let Some(fid) = contract
+            .functions()
+            .find(|&f| hir.function(f).name.as_ref().map(|n| n.as_str() == cur).unwrap_or(false))
+        {
+            let func = hir.function(fid);
+            if let res @ Some(_) = func_members(func, custom_type) {
+                return Ok(res);
             }
-            _ => None,
-        }
-    }
 
-    /// Returns whether this type is dynamic.
-    #[inline]
-    const fn is_dynamic(&self) -> bool {
-        match self {
-            // TODO: Note, this is not entirely correct. Fixed arrays of non-dynamic types are
-            // not dynamic, nor are tuples of non-dynamic types.
-            Self::Builtin(DynSolType::Bytes | DynSolType::String | DynSolType::Array(_)) => true,
-            Self::Array(_) => true,
-            _ => false,
-        }
-    }
+            if func.returns.is_empty() {
+                eyre::bail!(
+                    "This call expression does not return any values to inspect. Insert as statement."
+                )
+            }
 
-    /// Returns whether this type is an array.
-    #[inline]
-    const fn is_array(&self) -> bool {
-        matches!(
-            self,
-            Self::Array(_)
-                | Self::FixedArray(_, _)
-                | Self::Builtin(DynSolType::Array(_) | DynSolType::FixedArray(_, _))
+            let sm = func.state_mutability;
+            if !matches!(sm, StateMutability::View | StateMutability::Pure) {
+                eyre::bail!("This function mutates state. Insert as a statement.")
+            }
+
+            let ret_id = func.returns[0];
+            let ret_var = hir.variable(ret_id);
+            return Ok(solar_ty_to_dyn(gcx, gcx.type_of_item(ret_id.into()))
+                .or_else(|| hir_ty_to_dyn(gcx, &ret_var.ty)));
+        }
+
+        // Variable?
+        if let Some(vid) = contract
+            .variables()
+            .find(|&v| hir.variable(v).name.as_ref().map(|n| n.as_str() == cur).unwrap_or(false))
+        {
+            if let Some(ty) = solar_ty_to_dyn(gcx, gcx.type_of_item(vid.into())) {
+                custom_type.pop();
+                if custom_type.is_empty() {
+                    return Ok(Some(ty));
+                }
+                let next_member = custom_type.drain(..).next().unwrap_or(Symbol::DUMMY);
+                return Ok(dyn_member(&ty, next_member.as_str()).or(Some(ty)));
+            }
+            let var = hir.variable(vid);
+            return infer_var_ty(gcx, &var.ty, custom_type);
+        }
+
+        // Struct?
+        if let Some(sid) = contract.items.iter().find_map(|i| {
+            if let ItemId::Struct(sid) = i
+                && hir.strukt(*sid).name.as_str() == cur
+            {
+                Some(*sid)
+            } else {
+                None
+            }
+        }) {
+            let inner = gcx
+                .struct_field_types(sid)
+                .iter()
+                .map(|&t| {
+                    solar_ty_to_dyn(gcx, t)
+                        .ok_or_else(|| eyre::eyre!("Struct `{cur}` has invalid fields"))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            return Ok(Some(DynSolType::Tuple(inner)));
+        }
+
+        eyre::bail!(
+            "Could not find any definition in contract \"{}\" for type: {custom_type:?}",
+            contract.name.as_str()
         )
     }
 
-    /// Returns whether this type is a dynamic array (can call push, pop).
-    #[inline]
-    const fn is_dynamic_array(&self) -> bool {
-        matches!(self, Self::Array(_) | Self::Builtin(DynSolType::Array(_)))
+    let repl_id = gcx
+        .hir
+        .contracts_enumerated()
+        .find_map(|(cid, c)| (c.name.as_str() == "REPL").then_some(cid));
+    if let Some(repl_id) = repl_id
+        && let Ok(res) = infer_custom_type(gcx, custom_type, Some(repl_id))
+    {
+        return Ok(res);
     }
 
-    const fn is_fixed_bytes(&self) -> bool {
-        matches!(self, Self::Builtin(DynSolType::FixedBytes(_)))
+    let last_name = *custom_type.last().unwrap();
+    let last = last_name.as_str();
+    let contract_match = gcx
+        .hir
+        .contracts_enumerated()
+        .find_map(|(cid, c)| (c.name.as_str() == last).then_some(cid));
+    if let Some(cid) = contract_match {
+        custom_type.pop();
+        return infer_custom_type(gcx, custom_type, Some(cid));
     }
+
+    Ok(None)
+}
+
+/// Infers the type from a variable's HIR type, optionally accessing a named member.
+fn infer_var_ty(
+    gcx: Gcx<'_>,
+    ty: &HirType<'_>,
+    custom_type: &mut Vec<Symbol>,
+) -> Result<Option<DynSolType>> {
+    let Some(ty) = hir_ty_to_dyn(gcx, ty) else { return Ok(None) };
+    let next_member = custom_type.drain(..).next();
+    if let Some(m) = next_member {
+        Ok(dyn_member(&ty, m.as_str()).or(Some(ty)))
+    } else {
+        Ok(Some(ty))
+    }
+}
+
+/// Get the return type of a contract method call `receiver.method()`.
+fn get_function_return_type(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<DynSolType> {
+    let ExprKind::Call(callee, _, _) = &expr.kind else { return None };
+    let ExprKind::Member(obj, fn_ident) = &callee.kind else { return None };
+    let ExprKind::Ident(reses) = &obj.kind else { return None };
+    let res = reses.first()?;
+    let var_id = match res {
+        Res::Item(ItemId::Variable(vid)) => *vid,
+        _ => return None,
+    };
+    let var_ty = gcx.type_of_item(var_id.into()).peel_refs();
+    let cid = match var_ty.kind {
+        TyKind::Contract(cid) => cid,
+        _ => return None,
+    };
+
+    let hir = &gcx.hir;
+    let contract = hir.contract(cid);
+    let fid = contract
+        .functions()
+        .find(|&f| hir.function(f).name.as_ref().map(|n| n.as_str()) == Some(fn_ident.as_str()))?;
+    let func = hir.function(fid);
+    let ret_id = *func.returns.first()?;
+    solar_ty_to_dyn(gcx, gcx.type_of_item(ret_id.into()))
 }
 
 /// Returns Some if the custom type is a function member access.
@@ -1205,14 +1046,6 @@ fn should_continue(expr: &Expr<'_>) -> bool {
         },
         _ => false,
     }
-}
-
-fn types_to_parameters(
-    types: Vec<Option<Type>>,
-    lookup: bool,
-    gcx: Option<Gcx<'_>>,
-) -> Vec<DynSolType> {
-    types.into_iter().filter_map(|ty| ty.and_then(|ty| ty.try_as_ethabi(lookup, gcx))).collect()
 }
 
 /// Parses an [`hir::Expr`] number/hex literal into a `U256`. Returns `None` if the expression
@@ -1312,6 +1145,7 @@ fn solar_ty_to_dyn<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> Option<DynSolType> {
 mod tests {
     use super::*;
     use foundry_compilers::{error::SolcError, solc::Solc};
+    use solar::sema::Compiler;
     use std::sync::Mutex;
 
     #[test]
@@ -1630,8 +1464,6 @@ mod tests {
     /// `abi.decode(bytes, (uint8[13]))` or `a[0:3]` on a memory array) can still exercise the
     /// HIR-based type-inference engine.
     fn get_type_ethabi(s: &mut SessionSource, input: &str, clear: bool) -> Option<DynSolType> {
-        use solar::sema::Compiler;
-
         if clear {
             s.clear();
         }
@@ -1681,7 +1513,7 @@ mod tests {
                 StmtKind::Expr(e) => e,
                 _ => return None,
             };
-            Type::ethabi(gcx, expr, true)
+            expr_to_dyn(gcx, expr, true)
         })
     }
 

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -372,7 +372,7 @@ fn format_token(token: DynSolValue) -> String {
     }
 }
 
-/// Formats an [`hir::Event`] into an inspection message.
+/// Formats an [`Event`] into an inspection message.
 // TODO: Verbosity option
 fn format_event_definition(gcx: Gcx<'_>, event: &Event<'_>) -> Result<String> {
     let event_name = event.name.as_str().to_string();
@@ -1048,7 +1048,7 @@ fn should_continue(expr: &Expr<'_>) -> bool {
     }
 }
 
-/// Parses an [`hir::Expr`] number/hex literal into a `U256`. Returns `None` if the expression
+/// Parses an [`Expr`] number/hex literal into a `U256`. Returns `None` if the expression
 /// is not a numeric literal.
 ///
 /// SubDenominations are already applied to numeric literals in solar's HIR.

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -2,10 +2,7 @@
 //!
 //! This module contains the execution logic for the [SessionSource].
 
-use crate::{
-    prelude::{ChiselDispatcher, ChiselResult, ChiselRunner, SessionSource, SolidityHelper},
-    source::IntermediateOutput,
-};
+use crate::prelude::{ChiselDispatcher, ChiselResult, ChiselRunner, SessionSource, SolidityHelper};
 use alloy_dyn_abi::{DynSolType, DynSolValue};
 use alloy_json_abi::EventParam;
 use alloy_primitives::{Address, B256, U256, hex};
@@ -15,7 +12,14 @@ use foundry_evm::{
     backend::Backend, decode::decode_console_logs, executors::ExecutorBuilder,
     inspectors::CheatsConfig, traces::TraceMode,
 };
-use solang_parser::pt;
+use solar::{
+    ast::{BinOpKind, ElementaryType, FunctionKind, LitKind, StateMutability, StrKind, UnOpKind},
+    interface::Symbol,
+    sema::{
+        hir::{self, Visibility},
+        ty::{Gcx, Ty, TyKind},
+    },
+};
 use std::ops::ControlFlow;
 use yansi::Paint;
 
@@ -86,8 +90,10 @@ impl SessionSource {
         if let Some(err) = err {
             let output = source_without_inspector.build()?;
 
-            let formatted_event =
-                output.enter(|output| output.get_event(input).map(format_event_definition));
+            let formatted_event = output.enter(|output| {
+                let gcx = output.gcx();
+                output.get_event(input).map(|eid| format_event_definition(gcx, gcx.hir.event(eid)))
+            });
             if let Some(formatted_event) = formatted_event {
                 return Ok((ControlFlow::Break(()), Some(formatted_event?)));
             }
@@ -122,30 +128,37 @@ impl SessionSource {
         // which was wrapped in `abi.encode`.
         let generated_output = source.build()?;
 
-        // If the expression is a variable declaration within the REPL contract, use its type;
-        // otherwise, attempt to infer the type.
-        let contract_expr = generated_output
-            .intermediate
-            .repl_contract_expressions
-            .get(input)
-            .or_else(|| source.infer_inner_expr_type());
+        // Inside the compiler closure, infer the DynSolType of the inspected expression and
+        // determine whether the REPL should continue.
+        let res_ty = generated_output.enter(|out| -> Option<(bool, DynSolType)> {
+            let gcx = out.gcx();
 
-        // If the current action is a function call, we get its return type
-        // otherwise it returns None
-        let function_call_return_type =
-            Type::get_function_return_type(contract_expr, &generated_output.intermediate);
-
-        let (contract_expr, ty) = if let Some(function_call_return_type) = function_call_return_type
-        {
-            (function_call_return_type.0, function_call_return_type.1)
-        } else {
-            match contract_expr.and_then(|e| {
-                Type::ethabi(e, Some(&generated_output.intermediate)).map(|ty| (e, ty))
-            }) {
-                Some(res) => res,
-                // this type was denied for inspection, continue
-                None => return Ok((ControlFlow::Continue(()), None)),
+            // Try direct lookup of `input` as a named variable in the REPL contract.
+            if let Some(direct_ty) = lookup_named_variable_type(gcx, input) {
+                return Some((false, direct_ty));
             }
+
+            // Otherwise, find the appended `bytes memory inspectoor = abi.encode(<input>);`
+            // and pull out the first call argument.
+            let block = out.run_func_body();
+            let last = block.last()?;
+            let hir::StmtKind::DeclSingle(vid) = last.kind else { return None };
+            let var = gcx.hir.variable(vid);
+            let init = var.initializer?;
+            let hir::ExprKind::Call(_callee, args, _) = &init.kind else { return None };
+            let inner_expr = args.exprs().next()?;
+
+            // If the call is `func()` returning a single value, prefer the function return type.
+            if let Some(ty) = Type::get_function_return_type(gcx, inner_expr) {
+                return Some((should_continue(inner_expr), ty));
+            }
+
+            let ty = Type::ethabi(gcx, inner_expr, true)?;
+            Some((should_continue(inner_expr), ty))
+        });
+
+        let Some((cont, ty)) = res_ty else {
+            return Ok((ControlFlow::Continue(()), None));
         };
 
         // the file compiled correctly, thus the last stack item must be the memory offset of
@@ -162,40 +175,8 @@ impl SessionSource {
             eyre::bail!("Failed to inspect last expression: could not retrieve data from memory")
         };
         let token = ty.abi_decode(data).wrap_err("Could not decode inspected values")?;
-        let c = if should_continue(contract_expr) {
-            ControlFlow::Continue(())
-        } else {
-            ControlFlow::Break(())
-        };
+        let c = if cont { ControlFlow::Continue(()) } else { ControlFlow::Break(()) };
         Ok((c, Some(format_token(token))))
-    }
-
-    /// Gracefully attempts to extract the type of the expression within the `abi.encode(...)`
-    /// call inserted by the inspect function.
-    ///
-    /// ### Takes
-    ///
-    /// A reference to a [SessionSource]
-    ///
-    /// ### Returns
-    ///
-    /// Optionally, a [Type]
-    fn infer_inner_expr_type(&self) -> Option<&pt::Expression> {
-        let out = self.build().ok()?;
-        let run = out.run_func_body().ok()?.last();
-        match run {
-            Some(pt::Statement::VariableDefinition(
-                _,
-                _,
-                Some(pt::Expression::FunctionCall(_, _, args)),
-            )) => {
-                // We can safely unwrap the first expression because this function
-                // will only be called on a session source that has just had an
-                // `inspectoor` variable appended to it.
-                Some(args.first().unwrap())
-            }
-            _ => None,
-        }
     }
 
     async fn build_runner(&mut self, final_pc: usize) -> Result<ChiselRunner> {
@@ -239,6 +220,51 @@ impl SessionSource {
 
         Ok(ChiselRunner::new(executor, U256::MAX, Address::ZERO, self.config.calldata.clone()))
     }
+}
+
+/// Looks up `name` as a named variable in the REPL contract (state variables or run() locals)
+/// and returns its type as a [`DynSolType`].
+///
+/// Only top-level statements of `run()` are scanned. Variables declared inside nested blocks
+/// (`if`, `for`, `while`, `unchecked`, etc.) are not visible here; the caller falls back to
+/// the `inspectoor`-based path for those cases.
+fn lookup_named_variable_type(gcx: Gcx<'_>, name: &str) -> Option<DynSolType> {
+    let hir = &gcx.hir;
+    let repl = hir.contracts().find(|c| c.name.as_str() == "REPL")?;
+
+    // State variables.
+    for vid in repl.variables() {
+        let var = hir.variable(vid);
+        if var.name.map(|n| n.as_str() == name).unwrap_or(false) {
+            return solar_ty_to_dyn(gcx, gcx.type_of_item(vid.into()));
+        }
+    }
+
+    // Locals declared in run().
+    let run_fid = repl
+        .functions()
+        .find(|&f| hir.function(f).name.as_ref().map(|n| n.as_str()) == Some("run"))?;
+    let body = hir.function(run_fid).body?;
+    for stmt in body.stmts {
+        match stmt.kind {
+            hir::StmtKind::DeclSingle(vid) => {
+                let var = hir.variable(vid);
+                if var.name.map(|n| n.as_str() == name).unwrap_or(false) {
+                    return solar_ty_to_dyn(gcx, gcx.type_of_item(vid.into()));
+                }
+            }
+            hir::StmtKind::DeclMulti(vids, _) => {
+                for vid in vids.iter().flatten() {
+                    let var = hir.variable(*vid);
+                    if var.name.map(|n| n.as_str() == name).unwrap_or(false) {
+                        return solar_ty_to_dyn(gcx, gcx.type_of_item((*vid).into()));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Formats a value into an inspection message
@@ -343,41 +369,29 @@ fn format_token(token: DynSolValue) -> String {
     }
 }
 
-/// Formats a [pt::EventDefinition] into an inspection message
-///
-/// ### Takes
-///
-/// An borrowed [pt::EventDefinition]
-///
-/// ### Returns
-///
-/// A formatted [pt::EventDefinition] for use in inspection output.
+/// Formats an [`hir::Event`] into an inspection message.
 // TODO: Verbosity option
-fn format_event_definition(event_definition: &pt::EventDefinition) -> Result<String> {
-    let event_name = event_definition.name.as_ref().expect("Event has a name").to_string();
-    let inputs = event_definition
-        .fields
+fn format_event_definition(gcx: Gcx<'_>, event: &hir::Event<'_>) -> Result<String> {
+    let event_name = event.name.as_str().to_string();
+    let inputs = event
+        .parameters
         .iter()
-        .map(|param| {
-            let name = param
-                .name
-                .as_ref()
-                .map(ToString::to_string)
-                .unwrap_or_else(|| "<anonymous>".to_string());
-            let kind = Type::from_expression(&param.ty)
-                .and_then(Type::into_builtin)
+        .map(|&pid| {
+            let var = gcx.hir.variable(pid);
+            let name =
+                var.name.map(|n| n.as_str().to_string()).unwrap_or_else(|| "<anonymous>".into());
+            let kind = solar_ty_to_dyn(gcx, gcx.type_of_item(pid.into()))
                 .ok_or_else(|| eyre::eyre!("Invalid type in event {event_name}"))?;
             Ok(EventParam {
                 name,
                 ty: kind.to_string(),
                 components: vec![],
-                indexed: param.indexed,
+                indexed: var.indexed,
                 internal_type: None,
             })
         })
         .collect::<Result<Vec<_>>>()?;
-    let event =
-        alloy_json_abi::Event { name: event_name, inputs, anonymous: event_definition.anonymous };
+    let event = alloy_json_abi::Event { name: event_name, inputs, anonymous: event.anonymous };
 
     Ok(format!(
         "Type: {}\n├ Name: {}\n├ Signature: {:?}\n└ Selector: {:?}",
@@ -432,233 +446,285 @@ enum Type {
     Function(Box<Self>, Vec<Option<Self>>, Vec<Option<Self>>),
 
     /// (lhs, rhs)
-    Access(Box<Self>, String),
+    Access(Box<Self>, Symbol),
 
     /// (types)
-    Custom(Vec<String>),
+    Custom(Vec<Symbol>),
 }
 
 impl Type {
-    /// Convert a [pt::Expression] to a [Type]
-    ///
-    /// ### Takes
-    ///
-    /// A reference to a [pt::Expression] to convert.
-    ///
-    /// ### Returns
-    ///
-    /// Optionally, an owned [Type]
-    fn from_expression(expr: &pt::Expression) -> Option<Self> {
-        match expr {
-            pt::Expression::Type(_, ty) => Self::from_type(ty),
+    /// Convert a [`hir::Expr`] to a [`Type`].
+    fn from_expr(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> Option<Self> {
+        match &expr.kind {
+            // Elementary type expression: `uint256`, `address`, etc.
+            hir::ExprKind::Type(ty) => Self::from_hir_ty(gcx, ty),
 
-            pt::Expression::Variable(ident) => Some(Self::Custom(vec![ident.name.clone()])),
+            // `type(T)` expression. Modelled like a call to a builtin `type` function so that
+            // member access (e.g. `type(C).name` or `type(uint256).max`) can be resolved by
+            // [`Self::map_special`].
+            hir::ExprKind::TypeCall(ty) => {
+                let inner = Self::from_hir_ty(gcx, ty);
+                Some(Self::Function(
+                    Box::new(Self::Custom(vec![Symbol::intern("type")])),
+                    vec![inner],
+                    vec![],
+                ))
+            }
 
-            // array
-            pt::Expression::ArraySubscript(_, expr, num) => {
-                // if num is Some then this is either an index operation (arr[<num>])
-                // or a FixedArray statement (new uint256[<num>])
-                Self::from_expression(expr).and_then(|ty| {
-                    let boxed = Box::new(ty);
-                    let num = num.as_deref().and_then(parse_number_literal).and_then(|n| {
-                        usize::try_from(n).ok()
-                    });
-                    match expr.as_ref() {
-                        // statement
-                        pt::Expression::Type(_, _) => {
-                            if let Some(num) = num {
-                                Some(Self::FixedArray(boxed, num))
+            // Resolved identifier: `foo`.
+            hir::ExprKind::Ident(reses) => {
+                let res = reses.first()?;
+                match *res {
+                    hir::Res::Item(item) => match item {
+                        hir::ItemId::Variable(vid) => {
+                            let var = gcx.hir.variable(vid);
+                            let name = var.name?.name;
+                            // Try the resolved solar type first.
+                            let ty = gcx.type_of_item(vid.into());
+                            if let Some(dyn_ty) = solar_ty_to_dyn(gcx, ty) {
+                                Some(Self::Builtin(dyn_ty))
                             } else {
-                                Some(Self::Array(boxed))
+                                Some(Self::Custom(vec![name]))
                             }
                         }
-                        // index
-                        pt::Expression::Variable(_) => {
-                            Some(Self::ArrayIndex(boxed, num))
+                        hir::ItemId::Function(fid) => {
+                            let func = gcx.hir.function(fid);
+                            let name = func.name?.name;
+                            Some(Self::Custom(vec![name]))
                         }
-                        _ => None
-                    }
-                })
-            }
-            pt::Expression::ArrayLiteral(_, values) => {
-                values.first().and_then(Self::from_expression).map(|ty| {
-                    Self::FixedArray(Box::new(ty), values.len())
-                })
-            }
-
-            // tuple
-            pt::Expression::List(_, params) => Some(Self::Tuple(map_parameters(params))),
-
-            // <lhs>.<rhs>
-            pt::Expression::MemberAccess(_, lhs, rhs) => {
-                Self::from_expression(lhs).map(|lhs| {
-                    Self::Access(Box::new(lhs), rhs.name.clone())
-                })
-            }
-
-            // <inner>
-            pt::Expression::Parenthesis(_, inner) |         // (<inner>)
-            pt::Expression::New(_, inner) |                 // new <inner>
-            pt::Expression::UnaryPlus(_, inner) |           // +<inner>
-            // ops
-            pt::Expression::BitwiseNot(_, inner) |          // ~<inner>
-            pt::Expression::ArraySlice(_, inner, _, _) |    // <inner>[*start*:*end*]
-            // assign ops
-            pt::Expression::PreDecrement(_, inner) |        // --<inner>
-            pt::Expression::PostDecrement(_, inner) |       // <inner>--
-            pt::Expression::PreIncrement(_, inner) |        // ++<inner>
-            pt::Expression::PostIncrement(_, inner) |       // <inner>++
-            pt::Expression::Assign(_, inner, _) |           // <inner>   = ...
-            pt::Expression::AssignAdd(_, inner, _) |        // <inner>  += ...
-            pt::Expression::AssignSubtract(_, inner, _) |   // <inner>  -= ...
-            pt::Expression::AssignMultiply(_, inner, _) |   // <inner>  *= ...
-            pt::Expression::AssignDivide(_, inner, _) |     // <inner>  /= ...
-            pt::Expression::AssignModulo(_, inner, _) |     // <inner>  %= ...
-            pt::Expression::AssignAnd(_, inner, _) |        // <inner>  &= ...
-            pt::Expression::AssignOr(_, inner, _) |         // <inner>  |= ...
-            pt::Expression::AssignXor(_, inner, _) |        // <inner>  ^= ...
-            pt::Expression::AssignShiftLeft(_, inner, _) |  // <inner> <<= ...
-            pt::Expression::AssignShiftRight(_, inner, _)   // <inner> >>= ...
-            => Self::from_expression(inner),
-
-            // *condition* ? <if_true> : <if_false>
-            pt::Expression::ConditionalOperator(_, _, if_true, if_false) => {
-                Self::from_expression(if_true).or_else(|| Self::from_expression(if_false))
-            }
-
-            // address
-            pt::Expression::AddressLiteral(_, _) => Some(Self::Builtin(DynSolType::Address)),
-            pt::Expression::HexNumberLiteral(_, s, _) => {
-                match s.parse::<Address>() {
-                    Ok(addr) if *s == addr.to_checksum(None) => {
-                        Some(Self::Builtin(DynSolType::Address))
-                    }
-                    _ => Some(Self::Builtin(DynSolType::Uint(256))),
+                        hir::ItemId::Contract(cid) => {
+                            let c = gcx.hir.contract(cid);
+                            Some(Self::Custom(vec![c.name.name]))
+                        }
+                        hir::ItemId::Struct(sid) => {
+                            // Struct constructor: produces a value of the struct type, which we
+                            // model as a tuple of field types.
+                            let fields = gcx.struct_field_types(sid);
+                            let parts = fields
+                                .iter()
+                                .map(|&t| solar_ty_to_dyn(gcx, t).map(Self::Builtin))
+                                .collect();
+                            Some(Self::Tuple(parts))
+                        }
+                        hir::ItemId::Enum(eid) => {
+                            let e = gcx.hir.enumm(eid);
+                            Some(Self::Custom(vec![e.name.name]))
+                        }
+                        hir::ItemId::Udvt(uid) => {
+                            let u = gcx.hir.udvt(uid);
+                            Some(Self::Custom(vec![u.name.name]))
+                        }
+                        hir::ItemId::Error(eid) => {
+                            let e = gcx.hir.error(eid);
+                            Some(Self::Custom(vec![e.name.name]))
+                        }
+                        hir::ItemId::Event(eid) => {
+                            let e = gcx.hir.event(eid);
+                            Some(Self::Custom(vec![e.name.name]))
+                        }
+                    },
+                    hir::Res::Builtin(b) => Some(Self::Custom(vec![b.name()])),
+                    hir::Res::Namespace(_) | hir::Res::Err(_) => None,
                 }
             }
 
-            // uint and int
-            // invert
-            pt::Expression::Negate(_, inner) => Self::from_expression(inner).map(Self::invert_int),
-
-            // int if either operand is int
-            // TODO: will need an update for Solidity v0.8.18 user defined operators:
-            // https://github.com/ethereum/solidity/issues/13718#issuecomment-1341058649
-            pt::Expression::Add(_, lhs, rhs) |
-            pt::Expression::Subtract(_, lhs, rhs) |
-            pt::Expression::Multiply(_, lhs, rhs) |
-            pt::Expression::Divide(_, lhs, rhs) => {
-                match (Self::ethabi(lhs, None), Self::ethabi(rhs, None)) {
-                    (Some(DynSolType::Int(_) | DynSolType::Uint(_)), Some(DynSolType::Int(_))) |
-(Some(DynSolType::Int(_)), Some(DynSolType::Uint(_))) => {
-                        Some(Self::Builtin(DynSolType::Int(256)))
+            // Index/access: `arr[i]`, `MyType[]`.
+            hir::ExprKind::Index(base, idx) => Self::from_expr(gcx, base).map(|ty| {
+                let boxed = Box::new(ty);
+                let num =
+                    idx.and_then(|e| parse_number_literal(e)).and_then(|n| usize::try_from(n).ok());
+                match &base.kind {
+                    hir::ExprKind::Type(_) | hir::ExprKind::TypeCall(_) => {
+                        if let Some(num) = num {
+                            Self::FixedArray(boxed, num)
+                        } else {
+                            Self::Array(boxed)
+                        }
                     }
-                    _ => {
-                        Some(Self::Builtin(DynSolType::Uint(256)))
+                    _ => Self::ArrayIndex(boxed, num),
+                }
+            }),
+
+            // Slice expression: `arr[a:b]`.
+            hir::ExprKind::Slice(base, _, _) => Self::from_expr(gcx, base),
+
+            // Array literal `[a, b, c]`.
+            hir::ExprKind::Array(values) => values
+                .first()
+                .and_then(|e| Self::from_expr(gcx, e))
+                .map(|ty| Self::FixedArray(Box::new(ty), values.len())),
+
+            // Tuple expression `(a, b, c)`.
+            hir::ExprKind::Tuple(items) => Some(Self::Tuple(
+                items.iter().map(|opt| opt.and_then(|e| Self::from_expr(gcx, e))).collect(),
+            )),
+
+            // Member access `lhs.rhs`.
+            hir::ExprKind::Member(lhs, ident) => {
+                Self::from_expr(gcx, lhs).map(|lhs| Self::Access(Box::new(lhs), ident.name))
+            }
+
+            // `new T`.
+            hir::ExprKind::New(ty) => Self::from_hir_ty(gcx, ty),
+
+            // `payable(addr)`.
+            hir::ExprKind::Payable(_) => Some(Self::Builtin(DynSolType::Address)),
+
+            // Ternary: prefer truthy branch's type, fall back to else branch.
+            hir::ExprKind::Ternary(_, t, e) => {
+                Self::from_expr(gcx, t).or_else(|| Self::from_expr(gcx, e))
+            }
+
+            // Delete expression has no usable type.
+            hir::ExprKind::Delete(_) => None,
+
+            // Literals.
+            hir::ExprKind::Lit(lit) => match &lit.kind {
+                LitKind::Address(_) => Some(Self::Builtin(DynSolType::Address)),
+                LitKind::Bool(_) => Some(Self::Builtin(DynSolType::Bool)),
+                LitKind::Str(kind, _, _) => match kind {
+                    StrKind::Hex => Some(Self::Builtin(DynSolType::Bytes)),
+                    StrKind::Str | StrKind::Unicode => Some(Self::Builtin(DynSolType::String)),
+                },
+                LitKind::Number(_) | LitKind::Rational(_) => {
+                    Some(Self::Builtin(DynSolType::Uint(256)))
+                }
+                LitKind::Err(_) => None,
+            },
+
+            // Unary operations.
+            hir::ExprKind::Unary(op, inner) => match op.kind {
+                UnOpKind::Neg => Self::from_expr(gcx, inner).map(Self::invert_int),
+                UnOpKind::Not => Some(Self::Builtin(DynSolType::Bool)),
+                UnOpKind::BitNot
+                | UnOpKind::PreInc
+                | UnOpKind::PreDec
+                | UnOpKind::PostInc
+                | UnOpKind::PostDec => Self::from_expr(gcx, inner),
+            },
+
+            // Binary operations.
+            hir::ExprKind::Binary(lhs, op, rhs) => match op.kind {
+                BinOpKind::Lt
+                | BinOpKind::Le
+                | BinOpKind::Gt
+                | BinOpKind::Ge
+                | BinOpKind::Eq
+                | BinOpKind::Ne
+                | BinOpKind::And
+                | BinOpKind::Or => Some(Self::Builtin(DynSolType::Bool)),
+                BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul | BinOpKind::Div => {
+                    match (Self::ethabi(gcx, lhs, false), Self::ethabi(gcx, rhs, false)) {
+                        (
+                            Some(DynSolType::Int(_) | DynSolType::Uint(_)),
+                            Some(DynSolType::Int(_)),
+                        )
+                        | (Some(DynSolType::Int(_)), Some(DynSolType::Uint(_))) => {
+                            Some(Self::Builtin(DynSolType::Int(256)))
+                        }
+                        _ => Some(Self::Builtin(DynSolType::Uint(256))),
                     }
                 }
-            }
+                BinOpKind::Rem
+                | BinOpKind::Pow
+                | BinOpKind::BitAnd
+                | BinOpKind::BitOr
+                | BinOpKind::BitXor
+                | BinOpKind::Shl
+                | BinOpKind::Shr
+                | BinOpKind::Sar => Some(Self::Builtin(DynSolType::Uint(256))),
+            },
 
-            // always assume uint
-            pt::Expression::Modulo(_, _, _) |
-            pt::Expression::Power(_, _, _) |
-            pt::Expression::BitwiseOr(_, _, _) |
-            pt::Expression::BitwiseAnd(_, _, _) |
-            pt::Expression::BitwiseXor(_, _, _) |
-            pt::Expression::ShiftRight(_, _, _) |
-            pt::Expression::ShiftLeft(_, _, _) |
-            pt::Expression::NumberLiteral(_, _, _, _) => Some(Self::Builtin(DynSolType::Uint(256))),
+            // Assignments: type of the lhs.
+            hir::ExprKind::Assign(lhs, _, _) => Self::from_expr(gcx, lhs),
 
-            // TODO: Rational numbers
-            pt::Expression::RationalNumberLiteral(_, _, _, _, _) => {
-                Some(Self::Builtin(DynSolType::Uint(256)))
-            }
+            // Function call.
+            hir::ExprKind::Call(callee, args, _named) => Self::from_expr(gcx, callee).map(|name| {
+                let args = args.exprs().map(|e| Self::from_expr(gcx, e)).collect();
+                Self::Function(Box::new(name), args, vec![])
+            }),
 
-            // bool
-            pt::Expression::BoolLiteral(_, _) |
-            pt::Expression::And(_, _, _) |
-            pt::Expression::Or(_, _, _) |
-            pt::Expression::Equal(_, _, _) |
-            pt::Expression::NotEqual(_, _, _) |
-            pt::Expression::Less(_, _, _) |
-            pt::Expression::LessEqual(_, _, _) |
-            pt::Expression::More(_, _, _) |
-            pt::Expression::MoreEqual(_, _, _) |
-            pt::Expression::Not(_, _) => Some(Self::Builtin(DynSolType::Bool)),
-
-            // string
-            pt::Expression::StringLiteral(_) => Some(Self::Builtin(DynSolType::String)),
-
-            // bytes
-            pt::Expression::HexLiteral(_) => Some(Self::Builtin(DynSolType::Bytes)),
-
-            // function
-            pt::Expression::FunctionCall(_, name, args) => {
-                Self::from_expression(name).map(|name| {
-                    let args = args.iter().map(Self::from_expression).collect();
-                    Self::Function(Box::new(name), args, vec![])
-                })
-            }
-            pt::Expression::NamedFunctionCall(_, name, args) => {
-                Self::from_expression(name).map(|name| {
-                    let args = args.iter().map(|arg| Self::from_expression(&arg.expr)).collect();
-                    Self::Function(Box::new(name), args, vec![])
-                })
-            }
-
-            // explicitly None
-            pt::Expression::Delete(_, _) | pt::Expression::FunctionCallBlock(_, _, _) => None,
+            hir::ExprKind::Err(_) => None,
         }
     }
 
-    /// Convert a [pt::Type] to a [Type]
-    ///
-    /// ### Takes
-    ///
-    /// A reference to a [pt::Type] to convert.
-    ///
-    /// ### Returns
-    ///
-    /// Optionally, an owned [Type]
-    fn from_type(ty: &pt::Type) -> Option<Self> {
-        let ty = match ty {
-            pt::Type::Address | pt::Type::AddressPayable | pt::Type::Payable => {
-                Self::Builtin(DynSolType::Address)
+    /// Convert a [`hir::Type`] to a [`Type`].
+    fn from_hir_ty(gcx: Gcx<'_>, ty: &hir::Type<'_>) -> Option<Self> {
+        match &ty.kind {
+            hir::TypeKind::Elementary(et) => Some(Self::Builtin(elementary_to_dyn(*et)?)),
+            hir::TypeKind::Array(arr) => {
+                let elem = Self::from_hir_ty(gcx, &arr.element)?;
+                if let Some(size) = arr.size {
+                    let n = parse_number_literal(size).and_then(|n| usize::try_from(n).ok());
+                    if let Some(n) = n {
+                        Some(Self::FixedArray(Box::new(elem), n))
+                    } else {
+                        Some(Self::Array(Box::new(elem)))
+                    }
+                } else {
+                    Some(Self::Array(Box::new(elem)))
+                }
             }
-            pt::Type::Bool => Self::Builtin(DynSolType::Bool),
-            pt::Type::String => Self::Builtin(DynSolType::String),
-            pt::Type::Int(size) => Self::Builtin(DynSolType::Int(*size as usize)),
-            pt::Type::Uint(size) => Self::Builtin(DynSolType::Uint(*size as usize)),
-            pt::Type::Bytes(size) => Self::Builtin(DynSolType::FixedBytes(*size as usize)),
-            pt::Type::DynamicBytes => Self::Builtin(DynSolType::Bytes),
-            pt::Type::Mapping { value, .. } => Self::from_expression(value)?,
-            pt::Type::Function { params, returns, .. } => {
-                let params = map_parameters(params);
-                let returns = returns
-                    .as_ref()
-                    .map(|(returns, _)| map_parameters(returns))
-                    .unwrap_or_default();
-                Self::Function(
-                    Box::new(Self::Custom(vec!["__fn_type__".to_string()])),
+            hir::TypeKind::Function(f) => {
+                let params = f
+                    .parameters
+                    .iter()
+                    .map(|&pid| {
+                        let var = gcx.hir.variable(pid);
+                        Self::from_hir_ty(gcx, &var.ty)
+                    })
+                    .collect();
+                let returns = f
+                    .returns
+                    .iter()
+                    .map(|&pid| {
+                        let var = gcx.hir.variable(pid);
+                        Self::from_hir_ty(gcx, &var.ty)
+                    })
+                    .collect();
+                Some(Self::Function(
+                    Box::new(Self::Custom(vec![Symbol::intern("__fn_type__")])),
                     params,
                     returns,
-                )
+                ))
             }
-            // TODO: Rational numbers
-            pt::Type::Rational => return None,
-        };
-        Some(ty)
+            hir::TypeKind::Mapping(m) => Self::from_hir_ty(gcx, &m.value),
+            hir::TypeKind::Custom(item) => {
+                // User-defined type names always become `Custom([name])` here, mirroring the
+                // legacy pt-based engine where custom names came in via `Variable(name)` rather
+                // than the elementary `from_type` path. Conversion to a concrete `DynSolType`
+                // (e.g. struct → tuple, udvt → underlying) happens later in `try_as_ethabi`.
+                let name = match *item {
+                    hir::ItemId::Contract(id) => gcx.hir.contract(id).name.name,
+                    hir::ItemId::Struct(id) => gcx.hir.strukt(id).name.name,
+                    hir::ItemId::Enum(id) => gcx.hir.enumm(id).name.name,
+                    hir::ItemId::Udvt(id) => gcx.hir.udvt(id).name.name,
+                    hir::ItemId::Error(id) => gcx.hir.error(id).name.name,
+                    hir::ItemId::Event(id) => gcx.hir.event(id).name.name,
+                    hir::ItemId::Function(id) => gcx.hir.function(id).name?.name,
+                    hir::ItemId::Variable(id) => gcx.hir.variable(id).name?.name,
+                };
+                Some(Self::Custom(vec![name]))
+            }
+            hir::TypeKind::Err(_) => {
+                // Best-effort fallback: when name resolution failed, recover the textual name
+                // from the source span so the inference engine can still treat it as a custom
+                // type (e.g., `type(C).name` where contract `C` does not exist).
+                let snippet = gcx.sess.source_map().span_to_snippet(ty.span).ok()?;
+                let name = snippet.trim();
+                if name.is_empty() { None } else { Some(Self::Custom(vec![Symbol::intern(name)])) }
+            }
+        }
     }
 
-    /// Handle special expressions like [global variables](https://docs.soliditylang.org/en/latest/cheatsheet.html#global-variables)
-    ///
-    /// See: <https://github.com/ethereum/solidity/blob/81268e336573721819e39fbb3fefbc9344ad176c/libsolidity/ast/Types.cpp#L4106>
+    /// Handle special expressions like
+    /// [global variables](https://docs.soliditylang.org/en/latest/cheatsheet.html#global-variables).
     fn map_special(self) -> Self {
         if !matches!(self, Self::Function(_, _, _) | Self::Access(_, _) | Self::Custom(_)) {
             return self;
         }
 
-        let mut types = Vec::with_capacity(5);
+        let mut types: Vec<Symbol> = Vec::with_capacity(5);
         let mut args = None;
         self.recurse(&mut types, &mut args);
 
@@ -672,7 +738,7 @@ impl Type {
         #[allow(clippy::collapsible_match)]
         match &self {
             Self::Access(inner, access) => {
-                if let Some(ty) = inner.as_ref().clone().try_as_ethabi(None) {
+                if let Some(ty) = inner.as_ref().clone().try_as_ethabi(false, None) {
                     // Array / bytes members
                     let ty = Self::Builtin(ty);
                     match access.as_str() {
@@ -723,8 +789,6 @@ impl Type {
                         "abi" => match access {
                             "decode" => {
                                 // args = Some([Bytes(_), Tuple(args)])
-                                // unwrapping is safe because this is first compiled by solc so
-                                // it is guaranteed to be a valid call
                                 let mut args = args.unwrap();
                                 let last = args.pop().unwrap();
                                 match last {
@@ -784,13 +848,13 @@ impl Type {
     }
 
     /// Recurses over itself, appending all the idents and function arguments in the order that they
-    /// are found
-    fn recurse(&self, types: &mut Vec<String>, args: &mut Option<Vec<Option<Self>>>) {
+    /// are found.
+    fn recurse(&self, types: &mut Vec<Symbol>, args: &mut Option<Vec<Option<Self>>>) {
         match self {
-            Self::Builtin(ty) => types.push(ty.to_string()),
-            Self::Custom(tys) => types.extend(tys.clone()),
+            Self::Builtin(ty) => types.push(Symbol::intern(&ty.to_string())),
+            Self::Custom(tys) => types.extend(tys.iter().copied()),
             Self::Access(expr, name) => {
-                types.push(name.clone());
+                types.push(*name);
                 expr.recurse(types, args);
             }
             Self::Function(fn_name, fn_args, _fn_ret) => {
@@ -803,25 +867,15 @@ impl Type {
         }
     }
 
-    /// Infers a custom type's true type by recursing up the parse tree
-    ///
-    /// ### Takes
-    /// - A reference to the [IntermediateOutput]
-    /// - An array of custom types generated by the `MemberAccess` arm of [Self::from_expression]
-    /// - An optional contract name. This should always be `None` when this function is first
-    ///   called.
-    ///
-    /// ### Returns
-    ///
-    /// If successful, an `Ok(Some(DynSolType))` variant.
-    /// If gracefully failed, an `Ok(None)` variant.
-    /// If failed, an `Err(e)` variant.
+    /// Infers a custom type's true type by recursing through the HIR.
     fn infer_custom_type(
-        intermediate: &IntermediateOutput,
-        custom_type: &mut Vec<String>,
-        contract_name: Option<String>,
+        gcx: Gcx<'_>,
+        custom_type: &mut Vec<Symbol>,
+        contract_id: Option<hir::ContractId>,
     ) -> Result<Option<DynSolType>> {
-        if let Some("this" | "super") = custom_type.last().map(String::as_str) {
+        if let Some(last) = custom_type.last()
+            && (last.as_str() == "this" || last.as_str() == "super")
+        {
             custom_type.pop();
         }
         if custom_type.is_empty() {
@@ -829,232 +883,217 @@ impl Type {
         }
 
         // If a contract exists with the given name, check its definitions for a match.
-        // Otherwise look in the `run`
-        if let Some(contract_name) = contract_name {
-            let intermediate_contract = intermediate
-                .intermediate_contracts
-                .get(&contract_name)
-                .ok_or_else(|| eyre::eyre!("Could not find intermediate contract!"))?;
+        // Otherwise look in the `run`.
+        if let Some(cid) = contract_id {
+            let hir = &gcx.hir;
+            let contract = hir.contract(cid);
 
-            let cur_type = custom_type.last().unwrap();
-            if let Some(func) = intermediate_contract.function_definitions.get(cur_type) {
-                // Check if the custom type is a function pointer member access
+            let cur_name = *custom_type.last().unwrap();
+            let cur = cur_name.as_str();
+
+            // Function?
+            if let Some(fid) = contract.functions().find(|&f| {
+                hir.function(f).name.as_ref().map(|n| n.as_str() == cur).unwrap_or(false)
+            }) {
+                let func = hir.function(fid);
                 if let res @ Some(_) = func_members(func, custom_type) {
                     return Ok(res);
                 }
 
-                // Because tuple types cannot be passed to `abi.encode`, we will only be
-                // receiving functions that have 0 or 1 return parameters here.
                 if func.returns.is_empty() {
                     eyre::bail!(
                         "This call expression does not return any values to inspect. Insert as statement."
                     )
                 }
 
-                // Empty return types check is done above
-                let (_, param) = func.returns.first().unwrap();
-                // Return type should always be present
-                let return_ty = &param.as_ref().unwrap().ty;
-
-                // If the return type is a variable (not a type expression), re-enter the recursion
-                // on the same contract for a variable / struct search. It could be a contract,
-                // struct, array, etc.
-                if let pt::Expression::Variable(ident) = return_ty {
-                    custom_type.push(ident.name.clone());
-                    return Self::infer_custom_type(intermediate, custom_type, Some(contract_name));
-                }
-
                 // Check if our final function call alters the state. If it does, we bail so that it
-                // will be inserted normally without inspecting. If the state mutability was not
-                // expressly set, the function is inferred to alter state.
-                if let Some(pt::FunctionAttribute::Mutability(_mut)) = func
-                    .attributes
-                    .iter()
-                    .find(|attr| matches!(attr, pt::FunctionAttribute::Mutability(_)))
-                {
-                    if let pt::Mutability::Payable(_) = _mut {
-                        eyre::bail!("This function mutates state. Insert as a statement.")
-                    }
-                } else {
+                // will be inserted normally without inspecting.
+                let sm = func.state_mutability;
+                if !matches!(sm, StateMutability::View | StateMutability::Pure) {
                     eyre::bail!("This function mutates state. Insert as a statement.")
                 }
 
-                Ok(Self::ethabi(return_ty, Some(intermediate)))
-            } else if let Some(var) = intermediate_contract.variable_definitions.get(cur_type) {
-                Self::infer_var_expr(&var.ty, Some(intermediate), custom_type)
-            } else if let Some(strukt) = intermediate_contract.struct_definitions.get(cur_type) {
-                let inner_types = strukt
-                    .fields
+                // Resolve the return type.
+                let ret_id = func.returns[0];
+                let ret_var = hir.variable(ret_id);
+                // If the return type is a custom (user-defined) type, recurse on the same contract.
+                if let hir::TypeKind::Custom(_) = &ret_var.ty.kind
+                    && let Some(t) = Self::from_hir_ty(gcx, &ret_var.ty)
+                {
+                    return Ok(t.try_as_ethabi(true, Some(gcx)));
+                }
+                return Ok(solar_ty_to_dyn(gcx, gcx.type_of_item(ret_id.into())));
+            }
+
+            // Variable?
+            if let Some(vid) = contract.variables().find(|&v| {
+                hir.variable(v).name.as_ref().map(|n| n.as_str() == cur).unwrap_or(false)
+            }) {
+                let var = hir.variable(vid);
+                if let Some(ty) = solar_ty_to_dyn(gcx, gcx.type_of_item(vid.into())) {
+                    // Check if there are remaining members to access.
+                    custom_type.pop();
+                    if custom_type.is_empty() {
+                        return Ok(Some(ty));
+                    }
+                    // Try to use the resolved type for member-access lookups.
+                    let access = Self::Access(
+                        Box::new(Self::Builtin(ty.clone())),
+                        custom_type.drain(..).next().unwrap_or(Symbol::DUMMY),
+                    );
+                    if let Some(mapped) = access.map_special().try_as_ethabi(true, Some(gcx)) {
+                        return Ok(Some(mapped));
+                    }
+                    return Ok(Some(ty));
+                }
+                // Fall back to the type expression.
+                return Self::infer_var_ty(gcx, &var.ty, custom_type);
+            }
+
+            // Struct?
+            if let Some(sid) = contract.items.iter().find_map(|i| {
+                if let hir::ItemId::Struct(sid) = i
+                    && hir.strukt(*sid).name.as_str() == cur
+                {
+                    Some(*sid)
+                } else {
+                    None
+                }
+            }) {
+                let inner = gcx
+                    .struct_field_types(sid)
                     .iter()
-                    .map(|var| {
-                        Self::ethabi(&var.ty, Some(intermediate))
-                            .ok_or_else(|| eyre::eyre!("Struct `{cur_type}` has invalid fields"))
+                    .map(|&t| {
+                        solar_ty_to_dyn(gcx, t)
+                            .ok_or_else(|| eyre::eyre!("Struct `{cur}` has invalid fields"))
                     })
                     .collect::<Result<Vec<_>>>()?;
-                Ok(Some(DynSolType::Tuple(inner_types)))
-            } else {
-                eyre::bail!(
-                    "Could not find any definition in contract \"{contract_name}\" for type: {custom_type:?}"
-                )
-            }
-        } else {
-            // Check if the custom type is a variable or function within the REPL contract before
-            // anything. If it is, we can stop here.
-            if let Ok(res) = Self::infer_custom_type(intermediate, custom_type, Some("REPL".into()))
-            {
-                return Ok(res);
+                return Ok(Some(DynSolType::Tuple(inner)));
             }
 
-            // Check if the first element of the custom type is a known contract. If it is, begin
-            // our recursion on that contract's definitions.
-            let name = custom_type.last().unwrap();
-            let contract = intermediate.intermediate_contracts.get(name);
-            if contract.is_some() {
-                let contract_name = custom_type.pop();
-                return Self::infer_custom_type(intermediate, custom_type, contract_name);
-            }
-
-            // See [`Type::infer_var_expr`]
-            let name = custom_type.last().unwrap();
-            if let Some(expr) = intermediate.repl_contract_expressions.get(name) {
-                return Self::infer_var_expr(expr, Some(intermediate), custom_type);
-            }
-
-            // The first element of our custom type was neither a variable or a function within the
-            // REPL contract, move on to globally available types gracefully.
-            Ok(None)
+            eyre::bail!(
+                "Could not find any definition in contract \"{}\" for type: {custom_type:?}",
+                contract.name.as_str()
+            )
         }
+        // Check if the custom type is a variable or function within the REPL contract first.
+        let repl_id = gcx
+            .hir
+            .contracts_enumerated()
+            .find_map(|(cid, c)| (c.name.as_str() == "REPL").then_some(cid));
+        if let Some(repl_id) = repl_id
+            && let Ok(res) = Self::infer_custom_type(gcx, custom_type, Some(repl_id))
+        {
+            return Ok(res);
+        }
+
+        // Check if the first element of the custom type is a known contract.
+        let last_name = *custom_type.last().unwrap();
+        let last = last_name.as_str();
+        let contract_match = gcx
+            .hir
+            .contracts_enumerated()
+            .find_map(|(cid, c)| (c.name.as_str() == last).then_some(cid));
+        if let Some(cid) = contract_match {
+            custom_type.pop();
+            return Self::infer_custom_type(gcx, custom_type, Some(cid));
+        }
+
+        // Otherwise gracefully give up.
+        Ok(None)
     }
 
-    /// Infers the type from a variable's type
-    fn infer_var_expr(
-        expr: &pt::Expression,
-        intermediate: Option<&IntermediateOutput>,
-        custom_type: &mut Vec<String>,
+    /// Infers the type from a variable's HIR type.
+    fn infer_var_ty(
+        gcx: Gcx<'_>,
+        ty: &hir::Type<'_>,
+        custom_type: &mut Vec<Symbol>,
     ) -> Result<Option<DynSolType>> {
-        // Resolve local (in `run` function) or global (in the `REPL` or other contract) variable
-        let res = match &expr {
-            // Custom variable handling
-            pt::Expression::Variable(ident) => {
-                let name = &ident.name;
-
-                if let Some(intermediate) = intermediate {
-                    // expression in `run`
-                    if let Some(expr) = intermediate.repl_contract_expressions.get(name) {
-                        Self::infer_var_expr(expr, Some(intermediate), custom_type)
-                    } else if intermediate.intermediate_contracts.contains_key(name) {
-                        if custom_type.len() > 1 {
-                            // There is still some recursing left to do: jump into the contract.
-                            custom_type.pop();
-                            Self::infer_custom_type(intermediate, custom_type, Some(name.clone()))
-                        } else {
-                            // We have no types left to recurse: return the address of the contract.
-                            Ok(Some(DynSolType::Address))
-                        }
-                    } else {
-                        Err(eyre::eyre!("Could not infer variable type"))
-                    }
-                } else {
-                    Ok(None)
-                }
-            }
-            other_expr => Ok(Self::ethabi(other_expr, intermediate)),
+        let res: Option<DynSolType> = if let Some(t) = Self::from_hir_ty(gcx, ty) {
+            t.try_as_ethabi(true, Some(gcx))
+        } else {
+            None
         };
-        // re-run everything with the resolved variable in case we're accessing a builtin member
-        // for example array or bytes length etc
         match res {
-            Ok(Some(ty)) => {
-                let box_ty = Box::new(Self::Builtin(ty.clone()));
-                let access = Self::Access(box_ty, custom_type.drain(..).next().unwrap_or_default());
-                if let Some(mapped) = access.map_special().try_as_ethabi(intermediate) {
+            Some(ty) => {
+                let access = Self::Access(
+                    Box::new(Self::Builtin(ty.clone())),
+                    custom_type.drain(..).next().unwrap_or(Symbol::DUMMY),
+                );
+                if let Some(mapped) = access.map_special().try_as_ethabi(true, Some(gcx)) {
                     Ok(Some(mapped))
                 } else {
                     Ok(Some(ty))
                 }
             }
-            res => res,
+            None => Ok(None),
         }
     }
 
-    /// Attempt to convert this type into a [DynSolType]
+    /// Attempt to convert this type into a [`DynSolType`].
     ///
-    /// ### Takes
-    /// An immutable reference to an [IntermediateOutput]
-    ///
-    /// ### Returns
-    /// Optionally, a [DynSolType]
-    fn try_as_ethabi(self, intermediate: Option<&IntermediateOutput>) -> Option<DynSolType> {
+    /// `lookup` controls whether [`Self::Custom`] entries should be resolved via the HIR.
+    fn try_as_ethabi(self, lookup: bool, gcx: Option<Gcx<'_>>) -> Option<DynSolType> {
         match self {
             Self::Builtin(ty) => Some(ty),
-            Self::Tuple(types) => Some(DynSolType::Tuple(types_to_parameters(types, intermediate))),
+            Self::Tuple(types) => Some(DynSolType::Tuple(types_to_parameters(types, lookup, gcx))),
             Self::Array(inner) => match *inner {
-                ty @ Self::Custom(_) => ty.try_as_ethabi(intermediate),
-                _ => inner
-                    .try_as_ethabi(intermediate)
-                    .map(|inner| DynSolType::Array(Box::new(inner))),
+                ty @ Self::Custom(_) => ty.try_as_ethabi(lookup, gcx),
+                _ => {
+                    inner.try_as_ethabi(lookup, gcx).map(|inner| DynSolType::Array(Box::new(inner)))
+                }
             },
             Self::FixedArray(inner, size) => match *inner {
-                ty @ Self::Custom(_) => ty.try_as_ethabi(intermediate),
+                ty @ Self::Custom(_) => ty.try_as_ethabi(lookup, gcx),
                 _ => inner
-                    .try_as_ethabi(intermediate)
+                    .try_as_ethabi(lookup, gcx)
                     .map(|inner| DynSolType::FixedArray(Box::new(inner), size)),
             },
-            ty @ Self::ArrayIndex(_, _) => ty.into_array_index(intermediate),
-            Self::Function(ty, _, _) => ty.try_as_ethabi(intermediate),
+            ty @ Self::ArrayIndex(_, _) => ty.into_array_index(lookup, gcx),
+            Self::Function(ty, _, _) => ty.try_as_ethabi(lookup, gcx),
             // should have been mapped to `Custom` in previous steps
             Self::Access(_, _) => None,
             Self::Custom(mut types) => {
-                // Cover any local non-state-modifying function call expressions
-                intermediate.and_then(|intermediate| {
-                    Self::infer_custom_type(intermediate, &mut types, None).ok().flatten()
-                })
+                if !lookup {
+                    return None;
+                }
+                gcx.and_then(|gcx| Self::infer_custom_type(gcx, &mut types, None).ok().flatten())
             }
         }
     }
 
-    /// Equivalent to `Type::from_expression` + `Type::map_special` + `Type::try_as_ethabi`
-    fn ethabi(
-        expr: &pt::Expression,
-        intermediate: Option<&IntermediateOutput>,
-    ) -> Option<DynSolType> {
-        Self::from_expression(expr)
+    /// Equivalent to `Type::from_expr` + `Type::map_special` + `Type::try_as_ethabi`.
+    fn ethabi(gcx: Gcx<'_>, expr: &hir::Expr<'_>, lookup: bool) -> Option<DynSolType> {
+        Self::from_expr(gcx, expr)
             .map(Self::map_special)
-            .and_then(|ty| ty.try_as_ethabi(intermediate))
+            .and_then(|ty| ty.try_as_ethabi(lookup, Some(gcx)))
     }
 
     /// Get the return type of a function call expression.
-    fn get_function_return_type<'a>(
-        contract_expr: Option<&'a pt::Expression>,
-        intermediate: &IntermediateOutput,
-    ) -> Option<(&'a pt::Expression, DynSolType)> {
-        let function_call = match contract_expr? {
-            pt::Expression::FunctionCall(_, function_call, _) => function_call,
+    fn get_function_return_type<'a>(gcx: Gcx<'_>, expr: &'a hir::Expr<'a>) -> Option<DynSolType> {
+        let hir::ExprKind::Call(callee, _, _) = &expr.kind else { return None };
+        let hir::ExprKind::Member(obj, fn_ident) = &callee.kind else { return None };
+        // The receiver should be a variable holding a contract.
+        let hir::ExprKind::Ident(reses) = &obj.kind else { return None };
+        let res = reses.first()?;
+        let var_id = match res {
+            hir::Res::Item(hir::ItemId::Variable(vid)) => *vid,
             _ => return None,
         };
-        let (contract_name, function_name) = match function_call.as_ref() {
-            pt::Expression::MemberAccess(_, contract_name, function_name) => {
-                (contract_name, function_name)
-            }
-            _ => return None,
-        };
-        let contract_name = match contract_name.as_ref() {
-            pt::Expression::Variable(contract_name) => contract_name.to_owned(),
+        let var_ty = gcx.type_of_item(var_id.into()).peel_refs();
+        let cid = match var_ty.kind {
+            TyKind::Contract(cid) => cid,
             _ => return None,
         };
 
-        let pt::Expression::Variable(contract_name) =
-            intermediate.repl_contract_expressions.get(&contract_name.name)?
-        else {
-            return None;
-        };
-
-        let contract = intermediate
-            .intermediate_contracts
-            .get(&contract_name.name)?
-            .function_definitions
-            .get(&function_name.name)?;
-        let return_parameter = contract.as_ref().returns.first()?.to_owned().1?;
-        Self::ethabi(&return_parameter.ty, Some(intermediate)).map(|p| (contract_expr.unwrap(), p))
+        let hir = &gcx.hir;
+        let contract = hir.contract(cid);
+        let fid = contract.functions().find(|&f| {
+            hir.function(f).name.as_ref().map(|n| n.as_str()) == Some(fn_ident.as_str())
+        })?;
+        let func = hir.function(fid);
+        let ret_id = *func.returns.first()?;
+        solar_ty_to_dyn(gcx, gcx.type_of_item(ret_id.into()))
     }
 
     /// Inverts Int to Uint and vice-versa.
@@ -1066,7 +1105,7 @@ impl Type {
         }
     }
 
-    /// Returns the `DynSolType` contained by `Type::Builtin`
+    /// Returns the `DynSolType` contained by `Type::Builtin`.
     #[inline]
     fn into_builtin(self) -> Option<DynSolType> {
         match self {
@@ -1075,11 +1114,11 @@ impl Type {
         }
     }
 
-    /// Returns the resulting `DynSolType` of indexing self
-    fn into_array_index(self, intermediate: Option<&IntermediateOutput>) -> Option<DynSolType> {
+    /// Returns the resulting `DynSolType` of indexing self.
+    fn into_array_index(self, lookup: bool, gcx: Option<Gcx<'_>>) -> Option<DynSolType> {
         match self {
             Self::Array(inner) | Self::FixedArray(inner, _) | Self::ArrayIndex(inner, _) => {
-                match inner.try_as_ethabi(intermediate) {
+                match inner.try_as_ethabi(lookup, gcx) {
                     Some(DynSolType::Array(inner) | DynSolType::FixedArray(inner, _)) => {
                         Some(*inner)
                     }
@@ -1093,7 +1132,7 @@ impl Type {
         }
     }
 
-    /// Returns whether this type is dynamic
+    /// Returns whether this type is dynamic.
     #[inline]
     const fn is_dynamic(&self) -> bool {
         match self {
@@ -1105,7 +1144,7 @@ impl Type {
         }
     }
 
-    /// Returns whether this type is an array
+    /// Returns whether this type is an array.
     #[inline]
     const fn is_array(&self) -> bool {
         matches!(
@@ -1116,7 +1155,7 @@ impl Type {
         )
     }
 
-    /// Returns whether this type is a dynamic array (can call push, pop)
+    /// Returns whether this type is a dynamic array (can call push, pop).
     #[inline]
     const fn is_dynamic_array(&self) -> bool {
         matches!(self, Self::Array(_) | Self::Builtin(DynSolType::Array(_)))
@@ -1127,121 +1166,142 @@ impl Type {
     }
 }
 
-/// Returns Some if the custom type is a function member access
+/// Returns Some if the custom type is a function member access.
 ///
 /// Ref: <https://docs.soliditylang.org/en/latest/types.html#function-types>
 #[inline]
-fn func_members(func: &pt::FunctionDefinition, custom_type: &[String]) -> Option<DynSolType> {
-    if !matches!(func.ty, pt::FunctionTy::Function) {
+fn func_members(func: &hir::Function<'_>, custom_type: &[Symbol]) -> Option<DynSolType> {
+    if !matches!(func.kind, FunctionKind::Function) {
         return None;
     }
-
-    let vis = func.attributes.iter().find_map(|attr| match attr {
-        pt::FunctionAttribute::Visibility(vis) => Some(vis),
-        _ => None,
-    });
-    match vis {
-        Some(pt::Visibility::External(_) | pt::Visibility::Public(_)) => {
-            match custom_type.first().unwrap().as_str() {
-                "address" => Some(DynSolType::Address),
-                "selector" => Some(DynSolType::FixedBytes(4)),
-                _ => None,
-            }
-        }
+    if !matches!(func.visibility, Visibility::External | Visibility::Public) {
+        return None;
+    }
+    match custom_type.first().unwrap().as_str() {
+        "address" => Some(DynSolType::Address),
+        "selector" => Some(DynSolType::FixedBytes(4)),
         _ => None,
     }
 }
 
-/// Whether execution should continue after inspecting this expression
+/// Whether execution should continue after inspecting this expression.
 #[inline]
-fn should_continue(expr: &pt::Expression) -> bool {
-    match expr {
-        // assignments
-        pt::Expression::PreDecrement(_, _) |       // --<inner>
-        pt::Expression::PostDecrement(_, _) |      // <inner>--
-        pt::Expression::PreIncrement(_, _) |       // ++<inner>
-        pt::Expression::PostIncrement(_, _) |      // <inner>++
-        pt::Expression::Assign(_, _, _) |          // <inner>   = ...
-        pt::Expression::AssignAdd(_, _, _) |       // <inner>  += ...
-        pt::Expression::AssignSubtract(_, _, _) |  // <inner>  -= ...
-        pt::Expression::AssignMultiply(_, _, _) |  // <inner>  *= ...
-        pt::Expression::AssignDivide(_, _, _) |    // <inner>  /= ...
-        pt::Expression::AssignModulo(_, _, _) |    // <inner>  %= ...
-        pt::Expression::AssignAnd(_, _, _) |       // <inner>  &= ...
-        pt::Expression::AssignOr(_, _, _) |        // <inner>  |= ...
-        pt::Expression::AssignXor(_, _, _) |       // <inner>  ^= ...
-        pt::Expression::AssignShiftLeft(_, _, _) | // <inner> <<= ...
-        pt::Expression::AssignShiftRight(_, _, _)  // <inner> >>= ...
-        => {
-            true
-        }
-
+fn should_continue(expr: &hir::Expr<'_>) -> bool {
+    match &expr.kind {
+        // assignments and compound assignments
+        hir::ExprKind::Assign(_, _, _) => true,
+        // ++/-- pre/post operations
+        hir::ExprKind::Unary(op, _) => matches!(
+            op.kind,
+            UnOpKind::PreInc | UnOpKind::PreDec | UnOpKind::PostInc | UnOpKind::PostDec
+        ),
         // Array.pop()
-        pt::Expression::FunctionCall(_, lhs, _) => {
-            match lhs.as_ref() {
-                pt::Expression::MemberAccess(_, _inner, access) => access.name == "pop",
-                _ => false
-            }
-        }
-
-        _ => false
+        hir::ExprKind::Call(callee, _, _) => match &callee.kind {
+            hir::ExprKind::Member(_, ident) => ident.as_str() == "pop",
+            _ => false,
+        },
+        _ => false,
     }
-}
-
-fn map_parameters(params: &[(pt::Loc, Option<pt::Parameter>)]) -> Vec<Option<Type>> {
-    params
-        .iter()
-        .map(|(_, param)| param.as_ref().and_then(|param| Type::from_expression(&param.ty)))
-        .collect()
 }
 
 fn types_to_parameters(
     types: Vec<Option<Type>>,
-    intermediate: Option<&IntermediateOutput>,
+    lookup: bool,
+    gcx: Option<Gcx<'_>>,
 ) -> Vec<DynSolType> {
-    types.into_iter().filter_map(|ty| ty.and_then(|ty| ty.try_as_ethabi(intermediate))).collect()
+    types.into_iter().filter_map(|ty| ty.and_then(|ty| ty.try_as_ethabi(lookup, gcx))).collect()
 }
 
-fn parse_number_literal(expr: &pt::Expression) -> Option<U256> {
-    match expr {
-        pt::Expression::NumberLiteral(_, num, exp, unit) => {
-            let num = num.parse::<U256>().unwrap_or(U256::ZERO);
-            let exp = exp.parse().unwrap_or(0u32);
-            if exp > 77 {
-                None
-            } else {
-                let exp = U256::from(10usize.pow(exp));
-                let unit_mul = unit_multiplier(unit).ok()?;
-                Some(num * exp * unit_mul)
-            }
-        }
-        pt::Expression::HexNumberLiteral(_, num, unit) => {
-            let unit_mul = unit_multiplier(unit).ok()?;
-            num.parse::<U256>().map(|num| num * unit_mul).ok()
-        }
-        // TODO: Rational numbers
-        pt::Expression::RationalNumberLiteral(..) => None,
+/// Parses an [`hir::Expr`] number/hex literal into a `U256`. Returns `None` if the expression
+/// is not a numeric literal.
+///
+/// SubDenominations are already applied to numeric literals in solar's HIR.
+const fn parse_number_literal(expr: &hir::Expr<'_>) -> Option<U256> {
+    match &expr.kind {
+        hir::ExprKind::Lit(lit) => match &lit.kind {
+            LitKind::Number(n) => Some(*n),
+            _ => None,
+        },
         _ => None,
     }
 }
 
-#[inline]
-fn unit_multiplier(unit: &Option<pt::Identifier>) -> Result<U256> {
-    if let Some(unit) = unit {
-        let mul = match unit.name.as_str() {
-            "seconds" => 1,
-            "minutes" => 60,
-            "hours" => 60 * 60,
-            "days" => 60 * 60 * 24,
-            "weeks" => 60 * 60 * 24 * 7,
-            "wei" => 1,
-            "gwei" => 10_usize.pow(9),
-            "ether" => 10_usize.pow(18),
-            other => eyre::bail!("unknown unit: {other}"),
-        };
-        Ok(U256::from(mul))
-    } else {
-        Ok(U256::from(1))
+/// Maps a solar [`ElementaryType`] to a [`DynSolType`].
+const fn elementary_to_dyn(et: ElementaryType) -> Option<DynSolType> {
+    Some(match et {
+        ElementaryType::Address(_) => DynSolType::Address,
+        ElementaryType::Bool => DynSolType::Bool,
+        ElementaryType::String => DynSolType::String,
+        ElementaryType::Bytes => DynSolType::Bytes,
+        ElementaryType::Int(size) => DynSolType::Int(size.bits() as usize),
+        ElementaryType::UInt(size) => DynSolType::Uint(size.bits() as usize),
+        ElementaryType::FixedBytes(size) => DynSolType::FixedBytes(size.bytes() as usize),
+        // Fixed-point numbers are not yet representable as DynSolType.
+        ElementaryType::Fixed(_, _) | ElementaryType::UFixed(_, _) => return None,
+    })
+}
+
+/// Maps a solar [`Ty`] to a [`DynSolType`].
+fn solar_ty_to_dyn<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> Option<DynSolType> {
+    match ty.kind {
+        TyKind::Elementary(et) => elementary_to_dyn(et),
+        TyKind::Ref(inner, _) => solar_ty_to_dyn(gcx, inner),
+        TyKind::Array(elem, n) => {
+            let inner = solar_ty_to_dyn(gcx, elem)?;
+            let size: usize = n.try_into().ok()?;
+            Some(DynSolType::FixedArray(Box::new(inner), size))
+        }
+        TyKind::DynArray(elem) | TyKind::Slice(elem) => {
+            let inner = solar_ty_to_dyn(gcx, elem)?;
+            Some(DynSolType::Array(Box::new(inner)))
+        }
+        TyKind::Tuple(tys) => {
+            Some(DynSolType::Tuple(tys.iter().filter_map(|t| solar_ty_to_dyn(gcx, *t)).collect()))
+        }
+        TyKind::Mapping(_, _) => None,
+        TyKind::Struct(sid) => Some(DynSolType::Tuple(
+            gcx.struct_field_types(sid).iter().filter_map(|t| solar_ty_to_dyn(gcx, *t)).collect(),
+        )),
+        TyKind::Enum(_) => Some(DynSolType::Uint(8)),
+        TyKind::Udvt(inner, _) => solar_ty_to_dyn(gcx, inner),
+        TyKind::Contract(_) => Some(DynSolType::Address),
+        // For a function-pointer type we return the ABI type of what the call *produces*, not a
+        // representation of the pointer itself. This is intentional: chisel inspects values, so
+        // the interesting type is the returned value.  A zero-return function pointer has no
+        // inspectable value, so we return `None`.
+        TyKind::FnPtr(f) => match f.returns.len() {
+            0 => None,
+            1 => solar_ty_to_dyn(gcx, f.returns[0]),
+            _ => Some(DynSolType::Tuple(
+                f.returns.iter().filter_map(|t| solar_ty_to_dyn(gcx, *t)).collect(),
+            )),
+        },
+        TyKind::Type(inner) => solar_ty_to_dyn(gcx, inner),
+        TyKind::Meta(inner) => solar_ty_to_dyn(gcx, inner),
+        TyKind::IntLiteral(neg, size) => {
+            let bits = (size.bits() as usize).max(8);
+            // Round up to the nearest multiple of 8 bits, capped at 256.
+            let bits = bits.div_ceil(8) * 8;
+            let bits = bits.min(256);
+            if neg {
+                Some(DynSolType::Int(bits.max(8)))
+            } else {
+                Some(DynSolType::Uint(bits.max(8)))
+            }
+        }
+        TyKind::StringLiteral(valid_utf8, _) => {
+            if valid_utf8 {
+                Some(DynSolType::String)
+            } else {
+                Some(DynSolType::Bytes)
+            }
+        }
+        TyKind::Module(_)
+        | TyKind::BuiltinModule(_)
+        | TyKind::Error(_, _)
+        | TyKind::Event(_, _)
+        | TyKind::Err(_) => None,
+        _ => None,
     }
 }
 
@@ -1558,46 +1618,68 @@ mod tests {
         DynSolType::FixedArray(Box::new(ty), len)
     }
 
-    fn parse(s: &mut SessionSource, input: &str, clear: bool) -> IntermediateOutput {
+    /// Lowers the given snippet appended to the REPL contract via solar's HIR pipeline (without
+    /// invoking solc) and returns the resulting `DynSolType` of the last expression statement in
+    /// the run() body.
+    ///
+    /// Tests bypass `SessionSource::build` (which routes through foundry-compilers + solc) so that
+    /// inputs which are syntactically valid but semantically rejected by solc (e.g.
+    /// `abi.decode(bytes, (uint8[13]))` or `a[0:3]` on a memory array) can still exercise the
+    /// HIR-based type-inference engine.
+    fn get_type_ethabi(s: &mut SessionSource, input: &str, clear: bool) -> Option<DynSolType> {
+        use solar::sema::Compiler;
+
         if clear {
             s.clear();
         }
 
+        // Always declare a sample enum so `Enum1` is available for `type(Enum1)` tests.
         *s = s.clone_with_new_line("enum Enum1 { A }".into()).unwrap().0;
 
         let input = format!("{};", input.trim_end().trim_end_matches(';'));
-        let (mut _s, _) = s.clone_with_new_line(input).unwrap();
-        *s = _s.clone();
-        let s = &mut _s;
+        let (new_source, _) = s.clone_with_new_line(input).unwrap();
+        *s = new_source.clone();
 
-        if let Err(e) = s.parse() {
-            let source = s.to_repl_source();
-            panic!("{e}\n\ncould not parse input:\n{source}")
-        }
-        s.generate_intermediate_output().expect("could not generate intermediate output")
-    }
+        let src = new_source.to_repl_source();
+        let sess =
+            solar::interface::Session::builder().with_buffer_emitter(Default::default()).build();
+        let mut compiler = Compiler::new(sess);
 
-    fn expr(stmts: &[pt::Statement]) -> pt::Expression {
-        match stmts.last().expect("no statements") {
-            pt::Statement::Expression(_, e) => e.clone(),
-            s => panic!("Not an expression: {s:?}"),
-        }
-    }
+        compiler.enter_mut(|c| -> Option<DynSolType> {
+            // Stage 1: parse + lower (mutable access required).
+            let lowered = {
+                let mut pcx = c.parse();
+                let file = c
+                    .sess()
+                    .source_map()
+                    .new_source_file(
+                        std::path::PathBuf::from(new_source.file_name.clone()),
+                        src.clone(),
+                    )
+                    .ok()?;
+                pcx.add_file(file);
+                pcx.parse();
+                matches!(c.lower_asts(), Ok(ControlFlow::Continue(())))
+            };
+            if !lowered {
+                return None;
+            }
 
-    fn get_type(
-        s: &mut SessionSource,
-        input: &str,
-        clear: bool,
-    ) -> (Option<Type>, IntermediateOutput) {
-        let intermediate = parse(s, input, clear);
-        let run_func_body = intermediate.run_func_body().expect("no run func body");
-        let expr = expr(run_func_body);
-        (Type::from_expression(&expr).map(Type::map_special), intermediate)
-    }
-
-    fn get_type_ethabi(s: &mut SessionSource, input: &str, clear: bool) -> Option<DynSolType> {
-        let (ty, intermediate) = get_type(s, input, clear);
-        ty.and_then(|ty| ty.try_as_ethabi(Some(&intermediate)))
+            // Stage 2: walk HIR (immutable access).
+            let gcx = c.gcx();
+            let hir = &gcx.hir;
+            let repl = hir.contracts().find(|c| c.name.as_str() == "REPL")?;
+            let run_fid = repl
+                .functions()
+                .find(|&f| hir.function(f).name.as_ref().map(|n| n.as_str()) == Some("run"))?;
+            let body = hir.function(run_fid).body?;
+            let last = body.last()?;
+            let expr = match last.kind {
+                hir::StmtKind::Expr(e) => e,
+                _ => return None,
+            };
+            Type::ethabi(gcx, expr, true)
+        })
     }
 
     fn generic_type_test<'a, T, I>(s: &mut SessionSource, input: I)

--- a/crates/chisel/src/source.rs
+++ b/crates/chisel/src/source.rs
@@ -5,7 +5,6 @@
 //! execution helpers.
 
 use eyre::Result;
-use foundry_common::fs;
 use foundry_compilers::{
     Artifact, ProjectCompileOutput,
     artifacts::{ConfigurableContractArtifact, Source, Sources},
@@ -16,9 +15,11 @@ use foundry_config::{Config, SolcReq};
 use foundry_evm::{backend::Backend, core::bytecode::InstIter, opts::EvmOpts};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use solang_parser::pt::{self, CodeLocation};
-use solar::interface::diagnostics::EmittedDiagnostics;
-use std::{cell::OnceCell, collections::HashMap, fmt, path::PathBuf};
+use solar::{
+    interface::{Span, diagnostics::EmittedDiagnostics},
+    sema::{CompilerRef, hir, ty::Gcx},
+};
+use std::{cell::OnceCell, fmt};
 use walkdir::WalkDir;
 
 /// The minimum Solidity version of the `Vm` interface.
@@ -30,40 +31,7 @@ static VM_SOURCE: &str = include_str!("../../../testdata/utils/Vm.sol");
 /// [`SessionSource`] build output.
 pub struct GeneratedOutput {
     output: ProjectCompileOutput,
-    pub(crate) intermediate: IntermediateOutput,
 }
-
-pub struct GeneratedOutputRef<'a> {
-    output: &'a ProjectCompileOutput,
-    // compiler: &'b solar::sema::CompilerRef<'c>,
-    pub(crate) intermediate: &'a IntermediateOutput,
-}
-
-/// Intermediate output for the compiled [SessionSource]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct IntermediateOutput {
-    /// All expressions within the REPL contract's run function and top level scope.
-    pub repl_contract_expressions: HashMap<String, pt::Expression>,
-    /// Intermediate contracts
-    pub intermediate_contracts: IntermediateContracts,
-}
-
-/// A refined intermediate parse tree for a contract that enables easy lookups
-/// of definitions.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct IntermediateContract {
-    /// All function definitions within the contract
-    pub function_definitions: HashMap<String, Box<pt::FunctionDefinition>>,
-    /// All event definitions within the contract
-    pub event_definitions: HashMap<String, Box<pt::EventDefinition>>,
-    /// All struct definitions within the contract
-    pub struct_definitions: HashMap<String, Box<pt::StructDefinition>>,
-    /// All variable definitions within the top level scope of the contract
-    pub variable_definitions: HashMap<String, Box<pt::VariableDefinition>>,
-}
-
-/// A defined type for a map of contract names to [IntermediateContract]s
-type IntermediateContracts = HashMap<String, IntermediateContract>;
 
 impl fmt::Debug for GeneratedOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -72,158 +40,25 @@ impl fmt::Debug for GeneratedOutput {
 }
 
 impl GeneratedOutput {
-    pub fn enter<T: Send>(&self, f: impl FnOnce(GeneratedOutputRef<'_>) -> T + Send) -> T {
-        // TODO(dani): once intermediate is removed
-        // self.output
-        //     .parser()
-        //     .solc()
-        //     .compiler()
-        //     .enter(|compiler| f(GeneratedOutputRef { output: &self.output, compiler }))
-        f(GeneratedOutputRef { output: &self.output, intermediate: &self.intermediate })
+    /// Enters the solar compiler context, providing access to the HIR and `Gcx`.
+    pub fn enter<R: Send>(
+        &self,
+        f: impl for<'a, 'b, 'gcx> FnOnce(GeneratedOutputRef<'a, 'b, 'gcx>) -> R + Send,
+    ) -> R {
+        self.output
+            .parser()
+            .solc()
+            .compiler()
+            .enter(|c| f(GeneratedOutputRef { output: &self.output, compiler: c }))
     }
 }
 
-impl GeneratedOutputRef<'_> {
-    pub fn repl_contract(&self) -> Option<&ConfigurableContractArtifact> {
-        self.output.find_first("REPL")
-    }
+/// A scoped reference to a [`GeneratedOutput`] together with an entered solar compiler.
+pub struct GeneratedOutputRef<'a, 'b, 'gcx> {
+    output: &'a ProjectCompileOutput,
+    pub(crate) compiler: &'b CompilerRef<'gcx>,
 }
 
-impl std::ops::Deref for GeneratedOutput {
-    type Target = IntermediateOutput;
-    fn deref(&self) -> &Self::Target {
-        &self.intermediate
-    }
-}
-impl std::ops::Deref for GeneratedOutputRef<'_> {
-    type Target = IntermediateOutput;
-    fn deref(&self) -> &Self::Target {
-        self.intermediate
-    }
-}
-
-impl IntermediateOutput {
-    pub fn get_event(&self, input: &str) -> Option<&pt::EventDefinition> {
-        self.intermediate_contracts
-            .get("REPL")
-            .and_then(|contract| contract.event_definitions.get(input).map(std::ops::Deref::deref))
-    }
-
-    pub fn final_pc(&self, contract: &ConfigurableContractArtifact) -> Result<Option<usize>> {
-        let deployed_bytecode = contract
-            .get_deployed_bytecode()
-            .ok_or_else(|| eyre::eyre!("No deployed bytecode found for `REPL` contract"))?;
-        let deployed_bytecode_bytes = deployed_bytecode
-            .bytes()
-            .ok_or_else(|| eyre::eyre!("No deployed bytecode found for `REPL` contract"))?;
-
-        let run_func_statements = self.run_func_body()?;
-
-        // Record loc of first yul block return statement (if any).
-        // This is used to decide which is the final statement within the `run()` method.
-        // see <https://github.com/foundry-rs/foundry/issues/4617>.
-        let last_yul_return = run_func_statements.iter().find_map(|statement| {
-            if let pt::Statement::Assembly { loc: _, dialect: _, flags: _, block } = statement
-                && let Some(statement) = block.statements.last()
-                && let pt::YulStatement::FunctionCall(yul_call) = statement
-                && yul_call.id.name == "return"
-            {
-                return Some(statement.loc());
-            }
-            None
-        });
-
-        // Find the last statement within the "run()" method and get the program
-        // counter via the source map.
-        let Some(final_statement) = run_func_statements.last() else { return Ok(None) };
-
-        // If the final statement is some type of block (assembly, unchecked, or regular),
-        // we need to find the final statement within that block. Otherwise, default to
-        // the source loc of the final statement of the `run()` function's block.
-        //
-        // There is some code duplication within the arms due to the difference between
-        // the [pt::Statement] type and the [pt::YulStatement] types.
-        let mut source_loc = match final_statement {
-            pt::Statement::Assembly { loc: _, dialect: _, flags: _, block } => {
-                // Select last non variable declaration statement, see <https://github.com/foundry-rs/foundry/issues/4938>.
-                let last_statement = block.statements.iter().rev().find(|statement| {
-                    !matches!(statement, pt::YulStatement::VariableDeclaration(_, _, _))
-                });
-                if let Some(statement) = last_statement {
-                    statement.loc()
-                } else {
-                    // In the case where the block is empty, attempt to grab the statement
-                    // before the asm block. Because we use saturating sub to get the second
-                    // to last index, this can always be safely unwrapped.
-                    run_func_statements
-                        .get(run_func_statements.len().saturating_sub(2))
-                        .unwrap()
-                        .loc()
-                }
-            }
-            pt::Statement::Block { loc: _, unchecked: _, statements } => {
-                if let Some(statement) = statements.last() {
-                    statement.loc()
-                } else {
-                    // In the case where the block is empty, attempt to grab the statement
-                    // before the block. Because we use saturating sub to get the second to
-                    // last index, this can always be safely unwrapped.
-                    run_func_statements
-                        .get(run_func_statements.len().saturating_sub(2))
-                        .unwrap()
-                        .loc()
-                }
-            }
-            _ => final_statement.loc(),
-        };
-
-        // Consider yul return statement as final statement (if it's loc is lower) .
-        if let Some(yul_return) = last_yul_return
-            && yul_return.end() < source_loc.start()
-        {
-            source_loc = yul_return;
-        }
-
-        // Map the source location of the final statement of the `run()` function to its
-        // corresponding runtime program counter
-        let final_pc = {
-            let offset = source_loc.start() as u32;
-            let length = (source_loc.end() - source_loc.start()) as u32;
-            trace!(%offset, %length, "find pc");
-            contract
-                .get_source_map_deployed()
-                .unwrap()
-                .unwrap()
-                .into_iter()
-                .zip(InstIter::new(deployed_bytecode_bytes).with_pc().map(|(pc, _)| pc))
-                .filter(|(s, _)| s.offset() == offset && s.length() == length)
-                .map(|(_, pc)| pc)
-                .max()
-        };
-        trace!(?final_pc);
-        Ok(final_pc)
-    }
-
-    pub fn run_func_body(&self) -> Result<&Vec<pt::Statement>> {
-        match self
-            .intermediate_contracts
-            .get("REPL")
-            .ok_or_else(|| eyre::eyre!("Could not find REPL intermediate contract!"))?
-            .function_definitions
-            .get("run")
-            .ok_or_else(|| eyre::eyre!("Could not find run function definition in REPL contract!"))?
-            .body
-            .as_ref()
-            .ok_or_else(|| eyre::eyre!("Could not find run function body!"))?
-        {
-            pt::Statement::Block { statements, .. } => Ok(statements),
-            _ => eyre::bail!("Could not find statements within run function body!"),
-        }
-    }
-}
-
-// TODO(dani): further migration blocked on upstream work
-#[cfg(false)]
 impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
     pub fn gcx(&self) -> Gcx<'gcx> {
         self.compiler.gcx()
@@ -233,8 +68,35 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
         self.output.find_first("REPL")
     }
 
+    /// Looks up the REPL contract in the HIR.
+    pub fn repl_contract_hir(&self) -> Option<&'gcx hir::Contract<'gcx>> {
+        self.gcx().hir.contracts().find(|c| c.name.as_str() == "REPL")
+    }
+
+    /// Returns the body block of the REPL `run()` function.
+    pub fn run_func_body(&self) -> hir::Block<'gcx> {
+        let hir = &self.gcx().hir;
+        let c = self.repl_contract_hir().expect("REPL contract not found in HIR");
+        let f = c
+            .functions()
+            .find(|&f| hir.function(f).name.as_ref().map(|n| n.as_str()) == Some("run"))
+            .expect("`run()` function not found in REPL contract");
+        hir.function(f).body.expect("`run()` function does not have a body")
+    }
+
+    /// Returns the [`hir::EventId`] of an event named `input` in the REPL contract, if any.
     pub fn get_event(&self, input: &str) -> Option<hir::EventId> {
-        self.gcx().hir.events_enumerated().find(|(_, e)| e.name.as_str() == input).map(|(id, _)| id)
+        let hir = &self.gcx().hir;
+        let c = self.repl_contract_hir()?;
+        c.items.iter().find_map(|id| {
+            if let hir::ItemId::Event(eid) = id
+                && hir.event(*eid).name.as_str() == input
+            {
+                Some(*eid)
+            } else {
+                None
+            }
+        })
     }
 
     pub fn final_pc(&self, contract: &ConfigurableContractArtifact) -> Result<Option<usize>> {
@@ -251,51 +113,24 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
         // Record loc of first yul block return statement (if any).
         // This is used to decide which is the final statement within the `run()` method.
         // see <https://github.com/foundry-rs/foundry/issues/4617>.
-        let last_yul_return_span: Option<Span> = run_body.iter().find_map(|stmt| {
-            // TODO(dani): Yul is not yet lowered to HIR.
-            let _ = stmt;
-            /*
-            if let hir::StmtKind::Assembly { block, .. } = stmt {
-                if let Some(stmt) = block.last() {
-                    if let pt::YulStatement::FunctionCall(yul_call) = stmt {
-                        if yul_call.id.name == "return" {
-                            return Some(stmt.loc())
-                        }
-                    }
-                }
-            }
-            */
-            None
-        });
+        //
+        // Yul is not yet lowered to HIR (assembly statements appear as `StmtKind::Err`),
+        // so we walk the AST of the REPL source to find a top-level `return(...)` call
+        // inside any `assembly { ... }` block in `run()`.
+        let last_yul_return_span: Option<Span> = self.first_yul_return_span();
 
         // Find the last statement within the "run()" method and get the program
         // counter via the source map.
         let Some(last_stmt) = run_body.last() else { return Ok(None) };
 
-        // If the final statement is some type of block (assembly, unchecked, or regular),
+        // If the final statement is some type of block (unchecked or regular),
         // we need to find the final statement within that block. Otherwise, default to
         // the source loc of the final statement of the `run()` function's block.
         //
-        // There is some code duplication within the arms due to the difference between
-        // the [pt::Statement] type and the [pt::YulStatement] types.
+        // Inline assembly blocks (lowered to `StmtKind::Err` in HIR in the pinned solar
+        // version) are handled separately via `trailing_assembly_last_stmt_span`, which
+        // walks the AST to recover the last meaningful Yul statement.
         let source_stmt = match &last_stmt.kind {
-            // TODO(dani): Yul is not yet lowered to HIR.
-            /*
-            pt::Statement::Assembly { loc: _, dialect: _, flags: _, block } => {
-                // Select last non variable declaration statement, see <https://github.com/foundry-rs/foundry/issues/4938>.
-                let last_statement = block.statements.iter().rev().find(|statement| {
-                    !matches!(statement, pt::YulStatement::VariableDeclaration(_, _, _))
-                });
-                if let Some(stmt) = last_statement {
-                    stmt
-                } else {
-                    // In the case where the block is empty, attempt to grab the statement
-                    // before the block. Because we use saturating sub to get the second to
-                    // last index, this can always be safely unwrapped.
-                    &run_body[run_body.len().saturating_sub(2)]
-                }
-            }
-            */
             hir::StmtKind::UncheckedBlock(stmts) | hir::StmtKind::Block(stmts) => {
                 if let Some(stmt) = stmts.last() {
                     stmt
@@ -308,9 +143,25 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
             }
             _ => last_stmt,
         };
-        let mut source_span = self.stmt_span_without_semicolon(source_stmt);
+        // If the trailing statement is an assembly block, prefer the last meaningful
+        // (non-`let`) Yul statement's span as the source location for `final_pc`.
+        // See <https://github.com/foundry-rs/foundry/issues/4938>.
+        //
+        // Two guards are required:
+        //   1. `StmtKind::Err`, assembly lowers to an error node in the current pinned solar
+        //      version; this ensures we don't apply the AST fallback to properly-lowered stmts.
+        //   2. `trailing_assembly_last_stmt_span` returning `Some`, verifies via the AST that the
+        //      failing HIR node actually corresponds to an assembly block (not some other lowering
+        //      failure), and supplies the concrete span to use.
+        let mut source_span = if matches!(last_stmt.kind, hir::StmtKind::Err(_))
+            && let Some(span) = self.trailing_assembly_last_stmt_span()
+        {
+            span
+        } else {
+            self.stmt_span_without_semicolon(source_stmt)
+        };
 
-        // Consider yul return statement as final statement (if it's loc is lower) .
+        // Consider yul return statement as final statement (if it's loc is lower).
         if let Some(yul_return_span) = last_yul_return_span
             && yul_return_span.hi() < source_span.lo()
         {
@@ -319,20 +170,26 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
 
         // Map the source location of the final statement of the `run()` function to its
         // corresponding runtime program counter
-        let (_sf, range) = self.compiler.sess().source_map().span_to_source(source_span).unwrap();
-        dbg!(source_span, &range, &_sf.src[range.clone()]);
+        let result = self
+            .compiler
+            .sess()
+            .source_map()
+            .span_to_source(source_span)
+            .map_err(|e| eyre::eyre!("failed to resolve span: {e:?}"))?;
+        let range = result.data;
         let offset = range.start as u32;
         let length = range.len() as u32;
-        let final_pc = deployed_bytecode
-            .source_map()
+        trace!(%offset, %length, "find pc");
+        let final_pc = contract
+            .get_source_map_deployed()
             .ok_or_else(|| eyre::eyre!("No source map found for `REPL` contract"))??
             .into_iter()
-            .zip(InstructionIter::new(deployed_bytecode_bytes))
+            .zip(InstIter::new(deployed_bytecode_bytes).with_pc().map(|(pc, _)| pc))
             .filter(|(s, _)| s.offset() == offset && s.length() == length)
-            .map(|(_, i)| i.pc)
-            .max()
-            .unwrap_or_default();
-        Ok(Some(final_pc))
+            .map(|(_, pc)| pc)
+            .max();
+        trace!(?final_pc);
+        Ok(final_pc)
     }
 
     /// Statements' ranges in the solc source map do not include the semicolon.
@@ -352,17 +209,65 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
         }
     }
 
-    fn run_func_body(&self) -> hir::Block<'_> {
-        let c = self.repl_contract_hir().expect("REPL contract not found in HIR");
-        let f = c
-            .functions()
-            .find(|&f| self.gcx().hir.function(f).name.as_ref().map(|n| n.as_str()) == Some("run"))
-            .expect("`run()` function not found in REPL contract");
-        self.gcx().hir.function(f).body.expect("`run()` function does not have a body")
+    /// Returns the AST `run()` body of the REPL contract, if any.
+    ///
+    /// Yul/assembly is not yet lowered to HIR in the pinned solar version, so we
+    /// keep around the AST to be able to inspect inline assembly blocks.
+    fn repl_run_ast_body(&self) -> Option<&'gcx solar::ast::Block<'gcx>> {
+        use solar::ast::ItemKind;
+
+        let contract = self.repl_contract_hir()?;
+        let source = self.gcx().sources.get(contract.source)?;
+        let ast = source.ast.as_ref()?;
+
+        let contract_ast = ast.items.iter().find_map(|i| match &i.kind {
+            ItemKind::Contract(c) if c.name.as_str() == "REPL" => Some(c),
+            _ => None,
+        })?;
+        contract_ast.body.iter().find_map(|i| match &i.kind {
+            ItemKind::Function(f) if f.header.name.is_some_and(|n| n.as_str() == "run") => {
+                f.body.as_ref()
+            }
+            _ => None,
+        })
     }
 
-    fn repl_contract_hir(&self) -> Option<&hir::Contract<'_>> {
-        self.gcx().hir.contracts().find(|c| c.name.as_str() == "REPL")
+    /// Returns the span of the first top-level `return(...)` call inside any
+    /// `assembly { ... }` block in the REPL `run()` function, if any.
+    fn first_yul_return_span(&self) -> Option<Span> {
+        use solar::ast::{StmtKind, yul};
+
+        let run_body = self.repl_run_ast_body()?;
+        for stmt in run_body.stmts.iter() {
+            let StmtKind::Assembly(asm) = &stmt.kind else { continue };
+            for ystmt in asm.block.stmts.iter() {
+                if let yul::StmtKind::Expr(e) = &ystmt.kind
+                    && let yul::ExprKind::Call(call) = &e.kind
+                    && call.name.as_str() == "return"
+                {
+                    return Some(ystmt.span);
+                }
+            }
+        }
+        None
+    }
+
+    /// If the last statement of the REPL `run()` function is an `assembly { ... }` block,
+    /// returns the span of its last non-`let` (i.e. non-VarDecl) Yul statement.
+    ///
+    /// This mirrors the legacy behavior used to pick a meaningful end-of-function PC when
+    /// the trailing statement is inline assembly.
+    fn trailing_assembly_last_stmt_span(&self) -> Option<Span> {
+        use solar::ast::{StmtKind, yul};
+
+        let run_body = self.repl_run_ast_body()?;
+        let StmtKind::Assembly(asm) = &run_body.stmts.last()?.kind else { return None };
+        asm.block
+            .stmts
+            .iter()
+            .rev()
+            .find(|s| !matches!(s.kind, yul::StmtKind::VarDecl(_, _)))
+            .map(|s| s.span)
     }
 }
 
@@ -584,8 +489,7 @@ impl SessionSource {
             return Ok(output);
         }
         let output = self.compile()?;
-        let intermediate = self.generate_intermediate_output()?;
-        let output = GeneratedOutput { output, intermediate };
+        let output = GeneratedOutput { output };
         Ok(self.output.get_or_init(|| output))
     }
 
@@ -602,12 +506,11 @@ impl SessionSource {
             eyre::bail!("{output}");
         }
 
-        // TODO(dani): re-enable
-        if cfg!(false) {
-            output.parser_mut().solc_mut().compiler_mut().enter_mut(|c| {
-                let _ = c.lower_asts();
-            });
-        }
+        // Drive HIR lowering and analysis so that subsequent `enter` queries can use them.
+        output.parser_mut().solc_mut().compiler_mut().enter_mut(|c| {
+            let _ = c.lower_asts();
+            let _ = c.analysis();
+        });
 
         Ok(output)
     }
@@ -630,53 +533,6 @@ impl SessionSource {
         }
 
         sources
-    }
-
-    /// Generate intermediate contracts for all contract definitions in the compilation source.
-    ///
-    /// ### Returns
-    ///
-    /// Optionally, a map of contract names to a vec of [IntermediateContract]s.
-    pub fn generate_intermediate_contracts(&self) -> Result<HashMap<String, IntermediateContract>> {
-        let mut res_map = HashMap::default();
-        let parsed_map = self.get_sources();
-        for source in parsed_map.values() {
-            Self::get_intermediate_contract(&source.content, &mut res_map);
-        }
-        Ok(res_map)
-    }
-
-    /// Generate intermediate output for the REPL contract
-    pub fn generate_intermediate_output(&self) -> Result<IntermediateOutput> {
-        // Parse generate intermediate contracts
-        let intermediate_contracts = self.generate_intermediate_contracts()?;
-
-        // Construct variable definitions
-        let variable_definitions = intermediate_contracts
-            .get("REPL")
-            .ok_or_else(|| eyre::eyre!("Could not find intermediate REPL contract!"))?
-            .variable_definitions
-            .clone()
-            .into_iter()
-            .map(|(k, v)| (k, v.ty))
-            .collect::<HashMap<String, pt::Expression>>();
-        // Construct intermediate output
-        let mut intermediate_output = IntermediateOutput {
-            repl_contract_expressions: variable_definitions,
-            intermediate_contracts,
-        };
-
-        // Add all statements within the run function to the repl_contract_expressions map
-        for (key, val) in intermediate_output
-            .run_func_body()?
-            .clone()
-            .iter()
-            .flat_map(Self::get_statement_definitions)
-        {
-            intermediate_output.repl_contract_expressions.insert(key, val);
-        }
-
-        Ok(intermediate_output)
     }
 
     /// Construct the REPL source.
@@ -740,108 +596,6 @@ contract {contract_name} {{
             Ok(())
         });
         sess.dcx.emitted_errors().unwrap()
-    }
-
-    /// Gets the [IntermediateContract] for a Solidity source string and inserts it into the
-    /// passed `res_map`. In addition, recurses on any imported files as well.
-    ///
-    /// ### Takes
-    /// - `content` - A Solidity source string
-    /// - `res_map` - A mutable reference to a map of contract names to [IntermediateContract]s
-    pub fn get_intermediate_contract(
-        content: &str,
-        res_map: &mut HashMap<String, IntermediateContract>,
-    ) {
-        if let Ok((pt::SourceUnit(source_unit_parts), _)) = solang_parser::parse(content, 0) {
-            let func_defs = source_unit_parts
-                .into_iter()
-                .filter_map(|sup| match sup {
-                    pt::SourceUnitPart::ImportDirective(i) => match i {
-                        pt::Import::Plain(s, _)
-                        | pt::Import::Rename(s, _, _)
-                        | pt::Import::GlobalSymbol(s, _, _) => {
-                            let s = match s {
-                                pt::ImportPath::Filename(s) => s.string,
-                                pt::ImportPath::Path(p) => p.to_string(),
-                            };
-                            let path = PathBuf::from(s);
-
-                            match fs::read_to_string(path) {
-                                Ok(source) => {
-                                    Self::get_intermediate_contract(&source, res_map);
-                                    None
-                                }
-                                Err(_) => None,
-                            }
-                        }
-                    },
-                    pt::SourceUnitPart::ContractDefinition(cd) => {
-                        let mut intermediate = IntermediateContract::default();
-
-                        cd.parts.into_iter().for_each(|part| match part {
-                            pt::ContractPart::FunctionDefinition(def) => {
-                                // Only match normal function definitions here.
-                                if matches!(def.ty, pt::FunctionTy::Function) {
-                                    intermediate
-                                        .function_definitions
-                                        .insert(def.name.clone().unwrap().name, def);
-                                }
-                            }
-                            pt::ContractPart::EventDefinition(def) => {
-                                let event_name = def.name.as_ref().unwrap().name.clone();
-                                intermediate.event_definitions.insert(event_name, def);
-                            }
-                            pt::ContractPart::StructDefinition(def) => {
-                                let struct_name = def.name.as_ref().unwrap().name.clone();
-                                intermediate.struct_definitions.insert(struct_name, def);
-                            }
-                            pt::ContractPart::VariableDefinition(def) => {
-                                let var_name = def.name.as_ref().unwrap().name.clone();
-                                intermediate.variable_definitions.insert(var_name, def);
-                            }
-                            _ => {}
-                        });
-                        Some((cd.name.as_ref().unwrap().name.clone(), intermediate))
-                    }
-                    _ => None,
-                })
-                .collect::<HashMap<String, IntermediateContract>>();
-            res_map.extend(func_defs);
-        }
-    }
-
-    /// Helper to deconstruct a statement
-    ///
-    /// ### Takes
-    ///
-    /// A reference to a [pt::Statement]
-    ///
-    /// ### Returns
-    ///
-    /// A vector containing tuples of the inner expressions' names, types, and storage locations.
-    pub fn get_statement_definitions(statement: &pt::Statement) -> Vec<(String, pt::Expression)> {
-        match statement {
-            pt::Statement::VariableDefinition(_, def, _) => {
-                vec![(def.name.as_ref().unwrap().name.clone(), def.ty.clone())]
-            }
-            pt::Statement::Expression(_, pt::Expression::Assign(_, left, _)) => {
-                if let pt::Expression::List(_, list) = left.as_ref() {
-                    list.iter()
-                        .filter_map(|(_, param)| {
-                            param.as_ref().and_then(|param| {
-                                param
-                                    .name
-                                    .as_ref()
-                                    .map(|name| (name.name.clone(), param.ty.clone()))
-                            })
-                        })
-                        .collect()
-                } else {
-                    Vec::default()
-                }
-            }
-            _ => Vec::default(),
-        }
     }
 }
 

--- a/crates/chisel/src/source.rs
+++ b/crates/chisel/src/source.rs
@@ -16,10 +16,11 @@ use foundry_evm::{backend::Backend, core::bytecode::InstIter, opts::EvmOpts};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use solar::{
+    ast::{ItemKind, StmtKind as AstStmtKind, yul},
     interface::{Span, diagnostics::EmittedDiagnostics},
     sema::{
         CompilerRef,
-        hir::{Block, Contract, EventId, ItemId, Stmt, StmtKind},
+        hir::{Block, Contract, EventId, ItemId, Stmt, StmtKind as HirStmtKind},
         ty::Gcx,
     },
 };
@@ -135,7 +136,7 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
         // version) are handled separately via `trailing_assembly_last_stmt_span`, which
         // walks the AST to recover the last meaningful Yul statement.
         let source_stmt = match &last_stmt.kind {
-            StmtKind::UncheckedBlock(stmts) | StmtKind::Block(stmts) => {
+            HirStmtKind::UncheckedBlock(stmts) | HirStmtKind::Block(stmts) => {
                 if let Some(stmt) = stmts.last() {
                     stmt
                 } else {
@@ -157,7 +158,7 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
         //   2. `trailing_assembly_last_stmt_span` returning `Some`, verifies via the AST that the
         //      failing HIR node actually corresponds to an assembly block (not some other lowering
         //      failure), and supplies the concrete span to use.
-        let mut source_span = if matches!(last_stmt.kind, StmtKind::Err(_))
+        let mut source_span = if matches!(last_stmt.kind, HirStmtKind::Err(_))
             && let Some(span) = self.trailing_assembly_last_stmt_span()
         {
             span
@@ -199,7 +200,7 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
     /// Statements' ranges in the solc source map do not include the semicolon.
     fn stmt_span_without_semicolon(&self, stmt: &Stmt<'_>) -> Span {
         match stmt.kind {
-            StmtKind::DeclSingle(id) => {
+            HirStmtKind::DeclSingle(id) => {
                 let decl = self.gcx().hir.variable(id);
                 if let Some(expr) = decl.initializer {
                     stmt.span.with_hi(expr.span.hi())
@@ -207,8 +208,8 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
                     stmt.span
                 }
             }
-            StmtKind::DeclMulti(_, expr) => stmt.span.with_hi(expr.span.hi()),
-            StmtKind::Expr(expr) => expr.span,
+            HirStmtKind::DeclMulti(_, expr) => stmt.span.with_hi(expr.span.hi()),
+            HirStmtKind::Expr(expr) => expr.span,
             _ => stmt.span,
         }
     }
@@ -218,8 +219,6 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
     /// Yul/assembly is not yet lowered to HIR in the pinned solar version, so we
     /// keep around the AST to be able to inspect inline assembly blocks.
     fn repl_run_ast_body(&self) -> Option<&'gcx solar::ast::Block<'gcx>> {
-        use solar::ast::ItemKind;
-
         let contract = self.repl_contract_hir()?;
         let source = self.gcx().sources.get(contract.source)?;
         let ast = source.ast.as_ref()?;
@@ -239,11 +238,9 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
     /// Returns the span of the first top-level `return(...)` call inside any
     /// `assembly { ... }` block in the REPL `run()` function, if any.
     fn first_yul_return_span(&self) -> Option<Span> {
-        use solar::ast::{StmtKind, yul};
-
         let run_body = self.repl_run_ast_body()?;
         for stmt in run_body.stmts.iter() {
-            let StmtKind::Assembly(asm) = &stmt.kind else { continue };
+            let AstStmtKind::Assembly(asm) = &stmt.kind else { continue };
             for ystmt in asm.block.stmts.iter() {
                 if let yul::StmtKind::Expr(e) = &ystmt.kind
                     && let yul::ExprKind::Call(call) = &e.kind
@@ -262,10 +259,8 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
     /// This mirrors the legacy behavior used to pick a meaningful end-of-function PC when
     /// the trailing statement is inline assembly.
     fn trailing_assembly_last_stmt_span(&self) -> Option<Span> {
-        use solar::ast::{StmtKind, yul};
-
         let run_body = self.repl_run_ast_body()?;
-        let StmtKind::Assembly(asm) = &run_body.stmts.last()?.kind else { return None };
+        let AstStmtKind::Assembly(asm) = &run_body.stmts.last()?.kind else { return None };
         asm.block
             .stmts
             .iter()

--- a/crates/chisel/src/source.rs
+++ b/crates/chisel/src/source.rs
@@ -17,7 +17,11 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use solar::{
     interface::{Span, diagnostics::EmittedDiagnostics},
-    sema::{CompilerRef, hir, ty::Gcx},
+    sema::{
+        CompilerRef,
+        hir::{Block, Contract, EventId, ItemId, Stmt, StmtKind},
+        ty::Gcx,
+    },
 };
 use std::{cell::OnceCell, fmt};
 use walkdir::WalkDir;
@@ -69,12 +73,12 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
     }
 
     /// Looks up the REPL contract in the HIR.
-    pub fn repl_contract_hir(&self) -> Option<&'gcx hir::Contract<'gcx>> {
+    pub fn repl_contract_hir(&self) -> Option<&'gcx Contract<'gcx>> {
         self.gcx().hir.contracts().find(|c| c.name.as_str() == "REPL")
     }
 
     /// Returns the body block of the REPL `run()` function.
-    pub fn run_func_body(&self) -> hir::Block<'gcx> {
+    pub fn run_func_body(&self) -> Block<'gcx> {
         let hir = &self.gcx().hir;
         let c = self.repl_contract_hir().expect("REPL contract not found in HIR");
         let f = c
@@ -84,12 +88,12 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
         hir.function(f).body.expect("`run()` function does not have a body")
     }
 
-    /// Returns the [`hir::EventId`] of an event named `input` in the REPL contract, if any.
-    pub fn get_event(&self, input: &str) -> Option<hir::EventId> {
+    /// Returns the [`EventId`] of an event named `input` in the REPL contract, if any.
+    pub fn get_event(&self, input: &str) -> Option<EventId> {
         let hir = &self.gcx().hir;
         let c = self.repl_contract_hir()?;
         c.items.iter().find_map(|id| {
-            if let hir::ItemId::Event(eid) = id
+            if let ItemId::Event(eid) = id
                 && hir.event(*eid).name.as_str() == input
             {
                 Some(*eid)
@@ -131,7 +135,7 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
         // version) are handled separately via `trailing_assembly_last_stmt_span`, which
         // walks the AST to recover the last meaningful Yul statement.
         let source_stmt = match &last_stmt.kind {
-            hir::StmtKind::UncheckedBlock(stmts) | hir::StmtKind::Block(stmts) => {
+            StmtKind::UncheckedBlock(stmts) | StmtKind::Block(stmts) => {
                 if let Some(stmt) = stmts.last() {
                     stmt
                 } else {
@@ -153,7 +157,7 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
         //   2. `trailing_assembly_last_stmt_span` returning `Some`, verifies via the AST that the
         //      failing HIR node actually corresponds to an assembly block (not some other lowering
         //      failure), and supplies the concrete span to use.
-        let mut source_span = if matches!(last_stmt.kind, hir::StmtKind::Err(_))
+        let mut source_span = if matches!(last_stmt.kind, StmtKind::Err(_))
             && let Some(span) = self.trailing_assembly_last_stmt_span()
         {
             span
@@ -193,9 +197,9 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
     }
 
     /// Statements' ranges in the solc source map do not include the semicolon.
-    fn stmt_span_without_semicolon(&self, stmt: &hir::Stmt<'_>) -> Span {
+    fn stmt_span_without_semicolon(&self, stmt: &Stmt<'_>) -> Span {
         match stmt.kind {
-            hir::StmtKind::DeclSingle(id) => {
+            StmtKind::DeclSingle(id) => {
                 let decl = self.gcx().hir.variable(id);
                 if let Some(expr) = decl.initializer {
                     stmt.span.with_hi(expr.span.hi())
@@ -203,8 +207,8 @@ impl<'gcx> GeneratedOutputRef<'_, '_, 'gcx> {
                     stmt.span
                 }
             }
-            hir::StmtKind::DeclMulti(_, expr) => stmt.span.with_hi(expr.span.hi()),
-            hir::StmtKind::Expr(expr) => expr.span,
+            StmtKind::DeclMulti(_, expr) => stmt.span.with_hi(expr.span.hi()),
+            StmtKind::Expr(expr) => expr.span,
             _ => stmt.span,
         }
     }

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -153,6 +153,26 @@ assembly {
     repl.expect("[0x00:0x20]");
 });
 
+// Assembly as the final statement with a return — exercises the path where both
+// `first_yul_return_span` and `trailing_assembly_last_stmt_span` resolve to the same `return(...)`
+// span (no subsequent Solidity statement after the assembly block).
+repl_test!(assembly_return_final, |repl| {
+    repl.sendln("uint x = 0xbeef;");
+    repl.sendln("assembly { mstore(0x0, sload(0)) return(0x0, 0x20) }");
+    repl.sendln("!md");
+    repl.expect("[0x00:0x20]");
+});
+
+// Assembly block without a `return(...)` call as an intermediate statement, exercises
+// `first_yul_return_span` returning `None` while a subsequent Solidity statement is still evaluated
+// correctly.
+repl_test!(assembly_no_return_intermediate, |repl| {
+    repl.sendln("uint x = 1;");
+    repl.sendln("assembly { x := add(x, 1) }");
+    repl.sendln("x");
+    repl.expect("Decimal: 2");
+});
+
 // Issue #5051, #8978: Test EVM version normalization.
 repl_test!(flaky_evm_version_normalization, "--use 0.7.6 --evm-version london", |repl| {
     repl.sendln("uint x;\nx");


### PR DESCRIPTION
## Motivation

Migrate `chisel` from `solang` to `solar`.

All existing tests pass.