### PR TITLE
fix(anvil): saturate `mint` when parsing OP deposit txs 

### DIFF
--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -195,7 +195,7 @@ pub fn get_deposit_tx_parts(
             missing.push("mint");
             Default::default()
         })
-        .map(|value| value.to::<u128>());
+        .map(|value| value.saturating_to::<u128>());
     let is_system_transaction =
         other.get_deserialized::<bool>("isSystemTx").transpose().ok().flatten().unwrap_or_else(
             || {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #14651 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Replace `U256::to::<u128>()` with `U256::saturating_to::<u128>()` in `get_deposit_tx_parts`. 

Mirrors the fix in #10503 and in 
https://github.com/foundry-rs/foundry/blob/5581adf9041cc4df777de01d6867c070500fe712/crates/anvil/src/eth/api.rs#L2590-L2591

Verified locally against master built with this patch and run with `--optimism`: the same payload that crashes the released binary returns a normal tx hash and the node continues serving subsequent requests.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
