### PR TITLE
Revert "fix(config): disable proxy detection in Etherscan client"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5219,7 +5219,6 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "reqwest 0.13.3",
  "semver 1.0.28",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5219,7 +5219,6 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "reqwest 0.13.2",
  "semver 1.0.28",
  "serde",
  "serde_json",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -37,7 +37,6 @@ mesc.workspace = true
 unit-prefix = "0.5.2"
 rayon.workspace = true
 regex.workspace = true
-reqwest.workspace = true
 semver = { workspace = true, features = ["serde"] }
 serde_json.workspace = true
 serde.workspace = true

--- a/crates/config/src/etherscan.rs
+++ b/crates/config/src/etherscan.rs
@@ -307,13 +307,7 @@ impl ResolvedEtherscanConfig {
             }
         }
 
-        // Disable automatic proxy detection. In sandboxed environments (e.g., Cursor IDE,
-        // macOS App Sandbox), reqwest's system proxy lookup via SCDynamicStore can crash
-        // when the API returns NULL. See: https://github.com/foundry-rs/foundry/issues/12733
-        let http_client = reqwest::Client::builder().no_proxy().build()?;
-
         let mut client_builder = foundry_block_explorers::Client::builder()
-            .with_client(http_client)
             .with_api_key(api_key)
             .with_cache(cache, Duration::from_secs(24 * 60 * 60));
         if let Some(ref browser_url) = browser_url {


### PR DESCRIPTION
Decided that the current default is not desirable; if we do want something like this it should be explicitly done so through a provided flag: https://github.com/search?q=repo%3Afoundry-rs%2Ffoundry%20no_proxy&type=code

Reverts foundry-rs/foundry#14454

