### PR TITLE
fix: compact fish completions

### DIFF
--- a/crates/cli/src/clap.rs
+++ b/crates/cli/src/clap.rs
@@ -40,21 +40,27 @@ impl Generator for Shell {
     fn generate(&self, cmd: &clap::Command, buf: &mut dyn std::io::Write) {
         match self {
             Self::ClapCompleteShell(ClapCompleteShell::Bash) => {
-                let mut completion = Vec::new();
-                ClapCompleteShell::Bash.generate(cmd, &mut completion);
-                let completion = compact_bash_completion(cmd.get_name(), completion);
-                buf.write_all(completion.as_bytes()).expect("failed to write completion file");
+                generate_compacted(ClapCompleteShell::Bash, cmd, compact_bash_completion, buf)
             }
             Self::ClapCompleteShell(ClapCompleteShell::Fish) => {
-                let mut completion = Vec::new();
-                ClapCompleteShell::Fish.generate(cmd, &mut completion);
-                let completion = compact_fish_completion(cmd.get_name(), completion);
-                buf.write_all(completion.as_bytes()).expect("failed to write completion file");
+                generate_compacted(ClapCompleteShell::Fish, cmd, compact_fish_completion, buf)
             }
             Self::ClapCompleteShell(shell) => shell.generate(cmd, buf),
             Self::Nushell => Nushell.generate(cmd, buf),
         }
     }
+}
+
+fn generate_compacted(
+    generator: impl Generator,
+    cmd: &clap::Command,
+    compact: fn(&str, Vec<u8>) -> String,
+    buf: &mut dyn std::io::Write,
+) {
+    let mut completion = Vec::new();
+    generator.generate(cmd, &mut completion);
+    let completion = compact(cmd.get_name(), completion);
+    buf.write_all(completion.as_bytes()).expect("failed to write completion file");
 }
 
 fn compact_bash_completion(cmd_name: &str, completion: Vec<u8>) -> String {

--- a/crates/cli/src/clap.rs
+++ b/crates/cli/src/clap.rs
@@ -39,6 +39,12 @@ impl Generator for Shell {
 
     fn generate(&self, cmd: &clap::Command, buf: &mut dyn std::io::Write) {
         match self {
+            Self::ClapCompleteShell(ClapCompleteShell::Bash) => {
+                let mut completion = Vec::new();
+                ClapCompleteShell::Bash.generate(cmd, &mut completion);
+                let completion = compact_bash_completion(cmd.get_name(), completion);
+                buf.write_all(completion.as_bytes()).expect("failed to write completion file");
+            }
             Self::ClapCompleteShell(ClapCompleteShell::Fish) => {
                 let mut completion = Vec::new();
                 ClapCompleteShell::Fish.generate(cmd, &mut completion);
@@ -49,6 +55,76 @@ impl Generator for Shell {
             Self::Nushell => Nushell.generate(cmd, buf),
         }
     }
+}
+
+fn compact_bash_completion(cmd_name: &str, completion: Vec<u8>) -> String {
+    let completion =
+        String::from_utf8(completion).expect("bash completion scripts should be UTF-8");
+
+    let prev_case_start = "            case \"${prev}\" in";
+    let prev_case_end = "            esac";
+    let mut counts = BTreeMap::<String, usize>::new();
+    let lines: Vec<_> = completion.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        if lines[i] == prev_case_start {
+            if let Some(end) = lines[i + 1..].iter().position(|line| *line == prev_case_end) {
+                let end = i + 1 + end;
+                let block = format!("{}\n", lines[i..=end].join("\n"));
+                *counts.entry(block).or_default() += 1;
+                i = end + 1;
+                continue;
+            }
+        }
+        i += 1;
+    }
+
+    let prefix = bash_helper_prefix(cmd_name);
+    let mut replacements = BTreeMap::<String, String>::new();
+    let mut helpers = String::new();
+    for (block, count) in counts {
+        if count < 2 {
+            continue;
+        }
+
+        let helper = format!("{prefix}{}", replacements.len());
+        let replacement = format!("            {helper} && return 0\n");
+        let definition = format!("{helper}() {{\n{block}            return 1\n}}\n");
+        let old_len = block.len() * count;
+        let new_len = replacement.len() * count + definition.len();
+        if old_len <= new_len {
+            continue;
+        }
+
+        helpers.push_str(&definition);
+        replacements.insert(block, replacement);
+    }
+
+    if replacements.is_empty() {
+        return completion;
+    }
+
+    let mut out = String::with_capacity(completion.len().saturating_sub(helpers.len()));
+    out.push_str(&helpers);
+    let mut i = 0;
+    while i < lines.len() {
+        if lines[i] == prev_case_start {
+            if let Some(end) = lines[i + 1..].iter().position(|line| *line == prev_case_end) {
+                let end = i + 1 + end;
+                let block = format!("{}\n", lines[i..=end].join("\n"));
+                if let Some(replacement) = replacements.get(&block) {
+                    out.push_str(replacement);
+                    i = end + 1;
+                    continue;
+                }
+            }
+        }
+        out.push_str(lines[i]);
+        out.push('\n');
+        i += 1;
+    }
+
+    out
 }
 
 fn compact_fish_completion(cmd_name: &str, completion: Vec<u8>) -> String {
@@ -121,6 +197,12 @@ fn fish_complete_condition(line: &str) -> Option<&str> {
     let (_, rest) = line.split_once(" -n \"")?;
     let (condition, _) = rest.split_once('"')?;
     Some(condition)
+}
+
+fn bash_helper_prefix(cmd_name: &str) -> String {
+    let short_name: String =
+        cmd_name.chars().filter(|c| c.is_ascii_alphanumeric()).take(2).collect();
+    format!("__b{short_name}")
 }
 
 fn fish_condition_helper_prefix(cmd_name: &str) -> String {

--- a/crates/cli/src/clap.rs
+++ b/crates/cli/src/clap.rs
@@ -45,6 +45,9 @@ impl Generator for Shell {
             Self::ClapCompleteShell(ClapCompleteShell::Fish) => {
                 generate_compacted(ClapCompleteShell::Fish, cmd, compact_fish_completion, buf)
             }
+            Self::ClapCompleteShell(ClapCompleteShell::Zsh) => {
+                generate_compacted(ClapCompleteShell::Zsh, cmd, compact_zsh_completion, buf)
+            }
             Self::ClapCompleteShell(shell) => shell.generate(cmd, buf),
             Self::Nushell => Nushell.generate(cmd, buf),
         }
@@ -133,6 +136,86 @@ fn compact_bash_completion(cmd_name: &str, completion: Vec<u8>) -> String {
     out
 }
 
+fn compact_zsh_completion(cmd_name: &str, completion: Vec<u8>) -> String {
+    let completion = String::from_utf8(completion).expect("zsh completion scripts should be UTF-8");
+
+    let start = "_arguments \"${_arguments_options[@]}\" : \\";
+    let end = "&& ret=0";
+    let lines: Vec<_> = completion.lines().collect();
+    let mut counts = BTreeMap::<String, usize>::new();
+    let mut i = 0;
+    while i < lines.len() {
+        if lines[i] == start {
+            if let Some(block_end) = lines[i + 1..].iter().position(|line| *line == end) {
+                let block_end = i + 1 + block_end;
+                let block = format!("{}\n", lines[i..=block_end].join("\n"));
+                *counts.entry(block).or_default() += 1;
+                i = block_end + 1;
+                continue;
+            }
+        }
+        i += 1;
+    }
+
+    let prefix = zsh_helper_prefix(cmd_name);
+    let mut replacements = BTreeMap::<String, String>::new();
+    let mut helpers = String::new();
+    for (block, count) in counts {
+        if count < 2 {
+            continue;
+        }
+
+        let helper = format!("{prefix}{}", replacements.len());
+        let replacement = format!("{helper} && ret=0\n");
+        let mut body = block.replace("&& ret=0\n", "");
+        if body.as_bytes().ends_with(b" \\\n") {
+            body.truncate(body.len() - 3);
+            body.push('\n');
+        }
+        let definition = format!("{helper}() {{\n{body}}}\n");
+        let old_len = block.len() * count;
+        let new_len = replacement.len() * count + definition.len();
+        if old_len <= new_len {
+            continue;
+        }
+
+        helpers.push_str(&definition);
+        replacements.insert(block, replacement);
+    }
+
+    if replacements.is_empty() {
+        return completion;
+    }
+
+    let mut out = String::with_capacity(completion.len().saturating_sub(helpers.len()));
+    let mut inserted_helpers = false;
+    let mut i = 0;
+    while i < lines.len() {
+        if !inserted_helpers && lines[i].starts_with(&format!("_{}_commands()", cmd_name)) {
+            out.push_str(&helpers);
+            inserted_helpers = true;
+        }
+
+        if lines[i] == start {
+            if let Some(block_end) = lines[i + 1..].iter().position(|line| *line == end) {
+                let block_end = i + 1 + block_end;
+                let block = format!("{}\n", lines[i..=block_end].join("\n"));
+                if let Some(replacement) = replacements.get(&block) {
+                    out.push_str(replacement);
+                    i = block_end + 1;
+                    continue;
+                }
+            }
+        }
+
+        out.push_str(lines[i]);
+        out.push('\n');
+        i += 1;
+    }
+
+    out
+}
+
 fn compact_fish_completion(cmd_name: &str, completion: Vec<u8>) -> String {
     let completion =
         String::from_utf8(completion).expect("fish completion scripts should be UTF-8");
@@ -209,6 +292,12 @@ fn bash_helper_prefix(cmd_name: &str) -> String {
     let short_name: String =
         cmd_name.chars().filter(|c| c.is_ascii_alphanumeric()).take(2).collect();
     format!("__b{short_name}")
+}
+
+fn zsh_helper_prefix(cmd_name: &str) -> String {
+    let short_name: String =
+        cmd_name.chars().filter(|c| c.is_ascii_alphanumeric()).take(2).collect();
+    format!("__z{short_name}")
 }
 
 fn fish_condition_helper_prefix(cmd_name: &str) -> String {

--- a/crates/cli/src/clap.rs
+++ b/crates/cli/src/clap.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use clap_complete::{Shell as ClapCompleteShell, aot::Generator};
 use clap_complete_nushell::Nushell;
 
@@ -37,8 +39,92 @@ impl Generator for Shell {
 
     fn generate(&self, cmd: &clap::Command, buf: &mut dyn std::io::Write) {
         match self {
+            Self::ClapCompleteShell(ClapCompleteShell::Fish) => {
+                let mut completion = Vec::new();
+                ClapCompleteShell::Fish.generate(cmd, &mut completion);
+                let completion = compact_fish_completion(cmd.get_name(), completion);
+                buf.write_all(completion.as_bytes()).expect("failed to write completion file");
+            }
             Self::ClapCompleteShell(shell) => shell.generate(cmd, buf),
             Self::Nushell => Nushell.generate(cmd, buf),
         }
     }
+}
+
+fn compact_fish_completion(cmd_name: &str, completion: Vec<u8>) -> String {
+    let completion =
+        String::from_utf8(completion).expect("fish completion scripts should be UTF-8");
+
+    let mut counts = BTreeMap::<String, usize>::new();
+    for line in completion.lines() {
+        if let Some(condition) = fish_complete_condition(line) {
+            *counts.entry(condition.to_owned()).or_default() += 1;
+        }
+    }
+
+    let prefix = fish_condition_helper_prefix(cmd_name);
+    let mut replacements = BTreeMap::<String, String>::new();
+    let mut helpers = String::new();
+    for (condition, count) in counts {
+        if count < 2 {
+            continue;
+        }
+
+        let helper = format!("{prefix}{}", replacements.len());
+        let old_len = format!("-n \"{condition}\"").len();
+        let new_len = format!("-n \"{helper}\"").len();
+        let helper_len = format!("function {helper}\n    {condition}\nend\n").len();
+        if old_len <= new_len || (old_len - new_len) * count <= helper_len {
+            continue;
+        }
+
+        helpers.push_str(&format!("function {helper}\n    {condition}\nend\n"));
+        replacements.insert(condition, helper);
+    }
+
+    if replacements.is_empty() {
+        return completion;
+    }
+
+    let mut out = String::with_capacity(completion.len().saturating_sub(helpers.len()));
+    let mut inserted_helpers = false;
+    for line in completion.lines() {
+        if !inserted_helpers && line.starts_with("complete ") {
+            out.push_str(&helpers);
+            inserted_helpers = true;
+        }
+
+        if let Some(condition) = fish_complete_condition(line)
+            && let Some(helper) = replacements.get(condition)
+        {
+            out.push_str(&line.replacen(
+                &format!("-n \"{condition}\""),
+                &format!("-n \"{helper}\""),
+                1,
+            ));
+            out.push('\n');
+            continue;
+        }
+
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    out
+}
+
+fn fish_complete_condition(line: &str) -> Option<&str> {
+    if !line.starts_with("complete ") {
+        return None;
+    }
+
+    let (_, rest) = line.split_once(" -n \"")?;
+    let (condition, _) = rest.split_once('"')?;
+    Some(condition)
+}
+
+fn fish_condition_helper_prefix(cmd_name: &str) -> String {
+    let short_name: String =
+        cmd_name.chars().filter(|c| c.is_ascii_alphanumeric()).take(2).collect();
+    format!("__f{short_name}")
 }

--- a/crates/cli/src/clap.rs
+++ b/crates/cli/src/clap.rs
@@ -76,14 +76,14 @@ fn compact_bash_completion(cmd_name: &str, completion: Vec<u8>) -> String {
     let lines: Vec<_> = completion.lines().collect();
     let mut i = 0;
     while i < lines.len() {
-        if lines[i] == prev_case_start {
-            if let Some(end) = lines[i + 1..].iter().position(|line| *line == prev_case_end) {
-                let end = i + 1 + end;
-                let block = format!("{}\n", lines[i..=end].join("\n"));
-                *counts.entry(block).or_default() += 1;
-                i = end + 1;
-                continue;
-            }
+        if lines[i] == prev_case_start
+            && let Some(end) = lines[i + 1..].iter().position(|line| *line == prev_case_end)
+        {
+            let end = i + 1 + end;
+            let block = format!("{}\n", lines[i..=end].join("\n"));
+            *counts.entry(block).or_default() += 1;
+            i = end + 1;
+            continue;
         }
         i += 1;
     }
@@ -117,15 +117,15 @@ fn compact_bash_completion(cmd_name: &str, completion: Vec<u8>) -> String {
     out.push_str(&helpers);
     let mut i = 0;
     while i < lines.len() {
-        if lines[i] == prev_case_start {
-            if let Some(end) = lines[i + 1..].iter().position(|line| *line == prev_case_end) {
-                let end = i + 1 + end;
-                let block = format!("{}\n", lines[i..=end].join("\n"));
-                if let Some(replacement) = replacements.get(&block) {
-                    out.push_str(replacement);
-                    i = end + 1;
-                    continue;
-                }
+        if lines[i] == prev_case_start
+            && let Some(end) = lines[i + 1..].iter().position(|line| *line == prev_case_end)
+        {
+            let end = i + 1 + end;
+            let block = format!("{}\n", lines[i..=end].join("\n"));
+            if let Some(replacement) = replacements.get(&block) {
+                out.push_str(replacement);
+                i = end + 1;
+                continue;
             }
         }
         out.push_str(lines[i]);
@@ -145,14 +145,14 @@ fn compact_zsh_completion(cmd_name: &str, completion: Vec<u8>) -> String {
     let mut counts = BTreeMap::<String, usize>::new();
     let mut i = 0;
     while i < lines.len() {
-        if lines[i] == start {
-            if let Some(block_end) = lines[i + 1..].iter().position(|line| *line == end) {
-                let block_end = i + 1 + block_end;
-                let block = format!("{}\n", lines[i..=block_end].join("\n"));
-                *counts.entry(block).or_default() += 1;
-                i = block_end + 1;
-                continue;
-            }
+        if lines[i] == start
+            && let Some(block_end) = lines[i + 1..].iter().position(|line| *line == end)
+        {
+            let block_end = i + 1 + block_end;
+            let block = format!("{}\n", lines[i..=block_end].join("\n"));
+            *counts.entry(block).or_default() += 1;
+            i = block_end + 1;
+            continue;
         }
         i += 1;
     }
@@ -191,20 +191,20 @@ fn compact_zsh_completion(cmd_name: &str, completion: Vec<u8>) -> String {
     let mut inserted_helpers = false;
     let mut i = 0;
     while i < lines.len() {
-        if !inserted_helpers && lines[i].starts_with(&format!("_{}_commands()", cmd_name)) {
+        if !inserted_helpers && lines[i].starts_with(&format!("_{cmd_name}_commands()")) {
             out.push_str(&helpers);
             inserted_helpers = true;
         }
 
-        if lines[i] == start {
-            if let Some(block_end) = lines[i + 1..].iter().position(|line| *line == end) {
-                let block_end = i + 1 + block_end;
-                let block = format!("{}\n", lines[i..=block_end].join("\n"));
-                if let Some(replacement) = replacements.get(&block) {
-                    out.push_str(replacement);
-                    i = block_end + 1;
-                    continue;
-                }
+        if lines[i] == start
+            && let Some(block_end) = lines[i + 1..].iter().position(|line| *line == end)
+        {
+            let block_end = i + 1 + block_end;
+            let block = format!("{}\n", lines[i..=block_end].join("\n"));
+            if let Some(replacement) = replacements.get(&block) {
+                out.push_str(replacement);
+                i = block_end + 1;
+                continue;
             }
         }
 

--- a/crates/cli/src/clap.rs
+++ b/crates/cli/src/clap.rs
@@ -189,9 +189,13 @@ fn compact_zsh_completion(cmd_name: &str, completion: Vec<u8>) -> String {
 
     let mut out = String::with_capacity(completion.len().saturating_sub(helpers.len()));
     let mut inserted_helpers = false;
+    let command_guard = format!("(( $+functions[_{cmd_name}_commands] )) ||");
+    let command_function = format!("_{cmd_name}_commands()");
     let mut i = 0;
     while i < lines.len() {
-        if !inserted_helpers && lines[i].starts_with(&format!("_{cmd_name}_commands()")) {
+        if !inserted_helpers
+            && (lines[i] == command_guard || lines[i].starts_with(&command_function))
+        {
             out.push_str(&helpers);
             inserted_helpers = true;
         }
@@ -304,4 +308,38 @@ fn fish_condition_helper_prefix(cmd_name: &str) -> String {
     let short_name: String =
         cmd_name.chars().filter(|c| c.is_ascii_alphanumeric()).take(2).collect();
     format!("__f{short_name}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zsh_helpers_are_inserted_before_command_guard() {
+        let block = "_arguments \"${_arguments_options[@]}\" : \\\n'--root=[Project root]:PATH:_files' \\\n&& ret=0\n";
+        let completion = format!(
+            "#compdef forge\n\
+             _forge() {{\n\
+             {block}\
+             case $state in\n\
+             (test)\n\
+             {block}\
+             ;;\n\
+             esac\n\
+             }}\n\
+             (( $+functions[_forge_commands] )) ||\n\
+             _forge_commands() {{\n\
+             }}\n"
+        );
+
+        let compacted = compact_zsh_completion("forge", completion.into_bytes());
+        let helper = compacted.find("__zfo0()").expect("helper should be generated");
+        let guard = compacted
+            .find("(( $+functions[_forge_commands] )) ||")
+            .expect("command guard should be preserved");
+        let command = compacted.find("_forge_commands()").expect("command function should exist");
+
+        assert!(helper < guard, "helper should be inserted before command guard");
+        assert!(guard < command, "command guard should still apply to command function");
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

I was investigating why my shell was slow so on the things I examined were foundry tools completions. I'm on `fish` and completions size for `cast` was 1.59 MB.

I looked into the CLI impl and saw potential for substantial reduction in completions size.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Problem: completions for tools are too big.
Size reduction strategy: kept `clap_complete` as the source of truth then post-processes the generated output for `fish`, `bash`, and `zsh` to factor repeated generated blocks into helper functions.

## Solution


| Tool | Fish | Bash | Zsh |
|---|---:|---:|---:|
| cast | 1.59 MB -> 1.00 MB | 0.56 MB -> 0.40 MB | 1.14 MB -> 0.45 MB |
| forge | 0.41 MB -> 0.31 MB | 0.27 MB -> 0.23 MB | 0.34 MB -> 0.21 MB |
| anvil | 0.014 MB -> 0.012 MB | 0.014 MB -> 0.014 MB | 0.014 MB -> 0.013 MB |

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I put more details in this gist as well: https://gists.sh/o-az/b937e947a8db20d2b6f634343ad27c99?noheader&nofooter

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
