### PR TITLE
fix(anvil): cancel full pending transaction listener

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3380,13 +3380,27 @@ impl EthApi<FoundryNetwork> {
         let this = self.clone();
 
         tokio::spawn(async move {
-            while let Some(hash) = hashes.next().await {
-                if let Ok(Some(txn)) = this.transaction_by_hash(hash).await
-                    && tx.send(txn).is_err()
-                {
-                    break;
+            let tx_closed = tx.clone();
+
+            loop {
+                tokio::select! {
+                    _ = tx_closed.closed() => break,
+                    maybe_hash = hashes.next() => {
+                        let Some(hash) = maybe_hash else {
+                            break;
+                        };
+
+                        if let Ok(Some(txn)) = this.transaction_by_hash(hash).await
+                            && tx.send(txn).is_err()
+                        {
+                            break;
+                        }
+                    }
                 }
             }
+
+            hashes.close();
+            this.pool.prune_closed_ready_listeners();
         });
 
         rx

--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -90,6 +90,11 @@ impl<T> Pool<T> {
         rx
     }
 
+    /// Removes ready transaction listeners whose receiving ends were closed.
+    pub(crate) fn prune_closed_ready_listeners(&self) {
+        self.transaction_listener.lock().retain(|tx| !tx.is_closed());
+    }
+
     /// Returns true if this pool already contains the transaction
     pub fn contains(&self, tx_hash: &TxHash) -> bool {
         self.inner.read().contains(tx_hash)
@@ -515,5 +520,23 @@ impl<T> AddedTransaction<T> {
             Self::Ready(tx) => &tx.hash,
             Self::Pending { hash } => hash,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prunes_closed_ready_listeners() {
+        let pool = Pool::<()>::default();
+        let mut listener = pool.add_ready_listener();
+
+        assert_eq!(pool.transaction_listener.lock().len(), 1);
+
+        listener.close();
+        pool.prune_closed_ready_listeners();
+
+        assert!(pool.transaction_listener.lock().is_empty());
     }
 }


### PR DESCRIPTION
## Motivation

`eth_subscribe` with `newPendingTransactions` and `true` spawns a task that waits on ready transaction hashes before forwarding full transactions. When the websocket subscription is dropped while no new transaction arrives, that task can stay parked and keep the pool listener alive until a later notification.

## Solution

Watch the downstream full-transaction receiver's close signal in the forwarding task, close the ready hash listener on exit, and prune closed ready listeners from the pool immediately. Added a unit test for pruning closed ready listeners and verified the existing full-pending subscription path.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes