### PR TITLE
fix(config): suppress spurious unknown-key warning for `network`

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6698,6 +6698,55 @@ mod tests {
     }
 
     #[test]
+    fn no_unknown_key_warning_for_network_field() {
+        // Regression test: `network` is a flattened `Option` field of `NetworkConfigs`. It must
+        // not trigger an unknown-key warning, regardless of whether it is set.
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                network = "tempo"
+                "#,
+            )?;
+
+            let cfg = Config::load().unwrap();
+            assert!(
+                !cfg.warnings.iter().any(
+                    |w| matches!(w, crate::Warning::UnknownKey { key, .. } if key == "network")
+                ),
+                "did not expect UnknownKey warning for `network`, got: {:?}",
+                cfg.warnings
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn no_unknown_key_warning_for_legacy_tempo_alias() {
+        // Regression test: the legacy `tempo = true` alias must keep working without warnings.
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                tempo = true
+                "#,
+            )?;
+
+            let cfg = Config::load().unwrap();
+            assert!(
+                !cfg.warnings.iter().any(
+                    |w| matches!(w, crate::Warning::UnknownKey { key, .. } if key == "tempo")
+                ),
+                "did not expect UnknownKey warning for `tempo`, got: {:?}",
+                cfg.warnings
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
     fn fails_on_ambiguous_version_in_compilation_restrictions() {
         figment::Jail::expect_with(|jail| {
             jail.create_file(

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6736,9 +6736,9 @@ mod tests {
 
             let cfg = Config::load().unwrap();
             assert!(
-                !cfg.warnings.iter().any(
-                    |w| matches!(w, crate::Warning::UnknownKey { key, .. } if key == "tempo")
-                ),
+                !cfg.warnings
+                    .iter()
+                    .any(|w| matches!(w, crate::Warning::UnknownKey { key, .. } if key == "tempo")),
                 "did not expect UnknownKey warning for `tempo`, got: {:?}",
                 cfg.warnings
             );

--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -38,7 +38,10 @@ const DOC_KEYS: &[&str] = &["out", "title", "book", "homepage", "repository", "p
 const RESERVED_KEYS: &[&str] = &["extends"];
 
 /// Keys kept for backward compatibility that should not trigger unknown key warnings.
-const BACKWARD_COMPATIBLE_KEYS: &[&str] = &["solc_version"];
+///
+/// `tempo` and `optimism` are legacy aliases for `network = "tempo"` / `network = "optimism"` —
+/// still accepted on input but no longer serialized in the default config.
+const BACKWARD_COMPATIBLE_KEYS: &[&str] = &["solc_version", "tempo", "optimism"];
 
 /// Generate warnings for unknown sections and deprecated keys
 pub struct WarningsProvider<P> {

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -63,7 +63,7 @@ impl From<ChainId> for NetworkVariant {
 pub struct NetworkConfigs {
     /// Enable a specific network family.
     #[arg(help_heading = "Networks", long, short, num_args = 1, value_name = "NETWORK", value_enum, conflicts_with_all = ["celo", "optimism", "tempo"])]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     network: Option<NetworkVariant>,
     /// Enable Celo network features.
     #[arg(help_heading = "Networks", long, conflicts_with_all = ["network", "optimism", "tempo"])]

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -59,7 +59,7 @@ impl From<ChainId> for NetworkVariant {
     }
 }
 
-#[derive(Clone, Debug, Default, Parser, Serialize, Deserialize, Copy, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Parser, Deserialize, Copy, PartialEq, Eq)]
 pub struct NetworkConfigs {
     /// Enable a specific network family.
     #[arg(help_heading = "Networks", long, short, num_args = 1, value_name = "NETWORK", value_enum, conflicts_with_all = ["celo", "optimism", "tempo"])]
@@ -70,17 +70,35 @@ pub struct NetworkConfigs {
     celo: bool,
     /// Enable Optimism network features (deprecated: use --network optimism).
     #[arg(long, hide = true, conflicts_with_all = ["network", "celo", "tempo"])]
-    // Skipped from configs (forge) as there is no feature to be added yet.
-    #[serde(skip)]
+    // Deserialize-only legacy alias: accepted in foundry.toml but never serialized — the
+    // canonical form is `network = "optimism"`.
+    #[serde(default)]
     optimism: bool,
     /// Enable Tempo network features (deprecated: use --network tempo).
     #[arg(long, hide = true, conflicts_with_all = ["network", "celo", "optimism"])]
+    // Deserialize-only legacy alias: accepted in foundry.toml but never serialized — the
+    // canonical form is `network = "tempo"`.
     #[serde(default)]
     tempo: bool,
     /// Whether to bypass prevrandao.
     #[arg(skip)]
     #[serde(default)]
     bypass_prevrandao: bool,
+}
+
+// Custom `Serialize` impl: always emits the *resolved* network as the canonical
+// `network = "..."` field, and never emits the legacy `tempo` / `optimism` aliases. This avoids
+// confusing output like `network = "tempo"` next to `tempo = false`, and ensures `tempo = true`
+// in foundry.toml round-trips as `network = "tempo"`.
+impl Serialize for NetworkConfigs {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut s = serializer.serialize_struct("NetworkConfigs", 3)?;
+        s.serialize_field("network", &self.resolved_network())?;
+        s.serialize_field("celo", &self.celo)?;
+        s.serialize_field("bypass_prevrandao", &self.bypass_prevrandao)?;
+        s.end()
+    }
 }
 
 impl NetworkConfigs {
@@ -309,6 +327,17 @@ mod tests {
         let json = r#"{"tempo": true, "celo": false, "bypass_prevrandao": false}"#;
         let cfg: NetworkConfigs = serde_json::from_str(json).unwrap();
         assert!(cfg.is_tempo());
+    }
+
+    #[test]
+    fn serde_serializes_legacy_alias_as_canonical_network() {
+        // Legacy `tempo = true` should serialize as the canonical `network = "tempo"`,
+        // and the legacy `tempo` / `optimism` keys must not appear in the output.
+        let cfg = NetworkConfigs { tempo: true, ..Default::default() };
+        let json = serde_json::to_value(cfg).unwrap();
+        assert_eq!(json["network"], serde_json::json!("tempo"));
+        assert!(json.get("tempo").is_none(), "legacy `tempo` key should not be serialized");
+        assert!(json.get("optimism").is_none(), "legacy `optimism` key should not be serialized");
     }
 
     #[test]

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -112,7 +112,6 @@ create2_deployer = "0x4e59b44847b379578588920ca78fbf26c0b4956c"
 assertions_revert = true
 legacy_assertions = false
 celo = false
-tempo = false
 bypass_prevrandao = false
 transaction_timeout = 120
 additional_compiler_profiles = []
@@ -1439,7 +1438,6 @@ forgetest_init!(test_default_config, |prj, cmd| {
   "legacy_assertions": false,
   "network": null,
   "celo": false,
-  "tempo": false,
   "bypass_prevrandao": false,
   "transaction_timeout": 120,
   "additional_compiler_profiles": [],

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1437,6 +1437,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
   "soldeer": null,
   "assertions_revert": true,
   "legacy_assertions": false,
+  "network": null,
   "celo": false,
   "tempo": false,
   "bypass_prevrandao": false,


### PR DESCRIPTION
## Summary

After the recent Tempo template upgrade, projects with `network = "tempo"` in their `foundry.toml` started emitting a spurious warning, and `forge config` produced inconsistent / contradictory output for the network configuration.

```
Warning: Found unknown `network` config for profile `default` defined in foundry.toml.
```

## Root cause

The `network` field on `NetworkConfigs` had `#[serde(skip_serializing_if = "Option::is_none")]`, so it was omitted from the serialized default `Config`. The warnings provider builds its allowed-keys set from that default, so the valid `network` key wasn't recognized.

In addition, the legacy `tempo` / `optimism` boolean aliases were being serialized alongside `network`, leading to confusing output like `network = "tempo"` next to `tempo = false`.

## Fix

1. **Recognize `network` as a known key.** Replaced `skip_serializing_if` with `#[serde(default)]` on the `network` field so it always appears in the serialized default and the warnings provider treats it as known.
2. **Canonicalize on serialization.** Added a custom `Serialize` impl for `NetworkConfigs` that always emits the *resolved* network as the canonical `network = "..."` field and never emits the legacy `tempo` / `optimism` aliases. The legacy aliases remain accepted on deserialization for backward compatibility, and `tempo` / `optimism` are added to `BACKWARD_COMPATIBLE_KEYS` so they don't trigger unknown-key warnings on input.
3. **Regression tests.** Added unit tests covering both the new `network = "tempo"` form and the legacy `tempo = true` alias.

## Behavior

| Input (`foundry.toml`)           | Output (`forge config`)            |
|------------------------------------|--------------------------------------|
| `network = "tempo"`            | `network = "tempo"`              |
| `tempo = true` (legacy)          | `network = "tempo"` (canonicalized) |
| `optimism = true` (legacy)       | `network = "optimism"` (canonicalized) |
| (none set)                         | (omitted)                            |

- TOML output is unchanged for the no-network case (`toml-rs` omits `None`).
- JSON output now includes `"network": null` when unset; the `test_default_config` snapshot is updated.
- The `tempo = false` line previously emitted by default is gone (it duplicated information now carried by `network`).

## Verification

- `forge build` with `network = "tempo"` → no warning.
- `forge build` with `tempo = true` → no warning, network resolves to Tempo.
- `forge build` with no network setting → no warning.
- `cargo test -p foundry-evm-networks` → 11 passed.
- `cargo test -p foundry-config` → all passing, including new regression tests.
- `forge test_default_config` and `can_extract_config_values` snapshots pass.