### PR TITLE
chore: bump version to 1.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-core"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-rpc"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-server"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "anvil-rpc",
  "async-trait",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "cast"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "chisel"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -4583,7 +4583,7 @@ checksum = "932dcfbd51320af5f27f1ba02d2e567dec332cac7d2c221ba45d8e767264c4dc"
 
 [[package]]
 name = "forge"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4665,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "forge-doc"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -4687,7 +4687,7 @@ dependencies = [
 
 [[package]]
 name = "forge-fmt"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "foundry-common",
  "foundry-config",
@@ -4701,7 +4701,7 @@ dependencies = [
 
 [[package]]
 name = "forge-lint"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "eyre",
  "foundry-common",
@@ -4715,7 +4715,7 @@ dependencies = [
 
 [[package]]
 name = "forge-script"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4763,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "forge-script-sequence"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "forge-sol-macro-gen"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "forge-verify"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -4840,7 +4840,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-bench"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "chrono",
  "clap",
@@ -4875,7 +4875,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cheatcodes"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4928,7 +4928,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cheatcodes-spec"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-sol-types",
  "foundry-macros",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cli"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-dyn-abi",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cli-markdown"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "clap",
  "pretty_assertions",
@@ -5000,7 +5000,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-common"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5075,7 +5075,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-common-fmt"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -5198,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-config"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -5238,7 +5238,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-debugger"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-primitives",
  "crossterm",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-abi"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-core"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5357,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-coverage"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -5373,7 +5373,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-fuzz"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-hardforks"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-networks"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-eips 2.0.4",
@@ -5429,11 +5429,11 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-sancov"
-version = "1.7.1"
+version = "1.7.2"
 
 [[package]]
 name = "foundry-evm-traces"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -5490,7 +5490,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-linking"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-primitives",
  "foundry-compilers",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-macros"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-primitives"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-test-utils"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.7.1"
+version = "1.7.2"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Foundry Contributors"]


### PR DESCRIPTION
Bumps the workspace version to 1.7.2 so the next nightly builds use the correct version prefix.