### PR TITLE
fix(cheatcodes): innermost as reverter for nested CREATE chain revert

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -5627,7 +5627,7 @@
     {
       "func": {
         "id": "expectPartialRevert_1",
-        "description": "Expects an error on next call to reverter address, that starts with the revert data.",
+        "description": "Expects an error on next call to reverter address, that starts with the revert data.\nSee `expectRevert(address)` for `reverter` matching semantics.",
         "declaration": "function expectPartialRevert(bytes4 revertData, address reverter) external;",
         "visibility": "external",
         "mutability": "",
@@ -5687,7 +5687,7 @@
     {
       "func": {
         "id": "expectRevert_10",
-        "description": "Expects a `count` number of reverts from the upcoming calls from the reverter address that match the revert data.",
+        "description": "Expects a `count` number of reverts from the upcoming calls from the reverter address that match the revert data.\nSee `expectRevert(address)` for `reverter` matching semantics.",
         "declaration": "function expectRevert(bytes4 revertData, address reverter, uint64 count) external;",
         "visibility": "external",
         "mutability": "",
@@ -5707,7 +5707,7 @@
     {
       "func": {
         "id": "expectRevert_11",
-        "description": "Expects a `count` number of reverts from the upcoming calls from the reverter address that exactly match the revert data.",
+        "description": "Expects a `count` number of reverts from the upcoming calls from the reverter address that exactly match the revert data.\nSee `expectRevert(address)` for `reverter` matching semantics.",
         "declaration": "function expectRevert(bytes calldata revertData, address reverter, uint64 count) external;",
         "visibility": "external",
         "mutability": "",
@@ -5747,7 +5747,7 @@
     {
       "func": {
         "id": "expectRevert_3",
-        "description": "Expects an error with any revert data on next call to reverter address.",
+        "description": "Expects an error with any revert data on next call to reverter address.\nThe `reverter` argument is matched against the address of the innermost\nframe that produced the revert:\n  - For a CALL: the address that was called.\n  - For a CREATE / CREATE2: the would-be deployed address of the failed\n    deployment (computed from the deployer + nonce, or salt + initcode).\nIn a nested chain the deepest reverting frame wins, regardless of whether\nthe chain is composed of CALLs, CREATEs, or a mix. With `count > 1` the\nsame rule applies independently to each iteration.",
         "declaration": "function expectRevert(address reverter) external;",
         "visibility": "external",
         "mutability": "",
@@ -5767,7 +5767,7 @@
     {
       "func": {
         "id": "expectRevert_4",
-        "description": "Expects an error from reverter address on next call, with any revert data.",
+        "description": "Expects an error from reverter address on next call, with any revert data.\nSee `expectRevert(address)` for `reverter` matching semantics.",
         "declaration": "function expectRevert(bytes4 revertData, address reverter) external;",
         "visibility": "external",
         "mutability": "",
@@ -5787,7 +5787,7 @@
     {
       "func": {
         "id": "expectRevert_5",
-        "description": "Expects an error from reverter address on next call, that exactly matches the revert data.",
+        "description": "Expects an error from reverter address on next call, that exactly matches the revert data.\nSee `expectRevert(address)` for `reverter` matching semantics.",
         "declaration": "function expectRevert(bytes calldata revertData, address reverter) external;",
         "visibility": "external",
         "mutability": "",
@@ -5867,7 +5867,7 @@
     {
       "func": {
         "id": "expectRevert_9",
-        "description": "Expects a `count` number of reverts from the upcoming calls from the reverter address.",
+        "description": "Expects a `count` number of reverts from the upcoming calls from the reverter address.\nSee `expectRevert(address)` for `reverter` matching semantics.",
         "declaration": "function expectRevert(address reverter, uint64 count) external;",
         "visibility": "external",
         "mutability": "",

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -5747,7 +5747,7 @@
     {
       "func": {
         "id": "expectRevert_3",
-        "description": "Expects an error with any revert data on next call to reverter address.\nThe `reverter` argument is matched against the address of the innermost\nframe that produced the revert:\n  - For a CALL: the address that was called.\n  - For a CREATE / CREATE2: the would-be deployed address of the failed\n    deployment (computed from the deployer + nonce, or salt + initcode).\nIn a nested chain the deepest reverting frame wins, regardless of whether\nthe chain is composed of CALLs, CREATEs, or a mix. With `count > 1` the\nsame rule applies independently to each iteration.",
+        "description": "Expects an error with any revert data on next call to reverter address.\nThe `reverter` argument is matched against the address associated with\nthe frame that produced the revert:\n  - For a CALL: the address that was called.\n  - For a CREATE / CREATE2: the would-be deployed address of the failed\n    deployment (computed from the deployer + nonce, or salt + initcode).\nFor a single expected revert, the innermost reverting frame wins in\nnested CALL, CREATE, or mixed chains. With `count > 1`, nested\nCREATE / CREATE2 chains apply the same rule independently to each\niteration; nested CALL chains keep their existing\noutermost-call-per-iteration behavior.",
         "declaration": "function expectRevert(address reverter) external;",
         "visibility": "external",
         "mutability": "",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -1165,14 +1165,26 @@ interface Vm {
     function expectRevert(bytes calldata revertData) external;
 
     /// Expects an error with any revert data on next call to reverter address.
+    ///
+    /// The `reverter` argument is matched against the address of the innermost
+    /// frame that produced the revert:
+    ///   - For a CALL: the address that was called.
+    ///   - For a CREATE / CREATE2: the would-be deployed address of the failed
+    ///     deployment (computed from the deployer + nonce, or salt + initcode).
+    ///
+    /// In a nested chain the deepest reverting frame wins, regardless of whether
+    /// the chain is composed of CALLs, CREATEs, or a mix. With `count > 1` the
+    /// same rule applies independently to each iteration.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(address reverter) external;
 
     /// Expects an error from reverter address on next call, with any revert data.
+    /// See `expectRevert(address)` for `reverter` matching semantics.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(bytes4 revertData, address reverter) external;
 
     /// Expects an error from reverter address on next call, that exactly matches the revert data.
+    /// See `expectRevert(address)` for `reverter` matching semantics.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(bytes calldata revertData, address reverter) external;
 
@@ -1189,14 +1201,17 @@ interface Vm {
     function expectRevert(bytes calldata revertData, uint64 count) external;
 
     /// Expects a `count` number of reverts from the upcoming calls from the reverter address.
+    /// See `expectRevert(address)` for `reverter` matching semantics.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(address reverter, uint64 count) external;
 
     /// Expects a `count` number of reverts from the upcoming calls from the reverter address that match the revert data.
+    /// See `expectRevert(address)` for `reverter` matching semantics.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(bytes4 revertData, address reverter, uint64 count) external;
 
     /// Expects a `count` number of reverts from the upcoming calls from the reverter address that exactly match the revert data.
+    /// See `expectRevert(address)` for `reverter` matching semantics.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(bytes calldata revertData, address reverter, uint64 count) external;
 
@@ -1205,6 +1220,7 @@ interface Vm {
     function expectPartialRevert(bytes4 revertData) external;
 
     /// Expects an error on next call to reverter address, that starts with the revert data.
+    /// See `expectRevert(address)` for `reverter` matching semantics.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectPartialRevert(bytes4 revertData, address reverter) external;
 

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -1166,15 +1166,17 @@ interface Vm {
 
     /// Expects an error with any revert data on next call to reverter address.
     ///
-    /// The `reverter` argument is matched against the address of the innermost
-    /// frame that produced the revert:
+    /// The `reverter` argument is matched against the address associated with
+    /// the frame that produced the revert:
     ///   - For a CALL: the address that was called.
     ///   - For a CREATE / CREATE2: the would-be deployed address of the failed
     ///     deployment (computed from the deployer + nonce, or salt + initcode).
     ///
-    /// In a nested chain the deepest reverting frame wins, regardless of whether
-    /// the chain is composed of CALLs, CREATEs, or a mix. With `count > 1` the
-    /// same rule applies independently to each iteration.
+    /// For a single expected revert, the innermost reverting frame wins in
+    /// nested CALL, CREATE, or mixed chains. With `count > 1`, nested
+    /// CREATE / CREATE2 chains apply the same rule independently to each
+    /// iteration; nested CALL chains keep their existing
+    /// outermost-call-per-iteration behavior.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(address reverter) external;
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1408,12 +1408,11 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             // Record current reverter address and call scheme before processing the expect revert
             // if call reverted.
             if outcome.result.is_revert() {
-                // Record current reverter address if expect revert is set with expected reverter
-                // address and no actual reverter was set yet or if we're expecting more than one
-                // revert.
-                if expected_revert.reverter.is_some()
-                    && (expected_revert.reverted_by.is_none() || expected_revert.count > 1)
-                {
+                // Record current reverter address. The deepest reverting frame fires
+                // `call_end` first and the `is_none()` lock pins it as the innermost; the
+                // lock is released after each successful iteration (see below) so
+                // `count > 1` keeps "innermost per iteration", matching `create_end`.
+                if expected_revert.reverter.is_some() && expected_revert.reverted_by.is_none() {
                     expected_revert.reverted_by = Some(call.target_address);
                 }
             }
@@ -1448,6 +1447,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         Ok((_, retdata)) => {
                             expected_revert.actual_count += 1;
                             if expected_revert.actual_count < expected_revert.count {
+                                // Reset so the next iteration's innermost frame wins again.
+                                expected_revert.reverted_by = None;
                                 self.expected_revert = Some(expected_revert);
                             }
                             outcome.result.result = InstructionResult::Return;

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1900,11 +1900,19 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
 
         // Handle expected reverts.
         if let Some(expected_revert) = &mut self.expected_revert {
-            // Record the would-be deployed address as the reverter, mirroring `call_end`.
-            // Runs at every depth so the innermost CREATE wins (deepest frame fires first
-            // and the `is_none()` lock pins it). `outcome.address` is `None` only when the
-            // constructor never ran (pre-frame rejection), in which case the surrounding
-            // `call_end` records the caller.
+            // Record the would-be deployed address as the reverter. We run at every depth
+            // (no depth gate here) so the deepest reverting CREATE fires first; the
+            // `is_none()` lock then pins it as the innermost. For `count > 1` the lock is
+            // released after each successful iteration (see below) so each iteration
+            // independently records its own innermost CREATE.
+            //
+            // Differs from `call_end` for `count > 1`: `call_end` overwrites every frame
+            // (outermost wins per iteration). The CREATE-side rule here is "innermost wins
+            // per iteration" — see <https://github.com/foundry-rs/foundry/issues/14613>.
+            //
+            // `outcome.address` is `None` only for pre-frame rejection
+            // (depth/balance/nonce). In that case the surrounding `call_end` records the
+            // caller as the reverter.
             if outcome.result.is_revert()
                 && expected_revert.reverter.is_some()
                 && expected_revert.reverted_by.is_none()

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1906,6 +1906,9 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             // released after each successful iteration (see below) so each iteration
             // independently records its own innermost CREATE.
             //
+            // This intentionally differs from `call_end` for `count > 1`, where
+            // legacy nested CALL handling reports the outermost call per iteration.
+            //
             // `outcome.address` is `None` for pre-frame rejection (depth/balance/nonce);
             // in that case the surrounding `call_end` records the caller as the reverter.
             if outcome.result.is_revert()

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1408,11 +1408,12 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             // Record current reverter address and call scheme before processing the expect revert
             // if call reverted.
             if outcome.result.is_revert() {
-                // Record current reverter address. The deepest reverting frame fires
-                // `call_end` first and the `is_none()` lock pins it as the innermost; the
-                // lock is released after each successful iteration (see below) so
-                // `count > 1` keeps "innermost per iteration", matching `create_end`.
-                if expected_revert.reverter.is_some() && expected_revert.reverted_by.is_none() {
+                // Record current reverter address if expect revert is set with expected reverter
+                // address and no actual reverter was set yet or if we're expecting more than one
+                // revert.
+                if expected_revert.reverter.is_some()
+                    && (expected_revert.reverted_by.is_none() || expected_revert.count > 1)
+                {
                     expected_revert.reverted_by = Some(call.target_address);
                 }
             }
@@ -1447,8 +1448,6 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         Ok((_, retdata)) => {
                             expected_revert.actual_count += 1;
                             if expected_revert.actual_count < expected_revert.count {
-                                // Reset so the next iteration's innermost frame wins again.
-                                expected_revert.reverted_by = None;
                                 self.expected_revert = Some(expected_revert);
                             }
                             outcome.result.result = InstructionResult::Return;
@@ -1901,19 +1900,14 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
 
         // Handle expected reverts.
         if let Some(expected_revert) = &mut self.expected_revert {
-            // Record the would-be deployed address as the reverter. We run at every depth
-            // (no depth gate here) so the deepest reverting CREATE fires first; the
-            // `is_none()` lock then pins it as the innermost. For `count > 1` the lock is
+            // Record the would-be deployed address as the reverter, picking the innermost
+            // reverting CREATE: this hook runs at every depth, the deepest frame fires
+            // first, and the `is_none()` lock pins it. For `count > 1` the lock is
             // released after each successful iteration (see below) so each iteration
             // independently records its own innermost CREATE.
             //
-            // Differs from `call_end` for `count > 1`: `call_end` overwrites every frame
-            // (outermost wins per iteration). The CREATE-side rule here is "innermost wins
-            // per iteration" — see <https://github.com/foundry-rs/foundry/issues/14613>.
-            //
-            // `outcome.address` is `None` only for pre-frame rejection
-            // (depth/balance/nonce). In that case the surrounding `call_end` records the
-            // caller as the reverter.
+            // `outcome.address` is `None` for pre-frame rejection (depth/balance/nonce);
+            // in that case the surrounding `call_end` records the caller as the reverter.
             if outcome.result.is_revert()
                 && expected_revert.reverter.is_some()
                 && expected_revert.reverted_by.is_none()

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1907,7 +1907,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             // `call_end` records the caller.
             if outcome.result.is_revert()
                 && expected_revert.reverter.is_some()
-                && (expected_revert.reverted_by.is_none() || expected_revert.count > 1)
+                && expected_revert.reverted_by.is_none()
                 && let Some(addr) = outcome.address
             {
                 expected_revert.reverted_by = Some(addr);
@@ -1929,6 +1929,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                     Ok((address, retdata)) => {
                         expected_revert.actual_count += 1;
                         if expected_revert.actual_count < expected_revert.count {
+                            // Reset so the next iteration's innermost CREATE wins again.
+                            expected_revert.reverted_by = None;
                             self.expected_revert = Some(expected_revert.clone());
                         }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1896,36 +1896,50 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             }
         }
 
-        // Handle expected reverts
-        if let Some(expected_revert) = &self.expected_revert
-            && curr_depth <= expected_revert.depth
-            && matches!(expected_revert.kind, ExpectedRevertKind::Default)
-        {
-            let mut expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
-            return match revert_handlers::handle_expect_revert(
-                false,
-                true,
-                self.config.internal_expect_revert,
-                &expected_revert,
-                outcome.result.result,
-                outcome.result.output.clone(),
-                &self.config.available_artifacts,
-            ) {
-                Ok((address, retdata)) => {
-                    expected_revert.actual_count += 1;
-                    if expected_revert.actual_count < expected_revert.count {
-                        self.expected_revert = Some(expected_revert.clone());
-                    }
+        // Handle expected reverts.
+        if let Some(expected_revert) = &mut self.expected_revert {
+            // Record the would-be deployed address as the reverter, mirroring `call_end`.
+            // Runs at every depth so the innermost CREATE wins (deepest frame fires first
+            // and the `is_none()` lock pins it). `outcome.address` is `None` only when the
+            // constructor never ran (pre-frame rejection), in which case the surrounding
+            // `call_end` records the caller.
+            if outcome.result.is_revert()
+                && expected_revert.reverter.is_some()
+                && (expected_revert.reverted_by.is_none() || expected_revert.count > 1)
+                && let Some(addr) = outcome.address
+            {
+                expected_revert.reverted_by = Some(addr);
+            }
 
-                    outcome.result.result = InstructionResult::Return;
-                    outcome.result.output = retdata;
-                    outcome.address = address;
-                }
-                Err(err) => {
-                    outcome.result.result = InstructionResult::Revert;
-                    outcome.result.output = err.abi_encode().into();
-                }
-            };
+            if curr_depth <= expected_revert.depth
+                && matches!(expected_revert.kind, ExpectedRevertKind::Default)
+            {
+                let mut expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
+                return match revert_handlers::handle_expect_revert(
+                    false,
+                    true,
+                    self.config.internal_expect_revert,
+                    &expected_revert,
+                    outcome.result.result,
+                    outcome.result.output.clone(),
+                    &self.config.available_artifacts,
+                ) {
+                    Ok((address, retdata)) => {
+                        expected_revert.actual_count += 1;
+                        if expected_revert.actual_count < expected_revert.count {
+                            self.expected_revert = Some(expected_revert.clone());
+                        }
+
+                        outcome.result.result = InstructionResult::Return;
+                        outcome.result.output = retdata;
+                        outcome.address = address;
+                    }
+                    Err(err) => {
+                        outcome.result.result = InstructionResult::Revert;
+                        outcome.result.output = err.abi_encode().into();
+                    }
+                };
+            }
         }
 
         // If `startStateDiffRecording` has been called, update the `reverted` status of the

--- a/crates/forge/tests/cli/failure_assertions.rs
+++ b/crates/forge/tests/cli/failure_assertions.rs
@@ -70,8 +70,9 @@ Suite result: FAILED. 0 passed; 7 failed; 0 skipped; [ELAPSED]
         .stdout_eq(
             r#"No files changed, compilation skipped
 ...
+[FAIL: Reverter != expected reverter: [..] != 0x000000000000000000000000000000000000dEaD] testShouldFailExpectRevertWrongReverterTopLevelCreate() ([GAS])
 [FAIL: next call did not revert as expected] testShouldFailExpectRevertsNotOnImmediateNextCall() ([GAS])
-Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+Suite result: FAILED. 0 passed; 2 failed; 0 skipped; [ELAPSED]
 ...
 "#,
         );

--- a/crates/forge/tests/fixtures/ExpectRevertFailures.t.sol
+++ b/crates/forge/tests/fixtures/ExpectRevertFailures.t.sol
@@ -269,8 +269,8 @@ contract ExpectRevertWithReverterFailureTest is DSTest {
 
     // <https://github.com/foundry-rs/foundry/issues/14613>
     // Regression: documents innermost-wins semantics for nested CREATEs — the
-    // matched reverter is the *innermost* would-be-deployed address, mirroring
-    // CALL semantics. Supplying the outer address must fail.
+    // matched reverter is the *innermost* would-be-deployed address. Supplying
+    // the outer address must fail.
     function testShouldFailExpectRevertNestedCreateOuterAddress() public {
         // Outer = NestedDContractCreator at this contract's next nonce. Under
         // innermost-wins, the matched reverter is the inner DContract, not the

--- a/crates/forge/tests/fixtures/ExpectRevertFailures.t.sol
+++ b/crates/forge/tests/fixtures/ExpectRevertFailures.t.sol
@@ -234,44 +234,55 @@ contract ExpectRevertWithReverterFailureTest is DSTest {
         aContract.callAndRevert();
     }
 
-    // https://github.com/foundry-rs/foundry/issues/14613
-    // Wrong reverter for a top-level CREATE that reverts must fail.
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: must fail because 0xdead is not the actual reverter when a
+    // top-level CREATE constructor reverts directly.
     function testShouldFailExpectRevertWrongReverterTopLevelCreate() public {
         vm.expectRevert(address(0xdead));
         new DContract();
     }
 
-    // https://github.com/foundry-rs/foundry/issues/14613
-    // Reverter is enforced even when an exact-bytes pattern is also supplied.
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: must fail because the reverter address argument is enforced
+    // even when an exact-bytes pattern is also supplied for a top-level CREATE.
     function testShouldFailExpectRevertWithBytesWrongReverterTopLevelCreate() public {
         vm.expectRevert(abi.encodePacked("Reverted by DContract"), address(0xdead));
         new DContract();
     }
 
-    // https://github.com/foundry-rs/foundry/issues/14613
-    // Reverter is enforced for `expectPartialRevert(bytes4, address)`.
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: must fail because the reverter address argument is enforced
+    // for `expectPartialRevert(bytes4, address)` against a top-level CREATE.
     function testShouldFailExpectPartialRevertWrongReverterTopLevelCreate() public {
         vm.expectPartialRevert(bytes4(keccak256("Error(string)")), address(0xdead));
         new DContract();
     }
 
-    // https://github.com/foundry-rs/foundry/issues/14613
-    // Wrong reverter for a nested CREATE chain must fail.
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: must fail when the innermost reverting frame is a nested
+    // CREATE and the reverter address argument does not match the would-be
+    // deployed address of the failed (innermost) deployment.
     function testShouldFailExpectRevertWrongReverterNestedCreate() public {
         vm.expectRevert(address(0xdead));
         new NestedDContractCreator();
     }
 
-    // https://github.com/foundry-rs/foundry/issues/14613
-    // Innermost-wins semantics: supplying the *outer* would-be address must
-    // fail; only the *innermost* (DContract) address matches.
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: documents innermost-wins semantics for nested CREATEs — the
+    // matched reverter is the *innermost* would-be-deployed address, mirroring
+    // CALL semantics. Supplying the outer address must fail.
     function testShouldFailExpectRevertNestedCreateOuterAddress() public {
+        // Outer = NestedDContractCreator at this contract's next nonce. Under
+        // innermost-wins, the matched reverter is the inner DContract, not the
+        // outer.
         address outer = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
         vm.expectRevert(outer);
         new NestedDContractCreator();
     }
 }
 
+// Used by `testShouldFailExpectRevertWrongReverterNestedCreate`: a contract whose
+// constructor directly creates another contract that reverts.
 contract NestedDContractCreator {
     constructor() {
         new DContract();

--- a/crates/forge/tests/fixtures/ExpectRevertFailures.t.sol
+++ b/crates/forge/tests/fixtures/ExpectRevertFailures.t.sol
@@ -233,6 +233,13 @@ contract ExpectRevertWithReverterFailureTest is DSTest {
         aContract.doNotRevert();
         aContract.callAndRevert();
     }
+
+    // https://github.com/foundry-rs/foundry/issues/14613
+    // Wrong reverter for a top-level CREATE that reverts must fail.
+    function testShouldFailExpectRevertWrongReverterTopLevelCreate() public {
+        vm.expectRevert(address(0xdead));
+        new DContract();
+    }
 }
 
 contract ExpectRevertCountFailureTest is DSTest {

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -288,8 +288,7 @@ contract ExpectRevertWithReverterTest is Test {
         aContract.callAndRevertInCContract();
     }
 
-    // The reverter for a CREATE that reverts is the would-be deployed address
-    // (innermost-wins, mirroring CALL semantics).
+    // The reverter for a CREATE that reverts is the would-be deployed address.
     function testExpectRevertsWithReverterInConstructor() public {
         address expected;
 
@@ -330,7 +329,7 @@ contract ExpectRevertWithReverterTest is Test {
     }
 
     // <https://github.com/foundry-rs/foundry/issues/14613>
-    // Nested CREATE chain: innermost reverter wins, matching CALL semantics.
+    // Nested CREATE chain: innermost failed deployment wins.
     function testExpectRevertsWithReverterNestedCreate() public {
         address outer = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
         // Contracts start at nonce 1; the inner DContract is outer's first creation.

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -387,12 +387,9 @@ contract ExpectRevertWithReverterTest is Test {
     function testExpectRevertsWithReverterCountNestedCreate2() public {
         bytes32 outerSalt = bytes32(uint256(0xBEEF));
         bytes32 innerSalt = NESTED_DCONTRACT_CREATOR2_INNER_SALT;
-        address outer = vm.computeCreate2Address(
-            outerSalt, keccak256(type(NestedDContractCreator2).creationCode), address(this)
-        );
-        address inner = vm.computeCreate2Address(
-            innerSalt, keccak256(type(DContract).creationCode), outer
-        );
+        address outer =
+            vm.computeCreate2Address(outerSalt, keccak256(type(NestedDContractCreator2).creationCode), address(this));
+        address inner = vm.computeCreate2Address(innerSalt, keccak256(type(DContract).creationCode), outer);
 
         vm.expectRevert(inner, 2);
         new NestedDContractCreator2{salt: outerSalt}();

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -315,8 +315,10 @@ contract ExpectRevertWithReverterTest is Test {
         aContract.createDContractThroughCContract();
     }
 
-    // https://github.com/foundry-rs/foundry/issues/14613
-    // Top-level CREATE that reverts: reverter is the would-be deployed address.
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: when the next operation is a top-level CREATE whose constructor
+    // reverts directly, the reverter address argument must be enforced (it used to
+    // be silently ignored). The matched reverter is the would-be-deployed address.
     function testExpectRevertsWithReverterTopLevelCreate() public {
         address expected = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
         vm.expectRevert(expected);
@@ -327,7 +329,7 @@ contract ExpectRevertWithReverterTest is Test {
         new DContract();
     }
 
-    // https://github.com/foundry-rs/foundry/issues/14613
+    // <https://github.com/foundry-rs/foundry/issues/14613>
     // Nested CREATE chain: innermost reverter wins, matching CALL semantics.
     function testExpectRevertsWithReverterNestedCreate() public {
         address outer = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
@@ -337,9 +339,9 @@ contract ExpectRevertWithReverterTest is Test {
         new NestedDContractCreator();
     }
 
-    // https://github.com/foundry-rs/foundry/issues/14613
-    // `expectPartialRevert(bytes4, address)` must enforce the reverter for a
-    // top-level CREATE.
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: `expectPartialRevert(bytes4, address)` overload must enforce
+    // the reverter address argument when matching a top-level CREATE revert.
     function testExpectPartialRevertWithReverterTopLevelCreate() public {
         address expected = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
         // `Reverted by DContract` triggers Solidity's `Error(string)` selector.
@@ -347,18 +349,20 @@ contract ExpectRevertWithReverterTest is Test {
         new DContract();
     }
 
-    // https://github.com/foundry-rs/foundry/issues/14613
-    // `expectRevert(bytes4, address)` must enforce the reverter for a top-level CREATE.
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: `expectRevert(bytes4, address)` (exact 4-byte selector + reverter)
+    // overload must enforce the reverter address argument for a top-level CREATE.
     function testExpectRevertWithBytes4SelectorAndReverterTopLevelCreate() public {
         address expected = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
         vm.expectRevert(DCustomErrorContract.CustomError.selector, expected);
         new DCustomErrorContract();
     }
 
-    // https://github.com/foundry-rs/foundry/issues/14613
-    // `expectRevert(address, uint64)` exercises the `count > 1` branch in
-    // `create_end`. CREATE2 with the same salt resolves to the same would-be
-    // address for both reverting deploys.
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: `expectRevert(address, uint64)` count-bearing overload must
+    // exercise the `count > 1` branch in `create_end`. Use CREATE2 with the same
+    // salt so both deploys would resolve to the same would-be address (each
+    // constructor reverts so no contract is ever actually placed there).
     function testExpectRevertsWithReverterCountTopLevelCreate2() public {
         bytes32 salt = bytes32(uint256(0x42));
         address expected = vm.computeCreate2Address(salt, keccak256(type(DContract).creationCode), address(this));
@@ -367,8 +371,8 @@ contract ExpectRevertWithReverterTest is Test {
         new DContract{salt: salt}();
     }
 
-    // https://github.com/foundry-rs/foundry/issues/14613
-    // CREATE2 deploys must also enforce the reverter address argument.
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: CREATE2 deploys must also enforce the reverter address argument.
     function testExpectRevertsWithReverterTopLevelCreate2() public {
         bytes32 salt = bytes32(uint256(0xC0FFEE));
         address expected = vm.computeCreate2Address(salt, keccak256(type(DContract).creationCode), address(this));
@@ -377,6 +381,8 @@ contract ExpectRevertWithReverterTest is Test {
     }
 }
 
+// Used by `testExpectRevertsWithReverterNestedCreate`: a contract whose constructor
+// directly creates another contract that reverts.
 contract NestedDContractCreator {
     constructor() {
         new DContract();
@@ -393,7 +399,6 @@ contract DCustomErrorContract {
         revert CustomError();
     }
 }
-
 
 contract ExpectRevertCount is Test {
     function testRevertCountAny() public {

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -288,22 +288,59 @@ contract ExpectRevertWithReverterTest is Test {
         aContract.callAndRevertInCContract();
     }
 
+    // The reverter for a CREATE that reverts is the would-be deployed address
+    // (innermost-wins, mirroring CALL semantics).
     function testExpectRevertsWithReverterInConstructor() public {
-        // Test expect revert with reverter when constructor reverts.
-        vm.expectRevert(abi.encodePacked("Reverted by DContract"), address(cContract));
+        address expected;
+
+        expected = vm.computeCreateAddress(address(cContract), vm.getNonce(address(cContract)));
+        vm.expectRevert(abi.encodePacked("Reverted by DContract"), expected);
         cContract.createDContract();
 
-        vm.expectRevert(address(bContract));
+        expected = vm.computeCreateAddress(address(bContract), vm.getNonce(address(bContract)));
+        vm.expectRevert(expected);
         bContract.createDContract();
-        vm.expectRevert(address(cContract));
+        expected = vm.computeCreateAddress(address(cContract), vm.getNonce(address(cContract)));
+        vm.expectRevert(expected);
         bContract.createDContractThroughCContract();
 
-        vm.expectRevert(address(aContract));
+        expected = vm.computeCreateAddress(address(aContract), vm.getNonce(address(aContract)));
+        vm.expectRevert(expected);
         aContract.createDContract();
-        vm.expectRevert(address(bContract));
+        expected = vm.computeCreateAddress(address(bContract), vm.getNonce(address(bContract)));
+        vm.expectRevert(expected);
         aContract.createDContractThroughBContract();
-        vm.expectRevert(address(cContract));
+        expected = vm.computeCreateAddress(address(cContract), vm.getNonce(address(cContract)));
+        vm.expectRevert(expected);
         aContract.createDContractThroughCContract();
+    }
+
+    // https://github.com/foundry-rs/foundry/issues/14613
+    // Top-level CREATE that reverts: reverter is the would-be deployed address.
+    function testExpectRevertsWithReverterTopLevelCreate() public {
+        address expected = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        vm.expectRevert(expected);
+        new DContract();
+
+        expected = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        vm.expectRevert(abi.encodePacked("Reverted by DContract"), expected);
+        new DContract();
+    }
+
+    // https://github.com/foundry-rs/foundry/issues/14613
+    // Nested CREATE chain: innermost reverter wins, matching CALL semantics.
+    function testExpectRevertsWithReverterNestedCreate() public {
+        address outer = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        // Contracts start at nonce 1; the inner DContract is outer's first creation.
+        address innerReverter = vm.computeCreateAddress(outer, 1);
+        vm.expectRevert(innerReverter);
+        new NestedDContractCreator();
+    }
+}
+
+contract NestedDContractCreator {
+    constructor() {
+        new DContract();
     }
 }
 

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -379,6 +379,25 @@ contract ExpectRevertWithReverterTest is Test {
         vm.expectRevert(expected);
         new DContract{salt: salt}();
     }
+
+    // <https://github.com/foundry-rs/foundry/issues/14613>
+    // Regression: `count > 1` with a nested CREATE chain must still report the
+    // innermost reverter, not the outer frame. Uses fixed outer+inner CREATE2 salts
+    // so both iterations resolve to the same would-be addresses.
+    function testExpectRevertsWithReverterCountNestedCreate2() public {
+        bytes32 outerSalt = bytes32(uint256(0xBEEF));
+        bytes32 innerSalt = NESTED_DCONTRACT_CREATOR2_INNER_SALT;
+        address outer = vm.computeCreate2Address(
+            outerSalt, keccak256(type(NestedDContractCreator2).creationCode), address(this)
+        );
+        address inner = vm.computeCreate2Address(
+            innerSalt, keccak256(type(DContract).creationCode), outer
+        );
+
+        vm.expectRevert(inner, 2);
+        new NestedDContractCreator2{salt: outerSalt}();
+        new NestedDContractCreator2{salt: outerSalt}();
+    }
 }
 
 // Used by `testExpectRevertsWithReverterNestedCreate`: a contract whose constructor
@@ -386,6 +405,17 @@ contract ExpectRevertWithReverterTest is Test {
 contract NestedDContractCreator {
     constructor() {
         new DContract();
+    }
+}
+
+// File-level constant shared between NestedDContractCreator2 and its test.
+bytes32 constant NESTED_DCONTRACT_CREATOR2_INNER_SALT = bytes32(uint256(0xDEAD));
+
+// Used by `testExpectRevertsWithReverterCountNestedCreate2`: fixed inner salt so
+// both CREATE2 iterations produce the same inner would-be address.
+contract NestedDContractCreator2 {
+    constructor() {
+        new DContract{salt: NESTED_DCONTRACT_CREATOR2_INNER_SALT}();
     }
 }
 


### PR DESCRIPTION

## Motivation

#14615 follow-up, `vm.expectRevert` for nested `CREATE` chains recorded the outer would-be address as the reverter, inconsistent with single-revert `CALL` semantics (which record the innermost reverting address) https://github.com/foundry-rs/foundry/pull/14615#issuecomment-4389574212.

## Solution

Moved `create_end`'s `reverted_by` write outside the depth gate so every reverting `CREATE` frame can attempt to record its would-be deployed address. The deepest `CREATE` frame fires first and the `is_none()` lock pins it, so nested `CREATE` / `CREATE2` chains use the innermost failed deployment as the reverter. For `count > 1`, the lock is reset after each successful CREATE expectation iteration. Existing nested `CALL` count behavior is intentionally unchanged.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
