### PR TITLE
feat(hardforks, networks): gate optimism behind cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,7 +328,7 @@ foundry-evm = { path = "crates/evm/evm" }
 foundry-evm-abi = { path = "crates/evm/abi" }
 foundry-evm-core = { path = "crates/evm/core" }
 foundry-evm-coverage = { path = "crates/evm/coverage" }
-foundry-evm-hardforks = { path = "crates/evm/hardforks" }
+foundry-evm-hardforks = { path = "crates/evm/hardforks", default-features = false }
 foundry-evm-networks = { path = "crates/evm/networks" }
 foundry-evm-fuzz = { path = "crates/evm/fuzz" }
 foundry-evm-sancov = { path = "crates/evm/sancov" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-abi = { path = "crates/evm/abi" }
 foundry-evm-core = { path = "crates/evm/core" }
 foundry-evm-coverage = { path = "crates/evm/coverage" }
 foundry-evm-hardforks = { path = "crates/evm/hardforks", default-features = false }
-foundry-evm-networks = { path = "crates/evm/networks" }
+foundry-evm-networks = { path = "crates/evm/networks", default-features = false }
 foundry-evm-fuzz = { path = "crates/evm/fuzz" }
 foundry-evm-sancov = { path = "crates/evm/sancov" }
 foundry-evm-traces = { path = "crates/evm/traces" }

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -27,7 +27,7 @@ foundry-cli.workspace = true
 foundry-common.workspace = true
 foundry-config.workspace = true
 foundry-evm.workspace = true
-foundry-evm-networks.workspace = true
+foundry-evm-networks = { workspace = true, features = ["optimism"] }
 foundry-primitives = { workspace = true, features = ["optimism"] }
 tempo-chainspec.workspace = true
 tempo-primitives.workspace = true

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -490,12 +490,12 @@ impl<N: Network> Backend<N> {
     }
 
     /// Returns true if op-stack deposits are active
-    pub fn is_optimism(&self) -> bool {
+    pub const fn is_optimism(&self) -> bool {
         self.networks.is_optimism()
     }
 
     /// Returns true if Tempo network mode is active
-    pub fn is_tempo(&self) -> bool {
+    pub const fn is_tempo(&self) -> bool {
         self.networks.is_tempo()
     }
 
@@ -589,7 +589,7 @@ impl<N: Network> Backend<N> {
     }
 
     /// Returns an error if op-stack deposits are not active
-    pub fn ensure_op_deposits_active(&self) -> Result<(), BlockchainError> {
+    pub const fn ensure_op_deposits_active(&self) -> Result<(), BlockchainError> {
         if self.is_optimism() {
             return Ok(());
         }
@@ -597,7 +597,7 @@ impl<N: Network> Backend<N> {
     }
 
     /// Returns an error if Tempo transactions are not active
-    pub fn ensure_tempo_active(&self) -> Result<(), BlockchainError> {
+    pub const fn ensure_tempo_active(&self) -> Result<(), BlockchainError> {
         if self.is_tempo() {
             return Ok(());
         }

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -28,7 +28,7 @@ foundry-compilers.workspace = true
 foundry-config.workspace = true
 foundry-debugger.workspace = true
 foundry-evm.workspace = true
-foundry-evm-networks.workspace = true
+foundry-evm-networks = { workspace = true, features = ["optimism"] }
 foundry-wallets = { workspace = true, features = ["browser", "tempo"] }
 forge-fmt.workspace = true
 

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -19,7 +19,7 @@ foundry-common.workspace = true
 foundry-config.workspace = true
 foundry-evm-abi.workspace = true
 foundry-evm-hardforks.workspace = true
-foundry-evm-networks.workspace = true
+foundry-evm-networks = { workspace = true, features = ["optimism"] }
 
 alloy-chains.workspace = true
 alloy-dyn-abi = { workspace = true, features = ["arbitrary", "eip712"] }

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -22,7 +22,7 @@ foundry-evm-core.workspace = true
 foundry-evm-coverage.workspace = true
 foundry-evm-fuzz.workspace = true
 foundry-evm-sancov.workspace = true
-foundry-evm-hardforks.workspace = true
+foundry-evm-hardforks = { workspace = true, features = ["optimism"] }
 foundry-evm-networks.workspace = true
 foundry-evm-traces.workspace = true
 

--- a/crates/evm/hardforks/Cargo.toml
+++ b/crates/evm/hardforks/Cargo.toml
@@ -16,10 +16,14 @@ workspace = true
 [dependencies]
 alloy-chains.workspace = true
 alloy-hardforks = { workspace = true, features = ["serde"] }
-alloy-op-hardforks = { workspace = true, features = ["serde"] }
+alloy-op-hardforks = { workspace = true, features = ["serde"], optional = true }
 alloy-rpc-types.workspace = true
-op-revm.workspace = true
+op-revm = { workspace = true, optional = true }
 revm.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tempo-chainspec.workspace = true
 foundry-compilers.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = ["dep:alloy-op-hardforks", "dep:op-revm"]

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -8,11 +8,13 @@ use std::str::FromStr;
 use alloy_chains::Chain;
 use alloy_rpc_types::BlockNumberOrTag;
 use foundry_compilers::artifacts::EvmVersion;
+#[cfg(feature = "optimism")]
 use op_revm::OpSpecId;
 use revm::primitives::hardfork::SpecId;
 use serde::{Deserialize, Serialize};
 
 pub use alloy_hardforks::EthereumHardfork;
+#[cfg(feature = "optimism")]
 pub use alloy_op_hardforks::OpHardfork;
 pub use tempo_chainspec::hardfork::TempoHardfork;
 
@@ -20,6 +22,7 @@ pub use tempo_chainspec::hardfork::TempoHardfork;
 #[serde(into = "String")]
 pub enum FoundryHardfork {
     Ethereum(EthereumHardfork),
+    #[cfg(feature = "optimism")]
     Optimism(OpHardfork),
     Tempo(TempoHardfork),
 }
@@ -28,6 +31,7 @@ impl From<FoundryHardfork> for String {
     fn from(fork: FoundryHardfork) -> Self {
         match fork {
             FoundryHardfork::Ethereum(h) => format!("{h}"),
+            #[cfg(feature = "optimism")]
             FoundryHardfork::Optimism(h) => format!("optimism:{h}"),
             FoundryHardfork::Tempo(h) => format!("tempo:{h}"),
         }
@@ -64,6 +68,7 @@ impl FromStr for FoundryHardfork {
                 .map(Self::Ethereum)
                 .map_err(|_| format!("unknown ethereum hardfork '{fork_raw}'")),
 
+            #[cfg(feature = "optimism")]
             "op" | "optimism" => OpHardfork::from_str(&fork)
                 .map(Self::Optimism)
                 .map_err(|_| format!("unknown optimism hardfork '{fork_raw}'")),
@@ -83,6 +88,7 @@ impl FoundryHardfork {
         Self::Ethereum(h)
     }
 
+    #[cfg(feature = "optimism")]
     pub const fn optimism(h: OpHardfork) -> Self {
         Self::Optimism(h)
     }
@@ -95,6 +101,7 @@ impl FoundryHardfork {
     pub fn name(&self) -> String {
         match self {
             Self::Ethereum(h) => format!("{h}"),
+            #[cfg(feature = "optimism")]
             Self::Optimism(h) => format!("{h}"),
             Self::Tempo(h) => format!("{h}"),
         }
@@ -106,6 +113,7 @@ impl FoundryHardfork {
     pub const fn namespace(&self) -> Option<&'static str> {
         match self {
             Self::Ethereum(_) => None,
+            #[cfg(feature = "optimism")]
             Self::Optimism(_) => Some("optimism"),
             Self::Tempo(_) => Some("tempo"),
         }
@@ -119,6 +127,7 @@ impl FoundryHardfork {
         if let Some(fork) = EthereumHardfork::from_chain_and_timestamp(chain, timestamp) {
             return Some(Self::Ethereum(fork));
         }
+        #[cfg(feature = "optimism")]
         if let Some(fork) = OpHardfork::from_chain_and_timestamp(chain, timestamp) {
             return Some(Self::Optimism(fork));
         }
@@ -143,12 +152,14 @@ impl From<FoundryHardfork> for EthereumHardfork {
     }
 }
 
+#[cfg(feature = "optimism")]
 impl From<OpHardfork> for FoundryHardfork {
     fn from(value: OpHardfork) -> Self {
         Self::Optimism(value)
     }
 }
 
+#[cfg(feature = "optimism")]
 impl From<FoundryHardfork> for OpHardfork {
     fn from(fork: FoundryHardfork) -> Self {
         match fork {
@@ -177,12 +188,14 @@ impl From<FoundryHardfork> for SpecId {
     fn from(fork: FoundryHardfork) -> Self {
         match fork {
             FoundryHardfork::Ethereum(hardfork) => spec_id_from_ethereum_hardfork(hardfork),
+            #[cfg(feature = "optimism")]
             FoundryHardfork::Optimism(hardfork) => spec_id_from_optimism_hardfork(hardfork).into(),
             FoundryHardfork::Tempo(hardfork) => hardfork.into(),
         }
     }
 }
 
+#[cfg(feature = "optimism")]
 impl From<FoundryHardfork> for OpSpecId {
     fn from(fork: FoundryHardfork) -> Self {
         match fork {
@@ -223,6 +236,7 @@ pub fn spec_id_from_ethereum_hardfork(hardfork: EthereumHardfork) -> SpecId {
 }
 
 /// Map an `OptimismHardfork` enum into its corresponding `OpSpecId`.
+#[cfg(feature = "optimism")]
 pub fn spec_id_from_optimism_hardfork(hardfork: OpHardfork) -> OpSpecId {
     match hardfork {
         OpHardfork::Bedrock => OpSpecId::BEDROCK,
@@ -265,6 +279,7 @@ impl FromEvmVersion for SpecId {
     }
 }
 
+#[cfg(feature = "optimism")]
 impl FromEvmVersion for OpSpecId {
     fn from_evm_version(version: EvmVersion) -> Self {
         match version {
@@ -325,16 +340,6 @@ mod tests {
     }
 
     #[test]
-    fn test_optimism_spec_id_mapping() {
-        assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Bedrock), OpSpecId::BEDROCK);
-        assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Regolith), OpSpecId::REGOLITH);
-
-        // Test latest hardforks
-        assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Holocene), OpSpecId::HOLOCENE);
-        assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Interop), OpSpecId::INTEROP);
-    }
-
-    #[test]
     fn test_tempo_spec_id_mapping() {
         assert_eq!(SpecId::from(TempoHardfork::Genesis), SpecId::OSAKA);
     }
@@ -371,25 +376,40 @@ mod tests {
     }
 
     #[test]
-    fn test_from_chain_and_timestamp_op_mainnet() {
-        let op_chain_id = 10;
-        assert!(matches!(
-            FoundryHardfork::from_chain_and_timestamp(op_chain_id, u64::MAX),
-            Some(FoundryHardfork::Optimism(_))
-        ));
-    }
-
-    #[test]
-    fn test_from_chain_and_timestamp_base() {
-        let base_chain_id = 8453;
-        assert!(matches!(
-            FoundryHardfork::from_chain_and_timestamp(base_chain_id, u64::MAX),
-            Some(FoundryHardfork::Optimism(_))
-        ));
-    }
-
-    #[test]
     fn test_from_chain_and_timestamp_unknown_chain() {
         assert_eq!(FoundryHardfork::from_chain_and_timestamp(999999, 0), None);
+    }
+
+    #[cfg(feature = "optimism")]
+    mod optimism {
+        use super::*;
+
+        #[test]
+        fn test_optimism_spec_id_mapping() {
+            assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Bedrock), OpSpecId::BEDROCK);
+            assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Regolith), OpSpecId::REGOLITH);
+
+            // Test latest hardforks
+            assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Holocene), OpSpecId::HOLOCENE);
+            assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Interop), OpSpecId::INTEROP);
+        }
+
+        #[test]
+        fn test_from_chain_and_timestamp_op_mainnet() {
+            let op_chain_id = 10;
+            assert!(matches!(
+                FoundryHardfork::from_chain_and_timestamp(op_chain_id, u64::MAX),
+                Some(FoundryHardfork::Optimism(_))
+            ));
+        }
+
+        #[test]
+        fn test_from_chain_and_timestamp_base() {
+            let base_chain_id = 8453;
+            assert!(matches!(
+                FoundryHardfork::from_chain_and_timestamp(base_chain_id, u64::MAX),
+                Some(FoundryHardfork::Optimism(_))
+            ));
+        }
     }
 }

--- a/crates/evm/networks/Cargo.toml
+++ b/crates/evm/networks/Cargo.toml
@@ -14,12 +14,12 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-foundry-evm-hardforks = { workspace = true, features = ["optimism"] }
+foundry-evm-hardforks.workspace = true
 
 alloy-chains.workspace = true
 alloy-eips.workspace = true
 alloy-evm.workspace = true
-alloy-op-hardforks.workspace = true
+alloy-op-hardforks = { workspace = true, optional = true }
 alloy-primitives = { workspace = true, features = [
     "serde",
     "getrandom",
@@ -44,3 +44,7 @@ serde.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = ["dep:alloy-op-hardforks", "foundry-evm-hardforks/optimism"]

--- a/crates/evm/networks/Cargo.toml
+++ b/crates/evm/networks/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-foundry-evm-hardforks.workspace = true
+foundry-evm-hardforks = { workspace = true, features = ["optimism"] }
 
 alloy-chains.workspace = true
 alloy-eips.workspace = true

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -11,7 +11,6 @@ use alloy_chains::{
 };
 use alloy_eips::eip1559::BaseFeeParams;
 use alloy_evm::precompiles::PrecompilesMap;
-use alloy_op_hardforks::{OpChainHardforks, OpHardforks};
 use alloy_primitives::{Address, ChainId, map::AddressHashMap};
 use clap::Parser;
 use foundry_evm_hardforks::FoundryHardfork;
@@ -19,6 +18,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 pub mod celo;
+
+#[cfg(feature = "optimism")]
+mod optimism;
 
 #[derive(
     Clone,
@@ -39,6 +41,7 @@ pub mod celo;
 pub enum NetworkVariant {
     #[default]
     Ethereum,
+    #[cfg(feature = "optimism")]
     Optimism,
     Tempo,
 }
@@ -49,6 +52,7 @@ impl std::str::FromStr for NetworkVariant {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "ethereum" => Ok(Self::Ethereum),
+            #[cfg(feature = "optimism")]
             "optimism" => Ok(Self::Optimism),
             "tempo" => Ok(Self::Tempo),
             _ => Err(format!("unknown network variant: {s}")),
@@ -60,6 +64,7 @@ impl NetworkVariant {
     pub const fn name(&self) -> &'static str {
         match self {
             Self::Ethereum => "ethereum",
+            #[cfg(feature = "optimism")]
             Self::Optimism => "optimism",
             Self::Tempo => "tempo",
         }
@@ -76,32 +81,37 @@ impl From<ChainId> for NetworkVariant {
     fn from(chain_id: ChainId) -> Self {
         let chain = Chain::from_id(chain_id);
         if chain.is_tempo() {
-            Self::Tempo
-        } else if chain.is_optimism() {
-            Self::Optimism
-        } else {
-            Self::Ethereum
+            return Self::Tempo;
         }
+        #[cfg(feature = "optimism")]
+        if chain.is_optimism() {
+            return Self::Optimism;
+        }
+        Self::Ethereum
     }
 }
 
 #[derive(Clone, Debug, Default, Parser, Deserialize, Copy, PartialEq, Eq)]
 pub struct NetworkConfigs {
     /// Enable a specific network family.
-    #[arg(help_heading = "Networks", long, short, num_args = 1, value_name = "NETWORK", value_enum, conflicts_with_all = ["celo", "optimism", "tempo"])]
+    #[arg(help_heading = "Networks", long, short, num_args = 1, value_name = "NETWORK", value_enum, conflicts_with_all = ["celo", "tempo"])]
+    #[cfg_attr(feature = "optimism", arg(conflicts_with = "optimism"))]
     #[serde(default)]
-    network: Option<NetworkVariant>,
+    pub(crate) network: Option<NetworkVariant>,
     /// Enable Celo network features.
-    #[arg(help_heading = "Networks", long, conflicts_with_all = ["network", "optimism", "tempo"])]
+    #[arg(help_heading = "Networks", long, conflicts_with_all = ["network", "tempo"])]
+    #[cfg_attr(feature = "optimism", arg(conflicts_with = "optimism"))]
     celo: bool,
     /// Enable Optimism network features (deprecated: use --network optimism).
+    #[cfg(feature = "optimism")]
     #[arg(long, hide = true, conflicts_with_all = ["network", "celo", "tempo"])]
     // Deserialize-only legacy alias: accepted in foundry.toml but never serialized — the
     // canonical form is `network = "optimism"`.
     #[serde(default)]
-    optimism: bool,
+    pub(crate) optimism: bool,
     /// Enable Tempo network features (deprecated: use --network tempo).
-    #[arg(long, hide = true, conflicts_with_all = ["network", "celo", "optimism"])]
+    #[arg(long, hide = true, conflicts_with_all = ["network", "celo"])]
+    #[cfg_attr(feature = "optimism", arg(conflicts_with = "optimism"))]
     // Deserialize-only legacy alias: accepted in foundry.toml but never serialized — the
     // canonical form is `network = "tempo"`.
     #[serde(default)]
@@ -128,20 +138,12 @@ impl Serialize for NetworkConfigs {
 }
 
 impl NetworkConfigs {
-    pub fn with_optimism() -> Self {
-        Self { network: Some(NetworkVariant::Optimism), optimism: true, ..Default::default() }
-    }
-
     pub fn with_celo() -> Self {
         Self { celo: true, ..Default::default() }
     }
 
     pub fn with_tempo() -> Self {
         Self { network: Some(NetworkVariant::Tempo), tempo: true, ..Default::default() }
-    }
-
-    pub fn is_optimism(&self) -> bool {
-        matches!(self.resolved_network(), Some(NetworkVariant::Optimism))
     }
 
     pub fn is_tempo(&self) -> bool {
@@ -153,14 +155,18 @@ impl NetworkConfigs {
     }
 
     /// Returns the resolved network variant, folding legacy flags.
-    fn resolved_network(&self) -> Option<NetworkVariant> {
-        self.network.or(if self.optimism {
-            Some(NetworkVariant::Optimism)
-        } else if self.tempo {
-            Some(NetworkVariant::Tempo)
-        } else {
-            None
-        })
+    const fn resolved_network(&self) -> Option<NetworkVariant> {
+        if let Some(n) = self.network {
+            return Some(n);
+        }
+        #[cfg(feature = "optimism")]
+        if self.optimism {
+            return Some(NetworkVariant::Optimism);
+        }
+        if self.tempo {
+            return Some(NetworkVariant::Tempo);
+        }
+        None
     }
 
     /// Returns the name of the currently active non-Ethereum network, or `None` for plain Ethereum.
@@ -176,16 +182,12 @@ impl NetworkConfigs {
     /// For Optimism networks, returns Canyon parameters if the Canyon hardfork is active
     /// at the given timestamp, otherwise returns pre-Canyon parameters.
     pub fn base_fee_params(&self, timestamp: u64) -> BaseFeeParams {
+        #[cfg(feature = "optimism")]
         if self.is_optimism() {
-            let op_hardforks = OpChainHardforks::op_mainnet();
-            if op_hardforks.is_canyon_active_at_timestamp(timestamp) {
-                BaseFeeParams::optimism_canyon()
-            } else {
-                BaseFeeParams::optimism()
-            }
-        } else {
-            BaseFeeParams::ethereum()
+            return self.op_base_fee_params(timestamp);
         }
+        let _ = timestamp;
+        BaseFeeParams::ethereum()
     }
 
     pub fn bypass_prevrandao(&self, chain_id: u64) -> bool {
@@ -200,21 +202,23 @@ impl NetworkConfigs {
 
     pub fn with_chain_id(self, chain_id: u64) -> Self {
         let chain = Chain::from_id(chain_id);
-        if self.resolved_network().is_none() {
-            if chain.is_tempo() {
-                Self::with_tempo()
-            } else if chain.is_optimism() {
-                Self::with_optimism()
+        if self.resolved_network().is_some() {
+            return if !self.celo
+                && matches!(chain.named(), Some(NamedChain::Celo | NamedChain::CeloSepolia))
+            {
+                Self::with_celo()
             } else {
                 self
-            }
-        } else if !self.celo
-            && matches!(chain.named(), Some(NamedChain::Celo | NamedChain::CeloSepolia))
-        {
-            Self::with_celo()
-        } else {
-            self
+            };
         }
+        if chain.is_tempo() {
+            return Self::with_tempo();
+        }
+        #[cfg(feature = "optimism")]
+        if chain.is_optimism() {
+            return Self::with_optimism();
+        }
+        self
     }
 
     /// Validates `hardfork` against the current `NetworkConfigs` and, if consistent, returns an
@@ -234,6 +238,7 @@ impl NetworkConfigs {
         let network = match hardfork {
             FoundryHardfork::Ethereum(_) => self,
             FoundryHardfork::Tempo(_) => Self::with_tempo(),
+            #[cfg(feature = "optimism")]
             FoundryHardfork::Optimism(_) => Self::with_optimism(),
         };
 
@@ -276,6 +281,7 @@ impl From<NetworkVariant> for NetworkConfigs {
             NetworkVariant::Tempo => {
                 Self { network: Some(network), tempo: true, ..Default::default() }
             }
+            #[cfg(feature = "optimism")]
             NetworkVariant::Optimism => {
                 Self { network: Some(network), optimism: true, ..Default::default() }
             }
@@ -294,17 +300,6 @@ mod tests {
         let via_new = NetworkConfigs { network: Some(NetworkVariant::Tempo), ..Default::default() };
         let via_old = NetworkConfigs { tempo: true, ..Default::default() };
         assert_eq!(via_new.is_tempo(), via_old.is_tempo());
-        assert_eq!(via_new.is_optimism(), via_old.is_optimism());
-        assert_eq!(via_new.active_network_name(), via_old.active_network_name());
-    }
-
-    #[test]
-    fn new_optimism_flag_equivalent_to_legacy() {
-        let via_new =
-            NetworkConfigs { network: Some(NetworkVariant::Optimism), ..Default::default() };
-        let via_old = NetworkConfigs { optimism: true, ..Default::default() };
-        assert_eq!(via_new.is_optimism(), via_old.is_optimism());
-        assert_eq!(via_new.is_tempo(), via_old.is_tempo());
         assert_eq!(via_new.active_network_name(), via_old.active_network_name());
     }
 
@@ -317,28 +312,8 @@ mod tests {
     }
 
     #[test]
-    fn active_network_name_optimism() {
-        let cfg = NetworkConfigs::with_optimism();
-        assert_eq!(cfg.active_network_name(), Some("optimism"));
-    }
-
-    #[test]
     fn active_network_name_default_is_none() {
         assert_eq!(NetworkConfigs::default().active_network_name(), None);
-    }
-
-    // --- new flag takes precedence over legacy flag ---
-
-    #[test]
-    fn new_flag_wins_over_legacy_when_both_set() {
-        // --network optimism --tempo: network field wins
-        let cfg = NetworkConfigs {
-            network: Some(NetworkVariant::Optimism),
-            tempo: true,
-            ..Default::default()
-        };
-        assert!(cfg.is_optimism());
-        assert!(!cfg.is_tempo());
     }
 
     // --- Serde round-trip ---
@@ -349,16 +324,6 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
         let restored: NetworkConfigs = serde_json::from_str(&json).unwrap();
         assert!(restored.is_tempo());
-        assert!(!restored.is_optimism());
-    }
-
-    #[test]
-    fn serde_roundtrip_optimism() {
-        let original = NetworkConfigs::with_optimism();
-        let json = serde_json::to_string(&original).unwrap();
-        let restored: NetworkConfigs = serde_json::from_str(&json).unwrap();
-        assert!(restored.is_optimism());
-        assert!(!restored.is_tempo());
     }
 
     #[test]
@@ -385,8 +350,55 @@ mod tests {
         let json_tempo = r#"{"network": "tempo", "celo": false, "bypass_prevrandao": false}"#;
         let cfg_tempo: NetworkConfigs = serde_json::from_str(json_tempo).unwrap();
         assert!(cfg_tempo.is_tempo());
-        let json_optimism = r#"{"network": "optimism", "celo": false, "bypass_prevrandao": false}"#;
-        let cfg_optimism: NetworkConfigs = serde_json::from_str(json_optimism).unwrap();
-        assert!(cfg_optimism.is_optimism());
+    }
+
+    #[cfg(feature = "optimism")]
+    mod optimism {
+        use super::*;
+
+        #[test]
+        fn new_optimism_flag_equivalent_to_legacy() {
+            let via_new =
+                NetworkConfigs { network: Some(NetworkVariant::Optimism), ..Default::default() };
+            let via_old = NetworkConfigs { optimism: true, ..Default::default() };
+            assert_eq!(via_new.is_optimism(), via_old.is_optimism());
+            assert_eq!(via_new.is_tempo(), via_old.is_tempo());
+            assert_eq!(via_new.active_network_name(), via_old.active_network_name());
+        }
+
+        #[test]
+        fn active_network_name_optimism() {
+            let cfg = NetworkConfigs::with_optimism();
+            assert_eq!(cfg.active_network_name(), Some("optimism"));
+        }
+
+        #[test]
+        fn new_flag_wins_over_legacy_when_both_set() {
+            // --network optimism --tempo: network field wins
+            let cfg = NetworkConfigs {
+                network: Some(NetworkVariant::Optimism),
+                tempo: true,
+                ..Default::default()
+            };
+            assert!(cfg.is_optimism());
+            assert!(!cfg.is_tempo());
+        }
+
+        #[test]
+        fn serde_roundtrip_optimism() {
+            let original = NetworkConfigs::with_optimism();
+            let json = serde_json::to_string(&original).unwrap();
+            let restored: NetworkConfigs = serde_json::from_str(&json).unwrap();
+            assert!(restored.is_optimism());
+            assert!(!restored.is_tempo());
+        }
+
+        #[test]
+        fn serde_optimism_field_deserialized() {
+            let json_optimism =
+                r#"{"network": "optimism", "celo": false, "bypass_prevrandao": false}"#;
+            let cfg_optimism: NetworkConfigs = serde_json::from_str(json_optimism).unwrap();
+            assert!(cfg_optimism.is_optimism());
+        }
     }
 }

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -146,7 +146,7 @@ impl NetworkConfigs {
         Self { network: Some(NetworkVariant::Tempo), tempo: true, ..Default::default() }
     }
 
-    pub fn is_tempo(&self) -> bool {
+    pub const fn is_tempo(&self) -> bool {
         matches!(self.resolved_network(), Some(NetworkVariant::Tempo))
     }
 

--- a/crates/evm/networks/src/optimism.rs
+++ b/crates/evm/networks/src/optimism.rs
@@ -9,7 +9,7 @@ impl NetworkConfigs {
         Self { network: Some(NetworkVariant::Optimism), optimism: true, ..Default::default() }
     }
 
-    pub fn is_optimism(&self) -> bool {
+    pub const fn is_optimism(&self) -> bool {
         matches!(self.resolved_network(), Some(NetworkVariant::Optimism))
     }
 

--- a/crates/evm/networks/src/optimism.rs
+++ b/crates/evm/networks/src/optimism.rs
@@ -1,0 +1,25 @@
+//! Optimism-specific extensions for [`NetworkConfigs`] and related helpers.
+
+use crate::{NetworkConfigs, NetworkVariant};
+use alloy_eips::eip1559::BaseFeeParams;
+use alloy_op_hardforks::{OpChainHardforks, OpHardforks};
+
+impl NetworkConfigs {
+    pub fn with_optimism() -> Self {
+        Self { network: Some(NetworkVariant::Optimism), optimism: true, ..Default::default() }
+    }
+
+    pub fn is_optimism(&self) -> bool {
+        matches!(self.resolved_network(), Some(NetworkVariant::Optimism))
+    }
+
+    /// Optimism-specific base fee parameters, picking Canyon vs pre-Canyon based on `timestamp`.
+    pub(crate) fn op_base_fee_params(&self, timestamp: u64) -> BaseFeeParams {
+        let op_hardforks = OpChainHardforks::op_mainnet();
+        if op_hardforks.is_canyon_active_at_timestamp(timestamp) {
+            BaseFeeParams::optimism_canyon()
+        } else {
+            BaseFeeParams::optimism()
+        }
+    }
+}

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -29,7 +29,7 @@ foundry-common.workspace = true
 foundry-compilers.workspace = true
 foundry-config.workspace = true
 foundry-evm.workspace = true
-foundry-evm-networks.workspace = true
+foundry-evm-networks = { workspace = true, features = ["optimism"] }
 foundry-linking.workspace = true
 
 comfy-table.workspace = true

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -19,7 +19,7 @@ foundry-cli.workspace = true
 foundry-config.workspace = true
 foundry-common.workspace = true
 foundry-evm.workspace = true
-foundry-evm-networks.workspace = true
+foundry-evm-networks = { workspace = true, features = ["optimism"] }
 alloy-evm.workspace = true
 foundry-debugger.workspace = true
 foundry-cheatcodes.workspace = true


### PR DESCRIPTION
Phase 7 of the Foundry × Optimism feature-gate rollout.

Gates `foundry-evm-hardforks` and `foundry-evm-networks` behind a default-on `optimism` cargo feature. Workspace deps for both are set to `default-features = false`; consumers that directly reference the gated API opt back in via `features = ["optimism"]` at the dep line (transitional — replaced by proper feature forwarding in later phases).

Independent of #14577.

### Verification
- `cargo build --workspace`
- `cargo build --workspace --no-default-features`
- `cargo test -p foundry-evm-hardforks --lib` (default + `--no-default-features`)
- `cargo test -p foundry-evm-networks --lib` (default + `--no-default-features`)
- `cargo tree -p foundry-evm-hardforks --no-default-features` → zero OP deps
- `cargo tree -p foundry-evm-networks --no-default-features` → zero OP deps
