### PR TITLE
fix(forge): `--fuzz-seed` parameter is not effective in `forge coverage`

### DIFF
--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -87,8 +87,11 @@ impl CoverageArgs {
             config = self.load_config()?;
         }
 
-        // Set fuzz seed so coverage reports are deterministic
-        config.fuzz.seed = Some(U256::from_be_bytes(STATIC_FUZZ_SEED));
+        // Default to a static fuzz seed so coverage reports are deterministic,
+        // but allow the user to override it via `--fuzz-seed` or `[fuzz] seed` in config.
+        if config.fuzz.seed.is_none() {
+            config.fuzz.seed = Some(U256::from_be_bytes(STATIC_FUZZ_SEED));
+        }
 
         let (paths, mut output) = {
             let (project, output) = self.build(&config)?;

--- a/crates/forge/src/cmd/snapshot.rs
+++ b/crates/forge/src/cmd/snapshot.rs
@@ -99,8 +99,11 @@ impl GasSnapshotArgs {
     }
 
     pub async fn run(mut self) -> Result<()> {
-        // Set fuzz seed so gas snapshots are deterministic
-        self.test.fuzz_seed = Some(U256::from_be_bytes(STATIC_FUZZ_SEED));
+        // Default to a static fuzz seed so gas snapshots are deterministic,
+        // but allow the user to override it via `--fuzz-seed`.
+        if self.test.fuzz_seed.is_none() {
+            self.test.fuzz_seed = Some(U256::from_be_bytes(STATIC_FUZZ_SEED));
+        }
 
         let outcome = self.test.compile_and_run().await?;
         outcome.ensure_ok(false)?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The `forge coverage --fuzz-seed ...` is ignored. Trivial patch.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Check if the seed is given. If the seed is given, use the seed, otherwise fallback to previous behavior using static seeds. No break changes are introduced for this patch.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
