### PR TITLE
feat(cli): add JSON output envelope helpers

### DIFF
--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -18,8 +18,7 @@ pub struct JsonEnvelope<T> {
     pub schema_version: u32,
     /// Whether the command completed successfully.
     ///
-    /// For streaming output this should be known only by a final summary record,
-    /// not by intermediate progress events.
+    /// Only meaningful for a complete/terminal command outcome.
     pub success: bool,
     /// Command-specific payload.
     pub data: Option<T>,

--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -2,7 +2,7 @@
 
 use eyre::Result;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Value, to_string, to_value};
 
 /// The current version of Foundry's top-level JSON output envelope.
 pub const JSON_SCHEMA_VERSION: u32 = 1;
@@ -116,14 +116,9 @@ impl JsonMessage {
     }
 }
 
-/// Serializes a value as compact JSON.
-pub fn to_json_string<T: Serialize>(value: &T) -> Result<String> {
-    Ok(serde_json::to_string(value)?)
-}
-
 /// Prints a value as compact JSON to stdout.
 pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
-    sh_println!("{}", to_json_string(value)?)?;
+    sh_println!("{}", to_string(value)?)?;
     Ok(())
 }
 
@@ -154,7 +149,7 @@ mod tests {
     fn success_envelope_serializes_all_top_level_fields() {
         let envelope = JsonEnvelope::success(BuildData { contracts: 2 });
 
-        let json = to_json_string(&envelope).unwrap();
+        let json = to_string(&envelope).unwrap();
 
         assert_eq!(
             json,
@@ -169,7 +164,7 @@ mod tests {
         let envelope =
             JsonEnvelope::success_with_warnings(BuildData { contracts: 1 }, vec![warning]);
 
-        let value: Value = serde_json::from_str(&to_json_string(&envelope).unwrap()).unwrap();
+        let value = to_value(&envelope).unwrap();
 
         assert_eq!(value["success"], true);
         assert_eq!(value["warnings"][0]["level"], "warning");
@@ -183,7 +178,7 @@ mod tests {
             .with_details(json!({ "path": "foundry.toml" }));
         let envelope = JsonEnvelope::error(error);
 
-        let value: Value = serde_json::from_str(&to_json_string(&envelope).unwrap()).unwrap();
+        let value = to_value(&envelope).unwrap();
 
         assert_eq!(value["schema_version"], JSON_SCHEMA_VERSION);
         assert_eq!(value["success"], false);

--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -138,16 +138,6 @@ pub fn print_json_success_with_warnings<T: Serialize>(
     print_json(&JsonEnvelope::success_with_warnings(data, warnings))
 }
 
-/// Prints a failed JSON envelope with one structured error to stdout.
-pub fn print_json_error(error: JsonError) -> Result<()> {
-    print_json(&JsonEnvelope::error(error))
-}
-
-/// Prints a failed JSON envelope with structured errors to stdout.
-pub fn print_json_failure(errors: Vec<JsonError>) -> Result<()> {
-    print_json(&JsonEnvelope::failure(errors))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -17,9 +17,9 @@ pub struct JsonEnvelope<T> {
     /// Command-specific payload.
     pub data: Option<T>,
     /// Structured errors emitted by the command.
-    pub errors: Vec<JsonError>,
+    pub errors: Vec<JsonMessage>,
     /// Structured warnings emitted by the command.
-    pub warnings: Vec<JsonWarning>,
+    pub warnings: Vec<JsonMessage>,
 }
 
 impl<T> JsonEnvelope<T> {
@@ -35,7 +35,7 @@ impl<T> JsonEnvelope<T> {
     }
 
     /// Creates a successful envelope with command-specific data and warnings.
-    pub const fn success_with_warnings(data: T, warnings: Vec<JsonWarning>) -> Self {
+    pub const fn success_with_warnings(data: T, warnings: Vec<JsonMessage>) -> Self {
         Self {
             schema_version: JSON_SCHEMA_VERSION,
             success: true,
@@ -48,12 +48,12 @@ impl<T> JsonEnvelope<T> {
 
 impl JsonEnvelope<()> {
     /// Creates a failed envelope with one structured error.
-    pub fn error(error: JsonError) -> Self {
+    pub fn error(error: JsonMessage) -> Self {
         Self::failure(vec![error])
     }
 
     /// Creates a failed envelope with structured errors.
-    pub const fn failure(errors: Vec<JsonError>) -> Self {
+    pub const fn failure(errors: Vec<JsonMessage>) -> Self {
         Self {
             schema_version: JSON_SCHEMA_VERSION,
             success: false,
@@ -64,62 +64,64 @@ impl JsonEnvelope<()> {
     }
 }
 
-/// Structured error entry for JSON output.
+/// Severity level for a structured JSON message.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct JsonError {
-    /// Stable machine-readable error code.
+#[serde(rename_all = "snake_case")]
+pub enum JsonMessageLevel {
+    /// Error message.
+    Error,
+    /// Warning message.
+    Warning,
+}
+
+/// Structured diagnostic entry for JSON output.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JsonMessage {
+    /// Diagnostic severity level.
+    pub level: JsonMessageLevel,
+    /// Stable machine-readable diagnostic code.
     pub code: String,
-    /// Human-readable error message.
+    /// Human-readable diagnostic message.
     pub message: String,
-    /// Optional structured context for the error.
+    /// Optional structured context for the diagnostic.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub details: Option<Value>,
 }
 
-impl JsonError {
+impl JsonMessage {
     /// Creates a structured error without details.
-    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
-        Self { code: code.into(), message: message.into(), details: None }
+    pub fn error(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            level: JsonMessageLevel::Error,
+            code: code.into(),
+            message: message.into(),
+            details: None,
+        }
     }
 
-    /// Adds structured details to the error.
-    pub fn with_details(mut self, details: Value) -> Self {
-        self.details = Some(details);
-        self
-    }
-}
-
-/// Structured warning entry for JSON output.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct JsonWarning {
-    /// Stable machine-readable warning code.
-    pub code: String,
-    /// Human-readable warning message.
-    pub message: String,
-    /// Optional structured context for the warning.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub details: Option<Value>,
-}
-
-impl JsonWarning {
     /// Creates a structured warning without details.
-    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
-        Self { code: code.into(), message: message.into(), details: None }
+    pub fn warning(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            level: JsonMessageLevel::Warning,
+            code: code.into(),
+            message: message.into(),
+            details: None,
+        }
     }
 
-    /// Adds structured details to the warning.
+    /// Adds structured details to the diagnostic.
     pub fn with_details(mut self, details: Value) -> Self {
         self.details = Some(details);
         self
     }
 }
 
-/// Serializes a value as pretty JSON.
+/// Serializes a value as compact JSON.
 pub fn to_json_string<T: Serialize>(value: &T) -> Result<String> {
-    Ok(serde_json::to_string_pretty(value)?)
+    Ok(serde_json::to_string(value)?)
 }
 
-/// Prints a value as pretty JSON to stdout.
+/// Prints a value as compact JSON to stdout.
 pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
     sh_println!("{}", to_json_string(value)?)?;
     Ok(())
@@ -133,7 +135,7 @@ pub fn print_json_success<T: Serialize>(data: T) -> Result<()> {
 /// Prints a successful JSON envelope with warnings to stdout.
 pub fn print_json_success_with_warnings<T: Serialize>(
     data: T,
-    warnings: Vec<JsonWarning>,
+    warnings: Vec<JsonMessage>,
 ) -> Result<()> {
     print_json(&JsonEnvelope::success_with_warnings(data, warnings))
 }
@@ -156,21 +158,13 @@ mod tests {
 
         assert_eq!(
             json,
-            r#"{
-  "schema_version": 1,
-  "success": true,
-  "data": {
-    "contracts": 2
-  },
-  "errors": [],
-  "warnings": []
-}"#
+            r#"{"schema_version":1,"success":true,"data":{"contracts":2},"errors":[],"warnings":[]}"#
         );
     }
 
     #[test]
     fn warning_details_are_structured() {
-        let warning = JsonWarning::new("compiler.remappings", "auto-detected remappings")
+        let warning = JsonMessage::warning("compiler.remappings", "auto-detected remappings")
             .with_details(json!({ "count": 3 }));
         let envelope =
             JsonEnvelope::success_with_warnings(BuildData { contracts: 1 }, vec![warning]);
@@ -178,13 +172,14 @@ mod tests {
         let value: Value = serde_json::from_str(&to_json_string(&envelope).unwrap()).unwrap();
 
         assert_eq!(value["success"], true);
+        assert_eq!(value["warnings"][0]["level"], "warning");
         assert_eq!(value["warnings"][0]["code"], "compiler.remappings");
         assert_eq!(value["warnings"][0]["details"]["count"], 3);
     }
 
     #[test]
     fn failure_envelope_serializes_null_data_and_structured_errors() {
-        let error = JsonError::new("config.invalid", "invalid foundry.toml")
+        let error = JsonMessage::error("config.invalid", "invalid foundry.toml")
             .with_details(json!({ "path": "foundry.toml" }));
         let envelope = JsonEnvelope::error(error);
 
@@ -193,6 +188,7 @@ mod tests {
         assert_eq!(value["schema_version"], JSON_SCHEMA_VERSION);
         assert_eq!(value["success"], false);
         assert!(value["data"].is_null());
+        assert_eq!(value["errors"][0]["level"], "error");
         assert_eq!(value["errors"][0]["code"], "config.invalid");
         assert_eq!(value["errors"][0]["details"]["path"], "foundry.toml");
         assert_eq!(value["warnings"], json!([]));

--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -2,17 +2,24 @@
 
 use eyre::Result;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, to_string, to_value};
+use serde_json::{Value, to_string};
 
 /// The current version of Foundry's top-level JSON output envelope.
 pub const JSON_SCHEMA_VERSION: u32 = 1;
 
-/// Stable top-level envelope for machine-readable command output.
+/// Stable top-level envelope for complete machine-readable command output.
+///
+/// This envelope represents a terminal command outcome. Long-running commands
+/// that stream intermediate records should use a separate event type and reserve
+/// this shape for final, complete results.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JsonEnvelope<T> {
     /// Version of the envelope schema.
     pub schema_version: u32,
     /// Whether the command completed successfully.
+    ///
+    /// For streaming output this should be known only by a final summary record,
+    /// not by intermediate progress events.
     pub success: bool,
     /// Command-specific payload.
     pub data: Option<T>,
@@ -64,7 +71,11 @@ impl JsonEnvelope<()> {
     }
 }
 
-/// Severity level for a structured JSON message.
+/// Severity level for a structured JSON diagnostic.
+///
+/// These levels classify diagnostics attached to an envelope. Progress,
+/// informational, and debug records should be modeled as command output data or
+/// stream events instead.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum JsonMessageLevel {
@@ -75,6 +86,9 @@ pub enum JsonMessageLevel {
 }
 
 /// Structured diagnostic entry for JSON output.
+///
+/// Diagnostics describe errors and warnings associated with command output. They
+/// are not intended for progress, informational, or debug events.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JsonMessage {
     /// Diagnostic severity level.
@@ -116,7 +130,10 @@ impl JsonMessage {
     }
 }
 
-/// Prints a value as compact JSON to stdout.
+/// Prints a value as compact, single-line JSON to stdout.
+///
+/// The trailing newline makes this suitable for NDJSON streams when each call
+/// emits one self-contained JSON record.
 pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
     sh_println!("{}", to_string(value)?)?;
     Ok(())
@@ -138,7 +155,7 @@ pub fn print_json_success_with_warnings<T: Serialize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
+    use serde_json::{json, to_value};
 
     #[derive(Serialize)]
     struct BuildData {

--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -1,0 +1,210 @@
+//! Shared JSON output primitives for Foundry CLIs.
+
+use eyre::Result;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// The current version of Foundry's top-level JSON output envelope.
+pub const JSON_SCHEMA_VERSION: u32 = 1;
+
+/// Stable top-level envelope for machine-readable command output.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JsonEnvelope<T> {
+    /// Version of the envelope schema.
+    pub schema_version: u32,
+    /// Whether the command completed successfully.
+    pub success: bool,
+    /// Command-specific payload.
+    pub data: Option<T>,
+    /// Structured errors emitted by the command.
+    pub errors: Vec<JsonError>,
+    /// Structured warnings emitted by the command.
+    pub warnings: Vec<JsonWarning>,
+}
+
+impl<T> JsonEnvelope<T> {
+    /// Creates a successful envelope with command-specific data.
+    pub const fn success(data: T) -> Self {
+        Self {
+            schema_version: JSON_SCHEMA_VERSION,
+            success: true,
+            data: Some(data),
+            errors: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Creates a successful envelope with command-specific data and warnings.
+    pub const fn success_with_warnings(data: T, warnings: Vec<JsonWarning>) -> Self {
+        Self {
+            schema_version: JSON_SCHEMA_VERSION,
+            success: true,
+            data: Some(data),
+            errors: Vec::new(),
+            warnings,
+        }
+    }
+}
+
+impl JsonEnvelope<()> {
+    /// Creates a failed envelope with one structured error.
+    pub fn error(error: JsonError) -> Self {
+        Self::failure(vec![error])
+    }
+
+    /// Creates a failed envelope with structured errors.
+    pub const fn failure(errors: Vec<JsonError>) -> Self {
+        Self {
+            schema_version: JSON_SCHEMA_VERSION,
+            success: false,
+            data: None,
+            errors,
+            warnings: Vec::new(),
+        }
+    }
+}
+
+/// Structured error entry for JSON output.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JsonError {
+    /// Stable machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Optional structured context for the error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<Value>,
+}
+
+impl JsonError {
+    /// Creates a structured error without details.
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self { code: code.into(), message: message.into(), details: None }
+    }
+
+    /// Adds structured details to the error.
+    pub fn with_details(mut self, details: Value) -> Self {
+        self.details = Some(details);
+        self
+    }
+}
+
+/// Structured warning entry for JSON output.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JsonWarning {
+    /// Stable machine-readable warning code.
+    pub code: String,
+    /// Human-readable warning message.
+    pub message: String,
+    /// Optional structured context for the warning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<Value>,
+}
+
+impl JsonWarning {
+    /// Creates a structured warning without details.
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self { code: code.into(), message: message.into(), details: None }
+    }
+
+    /// Adds structured details to the warning.
+    pub fn with_details(mut self, details: Value) -> Self {
+        self.details = Some(details);
+        self
+    }
+}
+
+/// Serializes a value as pretty JSON.
+pub fn to_json_string<T: Serialize>(value: &T) -> Result<String> {
+    Ok(serde_json::to_string_pretty(value)?)
+}
+
+/// Prints a value as pretty JSON to stdout.
+pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
+    sh_println!("{}", to_json_string(value)?)?;
+    Ok(())
+}
+
+/// Prints a successful JSON envelope to stdout.
+pub fn print_json_success<T: Serialize>(data: T) -> Result<()> {
+    print_json(&JsonEnvelope::success(data))
+}
+
+/// Prints a successful JSON envelope with warnings to stdout.
+pub fn print_json_success_with_warnings<T: Serialize>(
+    data: T,
+    warnings: Vec<JsonWarning>,
+) -> Result<()> {
+    print_json(&JsonEnvelope::success_with_warnings(data, warnings))
+}
+
+/// Prints a failed JSON envelope with one structured error to stdout.
+pub fn print_json_error(error: JsonError) -> Result<()> {
+    print_json(&JsonEnvelope::error(error))
+}
+
+/// Prints a failed JSON envelope with structured errors to stdout.
+pub fn print_json_failure(errors: Vec<JsonError>) -> Result<()> {
+    print_json(&JsonEnvelope::failure(errors))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[derive(Serialize)]
+    struct BuildData {
+        contracts: usize,
+    }
+
+    #[test]
+    fn success_envelope_serializes_all_top_level_fields() {
+        let envelope = JsonEnvelope::success(BuildData { contracts: 2 });
+
+        let json = to_json_string(&envelope).unwrap();
+
+        assert_eq!(
+            json,
+            r#"{
+  "schema_version": 1,
+  "success": true,
+  "data": {
+    "contracts": 2
+  },
+  "errors": [],
+  "warnings": []
+}"#
+        );
+    }
+
+    #[test]
+    fn warning_details_are_structured() {
+        let warning = JsonWarning::new("compiler.remappings", "auto-detected remappings")
+            .with_details(json!({ "count": 3 }));
+        let envelope =
+            JsonEnvelope::success_with_warnings(BuildData { contracts: 1 }, vec![warning]);
+
+        let value: Value = serde_json::from_str(&to_json_string(&envelope).unwrap()).unwrap();
+
+        assert_eq!(value["success"], true);
+        assert_eq!(value["warnings"][0]["code"], "compiler.remappings");
+        assert_eq!(value["warnings"][0]["details"]["count"], 3);
+    }
+
+    #[test]
+    fn failure_envelope_serializes_null_data_and_structured_errors() {
+        let error = JsonError::new("config.invalid", "invalid foundry.toml")
+            .with_details(json!({ "path": "foundry.toml" }));
+        let envelope = JsonEnvelope::error(error);
+
+        let value: Value = serde_json::from_str(&to_json_string(&envelope).unwrap()).unwrap();
+
+        assert_eq!(value["schema_version"], JSON_SCHEMA_VERSION);
+        assert_eq!(value["success"], false);
+        assert!(value["data"].is_null());
+        assert_eq!(value["errors"][0]["code"], "config.invalid");
+        assert_eq!(value["errors"][0]["details"]["path"], "foundry.toml");
+        assert_eq!(value["warnings"], json!([]));
+    }
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -13,6 +13,7 @@ extern crate tracing;
 
 pub mod clap;
 pub mod handler;
+pub mod json;
 pub mod opts;
 pub mod utils;
 


### PR DESCRIPTION
## Summary

- add `foundry_cli::json` with a versioned top-level JSON envelope
- add structured `JsonError` and `JsonWarning` payloads with optional details
- add reusable JSON serialization/printing helpers for future command migrations
- cover success, warning, and failure envelope serialization with unit tests

Closes OSS-237

## Validation

- `cargo +1.94 test -p foundry-cli`
- `cargo +1.94 clippy -p foundry-cli --all-targets -- -D warnings`

Note: the local default toolchain is Rust 1.93.1, but current dependencies require Rust 1.94, so validation used the installed `1.94` toolchain explicitly.
