### PR TITLE
fix(cast): infer evm opts with `--trace`

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -229,7 +229,14 @@ impl CallArgs {
 
         let figment = self.rpc.clone().into_figment(self.with_local_artifacts).merge(&self);
         let mut evm_opts = figment.extract::<EvmOpts>()?;
+        if let Some(chain) = self.chain {
+            evm_opts.networks = evm_opts.networks.with_chain_id(chain.id());
+        }
         evm_opts.infer_network_from_fork().await;
+
+        if evm_opts.networks.is_tempo() {
+            return self.run_with_network::<TempoEvmNetwork>().await;
+        }
 
         #[cfg(feature = "optimism")]
         if evm_opts.networks.is_optimism() {

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -10,6 +10,7 @@ use alloy_rpc_types::{Authorization, BlockNumberOrTag, Index, TransactionRequest
 use alloy_signer::Signer;
 use alloy_signer_local::PrivateKeySigner;
 use anvil::NodeConfig;
+use foundry_evm::core::tempo::PATH_USD_ADDRESS;
 use foundry_test_utils::{
     rpc::{
         next_etherscan_api_key, next_http_archive_rpc_url, next_http_rpc_endpoint,
@@ -4416,6 +4417,30 @@ casttest!(can_disassemble_contract_code, |_prj, cmd| {
 0000002e: PUSH1 0x00
 ...
 "#]]);
+});
+
+// tests that cast call --trace selects TempoEvmNetwork when Tempo is inferred from
+// the fork RPC, or when a Tempo chain ID is provided explicitly via --chain.
+casttest!(cast_call_trace_selects_tempo_network, async |_prj, cmd| {
+    let (_, tempo_handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let (_, eth_handle) = anvil::spawn(NodeConfig::test()).await;
+
+    let token = PATH_USD_ADDRESS.to_string();
+    for (name, rpc, extra_args) in [
+        ("inferred Tempo RPC", tempo_handle.http_endpoint(), Vec::<&str>::new()),
+        ("explicit Tempo --chain", eth_handle.http_endpoint(), vec!["--chain", "4217"]),
+    ] {
+        cmd.cast_fuse();
+        let mut args = vec!["call", &token, "decimals()(uint8)", "--rpc-url", &rpc, "--trace"];
+        args.extend(extra_args);
+
+        let output = cmd.args(args).assert_success().get_output().stdout_lossy();
+
+        assert!(
+            output.contains("PathUSD::decimals()") && output.contains("← [Return] 6"),
+            "expected traced Tempo TIP20 call to execute successfully for {name}, got:\n{output}"
+        );
+    }
 });
 
 // tests that cast call properly applies state diff override


### PR DESCRIPTION
## Motivation

`cast call --trace` only selected `TempoEvmNetwork` when the transaction itself used a Tempo-specific option.

that meant that tempo-configured foundry.toml was ignored for trace dispatch, and there was also no way to force Tempo tracing with `--chain`.

```sh
cast call --from 0x0000000071727De22E5E9d8BAf0edAc6f37da032 0xc29fd77f8B46b946563C71c071ee70B0b31A98De 0xe9ae5c530000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000983DE400E3F79113194fa5AF6Ae5C474947E0C82Db0000000000000000000000000000000000000000000000000000000000000000a7a28469000000000000000000000000c29fd77f8b46b946563c71c071ee70b0b31a98de00000000000000000000000020c0000000000000000000000000000000000000b5da235be1095024b4992ce044b90177554e1fd7d92af7e5924615c6673b4fdd0000000000000000 --override-code "0xc29fd77f8B46b946563C71c071ee70B0b31A98De:0xef0100d6CEDDe84be40893d153Be9d467CD6aD37875b28" --rpc-url https://rpc.tempo.xyz --trace%
adamegyed@st-adamegyed1(laptop) ~/stripe/temp/tempo-debug % cast call --from 0x0000000071727De22E5E9d8BAf0edAc6f37da032 0xc29fd77f8B46b946563C71c071ee70B0b31A98De 0xe9ae5c530000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000983DE400E3F79113194fa5AF6Ae5C474947E0C82Db0000000000000000000000000000000000000000000000000000000000000000a7a28469000000000000000000000000c29fd77f8b46b946563c71c071ee70b0b31a98de00000000000000000000000020c0000000000000000000000000000000000000b5da235be1095024b4992ce044b90177554e1fd7d92af7e5924615c6673b4fdd0000000000000000 --override-code "0xc29fd77f8B46b946563C71c071ee70B0b31A98De:0xef0100d6CEDDe84be40893d153Be9d467CD6aD37875b28" --rpc-url https://rpc.tempo.xyz --trace
Traces:
  [17595493375392330634] 0xc29fd77f8B46b946563C71c071ee70B0b31A98De::execute(0x0000000000000000000000000000000000000000000000000000000000000000, 0x3de400e3f79113194fa5af6ae5c474947e0c82db0000000000000000000000000000000000000000000000000000000000000000a7a28469000000000000000000000000c29fd77f8b46b946563c71c071ee70b0b31a98de00000000000000000000000020c0000000000000000000000000000000000000b5da235be1095024b4992ce044b90177554e1fd7d92af7e5924615c6673b4fdd)
    ├─ [17595493375392326298] 0x3DE400E3F79113194fa5AF6Ae5C474947E0C82Db::createVaultV2(0xc29fd77f8B46b946563C71c071ee70B0b31A98De, 0x20C0000000000000000000000000000000000000, 0xb5da235be1095024b4992ce044b90177554e1fd7d92af7e5924615c6673b4fdd)
    │   ├─ [17595493375392283051] → new <unknown>@0x8AEEb7B146D4607DCb81058652199884e8e2BeCF
    │   │   ├─ [0] 0x20C0000000000000000000000000000000000000::decimals() [staticcall]
    │   │   │   └─ ← [OpcodeNotFound] EvmError: OpcodeNotFound
    │   │   └─ ← [Revert]
    │   └─ ← [Revert] EvmError: Revert
    └─ ← [Revert] EvmError: Revert


Error: Transaction failed.
Gas used: 17595493375392353670
```

## Solution

update `cast call` network dispatch so `--trace` selects `TempoEvmNetwork` from the resolved evm opts, not only from tx options.

## PR Checklist

 - [x] Added Tests
 - [ ] Added Documentation
 - [ ] Breaking changes