### PR TITLE
feat(forge): add noop --no-commit flag to forge init for backwards compatibility

### DIFF
--- a/crates/forge/src/cmd/init.rs
+++ b/crates/forge/src/cmd/init.rs
@@ -55,6 +55,13 @@ pub struct InitArgs {
     #[arg(long, conflicts_with = "template")]
     pub empty: bool,
 
+    /// Do not create an initial commit.
+    ///
+    /// This is a noop flag kept for backwards compatibility, as `forge init` no longer commits by
+    /// default. Use `--commit` to opt into creating a commit.
+    #[arg(long, hide = true)]
+    pub no_commit: bool,
+
     #[command(flatten)]
     pub install: DependencyInstallOpts,
 }
@@ -73,6 +80,7 @@ impl InitArgs {
             vyper,
             network,
             empty,
+            no_commit: _,
         } = self;
         let DependencyInstallOpts { shallow, no_git, commit } = install;
 

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -366,6 +366,20 @@ Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag:
     assert!(!prj.root().join("lib/forge-std/.git").exists());
 });
 
+// Checks that `--no-commit` is accepted as a noop backwards-compatibility flag
+forgetest!(can_init_with_no_commit, |prj, cmd| {
+    prj.wipe();
+
+    cmd.arg("init").arg(prj.root()).arg("--no-commit").assert_success().stdout_eq(str![[r#"
+Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
+    Installed forge-std[..]
+    Initialized forge project
+
+"#]]);
+    prj.assert_config_exists();
+});
+
 // Checks that quiet mode does not print anything
 forgetest!(can_init_quiet, |prj, cmd| {
     prj.wipe();


### PR DESCRIPTION
## Summary

`forge init` no longer commits by default (commit is opt-in via `--commit`). Many AI tools and scripts still pass `--no-commit`, causing an unrecognized flag error.

This adds a hidden, noop `--no-commit` flag so those invocations continue to work without error.

## Changes

- Added a hidden `--no-commit` flag to `InitArgs` in `crates/forge/src/cmd/init.rs`
- The flag is accepted but ignored (destructured as `no_commit: _`)
- No behavior change — just prevents CLI errors for callers still passing `--no-commit`