### PR TITLE
fix(forge): bind generates bindings for all same-named contracts

### DIFF
--- a/crates/forge/src/cmd/bind.rs
+++ b/crates/forge/src/cmd/bind.rs
@@ -1,4 +1,3 @@
-use alloy_primitives::map::HashSet;
 use clap::{Parser, ValueHint};
 use eyre::Result;
 use forge_sol_macro_gen::{MultiSolMacroGen, SolMacroGen};
@@ -7,6 +6,7 @@ use foundry_common::{compile::ProjectCompiler, fs::json_files};
 use foundry_config::impl_figment_convert;
 use regex::Regex;
 use std::{
+    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -197,14 +197,35 @@ impl BindArgs {
     }
 
     fn get_solmacrogen(&self, artifacts: &Path) -> Result<MultiSolMacroGen> {
-        let mut dup = HashSet::<String>::default();
-        let instances = self
-            .get_json_files(artifacts)?
-            .filter_map(|(name, path)| {
-                trace!(?path, "parsing SolMacroGen from file");
-                dup.insert(name.clone()).then(|| SolMacroGen::new(path, name))
-            })
-            .collect::<Vec<_>>();
+        // Group artifacts by Solidity contract name. Same-named contracts in different
+        // source paths share a name but produce separate artifacts (e.g.
+        // `out/A.sol/A.json` vs `out/nested/A.sol/A.json`); they all need bindings.
+        let mut by_name: BTreeMap<String, Vec<PathBuf>> = BTreeMap::new();
+        for (name, path) in self.get_json_files(artifacts)? {
+            trace!(?path, "parsing SolMacroGen from file");
+            by_name.entry(name).or_default().push(path);
+        }
+
+        let mut instances = Vec::new();
+        for (name, mut paths) in by_name {
+            if paths.len() == 1 {
+                let path = paths.pop().expect("non-empty");
+                instances.push(SolMacroGen::new(path, name));
+            } else {
+                // Disambiguate: derive a unique Rust module name from the artifact path
+                // for each colliding contract so all of them get bindings.
+                paths.sort();
+                let mut used = alloy_primitives::map::HashSet::<String>::default();
+                for path in paths {
+                    let binding_name = unique_binding_name(&name, &path, artifacts, &mut used);
+                    instances.push(SolMacroGen::with_binding_name(
+                        path,
+                        name.clone(),
+                        binding_name,
+                    ));
+                }
+            }
+        }
 
         let multi = MultiSolMacroGen::new(instances);
         eyre::ensure!(!multi.instances.is_empty(), "No contract artifacts found");
@@ -293,4 +314,45 @@ impl Filter {
 
         Self::Skip(skip)
     }
+}
+
+/// Derives a Rust module name for an artifact whose contract name collides with
+/// other artifacts. The artifact layout is
+/// `<artifacts>/[<dir>/...]<source>.sol/<contract>.json`; leading directory
+/// components are added by the compiler precisely to disambiguate same-named
+/// contracts, so they are folded into the binding name.
+///
+/// Numeric suffixes are appended on the rare chance that the derived name
+/// collides with a previously generated one.
+fn unique_binding_name(
+    name: &str,
+    path: &Path,
+    artifacts: &Path,
+    used: &mut alloy_primitives::map::HashSet<String>,
+) -> String {
+    let rel = path.strip_prefix(artifacts).unwrap_or(path);
+    let mut comps: Vec<_> = rel.components().filter_map(|c| c.as_os_str().to_str()).collect();
+    // Drop the file name (e.g. `Counter.json`) and the per-source directory
+    // (e.g. `Counter.sol`). What remains are the disambiguating parents.
+    if !comps.is_empty() {
+        comps.pop();
+    }
+    if !comps.is_empty() {
+        comps.pop();
+    }
+    let prefix = comps
+        .into_iter()
+        .map(|s| s.replace(char::is_whitespace, "").replace('-', "_"))
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("_");
+
+    let base = if prefix.is_empty() { name.to_string() } else { format!("{prefix}_{name}") };
+    let mut candidate = base.clone();
+    let mut suffix = 1usize;
+    while !used.insert(candidate.clone()) {
+        suffix += 1;
+        candidate = format!("{base}_{suffix}");
+    }
+    candidate
 }

--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -1,3 +1,60 @@
+// Same-named contracts in different source paths must each get their own binding.
+// Previously `forge bind` deduplicated artifacts by contract name string, silently
+// dropping all but the first occurrence.
+forgetest!(bind_same_name_contracts, |prj, cmd| {
+    prj.add_source(
+        "Counter",
+        r#"
+contract Counter {
+    function a() external pure returns (uint256) { return 1; }
+}
+"#,
+    );
+    prj.add_source(
+        "a/Counter",
+        r#"
+contract Counter {
+    function b() external pure returns (uint256) { return 2; }
+}
+"#,
+    );
+    prj.add_source(
+        "b/Counter",
+        r#"
+contract Counter {
+    function c() external pure returns (uint256) { return 3; }
+}
+"#,
+    );
+
+    cmd.args(["bind", "--select", "^Counter$"]).assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+Generating bindings for 3 contracts
+Bindings have been generated to [..]
+"#]]);
+
+    let bindings_src = prj.root().join("out/bindings/src");
+    let mut module_files: Vec<String> = std::fs::read_dir(&bindings_src)
+        .unwrap_or_else(|_| panic!("missing bindings src dir at {}", bindings_src.display()))
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.ends_with(".rs") && n != "lib.rs")
+        .collect();
+    module_files.sort();
+    assert_eq!(module_files.len(), 3, "expected 3 distinct binding modules, got: {module_files:?}");
+
+    let lib_rs = std::fs::read_to_string(bindings_src.join("lib.rs")).unwrap();
+    let mod_lines: Vec<&str> =
+        lib_rs.lines().filter(|l| l.trim_start().starts_with("pub mod ")).collect();
+    assert_eq!(mod_lines.len(), 3, "expected 3 `pub mod` lines in lib.rs, got: {mod_lines:?}");
+    let mut unique = mod_lines.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(unique.len(), 3, "duplicate `pub mod` lines: {mod_lines:?}");
+});
+
 // <https://github.com/foundry-rs/foundry/issues/9482>
 forgetest!(bind_unlinked_bytecode, |prj, cmd| {
     prj.add_source(

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -24,13 +24,21 @@ use heck::ToSnakeCase;
 
 pub struct SolMacroGen {
     pub path: PathBuf,
+    /// Solidity contract name used for the `sol!` macro identifier.
     pub name: String,
+    /// Identifier used to derive the Rust module and file name for this binding.
+    /// Defaults to `name` but may be disambiguated when multiple contracts share `name`.
+    pub binding_name: String,
     pub expansion: Option<TokenStream>,
 }
 
 impl SolMacroGen {
-    pub const fn new(path: PathBuf, name: String) -> Self {
-        Self { path, name, expansion: None }
+    pub fn new(path: PathBuf, name: String) -> Self {
+        Self { binding_name: name.clone(), path, name, expansion: None }
+    }
+
+    pub const fn with_binding_name(path: PathBuf, name: String, binding_name: String) -> Self {
+        Self { path, name, binding_name, expansion: None }
     }
 
     pub fn get_sol_input(&self) -> Result<SolInput> {
@@ -59,7 +67,7 @@ impl MultiSolMacroGen {
 
     pub fn populate_expansion(&mut self, bindings_path: &Path) -> Result<()> {
         for instance in &mut self.instances {
-            let path = bindings_path.join(format!("{}.rs", instance.name.to_snake_case()));
+            let path = bindings_path.join(format!("{}.rs", instance.binding_name.to_snake_case()));
             let expansion = fs::read_to_string(path).wrap_err("Failed to read file")?;
 
             let tokens = TokenStream::from_str(&expansion)
@@ -179,7 +187,7 @@ edition = "2021"
         for instance in &self.instances {
             let contents = instance.expansion.as_ref().unwrap();
 
-            let name = instance.name.to_snake_case();
+            let name = instance.binding_name.to_snake_case();
             let path = src.join(format!("{name}.rs"));
             let file = syn::parse2(contents.clone())
                 .wrap_err_with(|| parse_error(&format!("{}:{}", path.display(), name)))?;
@@ -237,7 +245,7 @@ edition = "2021"
             .to_string();
 
         for instance in &self.instances {
-            let name = instance.name.to_snake_case();
+            let name = instance.binding_name.to_snake_case();
             if single_file {
                 // Single File
                 let mut contents = String::new();
@@ -299,7 +307,7 @@ edition = "2021"
         )?;
         if !single_file {
             for instance in &self.instances {
-                let name = instance.name.to_snake_case();
+                let name = instance.binding_name.to_snake_case();
                 let path = if is_mod {
                     crate_path.join(format!("{name}.rs"))
                 } else {


### PR DESCRIPTION
## Summary
            
  `forge bind` previously deduplicated artifacts using a `HashSet<String>` keyed on contract name, silently dropping all but the first occurrence whenever the same contract name appeared in different source paths (e.g.                                                                                                                                                                   
  `src/Counter.sol`, `src/a/Counter.sol`, `src/b/Counter.sol`). The resulting bindings crate was missing entries with no warning — a real correctness issue

keeps every artifact and disambiguates the *Rust* binding name only, preserving the Solidity contract name used by the `sol!` macro.

  ## Changes

  - `SolMacroGen` now carries a separate `binding_name` (Rust module/file name)
    in addition to `name` (Solidity contract identifier). All downstream code
    that names files and `pub mod` declarations switches to `binding_name`;
    `sol!` expansion keeps using `name`.
  - `forge bind` groups artifacts by contract name. Single-occurrence contracts
    keep the previous behavior (`binding_name == name`, fully backward
    compatible). Multi-occurrence contracts derive a unique `binding_name` from
    the artifact path's disambiguating parent directories
    (`out/a/Counter.sol/Counter.json` → `a_Counter`), with a numeric suffix as a
    last-resort tiebreaker.

under the help with claude opus-4.7