### PR TITLE
anvil: unify Tempo nonce markers across send RPCs

### DIFF
--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run Tempo check on devnet
         if: |
           github.event_name == 'push' ||
-          github.event_name == 'pull_request' ||
+          (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
           github.event.inputs.network == 'devnet' ||
           github.event.inputs.network == 'all'
         env:
@@ -89,7 +89,7 @@ jobs:
       - name: Run Tempo wallet tests on devnet
         if: |
           github.event_name == 'push' ||
-          github.event_name == 'pull_request' ||
+          (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
           github.event.inputs.network == 'devnet' ||
           github.event.inputs.network == 'all'
         env:

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run Tempo check on devnet
         if: |
           github.event_name == 'push' ||
-          (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
+          github.event_name == 'pull_request' ||
           github.event.inputs.network == 'devnet' ||
           github.event.inputs.network == 'all'
         env:
@@ -89,7 +89,7 @@ jobs:
       - name: Run Tempo wallet tests on devnet
         if: |
           github.event_name == 'push' ||
-          (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
+          github.event_name == 'pull_request' ||
           github.event.inputs.network == 'devnet' ||
           github.event.inputs.network == 'all'
         env:

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2217,7 +2217,6 @@ impl EthApi<FoundryNetwork> {
         } else {
             (required_marker(nonce, on_chain_nonce, from), vec![to_marker(nonce, from)])
         };
-        debug_assert!(requires != provides);
 
         self.add_pending_transaction(pending_transaction, requires, provides)
     }
@@ -3558,6 +3557,7 @@ impl EthApi<FoundryNetwork> {
         requires: Vec<TxMarker>,
         provides: Vec<TxMarker>,
     ) -> Result<TxHash> {
+        debug_assert!(requires != provides);
         let from = *pending_transaction.sender();
         let priority = self.transaction_priority(&pending_transaction.transaction);
         let pool_transaction =

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2210,8 +2210,13 @@ impl EthApi<FoundryNetwork> {
         // pre-validate
         self.backend.validate_pool_transaction(&pending_transaction).await?;
 
-        let requires = required_marker(nonce, on_chain_nonce, from);
-        let provides = vec![to_marker(nonce, from)];
+        let (requires, provides) = if let Some((requires, provides)) =
+            tempo_parallel_nonce_markers(&pending_transaction)
+        {
+            (requires, provides)
+        } else {
+            (required_marker(nonce, on_chain_nonce, from), vec![to_marker(nonce, from)])
+        };
         debug_assert!(requires != provides);
 
         self.add_pending_transaction(pending_transaction, requires, provides)
@@ -2288,11 +2293,10 @@ impl EthApi<FoundryNetwork> {
         let priority = self.transaction_priority(&pending_transaction.transaction);
 
         // Tempo txs use a 2D nonce system — no sequential ordering by account nonce.
-        let (requires, provides) = if let FoundryTxEnvelope::Tempo(aa_tx) =
-            pending_transaction.transaction.as_ref()
-            && !aa_tx.tx().nonce_key.is_zero()
+        let (requires, provides) = if let Some((requires, provides)) =
+            tempo_parallel_nonce_markers(&pending_transaction)
         {
-            (vec![], vec![pending_transaction.hash().to_vec()])
+            (requires, provides)
         } else {
             let on_chain_nonce = self.backend.current_nonce(from).await?;
             let nonce = pending_transaction.transaction.nonce();
@@ -3192,8 +3196,13 @@ impl EthApi<FoundryNetwork> {
         // pre-validate
         self.backend.validate_pool_transaction(&pending_transaction).await?;
 
-        let requires = required_marker(nonce, on_chain_nonce, from);
-        let provides = vec![to_marker(nonce, from)];
+        let (requires, provides) = if let Some((requires, provides)) =
+            tempo_parallel_nonce_markers(&pending_transaction)
+        {
+            (requires, provides)
+        } else {
+            (required_marker(nonce, on_chain_nonce, from), vec![to_marker(nonce, from)])
+        };
 
         self.add_pending_transaction(pending_transaction, requires, provides)
     }
@@ -3632,6 +3641,20 @@ fn required_marker(provided_nonce: u64, on_chain_nonce: u64, from: Address) -> V
     }
     let prev_nonce = provided_nonce.saturating_sub(1);
     if on_chain_nonce <= prev_nonce { vec![to_marker(prev_nonce, from)] } else { Vec::new() }
+}
+
+fn tempo_parallel_nonce_markers(
+    pending_transaction: &PendingTransaction<FoundryTxEnvelope>,
+) -> Option<(Vec<TxMarker>, Vec<TxMarker>)> {
+    // Tempo txs with non-zero nonce_key use a 2D nonce system and should not
+    // be sequenced by account nonce markers.
+    if let FoundryTxEnvelope::Tempo(aa_tx) = pending_transaction.transaction.as_ref()
+        && !aa_tx.tx().nonce_key.is_zero()
+    {
+        Some((vec![], vec![pending_transaction.hash().to_vec()]))
+    } else {
+        None
+    }
 }
 
 fn convert_transact_out(out: &Option<Output>) -> Bytes {


### PR DESCRIPTION
  ## Motivation
                                                                                                                                                                                               
  Tempo transactions with `nonce_key != 0` currently behave inconsistently across RPC send entrypoints:                                                                                        
                                                                                                                                                                                               
  - `eth_sendRawTransaction` uses hash-based pool markers (2D nonce semantics).                                                                                                                
  - `eth_sendTransaction` and `eth_sendUnsignedTransaction` still use `(from, nonce)` sequential markers.
                                                                                                                                                                                               
  This makes parallel nonce behavior endpoint-dependent, which can cause correctness and compatibility issues for clients that switch between RPC methods.
                                                                                                                                                                                               
  ## Solution                                                                                                                                                                                  
                                                                                                                                                                                               
  Unify marker assignment logic for Tempo parallel nonce transactions across all three send paths in `crates/anvil/src/eth/api.rs`.                                                            

  - Added a shared helper: `tempo_parallel_nonce_markers(...)`.                                                                                                                                
  - Applied it in:
    - `eth_sendTransaction`                                                                                                                                                                    
    - `eth_sendRawTransaction`                                                                                                                                                                 
    - `eth_sendUnsignedTransaction`                                                                                                                                                            
  - Behavior:                                                                                                                                                                                  
    - If tx is Tempo and `nonce_key != 0`: `requires = []`, `provides = [tx_hash]`.                                                                                                            
    - Otherwise: keep existing `(from, nonce)` marker behavior unchanged.                                                                                                                      
                                                                                                                                                                                               
  This keeps legacy and non-parallel nonce behavior intact while removing endpoint-specific divergence for Tempo parallel nonce txs.
                                                                                                                                                                                               
  ## PR Checklist                                                                                                                                                                              
                                                                                                                                                                                               
  - [ ] Added Tests                                                                                                                                                                            
  - [ ] Added Documentation                                                                                                                                                                    
  - [ ] Breaking changes