### PR TITLE
feat: improve forge build lint-failure UX

### DIFF
--- a/crates/common/src/errors/mod.rs
+++ b/crates/common/src/errors/mod.rs
@@ -45,8 +45,15 @@ fn all_sources<E: private::ErrorChain + ?Sized>(err: &E) -> Vec<String> {
 pub fn convert_solar_errors(dcx: &solar::interface::diagnostics::DiagCtxt) -> eyre::Result<()> {
     match dcx.emitted_errors() {
         Some(Ok(())) => Ok(()),
-        Some(Err(e)) if !e.is_empty() => eyre::bail!("solar run failed:\n\n{e}"),
-        _ if dcx.has_errors().is_err() => eyre::bail!("solar run failed"),
+        Some(Err(e)) if !e.is_empty() => eyre::bail!("solar reported errors:\n\n{e}"),
+        _ if dcx.has_errors().is_err() => {
+            // Non-buffer emitter: diagnostics already went to stderr; include the count.
+            let n = dcx.err_count();
+            let plural = if n == 1 { "" } else { "s" };
+            eyre::bail!(
+                "solar reported {n} error{plural}; see the diagnostic{plural} printed above"
+            )
+        }
         _ => Ok(()),
     }
 }

--- a/crates/common/src/errors/mod.rs
+++ b/crates/common/src/errors/mod.rs
@@ -61,6 +61,7 @@ pub fn convert_solar_errors(dcx: &solar::interface::diagnostics::DiagCtxt) -> ey
 #[cfg(test)]
 mod tests {
     use super::*;
+    use solar::interface::diagnostics::{DiagCtxt, SilentEmitter};
 
     #[test]
     fn dedups_contained() {
@@ -78,5 +79,42 @@ mod tests {
         assert_eq!(full, "my error: hello; hello");
         let chained = display_chain(&ee);
         assert_eq!(chained, "my error: hello");
+    }
+
+    /// Regression test for the "non-buffer emitter" branch of [`convert_solar_errors`].
+    ///
+    /// Simulates an unhandled solar edge case: the linter installs a non-buffer (stderr-style)
+    /// emitter, errors are emitted to it, and only the count is recoverable afterwards. The
+    /// returned eyre error must reference the count and direct the user to the diagnostics that
+    /// were already printed above.
+    #[test]
+    fn solar_non_buffer_emitter_singular() {
+        let dcx = DiagCtxt::new(Box::new(SilentEmitter::new_silent()));
+        dcx.err("boom").emit();
+
+        let err = convert_solar_errors(&dcx).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "solar reported 1 error; see the diagnostic printed above"
+        );
+    }
+
+    #[test]
+    fn solar_non_buffer_emitter_plural() {
+        let dcx = DiagCtxt::new(Box::new(SilentEmitter::new_silent()));
+        dcx.err("boom 1").emit();
+        dcx.err("boom 2").emit();
+
+        let err = convert_solar_errors(&dcx).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "solar reported 2 errors; see the diagnostics printed above"
+        );
+    }
+
+    #[test]
+    fn solar_no_errors_is_ok() {
+        let dcx = DiagCtxt::new(Box::new(SilentEmitter::new_silent()));
+        assert!(convert_solar_errors(&dcx).is_ok());
     }
 }

--- a/crates/common/src/errors/mod.rs
+++ b/crates/common/src/errors/mod.rs
@@ -93,10 +93,7 @@ mod tests {
         dcx.err("boom").emit();
 
         let err = convert_solar_errors(&dcx).unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "solar reported 1 error; see the diagnostic printed above"
-        );
+        assert_eq!(err.to_string(), "solar reported 1 error; see the diagnostic printed above");
     }
 
     #[test]
@@ -106,10 +103,7 @@ mod tests {
         dcx.err("boom 2").emit();
 
         let err = convert_solar_errors(&dcx).unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "solar reported 2 errors; see the diagnostics printed above"
-        );
+        assert_eq!(err.to_string(), "solar reported 2 errors; see the diagnostics printed above");
     }
 
     #[test]

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -1,6 +1,6 @@
 use super::{install, watch::WatchArgs};
 use clap::Parser;
-use eyre::{Context, Result};
+use eyre::Result;
 use forge_lint::{linter::Linter, sol::SolidityLinter};
 use foundry_cli::{
     opts::{BuildOpts, configure_pcx_from_solc, get_solar_sources_from_compile_output},
@@ -61,6 +61,14 @@ pub struct BuildArgs {
     #[serde(skip)]
     pub ignore_eip_3860: bool,
 
+    /// Skip the post-build lint step for this invocation.
+    ///
+    /// Equivalent to setting `lint_on_build = false` under `[lint]` in foundry.toml,
+    /// but only for the current command.
+    #[arg(long, visible_alias = "skip-lint")]
+    #[serde(skip)]
+    pub no_lint: bool,
+
     #[command(flatten)]
     #[serde(flatten)]
     pub build: BuildOpts,
@@ -117,9 +125,16 @@ impl BuildArgs {
         }
 
         // Only run the `SolidityLinter` if lint on build and no compilation errors.
-        if config.lint.lint_on_build && !output.output().errors.iter().any(|e| e.is_error()) {
-            self.lint(&project, &config, self.paths.as_deref(), &mut output)
-                .wrap_err("Lint failed")?;
+        if !self.no_lint
+            && config.lint.lint_on_build
+            && !output.output().errors.iter().any(|e| e.is_error())
+            && let Err(err) = self.lint(&project, &config, self.paths.as_deref(), &mut output)
+        {
+            emit_lint_failure_notice();
+            return Err(err.wrap_err(
+                "post-build lint step failed; rerun with --no-lint or set \
+                 `lint_on_build = false` under `[lint]` in foundry.toml to bypass",
+            ));
         }
 
         Ok(output)
@@ -188,8 +203,12 @@ impl BuildArgs {
 
             // NOTE(rusowsky): Once solar can drop unsupported versions, rather than creating a new
             // compiler, we should reuse the parser from the project output.
+            //
+            // Buffer emitter so parse-phase errors surface verbatim in `convert_solar_errors`.
             let mut compiler = solar::sema::Compiler::new(
-                solar::interface::Session::builder().with_stderr_emitter().build(),
+                solar::interface::Session::builder()
+                    .with_buffer_emitter(Default::default())
+                    .build(),
             );
 
             // Load the solar-compatible sources to the pcx before linting
@@ -199,6 +218,18 @@ impl BuildArgs {
                 pcx.set_resolve_imports(true);
                 pcx.parse();
             });
+
+            // Flush buffered parse-phase warnings; on error, `convert_solar_errors` surfaces
+            // them in the returned error instead, so skip to avoid duplicates.
+            if compiler.sess().dcx.has_errors().is_ok()
+                && let Some(diags) = compiler.sess().emitted_diagnostics()
+            {
+                let s = diags.to_string();
+                if !s.is_empty() {
+                    let _ = sh_eprint!("{s}");
+                }
+            }
+
             linter.lint(&input_files, config.deny, &mut compiler)?;
         }
 
@@ -320,6 +351,21 @@ impl BuildArgs {
             }
         }
     }
+}
+
+/// Notice shown on lint-on-build failure; printed separately so it survives single-line
+/// cause-chain rendering.
+const LINT_FAILURE_NOTICE: &str = "\
+note: post-build lint failed, but compilation succeeded.
+bypass with `--no-lint` or set `lint_on_build = false` under `[lint]` in foundry.toml
+docs: https://getfoundry.sh/forge/linting#disable-linting-on-build
+";
+
+fn emit_lint_failure_notice() {
+    if shell::is_json() {
+        return;
+    }
+    let _ = sh_eprintln!("\n{LINT_FAILURE_NOTICE}");
 }
 
 // Make this args a `figment::Provider` so that it can be merged into the `Config`

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -336,10 +336,21 @@ impl BuildArgs {
 
 /// Notice shown on lint-on-build failure; printed separately so it survives single-line
 /// cause-chain rendering.
+///
+/// Modeled on rustc's ICE notice: short, action-first, no prose. The reporting CTA comes first
+/// because `lint_on_build` is on by default and these failures are almost always bugs in the
+/// lint engine that we want to fix. The link goes straight to the bug-report form so the user
+/// lands on the structured template (component, version, repro, etc.). Two escape hatches are
+/// offered, both framed as temporary: `--no-lint` for the current run, and a docs link for
+/// turning lint-on-build off until the bug is fixed.
 const LINT_FAILURE_NOTICE: &str = "\
-note: post-build lint failed, but compilation succeeded.
-bypass with `--no-lint` or set `lint_on_build = false` under `[lint]` in foundry.toml
-docs: https://getfoundry.sh/forge/linting#disable-linting-on-build
+note: internal lint engine failure (compilation itself succeeded).
+note: please file a bug report at
+      https://github.com/foundry-rs/foundry/issues/new?template=BUG-FORM.yml
+      and attach the full output above.
+help: rerun with `--no-lint` to skip linting for this build, or consider temporarily
+      disabling forge lint on build:
+      https://getfoundry.sh/forge/linting#disable-linting-on-build
 ";
 
 fn emit_lint_failure_notice() {

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -336,13 +336,6 @@ impl BuildArgs {
 
 /// Notice shown on lint-on-build failure; printed separately so it survives single-line
 /// cause-chain rendering.
-///
-/// Modeled on rustc's ICE notice: short, action-first, no prose. The reporting CTA comes first
-/// because `lint_on_build` is on by default and these failures are almost always bugs in the
-/// lint engine that we want to fix. The link goes straight to the bug-report form so the user
-/// lands on the structured template (component, version, repro, etc.). Two escape hatches are
-/// offered, both framed as temporary: `--no-lint` for the current run, and a docs link for
-/// turning lint-on-build off until the bug is fixed.
 const LINT_FAILURE_NOTICE: &str = "\
 note: internal lint engine failure (compilation itself succeeded).
 note: please file a bug report at

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -23,6 +23,7 @@ use foundry_config::{
     filter::expand_globs,
 };
 use serde::Serialize;
+use solar::{interface::Session, sema::Compiler};
 use std::path::PathBuf;
 
 foundry_config::merge_impl_figment_convert!(BuildArgs, build);
@@ -131,10 +132,7 @@ impl BuildArgs {
             && let Err(err) = self.lint(&project, &config, self.paths.as_deref(), &mut output)
         {
             emit_lint_failure_notice();
-            return Err(err.wrap_err(
-                "post-build lint step failed; rerun with --no-lint or set \
-                 `lint_on_build = false` under `[lint]` in foundry.toml to bypass",
-            ));
+            return Err(err.wrap_err("post-build lint step failed"));
         }
 
         Ok(output)
@@ -203,13 +201,7 @@ impl BuildArgs {
 
             // NOTE(rusowsky): Once solar can drop unsupported versions, rather than creating a new
             // compiler, we should reuse the parser from the project output.
-            //
-            // Buffer emitter so parse-phase errors surface verbatim in `convert_solar_errors`.
-            let mut compiler = solar::sema::Compiler::new(
-                solar::interface::Session::builder()
-                    .with_buffer_emitter(Default::default())
-                    .build(),
-            );
+            let mut compiler = Compiler::new(Session::builder().with_stderr_emitter().build());
 
             // Load the solar-compatible sources to the pcx before linting
             compiler.enter_mut(|compiler| {
@@ -218,17 +210,6 @@ impl BuildArgs {
                 pcx.set_resolve_imports(true);
                 pcx.parse();
             });
-
-            // Flush buffered parse-phase warnings; on error, `convert_solar_errors` surfaces
-            // them in the returned error instead, so skip to avoid duplicates.
-            if compiler.sess().dcx.has_errors().is_ok()
-                && let Some(diags) = compiler.sess().emitted_diagnostics()
-            {
-                let s = diags.to_string();
-                if !s.is_empty() {
-                    let _ = sh_eprint!("{s}");
-                }
-            }
 
             linter.lint(&input_files, config.deny, &mut compiler)?;
         }

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -837,6 +837,84 @@ Warning (2018): Function state mutability can be restricted to pure
 "#]]);
 });
 
+// Regression test: after switching the lint session to a buffer emitter, lint diagnostics
+// produced during `forge build` must still stream to stderr (they are emitted through a
+// separate emitter installed inside `SolidityLinter::lint`, not the session emitter).
+forgetest!(build_emits_lint_diagnostics, |prj, cmd| {
+    prj.add_source("CounterAWithLints", COUNTER_A);
+
+    prj.update_config(|config| {
+        config.lint.severity = vec![LintSeverity::Info];
+    });
+
+    cmd.arg("build").assert_success().stderr_eq(str![[r#"
+note[mixed-case-variable]: mutable variables should use mixedCase
+  [FILE]:6:20
+  │
+6 │     uint256 public CounterA_Fail_Lint;
+  │                    ━━━━━━━━━━━━━━━━━━ help: consider using: `counterAFailLint`
+  │
+  ╰ help: https://getfoundry.sh/forge/linting/mixed-case-variable
+
+
+"#]]);
+});
+
+forgetest!(build_no_lint_flag_skips_lint, |prj, cmd| {
+    prj.add_source("ContractWithLints", CONTRACT);
+
+    // Configure linter with medium severity lints and ensure lint_on_build is enabled
+    // so the only thing skipping the lint step is the `--no-lint` flag.
+    prj.update_config(|config| {
+        config.lint = LinterConfig {
+            severity: vec![LintSeverity::Med],
+            exclude_lints: vec!["incorrect-shift".into()],
+            ignore: vec![],
+            lint_on_build: true,
+            ..Default::default()
+        };
+    });
+
+    cmd.args(["build", "--no-lint"]).assert_success().stderr_eq(str![[r#""#]]).stdout_eq(str![[
+        r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful with warnings:
+Warning (2072): Unused local variable.
+  [FILE]:13:9:
+   |
+13 |         uint256 result = 8 >> localValue;
+   |         ^^^^^^^^^^^^^^
+
+Warning (6133): Statement has no effect.
+  [FILE]:16:9:
+   |
+16 |         (1 / 2) * 3;
+   |         ^^^^^^^^^^^
+
+Warning (2018): Function state mutability can be restricted to pure
+  [FILE]:11:5:
+   |
+11 |     function incorrectShiftHigh() public {
+   |     ^ (Relevant source part starts here and spans across multiple lines).
+
+Warning (2018): Function state mutability can be restricted to pure
+  [FILE]:15:5:
+   |
+15 |     function divideBeforeMultiplyMedium() public {
+   |     ^ (Relevant source part starts here and spans across multiple lines).
+
+Warning (2018): Function state mutability can be restricted to pure
+  [FILE]:18:5:
+   |
+18 |     function unoptimizedHashGas(uint256 a, uint256 b) public view {
+   |     ^ (Relevant source part starts here and spans across multiple lines).
+
+
+"#
+    ]]);
+});
+
 forgetest!(can_process_inline_config_regardless_of_input_order, |prj, cmd| {
     prj.add_source("ContractWithLints", CONTRACT);
     prj.add_source("OtherContractWithLints", OTHER_CONTRACT);

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -914,6 +914,110 @@ Warning (2018): Function state mutability can be restricted to pure
     ]]);
 });
 
+// When the post-build lint step itself fails (e.g. an unhandled lint engine edge case, or a
+// real lint tripping the configured `deny` threshold), `forge build` must surface a notice
+// that leads with a "report this bug" CTA and offers `--no-lint` only as a temporary
+// workaround. We trigger the failure deterministically by combining a source with a lint note
+// (mixed-case variable) and `deny = notes`, which makes the linter return Err — exactly the
+// same exit path an unhandled solar edge case would take.
+//
+// `COUNTER_A` is used because it produces zero solc warnings, so `deny.warnings()`
+// (which propagates to the project compiler) does not block compilation before lint runs.
+forgetest!(build_emits_lint_failure_notice_on_failure, |prj, cmd| {
+    prj.add_source("CounterAWithLints", COUNTER_A);
+
+    prj.update_config(|config| {
+        config.lint.severity = vec![LintSeverity::Info];
+        config.deny = DenyLevel::Notes;
+    });
+
+    let output = cmd.arg("build").assert_failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+
+    // Header makes clear compilation succeeded; the failure is internal to the lint engine.
+    assert!(
+        stderr.contains("internal lint engine failure"),
+        "missing failure header in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("compilation itself succeeded"),
+        "header should clarify compilation succeeded:\n{stderr}"
+    );
+
+    // Primary action: report the bug. The link must deep-link into the structured BUG-FORM
+    // template (component, version, repro, etc.) — not the bare `/issues/new` page.
+    assert!(
+        stderr.contains(
+            "https://github.com/foundry-rs/foundry/issues/new?template=BUG-FORM.yml"
+        ),
+        "missing bug-form template link in stderr:\n{stderr}"
+    );
+    // Output-attach hint helps the maintainer reproduce the failure.
+    assert!(
+        stderr.contains("attach the full output above"),
+        "should tell the user to attach the full output above in stderr:\n{stderr}"
+    );
+
+    // Secondary action: per-run bypass with `--no-lint`, plus a docs link for users who want
+    // to temporarily turn lint-on-build off while waiting for the bug fix. The framing must
+    // stay temporary — we never want to hand users a verbatim `lint_on_build = false` snippet
+    // they can paste into their config and forget about.
+    assert!(
+        stderr.contains("--no-lint"),
+        "missing --no-lint hint in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("temporarily"),
+        "the lint-on-build escape hatch must be framed as temporary:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("https://getfoundry.sh/forge/linting#disable-linting-on-build"),
+        "missing docs link for disabling lint on build:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("lint_on_build = false"),
+        "notice must not hand the user a paste-and-forget config snippet:\n{stderr}"
+    );
+
+    // We don't ask for a backtrace — the failure is an `eyre` error from a single call site,
+    // so a backtrace adds noise without signal.
+    assert!(
+        !stderr.contains("RUST_BACKTRACE"),
+        "notice must not ask for a backtrace; it adds no signal here:\n{stderr}"
+    );
+
+    // Underlying error is still wrapped so the cause chain stays intact.
+    assert!(
+        stderr.contains("post-build lint step failed"),
+        "missing wrap_err context in stderr:\n{stderr}"
+    );
+});
+
+// `--no-lint` must not print the failure notice, since the lint step is skipped entirely.
+// Same setup as `build_emits_lint_failure_notice_on_failure` so the only difference is the
+// `--no-lint` flag.
+forgetest!(build_no_lint_flag_does_not_emit_lint_failure_notice, |prj, cmd| {
+    prj.add_source("CounterAWithLints", COUNTER_A);
+
+    prj.update_config(|config| {
+        config.lint.severity = vec![LintSeverity::Info];
+        // Without `--no-lint` this would trigger the lint Err path and the failure notice.
+        config.deny = DenyLevel::Notes;
+    });
+
+    let output = cmd.args(["build", "--no-lint"]).assert_success();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+
+    assert!(
+        !stderr.contains("internal lint engine failure"),
+        "failure notice must not appear when lint is skipped:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("BUG-FORM.yml"),
+        "bug-report CTA must not appear when lint is skipped:\n{stderr}"
+    );
+});
+
 forgetest!(can_process_inline_config_regardless_of_input_order, |prj, cmd| {
     prj.add_source("ContractWithLints", CONTRACT);
     prj.add_source("OtherContractWithLints", OTHER_CONTRACT);

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -947,9 +947,7 @@ forgetest!(build_emits_lint_failure_notice_on_failure, |prj, cmd| {
     // Primary action: report the bug. The link must deep-link into the structured BUG-FORM
     // template (component, version, repro, etc.) — not the bare `/issues/new` page.
     assert!(
-        stderr.contains(
-            "https://github.com/foundry-rs/foundry/issues/new?template=BUG-FORM.yml"
-        ),
+        stderr.contains("https://github.com/foundry-rs/foundry/issues/new?template=BUG-FORM.yml"),
         "missing bug-form template link in stderr:\n{stderr}"
     );
     // Output-attach hint helps the maintainer reproduce the failure.
@@ -962,10 +960,7 @@ forgetest!(build_emits_lint_failure_notice_on_failure, |prj, cmd| {
     // to temporarily turn lint-on-build off while waiting for the bug fix. The framing must
     // stay temporary — we never want to hand users a verbatim `lint_on_build = false` snippet
     // they can paste into their config and forget about.
-    assert!(
-        stderr.contains("--no-lint"),
-        "missing --no-lint hint in stderr:\n{stderr}"
-    );
+    assert!(stderr.contains("--no-lint"), "missing --no-lint hint in stderr:\n{stderr}");
     assert!(
         stderr.contains("temporarily"),
         "the lint-on-build escape hatch must be framed as temporary:\n{stderr}"

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -931,61 +931,30 @@ forgetest!(build_emits_lint_failure_notice_on_failure, |prj, cmd| {
         config.deny = DenyLevel::Notes;
     });
 
-    let output = cmd.arg("build").assert_failure();
-    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    cmd.arg("build").assert_failure().stderr_eq(str![[r#"
+note[mixed-case-variable]: mutable variables should use mixedCase
+  [FILE]:6:20
+  │
+6 │     uint256 public CounterA_Fail_Lint;
+  │                    ━━━━━━━━━━━━━━━━━━ help: consider using: `counterAFailLint`
+  │
+  ╰ help: https://getfoundry.sh/forge/linting/mixed-case-variable
 
-    // Header makes clear compilation succeeded; the failure is internal to the lint engine.
-    assert!(
-        stderr.contains("internal lint engine failure"),
-        "missing failure header in stderr:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("compilation itself succeeded"),
-        "header should clarify compilation succeeded:\n{stderr}"
-    );
 
-    // Primary action: report the bug. The link must deep-link into the structured BUG-FORM
-    // template (component, version, repro, etc.) — not the bare `/issues/new` page.
-    assert!(
-        stderr.contains("https://github.com/foundry-rs/foundry/issues/new?template=BUG-FORM.yml"),
-        "missing bug-form template link in stderr:\n{stderr}"
-    );
-    // Output-attach hint helps the maintainer reproduce the failure.
-    assert!(
-        stderr.contains("attach the full output above"),
-        "should tell the user to attach the full output above in stderr:\n{stderr}"
-    );
+note: internal lint engine failure (compilation itself succeeded).
+note: please file a bug report at
+      https://github.com/foundry-rs/foundry/issues/new?template=BUG-FORM.yml
+      and attach the full output above.
+help: rerun with `--no-lint` to skip linting for this build, or consider temporarily
+      disabling forge lint on build:
+      https://getfoundry.sh/forge/linting#disable-linting-on-build
 
-    // Secondary action: per-run bypass with `--no-lint`, plus a docs link for users who want
-    // to temporarily turn lint-on-build off while waiting for the bug fix. The framing must
-    // stay temporary — we never want to hand users a verbatim `lint_on_build = false` snippet
-    // they can paste into their config and forget about.
-    assert!(stderr.contains("--no-lint"), "missing --no-lint hint in stderr:\n{stderr}");
-    assert!(
-        stderr.contains("temporarily"),
-        "the lint-on-build escape hatch must be framed as temporary:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("https://getfoundry.sh/forge/linting#disable-linting-on-build"),
-        "missing docs link for disabling lint on build:\n{stderr}"
-    );
-    assert!(
-        !stderr.contains("lint_on_build = false"),
-        "notice must not hand the user a paste-and-forget config snippet:\n{stderr}"
-    );
+Error: post-build lint step failed
 
-    // We don't ask for a backtrace — the failure is an `eyre` error from a single call site,
-    // so a backtrace adds noise without signal.
-    assert!(
-        !stderr.contains("RUST_BACKTRACE"),
-        "notice must not ask for a backtrace; it adds no signal here:\n{stderr}"
-    );
+Context:
+- aborting due to 1 linter note(s)
 
-    // Underlying error is still wrapped so the cause chain stays intact.
-    assert!(
-        stderr.contains("post-build lint step failed"),
-        "missing wrap_err context in stderr:\n{stderr}"
-    );
+"#]]);
 });
 
 // `--no-lint` must not print the failure notice, since the lint step is skipped entirely.
@@ -1000,17 +969,7 @@ forgetest!(build_no_lint_flag_does_not_emit_lint_failure_notice, |prj, cmd| {
         config.deny = DenyLevel::Notes;
     });
 
-    let output = cmd.args(["build", "--no-lint"]).assert_success();
-    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
-
-    assert!(
-        !stderr.contains("internal lint engine failure"),
-        "failure notice must not appear when lint is skipped:\n{stderr}"
-    );
-    assert!(
-        !stderr.contains("BUG-FORM.yml"),
-        "bug-report CTA must not appear when lint is skipped:\n{stderr}"
-    );
+    cmd.args(["build", "--no-lint"]).assert_success().stderr_eq(str![[r#""#]]);
 });
 
 forgetest!(can_process_inline_config_regardless_of_input_order, |prj, cmd| {

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -914,15 +914,8 @@ Warning (2018): Function state mutability can be restricted to pure
     ]]);
 });
 
-// When the post-build lint step itself fails (e.g. an unhandled lint engine edge case, or a
-// real lint tripping the configured `deny` threshold), `forge build` must surface a notice
-// that leads with a "report this bug" CTA and offers `--no-lint` only as a temporary
-// workaround. We trigger the failure deterministically by combining a source with a lint note
-// (mixed-case variable) and `deny = notes`, which makes the linter return Err — exactly the
-// same exit path an unhandled solar edge case would take.
-//
-// `COUNTER_A` is used because it produces zero solc warnings, so `deny.warnings()`
-// (which propagates to the project compiler) does not block compilation before lint runs.
+// `deny = notes` + an info-level lint forces the linter to return Err, exercising the same
+// failure-notice path an unhandled solar edge case would take.
 forgetest!(build_emits_lint_failure_notice_on_failure, |prj, cmd| {
     prj.add_source("CounterAWithLints", COUNTER_A);
 
@@ -957,15 +950,12 @@ Context:
 "#]]);
 });
 
-// `--no-lint` must not print the failure notice, since the lint step is skipped entirely.
-// Same setup as `build_emits_lint_failure_notice_on_failure` so the only difference is the
-// `--no-lint` flag.
+// Same setup as above, but `--no-lint` skips the lint step so the failure notice never fires.
 forgetest!(build_no_lint_flag_does_not_emit_lint_failure_notice, |prj, cmd| {
     prj.add_source("CounterAWithLints", COUNTER_A);
 
     prj.update_config(|config| {
         config.lint.severity = vec![LintSeverity::Info];
-        // Without `--no-lint` this would trigger the lint Err path and the failure notice.
         config.deny = DenyLevel::Notes;
     });
 

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -837,9 +837,8 @@ Warning (2018): Function state mutability can be restricted to pure
 "#]]);
 });
 
-// Regression test: after switching the lint session to a buffer emitter, lint diagnostics
-// produced during `forge build` must still stream to stderr (they are emitted through a
-// separate emitter installed inside `SolidityLinter::lint`, not the session emitter).
+// Lint diagnostics produced during `forge build` must stream to stderr through the emitter
+// installed inside `SolidityLinter::lint`.
 forgetest!(build_emits_lint_diagnostics, |prj, cmd| {
     prj.add_source("CounterAWithLints", COUNTER_A);
 


### PR DESCRIPTION
`forge build` previously failed lint with an opaque `Error: Lint failed / * solar run failed`.

- Add `--no-lint` (alias `--skip-lint`) for one-shot bypass.
- Capture solar's actual diagnostics into the error via a buffer emitter.
- Print a 3-line notice with bypass instructions and docs link.
- Concise `wrap_err` and clearer `convert_solar_errors` fallback.