### PR TITLE
feat(lint): extract shared naming-convention helpers

### DIFF
--- a/crates/lint/src/sol/info/mixed_case.rs
+++ b/crates/lint/src/sol/info/mixed_case.rs
@@ -1,7 +1,10 @@
 use super::{MixedCaseFunction, MixedCaseVariable};
 use crate::{
     linter::{EarlyLintPass, LintContext, Suggestion},
-    sol::{Severity, SolLint, info::screaming_snake_case::check_screaming_snake_case},
+    sol::{
+        Severity, SolLint,
+        naming::{check_mixed_case as check_mixed_case_pure, check_screaming_snake_case},
+    },
 };
 use solar::ast::{FunctionHeader, ItemFunction, VariableDefinition, Visibility};
 
@@ -69,13 +72,8 @@ impl<'ast> EarlyLintPass<'ast> for MixedCaseVariable {
     }
 }
 
-/// If the string `s` is not mixedCase, returns a `Some(String)` with the
-/// suggested conversion. Otherwise, returns `None`.
-///
-/// To avoid false positives:
-/// - lowercase strings like `fn increment()` or `uint256 counter`, are treated as mixedCase.
-/// - test functions starting with `test`, `invariant_` or `statefulFuzz` are ignored.
-/// - user-defined patterns like `ERC20` are allowed.
+/// Wraps [`check_mixed_case_pure`] with two domain exceptions:
+/// foundry test-function prefixes and user-defined infix patterns.
 fn check_mixed_case(s: &str, is_fn: bool, allowed_patterns: &[String]) -> Option<String> {
     if s.len() <= 1 {
         return None;
@@ -94,10 +92,10 @@ fn check_mixed_case(s: &str, is_fn: bool, allowed_patterns: &[String]) -> Option
             let (pre, post) = s.split_at(pos);
             let post = &post[pattern.len()..];
 
-            // Check if the part before the pattern is valid lowerCamelCase.
+            // Pre-pattern must be valid lowerCamelCase.
             let is_pre_valid = pre == heck::AsLowerCamelCase(pre).to_string();
 
-            // Check if the part after is valid UpperCamelCase (allowing leading numbers).
+            // Post-pattern must be valid UpperCamelCase (allowing leading numbers).
             let post_trimmed = post.trim_start_matches(|c: char| c.is_numeric());
             let is_post_valid = post_trimmed == heck::AsUpperCamelCase(post_trimmed).to_string();
 
@@ -107,16 +105,7 @@ fn check_mixed_case(s: &str, is_fn: bool, allowed_patterns: &[String]) -> Option
         }
     }
 
-    // Generate the expected mixedCase version.
-    let suggestion = format!(
-        "{prefix}{name}{suffix}",
-        prefix = if s.starts_with('_') { "_" } else { "" },
-        name = heck::AsLowerCamelCase(s),
-        suffix = if s.ends_with('_') { "_" } else { "" }
-    );
-
-    // If the original string already matches the suggestion, it's valid.
-    if s == suggestion { None } else { Some(suggestion) }
+    check_mixed_case_pure(s)
 }
 
 /// Checks if a function getter is a valid constant getter with a heuristic:

--- a/crates/lint/src/sol/info/pascal_case.rs
+++ b/crates/lint/src/sol/info/pascal_case.rs
@@ -1,7 +1,7 @@
 use super::PascalCaseStruct;
 use crate::{
     linter::{EarlyLintPass, LintContext, Suggestion},
-    sol::{Severity, SolLint},
+    sol::{Severity, SolLint, naming::check_pascal_case},
 };
 use solar::ast::ItemStruct;
 
@@ -27,15 +27,4 @@ impl<'ast> EarlyLintPass<'ast> for PascalCaseStruct {
             );
         }
     }
-}
-
-/// If the string `s` is not PascalCase, returns a `Some(String)` with the
-/// suggested conversion. Otherwise, returns `None`.
-pub fn check_pascal_case(s: &str) -> Option<String> {
-    if s.len() <= 1 {
-        return None;
-    }
-
-    let expected = heck::AsPascalCase(s).to_string();
-    if s == expected.as_str() { None } else { Some(expected) }
 }

--- a/crates/lint/src/sol/info/screaming_snake_case.rs
+++ b/crates/lint/src/sol/info/screaming_snake_case.rs
@@ -1,7 +1,7 @@
 use super::ScreamingSnakeCase;
 use crate::{
     linter::{EarlyLintPass, LintContext, Suggestion},
-    sol::{Severity, SolLint},
+    sol::{Severity, SolLint, naming::check_screaming_snake_case},
 };
 use solar::ast::{VarMut, VariableDefinition};
 
@@ -44,21 +44,4 @@ impl<'ast> EarlyLintPass<'ast> for ScreamingSnakeCase {
             }
         }
     }
-}
-
-/// If the string `s` is not SCREAMING_SNAKE_CASE, returns a `Some(String)` with the suggested
-/// conversion. Otherwise, returns `None`.
-pub fn check_screaming_snake_case(s: &str) -> Option<String> {
-    if s.len() <= 1 {
-        return None;
-    }
-
-    // Handle leading/trailing underscores like `heck` does
-    let expected = format!(
-        "{prefix}{name}{suffix}",
-        prefix = if s.starts_with('_') { "_" } else { "" },
-        name = heck::AsShoutySnakeCase(s),
-        suffix = if s.ends_with('_') { "_" } else { "" }
-    );
-    if s == expected { None } else { Some(expected) }
 }

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -43,6 +43,7 @@ pub mod high;
 pub mod info;
 pub mod low;
 pub mod med;
+pub mod naming;
 
 static ALL_REGISTERED_LINTS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
     let mut lints = Vec::new();

--- a/crates/lint/src/sol/naming.rs
+++ b/crates/lint/src/sol/naming.rs
@@ -1,0 +1,96 @@
+//! Naming-convention helpers shared by Solidity lints.
+//!
+//! Each `check_*` returns `Some(suggestion)` when `s` violates the convention,
+//! `None` when it already matches. Leading/trailing underscores are preserved.
+
+/// `Some(suggestion)` if `s` is not `PascalCase`.
+pub fn check_pascal_case(s: &str) -> Option<String> {
+    if s.len() <= 1 {
+        return None;
+    }
+    let expected = heck::AsPascalCase(s).to_string();
+    if s == expected { None } else { Some(expected) }
+}
+
+/// `Some(suggestion)` if `s` is not `SCREAMING_SNAKE_CASE`.
+pub fn check_screaming_snake_case(s: &str) -> Option<String> {
+    if s.len() <= 1 {
+        return None;
+    }
+    let expected = preserve_underscores(s, heck::AsShoutySnakeCase(s).to_string());
+    if s == expected { None } else { Some(expected) }
+}
+
+/// `Some(suggestion)` if `s` is not `mixedCase`. Pure check — domain
+/// exceptions (test-prefixes, allowed patterns, ...) live in the lint.
+pub fn check_mixed_case(s: &str) -> Option<String> {
+    if s.len() <= 1 {
+        return None;
+    }
+    let expected = preserve_underscores(s, heck::AsLowerCamelCase(s).to_string());
+    if s == expected { None } else { Some(expected) }
+}
+
+fn preserve_underscores(s: &str, body: String) -> String {
+    let prefix = if s.starts_with('_') { "_" } else { "" };
+    let suffix = if s.ends_with('_') { "_" } else { "" };
+    format!("{prefix}{body}{suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pascal_case_accepts_valid() {
+        assert_eq!(check_pascal_case("MyStruct"), None);
+        assert_eq!(check_pascal_case("Erc20"), None);
+        assert_eq!(check_pascal_case("A"), None);
+    }
+
+    #[test]
+    fn pascal_case_suggests_for_invalid() {
+        assert_eq!(check_pascal_case("my_struct").as_deref(), Some("MyStruct"));
+        assert_eq!(check_pascal_case("myStruct").as_deref(), Some("MyStruct"));
+        assert_eq!(check_pascal_case("MY_STRUCT").as_deref(), Some("MyStruct"));
+    }
+
+    #[test]
+    fn screaming_snake_case_accepts_valid() {
+        assert_eq!(check_screaming_snake_case("MAX_VALUE"), None);
+        assert_eq!(check_screaming_snake_case("_PRIVATE_CONST"), None);
+        assert_eq!(check_screaming_snake_case("VALUE_"), None);
+    }
+
+    #[test]
+    fn screaming_snake_case_suggests_for_invalid() {
+        assert_eq!(check_screaming_snake_case("maxValue").as_deref(), Some("MAX_VALUE"));
+        assert_eq!(check_screaming_snake_case("MaxValue").as_deref(), Some("MAX_VALUE"));
+    }
+
+    #[test]
+    fn screaming_snake_case_preserves_underscores() {
+        assert_eq!(check_screaming_snake_case("_maxValue").as_deref(), Some("_MAX_VALUE"));
+        assert_eq!(check_screaming_snake_case("maxValue_").as_deref(), Some("MAX_VALUE_"));
+    }
+
+    #[test]
+    fn mixed_case_accepts_valid() {
+        assert_eq!(check_mixed_case("counter"), None);
+        assert_eq!(check_mixed_case("totalSupply"), None);
+        assert_eq!(check_mixed_case("_internalVar"), None);
+    }
+
+    #[test]
+    fn mixed_case_suggests_for_invalid() {
+        assert_eq!(check_mixed_case("TotalSupply").as_deref(), Some("totalSupply"));
+        assert_eq!(check_mixed_case("total_supply").as_deref(), Some("totalSupply"));
+        assert_eq!(check_mixed_case("TOTAL_SUPPLY").as_deref(), Some("totalSupply"));
+    }
+
+    #[test]
+    fn mixed_case_preserves_underscores() {
+        assert_eq!(check_mixed_case("_TotalSupply").as_deref(), Some("_totalSupply"));
+        assert_eq!(check_mixed_case("totalSupply_"), None);
+    }
+}


### PR DESCRIPTION
Adds `crates/lint/src/sol/naming.rs` with `check_pascal_case`, `check_mixed_case`, `check_screaming_snake_case`, plus shared underscore-preservation. Migrates the three existing naming lints to use them. No behavior changes