### PR TITLE
fix(anvil): stop node tasks on handle shutdown

### DIFF
--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -33,7 +33,7 @@ use foundry_primitives::FoundryNetwork;
 use futures::{FutureExt, TryFutureExt};
 use parking_lot::Mutex;
 use revm::primitives::hardfork::SpecId;
-use server::try_spawn_ipc;
+use server::try_spawn_ipc_with_shutdown;
 use std::{
     net::SocketAddr,
     pin::Pin,
@@ -240,9 +240,18 @@ pub async fn try_spawn(mut config: NodeConfig) -> Result<(EthApi<FoundryNetwork>
         transaction_order,
     );
 
+    let tokio_handle = Handle::current();
+    let (signal, on_shutdown) = shutdown::signal();
+
     // spawn the node service
-    let node_service =
-        tokio::task::spawn(NodeService::new(pool, backend, miner, fee_history_service, filters));
+    let node_service = tokio::task::spawn(NodeService::new(
+        pool,
+        backend,
+        miner,
+        fee_history_service,
+        filters,
+        on_shutdown.clone(),
+    ));
 
     let mut servers = Vec::with_capacity(config.host.len());
     let mut addresses = Vec::with_capacity(config.host.len());
@@ -255,16 +264,21 @@ pub async fn try_spawn(mut config: NodeConfig) -> Result<(EthApi<FoundryNetwork>
         addresses.push(tcp_listener.local_addr()?);
 
         // Spawn the server future on a new task.
-        let srv = server::serve_on(tcp_listener, api.clone(), server_config.clone());
+        let srv = server::serve_on_with_shutdown(
+            tcp_listener,
+            api.clone(),
+            server_config.clone(),
+            on_shutdown.clone(),
+        );
         servers.push(tokio::task::spawn(srv.map_err(Into::into)));
     }
 
-    let tokio_handle = Handle::current();
-    let (signal, on_shutdown) = shutdown::signal();
-    let task_manager = TaskManager::new(tokio_handle, on_shutdown);
+    let task_manager = TaskManager::new(tokio_handle, on_shutdown.clone());
 
-    let ipc_task =
-        config.get_ipc_path().map(|path| try_spawn_ipc(api.clone(), path)).transpose()?;
+    let ipc_task = config
+        .get_ipc_path()
+        .map(|path| try_spawn_ipc_with_shutdown(api.clone(), path, on_shutdown.clone()))
+        .transpose()?;
 
     let handle = NodeHandle {
         config,

--- a/crates/anvil/src/server/mod.rs
+++ b/crates/anvil/src/server/mod.rs
@@ -32,7 +32,22 @@ pub async fn serve_on(
     api: EthApi<FoundryNetwork>,
     config: ServerConfig,
 ) -> io::Result<()> {
-    axum::serve(tcp_listener, router(api, config).into_make_service()).await
+    axum::serve(tcp_listener, router(api, config).into_make_service())
+        .with_graceful_shutdown(std::future::pending())
+        .await
+}
+
+/// Configures a server that handles [`EthApi`] related JSON-RPC calls via HTTP and WS and exits
+/// when the provided shutdown future resolves.
+pub async fn serve_on_with_shutdown(
+    tcp_listener: TcpListener,
+    api: EthApi<FoundryNetwork>,
+    config: ServerConfig,
+    on_shutdown: impl Future<Output = ()> + Send + 'static,
+) -> io::Result<()> {
+    axum::serve(tcp_listener, router(api, config).into_make_service())
+        .with_graceful_shutdown(on_shutdown)
+        .await
 }
 
 /// Configures an [`axum::Router`] that handles [`EthApi`] related JSON-RPC calls via HTTP and WS,
@@ -63,15 +78,34 @@ pub fn spawn_ipc(api: EthApi<FoundryNetwork>, path: String) -> IpcTask {
 
 /// Launches an ipc server at the given path in a new task.
 pub fn try_spawn_ipc(api: EthApi<FoundryNetwork>, path: String) -> io::Result<IpcTask> {
+    try_spawn_ipc_with_shutdown(api, path, std::future::pending())
+}
+
+/// Launches an ipc server at the given path in a new task, stopping when the provided shutdown
+/// future resolves.
+pub fn try_spawn_ipc_with_shutdown(
+    api: EthApi<FoundryNetwork>,
+    path: String,
+    on_shutdown: impl Future<Output = ()> + Send + 'static,
+) -> io::Result<IpcTask> {
     let handler = PubSubEthRpcHandler::new(api);
     let ipc = IpcEndpoint::new(handler, path);
     let incoming = ipc.incoming()?;
 
     let task = tokio::task::spawn(async move {
         let mut incoming = pin!(incoming);
-        while let Some(stream) = incoming.next().await {
-            trace!(target: "ipc", "new ipc connection");
-            tokio::task::spawn(stream);
+        let mut on_shutdown = pin!(on_shutdown);
+        loop {
+            tokio::select! {
+                _ = &mut on_shutdown => break,
+                stream = incoming.next() => {
+                    let Some(stream) = stream else {
+                        break;
+                    };
+                    trace!(target: "ipc", "new ipc connection");
+                    tokio::task::spawn(stream);
+                }
+            }
         }
     });
 

--- a/crates/anvil/src/service.rs
+++ b/crates/anvil/src/service.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     filter::Filters,
     mem::{Backend, storage::MinedBlockOutcome},
+    shutdown::Shutdown,
 };
 use alloy_consensus::TxReceipt;
 use alloy_network::Network;
@@ -45,6 +46,8 @@ where
     filters: Filters<N>,
     /// The interval at which to check for filters that need to be evicted
     filter_eviction_interval: Interval,
+    /// Resolves when the owning node handle starts shutdown.
+    on_shutdown: Shutdown,
 }
 
 impl<N: Network> NodeService<N>
@@ -58,6 +61,7 @@ where
         miner: Miner<N::TxEnvelope>,
         fee_history: FeeHistoryService<N>,
         filters: Filters<N>,
+        on_shutdown: Shutdown,
     ) -> Self {
         let start = tokio::time::Instant::now() + filters.keep_alive();
         let filter_eviction_interval = tokio::time::interval_at(start, filters.keep_alive());
@@ -68,6 +72,7 @@ where
             fee_history,
             filter_eviction_interval,
             filters,
+            on_shutdown,
         }
     }
 }
@@ -81,6 +86,10 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let pin = self.get_mut();
+
+        if pin.on_shutdown.poll_unpin(cx).is_ready() {
+            return Poll::Ready(Ok(()));
+        }
 
         // this drives block production and feeds new sets of ready transactions to the block
         // producer

--- a/crates/anvil/tests/it/anvil.rs
+++ b/crates/anvil/tests/it/anvil.rs
@@ -11,6 +11,28 @@ use anvil::{NodeConfig, spawn};
 use foundry_evm::hardfork::EthereumHardfork;
 
 #[tokio::test(flavor = "multi_thread")]
+async fn dropping_handle_releases_http_listener() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let addr = *handle.socket_address();
+
+    drop(handle);
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            match tokio::net::TcpListener::bind(addr).await {
+                Ok(listener) => {
+                    drop(listener);
+                    break;
+                }
+                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+            }
+        }
+    })
+    .await
+    .expect("HTTP listener should shut down after NodeHandle is dropped");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_can_change_mining_mode() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();


### PR DESCRIPTION
## Motivation

Dropping `NodeHandle` fired the shutdown signal, but the core HTTP/WS server tasks, IPC listener, and `NodeService` did not observe that signal. That could leave listeners running after the handle was dropped.

## Solution

Thread the existing shutdown receiver into `NodeService`, HTTP/WS server tasks, and the IPC listener. Add a regression test that drops a handle and verifies the HTTP listener address can be rebound.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes