### PR TITLE
fix: clean --no-default-features test build

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1494,7 +1494,7 @@ impl<N: Network> Backend<N> {
         let op_deposit = {
             // `other` carries OP-only deposit fields; consumed only when feature is enabled.
             let _ = &other;
-            OpCallDepositInfo::default()
+            OpCallDepositInfo
         };
 
         (evm_env, tx_env, op_deposit)

--- a/crates/anvil/tests/it/main.rs
+++ b/crates/anvil/tests/it/main.rs
@@ -19,6 +19,7 @@ mod pubsub;
 mod revert;
 mod sign;
 mod simulate;
+#[cfg(feature = "cmd")]
 mod state;
 mod tempo;
 mod traces;

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -763,7 +763,7 @@ mod tests {
     use std::num::NonZeroU64;
 
     use super::*;
-    use alloy_consensus::{Sealed, Signed, TxEip1559, transaction::Recovered};
+    use alloy_consensus::{Signed, TxEip1559, transaction::Recovered};
     use alloy_evm::{EthEvmFactory, EvmFactory};
     use alloy_network::{AnyTxType, UnknownTxEnvelope, UnknownTypedTransaction};
     use alloy_primitives::Signature;
@@ -941,6 +941,7 @@ mod tests {
     #[cfg(feature = "optimism")]
     mod optimism {
         use super::*;
+        use alloy_consensus::Sealed;
         use alloy_op_evm::{OpEvmFactory, OpTx};
         use op_alloy_consensus::{OpTxEnvelope, TxDeposit, transaction::OpTransactionInfo};
         use op_alloy_rpc_types::Transaction as OpRpcTransaction;


### PR DESCRIPTION
Fixes `cargo check --tests --workspace --no-default-features`:

- Gate `mod state;` in anvil's `it` test binary behind `cfg(feature = "cmd")` — its tests use `NodeConfig::with_init_state_path()`, which is itself gated on `cmd`.
- Drop redundant `::default()` on the unit-struct `OpCallDepositInfo` in the `not(optimism)` arm of `mod.rs` (clippy `default_constructed_unit_structs`).
- Move `alloy_consensus::Sealed` import in `evm/core/src/env.rs` tests into the `optimism` submodule where it's actually used.
