### PR TITLE
fix(anvil): classify EVM halts as transaction rejections

### DIFF
--- a/crates/anvil/src/eth/error/mod.rs
+++ b/crates/anvil/src/eth/error/mod.rs
@@ -524,9 +524,13 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                         err => RpcError::internal_error_with(format!("Fork Error: {err:?}")),
                     }
                 }
-                err @ BlockchainError::EvmError(_) => {
-                    RpcError::internal_error_with(err.to_string())
-                }
+                err @ BlockchainError::EvmError(_) => RpcError {
+                    // VM halts are execution failures, not JSON-RPC server faults. REVERT has a
+                    // dedicated code/data path above; other halts, such as invalid opcode, do not.
+                    code: ErrorCode::TransactionRejected,
+                    message: err.to_string().into(),
+                    data: None,
+                },
                 err @ BlockchainError::EvmOverrideError(_) => {
                     RpcError::invalid_params(err.to_string())
                 }

--- a/crates/anvil/tests/it/revert.rs
+++ b/crates/anvil/tests/it/revert.rs
@@ -29,6 +29,38 @@ async fn test_deploy_reverting() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_invalid_opcode_rpc_error_code() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+    let sender = handle.dev_accounts().next().unwrap();
+
+    // Deploy a contract whose runtime bytecode is the invalid opcode 0xfe.
+    let code = bytes!("60fe60005360016000f3");
+    let tx = TransactionRequest::default().from(sender).with_deploy_code(code);
+    let receipt = provider
+        .send_transaction(WithOtherFields::new(tx))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    let contract = receipt.contract_address.unwrap();
+
+    for (method, params) in [
+        ("eth_call", serde_json::json!([{ "from": sender, "to": contract }, "latest"])),
+        ("eth_estimateGas", serde_json::json!([{ "from": sender, "to": contract }])),
+    ] {
+        let error = rpc_error(&handle.http_endpoint(), method, params).await;
+        assert_eq!(error["code"], serde_json::json!(-32003), "{error}");
+        assert!(error.get("data").is_none(), "{error}");
+
+        let message = error["message"].as_str().unwrap();
+        assert!(message.contains("EVM error InvalidFEOpcode"), "{error}");
+        assert!(!message.contains("execution reverted"), "{error}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_revert_messages() {
     sol!(
         #[sol(rpc, bytecode = "608080604052346025575f80546001600160a01b031916600117905560b69081602a8239f35b5f80fdfe60808060405260043610156011575f80fd5b5f3560e01c635b9fdc30146023575f80fd5b34607c575f366003190112607c575f546001600160a01b03163303604c576020604051607b8152f35b62461bcd60e51b815260206004820152600b60248201526a08585d5d1a1bdc9a5e995960aa1b6044820152606490fd5b5f80fdfea2646970667358221220f593e5ccd46935f623185de62a72d9f1492d8d15075a111b0fa4d7e16acf4a7064736f6c63430008190033")]
@@ -123,4 +155,22 @@ async fn test_solc_revert_custom_errors() {
     let err = contract.revertAddress().call().await.unwrap_err();
     let s = err.to_string();
     assert!(s.contains("execution reverted"), "{s:?}");
+}
+
+async fn rpc_error(endpoint: &str, method: &str, params: serde_json::Value) -> serde_json::Value {
+    let response = reqwest::Client::new()
+        .post(endpoint)
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let body = response.json::<serde_json::Value>().await.unwrap();
+    body.get("error").cloned().unwrap_or_else(|| panic!("expected JSON-RPC error, got {body}"))
 }


### PR DESCRIPTION
## Motivation

Anvil currently maps non-`REVERT` EVM execution halts, such as `InvalidFEOpcode`, to a JSON-RPC internal error (`-32603`). These are execution failures caused by the simulated transaction, not JSON-RPC server faults.

Other clients do not all use the same JSON-RPC code for this case, but they do distinguish these halts from `REVERT` and do not classify them as internal server errors:

- Geth handles `REVERT` through a dedicated revert error path with JSON-RPC code `3` and revert data. Other VM errors, such as invalid opcode, are returned through the generic VM error path and surface with the default JSON-RPC error code (`-32000`), without revert data.
- Reth similarly maps `REVERT` to its dedicated `RevertError` / execution-error path, while halt reasons such as invalid opcode go through `EvmHalt` and are surfaced as transaction rejections (`-32003`).

## Solution

Map `BlockchainError::EvmError(_)` to `ErrorCode::TransactionRejected` (`-32003`) instead of `InternalError` (`-32603`). This follows Reth's treatment of non-`REVERT` EVM halts as transaction/execution failures while keeping Anvil's existing `REVERT` path unchanged.

Added a regression test that deploys runtime bytecode `0xfe` and verifies both `eth_call` and `eth_estimateGas` return `-32003`, omit revert data, preserve the `InvalidFEOpcode` message, and do not label the halt as `execution reverted`.

This is marked as a breaking change because callers that explicitly match Anvil's current `-32603` JSON-RPC code for non-`REVERT` EVM halts may need to update that handling.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes