### PR TITLE
fix npm installer HTTPS guard

### DIFF
--- a/npm/src/install.mjs
+++ b/npm/src/install.mjs
@@ -6,7 +6,7 @@ import * as NodeHttp from 'node:http'
 import * as NodeHttps from 'node:https'
 import * as NodeModule from 'node:module'
 import * as NodePath from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import * as NodeZlib from 'node:zlib'
 
 import { BINARY_NAME, colors, getRegistryUrl, PLATFORM_SPECIFIC_PACKAGE_NAME, resolveTargetTool } from './const.mjs'
@@ -32,24 +32,27 @@ const require = NodeModule.createRequire(import.meta.url)
  * @param {string} purpose
  * @returns {void}
  */
-function ensureSecureUrl(urlString, purpose) {
+export function ensureSecureUrl(urlString, purpose) {
+  let url
   try {
-    const url = new URL(urlString)
-    if (url.protocol === 'http:') {
-      const allowInsecure = process.env.ALLOW_INSECURE_REGISTRY === 'true'
-      if (
-        // Accept typical localhost variants by default
-        !['localhost', '127.0.0.1', '::1'].includes(url.hostname)
-        && !allowInsecure
-      ) {
-        throw new Error(
-          `Refusing to use insecure HTTP for ${purpose}: ${urlString}. `
-            + `Set ALLOW_INSECURE_REGISTRY=true to override (not recommended).`
-        )
-      }
-    }
+    url = new URL(urlString)
   } catch {
     // If parsing fails, the request will fail so no need to do anything here
+    return
+  }
+
+  if (url.protocol === 'http:') {
+    const allowInsecure = process.env.ALLOW_INSECURE_REGISTRY === 'true'
+    if (
+      // Accept typical localhost variants by default
+      !['localhost', '127.0.0.1', '::1', '[::1]'].includes(url.hostname)
+      && !allowInsecure
+    ) {
+      throw new Error(
+        `Refusing to use insecure HTTP for ${purpose}: ${urlString}. `
+          + `Set ALLOW_INSECURE_REGISTRY=true to override (not recommended).`
+      )
+    }
   }
 }
 
@@ -349,15 +352,23 @@ function isPlatformSpecificPackageInstalled() {
   }
 }
 
-// Skip downloading the binary if it was already installed via optionalDependencies
-if (!isPlatformSpecificPackageInstalled()) {
-  console.log('Platform specific package not found. Will manually download binary.')
-  downloadBinaryFromRegistry().catch(error => {
-    console.error(colors.red, 'Failed to download binary:', error, colors.reset)
-    process.exitCode = 1
-  })
-} else {
-  console.log(
-    'Platform specific package already installed. Skipping manual download.'
-  )
+export function main() {
+  // Skip downloading the binary if it was already installed via optionalDependencies
+  if (!isPlatformSpecificPackageInstalled()) {
+    console.log('Platform specific package not found. Will manually download binary.')
+    downloadBinaryFromRegistry().catch(error => {
+      console.error(colors.red, 'Failed to download binary:', error, colors.reset)
+      process.exitCode = 1
+    })
+  } else {
+    console.log(
+      'Platform specific package already installed. Skipping manual download.'
+    )
+  }
 }
+
+function isMainModule() {
+  return process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+}
+
+if (isMainModule()) main()

--- a/npm/src/install.test.mjs
+++ b/npm/src/install.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+process.argv[2] = 'forge'
+
+const { ensureSecureUrl } = await import('./install.mjs')
+
+test('ensureSecureUrl rejects non-local HTTP URLs by default', () => {
+  delete process.env.ALLOW_INSECURE_REGISTRY
+
+  assert.throws(
+    () => ensureSecureUrl('http://example.com/@foundry-rs/forge', 'registry URL'),
+    /Refusing to use insecure HTTP for registry URL/
+  )
+})
+
+test('ensureSecureUrl allows local HTTP registry URLs', () => {
+  delete process.env.ALLOW_INSECURE_REGISTRY
+
+  assert.doesNotThrow(() => {
+    ensureSecureUrl('http://localhost:4873/@foundry-rs/forge', 'registry URL')
+    ensureSecureUrl('http://127.0.0.1:4873/@foundry-rs/forge', 'registry URL')
+    ensureSecureUrl('http://[::1]:4873/@foundry-rs/forge', 'registry URL')
+  })
+})
+
+test('ensureSecureUrl allows explicit insecure registry override', () => {
+  process.env.ALLOW_INSECURE_REGISTRY = 'true'
+
+  assert.doesNotThrow(() => {
+    ensureSecureUrl('http://example.com/@foundry-rs/forge', 'registry URL')
+  })
+
+  delete process.env.ALLOW_INSECURE_REGISTRY
+})
+
+test('ensureSecureUrl allows HTTPS URLs', () => {
+  delete process.env.ALLOW_INSECURE_REGISTRY
+
+  assert.doesNotThrow(() => {
+    ensureSecureUrl('https://registry.npmjs.org/@foundry-rs/forge', 'registry URL')
+  })
+})
+
+test('ensureSecureUrl leaves invalid URLs for the request layer', () => {
+  delete process.env.ALLOW_INSECURE_REGISTRY
+
+  assert.doesNotThrow(() => {
+    ensureSecureUrl('not a url', 'registry URL')
+  })
+})


### PR DESCRIPTION
## Motivation

Closes #14699.

The npm fallback installer intends to reject non-local `http://` registry and tarball URLs unless `ALLOW_INSECURE_REGISTRY=true` is set. The rejection was thrown inside the same broad `try` block that handles URL parse errors, so the `catch` swallowed the policy error and let insecure HTTP requests continue.

## Solution

- Narrow `ensureSecureUrl` so URL parse errors still fall through to the request layer, while insecure HTTP policy errors propagate.
- Keep localhost registry development and the explicit insecure override working.
- Export the helper and guard postinstall execution behind direct module invocation so the invariant can be tested without starting a download.
- Add focused `node:test` coverage for non-local HTTP rejection, localhost allowance, explicit override allowance, HTTPS allowance, and invalid URL passthrough.

Validation:

```sh
node --test npm/src/install.test.mjs
node --check npm/src/install.mjs
node --check npm/src/install.test.mjs
git diff --check
```

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
