### PR TITLE
fix(`anvil`): saturate U256 casts on user controlled RPC inputs

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -357,7 +357,7 @@ impl<N: Network> EthApi<N> {
             )
             .into());
         }
-        self.backend.set_gas_price(gas.to());
+        self.backend.set_gas_price(gas.saturating_to());
         Ok(())
     }
 
@@ -372,7 +372,7 @@ impl<N: Network> EthApi<N> {
             )
             .into());
         }
-        self.backend.set_base_fee(basefee.to());
+        self.backend.set_base_fee(basefee.saturating_to());
         Ok(())
     }
 
@@ -503,7 +503,7 @@ impl<N: Network> EthApi<N> {
     /// Handler for RPC call: `evm_setBlockGasLimit`
     pub fn evm_set_block_gas_limit(&self, gas_limit: U256) -> Result<bool> {
         node_info!("evm_setBlockGasLimit");
-        self.backend.set_gas_limit(gas_limit.to());
+        self.backend.set_gas_limit(gas_limit.saturating_to());
         Ok(true)
     }
 
@@ -1126,7 +1126,7 @@ impl<N: Network> EthApi<N> {
         }
 
         const MAX_BLOCK_COUNT: u64 = 1024u64;
-        let block_count = block_count.to::<u64>().min(MAX_BLOCK_COUNT);
+        let block_count = block_count.saturating_to::<u64>().min(MAX_BLOCK_COUNT);
 
         // highest and lowest block num in the requested range
         let highest = number;
@@ -2829,7 +2829,7 @@ impl EthApi<FoundryNetwork> {
     /// Handler for ETH RPC call: `anvil_mine`
     pub async fn anvil_mine(&self, num_blocks: Option<U256>, interval: Option<U256>) -> Result<()> {
         node_info!("anvil_mine");
-        let interval = interval.map(|i| i.to::<u64>());
+        let interval = interval.map(|i| i.saturating_to::<u64>());
         let blocks = num_blocks.unwrap_or(U256::from(1));
         if blocks.is_zero() {
             return Ok(());
@@ -2837,7 +2837,7 @@ impl EthApi<FoundryNetwork> {
 
         self.on_blocking_task(|this| async move {
             // mine all the blocks
-            for _ in 0..blocks.to::<u64>() {
+            for _ in 0..blocks.saturating_to::<u64>() {
                 // If we have an interval, jump forwards in time to the "next" timestamp
                 if let Some(interval) = interval {
                     this.backend.time().increase_time(interval);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

After finding #14651 I began looking at whether there were any other user controlled inputs that were cast unsafely. This is my result for the evening: 
- #14653 
- #14654 
- #14655 
- #14656 
- #14657    

Six handlers in [crates/anvil/src/eth/api.rs](https://github.com/foundry-rs/foundry/blob/master/crates/anvil/src/eth/api.rs) casted `U256` fields to `u64`/`u128` with `Uint::to::<_>()`, which panics on overflow. A single call with the field set to a value above `T::MAX` aborts anvil.

  - `eth_feeHistory` for `blockCount` (u64)
  - `anvil_mine` for `numBlocks` and `interval` (u64)
  - `evm_setBlockGasLimit` for `gasLimit` (u64)
  - `anvil_setNextBlockBaseFeePerGas` for `basefee` (u64)
  - `anvil_setMinGasPrice` for `gas` (u128)


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Swap each `value.to::<uN>()` for `value.saturating_to::<uN>()`. Matches the patched I used in #14652 . In range inputs are unchanged, only out of range inputs saturate to `T::MAX` instead of aborting.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes