### PR TITLE
refactor(script): reuse shared Tempo CLI opts

### DIFF
--- a/crates/cli/src/opts/tempo.rs
+++ b/crates/cli/src/opts/tempo.rs
@@ -11,10 +11,10 @@ use std::{
 
 use crate::utils::parse_fee_token_address;
 
-/// CLI options for Tempo transactions.
+/// CLI options common to Tempo transactions across commands.
 #[derive(Clone, Debug, Default, Parser)]
 #[command(next_help_heading = "Tempo")]
-pub struct TempoOpts {
+pub struct TempoCommonOpts {
     /// Fee token address for Tempo transactions.
     ///
     /// When set, builds a Tempo (type 0x76) transaction that pays gas fees
@@ -24,6 +24,40 @@ pub struct TempoOpts {
     /// for more information.
     #[arg(long = "tempo.fee-token", value_parser = parse_fee_token_address)]
     pub fee_token: Option<Address>,
+
+    /// Opt into TIP-1009 expiring-nonce mode with a validity window.
+    ///
+    /// Convenience flag that combines `--tempo.expiring-nonce` with a relative
+    /// `--tempo.valid-before`. Sets nonce_key = U256::MAX, nonce = 0, and valid_before = now +
+    /// seconds.
+    ///
+    /// Maximum value is 30 seconds. The transaction must be mined before the deadline or it
+    /// becomes permanently invalid, giving safe retry semantics: retries produce a fresh tx hash
+    /// and the old tx can never land late.
+    #[arg(long = "tempo.expires", value_name = "SECONDS", value_parser = parse_expires_seconds)]
+    pub expires: Option<u64>,
+}
+
+impl TempoCommonOpts {
+    /// Returns `true` if any Tempo-specific option is set.
+    pub const fn is_tempo(&self) -> bool {
+        self.fee_token.is_some() || self.expires.is_some()
+    }
+
+    /// Returns the absolute `valid_before` unix timestamp derived from `--tempo.expires`, if set.
+    pub fn expires_at(&self) -> Option<u64> {
+        let secs = self.expires?;
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("time went backwards");
+        Some(now.as_secs() + secs)
+    }
+}
+
+/// CLI options for Tempo transactions.
+#[derive(Clone, Debug, Default, Parser)]
+#[command(next_help_heading = "Tempo")]
+pub struct TempoOpts {
+    #[command(flatten)]
+    pub common: TempoCommonOpts,
 
     /// Nonce key for Tempo parallelizable nonces.
     ///
@@ -60,14 +94,14 @@ pub struct TempoOpts {
     ///
     /// Sets nonce to 0 and nonce_key to U256::MAX, enabling time-bounded transaction
     /// validity via `--tempo.valid-before` and `--tempo.valid-after`.
-    #[arg(long = "tempo.expiring-nonce", requires = "valid_before")]
+    #[arg(long = "tempo.expiring-nonce", requires = "valid_before", conflicts_with = "expires")]
     pub expiring_nonce: bool,
 
     /// Upper bound timestamp for Tempo expiring nonce transactions.
     ///
     /// The transaction is only valid before this unix timestamp.
     /// Requires `--tempo.expiring-nonce`.
-    #[arg(long = "tempo.valid-before")]
+    #[arg(long = "tempo.valid-before", conflicts_with = "expires")]
     pub valid_before: Option<u64>,
 
     /// Lower bound timestamp for Tempo expiring nonce transactions.
@@ -76,29 +110,12 @@ pub struct TempoOpts {
     /// Requires `--tempo.expiring-nonce`.
     #[arg(long = "tempo.valid-after")]
     pub valid_after: Option<u64>,
-
-    /// Opt into TIP-1009 expiring-nonce mode with a validity window.
-    ///
-    /// Convenience flag that combines `--tempo.expiring-nonce` with a relative
-    /// `--tempo.valid-before`. Sets nonce_key = U256::MAX, nonce = 0, and valid_before = now +
-    /// seconds.
-    ///
-    /// Maximum value is 30 seconds. The transaction must be mined before the deadline or it
-    /// becomes permanently invalid, giving safe retry semantics: retries produce a fresh tx hash
-    /// and the old tx can never land late.
-    #[arg(
-        long = "tempo.expires",
-        value_name = "SECONDS",
-        value_parser = parse_expires_seconds,
-        conflicts_with_all = &["expiring_nonce", "valid_before"],
-    )]
-    pub expires: Option<u64>,
 }
 
 impl TempoOpts {
     /// Returns `true` if any Tempo-specific option is set.
     pub const fn is_tempo(&self) -> bool {
-        self.fee_token.is_some()
+        self.common.is_tempo()
             || self.nonce_key.is_some()
             || self.sponsor_signature.is_some()
             || self.print_sponsor_hash
@@ -106,14 +123,11 @@ impl TempoOpts {
             || self.expiring_nonce
             || self.valid_before.is_some()
             || self.valid_after.is_some()
-            || self.expires.is_some()
     }
 
     /// Returns the absolute `valid_before` unix timestamp derived from `--tempo.expires`, if set.
     pub fn expires_at(&self) -> Option<u64> {
-        let secs = self.expires?;
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("time went backwards");
-        Some(now.as_secs() + secs)
+        self.common.expires_at()
     }
 
     /// Applies Tempo-specific options to a transaction request.
@@ -125,7 +139,7 @@ impl TempoOpts {
     {
         // Handle expiring nonce mode: sets nonce=0 and nonce_key=U256::MAX.
         // --tempo.expires is a convenience alias that also sets valid_before = now + duration.
-        if self.expiring_nonce || self.expires.is_some() {
+        if self.expiring_nonce || self.common.expires.is_some() {
             tx.set_nonce(0);
             tx.set_nonce_key(U256::MAX);
         } else {
@@ -137,7 +151,7 @@ impl TempoOpts {
             }
         }
 
-        if let Some(fee_token) = self.fee_token {
+        if let Some(fee_token) = self.common.fee_token {
             tx.set_fee_token(fee_token);
         }
 
@@ -194,10 +208,10 @@ mod tests {
     #[test]
     fn parse_expires_flag() {
         let opts = TempoOpts::try_parse_from(["", "--tempo.expires", "30"]).unwrap();
-        assert_eq!(opts.expires, Some(30));
+        assert_eq!(opts.common.expires, Some(30));
 
         let opts = TempoOpts::try_parse_from(["", "--tempo.expires", "10"]).unwrap();
-        assert_eq!(opts.expires, Some(10));
+        assert_eq!(opts.common.expires, Some(10));
 
         // exceeds 30s maximum
         assert!(TempoOpts::try_parse_from(["", "--tempo.expires", "31"]).is_err());
@@ -224,12 +238,15 @@ mod tests {
             "0x20C0000000000000000000000000000000000002",
         ])
         .unwrap();
-        assert_eq!(opts.fee_token, Some(address!("0x20C0000000000000000000000000000000000002")),);
+        assert_eq!(
+            opts.common.fee_token,
+            Some(address!("0x20C0000000000000000000000000000000000002")),
+        );
 
         // AlphaUSD token ID is 1u64
         let opts_with_id = TempoOpts::try_parse_from(["", "--tempo.fee-token", "1"]).unwrap();
         assert_eq!(
-            opts_with_id.fee_token,
+            opts_with_id.common.fee_token,
             Some(address!("0x20C0000000000000000000000000000000000001")),
         );
     }

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -398,7 +398,7 @@ impl CreateArgs {
 
         // If Tempo chain fee token must be set
         if chain.is_tempo() {
-            if let Some(fee_token) = self.tx.tempo.fee_token {
+            if let Some(fee_token) = self.tx.tempo.common.fee_token {
                 deployer.tx.set_fee_token(fee_token);
             } else {
                 deployer.tx.set_fee_token(DEFAULT_FEE_TOKEN);

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -28,8 +28,8 @@ use eyre::{ContextCompat, Result};
 use forge_script_sequence::{AdditionalContract, NestedValue};
 use forge_verify::{RetryArgs, VerifierArgs};
 use foundry_cli::{
-    opts::{BuildOpts, EvmArgs, GlobalArgs},
-    utils::{LoadConfig, parse_fee_token_address},
+    opts::{BuildOpts, EvmArgs, GlobalArgs, TempoCommonOpts},
+    utils::LoadConfig,
 };
 use foundry_common::{
     CONTRACT_MAX_SIZE, ContractsByArtifact, SELECTOR_LEN,
@@ -140,17 +140,9 @@ pub struct ScriptArgs {
     #[arg(long, requires = "batch", default_value = "100")]
     pub batch_size: usize,
 
-    /// Tempo fee token address for paying transaction fees.
-    #[arg(long = "tempo.fee-token", value_parser = parse_fee_token_address)]
-    pub fee_token: Option<Address>,
-
-    /// Opt into TIP-1009 expiring-nonce mode with a validity window.
-    ///
-    /// Sets nonce_key = U256::MAX, nonce = 0, and valid_before = now + seconds on every
-    /// broadcast transaction. The transaction (or batch) must be mined before the deadline or it
-    /// becomes permanently invalid, preventing late-landing replays. Maximum value is 30 seconds.
-    #[arg(long = "tempo.expires", value_name = "SECONDS", value_parser = parse_expires_seconds_script)]
-    pub expires: Option<u64>,
+    /// Tempo transaction options.
+    #[command(flatten)]
+    pub tempo: TempoCommonOpts,
 
     /// Skips on-chain simulation.
     #[arg(long)]
@@ -259,7 +251,7 @@ impl ScriptArgs {
     async fn resolved_evm_opts(&self) -> Result<(Config, EvmOpts)> {
         let (config, mut evm_opts) = self.load_config_and_evm_opts()?;
 
-        if self.fee_token.is_some() || self.expires.is_some() {
+        if self.tempo.is_tempo() {
             // If fee token or expiry is set directly select tempo
             evm_opts.networks = NetworkConfigs::with_tempo();
         } else {
@@ -293,19 +285,13 @@ impl ScriptArgs {
             }
         }
 
-        let fee_token = if evm_opts.networks.is_tempo() && self.fee_token.is_none() {
+        let fee_token = if evm_opts.networks.is_tempo() && self.tempo.fee_token.is_none() {
             Some(PATH_USD_ADDRESS)
         } else {
-            self.fee_token
+            self.tempo.fee_token
         };
 
-        let expires_at = self.expires.map(|secs| {
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("time went backwards")
-                .as_secs()
-                + secs
-        });
+        let expires_at = self.tempo.expires_at();
 
         let script_config =
             ScriptConfig::new(config, evm_opts, self.batch, fee_token, expires_at).await?;
@@ -847,20 +833,11 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
     }
 }
 
-fn parse_expires_seconds_script(s: &str) -> Result<u64, String> {
-    let secs: u64 = s
-        .parse()
-        .map_err(|_| format!("invalid value '{s}': expected an integer number of seconds"))?;
-    if secs > 30 {
-        return Err(format!("expires must be at most 30 seconds (got {secs})"));
-    }
-    Ok(secs)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use alloy_network::Ethereum;
+    use alloy_primitives::address;
     use foundry_config::{NamedChain, UnresolvedEnvVarError};
     use std::fs;
     use tempfile::tempdir;
@@ -870,6 +847,32 @@ mod tests {
         let sig = "0x522bb704000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfFFb92266";
         let args = ScriptArgs::parse_from(["foundry-cli", "Contract.sol", "--sig", sig]);
         assert_eq!(args.sig, sig);
+    }
+
+    #[test]
+    fn can_parse_shared_tempo_opts() {
+        let args = ScriptArgs::parse_from([
+            "foundry-cli",
+            "Contract.sol",
+            "--tempo.fee-token",
+            "1",
+            "--tempo.expires",
+            "10",
+        ]);
+
+        assert_eq!(
+            args.tempo.fee_token,
+            Some(address!("0x20C0000000000000000000000000000000000001"))
+        );
+        assert_eq!(args.tempo.expires, Some(10));
+    }
+
+    #[test]
+    fn does_not_parse_unsupported_tempo_opts() {
+        assert!(
+            ScriptArgs::try_parse_from(["foundry-cli", "Contract.sol", "--tempo.nonce-key", "1"])
+                .is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extract shared Tempo CLI args into `TempoCommonOpts` containing only `--tempo.fee-token` and `--tempo.expires`
- flatten `TempoCommonOpts` into both full `TempoOpts` and `forge script` args