### PR TITLE
chore(vyper): bump CI to vyper 0.5.0a1 and update fixtures

### DIFF
--- a/.github/workflows/test-flaky.yml
+++ b/.github/workflows/test-flaky.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: "3.14"
       - name: Install Vyper
         # Also update vyper version in .devcontainer/Dockerfile.dev
-        run: pip --version && pip install vyper==0.4.3
+        run: pip --version && pip install --pre vyper==0.5.0a1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Test flaky tests
@@ -75,7 +75,7 @@ jobs:
           python-version: "3.14"
       - name: Install Vyper
         # Also update vyper version in .devcontainer/Dockerfile.dev
-        run: pip --version && pip install vyper==0.4.3
+        run: pip --version && pip install --pre vyper==0.5.0a1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Test flaky tests with isolation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
           python-version: "3.14"
       - name: Install Vyper
         # Also update vyper version in .devcontainer/Dockerfile.dev
-        run: pip --version && pip install vyper==0.4.3
+        run: pip --version && pip install --pre vyper==0.5.0a1
 
       - name: Foundry test cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/crates/forge/assets/vyper/CounterTemplate.vy
+++ b/crates/forge/assets/vyper/CounterTemplate.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.3
+# pragma version ~=0.5.0a1
 
 number: public(uint256)
 

--- a/crates/forge/tests/cli/compiler.rs
+++ b/crates/forge/tests/cli/compiler.rs
@@ -31,20 +31,20 @@ contract ContractD {}
 "#;
 
 const VYPER_INTERFACE: &str = r#"
-# pragma version >=0.4.0
+# pragma version >=0.5.0a1
 
 @external
 @view
 def number() -> uint256:
-    return empty(uint256)
+    ...
 
 @external
 def set_number(new_number: uint256):
-    pass
+    ...
 
 @external
 def increment() -> uint256:
-    return empty(uint256)
+    ...
 "#;
 
 const VYPER_CONTRACT: &str = r#"
@@ -156,7 +156,7 @@ Solidity:
 - 0.8.33
 
 Vyper:
-- 0.4.3
+- 0.5.0
 
 
 "#]]);
@@ -174,7 +174,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_skipped, |prj, cmd| {
         r#"
 Vyper:
 
-0.4.3:
+0.5.0:
 ├── src/Counter.vy
 └── src/ICounter.vyi
 
@@ -206,7 +206,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_skipped_json, |prj, cmd|
   ],
   "Vyper": [
     {
-      "version": "0.4.3",
+      "version": "0.5.0",
       "paths": [
         "src/Counter.vy",
         "src/ICounter.vyi"
@@ -242,7 +242,7 @@ Solidity:
 
 Vyper:
 
-0.4.3 (<= prague):
+0.5.0 (<= constantinople):
 ├── src/Counter.vy
 └── src/ICounter.vyi
 
@@ -287,7 +287,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_verbose_json, |prj, cmd|
   ],
   "Vyper": [
     {
-      "version": "0.4.3",
+      "version": "0.5.0",
       "evm_version": "[..]",
       "paths": [
         "src/Counter.vy",
@@ -303,10 +303,10 @@ forgetest!(can_list_resolved_multiple_compiler_versions_verbose_json, |prj, cmd|
 
 // Vyper `pragma version` regression coverage for foundry-rs/foundry-core#59. The released
 // `foundry-compilers` silently dropped every Vyper version constraint; these tests pin the
-// fixed parser end-to-end through the resolver.
+// fixed parser end-to-end through the resolver against an installed Vyper 0.5.0a1 binary.
 
 const VYPER_PEP440_COMPAT_RELEASE: &str = r#"
-# pragma version ~=0.4.0
+# pragma version ~=0.5.0a1
 
 number: public(uint256)
 
@@ -316,7 +316,7 @@ def setNumber(newNumber: uint256):
 "#;
 
 const VYPER_LEGACY_AT_VERSION: &str = r#"
-#@version ^0.4.0
+#@version >=0.5.0a1
 
 number: public(uint256)
 
@@ -331,13 +331,14 @@ const VYPER_UNSATISFIABLE_PRAGMA: &str = r#"
 number: public(uint256)
 "#;
 
-// `~=0.4.0` (PEP 440 "compatible release") translates to `>=0.4.0, <0.5.0`, satisfied by 0.4.3.
+// `~=0.5.0a1` (PEP 440 "compatible release") translates to `>=0.5.0-a1, <0.6.0`, satisfied by
+// the installed Vyper 0.5.0a1.
 forgetest!(vyper_pep440_compatible_release_pragma_resolves, |prj, cmd| {
     prj.add_raw_source("Counter.vy", VYPER_PEP440_COMPAT_RELEASE);
 
     cmd.args(["compiler", "resolve"]).assert_success().stdout_eq(str![[r#"
 Vyper:
-- 0.4.3
+- 0.5.0
 
 
 "#]]);
@@ -349,7 +350,7 @@ forgetest!(vyper_legacy_at_version_pragma_resolves, |prj, cmd| {
 
     cmd.args(["compiler", "resolve"]).assert_success().stdout_eq(str![[r#"
 Vyper:
-- 0.4.3
+- 0.5.0
 
 
 "#]]);
@@ -366,25 +367,8 @@ Error: Encountered invalid compiler version in src/Counter.vy: No compiler versi
 "#]]);
 });
 
-// PEP 440 → semver translation cases for the upcoming Vyper 0.5 line. CI has no Vyper 0.5
-// binary, so we assert the *translated* requirement string surfaces in the resolver error.
-
-// `~=0.5.0a1` → `>=0.5.0-a1, <0.6.0`
-forgetest!(vyper_pep440_compatible_release_alpha_pragma_is_translated, |prj, cmd| {
-    prj.add_raw_source(
-        "Counter.vy",
-        r#"
-# pragma version ~=0.5.0a1
-
-number: public(uint256)
-"#,
-    );
-
-    cmd.args(["build"]).assert_failure().stderr_eq(str![[r#"
-Error: Encountered invalid compiler version in src/Counter.vy: No compiler version exists that matches the version requirement: >=0.5.0-a1, <0.6.0
-
-"#]]);
-});
+// Beta and rc cases below: Vyper 0.5.0a1 cannot satisfy `=0.5.0-b1` or `=0.5.0-rc1`, so we
+// assert the *translated* requirement string surfaces in the resolver error.
 
 // `==0.5.0b1` → `=0.5.0-b1`
 forgetest!(vyper_pep440_exact_beta_pragma_is_translated, |prj, cmd| {


### PR DESCRIPTION
> [!WARNING]
> **Do not merge.** Vyper 0.5.0a1 is a pre-release alpha — pinning foundry CI to it is not appropriate as a default. This branch only exists to demonstrate end-to-end that the PEP 440 pragma fix from foundry-rs/foundry-core#59 actually compiles a contract against a Vyper 0.5 binary, complementing the resolver-only coverage in #14664.
>
> Once Vyper 0.5.0 ships as a stable release, a follow-up can revisit whether to bump CI from 0.4.3.

Stacked on top of #14664. The parent PR keeps CI on Vyper `0.4.3` and only proves the parser/resolver path through snapshot assertions; this branch bumps CI to `0.5.0a1` so we can confirm a contract using PEP 440 syntax (`~=0.5.0a1`) actually compiles end-to-end.

### Changes

- **CI** (`.github/workflows/test{,-flaky}.yml`): `pip install vyper==0.4.3` → `pip install --pre vyper==0.5.0a1`.
- **Template** (`crates/forge/assets/vyper/CounterTemplate.vy`): pragma `~=0.4.3` → `~=0.5.0a1` so `forge init --vyper` builds out of the box.
- **`VYPER_INTERFACE`** test fixture: pragma bumped to `>=0.5.0a1` and function bodies switched to `...` (Vyper 0.5 only allows `...` inside interface bodies).
- **Snapshots**: `compiler::can_list_resolved_multiple_compiler_versions*` updated for `0.4.3` → `0.5.0` and `<= prague` → `<= constantinople` (Vyper 0.5's default EVM target).
- **PEP 440 regression tests** retargeted to Vyper 0.5.0a1: the alpha compatible-release pragma now resolves successfully (subsumes the previous translated-but-unsatisfiable test, which has been removed); the legacy `#@version` test uses `>=0.5.0a1`; `==0.3.10`, `==0.5.0b1`, and `==0.5.0rc1` keep their negative assertions because Vyper 0.5.0a1 still does not satisfy any of them.