### PR TITLE
fix(script): keep plain Tempo broadcasts non-AA

### DIFF
--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -1,8 +1,8 @@
 use std::{cmp::Ordering, num::NonZeroU64, sync::Arc, time::Duration};
 
 use crate::{
-    ScriptArgs, ScriptConfig, build::LinkedBuildData, progress::ScriptProgress,
-    sequence::ScriptSequenceKind, verify::BroadcastedState,
+    ScriptArgs, ScriptConfig, build::LinkedBuildData, needs_tempo_aa_rpc_estimate,
+    progress::ScriptProgress, sequence::ScriptSequenceKind, verify::BroadcastedState,
 };
 use alloy_chains::{Chain, NamedChain};
 use alloy_consensus::{SignableTransaction, Signed};
@@ -554,7 +554,11 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
                     .collect::<Result<Vec<_>>>()?;
 
                 let estimate_via_rpc = has_different_gas_calc(sequence.chain)
-                    || self.script_config.evm_opts.networks.is_tempo()
+                    || needs_tempo_aa_rpc_estimate(
+                        self.script_config.evm_opts.networks.is_tempo(),
+                        self.script_config.batch,
+                        &self.script_config.tempo,
+                    )
                     || self.args.skip_simulation;
 
                 // We only wait for a transaction receipt before sending the next transaction, if

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, num::NonZeroU64, sync::Arc, time::Duration};
 
 use crate::{
-    ScriptArgs, ScriptConfig, build::LinkedBuildData, needs_tempo_aa_rpc_estimate,
+    ScriptArgs, ScriptConfig, build::LinkedBuildData, needs_script_rpc_estimate,
     progress::ScriptProgress, sequence::ScriptSequenceKind, verify::BroadcastedState,
 };
 use alloy_chains::{Chain, NamedChain};
@@ -21,7 +21,7 @@ use alloy_signer::Signature;
 use eyre::{Context, Result, bail};
 use forge_verify::provider::VerificationProviderType;
 use foundry_cheatcodes::Wallets;
-use foundry_cli::utils::{has_batch_support, has_different_gas_calc};
+use foundry_cli::utils::has_batch_support;
 use foundry_common::{
     FoundryTransactionBuilder, TransactionMaybeSigned,
     provider::{ProviderBuilder, try_get_http_provider},
@@ -553,13 +553,13 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
                     })
                     .collect::<Result<Vec<_>>>()?;
 
-                let estimate_via_rpc = has_different_gas_calc(sequence.chain)
-                    || needs_tempo_aa_rpc_estimate(
-                        self.script_config.evm_opts.networks.is_tempo(),
-                        self.script_config.batch,
-                        &self.script_config.tempo,
-                    )
-                    || self.args.skip_simulation;
+                let estimate_via_rpc = needs_script_rpc_estimate(
+                    sequence.chain,
+                    self.script_config.evm_opts.networks.is_tempo(),
+                    self.script_config.batch,
+                    &self.script_config.tempo,
+                    self.args.skip_simulation,
+                );
 
                 // We only wait for a transaction receipt before sending the next transaction, if
                 // there is more than one signer. There would be no way of assuring

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -29,7 +29,7 @@ use forge_script_sequence::{AdditionalContract, NestedValue};
 use forge_verify::{RetryArgs, VerifierArgs};
 use foundry_cli::{
     opts::{BuildOpts, EvmArgs, GlobalArgs, TempoOpts},
-    utils::LoadConfig,
+    utils::{LoadConfig, has_different_gas_calc},
 };
 use foundry_common::{
     CONTRACT_MAX_SIZE, ContractsByArtifact, SELECTOR_LEN,
@@ -248,50 +248,34 @@ pub struct ScriptArgs {
     pub retry: RetryArgs,
 }
 
-/// Returns whether script broadcasts on a Tempo network should default the Tempo
-/// `fee_token` to [`PATH_USD_ADDRESS`].
-///
-/// Plain `--network tempo` (or any other selection that just sets the network to Tempo) does
-/// **not** by itself imply a Tempo AA / type `0x76` transaction. We must only default the fee
-/// token when the user has actually opted into Tempo AA semantics, otherwise routing every
-/// unsigned broadcast tx through `TempoOpts::apply` would force ordinary EVM-style script
-/// transactions into Tempo AA, which breaks signers that only know how to sign ordinary
-/// Ethereum transactions (notably the Ledger Ethereum app, which returns an empty response).
-///
-/// We therefore gate defaulting on:
-///
-/// - `--batch` (Tempo batch transactions are themselves Tempo AA and require a fee token), or
-/// - any explicit `--tempo.*` flag (sponsor, expiring nonce, nonce key/lane, etc.) which already
-///   forces a Tempo AA transaction shape and benefits from a sensible default fee token.
 const fn should_default_tempo_fee_token(
     is_tempo_network: bool,
     batch: bool,
     tempo: &TempoOpts,
 ) -> bool {
+    // Plain `--network tempo` should stay an ordinary transaction; only Tempo AA opts get defaults.
     is_tempo_network && tempo.common.fee_token.is_none() && (batch || tempo.is_tempo())
 }
 
-/// Returns whether script broadcasts on a Tempo network should force `eth_estimateGas`
-/// re-estimation against the RPC node before submitting each transaction.
-///
-/// Plain `--network tempo` produces an ordinary EIP-1559/legacy transaction (see
-/// `tempo-alloy::TempoTransactionRequest::output_tx_type`), and the local simulation gas
-/// estimate is sufficient for those flows. Forcing RPC re-estimation in that case can
-/// surface node-side errors (e.g. `gas required exceeds allowance (0)` when the sender's
-/// native balance is at or near zero relative to `--gas-price`) on flows that previously
-/// worked fine, including Ledger-signed broadcasts.
-///
-/// Re-estimation is only forced when the user has actually opted into Tempo AA semantics:
-///
-/// - `--batch` (Tempo batch transactions are AA), or
-/// - any explicit `--tempo.*` flag (sponsor, expiring nonce, nonce key/lane, etc.) which
-///   forces a Tempo AA transaction shape and benefits from node-side gas estimation.
-pub(crate) const fn needs_tempo_aa_rpc_estimate(
+const fn needs_tempo_aa_rpc_estimate(
     is_tempo_network: bool,
     batch: bool,
     tempo: &TempoOpts,
 ) -> bool {
     is_tempo_network && (batch || tempo.is_tempo())
+}
+
+pub(crate) fn needs_script_rpc_estimate(
+    chain_id: u64,
+    is_tempo_network: bool,
+    batch: bool,
+    tempo: &TempoOpts,
+    skip_simulation: bool,
+) -> bool {
+    // Tempo AA needs RPC estimation; plain Tempo scripts can use the local simulation result.
+    (has_different_gas_calc(chain_id) && !is_tempo_network)
+        || needs_tempo_aa_rpc_estimate(is_tempo_network, batch, tempo)
+        || skip_simulation
 }
 
 impl ScriptArgs {
@@ -929,102 +913,6 @@ mod tests {
             ScriptArgs::parse_from(["foundry-cli", "Contract.sol", "--tempo.nonce-key", "1"]);
 
         assert_eq!(args.tempo.nonce_key, Some(U256::from(1)));
-    }
-
-    /// Plain `--network tempo` must NOT default `tempo.common.fee_token` to
-    /// `PATH_USD_ADDRESS`, otherwise every unsigned broadcast transaction is forced
-    /// into Tempo AA / type `0x76` and signers that only know ordinary Ethereum
-    /// transactions (e.g. the Ledger Ethereum app) reject it with
-    /// "received an unexpected empty response".
-    #[test]
-    fn network_tempo_alone_does_not_default_fee_token() {
-        let tempo = TempoOpts::default();
-        assert!(!should_default_tempo_fee_token(true, false, &tempo));
-    }
-
-    /// `--batch` requires Tempo AA semantics, so we still default the fee token.
-    #[test]
-    fn batch_defaults_fee_token() {
-        let tempo = TempoOpts::default();
-        assert!(should_default_tempo_fee_token(true, true, &tempo));
-    }
-
-    /// Explicit `--tempo.fee-token` from the user must always win over the default.
-    #[test]
-    fn explicit_fee_token_is_preserved() {
-        let tempo = TempoOpts::try_parse_from(["", "--tempo.fee-token", "1"]).unwrap();
-        assert!(tempo.common.fee_token.is_some());
-        // Even with `--batch` the predicate should report "no default needed", since the
-        // user already supplied a fee token.
-        assert!(!should_default_tempo_fee_token(true, true, &tempo));
-        assert!(!should_default_tempo_fee_token(true, false, &tempo));
-    }
-
-    /// Explicit Tempo AA opt-ins (sponsor, expiring-nonce, nonce-key, lane, ...) keep the
-    /// default fee-token convenience that existed before the regression fix.
-    #[test]
-    fn explicit_tempo_aa_opts_default_fee_token() {
-        let tempo = TempoOpts::try_parse_from([
-            "",
-            "--tempo.sponsor",
-            "0x1111111111111111111111111111111111111111",
-            "--tempo.sponsor-signer",
-            "env://TEMPO_SPONSOR_PK",
-        ])
-        .unwrap();
-        assert!(should_default_tempo_fee_token(true, false, &tempo));
-
-        let tempo = TempoOpts::try_parse_from(["", "--tempo.nonce-key", "1"]).unwrap();
-        assert!(should_default_tempo_fee_token(true, false, &tempo));
-
-        let tempo = TempoOpts::try_parse_from(["", "--tempo.expires", "10"]).unwrap();
-        assert!(should_default_tempo_fee_token(true, false, &tempo));
-    }
-
-    /// Non-Tempo networks must never default the fee token regardless of other flags.
-    #[test]
-    fn non_tempo_network_never_defaults_fee_token() {
-        let tempo = TempoOpts::default();
-        assert!(!should_default_tempo_fee_token(false, false, &tempo));
-        assert!(!should_default_tempo_fee_token(false, true, &tempo));
-    }
-
-    /// Plain `--network tempo` must NOT force `eth_estimateGas` re-estimation. The local
-    /// simulation gas estimate is enough for plain EIP-1559/legacy Tempo txs and forcing
-    /// node-side estimation can surface "gas required exceeds allowance (0)" failures on
-    /// flows that previously worked, including Ledger-signed broadcasts.
-    #[test]
-    fn network_tempo_alone_does_not_force_rpc_estimate() {
-        let tempo = TempoOpts::default();
-        assert!(!needs_tempo_aa_rpc_estimate(true, false, &tempo));
-    }
-
-    /// `--batch` requires Tempo AA semantics, so RPC re-estimation must remain on.
-    #[test]
-    fn batch_forces_rpc_estimate() {
-        let tempo = TempoOpts::default();
-        assert!(needs_tempo_aa_rpc_estimate(true, true, &tempo));
-    }
-
-    /// Explicit Tempo AA opt-ins keep RPC re-estimation on.
-    #[test]
-    fn explicit_tempo_aa_opts_force_rpc_estimate() {
-        let tempo = TempoOpts::try_parse_from(["", "--tempo.fee-token", "1"]).unwrap();
-        assert!(needs_tempo_aa_rpc_estimate(true, false, &tempo));
-
-        let tempo = TempoOpts::try_parse_from(["", "--tempo.nonce-key", "1"]).unwrap();
-        assert!(needs_tempo_aa_rpc_estimate(true, false, &tempo));
-
-        let tempo = TempoOpts::try_parse_from(["", "--tempo.expires", "10"]).unwrap();
-        assert!(needs_tempo_aa_rpc_estimate(true, false, &tempo));
-    }
-
-    /// Non-Tempo networks must never force Tempo-specific RPC re-estimation.
-    #[test]
-    fn non_tempo_network_never_forces_rpc_estimate() {
-        let tempo = TempoOpts::default();
-        assert!(!needs_tempo_aa_rpc_estimate(false, false, &tempo));
-        assert!(!needs_tempo_aa_rpc_estimate(false, true, &tempo));
     }
 
     #[test]

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -271,6 +271,29 @@ const fn should_default_tempo_fee_token(
     is_tempo_network && tempo.common.fee_token.is_none() && (batch || tempo.is_tempo())
 }
 
+/// Returns whether script broadcasts on a Tempo network should force `eth_estimateGas`
+/// re-estimation against the RPC node before submitting each transaction.
+///
+/// Plain `--network tempo` produces an ordinary EIP-1559/legacy transaction (see
+/// `tempo-alloy::TempoTransactionRequest::output_tx_type`), and the local simulation gas
+/// estimate is sufficient for those flows. Forcing RPC re-estimation in that case can
+/// surface node-side errors (e.g. `gas required exceeds allowance (0)` when the sender's
+/// native balance is at or near zero relative to `--gas-price`) on flows that previously
+/// worked fine, including Ledger-signed broadcasts.
+///
+/// Re-estimation is only forced when the user has actually opted into Tempo AA semantics:
+///
+/// - `--batch` (Tempo batch transactions are AA), or
+/// - any explicit `--tempo.*` flag (sponsor, expiring nonce, nonce key/lane, etc.) which
+///   forces a Tempo AA transaction shape and benefits from node-side gas estimation.
+pub(crate) const fn needs_tempo_aa_rpc_estimate(
+    is_tempo_network: bool,
+    batch: bool,
+    tempo: &TempoOpts,
+) -> bool {
+    is_tempo_network && (batch || tempo.is_tempo())
+}
+
 impl ScriptArgs {
     /// Loads config, resolves evm_opts (including network inference from fork), and returns them.
     async fn resolved_evm_opts(&self) -> Result<(Config, EvmOpts)> {
@@ -964,6 +987,44 @@ mod tests {
         let tempo = TempoOpts::default();
         assert!(!should_default_tempo_fee_token(false, false, &tempo));
         assert!(!should_default_tempo_fee_token(false, true, &tempo));
+    }
+
+    /// Plain `--network tempo` must NOT force `eth_estimateGas` re-estimation. The local
+    /// simulation gas estimate is enough for plain EIP-1559/legacy Tempo txs and forcing
+    /// node-side estimation can surface "gas required exceeds allowance (0)" failures on
+    /// flows that previously worked, including Ledger-signed broadcasts.
+    #[test]
+    fn network_tempo_alone_does_not_force_rpc_estimate() {
+        let tempo = TempoOpts::default();
+        assert!(!needs_tempo_aa_rpc_estimate(true, false, &tempo));
+    }
+
+    /// `--batch` requires Tempo AA semantics, so RPC re-estimation must remain on.
+    #[test]
+    fn batch_forces_rpc_estimate() {
+        let tempo = TempoOpts::default();
+        assert!(needs_tempo_aa_rpc_estimate(true, true, &tempo));
+    }
+
+    /// Explicit Tempo AA opt-ins keep RPC re-estimation on.
+    #[test]
+    fn explicit_tempo_aa_opts_force_rpc_estimate() {
+        let tempo = TempoOpts::try_parse_from(["", "--tempo.fee-token", "1"]).unwrap();
+        assert!(needs_tempo_aa_rpc_estimate(true, false, &tempo));
+
+        let tempo = TempoOpts::try_parse_from(["", "--tempo.nonce-key", "1"]).unwrap();
+        assert!(needs_tempo_aa_rpc_estimate(true, false, &tempo));
+
+        let tempo = TempoOpts::try_parse_from(["", "--tempo.expires", "10"]).unwrap();
+        assert!(needs_tempo_aa_rpc_estimate(true, false, &tempo));
+    }
+
+    /// Non-Tempo networks must never force Tempo-specific RPC re-estimation.
+    #[test]
+    fn non_tempo_network_never_forces_rpc_estimate() {
+        let tempo = TempoOpts::default();
+        assert!(!needs_tempo_aa_rpc_estimate(false, false, &tempo));
+        assert!(!needs_tempo_aa_rpc_estimate(false, true, &tempo));
     }
 
     #[test]

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -248,6 +248,29 @@ pub struct ScriptArgs {
     pub retry: RetryArgs,
 }
 
+/// Returns whether script broadcasts on a Tempo network should default the Tempo
+/// `fee_token` to [`PATH_USD_ADDRESS`].
+///
+/// Plain `--network tempo` (or any other selection that just sets the network to Tempo) does
+/// **not** by itself imply a Tempo AA / type `0x76` transaction. We must only default the fee
+/// token when the user has actually opted into Tempo AA semantics, otherwise routing every
+/// unsigned broadcast tx through `TempoOpts::apply` would force ordinary EVM-style script
+/// transactions into Tempo AA, which breaks signers that only know how to sign ordinary
+/// Ethereum transactions (notably the Ledger Ethereum app, which returns an empty response).
+///
+/// We therefore gate defaulting on:
+///
+/// - `--batch` (Tempo batch transactions are themselves Tempo AA and require a fee token), or
+/// - any explicit `--tempo.*` flag (sponsor, expiring nonce, nonce key/lane, etc.) which already
+///   forces a Tempo AA transaction shape and benefits from a sensible default fee token.
+const fn should_default_tempo_fee_token(
+    is_tempo_network: bool,
+    batch: bool,
+    tempo: &TempoOpts,
+) -> bool {
+    is_tempo_network && tempo.common.fee_token.is_none() && (batch || tempo.is_tempo())
+}
+
 impl ScriptArgs {
     /// Loads config, resolves evm_opts (including network inference from fork), and returns them.
     async fn resolved_evm_opts(&self) -> Result<(Config, EvmOpts)> {
@@ -290,7 +313,7 @@ impl ScriptArgs {
         let mut tempo = self.tempo.clone();
         tempo.resolve_expires();
 
-        if evm_opts.networks.is_tempo() && tempo.common.fee_token.is_none() {
+        if should_default_tempo_fee_token(evm_opts.networks.is_tempo(), self.batch, &tempo) {
             tempo.common.fee_token = Some(PATH_USD_ADDRESS);
         }
 
@@ -883,6 +906,64 @@ mod tests {
             ScriptArgs::parse_from(["foundry-cli", "Contract.sol", "--tempo.nonce-key", "1"]);
 
         assert_eq!(args.tempo.nonce_key, Some(U256::from(1)));
+    }
+
+    /// Plain `--network tempo` must NOT default `tempo.common.fee_token` to
+    /// `PATH_USD_ADDRESS`, otherwise every unsigned broadcast transaction is forced
+    /// into Tempo AA / type `0x76` and signers that only know ordinary Ethereum
+    /// transactions (e.g. the Ledger Ethereum app) reject it with
+    /// "received an unexpected empty response".
+    #[test]
+    fn network_tempo_alone_does_not_default_fee_token() {
+        let tempo = TempoOpts::default();
+        assert!(!should_default_tempo_fee_token(true, false, &tempo));
+    }
+
+    /// `--batch` requires Tempo AA semantics, so we still default the fee token.
+    #[test]
+    fn batch_defaults_fee_token() {
+        let tempo = TempoOpts::default();
+        assert!(should_default_tempo_fee_token(true, true, &tempo));
+    }
+
+    /// Explicit `--tempo.fee-token` from the user must always win over the default.
+    #[test]
+    fn explicit_fee_token_is_preserved() {
+        let tempo = TempoOpts::try_parse_from(["", "--tempo.fee-token", "1"]).unwrap();
+        assert!(tempo.common.fee_token.is_some());
+        // Even with `--batch` the predicate should report "no default needed", since the
+        // user already supplied a fee token.
+        assert!(!should_default_tempo_fee_token(true, true, &tempo));
+        assert!(!should_default_tempo_fee_token(true, false, &tempo));
+    }
+
+    /// Explicit Tempo AA opt-ins (sponsor, expiring-nonce, nonce-key, lane, ...) keep the
+    /// default fee-token convenience that existed before the regression fix.
+    #[test]
+    fn explicit_tempo_aa_opts_default_fee_token() {
+        let tempo = TempoOpts::try_parse_from([
+            "",
+            "--tempo.sponsor",
+            "0x1111111111111111111111111111111111111111",
+            "--tempo.sponsor-signer",
+            "env://TEMPO_SPONSOR_PK",
+        ])
+        .unwrap();
+        assert!(should_default_tempo_fee_token(true, false, &tempo));
+
+        let tempo = TempoOpts::try_parse_from(["", "--tempo.nonce-key", "1"]).unwrap();
+        assert!(should_default_tempo_fee_token(true, false, &tempo));
+
+        let tempo = TempoOpts::try_parse_from(["", "--tempo.expires", "10"]).unwrap();
+        assert!(should_default_tempo_fee_token(true, false, &tempo));
+    }
+
+    /// Non-Tempo networks must never default the fee token regardless of other flags.
+    #[test]
+    fn non_tempo_network_never_defaults_fee_token() {
+        let tempo = TempoOpts::default();
+        assert!(!should_default_tempo_fee_token(false, false, &tempo));
+        assert!(!should_default_tempo_fee_token(false, true, &tempo));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Plain `forge script --network tempo` should select Tempo network rules, not opt into Tempo AA.

Before this PR, plain Tempo script broadcasts could:

- default `fee_token` to PathUSD, promoting ordinary script txs into Tempo type `0x76`
- force `eth_estimateGas` before submission

That broke Ledger broadcasts on Tempo with errors like:

```text
received an unexpected empty response
Failed to estimate gas for tx
```

This PR keeps plain Tempo script broadcasts as ordinary EIP-1559/legacy transactions. Tempo AA defaults and RPC re-estimation now only apply when the user opts into AA behavior, such as:

- `--batch`
- explicit `--tempo.*` options
- explicit `--tempo.fee-token`

## Repro

```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.19;

import {Script} from "forge-std/Script.sol";

contract TempoNetworkLedgerRepro is Script {
    function run() external {
        vm.startBroadcast();
        (bool success,) = payable(address(0)).call{value: 0}("");
        require(success, "zero-value self-call failed");
        vm.stopBroadcast();
    }
}
```

```sh
forge script script/repro/TempoNetworkLedgerRepro.s.sol:TempoNetworkLedgerRepro \
  --rpc-url "$TEMPO_RPC" \
  --chain 4217 \
  --network tempo \
  --ledger \
  --broadcast \
  --gas-price 1 \
  -vvv
```

The same plain broadcast path works in `tempo-foundry`; this PR brings upstream Foundry in line with that behavior.

## Tests

```sh
cargo fmt --check
cargo test -p forge-script --lib
cargo test -p forge-script --lib tempo --no-fail-fast
```
