### PR TITLE
feat(anvil): gate optimism behind cargo feature

### DIFF
--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["cli"]
 
 [dependencies]
 # foundry internal
-anvil-core = { path = "core" }
+anvil-core = { path = "core", default-features = false }
 anvil-rpc = { path = "rpc" }
 anvil-server = { path = "server" }
 foundry-cli.workspace = true
@@ -28,7 +28,7 @@ foundry-common.workspace = true
 foundry-config.workspace = true
 foundry-evm.workspace = true
 foundry-evm-networks.workspace = true
-foundry-primitives = { workspace = true, features = ["optimism"] }
+foundry-primitives = { workspace = true, default-features = false }
 tempo-chainspec.workspace = true
 tempo-primitives.workspace = true
 tempo-precompiles.workspace = true
@@ -37,7 +37,7 @@ tempo-revm.workspace = true
 
 # alloy
 alloy-evm = { workspace = true, features = ["call-util"] }
-alloy-op-evm.workspace = true
+alloy-op-evm = { workspace = true, optional = true }
 alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-consensus = { workspace = true, features = ["k256", "kzg"] }
 alloy-contract = { workspace = true, features = ["pubsub"] }
@@ -63,7 +63,7 @@ alloy-transport.workspace = true
 alloy-chains.workspace = true
 alloy-genesis.workspace = true
 alloy-trie.workspace = true
-op-alloy-consensus = { workspace = true, features = ["serde"] }
+op-alloy-consensus = { workspace = true, features = ["serde"], optional = true }
 
 # revm
 revm = { workspace = true, features = [
@@ -73,7 +73,7 @@ revm = { workspace = true, features = [
     "c-kzg",
 ] }
 revm-inspectors.workspace = true
-op-revm.workspace = true
+op-revm = { workspace = true, optional = true }
 
 # axum related
 axum.workspace = true
@@ -124,7 +124,15 @@ op-alloy-rpc-types.workspace = true
 tempo-alloy.workspace = true
 
 [features]
-default = ["cli", "jemalloc", "asm-keccak"]
+default = ["cli", "jemalloc", "asm-keccak", "optimism"]
+optimism = [
+    "dep:op-alloy-consensus",
+    "dep:alloy-op-evm",
+    "dep:op-revm",
+    "anvil-core/optimism",
+    "foundry-primitives/optimism",
+    "foundry-common/optimism",
+]
 asm-keccak = ["alloy-primitives/asm-keccak", "revm/asm-keccak"]
 jemalloc = ["foundry-cli/jemalloc"]
 mimalloc = ["foundry-cli/mimalloc"]

--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 foundry-common.workspace = true
 foundry-evm.workspace = true
-foundry-primitives = { workspace = true, features = ["optimism"] }
+foundry-primitives = { workspace = true, default-features = false }
 revm = { workspace = true, default-features = false, features = [
     "std",
     "serde",
@@ -39,3 +39,7 @@ bytes.workspace = true
 # misc
 rand.workspace = true
 thiserror.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = ["foundry-primitives/optimism"]

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1882,6 +1882,7 @@ impl EthApi<FoundryNetwork> {
 
     fn sign_request(&self, from: &Address, typed_tx: FoundryTypedTx) -> Result<FoundryTxEnvelope> {
         match typed_tx {
+            #[cfg(feature = "optimism")]
             FoundryTypedTx::Deposit(_) => return Ok(build_impersonated(typed_tx)),
             _ => {
                 for signer in self.signers.iter() {
@@ -3574,7 +3575,9 @@ impl EthApi<FoundryNetwork> {
             FoundryTxEnvelope::Eip1559(_) => self.backend.ensure_eip1559_active(),
             FoundryTxEnvelope::Eip4844(_) => self.backend.ensure_eip4844_active(),
             FoundryTxEnvelope::Eip7702(_) => self.backend.ensure_eip7702_active(),
+            #[cfg(feature = "optimism")]
             FoundryTxEnvelope::Deposit(_) => self.backend.ensure_op_deposits_active(),
+            #[cfg(feature = "optimism")]
             FoundryTxEnvelope::PostExec(_) => Err(BlockchainError::InvalidTransactionRequest(
                 "not implemented for post-exec tx".to_string(),
             )),

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -67,9 +67,11 @@ impl ReceiptBuilder for FoundryReceiptBuilder {
             FoundryTxType::Eip1559 => FoundryReceiptEnvelope::Eip1559(receipt),
             FoundryTxType::Eip4844 => FoundryReceiptEnvelope::Eip4844(receipt),
             FoundryTxType::Eip7702 => FoundryReceiptEnvelope::Eip7702(receipt),
+            #[cfg(feature = "optimism")]
             FoundryTxType::Deposit => {
                 unreachable!("deposit receipts are built in commit_transaction")
             }
+            #[cfg(feature = "optimism")]
             FoundryTxType::PostExec => FoundryReceiptEnvelope::PostExec(receipt),
             FoundryTxType::Tempo => FoundryReceiptEnvelope::Tempo(receipt),
         }
@@ -220,6 +222,7 @@ where
     fn commit_transaction(&mut self, output: Self::Result) -> GasOutput {
         let AnvilTxResult {
             inner: EthTxResult { result: ResultAndState { result, state }, blob_gas_used, tx_type },
+            #[cfg_attr(not(feature = "optimism"), allow(unused_variables))]
             sender,
         } = output;
 
@@ -234,6 +237,7 @@ where
             self.blob_gas_used = self.blob_gas_used.saturating_add(blob_gas_used);
         }
 
+        #[cfg(feature = "optimism")]
         let receipt = if tx_type == FoundryTxType::Deposit {
             let deposit_nonce = state.get(&sender).map(|acc| acc.info.nonce);
             let receipt = alloy_consensus::Receipt {
@@ -259,6 +263,14 @@ where
                 cumulative_gas_used: self.gas_used,
             })
         };
+        #[cfg(not(feature = "optimism"))]
+        let receipt = self.receipt_builder.build_receipt(ReceiptBuilderCtx {
+            tx_type,
+            evm: &self.evm,
+            result,
+            state: &state,
+            cumulative_gas_used: self.gas_used,
+        });
 
         self.receipts.push(receipt);
         self.evm.db_mut().commit(state);

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -57,6 +57,7 @@ use alloy_network::{
     AnyHeader, AnyRpcBlock, AnyRpcHeader, AnyRpcTransaction, AnyTxEnvelope, AnyTxType, Network,
     NetworkTransactionBuilder, ReceiptResponse, UnknownTxEnvelope, UnknownTypedTransaction,
 };
+#[cfg(feature = "optimism")]
 use alloy_op_evm::{OpEvmContext, OpEvmFactory, OpTx};
 use alloy_primitives::{
     Address, B256, Bloom, Bytes, TxHash, TxKind, U64, U256, hex, keccak256, logs_bloom,
@@ -108,20 +109,60 @@ use foundry_evm::{
     },
 };
 use foundry_evm_networks::NetworkConfigs;
+#[cfg(feature = "optimism")]
+use foundry_primitives::get_deposit_tx_parts;
 use foundry_primitives::{
     FoundryNetwork, FoundryReceiptEnvelope, FoundryTransactionRequest, FoundryTxEnvelope,
-    FoundryTxReceipt, get_deposit_tx_parts,
+    FoundryTxReceipt,
 };
 use futures::channel::mpsc::{UnboundedSender, unbounded};
+#[cfg(feature = "optimism")]
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpTransaction as OpTransactionTrait};
-use op_revm::{OpHaltReason, OpSpecId, OpTransaction};
+#[cfg(feature = "optimism")]
+use op_revm::{OpSpecId, OpTransaction, transaction::deposit::DepositTransactionParts};
+
+/// Side-channel container for OP-specific deposit info produced by
+/// [`Backend::build_call_env`] and consumed by the OP transact path.
+///
+/// When the `optimism` feature is enabled, this is an alias for
+/// `op_revm::DepositTransactionParts`. When disabled, it is a zero-sized
+/// stand-in so the eth/tempo dispatch chain still type-checks.
+#[cfg(feature = "optimism")]
+type OpCallDepositInfo = DepositTransactionParts;
+#[cfg(not(feature = "optimism"))]
+#[derive(Default, Clone, Debug)]
+struct OpCallDepositInfo;
+
+/// Marker trait that abstracts over the per-network inspector trait bounds
+/// required by the in-memory backend. The OP bound is only included when the
+/// `optimism` feature is enabled.
+#[cfg(feature = "optimism")]
+pub trait BackendInspector<DB: Database>:
+    Inspector<EthEvmContext<DB>> + Inspector<OpEvmContext<DB>> + Inspector<TempoContext<DB>>
+{
+}
+#[cfg(feature = "optimism")]
+impl<DB: Database, T> BackendInspector<DB> for T where
+    T: Inspector<EthEvmContext<DB>> + Inspector<OpEvmContext<DB>> + Inspector<TempoContext<DB>>
+{
+}
+#[cfg(not(feature = "optimism"))]
+pub trait BackendInspector<DB: Database>:
+    Inspector<EthEvmContext<DB>> + Inspector<TempoContext<DB>>
+{
+}
+#[cfg(not(feature = "optimism"))]
+impl<DB: Database, T> BackendInspector<DB> for T where
+    T: Inspector<EthEvmContext<DB>> + Inspector<TempoContext<DB>>
+{
+}
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use revm::{
     DatabaseCommit, Inspector,
     context::{Block as RevmBlock, BlockEnv, Cfg, TxEnv},
     context_interface::{
         block::BlobExcessGasAndPrice,
-        result::{EVMError, ExecutionResult, HaltReason, Output, ResultAndState},
+        result::{ExecutionResult, HaltReason, Output, ResultAndState},
     },
     database::{CacheDB, DbAccount, WrapDatabaseRef},
     interpreter::InstructionResult,
@@ -157,6 +198,8 @@ pub mod cache;
 pub mod fork_db;
 pub mod in_memory_db;
 pub mod inspector;
+#[cfg(feature = "optimism")]
+pub mod optimism;
 pub mod state;
 pub mod storage;
 
@@ -1139,56 +1182,51 @@ impl<N: Network> Backend<N> {
         db: &'db DB,
         evm_env: &EvmEnv,
         inspector: &mut I,
-        tx_env: OpTransaction<TxEnv>,
+        tx_env: TxEnv,
+        op_deposit: OpCallDepositInfo,
     ) -> Result<ResultAndState<HaltReason>, BlockchainError>
     where
         DB: DatabaseRef + ?Sized,
-        I: Inspector<EthEvmContext<WrapDatabaseRef<&'db DB>>>
-            + Inspector<OpEvmContext<WrapDatabaseRef<&'db DB>>>
-            + Inspector<TempoContext<WrapDatabaseRef<&'db DB>>>,
+        I: BackendInspector<WrapDatabaseRef<&'db DB>>,
         WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
     {
+        #[cfg(feature = "optimism")]
         if self.is_optimism() {
-            let op_env = EvmEnv::new(
-                evm_env.cfg_env.clone().with_spec_and_mainnet_gas_params(OpSpecId::ISTHMUS),
-                evm_env.block_env.clone(),
-            );
-            let mut evm = OpEvmFactory::default().create_evm_with_inspector(
-                WrapDatabaseRef(db),
-                op_env,
-                inspector,
-            );
-            self.inject_precompiles(evm.precompiles_mut());
-            let result = evm.transact(OpTx(tx_env)).map_err(|e| match e {
-                EVMError::Database(db) => EVMError::Database(db),
-                EVMError::Header(h) => EVMError::Header(h),
-                EVMError::Custom(s) => EVMError::Custom(s),
-                EVMError::CustomAny(err) => EVMError::CustomAny(err),
-                EVMError::Transaction(t) => EVMError::Transaction(t),
-            })?;
-            Ok(ResultAndState {
-                result: result.result.map_haltreason(|h| match h {
-                    OpHaltReason::Base(eth) => eth,
-                    _ => HaltReason::PrecompileError,
-                }),
-                state: result.state,
-            })
-        } else if self.is_tempo() {
-            self.transact_tempo_with_inspector_ref(
-                db,
-                evm_env,
-                inspector,
-                TempoTxEnv::from(tx_env.base),
-            )
-        } else {
-            let mut evm = EthEvmFactory::default().create_evm_with_inspector(
-                WrapDatabaseRef(db),
-                evm_env.clone(),
-                inspector,
-            );
-            self.inject_precompiles(evm.precompiles_mut());
-            Ok(evm.transact(tx_env.base)?)
+            let op_tx = OpTransaction { base: tx_env, deposit: op_deposit, ..Default::default() };
+            return self.transact_op_with_inspector_ref(db, evm_env, inspector, op_tx);
         }
+        // `op_deposit` only matters on the OP path; eth/tempo ignore it.
+        let _ = op_deposit;
+        if self.is_tempo() {
+            self.transact_tempo_with_inspector_ref(db, evm_env, inspector, TempoTxEnv::from(tx_env))
+        } else {
+            self.transact_eth_with_inspector_ref(db, evm_env, inspector, tx_env)
+        }
+    }
+
+    /// Eth path of [`Backend::transact_with_inspector_ref`].
+    ///
+    /// Creates an Ethereum EVM, injects precompiles, and transacts with a
+    /// plain [`TxEnv`].
+    fn transact_eth_with_inspector_ref<'db, I, DB>(
+        &self,
+        db: &'db DB,
+        evm_env: &EvmEnv,
+        inspector: &mut I,
+        tx_env: TxEnv,
+    ) -> Result<ResultAndState<HaltReason>, BlockchainError>
+    where
+        DB: DatabaseRef + ?Sized,
+        I: Inspector<EthEvmContext<WrapDatabaseRef<&'db DB>>>,
+        WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
+    {
+        let mut evm = EthEvmFactory::default().create_evm_with_inspector(
+            WrapDatabaseRef(db),
+            evm_env.clone(),
+            inspector,
+        );
+        self.inject_precompiles(evm.precompiles_mut());
+        Ok(evm.transact(tx_env)?)
     }
 
     /// Builds the appropriate tx env from a [`FoundryTxEnvelope`], executes via the correct
@@ -1203,9 +1241,7 @@ impl<N: Network> Backend<N> {
     ) -> Result<(ResultAndState<HaltReason>, TxEnv), BlockchainError>
     where
         DB: DatabaseRef + ?Sized,
-        I: Inspector<EthEvmContext<WrapDatabaseRef<&'db DB>>>
-            + Inspector<OpEvmContext<WrapDatabaseRef<&'db DB>>>
-            + Inspector<TempoContext<WrapDatabaseRef<&'db DB>>>,
+        I: BackendInspector<WrapDatabaseRef<&'db DB>>,
         WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
     {
         if tx.is_tempo() {
@@ -1213,14 +1249,21 @@ impl<N: Network> Backend<N> {
                 FromTxWithEncoded::from_encoded_tx(tx, sender, tx.encoded_2718().into());
             let base = tx_env.inner.clone();
             let result = self.transact_tempo_with_inspector_ref(db, evm_env, inspector, tx_env)?;
-            Ok((result, base))
-        } else {
-            let tx_env: OpTransaction<TxEnv> =
-                FromTxWithEncoded::from_encoded_tx(tx, sender, tx.encoded_2718().into());
-            let base = tx_env.base.clone();
-            let result = self.transact_with_inspector_ref(db, evm_env, inspector, tx_env)?;
-            Ok((result, base))
+            return Ok((result, base));
         }
+        #[cfg(feature = "optimism")]
+        if self.is_optimism() {
+            let op_tx: OpTransaction<TxEnv> =
+                FromTxWithEncoded::from_encoded_tx(tx, sender, tx.encoded_2718().into());
+            let base = op_tx.base.clone();
+            let result = self.transact_op_with_inspector_ref(db, evm_env, inspector, op_tx)?;
+            return Ok((result, base));
+        }
+        let tx_env: TxEnv =
+            FromTxWithEncoded::from_encoded_tx(tx, sender, tx.encoded_2718().into());
+        let base = tx_env.clone();
+        let result = self.transact_eth_with_inspector_ref(db, evm_env, inspector, tx_env)?;
+        Ok((result, base))
     }
 
     /// Creates a Tempo EVM, injects precompiles, and transacts with a native [`TempoTxEnv`].
@@ -1298,6 +1341,7 @@ impl<N: Network> Backend<N> {
             }};
         }
 
+        #[cfg(feature = "optimism")]
         if self.is_optimism() {
             let op_env = EvmEnv::new(
                 evm_env.cfg_env.clone().with_spec_and_mainnet_gas_params(OpSpecId::ISTHMUS),
@@ -1305,8 +1349,10 @@ impl<N: Network> Backend<N> {
             );
             let mut evm =
                 OpEvmFactory::<OpTx>::default().create_evm_with_inspector(db, op_env, inspector);
-            run!(evm)
-        } else if self.is_tempo() {
+            return run!(evm);
+        }
+
+        if self.is_tempo() {
             let hardfork = TempoHardfork::from(self.hardfork);
             let tempo_env = EvmEnv::new(
                 evm_env
@@ -1338,7 +1384,7 @@ impl<N: Network> Backend<N> {
         request: WithOtherFields<TransactionRequest>,
         fee_details: FeeDetails,
         block_env: BlockEnv,
-    ) -> (EvmEnv, OpTransaction<TxEnv>) {
+    ) -> (EvmEnv, TxEnv, OpCallDepositInfo) {
         let tx_type = request.minimal_tx_type() as u8;
 
         let WithOtherFields::<TransactionRequest> {
@@ -1391,7 +1437,7 @@ impl<N: Network> Backend<N> {
         let caller = from.unwrap_or_default();
         let to = to.as_ref().and_then(TxKind::to);
         let blob_hashes = blob_versioned_hashes.unwrap_or_default();
-        let mut base = TxEnv {
+        let mut tx_env = TxEnv {
             caller,
             gas_limit,
             gas_price,
@@ -1413,11 +1459,10 @@ impl<N: Network> Backend<N> {
             blob_hashes,
             ..Default::default()
         };
-        base.set_signed_authorization(authorization_list.unwrap_or_default());
-        let mut tx_env = OpTransaction { base, ..Default::default() };
+        tx_env.set_signed_authorization(authorization_list.unwrap_or_default());
 
         if let Some(nonce) = nonce {
-            tx_env.base.nonce = nonce;
+            tx_env.nonce = nonce;
         }
 
         if evm_env.block_env.basefee == 0 {
@@ -1427,13 +1472,22 @@ impl<N: Network> Backend<N> {
         }
 
         // Deposit transaction? (only valid when op-stack deposits are active)
-        if self.ensure_op_deposits_active().is_ok()
+        #[cfg(feature = "optimism")]
+        let op_deposit = if self.ensure_op_deposits_active().is_ok()
             && let Ok(deposit) = get_deposit_tx_parts(&other)
         {
-            tx_env.deposit = deposit;
-        }
+            deposit
+        } else {
+            OpCallDepositInfo::default()
+        };
+        #[cfg(not(feature = "optimism"))]
+        let op_deposit = {
+            // `other` carries OP-only deposit fields; consumed only when feature is enabled.
+            let _ = &other;
+            OpCallDepositInfo::default()
+        };
 
-        (evm_env, tx_env)
+        (evm_env, tx_env, op_deposit)
     }
 
     pub fn call_with_state(
@@ -1467,13 +1521,13 @@ impl<N: Network> Backend<N> {
             (fee_token, nonce_key, valid_before, valid_after)
         });
 
-        let (evm_env, tx_env) = self.build_call_env(request, fee_details, block_env);
+        let (evm_env, tx_env, op_deposit) = self.build_call_env(request, fee_details, block_env);
 
         let ResultAndState { result, state } =
             if let Some((fee_token, nonce_key, valid_before, valid_after)) = tempo_overrides {
                 use tempo_primitives::transaction::Call;
 
-                let base = tx_env.base;
+                let base = tx_env;
                 let mut tempo_tx = TempoTxEnv::from(base.clone());
                 tempo_tx.fee_token = fee_token;
 
@@ -1495,7 +1549,13 @@ impl<N: Network> Backend<N> {
                 }
                 self.transact_tempo_with_inspector_ref(state, &evm_env, &mut inspector, tempo_tx)?
             } else {
-                self.transact_with_inspector_ref(state, &evm_env, &mut inspector, tx_env)?
+                self.transact_with_inspector_ref(
+                    state,
+                    &evm_env,
+                    &mut inspector,
+                    tx_env,
+                    op_deposit,
+                )?
             };
 
         let (exit_reason, gas_used, out, _logs) = unpack_execution_result(result);
@@ -1518,9 +1578,9 @@ impl<N: Network> Backend<N> {
         let mut inspector =
             AccessListInspector::new(request.access_list.clone().unwrap_or_default());
 
-        let (evm_env, tx_env) = self.build_call_env(request, fee_details, block_env);
+        let (evm_env, tx_env, op_deposit) = self.build_call_env(request, fee_details, block_env);
         let ResultAndState { result, state: _ } =
-            self.transact_with_inspector_ref(state, &evm_env, &mut inspector, tx_env)?;
+            self.transact_with_inspector_ref(state, &evm_env, &mut inspector, tx_env, op_deposit)?;
         let (exit_reason, gas_used, out, _logs) = unpack_execution_result(result);
         let access_list = inspector.access_list();
         Ok((exit_reason, out, gas_used, access_list))
@@ -2912,7 +2972,7 @@ where
                                 TracingInspectorConfig::from_geth_call_config(&call_config),
                             );
 
-                            let (evm_env, tx_env) =
+                            let (evm_env, tx_env, op_deposit) =
                                 self.build_call_env(request, fee_details, block);
                             let ResultAndState { result, state: _ } = self
                                 .transact_with_inspector_ref(
@@ -2920,6 +2980,7 @@ where
                                     &evm_env,
                                     &mut inspector,
                                     tx_env,
+                                    op_deposit,
                                 )?;
 
                             inspector.print_logs();
@@ -2945,13 +3006,14 @@ where
                                 ),
                             );
 
-                            let (evm_env, tx_env) =
+                            let (evm_env, tx_env, op_deposit) =
                                 self.build_call_env(request, fee_details, block);
                             let result = self.transact_with_inspector_ref(
                                 &cache_db,
                                 &evm_env,
                                 &mut inspector,
                                 tx_env,
+                                op_deposit,
                             )?;
 
                             Ok(inspector
@@ -2973,22 +3035,22 @@ where
                     }
                     #[cfg(feature = "js-tracer")]
                     GethDebugTracerType::JsTracer(code) => {
-                        use alloy_evm::IntoTxEnv;
                         let config = tracer_config.into_json();
                         let mut inspector =
                             revm_inspectors::tracing::js::JsInspector::new(code, config)
                                 .map_err(|err| BlockchainError::Message(err.to_string()))?;
 
-                        let (evm_env, tx_env) =
+                        let (evm_env, tx_env, op_deposit) =
                             self.build_call_env(request, fee_details, block.clone());
                         let result = self.transact_with_inspector_ref(
                             &cache_db,
                             &evm_env,
                             &mut inspector,
                             tx_env.clone(),
+                            op_deposit,
                         )?;
                         let res = inspector
-                            .json_result(result, &OpTx(tx_env).into_tx_env(), &block, &cache_db)
+                            .json_result(result, &tx_env, &block, &cache_db)
                             .map_err(|err| BlockchainError::Message(err.to_string()))?;
 
                         Ok(GethTrace::JS(res))
@@ -3001,9 +3063,14 @@ where
                 .build_inspector()
                 .with_tracing_config(TracingInspectorConfig::from_geth_config(&config));
 
-            let (evm_env, tx_env) = self.build_call_env(request, fee_details, block);
-            let ResultAndState { result, state: _ } =
-                self.transact_with_inspector_ref(&cache_db, &evm_env, &mut inspector, tx_env)?;
+            let (evm_env, tx_env, op_deposit) = self.build_call_env(request, fee_details, block);
+            let ResultAndState { result, state: _ } = self.transact_with_inspector_ref(
+                &cache_db,
+                &evm_env,
+                &mut inspector,
+                tx_env,
+                op_deposit,
+            )?;
 
             let (exit_reason, gas_used, out, _logs) = unpack_execution_result(result);
 
@@ -3187,10 +3254,7 @@ where
         f: F,
     ) -> Result<T, BlockchainError>
     where
-        for<'a> I: Inspector<EthEvmContext<WrapDatabaseRef<&'a CacheDB<Box<&'a StateDb>>>>>
-            + Inspector<OpEvmContext<WrapDatabaseRef<&'a CacheDB<Box<&'a StateDb>>>>>
-            + Inspector<TempoContext<WrapDatabaseRef<&'a CacheDB<Box<&'a StateDb>>>>>
-            + 'a,
+        for<'a> I: BackendInspector<WrapDatabaseRef<&'a CacheDB<Box<&'a StateDb>>>> + 'a,
         for<'a> F:
             FnOnce(ResultAndState<HaltReason>, CacheDB<Box<&'a StateDb>>, I, TxEnv, EvmEnv) -> T,
     {
@@ -3965,7 +4029,7 @@ impl Backend<FoundryNetwork> {
                     )?
                     .or_zero_fees();
 
-                    let (mut evm_env, tx_env) = self.build_call_env(
+                    let (mut evm_env, tx_env, op_deposit) = self.build_call_env(
                         WithOtherFields::new(request.clone()),
                         fee_details,
                         block_env.clone(),
@@ -3986,8 +4050,13 @@ impl Backend<FoundryNetwork> {
                         inspector = inspector.with_transfers();
                     }
                     trace!(target: "backend", env=?evm_env, spec=?evm_env.spec_id(),"simulate evm env");
-                    let ResultAndState { result, state } =
-                        self.transact_with_inspector_ref(&cache_db, &evm_env, &mut inspector, tx_env)?;
+                    let ResultAndState { result, state } = self.transact_with_inspector_ref(
+                        &cache_db,
+                        &evm_env,
+                        &mut inspector,
+                        tx_env,
+                        op_deposit,
+                    )?;
                     trace!(target: "backend", ?result, ?request, "simulate call");
 
                     inspector.print_logs();
@@ -4359,7 +4428,10 @@ where
         }
 
         // Nonce validation — skip for deposits (L1→L2) and Tempo txs (2D nonce system)
+        #[cfg(feature = "optimism")]
         let is_deposit_tx = pending.transaction.as_ref().is_deposit();
+        #[cfg(not(feature = "optimism"))]
+        let is_deposit_tx = false;
         let is_tempo_tx = pending.transaction.as_ref().is_tempo();
         let nonce = tx.nonce();
         if nonce < account.nonce && !is_deposit_tx && !is_tempo_tx {
@@ -4475,6 +4547,7 @@ where
                 );
             let value = tx.value();
             match tx.as_ref() {
+                #[cfg(feature = "optimism")]
                 FoundryTxEnvelope::Deposit(deposit_tx) => {
                     // Deposit transactions
                     // https://specs.optimism.io/protocol/deposits.html#execution
@@ -4538,6 +4611,7 @@ pub fn transaction_build(
     info: Option<TransactionInfo>,
     base_fee: Option<u64>,
 ) -> AnyRpcTransaction {
+    #[cfg(feature = "optimism")]
     if let FoundryTxEnvelope::Deposit(deposit_tx) = eth_transaction.as_ref() {
         let dep_tx = deposit_tx;
 

--- a/crates/anvil/src/eth/backend/mem/optimism.rs
+++ b/crates/anvil/src/eth/backend/mem/optimism.rs
@@ -1,0 +1,61 @@
+//! Optimism-specific transact helpers for the in-memory backend.
+
+use super::Backend;
+use crate::eth::error::BlockchainError;
+use alloy_evm::{Database, Evm, EvmEnv, EvmFactory};
+use alloy_network::Network;
+use alloy_op_evm::{OpEvmContext, OpEvmFactory, OpTx};
+use foundry_evm::backend::DatabaseError;
+use op_revm::{OpHaltReason, OpSpecId, OpTransaction};
+use revm::{
+    DatabaseRef, Inspector,
+    context::{
+        TxEnv,
+        result::{EVMError, HaltReason, ResultAndState},
+    },
+    database_interface::WrapDatabaseRef,
+};
+
+impl<N: Network> Backend<N> {
+    /// Optimism path of [`Backend::transact_with_inspector_ref`].
+    ///
+    /// Creates an OP EVM, injects precompiles, transacts, and maps the
+    /// OP-specific halt reason back to the shared [`HaltReason`].
+    pub(super) fn transact_op_with_inspector_ref<'db, I, DB>(
+        &self,
+        db: &'db DB,
+        evm_env: &EvmEnv,
+        inspector: &mut I,
+        tx_env: OpTransaction<TxEnv>,
+    ) -> Result<ResultAndState<HaltReason>, BlockchainError>
+    where
+        DB: DatabaseRef + ?Sized,
+        I: Inspector<OpEvmContext<WrapDatabaseRef<&'db DB>>>,
+        WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
+    {
+        let op_env = EvmEnv::new(
+            evm_env.cfg_env.clone().with_spec_and_mainnet_gas_params(OpSpecId::ISTHMUS),
+            evm_env.block_env.clone(),
+        );
+        let mut evm = OpEvmFactory::default().create_evm_with_inspector(
+            WrapDatabaseRef(db),
+            op_env,
+            inspector,
+        );
+        self.inject_precompiles(evm.precompiles_mut());
+        let result = evm.transact(OpTx(tx_env)).map_err(|e| match e {
+            EVMError::Database(db) => EVMError::Database(db),
+            EVMError::Header(h) => EVMError::Header(h),
+            EVMError::Custom(s) => EVMError::Custom(s),
+            EVMError::CustomAny(err) => EVMError::CustomAny(err),
+            EVMError::Transaction(t) => EVMError::Transaction(t),
+        })?;
+        Ok(ResultAndState {
+            result: result.result.map_haltreason(|h| match h {
+                OpHaltReason::Base(eth) => eth,
+                _ => HaltReason::PrecompileError,
+            }),
+            state: result.state,
+        })
+    }
+}

--- a/crates/anvil/src/eth/error/mod.rs
+++ b/crates/anvil/src/eth/error/mod.rs
@@ -12,7 +12,6 @@ use anvil_rpc::{
     response::ResponseResult,
 };
 use foundry_evm::{backend::DatabaseError, decode::RevertDecoder};
-use op_revm::OpTransactionError;
 use revm::{
     context_interface::result::{EVMError, InvalidHeader, InvalidTransaction},
     interpreter::InstructionResult,
@@ -20,6 +19,9 @@ use revm::{
 use serde::Serialize;
 use tempo_revm::TempoInvalidTransaction;
 use tokio::time::Duration;
+
+#[cfg(feature = "optimism")]
+mod optimism;
 
 pub(crate) type Result<T> = std::result::Result<T, BlockchainError>;
 
@@ -156,51 +158,6 @@ where
                 InvalidHeader::ExcessBlobGasNotSet => Self::ExcessBlobGasNotSet,
                 InvalidHeader::PrevrandaoNotSet => Self::PrevrandaoNotSet,
             },
-            EVMError::Database(err) => err.into(),
-            EVMError::Custom(err) => Self::Message(err),
-            EVMError::CustomAny(err) => Self::Message(err.to_string()),
-        }
-    }
-}
-
-impl<T> From<EVMError<T, OpTransactionError>> for BlockchainError
-where
-    T: Into<Self>,
-{
-    fn from(err: EVMError<T, OpTransactionError>) -> Self {
-        match err {
-            EVMError::Transaction(err) => match err {
-                OpTransactionError::Base(err) => InvalidTransactionError::from(err).into(),
-                OpTransactionError::DepositSystemTxPostRegolith => {
-                    Self::DepositTransactionUnsupported
-                }
-                OpTransactionError::HaltedDepositPostRegolith => {
-                    Self::DepositTransactionUnsupported
-                }
-                OpTransactionError::MissingEnvelopedTx => Self::InvalidTransaction(err.into()),
-            },
-            EVMError::Header(err) => match err {
-                InvalidHeader::ExcessBlobGasNotSet => Self::ExcessBlobGasNotSet,
-                InvalidHeader::PrevrandaoNotSet => Self::PrevrandaoNotSet,
-            },
-            EVMError::Database(err) => err.into(),
-            EVMError::Custom(err) => Self::Message(err),
-            EVMError::CustomAny(err) => Self::Message(err.to_string()),
-        }
-    }
-}
-
-impl<T> From<EVMError<T, alloy_op_evm::OpTxError>> for BlockchainError
-where
-    T: Into<Self>,
-{
-    fn from(err: EVMError<T, alloy_op_evm::OpTxError>) -> Self {
-        match err {
-            EVMError::Transaction(err) => {
-                let op_err: OpTransactionError = err.0;
-                EVMError::<T, OpTransactionError>::Transaction(op_err).into()
-            }
-            EVMError::Header(err) => EVMError::<T, OpTransactionError>::Header(err).into(),
             EVMError::Database(err) => err.into(),
             EVMError::Custom(err) => Self::Message(err),
             EVMError::CustomAny(err) => Self::Message(err.to_string()),
@@ -451,16 +408,6 @@ impl From<InvalidTransaction> for InvalidTransactionError {
     }
 }
 
-impl From<OpTransactionError> for InvalidTransactionError {
-    fn from(value: OpTransactionError) -> Self {
-        match value {
-            OpTransactionError::Base(err) => err.into(),
-            OpTransactionError::DepositSystemTxPostRegolith
-            | OpTransactionError::HaltedDepositPostRegolith => Self::DepositTxErrorPostRegolith,
-            OpTransactionError::MissingEnvelopedTx => Self::MissingEnvelopedTx,
-        }
-    }
-}
 /// Helper trait to easily convert results to rpc results
 pub(crate) trait ToRpcResponseResult {
     fn to_rpc_result(self) -> ResponseResult;

--- a/crates/anvil/src/eth/error/optimism.rs
+++ b/crates/anvil/src/eth/error/optimism.rs
@@ -1,0 +1,62 @@
+//! Optimism-specific error conversions for [`BlockchainError`] and
+//! [`InvalidTransactionError`].
+
+use super::{BlockchainError, InvalidTransactionError};
+use op_revm::OpTransactionError;
+use revm::context_interface::result::{EVMError, InvalidHeader};
+
+impl<T> From<EVMError<T, OpTransactionError>> for BlockchainError
+where
+    T: Into<Self>,
+{
+    fn from(err: EVMError<T, OpTransactionError>) -> Self {
+        match err {
+            EVMError::Transaction(err) => match err {
+                OpTransactionError::Base(err) => InvalidTransactionError::from(err).into(),
+                OpTransactionError::DepositSystemTxPostRegolith => {
+                    Self::DepositTransactionUnsupported
+                }
+                OpTransactionError::HaltedDepositPostRegolith => {
+                    Self::DepositTransactionUnsupported
+                }
+                OpTransactionError::MissingEnvelopedTx => Self::InvalidTransaction(err.into()),
+            },
+            EVMError::Header(err) => match err {
+                InvalidHeader::ExcessBlobGasNotSet => Self::ExcessBlobGasNotSet,
+                InvalidHeader::PrevrandaoNotSet => Self::PrevrandaoNotSet,
+            },
+            EVMError::Database(err) => err.into(),
+            EVMError::Custom(err) => Self::Message(err),
+            EVMError::CustomAny(err) => Self::Message(err.to_string()),
+        }
+    }
+}
+
+impl<T> From<EVMError<T, alloy_op_evm::OpTxError>> for BlockchainError
+where
+    T: Into<Self>,
+{
+    fn from(err: EVMError<T, alloy_op_evm::OpTxError>) -> Self {
+        match err {
+            EVMError::Transaction(err) => {
+                let op_err: OpTransactionError = err.0;
+                EVMError::<T, OpTransactionError>::Transaction(op_err).into()
+            }
+            EVMError::Header(err) => EVMError::<T, OpTransactionError>::Header(err).into(),
+            EVMError::Database(err) => err.into(),
+            EVMError::Custom(err) => Self::Message(err),
+            EVMError::CustomAny(err) => Self::Message(err.to_string()),
+        }
+    }
+}
+
+impl From<OpTransactionError> for InvalidTransactionError {
+    fn from(value: OpTransactionError) -> Self {
+        match value {
+            OpTransactionError::Base(err) => err.into(),
+            OpTransactionError::DepositSystemTxPostRegolith
+            | OpTransactionError::HaltedDepositPostRegolith => Self::DepositTxErrorPostRegolith,
+            OpTransactionError::MissingEnvelopedTx => Self::MissingEnvelopedTx,
+        }
+    }
+}

--- a/crates/anvil/src/eth/sign.rs
+++ b/crates/anvil/src/eth/sign.rs
@@ -1,5 +1,7 @@
 use crate::eth::error::BlockchainError;
-use alloy_consensus::{Sealed, SignableTransaction};
+#[cfg(feature = "optimism")]
+use alloy_consensus::Sealed;
+use alloy_consensus::SignableTransaction;
 use alloy_dyn_abi::TypedData;
 use alloy_network::{Network, TxSignerSync};
 use alloy_primitives::{Address, B256, Signature, map::AddressHashMap};
@@ -130,9 +132,11 @@ impl Signer<foundry_primitives::FoundryNetwork> for DevSigner {
                 let sig = signer.sign_transaction_sync(&mut t)?;
                 FoundryTxEnvelope::Eip4844(t.into_signed(sig))
             }
+            #[cfg(feature = "optimism")]
             FoundryTypedTx::Deposit(_) => {
                 unreachable!("op deposit txs should not be signed")
             }
+            #[cfg(feature = "optimism")]
             FoundryTypedTx::PostExec(_) => {
                 unreachable!("op post-exec txs should not be signed")
             }
@@ -156,7 +160,9 @@ pub fn build_impersonated(typed_tx: FoundryTypedTx) -> FoundryTxEnvelope {
         FoundryTypedTx::Eip1559(tx) => FoundryTxEnvelope::Eip1559(tx.into_signed(signature)),
         FoundryTypedTx::Eip7702(tx) => FoundryTxEnvelope::Eip7702(tx.into_signed(signature)),
         FoundryTypedTx::Eip4844(tx) => FoundryTxEnvelope::Eip4844(tx.into_signed(signature)),
+        #[cfg(feature = "optimism")]
         FoundryTypedTx::Deposit(tx) => FoundryTxEnvelope::Deposit(Sealed::new(tx)),
+        #[cfg(feature = "optimism")]
         FoundryTypedTx::PostExec(_) => {
             unreachable!("op post-exec txs should not be impersonated")
         }

--- a/crates/anvil/src/evm/mod.rs
+++ b/crates/anvil/src/evm/mod.rs
@@ -2,6 +2,9 @@ use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::Address;
 use std::fmt::Debug;
 
+#[cfg(feature = "optimism")]
+mod optimism;
+
 /// Object-safe trait that enables injecting extra precompiles when using
 /// `anvil` as a library.
 pub trait PrecompileFactory: Send + Sync + Unpin + Debug {
@@ -15,14 +18,12 @@ mod tests {
 
     use crate::PrecompileFactory;
     use alloy_evm::{
-        EthEvm, Evm, EvmEnv, EvmFactory,
+        EthEvm, Evm,
         eth::EthEvmContext,
         precompiles::{DynPrecompile, PrecompilesMap},
     };
-    use alloy_op_evm::{OpEvm, OpEvmFactory, OpTx};
-    use alloy_primitives::{Address, Bytes, TxKind, U256, address};
+    use alloy_primitives::{Address, Bytes, TxKind, address};
     use itertools::Itertools;
-    use op_revm::{OpSpecId, OpTransaction};
     use revm::{
         Journal,
         context::{BlockEnv, CfgEnv, Evm as RevmEvm, JournalTr, LocalContext, TxEnv},
@@ -35,20 +36,19 @@ mod tests {
     };
 
     // A precompile activated in the `Prague` spec (BLS12-381 G2 map).
-    const ETH_PRAGUE_PRECOMPILE: Address = address!("0x0000000000000000000000000000000000000011");
+    pub(super) const ETH_PRAGUE_PRECOMPILE: Address =
+        address!("0x0000000000000000000000000000000000000011");
 
     // A precompile activated in the `Osaka` spec (EIP-7951).
     const ETH_OSAKA_PRECOMPILE: Address = address!("0x0000000000000000000000000000000000000100");
 
-    // A precompile activated in the `Isthmus` spec.
-    const OP_ISTHMUS_PRECOMPILE: Address = address!("0x0000000000000000000000000000000000000100");
-
     // A custom precompile address and payload for testing.
-    const PRECOMPILE_ADDR: Address = address!("0x0000000000000000000000000000000000000071");
-    const PAYLOAD: &[u8] = &[0xde, 0xad, 0xbe, 0xef];
+    pub(super) const PRECOMPILE_ADDR: Address =
+        address!("0x0000000000000000000000000000000000000071");
+    pub(super) const PAYLOAD: &[u8] = &[0xde, 0xad, 0xbe, 0xef];
 
     #[derive(Debug)]
-    struct CustomPrecompileFactory;
+    pub(super) struct CustomPrecompileFactory;
 
     impl PrecompileFactory for CustomPrecompileFactory {
         fn precompiles(&self) -> Vec<(Address, DynPrecompile)> {
@@ -109,34 +109,6 @@ mod tests {
         (tx_env, eth_evm)
     }
 
-    /// Creates a new OP EVM instance.
-    fn create_op_evm(
-        _spec: SpecId,
-        op_spec: OpSpecId,
-    ) -> (OpTx, OpEvm<EmptyDBTyped<Infallible>, NoOpInspector, PrecompilesMap, OpTx>) {
-        let tx = OpTx(OpTransaction::<TxEnv> {
-            base: TxEnv {
-                kind: TxKind::Call(PRECOMPILE_ADDR),
-                data: PAYLOAD.into(),
-                ..Default::default()
-            },
-            ..Default::default()
-        });
-
-        let mut evm = OpEvmFactory::<OpTx>::default().create_evm_with_inspector(
-            EmptyDB::default(),
-            EvmEnv::new(CfgEnv::new_with_spec(op_spec), BlockEnv::default()),
-            NoOpInspector,
-        );
-
-        if op_spec == OpSpecId::ISTHMUS {
-            evm.ctx_mut().chain.operator_fee_constant = Some(U256::ZERO);
-            evm.ctx_mut().chain.operator_fee_scalar = Some(U256::ZERO);
-        }
-
-        (tx, evm)
-    }
-
     #[test]
     fn build_eth_evm_with_extra_precompiles_osaka_spec() {
         let (tx_env, mut evm) = create_eth_evm(SpecId::OSAKA);
@@ -184,40 +156,6 @@ mod tests {
         assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
 
         let result = evm.transact(tx_env).unwrap();
-        assert!(result.result.is_success());
-        assert_eq!(result.result.output(), Some(&PAYLOAD.into()));
-    }
-
-    #[test]
-    fn build_op_evm_with_extra_precompiles_isthmus_spec() {
-        let (tx, mut evm) = create_op_evm(SpecId::OSAKA, OpSpecId::ISTHMUS);
-
-        assert!(evm.precompiles().addresses().contains(&OP_ISTHMUS_PRECOMPILE));
-        assert!(evm.precompiles().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
-        assert!(!evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
-
-        evm.precompiles_mut().extend_precompiles(CustomPrecompileFactory.precompiles());
-
-        assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
-
-        let result = evm.transact(tx).unwrap();
-        assert!(result.result.is_success());
-        assert_eq!(result.result.output(), Some(&PAYLOAD.into()));
-    }
-
-    #[test]
-    fn build_op_evm_with_extra_precompiles_bedrock_spec() {
-        let (tx, mut evm) = create_op_evm(SpecId::OSAKA, OpSpecId::BEDROCK);
-
-        assert!(!evm.precompiles().addresses().contains(&OP_ISTHMUS_PRECOMPILE));
-        assert!(!evm.precompiles().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
-        assert!(!evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
-
-        evm.precompiles_mut().extend_precompiles(CustomPrecompileFactory.precompiles());
-
-        assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
-
-        let result = evm.transact(tx).unwrap();
         assert!(result.result.is_success());
         assert_eq!(result.result.output(), Some(&PAYLOAD.into()));
     }

--- a/crates/anvil/src/evm/optimism.rs
+++ b/crates/anvil/src/evm/optimism.rs
@@ -1,0 +1,87 @@
+//! Optimism-specific EVM helpers.
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use super::super::tests::{
+        CustomPrecompileFactory, ETH_PRAGUE_PRECOMPILE, PAYLOAD, PRECOMPILE_ADDR,
+    };
+    use crate::PrecompileFactory;
+    use alloy_evm::{Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
+    use alloy_op_evm::{OpEvm, OpEvmFactory, OpTx};
+    use alloy_primitives::{Address, TxKind, U256, address};
+    use itertools::Itertools;
+    use op_revm::{OpSpecId, OpTransaction};
+    use revm::{
+        context::{BlockEnv, CfgEnv, TxEnv},
+        database::{EmptyDB, EmptyDBTyped},
+        inspector::NoOpInspector,
+        primitives::hardfork::SpecId,
+    };
+
+    // A precompile activated in the `Isthmus` spec.
+    const OP_ISTHMUS_PRECOMPILE: Address = address!("0x0000000000000000000000000000000000000100");
+
+    /// Creates a new OP EVM instance.
+    fn create_op_evm(
+        _spec: SpecId,
+        op_spec: OpSpecId,
+    ) -> (OpTx, OpEvm<EmptyDBTyped<Infallible>, NoOpInspector, PrecompilesMap, OpTx>) {
+        let tx = OpTx(OpTransaction::<TxEnv> {
+            base: TxEnv {
+                kind: TxKind::Call(PRECOMPILE_ADDR),
+                data: PAYLOAD.into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let mut evm = OpEvmFactory::<OpTx>::default().create_evm_with_inspector(
+            EmptyDB::default(),
+            EvmEnv::new(CfgEnv::new_with_spec(op_spec), BlockEnv::default()),
+            NoOpInspector,
+        );
+
+        if op_spec == OpSpecId::ISTHMUS {
+            evm.ctx_mut().chain.operator_fee_constant = Some(U256::ZERO);
+            evm.ctx_mut().chain.operator_fee_scalar = Some(U256::ZERO);
+        }
+
+        (tx, evm)
+    }
+
+    #[test]
+    fn build_op_evm_with_extra_precompiles_isthmus_spec() {
+        let (tx, mut evm) = create_op_evm(SpecId::OSAKA, OpSpecId::ISTHMUS);
+
+        assert!(evm.precompiles().addresses().contains(&OP_ISTHMUS_PRECOMPILE));
+        assert!(evm.precompiles().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
+        assert!(!evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
+
+        evm.precompiles_mut().extend_precompiles(CustomPrecompileFactory.precompiles());
+
+        assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
+
+        let result = evm.transact(tx).unwrap();
+        assert!(result.result.is_success());
+        assert_eq!(result.result.output(), Some(&PAYLOAD.into()));
+    }
+
+    #[test]
+    fn build_op_evm_with_extra_precompiles_bedrock_spec() {
+        let (tx, mut evm) = create_op_evm(SpecId::OSAKA, OpSpecId::BEDROCK);
+
+        assert!(!evm.precompiles().addresses().contains(&OP_ISTHMUS_PRECOMPILE));
+        assert!(!evm.precompiles().addresses().contains(&ETH_PRAGUE_PRECOMPILE));
+        assert!(!evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
+
+        evm.precompiles_mut().extend_precompiles(CustomPrecompileFactory.precompiles());
+
+        assert!(evm.precompiles().addresses().contains(&PRECOMPILE_ADDR));
+
+        let result = evm.transact(tx).unwrap();
+        assert!(result.result.is_success());
+        assert_eq!(result.result.output(), Some(&PAYLOAD.into()));
+    }
+}

--- a/crates/anvil/tests/it/main.rs
+++ b/crates/anvil/tests/it/main.rs
@@ -11,6 +11,7 @@ mod gas;
 mod genesis;
 mod ipc;
 mod logs;
+#[cfg(feature = "optimism")]
 mod optimism;
 mod otterscan;
 mod proof;


### PR DESCRIPTION
Adds a default-on `optimism` cargo feature to `anvil` and `anvil-core`, gating all OP-specific code, deps, and tests. Phase 5 of the workspace optimism feature-gate rollout (follows #14572).

**Changes:**
- `anvil` and `anvil-core` Cargo.toml: new `optimism` feature (default-on), `op-revm` / `alloy-op-evm` / `op-alloy-consensus` marked optional.
- `crates/anvil/src/eth/backend/mem/mod.rs`: refactored `build_call_env` and `transact_with_inspector_ref` so the eth path uses plain `TxEnv` (no longer wraps in `OpTransaction`); OP path gated behind the feature; new `BackendInspector` marker trait abstracts the per-network inspector bounds.
- OP imports, dispatch branches, error conversions, receipt construction, and test scaffolding all gated.
- New sibling `optimism.rs` submodules under `mem/`, `error/`, `evm/`.

**Verification:**
- `cargo build --workspace` ✅
- `cargo build --workspace --no-default-features` ✅
- `cargo test -p anvil --lib` passes on both feature configurations.

**Known residual OP leak:** `cargo tree -p anvil --no-default-features` still shows `op-revm`, `alloy-op-evm`, and `op-alloy-consensus` reaching anvil transitively via `foundry-evm-core` → `foundry-cheatcodes` → `foundry-evm`. `foundry-evm-core` has `alloy-op-evm` as a hard dep and uses `op_alloy_network::Optimism` directly. Closing this leak requires gating `foundry-evm-core` / `foundry-evm-networks` / `foundry-evm` (Phases 7 and 8 of the rollout plan) and is intentionally out of scope for this PR.
