### PR TITLE
feat(fuzz): generate msg.value for payable functions in invariant fuzzing

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -45,7 +45,7 @@ use foundry_evm_core::evm::FoundryEvmNetwork;
 use foundry_evm_fuzz::{
     BasicTxDetails,
     invariant::FuzzRunIdentifiedContracts,
-    strategies::{EvmFuzzState, mutate_param_value},
+    strategies::{EvmFuzzState, generate_msg_value, mutate_param_value},
 };
 use proptest::{
     prelude::{Just, Rng, Strategy},
@@ -802,7 +802,14 @@ impl WorkerCorpus {
         test_runner: &mut TestRunner,
         fuzz_state: &EvmFuzzState,
     ) -> Result<()> {
-        // let rng = test_runner.rng();
+        // Mutate value with 15% probability for payable functions.
+        if function.state_mutability == alloy_json_abi::StateMutability::Payable
+            && test_runner.rng().random_ratio(15, 100)
+        {
+            tx.call_details.value = Some(generate_msg_value(test_runner));
+        }
+
+        // Mutate calldata.
         let mut arg_mutation_rounds =
             test_runner.rng().random_range(0..=function.inputs.len()).max(1);
         let round_arg_idx: Vec<usize> = if function.inputs.len() <= 1 {
@@ -1219,6 +1226,7 @@ mod tests {
             call_details: foundry_evm_fuzz::CallDetails {
                 target: Address::ZERO,
                 calldata: Bytes::new(),
+                value: None,
             },
         }
     }

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -263,7 +263,11 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                 warp: None,
                 roll: None,
                 sender: self.sender,
-                call_details: CallDetails { target: address, calldata: calldata.clone() },
+                call_details: CallDetails {
+                    target: address,
+                    calldata: calldata.clone(),
+                    value: None,
+                },
             }],
             new_coverage,
             None,
@@ -427,7 +431,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             warp: None,
             roll: None,
             sender: Default::default(),
-            call_details: CallDetails { target: Default::default(), calldata },
+            call_details: CallDetails { target: Default::default(), calldata, value: None },
         });
 
         let mut corpus = WorkerCorpus::new(

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1538,8 +1538,12 @@ pub(crate) fn execute_tx<FEN: FoundryEvmNetwork>(
         }
     }
 
+    // Only use value if sender has sufficient balance, otherwise fall back to 0.
+    let requested_value = tx.call_details.value.unwrap_or(U256::ZERO);
+    let sender_balance = executor.get_balance(tx.sender)?;
+    let value = if sender_balance >= requested_value { requested_value } else { U256::ZERO };
     executor
-        .call_raw(tx.sender, tx.call_details.target, tx.call_details.calldata.clone(), U256::ZERO)
+        .call_raw(tx.sender, tx.call_details.target, tx.call_details.calldata.clone(), value)
         .map_err(|e| eyre!(format!("Could not make raw evm call: {e}")))
 }
 

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -727,7 +727,11 @@ mod tests {
             warp: warp.map(U256::from),
             roll: roll.map(U256::from),
             sender: Address::ZERO,
-            call_details: CallDetails { target: Address::ZERO, calldata: Bytes::new() },
+            call_details: CallDetails {
+                target: Address::ZERO,
+                calldata: Bytes::new(),
+                value: None,
+            },
         }
     }
 

--- a/crates/evm/fuzz/src/strategies/mod.rs
+++ b/crates/evm/fuzz/src/strategies/mod.rs
@@ -6,8 +6,8 @@ pub use uint::UintStrategy;
 
 mod param;
 pub use param::{
-    fuzz_param, fuzz_param_from_state, fuzz_param_with_fixtures, mutate_param_value,
-    mutate_param_value_with_senders,
+    fuzz_msg_value, fuzz_param, fuzz_param_from_state, fuzz_param_with_fixtures,
+    generate_msg_value, mutate_param_value, mutate_param_value_with_senders,
 };
 
 mod calldata;

--- a/crates/evm/fuzz/src/strategies/param.rs
+++ b/crates/evm/fuzz/src/strategies/param.rs
@@ -512,6 +512,53 @@ fn mutate_random_array_value(
     *elem = new_val;
 }
 
+/// 0.001 ETH in wei.
+const MILLI_ETH: u64 = 1_000_000_000_000_000;
+/// 1 ETH in wei.
+const ONE_ETH: u64 = 1_000_000_000_000_000_000;
+
+/// Returns a proptest strategy for generating random msg.value for payable functions.
+/// Biased towards smaller values to avoid balance issues.
+///
+/// Distribution:
+/// - 85% chance: no value (None)
+/// - 10% chance: small values (0-1000 wei)
+/// - 4% chance: medium values (up to 0.001 ETH)
+/// - 1% chance: larger values (up to 1 ETH)
+pub fn fuzz_msg_value() -> impl Strategy<Value = Option<U256>> {
+    proptest::prop_oneof![
+        // 85% chance: no value
+        85 => proptest::strategy::Just(None),
+        // 10% chance: small values (0-1000 wei)
+        10 => (0u64..=1000).prop_map(|v| Some(U256::from(v))),
+        // 4% chance: medium values (up to 0.001 ETH)
+        4 => (0u64..=MILLI_ETH).prop_map(|v| Some(U256::from(v))),
+        // 1% chance: larger values (up to 1 ETH)
+        1 => (0u64..=ONE_ETH).prop_map(|v| Some(U256::from(v))),
+    ]
+}
+
+/// Generates a random msg.value for payable functions using TestRunner's RNG.
+/// Biased towards smaller values to avoid balance issues.
+///
+/// Distribution:
+/// - 60% chance: small values (0-1000 wei)
+/// - 30% chance: medium values (up to 0.001 ETH)
+/// - 9% chance: larger values (up to 1 ETH)
+/// - 1% chance: max value (edge case)
+pub fn generate_msg_value(test_runner: &mut TestRunner) -> U256 {
+    match test_runner.rng().random_range(0..=10) {
+        // Small values (0-1000 wei) - 60% chance.
+        0..=5 => U256::from(test_runner.rng().random_range(0u64..=1000)),
+        // Medium values (up to 0.001 ETH) - 30% chance.
+        6..=8 => U256::from(test_runner.rng().random_range(0u64..=MILLI_ETH)),
+        // Larger values (up to 1 ETH) - 9% chance.
+        9 => U256::from(test_runner.rng().random_range(0u64..=ONE_ETH)),
+        // Edge case (max) - 1% chance.
+        _ => U256::MAX,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1552,6 +1552,7 @@ fn base_counterexamples_to_txes(
                 call_details: CallDetails {
                     target: seq.addr.unwrap_or_default(),
                     calldata: seq.calldata.clone(),
+                    value: seq.value,
                 },
             }
         })

--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -2698,3 +2698,84 @@ contract InvariantWarp is Test {
 "#
     ]]);
 });
+
+// Test that invariant fuzzer generates random msg.value for payable functions.
+// Based on the example from https://github.com/foundry-rs/foundry/pull/8644
+forgetest_init!(invariant_msg_value, |prj, cmd| {
+    prj.update_config(|config| {
+        config.fuzz.seed = Some(U256::from(42u32));
+        config.invariant.runs = 200;
+        config.invariant.depth = 20;
+    });
+
+    prj.add_test(
+        "InvariantMsgValue.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract ValueTarget {
+    bool public valueReceived;
+
+    // Payable function that tracks if any value was received
+    function deposit() external payable {
+        if (msg.value > 0) {
+            valueReceived = true;
+        }
+    }
+}
+
+contract InvariantMsgValue is Test {
+    ValueTarget target;
+    address sender1;
+    address sender2;
+
+    function setUp() public {
+        target = new ValueTarget();
+        // Create and fund specific senders
+        sender1 = makeAddr("sender1");
+        sender2 = makeAddr("sender2");
+        vm.deal(sender1, 1000 ether);
+        vm.deal(sender2, 1000 ether);
+        // Target only these funded senders
+        targetSender(sender1);
+        targetSender(sender2);
+        // Target only the ValueTarget contract
+        targetContract(address(target));
+    }
+
+    function invariant_value_never_received() public view {
+        require(!target.valueReceived(), "Value was received");
+    }
+}
+"#,
+    );
+
+    // The test should fail because the fuzzer generates msg.value > 0 for payable functions
+    // First check regular output format shows value=X
+    cmd.args(["test", "--mt", "invariant_value_never_received"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
+...
+[FAIL: Value was received]
+	[Sequence] (original: [..], shrunk: 1)
+		sender=[..] addr=[test/InvariantMsgValue.t.sol:ValueTarget][..] value=[..] calldata=deposit() args=[]
+...
+"#]]);
+
+    // Now check solidity output format shows proper {value: X} syntax
+    cmd.forge_fuse().arg("clean").assert_success();
+    prj.update_config(|config| {
+        config.invariant.show_solidity = true;
+    });
+    cmd.forge_fuse()
+        .args(["test", "--mt", "invariant_value_never_received"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
+...
+[FAIL: Value was received]
+	[Sequence] (original: [..], shrunk: 1)
+		vm.prank([..]);
+		ValueTarget([..]).deposit{value: [..]}();
+...
+"#]]);
+});


### PR DESCRIPTION
Adds automatic msg.value generation for payable functions during initial
call generation and corpus mutation. Stacked on top of #14482.

- Add value: Option<U256> field to CallDetails and BaseCounterExample
  (serde-default for corpus back-compat)
- Add fuzz_msg_value() proptest strategy and generate_msg_value() runner
  helper, biased toward small values (85% none / 10% wei / 4% milli-eth /
  1% eth for proptest; 60/30/9/1 for runner)
- Detect payable mutability in fuzz_contract_with_calldata and compose
  the value strategy
- Forward value through execute_tx with balance-aware fallback to 0 when
  sender has insufficient balance
- Mutate value with 15% probability in abi_mutate for payable functions
- Render value in counterexamples (regular: value=X; solidity: {value: X})
- Add invariant_msg_value cli test

Excludes the all-call mutation strategy, sender-mutation, and max_deal
config from the original PR #13177 — those are independent concerns.

Based on https://github.com/foundry-rs/foundry/pull/8644

Co-authored-by: QiuhaoLi <qiuhaoli@outlook.com>

