### PR TITLE
chore(clippy): fix workspace-wide clippy regressions

### DIFF
--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -123,10 +123,10 @@ impl<T: Typed2718> PoolTransaction<T> {
 impl<T: fmt::Debug> fmt::Debug for PoolTransaction<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "Transaction {{ ")?;
-        write!(fmt, "hash: {:?}, ", &self.pending_transaction.hash())?;
+        write!(fmt, "hash: {:?}, ", self.pending_transaction.hash())?;
         write!(fmt, "requires: [{}], ", hex_fmt_many(self.requires.iter()))?;
         write!(fmt, "provides: [{}], ", hex_fmt_many(self.provides.iter()))?;
-        write!(fmt, "raw tx: {:?}", &self.pending_transaction)?;
+        write!(fmt, "raw tx: {:?}", self.pending_transaction)?;
         write!(fmt, "}}")?;
         Ok(())
     }

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -779,8 +779,7 @@ flag to set your key via:
                 )?;
                 let address = wallet.address();
                 let success_message = format!(
-                    "`{}` keystore was saved successfully. Address: {:?}",
-                    &account_name, address,
+                    "`{account_name}` keystore was saved successfully. Address: {address:?}",
                 );
                 sh_println!("{}", success_message.green())?;
             }
@@ -944,10 +943,9 @@ flag to set your key via:
                     Some(&account_name),
                 )?;
 
+                let address = wallet.address();
                 let success_message = format!(
-                    "Password for keystore `{}` was changed successfully. Address: {:?}",
-                    &account_name,
-                    wallet.address(),
+                    "Password for keystore `{account_name}` was changed successfully. Address: {address:?}",
                 );
                 sh_println!("{}", success_message.green())?;
             }

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -815,7 +815,7 @@ flag to set your key via:
                     format!("Failed to remove keystore file at {}", keystore_path.display())
                 })?;
 
-                let success_message = format!("`{}` keystore was removed successfully.", &name);
+                let success_message = format!("`{name}` keystore was removed successfully.");
                 sh_println!("{}", success_message.green())?;
             }
             Self::PrivateKey {
@@ -887,7 +887,7 @@ flag to set your key via:
                 let private_key = B256::from_slice(&wallet.credential().to_bytes());
 
                 let success_message =
-                    format!("{}'s private key is: {}", &account_name, private_key);
+                    format!("{account_name}'s private key is: {private_key}");
 
                 sh_println!("{}", success_message.green())?;
             }

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -886,8 +886,7 @@ flag to set your key via:
 
                 let private_key = B256::from_slice(&wallet.credential().to_bytes());
 
-                let success_message =
-                    format!("{account_name}'s private key is: {private_key}");
+                let success_message = format!("{account_name}'s private key is: {private_key}");
 
                 sh_println!("{}", success_message.green())?;
             }

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -246,7 +246,7 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
             let mut s =
                 vec![format!("gas used: {}", access_list.gas_used), "access list:".to_string()];
             for al in access_list.access_list.0 {
-                s.push(format!("- address: {}", &al.address.to_checksum(None)));
+                s.push(format!("- address: {}", al.address.to_checksum(None)));
                 if !al.storage_keys.is_empty() {
                     s.push("  keys:".to_string());
                     for key in al.storage_keys {

--- a/crates/cheatcodes/src/test/assert.rs
+++ b/crates/cheatcodes/src/test/assert.rs
@@ -164,7 +164,7 @@ impl EqRelAssertionError<U256> {
                 format_units_uint(&f.left, decimals),
                 format_units_uint(&f.right, decimals),
                 format_delta_percent(&f.max_delta),
-                &f.real_delta,
+                f.real_delta,
             ),
             Self::Overflow => self.to_string(),
         }
@@ -179,7 +179,7 @@ impl EqRelAssertionError<I256> {
                 format_units_int(&f.left, decimals),
                 format_units_int(&f.right, decimals),
                 format_delta_percent(&f.max_delta),
-                &f.real_delta,
+                f.real_delta,
             ),
             Self::Overflow => self.to_string(),
         }

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -395,7 +395,7 @@ fn format_event_definition(event_definition: &pt::EventDefinition) -> Result<Str
                     if param.name.is_empty() {
                         String::default()
                     } else {
-                        format!(" {}", &param.name)
+                        format!(" {}", param.name)
                     },
                 ))
                 .collect::<Vec<_>>()

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -384,8 +384,8 @@ fn format_event_definition(event_definition: &pt::EventDefinition) -> Result<Str
         "event".red(),
         SolidityHelper::new().highlight(&format!(
             "{}({})",
-            &event.name,
-            &event
+            event.name,
+            event
                 .inputs
                 .iter()
                 .map(|param| format!(

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -411,7 +411,7 @@ impl ContractsByArtifact {
         let mut funcs = BTreeMap::new();
         let mut events = BTreeMap::new();
         let mut errors_abi = JsonAbi::new();
-        for (_name, contract) in self.iter() {
+        for contract in self.values() {
             for func in contract.abi.functions() {
                 funcs.insert(func.selector(), func.clone());
             }

--- a/crates/doc/src/writer/as_doc.rs
+++ b/crates/doc/src/writer/as_doc.rs
@@ -72,8 +72,8 @@ impl AsDoc for CommentsRef<'_> {
                 writer.writeln_raw(format!(
                     "{}{}: {}",
                     if customs.len() == 1 { "" } else { "- " },
-                    &c.tag,
-                    &c.value
+                    c.tag,
+                    c.value
                 ))?;
                 writer.writeln()?;
             }

--- a/crates/evm/core/src/decode.rs
+++ b/crates/evm/core/src/decode.rs
@@ -223,8 +223,8 @@ fn trimmed_hex(s: &[u8]) -> String {
     } else {
         format!(
             "{}…{} ({} bytes)",
-            &hex::encode(&s[..n / 2]),
-            &hex::encode(&s[s.len() - n / 2..]),
+            hex::encode(&s[..n / 2]),
+            hex::encode(&s[s.len() - n / 2..]),
             s.len(),
         )
     }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -736,7 +736,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         if !msg.is_empty() {
                             msg.push_str(", ");
                         }
-                        msg.push_str(&format!("{}", &corpus_manager.metrics));
+                        msg.push_str(&format!("{}", corpus_manager.metrics));
                     }
                     progress.set_message(msg);
                 }

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -229,7 +229,7 @@ impl fmt::Display for BaseCounterExample {
         if let Some(sig) = &self.signature {
             write!(f, "calldata={sig}")?
         } else {
-            write!(f, "calldata={}", &self.calldata)?
+            write!(f, "calldata={}", self.calldata)?
         }
 
         if let Some(args) = &self.args {

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -711,7 +711,7 @@ impl<'sess> State<'sess, '_> {
                         // Merge the lines and let the wrapper handle breaking if needed
                         let merged_line = format!(
                             "{current_line} {next_content}",
-                            next_content = &next_line[prefix.len()..].trim_start()
+                            next_content = next_line[prefix.len()..].trim_start()
                         );
                         result.push(merged_line);
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -903,7 +903,7 @@ impl TestArgs {
 
         if let Some(gas_report) = gas_report {
             let finalized = gas_report.finalize();
-            sh_println!("{}", &finalized)?;
+            sh_println!("{finalized}")?;
             outcome.gas_report = Some(finalized);
         }
 
@@ -913,7 +913,7 @@ impl TestArgs {
 
         if self.summary && !outcome.results.is_empty() {
             let summary_report = TestSummaryReport::new(self.detailed, outcome.clone());
-            sh_println!("{}", &summary_report)?;
+            sh_println!("{summary_report}")?;
         }
 
         // Reattach the task.

--- a/crates/forge/src/cmd/test/summary.rs
+++ b/crates/forge/src/cmd/test/summary.rs
@@ -25,9 +25,9 @@ impl TestSummaryReport {
 impl Display for TestSummaryReport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         if shell::is_json() {
-            writeln!(f, "{}", &self.format_json_output(&self.is_detailed, &self.outcome))?;
+            writeln!(f, "{}", self.format_json_output(&self.is_detailed, &self.outcome))?;
         } else {
-            writeln!(f, "\n{}", &self.format_table_output(&self.is_detailed, &self.outcome))?;
+            writeln!(f, "\n{}", self.format_table_output(&self.is_detailed, &self.outcome))?;
         }
         Ok(())
     }

--- a/crates/forge/src/gas_report.rs
+++ b/crates/forge/src/gas_report.rs
@@ -146,7 +146,7 @@ impl GasReport {
 impl Display for GasReport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         if shell::is_json() {
-            writeln!(f, "{}", &self.format_json_output())?;
+            writeln!(f, "{}", self.format_json_output())?;
         } else {
             for (name, contract) in &self.contracts {
                 if contract.functions.is_empty() {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -826,7 +826,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 );
 
                 if let Some(ref progress) = progress {
-                    progress.set_prefix(format!("{}\n{warn}\n", &func.name));
+                    progress.set_prefix(format!("{}\n{warn}\n", func.name));
                 } else {
                     let _ = sh_warn!("{warn}");
                 }

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -129,7 +129,7 @@ impl VerifyBundle {
                     path: Some(artifact.source.to_string_lossy().to_string()),
                     name: artifact
                         .name
-                        .strip_suffix(&format!(".{}", &artifact.profile))
+                        .strip_suffix(&format!(".{}", artifact.profile))
                         .unwrap_or_else(|| &artifact.name)
                         .to_string(),
                 };


### PR DESCRIPTION
Trivial clippy fixes for lints fired under recent nightly clippy across the workspace.

Lints addressed:
- `clippy::for_kv_map` — `crates/common/src/contracts.rs`
- `clippy::useless_borrows_in_formatting` — drop redundant `&` on `format!`/`write!`/`sh_println!` arguments across:
  - `crates/anvil/src/eth/pool/transactions.rs`
  - `crates/cast/src/cmd/wallet/mod.rs`, `crates/cast/src/lib.rs`
  - `crates/cheatcodes/src/test/assert.rs`
  - `crates/chisel/src/executor.rs`
  - `crates/doc/src/writer/as_doc.rs`
  - `crates/evm/core/src/decode.rs`
  - `crates/evm/evm/src/executors/invariant/mod.rs`
  - `crates/evm/fuzz/src/lib.rs`
  - `crates/fmt/src/state/mod.rs`
  - `crates/forge/src/cmd/test/mod.rs`, `crates/forge/src/cmd/test/summary.rs`, `crates/forge/src/gas_report.rs`, `crates/forge/src/runner.rs`
  - `crates/script/src/verify.rs`
- `clippy::uninlined_format_args` — inline format args at two cast wallet messages exposed after removing the borrows.

No behavior change.