### PR TITLE
feat(tempo): add sponsored transaction plumbing

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -445,7 +445,7 @@ echo -e "\n=== CAST SEND WITH SPONSOR (--tempo.sponsor-signature) ==="
 # Test sponsored transactions using pre-signed signature.
 # Step 1: Get the fee_payer_signature_hash using --tempo.print-sponsor-hash
 # Step 2: Sign it with the sponsor's private key
-# Step 3: Send with --tempo.sponsor-signature
+# Step 3: Send with --tempo.sponsor and --tempo.sponsor-signature
 
 # Step 1: Get the hash that the sponsor needs to sign
 FEE_PAYER_HASH=$(cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
@@ -460,7 +460,7 @@ printf "Sponsor signature: %s\n" "$SPONSOR_SIG"
 # Step 3: Send the sponsored transaction with the signature
 RECEIPT=$(cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
   0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" \
-  --tempo.sponsor-signature "$SPONSOR_SIG" --json)
+  --tempo.sponsor "$SPONSOR_ADDR" --tempo.sponsor-signature "$SPONSOR_SIG" --json)
 
 # Verify the fee_payer in the receipt matches the sponsor address
 RECEIPT_FEE_PAYER=$(echo "$RECEIPT" | jq -r '.feePayer // .fee_payer // empty')

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -1117,7 +1117,8 @@ async fn send_keychain_tx(
 ) -> Result<()> {
     let (signer, tempo_access_key) = send_tx.eth.wallet.maybe_signer().await?;
     let print_sponsor_hash = tx_opts.tempo.print_sponsor_hash;
-    let sponsor_signature = tx_opts.tempo.sponsor_signature;
+    let tempo_sponsor =
+        if print_sponsor_hash { None } else { tx_opts.tempo.sponsor_config().await? };
 
     let config = send_tx.eth.load_config()?;
     let timeout = send_tx.timeout.unwrap_or(config.transaction_timeout);
@@ -1169,8 +1170,8 @@ async fn send_keychain_tx(
         {
             tx.set_gas_limit(gas + TEMPO_BROWSER_GAS_BUFFER);
         }
-        if let Some(sig) = sponsor_signature {
-            tx.set_fee_payer_signature(sig);
+        if let Some(sponsor) = &tempo_sponsor {
+            sponsor.attach_and_print::<TempoNetwork>(&mut tx, browser.address()).await?;
         }
 
         let tx_hash = browser.send_transaction_via_browser(tx).await?;
@@ -1190,8 +1191,8 @@ async fn send_keychain_tx(
         };
         let from = signer.address();
         let (mut tx, _) = builder.build(from).await?;
-        if let Some(sig) = sponsor_signature {
-            tx.set_fee_payer_signature(sig);
+        if let Some(sponsor) = &tempo_sponsor {
+            sponsor.attach_and_print::<TempoNetwork>(&mut tx, from).await?;
         }
 
         let wallet = EthereumWallet::from(signer);

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -98,6 +98,8 @@ impl MakeTxArgs {
 
         let print_sponsor_hash = tx.tempo.print_sponsor_hash;
         let expires_at = tx.tempo.expires_at();
+        let tempo_sponsor =
+            if print_sponsor_hash { None } else { tx.tempo.sponsor_config().await? };
 
         let blob_data = if let Some(path) = path { Some(std::fs::read(path)?) } else { None };
 
@@ -153,11 +155,19 @@ impl MakeTxArgs {
                     "Missing required parameters for raw unsigned transaction. When --from is not provided, you must specify: --nonce"
                 );
             }
+            if tempo_sponsor.is_some() && eth.wallet.from.is_none() {
+                eyre::bail!(
+                    "--tempo.sponsor requires --from for --raw-unsigned because the sponsor digest commits to the sender"
+                );
+            }
 
             // Use zero address as placeholder for unsigned transactions
             let from = eth.wallet.from.unwrap_or(Address::ZERO);
 
-            let (tx, _) = tx_builder.build(from).await?;
+            let (mut tx, _) = tx_builder.build(from).await?;
+            if let Some(sponsor) = &tempo_sponsor {
+                sponsor.attach_and_print::<N>(&mut tx, from).await?;
+            }
             let raw_tx = hex::encode_prefixed(tx.build_unsigned()?.encoded_for_signing());
 
             sh_println!("{raw_tx}")?;
@@ -167,7 +177,10 @@ impl MakeTxArgs {
         if ethsign {
             // Use "eth_signTransaction" to sign the transaction only works if the node/RPC has
             // unlocked accounts.
-            let (tx, _) = tx_builder.build(config.sender).await?;
+            let (mut tx, _) = tx_builder.build(config.sender).await?;
+            if let Some(sponsor) = &tempo_sponsor {
+                sponsor.attach_and_print::<N>(&mut tx, config.sender).await?;
+            }
             let signed_tx = provider.sign_transaction(tx).await?;
 
             sh_println!("{signed_tx}")?;
@@ -181,7 +194,10 @@ impl MakeTxArgs {
 
         tx::validate_from_address(eth.wallet.from, from)?;
 
-        let (tx, _) = tx_builder.build(&signer).await?;
+        let (mut tx, _) = tx_builder.build(&signer).await?;
+        if let Some(sponsor) = &tempo_sponsor {
+            sponsor.attach_and_print::<N>(&mut tx, from).await?;
+        }
 
         let tx = tx.build(&EthereumWallet::new(signer)).await?;
 

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -119,8 +119,9 @@ impl SendTxArgs {
             self;
 
         let print_sponsor_hash = tx.tempo.print_sponsor_hash;
-        let sponsor_signature = tx.tempo.sponsor_signature;
         let expires_at = tx.tempo.expires_at();
+        let tempo_sponsor =
+            if print_sponsor_hash { None } else { tx.tempo.sponsor_config().await? };
 
         let blob_data = if let Some(path) = path { Some(std::fs::read(path)?) } else { None };
 
@@ -203,13 +204,19 @@ impl SendTxArgs {
 
         // If --tempo.print-sponsor-hash was passed, build the tx, print the hash, and exit.
         if print_sponsor_hash {
-            // Use the pre-resolved signer to derive the actual sender address, since the
-            // sponsor hash commits to the sender.
-            let signer = pre_resolved_signer.as_ref().ok_or_else(|| {
-                eyre!("--tempo.print-sponsor-hash requires a signer (e.g. --private-key)")
-            })?;
-            let from = signer.address();
-            let (tx, _) = builder.build(from).await?;
+            let (tx, from) = if let Some(ref ak) = access_key {
+                let (tx, _) = builder.build_with_access_key(ak.wallet_address, ak).await?;
+                (tx, ak.wallet_address)
+            } else {
+                // Use the pre-resolved signer to derive the actual sender address, since the
+                // sponsor hash commits to the sender.
+                let signer = pre_resolved_signer.as_ref().ok_or_else(|| {
+                    eyre!("--tempo.print-sponsor-hash requires a signer (e.g. --private-key)")
+                })?;
+                let from = signer.address();
+                let (tx, _) = builder.build(from).await?;
+                (tx, from)
+            };
             let hash = tx
                 .compute_sponsor_hash(from)
                 .ok_or_else(|| eyre!("This network does not support sponsored transactions"))?;
@@ -251,6 +258,10 @@ impl SendTxArgs {
             }
 
             let (tx, _) = builder.build(config.sender).await?;
+            let mut tx = tx;
+            if let Some(sponsor) = &tempo_sponsor {
+                sponsor.attach_and_print::<N>(&mut tx, config.sender).await?;
+            }
 
             cast_send(
                 provider,
@@ -275,6 +286,9 @@ impl SendTxArgs {
             {
                 tx_request.set_gas_limit(gas + TEMPO_BROWSER_GAS_BUFFER);
             }
+            if let Some(sponsor) = &tempo_sponsor {
+                sponsor.attach_and_print::<N>(&mut tx_request, browser.address()).await?;
+            }
 
             let tx_hash = browser.send_transaction_via_browser(tx_request).await?;
 
@@ -288,7 +302,10 @@ impl SendTxArgs {
                 Some(s) => s,
                 None => send_tx.eth.wallet.signer().await?,
             };
-            let (tx_request, _) = builder.build(ak.wallet_address).await?;
+            let (mut tx_request, _) = builder.build_with_access_key(ak.wallet_address, &ak).await?;
+            if let Some(sponsor) = &tempo_sponsor {
+                sponsor.attach_and_print::<N>(&mut tx_request, ak.wallet_address).await?;
+            }
             cast_send_with_access_key(
                 &provider,
                 tx_request,
@@ -314,10 +331,8 @@ impl SendTxArgs {
 
             let (mut tx_request, _) = builder.build(&signer).await?;
 
-            // Apply sponsor signature after gas estimation so the estimate is
-            // consistent with what `--tempo.print-sponsor-hash` computes.
-            if let Some(sig) = sponsor_signature {
-                tx_request.set_fee_payer_signature(sig);
+            if let Some(sponsor) = &tempo_sponsor {
+                sponsor.attach_and_print::<N>(&mut tx_request, from).await?;
             }
 
             let wallet = EthereumWallet::from(signer);

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -60,6 +60,7 @@ pub use foundry_evm::*;
 pub mod args;
 pub mod cmd;
 pub mod opts;
+pub mod tempo;
 
 pub mod base;
 pub mod call_spec;

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -1,0 +1,3 @@
+//! Tempo transaction helpers used by Cast-facing commands.
+
+pub use foundry_common::tempo::{TempoSponsor, TempoSponsorPreview, resolve_tempo_sponsor_signer};

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -20,7 +20,7 @@ use foundry_common::{
     get_pretty_receipt_w_reason_attr, shell,
 };
 use foundry_config::{Chain, Config};
-use foundry_wallets::{BrowserWalletOpts, WalletOpts, WalletSigner};
+use foundry_wallets::{BrowserWalletOpts, TempoAccessKeyConfig, WalletOpts, WalletSigner};
 use itertools::Itertools;
 use serde_json::value::RawValue;
 use std::{fmt::Write, marker::PhantomData, str::FromStr, time::Duration};
@@ -535,13 +535,27 @@ where
         sender: impl Into<SenderKind<'_>>,
     ) -> Result<(N::TransactionRequest, Option<Function>)> {
         let fill = self.fill;
-        self._build(sender, fill).await
+        self._build(sender, fill, None).await
+    }
+
+    /// Builds a transaction that will be signed by a Tempo access key.
+    ///
+    /// If the access key needs on-chain provisioning, its authorization is embedded before
+    /// access-list/gas estimation and before any sponsor digest can be computed.
+    pub async fn build_with_access_key(
+        self,
+        sender: impl Into<SenderKind<'_>>,
+        access_key: &TempoAccessKeyConfig,
+    ) -> Result<(N::TransactionRequest, Option<Function>)> {
+        let fill = self.fill;
+        self._build(sender, fill, Some(access_key)).await
     }
 
     async fn _build(
         mut self,
         sender: impl Into<SenderKind<'_>>,
         fill: bool,
+        access_key: Option<&TempoAccessKeyConfig>,
     ) -> Result<(N::TransactionRequest, Option<Function>)> {
         // prepare
         let sender = sender.into();
@@ -555,6 +569,16 @@ where
         // resolve
         let tx_nonce = self.resolve_nonce(sender.address(), fill).await?;
         self.resolve_auth(&sender, tx_nonce).await?;
+        if let Some(access_key) = access_key {
+            self.tx
+                .prepare_access_key_authorization(
+                    &self.provider,
+                    access_key.wallet_address,
+                    access_key.key_address,
+                    access_key.key_authorization.as_ref(),
+                )
+                .await?;
+        }
         self.resolve_access_list().await?;
 
         // fill

--- a/crates/cli/src/opts/tempo.rs
+++ b/crates/cli/src/opts/tempo.rs
@@ -171,14 +171,11 @@ impl TempoOpts {
     /// Resolves sponsor CLI options into a reusable sponsor config for transaction submission.
     pub async fn sponsor_config(&self) -> Result<Option<TempoSponsor>> {
         let Some(sponsor) = self.sponsor else {
-            if self.sponsor_signer.is_some() || self.sponsor_sig.is_some() {
-                eyre::bail!("--tempo.sponsor is required when configuring Tempo sponsorship");
-            }
             return Ok(None);
         };
 
         let signer = if let Some(spec) = &self.sponsor_signer {
-            Some(Arc::new(Box::pin(resolve_tempo_sponsor_signer(spec)).await?))
+            Some(Arc::new(resolve_tempo_sponsor_signer(spec).await?))
         } else {
             None
         };

--- a/crates/cli/src/opts/tempo.rs
+++ b/crates/cli/src/opts/tempo.rs
@@ -1,11 +1,16 @@
 use alloy_network::{Network, TransactionBuilder};
 use alloy_primitives::{Address, ruint::aliases::U256};
-use alloy_signer::Signature;
+use alloy_signer::{Signature, Signer};
 use clap::Parser;
-use foundry_common::FoundryTransactionBuilder;
+use eyre::Result;
+use foundry_common::{
+    FoundryTransactionBuilder,
+    tempo::{TempoSponsor, resolve_tempo_sponsor_signer},
+};
 use std::{
     num::NonZeroU64,
     str::FromStr,
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -69,18 +74,44 @@ pub struct TempoOpts {
     #[arg(long = "tempo.nonce-key", value_name = "NONCE_KEY")]
     pub nonce_key: Option<U256>,
 
+    /// Sponsor (fee payer) address for Tempo sponsored transactions.
+    #[arg(long = "tempo.sponsor", value_name = "ADDRESS")]
+    pub sponsor: Option<Address>,
+
+    /// Sign Tempo sponsor digests in-band with the given signer URI.
+    ///
+    /// Supported forms include `env://VAR`, `keystore://PATH`, `account://NAME`,
+    /// `ledger://`, `trezor://`, `aws://`, `gcp://`, `turnkey://`, and
+    /// `private-key://KEY`.
+    #[arg(
+        long = "tempo.sponsor-signer",
+        value_name = "SIGNER",
+        requires = "sponsor",
+        conflicts_with = "sponsor_sig"
+    )]
+    pub sponsor_signer: Option<String>,
+
     /// Sponsor (fee payer) signature for Tempo sponsored transactions.
     ///
     /// The sponsor signs the `fee_payer_signature_hash` to commit to paying gas fees
     /// on behalf of the sender. Provide as a hex-encoded signature.
-    #[arg(long = "tempo.sponsor-signature", value_parser = parse_signature)]
-    pub sponsor_signature: Option<Signature>,
+    #[arg(
+        long = "tempo.sponsor-sig",
+        alias = "tempo.sponsor-signature",
+        value_parser = parse_signature,
+        requires = "sponsor",
+        conflicts_with = "sponsor_signer"
+    )]
+    pub sponsor_sig: Option<Signature>,
 
     /// Print the sponsor signature hash and exit.
     ///
     /// Computes the `fee_payer_signature_hash` for the transaction so that a sponsor
     /// knows what hash to sign. The transaction is not sent.
-    #[arg(long = "tempo.print-sponsor-hash")]
+    #[arg(
+        long = "tempo.print-sponsor-hash",
+        conflicts_with_all = &["sponsor", "sponsor_signer", "sponsor_sig"]
+    )]
     pub print_sponsor_hash: bool,
 
     /// Access key ID for Tempo Keychain signature transactions.
@@ -117,7 +148,9 @@ impl TempoOpts {
     pub const fn is_tempo(&self) -> bool {
         self.common.is_tempo()
             || self.nonce_key.is_some()
-            || self.sponsor_signature.is_some()
+            || self.sponsor.is_some()
+            || self.sponsor_signer.is_some()
+            || self.sponsor_sig.is_some()
             || self.print_sponsor_hash
             || self.key_id.is_some()
             || self.expiring_nonce
@@ -128,6 +161,44 @@ impl TempoOpts {
     /// Returns the absolute `valid_before` unix timestamp derived from `--tempo.expires`, if set.
     pub fn expires_at(&self) -> Option<u64> {
         self.common.expires_at()
+    }
+
+    /// Returns `true` if a sponsor signature should be attached before submission.
+    pub const fn has_sponsor_submission(&self) -> bool {
+        self.sponsor.is_some() || self.sponsor_signer.is_some() || self.sponsor_sig.is_some()
+    }
+
+    /// Resolves sponsor CLI options into a reusable sponsor config for transaction submission.
+    pub async fn sponsor_config(&self) -> Result<Option<TempoSponsor>> {
+        let Some(sponsor) = self.sponsor else {
+            if self.sponsor_signer.is_some() || self.sponsor_sig.is_some() {
+                eyre::bail!("--tempo.sponsor is required when configuring Tempo sponsorship");
+            }
+            return Ok(None);
+        };
+
+        let signer = if let Some(spec) = &self.sponsor_signer {
+            Some(Arc::new(Box::pin(resolve_tempo_sponsor_signer(spec)).await?))
+        } else {
+            None
+        };
+
+        if let Some(signer) = &signer {
+            let signer_address = signer.address();
+            if signer_address != sponsor {
+                eyre::bail!(
+                    "Tempo sponsor signer address {signer_address} does not match --tempo.sponsor {sponsor}"
+                );
+            }
+        }
+
+        if signer.is_none() && self.sponsor_sig.is_none() {
+            eyre::bail!(
+                "--tempo.sponsor requires either --tempo.sponsor-signer or --tempo.sponsor-sig"
+            );
+        }
+
+        Ok(Some(TempoSponsor::new(sponsor, signer, self.sponsor_sig)))
     }
 
     /// Applies Tempo-specific options to a transaction request.
@@ -178,8 +249,7 @@ impl TempoOpts {
         // gas estimation so that `--tempo.print-sponsor-hash` and
         // `--tempo.sponsor-signature` produce identical gas estimates. Callers
         // should call `set_fee_payer_signature` on the built tx request.
-        if (self.sponsor_signature.is_some() || self.print_sponsor_hash) && tx.nonce_key().is_none()
-        {
+        if (self.has_sponsor_submission() || self.print_sponsor_hash) && tx.nonce_key().is_none() {
             tx.set_nonce_key(U256::ZERO);
         }
     }
@@ -248,6 +318,59 @@ mod tests {
         assert_eq!(
             opts_with_id.common.fee_token,
             Some(address!("0x20C0000000000000000000000000000000000001")),
+        );
+    }
+
+    #[test]
+    fn parse_sponsor_signer() {
+        let opts = TempoOpts::try_parse_from([
+            "",
+            "--tempo.sponsor",
+            "0x1111111111111111111111111111111111111111",
+            "--tempo.sponsor-signer",
+            "env://TEMPO_SPONSOR_PK",
+        ])
+        .unwrap();
+
+        assert_eq!(opts.sponsor, Some(address!("0x1111111111111111111111111111111111111111")));
+        assert_eq!(opts.sponsor_signer.as_deref(), Some("env://TEMPO_SPONSOR_PK"));
+        assert!(opts.sponsor_sig.is_none());
+        assert!(opts.is_tempo());
+        assert!(opts.has_sponsor_submission());
+    }
+
+    #[test]
+    fn sponsor_signer_requires_sponsor() {
+        assert!(
+            TempoOpts::try_parse_from(["", "--tempo.sponsor-signer", "env://SPONSOR"]).is_err()
+        );
+    }
+
+    #[test]
+    fn parse_sponsor_signature_alias() {
+        let opts = TempoOpts::try_parse_from([
+            "",
+            "--tempo.sponsor",
+            "0x1111111111111111111111111111111111111111",
+            "--tempo.sponsor-signature",
+            "0x0eb96ca19e8a77102767a41fc85a36afd5c61ccb09911cec5d3e86e193d9c5ae3a456401896b1b6055311536bf00a718568c744d8c1f9df59879e8350220ca182b",
+        ])
+        .unwrap();
+
+        assert_eq!(opts.sponsor, Some(address!("0x1111111111111111111111111111111111111111")));
+        assert!(opts.sponsor_sig.is_some());
+    }
+
+    #[test]
+    fn print_sponsor_hash_conflicts_with_sponsor_submission() {
+        assert!(
+            TempoOpts::try_parse_from([
+                "",
+                "--tempo.print-sponsor-hash",
+                "--tempo.sponsor",
+                "0x1111111111111111111111111111111111111111",
+            ])
+            .is_err()
         );
     }
 }

--- a/crates/cli/src/opts/tempo.rs
+++ b/crates/cli/src/opts/tempo.rs
@@ -175,7 +175,7 @@ impl TempoOpts {
         };
 
         let signer = if let Some(spec) = &self.sponsor_signer {
-            Some(Arc::new(resolve_tempo_sponsor_signer(spec).await?))
+            Some(Arc::new(Box::pin(resolve_tempo_sponsor_signer(spec)).await?))
         } else {
             None
         };

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -1,5 +1,13 @@
 //! Tempo network utilities.
 
+use crate::FoundryTransactionBuilder;
+use alloy_network::Network;
+use alloy_primitives::{Address, B256, Signature};
+use alloy_signer::Signer;
+use eyre::{Context, Result};
+use foundry_wallets::{RawWalletOpts, WalletOpts, WalletSigner};
+use std::sync::Arc;
+
 mod keystore;
 pub use keystore::*;
 
@@ -16,3 +24,173 @@ mod tests;
 ///
 /// See <https://github.com/tempoxyz/tempo/blob/6ebf1a8/crates/revm/src/handler.rs#L108-L124>
 pub const TEMPO_BROWSER_GAS_BUFFER: u64 = 7_000;
+
+/// Gas sponsor configuration for Tempo fee-payer signatures.
+#[derive(Clone, Debug)]
+pub struct TempoSponsor {
+    sponsor: Address,
+    signer: Option<Arc<WalletSigner>>,
+    signature: Option<Signature>,
+}
+
+impl TempoSponsor {
+    pub const fn new(
+        sponsor: Address,
+        signer: Option<Arc<WalletSigner>>,
+        signature: Option<Signature>,
+    ) -> Self {
+        Self { sponsor, signer, signature }
+    }
+
+    pub const fn sponsor(&self) -> Address {
+        self.sponsor
+    }
+
+    pub async fn attach_and_print<N: Network>(
+        &self,
+        tx: &mut N::TransactionRequest,
+        sender: Address,
+    ) -> Result<TempoSponsorPreview>
+    where
+        N::TransactionRequest: FoundryTransactionBuilder<N>,
+    {
+        if self.sponsor == sender {
+            eyre::bail!(
+                "invalid Tempo sponsorship: sponsor {} must not equal transaction sender",
+                self.sponsor
+            );
+        }
+
+        let digest = tx.compute_sponsor_hash(sender).ok_or_else(|| {
+            eyre::eyre!(
+                "failed to compute Tempo sponsor digest; make sure this is a complete Tempo AA transaction"
+            )
+        })?;
+
+        let preview = TempoSponsorPreview {
+            sponsor: self.sponsor,
+            fee_token: tx.fee_token(),
+            valid_before: tx.valid_before().map(|v| v.get()),
+            valid_after: tx.valid_after().map(|v| v.get()),
+            digest,
+        };
+        preview.print()?;
+
+        let signature = if let Some(signature) = self.signature {
+            signature
+        } else if let Some(signer) = &self.signer {
+            signer.sign_hash(&digest).await.context("failed to sign Tempo sponsor digest")?
+        } else {
+            eyre::bail!("missing Tempo sponsor signature or signer")
+        };
+
+        let recovered = signature
+            .recover_address_from_prehash(&digest)
+            .context("failed to recover Tempo sponsor signature")?;
+        if recovered != self.sponsor {
+            eyre::bail!("Tempo sponsor signature recovered {recovered}, expected {}", self.sponsor);
+        }
+        if recovered == sender {
+            eyre::bail!(
+                "invalid Tempo sponsorship: recovered fee payer {recovered} must not equal transaction sender"
+            );
+        }
+
+        tx.set_fee_payer_signature(signature);
+        Ok(preview)
+    }
+}
+
+/// User-visible sponsor digest metadata for a single outgoing Tempo transaction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TempoSponsorPreview {
+    pub sponsor: Address,
+    pub fee_token: Option<Address>,
+    pub valid_before: Option<u64>,
+    pub valid_after: Option<u64>,
+    pub digest: B256,
+}
+
+impl TempoSponsorPreview {
+    pub fn print(&self) -> Result<()> {
+        crate::sh_println!("Tempo sponsor: {}", self.sponsor)?;
+        crate::sh_println!(
+            "Tempo fee token: {}",
+            self.fee_token.map_or_else(|| "network default".to_string(), |addr| addr.to_string())
+        )?;
+        crate::sh_println!(
+            "Tempo validity: after {}, before {}",
+            self.valid_after.map_or_else(|| "none".to_string(), |v| v.to_string()),
+            self.valid_before.map_or_else(|| "none".to_string(), |v| v.to_string())
+        )?;
+        crate::sh_println!("Tempo sponsor digest: {:?}", self.digest)?;
+        Ok(())
+    }
+}
+
+/// Resolves a `--tempo.sponsor-signer` URI into a Foundry wallet signer.
+pub async fn resolve_tempo_sponsor_signer(spec: &str) -> Result<WalletSigner> {
+    let spec = spec.trim();
+    let (scheme, value) = spec
+        .split_once("://")
+        .map(|(scheme, value)| (scheme.to_ascii_lowercase(), value))
+        .unwrap_or_else(|| (spec.to_ascii_lowercase(), ""));
+
+    match scheme.as_str() {
+        "env" => {
+            if value.is_empty() {
+                eyre::bail!("env:// sponsor signer requires an environment variable name");
+            }
+            let private_key = std::env::var(value)
+                .wrap_err_with(|| format!("{value} environment variable is required"))?;
+            foundry_wallets::utils::create_private_key_signer(&private_key)
+        }
+        "private-key" => {
+            if value.is_empty() {
+                eyre::bail!("private-key:// sponsor signer requires a private key");
+            }
+            foundry_wallets::utils::create_private_key_signer(value)
+        }
+        "keystore" => {
+            if value.is_empty() {
+                eyre::bail!("keystore:// sponsor signer requires a keystore path");
+            }
+            WalletOpts { keystore_path: Some(value.to_string()), ..Default::default() }
+                .signer()
+                .await
+        }
+        "account" => {
+            if value.is_empty() {
+                eyre::bail!("account:// sponsor signer requires an account name");
+            }
+            WalletOpts { keystore_account_name: Some(value.to_string()), ..Default::default() }
+                .signer()
+                .await
+        }
+        "ledger" => {
+            let raw = RawWalletOpts {
+                hd_path: (!value.is_empty()).then(|| value.to_string()),
+                ..Default::default()
+            };
+            WalletOpts { ledger: true, raw, ..Default::default() }.signer().await
+        }
+        "trezor" => {
+            let raw = RawWalletOpts {
+                hd_path: (!value.is_empty()).then(|| value.to_string()),
+                ..Default::default()
+            };
+            WalletOpts { trezor: true, raw, ..Default::default() }.signer().await
+        }
+        "aws" => WalletOpts { aws: true, ..Default::default() }.signer().await,
+        "gcp" => WalletOpts { gcp: true, ..Default::default() }.signer().await,
+        "turnkey" => WalletOpts { turnkey: true, ..Default::default() }.signer().await,
+        "browser" => {
+            eyre::bail!(
+                "browser:// sponsor signing is not supported by the current browser wallet API; use --tempo.sponsor-sig or another sponsor signer"
+            )
+        }
+        _ => eyre::bail!(
+            "unsupported Tempo sponsor signer `{spec}`; expected env://VAR, keystore://PATH, account://NAME, ledger://, trezor://, aws://, gcp://, turnkey://, or private-key://KEY"
+        ),
+    }
+}

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -113,17 +113,17 @@ pub struct TempoSponsorPreview {
 
 impl TempoSponsorPreview {
     pub fn print(&self) -> Result<()> {
-        crate::sh_println!("Tempo sponsor: {}", self.sponsor)?;
-        crate::sh_println!(
+        crate::sh_eprintln!("Tempo sponsor: {}", self.sponsor)?;
+        crate::sh_eprintln!(
             "Tempo fee token: {}",
             self.fee_token.map_or_else(|| "network default".to_string(), |addr| addr.to_string())
         )?;
-        crate::sh_println!(
+        crate::sh_eprintln!(
             "Tempo validity: after {}, before {}",
             self.valid_after.map_or_else(|| "none".to_string(), |v| v.to_string()),
             self.valid_before.map_or_else(|| "none".to_string(), |v| v.to_string())
         )?;
-        crate::sh_println!("Tempo sponsor digest: {:?}", self.digest)?;
+        crate::sh_eprintln!("Tempo sponsor digest: {:?}", self.digest)?;
         Ok(())
     }
 }

--- a/crates/common/src/transactions/builder.rs
+++ b/crates/common/src/transactions/builder.rs
@@ -246,6 +246,24 @@ pub trait FoundryTransactionBuilder<N: Network>: NetworkTransactionBuilder<N> {
     /// on-chain as part of this transaction.
     fn set_key_authorization(&mut self, _key_authorization: SignedKeyAuthorization) {}
 
+    /// Embeds key authorization before gas estimation/signing if the access key is not yet
+    /// provisioned on-chain.
+    ///
+    /// This mirrors the mutation performed by [`Self::sign_with_access_key`], but makes the final
+    /// transaction body available before fee-payer sponsor digests are computed.
+    fn prepare_access_key_authorization<'a>(
+        &'a mut self,
+        _provider: &'a impl Provider<N>,
+        _wallet_address: Address,
+        _key_address: Address,
+        _key_authorization: Option<&'a SignedKeyAuthorization>,
+    ) -> impl Future<Output = Result<()>> + Send + 'a
+    where
+        Self: Send,
+    {
+        async { Ok(()) }
+    }
+
     /// Converts a CREATE transaction into an AA-compatible call entry.
     ///
     /// Tempo AA transactions use a `calls` list instead of `to`+`input`. Must be
@@ -442,6 +460,35 @@ impl FoundryTransactionBuilder<TempoNetwork> for <TempoNetwork as Network>::Tran
         self.key_authorization = Some(key_authorization);
     }
 
+    fn prepare_access_key_authorization<'a>(
+        &'a mut self,
+        provider: &'a impl Provider<TempoNetwork>,
+        wallet_address: Address,
+        key_address: Address,
+        key_authorization: Option<&'a SignedKeyAuthorization>,
+    ) -> impl Future<Output = Result<()>> + Send + 'a
+    where
+        Self: Send,
+    {
+        let auth = key_authorization.cloned();
+
+        async move {
+            if let Some(auth) = auth {
+                let is_provisioned = provider
+                    .get_keychain_key(wallet_address, key_address)
+                    .await
+                    .map(|info| info.keyId != Address::ZERO)
+                    .unwrap_or(false);
+
+                if !is_provisioned {
+                    self.set_key_authorization(auth);
+                }
+            }
+
+            Ok(())
+        }
+    }
+
     fn convert_create_to_call(&mut self) {
         if self.calls.is_empty() && self.inner.to.is_some_and(|to| to.is_create()) {
             let input = self.inner.input.input().cloned().unwrap_or_default();
@@ -476,7 +523,12 @@ impl FoundryTransactionBuilder<TempoNetwork> for <TempoNetwork as Network>::Tran
                 let is_provisioned =
                     provisioning_fut.await.map(|info| info.keyId != Address::ZERO).unwrap_or(false);
 
-                if !is_provisioned {
+                if !is_provisioned && self.key_authorization.is_none() {
+                    if self.fee_payer_signature.is_some() {
+                        eyre::bail!(
+                            "cannot add Tempo key authorization after fee payer signature was attached"
+                        );
+                    }
                     self.set_key_authorization(auth);
                 }
             }

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -427,6 +427,18 @@ impl CreateArgs {
             deployer.tx.set_nonce(provider.get_transaction_count(deployer_address).await?);
         }
 
+        if let Some((_, ref ak)) = tempo_keychain {
+            deployer
+                .tx
+                .prepare_access_key_authorization(
+                    provider.as_ref(),
+                    ak.wallet_address,
+                    ak.key_address,
+                    ak.key_authorization.as_ref(),
+                )
+                .await?;
+        }
+
         // set access list if specified
         if let Some(access_list) = match self.tx.access_list {
             None => None,
@@ -501,6 +513,11 @@ impl CreateArgs {
             }
 
             return Ok(());
+        }
+
+        let tempo_sponsor = self.tx.tempo.sponsor_config().await?;
+        if let Some(sponsor) = &tempo_sponsor {
+            sponsor.attach_and_print::<N>(&mut deployer.tx, deployer_address).await?;
         }
 
         // Deploy the actual contract

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -26,6 +26,7 @@ use foundry_common::{
     FoundryTransactionBuilder, TransactionMaybeSigned,
     provider::{ProviderBuilder, try_get_http_provider},
     shell,
+    tempo::TempoSponsor,
 };
 use foundry_config::Config;
 use foundry_evm::core::evm::{FoundryEvmNetwork, TempoEvmNetwork};
@@ -100,7 +101,17 @@ where
         is_fixed_gas_limit: bool,
         estimate_via_rpc: bool,
         estimate_multiplier: u64,
+        tempo_sponsor: Option<&TempoSponsor>,
     ) -> Result<()> {
+        let access_key_authorization = match self {
+            Self::AccessKey(_, _, access_key) => Some((
+                access_key.wallet_address,
+                access_key.key_address,
+                access_key.key_authorization.clone(),
+            )),
+            _ => None,
+        };
+
         if let Self::Raw(tx, _)
         | Self::Unlocked(tx)
         | Self::Browser(tx, _)
@@ -137,10 +148,27 @@ where
                 }
             }
 
+            if let Some((wallet_address, key_address, key_authorization)) =
+                access_key_authorization.as_ref()
+            {
+                tx.prepare_access_key_authorization(
+                    provider,
+                    *wallet_address,
+                    *key_address,
+                    key_authorization.as_ref(),
+                )
+                .await?;
+            }
+
             // Chains which use `eth_estimateGas` are being sent sequentially and require their
             // gas to be re-estimated right before broadcasting.
             if !is_fixed_gas_limit && estimate_via_rpc {
                 estimate_gas(tx, provider, estimate_multiplier).await?;
+            }
+
+            if let Some(sponsor) = tempo_sponsor {
+                let from = tx.from().expect("no sender");
+                sponsor.attach_and_print::<N>(tx, from).await?;
             }
         }
 
@@ -211,6 +239,7 @@ where
         is_fixed_gas_limit: bool,
         estimate_via_rpc: bool,
         estimate_multiplier: u64,
+        tempo_sponsor: Option<&TempoSponsor>,
     ) -> Result<TxHash> {
         self.prepare(
             &provider,
@@ -218,6 +247,7 @@ where
             is_fixed_gas_limit,
             estimate_via_rpc,
             estimate_multiplier,
+            tempo_sponsor,
         )
         .await?;
 
@@ -387,6 +417,27 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
             SendTransactionsKind::Raw { eth_wallets, browser: self.browser_wallet, access_keys }
         };
 
+        let tempo_sponsor = self.script_config.tempo.sponsor_config().await?.map(Arc::new);
+        if tempo_sponsor.is_some() && self.script_config.tempo.sponsor_sig.is_some() {
+            let remaining = self
+                .sequence
+                .sequences()
+                .iter()
+                .map(|sequence| {
+                    sequence
+                        .transactions()
+                        .skip(sequence.receipts.len())
+                        .filter(|tx| tx.is_unsigned())
+                        .count()
+                })
+                .sum::<usize>();
+            if remaining > 1 {
+                eyre::bail!(
+                    "--tempo.sponsor-sig can only sponsor one remaining script transaction; use --tempo.sponsor-signer for multi-transaction scripts"
+                );
+            }
+        }
+
         let progress = ScriptProgress::default();
 
         for i in 0..self.sequence.sequences().len() {
@@ -464,6 +515,11 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
 
                         let kind = match tx_with_metadata.tx().clone() {
                             TransactionMaybeSigned::Signed { tx, .. } => {
+                                if tempo_sponsor.is_some() {
+                                    eyre::bail!(
+                                        "cannot attach Tempo sponsor signature to an already signed script transaction"
+                                    );
+                                }
                                 SendTransactionKind::Signed(tx)
                             }
                             TransactionMaybeSigned::Unsigned(mut tx) => {
@@ -486,6 +542,8 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
                                     );
                                     tx.set_max_fee_per_gas(eip1559_fees.max_fee_per_gas);
                                 }
+
+                                self.script_config.tempo.apply::<FEN::Network>(&mut tx, None);
 
                                 send_kind.for_sender(&from, tx)?
                             }
@@ -525,6 +583,7 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
                         let pending_transactions =
                             batch.iter().map(|(kind, is_fixed_gas_limit)| {
                                 let provider = provider.clone();
+                                let tempo_sponsor = tempo_sponsor.clone();
                                 async move {
                                     let res = kind
                                         .clone()
@@ -534,22 +593,36 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
                                             *is_fixed_gas_limit,
                                             estimate_via_rpc,
                                             self.args.gas_estimate_multiplier,
+                                            tempo_sponsor.as_deref(),
                                         )
                                         .await;
-                                    (res, kind, 0, None)
+                                    (res, kind, *is_fixed_gas_limit, 0, None)
                                 }
                                 .boxed()
                             });
 
                         let mut buffer = pending_transactions.collect::<FuturesUnordered<_>>();
 
-                        'send: while let Some((res, kind, attempt, original_res)) =
-                            buffer.next().await
+                        'send: while let Some((
+                            res,
+                            kind,
+                            is_fixed_gas_limit,
+                            attempt,
+                            original_res,
+                        )) = buffer.next().await
                         {
-                            if res.is_err() && attempt <= 3 {
+                            if res.is_err()
+                                && self.script_config.tempo.sponsor_sig.is_some()
+                                && attempt == 0
+                            {
+                                debug!(
+                                    "not retrying transaction because --tempo.sponsor-sig is a static signature"
+                                );
+                            } else if res.is_err() && attempt <= 3 {
                                 // Try to resubmit the transaction
                                 let provider = provider.clone();
                                 let progress = seq_progress.inner.clone();
+                                let tempo_sponsor = tempo_sponsor.clone();
                                 buffer.push(Box::pin(async move {
                                     debug!(err=?res, ?attempt, "retrying transaction ");
                                     let attempt = attempt + 1;
@@ -557,8 +630,24 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
                                         "retrying transaction {res:?} (attempt {attempt})"
                                     ));
                                     tokio::time::sleep(Duration::from_millis(1000 * attempt)).await;
-                                    let r = kind.clone().send(provider).await;
-                                    (r, kind, attempt, original_res.or(Some(res)))
+                                    let r = kind
+                                        .clone()
+                                        .prepare_and_send(
+                                            provider,
+                                            sequential_broadcast,
+                                            is_fixed_gas_limit,
+                                            estimate_via_rpc,
+                                            self.args.gas_estimate_multiplier,
+                                            tempo_sponsor.as_deref(),
+                                        )
+                                        .await;
+                                    (
+                                        r,
+                                        kind,
+                                        is_fixed_gas_limit,
+                                        attempt,
+                                        original_res.or(Some(res)),
+                                    )
                                 }));
 
                                 continue 'send;
@@ -675,6 +764,7 @@ impl BundledState<TempoEvmNetwork> {
 
         let sequence = self.sequence.sequences_mut().get_mut(0).unwrap();
         let provider = Arc::new(ProviderBuilder::<TempoNetwork>::new(sequence.rpc_url()).build()?);
+        let tempo_sponsor = self.script_config.tempo.sponsor_config().await?;
 
         // Collect sender addresses - batch mode requires single sender
         let senders: AddressHashSet = sequence
@@ -800,11 +890,27 @@ impl BundledState<TempoEvmNetwork> {
             valid_before: self.script_config.expires_at.and_then(NonZeroU64::new),
             ..Default::default()
         };
+        self.script_config.tempo.apply::<TempoNetwork>(&mut batch_tx, None);
+
+        if let BatchSigner::TempoKeychain(_, ak) = &batch_signer {
+            batch_tx
+                .prepare_access_key_authorization(
+                    provider.as_ref(),
+                    ak.wallet_address,
+                    ak.key_address,
+                    ak.key_authorization.as_ref(),
+                )
+                .await?;
+        }
 
         // Estimate gas for the batch transaction
         estimate_gas(&mut batch_tx, provider.as_ref(), self.args.gas_estimate_multiplier).await?;
 
         sh_println!("Estimated gas: {}", batch_tx.inner.gas.unwrap_or(0))?;
+
+        if let Some(sponsor) = &tempo_sponsor {
+            sponsor.attach_and_print::<TempoNetwork>(&mut batch_tx, sender).await?;
+        }
 
         // Sign and send
         let tx_hash = match batch_signer {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -28,7 +28,7 @@ use eyre::{ContextCompat, Result};
 use forge_script_sequence::{AdditionalContract, NestedValue};
 use forge_verify::{RetryArgs, VerifierArgs};
 use foundry_cli::{
-    opts::{BuildOpts, EvmArgs, GlobalArgs, TempoCommonOpts},
+    opts::{BuildOpts, EvmArgs, GlobalArgs, TempoOpts},
     utils::LoadConfig,
 };
 use foundry_common::{
@@ -142,7 +142,7 @@ pub struct ScriptArgs {
 
     /// Tempo transaction options.
     #[command(flatten)]
-    pub tempo: TempoCommonOpts,
+    pub tempo: TempoOpts,
 
     /// Skips on-chain simulation.
     #[arg(long)]
@@ -285,16 +285,22 @@ impl ScriptArgs {
             }
         }
 
-        let fee_token = if evm_opts.networks.is_tempo() && self.tempo.fee_token.is_none() {
+        let mut tempo = self.tempo.clone();
+        let expires_at = tempo.expires_at();
+        if let Some(ts) = expires_at {
+            tempo.expiring_nonce = true;
+            tempo.valid_before = Some(ts);
+            tempo.common.expires = None;
+        }
+
+        let fee_token = if evm_opts.networks.is_tempo() && tempo.common.fee_token.is_none() {
             Some(PATH_USD_ADDRESS)
         } else {
-            self.tempo.fee_token
+            tempo.common.fee_token
         };
 
-        let expires_at = self.tempo.expires_at();
-
         let script_config =
-            ScriptConfig::new(config, evm_opts, self.batch, fee_token, expires_at).await?;
+            ScriptConfig::new(config, evm_opts, self.batch, fee_token, expires_at, tempo).await?;
         Ok(PreprocessedState { args: self, script_config, script_wallets, browser_wallet })
     }
 
@@ -715,6 +721,8 @@ pub struct ScriptConfig<FEN: FoundryEvmNetwork> {
     pub fee_token: Option<Address>,
     /// TIP-1009 expiring-nonce valid_before unix timestamp, derived from `--tempo.expires`.
     pub expires_at: Option<u64>,
+    /// Tempo transaction options applied to broadcast transactions.
+    pub tempo: TempoOpts,
 }
 
 impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
@@ -724,6 +732,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         batch: bool,
         fee_token: Option<Address>,
         expires_at: Option<u64>,
+        tempo: TempoOpts,
     ) -> Result<Self> {
         let sender_nonce = if let Some(fork_url) = evm_opts.fork_url.as_ref() {
             next_nonce(evm_opts.sender, fork_url, evm_opts.fork_block_number).await?
@@ -740,6 +749,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
             batch,
             fee_token,
             expires_at,
+            tempo,
         })
     }
 
@@ -861,18 +871,28 @@ mod tests {
         ]);
 
         assert_eq!(
-            args.tempo.fee_token,
+            args.tempo.common.fee_token,
             Some(address!("0x20C0000000000000000000000000000000000001"))
         );
-        assert_eq!(args.tempo.expires, Some(10));
+        assert_eq!(args.tempo.common.expires, Some(10));
     }
 
     #[test]
-    fn does_not_parse_unsupported_tempo_opts() {
-        assert!(
-            ScriptArgs::try_parse_from(["foundry-cli", "Contract.sol", "--tempo.nonce-key", "1"])
-                .is_err()
+    fn can_parse_sponsor_tempo_opts() {
+        let args = ScriptArgs::parse_from([
+            "foundry-cli",
+            "Contract.sol",
+            "--tempo.sponsor",
+            "0x1111111111111111111111111111111111111111",
+            "--tempo.sponsor-signer",
+            "env://TEMPO_SPONSOR_PK",
+        ]);
+
+        assert_eq!(
+            args.tempo.sponsor,
+            Some(address!("0x1111111111111111111111111111111111111111"))
         );
+        assert_eq!(args.tempo.sponsor_signer.as_deref(), Some("env://TEMPO_SPONSOR_PK"));
     }
 
     #[test]

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -896,6 +896,14 @@ mod tests {
     }
 
     #[test]
+    fn can_parse_full_tempo_opts() {
+        let args =
+            ScriptArgs::parse_from(["foundry-cli", "Contract.sol", "--tempo.nonce-key", "1"]);
+
+        assert_eq!(args.tempo.nonce_key, Some(U256::from(1)));
+    }
+
+    #[test]
     fn can_parse_unlocked() {
         let args = ScriptArgs::parse_from([
             "foundry-cli",


### PR DESCRIPTION
## Summary
- Adds Tempo sponsor CLI opts: `--tempo.sponsor`, `--tempo.sponsor-signer`, and `--tempo.sponsor-sig`
- Computes and prints the sponsor digest/fee token/validity window before submission
- Attaches `fee_payer_signature` for sponsored cast send/mktx/keychain, forge script, and forge create flows

NOTE: Previously, a caller could pass only the raw sponsor signature and let the node validate it. This PR makes the expected fee payer explicit so the CLI can recover the signature locally, verify it matches the intended sponsor, reject `sponsor == sender`, and print the sponsor identity before submission.