### PR TITLE
fix(ci): keep no-default builds free of op deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,23 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --workspace --doc --locked
 
+  no-default-features:
+    runs-on: depot-ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+        with:
+          toolchain: stable
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo build --workspace --no-default-features --locked
+
   typos:
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,10 +304,10 @@ crossterm.opt-level = "s"
 alloy-json-abi.opt-level = "s"
 
 [workspace.dependencies]
-anvil = { path = "crates/anvil" }
-cast = { path = "crates/cast" }
+anvil = { path = "crates/anvil", default-features = false }
+cast = { path = "crates/cast", default-features = false }
 chisel = { path = "crates/chisel", default-features = false }
-forge = { path = "crates/forge" }
+forge = { path = "crates/forge", default-features = false }
 
 forge-doc = { path = "crates/doc", default-features = false }
 forge-fmt = { path = "crates/fmt", default-features = false }

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["cli"]
 anvil-core = { path = "core", default-features = false }
 anvil-rpc = { path = "rpc" }
 anvil-server = { path = "server" }
-foundry-cli.workspace = true
+foundry-cli = { workspace = true, optional = true }
 foundry-common.workspace = true
 foundry-config.workspace = true
 foundry-evm.workspace = true
@@ -64,6 +64,7 @@ alloy-chains.workspace = true
 alloy-genesis.workspace = true
 alloy-trie.workspace = true
 op-alloy-consensus = { workspace = true, features = ["serde"], optional = true }
+op-alloy-rpc-types = { workspace = true, optional = true }
 
 # revm
 revm = { workspace = true, features = [
@@ -120,27 +121,28 @@ reqwest.workspace = true
 foundry-test-utils.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
-op-alloy-rpc-types.workspace = true
 tempo-alloy.workspace = true
 
 [features]
 default = ["cli", "jemalloc", "asm-keccak", "optimism"]
 optimism = [
     "dep:op-alloy-consensus",
+    "dep:op-alloy-rpc-types",
     "dep:alloy-op-evm",
     "dep:op-revm",
     "anvil-core/optimism",
     "foundry-primitives/optimism",
     "foundry-common/optimism",
     "foundry-evm/optimism",
-    "foundry-cli/optimism",
+    "foundry-cli?/optimism",
 ]
 asm-keccak = ["alloy-primitives/asm-keccak", "revm/asm-keccak"]
-jemalloc = ["foundry-cli/jemalloc"]
-mimalloc = ["foundry-cli/mimalloc"]
-tracy-allocator = ["foundry-cli/tracy-allocator"]
+jemalloc = ["foundry-cli?/jemalloc"]
+mimalloc = ["foundry-cli?/mimalloc"]
+tracy-allocator = ["foundry-cli?/tracy-allocator"]
 cli = ["tokio/full", "cmd"]
 cmd = [
+    "dep:foundry-cli",
     "clap",
     "clap_complete",
     "dep:fdlimit",

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -3,6 +3,9 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "optimism")]
+use op_alloy_rpc_types as _;
+
 use crate::{
     error::{NodeError, NodeResult},
     eth::{

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -56,6 +56,7 @@ revm = { workspace = true, features = [
 revm-inspectors.workspace = true
 op-alloy-consensus = { workspace = true, features = ["k256"], optional = true }
 op-alloy-network = { workspace = true, optional = true }
+op-alloy-rpc-types = { workspace = true, optional = true }
 op-revm = { workspace = true, optional = true }
 tempo-revm.workspace = true
 tempo-alloy.workspace = true
@@ -77,8 +78,6 @@ url.workspace = true
 
 [dev-dependencies]
 alloy-serde.workspace = true
-op-alloy-consensus.workspace = true
-op-alloy-rpc-types.workspace = true
 anvil.workspace = true
 foundry-test-utils.workspace = true
 
@@ -87,8 +86,10 @@ default = ["optimism"]
 optimism = [
     "dep:op-alloy-consensus",
     "dep:op-alloy-network",
+    "dep:op-alloy-rpc-types",
     "dep:alloy-op-evm",
     "dep:op-revm",
+    "foundry-common/optimism",
     "foundry-evm-hardforks/optimism",
     "foundry-evm-networks/optimism",
 ]

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -5,6 +5,9 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "optimism")]
+use op_alloy_rpc_types as _;
+
 use crate::constants::DEFAULT_CREATE2_DEPLOYER;
 use alloy_primitives::{Address, map::HashMap};
 use auto_impl::auto_impl;


### PR DESCRIPTION
## Summary
- set the leaf binary workspace deps (`anvil`, `cast`, `forge`) to `default-features = false` so dev-dep edges do not re-enable OP support in no-default builds
- move OP-only RPC test deps in `anvil` and `foundry-evm-core` behind the existing `optimism` feature
- add a CI job for `cargo build --workspace --no-default-features --locked`

## Verification
- `cargo build --workspace --no-default-features --locked`
- `cargo tree --workspace --no-default-features | rg "(^|[[:space:]])(op-|alloy-op)" || true` (no output)
- `cargo +1.94 test -p foundry-evm-core --lib --locked`
- `cargo +1.94 test -p anvil --test it --no-run --locked`
- `cargo +nightly fmt --all --check`