### PR TITLE
Revert "fix(script): keep plain Tempo broadcasts non-AA"

### DIFF
--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -1,8 +1,8 @@
 use std::{cmp::Ordering, num::NonZeroU64, sync::Arc, time::Duration};
 
 use crate::{
-    ScriptArgs, ScriptConfig, build::LinkedBuildData, needs_script_rpc_estimate,
-    progress::ScriptProgress, sequence::ScriptSequenceKind, verify::BroadcastedState,
+    ScriptArgs, ScriptConfig, build::LinkedBuildData, progress::ScriptProgress,
+    sequence::ScriptSequenceKind, verify::BroadcastedState,
 };
 use alloy_chains::{Chain, NamedChain};
 use alloy_consensus::{SignableTransaction, Signed};
@@ -21,7 +21,7 @@ use alloy_signer::Signature;
 use eyre::{Context, Result, bail};
 use forge_verify::provider::VerificationProviderType;
 use foundry_cheatcodes::Wallets;
-use foundry_cli::utils::has_batch_support;
+use foundry_cli::utils::{has_batch_support, has_different_gas_calc};
 use foundry_common::{
     FoundryTransactionBuilder, TransactionMaybeSigned,
     provider::{ProviderBuilder, try_get_http_provider},
@@ -553,13 +553,9 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
                     })
                     .collect::<Result<Vec<_>>>()?;
 
-                let estimate_via_rpc = needs_script_rpc_estimate(
-                    sequence.chain,
-                    self.script_config.evm_opts.networks.is_tempo(),
-                    self.script_config.batch,
-                    &self.script_config.tempo,
-                    self.args.skip_simulation,
-                );
+                let estimate_via_rpc = has_different_gas_calc(sequence.chain)
+                    || self.script_config.evm_opts.networks.is_tempo()
+                    || self.args.skip_simulation;
 
                 // We only wait for a transaction receipt before sending the next transaction, if
                 // there is more than one signer. There would be no way of assuring

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -29,7 +29,7 @@ use forge_script_sequence::{AdditionalContract, NestedValue};
 use forge_verify::{RetryArgs, VerifierArgs};
 use foundry_cli::{
     opts::{BuildOpts, EvmArgs, GlobalArgs, TempoOpts},
-    utils::{LoadConfig, has_different_gas_calc},
+    utils::LoadConfig,
 };
 use foundry_common::{
     CONTRACT_MAX_SIZE, ContractsByArtifact, SELECTOR_LEN,
@@ -248,36 +248,6 @@ pub struct ScriptArgs {
     pub retry: RetryArgs,
 }
 
-const fn should_default_tempo_fee_token(
-    is_tempo_network: bool,
-    batch: bool,
-    tempo: &TempoOpts,
-) -> bool {
-    // Plain `--network tempo` should stay an ordinary transaction; only Tempo AA opts get defaults.
-    is_tempo_network && tempo.common.fee_token.is_none() && (batch || tempo.is_tempo())
-}
-
-const fn needs_tempo_aa_rpc_estimate(
-    is_tempo_network: bool,
-    batch: bool,
-    tempo: &TempoOpts,
-) -> bool {
-    is_tempo_network && (batch || tempo.is_tempo())
-}
-
-pub(crate) fn needs_script_rpc_estimate(
-    chain_id: u64,
-    is_tempo_network: bool,
-    batch: bool,
-    tempo: &TempoOpts,
-    skip_simulation: bool,
-) -> bool {
-    // Tempo AA needs RPC estimation; plain Tempo scripts can use the local simulation result.
-    (has_different_gas_calc(chain_id) && !is_tempo_network)
-        || needs_tempo_aa_rpc_estimate(is_tempo_network, batch, tempo)
-        || skip_simulation
-}
-
 impl ScriptArgs {
     /// Loads config, resolves evm_opts (including network inference from fork), and returns them.
     async fn resolved_evm_opts(&self) -> Result<(Config, EvmOpts)> {
@@ -320,7 +290,7 @@ impl ScriptArgs {
         let mut tempo = self.tempo.clone();
         tempo.resolve_expires();
 
-        if should_default_tempo_fee_token(evm_opts.networks.is_tempo(), self.batch, &tempo) {
+        if evm_opts.networks.is_tempo() && tempo.common.fee_token.is_none() {
             tempo.common.fee_token = Some(PATH_USD_ADDRESS);
         }
 


### PR DESCRIPTION
## Motivation

This reverts #14616 (commit 24b023c9959ce4535e58851963308aab6d64f531).

PR #14616 stopped forcing `eth_estimateGas` for non-AA-Tx Tempo broadcasts, so forge fell back to local-simulation gas which doesn't include Tempo's TIP-1000 +250k surcharge for `nonce == 0`, causing the very first broadcast tx to be silently dropped by anvil/Tempo as under-gassed and the script to hang forever waiting for its receipt.