### PR TITLE
fix(forge): allow verify-bytecode to run without external explorer dependencies

### DIFF
--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -171,17 +171,30 @@ impl VerifyBytecodeArgs {
 
         trace!(maybe_predeploy = ?maybe_predeploy);
 
-        // Get the constructor args using `source_code` endpoint.
-        let source_code = etherscan.contract_source_code(self.address).await?;
+        // Try to get the source code from the block explorer.
+        // This may fail if the contract is not verified on any block scanner.
+        let source_code = match etherscan.contract_source_code(self.address).await {
+            Ok(source_code) => Some(source_code),
+            Err(e) => {
+                if !shell::is_json() {
+                    sh_warn!(
+                        "Failed to fetch source code from block explorer: {e}. Proceeding without explorer verification."
+                    )?;
+                }
+                None
+            }
+        };
 
-        // Check if the contract name matches.
-        let name = source_code.items.first().map(|item| item.contract_name.clone());
-        if name.as_ref() != Some(&self.contract.name) {
-            eyre::bail!("Contract name mismatch");
+        // Check if the contract name matches (only if source code is available).
+        if let Some(ref source_code) = source_code {
+            let name = source_code.items.first().map(|item| item.contract_name.to_owned());
+            if name.as_ref() != Some(&self.contract.name) {
+                eyre::bail!("Contract name mismatch");
+            }
         }
 
-        // Obtain Etherscan compilation metadata.
-        let etherscan_metadata = source_code.items.first().unwrap();
+        // Obtain Etherscan compilation metadata (if available).
+        let etherscan_metadata = source_code.as_ref().and_then(|sc| sc.items.first());
 
         // Obtain local artifact
         let artifact = crate::utils::build_project(&self, &config)?;
@@ -206,9 +219,12 @@ impl VerifyBytecodeArgs {
 
         let mut constructor_args = if let Some(provided) = provided_constructor_args {
             provided.into()
-        } else {
+        } else if let Some(ref source_code) = source_code {
             // If no constructor args were provided, try to retrieve them from the explorer.
             check_explorer_args(source_code.clone())?
+        } else {
+            // No constructor args provided and no explorer data available.
+            Bytes::new()
         };
 
         // This fails only when the contract expects constructor args but NONE were provided OR
@@ -234,7 +250,7 @@ impl VerifyBytecodeArgs {
             let (mut evm_env, _, mut executor) = crate::utils::get_tracing_executor(
                 &mut fork_config,
                 gen_blk_num,
-                etherscan_metadata.evm_version()?.unwrap_or(EvmVersion::default()),
+                etherscan_metadata.and_then(|m| m.evm_version().ok().flatten()).unwrap_or(config.evm_version),
                 evm_opts,
             )
             .await?;
@@ -450,7 +466,7 @@ impl VerifyBytecodeArgs {
             let (mut evm_env, mut tx_env, mut executor) = crate::utils::get_tracing_executor(
                 &mut fork_config,
                 simulation_block - 1, // env.fork_block_number
-                etherscan_metadata.evm_version()?.unwrap_or(EvmVersion::default()),
+                etherscan_metadata.and_then(|m| m.evm_version().ok().flatten()).unwrap_or(config.evm_version),
                 evm_opts,
             )
             .await?;

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -479,4 +479,39 @@ mod tests {
         let msg = format!("{wrapped:#}");
         assert!(msg.contains("Invalid URL"), "message: {msg}");
     }
+
+    /// Regression test for #13479: print_result must not panic when no etherscan
+    /// metadata is available (i.e. the contract is not verified on any block explorer).
+    #[test]
+    fn print_result_succeeds_without_etherscan_metadata_on_match() {
+        let mut json_results = vec![];
+        let config = Config::default();
+        // Should not panic when metadata is None and verification matches.
+        print_result(
+            Some(VerificationType::Full),
+            BytecodeType::Creation,
+            &mut json_results,
+            None,
+            &config,
+        );
+    }
+
+    /// Regression test for #13479: when bytecodes don't match and no etherscan
+    /// metadata is present, print_result must not panic or try to compare
+    /// settings that don't exist.
+    #[test]
+    fn print_result_succeeds_without_etherscan_metadata_on_mismatch() {
+        let mut json_results = vec![];
+        let config = Config::default();
+        // Previously this would panic because it unconditionally called
+        // find_mismatch_in_settings with etherscan metadata. Now it
+        // skips that step when metadata is None.
+        print_result(
+            None,
+            BytecodeType::Runtime,
+            &mut json_results,
+            None,
+            &config,
+        );
+    }
 }

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -103,7 +103,7 @@ pub fn print_result(
     res: Option<VerificationType>,
     bytecode_type: BytecodeType,
     json_results: &mut Vec<JsonResult>,
-    etherscan_config: &Metadata,
+    etherscan_config: Option<&Metadata>,
     config: &Config,
 ) {
     if let Some(res) = res {
@@ -121,9 +121,11 @@ pub fn print_result(
         let _ = sh_err!(
             "{bytecode_type:?} code did not match - this may be due to varying compiler settings"
         );
-        let mismatches = find_mismatch_in_settings(etherscan_config, config);
-        for mismatch in mismatches {
-            let _ = sh_eprintln!("{}", mismatch.red().bold());
+        if let Some(etherscan_config) = etherscan_config {
+            let mismatches = find_mismatch_in_settings(etherscan_config, config);
+            for mismatch in mismatches {
+                let _ = sh_eprintln!("{}", mismatch.red().bold());
+            }
         }
     } else {
         let json_res = JsonResult {


### PR DESCRIPTION
Fixes #13479 

## Description

This PR fixes an issue where the `forge verify-bytecode` command unconditionally required the target contract to be verified on a block explorer (via Etherscan/Blockscout API) before comparing the bytecode. This prevented users from relying solely on an RPC node to verify locally compiled bytecode against the onchain version.

With these changes, if fetching the contract's source code from the explorer fails, the command degrades gracefully:
- It skips the contract name check that relied on explorer metadata.
- It falls back to the user-provided config's `evm_version`.
- It defaults to empty constructor arguments if none were provided by the user (rather than failing outright).
- It gracefully skips the settings mismatch diagnostic messaging, since there is no explorer metadata to compare against.

## Manual Testing

1. Deployed a small contract to a testnet (e.g., Sepolia) via `forge create` without verifying.
2. Ran `forge verify-bytecode <Address> src/MyContract.sol:MyContract --rpc-url <RPC>`
3. Earlier, it would error out with `Contract source code not verified`. Now, it prints a warning and proceeds to match the bytecode using the RPC.
