### PR TITLE
fix(forge): ignore ETH_RPC_URL for test forking

### DIFF
--- a/crates/cli/src/opts/evm.rs
+++ b/crates/cli/src/opts/evm.rs
@@ -308,6 +308,17 @@ mod tests {
     }
 
     #[test]
+    fn rpc_url_arg_does_not_read_eth_rpc_url_env() {
+        use clap::CommandFactory;
+
+        let command = EvmArgs::command();
+        let rpc_url =
+            command.get_arguments().find(|arg| arg.get_id() == "rpc_url").expect("rpc_url arg");
+
+        assert!(rpc_url.get_env().is_none());
+    }
+
+    #[test]
     fn can_parse_chain_id() {
         let args = EvmArgs {
             env: EnvArgs { chain: Some(NamedChain::Mainnet.into()), ..Default::default() },

--- a/crates/cli/src/opts/rpc.rs
+++ b/crates/cli/src/opts/rpc.rs
@@ -66,8 +66,20 @@ impl figment::Provider for RpcOpts {
 impl RpcOpts {
     /// Returns the RPC endpoint.
     pub fn url<'a>(&'a self, config: Option<&'a Config>) -> Result<Option<Cow<'a, str>>> {
+        self.url_with_env(config, std::env::var("ETH_RPC_URL").ok())
+    }
+
+    fn url_with_env<'a>(
+        &'a self,
+        config: Option<&'a Config>,
+        env_url: Option<String>,
+    ) -> Result<Option<Cow<'a, str>>> {
         if self.flashbots {
             Ok(Some(Cow::Borrowed(FLASHBOTS_URL)))
+        } else if let Some(url) = self.common.rpc_url.as_deref() {
+            Ok(Some(Cow::Borrowed(url)))
+        } else if let Some(url) = env_url {
+            Ok(Some(Cow::Owned(url)))
         } else {
             self.common.url(config)
         }
@@ -85,6 +97,9 @@ impl RpcOpts {
 
     pub fn dict(&self) -> Dict {
         let mut dict = self.common.dict();
+        if let Ok(Some(url)) = self.url(None) {
+            dict.insert("eth_rpc_url".into(), url.into_owned().into());
+        }
         if self.flashbots {
             dict.insert("eth_rpc_url".into(), FLASHBOTS_URL.into());
         }
@@ -199,6 +214,7 @@ impl figment::Provider for EthereumOpts {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
 
     #[test]
     fn parse_etherscan_opts() {
@@ -222,5 +238,42 @@ mod tests {
         let chain_id = dict.get("chain_id").expect("chain_id should be present");
         let id: u64 = chain_id.deserialize().expect("chain_id should deserialize as u64");
         assert_eq!(id, 9745);
+    }
+
+    #[test]
+    fn rpc_url_arg_does_not_read_eth_rpc_url_env() {
+        let command = RpcOpts::command();
+        let rpc_url =
+            command.get_arguments().find(|arg| arg.get_id() == "rpc_url").expect("rpc_url arg");
+
+        assert!(rpc_url.get_env().is_none());
+    }
+
+    #[test]
+    fn rpc_url_resolves_eth_rpc_url_env() {
+        let args = RpcOpts::default();
+        let url = args
+            .url_with_env(None, Some("http://127.0.0.1:8545".to_string()))
+            .expect("url")
+            .expect("url");
+
+        assert_eq!(url.as_ref(), "http://127.0.0.1:8545");
+    }
+
+    #[test]
+    fn explicit_rpc_url_takes_precedence_over_eth_rpc_url_env() {
+        let args = RpcOpts {
+            common: RpcCommonOpts {
+                rpc_url: Some("http://127.0.0.1:8546".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let url = args
+            .url_with_env(None, Some("http://127.0.0.1:8545".to_string()))
+            .expect("url")
+            .expect("url");
+
+        assert_eq!(url.as_ref(), "http://127.0.0.1:8546");
     }
 }

--- a/crates/cli/src/opts/rpc_common.rs
+++ b/crates/cli/src/opts/rpc_common.rs
@@ -13,14 +13,10 @@ use serde::Serialize;
 use std::borrow::Cow;
 
 /// Common RPC-related options shared across CLI commands.
-///
-/// This struct holds fields that both [`super::RpcOpts`] (cast) and
-/// [`super::EvmArgs`] (forge/script) need, eliminating duplication and
-/// making the two structs composable.
 #[derive(Clone, Debug, Default, Serialize, Parser)]
 pub struct RpcCommonOpts {
     /// The RPC endpoint.
-    #[arg(short, long, visible_alias = "fork-url", env = "ETH_RPC_URL")]
+    #[arg(short, long, visible_alias = "fork-url", value_name = "URL")]
     #[serde(rename = "eth_rpc_url", skip_serializing_if = "Option::is_none")]
     pub rpc_url: Option<String>,
 
@@ -80,12 +76,7 @@ impl figment::Provider for RpcCommonOpts {
 impl RpcCommonOpts {
     /// Returns the RPC endpoint URL, resolving from CLI args or config.
     pub fn url<'a>(&'a self, config: Option<&'a Config>) -> Result<Option<Cow<'a, str>>> {
-        let url = match (self.rpc_url.as_deref(), config) {
-            (Some(url), _) => Some(Cow::Borrowed(url)),
-            (None, Some(config)) => config.get_rpc_url().transpose()?,
-            (None, None) => None,
-        };
-        Ok(url)
+        resolve_rpc_url(self.rpc_url.as_deref(), config)
     }
 
     /// Builds a figment-compatible dictionary from these options.
@@ -111,4 +102,17 @@ impl RpcCommonOpts {
         }
         dict
     }
+}
+
+/// Resolves an RPC URL from an explicit CLI value or config.
+pub fn resolve_rpc_url<'a>(
+    rpc_url: Option<&'a str>,
+    config: Option<&'a Config>,
+) -> Result<Option<Cow<'a, str>>> {
+    let url = match (rpc_url, config) {
+        (Some(url), _) => Some(Cow::Borrowed(url)),
+        (None, Some(config)) => config.get_rpc_url().transpose()?,
+        (None, None) => None,
+    };
+    Ok(url)
 }

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3241,7 +3241,7 @@ contract CounterScript is Script {
 error: the following required arguments were not provided:
   --broadcast
 
-Usage: [..] script --broadcast --verify --rpc-url <RPC_URL> <PATH> [ARGS]...
+Usage: [..] script --broadcast --verify --rpc-url <URL> <PATH> [ARGS]...
 
 For more information, try '--help'.
 


### PR DESCRIPTION
## Summary

- keep `ETH_RPC_URL` support for cast RPC commands
- keep the shared `--rpc-url`/`--fork-url` option on `RpcCommonOpts`, but remove the shared `ETH_RPC_URL` Clap binding so Forge only forks when CLI/config provides an RPC URL
- make Cast resolve `ETH_RPC_URL` as a command-specific fallback
- add tests for the command-specific Clap env bindings

Closes #14538
