### PR TITLE
feat(lint): add tx-origin detector

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -17,6 +17,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `divide-before-multiply`: Warns against performing division before multiplication in the same expression, which can cause precision loss.
   - `incorrect-erc20-interface`: Flags ERC20 interfaces and implementations with non-compliant function signatures.
   - `incorrect-erc721-interface`: Flags ERC721 interfaces and implementations with non-compliant function signatures.
+  - `tx-origin`: Flags use of `tx.origin` in authorization-like predicates.
   - `unsafe-typecast`: Typecasts that can truncate values should be checked.
 - **Low Severity:**
   - `block-timestamp`: Warns when `block.timestamp` is used in a comparison, as it may be manipulated by validators.

--- a/crates/lint/docs/tx-origin.md
+++ b/crates/lint/docs/tx-origin.md
@@ -1,0 +1,34 @@
+# Use of tx.origin for authorization
+
+**Severity**: `Med`
+**ID**: `tx-origin`
+
+Flags use of `tx.origin` inside authorization-like predicates such as `require`, `assert`, `if`,
+`while`, and `for` conditions.
+
+## What it does
+
+Reports `tx.origin` reads when they are used as part of a guard condition. Plain reads outside of
+guard predicates are not reported.
+
+## Why is this bad?
+
+`tx.origin` is the original externally owned account that started the whole transaction, not the
+immediate caller. If authorization checks rely on `tx.origin`, a malicious contract can call the
+protected contract while the legitimate owner is the transaction origin.
+
+Use `msg.sender` for authorization checks instead.
+
+## Example
+
+### Bad
+
+```solidity
+require(tx.origin == owner, "not owner");
+```
+
+### Good
+
+```solidity
+require(msg.sender == owner, "not owner");
+```

--- a/crates/lint/src/sol/med/mod.rs
+++ b/crates/lint/src/sol/med/mod.rs
@@ -9,6 +9,9 @@ use incorrect_erc20_interface::INCORRECT_ERC20_INTERFACE;
 mod incorrect_erc721_interface;
 use incorrect_erc721_interface::INCORRECT_ERC721_INTERFACE;
 
+mod tx_origin;
+use tx_origin::TX_ORIGIN;
+
 mod unsafe_typecast;
 use unsafe_typecast::UNSAFE_TYPECAST;
 
@@ -16,5 +19,6 @@ register_lints!(
     (DivideBeforeMultiply, early, (DIVIDE_BEFORE_MULTIPLY)),
     (IncorrectERC20Interface, late, (INCORRECT_ERC20_INTERFACE)),
     (IncorrectERC721Interface, late, (INCORRECT_ERC721_INTERFACE)),
+    (TxOrigin, early, (TX_ORIGIN)),
     (UnsafeTypecast, late, (UNSAFE_TYPECAST))
 );

--- a/crates/lint/src/sol/med/tx_origin.rs
+++ b/crates/lint/src/sol/med/tx_origin.rs
@@ -4,7 +4,7 @@ use crate::{
     sol::{Severity, SolLint},
 };
 use solar::{
-    ast::{Expr, ExprKind, Stmt, StmtKind},
+    ast::{Expr, ExprKind, IndexKind, Stmt, StmtKind},
     interface::SpannedOption,
 };
 
@@ -54,6 +54,17 @@ fn contains_tx_origin(expr: &Expr<'_>) -> bool {
     match &expr.kind {
         ExprKind::Unary(_, inner) => contains_tx_origin(inner),
         ExprKind::Binary(lhs, _, rhs) => contains_tx_origin(lhs) || contains_tx_origin(rhs),
+        ExprKind::Index(base, index) => {
+            contains_tx_origin(base)
+                || match index {
+                    IndexKind::Index(Some(index)) => contains_tx_origin(index),
+                    IndexKind::Range(start, end) => {
+                        start.as_ref().is_some_and(|start| contains_tx_origin(start))
+                            || end.as_ref().is_some_and(|end| contains_tx_origin(end))
+                    }
+                    _ => false,
+                }
+        }
         ExprKind::Tuple(elems) => elems.iter().any(|elem| {
             if let SpannedOption::Some(inner) = elem.as_ref() {
                 contains_tx_origin(inner)
@@ -63,6 +74,11 @@ fn contains_tx_origin(expr: &Expr<'_>) -> bool {
         }),
         ExprKind::Call(callee, args) => {
             contains_tx_origin(callee) || args.exprs().any(contains_tx_origin)
+        }
+        ExprKind::Ternary(cond, then_expr, else_expr) => {
+            contains_tx_origin(cond)
+                || contains_tx_origin(then_expr)
+                || contains_tx_origin(else_expr)
         }
         _ => false,
     }

--- a/crates/lint/src/sol/med/tx_origin.rs
+++ b/crates/lint/src/sol/med/tx_origin.rs
@@ -19,13 +19,13 @@ impl<'ast> EarlyLintPass<'ast> for TxOrigin {
     fn check_stmt(&mut self, ctx: &LintContext, stmt: &'ast Stmt<'ast>) {
         match &stmt.kind {
             StmtKind::If(cond, ..) | StmtKind::DoWhile(_, cond) => {
-                emit_tx_origin_reads(ctx, cond);
+                emit_if_contains_tx_origin(ctx, cond);
             }
             StmtKind::While(cond, _) => {
-                emit_tx_origin_reads(ctx, cond);
+                emit_if_contains_tx_origin(ctx, cond);
             }
             StmtKind::For { cond: Some(cond), .. } => {
-                emit_tx_origin_reads(ctx, cond);
+                emit_if_contains_tx_origin(ctx, cond);
             }
             _ => {}
         }
@@ -36,75 +36,35 @@ impl<'ast> EarlyLintPass<'ast> for TxOrigin {
             && is_require_or_assert_call(callee)
             && let Some(cond) = args.exprs().next()
         {
-            emit_tx_origin_reads(ctx, cond);
+            emit_if_contains_tx_origin(ctx, cond);
         }
     }
 }
 
-fn emit_tx_origin_reads(ctx: &LintContext, expr: &Expr<'_>) {
-    if is_tx_origin(expr) {
+fn emit_if_contains_tx_origin(ctx: &LintContext, expr: &Expr<'_>) {
+    if contains_tx_origin(expr) {
         ctx.emit(&TX_ORIGIN, expr.span);
-        return;
     }
+}
 
+fn contains_tx_origin(expr: &Expr<'_>) -> bool {
+    if is_tx_origin(expr) {
+        return true;
+    }
     match &expr.kind {
-        ExprKind::Array(elems) => {
-            for elem in elems.iter() {
-                emit_tx_origin_reads(ctx, elem);
+        ExprKind::Unary(_, inner) => contains_tx_origin(inner),
+        ExprKind::Binary(lhs, _, rhs) => contains_tx_origin(lhs) || contains_tx_origin(rhs),
+        ExprKind::Tuple(elems) => elems.iter().any(|elem| {
+            if let SpannedOption::Some(inner) = elem.as_ref() {
+                contains_tx_origin(inner)
+            } else {
+                false
             }
-        }
-        ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {
-            emit_tx_origin_reads(ctx, lhs);
-            emit_tx_origin_reads(ctx, rhs);
-        }
+        }),
         ExprKind::Call(callee, args) => {
-            emit_tx_origin_reads(ctx, callee);
-            for arg in args.exprs() {
-                emit_tx_origin_reads(ctx, arg);
-            }
+            contains_tx_origin(callee) || args.exprs().any(contains_tx_origin)
         }
-        ExprKind::CallOptions(callee, args) => {
-            emit_tx_origin_reads(ctx, callee);
-            for arg in args.iter() {
-                emit_tx_origin_reads(ctx, &arg.value);
-            }
-        }
-        ExprKind::Delete(inner) | ExprKind::Member(inner, _) | ExprKind::Unary(_, inner) => {
-            emit_tx_origin_reads(ctx, inner);
-        }
-        ExprKind::Index(base, kind) => {
-            emit_tx_origin_reads(ctx, base);
-            match kind {
-                solar::ast::IndexKind::Index(Some(index)) => emit_tx_origin_reads(ctx, index),
-                solar::ast::IndexKind::Range(start, end) => {
-                    if let Some(start) = start {
-                        emit_tx_origin_reads(ctx, start);
-                    }
-                    if let Some(end) = end {
-                        emit_tx_origin_reads(ctx, end);
-                    }
-                }
-                _ => {}
-            }
-        }
-        ExprKind::Payable(args) => {
-            for arg in args.exprs() {
-                emit_tx_origin_reads(ctx, arg);
-            }
-        }
-        ExprKind::Ternary(cond, then_expr, else_expr) => {
-            emit_tx_origin_reads(ctx, cond);
-            emit_tx_origin_reads(ctx, then_expr);
-            emit_tx_origin_reads(ctx, else_expr);
-        }
-        ExprKind::Tuple(elems) => {
-            for elem in elems.iter() {
-                if let SpannedOption::Some(elem) = elem.as_ref() {
-                    emit_tx_origin_reads(ctx, elem);
-                }
-            }
-        }
-        _ => {}
+        _ => false,
     }
 }
 

--- a/crates/lint/src/sol/med/tx_origin.rs
+++ b/crates/lint/src/sol/med/tx_origin.rs
@@ -1,0 +1,125 @@
+use super::TxOrigin;
+use crate::{
+    linter::{EarlyLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::{
+    ast::{Expr, ExprKind, Stmt, StmtKind},
+    interface::SpannedOption,
+};
+
+declare_forge_lint!(
+    TX_ORIGIN,
+    Severity::Med,
+    "tx-origin",
+    "`tx.origin` should not be used for authorization"
+);
+
+impl<'ast> EarlyLintPass<'ast> for TxOrigin {
+    fn check_stmt(&mut self, ctx: &LintContext, stmt: &'ast Stmt<'ast>) {
+        match &stmt.kind {
+            StmtKind::If(cond, ..) | StmtKind::DoWhile(_, cond) => {
+                emit_tx_origin_reads(ctx, cond);
+            }
+            StmtKind::While(cond, _) => {
+                emit_tx_origin_reads(ctx, cond);
+            }
+            StmtKind::For { cond: Some(cond), .. } => {
+                emit_tx_origin_reads(ctx, cond);
+            }
+            _ => {}
+        }
+    }
+
+    fn check_expr(&mut self, ctx: &LintContext, expr: &'ast Expr<'ast>) {
+        if let ExprKind::Call(callee, args) = &expr.kind
+            && is_require_or_assert_call(callee)
+            && let Some(cond) = args.exprs().next()
+        {
+            emit_tx_origin_reads(ctx, cond);
+        }
+    }
+}
+
+fn emit_tx_origin_reads(ctx: &LintContext, expr: &Expr<'_>) {
+    if is_tx_origin(expr) {
+        ctx.emit(&TX_ORIGIN, expr.span);
+        return;
+    }
+
+    match &expr.kind {
+        ExprKind::Array(elems) => {
+            for elem in elems.iter() {
+                emit_tx_origin_reads(ctx, elem);
+            }
+        }
+        ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {
+            emit_tx_origin_reads(ctx, lhs);
+            emit_tx_origin_reads(ctx, rhs);
+        }
+        ExprKind::Call(callee, args) => {
+            emit_tx_origin_reads(ctx, callee);
+            for arg in args.exprs() {
+                emit_tx_origin_reads(ctx, arg);
+            }
+        }
+        ExprKind::CallOptions(callee, args) => {
+            emit_tx_origin_reads(ctx, callee);
+            for arg in args.iter() {
+                emit_tx_origin_reads(ctx, &arg.value);
+            }
+        }
+        ExprKind::Delete(inner) | ExprKind::Member(inner, _) | ExprKind::Unary(_, inner) => {
+            emit_tx_origin_reads(ctx, inner);
+        }
+        ExprKind::Index(base, kind) => {
+            emit_tx_origin_reads(ctx, base);
+            match kind {
+                solar::ast::IndexKind::Index(Some(index)) => emit_tx_origin_reads(ctx, index),
+                solar::ast::IndexKind::Range(start, end) => {
+                    if let Some(start) = start {
+                        emit_tx_origin_reads(ctx, start);
+                    }
+                    if let Some(end) = end {
+                        emit_tx_origin_reads(ctx, end);
+                    }
+                }
+                _ => {}
+            }
+        }
+        ExprKind::Payable(args) => {
+            for arg in args.exprs() {
+                emit_tx_origin_reads(ctx, arg);
+            }
+        }
+        ExprKind::Ternary(cond, then_expr, else_expr) => {
+            emit_tx_origin_reads(ctx, cond);
+            emit_tx_origin_reads(ctx, then_expr);
+            emit_tx_origin_reads(ctx, else_expr);
+        }
+        ExprKind::Tuple(elems) => {
+            for elem in elems.iter() {
+                if let SpannedOption::Some(elem) = elem.as_ref() {
+                    emit_tx_origin_reads(ctx, elem);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_tx_origin(expr: &Expr<'_>) -> bool {
+    matches!(
+        &expr.kind,
+        ExprKind::Member(base, member)
+            if member.as_str() == "origin"
+            && matches!(&base.kind, ExprKind::Ident(ident) if ident.as_str() == "tx")
+    )
+}
+
+fn is_require_or_assert_call(callee: &Expr<'_>) -> bool {
+    matches!(
+        &callee.kind,
+        ExprKind::Ident(ident) if matches!(ident.as_str(), "require" | "assert")
+    )
+}

--- a/crates/lint/testdata/TxOrigin.sol
+++ b/crates/lint/testdata/TxOrigin.sol
@@ -24,6 +24,24 @@ contract TxOrigin {
         assert(isOwner(tx.origin)); //~WARN: `tx.origin` should not be used for authorization
     }
 
+    function guardedByWhile() external view {
+        while (tx.origin == owner) { //~WARN: `tx.origin` should not be used for authorization
+            break;
+        }
+    }
+
+    function guardedByFor() external view {
+        for (; tx.origin == owner;) { //~WARN: `tx.origin` should not be used for authorization
+            break;
+        }
+    }
+
+    function guardedByDoWhile() external view {
+        do {
+            break;
+        } while (tx.origin == owner); //~WARN: `tx.origin` should not be used for authorization
+    }
+
     function readForLogging() external view returns (address) {
         return tx.origin;
     }

--- a/crates/lint/testdata/TxOrigin.sol
+++ b/crates/lint/testdata/TxOrigin.sol
@@ -1,0 +1,38 @@
+//@compile-flags: --only-lint tx-origin
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+contract TxOrigin {
+    address public owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        require(tx.origin == owner, "not owner"); //~WARN: `tx.origin` should not be used for authorization
+        _;
+    }
+
+    function guardedByIf() external view {
+        if (tx.origin != owner) { //~WARN: `tx.origin` should not be used for authorization
+            revert("not owner");
+        }
+    }
+
+    function guardedByPredicate() external view {
+        assert(isOwner(tx.origin)); //~WARN: `tx.origin` should not be used for authorization
+    }
+
+    function readForLogging() external view returns (address) {
+        return tx.origin;
+    }
+
+    function explicitSenderCheck() external view {
+        require(msg.sender == owner, "not owner");
+    }
+
+    function isOwner(address account) internal view returns (bool) {
+        return account == owner;
+    }
+}

--- a/crates/lint/testdata/TxOrigin.sol
+++ b/crates/lint/testdata/TxOrigin.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.18;
 
 contract TxOrigin {
     address public owner;
+    mapping(address => bool) public allowed;
 
     constructor() {
         owner = msg.sender;
@@ -38,8 +39,16 @@ contract TxOrigin {
 
     function guardedByDoWhile() external view {
         do {
-            break;
         } while (tx.origin == owner); //~WARN: `tx.origin` should not be used for authorization
+    }
+
+    function guardedByMapping() external view {
+        require(allowed[tx.origin], "not allowed"); //~WARN: `tx.origin` should not be used for authorization
+        require(allowed[tx.origin] == true, "not allowed"); //~WARN: `tx.origin` should not be used for authorization
+    }
+
+    function guardedByTernary() external view {
+        require(tx.origin == owner ? true : false, "not owner"); //~WARN: `tx.origin` should not be used for authorization
     }
 
     function readForLogging() external view returns (address) {

--- a/crates/lint/testdata/TxOrigin.stderr
+++ b/crates/lint/testdata/TxOrigin.stderr
@@ -69,3 +69,4 @@ LL │         require(tx.origin == owner ? true : false, "not owner");
    │                 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/tx-origin
+

--- a/crates/lint/testdata/TxOrigin.stderr
+++ b/crates/lint/testdata/TxOrigin.stderr
@@ -45,3 +45,4 @@ LL │         } while (tx.origin == owner);
    │                  ━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/tx-origin
+

--- a/crates/lint/testdata/TxOrigin.stderr
+++ b/crates/lint/testdata/TxOrigin.stderr
@@ -46,3 +46,26 @@ LL │         } while (tx.origin == owner);
    │
    ╰ help: https://getfoundry.sh/forge/linting/tx-origin
 
+warning[tx-origin]: `tx.origin` should not be used for authorization
+   ╭▸ ROOT/testdata/TxOrigin.sol:LL:CC
+   │
+LL │         require(allowed[tx.origin], "not allowed");
+   │                 ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/tx-origin
+
+warning[tx-origin]: `tx.origin` should not be used for authorization
+   ╭▸ ROOT/testdata/TxOrigin.sol:LL:CC
+   │
+LL │         require(allowed[tx.origin] == true, "not allowed");
+   │                 ━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/tx-origin
+
+warning[tx-origin]: `tx.origin` should not be used for authorization
+   ╭▸ ROOT/testdata/TxOrigin.sol:LL:CC
+   │
+LL │         require(tx.origin == owner ? true : false, "not owner");
+   │                 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/tx-origin

--- a/crates/lint/testdata/TxOrigin.stderr
+++ b/crates/lint/testdata/TxOrigin.stderr
@@ -1,0 +1,24 @@
+warning[tx-origin]: `tx.origin` should not be used for authorization
+   ╭▸ ROOT/testdata/TxOrigin.sol:LL:CC
+   │
+LL │         require(tx.origin == owner, "not owner");
+   │                 ━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/tx-origin
+
+warning[tx-origin]: `tx.origin` should not be used for authorization
+   ╭▸ ROOT/testdata/TxOrigin.sol:LL:CC
+   │
+LL │         if (tx.origin != owner) {
+   │             ━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/tx-origin
+
+warning[tx-origin]: `tx.origin` should not be used for authorization
+   ╭▸ ROOT/testdata/TxOrigin.sol:LL:CC
+   │
+LL │         assert(isOwner(tx.origin));
+   │                        ━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/tx-origin
+

--- a/crates/lint/testdata/TxOrigin.stderr
+++ b/crates/lint/testdata/TxOrigin.stderr
@@ -2,7 +2,7 @@ warning[tx-origin]: `tx.origin` should not be used for authorization
    ╭▸ ROOT/testdata/TxOrigin.sol:LL:CC
    │
 LL │         require(tx.origin == owner, "not owner");
-   │                 ━━━━━━━━━
+   │                 ━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/tx-origin
 
@@ -10,7 +10,7 @@ warning[tx-origin]: `tx.origin` should not be used for authorization
    ╭▸ ROOT/testdata/TxOrigin.sol:LL:CC
    │
 LL │         if (tx.origin != owner) {
-   │             ━━━━━━━━━
+   │             ━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/tx-origin
 
@@ -18,7 +18,30 @@ warning[tx-origin]: `tx.origin` should not be used for authorization
    ╭▸ ROOT/testdata/TxOrigin.sol:LL:CC
    │
 LL │         assert(isOwner(tx.origin));
-   │                        ━━━━━━━━━
+   │                ━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/tx-origin
 
+warning[tx-origin]: `tx.origin` should not be used for authorization
+   ╭▸ ROOT/testdata/TxOrigin.sol:LL:CC
+   │
+LL │         while (tx.origin == owner) {
+   │                ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/tx-origin
+
+warning[tx-origin]: `tx.origin` should not be used for authorization
+   ╭▸ ROOT/testdata/TxOrigin.sol:LL:CC
+   │
+LL │         for (; tx.origin == owner;) {
+   │                ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/tx-origin
+
+warning[tx-origin]: `tx.origin` should not be used for authorization
+   ╭▸ ROOT/testdata/TxOrigin.sol:LL:CC
+   │
+LL │         } while (tx.origin == owner);
+   │                  ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/tx-origin


### PR DESCRIPTION
## Summary

- Adds a `tx-origin` medium-severity lint.
- Reports `tx.origin` when it is used in authorization-like predicates such as `require`, `assert`, `if`, `while`, and `for` conditions.
- Leaves plain reads like `return tx.origin` unreported to avoid broad false positives.
- Adds lint docs and UI test coverage.

Partially addresses #14381.

## Testing

- `cargo fmt --package forge-lint`
- `cargo fmt --check --package forge-lint`
- `git diff --check`
- `forge build --root /tmp/foundry-tx-origin`

