### PR TITLE
test(cast): mark estimate_base_da as flaky

### DIFF
--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -4030,7 +4030,7 @@ Error: Failed to estimate gas: server returned an error response: error code 3: 
 });
 
 // <https://basescan.org/block/30558838>
-casttest!(estimate_base_da, |_prj, cmd| {
+casttest!(flaky_estimate_base_da, |_prj, cmd| {
     cmd.args(["da-estimate", "30558838", "-r", "https://mainnet.base.org/"])
         .assert_success()
         .stdout_eq(str![[r#"


### PR DESCRIPTION
## Summary

Marks `estimate_base_da` as flaky by renaming it to `flaky_estimate_base_da`, matching the existing convention for flaky tests in `crates/cast/tests/cli/main.rs`.

## Why

The test hits `https://mainnet.base.org/` for block `30558838` and asserts that 225 transactions are returned. In practice the public Base RPC frequently returns `0` transactions for the same block, causing intermittent CI failures.

### Reproduction

Running the same command back-to-back locally produces inconsistent results:

```
➜ cast da-estimate 30558838 -r https://mainnet.base.org/
Estimated data availability size for block 30558838 with 225 transactions: 52916546100
➜ cast da-estimate 30558838 -r https://mainnet.base.org/
Estimated data availability size for block 30558838 with 225 transactions: 52916546100
➜ cast da-estimate 30558838 -r https://mainnet.base.org/
Estimated data availability size for block 30558838 with 0 transactions: 0
➜ cast da-estimate 30558838 -r https://mainnet.base.org/
Estimated data availability size for block 30558838 with 225 transactions: 52916546100
➜ cast da-estimate 30558838 -r https://mainnet.base.org/
Estimated data availability size for block 30558838 with 0 transactions: 0
➜ cast da-estimate 30558838 -r https://mainnet.base.org/
Estimated data availability size for block 30558838 with 0 transactions: 0
➜ cast da-estimate 30558838 -r https://mainnet.base.org/
Estimated data availability size for block 30558838 with 0 transactions: 0
➜ cast da-estimate 30558838 -r https://mainnet.base.org/
Estimated data availability size for block 30558838 with 0 transactions: 0
➜ cast da-estimate 30558838 -r https://mainnet.base.org/
Estimated data availability size for block 30558838 with 0 transactions: 0
➜ cast da-estimate 30558838 -r https://mainnet.base.org/
Estimated data availability size for block 30558838 with 0 transactions: 0
➜ cast da-estimate 30558838 -r https://mainnet.base.org/
Estimated data availability size for block 30558838 with 0 transactions: 0
➜ cast da-estimate 30558838 -r https://mainnet.base.org/
Estimated data availability size for block 30558838 with 0 transactions: 0
➜ cast da-estimate 30558838 -r https://mainnet.base.org/
Estimated data availability size for block 30558838 with 225 transactions: 52916546100
```

That is **9 of 13** invocations returning `0` — roughly a 70% failure rate against the assertion.

### Observed CI failure

```
running 1 test
2026-05-08T14:32:23.585638Z DEBUG foundry_test_utils: executing cd "/tmp/estimate_base_da-02h443U" && NO_COLOR="1" "/home/runner/work/foundry/foundry/target/debug/cast" "da-estimate" "30558838" "-r" "https://mainnet.base.org/"
2026-05-08T14:32:23.767978Z DEBUG foundry_test_utils: exited with exit status: 0
test estimate_base_da ... FAILED

failures:
    estimate_base_da

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 213 filtered out; finished in 0.42s

stderr ───
The application panicked (crashed).
Message:
---- expected: tests/cli/main.rs:4036:20
++++ actual:   stdout
   1      - Estimated data availability size for block 30558838 with 225 transactions: 52916546100
        1 + Estimated data availability size for block 30558838 with 0 transactions: 0
```
