### PR TITLE
refactor(tempo): prepare batch access key txs w/ helper

### DIFF
--- a/crates/cast/src/cmd/batch_mktx.rs
+++ b/crates/cast/src/cmd/batch_mktx.rs
@@ -96,13 +96,13 @@ impl BatchMakeTxArgs {
 
         sh_println!("Building batch transaction with {} call(s)...", tempo_calls.len())?;
 
+        // Preserve key_id for modes that do not call build_with_access_key, such as raw unsigned.
+        if let Some(ref access_key) = tempo_access_key {
+            tx.tempo.key_id = Some(access_key.key_address);
+        }
+
         // Build transaction request with calls
         let mut builder = CastTxBuilder::<TempoNetwork, _, _>::new(&provider, tx, &config).await?;
-
-        // Set key_id for access key transactions
-        if let Some(ref access_key) = tempo_access_key {
-            builder.tx.set_key_id(access_key.key_address);
-        }
 
         // Set calls on the transaction
         builder.tx.calls = tempo_calls;
@@ -143,7 +143,8 @@ impl BatchMakeTxArgs {
         };
 
         let signed_tx = if let Some(ref access_key) = tempo_access_key {
-            let (tx, _) = tx_builder.build(access_key.wallet_address).await?;
+            let (tx, _) =
+                tx_builder.build_with_access_key(access_key.wallet_address, access_key).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
             let raw_tx = tx
                 .sign_with_access_key(

--- a/crates/cast/src/cmd/batch_send.rs
+++ b/crates/cast/src/cmd/batch_send.rs
@@ -97,13 +97,13 @@ impl BatchSendArgs {
 
         sh_println!("Building batch transaction with {} call(s)...", tempo_calls.len())?;
 
+        // Preserve key_id for modes that do not call build_with_access_key, such as unlocked.
+        if let Some(ref access_key) = tempo_access_key {
+            tx.tempo.key_id = Some(access_key.key_address);
+        }
+
         // Build transaction request with calls
         let mut builder = CastTxBuilder::<TempoNetwork, _, _>::new(&provider, tx, &config).await?;
-
-        // Set key_id for access key transactions
-        if let Some(ref access_key) = tempo_access_key {
-            builder.tx.set_key_id(access_key.key_address);
-        }
 
         // Access the inner tx and set calls
         builder.tx.calls = tempo_calls;
@@ -137,7 +137,8 @@ impl BatchSendArgs {
             };
 
             if let Some(ref access_key) = tempo_access_key {
-                let (tx_request, _) = builder.build(access_key.wallet_address).await?;
+                let (tx_request, _) =
+                    builder.build_with_access_key(access_key.wallet_address, access_key).await?;
                 maybe_print_resolved_lane(
                     resolved_lane.as_ref(),
                     tx_request.nonce().unwrap_or_default(),

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -540,13 +540,15 @@ where
 
     /// Builds a transaction that will be signed by a Tempo access key.
     ///
-    /// If the access key needs on-chain provisioning, its authorization is embedded before
-    /// access-list/gas estimation and before any sponsor digest can be computed.
+    /// The access-key id is set before gas estimation. If the access key needs on-chain
+    /// provisioning, its authorization is embedded before access-list/gas estimation and before
+    /// any sponsor digest can be computed.
     pub async fn build_with_access_key(
-        self,
+        mut self,
         sender: impl Into<SenderKind<'_>>,
         access_key: &TempoAccessKeyConfig,
     ) -> Result<(N::TransactionRequest, Option<Function>)> {
+        self.tx.set_key_id(access_key.key_address);
         let fill = self.fill;
         self._build(sender, fill, Some(access_key)).await
     }

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -893,6 +893,7 @@ impl BundledState<TempoEvmNetwork> {
         self.script_config.tempo.apply::<TempoNetwork>(&mut batch_tx, None);
 
         if let BatchSigner::TempoKeychain(_, ak) = &batch_signer {
+            batch_tx.key_id = Some(ak.key_address);
             batch_tx
                 .prepare_access_key_authorization(
                     provider.as_ref(),
@@ -924,8 +925,6 @@ impl BundledState<TempoEvmNetwork> {
                 *pending.tx_hash()
             }
             BatchSigner::TempoKeychain(signer, access_key) => {
-                batch_tx.key_id = Some(access_key.key_address);
-
                 let raw_tx = batch_tx
                     .sign_with_access_key(
                         provider.as_ref(),


### PR DESCRIPTION
## Summary
- ensure batch access-key transactions set `key_id` before gas/access-list/sponsor-digest resolution
- make `CastTxBuilder::build_with_access_key` apply the access-key id and route `cast batch-send` / `cast batch-mktx` through it
- move `forge script --batch` key-id assignment before key authorization, gas estimation, and sponsor attachment