### PR TITLE
refactor(script): remove `ScriptConfig::{fee_token,expires_at}` in favour of `TempoOpts`

### DIFF
--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -884,10 +884,10 @@ impl BundledState<TempoEvmNetwork> {
                 max_priority_fee_per_gas: Some(max_priority_fee_per_gas),
                 ..Default::default()
             },
-            fee_token: self.script_config.fee_token,
+            fee_token: self.script_config.tempo.common.fee_token,
             calls: calls.clone(),
-            nonce_key: self.script_config.expires_at.map(|_| alloy_primitives::U256::MAX),
-            valid_before: self.script_config.expires_at.and_then(NonZeroU64::new),
+            nonce_key: self.script_config.tempo.expiring_nonce.then_some(U256::MAX),
+            valid_before: self.script_config.tempo.valid_before.and_then(NonZeroU64::new),
             ..Default::default()
         };
         self.script_config.tempo.apply::<TempoNetwork>(&mut batch_tx, None);

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -286,21 +286,17 @@ impl ScriptArgs {
         }
 
         let mut tempo = self.tempo.clone();
-        let expires_at = tempo.expires_at();
-        if let Some(ts) = expires_at {
+        if let Some(ts) = tempo.expires_at() {
             tempo.expiring_nonce = true;
             tempo.valid_before = Some(ts);
             tempo.common.expires = None;
         }
 
-        let fee_token = if evm_opts.networks.is_tempo() && tempo.common.fee_token.is_none() {
-            Some(PATH_USD_ADDRESS)
-        } else {
-            tempo.common.fee_token
-        };
+        if evm_opts.networks.is_tempo() && tempo.common.fee_token.is_none() {
+            tempo.common.fee_token = Some(PATH_USD_ADDRESS);
+        }
 
-        let script_config =
-            ScriptConfig::new(config, evm_opts, self.batch, fee_token, expires_at, tempo).await?;
+        let script_config = ScriptConfig::new(config, evm_opts, self.batch, tempo).await?;
         Ok(PreprocessedState { args: self, script_config, script_wallets, browser_wallet })
     }
 
@@ -717,10 +713,6 @@ pub struct ScriptConfig<FEN: FoundryEvmNetwork> {
     pub backends: HashMap<String, Backend<FEN>>,
     /// Whether to batch all broadcast transactions into a single Tempo batch transaction.
     pub batch: bool,
-    /// Tempo fee token address for paying transaction fees.
-    pub fee_token: Option<Address>,
-    /// TIP-1009 expiring-nonce valid_before unix timestamp, derived from `--tempo.expires`.
-    pub expires_at: Option<u64>,
     /// Tempo transaction options applied to broadcast transactions.
     pub tempo: TempoOpts,
 }
@@ -730,8 +722,6 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         config: Config,
         evm_opts: EvmOpts,
         batch: bool,
-        fee_token: Option<Address>,
-        expires_at: Option<u64>,
         tempo: TempoOpts,
     ) -> Result<Self> {
         let sender_nonce = if let Some(fork_url) = evm_opts.fork_url.as_ref() {
@@ -741,16 +731,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
             1
         };
 
-        Ok(Self {
-            config,
-            evm_opts,
-            sender_nonce,
-            backends: HashMap::default(),
-            batch,
-            fee_token,
-            expires_at,
-            tempo,
-        })
+        Ok(Self { config, evm_opts, sender_nonce, backends: HashMap::default(), batch, tempo })
     }
 
     pub async fn update_sender(&mut self, sender: Address) -> Result<()> {
@@ -826,7 +807,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
                             self.evm_opts.clone(),
                             Some(known_contracts),
                             Some(target),
-                            self.fee_token,
+                            self.tempo.common.fee_token,
                         )
                         .into(),
                     )
@@ -837,7 +818,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
 
         // Propagate fee token to the transaction environment so that internal EVM calls
         // (e.g. script deployment, setUp) use the correct fee token for Tempo networks.
-        tx_env.set_fee_token(self.fee_token);
+        tx_env.set_fee_token(self.tempo.common.fee_token);
 
         Ok(ScriptRunner::new(builder.build(evm_env, tx_env, db), self.evm_opts.clone()))
     }

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -6,7 +6,7 @@ use alloy_network::TransactionBuilder;
 use alloy_primitives::{Address, Bytes, U256};
 use eyre::Result;
 use foundry_cheatcodes::BroadcastableTransaction;
-use foundry_common::{FoundryTransactionBuilder, TransactionMaybeSigned};
+use foundry_common::TransactionMaybeSigned;
 use foundry_config::Config;
 use foundry_evm::{
     constants::CALLER,
@@ -19,7 +19,7 @@ use foundry_evm::{
     revm::interpreter::{InstructionResult, return_ok},
     traces::{TraceKind, Traces},
 };
-use std::{collections::VecDeque, num::NonZeroU64};
+use std::collections::VecDeque;
 
 /// Drives script execution
 #[derive(Debug)]
@@ -84,10 +84,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                     .with_input(code.clone())
                     .with_nonce(sender_nonce + library_transactions.len() as u64);
 
-                if let Some(fee_token) = script_config.fee_token {
-                    tx_req.set_fee_token(fee_token);
-                }
-                apply_expires::<FEN>(&mut tx_req, script_config.expires_at);
+                script_config.tempo.apply::<FEN::Network>(&mut tx_req, None);
 
                 library_transactions.push_back(BroadcastableTransaction {
                     rpc: self.evm_opts.fork_url.clone(),
@@ -123,10 +120,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                         .with_nonce(sender_nonce + library_transactions.len() as u64)
                         .with_to(create2_deployer);
 
-                    if let Some(fee_token) = script_config.fee_token {
-                        tx_req.set_fee_token(fee_token);
-                    }
-                    apply_expires::<FEN>(&mut tx_req, script_config.expires_at);
+                    script_config.tempo.apply::<FEN::Network>(&mut tx_req, None);
 
                     library_transactions.push_back(BroadcastableTransaction {
                         rpc: self.evm_opts.fork_url.clone(),
@@ -431,22 +425,5 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
             self.executor.tx_env_mut().set_gas_limit(init_gas_limit);
         }
         Ok(gas_used)
-    }
-}
-
-/// Applies TIP-1009 expiring-nonce fields to a transaction request when `expires_at` is set.
-///
-/// Sets `nonce = 0`, `nonce_key = U256::MAX`, and `valid_before = expires_at`.
-fn apply_expires<FEN: FoundryEvmNetwork>(
-    tx: &mut TransactionRequestFor<FEN>,
-    expires_at: Option<u64>,
-) where
-    TransactionRequestFor<FEN>: FoundryTransactionBuilder<FEN::Network>,
-{
-    let Some(ts) = expires_at else { return };
-    tx.set_nonce(0);
-    tx.set_nonce_key(U256::MAX);
-    if let Some(v) = NonZeroU64::new(ts) {
-        tx.set_valid_before(v);
     }
 }


### PR DESCRIPTION
## Summary

Removes two redundant fields from `ScriptConfig` that duplicated state already present in `TempoOpts`:

- **`expires_at`**  was a copy of `tempo.valid_before`, populated only when `--tempo.expires` was passed. Dropped in favour of reading `tempo.expiring_nonce` / `tempo.valid_before` directly.
- **`fee_token`**  was a copy of `tempo.common.fee_token` with a `PATH_USD_ADDRESS` default applied for Tempo networks. The default is now resolved into `tempo.common.fee_token` during `preprocess()`, removing the need for a separate field.

The `apply_expires` helper in `runner.rs` is removed: library-deploy transactions now call `tempo.apply()` directly, which already handles both the fee token and expiring-nonce fields in one place.