### PR TITLE
fix(Makefile): prevent backtick command substitution in lint-typos message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ lint-clippy-fix: ## Run clippy on the codebase and fix warnings.
 .PHONY: lint-typos
 lint-typos: ## Run typos on the codebase.
 	@command -v typos >/dev/null || { \
-		echo "typos not found. Please install it by running the command `cargo install typos-cli` or refer to the following link for more information: https://github.com/crate-ci/typos"; \
+		echo "typos not found. Please install it by running the command 'cargo install typos-cli' or refer to the following link for more information: https://github.com/crate-ci/typos"; \
 		exit 1; \
 	}
 	typos


### PR DESCRIPTION
## Motivation

The `lint-typos` rule in the Makefile contains an unintended bug: backticks around `cargo install typos-cli` inside the `echo` message are evaluated by the shell as command substitution, causing every invocation of `make lint-typos` (and therefore `make lint`) on a system without `typos` installed to silently run `cargo install typos-cli` as a side effect — and then print a broken error message with a blank where the command name should have been.

```
typos not found. Please install it by running the command  or refer to the following link for more information: https://github.com/crate-ci/typos
```

## Solution

Replace the backticks with single quotes inside the double-quoted echo string so the command is shown literally and not executed.