### PR TITLE
fix(anvil): load blocks and transactions atomically in `load_state`

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3888,9 +3888,13 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
 
     /// Apply [SerializableState] data to the backend storage.
     pub async fn load_state(&self, state: SerializableState) -> Result<bool, BlockchainError> {
-        // load the blocks and transactions into the storage
-        self.blockchain.storage.write().load_blocks(state.blocks.clone());
-        self.blockchain.storage.write().load_transactions(state.transactions.clone());
+        // load the blocks and transactions into the storage atomically so concurrent readers
+        // never observe blocks without their transactions
+        {
+            let mut storage = self.blockchain.storage.write();
+            storage.load_blocks(state.blocks.clone());
+            storage.load_transactions(state.transactions.clone());
+        }
         // reset the block env
         if let Some(block) = state.block.clone() {
             self.evm_env.write().block_env = block.clone();


### PR DESCRIPTION
 ## Summary      

  `load_state` took two separate `write()` locks — one for `load_blocks`, one for `load_transactions` —
   leaving a window where `storage.blocks` held the new entries but `storage.transactions` was still
  empty. Concurrent `eth_getBlockByHash` (full), `eth_getTransactionReceipt` and `eth_getBlockReceipts`
   hit that window, short-circuited via `?` in `mined_transactions_in_block` / `mined_receipts`, and
  returned `None` — making freshly loaded blocks transiently appear missing. Fix: hold a single
  `write()` guard across both calls.

## Reproduction

  Stress test: 6 reader tasks tight-loop `block_by_hash` + `block_by_hash_full` on known hashes while  
  the main task calls `load_state`. A race read = lite form `Some` but full form `None`. To make the
  window observable I temporarily inserted `std::thread::sleep(50ms)` between the two `write()` calls  
  (experiment only, not in this patch).

  | Code | Mismatched reads |
  | --- | --- |
  | Before (two `write()` locks) | **36,754** |
  | After (single `write()` guard) | **0** |

  Before fix:
  ```
  assertion `left == right` failed: observed 36754 reads where the block hash existed but the full
  block was None — load_state left a window with blocks loaded but transactions missing                
    left: 36754
   right: 0                                                                                            
  test state::load_state_atomic_blocks_and_transactions ... FAILED                                     
  ```
                                                                                                       
  After fix:          
  ```
  test state::load_state_atomic_blocks_and_transactions ... ok
  ```                                                     