### PR TITLE
feat(tui): add shared terminal foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5249,6 +5249,7 @@ dependencies = [
  "foundry-compilers",
  "foundry-evm-core",
  "foundry-evm-traces",
+ "foundry-tui",
  "ratatui",
  "revm",
  "revm-inspectors",
@@ -5564,6 +5565,14 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.23",
  "ui_test",
+]
+
+[[package]]
+name = "foundry-tui"
+version = "1.7.2"
+dependencies = [
+ "crossterm",
+ "ratatui",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/script-sequence/",
     "crates/test-utils/",
     "crates/cli-markdown/",
+    "crates/tui/",
 ]
 resolver = "2"
 
@@ -338,6 +339,7 @@ foundry-test-utils = { path = "crates/test-utils", default-features = false }
 foundry-wallets = { version = "0.1.0", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
+foundry-tui = { path = "crates/tui", default-features = false }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.23.1", default-features = false }
@@ -449,6 +451,7 @@ axum = "0.8"
 ciborium = "0.2"
 color-eyre = "0.6"
 comfy-table = "7"
+crossterm = "0.29"
 dirs = "6"
 dunce = "1"
 evm-disassembler = "0.6"
@@ -468,6 +471,7 @@ parking_lot = "0.12"
 proptest = "1.9.0"
 rand = "0.9"
 rand_08 = { package = "rand", version = "0.8" }
+ratatui = { version = "0.30", default-features = false }
 rayon = "1"
 regex = { version = "1", default-features = false }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }

--- a/crates/debugger/Cargo.toml
+++ b/crates/debugger/Cargo.toml
@@ -17,15 +17,14 @@ foundry-common.workspace = true
 foundry-compilers.workspace = true
 foundry-evm-traces.workspace = true
 foundry-evm-core.workspace = true
+foundry-tui.workspace = true
 revm-inspectors.workspace = true
 
 alloy-primitives.workspace = true
 
-crossterm = "0.29"
+crossterm.workspace = true
 eyre.workspace = true
-ratatui = { version = "0.30", default-features = false, features = [
-    "crossterm",
-] }
+ratatui = { workspace = true, features = ["crossterm"] }
 revm.workspace = true
 tracing.workspace = true
 serde.workspace = true

--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -2,7 +2,7 @@
 
 use crossterm::event;
 use eyre::Result;
-use foundry_tui::CrosstermTerminal;
+use foundry_tui::{CrosstermTerminal, with_terminal};
 use std::ops::ControlFlow;
 
 mod context;
@@ -33,7 +33,7 @@ impl<'a> TUI<'a> {
 
     /// Starts the debugger TUI.
     pub fn try_run(&mut self) -> Result<ExitReason> {
-        foundry_tui::with_terminal(|terminal| self.run_inner(terminal))?
+        with_terminal(|terminal| self.run_inner(terminal))?
     }
 
     #[instrument(target = "debugger", name = "run", skip_all, ret)]

--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -1,16 +1,9 @@
 //! The debugger TUI.
 
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture},
-    execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
-};
+use crossterm::event;
 use eyre::Result;
-use ratatui::{
-    Terminal,
-    backend::{Backend, CrosstermBackend},
-};
-use std::{io, ops::ControlFlow, sync::Arc};
+use foundry_tui::CrosstermTerminal;
+use std::ops::ControlFlow;
 
 mod context;
 use crate::debugger::DebuggerContext;
@@ -18,7 +11,7 @@ use context::TUIContext;
 
 mod draw;
 
-type DebuggerTerminal = Terminal<CrosstermBackend<io::Stdout>>;
+type DebuggerTerminal = CrosstermTerminal;
 
 /// Debugger exit reason.
 #[derive(Debug)]
@@ -40,9 +33,7 @@ impl<'a> TUI<'a> {
 
     /// Starts the debugger TUI.
     pub fn try_run(&mut self) -> Result<ExitReason> {
-        let backend = CrosstermBackend::new(io::stdout());
-        let terminal = Terminal::new(backend)?;
-        TerminalGuard::with(terminal, |terminal| self.run_inner(terminal))
+        foundry_tui::with_terminal(|terminal| self.run_inner(terminal))?
     }
 
     #[instrument(target = "debugger", name = "run", skip_all, ret)]
@@ -56,70 +47,5 @@ impl<'a> TUI<'a> {
                 ControlFlow::Break(reason) => return Ok(reason),
             }
         }
-    }
-}
-
-type PanicHandler = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + 'static + Sync + Send>;
-
-/// Handles terminal state.
-#[must_use]
-struct TerminalGuard<B: Backend + io::Write> {
-    terminal: Terminal<B>,
-    hook: Option<Arc<PanicHandler>>,
-}
-
-impl<B: Backend + io::Write> TerminalGuard<B> {
-    fn with<T>(terminal: Terminal<B>, mut f: impl FnMut(&mut Terminal<B>) -> T) -> T {
-        let mut guard = Self { terminal, hook: None };
-        guard.setup();
-        f(&mut guard.terminal)
-    }
-
-    fn setup(&mut self) {
-        let previous = Arc::new(std::panic::take_hook());
-        self.hook = Some(previous.clone());
-        // We need to restore the terminal state before displaying the panic message.
-        // TODO: Use `std::panic::update_hook` when it's stable
-        std::panic::set_hook(Box::new(move |info| {
-            Self::half_restore(&mut std::io::stdout());
-            (previous)(info)
-        }));
-
-        let _ = enable_raw_mode();
-        let _ = execute!(*self.terminal.backend_mut(), EnterAlternateScreen, EnableMouseCapture);
-        let _ = self.terminal.hide_cursor();
-        let _ = self.terminal.clear();
-    }
-
-    fn restore(&mut self) {
-        if !std::thread::panicking() {
-            // Drop the current hook to guarantee that `self.hook` is the only reference to it.
-            let _ = std::panic::take_hook();
-            // Restore the previous panic hook.
-            let prev = self.hook.take().unwrap();
-            let prev = match Arc::try_unwrap(prev) {
-                Ok(prev) => prev,
-                Err(_) => unreachable!("`self.hook` is not the only reference to the panic hook"),
-            };
-            std::panic::set_hook(prev);
-
-            // NOTE: Our panic handler calls this function, so we only have to call it here if we're
-            // not panicking.
-            Self::half_restore(self.terminal.backend_mut());
-        }
-
-        let _ = self.terminal.show_cursor();
-    }
-
-    fn half_restore(w: &mut impl io::Write) {
-        let _ = disable_raw_mode();
-        let _ = execute!(*w, LeaveAlternateScreen, DisableMouseCapture);
-    }
-}
-
-impl<B: Backend + io::Write> Drop for TerminalGuard<B> {
-    #[inline]
-    fn drop(&mut self) {
-        self.restore();
     }
 }

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "foundry-tui"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+crossterm.workspace = true
+ratatui = { workspace = true, features = ["crossterm"] }

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -1,0 +1,83 @@
+//! Shared terminal UI utilities for Foundry.
+
+use crossterm::{
+    event::{DisableMouseCapture, EnableMouseCapture},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{
+    Terminal,
+    backend::{Backend, CrosstermBackend},
+};
+use std::{io, sync::Arc};
+
+/// The default terminal backend used by Foundry TUIs.
+pub type CrosstermTerminal = Terminal<CrosstermBackend<io::Stdout>>;
+
+type PanicHandler = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + 'static + Sync + Send>;
+
+/// Runs a closure with the default Foundry terminal setup.
+pub fn with_terminal<T>(f: impl FnMut(&mut CrosstermTerminal) -> T) -> io::Result<T> {
+    let backend = CrosstermBackend::new(io::stdout());
+    let terminal = Terminal::new(backend)?;
+    Ok(TerminalGuard::with(terminal, f))
+}
+
+/// Handles terminal setup and teardown for interactive TUIs.
+#[must_use]
+pub struct TerminalGuard<B: Backend + io::Write> {
+    terminal: Terminal<B>,
+    hook: Option<Arc<PanicHandler>>,
+}
+
+impl<B: Backend + io::Write> TerminalGuard<B> {
+    /// Runs a closure while the terminal is in alternate-screen raw mode.
+    pub fn with<T>(terminal: Terminal<B>, mut f: impl FnMut(&mut Terminal<B>) -> T) -> T {
+        let mut guard = Self { terminal, hook: None };
+        guard.setup();
+        f(&mut guard.terminal)
+    }
+
+    fn setup(&mut self) {
+        let previous = Arc::new(std::panic::take_hook());
+        self.hook = Some(previous.clone());
+        // Restore terminal state before displaying the panic message.
+        std::panic::set_hook(Box::new(move |info| {
+            Self::half_restore(&mut std::io::stdout());
+            (previous)(info)
+        }));
+
+        let _ = enable_raw_mode();
+        let _ = execute!(*self.terminal.backend_mut(), EnterAlternateScreen, EnableMouseCapture);
+        let _ = self.terminal.hide_cursor();
+        let _ = self.terminal.clear();
+    }
+
+    fn restore(&mut self) {
+        if !std::thread::panicking() {
+            let _ = std::panic::take_hook();
+            let prev = self.hook.take().unwrap();
+            let prev = match Arc::try_unwrap(prev) {
+                Ok(prev) => prev,
+                Err(_) => unreachable!("`self.hook` is not the only reference to the panic hook"),
+            };
+            std::panic::set_hook(prev);
+
+            Self::half_restore(self.terminal.backend_mut());
+        }
+
+        let _ = self.terminal.show_cursor();
+    }
+
+    fn half_restore(w: &mut impl io::Write) {
+        let _ = disable_raw_mode();
+        let _ = execute!(*w, LeaveAlternateScreen, DisableMouseCapture);
+    }
+}
+
+impl<B: Backend + io::Write> Drop for TerminalGuard<B> {
+    #[inline]
+    fn drop(&mut self) {
+        self.restore();
+    }
+}

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -9,28 +9,33 @@ use ratatui::{
     Terminal,
     backend::{Backend, CrosstermBackend},
 };
-use std::{io, sync::Arc};
+use std::{
+    io::{Result as IoResult, Stdout, Write, stdout},
+    panic::{PanicHookInfo, set_hook, take_hook},
+    sync::Arc,
+    thread::panicking,
+};
 
 /// The default terminal backend used by Foundry TUIs.
-pub type CrosstermTerminal = Terminal<CrosstermBackend<io::Stdout>>;
+pub type CrosstermTerminal = Terminal<CrosstermBackend<Stdout>>;
 
-type PanicHandler = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + 'static + Sync + Send>;
+type PanicHandler = Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send>;
 
 /// Runs a closure with the default Foundry terminal setup.
-pub fn with_terminal<T>(f: impl FnMut(&mut CrosstermTerminal) -> T) -> io::Result<T> {
-    let backend = CrosstermBackend::new(io::stdout());
+pub fn with_terminal<T>(f: impl FnMut(&mut CrosstermTerminal) -> T) -> IoResult<T> {
+    let backend = CrosstermBackend::new(stdout());
     let terminal = Terminal::new(backend)?;
     Ok(TerminalGuard::with(terminal, f))
 }
 
 /// Handles terminal setup and teardown for interactive TUIs.
 #[must_use]
-pub struct TerminalGuard<B: Backend + io::Write> {
+pub struct TerminalGuard<B: Backend + Write> {
     terminal: Terminal<B>,
     hook: Option<Arc<PanicHandler>>,
 }
 
-impl<B: Backend + io::Write> TerminalGuard<B> {
+impl<B: Backend + Write> TerminalGuard<B> {
     /// Runs a closure while the terminal is in alternate-screen raw mode.
     pub fn with<T>(terminal: Terminal<B>, mut f: impl FnMut(&mut Terminal<B>) -> T) -> T {
         let mut guard = Self { terminal, hook: None };
@@ -39,11 +44,11 @@ impl<B: Backend + io::Write> TerminalGuard<B> {
     }
 
     fn setup(&mut self) {
-        let previous = Arc::new(std::panic::take_hook());
+        let previous = Arc::new(take_hook());
         self.hook = Some(previous.clone());
         // Restore terminal state before displaying the panic message.
-        std::panic::set_hook(Box::new(move |info| {
-            Self::half_restore(&mut std::io::stdout());
+        set_hook(Box::new(move |info| {
+            Self::half_restore(&mut stdout());
             (previous)(info)
         }));
 
@@ -54,14 +59,14 @@ impl<B: Backend + io::Write> TerminalGuard<B> {
     }
 
     fn restore(&mut self) {
-        if !std::thread::panicking() {
-            let _ = std::panic::take_hook();
+        if !panicking() {
+            let _ = take_hook();
             let prev = self.hook.take().unwrap();
             let prev = match Arc::try_unwrap(prev) {
                 Ok(prev) => prev,
                 Err(_) => unreachable!("`self.hook` is not the only reference to the panic hook"),
             };
-            std::panic::set_hook(prev);
+            set_hook(prev);
 
             Self::half_restore(self.terminal.backend_mut());
         }
@@ -69,13 +74,13 @@ impl<B: Backend + io::Write> TerminalGuard<B> {
         let _ = self.terminal.show_cursor();
     }
 
-    fn half_restore(w: &mut impl io::Write) {
+    fn half_restore(w: &mut impl Write) {
         let _ = disable_raw_mode();
         let _ = execute!(*w, LeaveAlternateScreen, DisableMouseCapture);
     }
 }
 
-impl<B: Backend + io::Write> Drop for TerminalGuard<B> {
+impl<B: Backend + Write> Drop for TerminalGuard<B> {
     #[inline]
     fn drop(&mut self) {
         self.restore();


### PR DESCRIPTION
## Summary
- add a new foundry-tui crate for shared terminal setup and teardown
- move the debugger TUI onto the shared terminal runner
- centralize crossterm and ratatui workspace dependencies