### PR TITLE
feat(lint): add inline-assembly lint

### DIFF
--- a/crates/lint/docs/inline-assembly.md
+++ b/crates/lint/docs/inline-assembly.md
@@ -1,0 +1,66 @@
+# Inline assembly
+
+**Severity**: `Info`
+**ID**: `inline-assembly`
+
+Flags every `assembly { ... }` block. Inline assembly bypasses many of Solidity's safety
+features (type checks, overflow checks, memory layout invariants) and is a common source of
+high-impact bugs, so each occurrence should be reviewed deliberately.
+
+## What it does
+
+Reports every inline assembly statement, including blocks declared with the `"evmasm"` dialect
+and/or the `("memory-safe")` flag. Blocks declared `("memory-safe")` are still reported, but
+with a softer message acknowledging the developer attestation: review focuses on business logic
+and side effects rather than memory layout.
+
+## Why is this bad?
+
+Assembly skips Solidity's compile-time checks and many of its runtime guarantees. Mistakes
+inside an `assembly` block can corrupt memory, break the free memory pointer, leak storage,
+escalate privileges via `delegatecall`, or destroy the contract via `selfdestruct`. Even when
+required for gas or features unavailable in high-level Solidity, assembly should be small,
+documented, and reviewed.
+
+## When inline assembly is reasonable
+
+Some idioms are widely used and generally safe:
+
+- Reading transaction/chain context: `chainid()`, `gas()`, `returndatasize()`.
+- Probing code: `codesize()`, `extcodesize(addr)`, `extcodehash(addr)`.
+- Reading the free memory pointer: `mload(0x40)`.
+- Cheap hashing of a known memory layout, when paired with `("memory-safe")`.
+
+If you must use assembly:
+
+1. Keep the block minimal and well-commented.
+2. Add the `("memory-safe")` flag when the block does not violate Solidity's memory model, so
+   the optimizer (and reviewers) can rely on it.
+3. Suppress the lint locally to mark the block as audited:
+   ```solidity
+   // forge-lint: disable-next-line(inline-assembly)
+   assembly ("memory-safe") { /* reviewed: ... */ }
+   ```
+
+## Example
+
+### Bad
+
+```solidity
+function rawCall(address target, bytes calldata data) external returns (bytes memory) {
+    assembly {
+        let ok := call(gas(), target, 0, add(data.offset, 0), data.length, 0, 0)
+        // ...
+    }
+}
+```
+
+### Good
+
+```solidity
+function rawCall(address target, bytes calldata data) external returns (bytes memory result) {
+    bool ok;
+    (ok, result) = target.call(data);
+    require(ok, "call failed");
+}
+```

--- a/crates/lint/docs/inline-assembly.md
+++ b/crates/lint/docs/inline-assembly.md
@@ -10,9 +10,10 @@ high-impact bugs, so each occurrence should be reviewed deliberately.
 ## What it does
 
 Reports every inline assembly statement, including blocks declared with the `"evmasm"` dialect
-and/or the `("memory-safe")` flag. Blocks declared `("memory-safe")` are still reported, but
-with a softer message acknowledging the developer attestation: review focuses on business logic
-and side effects rather than memory layout.
+and/or the `("memory-safe")` flag. Blocks declared as memory-safe — either via the modern
+`("memory-safe")` flag or the legacy `/// @solidity memory-safe-assembly` NatSpec marker — are
+still reported, but with a softer message acknowledging the developer attestation: review
+focuses on business logic and side effects rather than memory layout.
 
 ## Why is this bad?
 
@@ -35,7 +36,9 @@ If you must use assembly:
 
 1. Keep the block minimal and well-commented.
 2. Add the `("memory-safe")` flag when the block does not violate Solidity's memory model, so
-   the optimizer (and reviewers) can rely on it.
+   the optimizer (and reviewers) can rely on it. The legacy
+   `/// @solidity memory-safe-assembly` NatSpec marker on the line directly above the block is
+   also recognized for compatibility with older codebases.
 3. Suppress the lint locally to mark the block as audited:
    ```solidity
    // forge-lint: disable-next-line(inline-assembly)

--- a/crates/lint/src/sol/info/inline_assembly.rs
+++ b/crates/lint/src/sol/info/inline_assembly.rs
@@ -1,0 +1,46 @@
+use super::InlineAssembly;
+use crate::{
+    linter::{EarlyLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::{
+    ast::{Stmt, StmtKind},
+    interface::{BytePos, Span},
+};
+
+declare_forge_lint!(
+    INLINE_ASSEMBLY,
+    Severity::Info,
+    "inline-assembly",
+    "usage of inline assembly; assembly bypasses Solidity safety features and should be reviewed"
+);
+
+// `assembly` keyword length, used to narrow the diagnostic span so multi-line blocks don't
+// flood the output.
+const ASSEMBLY_KW_LEN: u32 = 8;
+
+impl<'ast> EarlyLintPass<'ast> for InlineAssembly {
+    fn check_stmt(&mut self, ctx: &LintContext, stmt: &'ast Stmt<'ast>) {
+        let StmtKind::Assembly(asm) = &stmt.kind else { return };
+
+        // Underline only the `assembly` keyword to keep diagnostics readable for large blocks.
+        let kw_span = assembly_keyword_span(stmt.span);
+
+        // `assembly ("memory-safe") { ... }` is a self-attestation by the developer that the
+        // block does not violate Solidity's memory model. We still flag it (the lint's job is
+        // to surface every block for review), but tailor the message so reviewers know they
+        // can focus on business logic rather than memory layout.
+        let memory_safe = asm.flags.iter().any(|f| f.value.as_str() == "memory-safe");
+        let msg = if memory_safe {
+            "inline assembly (declared memory-safe); review business logic and side effects"
+        } else {
+            "inline assembly used; review for memory safety and side effects"
+        };
+
+        ctx.emit_with_msg(&INLINE_ASSEMBLY, kw_span, msg);
+    }
+}
+
+fn assembly_keyword_span(span: Span) -> Span {
+    span.with_hi(span.lo() + BytePos(ASSEMBLY_KW_LEN))
+}

--- a/crates/lint/src/sol/info/inline_assembly.rs
+++ b/crates/lint/src/sol/info/inline_assembly.rs
@@ -15,22 +15,18 @@ declare_forge_lint!(
     "usage of inline assembly; assembly bypasses Solidity safety features and should be reviewed"
 );
 
-// `assembly` keyword length, used to narrow the diagnostic span so multi-line blocks don't
-// flood the output.
 const ASSEMBLY_KW_LEN: u32 = 8;
+const NATSPEC_MEMORY_SAFE_MARKER: &str = "@solidity memory-safe-assembly";
 
 impl<'ast> EarlyLintPass<'ast> for InlineAssembly {
     fn check_stmt(&mut self, ctx: &LintContext, stmt: &'ast Stmt<'ast>) {
         let StmtKind::Assembly(asm) = &stmt.kind else { return };
 
-        // Underline only the `assembly` keyword to keep diagnostics readable for large blocks.
         let kw_span = assembly_keyword_span(stmt.span);
 
-        // `assembly ("memory-safe") { ... }` is a self-attestation by the developer that the
-        // block does not violate Solidity's memory model. We still flag it (the lint's job is
-        // to surface every block for review), but tailor the message so reviewers know they
-        // can focus on business logic rather than memory layout.
-        let memory_safe = asm.flags.iter().any(|f| f.value.as_str() == "memory-safe");
+        let memory_safe = asm.flags.iter().any(|f| f.value.as_str() == "memory-safe")
+            || has_memory_safe_natspec(ctx, stmt.span.lo());
+
         let msg = if memory_safe {
             "inline assembly (declared memory-safe); review business logic and side effects"
         } else {
@@ -41,6 +37,35 @@ impl<'ast> EarlyLintPass<'ast> for InlineAssembly {
     }
 }
 
+/// Narrows a span to the leading `assembly` keyword to keep diagnostics readable.
 fn assembly_keyword_span(span: Span) -> Span {
     span.with_hi(span.lo() + BytePos(ASSEMBLY_KW_LEN))
+}
+
+/// Returns `true` when the lines immediately preceding `stmt_lo` form a `///` NatSpec block
+/// containing `@solidity memory-safe-assembly`.
+fn has_memory_safe_natspec(ctx: &LintContext, stmt_lo: BytePos) -> bool {
+    let Some(source_file) = ctx.source_file() else { return false };
+    let src = source_file.src.as_str();
+    let start_pos = source_file.start_pos.to_u32();
+    let lo_abs = stmt_lo.to_u32();
+    if lo_abs < start_pos {
+        return false;
+    }
+    let offset = (lo_abs - start_pos) as usize;
+    if offset > src.len() {
+        return false;
+    }
+
+    for line in src[..offset].lines().rev() {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some(rest) = trimmed.strip_prefix("///") else { return false };
+        if rest.trim_start().starts_with(NATSPEC_MEMORY_SAFE_MARKER) {
+            return true;
+        }
+    }
+    false
 }

--- a/crates/lint/src/sol/info/mod.rs
+++ b/crates/lint/src/sol/info/mod.rs
@@ -36,6 +36,9 @@ use too_many_digits::TOO_MANY_DIGITS;
 mod pragma_directive;
 use pragma_directive::PRAGMA_INCONSISTENT;
 
+mod inline_assembly;
+use inline_assembly::INLINE_ASSEMBLY;
+
 register_lints!(
     (BooleanCst, early, (BOOLEAN_CST)),
     (BooleanEqual, early, (BOOLEAN_EQUAL)),
@@ -50,4 +53,5 @@ register_lints!(
     (InterfaceFileNaming, early, (INTERFACE_FILE_NAMING, INTERFACE_NAMING)),
     (TooManyDigits, early, (TOO_MANY_DIGITS)),
     (PragmaDirective, project, (PRAGMA_INCONSISTENT)),
+    (InlineAssembly, early, (INLINE_ASSEMBLY)),
 );

--- a/crates/lint/testdata/InlineAssembly.sol
+++ b/crates/lint/testdata/InlineAssembly.sol
@@ -1,0 +1,88 @@
+//@compile-flags: --severity info
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+contract InlineAssembly {
+    function bare() public view returns (uint256 id) {
+        assembly { //~NOTE: inline assembly used; review for memory safety and side effects
+            id := chainid()
+        }
+    }
+
+    function withMemorySafe() public view returns (uint256 size) {
+        assembly ("memory-safe") { //~NOTE: inline assembly (declared memory-safe); review business logic and side effects
+            size := extcodesize(address())
+        }
+    }
+
+    function withDialectAndMemorySafe() public view returns (uint256 ptr) {
+        assembly "evmasm" ("memory-safe") { //~NOTE: inline assembly (declared memory-safe); review business logic and side effects
+            ptr := mload(0x40)
+        }
+    }
+
+    function nestedInControlFlow(bool flag) public view returns (uint256 v) {
+        if (flag) {
+            assembly { //~NOTE: inline assembly used; review for memory safety and side effects
+                v := gas()
+            }
+        }
+
+        for (uint256 i = 0; i < 1; ++i) {
+            assembly { //~NOTE: inline assembly used; review for memory safety and side effects
+                v := add(v, 1)
+            }
+        }
+    }
+
+    function nestedInUnchecked(uint256 x) public pure returns (uint256 v) {
+        unchecked {
+            v = x + 1;
+            assembly { //~NOTE: inline assembly used; review for memory safety and side effects
+                v := add(v, 1)
+            }
+        }
+    }
+
+    function nestedInTryCatch() public returns (uint256 v) {
+        try this.bare() returns (uint256) {
+            assembly { //~NOTE: inline assembly used; review for memory safety and side effects
+                v := 1
+            }
+        } catch {
+            assembly { //~NOTE: inline assembly used; review for memory safety and side effects
+                v := 2
+            }
+        }
+    }
+
+    function suppressed() public view returns (uint256 id) {
+        // forge-lint: disable-next-line(inline-assembly)
+        assembly {
+            id := chainid()
+        }
+    }
+
+    modifier guarded() {
+        assembly { //~NOTE: inline assembly used; review for memory safety and side effects
+            if iszero(caller()) { revert(0, 0) }
+        }
+        _;
+    }
+
+    function suppressedRegion() public view returns (uint256 a, uint256 b) {
+        // forge-lint: disable-start(inline-assembly)
+        assembly {
+            a := chainid()
+        }
+        assembly ("memory-safe") {
+            b := gas()
+        }
+        // forge-lint: disable-end(inline-assembly)
+    }
+
+    function noAssembly() public pure returns (uint256) {
+        return 42;
+    }
+}

--- a/crates/lint/testdata/InlineAssembly.sol
+++ b/crates/lint/testdata/InlineAssembly.sol
@@ -22,6 +22,28 @@ contract InlineAssembly {
         }
     }
 
+    function withNatspecMemorySafe() public view returns (uint256 v) {
+        /// @solidity memory-safe-assembly
+        assembly { //~NOTE: inline assembly (declared memory-safe); review business logic and side effects
+            v := chainid()
+        }
+    }
+
+    function withNatspecMemorySafeAndOtherDocs() public view returns (uint256 v) {
+        /// @notice does a thing
+        /// @solidity memory-safe-assembly
+        assembly { //~NOTE: inline assembly (declared memory-safe); review business logic and side effects
+            v := gas()
+        }
+    }
+
+    function plainCommentDoesNotCount() public view returns (uint256 v) {
+        // solidity memory-safe-assembly
+        assembly { //~NOTE: inline assembly used; review for memory safety and side effects
+            v := chainid()
+        }
+    }
+
     function nestedInControlFlow(bool flag) public view returns (uint256 v) {
         if (flag) {
             assembly { //~NOTE: inline assembly used; review for memory safety and side effects

--- a/crates/lint/testdata/InlineAssembly.stderr
+++ b/crates/lint/testdata/InlineAssembly.stderr
@@ -1,0 +1,72 @@
+note[inline-assembly]: inline assembly used; review for memory safety and side effects
+   ╭▸ ROOT/testdata/InlineAssembly.sol:LL:CC
+   │
+LL │         assembly {
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
+note[inline-assembly]: inline assembly (declared memory-safe); review business logic and side effects
+   ╭▸ ROOT/testdata/InlineAssembly.sol:LL:CC
+   │
+LL │         assembly ("memory-safe") {
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
+note[inline-assembly]: inline assembly (declared memory-safe); review business logic and side effects
+   ╭▸ ROOT/testdata/InlineAssembly.sol:LL:CC
+   │
+LL │         assembly "evmasm" ("memory-safe") {
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
+note[inline-assembly]: inline assembly used; review for memory safety and side effects
+   ╭▸ ROOT/testdata/InlineAssembly.sol:LL:CC
+   │
+LL │             assembly {
+   │             ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
+note[inline-assembly]: inline assembly used; review for memory safety and side effects
+   ╭▸ ROOT/testdata/InlineAssembly.sol:LL:CC
+   │
+LL │             assembly {
+   │             ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
+note[inline-assembly]: inline assembly used; review for memory safety and side effects
+   ╭▸ ROOT/testdata/InlineAssembly.sol:LL:CC
+   │
+LL │             assembly {
+   │             ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
+note[inline-assembly]: inline assembly used; review for memory safety and side effects
+   ╭▸ ROOT/testdata/InlineAssembly.sol:LL:CC
+   │
+LL │             assembly {
+   │             ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
+note[inline-assembly]: inline assembly used; review for memory safety and side effects
+   ╭▸ ROOT/testdata/InlineAssembly.sol:LL:CC
+   │
+LL │             assembly {
+   │             ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
+note[inline-assembly]: inline assembly used; review for memory safety and side effects
+   ╭▸ ROOT/testdata/InlineAssembly.sol:LL:CC
+   │
+LL │         assembly {
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+

--- a/crates/lint/testdata/InlineAssembly.stderr
+++ b/crates/lint/testdata/InlineAssembly.stderr
@@ -22,6 +22,30 @@ LL │         assembly "evmasm" ("memory-safe") {
    │
    ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
 
+note[inline-assembly]: inline assembly (declared memory-safe); review business logic and side effects
+   ╭▸ ROOT/testdata/InlineAssembly.sol:LL:CC
+   │
+LL │         assembly {
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
+note[inline-assembly]: inline assembly (declared memory-safe); review business logic and side effects
+   ╭▸ ROOT/testdata/InlineAssembly.sol:LL:CC
+   │
+LL │         assembly {
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
+note[inline-assembly]: inline assembly used; review for memory safety and side effects
+   ╭▸ ROOT/testdata/InlineAssembly.sol:LL:CC
+   │
+LL │         assembly {
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
 note[inline-assembly]: inline assembly used; review for memory safety and side effects
    ╭▸ ROOT/testdata/InlineAssembly.sol:LL:CC
    │

--- a/crates/lint/testdata/Keccak256.sol
+++ b/crates/lint/testdata/Keccak256.sol
@@ -52,6 +52,7 @@ contract AsmKeccak256 {
 
     function assemblyHash(uint256 a, uint256 b) public pure returns (bytes32) {
         //optimized
+        // forge-lint: disable-next-line(inline-assembly)
         assembly {
             mstore(0x00, a)
             mstore(0x20, b)


### PR DESCRIPTION
Info-severity lint that flags every `assembly { ... }` block. Blocks declared `("memory-safe")` get a softer message. Diagnostic span narrowed to the `assembly` keyword.