### PR TITLE
fix(evm): preserve `CREATE` address on revert in isolation mode

### DIFF
--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1291,6 +1291,15 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
             && !self.in_inner_context
             && ecx.journal().depth() == 1
         {
+            // In isolation mode, transact_inner returns None for the address on revert; pre-compute
+            // the would-be deployed address so create_end can enforce expected_revert reverter
+            // checks.
+            let precomputed_address = ecx
+                .journal()
+                .evm_state()
+                .get(&create.caller())
+                .map(|acc| create.caller().create(acc.info.nonce));
+
             let (result, address) = self.transact_inner(
                 ecx,
                 TxKind::Create,
@@ -1299,6 +1308,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
                 create.gas_limit(),
                 create.value(),
             );
+            let address =
+                address.or_else(|| if result.is_revert() { precomputed_address } else { None });
             return Some(CreateOutcome { result, address });
         }
 


### PR DESCRIPTION

## Motivation

#14615 Follow-up

Close #14632

In isolation mode, top-level CREATEs are executed via `transact_inner`, which returns `None` for the address on `ExecutionResult::Revert`. This caused `create_end` to never populate `expected_revert.reverted_by`, silently skipping the reverter address check and letting wrong-reverter `expectRevert` tests pass.


## Solution

Pre-compute the would-be deployed address before `transact_inner` and attach it to the `CreateOutcome` on revert.


## Testing

```
cargo test -p forge --test cli failure_assertions::expect_revert_tests_should_fail
cargo test -p forge --test cli failure_assertions::expect_revert_tests_should_fail --features=isolate-by-default
```