### PR TITLE
refactor(cli): merge `TempoCommonOpts` back to `TempoOpts`

### DIFF
--- a/crates/cli/src/opts/tempo.rs
+++ b/crates/cli/src/opts/tempo.rs
@@ -17,10 +17,10 @@ use std::{
 
 use crate::utils::parse_fee_token_address;
 
-/// CLI options common to Tempo transactions across commands.
+/// CLI options for Tempo transactions.
 #[derive(Clone, Debug, Default, Parser)]
 #[command(next_help_heading = "Tempo")]
-pub struct TempoCommonOpts {
+pub struct TempoOpts {
     /// Fee token address for Tempo transactions.
     ///
     /// When set, builds a Tempo (type 0x76) transaction that pays gas fees
@@ -42,28 +42,6 @@ pub struct TempoCommonOpts {
     /// and the old tx can never land late.
     #[arg(long = "tempo.expires", value_name = "SECONDS", value_parser = parse_expires_seconds)]
     pub expires: Option<u64>,
-}
-
-impl TempoCommonOpts {
-    /// Returns `true` if any Tempo-specific option is set.
-    pub const fn is_tempo(&self) -> bool {
-        self.fee_token.is_some() || self.expires.is_some()
-    }
-
-    /// Returns the absolute `valid_before` unix timestamp derived from `--tempo.expires`, if set.
-    pub fn expires_at(&self) -> Option<u64> {
-        let secs = self.expires?;
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("time went backwards");
-        Some(now.as_secs() + secs)
-    }
-}
-
-/// CLI options for Tempo transactions.
-#[derive(Clone, Debug, Default, Parser)]
-#[command(next_help_heading = "Tempo")]
-pub struct TempoOpts {
-    #[command(flatten)]
-    pub common: TempoCommonOpts,
 
     /// Nonce key for Tempo parallelizable nonces.
     ///
@@ -169,7 +147,8 @@ pub struct TempoOpts {
 impl TempoOpts {
     /// Returns `true` if any Tempo-specific option is set.
     pub const fn is_tempo(&self) -> bool {
-        self.common.is_tempo()
+        self.fee_token.is_some()
+            || self.expires.is_some()
             || self.nonce_key.is_some()
             || self.lane.is_some()
             || self.sponsor.is_some()
@@ -184,7 +163,9 @@ impl TempoOpts {
 
     /// Returns the absolute `valid_before` unix timestamp derived from `--tempo.expires`, if set.
     pub fn expires_at(&self) -> Option<u64> {
-        self.common.expires_at()
+        let secs = self.expires?;
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("time went backwards");
+        Some(now.as_secs() + secs)
     }
 
     /// Resolves `--tempo.expires` into concrete expiring-nonce fields.
@@ -195,7 +176,7 @@ impl TempoOpts {
         let ts = self.expires_at()?;
         self.expiring_nonce = true;
         self.valid_before = Some(ts);
-        self.common.expires = None;
+        self.expires = None;
         Some(ts)
     }
 
@@ -243,7 +224,7 @@ impl TempoOpts {
     {
         // Handle expiring nonce mode: sets nonce=0 and nonce_key=U256::MAX.
         // --tempo.expires is a convenience alias that also sets valid_before = now + duration.
-        if self.expiring_nonce || self.common.expires.is_some() {
+        if self.expiring_nonce || self.expires.is_some() {
             tx.set_nonce(0);
             tx.set_nonce_key(U256::MAX);
         } else {
@@ -255,7 +236,7 @@ impl TempoOpts {
             }
         }
 
-        if let Some(fee_token) = self.common.fee_token {
+        if let Some(fee_token) = self.fee_token {
             tx.set_fee_token(fee_token);
         }
 
@@ -329,10 +310,10 @@ mod tests {
     #[test]
     fn parse_expires_flag() {
         let opts = TempoOpts::try_parse_from(["", "--tempo.expires", "30"]).unwrap();
-        assert_eq!(opts.common.expires, Some(30));
+        assert_eq!(opts.expires, Some(30));
 
         let opts = TempoOpts::try_parse_from(["", "--tempo.expires", "10"]).unwrap();
-        assert_eq!(opts.common.expires, Some(10));
+        assert_eq!(opts.expires, Some(10));
 
         // exceeds 30s maximum
         assert!(TempoOpts::try_parse_from(["", "--tempo.expires", "31"]).is_err());
@@ -365,7 +346,7 @@ mod tests {
         assert!(resolved <= after + 10);
         assert!(opts.expiring_nonce);
         assert_eq!(opts.valid_before, Some(resolved));
-        assert_eq!(opts.common.expires, None);
+        assert_eq!(opts.expires, None);
         assert_eq!(opts.expires_at(), None);
     }
 
@@ -377,15 +358,12 @@ mod tests {
             "0x20C0000000000000000000000000000000000002",
         ])
         .unwrap();
-        assert_eq!(
-            opts.common.fee_token,
-            Some(address!("0x20C0000000000000000000000000000000000002")),
-        );
+        assert_eq!(opts.fee_token, Some(address!("0x20C0000000000000000000000000000000000002")),);
 
         // AlphaUSD token ID is 1u64
         let opts_with_id = TempoOpts::try_parse_from(["", "--tempo.fee-token", "1"]).unwrap();
         assert_eq!(
-            opts_with_id.common.fee_token,
+            opts_with_id.fee_token,
             Some(address!("0x20C0000000000000000000000000000000000001")),
         );
     }

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -417,7 +417,7 @@ impl CreateArgs {
 
         // If Tempo chain fee token must be set
         if chain.is_tempo() {
-            if let Some(fee_token) = self.tx.tempo.common.fee_token {
+            if let Some(fee_token) = self.tx.tempo.fee_token {
                 deployer.tx.set_fee_token(fee_token);
             } else {
                 deployer.tx.set_fee_token(DEFAULT_FEE_TOKEN);

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -884,7 +884,7 @@ impl BundledState<TempoEvmNetwork> {
                 max_priority_fee_per_gas: Some(max_priority_fee_per_gas),
                 ..Default::default()
             },
-            fee_token: self.script_config.tempo.common.fee_token,
+            fee_token: self.script_config.tempo.fee_token,
             calls: calls.clone(),
             nonce_key: self.script_config.tempo.expiring_nonce.then_some(U256::MAX),
             valid_before: self.script_config.tempo.valid_before.and_then(NonZeroU64::new),

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -290,8 +290,8 @@ impl ScriptArgs {
         let mut tempo = self.tempo.clone();
         tempo.resolve_expires();
 
-        if evm_opts.networks.is_tempo() && tempo.common.fee_token.is_none() {
-            tempo.common.fee_token = Some(PATH_USD_ADDRESS);
+        if evm_opts.networks.is_tempo() && tempo.fee_token.is_none() {
+            tempo.fee_token = Some(PATH_USD_ADDRESS);
         }
 
         let script_config = ScriptConfig::new(config, evm_opts, self.batch, tempo).await?;
@@ -808,7 +808,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
                             self.evm_opts.clone(),
                             Some(known_contracts),
                             Some(target),
-                            self.tempo.common.fee_token,
+                            self.tempo.fee_token,
                         )
                         .into(),
                     )
@@ -819,7 +819,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
 
         // Propagate fee token to the transaction environment so that internal EVM calls
         // (e.g. script deployment, setUp) use the correct fee token for Tempo networks.
-        tx_env.set_fee_token(self.tempo.common.fee_token);
+        tx_env.set_fee_token(self.tempo.fee_token);
 
         Ok(ScriptRunner::new(builder.build(evm_env, tx_env, db), self.evm_opts.clone()))
     }
@@ -853,10 +853,10 @@ mod tests {
         ]);
 
         assert_eq!(
-            args.tempo.common.fee_token,
+            args.tempo.fee_token,
             Some(address!("0x20C0000000000000000000000000000000000001"))
         );
-        assert_eq!(args.tempo.common.expires, Some(10));
+        assert_eq!(args.tempo.expires, Some(10));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`TempoCommonOpts` introduced by #14558 is now pointless since it is used only in `TempoOpts`.

Merge `TempoCommonOpts` back to `TempoOpts` to keep things simple.

Further refactor on Tempo args will come later on `forge script` (see: https://github.com/foundry-rs/foundry/pull/14627#issuecomment-4394628523)
