### PR TITLE
chore(cli): tidy ETH_RPC_URL handling and add forge regression test

### DIFF
--- a/crates/cli/src/opts/rpc.rs
+++ b/crates/cli/src/opts/rpc.rs
@@ -97,11 +97,10 @@ impl RpcOpts {
 
     pub fn dict(&self) -> Dict {
         let mut dict = self.common.dict();
+        // `self.url(None)` already accounts for `flashbots` and the `ETH_RPC_URL` env var,
+        // so a single insert here covers both.
         if let Ok(Some(url)) = self.url(None) {
             dict.insert("eth_rpc_url".into(), url.into_owned().into());
-        }
-        if self.flashbots {
-            dict.insert("eth_rpc_url".into(), FLASHBOTS_URL.into());
         }
         if let Ok(Some(jwt)) = self.jwt(None) {
             dict.insert("eth_rpc_jwt".into(), jwt.into_owned().into());

--- a/crates/cli/src/opts/rpc_common.rs
+++ b/crates/cli/src/opts/rpc_common.rs
@@ -13,6 +13,15 @@ use serde::Serialize;
 use std::borrow::Cow;
 
 /// Common RPC-related options shared across CLI commands.
+///
+/// This struct holds fields that both [`super::RpcOpts`] (cast) and
+/// [`super::EvmArgs`] (forge/script) need, eliminating duplication and
+/// making the two structs composable.
+///
+/// Note: `ETH_RPC_URL` is intentionally **not** bound here as a clap env
+/// fallback; otherwise it would be inherited by `EvmArgs` and silently
+/// fork all `forge test` runs. Cast resolves `ETH_RPC_URL` explicitly
+/// at the call site (see [`super::RpcOpts::url`]).
 #[derive(Clone, Debug, Default, Serialize, Parser)]
 pub struct RpcCommonOpts {
     /// The RPC endpoint.
@@ -76,7 +85,12 @@ impl figment::Provider for RpcCommonOpts {
 impl RpcCommonOpts {
     /// Returns the RPC endpoint URL, resolving from CLI args or config.
     pub fn url<'a>(&'a self, config: Option<&'a Config>) -> Result<Option<Cow<'a, str>>> {
-        resolve_rpc_url(self.rpc_url.as_deref(), config)
+        let url = match (self.rpc_url.as_deref(), config) {
+            (Some(url), _) => Some(Cow::Borrowed(url)),
+            (None, Some(config)) => config.get_rpc_url().transpose()?,
+            (None, None) => None,
+        };
+        Ok(url)
     }
 
     /// Builds a figment-compatible dictionary from these options.
@@ -102,17 +116,4 @@ impl RpcCommonOpts {
         }
         dict
     }
-}
-
-/// Resolves an RPC URL from an explicit CLI value or config.
-pub fn resolve_rpc_url<'a>(
-    rpc_url: Option<&'a str>,
-    config: Option<&'a Config>,
-) -> Result<Option<Cow<'a, str>>> {
-    let url = match (rpc_url, config) {
-        (Some(url), _) => Some(Cow::Borrowed(url)),
-        (None, Some(config)) => config.get_rpc_url().transpose()?,
-        (None, None) => None,
-    };
-    Ok(url)
 }

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -577,6 +577,32 @@ forgetest_init!(can_get_evm_opts, |prj, _cmd| {
     }
 });
 
+// Regression test for <https://github.com/foundry-rs/foundry/issues/14538>:
+// the bare `ETH_RPC_URL` env var must NOT cause `forge` commands to set
+// `eth_rpc_url` (which would silently fork all `forge test` runs).
+// Only `--rpc-url`, `foundry.toml`, the `FOUNDRY_ETH_RPC_URL` env var, or
+// cheatcodes should configure forking.
+forgetest_init!(eth_rpc_url_env_does_not_set_fork_url, |prj, _cmd| {
+    prj.initialize_default_contracts();
+    let url = "http://127.0.0.1:8545";
+
+    let mut cmd = prj.forge_bin();
+    cmd.arg("config")
+        .arg("--root")
+        .arg(prj.root())
+        .arg("--json")
+        .env("ETH_RPC_URL", url)
+        // Make sure the figment-style env var is not set in the test environment.
+        .env_remove("FOUNDRY_ETH_RPC_URL");
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let config: Config = serde_json::from_str(stdout.as_ref()).unwrap();
+    assert_eq!(
+        config.eth_rpc_url, None,
+        "bare ETH_RPC_URL must not propagate to forge config (regression #14538)"
+    );
+});
+
 // checks that we can set various config values
 forgetest_init!(can_set_config_values, |prj, _cmd| {
     prj.initialize_default_contracts();


### PR DESCRIPTION
## Summary

Follow-up to #14555 addressing review feedback.

### Changes

- **Drop redundant flashbots branch in `RpcOpts::dict`.** `self.url(None)` already returns `FLASHBOTS_URL` when `--flashbots` is set, so the explicit `if self.flashbots { dict.insert(...) }` overwrite right after was dead code (it overwrites with the same value).
- **Inline `resolve_rpc_url` back into `RpcCommonOpts::url`.** It was only called from one place and exposed an unnecessary `pub fn` surface.
- **Restore the doc comment on `RpcCommonOpts`** and add a note explaining *why* `ETH_RPC_URL` is intentionally **not** a clap env on the shared field — so future readers don't reintroduce the regression by adding it back.
- **Add a forge integration test** that runs `forge config --json` with `ETH_RPC_URL` set in the environment and asserts that `config.eth_rpc_url` stays `None`. This directly exercises the regression scenario from #14538 (the existing structural tests only assert that the clap arg has no env binding, which would still pass if someone added the env binding on a wrapper struct elsewhere).

### Verification

- `cargo test -p foundry-cli --lib` — all opts tests pass
- `cargo test -p forge --test cli config::eth_rpc_url_env_does_not_set_fork_url` — new regression test passes
- `cargo test -p forge --test cli config::` — all 49 config tests pass