### PR TITLE
fix(common): preserve script CREATE2 broadcast in preprocessor

### DIFF
--- a/crates/common/src/preprocessor/deps.rs
+++ b/crates/common/src/preprocessor/deps.rs
@@ -27,6 +27,7 @@ impl PreprocessorDependencies {
     pub fn new(
         gcx: Gcx<'_>,
         paths: &[PathBuf],
+        script_paths: &HashSet<PathBuf>,
         src_dir: &Path,
         root_dir: &Path,
         mocks: &mut HashSet<PathBuf>,
@@ -81,8 +82,9 @@ impl PreprocessorDependencies {
             // which used to be a mock is refactored to a non-mock implementation).
             mocks.remove(&full_path);
 
+            let is_script = script_paths.contains(path);
             let mut deps_collector =
-                BytecodeDependencyCollector::new(gcx, source.file.src.as_str(), src_dir);
+                BytecodeDependencyCollector::new(gcx, source.file.src.as_str(), src_dir, is_script);
             // Analyze current contract.
             let _ = deps_collector.walk_contract(contract);
             // Ignore empty test contracts declared in source files with other contracts.
@@ -142,6 +144,12 @@ struct BytecodeDependencyCollector<'gcx, 'src> {
     src: &'src str,
     /// Project source dir, used to determine if referenced contract is a source contract.
     src_dir: &'src Path,
+    /// Whether the contract being analyzed lives in a script file.
+    /// Salted `new Contract{salt:...}()` in scripts must not be rewritten: at broadcast depth
+    /// Foundry redirects native CREATE2 through the deterministic factory, preserving the salt.
+    /// `vm.deployCode` runs at a deeper call depth and bypasses that redirect, so the broadcast
+    /// would record a plain CREATE and deploy at the wrong address.
+    is_script: bool,
     /// Dependencies collected for current contract.
     dependencies: Vec<BytecodeDependency>,
     /// Unique HIR ids of contracts referenced from current contract.
@@ -149,14 +157,29 @@ struct BytecodeDependencyCollector<'gcx, 'src> {
 }
 
 impl<'gcx, 'src> BytecodeDependencyCollector<'gcx, 'src> {
-    fn new(gcx: Gcx<'gcx>, src: &'src str, src_dir: &'src Path) -> Self {
-        Self { gcx, src, src_dir, dependencies: vec![], referenced_contracts: HashSet::default() }
+    fn new(gcx: Gcx<'gcx>, src: &'src str, src_dir: &'src Path, is_script: bool) -> Self {
+        Self {
+            gcx,
+            src,
+            src_dir,
+            is_script,
+            dependencies: vec![],
+            referenced_contracts: HashSet::default(),
+        }
     }
 
     /// Collects reference identified as bytecode dependency of analyzed contract.
     /// Discards any reference that is not in project src directory (e.g. external
     /// libraries or mock contracts that extend source contracts).
     fn collect_dependency(&mut self, dependency: BytecodeDependency) {
+        // Salted new-expressions in scripts must not be rewritten. See field doc on `is_script`.
+        if self.is_script
+            && let BytecodeDependencyKind::New { salt: Some(_), .. } = &dependency.kind
+        {
+            trace!("skip salted new-expression in script");
+            return;
+        }
+
         let contract = self.gcx.hir.contract(dependency.referenced_contract);
         let source = self.gcx.hir.source(contract.source);
         let FileName::Real(path) = &source.file.name else {

--- a/crates/common/src/preprocessor/deps.rs
+++ b/crates/common/src/preprocessor/deps.rs
@@ -82,7 +82,14 @@ impl PreprocessorDependencies {
             // which used to be a mock is refactored to a non-mock implementation).
             mocks.remove(&full_path);
 
-            let is_script = script_paths.contains(path);
+            // Treat the contract as a script when its file lives under the configured script
+            // directory, or when it inherits from a `Script` base (forge-std). The inheritance
+            // check covers atypical layouts where script contracts are placed under `src/`.
+            let is_script = script_paths.contains(path)
+                || contract
+                    .linearized_bases
+                    .iter()
+                    .any(|base_id| gcx.hir.contract(*base_id).name.as_str() == "Script");
             let mut deps_collector =
                 BytecodeDependencyCollector::new(gcx, source.file.src.as_str(), src_dir, is_script);
             // Analyze current contract.

--- a/crates/common/src/preprocessor/deps.rs
+++ b/crates/common/src/preprocessor/deps.rs
@@ -89,6 +89,7 @@ impl PreprocessorDependencies {
                 || contract
                     .linearized_bases
                     .iter()
+                    .skip(1)
                     .any(|base_id| gcx.hir.contract(*base_id).name.as_str() == "Script");
             let mut deps_collector =
                 BytecodeDependencyCollector::new(gcx, source.file.src.as_str(), src_dir, is_script);

--- a/crates/common/src/preprocessor/mod.rs
+++ b/crates/common/src/preprocessor/mod.rs
@@ -60,6 +60,7 @@ impl Preprocessor<SolcCompiler> for DynamicTestLinkingPreprocessor {
             // Include all sources in the source map so as to not re-load them from disk, but only
             // parse and preprocess tests and scripts.
             let mut preprocessed_paths = vec![];
+            let mut script_paths = HashSet::new();
             let sources = &mut input.input.sources;
             for (path, source) in sources.iter() {
                 if let Ok(src_file) = compiler
@@ -69,6 +70,9 @@ impl Preprocessor<SolcCompiler> for DynamicTestLinkingPreprocessor {
                     && paths.is_test_or_script(path)
                 {
                     pcx.add_file(src_file);
+                    if paths.is_script(path) {
+                        script_paths.insert(path.clone());
+                    }
                     preprocessed_paths.push(path.clone());
                 }
             }
@@ -78,9 +82,13 @@ impl Preprocessor<SolcCompiler> for DynamicTestLinkingPreprocessor {
             let ControlFlow::Continue(()) = compiler.lower_asts()? else { return Ok(()) };
             let gcx = compiler.gcx();
             // Collect tests and scripts dependencies and identify mock contracts.
+            // Script paths are passed separately so salted new-expressions are left untouched
+            // (Foundry's broadcast redirects native CREATE2 through the deterministic factory,
+            // but vm.deployCode runs at a deeper depth and bypasses that redirect).
             let deps = PreprocessorDependencies::new(
                 gcx,
                 &preprocessed_paths,
+                &script_paths,
                 &paths.paths_relative().sources,
                 &paths.root,
                 mocks,

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3399,6 +3399,63 @@ contract SaltedScript is Script {
     assert_eq!(tx["arguments"][0], "SaltedTok");
 });
 
+// Regression: same as above but the script contract lives under `src/` (not the configured
+// script directory). The preprocessor must still detect it as a script via inheritance
+// (`is Script`) and leave salted new-expressions untouched.
+forgetest_async!(can_broadcast_salted_create2_in_src_script, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    prj.update_config(|c| c.dynamic_test_linking = true);
+    prj.add_source(
+        "Token.sol",
+        r#"
+contract Token {
+    string public name;
+    constructor(string memory _name) { name = _name; }
+}
+        "#,
+    );
+    prj.add_source(
+        "SaltedSrc.s.sol",
+        r#"
+import "forge-std/Script.sol";
+import {Token} from "./Token.sol";
+contract SaltedSrcScript is Script {
+    function run() external {
+        vm.startBroadcast();
+        new Token{salt: bytes32(uint256(0xDEADBEEF))}("SaltedSrc");
+        vm.stopBroadcast();
+    }
+}
+        "#,
+    );
+
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    cmd.args([
+        "script",
+        "src/SaltedSrc.s.sol:SaltedSrcScript",
+        "--rpc-url",
+        &handle.http_endpoint(),
+        "--broadcast",
+        "--private-key",
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+    ])
+    .assert_success();
+
+    let run_latest = foundry_common::fs::json_files(&prj.root().join("broadcast"))
+        .find(|path| path.ends_with("run-latest.json"))
+        .expect("No broadcast artifacts");
+    let content = foundry_common::fs::read_to_string(run_latest).unwrap();
+    let json: Value = serde_json::from_str(&content).unwrap();
+    let tx = &json["transactions"][0];
+
+    assert_eq!(
+        tx["transactionType"], "CREATE2",
+        "salted broadcast must be recorded as CREATE2, got: {tx}"
+    );
+    assert_eq!(tx["contractName"], "Token");
+    assert_eq!(tx["arguments"][0], "SaltedSrc");
+});
+
 forgetest_async!(flaky_can_deploy_with_broadcast_in_setup, |prj, cmd| {
     foundry_test_utils::util::initialize(prj.root());
     prj.add_script(

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3340,6 +3340,65 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 "#]]);
 });
 
+// Regression: Salted `new Foo{salt: ...}(args)` in scripts must NOT be rewritten to
+// `vm.deployCode(...)` by the dynamic test linking preprocessor.
+//
+// NOTE: `dynamic_test_linking` config option is not yet taken into account by `forge script`.
+// The config is set explicitly here so the test fails if there is a regression.
+forgetest_async!(can_broadcast_salted_create2_in_script, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    prj.update_config(|c| c.dynamic_test_linking = true);
+    prj.add_source(
+        "Token.sol",
+        r#"
+contract Token {
+    string public name;
+    constructor(string memory _name) { name = _name; }
+}
+        "#,
+    );
+    prj.add_script(
+        "Salted.s.sol",
+        r#"
+import "forge-std/Script.sol";
+import {Token} from "../src/Token.sol";
+contract SaltedScript is Script {
+    function run() external {
+        vm.startBroadcast();
+        new Token{salt: bytes32(uint256(0xDEADBEEF))}("SaltedTok");
+        vm.stopBroadcast();
+    }
+}
+        "#,
+    );
+
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    cmd.args([
+        "script",
+        "script/Salted.s.sol:SaltedScript",
+        "--rpc-url",
+        &handle.http_endpoint(),
+        "--broadcast",
+        "--private-key",
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+    ])
+    .assert_success();
+
+    let run_latest = foundry_common::fs::json_files(&prj.root().join("broadcast"))
+        .find(|path| path.ends_with("run-latest.json"))
+        .expect("No broadcast artifacts");
+    let content = foundry_common::fs::read_to_string(run_latest).unwrap();
+    let json: Value = serde_json::from_str(&content).unwrap();
+    let tx = &json["transactions"][0];
+
+    assert_eq!(
+        tx["transactionType"], "CREATE2",
+        "salted broadcast must be recorded as CREATE2, got: {tx}"
+    );
+    assert_eq!(tx["contractName"], "Token");
+    assert_eq!(tx["arguments"][0], "SaltedTok");
+});
+
 forgetest_async!(flaky_can_deploy_with_broadcast_in_setup, |prj, cmd| {
     foundry_test_utils::util::initialize(prj.root());
     prj.add_script(


### PR DESCRIPTION
## Motivation

Towards #10285.

Salted `new Contract{salt:...}()` in scripts must not be rewritten by preprocessor when `dynamic-test-linking` is enabled: at broadcast depth, Foundry redirects native CREATE2 through the deterministic factory, preserving the salt `vm.deployCode` runs at a deeper call depth and bypasses that redirect, so the broadcast would record a plain CREATE and deploy at the wrong address.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
