### PR TITLE
fix(cast): include toBlock in chunked logs ranges

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -74,6 +74,22 @@ use rlp_converter::Item;
 
 // TODO: CastContract with common contract initializers? Same for CastProviders?
 
+/// Builds inclusive chunk ranges `[start, end]` over `[from, to]`.
+fn inclusive_chunk_ranges(from: u64, to: u64, chunk_size: u64) -> Vec<(u64, u64)> {
+    if from > to {
+        return Vec::new();
+    }
+
+    let chunk_size = chunk_size.max(1);
+    (from..=to)
+        .step_by(chunk_size as usize)
+        .map(|chunk_start| {
+            let chunk_end = chunk_start.saturating_add(chunk_size - 1).min(to);
+            (chunk_start, chunk_end)
+        })
+        .collect()
+}
+
 pub struct Cast<P, N = AnyNetwork> {
     provider: P,
     _phantom: PhantomData<N>,
@@ -693,20 +709,17 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
             return self.provider.get_logs(filter).await.map_err(Into::into);
         };
 
-        if from >= to {
+        if from > to {
             return Ok(vec![]);
         }
 
-        // Create chunk ranges using iterator
-        let chunk_ranges: Vec<(u64, u64)> = (from..to)
-            .step_by(chunk_size as usize)
-            .map(|chunk_start| (chunk_start, (chunk_start + chunk_size).min(to)))
-            .collect();
+        // Create inclusive chunk ranges.
+        let chunk_ranges = inclusive_chunk_ranges(from, to, chunk_size);
 
         // Process chunks with controlled concurrency using buffered stream
         let mut all_results: Vec<(u64, Vec<Log>)> = futures::stream::iter(chunk_ranges)
             .map(|(start_block, chunk_end)| {
-                let chunk_filter = filter.clone().from_block(start_block).to_block(chunk_end - 1);
+                let chunk_filter = filter.clone().from_block(start_block).to_block(chunk_end);
                 let provider = self.provider.clone();
 
                 async move {
@@ -716,7 +729,7 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
                         Err(_) => {
                             // Simple fallback: try individual blocks in this chunk
                             let mut fallback_logs = Vec::new();
-                            for single_block in start_block..chunk_end {
+                            for single_block in start_block..=chunk_end {
                                 let single_filter = chunk_filter
                                     .clone()
                                     .from_block(single_block)
@@ -2601,5 +2614,17 @@ mod tests {
             disassembled,
             "00000000: PUSH32 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\n"
         );
+    }
+
+    #[test]
+    fn inclusive_chunk_ranges_include_to_block() {
+        let ranges = super::inclusive_chunk_ranges(10, 15, 3);
+        assert_eq!(ranges, vec![(10, 12), (13, 15)]);
+    }
+
+    #[test]
+    fn inclusive_chunk_ranges_support_single_block_range() {
+        let ranges = super::inclusive_chunk_ranges(42, 42, 10);
+        assert_eq!(ranges, vec![(42, 42)]);
     }
 }

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -74,22 +74,6 @@ use rlp_converter::Item;
 
 // TODO: CastContract with common contract initializers? Same for CastProviders?
 
-/// Builds inclusive chunk ranges `[start, end]` over `[from, to]`.
-fn inclusive_chunk_ranges(from: u64, to: u64, chunk_size: u64) -> Vec<(u64, u64)> {
-    if from > to {
-        return Vec::new();
-    }
-
-    let chunk_size = chunk_size.max(1);
-    (from..=to)
-        .step_by(chunk_size as usize)
-        .map(|chunk_start| {
-            let chunk_end = chunk_start.saturating_add(chunk_size - 1).min(to);
-            (chunk_start, chunk_end)
-        })
-        .collect()
-}
-
 pub struct Cast<P, N = AnyNetwork> {
     provider: P,
     _phantom: PhantomData<N>,
@@ -714,7 +698,14 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
         }
 
         // Create inclusive chunk ranges.
-        let chunk_ranges = inclusive_chunk_ranges(from, to, chunk_size);
+        let chunk_size = chunk_size.max(1);
+        let chunk_ranges = (from..=to)
+            .step_by(chunk_size as usize)
+            .map(|chunk_start| {
+                let chunk_end = chunk_start.saturating_add(chunk_size - 1).min(to);
+                (chunk_start, chunk_end)
+            })
+            .collect::<Vec<_>>();
 
         // Process chunks with controlled concurrency using buffered stream
         let mut all_results: Vec<(u64, Vec<Log>)> = futures::stream::iter(chunk_ranges)
@@ -2614,17 +2605,5 @@ mod tests {
             disassembled,
             "00000000: PUSH32 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\n"
         );
-    }
-
-    #[test]
-    fn inclusive_chunk_ranges_include_to_block() {
-        let ranges = super::inclusive_chunk_ranges(10, 15, 3);
-        assert_eq!(ranges, vec![(10, 12), (13, 15)]);
-    }
-
-    #[test]
-    fn inclusive_chunk_ranges_support_single_block_range() {
-        let ranges = super::inclusive_chunk_ranges(42, 42, 10);
-        assert_eq!(ranges, vec![(42, 42)]);
     }
 }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1836,20 +1836,42 @@ casttest!(logs_sig_2, |_prj, cmd| {
 
 casttest!(logs_chunked_large_range, |_prj, cmd| {
     let rpc = next_http_archive_rpc_url();
-    cmd.args([
-        "logs",
-        "--rpc-url",
-        rpc.as_str(),
-        "--from-block",
-        "18000000",
-        "--to-block",
-        "18050000",
-        "--query-size",
-        "1000",
-        "Transfer(address indexed from, address indexed to, uint256 value)",
-        "0xA0b86a33E6441d02dd8C6B2b7E5D1E3eD7F73b4b",
-    ])
-    .assert_success();
+    let output = cmd
+        .args([
+            "logs",
+            "--rpc-url",
+            rpc.as_str(),
+            "--from-block",
+            "12370000",
+            "--to-block",
+            "12421182",
+            "--query-size",
+            "1000",
+            "Transfer(address indexed from, address indexed to, uint256 value)",
+            "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
+            "0x68A99f89E475a078645f4BAC491360aFe255Dff1",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(output.contains("0xb65bcbb85c1633b0ab4e4886c3cd8eeaeb63edbb39cacdb9223fdcf4454fd2c7"));
+
+    cmd.cast_fuse()
+        .args([
+            "logs",
+            "--rpc-url",
+            rpc.as_str(),
+            "--from-block",
+            "12421182",
+            "--to-block",
+            "12421182",
+            "Transfer(address indexed from, address indexed to, uint256 value)",
+            "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
+            "0x68A99f89E475a078645f4BAC491360aFe255Dff1",
+        ])
+        .assert_success()
+        .stdout_eq(file!["../fixtures/cast_logs.stdout"]);
 });
 
 casttest!(mktx, |_prj, cmd| {


### PR DESCRIPTION
  ## Motivation
                                                                                                                                                                                                 
  `cast logs` chunked querying has block-range boundary bugs that can produce incorrect results:                                                                                                 
                                                                                                                                                                                                 
  - `fromBlock == toBlock` is currently treated as an empty range.                                                                                                                               
  - Chunking uses half-open ranges and then applies `to_block(chunk_end - 1)`, which can miss the terminal `toBlock`.
                                                                                                                                                                                                 
  Since `eth_getLogs` uses inclusive block boundaries, this can return empty or incomplete log sets.                                                                                             
                                                                                                                                                                                                 
  ## Solution                                                                                                                                                                                    
                                                                                                                                                                                                 
  Switch chunk handling to inclusive range semantics across the chunked path:

  - Return empty only when `fromBlock > toBlock`.                                                                                                                                                
  - Build chunk ranges as inclusive `[start, end]`.                                                                                                                                              
  - Query chunk filters with `.from_block(start).to_block(end)`.                                                                                                                                 
  - Use inclusive fallback iteration (`start..=end`) for per-block retries.                                                                                                                      
  - Add unit tests for:                                                                                                                                                                          
    - terminal `toBlock` inclusion                                                                                                                                                               
    - single-block range handling (`fromBlock == toBlock`)                                                                                                                                       
                                                                                                                                                                                                 
  ## PR Checklist                                                                                                                                                                                
                                                                                                                                                                                                 
  - [x] Added Tests                                                                                                                                                                              
  - [ ] Added Documentation                                                                                                                                                                      
  - [ ] Breaking changes  