### PR TITLE
fix(forge): report unwritten gas snapshot on test failure

### DIFF
--- a/crates/forge/src/cmd/snapshot.rs
+++ b/crates/forge/src/cmd/snapshot.rs
@@ -106,6 +106,17 @@ impl GasSnapshotArgs {
         }
 
         let outcome = self.test.compile_and_run().await?;
+        if !shell::is_quiet()
+            && !outcome.allow_failure
+            && self.diff.is_none()
+            && self.check.is_none()
+            && outcome.failed() > 0
+        {
+            sh_eprintln!(
+                "Error: gas snapshot file \"{}\" was not written because the test run failed",
+                self.snap.display()
+            )?;
+        }
         outcome.ensure_ok(false)?;
         let tests = self.config.apply(outcome);
 

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1452,6 +1452,29 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 "#]]);
 });
 
+forgetest!(snapshot_reports_when_snap_file_is_not_written, |prj, cmd| {
+    prj.insert_ds_test();
+
+    prj.add_source(
+        "FailingSnapshot.t.sol",
+        r#"
+import "./test.sol";
+contract FailingSnapshotTest is DSTest {
+    function testSnapshotFailure() public {
+        assertTrue(false);
+    }
+}
+   "#,
+    );
+
+    let assert = cmd.args(["snapshot", "--snap", "failed.snap"]).assert_failure();
+    let output = assert.get_output();
+    assert!(output.stderr_lossy().contains(
+        "Error: gas snapshot file \"failed.snap\" was not written because the test run failed"
+    ));
+    assert!(!prj.root().join("failed.snap").exists());
+});
+
 // test that `forge build` does not print `(with warnings)` if file path is ignored
 forgetest!(can_compile_without_warnings_ignored_file_paths, |prj, cmd| {
     // Ignoring path and setting empty error_codes as default would set some error codes


### PR DESCRIPTION
## Motivation

Fixes #11106.

`forge snapshot --snap` exits on failing tests before writing the requested snapshot file, but the command did not explicitly tell users that no snapshot was written. This makes failure output ambiguous when users expected `.gas-snapshot` or a custom `--snap` file to be refreshed.

## Solution

Print a snapshot-specific error before `ensure_ok(false)` exits on failed tests, limited to normal write mode and disabled for `--allow-failure`, `--diff`, and `--check`.

Add a CLI regression test that asserts the error is shown and the requested snapshot file is not created.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes