### PR TITLE
fix(doc): preserve NatSpec blank lines in forge doc

### DIFF
--- a/crates/doc/src/parser/comment.rs
+++ b/crates/doc/src/parser/comment.rs
@@ -173,10 +173,18 @@ impl Comments {
             }
         };
 
+        fn push_continuation(value: &mut String, line: &str) {
+            if value.is_empty() {
+                value.push_str(line);
+            } else {
+                value.push('\n');
+                value.push_str(line);
+            }
+        }
+
         for raw_line in lines {
             let raw = raw_line.as_ref();
-            // For block comments, process each line individually
-            for line in raw.lines() {
+            let mut process_line = |line: &str| {
                 let trimmed = line.trim().trim_start_matches('*').trim();
 
                 if let Some(rest) = trimmed.strip_prefix('@') {
@@ -186,14 +194,19 @@ impl Comments {
                     let (tag, value) = rest.split_once(char::is_whitespace).unwrap_or((rest, ""));
                     current_tag = Some(tag.to_string());
                     current_value = value.trim().to_string();
-                } else if !trimmed.is_empty() {
+                } else if !trimmed.is_empty() || !current_value.is_empty() {
                     // Continuation of current tag
-                    if current_value.is_empty() {
-                        current_value = trimmed.to_string();
-                    } else {
-                        current_value.push('\n');
-                        current_value.push_str(trimmed);
-                    }
+                    push_continuation(&mut current_value, trimmed);
+                }
+            };
+
+            // For block comments, process each line individually. Empty `///` comments are
+            // represented as empty symbols, but `str::lines` yields no items for an empty string.
+            if raw.is_empty() {
+                process_line("");
+            } else {
+                for line in raw.lines() {
+                    process_line(line);
                 }
             }
         }
@@ -313,5 +326,36 @@ mod tests {
                 "Non-custom tag {tag:?} should return false for is_custom"
             );
         }
+    }
+
+    #[test]
+    fn parse_comment_preserves_empty_lines_within_tag_values() {
+        let comments = Comments::from_doc_lines([
+            "@notice Transfers the admin of the contract to a new address.",
+            "",
+            "Notes:",
+            "- Does not revert if the admin is the same.",
+            "",
+            "Requirements:",
+            "- The caller must be the current contract admin.",
+            "",
+            "@param newAdmin The address of the new admin.",
+        ]);
+
+        assert_eq!(comments.len(), 2);
+        assert_eq!(
+            comments[0],
+            Comment::new(
+                CommentTag::Notice,
+                "Transfers the admin of the contract to a new address.\n\nNotes:\n- Does not \
+                 revert if the admin is the same.\n\nRequirements:\n- The caller must be the \
+                 current contract admin."
+                    .to_owned()
+            )
+        );
+        assert_eq!(
+            comments[1],
+            Comment::new(CommentTag::Param, "newAdmin The address of the new admin.".to_owned())
+        );
     }
 }

--- a/crates/doc/src/parser/mod.rs
+++ b/crates/doc/src/parser/mod.rs
@@ -457,4 +457,43 @@ mod tests {
             Comment::new(CommentTag::Notice, "my function\ni like whitespace".to_owned())
         );
     }
+
+    #[test]
+    fn contract_with_doc_comments_preserves_empty_lines() {
+        let items = parse_source(
+            r"
+            interface IAdmin {
+                /// @notice Transfers the admin of the contract to a new address.
+                ///
+                /// Notes:
+                /// - Does not revert if the admin is the same.
+                ///
+                /// Requirements:
+                /// - The caller must be the current contract admin.
+                ///
+                /// @param newAdmin The address of the new admin.
+                function transferAdmin(address newAdmin) external;
+            }
+        ",
+        );
+
+        assert_eq!(items.len(), 1);
+
+        let contract = items.first().unwrap();
+        let function = contract.children.first().unwrap();
+        assert_eq!(
+            function.comments[0],
+            Comment::new(
+                CommentTag::Notice,
+                "Transfers the admin of the contract to a new address.\n\nNotes:\n- Does not \
+                 revert if the admin is the same.\n\nRequirements:\n- The caller must be the \
+                 current contract admin."
+                    .to_owned()
+            )
+        );
+        assert_eq!(
+            function.comments[1],
+            Comment::new(CommentTag::Param, "newAdmin The address of the new admin.".to_owned())
+        );
+    }
 }


### PR DESCRIPTION
Closes #4539

## Motivation

`forge doc` currently drops empty lines inside NatSpec tag bodies, so Markdown paragraph breaks such as the blank line between a notice summary and a `Notes:` section are lost in generated documentation.

## Solution

Preserve empty doc comment lines while parsing NatSpec continuations, including empty `///` symbols that `str::lines()` would otherwise skip. Added parser coverage for both direct comment parsing and Solidity source parsing to ensure blank lines are retained before `@param` tags are separated.

## Tests

- `cargo +nightly fmt --check`
- `cargo +1.94.0 test -p forge-doc`
- `git diff --check`

## AI Assistance Disclosure

This PR was prepared with assistance from ChatGPT/Codex for issue investigation, implementation, and PR text drafting.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes