### PR TITLE
fix(cast): infer Tempo network from config/chain for send, estimate, mktx, access-list, erc20

### DIFF
--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
     opts::{RpcOpts, TransactionOpts},
-    utils::LoadConfig,
+    utils::{LoadConfig, get_chain, get_provider},
 };
 use foundry_common::{FoundryTransactionBuilder, provider::ProviderBuilder};
 use foundry_wallets::WalletOpts;
@@ -60,10 +60,15 @@ pub struct AccessListArgs {
 impl AccessListArgs {
     pub async fn run(self) -> Result<()> {
         if self.tx.tempo.is_tempo() {
-            self.run_with_network::<TempoNetwork>().await
-        } else {
-            self.run_with_network::<Ethereum>().await
+            return self.run_with_network::<TempoNetwork>().await;
         }
+
+        let config = self.rpc.load_config()?;
+        if get_chain(config.chain, &get_provider(&config)?).await?.is_tempo() {
+            return self.run_with_network::<TempoNetwork>().await;
+        }
+
+        self.run_with_network::<Ethereum>().await
     }
 
     pub async fn run_with_network<N: Network + Unpin>(self) -> Result<()>

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -283,16 +283,6 @@ impl Erc20Subcommand {
         }
     }
 
-    const fn uses_browser_send(&self) -> bool {
-        match self {
-            Self::Transfer { send_tx, .. }
-            | Self::Approve { send_tx, .. }
-            | Self::Mint { send_tx, .. }
-            | Self::Burn { send_tx, .. } => send_tx.browser.browser,
-            _ => false,
-        }
-    }
-
     async fn should_use_tempo_network(
         &self,
         tempo_access_key: &Option<TempoAccessKeyConfig>,
@@ -303,12 +293,8 @@ impl Erc20Subcommand {
             return Ok(true);
         }
 
-        if self.uses_browser_send() {
-            let config = self.rpc_opts().load_config()?;
-            return Ok(get_chain(config.chain, &get_provider(&config)?).await?.is_tempo());
-        }
-
-        Ok(false)
+        let config = self.rpc_opts().load_config()?;
+        Ok(get_chain(config.chain, &get_provider(&config)?).await?.is_tempo())
     }
 
     pub async fn run(self) -> eyre::Result<()> {

--- a/crates/cast/src/cmd/estimate.rs
+++ b/crates/cast/src/cmd/estimate.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
     opts::{RpcOpts, TransactionOpts},
-    utils::{LoadConfig, parse_ether_value},
+    utils::{LoadConfig, get_chain, get_provider, parse_ether_value},
 };
 use foundry_common::{FoundryTransactionBuilder, provider::ProviderBuilder};
 use foundry_wallets::WalletOpts;
@@ -82,10 +82,15 @@ pub enum EstimateSubcommands {
 impl EstimateArgs {
     pub async fn run(self) -> Result<()> {
         if self.tx.tempo.is_tempo() {
-            self.run_with_network::<TempoNetwork>().await
-        } else {
-            self.run_with_network::<Ethereum>().await
+            return self.run_with_network::<TempoNetwork>().await;
         }
+
+        let config = self.rpc.load_config()?;
+        if get_chain(config.chain, &get_provider(&config)?).await?.is_tempo() {
+            return self.run_with_network::<TempoNetwork>().await;
+        }
+
+        self.run_with_network::<Ethereum>().await
     }
 
     pub async fn run_with_network<N: Network>(self) -> Result<()>

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
     opts::{EthereumOpts, TransactionOpts},
-    utils::{LoadConfig, maybe_print_resolved_lane, resolve_lane},
+    utils::{LoadConfig, get_chain, get_provider, maybe_print_resolved_lane, resolve_lane},
 };
 use foundry_common::{FoundryTransactionBuilder, provider::ProviderBuilder};
 use std::{path::PathBuf, str::FromStr};
@@ -84,10 +84,15 @@ pub enum MakeTxSubcommands {
 impl MakeTxArgs {
     pub async fn run(self) -> Result<()> {
         if self.tx.tempo.is_tempo() {
-            self.run_generic::<TempoNetwork>().await
-        } else {
-            self.run_generic::<Ethereum>().await
+            return self.run_generic::<TempoNetwork>().await;
         }
+
+        let config = self.eth.rpc.load_config()?;
+        if get_chain(config.chain, &get_provider(&config)?).await?.is_tempo() {
+            return self.run_generic::<TempoNetwork>().await;
+        }
+
+        self.run_generic::<Ethereum>().await
     }
 
     pub async fn run_generic<N: Network>(self) -> Result<()>

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use eyre::{Result, eyre};
 use foundry_cli::{
     opts::TransactionOpts,
-    utils::{LoadConfig, maybe_print_resolved_lane, resolve_lane},
+    utils::{LoadConfig, get_chain, get_provider, maybe_print_resolved_lane, resolve_lane},
 };
 use foundry_common::{
     FoundryTransactionBuilder,
@@ -101,10 +101,15 @@ impl SendTxArgs {
         let (signer, tempo_access_key) = self.send_tx.eth.wallet.maybe_signer().await?;
 
         if tempo_access_key.is_some() || self.tx.tempo.is_tempo() {
-            self.run_generic::<TempoNetwork>(signer, tempo_access_key).await
-        } else {
-            self.run_generic::<Ethereum>(signer, None).await
+            return self.run_generic::<TempoNetwork>(signer, tempo_access_key).await;
         }
+
+        let config = self.send_tx.eth.rpc.load_config()?;
+        if get_chain(config.chain, &get_provider(&config)?).await?.is_tempo() {
+            return self.run_generic::<TempoNetwork>(signer, tempo_access_key).await;
+        }
+
+        self.run_generic::<Ethereum>(signer, None).await
     }
 
     pub async fn run_generic<N: Network>(


### PR DESCRIPTION
## Motivation

Follow-up to #14673 — that PR fixed `cast call --trace` not inferring `TempoEvmNetwork` from resolved evm opts. The same class of bug exists in several other cast commands that only check `self.tx.tempo.is_tempo()` (explicit Tempo CLI flags like `--fee-token`) to select `TempoNetwork`, ignoring `foundry.toml` config and RPC URL-based chain detection.

**Affected commands:**
- `cast send` — checked access-key + tx opts, but not config/chain
- `cast estimate` — only checked tx opts
- `cast access-list` — only checked tx opts
- `cast mktx` — only checked tx opts
- `cast erc20` — only checked tx opts + access-key (chain inference was gated behind browser-send only)

## Solution

Each command now resolves the chain from config (`foundry.toml`) or by querying the provider's chain ID, and checks `chain.is_tempo()` before falling back to `Ethereum`. This matches the pattern in `cast call` and `cast run`.

For `cast erc20`, the browser-only gate on chain inference is removed so all paths benefit from config-based detection.

## PR Checklist
- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes