### PR TITLE
fix(anvil): use configured epoch slots for block tags

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1102,16 +1102,7 @@ impl<N: Network> EthApi<N> {
         node_info!("eth_feeHistory");
         // max number of blocks in the requested range
 
-        let current = self.backend.best_number();
-        let slots_in_an_epoch = 32u64;
-
-        let number = match newest_block {
-            BlockNumber::Latest | BlockNumber::Pending => current,
-            BlockNumber::Earliest => 0,
-            BlockNumber::Number(n) => n,
-            BlockNumber::Safe => current.saturating_sub(slots_in_an_epoch),
-            BlockNumber::Finalized => current.saturating_sub(slots_in_an_epoch * 2),
-        };
+        let number = self.backend.convert_block_number(Some(newest_block));
 
         // check if the number predates the fork, if in fork mode
         if let Some(fork) = self.get_fork() {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3916,14 +3916,16 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
                 // Ref: https://github.com/foundry-rs/foundry/issues/9539
                 if best_number > number {
                     self.blockchain.storage.write().best_number = best_number;
-                    let best_hash =
-                        self.blockchain.storage.read().hash(best_number.into()).ok_or_else(
-                            || {
-                                BlockchainError::RpcError(RpcError::internal_error_with(format!(
-                                    "Best hash not found for best number {best_number}",
-                                )))
-                            },
-                        )?;
+                    let best_hash = self
+                        .blockchain
+                        .storage
+                        .read()
+                        .hash(best_number.into(), self.slots_in_an_epoch)
+                        .ok_or_else(|| {
+                            BlockchainError::RpcError(RpcError::internal_error_with(format!(
+                                "Best hash not found for best number {best_number}",
+                            )))
+                        })?;
                     self.blockchain.storage.write().best_hash = best_hash;
                 } else {
                     // If loading state file on a fork, set best number to the fork block number.
@@ -3935,8 +3937,12 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
                 self.blockchain.storage.write().best_number = best_number;
 
                 // Set the current best block hash;
-                let best_hash =
-                    self.blockchain.storage.read().hash(best_number.into()).ok_or_else(|| {
+                let best_hash = self
+                    .blockchain
+                    .storage
+                    .read()
+                    .hash(best_number.into(), self.slots_in_an_epoch)
+                    .ok_or_else(|| {
                         BlockchainError::RpcError(RpcError::internal_error_with(format!(
                             "Best hash not found for best number {best_number}",
                         )))

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -434,23 +434,22 @@ impl<N: Network> BlockchainStorage<N> {
     }
 
     /// Returns the hash for [BlockNumberOrTag]
-    pub fn hash(&self, number: BlockNumberOrTag) -> Option<B256> {
-        let slots_in_an_epoch = 32;
+    pub fn hash(&self, number: BlockNumberOrTag, slots_in_an_epoch: u64) -> Option<B256> {
         match number {
             BlockNumberOrTag::Latest => Some(self.best_hash),
             BlockNumberOrTag::Earliest => Some(self.genesis_hash),
             BlockNumberOrTag::Pending => None,
             BlockNumberOrTag::Number(num) => self.hashes.get(&num).copied(),
             BlockNumberOrTag::Safe => {
-                if self.best_number > (slots_in_an_epoch) {
-                    self.hashes.get(&(self.best_number - (slots_in_an_epoch))).copied()
+                if self.best_number > slots_in_an_epoch {
+                    self.hashes.get(&(self.best_number - slots_in_an_epoch)).copied()
                 } else {
-                    Some(self.genesis_hash) // treat the genesis block as safe "by definition"
+                    Some(self.genesis_hash)
                 }
             }
             BlockNumberOrTag::Finalized => {
-                if self.best_number > (slots_in_an_epoch * 2) {
-                    self.hashes.get(&(self.best_number - (slots_in_an_epoch * 2))).copied()
+                if self.best_number > slots_in_an_epoch * 2 {
+                    self.hashes.get(&(self.best_number - slots_in_an_epoch * 2)).copied()
                 } else {
                     Some(self.genesis_hash)
                 }
@@ -509,10 +508,10 @@ impl<N: Network> Blockchain<N> {
     }
 
     /// returns the header hash of given block
-    pub fn hash(&self, id: BlockId) -> Option<B256> {
+    pub fn hash(&self, id: BlockId, slots_in_an_epoch: u64) -> Option<B256> {
         match id {
             BlockId::Hash(h) => Some(h.block_hash),
-            BlockId::Number(num) => self.storage.read().hash(num),
+            BlockId::Number(num) => self.storage.read().hash(num, slots_in_an_epoch),
         }
     }
 

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -145,6 +145,49 @@ async fn can_get_block_by_number() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn can_resolve_safe_and_finalized_block_tags_with_configured_epoch_slots() {
+    let slots_in_an_epoch = 3;
+    let (api, handle) = spawn(NodeConfig::test().with_slots_in_an_epoch(slots_in_an_epoch)).await;
+    let provider = handle.http_provider();
+
+    api.anvil_mine(Some(U256::from(8)), None).await.unwrap();
+    let latest = provider.get_block_number().await.unwrap();
+    assert_eq!(latest, 8);
+
+    let safe = provider.get_block(BlockId::Number(BlockNumberOrTag::Safe)).await.unwrap().unwrap();
+    assert_eq!(safe.header.number, latest - slots_in_an_epoch);
+
+    let finalized =
+        provider.get_block(BlockId::Number(BlockNumberOrTag::Finalized)).await.unwrap().unwrap();
+    assert_eq!(finalized.header.number, latest - slots_in_an_epoch * 2);
+
+    let fee_history = api.fee_history(U256::from(1), BlockNumberOrTag::Safe, vec![]).await.unwrap();
+    assert_eq!(fee_history.oldest_block, latest - slots_in_an_epoch);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_resolve_safe_and_finalized_block_tags_to_genesis_before_configured_epoch() {
+    let (api, handle) = spawn(NodeConfig::test().with_slots_in_an_epoch(3)).await;
+    let provider = handle.http_provider();
+
+    api.anvil_mine(Some(U256::from(2)), None).await.unwrap();
+    let genesis = provider.get_block(BlockId::number(0)).await.unwrap().unwrap();
+
+    let safe = provider.get_block(BlockId::Number(BlockNumberOrTag::Safe)).await.unwrap().unwrap();
+    assert_eq!(safe.header.number, genesis.header.number);
+    assert_eq!(safe.header.hash, genesis.header.hash);
+
+    let finalized =
+        provider.get_block(BlockId::Number(BlockNumberOrTag::Finalized)).await.unwrap().unwrap();
+    assert_eq!(finalized.header.number, genesis.header.number);
+    assert_eq!(finalized.header.hash, genesis.header.hash);
+
+    let fee_history =
+        api.fee_history(U256::from(1), BlockNumberOrTag::Finalized, vec![]).await.unwrap();
+    assert_eq!(fee_history.oldest_block, genesis.header.number);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_get_pending_block() {
     let (api, handle) = spawn(NodeConfig::test()).await;
 


### PR DESCRIPTION
## Summary
- resolves Anvil safe/finalized block tags with the configured slots-in-an-epoch value in fee history
- passes configured epoch slots through storage block hash lookup
- adds Anvil coverage for custom epoch slots and genesis fallback

Fixes #14713