### PR TITLE
chore(deps): pull foundry-compilers fix for PEP 440 Vyper pragmas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1219,7 +1219,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3027,7 +3027,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3180,7 +3180,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3984,7 +3984,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4280,7 +4280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.20.0"
-source = "git+https://github.com/figtracer/foundry-core?rev=63698079e3971a83fe643c4f14b8c5cd3fbed206#63698079e3971a83fe643c4f14b8c5cd3fbed206"
+source = "git+https://github.com/figtracer/foundry-core?rev=9e6c17d2029b359f2539e663c2c17a69a893e9f2#9e6c17d2029b359f2539e663c2c17a69a893e9f2"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5131,7 +5131,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.20.0"
-source = "git+https://github.com/figtracer/foundry-core?rev=63698079e3971a83fe643c4f14b8c5cd3fbed206#63698079e3971a83fe643c4f14b8c5cd3fbed206"
+source = "git+https://github.com/figtracer/foundry-core?rev=9e6c17d2029b359f2539e663c2c17a69a893e9f2#9e6c17d2029b359f2539e663c2c17a69a893e9f2"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5140,7 +5140,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.20.0"
-source = "git+https://github.com/figtracer/foundry-core?rev=63698079e3971a83fe643c4f14b8c5cd3fbed206#63698079e3971a83fe643c4f14b8c5cd3fbed206"
+source = "git+https://github.com/figtracer/foundry-core?rev=9e6c17d2029b359f2539e663c2c17a69a893e9f2#9e6c17d2029b359f2539e663c2c17a69a893e9f2"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5160,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.20.0"
-source = "git+https://github.com/figtracer/foundry-core?rev=63698079e3971a83fe643c4f14b8c5cd3fbed206#63698079e3971a83fe643c4f14b8c5cd3fbed206"
+source = "git+https://github.com/figtracer/foundry-core?rev=9e6c17d2029b359f2539e663c2c17a69a893e9f2#9e6c17d2029b359f2539e663c2c17a69a893e9f2"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5173,7 +5173,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.20.0"
-source = "git+https://github.com/figtracer/foundry-core?rev=63698079e3971a83fe643c4f14b8c5cd3fbed206#63698079e3971a83fe643c4f14b8c5cd3fbed206"
+source = "git+https://github.com/figtracer/foundry-core?rev=9e6c17d2029b359f2539e663c2c17a69a893e9f2#9e6c17d2029b359f2539e663c2c17a69a893e9f2"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6603,7 +6603,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7494,7 +7494,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8452,7 +8452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8621,7 +8621,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9886,7 +9886,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9945,7 +9945,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10659,7 +10659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10727,7 +10727,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -10739,7 +10739,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -10762,7 +10762,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11060,7 +11060,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "url",
  "zip",
 ]
@@ -11174,7 +11174,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11382,7 +11382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12630,7 +12630,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12780,7 +12780,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,7 +3027,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3180,7 +3180,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3984,7 +3984,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4280,7 +4280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5100,8 +5100,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a46823427db611c6b97506ee8f26b4424058366abcc9a97ac5c4c3419798518"
+source = "git+https://github.com/figtracer/foundry-core?rev=63698079e3971a83fe643c4f14b8c5cd3fbed206#63698079e3971a83fe643c4f14b8c5cd3fbed206"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5125,15 +5124,14 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
- "winnow 0.7.15",
+ "winnow 1.0.2",
  "yansi",
 ]
 
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29c6a49e82684909549e8e3a63a9dea4c92dfeb1b5b3a5e3ad683db42324ac3"
+source = "git+https://github.com/figtracer/foundry-core?rev=63698079e3971a83fe643c4f14b8c5cd3fbed206#63698079e3971a83fe643c4f14b8c5cd3fbed206"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5142,8 +5140,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d3e554932001133f433473b3bdb37c74b4a648750ab61cd7966e7db0ead16d"
+source = "git+https://github.com/figtracer/foundry-core?rev=63698079e3971a83fe643c4f14b8c5cd3fbed206#63698079e3971a83fe643c4f14b8c5cd3fbed206"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5163,8 +5160,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583168b6df6b73cc3de8d205a922dca58a9c0b4c2774f6b115b3ff7e79d23900"
+source = "git+https://github.com/figtracer/foundry-core?rev=63698079e3971a83fe643c4f14b8c5cd3fbed206#63698079e3971a83fe643c4f14b8c5cd3fbed206"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5177,8 +5173,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f80dd5d9f3ed065e412ecef2da3904ea21708d53f79fac29a3547c10ae947f"
+source = "git+https://github.com/figtracer/foundry-core?rev=63698079e3971a83fe643c4f14b8c5cd3fbed206#63698079e3971a83fe643c4f14b8c5cd3fbed206"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6608,7 +6603,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7499,7 +7494,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8457,7 +8452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8626,7 +8621,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9891,7 +9886,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9950,7 +9945,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10732,7 +10727,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -10744,7 +10739,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -10767,7 +10762,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11065,7 +11060,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
@@ -11179,7 +11174,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11387,7 +11382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12635,7 +12630,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12785,7 +12780,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1219,7 +1219,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3027,7 +3027,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3180,7 +3180,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3984,7 +3984,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4280,7 +4280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.20.0"
-source = "git+https://github.com/figtracer/foundry-core?rev=9e6c17d2029b359f2539e663c2c17a69a893e9f2#9e6c17d2029b359f2539e663c2c17a69a893e9f2"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=f406192cc95bebde3b6daa74804770d4d03d85c1#f406192cc95bebde3b6daa74804770d4d03d85c1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5131,7 +5131,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.20.0"
-source = "git+https://github.com/figtracer/foundry-core?rev=9e6c17d2029b359f2539e663c2c17a69a893e9f2#9e6c17d2029b359f2539e663c2c17a69a893e9f2"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=f406192cc95bebde3b6daa74804770d4d03d85c1#f406192cc95bebde3b6daa74804770d4d03d85c1"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5140,7 +5140,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.20.0"
-source = "git+https://github.com/figtracer/foundry-core?rev=9e6c17d2029b359f2539e663c2c17a69a893e9f2#9e6c17d2029b359f2539e663c2c17a69a893e9f2"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=f406192cc95bebde3b6daa74804770d4d03d85c1#f406192cc95bebde3b6daa74804770d4d03d85c1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5160,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.20.0"
-source = "git+https://github.com/figtracer/foundry-core?rev=9e6c17d2029b359f2539e663c2c17a69a893e9f2#9e6c17d2029b359f2539e663c2c17a69a893e9f2"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=f406192cc95bebde3b6daa74804770d4d03d85c1#f406192cc95bebde3b6daa74804770d4d03d85c1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5173,7 +5173,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.20.0"
-source = "git+https://github.com/figtracer/foundry-core?rev=9e6c17d2029b359f2539e663c2c17a69a893e9f2#9e6c17d2029b359f2539e663c2c17a69a893e9f2"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=f406192cc95bebde3b6daa74804770d4d03d85c1#f406192cc95bebde3b6daa74804770d4d03d85c1"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6603,7 +6603,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7494,7 +7494,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8452,7 +8452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8621,7 +8621,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9886,7 +9886,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9945,7 +9945,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10659,7 +10659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10727,7 +10727,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -10739,7 +10739,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -10762,7 +10762,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11060,7 +11060,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
@@ -11174,7 +11174,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11382,7 +11382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12630,7 +12630,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12780,7 +12780,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -596,6 +596,16 @@ alloy-op-hardforks = { git = "https://github.com/ethereum-optimism/optimism", re
 ## foundry-fork-db
 # foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "2f90eb86d4549fa15a8cc2d99bfc1039bc083977" }
 
+## foundry-compilers — pull in https://github.com/foundry-rs/foundry-core/pull/59
+## (fix(compilers/vyper): support PEP 440 pragmas) ahead of the next
+## foundry-compilers release. Drop this block once foundry-compilers >= 0.20.1
+## is published and bump the version in `[workspace.dependencies]`.
+foundry-compilers = { git = "https://github.com/figtracer/foundry-core", rev = "63698079e3971a83fe643c4f14b8c5cd3fbed206" }
+foundry-compilers-artifacts = { git = "https://github.com/figtracer/foundry-core", rev = "63698079e3971a83fe643c4f14b8c5cd3fbed206" }
+foundry-compilers-artifacts-solc = { git = "https://github.com/figtracer/foundry-core", rev = "63698079e3971a83fe643c4f14b8c5cd3fbed206" }
+foundry-compilers-artifacts-vyper = { git = "https://github.com/figtracer/foundry-core", rev = "63698079e3971a83fe643c4f14b8c5cd3fbed206" }
+foundry-compilers-core = { git = "https://github.com/figtracer/foundry-core", rev = "63698079e3971a83fe643c4f14b8c5cd3fbed206" }
+
 ## tempo — unify crates.io versions (pulled by mpp) with git rev
 tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "6bf9903d6a75cc264029dcf54183adea38d3cfaa" }
 tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "6bf9903d6a75cc264029dcf54183adea38d3cfaa" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -600,11 +600,11 @@ alloy-op-hardforks = { git = "https://github.com/ethereum-optimism/optimism", re
 ## (fix(compilers/vyper): support PEP 440 pragmas) ahead of the next
 ## foundry-compilers release. Drop this block once foundry-compilers >= 0.20.1
 ## is published and bump the version in `[workspace.dependencies]`.
-foundry-compilers = { git = "https://github.com/figtracer/foundry-core", rev = "63698079e3971a83fe643c4f14b8c5cd3fbed206" }
-foundry-compilers-artifacts = { git = "https://github.com/figtracer/foundry-core", rev = "63698079e3971a83fe643c4f14b8c5cd3fbed206" }
-foundry-compilers-artifacts-solc = { git = "https://github.com/figtracer/foundry-core", rev = "63698079e3971a83fe643c4f14b8c5cd3fbed206" }
-foundry-compilers-artifacts-vyper = { git = "https://github.com/figtracer/foundry-core", rev = "63698079e3971a83fe643c4f14b8c5cd3fbed206" }
-foundry-compilers-core = { git = "https://github.com/figtracer/foundry-core", rev = "63698079e3971a83fe643c4f14b8c5cd3fbed206" }
+foundry-compilers = { git = "https://github.com/figtracer/foundry-core", rev = "9e6c17d2029b359f2539e663c2c17a69a893e9f2" }
+foundry-compilers-artifacts = { git = "https://github.com/figtracer/foundry-core", rev = "9e6c17d2029b359f2539e663c2c17a69a893e9f2" }
+foundry-compilers-artifacts-solc = { git = "https://github.com/figtracer/foundry-core", rev = "9e6c17d2029b359f2539e663c2c17a69a893e9f2" }
+foundry-compilers-artifacts-vyper = { git = "https://github.com/figtracer/foundry-core", rev = "9e6c17d2029b359f2539e663c2c17a69a893e9f2" }
+foundry-compilers-core = { git = "https://github.com/figtracer/foundry-core", rev = "9e6c17d2029b359f2539e663c2c17a69a893e9f2" }
 
 ## tempo — unify crates.io versions (pulled by mpp) with git rev
 tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "6bf9903d6a75cc264029dcf54183adea38d3cfaa" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -596,15 +596,14 @@ alloy-op-hardforks = { git = "https://github.com/ethereum-optimism/optimism", re
 ## foundry-fork-db
 # foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "2f90eb86d4549fa15a8cc2d99bfc1039bc083977" }
 
-## foundry-compilers — pull in https://github.com/foundry-rs/foundry-core/pull/59
-## (fix(compilers/vyper): support PEP 440 pragmas) ahead of the next
-## foundry-compilers release. Drop this block once foundry-compilers >= 0.20.1
-## is published and bump the version in `[workspace.dependencies]`.
-foundry-compilers = { git = "https://github.com/figtracer/foundry-core", rev = "9e6c17d2029b359f2539e663c2c17a69a893e9f2" }
-foundry-compilers-artifacts = { git = "https://github.com/figtracer/foundry-core", rev = "9e6c17d2029b359f2539e663c2c17a69a893e9f2" }
-foundry-compilers-artifacts-solc = { git = "https://github.com/figtracer/foundry-core", rev = "9e6c17d2029b359f2539e663c2c17a69a893e9f2" }
-foundry-compilers-artifacts-vyper = { git = "https://github.com/figtracer/foundry-core", rev = "9e6c17d2029b359f2539e663c2c17a69a893e9f2" }
-foundry-compilers-core = { git = "https://github.com/figtracer/foundry-core", rev = "9e6c17d2029b359f2539e663c2c17a69a893e9f2" }
+## foundry-compilers — temporarily pinned to foundry-core `main` (which contains
+## https://github.com/foundry-rs/foundry-core/pull/59) until the next foundry-compilers release.
+## Drop this block and bump the version in `[workspace.dependencies]` once published.
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "f406192cc95bebde3b6daa74804770d4d03d85c1" }
+foundry-compilers-artifacts = { git = "https://github.com/foundry-rs/foundry-core", rev = "f406192cc95bebde3b6daa74804770d4d03d85c1" }
+foundry-compilers-artifacts-solc = { git = "https://github.com/foundry-rs/foundry-core", rev = "f406192cc95bebde3b6daa74804770d4d03d85c1" }
+foundry-compilers-artifacts-vyper = { git = "https://github.com/foundry-rs/foundry-core", rev = "f406192cc95bebde3b6daa74804770d4d03d85c1" }
+foundry-compilers-core = { git = "https://github.com/foundry-rs/foundry-core", rev = "f406192cc95bebde3b6daa74804770d4d03d85c1" }
 
 ## tempo — unify crates.io versions (pulled by mpp) with git rev
 tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "6bf9903d6a75cc264029dcf54183adea38d3cfaa" }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -2378,7 +2378,7 @@ casttest!(flaky_storage_with_invalid_solc_version_2, |_prj, cmd| {
     ])
     .assert_failure()
     .stderr_eq(str![[r#"
-Error: Encountered invalid solc version in contracts/Create2Deployer.sol: No solc version exists that matches the version requirement: ^0.8.9
+Error: Encountered invalid compiler version in contracts/Create2Deployer.sol: No compiler version exists that matches the version requirement: ^0.8.9
 
 "#]]);
 });

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -125,7 +125,7 @@ repl_test!(trailing_whitespace, |repl| {
 // Issue #4652: Test that solc flags are respected.
 repl_test!(solc_flags, "--use 0.8.23", |repl| {
     repl.sendln("pragma solidity 0.8.24;");
-    repl.expect("invalid solc version");
+    repl.expect("invalid compiler version");
 });
 
 // Issue #4915: `chisel eval`

--- a/crates/forge/tests/cli/compiler.rs
+++ b/crates/forge/tests/cli/compiler.rs
@@ -301,17 +301,9 @@ forgetest!(can_list_resolved_multiple_compiler_versions_verbose_json, |prj, cmd|
     );
 });
 
-// Regression coverage for https://github.com/foundry-rs/foundry-core/pull/59:
-// the upstream `foundry-compilers` previously dropped *every* Vyper `pragma version` constraint
-// silently (the regex did not accept a space after `#`, and even when it matched, the parser
-// passed the outer regex match instead of the named `version` group to `VersionReq::parse`).
-// The tests below exercise pragma syntaxes that round-trip through the fixed parser end-to-end.
-//
-// Verified by reverting the `[patch.crates-io]` entry in this branch:
-// `vyper_pragma_version_constraint_is_enforced` fails against released `foundry-compilers`
-// (the broken parser silently picks Vyper 0.4.3, then `vyper` itself rejects the pragma later
-// with a different message), while it passes once the fix is pulled in. The other two tests
-// guard against accidental regressions of the new and legacy pragma spellings.
+// Vyper `pragma version` regression coverage for foundry-rs/foundry-core#59. The released
+// `foundry-compilers` silently dropped every Vyper version constraint; these tests pin the
+// fixed parser end-to-end through the resolver.
 
 const VYPER_PEP440_COMPAT_RELEASE: &str = r#"
 # pragma version ~=0.4.0
@@ -339,8 +331,7 @@ const VYPER_UNSATISFIABLE_PRAGMA: &str = r#"
 number: public(uint256)
 "#;
 
-// `~=0.4.0` is PEP 440's "compatible release" operator (snekmate-style). The fixed parser
-// translates it to `>=0.4.0, <0.5.0`, which the locally-installed Vyper 0.4.3 satisfies.
+// `~=0.4.0` (PEP 440 "compatible release") translates to `>=0.4.0, <0.5.0`, satisfied by 0.4.3.
 forgetest!(vyper_pep440_compatible_release_pragma_resolves, |prj, cmd| {
     prj.add_raw_source("Counter.vy", VYPER_PEP440_COMPAT_RELEASE);
 
@@ -352,8 +343,7 @@ Vyper:
 "#]]);
 });
 
-// The legacy `#@version <req>` spelling (the only form Vyper supported prior to 0.3.10) must
-// keep resolving so existing contracts in the wild are not broken by the parser change.
+// Legacy `#@version <req>` spelling (only form supported prior to Vyper 0.3.10) must keep working.
 forgetest!(vyper_legacy_at_version_pragma_resolves, |prj, cmd| {
     prj.add_raw_source("Counter.vy", VYPER_LEGACY_AT_VERSION);
 
@@ -365,10 +355,8 @@ Vyper:
 "#]]);
 });
 
-// Distinguishing test: with the old code, `version_req` was always `None`, so the resolver
-// silently picked the only installed Vyper (0.4.3) and the build only failed later inside the
-// Vyper compiler with a different error. With the fix the constraint `==0.3.10` is honoured
-// and resolution fails up front.
+// Sanity check that an unsatisfiable constraint now fails up front in the resolver instead of
+// being silently dropped.
 forgetest!(vyper_pragma_version_constraint_is_enforced, |prj, cmd| {
     prj.add_raw_source("Counter.vy", VYPER_UNSATISFIABLE_PRAGMA);
 
@@ -378,14 +366,10 @@ Error: Encountered invalid compiler version in src/Counter.vy: No compiler versi
 "#]]);
 });
 
-// PEP 440 pre-release coverage for the upcoming Vyper 0.5 line. The resolver only has Vyper
-// 0.4.3 available in CI, so the build is expected to fail; the value of these tests is asserting
-// the *translated* version requirement that surfaces in the error, which proves the PEP 440 →
-// semver translation in `foundry-compilers` runs end-to-end through foundry. Without the fix,
-// these requirements would be silently dropped and the resolver would just pick 0.4.3.
+// PEP 440 → semver translation cases for the upcoming Vyper 0.5 line. CI has no Vyper 0.5
+// binary, so we assert the *translated* requirement string surfaces in the resolver error.
 
-// Compatible-release operator with a bare alpha tag (snekmate-style):
-// `~=0.5.0a1`  →  `>=0.5.0-a1, <0.6.0`
+// `~=0.5.0a1` → `>=0.5.0-a1, <0.6.0`
 forgetest!(vyper_pep440_compatible_release_alpha_pragma_is_translated, |prj, cmd| {
     prj.add_raw_source(
         "Counter.vy",
@@ -402,8 +386,7 @@ Error: Encountered invalid compiler version in src/Counter.vy: No compiler versi
 "#]]);
 });
 
-// Exact-equality operator with a bare beta tag:
-// `==0.5.0b1`  →  `=0.5.0-b1`
+// `==0.5.0b1` → `=0.5.0-b1`
 forgetest!(vyper_pep440_exact_beta_pragma_is_translated, |prj, cmd| {
     prj.add_raw_source(
         "Counter.vy",
@@ -420,8 +403,7 @@ Error: Encountered invalid compiler version in src/Counter.vy: No compiler versi
 "#]]);
 });
 
-// Exact-equality operator with a bare release-candidate tag:
-// `==0.5.0rc1`  →  `=0.5.0-rc1`
+// `==0.5.0rc1` → `=0.5.0-rc1`
 forgetest!(vyper_pep440_exact_rc_pragma_is_translated, |prj, cmd| {
     prj.add_raw_source(
         "Counter.vy",

--- a/crates/forge/tests/cli/compiler.rs
+++ b/crates/forge/tests/cli/compiler.rs
@@ -300,3 +300,140 @@ forgetest!(can_list_resolved_multiple_compiler_versions_verbose_json, |prj, cmd|
         .is_json(),
     );
 });
+
+// Regression coverage for https://github.com/foundry-rs/foundry-core/pull/59:
+// the upstream `foundry-compilers` previously dropped *every* Vyper `pragma version` constraint
+// silently (the regex did not accept a space after `#`, and even when it matched, the parser
+// passed the outer regex match instead of the named `version` group to `VersionReq::parse`).
+// The tests below exercise pragma syntaxes that round-trip through the fixed parser end-to-end.
+//
+// Verified by reverting the `[patch.crates-io]` entry in this branch:
+// `vyper_pragma_version_constraint_is_enforced` fails against released `foundry-compilers`
+// (the broken parser silently picks Vyper 0.4.3, then `vyper` itself rejects the pragma later
+// with a different message), while it passes once the fix is pulled in. The other two tests
+// guard against accidental regressions of the new and legacy pragma spellings.
+
+const VYPER_PEP440_COMPAT_RELEASE: &str = r#"
+# pragma version ~=0.4.0
+
+number: public(uint256)
+
+@external
+def setNumber(newNumber: uint256):
+    self.number = newNumber
+"#;
+
+const VYPER_LEGACY_AT_VERSION: &str = r#"
+#@version ^0.4.0
+
+number: public(uint256)
+
+@external
+def setNumber(newNumber: uint256):
+    self.number = newNumber
+"#;
+
+const VYPER_UNSATISFIABLE_PRAGMA: &str = r#"
+# pragma version ==0.3.10
+
+number: public(uint256)
+"#;
+
+// `~=0.4.0` is PEP 440's "compatible release" operator (snekmate-style). The fixed parser
+// translates it to `>=0.4.0, <0.5.0`, which the locally-installed Vyper 0.4.3 satisfies.
+forgetest!(vyper_pep440_compatible_release_pragma_resolves, |prj, cmd| {
+    prj.add_raw_source("Counter.vy", VYPER_PEP440_COMPAT_RELEASE);
+
+    cmd.args(["compiler", "resolve"]).assert_success().stdout_eq(str![[r#"
+Vyper:
+- 0.4.3
+
+
+"#]]);
+});
+
+// The legacy `#@version <req>` spelling (the only form Vyper supported prior to 0.3.10) must
+// keep resolving so existing contracts in the wild are not broken by the parser change.
+forgetest!(vyper_legacy_at_version_pragma_resolves, |prj, cmd| {
+    prj.add_raw_source("Counter.vy", VYPER_LEGACY_AT_VERSION);
+
+    cmd.args(["compiler", "resolve"]).assert_success().stdout_eq(str![[r#"
+Vyper:
+- 0.4.3
+
+
+"#]]);
+});
+
+// Distinguishing test: with the old code, `version_req` was always `None`, so the resolver
+// silently picked the only installed Vyper (0.4.3) and the build only failed later inside the
+// Vyper compiler with a different error. With the fix the constraint `==0.3.10` is honoured
+// and resolution fails up front.
+forgetest!(vyper_pragma_version_constraint_is_enforced, |prj, cmd| {
+    prj.add_raw_source("Counter.vy", VYPER_UNSATISFIABLE_PRAGMA);
+
+    cmd.args(["build"]).assert_failure().stderr_eq(str![[r#"
+Error: Encountered invalid compiler version in src/Counter.vy: No compiler version exists that matches the version requirement: =0.3.10
+
+"#]]);
+});
+
+// PEP 440 pre-release coverage for the upcoming Vyper 0.5 line. The resolver only has Vyper
+// 0.4.3 available in CI, so the build is expected to fail; the value of these tests is asserting
+// the *translated* version requirement that surfaces in the error, which proves the PEP 440 →
+// semver translation in `foundry-compilers` runs end-to-end through foundry. Without the fix,
+// these requirements would be silently dropped and the resolver would just pick 0.4.3.
+
+// Compatible-release operator with a bare alpha tag (snekmate-style):
+// `~=0.5.0a1`  →  `>=0.5.0-a1, <0.6.0`
+forgetest!(vyper_pep440_compatible_release_alpha_pragma_is_translated, |prj, cmd| {
+    prj.add_raw_source(
+        "Counter.vy",
+        r#"
+# pragma version ~=0.5.0a1
+
+number: public(uint256)
+"#,
+    );
+
+    cmd.args(["build"]).assert_failure().stderr_eq(str![[r#"
+Error: Encountered invalid compiler version in src/Counter.vy: No compiler version exists that matches the version requirement: >=0.5.0-a1, <0.6.0
+
+"#]]);
+});
+
+// Exact-equality operator with a bare beta tag:
+// `==0.5.0b1`  →  `=0.5.0-b1`
+forgetest!(vyper_pep440_exact_beta_pragma_is_translated, |prj, cmd| {
+    prj.add_raw_source(
+        "Counter.vy",
+        r#"
+# pragma version ==0.5.0b1
+
+number: public(uint256)
+"#,
+    );
+
+    cmd.args(["build"]).assert_failure().stderr_eq(str![[r#"
+Error: Encountered invalid compiler version in src/Counter.vy: No compiler version exists that matches the version requirement: =0.5.0-b1
+
+"#]]);
+});
+
+// Exact-equality operator with a bare release-candidate tag:
+// `==0.5.0rc1`  →  `=0.5.0-rc1`
+forgetest!(vyper_pep440_exact_rc_pragma_is_translated, |prj, cmd| {
+    prj.add_raw_source(
+        "Counter.vy",
+        r#"
+# pragma version ==0.5.0rc1
+
+number: public(uint256)
+"#,
+    );
+
+    cmd.args(["build"]).assert_failure().stderr_eq(str![[r#"
+Error: Encountered invalid compiler version in src/Counter.vy: No compiler version exists that matches the version requirement: =0.5.0-rc1
+
+"#]]);
+});


### PR DESCRIPTION
Counterpart to https://github.com/foundry-rs/foundry-core/pull/59 (`fix(compilers/vyper): support PEP 440 pragmas`).

The released `foundry-compilers` 0.20.0 silently drops every Vyper `pragma version` constraint:

1. `RE_VYPER_VERSION` does not match `# pragma version <req>` (with a space after `#`), which is exactly what [`crates/forge/assets/vyper/CounterTemplate.vy`](https://github.com/foundry-rs/foundry/blob/master/crates/forge/assets/vyper/CounterTemplate.vy) (`# pragma version ~=0.4.3`) and [`VYPER_INTERFACE`](https://github.com/foundry-rs/foundry/blob/master/crates/forge/tests/cli/compiler.rs#L34) (`# pragma version >=0.4.0`) use.
2. When the regex matches, the parser feeds the **outer** match to `semver::VersionReq::parse` instead of the named `version` group, so even legacy pragmas are discarded.
3. Vyper >= 0.4.0 uses PEP 440 (`~=0.5.0`, `0.5.0a1`, `==0.5.0`, …), none of which parse as semver.

Pulled in via a temporary `[patch.crates-io]` so foundry CI can verify the fix before `foundry-compilers` is released. **Draft**: drop the patch and bump the version in `[workspace.dependencies]` once the next `foundry-compilers` is published.

Adds five regression tests in `crates/forge/tests/cli/compiler.rs` covering positive (`~=0.4.0`, `#@version ^0.4.0`) and negative (`==0.3.10`, `==0.5.0b1`, `==0.5.0rc1`) pragma resolution, and updates the `cast` snapshot for the language-neutral error wording introduced by the upstream commit.

### Behavioural caveat

Because the released `foundry-compilers` returns `None` for `version_req` of *every* Vyper file today, this is the first time Vyper version pragmas actually constrain compiler resolution in foundry. Projects with stale or wrong pragmas may now see a version-mismatch error where they previously compiled silently. Worth a CHANGELOG note.