### PR TITLE
feat(lint): add `optimism-deprecation`

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -22,6 +22,7 @@ It helps enforce best practices and improve code quality within Foundry projects
 - **Low Severity:**
   - `block-timestamp`: Warns when `block.timestamp` is used in a comparison, as it may be manipulated by validators.
   - `missing-zero-check`: Address parameter is used in a state write or value transfer without a zero-address check.
+  - `optimism-deprecation`: Flags usage of Optimism predeploy addresses removed in the Bedrock upgrade and GasPriceOracle functions that revert unconditionally post-Ecotone.
 - **Informational / Style Guide:**
   - `boolean-equal`: Boolean comparisons to constants should be simplified.
   - `too-many-digits`: Numeric literals with 5+ consecutive zeros are error-prone.

--- a/crates/lint/docs/optimism-deprecation.md
+++ b/crates/lint/docs/optimism-deprecation.md
@@ -1,0 +1,80 @@
+# Optimism Deprecation
+
+**Severity**: `Low`
+**ID**: `optimism-deprecation`
+
+Flags usage of Optimism predeploy addresses that were removed in the Bedrock upgrade, and
+calls to GasPriceOracle functions that revert unconditionally since the Ecotone upgrade.
+
+## What it does
+
+Detects two categories of deprecated Optimism L2 patterns:
+
+1. **Removed predeploy address literals**: any hex literal matching one of the four predeploys
+   that no longer exist on Bedrock-and-later chains:
+   - `0x4200000000000000000000000000000000000000`: LegacyMessagePasser
+   - `0x4200000000000000000000000000000000000001`: L1MessageSender
+   - `0x4200000000000000000000000000000000000002`: DeployerWhitelist
+   - `0x4200000000000000000000000000000000000013`: L1BlockNumber
+
+2. **Deprecated GasPriceOracle functions**: calls to `.overhead()`, `.scalar()`, or
+   `.getL1GasUsed()` on the GasPriceOracle predeploy
+   (`0x420000000000000000000000000000000000000F`). These functions existed pre-Ecotone but
+   revert unconditionally on current OP Stack deployments.
+
+## Why is this bad?
+
+Calling removed predeploys will revert every time as there is no code at those addresses.
+Calling the deprecated GasPriceOracle functions will also revert, silently breaking any
+gas-estimation or fee-calculation logic that depends on them. Both issues are silent failures 
+that only surface at runtime on an OP Stack chain.
+
+## Example
+
+### Bad
+
+```solidity
+interface IGasPriceOracle {
+    function overhead() external view returns (uint256);
+    function scalar() external view returns (uint256);
+    function getL1GasUsed(bytes memory data) external view returns (uint256);
+}
+
+function legacyFee(bytes memory data) external view returns (uint256) {
+    // overhead() and scalar() revert post-Ecotone
+    uint256 o = IGasPriceOracle(0x420000000000000000000000000000000000000F).overhead();
+    uint256 s = IGasPriceOracle(0x420000000000000000000000000000000000000F).scalar();
+    return o + s;
+}
+
+function passMessage() external {
+    // LegacyMessagePasser no longer exists
+    address(0x4200000000000000000000000000000000000000).call("");
+}
+```
+
+### Good
+
+```solidity
+interface IGasPriceOracle {
+    function getL1Fee(bytes memory data) external view returns (uint256);
+    function baseFeeScalar() external view returns (uint32);
+    function blobBaseFeeScalar() external view returns (uint32);
+}
+
+function ecotoneL1Fee(bytes memory data) external view returns (uint256) {
+    // Use the current GasPriceOracle API available post-Ecotone
+    return IGasPriceOracle(0x420000000000000000000000000000000000000F).getL1Fee(data);
+}
+```
+
+## Notes
+
+This lint is only relevant to contracts deployed on OP Stack chains (Optimism, Base, etc.).
+On Ethereum mainnet these addresses are either absent or unrelated contracts, so violations
+are harmless there but still indicate dead code worth removing.
+
+Deprecated GasPriceOracle function calls are detected even when the predeploy address is
+accessed through a local variable alias (e.g. `IGasPriceOracle gpo = IGasPriceOracle(0x...000F); gpo.overhead()`).
+Local variable aliases initialised directly from a literal are tracked; state variables and
+reassigned locals are not.

--- a/crates/lint/src/sol/low/mod.rs
+++ b/crates/lint/src/sol/low/mod.rs
@@ -6,7 +6,11 @@ use block_timestamp::BLOCK_TIMESTAMP;
 mod missing_zero_check;
 use missing_zero_check::MISSING_ZERO_CHECK;
 
+mod optimism_deprecation;
+use optimism_deprecation::OPTIMISM_DEPRECATION;
+
 register_lints!(
     (BlockTimestamp, early, (BLOCK_TIMESTAMP)),
     (MissingZeroCheck, late, (MISSING_ZERO_CHECK)),
+    (OptimismDeprecation, late, (OPTIMISM_DEPRECATION)),
 );

--- a/crates/lint/src/sol/low/optimism_deprecation.rs
+++ b/crates/lint/src/sol/low/optimism_deprecation.rs
@@ -1,0 +1,121 @@
+use super::OptimismDeprecation;
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::{
+    ast::LitKind,
+    sema::hir::{self, ExprKind, ItemId, Res},
+};
+
+declare_forge_lint!(
+    OPTIMISM_DEPRECATION,
+    Severity::Low,
+    "optimism-deprecation",
+    "usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone"
+);
+
+/// Addresses of predeploys that were fully removed in the Bedrock upgrade.
+const DEPRECATED_PREDEPLOYS: &[&str] = &[
+    "0x4200000000000000000000000000000000000000", // LegacyMessagePasser
+    "0x4200000000000000000000000000000000000001", // L1MessageSender
+    "0x4200000000000000000000000000000000000002", // DeployerWhitelist
+    "0x4200000000000000000000000000000000000013", // L1BlockNumber
+];
+
+/// GasPriceOracle predeploy (`0x420000000000000000000000000000000000000F`), still deployed but
+/// `overhead`, `scalar`, and `getL1GasUsed` revert unconditionally since the Ecotone upgrade.
+const GPO_ADDRESS: &str = "0x420000000000000000000000000000000000000f";
+
+const DEPRECATED_GPO_FUNCTIONS: &[&str] = &["overhead", "scalar", "getL1GasUsed"];
+
+impl<'hir> LateLintPass<'hir> for OptimismDeprecation {
+    fn check_expr(
+        &mut self,
+        ctx: &LintContext,
+        hir: &'hir hir::Hir<'hir>,
+        expr: &'hir hir::Expr<'hir>,
+    ) {
+        match &expr.kind {
+            // Deprecated predeploy address literal.
+            ExprKind::Lit(lit)
+                if matches!(lit.kind, LitKind::Address(_))
+                    && is_deprecated_predeploy(lit.symbol.as_str()) =>
+            {
+                ctx.emit(&OPTIMISM_DEPRECATION, lit.span);
+            }
+
+            // Deprecated GasPriceOracle function call.
+            ExprKind::Call(callee, _, _) => {
+                let ExprKind::Member(receiver, member) = &callee.kind else { return };
+                if DEPRECATED_GPO_FUNCTIONS.contains(&member.as_str())
+                    && receiver_resolves_to_gpo(hir, receiver)
+                {
+                    ctx.emit(&OPTIMISM_DEPRECATION, expr.span);
+                }
+            }
+
+            _ => {}
+        }
+    }
+}
+
+fn is_deprecated_predeploy(sym: &str) -> bool {
+    let lower = sym.to_lowercase();
+    DEPRECATED_PREDEPLOYS.iter().any(|&addr| addr == lower)
+}
+
+/// Returns true if `expr` evaluates to the GasPriceOracle predeploy address.
+///
+/// Handles direct literals, contract type casts (`IGasPriceOracle(0x...000F)`), and
+/// single-assignment local variable aliases. Does not track reassignment or state variables.
+fn receiver_resolves_to_gpo(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    match &expr.kind {
+        // Direct address literal.
+        ExprKind::Lit(lit) => {
+            matches!(lit.kind, LitKind::Address(_))
+                && lit.symbol.as_str().to_lowercase() == GPO_ADDRESS
+        }
+
+        // `IGasPriceOracle(0x...000F)`: callee resolves to a Contract type cast.
+        // This is unambiguously a cast (not a function call) because the callee is a Contract.
+        ExprKind::Call(callee, args, _) => {
+            if !matches!(
+                callee.kind,
+                ExprKind::Ident([Res::Item(ItemId::Contract(_)), ..]) | ExprKind::Type(_)
+            ) {
+                return false;
+            }
+            let mut iter = args.exprs();
+            match (iter.next(), iter.next()) {
+                (Some(arg), None) => receiver_resolves_to_gpo(hir, arg),
+                _ => false,
+            }
+        }
+
+        // Variable reference: follow single-assignment locals back to their initializer.
+        ExprKind::Ident(reses) => {
+            for res in *reses {
+                if let Res::Item(ItemId::Variable(vid)) = res {
+                    let var = hir.variable(*vid);
+                    if var.kind.is_state() {
+                        continue;
+                    }
+                    if let Some(init) = var.initializer
+                        && receiver_resolves_to_gpo(hir, init)
+                    {
+                        return true;
+                    }
+                }
+            }
+            false
+        }
+
+        // Tuple elements (uncommon, but handle gracefully).
+        ExprKind::Tuple(elems) => {
+            elems.iter().any(|e| e.is_some_and(|inner| receiver_resolves_to_gpo(hir, inner)))
+        }
+
+        _ => false,
+    }
+}

--- a/crates/lint/testdata/OptimismDeprecation.sol
+++ b/crates/lint/testdata/OptimismDeprecation.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface IGasPriceOracle {
+    function overhead() external view returns (uint256);
+    function scalar() external view returns (uint256);
+    function getL1GasUsed(bytes memory data) external view returns (uint256);
+    function baseFee() external view returns (uint256);
+}
+
+contract OptimismDeprecation {
+    // SHOULD FAIL, deprecated predeploy address literals
+
+    function useLegacyMessagePasser() public {
+        address target = 0x4200000000000000000000000000000000000000; //~WARN: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+        (bool ok,) = target.call("");
+        require(ok);
+    }
+
+    function useL1MessageSender() public view returns (address) {
+        return address(0x4200000000000000000000000000000000000001); //~WARN: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+    }
+
+    function useDeployerWhitelist() public {
+        IGasPriceOracle(0x4200000000000000000000000000000000000002).baseFee(); //~WARN: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+    }
+
+    function useL1BlockNumber() public view returns (uint256) {
+        return IGasPriceOracle(0x4200000000000000000000000000000000000013).baseFee(); //~WARN: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+    }
+
+    // SHOULD FAIL, deprecated GasPriceOracle functions (revert post-Ecotone)
+
+    function getOverhead() public view returns (uint256) {
+        return IGasPriceOracle(0x420000000000000000000000000000000000000F).overhead(); //~WARN: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+    }
+
+    function getScalar() public view returns (uint256) {
+        return IGasPriceOracle(0x420000000000000000000000000000000000000F).scalar(); //~WARN: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+    }
+
+    function getL1GasUsed(bytes memory data) public view returns (uint256) {
+        return IGasPriceOracle(0x420000000000000000000000000000000000000F).getL1GasUsed(data); //~WARN: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+    }
+
+    // SHOULD PASS, GPO address used, but only calling a non-deprecated function
+
+    function getBaseFee() public view returns (uint256) {
+        return IGasPriceOracle(0x420000000000000000000000000000000000000F).baseFee();
+    }
+
+    // SHOULD FAIL, GPO accessed via aliased local variable
+
+    function gpoViaAlias() public view returns (uint256) {
+        IGasPriceOracle gpo = IGasPriceOracle(0x420000000000000000000000000000000000000F);
+        return gpo.overhead(); //~WARN: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+    }
+
+    // SHOULD PASS, GPO accessed via state variable constant as state vars are not tracked
+
+    IGasPriceOracle constant GPO = IGasPriceOracle(0x420000000000000000000000000000000000000F);
+
+    function gpoViaStateConst() public view returns (uint256) {
+        return GPO.overhead();
+    }
+
+    // SHOULD PASS, unrelated hex literals
+
+    function unrelatedHex() public pure returns (uint256) {
+        uint256 mask = 0xffffffff;
+        return mask;
+    }
+
+    function unrelatedAddress() public pure returns (address) {
+        return address(0x1234567890123456789012345678901234567890);
+    }
+}

--- a/crates/lint/testdata/OptimismDeprecation.stderr
+++ b/crates/lint/testdata/OptimismDeprecation.stderr
@@ -1,0 +1,64 @@
+warning[optimism-deprecation]: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+   ╭▸ ROOT/testdata/OptimismDeprecation.sol:LL:CC
+   │
+LL │ …     address target = 0x4200000000000000000000000000000000000000;
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/optimism-deprecation
+
+warning[optimism-deprecation]: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+   ╭▸ ROOT/testdata/OptimismDeprecation.sol:LL:CC
+   │
+LL │ …     return address(0x4200000000000000000000000000000000000001);
+   │                      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/optimism-deprecation
+
+warning[optimism-deprecation]: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+   ╭▸ ROOT/testdata/OptimismDeprecation.sol:LL:CC
+   │
+LL │ …     IGasPriceOracle(0x4200000000000000000000000000000000000002).baseFee();
+   │                       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/optimism-deprecation
+
+warning[optimism-deprecation]: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+   ╭▸ ROOT/testdata/OptimismDeprecation.sol:LL:CC
+   │
+LL │ …     return IGasPriceOracle(0x4200000000000000000000000000000000000013).baseFee();
+   │                              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/optimism-deprecation
+
+warning[optimism-deprecation]: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+   ╭▸ ROOT/testdata/OptimismDeprecation.sol:LL:CC
+   │
+LL │ …     return IGasPriceOracle(0x420000000000000000000000000000000000000F).overhead();
+   │              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/optimism-deprecation
+
+warning[optimism-deprecation]: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+   ╭▸ ROOT/testdata/OptimismDeprecation.sol:LL:CC
+   │
+LL │ …     return IGasPriceOracle(0x420000000000000000000000000000000000000F).scalar();
+   │              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/optimism-deprecation
+
+warning[optimism-deprecation]: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+   ╭▸ ROOT/testdata/OptimismDeprecation.sol:LL:CC
+   │
+LL │ …     return IGasPriceOracle(0x420000000000000000000000000000000000000F).getL1GasUsed(data);
+   │              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/optimism-deprecation
+
+warning[optimism-deprecation]: usage of a deprecated Optimism predeploy address or GasPriceOracle function that reverts post-Ecotone
+   ╭▸ ROOT/testdata/OptimismDeprecation.sol:LL:CC
+   │
+LL │ …     return gpo.overhead();
+   │              ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/optimism-deprecation
+


### PR DESCRIPTION
## Motivation

Add `optimism-deprecation` that flags usage of Optimism predeploy addresses removed in the Bedrock upgrade and GasPriceOracle functions that revert unconditionally post-Ecotone.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
