### PR TITLE
docs(lint): fix duplicated "use" in lintrules guide

### DIFF
--- a/docs/dev/lintrules.md
+++ b/docs/dev/lintrules.md
@@ -30,7 +30,7 @@ The `forge-lint` system operates by analyzing Solidity source code through a dua
 
 We recommend you start by writing out some Solidity code that you want to trigger a lint in [`crates/lint/testdata`](https://github.com/foundry-rs/foundry/tree/master/crates/lint/testdata). Name the file after your lint rule.
 
-Next, choose whether you want an [early or late lint pass](#choosing-between-early-and-late-passes). If your lint is early, you can use use [Solar](https://github.com/paradigmxyz/solar) to dump the AST and find the patterns you need to match on in your lint code using `solar -Zdump=ast crates/lint/testdata/<file.sol>`. If your lint is late, you can use `solar -Zdump=hir crates/lint/testdata/<file.sol>`.
+Next, choose whether you want an [early or late lint pass](#choosing-between-early-and-late-passes). If your lint is early, you can use [Solar](https://github.com/paradigmxyz/solar) to dump the AST and find the patterns you need to match on in your lint code using `solar -Zdump=ast crates/lint/testdata/<file.sol>`. If your lint is late, you can use `solar -Zdump=hir crates/lint/testdata/<file.sol>`.
 
 1. Specify an issue that is being addressed in the PR description.
 2. In your PR:


### PR DESCRIPTION
The `docs/dev/lintrules.md` "Developing a new lint rule" section reads "you can use use [Solar]" — the word "use" is duplicated. Pure typo fix, no semantic change.

### Why

This is the canonical contributor guide for adding new lint rules; the typo distracts every reader walking through the workflow.