### PR TITLE
feat(lint): add weak-prng lint

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -19,6 +19,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `incorrect-erc721-interface`: Flags ERC721 interfaces and implementations with non-compliant function signatures.
   - `tx-origin`: Flags use of `tx.origin` in authorization-like predicates.
   - `unsafe-typecast`: Typecasts that can truncate values should be checked.
+  - `weak-prng`: Flags randomness-like expressions derived from predictable on-chain values.
 - **Low Severity:**
   - `block-timestamp`: Warns when `block.timestamp` is used in a comparison, as it may be manipulated by validators.
   - `missing-zero-check`: Address parameter is used in a state write or value transfer without a zero-address check.

--- a/crates/lint/docs/weak-prng.md
+++ b/crates/lint/docs/weak-prng.md
@@ -1,0 +1,40 @@
+# Weak pseudo-random number generation
+
+**Severity**: `Med`
+**ID**: `weak-prng`
+
+Flags randomness-like expressions that directly derive entropy from predictable on-chain values.
+
+## What it does
+
+Reports direct use of `block.timestamp`, `blockhash(...)`, `block.prevrandao`, or
+`block.difficulty` in modulo expressions, `keccak256(...)`, or `abi.encodePacked(...)`.
+
+## Why is this bad?
+
+Block data is visible before transaction execution and can often be influenced or withheld by a
+block proposer. Hashing or applying modulo to these values does not make them unpredictable, so an
+attacker may be able to bias outcomes such as lotteries, mints, or game mechanics.
+
+Use a commit-reveal scheme, an oracle such as a VRF, or another protocol designed for
+unpredictable randomness.
+
+## Example
+
+### Bad
+
+```solidity
+uint256 winner = uint256(keccak256(abi.encodePacked(block.timestamp, msg.sender))) % players.length;
+```
+
+### Good
+
+```solidity
+// Example shape only: consume randomness that was committed before it was revealed.
+uint256 winner = uint256(keccak256(abi.encodePacked(revealedSeed, msg.sender))) % players.length;
+```
+
+## Notes
+
+This lint is intentionally local and conservative. It does not attempt interprocedural taint
+tracking, so values copied into a variable before use may require manual review.

--- a/crates/lint/src/sol/med/mod.rs
+++ b/crates/lint/src/sol/med/mod.rs
@@ -15,10 +15,14 @@ use tx_origin::TX_ORIGIN;
 mod unsafe_typecast;
 use unsafe_typecast::UNSAFE_TYPECAST;
 
+mod weak_prng;
+use weak_prng::WEAK_PRNG;
+
 register_lints!(
     (DivideBeforeMultiply, early, (DIVIDE_BEFORE_MULTIPLY)),
     (IncorrectERC20Interface, late, (INCORRECT_ERC20_INTERFACE)),
     (IncorrectERC721Interface, late, (INCORRECT_ERC721_INTERFACE)),
     (TxOrigin, early, (TX_ORIGIN)),
-    (UnsafeTypecast, late, (UNSAFE_TYPECAST))
+    (UnsafeTypecast, late, (UNSAFE_TYPECAST)),
+    (WeakPrng, early, (WEAK_PRNG))
 );

--- a/crates/lint/src/sol/med/weak_prng.rs
+++ b/crates/lint/src/sol/med/weak_prng.rs
@@ -1,0 +1,142 @@
+use super::WeakPrng;
+use crate::{
+    linter::{EarlyLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::{
+    ast::{BinOp, BinOpKind, Expr, ExprKind, IndexKind, ItemFunction, visit::Visit},
+    interface::SpannedOption,
+};
+use std::ops::ControlFlow;
+
+declare_forge_lint!(
+    WEAK_PRNG,
+    Severity::Med,
+    "weak-prng",
+    "weak randomness derived from a predictable on-chain value"
+);
+
+impl<'ast> EarlyLintPass<'ast> for WeakPrng {
+    fn check_item_function(&mut self, ctx: &LintContext, func: &'ast ItemFunction<'ast>) {
+        if let Some(body) = &func.body {
+            let mut checker = WeakPrngChecker { ctx };
+            let _ = checker.visit_block(body);
+        }
+    }
+}
+
+struct WeakPrngChecker<'a, 's> {
+    ctx: &'a LintContext<'s, 'a>,
+}
+
+impl<'ast> Visit<'ast> for WeakPrngChecker<'_, '_> {
+    type BreakValue = ();
+
+    fn visit_expr(&mut self, expr: &'ast Expr<'ast>) -> ControlFlow<Self::BreakValue> {
+        if is_randomness_expr(expr) {
+            self.ctx.emit(&WEAK_PRNG, expr.span);
+            ControlFlow::Continue(())
+        } else {
+            self.walk_expr(expr)
+        }
+    }
+}
+
+fn is_randomness_expr(expr: &Expr<'_>) -> bool {
+    match &expr.peel_parens().kind {
+        ExprKind::Binary(lhs, BinOp { kind: BinOpKind::Rem, .. }, rhs) => {
+            contains_predictable_source(lhs) || contains_predictable_source(rhs)
+        }
+        ExprKind::Call(callee, args) => {
+            let callee = callee.peel_parens();
+            (is_keccak256(callee) || is_abi_encode_packed(callee))
+                && args.exprs().any(contains_predictable_source)
+        }
+        _ => false,
+    }
+}
+
+fn contains_predictable_source(expr: &Expr<'_>) -> bool {
+    let expr = expr.peel_parens();
+    if is_predictable_source(expr) {
+        return true;
+    }
+
+    match &expr.kind {
+        ExprKind::Array(elems) => elems.iter().any(|elem| contains_predictable_source(elem)),
+        ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {
+            contains_predictable_source(lhs) || contains_predictable_source(rhs)
+        }
+        ExprKind::Call(callee, args) => {
+            contains_predictable_source(callee) || args.exprs().any(contains_predictable_source)
+        }
+        ExprKind::CallOptions(callee, options) => {
+            contains_predictable_source(callee)
+                || options.iter().any(|option| contains_predictable_source(&option.value))
+        }
+        ExprKind::Delete(inner) | ExprKind::Member(inner, _) | ExprKind::Unary(_, inner) => {
+            contains_predictable_source(inner)
+        }
+        ExprKind::Index(base, index) => {
+            contains_predictable_source(base)
+                || match index {
+                    IndexKind::Index(Some(index)) => contains_predictable_source(index),
+                    IndexKind::Range(start, end) => {
+                        start.as_ref().is_some_and(|start| contains_predictable_source(start))
+                            || end.as_ref().is_some_and(|end| contains_predictable_source(end))
+                    }
+                    _ => false,
+                }
+        }
+        ExprKind::Payable(args) => args.exprs().any(contains_predictable_source),
+        ExprKind::Ternary(cond, then_expr, else_expr) => {
+            contains_predictable_source(cond)
+                || contains_predictable_source(then_expr)
+                || contains_predictable_source(else_expr)
+        }
+        ExprKind::Tuple(elems) => elems.iter().any(|elem| {
+            if let SpannedOption::Some(inner) = elem.as_ref() {
+                contains_predictable_source(inner)
+            } else {
+                false
+            }
+        }),
+        _ => false,
+    }
+}
+
+fn is_predictable_source(expr: &Expr<'_>) -> bool {
+    is_block_member(expr) || is_blockhash_call(expr)
+}
+
+fn is_block_member(expr: &Expr<'_>) -> bool {
+    matches!(
+        &expr.kind,
+        ExprKind::Member(base, member)
+            if matches!(member.as_str(), "timestamp" | "prevrandao" | "difficulty")
+            && is_ident(base.peel_parens(), "block")
+    )
+}
+
+fn is_blockhash_call(expr: &Expr<'_>) -> bool {
+    matches!(
+        &expr.kind,
+        ExprKind::Call(callee, _) if is_ident(callee.peel_parens(), "blockhash")
+    )
+}
+
+fn is_keccak256(expr: &Expr<'_>) -> bool {
+    is_ident(expr, "keccak256")
+}
+
+fn is_abi_encode_packed(expr: &Expr<'_>) -> bool {
+    matches!(
+        &expr.kind,
+        ExprKind::Member(base, member)
+            if member.as_str() == "encodePacked" && is_ident(base.peel_parens(), "abi")
+    )
+}
+
+fn is_ident(expr: &Expr<'_>, name: &str) -> bool {
+    matches!(&expr.kind, ExprKind::Ident(ident) if ident.as_str() == name)
+}

--- a/crates/lint/src/sol/med/weak_prng.rs
+++ b/crates/lint/src/sol/med/weak_prng.rs
@@ -72,7 +72,7 @@ fn contains_predictable_source(expr: &Expr<'_>) -> bool {
         }
         ExprKind::CallOptions(callee, options) => {
             contains_predictable_source(callee)
-                || options.iter().any(|option| contains_predictable_source(&option.value))
+                || options.iter().any(|option| contains_predictable_source(option.value))
         }
         ExprKind::Delete(inner) | ExprKind::Member(inner, _) | ExprKind::Unary(_, inner) => {
             contains_predictable_source(inner)

--- a/crates/lint/testdata/WeakPrng.sol
+++ b/crates/lint/testdata/WeakPrng.sol
@@ -1,0 +1,60 @@
+//@compile-flags: --only-lint weak-prng
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+contract WeakPrng {
+    uint256 public deadline;
+
+    // SHOULD FAIL:
+
+    function timestampModulo(uint256 upper) external view returns (uint256) {
+        return block.timestamp % upper; //~WARN: weak randomness derived from a predictable on-chain value
+    }
+
+    function blockhashModulo(uint256 upper) external view returns (uint256) {
+        return uint256(blockhash(block.number - 1)) % upper; //~WARN: weak randomness derived from a predictable on-chain value
+    }
+
+    function hashTimestamp(uint256 upper) external view returns (uint256) {
+        return uint256(keccak256(abi.encodePacked(block.timestamp, msg.sender))) % upper; //~WARN: weak randomness derived from a predictable on-chain value
+    }
+
+    function encodePackedPrevrandao() external view returns (bytes memory) {
+        return abi.encodePacked(block.prevrandao, msg.sender); //~WARN: weak randomness derived from a predictable on-chain value
+    }
+
+    function hashDifficulty() external view returns (bytes32) {
+        return keccak256(abi.encodePacked(block.difficulty)); //~WARN: weak randomness derived from a predictable on-chain value
+    }
+
+    function hashBlockhash() external view returns (bytes32) {
+        return keccak256(abi.encodePacked(blockhash(block.number - 1))); //~WARN: weak randomness derived from a predictable on-chain value
+    }
+
+    // SHOULD PASS:
+
+    function timestampOnly() external view returns (uint256) {
+        return block.timestamp;
+    }
+
+    function schedulingOnly() external view returns (bool) {
+        return block.timestamp > deadline;
+    }
+
+    function hashInput(bytes memory data) external pure returns (bytes32) {
+        return keccak256(data);
+    }
+
+    function encodePackedInput(address account) external pure returns (bytes memory) {
+        return abi.encodePacked(account);
+    }
+
+    function moduloInput(uint256 seed, uint256 upper) external pure returns (uint256) {
+        return seed % upper;
+    }
+
+    function localValueNotTracked(uint256 upper) external view returns (uint256) {
+        uint256 seed = block.timestamp;
+        return seed % upper;
+    }
+}

--- a/crates/lint/testdata/WeakPrng.stderr
+++ b/crates/lint/testdata/WeakPrng.stderr
@@ -1,0 +1,48 @@
+warning[weak-prng]: weak randomness derived from a predictable on-chain value
+   ╭▸ ROOT/testdata/WeakPrng.sol:LL:CC
+   │
+LL │         return block.timestamp % upper;
+   │                ━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/weak-prng
+
+warning[weak-prng]: weak randomness derived from a predictable on-chain value
+   ╭▸ ROOT/testdata/WeakPrng.sol:LL:CC
+   │
+LL │         return uint256(blockhash(block.number - 1)) % upper;
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/weak-prng
+
+warning[weak-prng]: weak randomness derived from a predictable on-chain value
+   ╭▸ ROOT/testdata/WeakPrng.sol:LL:CC
+   │
+LL │ …     return uint256(keccak256(abi.encodePacked(block.timestamp, msg.sender))) % upper;
+   │              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/weak-prng
+
+warning[weak-prng]: weak randomness derived from a predictable on-chain value
+   ╭▸ ROOT/testdata/WeakPrng.sol:LL:CC
+   │
+LL │         return abi.encodePacked(block.prevrandao, msg.sender);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/weak-prng
+
+warning[weak-prng]: weak randomness derived from a predictable on-chain value
+   ╭▸ ROOT/testdata/WeakPrng.sol:LL:CC
+   │
+LL │         return keccak256(abi.encodePacked(block.difficulty));
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/weak-prng
+
+warning[weak-prng]: weak randomness derived from a predictable on-chain value
+   ╭▸ ROOT/testdata/WeakPrng.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(blockhash(block.number - 1)));
+   │              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/weak-prng
+


### PR DESCRIPTION
CLOSES OSS-54

## Summary
- add the medium-severity `weak-prng` forge lint for predictable on-chain randomness sources
- detect direct use of `block.timestamp`, `blockhash(...)`, `block.prevrandao`, and `block.difficulty` in modulo, `keccak256(...)`, and `abi.encodePacked(...)` expressions
- document the lint and add UI test coverage with blessed stderr

## Validation
- `cargo +1.94 test -p forge --test ui -- --bless WeakPrng`
- `cargo +1.94 fmt --check`
- `cargo +1.94 check -p forge-lint`
- `cargo +1.94 test -p forge --test ui -- lint`
- `cargo +1.94 test -p forge-lint`