### PR TITLE
feat(evm-core): gate optimism behind cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -326,7 +326,7 @@ foundry-config = { path = "crates/config" }
 foundry-debugger = { path = "crates/debugger" }
 foundry-evm = { path = "crates/evm/evm" }
 foundry-evm-abi = { path = "crates/evm/abi" }
-foundry-evm-core = { path = "crates/evm/core" }
+foundry-evm-core = { path = "crates/evm/core", default-features = false }
 foundry-evm-coverage = { path = "crates/evm/coverage" }
 foundry-evm-hardforks = { path = "crates/evm/hardforks", default-features = false }
 foundry-evm-networks = { path = "crates/evm/networks", default-features = false }

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -19,7 +19,7 @@ foundry-common.workspace = true
 foundry-config.workspace = true
 foundry-evm-abi.workspace = true
 foundry-evm-hardforks.workspace = true
-foundry-evm-networks = { workspace = true, features = ["optimism"] }
+foundry-evm-networks.workspace = true
 
 alloy-chains.workspace = true
 alloy-dyn-abi = { workspace = true, features = ["arbitrary", "eip712"] }
@@ -36,7 +36,7 @@ alloy-primitives = { workspace = true, features = [
 alloy-provider.workspace = true
 alloy-network.workspace = true
 alloy-consensus.workspace = true
-alloy-op-evm.workspace = true
+alloy-op-evm = { workspace = true, optional = true }
 alloy-rpc-types = { workspace = true, features = ["anvil"] }
 alloy-sol-types.workspace = true
 alloy-rlp.workspace = true
@@ -54,9 +54,9 @@ revm = { workspace = true, features = [
     "blst",
 ] }
 revm-inspectors.workspace = true
-op-alloy-consensus = { workspace = true, features = ["k256"] }
-op-alloy-network.workspace = true
-op-revm.workspace = true
+op-alloy-consensus = { workspace = true, features = ["k256"], optional = true }
+op-alloy-network = { workspace = true, optional = true }
+op-revm = { workspace = true, optional = true }
 tempo-revm.workspace = true
 tempo-alloy.workspace = true
 tempo-contracts.workspace = true
@@ -81,3 +81,14 @@ op-alloy-consensus.workspace = true
 op-alloy-rpc-types.workspace = true
 anvil.workspace = true
 foundry-test-utils.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = [
+    "dep:op-alloy-consensus",
+    "dep:op-alloy-network",
+    "dep:alloy-op-evm",
+    "dep:op-revm",
+    "foundry-evm-hardforks/optimism",
+    "foundry-evm-networks/optimism",
+]

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -4,13 +4,9 @@ use alloy_consensus::Typed2718;
 pub use alloy_evm::EvmEnv;
 use alloy_evm::FromRecoveredTx;
 use alloy_network::{AnyRpcTransaction, AnyTxEnvelope, TransactionResponse};
-use alloy_op_evm::OpTx;
 use alloy_primitives::{Address, B256, Bytes, U256};
-use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, TxDeposit};
-use op_revm::{
-    OpTransaction,
-    transaction::{OpTxTr, deposit::DEPOSIT_TRANSACTION_TYPE},
-};
+#[cfg(feature = "optimism")]
+use op_revm::transaction::deposit::DEPOSIT_TRANSACTION_TYPE;
 use revm::{
     Context, Database, Journal,
     context::{Block, BlockEnv, Cfg, CfgEnv, Transaction, TxEnv},
@@ -236,9 +232,16 @@ pub trait FoundryTransaction: Transaction {
     /// Sets whether the transaction is a system transaction
     fn set_system_transaction(&mut self, _is_system_transaction: bool) {}
 
-    /// Returns `true` if transaction is of type [`DEPOSIT_TRANSACTION_TYPE`].
+    /// Returns `true` if transaction is an Optimism deposit transaction.
     fn is_deposit(&self) -> bool {
-        self.tx_type() == DEPOSIT_TRANSACTION_TYPE
+        #[cfg(feature = "optimism")]
+        {
+            self.tx_type() == DEPOSIT_TRANSACTION_TYPE
+        }
+        #[cfg(not(feature = "optimism"))]
+        {
+            false
+        }
     }
 
     // Tempo methods
@@ -317,188 +320,6 @@ impl FoundryTransaction for TxEnv {
 
     fn set_max_fee_per_blob_gas(&mut self, max_fee_per_blob_gas: u128) {
         self.max_fee_per_blob_gas = max_fee_per_blob_gas;
-    }
-}
-
-impl<TX: FoundryTransaction> FoundryTransaction for OpTransaction<TX> {
-    fn set_tx_type(&mut self, tx_type: u8) {
-        self.base.set_tx_type(tx_type);
-    }
-
-    fn set_caller(&mut self, caller: Address) {
-        self.base.set_caller(caller);
-    }
-
-    fn set_gas_limit(&mut self, gas_limit: u64) {
-        self.base.set_gas_limit(gas_limit);
-    }
-
-    fn set_gas_price(&mut self, gas_price: u128) {
-        self.base.set_gas_price(gas_price);
-    }
-
-    fn set_kind(&mut self, kind: TxKind) {
-        self.base.set_kind(kind);
-    }
-
-    fn set_value(&mut self, value: U256) {
-        self.base.set_value(value);
-    }
-
-    fn set_data(&mut self, data: Bytes) {
-        self.base.set_data(data);
-    }
-
-    fn set_nonce(&mut self, nonce: u64) {
-        self.base.set_nonce(nonce);
-    }
-
-    fn set_chain_id(&mut self, chain_id: Option<u64>) {
-        self.base.set_chain_id(chain_id);
-    }
-
-    fn set_access_list(&mut self, access_list: AccessList) {
-        self.base.set_access_list(access_list);
-    }
-
-    fn authorization_list_mut(
-        &mut self,
-    ) -> &mut Vec<Either<SignedAuthorization, RecoveredAuthorization>> {
-        self.base.authorization_list_mut()
-    }
-
-    fn set_gas_priority_fee(&mut self, gas_priority_fee: Option<u128>) {
-        self.base.set_gas_priority_fee(gas_priority_fee);
-    }
-
-    fn set_blob_hashes(&mut self, _blob_hashes: Vec<B256>) {}
-
-    fn set_max_fee_per_blob_gas(&mut self, _max_fee_per_blob_gas: u128) {}
-
-    fn enveloped_tx(&self) -> Option<&Bytes> {
-        OpTxTr::enveloped_tx(self)
-    }
-
-    fn set_enveloped_tx(&mut self, bytes: Bytes) {
-        self.enveloped_tx = Some(bytes);
-    }
-
-    fn source_hash(&self) -> Option<B256> {
-        OpTxTr::source_hash(self)
-    }
-
-    fn set_source_hash(&mut self, source_hash: B256) {
-        if self.tx_type() == DEPOSIT_TRANSACTION_TYPE {
-            self.deposit.source_hash = source_hash;
-        }
-    }
-
-    fn mint(&self) -> Option<u128> {
-        OpTxTr::mint(self)
-    }
-
-    fn set_mint(&mut self, mint: u128) {
-        if self.tx_type() == DEPOSIT_TRANSACTION_TYPE {
-            self.deposit.mint = Some(mint);
-        }
-    }
-
-    fn is_system_transaction(&self) -> bool {
-        OpTxTr::is_system_transaction(self)
-    }
-
-    fn set_system_transaction(&mut self, is_system_transaction: bool) {
-        if self.tx_type() == DEPOSIT_TRANSACTION_TYPE {
-            self.deposit.is_system_transaction = is_system_transaction;
-        }
-    }
-}
-
-impl FoundryTransaction for OpTx {
-    fn set_tx_type(&mut self, tx_type: u8) {
-        self.0.set_tx_type(tx_type);
-    }
-
-    fn set_caller(&mut self, caller: Address) {
-        self.0.set_caller(caller);
-    }
-
-    fn set_gas_limit(&mut self, gas_limit: u64) {
-        self.0.set_gas_limit(gas_limit);
-    }
-
-    fn set_gas_price(&mut self, gas_price: u128) {
-        self.0.set_gas_price(gas_price);
-    }
-
-    fn set_kind(&mut self, kind: TxKind) {
-        self.0.set_kind(kind);
-    }
-
-    fn set_value(&mut self, value: U256) {
-        self.0.set_value(value);
-    }
-
-    fn set_data(&mut self, data: Bytes) {
-        self.0.set_data(data);
-    }
-
-    fn set_nonce(&mut self, nonce: u64) {
-        self.0.set_nonce(nonce);
-    }
-
-    fn set_chain_id(&mut self, chain_id: Option<u64>) {
-        self.0.set_chain_id(chain_id);
-    }
-
-    fn set_access_list(&mut self, access_list: AccessList) {
-        self.0.set_access_list(access_list);
-    }
-
-    fn authorization_list_mut(
-        &mut self,
-    ) -> &mut Vec<Either<SignedAuthorization, RecoveredAuthorization>> {
-        self.0.authorization_list_mut()
-    }
-
-    fn set_gas_priority_fee(&mut self, gas_priority_fee: Option<u128>) {
-        self.0.set_gas_priority_fee(gas_priority_fee);
-    }
-
-    fn set_blob_hashes(&mut self, _blob_hashes: Vec<B256>) {}
-
-    fn set_max_fee_per_blob_gas(&mut self, _max_fee_per_blob_gas: u128) {}
-
-    fn enveloped_tx(&self) -> Option<&Bytes> {
-        FoundryTransaction::enveloped_tx(&self.0)
-    }
-
-    fn set_enveloped_tx(&mut self, bytes: Bytes) {
-        self.0.set_enveloped_tx(bytes);
-    }
-
-    fn source_hash(&self) -> Option<B256> {
-        FoundryTransaction::source_hash(&self.0)
-    }
-
-    fn set_source_hash(&mut self, source_hash: B256) {
-        self.0.set_source_hash(source_hash);
-    }
-
-    fn mint(&self) -> Option<u128> {
-        FoundryTransaction::mint(&self.0)
-    }
-
-    fn set_mint(&mut self, mint: u128) {
-        self.0.set_mint(mint);
-    }
-
-    fn is_system_transaction(&self) -> bool {
-        FoundryTransaction::is_system_transaction(&self.0)
-    }
-
-    fn set_system_transaction(&mut self, is_system_transaction: bool) {
-        self.0.set_system_transaction(is_system_transaction);
     }
 }
 
@@ -687,32 +508,6 @@ impl FromAnyRpcTransaction for TxEnv {
     }
 }
 
-impl FromAnyRpcTransaction for OpTx {
-    fn from_any_rpc_transaction(tx: &AnyRpcTransaction) -> eyre::Result<Self> {
-        if let Some(envelope) = tx.as_envelope() {
-            return Ok(Self(OpTransaction::<TxEnv> {
-                base: TxEnv::from_recovered_tx(envelope, tx.from()),
-                enveloped_tx: None,
-                deposit: Default::default(),
-            }));
-        }
-
-        // Handle OP deposit transactions from `Unknown` envelope variant.
-        if let AnyTxEnvelope::Unknown(unknown) = &*tx.inner.inner
-            && unknown.ty() == DEPOSIT_TX_TYPE_ID
-        {
-            let mut fields = unknown.inner.fields.clone();
-            fields.insert("from".to_string(), serde_json::to_value(tx.from())?);
-            let deposit_tx: TxDeposit = fields
-                .deserialize_into()
-                .map_err(|e| eyre::eyre!("failed to deserialize deposit tx: {e}"))?;
-            return Ok(Self::from_recovered_tx(&deposit_tx, deposit_tx.from));
-        }
-
-        eyre::bail!("cannot convert unknown transaction type to OpTransaction")
-    }
-}
-
 impl FromAnyRpcTransaction for TempoTxEnv {
     fn from_any_rpc_transaction(tx: &AnyRpcTransaction) -> eyre::Result<Self> {
         use alloy_consensus::Transaction as _;
@@ -747,6 +542,222 @@ impl FromAnyRpcTransaction for TempoTxEnv {
     }
 }
 
+#[cfg(feature = "optimism")]
+mod optimism {
+    use super::*;
+    use alloy_op_evm::OpTx;
+    use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, TxDeposit};
+    use op_revm::{OpTransaction, transaction::OpTxTr};
+
+    impl<TX: FoundryTransaction> FoundryTransaction for OpTransaction<TX> {
+        fn set_tx_type(&mut self, tx_type: u8) {
+            self.base.set_tx_type(tx_type);
+        }
+
+        fn set_caller(&mut self, caller: Address) {
+            self.base.set_caller(caller);
+        }
+
+        fn set_gas_limit(&mut self, gas_limit: u64) {
+            self.base.set_gas_limit(gas_limit);
+        }
+
+        fn set_gas_price(&mut self, gas_price: u128) {
+            self.base.set_gas_price(gas_price);
+        }
+
+        fn set_kind(&mut self, kind: TxKind) {
+            self.base.set_kind(kind);
+        }
+
+        fn set_value(&mut self, value: U256) {
+            self.base.set_value(value);
+        }
+
+        fn set_data(&mut self, data: Bytes) {
+            self.base.set_data(data);
+        }
+
+        fn set_nonce(&mut self, nonce: u64) {
+            self.base.set_nonce(nonce);
+        }
+
+        fn set_chain_id(&mut self, chain_id: Option<u64>) {
+            self.base.set_chain_id(chain_id);
+        }
+
+        fn set_access_list(&mut self, access_list: AccessList) {
+            self.base.set_access_list(access_list);
+        }
+
+        fn authorization_list_mut(
+            &mut self,
+        ) -> &mut Vec<Either<SignedAuthorization, RecoveredAuthorization>> {
+            self.base.authorization_list_mut()
+        }
+
+        fn set_gas_priority_fee(&mut self, gas_priority_fee: Option<u128>) {
+            self.base.set_gas_priority_fee(gas_priority_fee);
+        }
+
+        fn set_blob_hashes(&mut self, _blob_hashes: Vec<B256>) {}
+
+        fn set_max_fee_per_blob_gas(&mut self, _max_fee_per_blob_gas: u128) {}
+
+        fn enveloped_tx(&self) -> Option<&Bytes> {
+            OpTxTr::enveloped_tx(self)
+        }
+
+        fn set_enveloped_tx(&mut self, bytes: Bytes) {
+            self.enveloped_tx = Some(bytes);
+        }
+
+        fn source_hash(&self) -> Option<B256> {
+            OpTxTr::source_hash(self)
+        }
+
+        fn set_source_hash(&mut self, source_hash: B256) {
+            if self.tx_type() == DEPOSIT_TRANSACTION_TYPE {
+                self.deposit.source_hash = source_hash;
+            }
+        }
+
+        fn mint(&self) -> Option<u128> {
+            OpTxTr::mint(self)
+        }
+
+        fn set_mint(&mut self, mint: u128) {
+            if self.tx_type() == DEPOSIT_TRANSACTION_TYPE {
+                self.deposit.mint = Some(mint);
+            }
+        }
+
+        fn is_system_transaction(&self) -> bool {
+            OpTxTr::is_system_transaction(self)
+        }
+
+        fn set_system_transaction(&mut self, is_system_transaction: bool) {
+            if self.tx_type() == DEPOSIT_TRANSACTION_TYPE {
+                self.deposit.is_system_transaction = is_system_transaction;
+            }
+        }
+    }
+
+    impl FoundryTransaction for OpTx {
+        fn set_tx_type(&mut self, tx_type: u8) {
+            self.0.set_tx_type(tx_type);
+        }
+
+        fn set_caller(&mut self, caller: Address) {
+            self.0.set_caller(caller);
+        }
+
+        fn set_gas_limit(&mut self, gas_limit: u64) {
+            self.0.set_gas_limit(gas_limit);
+        }
+
+        fn set_gas_price(&mut self, gas_price: u128) {
+            self.0.set_gas_price(gas_price);
+        }
+
+        fn set_kind(&mut self, kind: TxKind) {
+            self.0.set_kind(kind);
+        }
+
+        fn set_value(&mut self, value: U256) {
+            self.0.set_value(value);
+        }
+
+        fn set_data(&mut self, data: Bytes) {
+            self.0.set_data(data);
+        }
+
+        fn set_nonce(&mut self, nonce: u64) {
+            self.0.set_nonce(nonce);
+        }
+
+        fn set_chain_id(&mut self, chain_id: Option<u64>) {
+            self.0.set_chain_id(chain_id);
+        }
+
+        fn set_access_list(&mut self, access_list: AccessList) {
+            self.0.set_access_list(access_list);
+        }
+
+        fn authorization_list_mut(
+            &mut self,
+        ) -> &mut Vec<Either<SignedAuthorization, RecoveredAuthorization>> {
+            self.0.authorization_list_mut()
+        }
+
+        fn set_gas_priority_fee(&mut self, gas_priority_fee: Option<u128>) {
+            self.0.set_gas_priority_fee(gas_priority_fee);
+        }
+
+        fn set_blob_hashes(&mut self, _blob_hashes: Vec<B256>) {}
+
+        fn set_max_fee_per_blob_gas(&mut self, _max_fee_per_blob_gas: u128) {}
+
+        fn enveloped_tx(&self) -> Option<&Bytes> {
+            FoundryTransaction::enveloped_tx(&self.0)
+        }
+
+        fn set_enveloped_tx(&mut self, bytes: Bytes) {
+            self.0.set_enveloped_tx(bytes);
+        }
+
+        fn source_hash(&self) -> Option<B256> {
+            FoundryTransaction::source_hash(&self.0)
+        }
+
+        fn set_source_hash(&mut self, source_hash: B256) {
+            self.0.set_source_hash(source_hash);
+        }
+
+        fn mint(&self) -> Option<u128> {
+            FoundryTransaction::mint(&self.0)
+        }
+
+        fn set_mint(&mut self, mint: u128) {
+            self.0.set_mint(mint);
+        }
+
+        fn is_system_transaction(&self) -> bool {
+            FoundryTransaction::is_system_transaction(&self.0)
+        }
+
+        fn set_system_transaction(&mut self, is_system_transaction: bool) {
+            self.0.set_system_transaction(is_system_transaction);
+        }
+    }
+
+    impl FromAnyRpcTransaction for OpTx {
+        fn from_any_rpc_transaction(tx: &AnyRpcTransaction) -> eyre::Result<Self> {
+            if let Some(envelope) = tx.as_envelope() {
+                return Ok(Self(OpTransaction::<TxEnv> {
+                    base: TxEnv::from_recovered_tx(envelope, tx.from()),
+                    enveloped_tx: None,
+                    deposit: Default::default(),
+                }));
+            }
+
+            // Handle OP deposit transactions from `Unknown` envelope variant.
+            if let AnyTxEnvelope::Unknown(unknown) = &*tx.inner.inner
+                && unknown.ty() == DEPOSIT_TX_TYPE_ID
+            {
+                let mut fields = unknown.inner.fields.clone();
+                fields.insert("from".to_string(), serde_json::to_value(tx.from())?);
+                let deposit_tx: TxDeposit = fields
+                    .deserialize_into()
+                    .map_err(|e| eyre::eyre!("failed to deserialize deposit tx: {e}"))?;
+                return Ok(Self::from_recovered_tx(&deposit_tx, deposit_tx.from));
+            }
+
+            eyre::bail!("cannot convert unknown transaction type to OpTransaction")
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroU64;
@@ -755,14 +766,10 @@ mod tests {
     use alloy_consensus::{Sealed, Signed, TxEip1559, transaction::Recovered};
     use alloy_evm::{EthEvmFactory, EvmFactory};
     use alloy_network::{AnyTxType, UnknownTxEnvelope, UnknownTypedTransaction};
-    use alloy_op_evm::OpEvmFactory;
     use alloy_primitives::Signature;
     use alloy_rpc_types::{Transaction as RpcTransaction, TransactionInfo};
     use alloy_serde::WithOtherFields;
     use foundry_evm_hardforks::TempoHardfork;
-    use op_alloy_consensus::{OpTxEnvelope, transaction::OpTransactionInfo};
-    use op_alloy_rpc_types::Transaction as OpRpcTransaction;
-    use op_revm::OpSpecId;
     use revm::database::EmptyDB;
     use tempo_alloy::primitives::{
         AASigned, TempoSignature, TempoTransaction, TempoTxEnvelope,
@@ -785,30 +792,6 @@ mod tests {
         // Test EVM Context Cfg mutation
         evm.ctx_mut().cfg_mut().spec = SpecId::AMSTERDAM;
         assert_eq!(evm.ctx().cfg().spec, SpecId::AMSTERDAM);
-
-        // Round-trip test to ensure no issues with cloning and setting tx_env and evm_env
-        let tx_env = evm.ctx().tx_clone();
-        evm.ctx_mut().set_tx(tx_env);
-        let evm_env = evm.ctx().evm_clone();
-        evm.ctx_mut().set_evm(evm_env);
-    }
-
-    #[test]
-    fn op_evm_foundry_context_ext_implementation() {
-        let mut evm =
-            OpEvmFactory::<OpTx>::default().create_evm(EmptyDB::default(), EvmEnv::default());
-
-        // Test EVM Context Block mutation
-        evm.ctx_mut().block_mut().set_number(U256::from(123));
-        assert_eq!(evm.ctx().block().number(), U256::from(123));
-
-        // Test EVM Context Tx mutation
-        evm.ctx_mut().tx_mut().set_nonce(99);
-        assert_eq!(evm.ctx().tx().nonce(), 99);
-
-        // Test EVM Context Cfg mutation
-        evm.ctx_mut().cfg_mut().spec = OpSpecId::JOVIAN;
-        assert_eq!(evm.ctx().cfg().spec, OpSpecId::JOVIAN);
 
         // Round-trip test to ensure no issues with cloning and setting tx_env and evm_env
         let tx_env = evm.ctx().tx_clone();
@@ -875,23 +858,6 @@ mod tests {
     }
 
     #[test]
-    fn from_any_rpc_transaction_for_op() {
-        let from = Address::random();
-        let signed_tx = make_signed_eip1559();
-
-        // Build the eth TxEnv to compare against op base
-        let rpc_tx = RpcTransaction::from_transaction(
-            Recovered::new_unchecked(signed_tx.into(), from),
-            TransactionInfo::default(),
-        );
-        let any_tx = <AnyRpcTransaction as From<RpcTransaction>>::from(rpc_tx);
-        let expected_base = TxEnv::from_any_rpc_transaction(&any_tx).unwrap();
-
-        let op_tx_env = OpTx::from_any_rpc_transaction(&any_tx).unwrap();
-        assert_eq!(op_tx_env.base, expected_base);
-    }
-
-    #[test]
     fn from_any_rpc_transaction_unknown_envelope_errors() {
         let unknown = AnyTxEnvelope::Unknown(UnknownTxEnvelope {
             hash: B256::ZERO,
@@ -913,39 +879,6 @@ mod tests {
 
         let result = TxEnv::from_any_rpc_transaction(&any_tx).unwrap_err();
         assert!(result.to_string().contains("unknown transaction type"));
-    }
-
-    #[test]
-    fn from_any_rpc_transaction_for_op_deposit() {
-        let from = Address::random();
-        let source_hash = B256::random();
-        let deposit = TxDeposit {
-            source_hash,
-            from,
-            to: TxKind::Call(Address::with_last_byte(0xCC)),
-            mint: 1111,
-            value: U256::from(200),
-            gas_limit: 21000,
-            is_system_transaction: true,
-            input: Default::default(),
-        };
-
-        // Build a concrete OpRpcTransaction, serialize to JSON, deserialize as AnyRpcTransaction.
-        let op_rpc_tx = OpRpcTransaction::from_transaction(
-            Recovered::new_unchecked(OpTxEnvelope::Deposit(Sealed::new(deposit)), from),
-            OpTransactionInfo::default(),
-        );
-        let json = serde_json::to_value(&op_rpc_tx).unwrap();
-        let any_tx: AnyRpcTransaction = serde_json::from_value(json).unwrap();
-
-        let op_tx_env = OpTx::from_any_rpc_transaction(&any_tx).unwrap();
-        assert_eq!(op_tx_env.base.caller, from);
-        assert_eq!(op_tx_env.base.kind, TxKind::Call(Address::with_last_byte(0xCC)));
-        assert_eq!(op_tx_env.base.value, U256::from(200));
-        assert_eq!(op_tx_env.base.gas_limit, 21000);
-        assert_eq!(op_tx_env.deposit.source_hash, source_hash);
-        assert_eq!(op_tx_env.deposit.mint, Some(1111));
-        assert!(op_tx_env.deposit.is_system_transaction);
     }
 
     #[test]
@@ -1003,5 +936,89 @@ mod tests {
         assert_eq!(tx_env.inner.gas_limit, 424242);
         assert_eq!(tx_env.inner.chain_id, Some(42431));
         assert_eq!(tx_env.fee_token, fee_token);
+    }
+
+    #[cfg(feature = "optimism")]
+    mod optimism {
+        use super::*;
+        use alloy_op_evm::{OpEvmFactory, OpTx};
+        use op_alloy_consensus::{OpTxEnvelope, TxDeposit, transaction::OpTransactionInfo};
+        use op_alloy_rpc_types::Transaction as OpRpcTransaction;
+        use op_revm::OpSpecId;
+
+        #[test]
+        fn op_evm_foundry_context_ext_implementation() {
+            let mut evm =
+                OpEvmFactory::<OpTx>::default().create_evm(EmptyDB::default(), EvmEnv::default());
+
+            // Test EVM Context Block mutation
+            evm.ctx_mut().block_mut().set_number(U256::from(123));
+            assert_eq!(evm.ctx().block().number(), U256::from(123));
+
+            // Test EVM Context Tx mutation
+            evm.ctx_mut().tx_mut().set_nonce(99);
+            assert_eq!(evm.ctx().tx().nonce(), 99);
+
+            // Test EVM Context Cfg mutation
+            evm.ctx_mut().cfg_mut().spec = OpSpecId::JOVIAN;
+            assert_eq!(evm.ctx().cfg().spec, OpSpecId::JOVIAN);
+
+            // Round-trip test to ensure no issues with cloning and setting tx_env and evm_env
+            let tx_env = evm.ctx().tx_clone();
+            evm.ctx_mut().set_tx(tx_env);
+            let evm_env = evm.ctx().evm_clone();
+            evm.ctx_mut().set_evm(evm_env);
+        }
+
+        #[test]
+        fn from_any_rpc_transaction_for_op() {
+            let from = Address::random();
+            let signed_tx = make_signed_eip1559();
+
+            // Build the eth TxEnv to compare against op base
+            let rpc_tx = RpcTransaction::from_transaction(
+                Recovered::new_unchecked(signed_tx.into(), from),
+                TransactionInfo::default(),
+            );
+            let any_tx = <AnyRpcTransaction as From<RpcTransaction>>::from(rpc_tx);
+            let expected_base = TxEnv::from_any_rpc_transaction(&any_tx).unwrap();
+
+            let op_tx_env = OpTx::from_any_rpc_transaction(&any_tx).unwrap();
+            assert_eq!(op_tx_env.base, expected_base);
+        }
+
+        #[test]
+        fn from_any_rpc_transaction_for_op_deposit() {
+            let from = Address::random();
+            let source_hash = B256::random();
+            let deposit = TxDeposit {
+                source_hash,
+                from,
+                to: TxKind::Call(Address::with_last_byte(0xCC)),
+                mint: 1111,
+                value: U256::from(200),
+                gas_limit: 21000,
+                is_system_transaction: true,
+                input: Default::default(),
+            };
+
+            // Build a concrete OpRpcTransaction, serialize to JSON, deserialize as
+            // AnyRpcTransaction.
+            let op_rpc_tx = OpRpcTransaction::from_transaction(
+                Recovered::new_unchecked(OpTxEnvelope::Deposit(Sealed::new(deposit)), from),
+                OpTransactionInfo::default(),
+            );
+            let json = serde_json::to_value(&op_rpc_tx).unwrap();
+            let any_tx: AnyRpcTransaction = serde_json::from_value(json).unwrap();
+
+            let op_tx_env = OpTx::from_any_rpc_transaction(&any_tx).unwrap();
+            assert_eq!(op_tx_env.base.caller, from);
+            assert_eq!(op_tx_env.base.kind, TxKind::Call(Address::with_last_byte(0xCC)));
+            assert_eq!(op_tx_env.base.value, U256::from(200));
+            assert_eq!(op_tx_env.base.gas_limit, 21000);
+            assert_eq!(op_tx_env.deposit.source_hash, source_hash);
+            assert_eq!(op_tx_env.deposit.mint, Some(1111));
+            assert!(op_tx_env.deposit.is_system_transaction);
+        }
     }
 }

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -10,14 +10,11 @@ use alloy_evm::{
     EthEvmFactory, Evm, EvmEnv, EvmFactory, FromRecoveredTx, precompiles::PrecompilesMap,
 };
 use alloy_network::{Ethereum, Network};
-use alloy_op_evm::OpEvmFactory;
 use alloy_primitives::{Address, Signature, U256};
 use alloy_rlp::Decodable;
 use foundry_common::{FoundryReceiptResponse, FoundryTransactionBuilder, fmt::UIfmt};
 use foundry_config::FromEvmVersion;
 use foundry_fork_db::{DatabaseError, ForkBlockEnv};
-use op_alloy_network::Optimism;
-use op_revm::OpHaltReason;
 use revm::{
     Database,
     context::{
@@ -36,10 +33,12 @@ use tempo_evm::evm::TempoEvmFactory;
 use tempo_revm::TempoHaltReason;
 
 pub mod eth;
+#[cfg(feature = "optimism")]
 pub mod op;
 pub mod tempo;
 
 pub use eth::*;
+#[cfg(feature = "optimism")]
 pub use op::*;
 pub use tempo::*;
 
@@ -73,13 +72,6 @@ pub struct TempoEvmNetwork;
 impl FoundryEvmNetwork for TempoEvmNetwork {
     type Network = TempoNetwork;
     type EvmFactory = TempoEvmFactory;
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-pub struct OpEvmNetwork;
-impl FoundryEvmNetwork for OpEvmNetwork {
-    type Network = Optimism;
-    type EvmFactory = OpEvmFactory;
 }
 
 /// Convenience type aliases for accessing associated types through [`FoundryEvmNetwork`].
@@ -246,15 +238,6 @@ pub trait IntoInstructionResult {
 impl IntoInstructionResult for HaltReason {
     fn into_instruction_result(self) -> InstructionResult {
         self.into()
-    }
-}
-
-impl IntoInstructionResult for OpHaltReason {
-    fn into_instruction_result(self) -> InstructionResult {
-        match self {
-            Self::Base(eth) => eth.into(),
-            Self::FailedDeposit => InstructionResult::Stop,
-        }
     }
 }
 

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -1,6 +1,7 @@
 use alloy_evm::{Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
 use alloy_op_evm::{OpEvm, OpEvmContext, OpEvmFactory, OpTx};
 use foundry_fork_db::DatabaseError;
+use op_alloy_network::Optimism;
 use op_revm::{OpEvm as RevmEvm, OpHaltReason, OpSpecId, OpTransactionError, handler::OpHandler};
 use revm::{
     context::{
@@ -10,15 +11,32 @@ use revm::{
     handler::{EthFrame, EvmTr, FrameResult, Handler, instructions::EthInstructions},
     inspector::InspectorHandler,
     interpreter::{
-        FrameInput, SharedMemory, interpreter::EthInterpreter, interpreter_action::FrameInit,
+        FrameInput, InstructionResult, SharedMemory, interpreter::EthInterpreter,
+        interpreter_action::FrameInit,
     },
 };
 
 use crate::{
     FoundryContextExt, FoundryInspectorExt,
     backend::{DatabaseExt, JournaledState},
-    evm::{FoundryEvmFactory, NestedEvm},
+    evm::{FoundryEvmFactory, FoundryEvmNetwork, IntoInstructionResult, NestedEvm},
 };
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct OpEvmNetwork;
+impl FoundryEvmNetwork for OpEvmNetwork {
+    type Network = Optimism;
+    type EvmFactory = OpEvmFactory;
+}
+
+impl IntoInstructionResult for OpHaltReason {
+    fn into_instruction_result(self) -> InstructionResult {
+        match self {
+            Self::Base(eth) => eth.into(),
+            Self::FailedDeposit => InstructionResult::Stop,
+        }
+    }
+}
 
 type OpEvmHandler<'db, I> =
     OpHandler<OpRevmEvm<'db, I>, EVMError<DatabaseError, OpTransactionError>, EthFrame>;

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -137,8 +137,12 @@ impl EvmOpts {
     /// [`NetworkConfigs::with_chain_id`] to auto-enable the correct network
     /// (e.g. Tempo, OP Stack) based on the chain ID.
     pub async fn infer_network_from_fork(&mut self) {
+        #[cfg(feature = "optimism")]
+        let already_op = self.networks.is_optimism();
+        #[cfg(not(feature = "optimism"))]
+        let already_op = false;
         if !self.networks.is_tempo()
-            && !self.networks.is_optimism()
+            && !already_op
             && let Some(ref fork_url) = self.fork_url
             && let Ok(provider) = self.fork_provider_with_url::<AnyNetwork>(fork_url)
             && let Ok(chain_id) = provider.get_chain_id().await
@@ -474,6 +478,7 @@ mod tests {
 
         // Plain anvil (chain id 31337) without tempo flag -> Ethereum (no network flags set).
         assert!(!evm_opts.networks.is_tempo());
+        #[cfg(feature = "optimism")]
         assert!(!evm_opts.networks.is_optimism());
         assert!(!evm_opts.networks.is_celo());
         assert_eq!(evm_opts.networks, NetworkConfigs::default());

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -18,7 +18,7 @@ foundry-cheatcodes.workspace = true
 foundry-common.workspace = true
 foundry-compilers.workspace = true
 foundry-config.workspace = true
-foundry-evm-core.workspace = true
+foundry-evm-core = { workspace = true, features = ["optimism"] }
 foundry-evm-coverage.workspace = true
 foundry-evm-fuzz.workspace = true
 foundry-evm-sancov.workspace = true


### PR DESCRIPTION
Gates `foundry-evm-core` behind a default-on `optimism` cargo feature. The workspace dep is set to `default-features = false`; the `foundry-evm` umbrella opts back in via `features = ["optimism"]` to keep `OpEvmNetwork` reachable for `cast`/`script`/`forge`.

Closes the residual `op-revm` and `alloy-op-evm` leak from PR #14577. The remaining `op-alloy-consensus`/`op-alloy-network`/`op-alloy-rpc-types` leak goes through `foundry-common` and is out of scope here.

### Verification
- `cargo build --workspace`
- `cargo build --workspace --no-default-features`
- `cargo test -p foundry-evm-core --lib` → 32/32
- `cargo tree --manifest-path crates/evm/core/Cargo.toml --no-default-features -e normal` → no `op-revm`, no `alloy-op-evm`