### PR TITLE
fix(cheatcodes): enforce `expectRevert` reverter address for CREATE frames

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1897,10 +1897,23 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         }
 
         // Handle expected reverts
-        if let Some(expected_revert) = &self.expected_revert
+        if let Some(expected_revert) = &mut self.expected_revert
             && curr_depth <= expected_revert.depth
             && matches!(expected_revert.kind, ExpectedRevertKind::Default)
         {
+            // Mirror the logic in `call_end`: when an expected reverter address is set
+            // and we don't yet have one (or we're matching multiple reverts), record the
+            // would-be deployed address as the reverter. revm guarantees `outcome.address`
+            // is `Some(_)` whenever the constructor actually ran (including the revert
+            // case); it is only `None` for pre-frame rejection (depth/balance/nonce),
+            // for which a reverter address is meaningless.
+            if outcome.result.is_revert()
+                && expected_revert.reverter.is_some()
+                && (expected_revert.reverted_by.is_none() || expected_revert.count > 1)
+                && let Some(addr) = outcome.address
+            {
+                expected_revert.reverted_by = Some(addr);
+            }
             let mut expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
             return match revert_handlers::handle_expect_revert(
                 false,

--- a/crates/forge/tests/cli/failure_assertions.rs
+++ b/crates/forge/tests/cli/failure_assertions.rs
@@ -71,11 +71,12 @@ Suite result: FAILED. 0 passed; 7 failed; 0 skipped; [ELAPSED]
             r#"No files changed, compilation skipped
 ...
 [FAIL: Reverter != expected reverter: [..] != 0x000000000000000000000000000000000000dEaD] testShouldFailExpectPartialRevertWrongReverterTopLevelCreate() ([GAS])
+[FAIL: Reverter != expected reverter: [..] != [..]] testShouldFailExpectRevertNestedCreateInnerAddress() ([GAS])
 [FAIL: Reverter != expected reverter: [..] != 0x000000000000000000000000000000000000dEaD] testShouldFailExpectRevertWithBytesWrongReverterTopLevelCreate() ([GAS])
 [FAIL: Reverter != expected reverter: [..] != 0x000000000000000000000000000000000000dEaD] testShouldFailExpectRevertWrongReverterNestedCreate() ([GAS])
 [FAIL: Reverter != expected reverter: [..] != 0x000000000000000000000000000000000000dEaD] testShouldFailExpectRevertWrongReverterTopLevelCreate() ([GAS])
 [FAIL: next call did not revert as expected] testShouldFailExpectRevertsNotOnImmediateNextCall() ([GAS])
-Suite result: FAILED. 0 passed; 5 failed; 0 skipped; [ELAPSED]
+Suite result: FAILED. 0 passed; 6 failed; 0 skipped; [ELAPSED]
 ...
 "#,
         );

--- a/crates/forge/tests/cli/failure_assertions.rs
+++ b/crates/forge/tests/cli/failure_assertions.rs
@@ -70,8 +70,9 @@ Suite result: FAILED. 0 passed; 7 failed; 0 skipped; [ELAPSED]
         .stdout_eq(
             r#"No files changed, compilation skipped
 ...
+[FAIL: Reverter != expected reverter: [..] != 0x000000000000000000000000000000000000dEaD] testShouldFailExpectRevertWrongReverterTopLevelCreate() ([GAS])
 [FAIL: next call did not revert as expected] testShouldFailExpectRevertsNotOnImmediateNextCall() ([GAS])
-Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+Suite result: FAILED. 0 passed; 2 failed; 0 skipped; [ELAPSED]
 ...
 "#,
         );

--- a/crates/forge/tests/cli/failure_assertions.rs
+++ b/crates/forge/tests/cli/failure_assertions.rs
@@ -70,9 +70,12 @@ Suite result: FAILED. 0 passed; 7 failed; 0 skipped; [ELAPSED]
         .stdout_eq(
             r#"No files changed, compilation skipped
 ...
+[FAIL: Reverter != expected reverter: [..] != 0x000000000000000000000000000000000000dEaD] testShouldFailExpectPartialRevertWrongReverterTopLevelCreate() ([GAS])
+[FAIL: Reverter != expected reverter: [..] != 0x000000000000000000000000000000000000dEaD] testShouldFailExpectRevertWithBytesWrongReverterTopLevelCreate() ([GAS])
+[FAIL: Reverter != expected reverter: [..] != 0x000000000000000000000000000000000000dEaD] testShouldFailExpectRevertWrongReverterNestedCreate() ([GAS])
 [FAIL: Reverter != expected reverter: [..] != 0x000000000000000000000000000000000000dEaD] testShouldFailExpectRevertWrongReverterTopLevelCreate() ([GAS])
 [FAIL: next call did not revert as expected] testShouldFailExpectRevertsNotOnImmediateNextCall() ([GAS])
-Suite result: FAILED. 0 passed; 2 failed; 0 skipped; [ELAPSED]
+Suite result: FAILED. 0 passed; 5 failed; 0 skipped; [ELAPSED]
 ...
 "#,
         );

--- a/crates/forge/tests/fixtures/ExpectRevertFailures.t.sol
+++ b/crates/forge/tests/fixtures/ExpectRevertFailures.t.sol
@@ -241,6 +241,39 @@ contract ExpectRevertWithReverterFailureTest is DSTest {
         vm.expectRevert(address(0xdead));
         new DContract();
     }
+
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: must fail because the reverter address argument is enforced
+    // even when an exact-bytes pattern is also supplied for a top-level CREATE.
+    function testShouldFailExpectRevertWithBytesWrongReverterTopLevelCreate() public {
+        vm.expectRevert(abi.encodePacked("Reverted by DContract"), address(0xdead));
+        new DContract();
+    }
+
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: must fail because the reverter address argument is enforced
+    // for `expectPartialRevert(bytes4, address)` against a top-level CREATE.
+    function testShouldFailExpectPartialRevertWrongReverterTopLevelCreate() public {
+        vm.expectPartialRevert(bytes4(keccak256("Error(string)")), address(0xdead));
+        new DContract();
+    }
+
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: must fail when the innermost reverting frame is a nested
+    // CREATE and the reverter address argument does not match the would-be
+    // deployed address of the failed deployment.
+    function testShouldFailExpectRevertWrongReverterNestedCreate() public {
+        vm.expectRevert(address(0xdead));
+        new NestedDContractCreator();
+    }
+}
+
+// Used by `testShouldFailExpectRevertWrongReverterNestedCreate`: a contract whose
+// constructor directly creates another contract that reverts.
+contract NestedDContractCreator {
+    constructor() {
+        new DContract();
+    }
 }
 
 contract ExpectRevertCountFailureTest is DSTest {

--- a/crates/forge/tests/fixtures/ExpectRevertFailures.t.sol
+++ b/crates/forge/tests/fixtures/ExpectRevertFailures.t.sol
@@ -266,6 +266,22 @@ contract ExpectRevertWithReverterFailureTest is DSTest {
         vm.expectRevert(address(0xdead));
         new NestedDContractCreator();
     }
+
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: documents the intended semantics for nested CREATEs — the
+    // matched reverter is the *outer* would-be-deployed address (the contract
+    // whose deployment failed), NOT the innermost reverting CREATE's address.
+    // Supplying the inner address must fail.
+    function testShouldFailExpectRevertNestedCreateInnerAddress() public {
+        // Outer = NestedDContractCreator at this contract's next nonce.
+        // Inner = DContract created from inside the outer constructor (deployer
+        // is the outer, nonce 1).
+        address outer =
+            vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        address inner = vm.computeCreateAddress(outer, 1);
+        vm.expectRevert(inner);
+        new NestedDContractCreator();
+    }
 }
 
 // Used by `testShouldFailExpectRevertWrongReverterNestedCreate`: a contract whose

--- a/crates/forge/tests/fixtures/ExpectRevertFailures.t.sol
+++ b/crates/forge/tests/fixtures/ExpectRevertFailures.t.sol
@@ -233,6 +233,14 @@ contract ExpectRevertWithReverterFailureTest is DSTest {
         aContract.doNotRevert();
         aContract.callAndRevert();
     }
+
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: must fail because 0xdead is not the actual reverter when a
+    // top-level CREATE constructor reverts directly.
+    function testShouldFailExpectRevertWrongReverterTopLevelCreate() public {
+        vm.expectRevert(address(0xdead));
+        new DContract();
+    }
 }
 
 contract ExpectRevertCountFailureTest is DSTest {

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -330,6 +330,16 @@ contract ExpectRevertWithReverterTest is Test {
         vm.expectRevert(expected);
         new NestedDContractCreator();
     }
+
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: `expectPartialRevert(bytes4, address)` overload must enforce
+    // the reverter address argument when matching a top-level CREATE revert.
+    function testExpectPartialRevertWithReverterTopLevelCreate() public {
+        address expected = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        // `Reverted by DContract` triggers Solidity's `Error(string)` selector.
+        vm.expectPartialRevert(bytes4(keccak256("Error(string)")), expected);
+        new DContract();
+    }
 }
 
 // Used by `testExpectRevertsWithReverterNestedCreate`: a contract whose constructor

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -357,8 +357,7 @@ contract ExpectRevertWithReverterTest is Test {
     // constructor reverts so no contract is ever actually placed there).
     function testExpectRevertsWithReverterCountTopLevelCreate2() public {
         bytes32 salt = bytes32(uint256(0x42));
-        address expected =
-            vm.computeCreate2Address(salt, keccak256(type(DContract).creationCode), address(this));
+        address expected = vm.computeCreate2Address(salt, keccak256(type(DContract).creationCode), address(this));
         vm.expectRevert(expected, 2);
         new DContract{salt: salt}();
         new DContract{salt: salt}();
@@ -368,8 +367,7 @@ contract ExpectRevertWithReverterTest is Test {
     // Regression: CREATE2 deploys must also enforce the reverter address argument.
     function testExpectRevertsWithReverterTopLevelCreate2() public {
         bytes32 salt = bytes32(uint256(0xC0FFEE));
-        address expected =
-            vm.computeCreate2Address(salt, keccak256(type(DContract).creationCode), address(this));
+        address expected = vm.computeCreate2Address(salt, keccak256(type(DContract).creationCode), address(this));
         vm.expectRevert(expected);
         new DContract{salt: salt}();
     }

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -340,6 +340,39 @@ contract ExpectRevertWithReverterTest is Test {
         vm.expectPartialRevert(bytes4(keccak256("Error(string)")), expected);
         new DContract();
     }
+
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: `expectRevert(bytes4, address)` (exact 4-byte selector + reverter)
+    // overload must enforce the reverter address argument for a top-level CREATE.
+    function testExpectRevertWithBytes4SelectorAndReverterTopLevelCreate() public {
+        address expected = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        vm.expectRevert(DCustomErrorContract.CustomError.selector, expected);
+        new DCustomErrorContract();
+    }
+
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: `expectRevert(address, uint64)` count-bearing overload must
+    // exercise the `count > 1` branch in `create_end`. Use CREATE2 with the same
+    // salt so both deploys would resolve to the same would-be address (each
+    // constructor reverts so no contract is ever actually placed there).
+    function testExpectRevertsWithReverterCountTopLevelCreate2() public {
+        bytes32 salt = bytes32(uint256(0x42));
+        address expected =
+            vm.computeCreate2Address(salt, keccak256(type(DContract).creationCode), address(this));
+        vm.expectRevert(expected, 2);
+        new DContract{salt: salt}();
+        new DContract{salt: salt}();
+    }
+
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: CREATE2 deploys must also enforce the reverter address argument.
+    function testExpectRevertsWithReverterTopLevelCreate2() public {
+        bytes32 salt = bytes32(uint256(0xC0FFEE));
+        address expected =
+            vm.computeCreate2Address(salt, keccak256(type(DContract).creationCode), address(this));
+        vm.expectRevert(expected);
+        new DContract{salt: salt}();
+    }
 }
 
 // Used by `testExpectRevertsWithReverterNestedCreate`: a contract whose constructor
@@ -347,6 +380,17 @@ contract ExpectRevertWithReverterTest is Test {
 contract NestedDContractCreator {
     constructor() {
         new DContract();
+    }
+}
+
+// Used by `testExpectRevertWithBytes4SelectorAndReverterTopLevelCreate`: constructor
+// reverts with a parameter-less custom error so the full revert data is exactly the
+// 4-byte selector.
+contract DCustomErrorContract {
+    error CustomError();
+
+    constructor() {
+        revert CustomError();
     }
 }
 

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -305,6 +305,39 @@ contract ExpectRevertWithReverterTest is Test {
         vm.expectRevert(address(cContract));
         aContract.createDContractThroughCContract();
     }
+
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: when the next operation is a top-level CREATE whose constructor
+    // reverts directly, the reverter address argument must be enforced (it used to
+    // be silently ignored). The matched reverter is the would-be-deployed address.
+    function testExpectRevertsWithReverterTopLevelCreate() public {
+        address expected = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        vm.expectRevert(expected);
+        new DContract();
+
+        expected = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        vm.expectRevert(abi.encodePacked("Reverted by DContract"), expected);
+        new DContract();
+    }
+
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: when the next operation is a top-level CREATE whose constructor
+    // synchronously creates another contract that reverts (i.e. innermost frame is
+    // a CREATE), the matched reverter is the outer would-be-deployed address (the
+    // contract whose deployment failed).
+    function testExpectRevertsWithReverterNestedCreate() public {
+        address expected = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        vm.expectRevert(expected);
+        new NestedDContractCreator();
+    }
+}
+
+// Used by `testExpectRevertsWithReverterNestedCreate`: a contract whose constructor
+// directly creates another contract that reverts.
+contract NestedDContractCreator {
+    constructor() {
+        new DContract();
+    }
 }
 
 contract ExpectRevertCount is Test {


### PR DESCRIPTION

## Motivation

Close #14613


## Solution

The reverter address argument to `vm.expectRevert` was silently ignored when the innermost reverting frame was a CREATE (top-level or nested), because create_end never populated `expected_revert.reverted_by`.

Mirror call_end's logic in create_end: when the outcome reverts and a reverter address is expected, record `outcome.address` (revm guarantees this is Some(would-be address) whenever the constructor executed).

Adds positive regression tests for top-level and nested-CREATE reverts, and a negative regression test asserting wrong-reverter now fails.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
