### PR TITLE
fix(anvil): abort node tasks on handle drop

### DIFF
--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -291,9 +291,9 @@ pub struct NodeHandle {
     /// The address of the running rpc server.
     addresses: Vec<SocketAddr>,
     /// Join handle for the Node Service.
-    pub node_service: JoinHandle<Result<(), NodeError>>,
+    node_service: JoinHandle<Result<(), NodeError>>,
     /// Join handles (one per socket) for the Anvil server.
-    pub servers: Vec<JoinHandle<Result<(), NodeError>>>,
+    servers: Vec<JoinHandle<Result<(), NodeError>>>,
     /// The future that joins the ipc server, if any.
     ipc_task: Option<IpcTask>,
     /// A signal that fires the shutdown, fired on drop.
@@ -307,6 +307,13 @@ impl Drop for NodeHandle {
         // Fire shutdown signal to make sure anvil instance is terminated.
         if let Some(signal) = self._signal.take() {
             let _ = signal.fire();
+        }
+        self.node_service.abort();
+        for server in &self.servers {
+            server.abort();
+        }
+        if let Some(ipc_task) = &self.ipc_task {
+            ipc_task.abort();
         }
     }
 }

--- a/crates/anvil/tests/it/anvil.rs
+++ b/crates/anvil/tests/it/anvil.rs
@@ -11,6 +11,28 @@ use anvil::{NodeConfig, spawn};
 use foundry_evm::hardfork::EthereumHardfork;
 
 #[tokio::test(flavor = "multi_thread")]
+async fn dropping_handle_releases_http_listener() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let addr = *handle.socket_address();
+
+    drop(handle);
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            match tokio::net::TcpListener::bind(addr).await {
+                Ok(listener) => {
+                    drop(listener);
+                    break;
+                }
+                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+            }
+        }
+    })
+    .await
+    .expect("HTTP listener should shut down after NodeHandle is dropped");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_can_change_mining_mode() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();

--- a/crates/cast/tests/cli/erc20.rs
+++ b/crates/cast/tests/cli/erc20.rs
@@ -1,7 +1,7 @@
 //! Contains various tests for checking cast erc20 subcommands
 
 use alloy_primitives::U256;
-use anvil::NodeConfig;
+use anvil::{NodeConfig, NodeHandle};
 use foundry_test_utils::util::OutputExt;
 
 mod anvil_const {
@@ -68,7 +68,7 @@ fn deploy_test_token(
 async fn setup_token_test(
     prj: &foundry_test_utils::TestProject,
     cmd: &mut foundry_test_utils::TestCommand,
-) -> (String, String) {
+) -> (String, String, NodeHandle) {
     let (_, handle) = anvil::spawn(NodeConfig::test()).await;
     let rpc = handle.http_endpoint();
 
@@ -77,12 +77,12 @@ async fn setup_token_test(
     prj.add_source("TestToken.sol", include_str!("../fixtures/TestToken.sol"));
     let token = deploy_test_token(cmd, &rpc, anvil_const::PK1);
 
-    (rpc, token)
+    (rpc, token, handle)
 }
 
 // tests that `balance` and `transfer` commands works correctly
 forgetest_async!(erc20_transfer_approve_success, |prj, cmd| {
-    let (rpc, token) = setup_token_test(&prj, &mut cmd).await;
+    let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;
 
     // Test constants
     let transfer_amount = U256::from(100_000_000_000_000_000_000u128); // 100 tokens (18 decimals)
@@ -118,7 +118,7 @@ forgetest_async!(erc20_transfer_approve_success, |prj, cmd| {
 
 // tests that `approve` and `allowance` commands works correctly
 forgetest_async!(erc20_approval_allowance, |prj, cmd| {
-    let (rpc, token) = setup_token_test(&prj, &mut cmd).await;
+    let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;
 
     // ADDR1 approves ADDR2 to spend their tokens
     let approve_amount = U256::from(50_000_000_000_000_000_000u128); // 50 tokens
@@ -143,7 +143,7 @@ forgetest_async!(erc20_approval_allowance, |prj, cmd| {
 
 // tests that `name`, `symbol`, `decimals`, and `totalSupply` commands work correctly
 forgetest_async!(erc20_metadata_success, |prj, cmd| {
-    let (rpc, token) = setup_token_test(&prj, &mut cmd).await;
+    let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;
 
     // Test name
     let output = cmd
@@ -185,7 +185,7 @@ forgetest_async!(erc20_metadata_success, |prj, cmd| {
 
 // tests that `mint` command works correctly
 forgetest_async!(erc20_mint_success, |prj, cmd| {
-    let (rpc, token) = setup_token_test(&prj, &mut cmd).await;
+    let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;
 
     let mint_amount = U256::from(500_000_000_000_000_000_000u128); // 500 tokens
     let initial_supply = U256::from(1_000_000_000_000_000_000_000u128); // 1000 tokens
@@ -226,7 +226,7 @@ forgetest_async!(erc20_mint_success, |prj, cmd| {
 
 // tests that `burn` command works correctly
 forgetest_async!(erc20_burn_success, |prj, cmd| {
-    let (rpc, token) = setup_token_test(&prj, &mut cmd).await;
+    let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;
 
     let burn_amount = U256::from(200_000_000_000_000_000_000u128); // 200 tokens
     let initial_supply = U256::from(1_000_000_000_000_000_000_000u128); // 1000 tokens
@@ -266,7 +266,7 @@ forgetest_async!(erc20_burn_success, |prj, cmd| {
 
 // tests that `transfer` command works with gas options
 forgetest_async!(erc20_transfer_with_gas_opts, |prj, cmd| {
-    let (rpc, token) = setup_token_test(&prj, &mut cmd).await;
+    let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;
 
     let transfer_amount = U256::from(100_000_000_000_000_000_000u128); // 100 tokens
 
@@ -296,7 +296,7 @@ forgetest_async!(erc20_transfer_with_gas_opts, |prj, cmd| {
 
 // tests that `transfer` command fails with insufficient gas limit
 forgetest_async!(erc20_transfer_insufficient_gas, |prj, cmd| {
-    let (rpc, token) = setup_token_test(&prj, &mut cmd).await;
+    let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;
 
     let transfer_amount = U256::from(50_000_000_000_000_000_000u128); // 50 tokens
 
@@ -324,7 +324,7 @@ forgetest_async!(erc20_transfer_insufficient_gas, |prj, cmd| {
 
 // tests that `transfer` command fails with incorrect nonce
 forgetest_async!(erc20_transfer_incorrect_nonce, |prj, cmd| {
-    let (rpc, token) = setup_token_test(&prj, &mut cmd).await;
+    let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;
 
     let transfer_amount = U256::from(50_000_000_000_000_000_000u128); // 50 tokens
 
@@ -504,7 +504,7 @@ casttest!(erc20_curl_total_supply, |_prj, cmd| {
 
 // tests that `balance` command works correctly with --json flag
 forgetest_async!(erc20_balance_json, |prj, cmd| {
-    let (rpc, token) = setup_token_test(&prj, &mut cmd).await;
+    let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;
 
     let output = cmd
         .cast_fuse()
@@ -520,7 +520,7 @@ forgetest_async!(erc20_balance_json, |prj, cmd| {
 
 // tests that `allowance` command works correctly with --json flag
 forgetest_async!(erc20_allowance_json, |prj, cmd| {
-    let (rpc, token) = setup_token_test(&prj, &mut cmd).await;
+    let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;
 
     // First approve some tokens
     let approve_amount = U256::from(50_000_000_000_000_000_000u128);
@@ -563,7 +563,7 @@ forgetest_async!(erc20_allowance_json, |prj, cmd| {
 // tests that `name`, `symbol`, `decimals`, and `totalSupply` commands work correctly with --json
 // flag
 forgetest_async!(erc20_metadata_json, |prj, cmd| {
-    let (rpc, token) = setup_token_test(&prj, &mut cmd).await;
+    let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;
 
     // Test name with --json
     let output = cmd


### PR DESCRIPTION
## Motivation

Dropping `NodeHandle` already fires the shutdown signal, but the core `NodeService`, HTTP/WS server tasks, and IPC listener are also retained as join handles on the handle itself. PR #14635 identified that dropping the handle can leave listeners running; this keeps the same motivation while using the existing handle ownership path instead of threading shutdown through the server and service internals.

## Solution

Abort the stored node service, server, and IPC join handles from `NodeHandle::drop` after firing the existing shutdown signal. Make the `node_service` and `servers` fields private so task ownership remains internal to `NodeHandle`. Add a regression test that drops a handle and verifies the HTTP listener address can be rebound.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Breaking changes