### PR TITLE
feat(forge): add noop --no-commit flag to forge install and forge clone for backwards compatibility

### DIFF
--- a/crates/forge/src/cmd/clone.rs
+++ b/crates/forge/src/cmd/clone.rs
@@ -120,6 +120,13 @@ pub struct CloneArgs {
     #[command(flatten)]
     pub etherscan: EtherscanOpts,
 
+    /// Do not create a commit after cloning.
+    ///
+    /// This is a noop flag kept for backwards compatibility, as `forge clone` no longer commits
+    /// by default. Use `--commit` to opt into creating a commit.
+    #[arg(long, hide = true)]
+    pub no_commit: bool,
+
     #[command(flatten)]
     pub install: DependencyInstallOpts,
 }
@@ -135,6 +142,7 @@ impl CloneArgs {
             keep_directory_structure,
             source,
             sourcify_url,
+            no_commit: _,
         } = self;
 
         // step 0. get the chain and api key from the config

--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -53,6 +53,13 @@ pub struct InstallArgs {
     #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     pub root: Option<PathBuf>,
 
+    /// Do not create a commit after installing.
+    ///
+    /// This is a noop flag kept for backwards compatibility, as `forge install` no longer commits
+    /// by default. Use `--commit` to opt into creating a commit.
+    #[arg(long, hide = true)]
+    pub no_commit: bool,
+
     #[command(flatten)]
     opts: DependencyInstallOpts,
 }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -741,6 +741,21 @@ Compiler run successful!
     let _config: BasicConfig = parse_with_profile(&s).unwrap().unwrap().1;
 });
 
+// Checks that `--no-commit` is accepted as a noop backwards-compatibility flag for clone
+forgetest!(flaky_can_clone_with_no_commit, |prj, cmd| {
+    prj.wipe();
+
+    cmd.args([
+        "clone",
+        "--etherscan-api-key",
+        next_etherscan_api_key().as_str(),
+        "--no-commit",
+        "0x044b75f554b886A065b9567891e45c79542d7357",
+    ])
+    .arg(prj.root())
+    .assert_success();
+});
+
 // Checks that quiet mode does not print anything for clone
 forgetest!(flaky_can_clone_quiet, |prj, cmd| {
     prj.wipe();

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -702,3 +702,8 @@ forgetest_init!(sync_on_forge_update, |prj, cmd| {
         "Lockfile rev should match resolved origin/master after update"
     );
 });
+
+// Checks that `--no-commit` is accepted as a noop backwards-compatibility flag
+forgetest_init!(can_install_with_no_commit, |_prj, cmd| {
+    cmd.args(["install", "--no-commit"]).assert_success();
+});


### PR DESCRIPTION
## Summary

Follow-up to #14649.

`forge install` and `forge clone` no longer commit by default (commit is opt-in via `--commit`). Many AI tools and scripts still pass `--no-commit`, causing an unrecognized flag error.

This adds a hidden, noop `--no-commit` flag to both commands so those invocations continue to work without error.

## Changes

* Added a hidden `--no-commit` flag to `InstallArgs` in `crates/forge/src/cmd/install.rs`
* Added a hidden `--no-commit` flag to `CloneArgs` in `crates/forge/src/cmd/clone.rs` (destructured as `no_commit: _`)
* Added a test in `crates/forge/tests/cli/install.rs` verifying `forge install --no-commit` succeeds
* No behavior change — just prevents CLI errors for callers still passing `--no-commit`