### PR TITLE
ci(tempo): also run devnet checks on push to master

### DIFF
--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Run Tempo check on devnet
         if: |
+          github.event_name == 'push' ||
           github.event_name == 'pull_request' ||
           github.event.inputs.network == 'devnet' ||
           github.event.inputs.network == 'all'
@@ -87,6 +88,7 @@ jobs:
 
       - name: Run Tempo wallet tests on devnet
         if: |
+          github.event_name == 'push' ||
           github.event_name == 'pull_request' ||
           github.event.inputs.network == 'devnet' ||
           github.event.inputs.network == 'all'


### PR DESCRIPTION
## Summary

Devnet checks in `ci-tempo.yml` currently only run on `pull_request`, scheduled nightly, and `workflow_dispatch`. Add `push` to master as a trigger as well so regressions that slip through (e.g. due to flaky CI being re-run and merged) are caught at merge time.

## Change

Updated the `if:` conditions on `Run Tempo check on devnet` and `Run Tempo wallet tests on devnet` to include `github.event_name == 'push'`. The workflow's `on.push.branches: [master]` trigger already exists; this just enables the devnet steps to actually execute on those events.