### PR TITLE
chore(ci): increase nightly bench result retention days

### DIFF
--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -235,7 +235,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-results
-          retention-days: 7
+          retention-days: 45
           path: |
             benches/stable-*.json
             benches/nightly-*.json


### PR DESCRIPTION
## Motivation

Nightly bench compares everyday `nightly` release against `stable` (baseline).

As we aim to make releases at a monthly pace, let's increase the nightly bench result retention from 7d to 45d to record eventual regressions happening between 2 stable releases.

