### PR TITLE
fix(foundryup): mirror tag resolution for install & use

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -3,7 +3,7 @@ set -eo pipefail
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-FOUNDRYUP_INSTALLER_VERSION="1.8.2"
+FOUNDRYUP_INSTALLER_VERSION="1.8.3"
 
 BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
 FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}
@@ -118,51 +118,7 @@ main() {
   # Install by downloading binaries
   if [[ "$FOUNDRYUP_REPO" == "foundry-rs/foundry" && -z "$FOUNDRYUP_BRANCH" && -z "$FOUNDRYUP_COMMIT" ]]; then
     FOUNDRYUP_VERSION=${FOUNDRYUP_VERSION:-latest}
-
-    # Normalize versions (handle channels, versions without v prefix)
-    if [[ "$FOUNDRYUP_VERSION" == "latest" || "$FOUNDRYUP_VERSION" == "stable" ]]; then
-      # Resolve to the latest release (non-prerelease) via the GitHub API
-      say "fetching latest release from ${FOUNDRYUP_REPO}..."
-      FOUNDRYUP_TAG=$(fetch "https://api.github.com/repos/${FOUNDRYUP_REPO}/releases/latest" | awk '
-        /"tag_name"[[:space:]]*:/ && !found { gsub(/.*"tag_name"[[:space:]]*:[[:space:]]*"/, ""); gsub(/".*/, ""); print; found=1 }
-      ') || err "failed to fetch releases from GitHub API"
-      if [ -z "$FOUNDRYUP_TAG" ]; then
-        err "could not find a latest release for ${FOUNDRYUP_REPO}"
-      fi
-      say "resolved release tag: ${FOUNDRYUP_TAG}"
-      FOUNDRYUP_VERSION="$FOUNDRYUP_TAG"
-    elif [[ "$FOUNDRYUP_VERSION" == "nightly" ]]; then
-      # Resolve to the latest nightly (prerelease) release via the GitHub API.
-      # The GitHub API does not guarantee that releases are returned in
-      # chronological order, so we collect all matching nightlies along with
-      # their `published_at` timestamps and sort them ourselves.
-      say "fetching latest nightly releases from ${FOUNDRYUP_REPO}..."
-      FOUNDRYUP_TAG=$(fetch "https://api.github.com/repos/${FOUNDRYUP_REPO}/releases" | awk '
-        /"tag_name"[[:space:]]*:/ { gsub(/.*"tag_name"[[:space:]]*:[[:space:]]*"/, ""); gsub(/".*/, ""); tag=$0 }
-        /"published_at"[[:space:]]*:[[:space:]]*"/ {
-          pub=$0
-          gsub(/.*"published_at"[[:space:]]*:[[:space:]]*"/, "", pub)
-          gsub(/".*/, "", pub)
-          if (tag ~ /^nightly-/) print pub "\t" tag
-          tag=""
-        }
-      ' | sort -r | awk -F '\t' 'NR==1 { print $2 }') || err "failed to fetch releases from GitHub API"
-      if [ -z "$FOUNDRYUP_TAG" ]; then
-        err "could not find a nightly release for ${FOUNDRYUP_REPO}"
-      fi
-      say "resolved nightly release tag: ${FOUNDRYUP_TAG}"
-      FOUNDRYUP_VERSION="nightly"
-    elif [[ "$FOUNDRYUP_VERSION" =~ ^nightly- ]]; then
-      # Specific nightly tag (e.g. nightly-abc123...)
-      FOUNDRYUP_TAG="$FOUNDRYUP_VERSION"
-      FOUNDRYUP_VERSION="nightly"
-    elif [[ "$FOUNDRYUP_VERSION" == [[:digit:]]* ]]; then
-      # Add v prefix
-      FOUNDRYUP_VERSION="v${FOUNDRYUP_VERSION}"
-      FOUNDRYUP_TAG="${FOUNDRYUP_VERSION}"
-    else
-      FOUNDRYUP_TAG="${FOUNDRYUP_VERSION}"
-    fi
+    resolve_version_and_tag
 
     say "installing foundry (version ${FOUNDRYUP_VERSION}, tag ${FOUNDRYUP_TAG})"
 
@@ -186,7 +142,7 @@ main() {
       tmp_dir="$(mktemp -d 2>/dev/null)" || err "failed to create temp dir"
       tmp="$tmp_dir/attestation.txt"
       ensure download "$ATTESTATION_URL" "$tmp"
-      
+
       # Read the first line of the attestation file to get the artifact link.
       # The first line should contain the link to the attestation artifact.
       attestation_artifact_link="$(head -n1 "$tmp" | tr -d '\r')"
@@ -299,7 +255,7 @@ main() {
     else
       say 'skipping manpage download: missing "tar"'
     fi
-    
+
     if [ "$FOUNDRYUP_IGNORE_VERIFICATION" = true ]; then
       say "skipped SHA verification for downloaded binaries due to --force flag"
     else
@@ -512,6 +468,17 @@ list() {
 
 use() {
   [ -z "$FOUNDRYUP_VERSION" ] && err "no version provided"
+
+  # If the requested version is a channel (`latest`, `stable`, `nightly`), resolve it to the immutable
+  # tag directory created by `--install`.
+  # Falls back to the literal value for locally-built versions (branches, PRs, commits, custom names).
+  case "$FOUNDRYUP_VERSION" in
+    latest|stable|nightly)
+      resolve_version_and_tag
+      FOUNDRYUP_VERSION="$FOUNDRYUP_TAG"
+      ;;
+  esac
+
   FOUNDRY_VERSION_DIR="$FOUNDRY_VERSIONS_DIR/$FOUNDRYUP_VERSION"
   if [ -d "$FOUNDRY_VERSION_DIR" ]; then
 
@@ -688,6 +655,56 @@ check_bins_in_use() {
 # will immediately terminate with an error showing the failing command.
 ensure() {
   if ! "$@"; then err "command failed: $*"; fi
+}
+
+# Normalizes `FOUNDRYUP_VERSION` and resolves it to a concrete release tag,
+# populating `FOUNDRYUP_TAG`. Handles the `latest`/`stable`/`nightly` channels
+# (looked up via the GitHub API).
+resolve_version_and_tag() {
+  FOUNDRYUP_REPO=${FOUNDRYUP_REPO:-foundry-rs/foundry}
+  if [[ "$FOUNDRYUP_VERSION" == "latest" || "$FOUNDRYUP_VERSION" == "stable" ]]; then
+    # Resolve to the latest release (non-prerelease) via the GitHub API.
+    say "fetching latest release from ${FOUNDRYUP_REPO}..."
+    FOUNDRYUP_TAG=$(fetch "https://api.github.com/repos/${FOUNDRYUP_REPO}/releases/latest" | awk '
+      /"tag_name"[[:space:]]*:/ && !found { gsub(/.*"tag_name"[[:space:]]*:[[:space:]]*"/, ""); gsub(/".*/, ""); print; found=1 }
+    ') || err "failed to fetch releases from GitHub API"
+    if [ -z "$FOUNDRYUP_TAG" ]; then
+      err "could not find a latest release for ${FOUNDRYUP_REPO}"
+    fi
+    say "resolved release tag: ${FOUNDRYUP_TAG}"
+    FOUNDRYUP_VERSION="$FOUNDRYUP_TAG"
+  elif [[ "$FOUNDRYUP_VERSION" == "nightly" ]]; then
+    # Resolve to the latest nightly (prerelease) release via the GitHub API.
+    # The GitHub API does not guarantee that releases are returned in
+    # chronological order, so we collect all matching nightlies along with
+    # their `published_at` timestamps and sort them ourselves.
+    say "fetching latest nightly releases from ${FOUNDRYUP_REPO}..."
+    FOUNDRYUP_TAG=$(fetch "https://api.github.com/repos/${FOUNDRYUP_REPO}/releases" | awk '
+      /"tag_name"[[:space:]]*:/ { gsub(/.*"tag_name"[[:space:]]*:[[:space:]]*"/, ""); gsub(/".*/, ""); tag=$0 }
+      /"published_at"[[:space:]]*:[[:space:]]*"/ {
+        pub=$0
+        gsub(/.*"published_at"[[:space:]]*:[[:space:]]*"/, "", pub)
+        gsub(/".*/, "", pub)
+        if (tag ~ /^nightly-/) print pub "\t" tag
+        tag=""
+      }
+    ' | sort -r | awk -F '\t' 'NR==1 { print $2 }') || err "failed to fetch releases from GitHub API"
+    if [ -z "$FOUNDRYUP_TAG" ]; then
+      err "could not find a nightly release for ${FOUNDRYUP_REPO}"
+    fi
+    say "resolved nightly release tag: ${FOUNDRYUP_TAG}"
+    FOUNDRYUP_VERSION="nightly"
+  elif [[ "$FOUNDRYUP_VERSION" =~ ^nightly- ]]; then
+    # Specific nightly tag (e.g. nightly-abc123...)
+    FOUNDRYUP_TAG="$FOUNDRYUP_VERSION"
+    FOUNDRYUP_VERSION="nightly"
+  elif [[ "$FOUNDRYUP_VERSION" == [[:digit:]]* ]]; then
+    # Add v prefix
+    FOUNDRYUP_VERSION="v${FOUNDRYUP_VERSION}"
+    FOUNDRYUP_TAG="${FOUNDRYUP_VERSION}"
+  else
+    FOUNDRYUP_TAG="${FOUNDRYUP_VERSION}"
+  fi
 }
 
 # Silently fetches $1 to stdout.

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -665,12 +665,12 @@ resolve_version_and_tag() {
   FOUNDRYUP_REPO=${FOUNDRYUP_REPO:-foundry-rs/foundry}
   if [[ "$FOUNDRYUP_VERSION" == "latest" || "$FOUNDRYUP_VERSION" == "stable" ]]; then
     # Resolve to the latest release (non-prerelease) via the GitHub API.
-    say "fetching latest release from ${FOUNDRYUP_REPO}..."
+    say "fetching latest release tag from ${FOUNDRYUP_REPO}..."
     FOUNDRYUP_TAG=$(fetch "https://api.github.com/repos/${FOUNDRYUP_REPO}/releases/latest" | awk '
       /"tag_name"[[:space:]]*:/ && !found { gsub(/.*"tag_name"[[:space:]]*:[[:space:]]*"/, ""); gsub(/".*/, ""); print; found=1 }
-    ') || err "failed to fetch releases from GitHub API"
+    ') || err "failed to fetch release tags from GitHub API"
     if [ -z "$FOUNDRYUP_TAG" ]; then
-      err "could not find a latest release for ${FOUNDRYUP_REPO}"
+      err "could not find a latest release tag for ${FOUNDRYUP_REPO}"
     fi
     say "resolved release tag: ${FOUNDRYUP_TAG}"
     FOUNDRYUP_VERSION="$FOUNDRYUP_TAG"
@@ -679,7 +679,7 @@ resolve_version_and_tag() {
     # The GitHub API does not guarantee that releases are returned in
     # chronological order, so we collect all matching nightlies along with
     # their `published_at` timestamps and sort them ourselves.
-    say "fetching latest nightly releases from ${FOUNDRYUP_REPO}..."
+    say "fetching latest nightly release tags from ${FOUNDRYUP_REPO}..."
     FOUNDRYUP_TAG=$(fetch "https://api.github.com/repos/${FOUNDRYUP_REPO}/releases" | awk '
       /"tag_name"[[:space:]]*:/ { gsub(/.*"tag_name"[[:space:]]*:[[:space:]]*"/, ""); gsub(/".*/, ""); tag=$0 }
       /"published_at"[[:space:]]*:[[:space:]]*"/ {
@@ -689,9 +689,9 @@ resolve_version_and_tag() {
         if (tag ~ /^nightly-/) print pub "\t" tag
         tag=""
       }
-    ' | sort -r | awk -F '\t' 'NR==1 { print $2 }') || err "failed to fetch releases from GitHub API"
+    ' | sort -r | awk -F '\t' 'NR==1 { print $2 }') || err "failed to fetch release tags from GitHub API"
     if [ -z "$FOUNDRYUP_TAG" ]; then
-      err "could not find a nightly release for ${FOUNDRYUP_REPO}"
+      err "could not find a nightly release tag for ${FOUNDRYUP_REPO}"
     fi
     say "resolved nightly release tag: ${FOUNDRYUP_TAG}"
     FOUNDRYUP_VERSION="nightly"

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -469,11 +469,12 @@ list() {
 use() {
   [ -z "$FOUNDRYUP_VERSION" ] && err "no version provided"
 
-  # If the requested version is a channel (`latest`, `stable`, `nightly`), resolve it to the immutable
-  # tag directory created by `--install`.
+  # If the requested version is a channel (`latest`, `stable`, `nightly`) or a bare semver
+  # version (e.g. `1.7.0`, `1.6.0-rc1`), resolve it to the immutable tag directory created by
+  # `--install` (channels hit the GitHub API; semver versions get a `v` prefix).
   # Falls back to the literal value for locally-built versions (branches, PRs, commits, custom names).
   case "$FOUNDRYUP_VERSION" in
-    latest|stable|nightly)
+    latest|stable|nightly|[0-9]*.[0-9]*.[0-9]*)
       resolve_version_and_tag
       FOUNDRYUP_VERSION="$FOUNDRYUP_TAG"
       ;;


### PR DESCRIPTION
## Motivation

#14445 deprecated `nightly` tag because of immutable releases.


Make `foundryup -u` resolve version tag to mirror `foundryup -i` logic.

Before:

```
$ foundryup -i nightly
[...]
$ foundryup -u nightly
foundryup: version nightly not installed
```

After:

```
$ foundryup -i nightly
[...]
$ foundryup -u nightly
foundryup: fetching latest nightly releases from foundry-rs/foundry...
foundryup: resolved nightly release tag: nightly-1fd6466f96e4f52cea01093ae0f5772ddf3a6795
foundryup: use - forge 1.6.0-nightly (1fd6466f96 2026-05-05T08:14:33.455447000Z)
foundryup: use - cast 1.6.0-nightly (1fd6466f96 2026-05-05T08:14:33.455447000Z)
foundryup: use - anvil 1.6.0-nightly (1fd6466f96 2026-05-05T08:14:33.455447000Z)
foundryup: use - chisel 1.6.0-nightly (1fd6466f96 2026-05-05T08:14:33.455447000Z)
```