### PR TITLE
feat: drop optimism deps under no-default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,35 +306,35 @@ alloy-json-abi.opt-level = "s"
 [workspace.dependencies]
 anvil = { path = "crates/anvil" }
 cast = { path = "crates/cast" }
-chisel = { path = "crates/chisel" }
+chisel = { path = "crates/chisel", default-features = false }
 forge = { path = "crates/forge" }
 
-forge-doc = { path = "crates/doc" }
-forge-fmt = { path = "crates/fmt" }
-forge-lint = { path = "crates/lint" }
-forge-verify = { path = "crates/verify" }
-forge-script = { path = "crates/script" }
-forge-sol-macro-gen = { path = "crates/sol-macro-gen" }
-forge-script-sequence = { path = "crates/script-sequence" }
-foundry-cheatcodes = { path = "crates/cheatcodes" }
+forge-doc = { path = "crates/doc", default-features = false }
+forge-fmt = { path = "crates/fmt", default-features = false }
+forge-lint = { path = "crates/lint", default-features = false }
+forge-verify = { path = "crates/verify", default-features = false }
+forge-script = { path = "crates/script", default-features = false }
+forge-sol-macro-gen = { path = "crates/sol-macro-gen", default-features = false }
+forge-script-sequence = { path = "crates/script-sequence", default-features = false }
+foundry-cheatcodes = { path = "crates/cheatcodes", default-features = false }
 foundry-cheatcodes-spec = { path = "crates/cheatcodes/spec" }
-foundry-cli = { path = "crates/cli" }
+foundry-cli = { path = "crates/cli", default-features = false }
 foundry-cli-markdown = { path = "crates/cli-markdown" }
-foundry-common = { path = "crates/common" }
+foundry-common = { path = "crates/common", default-features = false }
 foundry-common-fmt = { path = "crates/common/fmt", default-features = false }
 foundry-config = { path = "crates/config" }
-foundry-debugger = { path = "crates/debugger" }
-foundry-evm = { path = "crates/evm/evm" }
+foundry-debugger = { path = "crates/debugger", default-features = false }
+foundry-evm = { path = "crates/evm/evm", default-features = false }
 foundry-evm-abi = { path = "crates/evm/abi" }
 foundry-evm-core = { path = "crates/evm/core", default-features = false }
-foundry-evm-coverage = { path = "crates/evm/coverage" }
+foundry-evm-coverage = { path = "crates/evm/coverage", default-features = false }
 foundry-evm-hardforks = { path = "crates/evm/hardforks", default-features = false }
 foundry-evm-networks = { path = "crates/evm/networks", default-features = false }
-foundry-evm-fuzz = { path = "crates/evm/fuzz" }
+foundry-evm-fuzz = { path = "crates/evm/fuzz", default-features = false }
 foundry-evm-sancov = { path = "crates/evm/sancov" }
-foundry-evm-traces = { path = "crates/evm/traces" }
+foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
-foundry-test-utils = { path = "crates/test-utils" }
+foundry-test-utils = { path = "crates/test-utils", default-features = false }
 foundry-wallets = { version = "0.1.0", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -27,8 +27,8 @@ foundry-cli.workspace = true
 foundry-common.workspace = true
 foundry-config.workspace = true
 foundry-evm.workspace = true
-foundry-evm-networks = { workspace = true, features = ["optimism"] }
-foundry-primitives = { workspace = true, default-features = false, features = ["optimism"] }
+foundry-evm-networks.workspace = true
+foundry-primitives = { workspace = true, default-features = false }
 tempo-chainspec.workspace = true
 tempo-primitives.workspace = true
 tempo-precompiles.workspace = true

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -132,6 +132,8 @@ optimism = [
     "anvil-core/optimism",
     "foundry-primitives/optimism",
     "foundry-common/optimism",
+    "foundry-evm/optimism",
+    "foundry-cli/optimism",
 ]
 asm-keccak = ["alloy-primitives/asm-keccak", "revm/asm-keccak"]
 jemalloc = ["foundry-cli/jemalloc"]

--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -42,4 +42,8 @@ thiserror.workspace = true
 
 [features]
 default = ["optimism"]
-optimism = ["foundry-primitives/optimism"]
+optimism = [
+    "foundry-primitives/optimism",
+    "foundry-common/optimism",
+    "foundry-evm/optimism",
+]

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -12,7 +12,9 @@ use clap::Parser;
 use core::fmt;
 use foundry_common::shell;
 use foundry_config::{Chain, Config, FigmentProviders};
-use foundry_evm::hardfork::{EthereumHardfork, OpHardfork};
+#[cfg(feature = "optimism")]
+use foundry_evm::hardfork::OpHardfork;
+use foundry_evm::hardfork::{EthereumHardfork, FoundryHardfork};
 use foundry_evm_networks::NetworkConfigs;
 use foundry_primitives::FoundryReceiptEnvelope;
 use futures::FutureExt;
@@ -240,15 +242,7 @@ impl NodeArgs {
         }
 
         let hardfork = match &self.hardfork {
-            Some(hf) => {
-                if self.evm.networks.is_optimism() {
-                    Some(OpHardfork::from_str(hf)?.into())
-                } else if self.evm.networks.is_tempo() {
-                    Some(TempoHardfork::from_str(hf)?.into())
-                } else {
-                    Some(EthereumHardfork::from_str(hf)?.into())
-                }
-            }
+            Some(hf) => Some(parse_hardfork(hf, &self.evm.networks)?),
             None => None,
         };
 
@@ -846,6 +840,19 @@ impl FromStr for ForkUrl {
             }
         }
         Ok(Self { url: s.to_string(), block: None })
+    }
+}
+
+/// Parses a hardfork string against the active network configuration.
+fn parse_hardfork(hf: &str, networks: &NetworkConfigs) -> eyre::Result<FoundryHardfork> {
+    #[cfg(feature = "optimism")]
+    if networks.is_optimism() {
+        return Ok(OpHardfork::from_str(hf)?.into());
+    }
+    if networks.is_tempo() {
+        Ok(TempoHardfork::from_str(hf)?.into())
+    } else {
+        Ok(EthereumHardfork::from_str(hf)?.into())
     }
 }
 

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -37,7 +37,7 @@ use foundry_config::Config;
 use foundry_evm::{
     backend::{BlockchainDb, BlockchainDbMeta, SharedBackend},
     constants::DEFAULT_CREATE2_DEPLOYER,
-    hardfork::{FoundryHardfork, OpHardfork},
+    hardfork::FoundryHardfork,
     utils::{
         apply_chain_and_block_specific_env_changes, block_env_from_header,
         get_blob_base_fee_update_fraction,
@@ -577,8 +577,9 @@ impl NodeConfig {
         if let Some(hardfork) = self.hardfork {
             return hardfork;
         }
+        #[cfg(feature = "optimism")]
         if self.networks.is_optimism() {
-            return OpHardfork::default().into();
+            return foundry_evm::hardforks::OpHardfork::default().into();
         }
         if self.networks.is_tempo() {
             return TempoHardfork::default().into();
@@ -1079,6 +1080,7 @@ impl NodeConfig {
     }
 
     /// Enable Optimism network features.
+    #[cfg(feature = "optimism")]
     #[must_use]
     pub fn with_optimism(mut self) -> Self {
         self.networks = NetworkConfigs::with_optimism();

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -533,8 +533,17 @@ impl<N: Network> Backend<N> {
     }
 
     /// Returns true if op-stack deposits are active
+    #[cfg(feature = "optimism")]
     pub const fn is_optimism(&self) -> bool {
         self.networks.is_optimism()
+    }
+
+    /// Returns true if op-stack deposits are active.
+    ///
+    /// Always `false` when built without the `optimism` feature.
+    #[cfg(not(feature = "optimism"))]
+    pub const fn is_optimism(&self) -> bool {
+        false
     }
 
     /// Returns true if Tempo network mode is active
@@ -632,6 +641,7 @@ impl<N: Network> Backend<N> {
     }
 
     /// Returns an error if op-stack deposits are not active
+    #[cfg(feature = "optimism")]
     pub const fn ensure_op_deposits_active(&self) -> Result<(), BlockchainError> {
         if self.is_optimism() {
             return Ok(());

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -116,4 +116,5 @@ optimism = [
     "foundry-common/optimism",
     "foundry-evm-networks/optimism",
     "foundry-evm/optimism",
+    "foundry-cli/optimism",
 ]

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -68,3 +68,13 @@ tracing.workspace = true
 walkdir.workspace = true
 proptest.workspace = true
 serde.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = [
+    "foundry-common/optimism",
+    "foundry-evm-core/optimism",
+    "foundry-evm-fuzz/optimism",
+    "foundry-evm-traces/optimism",
+    "forge-script-sequence/optimism",
+]

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -63,8 +63,13 @@ foundry-test-utils.workspace = true
 rexpect = "0.6"
 
 [features]
-default = ["jemalloc", "asm-keccak"]
+default = ["jemalloc", "asm-keccak", "optimism"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 jemalloc = ["foundry-cli/jemalloc"]
 mimalloc = ["foundry-cli/mimalloc"]
 tracy-allocator = ["foundry-cli/tracy-allocator"]
+optimism = [
+    "foundry-common/optimism",
+    "foundry-evm/optimism",
+    "foundry-cli/optimism",
+]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -76,4 +76,8 @@ tracy = ["dep:tracing-tracy"]
 tracy-allocator = ["tracy"]
 jemalloc = ["dep:tikv-jemallocator"]
 mimalloc = ["dep:mimalloc"]
-optimism = ["foundry-evm-networks/optimism", "foundry-common/optimism"]
+optimism = [
+    "foundry-evm-networks/optimism",
+    "foundry-common/optimism",
+    "foundry-evm/optimism",
+]

--- a/crates/debugger/Cargo.toml
+++ b/crates/debugger/Cargo.toml
@@ -29,3 +29,11 @@ ratatui = { version = "0.30", default-features = false, features = [
 revm.workspace = true
 tracing.workspace = true
 serde.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = [
+    "foundry-common/optimism",
+    "foundry-evm-core/optimism",
+    "foundry-evm-traces/optimism",
+]

--- a/crates/doc/Cargo.toml
+++ b/crates/doc/Cargo.toml
@@ -32,3 +32,7 @@ thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
 regex.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = ["foundry-common/optimism"]

--- a/crates/evm/coverage/Cargo.toml
+++ b/crates/evm/coverage/Cargo.toml
@@ -25,3 +25,7 @@ semver.workspace = true
 tracing.workspace = true
 rayon.workspace = true
 solar.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = ["foundry-common/optimism", "foundry-evm-core/optimism"]

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -69,4 +69,8 @@ optimism = [
     "foundry-evm-hardforks/optimism",
     "foundry-evm-networks/optimism",
     "foundry-common/optimism",
+    "foundry-cheatcodes/optimism",
+    "foundry-evm-coverage/optimism",
+    "foundry-evm-fuzz/optimism",
+    "foundry-evm-traces/optimism",
 ]

--- a/crates/evm/fuzz/Cargo.toml
+++ b/crates/evm/fuzz/Cargo.toml
@@ -50,3 +50,12 @@ rand.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = [
+    "foundry-common/optimism",
+    "foundry-evm-core/optimism",
+    "foundry-evm-coverage/optimism",
+    "foundry-evm-traces/optimism",
+]

--- a/crates/evm/traces/Cargo.toml
+++ b/crates/evm/traces/Cargo.toml
@@ -50,3 +50,7 @@ tempfile.workspace = true
 tokio = { workspace = true, features = ["time", "macros"] }
 tracing.workspace = true
 yansi.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = ["foundry-common/optimism", "foundry-evm-core/optimism"]

--- a/crates/fmt/Cargo.toml
+++ b/crates/fmt/Cargo.toml
@@ -26,3 +26,7 @@ foundry-test-utils.workspace = true
 
 toml.workspace = true
 snapbox.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = ["foundry-common/optimism"]

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -130,4 +130,11 @@ optimism = [
     "foundry-evm/optimism",
     "foundry-evm-networks/optimism",
     "foundry-common/optimism",
+    "foundry-cli/optimism",
+    "forge-script/optimism",
+    "forge-verify/optimism",
+    "forge-doc/optimism",
+    "forge-fmt/optimism",
+    "forge-lint/optimism",
+    "forge-sol-macro-gen/optimism",
 ]

--- a/crates/lint/Cargo.toml
+++ b/crates/lint/Cargo.toml
@@ -24,3 +24,7 @@ eyre.workspace = true
 heck.workspace = true
 rayon.workspace = true
 thiserror.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = ["foundry-common/optimism"]

--- a/crates/script-sequence/Cargo.toml
+++ b/crates/script-sequence/Cargo.toml
@@ -27,3 +27,7 @@ revm-inspectors.workspace = true
 
 alloy-network.workspace = true
 alloy-primitives.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = ["foundry-common/optimism"]

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -69,4 +69,8 @@ optimism = [
     "foundry-evm/optimism",
     "foundry-evm-networks/optimism",
     "foundry-common/optimism",
+    "foundry-cheatcodes/optimism",
+    "foundry-cli/optimism",
+    "forge-script-sequence/optimism",
+    "forge-verify/optimism",
 ]

--- a/crates/sol-macro-gen/Cargo.toml
+++ b/crates/sol-macro-gen/Cargo.toml
@@ -27,3 +27,7 @@ prettyplease.workspace = true
 eyre.workspace = true
 
 heck.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = ["foundry-common/optimism"]

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -44,3 +44,7 @@ idna_adapter.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = ["foundry-common/optimism"]

--- a/crates/verify/Cargo.toml
+++ b/crates/verify/Cargo.toml
@@ -48,3 +48,12 @@ url.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 foundry-test-utils.workspace = true
 tempfile.workspace = true
+
+[features]
+default = ["optimism"]
+optimism = [
+    "foundry-common/optimism",
+    "foundry-evm/optimism",
+    "foundry-evm-networks/optimism",
+    "foundry-cli/optimism",
+]


### PR DESCRIPTION
Mechanical Cargo plumbing to drop all `op-*` / `alloy-op-*` deps from `--no-default-features` builds.

Flips the workspace dep edges for every member that declares a default-on `optimism` feature to `default-features = false`, adds a default-on `optimism` feature with feature forwarding to the pass-through crates (`foundry-cheatcodes`, `foundry-debugger`, `foundry-evm-coverage`, `foundry-evm-fuzz`, `foundry-evm-traces`, `forge-doc`, `forge-fmt`, `forge-lint`, `forge-script-sequence`, `forge-sol-macro-gen`, `foundry-test-utils`, `chisel`, `forge-verify`), and extends the existing `optimism` lists in `cast`, `forge`, `forge-script`, `foundry-cli`, `foundry-evm`, `anvil` and `anvil-core` to forward through them.

Also drops the transitional `features = ["optimism"]` scaffolding on `anvil`'s `foundry-primitives` and `foundry-evm-networks` dep edges and cfg-gates the resulting `Backend::is_optimism()`, `with_optimism()`, `get_hardfork()` and `parse_hardfork()` call sites in `anvil` source.

### Verification

`cargo tree -p <leaf> --no-default-features -e normal -i <op-dep>` is empty for every combination of:

- leaves: `cast`, `forge`, `forge-script`, `foundry-cli`, `foundry-evm`, `foundry-common`, `chisel`, `forge-verify`, `anvil`
- deps: `op-revm`, `alloy-op-evm`, `alloy-op-hardforks`, `op-alloy-consensus`, `op-alloy-network`, `op-alloy-rpc-types`, `op-alloy-flz`

`cargo build --workspace` and `cargo build --workspace --no-default-features` are green.

### Next steps

Close the remaining `--workspace --no-default-features` dev-dep leaks (6 of the 7 OP deps still appear via dev-dep unification through `cast`, `forge` and `foundry-evm-core`) by flipping the workspace dep edges for the leaf binaries (`cast`, `forge`, `anvil`, `chisel`) to `default-features = false` and cascading `features = ["optimism"]` through the dev-dep edges that need OP support for tests.
