### PR TITLE
ci: sign release archives, docker images, and publish SBOMs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -92,6 +92,7 @@ jobs:
         uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 
       - name: Build and push Foundry image
+        id: build
         uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
         with:
           build-args: |
@@ -106,3 +107,30 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           no-cache: true
+          sbom: true
+          provenance: mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Sign image with cosign (keyless)
+        env:
+          DOCKER_TAGS: ${{ steps.docker_tagging.outputs.docker_tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          IFS=',' read -r -a tags <<< "$DOCKER_TAGS"
+          for tag in "${tags[@]}"; do
+            # Strip any tag suffix and pin to immutable digest, then sign.
+            ref="${tag%%:*}@${DIGEST}"
+            printf 'Signing %s\n' "$ref"
+            cosign sign --yes "$ref"
+          done
+
+      - name: Image build provenance attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@bcae7115752d4ed746ff92feb666574428a79415 # v6.2
+        uses: mikepenz/release-changelog-builder-action@bcae7115752d4ed746ff92feb666574428a79415 # v6.2.1
         with:
           configuration: "./.github/changelog.json"
           fromTag: ${{ steps.release_info.outputs.from_tag || '' }}
@@ -264,6 +264,38 @@ jobs:
             printf "file_name=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" >> "$GITHUB_OUTPUT"
           fi
           printf "foundry_attestation=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.attestation.txt" >> "$GITHUB_OUTPUT"
+          printf "foundry_sbom=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.spdx.json" >> "$GITHUB_OUTPUT"
+          printf "foundry_checksum=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.sha256" >> "$GITHUB_OUTPUT"
+          printf "foundry_signature=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.sigstore.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate archive checksum
+        env:
+          FILE_NAME: ${{ steps.artifacts.outputs.file_name }}
+          FOUNDRY_CHECKSUM: ${{ steps.artifacts.outputs.foundry_checksum }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$FILE_NAME" > "$FOUNDRY_CHECKSUM"
+          else
+            shasum -a 256 "$FILE_NAME" > "$FOUNDRY_CHECKSUM"
+          fi
+          cat "$FOUNDRY_CHECKSUM"
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Generate SBOM (SPDX)
+        env:
+          FOUNDRY_SBOM: ${{ steps.artifacts.outputs.foundry_sbom }}
+          VERSION_NAME: ${{ (env.IS_NIGHTLY == 'true' && 'nightly') || needs.prepare.outputs.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          syft scan dir:. \
+            --source-name foundry \
+            --source-version "$VERSION_NAME" \
+            -o spdx-json="$FOUNDRY_SBOM"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -292,15 +324,37 @@ jobs:
           tar -czvf "foundry_man_${VERSION_NAME}.tar.gz" forge.1.gz cast.1.gz anvil.1.gz chisel.1.gz
           printf 'foundry_man=%s\n' "foundry_man_${VERSION_NAME}.tar.gz" >> "$GITHUB_OUTPUT"
 
-      - name: Binaries attestation
+      - name: Binaries and archive provenance attestation
         id: attestation
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: |
             ${{ env.anvil_bin_path }}
             ${{ env.cast_bin_path }}
             ${{ env.chisel_bin_path }}
             ${{ env.forge_bin_path }}
+            ${{ steps.artifacts.outputs.file_name }}
+
+      - name: Archive SBOM attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ${{ steps.artifacts.outputs.file_name }}
+          sbom-path: ${{ steps.artifacts.outputs.foundry_sbom }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Sign archive with cosign (keyless)
+        env:
+          FILE_NAME: ${{ steps.artifacts.outputs.file_name }}
+          FOUNDRY_SIGNATURE: ${{ steps.artifacts.outputs.foundry_signature }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cosign sign-blob \
+            --yes \
+            --bundle "$FOUNDRY_SIGNATURE" \
+            "$FILE_NAME"
 
       - name: Record attestation URL
         env:
@@ -321,11 +375,20 @@ jobs:
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
           FILE_NAME: ${{ steps.artifacts.outputs.file_name }}
           FOUNDRY_ATTESTATION: ${{ steps.artifacts.outputs.foundry_attestation }}
+          FOUNDRY_SBOM: ${{ steps.artifacts.outputs.foundry_sbom }}
+          FOUNDRY_CHECKSUM: ${{ steps.artifacts.outputs.foundry_checksum }}
+          FOUNDRY_SIGNATURE: ${{ steps.artifacts.outputs.foundry_signature }}
           FOUNDRY_MAN: ${{ steps.man.outputs.foundry_man }}
         shell: bash
         run: |
           set -euo pipefail
-          files=("$FILE_NAME" "$FOUNDRY_ATTESTATION")
+          files=(
+            "$FILE_NAME"
+            "$FOUNDRY_ATTESTATION"
+            "$FOUNDRY_SBOM"
+            "$FOUNDRY_CHECKSUM"
+            "$FOUNDRY_SIGNATURE"
+          )
           if [[ -n "${FOUNDRY_MAN:-}" ]]; then
             files+=("$FOUNDRY_MAN")
           fi

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ foundryup
 
 See the [installation guide](https://getfoundry.sh/getting-started/installation) for more details.
 
+To verify a downloaded release archive or container image, see [Verifying Releases](./SECURITY.md#verifying-releases).
+
 ## Getting Started
 
 Initialize a new project, build and test:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,3 +3,112 @@
 ## Reporting a Vulnerability
 
 Contact [security@tempo.xyz](mailto:security@tempo.xyz).
+
+## Verifying Releases
+
+Every official Foundry release ships with multiple, independent integrity
+artifacts. All signing is keyless via [Sigstore](https://www.sigstore.dev/) —
+no Foundry-managed key material is involved, and every signature is recorded
+in the public [Rekor](https://docs.sigstore.dev/logging/overview/) transparency
+log. The signing identity is the GitHub Actions OIDC token of this repository's
+`release.yml` / `docker-publish.yml` workflows.
+
+### Per-release artifacts
+
+For each `foundry_<version>_<platform>_<arch>.{tar.gz,zip}` archive on the
+[releases page](https://github.com/foundry-rs/foundry/releases), the same
+release also publishes:
+
+| Suffix | Purpose |
+| --- | --- |
+| `.sha256` | SHA-256 checksum of the archive (`sha256sum` format) |
+| `.sigstore.json` | Cosign keyless signature bundle (cert + signature + Rekor proof) over the archive |
+| `.spdx.json` | SPDX 2.3 SBOM of the source workspace used for the build |
+| `.attestation.txt` | URL of the GitHub artifact-attestation summary |
+
+In addition, GitHub stores SLSA build-provenance and SBOM attestations against
+the archive's digest; these are queryable via `gh attestation` without
+downloading anything else.
+
+### Verifying an archive
+
+Pick whichever toolchain you have available — they verify the same signatures.
+
+#### Option 1: GitHub CLI (simplest)
+
+```bash
+gh attestation verify foundry_v1.4.0_linux_amd64.tar.gz \
+  --repo foundry-rs/foundry
+```
+
+This computes the file's digest, fetches the matching attestation from GitHub,
+and verifies the Sigstore signature plus the SLSA provenance predicate. Add
+`--signer-workflow foundry-rs/foundry/.github/workflows/release.yml` to also
+require the workflow identity.
+
+To verify the SBOM attestation specifically:
+
+```bash
+gh attestation verify foundry_v1.4.0_linux_amd64.tar.gz \
+  --repo foundry-rs/foundry \
+  --predicate-type 'https://spdx.dev/Document/v2.3'
+```
+
+#### Option 2: Cosign (offline-friendly)
+
+Download the archive and its `.sigstore.json` bundle from the release page,
+then:
+
+```bash
+cosign verify-blob \
+  --bundle foundry_v1.4.0_linux_amd64.sigstore.json \
+  --certificate-identity-regexp '^https://github.com/foundry-rs/foundry/\.github/workflows/release\.yml@.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  foundry_v1.4.0_linux_amd64.tar.gz
+```
+
+For nightly builds the certificate identity points at `refs/heads/master`
+instead of a tag; the regex above matches both.
+
+#### Option 3: Plain checksum (integrity only)
+
+```bash
+sha256sum -c foundry_v1.4.0_linux_amd64.sha256       # GNU coreutils
+shasum -a 256 -c foundry_v1.4.0_linux_amd64.sha256   # macOS
+```
+
+This proves the bytes match what was uploaded, but says nothing about who
+uploaded them. Combine with one of the verifications above for end-to-end
+trust.
+
+### Verifying the Docker image
+
+Container signatures and attestations are pushed as OCI referrers to GHCR, so
+no separate files need to be downloaded.
+
+```bash
+# Cosign keyless signature on the image
+cosign verify ghcr.io/foundry-rs/foundry:v1.4.0 \
+  --certificate-identity-regexp '^https://github.com/foundry-rs/foundry/\.github/workflows/(release|docker-publish)\.yml@.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+# SLSA build-provenance attestation
+gh attestation verify oci://ghcr.io/foundry-rs/foundry:v1.4.0 \
+  --repo foundry-rs/foundry
+
+# Inspect the buildx-attached SBOM and provenance
+docker buildx imagetools inspect ghcr.io/foundry-rs/foundry:v1.4.0 \
+  --format '{{ json .SBOM }}'
+docker buildx imagetools inspect ghcr.io/foundry-rs/foundry:v1.4.0 \
+  --format '{{ json .Provenance }}'
+```
+
+To pin to an immutable digest (recommended for reproducible deployments):
+
+```bash
+docker pull ghcr.io/foundry-rs/foundry:v1.4.0
+DIGEST=$(docker buildx imagetools inspect ghcr.io/foundry-rs/foundry:v1.4.0 --format '{{ .Manifest.Digest }}')
+cosign verify "ghcr.io/foundry-rs/foundry@${DIGEST}" \
+  --certificate-identity-regexp '^https://github.com/foundry-rs/foundry/\.github/workflows/(release|docker-publish)\.yml@.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```


### PR DESCRIPTION
ci: sign release archives, docker images, and publish SBOMs

- release.yml: emit per-archive sha256 + SPDX SBOM (Syft), cosign
  keyless sign-blob of the archive, and use actions/attest@v4 for both
  build provenance and SBOM attestations. Upload all artifacts to the
  draft release.
- docker-publish.yml: enable BuildKit SBOM, capture the build digest,
  cosign keyless sign each pushed tag, and publish a Sigstore-signed
  SLSA provenance attestation via actions/attest with push-to-registry.
- SECURITY.md: document how external users verify archives and the
  docker image (gh attestation, cosign, plain sha256, buildx imagetools).
- README.md: link to the new verification section.

