### PR TITLE
feat: add Amsterdam hardfork mapping and default to Osaka

### DIFF
--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -231,6 +231,7 @@ pub fn spec_id_from_ethereum_hardfork(hardfork: EthereumHardfork) -> SpecId {
         EthereumHardfork::Bpo3 | EthereumHardfork::Bpo4 | EthereumHardfork::Bpo5 => {
             unimplemented!()
         }
+        EthereumHardfork::Amsterdam => SpecId::AMSTERDAM,
         f => unreachable!("unimplemented {}", f),
     }
 }
@@ -337,6 +338,7 @@ mod tests {
         assert_eq!(spec_id_from_ethereum_hardfork(EthereumHardfork::Cancun), SpecId::CANCUN);
         assert_eq!(spec_id_from_ethereum_hardfork(EthereumHardfork::Prague), SpecId::PRAGUE);
         assert_eq!(spec_id_from_ethereum_hardfork(EthereumHardfork::Osaka), SpecId::OSAKA);
+        assert_eq!(spec_id_from_ethereum_hardfork(EthereumHardfork::Amsterdam), SpecId::AMSTERDAM);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add `EthereumHardfork::Amsterdam => SpecId::AMSTERDAM` mapping in `spec_id_from_ethereum_hardfork`. Without this, Amsterdam (from alloy-hardforks 0.4.7) would hit the `unreachable!()` catch-all arm at runtime.

### Changes
- Map `EthereumHardfork::Amsterdam` to `SpecId::AMSTERDAM` in `spec_id_from_ethereum_hardfork`
- Add test assertion for the Amsterdam mapping

### Notes
- The default `evm_version` is already set to `EvmVersion::Osaka`
- `EvmVersion::Amsterdam` in `FromEvmVersion` will be added once `foundry-compilers` adds the variant