### PR TITLE
feat: feature-gate optimism deps in common-fmt, common, cast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,7 +324,7 @@ foundry-cheatcodes-spec = { path = "crates/cheatcodes/spec" }
 foundry-cli = { path = "crates/cli" }
 foundry-cli-markdown = { path = "crates/cli-markdown" }
 foundry-common = { path = "crates/common" }
-foundry-common-fmt = { path = "crates/common/fmt" }
+foundry-common-fmt = { path = "crates/common/fmt", default-features = false }
 foundry-config = { path = "crates/config" }
 foundry-debugger = { path = "crates/debugger" }
 foundry-evm = { path = "crates/evm/evm" }

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -62,7 +62,7 @@ tempo-primitives.workspace = true
 alloy-evm.workspace = true
 
 op-alloy-consensus = { workspace = true, features = ["k256"] }
-op-alloy-flz.workspace = true
+op-alloy-flz = { workspace = true, optional = true }
 op-alloy-network.workspace = true
 
 chrono.workspace = true
@@ -100,7 +100,7 @@ anvil.workspace = true
 foundry-test-utils.workspace = true
 
 [features]
-default = ["jemalloc", "asm-keccak"]
+default = ["jemalloc", "asm-keccak", "optimism"]
 asm-keccak = ["alloy-primitives/asm-keccak", "revm/asm-keccak"]
 jemalloc = ["foundry-cli/jemalloc"]
 mimalloc = ["foundry-cli/mimalloc"]
@@ -109,3 +109,4 @@ aws-kms = ["foundry-wallets/aws-kms"]
 gcp-kms = ["foundry-wallets/gcp-kms"]
 turnkey = ["foundry-wallets/turnkey"]
 isolate-by-default = ["foundry-config/isolate-by-default"]
+optimism = ["dep:op-alloy-flz", "foundry-common/optimism"]

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -809,6 +809,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
         CastSubcommand::Erc20Token { command } => command.run().await?,
         CastSubcommand::Tip20Token { command } => command.run().await?,
         CastSubcommand::Keychain { command } => command.run().await?,
+        #[cfg(feature = "optimism")]
         CastSubcommand::DAEstimate(cmd) => {
             cmd.run().await?;
         }

--- a/crates/cast/src/cmd/mod.rs
+++ b/crates/cast/src/cmd/mod.rs
@@ -15,6 +15,7 @@ pub mod call;
 pub mod constructor_args;
 pub mod create2;
 pub mod creation_code;
+#[cfg(feature = "optimism")]
 pub mod da_estimate;
 pub mod erc20;
 pub mod estimate;

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -1,12 +1,13 @@
+#[cfg(feature = "optimism")]
+use crate::cmd::da_estimate::DAEstimateArgs;
 use crate::cmd::{
     access_list::AccessListArgs, artifact::ArtifactArgs, b2e_payload::B2EPayloadArgs,
     batch_mktx::BatchMakeTxArgs, batch_send::BatchSendArgs, bind::BindArgs, call::CallArgs,
     constructor_args::ConstructorArgsArgs, create2::Create2Args, creation_code::CreationCodeArgs,
-    da_estimate::DAEstimateArgs, erc20::Erc20Subcommand, estimate::EstimateArgs,
-    find_block::FindBlockArgs, interface::InterfaceArgs, keychain::KeychainSubcommand,
-    logs::LogsArgs, mktx::MakeTxArgs, rpc::RpcArgs, run::RunArgs, send::SendTxArgs,
-    storage::StorageArgs, tip20::Tip20Subcommand, trace::TraceArgs, txpool::TxPoolSubcommands,
-    wallet::WalletSubcommands,
+    erc20::Erc20Subcommand, estimate::EstimateArgs, find_block::FindBlockArgs,
+    interface::InterfaceArgs, keychain::KeychainSubcommand, logs::LogsArgs, mktx::MakeTxArgs,
+    rpc::RpcArgs, run::RunArgs, send::SendTxArgs, storage::StorageArgs, tip20::Tip20Subcommand,
+    trace::TraceArgs, txpool::TxPoolSubcommands, wallet::WalletSubcommands,
 };
 use alloy_ens::NameOrAddress;
 use alloy_primitives::{Address, B256, Selector, U256};
@@ -1163,6 +1164,7 @@ pub enum CastSubcommand {
         command: TxPoolSubcommands,
     },
     /// Estimates the data availability size of a given opstack block.
+    #[cfg(feature = "optimism")]
     #[command(name = "da-estimate")]
     DAEstimate(DAEstimateArgs),
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -43,8 +43,8 @@ alloy-transport.workspace = true
 alloy-consensus = { workspace = true, features = ["k256"] }
 alloy-network.workspace = true
 
-op-alloy-network.workspace = true
-op-alloy-rpc-types.workspace = true
+op-alloy-network = { workspace = true, optional = true }
+op-alloy-rpc-types = { workspace = true, optional = true }
 
 revm.workspace = true
 
@@ -96,3 +96,11 @@ foundry-evm-hardforks.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 axum = { workspace = true }
 tempfile.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = [
+    "dep:op-alloy-network",
+    "dep:op-alloy-rpc-types",
+    "foundry-common-fmt/optimism",
+]

--- a/crates/common/fmt/Cargo.toml
+++ b/crates/common/fmt/Cargo.toml
@@ -20,10 +20,10 @@ eyre.workspace = true
 
 # ui
 alloy-consensus.workspace = true
-op-alloy-consensus.workspace = true
+op-alloy-consensus = { workspace = true, optional = true }
 alloy-network.workspace = true
 alloy-rpc-types = { workspace = true, features = ["eth"] }
-op-alloy-rpc-types.workspace = true
+op-alloy-rpc-types = { workspace = true, optional = true }
 alloy-serde.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -38,3 +38,7 @@ tempo-alloy.workspace = true
 [dev-dependencies]
 foundry-macros.workspace = true
 similar-asserts.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = ["dep:op-alloy-consensus", "dep:op-alloy-rpc-types"]

--- a/crates/common/fmt/src/ui.rs
+++ b/crates/common/fmt/src/ui.rs
@@ -18,6 +18,7 @@ use alloy_rpc_types::{
     AccessListItem, Block, BlockTransactions, Header, Log, Transaction, TransactionReceipt,
 };
 use alloy_serde::{OtherFields, WithOtherFields};
+#[cfg(feature = "optimism")]
 use op_alloy_consensus::{OpTxEnvelope, TxDeposit, TxPostExec};
 use revm::context_interface::transaction::SignedAuthorization;
 use serde::Deserialize;
@@ -448,6 +449,7 @@ input                {}",
     }
 }
 
+#[cfg(feature = "optimism")]
 impl UIfmt for TxDeposit {
     fn pretty(&self) -> String {
         format!(
@@ -472,6 +474,7 @@ input                {}",
     }
 }
 
+#[cfg(feature = "optimism")]
 impl UIfmt for TxPostExec {
     fn pretty(&self) -> String {
         format!(
@@ -606,6 +609,7 @@ type               {:#x}
     }
 }
 
+#[cfg(feature = "optimism")]
 impl UIfmt for OpTxEnvelope {
     fn pretty(&self) -> String {
         match self {
@@ -651,6 +655,7 @@ effectiveGasPrice    {}
     }
 }
 
+#[cfg(feature = "optimism")]
 impl<T: UIfmt> UIfmt for op_alloy_rpc_types::Transaction<T> {
     fn pretty(&self) -> String {
         format!(
@@ -786,6 +791,7 @@ impl UIfmtSignatureExt for AnyTxEnvelope {
     }
 }
 
+#[cfg(feature = "optimism")]
 impl UIfmtSignatureExt for OpTxEnvelope {
     fn signature_pretty(&self) -> Option<(String, String, String)> {
         self.signature().map(|sig| {
@@ -1135,6 +1141,7 @@ mod tests {
         assert_eq!(b.pretty(), b32.pretty());
     }
 
+    #[cfg(feature = "optimism")]
     #[test]
     fn can_pretty_print_optimism_tx() {
         let s = r#"
@@ -1186,6 +1193,7 @@ yParity              1
         );
     }
 
+    #[cfg(feature = "optimism")]
     #[test]
     fn can_pretty_print_optimism_tx_through_any() {
         let s = r#"

--- a/crates/common/src/transactions/builder.rs
+++ b/crates/common/src/transactions/builder.rs
@@ -9,7 +9,9 @@ use alloy_primitives::{Address, B256, Signature, TxKind, U256};
 use alloy_provider::Provider;
 use alloy_signer::Signer;
 use eyre::Result;
+#[cfg(feature = "optimism")]
 use op_alloy_network::Optimism;
+#[cfg(feature = "optimism")]
 use op_alloy_rpc_types::OpTransactionRequest;
 use tempo_alloy::{TempoNetwork, provider::TempoProviderExt};
 use tempo_primitives::{
@@ -355,6 +357,7 @@ impl FoundryTransactionBuilder<AnyNetwork> for <AnyNetwork as Network>::Transact
     }
 }
 
+#[cfg(feature = "optimism")]
 impl FoundryTransactionBuilder<Optimism> for OpTransactionRequest {
     fn reset_gas_limit(&mut self) {
         self.as_mut().gas = None;

--- a/crates/common/src/transactions/receipt.rs
+++ b/crates/common/src/transactions/receipt.rs
@@ -7,6 +7,7 @@ use alloy_provider::{
 use alloy_rpc_types::{BlockId, TransactionReceipt};
 use eyre::Result;
 use foundry_common_fmt::{UIfmt, UIfmtReceiptExt, get_pretty_receipt_attr};
+#[cfg(feature = "optimism")]
 use op_alloy_rpc_types::OpTransactionReceipt;
 use serde::{Deserialize, Serialize};
 use tempo_alloy::rpc::TempoTransactionReceipt;
@@ -23,6 +24,7 @@ impl FoundryReceiptResponse for TransactionReceipt {
     }
 }
 
+#[cfg(feature = "optimism")]
 impl FoundryReceiptResponse for OpTransactionReceipt {
     fn set_contract_address(&mut self, contract_address: Address) {
         self.inner.contract_address = Some(contract_address);


### PR DESCRIPTION
Introduces an `optimism` cargo feature (default-on) gating Optimism dependencies in three leaf crates: `foundry-common-fmt`, `foundry-common`, and `cast` (`da-estimate` subcommand only).

Default builds are unchanged. With `--no-default-features`, these three crates compile without `op-alloy-consensus`, `op-alloy rpc-types`, `op-alloy-network`, or `op-alloy-flz`.

## Changes
- Workspace-level `default-features = false` for `foundry-common-fmt`.
- New `optimism` feature in `foundry-common-fmt`, `foundry-common`, and `cast`, included in each crate's `default`.
- OP deps marked `optional`; gated behind `#[cfg(feature = "optimism")]`:
  - `foundry-common-fmt`: `UIfmt`/`UIfmtSignatureExt` impls for `OpTxEnvelope`, `TxDeposit`, `TxPostExec`, `op_alloy_rpc_types::Transaction<T>`, plus 2 OP tests.
  - `foundry-common`: `FoundryTransactionBuilder<Optimism> for OpTransactionRequest`, `FoundryReceiptResponse for OpTransactionReceipt`.
  - `cast`: `da_estimate` module + its `CastSubcommand::DAEstimate` variant and dispatch arm.

## Next Steps
- `foundry-primitives` — extract OP impls into dedicated `optimism.rs` submodules (pure structural reorg, no gating).
- `anvil` — split the executor into `transact_eth` / `transact_op` / `transact_tempo` paths so the Ethereum path no longer requires `OpTransaction<TxEnv>`.
- `foundry-evm-core` — gate `evm/op.rs`, `OpEvmNetwork`, OP impls in `env.rs`.
- `foundry-evm-hardforks` + `foundry-evm-networks` — gate `FoundryHardfork::Optimism`, `NetworkVariant::Optimism`, `is_optimism()`, OP CLI flags. No silent fallbacks: when OP is disabled, OP-related CLI/config either compiles out or returns a clear runtime error.
- `cast` / `forge` / `script` / `anvil` CLI gating — gate remaining `is_optimism()`/`OpEvmNetwork` branches and the `--optimism` flag.