### PR TITLE
feat(lint): add cache-array-length lint

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -41,6 +41,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `missing-inheritance`: Flags contracts that implement every external function of an interface without explicitly inheriting from it.
 - **Gas Optimizations:**
   - `asm-keccak256`: Recommends using inline assembly for `keccak256` for potential gas savings.
+  - `cache-array-length`: Recommends caching dynamic array or `bytes` lengths used in `for` loop conditions.
   - `could-be-immutable`: Recommends declaring constructor-only state variables as `immutable`.
   - `custom-errors`: Recommends using custom errors instead of strings and plain reverts for potential gas savings.
   - `unused-state-variables`: State variables that are never used should be removed.

--- a/crates/lint/docs/cache-array-length.md
+++ b/crates/lint/docs/cache-array-length.md
@@ -1,0 +1,56 @@
+# Array length not cached
+
+**Severity**: `Gas`
+**ID**: `cache-array-length`
+
+Flags `for` loop conditions that read a dynamic array or `bytes` value's `.length` on every
+iteration instead of comparing against a cached local length.
+
+## What it does
+
+Reports comparison expressions in `for` loop conditions when either side reads `.length` from a
+dynamic array-like value, such as `i < values.length`, `values.length > i`, or compound conditions
+that repeat the same pattern.
+
+The lint does not report loops that already compare against a local cached length variable.
+
+## Why is this bad?
+
+Reading `.length` in the loop condition repeats the length lookup for every iteration. Caching the
+length once before entering the loop avoids repeated storage, memory, or calldata reads and can
+reduce gas for hot loops.
+
+## Example
+
+### Bad
+
+```solidity
+contract C {
+    uint256[] values;
+
+    function sum() external view returns (uint256 total) {
+        for (uint256 i = 0; i < values.length; ++i) {
+            total += values[i];
+        }
+    }
+}
+```
+
+### Good
+
+```solidity
+contract C {
+    uint256[] values;
+
+    function sum() external view returns (uint256 total) {
+        uint256 length = values.length;
+        for (uint256 i = 0; i < length; ++i) {
+            total += values[i];
+        }
+    }
+}
+```
+
+## Notes
+
+This is a `Gas`-severity lint and is **not** applied to test or script files.

--- a/crates/lint/src/sol/gas/cache_array_length.rs
+++ b/crates/lint/src/sol/gas/cache_array_length.rs
@@ -1,0 +1,197 @@
+use super::CacheArrayLength;
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::{
+    interface::{Symbol, sym},
+    sema::hir::{
+        self, BinOpKind, ElementaryType, ExprKind, ItemId, LoopSource, Res, StmtKind, TypeKind,
+        UnOpKind,
+    },
+};
+
+declare_forge_lint!(
+    CACHE_ARRAY_LENGTH,
+    Severity::Gas,
+    "cache-array-length",
+    "array length read in loop condition should be cached outside the loop"
+);
+
+impl<'hir> LateLintPass<'hir> for CacheArrayLength {
+    fn check_stmt(
+        &mut self,
+        ctx: &LintContext,
+        hir: &'hir hir::Hir<'hir>,
+        stmt: &'hir hir::Stmt<'hir>,
+    ) {
+        let StmtKind::Loop(block, LoopSource::For) = &stmt.kind else { return };
+        let Some(condition) = for_loop_condition(*block) else { return };
+
+        emit_condition_length_reads(ctx, hir, condition);
+    }
+}
+
+fn for_loop_condition<'hir>(block: hir::Block<'hir>) -> Option<&'hir hir::Expr<'hir>> {
+    let first = block.stmts.first()?;
+    match &first.kind {
+        StmtKind::If(condition, _, Some(else_stmt)) => {
+            matches!(&else_stmt.kind, StmtKind::Break).then_some(*condition)
+        }
+        _ => None,
+    }
+}
+
+fn emit_condition_length_reads<'hir>(
+    ctx: &LintContext,
+    hir: &'hir hir::Hir<'hir>,
+    expr: &'hir hir::Expr<'hir>,
+) {
+    match &expr.peel_parens().kind {
+        ExprKind::Binary(lhs, op, rhs) if is_comparison(op.kind) => {
+            emit_length_reads(ctx, hir, lhs);
+            emit_length_reads(ctx, hir, rhs);
+        }
+        ExprKind::Binary(lhs, op, rhs) if matches!(op.kind, BinOpKind::And | BinOpKind::Or) => {
+            emit_condition_length_reads(ctx, hir, lhs);
+            emit_condition_length_reads(ctx, hir, rhs);
+        }
+        ExprKind::Unary(op, inner) if op.kind == UnOpKind::Not => {
+            emit_condition_length_reads(ctx, hir, inner);
+        }
+        _ => {}
+    }
+}
+
+fn emit_length_reads<'hir>(
+    ctx: &LintContext,
+    hir: &'hir hir::Hir<'hir>,
+    expr: &'hir hir::Expr<'hir>,
+) {
+    let expr = expr.peel_parens();
+    if is_array_length_member(hir, expr) {
+        ctx.emit(&CACHE_ARRAY_LENGTH, expr.span);
+        return;
+    }
+
+    match &expr.kind {
+        ExprKind::Array(exprs) => {
+            for expr in *exprs {
+                emit_length_reads(ctx, hir, expr);
+            }
+        }
+        ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {
+            emit_length_reads(ctx, hir, lhs);
+            emit_length_reads(ctx, hir, rhs);
+        }
+        ExprKind::Call(callee, args, named_args) => {
+            emit_length_reads(ctx, hir, callee);
+            for arg in args.exprs() {
+                emit_length_reads(ctx, hir, arg);
+            }
+            if let Some(named_args) = named_args {
+                for arg in *named_args {
+                    emit_length_reads(ctx, hir, &arg.value);
+                }
+            }
+        }
+        ExprKind::Delete(inner) | ExprKind::Payable(inner) | ExprKind::Unary(_, inner) => {
+            emit_length_reads(ctx, hir, inner);
+        }
+        ExprKind::Index(base, index) => {
+            emit_length_reads(ctx, hir, base);
+            if let Some(index) = index {
+                emit_length_reads(ctx, hir, index);
+            }
+        }
+        ExprKind::Slice(base, start, end) => {
+            emit_length_reads(ctx, hir, base);
+            if let Some(start) = start {
+                emit_length_reads(ctx, hir, start);
+            }
+            if let Some(end) = end {
+                emit_length_reads(ctx, hir, end);
+            }
+        }
+        ExprKind::Member(base, _) => emit_length_reads(ctx, hir, base),
+        ExprKind::Ternary(condition, then_expr, else_expr) => {
+            emit_length_reads(ctx, hir, condition);
+            emit_length_reads(ctx, hir, then_expr);
+            emit_length_reads(ctx, hir, else_expr);
+        }
+        ExprKind::Tuple(exprs) => {
+            for expr in exprs.iter().flatten() {
+                emit_length_reads(ctx, hir, expr);
+            }
+        }
+        ExprKind::Ident(_)
+        | ExprKind::Lit(_)
+        | ExprKind::New(_)
+        | ExprKind::TypeCall(_)
+        | ExprKind::Type(_)
+        | ExprKind::Err(_) => {}
+    }
+}
+
+const fn is_comparison(op: BinOpKind) -> bool {
+    matches!(
+        op,
+        BinOpKind::Lt
+            | BinOpKind::Le
+            | BinOpKind::Gt
+            | BinOpKind::Ge
+            | BinOpKind::Eq
+            | BinOpKind::Ne
+    )
+}
+
+fn is_array_length_member(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    let ExprKind::Member(base, member) = &expr.kind else { return false };
+    member.name == sym::length && is_array_like(hir, base)
+}
+
+fn is_array_like(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    let Some(ty) = expr_type(hir, expr) else { return false };
+    match &ty.kind {
+        TypeKind::Array(array) => array.size.is_none(),
+        TypeKind::Elementary(ElementaryType::Bytes) => true,
+        _ => false,
+    }
+}
+
+fn expr_type<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    expr: &'hir hir::Expr<'hir>,
+) -> Option<&'hir hir::Type<'hir>> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(resolutions) => {
+            let var_id = resolutions.iter().find_map(|res| {
+                if let Res::Item(ItemId::Variable(var_id)) = res { Some(*var_id) } else { None }
+            })?;
+            Some(&hir.variable(var_id).ty)
+        }
+        ExprKind::Index(base, _) => match &expr_type(hir, base)?.kind {
+            TypeKind::Array(array) => Some(&array.element),
+            TypeKind::Mapping(mapping) => Some(&mapping.value),
+            _ => None,
+        },
+        ExprKind::Member(base, member) => {
+            struct_field_type(hir, expr_type(hir, base)?, member.name)
+        }
+        _ => None,
+    }
+}
+
+fn struct_field_type<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    ty: &'hir hir::Type<'hir>,
+    member: Symbol,
+) -> Option<&'hir hir::Type<'hir>> {
+    let TypeKind::Custom(ItemId::Struct(struct_id)) = &ty.kind else { return None };
+    hir.strukt(*struct_id)
+        .fields
+        .iter()
+        .map(|&field_id| hir.variable(field_id))
+        .find(|field| field.name.is_some_and(|name| name.name == member))
+        .map(|field| &field.ty)
+}

--- a/crates/lint/src/sol/gas/mod.rs
+++ b/crates/lint/src/sol/gas/mod.rs
@@ -1,10 +1,12 @@
 use crate::sol::{EarlyLintPass, LateLintPass, SolLint};
 
+mod cache_array_length;
 mod custom_errors;
 mod immutable;
 mod keccak;
 mod unused_state_variables;
 mod var_read_using_this;
+use cache_array_length::CACHE_ARRAY_LENGTH;
 use custom_errors::CUSTOM_ERRORS;
 use immutable::COULD_BE_IMMUTABLE;
 use keccak::ASM_KECCAK256;
@@ -13,6 +15,7 @@ use var_read_using_this::VAR_READ_USING_THIS;
 
 register_lints!(
     (AsmKeccak256, late, (ASM_KECCAK256)),
+    (CacheArrayLength, late, (CACHE_ARRAY_LENGTH)),
     (CustomErrors, early, (CUSTOM_ERRORS)),
     (CouldBeImmutable, late, (COULD_BE_IMMUTABLE)),
     (UnusedStateVariables, late, (UNUSED_STATE_VARIABLES)),

--- a/crates/lint/testdata/CacheArrayLength.sol
+++ b/crates/lint/testdata/CacheArrayLength.sol
@@ -1,0 +1,96 @@
+//@compile-flags: --only-lint cache-array-length
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract CacheArrayLength {
+    uint256[] internal items;
+    bytes internal data;
+    mapping(uint256 => uint256[]) internal buckets;
+    uint256[3] internal fixedItems;
+
+    struct Bag {
+        uint256[] values;
+    }
+
+    struct Counter {
+        uint256 length;
+    }
+
+    Bag internal bag;
+    Counter internal counter;
+
+    function storageArrayLength() external view returns (uint256 sum) {
+        for (uint256 i = 0; i < items.length; ++i) { //~NOTE: array length read in loop condition
+            sum += items[i];
+        }
+    }
+
+    function memoryArrayLength(uint256[] memory values) public pure returns (uint256 sum) {
+        for (uint256 i = 0; i <= values.length; ++i) { //~NOTE: array length read in loop condition
+            if (i < values.length) {
+                sum += values[i];
+            }
+        }
+    }
+
+    function calldataArrayLength(uint256[] calldata values) external pure returns (uint256 sum) {
+        for (uint256 i = 0; values.length > i; ++i) { //~NOTE: array length read in loop condition
+            sum += values[i];
+        }
+    }
+
+    function bytesLength() external view returns (uint256 sum) {
+        for (uint256 i = 0; i < data.length; ++i) { //~NOTE: array length read in loop condition
+            sum += uint8(data[i]);
+        }
+    }
+
+    function nestedArrayLength(uint256[][] memory values) public pure returns (uint256 sum) {
+        for (uint256 i = 0; i < values[0].length; ++i) { //~NOTE: array length read in loop condition
+            sum += values[0][i];
+        }
+    }
+
+    function mappingValueArrayLength(uint256 key) external view returns (uint256 sum) {
+        for (uint256 i = 0; i < buckets[key].length; ++i) { //~NOTE: array length read in loop condition
+            sum += buckets[key][i];
+        }
+    }
+
+    function structFieldArrayLength() external view returns (uint256 sum) {
+        for (uint256 i = 0; i < bag.values.length; ++i) { //~NOTE: array length read in loop condition
+            sum += bag.values[i];
+        }
+    }
+
+    function compoundCondition(uint256[] memory left, uint256[] memory right)
+        public
+        pure
+        returns (uint256 sum)
+    {
+        for (uint256 i = 0; i < left.length && i < right.length; ++i) { //~NOTE: array length read in loop condition
+            //~^NOTE: array length read in loop condition
+            sum += left[i] + right[i];
+        }
+    }
+
+    function cachedLength(uint256[] memory values) public pure returns (uint256 sum) {
+        uint256 length = values.length;
+        for (uint256 i = 0; i < length; ++i) {
+            sum += values[i];
+        }
+    }
+
+    function fixedArrayLength() external view returns (uint256 sum) {
+        for (uint256 i = 0; i < fixedItems.length; ++i) {
+            sum += fixedItems[i];
+        }
+    }
+
+    function nonArrayLengthField() external view returns (uint256 sum) {
+        for (uint256 i = 0; i < counter.length; ++i) {
+            sum += i;
+        }
+    }
+}

--- a/crates/lint/testdata/CacheArrayLength.stderr
+++ b/crates/lint/testdata/CacheArrayLength.stderr
@@ -1,0 +1,72 @@
+note[cache-array-length]: array length read in loop condition should be cached outside the loop
+   ╭▸ ROOT/testdata/CacheArrayLength.sol:LL:CC
+   │
+LL │         for (uint256 i = 0; i < items.length; ++i) {
+   │                                 ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
+
+note[cache-array-length]: array length read in loop condition should be cached outside the loop
+   ╭▸ ROOT/testdata/CacheArrayLength.sol:LL:CC
+   │
+LL │         for (uint256 i = 0; i <= values.length; ++i) {
+   │                                  ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
+
+note[cache-array-length]: array length read in loop condition should be cached outside the loop
+   ╭▸ ROOT/testdata/CacheArrayLength.sol:LL:CC
+   │
+LL │         for (uint256 i = 0; values.length > i; ++i) {
+   │                             ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
+
+note[cache-array-length]: array length read in loop condition should be cached outside the loop
+   ╭▸ ROOT/testdata/CacheArrayLength.sol:LL:CC
+   │
+LL │         for (uint256 i = 0; i < data.length; ++i) {
+   │                                 ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
+
+note[cache-array-length]: array length read in loop condition should be cached outside the loop
+   ╭▸ ROOT/testdata/CacheArrayLength.sol:LL:CC
+   │
+LL │         for (uint256 i = 0; i < values[0].length; ++i) {
+   │                                 ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
+
+note[cache-array-length]: array length read in loop condition should be cached outside the loop
+   ╭▸ ROOT/testdata/CacheArrayLength.sol:LL:CC
+   │
+LL │         for (uint256 i = 0; i < buckets[key].length; ++i) {
+   │                                 ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
+
+note[cache-array-length]: array length read in loop condition should be cached outside the loop
+   ╭▸ ROOT/testdata/CacheArrayLength.sol:LL:CC
+   │
+LL │         for (uint256 i = 0; i < bag.values.length; ++i) {
+   │                                 ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
+
+note[cache-array-length]: array length read in loop condition should be cached outside the loop
+   ╭▸ ROOT/testdata/CacheArrayLength.sol:LL:CC
+   │
+LL │         for (uint256 i = 0; i < left.length && i < right.length; ++i) {
+   │                                 ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
+
+note[cache-array-length]: array length read in loop condition should be cached outside the loop
+   ╭▸ ROOT/testdata/CacheArrayLength.sol:LL:CC
+   │
+LL │         for (uint256 i = 0; i < left.length && i < right.length; ++i) {
+   │                                                    ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
+


### PR DESCRIPTION
## Summary

- Add the `cache-array-length` gas lint as a late HIR pass for `for` loop conditions.
- Detect typed dynamic array and `bytes` `.length` reads in comparison expressions, including nested/indexed values and compound conditions.
- Add lint docs, README registration, and UI coverage for flagged and cached-length cases.

## Tests

- `cargo +1.94 check -p forge-lint`
- `cargo +1.94 test -p forge --test ui -- CacheArrayLength`

CLOSES OSS-85
