### PR TITLE
fix(script): only set fee_token on library deploy txs

### DIFF
--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -6,7 +6,7 @@ use alloy_network::TransactionBuilder;
 use alloy_primitives::{Address, Bytes, U256};
 use eyre::Result;
 use foundry_cheatcodes::BroadcastableTransaction;
-use foundry_common::TransactionMaybeSigned;
+use foundry_common::{FoundryTransactionBuilder, TransactionMaybeSigned};
 use foundry_config::Config;
 use foundry_evm::{
     constants::CALLER,
@@ -84,7 +84,12 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                     .with_input(code.clone())
                     .with_nonce(sender_nonce + library_transactions.len() as u64);
 
-                script_config.tempo.apply::<FEN::Network>(&mut tx_req, None);
+                // Only set fee_token for library deploys — do NOT call tempo.apply()
+                // which would overwrite the sequential nonce and set fields (nonce_key,
+                // valid_before, key_id, sponsor) that are only meant for user broadcast txs.
+                if let Some(fee_token) = script_config.tempo.common.fee_token {
+                    tx_req.set_fee_token(fee_token);
+                }
 
                 library_transactions.push_back(BroadcastableTransaction {
                     rpc: self.evm_opts.fork_url.clone(),
@@ -120,7 +125,10 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                         .with_nonce(sender_nonce + library_transactions.len() as u64)
                         .with_to(create2_deployer);
 
-                    script_config.tempo.apply::<FEN::Network>(&mut tx_req, None);
+                    // Only set fee_token for library deploys (see comment above).
+                    if let Some(fee_token) = script_config.tempo.common.fee_token {
+                        tx_req.set_fee_token(fee_token);
+                    }
 
                     library_transactions.push_back(BroadcastableTransaction {
                         rpc: self.evm_opts.fork_url.clone(),


### PR DESCRIPTION
## Motivation

[#14594](https://github.com/foundry-rs/foundry/pull/14594) replaced targeted `set_fee_token()` + `apply_expires()` calls in `runner.rs` with a blanket `tempo.apply()`. This applies **all** `TempoOpts` fields (nonce_key, valid_before, key_id, sponsor) to library deploy transactions, which breaks local Anvil (`--hardfork t3`) — the transactions are malformed and Anvil stops mining blocks.

`forge script --broadcast` then polls forever for receipts that never arrive. See [CI run](https://github.com/foundry-rs/foundry/actions/runs/25446318617/job/74667254337) — the hang is at `=== ANVIL LOCAL: FORGE SCRIPT BROADCAST ===`.

## Fix

Restore the pre-#14594 behaviour in `runner.rs`: only propagate `fee_token` to library deploy transaction requests. Library deploys use sequential nonces computed by the runner and should never receive expiring nonces, nonce keys, key_id, or sponsor fields — those belong on user broadcast transactions only.

The `tempo.apply()` call in `broadcast.rs` (for actual user broadcast txs) is unaffected.

## Note

[#14626](https://github.com/foundry-rs/foundry/pull/14626) separately fixes `forge script` hanging forever when a tx is dropped/rejected (a defence-in-depth improvement to `check_tx_status`). Both fixes are independently valuable — this PR fixes the root cause, #14626 fixes the symptom.