### PR TITLE
fix(anvil): use configured OP spec for execution

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -119,7 +119,7 @@ use futures::channel::mpsc::{UnboundedSender, unbounded};
 #[cfg(feature = "optimism")]
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpTransaction as OpTransactionTrait};
 #[cfg(feature = "optimism")]
-use op_revm::{OpSpecId, OpTransaction, transaction::deposit::DepositTransactionParts};
+use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
 
 /// Side-channel container for OP-specific deposit info produced by
 /// [`Backend::build_call_env`] and consumed by the OP transact path.
@@ -132,11 +132,6 @@ type OpCallDepositInfo = DepositTransactionParts;
 #[cfg(not(feature = "optimism"))]
 #[derive(Default, Clone, Debug)]
 struct OpCallDepositInfo;
-
-#[cfg(feature = "optimism")]
-fn op_spec_id_from_hardfork(hardfork: FoundryHardfork) -> OpSpecId {
-    hardfork.into()
-}
 
 /// Marker trait that abstracts over the per-network inspector trait bounds
 /// required by the in-memory backend. The OP bound is only included when the
@@ -1364,10 +1359,7 @@ impl<N: Network> Backend<N> {
         #[cfg(feature = "optimism")]
         if self.is_optimism() {
             let op_env = EvmEnv::new(
-                evm_env
-                    .cfg_env
-                    .clone()
-                    .with_spec_and_mainnet_gas_params(op_spec_id_from_hardfork(self.hardfork)),
+                evm_env.cfg_env.clone().with_spec_and_mainnet_gas_params(self.hardfork.into()),
                 evm_env.block_env.clone(),
             );
             let mut evm =
@@ -4819,17 +4811,6 @@ pub use foundry_evm::core::evm::IntoInstructionResult;
 #[cfg(test)]
 mod tests {
     use crate::{NodeConfig, spawn};
-
-    #[cfg(feature = "optimism")]
-    #[test]
-    fn op_spec_id_from_hardfork_preserves_optimism_hardfork() {
-        use foundry_evm::hardfork::OpHardfork;
-        use op_revm::OpSpecId;
-
-        assert_eq!(super::op_spec_id_from_hardfork(OpHardfork::Jovian.into()), OpSpecId::JOVIAN);
-        assert_eq!(super::op_spec_id_from_hardfork(OpHardfork::Karst.into()), OpSpecId::KARST);
-        assert_eq!(super::op_spec_id_from_hardfork(OpHardfork::Interop.into()), OpSpecId::INTEROP);
-    }
 
     #[tokio::test]
     async fn test_deterministic_block_mining() {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -133,6 +133,11 @@ type OpCallDepositInfo = DepositTransactionParts;
 #[derive(Default, Clone, Debug)]
 struct OpCallDepositInfo;
 
+#[cfg(feature = "optimism")]
+fn op_spec_id_from_hardfork(hardfork: FoundryHardfork) -> OpSpecId {
+    hardfork.into()
+}
+
 /// Marker trait that abstracts over the per-network inspector trait bounds
 /// required by the in-memory backend. The OP bound is only included when the
 /// `optimism` feature is enabled.
@@ -1359,7 +1364,10 @@ impl<N: Network> Backend<N> {
         #[cfg(feature = "optimism")]
         if self.is_optimism() {
             let op_env = EvmEnv::new(
-                evm_env.cfg_env.clone().with_spec_and_mainnet_gas_params(OpSpecId::ISTHMUS),
+                evm_env
+                    .cfg_env
+                    .clone()
+                    .with_spec_and_mainnet_gas_params(op_spec_id_from_hardfork(self.hardfork)),
                 evm_env.block_env.clone(),
             );
             let mut evm =
@@ -4811,6 +4819,17 @@ pub use foundry_evm::core::evm::IntoInstructionResult;
 #[cfg(test)]
 mod tests {
     use crate::{NodeConfig, spawn};
+
+    #[cfg(feature = "optimism")]
+    #[test]
+    fn op_spec_id_from_hardfork_preserves_optimism_hardfork() {
+        use foundry_evm::hardfork::OpHardfork;
+        use op_revm::OpSpecId;
+
+        assert_eq!(super::op_spec_id_from_hardfork(OpHardfork::Jovian.into()), OpSpecId::JOVIAN);
+        assert_eq!(super::op_spec_id_from_hardfork(OpHardfork::Karst.into()), OpSpecId::KARST);
+        assert_eq!(super::op_spec_id_from_hardfork(OpHardfork::Interop.into()), OpSpecId::INTEROP);
+    }
 
     #[tokio::test]
     async fn test_deterministic_block_mining() {

--- a/crates/anvil/src/eth/backend/mem/optimism.rs
+++ b/crates/anvil/src/eth/backend/mem/optimism.rs
@@ -1,6 +1,6 @@
 //! Optimism-specific transact helpers for the in-memory backend.
 
-use super::{Backend, op_spec_id_from_hardfork};
+use super::Backend;
 use crate::eth::error::BlockchainError;
 use alloy_evm::{Database, Evm, EvmEnv, EvmFactory};
 use alloy_network::Network;
@@ -34,10 +34,7 @@ impl<N: Network> Backend<N> {
         WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
     {
         let op_env = EvmEnv::new(
-            evm_env
-                .cfg_env
-                .clone()
-                .with_spec_and_mainnet_gas_params(op_spec_id_from_hardfork(self.hardfork())),
+            evm_env.cfg_env.clone().with_spec_and_mainnet_gas_params(self.hardfork().into()),
             evm_env.block_env.clone(),
         );
         let mut evm = OpEvmFactory::default().create_evm_with_inspector(

--- a/crates/anvil/src/eth/backend/mem/optimism.rs
+++ b/crates/anvil/src/eth/backend/mem/optimism.rs
@@ -1,12 +1,12 @@
 //! Optimism-specific transact helpers for the in-memory backend.
 
-use super::Backend;
+use super::{Backend, op_spec_id_from_hardfork};
 use crate::eth::error::BlockchainError;
 use alloy_evm::{Database, Evm, EvmEnv, EvmFactory};
 use alloy_network::Network;
 use alloy_op_evm::{OpEvmContext, OpEvmFactory, OpTx};
 use foundry_evm::backend::DatabaseError;
-use op_revm::{OpHaltReason, OpSpecId, OpTransaction};
+use op_revm::{OpHaltReason, OpTransaction};
 use revm::{
     DatabaseRef, Inspector,
     context::{
@@ -34,7 +34,10 @@ impl<N: Network> Backend<N> {
         WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
     {
         let op_env = EvmEnv::new(
-            evm_env.cfg_env.clone().with_spec_and_mainnet_gas_params(OpSpecId::ISTHMUS),
+            evm_env
+                .cfg_env
+                .clone()
+                .with_spec_and_mainnet_gas_params(op_spec_id_from_hardfork(self.hardfork())),
             evm_env.block_env.clone(),
         );
         let mut evm = OpEvmFactory::default().create_evm_with_inspector(


### PR DESCRIPTION
## Motivation

Anvil's OP execution paths rebuild the EVM with a fixed `OpSpecId::ISTHMUS`. That loses configured OP hardforks such as `Jovian`, `Karst`, and `Interop` during transaction execution and block mining.

## Solution

Derive the OP spec from the configured `FoundryHardfork` in both in-memory OP execution paths, and add assertions that the helper preserves recent Optimism hardfork mappings.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes