### PR TITLE
feat(tui): add shared app runner

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -4,6 +4,8 @@ use crate::{DebugNode, ExitReason, debugger::DebuggerContext};
 use alloy_primitives::{Address, hex};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use foundry_evm_core::buffer::BufferKind;
+use foundry_tui::TuiApp;
+use ratatui::Frame;
 use revm::bytecode::opcode::OpCode;
 use revm_inspectors::tracing::types::{CallKind, CallTraceStep};
 use std::ops::ControlFlow;
@@ -312,6 +314,18 @@ impl TUIContext<'_> {
 
     fn n_steps(&self) -> usize {
         self.debug_steps().len()
+    }
+}
+
+impl TuiApp for TUIContext<'_> {
+    type Exit = ExitReason;
+
+    fn draw(&mut self, frame: &mut Frame<'_>) {
+        self.draw_layout(frame);
+    }
+
+    fn handle_event(&mut self, event: Event) -> ControlFlow<Self::Exit> {
+        TUIContext::handle_event(self, event)
     }
 }
 

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -13,15 +13,10 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
 };
 use revm_inspectors::tracing::types::CallKind;
-use std::{collections::VecDeque, fmt::Write, io};
+use std::{collections::VecDeque, fmt::Write};
 
 impl TUIContext<'_> {
-    /// Draws the TUI layout and subcomponents to the given terminal.
-    pub(crate) fn draw(&self, terminal: &mut super::DebuggerTerminal) -> io::Result<()> {
-        terminal.draw(|f| self.draw_layout(f)).map(drop)
-    }
-
-    fn draw_layout(&self, f: &mut Frame<'_>) {
+    pub(crate) fn draw_layout(&self, f: &mut Frame<'_>) {
         // We need 100 columns to display a 32 byte word in the memory and stack panes.
         let area = f.area();
         let min_width = 100;

--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -1,17 +1,13 @@
 //! The debugger TUI.
 
-use crossterm::event;
 use eyre::Result;
-use foundry_tui::{CrosstermTerminal, with_terminal};
-use std::ops::ControlFlow;
+use foundry_tui::run_app;
 
 mod context;
 use crate::debugger::DebuggerContext;
 use context::TUIContext;
 
 mod draw;
-
-type DebuggerTerminal = CrosstermTerminal;
 
 /// Debugger exit reason.
 #[derive(Debug)]
@@ -33,19 +29,13 @@ impl<'a> TUI<'a> {
 
     /// Starts the debugger TUI.
     pub fn try_run(&mut self) -> Result<ExitReason> {
-        with_terminal(|terminal| self.run_inner(terminal))?
+        self.run_inner()
     }
 
     #[instrument(target = "debugger", name = "run", skip_all, ret)]
-    fn run_inner(&mut self, terminal: &mut DebuggerTerminal) -> Result<ExitReason> {
+    fn run_inner(&mut self) -> Result<ExitReason> {
         let mut cx = TUIContext::new(self.debugger_context);
         cx.init();
-        loop {
-            cx.draw(terminal)?;
-            match cx.handle_event(event::read()?) {
-                ControlFlow::Continue(()) => {}
-                ControlFlow::Break(reason) => return Ok(reason),
-            }
-        }
+        Ok(run_app(&mut cx)?)
     }
 }

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -1,16 +1,17 @@
 //! Shared terminal UI utilities for Foundry.
 
 use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture},
+    event::{DisableMouseCapture, EnableMouseCapture, Event, read},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::{
-    Terminal,
+    Frame, Terminal,
     backend::{Backend, CrosstermBackend},
 };
 use std::{
     io::{Result as IoResult, Stdout, Write, stdout},
+    ops::ControlFlow,
     panic::{PanicHookInfo, set_hook, take_hook},
     sync::Arc,
     thread::panicking,
@@ -26,6 +27,36 @@ pub fn with_terminal<T>(f: impl FnMut(&mut CrosstermTerminal) -> T) -> IoResult<
     let backend = CrosstermBackend::new(stdout());
     let terminal = Terminal::new(backend)?;
     Ok(TerminalGuard::with(terminal, f))
+}
+
+/// An interactive terminal application.
+pub trait TuiApp {
+    /// The reason the application exited.
+    type Exit;
+
+    /// Draws one frame.
+    fn draw(&mut self, frame: &mut Frame<'_>);
+
+    /// Handles one terminal event.
+    fn handle_event(&mut self, event: Event) -> ControlFlow<Self::Exit>;
+}
+
+/// Runs an interactive terminal application with the default Foundry terminal setup.
+pub fn run_app<App: TuiApp>(app: &mut App) -> IoResult<App::Exit> {
+    with_terminal(|terminal| run_app_inner(terminal, app))?
+}
+
+fn run_app_inner<App: TuiApp>(
+    terminal: &mut CrosstermTerminal,
+    app: &mut App,
+) -> IoResult<App::Exit> {
+    loop {
+        terminal.draw(|frame| app.draw(frame))?;
+        match app.handle_event(read()?) {
+            ControlFlow::Continue(()) => {}
+            ControlFlow::Break(reason) => return Ok(reason),
+        }
+    }
 }
 
 /// Handles terminal setup and teardown for interactive TUIs.


### PR DESCRIPTION
## Summary
- add a small TuiApp trait and run_app loop to foundry-tui
- move the debugger TUI draw/read loop onto the shared runner
- keep terminal setup/teardown in foundry-tui unchanged