### PR TITLE
feat(lint): add low-level-calls lint

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -9,6 +9,7 @@ It helps enforce best practices and improve code quality within Foundry projects
 
 - **High Severity:**
   - `incorrect-shift`: Warns against shift operations where operands might be in the wrong order.
+  - `low-level-calls`: Direct use of low-level calls should be avoided.
   - `unchecked-call`: Low-level calls should check the success return value.
   - `erc20-unchecked-transfer`: ERC20 `transfer` and `transferFrom` calls should check the return value.
   - `rtlo`: Flags Unicode bidirectional override characters ("Trojan Source", CVE-2021-42574) that can hide malicious code.

--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -9,7 +9,6 @@ It helps enforce best practices and improve code quality within Foundry projects
 
 - **High Severity:**
   - `incorrect-shift`: Warns against shift operations where operands might be in the wrong order.
-  - `low-level-calls`: Direct use of low-level calls should be avoided.
   - `unchecked-call`: Low-level calls should check the success return value.
   - `erc20-unchecked-transfer`: ERC20 `transfer` and `transferFrom` calls should check the return value.
   - `rtlo`: Flags Unicode bidirectional override characters ("Trojan Source", CVE-2021-42574) that can hide malicious code.
@@ -18,6 +17,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `divide-before-multiply`: Warns against performing division before multiplication in the same expression, which can cause precision loss.
   - `incorrect-erc20-interface`: Flags ERC20 interfaces and implementations with non-compliant function signatures.
   - `incorrect-erc721-interface`: Flags ERC721 interfaces and implementations with non-compliant function signatures.
+  - `low-level-calls`: Direct use of low-level calls should be avoided.
   - `tx-origin`: Flags use of `tx.origin` in authorization-like predicates.
   - `unsafe-typecast`: Typecasts that can truncate values should be checked.
 - **Low Severity:**

--- a/crates/lint/docs/low-level-calls.md
+++ b/crates/lint/docs/low-level-calls.md
@@ -1,6 +1,6 @@
 # Low-level calls
 
-**Severity**: `High`
+**Severity**: `Med`
 **ID**: `low-level-calls`
 
 Flags direct use of Solidity low-level calls (`call`, `delegatecall`, and `staticcall`).

--- a/crates/lint/docs/low-level-calls.md
+++ b/crates/lint/docs/low-level-calls.md
@@ -1,0 +1,32 @@
+# Low-level calls
+
+**Severity**: `High`
+**ID**: `low-level-calls`
+
+Flags direct use of Solidity low-level calls (`call`, `delegatecall`, and `staticcall`).
+
+## What it does
+
+Warns whenever a contract uses a low-level call expression, even if the success return value is
+captured and checked.
+
+## Why is this bad?
+
+Low-level calls bypass Solidity's normal ABI checks and function dispatch safety. They are also
+easy to misuse because failures are reported through return values instead of automatically
+reverting. Prefer typed interface calls when the target function is known.
+
+## Example
+
+### Bad
+
+```solidity
+(bool ok, bytes memory ret) = target.call(data);
+require(ok, "call failed");
+```
+
+### Good
+
+```solidity
+IReceiver(target).receiveMessage(data);
+```

--- a/crates/lint/src/sol/high/calls.rs
+++ b/crates/lint/src/sol/high/calls.rs
@@ -1,0 +1,25 @@
+use solar::{
+    ast::{Expr, ExprKind},
+    interface::kw,
+};
+
+/// Checks if an expression is a low-level call.
+///
+/// Detects patterns like:
+/// - `target.call(...)`
+/// - `target.delegatecall(...)`
+/// - `target.staticcall(...)`
+/// - `target.call{value: x}(...)`
+pub(super) const fn is_low_level_call(expr: &Expr<'_>) -> bool {
+    if let ExprKind::Call(call_expr, _args) = &expr.kind {
+        let callee = match &call_expr.kind {
+            ExprKind::CallOptions(inner_expr, _) => inner_expr,
+            _ => call_expr,
+        };
+
+        if let ExprKind::Member(_, member) = &callee.kind {
+            return matches!(member.name, kw::Call | kw::Delegatecall | kw::Staticcall);
+        }
+    }
+    false
+}

--- a/crates/lint/src/sol/high/low_level_calls.rs
+++ b/crates/lint/src/sol/high/low_level_calls.rs
@@ -1,0 +1,38 @@
+use super::{LowLevelCalls, calls::is_low_level_call};
+use crate::{
+    linter::{EarlyLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::ast::{Expr, ItemFunction, visit::Visit};
+use std::ops::ControlFlow;
+
+declare_forge_lint!(
+    LOW_LEVEL_CALLS,
+    Severity::High,
+    "low-level-calls",
+    "Low-level calls should be avoided"
+);
+
+impl<'ast> EarlyLintPass<'ast> for LowLevelCalls {
+    fn check_item_function(&mut self, ctx: &LintContext, func: &'ast ItemFunction<'ast>) {
+        if let Some(body) = &func.body {
+            let mut checker = LowLevelCallsChecker { ctx };
+            let _ = checker.visit_block(body);
+        }
+    }
+}
+
+struct LowLevelCallsChecker<'a, 's> {
+    ctx: &'a LintContext<'s, 'a>,
+}
+
+impl<'ast> Visit<'ast> for LowLevelCallsChecker<'_, '_> {
+    type BreakValue = ();
+
+    fn visit_expr(&mut self, expr: &'ast Expr<'ast>) -> ControlFlow<Self::BreakValue> {
+        if is_low_level_call(expr) {
+            self.ctx.emit(&LOW_LEVEL_CALLS, expr.span);
+        }
+        self.walk_expr(expr)
+    }
+}

--- a/crates/lint/src/sol/high/low_level_calls.rs
+++ b/crates/lint/src/sol/high/low_level_calls.rs
@@ -8,7 +8,7 @@ use std::ops::ControlFlow;
 
 declare_forge_lint!(
     LOW_LEVEL_CALLS,
-    Severity::High,
+    Severity::Med,
     "low-level-calls",
     "Low-level calls should be avoided"
 );

--- a/crates/lint/src/sol/high/mod.rs
+++ b/crates/lint/src/sol/high/mod.rs
@@ -1,15 +1,19 @@
 use crate::sol::{EarlyLintPass, LateLintPass, SolLint};
 
+mod calls;
 mod incorrect_shift;
+mod low_level_calls;
 mod rtlo;
 mod unchecked_calls;
 
 use incorrect_shift::INCORRECT_SHIFT;
+use low_level_calls::LOW_LEVEL_CALLS;
 use rtlo::RTLO;
 use unchecked_calls::{ERC20_UNCHECKED_TRANSFER, UNCHECKED_CALL};
 
 register_lints!(
     (IncorrectShift, early, (INCORRECT_SHIFT)),
+    (LowLevelCalls, early, (LOW_LEVEL_CALLS)),
     (UncheckedCall, early, (UNCHECKED_CALL)),
     (UncheckedTransferERC20, late, (ERC20_UNCHECKED_TRANSFER)),
     (Rtlo, early, (RTLO))

--- a/crates/lint/src/sol/high/unchecked_calls.rs
+++ b/crates/lint/src/sol/high/unchecked_calls.rs
@@ -1,11 +1,10 @@
-use super::{UncheckedCall, UncheckedTransferERC20};
+use super::{UncheckedCall, UncheckedTransferERC20, calls::is_low_level_call};
 use crate::{
     linter::{EarlyLintPass, LateLintPass, LintContext},
     sol::{Severity, SolLint},
 };
 use solar::{
     ast::{Expr, ExprKind, ItemFunction, Stmt, StmtKind, visit::Visit},
-    interface::kw,
     sema::hir::{self},
 };
 use std::ops::ControlFlow;
@@ -159,31 +158,6 @@ impl<'ast> Visit<'ast> for UncheckedCallChecker<'_, '_> {
         }
         self.walk_stmt(stmt)
     }
-}
-
-/// Checks if an expression is a low-level call that should be checked.
-///
-/// Detects patterns like:
-/// - `target.call(...)`
-/// - `target.delegatecall(...)`
-/// - `target.staticcall(...)`
-/// - `target.call{value: x}(...)`
-const fn is_low_level_call(expr: &Expr<'_>) -> bool {
-    if let ExprKind::Call(call_expr, _args) = &expr.kind {
-        // Check the callee expression
-        let callee = match &call_expr.kind {
-            // Handle call options like {value: x}
-            ExprKind::CallOptions(inner_expr, _) => inner_expr,
-            // Direct call without options
-            _ => call_expr,
-        };
-
-        if let ExprKind::Member(_, member) = &callee.kind {
-            // Check for low-level call methods
-            return matches!(member.name, kw::Call | kw::Delegatecall | kw::Staticcall);
-        }
-    }
-    false
 }
 
 /// Checks if a tuple assignment doesn't properly check the success value.

--- a/crates/lint/testdata/LowLevelCalls.sol
+++ b/crates/lint/testdata/LowLevelCalls.sol
@@ -1,0 +1,63 @@
+//@compile-flags: --only-lint low-level-calls
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface Receiver {
+    function ping(bytes calldata data) external returns (bool);
+}
+
+contract LowLevelCalls {
+    event CallResult(bool, bytes);
+
+    bytes existingData;
+
+    function checkedCall(address target, bytes memory data) public {
+        (bool success, bytes memory result) = target.call(data); //~WARN: Low-level calls should be avoided
+        require(success, "Call failed");
+        emit CallResult(success, result);
+    }
+
+    function checkedCallWithValue(address payable target, uint256 value) public {
+        (bool success, ) = target.call{value: value}(""); //~WARN: Low-level calls should be avoided
+        require(success, "Call failed");
+    }
+
+    function checkedDelegateCall(address target, bytes memory data) public returns (bool) {
+        (bool success, ) = target.delegatecall(data); //~WARN: Low-level calls should be avoided
+        return success;
+    }
+
+    function checkedStaticCall(address target, bytes memory data) public view returns (bytes memory) {
+        (bool success, bytes memory result) = target.staticcall(data); //~WARN: Low-level calls should be avoided
+        require(success, "Static call failed");
+        return result;
+    }
+
+    function uncheckedCall(address target, bytes memory data) public {
+        target.call(data); //~WARN: Low-level calls should be avoided
+    }
+
+    function uncheckedCallWithValue(address payable target, uint256 value) public {
+        target.call{value: value}(""); //~WARN: Low-level calls should be avoided
+    }
+
+    function uncheckedDelegateCall(address target, bytes memory data) public {
+        target.delegatecall(data); //~WARN: Low-level calls should be avoided
+    }
+
+    function uncheckedStaticCall(address target, bytes memory data) public view {
+        target.staticcall(data); //~WARN: Low-level calls should be avoided
+    }
+
+    function ignoredSuccess(address target) public {
+        (, existingData) = target.call(""); //~WARN: Low-level calls should be avoided
+    }
+
+    function nonLowLevelMemberCalls(Receiver receiver, address payable target, bytes calldata data) public {
+        receiver.ping(data);
+        target.transfer(1 wei);
+        bool sent = target.send(1 wei);
+        require(sent, "Send failed");
+    }
+}

--- a/crates/lint/testdata/LowLevelCalls.stderr
+++ b/crates/lint/testdata/LowLevelCalls.stderr
@@ -1,0 +1,72 @@
+warning[low-level-calls]: Low-level calls should be avoided
+   ╭▸ ROOT/testdata/LowLevelCalls.sol:LL:CC
+   │
+LL │         (bool success, bytes memory result) = target.call(data);
+   │                                               ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/low-level-calls
+
+warning[low-level-calls]: Low-level calls should be avoided
+   ╭▸ ROOT/testdata/LowLevelCalls.sol:LL:CC
+   │
+LL │         (bool success, ) = target.call{value: value}("");
+   │                            ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/low-level-calls
+
+warning[low-level-calls]: Low-level calls should be avoided
+   ╭▸ ROOT/testdata/LowLevelCalls.sol:LL:CC
+   │
+LL │         (bool success, ) = target.delegatecall(data);
+   │                            ━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/low-level-calls
+
+warning[low-level-calls]: Low-level calls should be avoided
+   ╭▸ ROOT/testdata/LowLevelCalls.sol:LL:CC
+   │
+LL │         (bool success, bytes memory result) = target.staticcall(data);
+   │                                               ━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/low-level-calls
+
+warning[low-level-calls]: Low-level calls should be avoided
+   ╭▸ ROOT/testdata/LowLevelCalls.sol:LL:CC
+   │
+LL │         target.call(data);
+   │         ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/low-level-calls
+
+warning[low-level-calls]: Low-level calls should be avoided
+   ╭▸ ROOT/testdata/LowLevelCalls.sol:LL:CC
+   │
+LL │         target.call{value: value}("");
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/low-level-calls
+
+warning[low-level-calls]: Low-level calls should be avoided
+   ╭▸ ROOT/testdata/LowLevelCalls.sol:LL:CC
+   │
+LL │         target.delegatecall(data);
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/low-level-calls
+
+warning[low-level-calls]: Low-level calls should be avoided
+   ╭▸ ROOT/testdata/LowLevelCalls.sol:LL:CC
+   │
+LL │         target.staticcall(data);
+   │         ━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/low-level-calls
+
+warning[low-level-calls]: Low-level calls should be avoided
+   ╭▸ ROOT/testdata/LowLevelCalls.sol:LL:CC
+   │
+LL │         (, existingData) = target.call("");
+   │                            ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/low-level-calls
+

--- a/crates/lint/testdata/MissingZeroCheck.sol
+++ b/crates/lint/testdata/MissingZeroCheck.sol
@@ -1,3 +1,5 @@
+//@compile-flags: --only-lint missing-zero-check
+
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 

--- a/crates/lint/testdata/UncheckedCall.sol
+++ b/crates/lint/testdata/UncheckedCall.sol
@@ -1,4 +1,4 @@
-//@compile-flags: --severity high
+//@compile-flags: --only-lint unchecked-call
 
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;


### PR DESCRIPTION
## Summary
- add a high-severity `low-level-calls` lint for direct `.call`, `.delegatecall`, and `.staticcall` usage
- extract the low-level-call matcher for reuse by `unchecked-call`
- add docs, README entry, and UI coverage for checked/unchecked calls, call options, and non-low-level members

## Tests
- `cargo +1.94 test -p forge --test ui -- LowLevelCalls --bless`
- `cargo +1.94 test -p forge --test ui -- lint`
- `rustfmt +1.94 --check --edition 2024 crates/lint/src/sol/high/calls.rs crates/lint/src/sol/high/low_level_calls.rs crates/lint/src/sol/high/mod.rs crates/lint/src/sol/high/unchecked_calls.rs`

CLOSES OSS-30
