### PR TITLE
fix(cli): resolve Tempo expires once

### DIFF
--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -100,7 +100,7 @@ impl MakeTxArgs {
             self;
 
         let print_sponsor_hash = tx.tempo.print_sponsor_hash;
-        let expires_at = tx.tempo.expires_at();
+        let expires_at = tx.tempo.resolve_expires();
         let tempo_sponsor =
             if print_sponsor_hash { None } else { tx.tempo.sponsor_config().await? };
 

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -122,7 +122,7 @@ impl SendTxArgs {
             self;
 
         let print_sponsor_hash = tx.tempo.print_sponsor_hash;
-        let expires_at = tx.tempo.expires_at();
+        let expires_at = tx.tempo.resolve_expires();
         let tempo_sponsor =
             if print_sponsor_hash { None } else { tx.tempo.sponsor_config().await? };
 

--- a/crates/cli/src/opts/tempo.rs
+++ b/crates/cli/src/opts/tempo.rs
@@ -187,6 +187,18 @@ impl TempoOpts {
         self.common.expires_at()
     }
 
+    /// Resolves `--tempo.expires` into concrete expiring-nonce fields.
+    ///
+    /// This computes the relative deadline once so later calls to [`Self::apply`] reuse the same
+    /// `valid_before` timestamp instead of deriving a fresh one.
+    pub fn resolve_expires(&mut self) -> Option<u64> {
+        let ts = self.expires_at()?;
+        self.expiring_nonce = true;
+        self.valid_before = Some(ts);
+        self.common.expires = None;
+        Some(ts)
+    }
+
     /// Returns `true` if a sponsor signature should be attached before submission.
     pub const fn has_sponsor_submission(&self) -> bool {
         self.sponsor.is_some() || self.sponsor_signer.is_some() || self.sponsor_sig.is_some()
@@ -337,6 +349,24 @@ mod tests {
             ])
             .is_err()
         );
+    }
+
+    #[test]
+    fn resolve_expires_materializes_valid_before() {
+        let before =
+            SystemTime::now().duration_since(UNIX_EPOCH).expect("time went backwards").as_secs();
+        let mut opts = TempoOpts::try_parse_from(["", "--tempo.expires", "10"]).unwrap();
+
+        let resolved = opts.resolve_expires().unwrap();
+        let after =
+            SystemTime::now().duration_since(UNIX_EPOCH).expect("time went backwards").as_secs();
+
+        assert!(resolved >= before + 10);
+        assert!(resolved <= after + 10);
+        assert!(opts.expiring_nonce);
+        assert_eq!(opts.valid_before, Some(resolved));
+        assert_eq!(opts.common.expires, None);
+        assert_eq!(opts.expires_at(), None);
     }
 
     #[test]

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -286,11 +286,7 @@ impl ScriptArgs {
         }
 
         let mut tempo = self.tempo.clone();
-        if let Some(ts) = tempo.expires_at() {
-            tempo.expiring_nonce = true;
-            tempo.valid_before = Some(ts);
-            tempo.common.expires = None;
-        }
+        tempo.resolve_expires();
 
         if evm_opts.networks.is_tempo() && tempo.common.fee_token.is_none() {
             tempo.common.fee_token = Some(PATH_USD_ADDRESS);


### PR DESCRIPTION
## Summary
- add `TempoOpts::resolve_expires()` to materialize `--tempo.expires` into the expiring nonce fields once
- use the resolved value in `cast send` and `cast mktx` so the printed expiry matches the submitted transaction