### PR TITLE
fix(forge): encode Tempo creates as AA calls

### DIFF
--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -408,15 +408,18 @@ impl CreateArgs {
         // Apply user-provided gas, fee, nonce, and Tempo options.
         self.tx.apply::<N>(&mut deployer.tx, is_legacy);
 
-        // For keychain mode, set key_id and nonce_key before gas estimation.
         // Convert the CREATE into an AA-compatible call entry since Tempo AA
         // transactions use a `calls` list instead of `to`+`input`.
+        if chain.is_tempo() {
+            deployer.tx.convert_create_to_call();
+        }
+
+        // For keychain mode, set key_id and nonce_key before gas estimation.
         if let Some((_, ref ak)) = tempo_keychain {
             deployer.tx.set_key_id(ak.key_address);
             if deployer.tx.nonce_key().is_none() {
                 deployer.tx.set_nonce_key(U256::ZERO);
             }
-            deployer.tx.convert_create_to_call();
         }
 
         // Fetch defaults from provider for values not specified by user.


### PR DESCRIPTION
## Summary
- Fixes Tempo `forge create` by converting CREATE deploys into Tempo AA `calls` for all Tempo create transactions.
- Previously this conversion only happened in keychain mode, so direct Tempo creates could be submitted with an empty `calls` list.

## Bug
Live testing hit this node rejection before inclusion:

```text
Error: server returned an error response: error code -32602: empty calls list
```

Root cause: `convert_create_to_call()` was inside the `tempo_keychain` branch, but Tempo AA create encoding is required for non-keychain create transactions too.

## Validation
After the fix, a live Tempo mainnet sponsored deploy from a zero-balance deployer succeeded.

- tx: [`0xd853dfa85f480782278dee6f66b4ee905885ac1aec38dd675178333f15cbbbed`](https://explore.tempo.xyz/tx/0xd853dfa85f480782278dee6f66b4ee905885ac1aec38dd675178333f15cbbbed)
- contract: `0x801fEC8Bb9a4574bB42cf6FEA9c83BCB81274f9C`
- receipt showed type `118`, deployer as `from`, sponsor as `feePayer`, and the deployer token balance stayed `0`.