### PR TITLE
feat(lint): add missing-inheritance lint

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -38,6 +38,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `interface-file-naming`: Interface file names should be prefixed with `I`.
   - `interface-naming`: Interface names should be prefixed with `I`.
   - `pragma-inconsistent`: Flags projects whose source files declare different Solidity pragma version requirements.
+  - `missing-inheritance`: Flags contracts that implement every external function of an interface without explicitly inheriting from it.
 - **Gas Optimizations:**
   - `asm-keccak256`: Recommends using inline assembly for `keccak256` for potential gas savings.
   - `could-be-immutable`: Recommends declaring constructor-only state variables as `immutable`.

--- a/crates/lint/docs/missing-inheritance.md
+++ b/crates/lint/docs/missing-inheritance.md
@@ -1,0 +1,64 @@
+# Missing inheritance
+
+**Severity**: `Info`
+**ID**: `missing-inheritance`
+
+A contract that implements every external function of an interface but does not explicitly inherit
+from it loses compile-time checks (the `override` keyword, signature/return-type validation, and
+`type(I).interfaceId` recognition) and obscures intent for readers and tooling.
+
+## What it does
+
+For each non-interface contract `C` in the analyzed sources, this lint reports each interface `I`
+where:
+
+- `C` does **not** transitively inherit from `I`,
+- `C` (including its inherited bases) implements every external selector exported by `I`, and
+- no already-inherited base of `C` already covers all of `I`'s selectors.
+
+When several candidate interfaces overlap (e.g. `IERC20` and `IERC20Metadata`), only the maximal
+one is reported. "Interface-like" abstract contracts — those with no state, no constructor, no
+modifier bodies, and no function bodies — are also treated as candidate interfaces, mirroring the
+behavior of Slither's `missing-inheritance` detector.
+
+## Why is this bad?
+
+Explicit inheritance:
+
+- documents which standards a contract claims to implement,
+- enables the compiler to verify function signatures, visibility, mutability, and return types via
+  `override`,
+- makes `type(I).interfaceId` and ERC-165 introspection meaningful,
+- makes refactors safer: changing the interface fails the build instead of silently drifting.
+
+Implementing the API by coincidence (or by copy-paste) skips all of those checks.
+
+## Example
+
+### Bad
+
+```solidity
+interface ISomething {
+    function f1() external returns (uint256);
+}
+
+contract Something {
+    function f1() external returns (uint256) {
+        return 42;
+    }
+}
+```
+
+### Good
+
+```solidity
+interface ISomething {
+    function f1() external returns (uint256);
+}
+
+contract Something is ISomething {
+    function f1() external override returns (uint256) {
+        return 42;
+    }
+}
+```

--- a/crates/lint/src/linter/project.rs
+++ b/crates/lint/src/linter/project.rs
@@ -4,6 +4,7 @@ use foundry_config::lint::LintSpecificConfig;
 use solar::{
     ast,
     interface::{Session, Span, diagnostics::DiagMsg, source_map::SourceFile},
+    sema::Gcx,
 };
 use std::{path::PathBuf, sync::Arc};
 
@@ -19,15 +20,17 @@ pub struct ProjectSource<'ast> {
 /// Trait for lints that need to inspect every input source at once (e.g. cross-file checks).
 ///
 /// `check_project` runs once after all per-file [`super::EarlyLintPass`] /
-/// [`super::LateLintPass`] passes have completed.
+/// [`super::LateLintPass`] passes have completed. Passes that need HIR or type-check info access
+/// it through [`ProjectLintEmitter::gcx`].
 pub trait ProjectLintPass<'ast>: Send + Sync {
     fn check_project(&mut self, ctx: &ProjectLintEmitter<'_, '_>, sources: &[ProjectSource<'ast>]);
 }
 
 /// Helper passed to [`ProjectLintPass::check_project`] for emitting diagnostics against a specific
-/// source.
+/// source and accessing the global compilation context.
 pub struct ProjectLintEmitter<'s, 'c> {
     sess: &'s Session,
+    gcx: Gcx<'s>,
     with_description: bool,
     with_json_emitter: bool,
     lint_specific: &'c LintSpecificConfig,
@@ -37,18 +40,24 @@ pub struct ProjectLintEmitter<'s, 'c> {
 impl<'s, 'c> ProjectLintEmitter<'s, 'c> {
     pub const fn new(
         sess: &'s Session,
+        gcx: Gcx<'s>,
         with_description: bool,
         with_json_emitter: bool,
         lint_specific: &'c LintSpecificConfig,
         active_lints: Vec<&'static str>,
     ) -> Self {
-        Self { sess, with_description, with_json_emitter, lint_specific, active_lints }
+        Self { sess, gcx, with_description, with_json_emitter, lint_specific, active_lints }
     }
 
     /// Returns `true` if the given lint id is enabled for this run. Project passes that perform
     /// expensive analysis should guard their work behind this check.
     pub fn is_lint_enabled(&self, id: &'static str) -> bool {
         self.active_lints.contains(&id)
+    }
+
+    /// Returns the global compilation context, for passes that need HIR or semantic info.
+    pub const fn gcx(&self) -> Gcx<'s> {
+        self.gcx
     }
 
     /// Emits a diagnostic with the lint's default description as the message.

--- a/crates/lint/src/sol/info/missing_inheritance.rs
+++ b/crates/lint/src/sol/info/missing_inheritance.rs
@@ -1,0 +1,204 @@
+use crate::{
+    linter::{Lint, ProjectLintEmitter, ProjectLintPass, ProjectSource},
+    sol::{Severity, SolLint, info::MissingInheritance},
+};
+use solar::{
+    interface::{Span, source_map::FileName},
+    sema::{
+        Gcx,
+        hir::{ContractId, ContractKind, FunctionKind, SourceId},
+    },
+};
+use std::collections::{BTreeSet, HashMap};
+
+declare_forge_lint!(
+    MISSING_INHERITANCE,
+    Severity::Info,
+    "missing-inheritance",
+    "contract implements an interface's external API but does not explicitly inherit from it"
+);
+
+impl<'ast> ProjectLintPass<'ast> for MissingInheritance {
+    fn check_project(&mut self, ctx: &ProjectLintEmitter<'_, '_>, sources: &[ProjectSource<'ast>]) {
+        if !ctx.is_lint_enabled(MISSING_INHERITANCE.id()) {
+            return;
+        }
+
+        let gcx = ctx.gcx();
+        let hir = &gcx.hir;
+
+        // Map every input source's HIR `SourceId` to the corresponding `ProjectSource` index, so
+        // we only analyze (and emit against) user-provided files.
+        let input_source_idx: HashMap<SourceId, usize> = hir
+            .sources_enumerated()
+            .filter_map(|(sid, src)| {
+                let path = match &src.file.name {
+                    FileName::Real(p) => p,
+                    _ => return None,
+                };
+                let idx = sources.iter().position(|s| &s.path == path)?;
+                Some((sid, idx))
+            })
+            .collect();
+
+        if input_source_idx.is_empty() {
+            return;
+        }
+
+        // Classify every contract in input sources into "candidate interface" or
+        // "analysis target", and precompute its external selector set.
+        let mut candidates: Vec<(ContractId, BTreeSet<[u8; 4]>)> = Vec::new();
+        let mut targets: Vec<ContractId> = Vec::new();
+        let mut selectors_by_contract: HashMap<ContractId, BTreeSet<[u8; 4]>> = HashMap::new();
+
+        for cid in hir.contract_ids() {
+            let contract = hir.contract(cid);
+            if contract.linearization_failed() || !input_source_idx.contains_key(&contract.source) {
+                continue;
+            }
+
+            let selectors: BTreeSet<[u8; 4]> =
+                gcx.interface_functions(cid).all().iter().map(|f| f.selector.0).collect();
+            selectors_by_contract.insert(cid, selectors.clone());
+
+            match contract.kind {
+                ContractKind::Library => {}
+                ContractKind::Interface => {
+                    if !selectors.is_empty() {
+                        candidates.push((cid, selectors));
+                    }
+                }
+                ContractKind::AbstractContract => {
+                    if is_signature_only(gcx, cid) {
+                        if !selectors.is_empty() {
+                            candidates.push((cid, selectors));
+                        }
+                    } else {
+                        targets.push(cid);
+                    }
+                }
+                ContractKind::Contract => targets.push(cid),
+            }
+        }
+
+        if candidates.is_empty() || targets.is_empty() {
+            return;
+        }
+
+        for tid in targets {
+            let target = hir.contract(tid);
+            let Some(target_selectors) = selectors_by_contract.get(&tid) else { continue };
+            if target_selectors.is_empty() {
+                continue;
+            }
+
+            // Collect intended interfaces for this target.
+            let mut intended: Vec<(ContractId, &BTreeSet<[u8; 4]>)> = Vec::new();
+            for (iid, isel) in &candidates {
+                if *iid == tid {
+                    continue;
+                }
+                // Skip if already inherited (transitively).
+                if target.linearized_bases.contains(iid) {
+                    continue;
+                }
+                // Target must implement every selector of the candidate.
+                if !isel.is_subset(target_selectors) {
+                    continue;
+                }
+                // Skip if some inherited base of the target already covers the candidate.
+                let subsumed_by_base =
+                    target.linearized_bases.iter().filter(|b| **b != tid).any(|b| {
+                        match selectors_by_contract.get(b) {
+                            Some(bsel) => isel.is_subset(bsel),
+                            None => false,
+                        }
+                    });
+                if subsumed_by_base {
+                    continue;
+                }
+                intended.push((*iid, isel));
+            }
+
+            if intended.is_empty() {
+                continue;
+            }
+
+            // Deterministic dedupe by maximal selector set:
+            // sort by descending selector count, tie-break by (path, contract name, id), then
+            // drop any candidate whose selector set is a subset/superset of a kept one.
+            intended.sort_by(|(a_id, a_sel), (b_id, b_sel)| {
+                b_sel
+                    .len()
+                    .cmp(&a_sel.len())
+                    .then_with(|| sort_key(hir, *a_id).cmp(&sort_key(hir, *b_id)))
+            });
+
+            let mut kept: Vec<(ContractId, &BTreeSet<[u8; 4]>)> = Vec::new();
+            'outer: for (iid, isel) in intended {
+                for (_, ksel) in &kept {
+                    if isel.is_subset(ksel) || ksel.is_subset(isel) {
+                        continue 'outer;
+                    }
+                }
+                kept.push((iid, isel));
+            }
+
+            // Emit one diagnostic per kept interface, against the source containing the target.
+            let Some(&src_idx) = input_source_idx.get(&target.source) else { continue };
+            let source = &sources[src_idx];
+            for (iid, _) in kept {
+                let interface = hir.contract(iid);
+                let msg = format!(
+                    "contract `{}` implements interface `{}`'s external API but does not explicitly inherit from it",
+                    target.name.as_str(),
+                    interface.name.as_str(),
+                );
+                ctx.emit_with_msg(source, &MISSING_INHERITANCE, target.name.span, msg);
+            }
+        }
+    }
+}
+
+/// Returns `true` if `cid` is an "interface-like" abstract contract: signature-only and free of
+/// state, constructors, and modifier bodies. Such contracts mirror the role of `interface` and
+/// should be considered as candidate interfaces for the missing-inheritance check.
+fn is_signature_only<'gcx>(gcx: Gcx<'gcx>, cid: ContractId) -> bool {
+    let hir = &gcx.hir;
+    let contract = hir.contract(cid);
+
+    let mut has_function = false;
+    for &item_id in contract.items {
+        match item_id {
+            solar::sema::hir::ItemId::Variable(_) => return false,
+            solar::sema::hir::ItemId::Function(fid) => {
+                let func = hir.function(fid);
+                match func.kind {
+                    FunctionKind::Constructor | FunctionKind::Receive | FunctionKind::Fallback => {
+                        return false;
+                    }
+                    FunctionKind::Modifier => {
+                        if func.body.is_some() {
+                            return false;
+                        }
+                    }
+                    FunctionKind::Function => {
+                        if func.body.is_some() {
+                            return false;
+                        }
+                        has_function = true;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    has_function
+}
+
+/// Stable sort key for deterministic dedupe ordering across runs.
+fn sort_key<'hir>(hir: &'hir solar::sema::hir::Hir<'hir>, cid: ContractId) -> (Span, &'hir str) {
+    let c = hir.contract(cid);
+    (c.name.span, c.name.as_str())
+}

--- a/crates/lint/src/sol/info/missing_inheritance.rs
+++ b/crates/lint/src/sol/info/missing_inheritance.rs
@@ -6,7 +6,7 @@ use solar::{
     interface::{Span, source_map::FileName},
     sema::{
         Gcx,
-        hir::{ContractId, ContractKind, FunctionKind, SourceId},
+        hir::{ContractId, ContractKind, FunctionKind, ItemId, SourceId},
     },
 };
 use std::collections::{BTreeSet, HashMap};
@@ -45,21 +45,23 @@ impl<'ast> ProjectLintPass<'ast> for MissingInheritance {
             return;
         }
 
-        // Classify every contract in input sources into "candidate interface" or
-        // "analysis target", and precompute its external selector set.
+        // Targets are restricted to user input; candidates span the whole HIR so dependency
+        // interfaces (e.g. OpenZeppelin's `IERC20`) are still matched.
         let mut candidates: Vec<(ContractId, BTreeSet<[u8; 4]>)> = Vec::new();
         let mut targets: Vec<ContractId> = Vec::new();
         let mut selectors_by_contract: HashMap<ContractId, BTreeSet<[u8; 4]>> = HashMap::new();
 
         for cid in hir.contract_ids() {
             let contract = hir.contract(cid);
-            if contract.linearization_failed() || !input_source_idx.contains_key(&contract.source) {
+            if contract.linearization_failed() {
                 continue;
             }
 
             let selectors: BTreeSet<[u8; 4]> =
                 gcx.interface_functions(cid).all().iter().map(|f| f.selector.0).collect();
             selectors_by_contract.insert(cid, selectors.clone());
+
+            let in_input = input_source_idx.contains_key(&contract.source);
 
             match contract.kind {
                 ContractKind::Library => {}
@@ -73,11 +75,15 @@ impl<'ast> ProjectLintPass<'ast> for MissingInheritance {
                         if !selectors.is_empty() {
                             candidates.push((cid, selectors));
                         }
-                    } else {
+                    } else if in_input {
                         targets.push(cid);
                     }
                 }
-                ContractKind::Contract => targets.push(cid),
+                ContractKind::Contract => {
+                    if in_input {
+                        targets.push(cid);
+                    }
+                }
             }
         }
 
@@ -170,8 +176,8 @@ fn is_signature_only<'gcx>(gcx: Gcx<'gcx>, cid: ContractId) -> bool {
     let mut has_function = false;
     for &item_id in contract.items {
         match item_id {
-            solar::sema::hir::ItemId::Variable(_) => return false,
-            solar::sema::hir::ItemId::Function(fid) => {
+            ItemId::Variable(_) => return false,
+            ItemId::Function(fid) => {
                 let func = hir.function(fid);
                 match func.kind {
                     FunctionKind::Constructor | FunctionKind::Receive | FunctionKind::Fallback => {

--- a/crates/lint/src/sol/info/mod.rs
+++ b/crates/lint/src/sol/info/mod.rs
@@ -39,6 +39,9 @@ use pragma_directive::PRAGMA_INCONSISTENT;
 mod inline_assembly;
 use inline_assembly::INLINE_ASSEMBLY;
 
+mod missing_inheritance;
+use missing_inheritance::MISSING_INHERITANCE;
+
 register_lints!(
     (BooleanCst, early, (BOOLEAN_CST)),
     (BooleanEqual, early, (BOOLEAN_EQUAL)),
@@ -54,4 +57,5 @@ register_lints!(
     (TooManyDigits, early, (TOO_MANY_DIGITS)),
     (PragmaDirective, project, (PRAGMA_INCONSISTENT)),
     (InlineAssembly, early, (INLINE_ASSEMBLY)),
+    (MissingInheritance, project, (MISSING_INHERITANCE)),
 );

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -225,6 +225,7 @@ impl<'a> SolidityLinter<'a> {
 
         let emitter = ProjectLintEmitter::new(
             gcx.sess,
+            gcx,
             self.with_description,
             self.with_json_emitter,
             self.lint_specific,

--- a/crates/lint/testdata/MissingInheritance.sol
+++ b/crates/lint/testdata/MissingInheritance.sol
@@ -1,0 +1,115 @@
+//@compile-flags: --only-lint missing-inheritance
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface ISomething {
+    function f1() external returns (uint256);
+}
+
+interface IExtra {
+    function g() external view returns (uint256);
+}
+
+interface IERC20Like {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function balanceOf(address who) external view returns (uint256);
+}
+
+interface IERC20LikeMetadata {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function balanceOf(address who) external view returns (uint256);
+    function name() external view returns (string memory);
+}
+
+// Signature-only abstract contract; treated as a candidate interface.
+abstract contract IFooLike {
+    function foo() external virtual returns (uint256);
+}
+
+// SHOULD FAIL: Implements ISomething but does not explicitly inherit from it.
+contract Something { //~NOTE: contract `Something` implements interface `ISomething`'s external API but does not explicitly inherit from it
+    function f1() external pure returns (uint256) {
+        return 42;
+    }
+}
+
+// SHOULD PASS: Explicitly inherits from ISomething.
+contract SomethingExplicit is ISomething {
+    function f1() external pure override returns (uint256) {
+        return 42;
+    }
+}
+
+// SHOULD PASS: Inherits from ISomething transitively through ISomethingExt.
+interface ISomethingExt is ISomething {}
+
+contract SomethingTransitive is ISomethingExt {
+    function f1() external pure override returns (uint256) {
+        return 7;
+    }
+}
+
+// SHOULD FAIL: Abstract contract with bodies is itself a target.
+abstract contract SomethingBase { //~NOTE: contract `SomethingBase` implements interface `ISomething`'s external API but does not explicitly inherit from it
+    function f1() external virtual returns (uint256) {
+        return 1;
+    }
+}
+
+// SHOULD PASS: Inherited base `SomethingBase` already covers ISomething's selectors.
+contract SomethingDerived is SomethingBase {
+    function f1() external override returns (uint256) {
+        return 2;
+    }
+}
+
+// SHOULD FAIL: Implements both IERC20Like and IERC20LikeMetadata; only the maximal interface is reported.
+contract Token { //~NOTE: contract `Token` implements interface `IERC20LikeMetadata`'s external API but does not explicitly inherit from it
+    function transfer(address, uint256) external pure returns (bool) {
+        return true;
+    }
+    function balanceOf(address) external pure returns (uint256) {
+        return 0;
+    }
+    function name() external pure returns (string memory) {
+        return "T";
+    }
+}
+
+// SHOULD FAIL: Signature-only abstract `IFooLike` is treated as a candidate interface.
+contract Foo { //~NOTE: contract `Foo` implements interface `IFooLike`'s external API but does not explicitly inherit from it
+    function foo() external pure returns (uint256) {
+        return 1;
+    }
+}
+
+// SHOULD PASS: No external functions, nothing to flag.
+contract Empty {
+    uint256 internal x;
+}
+
+// SHOULD PASS: Implements only a strict subset of IERC20Like's selectors.
+contract OnlyTransfer {
+    function transfer(address, uint256) external pure returns (bool) {
+        return true;
+    }
+}
+
+// SHOULD PASS: Libraries are not analyzed as targets.
+library SomeLib {
+    function f1() external pure returns (uint256) {
+        return 1;
+    }
+}
+
+// SHOULD FAIL: Implements two unrelated interfaces; both are reported.
+contract MultiNoInherit { //~NOTE: contract `MultiNoInherit` implements interface `ISomething`'s external API but does not explicitly inherit from it
+    //~^NOTE: contract `MultiNoInherit` implements interface `IExtra`'s external API but does not explicitly inherit from it
+    function f1() external pure returns (uint256) {
+        return 1;
+    }
+    function g() external pure returns (uint256) {
+        return 2;
+    }
+}

--- a/crates/lint/testdata/MissingInheritance.sol
+++ b/crates/lint/testdata/MissingInheritance.sol
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IExternalThing} from "./auxiliary/MissingInheritanceExternal.sol";
+
 interface ISomething {
     function f1() external returns (uint256);
 }
@@ -111,5 +113,19 @@ contract MultiNoInherit { //~NOTE: contract `MultiNoInherit` implements interfac
     }
     function g() external pure returns (uint256) {
         return 2;
+    }
+}
+
+// SHOULD FAIL: Implements an interface declared in an external dependency without inheriting it.
+contract External { //~NOTE: contract `External` implements interface `IExternalThing`'s external API but does not explicitly inherit from it
+    function doExternalThing() external pure returns (uint256) {
+        return 1;
+    }
+}
+
+// SHOULD PASS: Explicitly inherits the external dependency interface.
+contract ExternalExplicit is IExternalThing {
+    function doExternalThing() external pure override returns (uint256) {
+        return 1;
     }
 }

--- a/crates/lint/testdata/MissingInheritance.stderr
+++ b/crates/lint/testdata/MissingInheritance.stderr
@@ -46,3 +46,11 @@ LL │ contract MultiNoInherit {
    │
    ╰ help: https://getfoundry.sh/forge/linting/missing-inheritance
 
+note[missing-inheritance]: contract `External` implements interface `IExternalThing`'s external API but does not explicitly inherit from it
+   ╭▸ ROOT/testdata/MissingInheritance.sol:LL:CC
+   │
+LL │ contract External {
+   │          ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-inheritance
+

--- a/crates/lint/testdata/MissingInheritance.stderr
+++ b/crates/lint/testdata/MissingInheritance.stderr
@@ -1,0 +1,48 @@
+note[missing-inheritance]: contract `Something` implements interface `ISomething`'s external API but does not explicitly inherit from it
+   ╭▸ ROOT/testdata/MissingInheritance.sol:LL:CC
+   │
+LL │ contract Something {
+   │          ━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-inheritance
+
+note[missing-inheritance]: contract `SomethingBase` implements interface `ISomething`'s external API but does not explicitly inherit from it
+   ╭▸ ROOT/testdata/MissingInheritance.sol:LL:CC
+   │
+LL │ abstract contract SomethingBase {
+   │                   ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-inheritance
+
+note[missing-inheritance]: contract `Token` implements interface `IERC20LikeMetadata`'s external API but does not explicitly inherit from it
+   ╭▸ ROOT/testdata/MissingInheritance.sol:LL:CC
+   │
+LL │ contract Token {
+   │          ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-inheritance
+
+note[missing-inheritance]: contract `Foo` implements interface `IFooLike`'s external API but does not explicitly inherit from it
+   ╭▸ ROOT/testdata/MissingInheritance.sol:LL:CC
+   │
+LL │ contract Foo {
+   │          ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-inheritance
+
+note[missing-inheritance]: contract `MultiNoInherit` implements interface `ISomething`'s external API but does not explicitly inherit from it
+   ╭▸ ROOT/testdata/MissingInheritance.sol:LL:CC
+   │
+LL │ contract MultiNoInherit {
+   │          ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-inheritance
+
+note[missing-inheritance]: contract `MultiNoInherit` implements interface `IExtra`'s external API but does not explicitly inherit from it
+   ╭▸ ROOT/testdata/MissingInheritance.sol:LL:CC
+   │
+LL │ contract MultiNoInherit {
+   │          ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-inheritance
+

--- a/crates/lint/testdata/auxiliary/MissingInheritanceExternal.sol
+++ b/crates/lint/testdata/auxiliary/MissingInheritanceExternal.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// Stand-in for an interface declared in an external dependency (e.g. node_modules).
+// The lint must consider it as a candidate even though it is not in the input set.
+interface IExternalThing {
+    function doExternalThing() external returns (uint256);
+}


### PR DESCRIPTION
New info `missing-inheritance` lint that flags contracts implementing every external function of an interface without explicitly inheriting from it.

`ProjectLintPass` now exposes gcx via `ProjectLintEmitter::gcx()` so cross-file passes can opt into semantic analysis without bloating the trait signature.