### PR TITLE
fix: map Optimism Osaka to Karst

### DIFF
--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -248,8 +248,9 @@ pub fn spec_id_from_optimism_hardfork(hardfork: OpHardfork) -> OpSpecId {
         OpHardfork::Granite => OpSpecId::GRANITE,
         OpHardfork::Holocene => OpSpecId::HOLOCENE,
         OpHardfork::Isthmus => OpSpecId::ISTHMUS,
-        OpHardfork::Interop => OpSpecId::INTEROP,
         OpHardfork::Jovian => OpSpecId::JOVIAN,
+        OpHardfork::Karst => OpSpecId::KARST,
+        OpHardfork::Interop => OpSpecId::INTEROP,
         f => unreachable!("unimplemented {}", f),
     }
 }
@@ -297,7 +298,7 @@ impl FromEvmVersion for OpSpecId {
             EvmVersion::Shanghai => Self::CANYON,
             EvmVersion::Cancun => Self::ECOTONE,
             EvmVersion::Prague => Self::ISTHMUS,
-            EvmVersion::Osaka => Self::JOVIAN,
+            EvmVersion::Osaka => Self::KARST,
         }
     }
 }
@@ -393,7 +394,9 @@ mod tests {
 
             // Test latest hardforks
             assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Holocene), OpSpecId::HOLOCENE);
+            assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Karst), OpSpecId::KARST);
             assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Interop), OpSpecId::INTEROP);
+            assert_eq!(evm_spec_id::<OpSpecId>(EvmVersion::Osaka), OpSpecId::KARST);
         }
 
         #[test]


### PR DESCRIPTION
## Motivation

The locked Optimism dependencies include the `Karst` hardfork and map the Ethereum `Osaka` fork to `Karst`. Foundry still mapped `EvmVersion::Osaka` to `OpSpecId::JOVIAN`, and an explicit Optimism `Karst` hardfork would fall through the catch-all mapping arm.

## Solution

Map `OpHardfork::Karst` to `OpSpecId::KARST` and derive `OpSpecId::KARST` from `EvmVersion::Osaka`. Add assertions for both mappings in the hardfork tests.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes