### PR TITLE
fix(cast): `--json` output support for `vaddr`

### DIFF
--- a/crates/cast/src/cmd/vaddr/create.rs
+++ b/crates/cast/src/cmd/vaddr/create.rs
@@ -10,8 +10,9 @@ use alloy_primitives::{Address, B256};
 use alloy_signer::Signer;
 use eyre::Result;
 use foundry_cli::utils::{LoadConfig, get_chain};
-use foundry_common::provider::ProviderBuilder;
+use foundry_common::{provider::ProviderBuilder, shell};
 use rand::{RngCore, SeedableRng, rngs::StdRng};
+use serde_json::json;
 use std::time::Instant;
 use tempo_alloy::{
     TempoNetwork,
@@ -69,24 +70,19 @@ pub(super) async fn run(
             rng.fill_bytes(&mut start_salt[..]);
         }
 
-        sh_println!("Mining TIP-1022 salt for {owner} with {n_threads} threads...")?;
+        if !shell::is_json() {
+            sh_println!("Mining TIP-1022 salt for {owner} with {n_threads} threads...")?;
+        }
         let timer = Instant::now();
         let output = mine::mine(owner, start_salt, n_threads, POW_BYTES)?;
-        sh_println!("Found salt in {:?}", timer.elapsed())?;
+        if !shell::is_json() {
+            sh_println!("Found salt in {:?}", timer.elapsed())?;
+        }
         output
     };
 
-    sh_println!(
-        "Salt:              {}
-Registration hash: {}
-Master ID:         {}",
-        output.salt,
-        output.registration_hash,
-        output.master_id,
-    )?;
-
     const MAX_USER_TAG: u64 = 0x0000_FFFF_FFFF_FFFF;
-    sh_println!("\nVirtual addresses:")?;
+    let mut virtual_addresses = Vec::with_capacity(count as usize);
     for i in 0..count {
         let tag_value = tag
             .checked_add(i as u64)
@@ -95,7 +91,35 @@ Master ID:         {}",
         let raw = tag_value.to_be_bytes();
         let user_tag = UserTag::new(raw[2..].try_into().expect("slice is 6 bytes"));
         let vaddr = Address::new_virtual(output.master_id, user_tag);
-        sh_println!("  tag={user_tag}  {vaddr}")?;
+        virtual_addresses.push((user_tag, vaddr));
+    }
+
+    if shell::is_json() {
+        sh_println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "salt": format!("{}", output.salt),
+                "registration_hash": format!("{}", output.registration_hash),
+                "master_id": format!("{}", output.master_id),
+                "virtual_addresses": virtual_addresses.iter().map(|(tag, addr)| json!({
+                    "tag": format!("{tag}"),
+                    "address": format!("{addr}"),
+                })).collect::<Vec<_>>(),
+            }))?
+        )?;
+    } else {
+        sh_println!(
+            "Salt:              {}
+Registration hash: {}
+Master ID:         {}",
+            output.salt,
+            output.registration_hash,
+            output.master_id,
+        )?;
+        sh_println!("\nVirtual addresses:")?;
+        for (tag, vaddr) in &virtual_addresses {
+            sh_println!("  tag={tag}  {vaddr}")?;
+        }
     }
 
     if no_register {

--- a/crates/cast/src/cmd/vaddr/resolve.rs
+++ b/crates/cast/src/cmd/vaddr/resolve.rs
@@ -1,7 +1,8 @@
 use alloy_primitives::{Address, hex};
 use eyre::Result;
 use foundry_cli::{opts::RpcOpts, utils::LoadConfig};
-use foundry_common::provider::ProviderBuilder;
+use foundry_common::{provider::ProviderBuilder, shell};
+use serde_json::json;
 use tempo_alloy::{
     TempoNetwork,
     contracts::precompiles::{ADDRESS_REGISTRY_ADDRESS, IAddressRegistry},
@@ -25,13 +26,26 @@ pub(super) async fn run(addr: Address, rpc: RpcOpts) -> Result<()> {
     let user_tag = decoded.userTag;
     let master: Address = master;
 
-    sh_println!("Virtual address: {addr}")?;
-    sh_println!("Master ID:       0x{}", hex::encode(master_id))?;
-    sh_println!("User tag:        0x{}", hex::encode(user_tag))?;
-    if master.is_zero() {
-        sh_println!("Master address:  (unregistered)")?;
+    if shell::is_json() {
+        let master_address = if master.is_zero() { None } else { Some(format!("{master}")) };
+        sh_println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "address": format!("{addr}"),
+                "master_id": format!("0x{}", hex::encode(master_id)),
+                "user_tag": format!("0x{}", hex::encode(user_tag)),
+                "master_address": master_address,
+            }))?
+        )?;
     } else {
-        sh_println!("Master address:  {master}")?;
+        sh_println!("Virtual address: {addr}")?;
+        sh_println!("Master ID:       0x{}", hex::encode(master_id))?;
+        sh_println!("User tag:        0x{}", hex::encode(user_tag))?;
+        if master.is_zero() {
+            sh_println!("Master address:  (unregistered)")?;
+        } else {
+            sh_println!("Master address:  {master}")?;
+        }
     }
 
     Ok(())

--- a/crates/cast/src/cmd/vaddr/watch.rs
+++ b/crates/cast/src/cmd/vaddr/watch.rs
@@ -3,7 +3,8 @@ use alloy_provider::Provider;
 use alloy_rpc_types::{BlockNumberOrTag, Filter};
 use eyre::Result;
 use foundry_cli::{opts::RpcOpts, utils::LoadConfig};
-use foundry_common::provider::ProviderBuilder;
+use foundry_common::{provider::ProviderBuilder, shell};
+use serde_json::json;
 use std::sync::LazyLock;
 use tempo_alloy::TempoNetwork;
 use tempo_primitives::TempoAddressExt;
@@ -41,7 +42,9 @@ pub(super) async fn run(
         filter = filter.address(tok);
     }
 
-    sh_println!("Watching transfers to {addr}... (Ctrl-C to stop)")?;
+    if !shell::is_json() {
+        sh_println!("Watching transfers to {addr}... (Ctrl-C to stop)")?;
+    }
 
     // Fetch logs from the requested start block (historical when from_block is set)
     let logs = provider.get_logs(&filter).await?;
@@ -84,9 +87,22 @@ fn print_transfer_log(log: &alloy_rpc_types::Log) -> Result<()> {
         alloy_primitives::U256::ZERO
     };
 
-    sh_println!(
-        "block={block} tx={tx} token={token} from={} amount={amount}",
-        from.map(|a| a.to_string()).unwrap_or_default(),
-    )?;
+    if shell::is_json() {
+        sh_println!(
+            "{}",
+            serde_json::to_string(&json!({
+                "block": block,
+                "tx": format!("{tx}"),
+                "token": format!("{token}"),
+                "from": from.map(|a| format!("{a}")).unwrap_or_default(),
+                "amount": amount.to_string(),
+            }))?
+        )?;
+    } else {
+        sh_println!(
+            "block={block} tx={tx} token={token} from={} amount={amount}",
+            from.map(|a| a.to_string()).unwrap_or_default(),
+        )?;
+    }
     Ok(())
 }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -5076,3 +5076,68 @@ casttest!(run_evm_version_updates_gas_params, |_prj, cmd| {
         "expected Spurious Dragon gas (177241), got: {sd_output}"
     );
 });
+
+// Tests for `cast vaddr` JSON output
+casttest!(vaddr_create_json_output, |_prj, cmd| {
+    // Use a pre-computed salt that satisfies the 4-byte PoW requirement for this owner.
+    // Salt: 0x0000000000000000000000000000000000000000000000003ee0a78d00000000
+    // Owner: 0x1234567890123456789012345678901234567890
+    let out = cmd
+        .args([
+            "--json",
+            "vaddr",
+            "create",
+            "--owner",
+            "0x1234567890123456789012345678901234567890",
+            "--salt",
+            "0x0000000000000000000000000000000000000000000000003ee0a78d00000000",
+            "--no-register",
+            "--count",
+            "2",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    let v: serde_json::Value = serde_json::from_str(out.trim()).expect("valid JSON");
+    assert_eq!(v["salt"], "0x0000000000000000000000000000000000000000000000003ee0a78d00000000");
+    assert_eq!(
+        v["registration_hash"],
+        "0x000000002f51c0c4f66f3910f799c6b98e2123ef43a401a062eb8ee07498c396"
+    );
+    assert_eq!(v["master_id"], "0x2f51c0c4");
+    let addrs = v["virtual_addresses"].as_array().expect("array");
+    assert_eq!(addrs.len(), 2);
+    assert_eq!(addrs[0]["tag"], "0x000000000000");
+    assert_eq!(
+        addrs[0]["address"].as_str().unwrap().to_lowercase(),
+        "0x2f51c0c4fdfdfdfdfdfdfdfdfdfd000000000000"
+    );
+    assert_eq!(addrs[1]["tag"], "0x000000000001");
+    assert_eq!(
+        addrs[1]["address"].as_str().unwrap().to_lowercase(),
+        "0x2f51c0c4fdfdfdfdfdfdfdfdfdfd000000000001"
+    );
+});
+
+casttest!(vaddr_create_plain_output, |_prj, cmd| {
+    cmd.args([
+        "vaddr",
+        "create",
+        "--owner",
+        "0x1234567890123456789012345678901234567890",
+        "--salt",
+        "0x0000000000000000000000000000000000000000000000003ee0a78d00000000",
+        "--no-register",
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+Salt:              0x0000000000000000000000000000000000000000000000003ee0a78d00000000
+Registration hash: 0x000000002f51c0c4f66f3910f799c6b98e2123ef43a401a062eb8ee07498c396
+Master ID:         0x2f51c0c4
+
+Virtual addresses:
+  tag=0x000000000000  [..]
+
+"#]]);
+});


### PR DESCRIPTION

## Motivation

#14508 follow-up

Add `--json` output support for `cast vaddr` command.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
