### PR TITLE
feat(lint): add `type-based-tautology`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4703,6 +4703,7 @@ dependencies = [
 name = "forge-lint"
 version = "1.7.2"
 dependencies = [
+ "alloy-primitives",
  "eyre",
  "foundry-common",
  "foundry-compilers",

--- a/crates/lint/Cargo.toml
+++ b/crates/lint/Cargo.toml
@@ -18,6 +18,7 @@ foundry-common.workspace = true
 foundry-compilers.workspace = true
 foundry-config.workspace = true
 
+alloy-primitives.workspace = true
 solar.workspace = true
 
 eyre.workspace = true

--- a/crates/lint/docs/type-based-tautology.md
+++ b/crates/lint/docs/type-based-tautology.md
@@ -16,6 +16,8 @@ Examples:
 
 The check also applies to explicit type casts: `uint8(x) < 256` is always true.
 
+> **Limitation:** The lint only fires when the left-hand variable is a local or state variable identifier, or an explicit cast expression (e.g. `uint8(x)`). It does not fire on struct member access (`s.field < 0`) or function return values (`foo() < 0`).
+
 ## Why is this bad?
 
 A condition that is permanently true contributes no useful logic and may hide a bug where the developer intended to compare against a different value or use a differently sized type. A condition that is permanently false creates unreachable code, which can silently suppress intended behavior such as access control checks or error handling.

--- a/crates/lint/docs/type-based-tautology.md
+++ b/crates/lint/docs/type-based-tautology.md
@@ -7,12 +7,14 @@ Detects comparison expressions that are always true or always false due to the n
 
 ## What it does
 
-Flags binary comparisons (`<`, `<=`, `>`, `>=`) where one operand is a typed integer variable and the other is a constant that lies outside, or exactly at the boundary of the variable's representable range, making the condition unconditionally true or false.
+Flags binary comparisons (`<`, `<=`, `>`, `>=`, `==`, `!=`) where one operand is a typed integer variable and the other is a constant that lies outside, or exactly at the boundary of the variable's representable range, making the condition unconditionally true or false.
 
 Examples:
 - `uint x >= 0` is always true because unsigned integers cannot be negative.
 - `uint8 x > 255` is always false because 255 is the maximum value of `uint8`.
 - `int8 x < -128` is always false because -128 is the minimum value of `int8`.
+- `uint8 x == 256` is always false because 256 is outside the range of `uint8`.
+- `uint8 x != 256` is always true because 256 is outside the range of `uint8`.
 
 The check also applies to explicit type casts: `uint8(x) < 256` is always true.
 
@@ -37,6 +39,10 @@ function isInRange(uint8 x) public pure returns (bool) {
 
 function isBelowMin(int8 x) public pure returns (bool) {
     return x < -128; // always false, int8 min is -128
+}
+
+function isImpossible(uint8 x) public pure returns (bool) {
+    return x == 256; // always false, 256 is outside uint8 range
 }
 ```
 

--- a/crates/lint/docs/type-based-tautology.md
+++ b/crates/lint/docs/type-based-tautology.md
@@ -1,0 +1,55 @@
+# Type-Based Tautology
+
+**Severity**: `Med`
+**ID**: `type-based-tautology`
+
+Detects comparison expressions that are always true or always false due to the numeric range of the variable's type. These dead conditions indicate logic errors or misunderstandings about integer bounds.
+
+## What it does
+
+Flags binary comparisons (`<`, `<=`, `>`, `>=`) where one operand is a typed integer variable and the other is a constant that lies outside, or exactly at the boundary of the variable's representable range, making the condition unconditionally true or false.
+
+Examples:
+- `uint x >= 0` is always true because unsigned integers cannot be negative.
+- `uint8 x > 255` is always false because 255 is the maximum value of `uint8`.
+- `int8 x < -128` is always false because -128 is the minimum value of `int8`.
+
+The check also applies to explicit type casts: `uint8(x) < 256` is always true.
+
+## Why is this bad?
+
+A condition that is permanently true contributes no useful logic and may hide a bug where the developer intended to compare against a different value or use a differently sized type. A condition that is permanently false creates unreachable code, which can silently suppress intended behavior such as access control checks or error handling.
+
+## Example
+
+### Bad
+
+```solidity
+function isValid(uint256 x) public pure returns (bool) {
+    return x >= 0; // always true, uint cannot be negative
+}
+
+function isInRange(uint8 x) public pure returns (bool) {
+    return x < 256; // always true, uint8 max is 255
+}
+
+function isBelowMin(int8 x) public pure returns (bool) {
+    return x < -128; // always false, int8 min is -128
+}
+```
+
+### Good
+
+```solidity
+function isValid(uint256 x) public pure returns (bool) {
+    return x > 0; // meaningful: false when x == 0
+}
+
+function isInRange(uint8 x, uint8 limit) public pure returns (bool) {
+    return x < limit; // compare against a runtime value
+}
+
+function isBelowThreshold(int8 x) public pure returns (bool) {
+    return x < -100; // a value within the representable range
+}
+```

--- a/crates/lint/src/sol/med/mod.rs
+++ b/crates/lint/src/sol/med/mod.rs
@@ -9,6 +9,9 @@ use incorrect_erc20_interface::INCORRECT_ERC20_INTERFACE;
 mod incorrect_erc721_interface;
 use incorrect_erc721_interface::INCORRECT_ERC721_INTERFACE;
 
+mod tautology;
+use tautology::TYPE_BASED_TAUTOLOGY;
+
 mod tx_origin;
 use tx_origin::TX_ORIGIN;
 
@@ -19,6 +22,7 @@ register_lints!(
     (DivideBeforeMultiply, early, (DIVIDE_BEFORE_MULTIPLY)),
     (IncorrectERC20Interface, late, (INCORRECT_ERC20_INTERFACE)),
     (IncorrectERC721Interface, late, (INCORRECT_ERC721_INTERFACE)),
+    (TypeBasedTautology, late, (TYPE_BASED_TAUTOLOGY)),
     (TxOrigin, early, (TX_ORIGIN)),
     (UnsafeTypecast, late, (UNSAFE_TYPECAST))
 );

--- a/crates/lint/src/sol/med/tautology.rs
+++ b/crates/lint/src/sol/med/tautology.rs
@@ -57,7 +57,7 @@ const fn flip(op: BinOpKind) -> BinOpKind {
         BinOpKind::Le => BinOpKind::Ge,
         BinOpKind::Gt => BinOpKind::Lt,
         BinOpKind::Ge => BinOpKind::Le,
-        other => other,
+        _ => unreachable!(),
     }
 }
 

--- a/crates/lint/src/sol/med/tautology.rs
+++ b/crates/lint/src/sol/med/tautology.rs
@@ -1,0 +1,152 @@
+use super::TypeBasedTautology;
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use alloy_primitives::U256;
+use solar::{
+    ast::{BinOpKind, LitKind, UnOpKind},
+    sema::hir::{self, ElementaryType, ExprKind, ItemId, Res, TypeKind},
+};
+
+declare_forge_lint!(
+    TYPE_BASED_TAUTOLOGY,
+    Severity::Med,
+    "type-based-tautology",
+    "condition is always true or false based on the variable's type"
+);
+
+impl<'hir> LateLintPass<'hir> for TypeBasedTautology {
+    fn check_expr(
+        &mut self,
+        ctx: &LintContext,
+        hir: &'hir hir::Hir<'hir>,
+        expr: &'hir hir::Expr<'hir>,
+    ) {
+        let ExprKind::Binary(left, op, right) = &expr.kind else { return };
+
+        // Only relational comparisons can produce tautologies via type bounds.
+        if !matches!(op.kind, BinOpKind::Lt | BinOpKind::Le | BinOpKind::Gt | BinOpKind::Ge) {
+            return;
+        }
+
+        // var op const
+        if let Some(elem_ty) = elem_type_of(hir, left)
+            && let Some((val_neg, val_mag)) = lit_value_of(right)
+            && is_tautology(elem_ty, val_neg, val_mag, op.kind)
+        {
+            ctx.emit(&TYPE_BASED_TAUTOLOGY, expr.span);
+            return;
+        }
+
+        // const op var: swap operands and flip the operator
+        if let Some((val_neg, val_mag)) = lit_value_of(left)
+            && let Some(elem_ty) = elem_type_of(hir, right)
+            && is_tautology(elem_ty, val_neg, val_mag, flip(op.kind))
+        {
+            ctx.emit(&TYPE_BASED_TAUTOLOGY, expr.span);
+        }
+    }
+}
+
+/// Returns the equivalent operator after swapping left and right operands.
+/// e.g. `const < var` rewritten as `var > const` needs `Gt`.
+const fn flip(op: BinOpKind) -> BinOpKind {
+    match op {
+        BinOpKind::Lt => BinOpKind::Gt,
+        BinOpKind::Le => BinOpKind::Ge,
+        BinOpKind::Gt => BinOpKind::Lt,
+        BinOpKind::Ge => BinOpKind::Le,
+        other => other,
+    }
+}
+
+/// Returns true if `var <op> val` is always true or always false for every value in the
+/// type's range.
+///
+/// The constant is represented as a sign bit (`val_neg`) and a magnitude (`val_mag`), matching
+/// how solar stores negated literals (e.g. `-128` -> `Unary(Neg, Lit(128))`).
+fn is_tautology(ty: ElementaryType, val_neg: bool, val_mag: U256, op: BinOpKind) -> bool {
+    match ty {
+        ElementaryType::UInt(size) => {
+            // lo = 0, hi = 2^bits - 1
+            let bits = size.bits();
+            let hi =
+                if bits == 256 { U256::MAX } else { (U256::from(1u8) << bits) - U256::from(1u8) };
+            let val_lt_lo = val_neg && val_mag != U256::ZERO; // val < 0
+            let val_le_lo = val_neg || val_mag == U256::ZERO; // val <= 0
+            let hi_lt_val = !val_neg && val_mag > hi; // val > hi
+            let hi_le_val = !val_neg && val_mag >= hi; // val >= hi
+            match op {
+                BinOpKind::Gt | BinOpKind::Le => hi_le_val || val_lt_lo,
+                BinOpKind::Ge | BinOpKind::Lt => val_le_lo || hi_lt_val,
+                _ => false,
+            }
+        }
+        ElementaryType::Int(size) => {
+            // lo = -(2^(bits-1)), hi = 2^(bits-1) - 1
+            let bits = size.bits();
+            let half = U256::from(1u8) << (bits - 1); // 2^(bits-1)
+            let hi = half - U256::from(1u8); // 2^(bits-1) - 1
+            let val_lt_lo = val_neg && val_mag > half; // val < -half
+            let val_le_lo = val_neg && val_mag >= half; // val <= -half
+            let hi_lt_val = !val_neg && val_mag > hi; // val > hi
+            let hi_le_val = !val_neg && val_mag >= hi; // val >= hi
+            match op {
+                BinOpKind::Gt | BinOpKind::Le => hi_le_val || val_lt_lo,
+                BinOpKind::Ge | BinOpKind::Lt => val_le_lo || hi_lt_val,
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Extracts the elementary integer type from a variable reference or explicit cast.
+fn elem_type_of<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    expr: &'hir hir::Expr<'hir>,
+) -> Option<ElementaryType> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(resolutions) => {
+            if let Some(Res::Item(ItemId::Variable(var_id))) = resolutions.first()
+                && let TypeKind::Elementary(ty) = hir.variable(*var_id).ty.kind
+            {
+                return Some(ty);
+            }
+            None
+        }
+        // Explicit cast: `uint8(x)`, the cast type determines the effective range.
+        ExprKind::Call(call_expr, _, _) => {
+            if let ExprKind::Type(hir::Type { kind: TypeKind::Elementary(ty), .. }) =
+                &call_expr.kind
+            {
+                return Some(*ty);
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Extracts a signed constant from a numeric literal or negated numeric literal,
+/// returning `(is_negative, magnitude)`.
+fn lit_value_of(expr: &hir::Expr<'_>) -> Option<(bool, U256)> {
+    match &expr.peel_parens().kind {
+        ExprKind::Lit(lit) => {
+            if let LitKind::Number(n) = lit.kind {
+                return Some((false, n));
+            }
+            None
+        }
+        ExprKind::Unary(op, inner) if op.kind == UnOpKind::Neg => {
+            if let ExprKind::Lit(lit) = &inner.peel_parens().kind
+                && let LitKind::Number(n) = lit.kind
+            {
+                return Some((true, n));
+            }
+            None
+        }
+        _ => None,
+    }
+}

--- a/crates/lint/src/sol/med/tautology.rs
+++ b/crates/lint/src/sol/med/tautology.rs
@@ -25,8 +25,16 @@ impl<'hir> LateLintPass<'hir> for TypeBasedTautology {
     ) {
         let ExprKind::Binary(left, op, right) = &expr.kind else { return };
 
-        // Only relational comparisons can produce tautologies via type bounds.
-        if !matches!(op.kind, BinOpKind::Lt | BinOpKind::Le | BinOpKind::Gt | BinOpKind::Ge) {
+        // Only relational/equality comparisons can produce tautologies via type bounds.
+        if !matches!(
+            op.kind,
+            BinOpKind::Lt
+                | BinOpKind::Le
+                | BinOpKind::Gt
+                | BinOpKind::Ge
+                | BinOpKind::Eq
+                | BinOpKind::Ne
+        ) {
             return;
         }
 
@@ -57,6 +65,7 @@ const fn flip(op: BinOpKind) -> BinOpKind {
         BinOpKind::Le => BinOpKind::Ge,
         BinOpKind::Gt => BinOpKind::Lt,
         BinOpKind::Ge => BinOpKind::Le,
+        BinOpKind::Eq | BinOpKind::Ne => op, // symmetric
         _ => unreachable!(),
     }
 }
@@ -80,6 +89,7 @@ fn is_tautology(ty: ElementaryType, val_neg: bool, val_mag: U256, op: BinOpKind)
             match op {
                 BinOpKind::Gt | BinOpKind::Le => hi_le_val || val_lt_lo,
                 BinOpKind::Ge | BinOpKind::Lt => val_le_lo || hi_lt_val,
+                BinOpKind::Eq | BinOpKind::Ne => hi_lt_val || val_lt_lo,
                 _ => false,
             }
         }
@@ -95,6 +105,7 @@ fn is_tautology(ty: ElementaryType, val_neg: bool, val_mag: U256, op: BinOpKind)
             match op {
                 BinOpKind::Gt | BinOpKind::Le => hi_le_val || val_lt_lo,
                 BinOpKind::Ge | BinOpKind::Lt => val_le_lo || hi_lt_val,
+                BinOpKind::Eq | BinOpKind::Ne => hi_lt_val || val_lt_lo,
                 _ => false,
             }
         }

--- a/crates/lint/testdata/TypeBasedTautology.sol
+++ b/crates/lint/testdata/TypeBasedTautology.sol
@@ -1,0 +1,106 @@
+//@compile-flags: --severity high med low info
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+contract TypeBasedTautology {
+    // --- uint: comparisons against 0 ---
+
+    function uintGeZero(uint256 x) public pure returns (bool) {
+        return x >= 0; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function uintLtZero(uint256 x) public pure returns (bool) {
+        return x < 0; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function uintGtZero(uint256 x) public pure returns (bool) {
+        return x > 0; // ok – can be false when x == 0
+    }
+
+    function uintLeZero(uint256 x) public pure returns (bool) {
+        return x <= 0; // ok – can be true when x == 0
+    }
+
+    // --- uint: comparisons with out-of-range constants ---
+
+    function uint8LtMax256(uint8 x) public pure returns (bool) {
+        return x < 256; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function uint8GtMax255(uint8 x) public pure returns (bool) {
+        return x > 255; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function uint8GeMax256(uint8 x) public pure returns (bool) {
+        return x >= 256; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function uint8LeMax255(uint8 x) public pure returns (bool) {
+        return x <= 255; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function uint8GtMax254(uint8 x) public pure returns (bool) {
+        return x > 254; // ok – false when x == 254 or below
+    }
+
+    function uint8LtMax255(uint8 x) public pure returns (bool) {
+        return x < 255; // ok – false when x == 255
+    }
+
+    // --- flipped operands (constant on left) ---
+
+    function zeroGtUint(uint256 x) public pure returns (bool) {
+        return 0 > x; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function zeroLeUint(uint256 x) public pure returns (bool) {
+        return 0 <= x; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function val256GtUint8(uint8 x) public pure returns (bool) {
+        return 256 > x; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function val256LeUint8(uint8 x) public pure returns (bool) {
+        return 256 <= x; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    // --- int: boundary comparisons ---
+
+    function int8GeMin(int8 x) public pure returns (bool) {
+        return x >= -128; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function int8LtMin(int8 x) public pure returns (bool) {
+        return x < -128; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function int8GtMax(int8 x) public pure returns (bool) {
+        return x > 127; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function int8LeMax(int8 x) public pure returns (bool) {
+        return x <= 127; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function int8GeAlmostMin(int8 x) public pure returns (bool) {
+        return x >= -127; // ok
+    }
+
+    function int8LeAlmostMax(int8 x) public pure returns (bool) {
+        return x <= 126; // ok
+    }
+
+    // --- explicit casts ---
+
+    function castedUint8GtMax(uint256 raw) public pure returns (bool) {
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint8(raw) > 255; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function castedInt8LtMin(int256 raw) public pure returns (bool) {
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return int8(raw) < -128; //~WARN: condition is always true or false based on the variable's type
+    }
+}

--- a/crates/lint/testdata/TypeBasedTautology.sol
+++ b/crates/lint/testdata/TypeBasedTautology.sol
@@ -103,4 +103,27 @@ contract TypeBasedTautology {
         // forge-lint: disable-next-line(unsafe-typecast)
         return int8(raw) < -128; //~WARN: condition is always true or false based on the variable's type
     }
+
+    // --- eq / ne with out-of-range constants ---
+    // (solc rejects comparisons with sign-mismatched literals, e.g. uint == -1 or int8 == 128)
+
+    function uint8EqOutOfRange(uint8 x) public pure returns (bool) {
+        return x == 256; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function uint8NeOutOfRange(uint8 x) public pure returns (bool) {
+        return x != 256; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function int8EqBelowMin(int8 x) public pure returns (bool) {
+        return x == -129; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function uint8EqInRange(uint8 x) public pure returns (bool) {
+        return x == 255; // ok, 255 is the maximum of uint8, not out-of-range
+    }
+
+    function int8EqAtMin(int8 x) public pure returns (bool) {
+        return x == -128; // ok, -128 is within int8 range
+    }
 }

--- a/crates/lint/testdata/TypeBasedTautology.sol
+++ b/crates/lint/testdata/TypeBasedTautology.sol
@@ -19,7 +19,7 @@ contract TypeBasedTautology {
     }
 
     function uintLeZero(uint256 x) public pure returns (bool) {
-        return x <= 0; // ok – can be true when x == 0
+        return x <= 0; // ok, equivalent to x == 0, not a tautology
     }
 
     // --- uint: comparisons with out-of-range constants ---

--- a/crates/lint/testdata/TypeBasedTautology.stderr
+++ b/crates/lint/testdata/TypeBasedTautology.stderr
@@ -1,0 +1,128 @@
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return x >= 0;
+   │                ━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return x < 0;
+   │                ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return x < 256;
+   │                ━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return x > 255;
+   │                ━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return x >= 256;
+   │                ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return x <= 255;
+   │                ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return 0 > x;
+   │                ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return 0 <= x;
+   │                ━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return 256 > x;
+   │                ━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return 256 <= x;
+   │                ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return x >= -128;
+   │                ━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return x < -128;
+   │                ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return x > 127;
+   │                ━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return x <= 127;
+   │                ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return uint8(raw) > 255;
+   │                ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return int8(raw) < -128;
+   │                ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+

--- a/crates/lint/testdata/TypeBasedTautology.stderr
+++ b/crates/lint/testdata/TypeBasedTautology.stderr
@@ -126,3 +126,27 @@ LL │         return int8(raw) < -128;
    │
    ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
 
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return x == 256;
+   │                ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return x != 256;
+   │                ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return x == -129;
+   │                ━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+


### PR DESCRIPTION
## Motivation

Add `type-based-tautology` lint,  detecting comparison expressions that are always true or always false due to the numeric range of the variable's type.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
