### PR TITLE
fix(forge): honor foundry.lock revs in forge install

### DIFF
--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -149,6 +149,14 @@ impl DependencyInstallOpts {
 
                     // recursively fetch all submodules (without fetching latest)
                     git.submodule_update(false, false, false, true, Some(&libs))?;
+
+                    // checkout submodules at the revs recorded in `foundry.lock`
+                    if let Some(out_of_sync) = &out_of_sync_deps {
+                        for (rel_path, dep_id) in out_of_sync {
+                            git.checkout_at(dep_id.checkout_id(), &git.root.join(rel_path))?;
+                        }
+                    }
+
                     lockfile.write()?;
                 }
                 Err(err) => {


### PR DESCRIPTION
`forge install` only ran `git submodule update`, so it followed the gitlink and ignored `foundry.lock`. Now it checks out each out-of-sync submodule at the rev recorded in `foundry.lock`, matching `forge update`.