### PR TITLE
feat(lint): add `dead-code`

### DIFF
--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -1034,6 +1034,47 @@ Compiler run successful!
 "#]]);
 });
 
+forgetest!(dead_code_ignores_test_reachability_roots, |prj, cmd| {
+    prj.add_source(
+        "DeadCodeProd",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract DeadCodeProd {
+    function live() external pure returns (uint256) {
+        return 1;
+    }
+
+    function helperOnlyUsedByTest() internal pure returns (uint256) {
+        return 2;
+    }
+}
+"#,
+    );
+    prj.add_test(
+        "DeadCodeProdTest",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { DeadCodeProd } from "../src/DeadCodeProd.sol";
+
+contract DeadCodeProdTest is DeadCodeProd {
+    function testCallsHelper() external pure returns (uint256) {
+        return helperOnlyUsedByTest();
+    }
+}
+"#,
+    );
+
+    let output = cmd.arg("lint").args(["--only-lint", "dead-code"]).assert_success();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+
+    assert_eq!(stderr.matches("note[dead-code]").count(), 1);
+    assert!(stderr.contains("helperOnlyUsedByTest"));
+});
+
 // <https://github.com/foundry-rs/foundry/issues/11460>
 forgetest!(lint_json_output_no_ansi_escape_codes, |prj, cmd| {
     prj.add_source(

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -1075,6 +1075,50 @@ contract DeadCodeProdTest is DeadCodeProd {
     assert!(stderr.contains("helperOnlyUsedByTest"));
 });
 
+forgetest!(dead_code_scopes_reachability_to_linted_sources, |prj, cmd| {
+    prj.add_source(
+        "DeadCodeSubsetTarget",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract DeadCodeSubsetTarget {
+    function live() external pure returns (uint256) {
+        return 1;
+    }
+
+    function helperOnlyUsedByOtherSource() internal pure returns (uint256) {
+        return 2;
+    }
+}
+"#,
+    );
+    prj.add_source(
+        "DeadCodeSubsetOther",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { DeadCodeSubsetTarget } from "./DeadCodeSubsetTarget.sol";
+
+contract DeadCodeSubsetOther is DeadCodeSubsetTarget {
+    function callsTargetHelper() external pure returns (uint256) {
+        return helperOnlyUsedByOtherSource();
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .arg("lint")
+        .args(["src/DeadCodeSubsetTarget.sol", "--only-lint", "dead-code"])
+        .assert_success();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+
+    assert_eq!(stderr.matches("note[dead-code]").count(), 1);
+    assert!(stderr.contains("helperOnlyUsedByOtherSource"));
+});
+
 // <https://github.com/foundry-rs/foundry/issues/11460>
 forgetest!(lint_json_output_no_ansi_escape_codes, |prj, cmd| {
     prj.add_source(

--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -46,6 +46,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `unused-state-variables`: State variables that are never used should be removed.
   - `var-read-using-this`: Reads of state variables (or other `view`/`pure` functions) via `this` cause an unnecessary `STATICCALL`; access them directly.
 - **Code Size:**
+  - `dead-code`: Internal or private functions that are unreachable should be removed.
   - `unwrapped-modifier-logic`: Recommends wrapping modifier logic to reduce contract code size.
 
 ## Configuration

--- a/crates/lint/docs/dead-code.md
+++ b/crates/lint/docs/dead-code.md
@@ -49,3 +49,6 @@ contract C {
 ## Notes
 
 This is a `CodeSize`-severity lint and is **not** applied to test or script files.
+Foundry intentionally treats every public or external function in the linted sources as an entry
+point, so this lint prefers avoiding false positives over proving deployability from the most-derived
+contracts only.

--- a/crates/lint/docs/dead-code.md
+++ b/crates/lint/docs/dead-code.md
@@ -1,0 +1,51 @@
+# Dead code
+
+**Severity**: `CodeSize`
+**ID**: `dead-code`
+
+Flags internal and private functions that are not reachable from contract entry points or
+construction-time initializers.
+
+## What it does
+
+Reports implemented internal or private functions that are never reachable from public/external
+functions, constructors, fallback/receive functions, modifiers used by reachable functions, or state
+variable initializers. Public and external functions are treated as entry points. Abstract
+declarations, library functions, and virtual base implementations that are overridden are skipped.
+
+## Why is this bad?
+
+Dead functions increase bytecode size and make review harder. Removing them reduces deployment cost,
+keeps contracts easier to audit, and avoids carrying stale implementation paths.
+
+## Example
+
+### Bad
+
+```solidity
+contract C {
+    function run() external {}
+
+    function unused() internal pure returns (uint256) {
+        return 1;
+    }
+}
+```
+
+### Good
+
+```solidity
+contract C {
+    function run() external pure returns (uint256) {
+        return helper();
+    }
+
+    function helper() internal pure returns (uint256) {
+        return 1;
+    }
+}
+```
+
+## Notes
+
+This is a `CodeSize`-severity lint and is **not** applied to test or script files.

--- a/crates/lint/src/linter/project.rs
+++ b/crates/lint/src/linter/project.rs
@@ -15,6 +15,7 @@ pub struct ProjectSource<'ast> {
     pub file: Arc<SourceFile>,
     pub ast: &'ast ast::SourceUnit<'ast>,
     pub inline_config: InlineConfig<Vec<String>>,
+    pub is_test_or_script: bool,
 }
 
 /// Trait for lints that need to inspect every input source at once (e.g. cross-file checks).

--- a/crates/lint/src/sol/codesize/dead_code.rs
+++ b/crates/lint/src/sol/codesize/dead_code.rs
@@ -92,9 +92,9 @@ fn dead_code_analysis(hir: &Hir<'_>) -> Arc<DeadCodeAnalysis> {
     });
 
     let mut cache = ANALYSIS_CACHE.lock().unwrap();
-    // `check_nested_source` is called once per source and constructs fresh pass instances each time,
-    // so cache per-HIR analysis across those calls. Keep it bounded for long-running test processes
-    // that lint many independent HIRs in one process.
+    // `check_nested_source` is called once per source and constructs fresh pass instances each
+    // time, so cache per-HIR analysis across those calls. Keep it bounded for long-running test
+    // processes that lint many independent HIRs in one process.
     if cache.len() >= ANALYSIS_CACHE_LIMIT {
         cache.clear();
     }

--- a/crates/lint/src/sol/codesize/dead_code.rs
+++ b/crates/lint/src/sol/codesize/dead_code.rs
@@ -4,7 +4,7 @@ use crate::{
     sol::{Severity, SolLint},
 };
 use solar::{
-    ast::{ContractKind, ElementaryType, FunctionKind, LitKind, Visibility},
+    ast::{self, ContractKind, ElementaryType, FunctionKind, LitKind, Visibility},
     interface::{Symbol, data_structures::Never, source_map::FileName, sym},
     sema::hir::{
         CallArgs, ContractId, Expr, ExprKind, Function, FunctionId, Hir, ItemId, Modifier, Res,
@@ -37,7 +37,8 @@ impl<'ast> ProjectLintPass<'ast> for DeadCode {
             return;
         }
 
-        let analysis = dead_code_analysis(hir, &input_sources.excluded);
+        let using_for = collect_using_for(hir, sources, &input_sources);
+        let analysis = dead_code_analysis(hir, &input_sources.included, &using_for);
 
         for function_id in hir.function_ids() {
             let function = hir.function(function_id);
@@ -64,17 +65,21 @@ struct DeadCodeAnalysis {
     overridden: HashSet<FunctionId>,
 }
 
-fn dead_code_analysis(hir: &Hir<'_>, excluded_sources: &HashSet<SourceId>) -> DeadCodeAnalysis {
+fn dead_code_analysis(
+    hir: &Hir<'_>,
+    included_sources: &HashSet<SourceId>,
+    using_for: &UsingFor,
+) -> DeadCodeAnalysis {
     DeadCodeAnalysis {
-        reachable: Reachability::compute(hir, excluded_sources),
-        overridden: collect_overridden_functions(hir, excluded_sources),
+        reachable: Reachability::compute(hir, included_sources, using_for),
+        overridden: collect_overridden_functions(hir, included_sources),
     }
 }
 
 #[derive(Default)]
 struct InputSources {
     emitted: HashMap<SourceId, usize>,
-    excluded: HashSet<SourceId>,
+    included: HashSet<SourceId>,
 }
 
 fn input_sources<'ast>(hir: &Hir<'_>, sources: &[ProjectSource<'ast>]) -> InputSources {
@@ -87,12 +92,149 @@ fn input_sources<'ast>(hir: &Hir<'_>, sources: &[ProjectSource<'ast>]) -> InputS
         let Some(&source_idx) = source_indices_by_path.get(path.as_path()) else { continue };
 
         if sources[source_idx].is_test_or_script {
-            input_sources.excluded.insert(source_id);
+            continue;
         } else {
             input_sources.emitted.insert(source_id, source_idx);
+            input_sources.included.insert(source_id);
         }
     }
     input_sources
+}
+
+#[derive(Default)]
+struct UsingFor {
+    global_functions: Vec<FunctionId>,
+    source_functions: HashMap<SourceId, Vec<FunctionId>>,
+    contract_functions: HashMap<ContractId, Vec<FunctionId>>,
+}
+
+struct UsingLookup {
+    contracts_by_source_name: HashMap<(SourceId, Symbol), ContractId>,
+    contracts_by_name: HashMap<Symbol, Vec<ContractId>>,
+    free_functions_by_name: HashMap<Symbol, Vec<FunctionId>>,
+    contract_functions_by_name: HashMap<(ContractId, Symbol), Vec<FunctionId>>,
+}
+
+fn collect_using_for<'ast>(
+    hir: &Hir<'_>,
+    sources: &[ProjectSource<'ast>],
+    input_sources: &InputSources,
+) -> UsingFor {
+    let lookup = UsingLookup::new(hir);
+    let mut using_for = UsingFor::default();
+
+    for (&source_id, &source_idx) in &input_sources.emitted {
+        for item in sources[source_idx].ast.items.iter() {
+            match &item.kind {
+                ast::ItemKind::Using(using) => {
+                    let functions = lookup.resolve_using_functions(hir, using);
+                    if using.global {
+                        using_for.global_functions.extend(functions);
+                    } else {
+                        using_for.source_functions.entry(source_id).or_default().extend(functions);
+                    }
+                }
+                ast::ItemKind::Contract(contract) => {
+                    let Some(&contract_id) =
+                        lookup.contracts_by_source_name.get(&(source_id, contract.name.name))
+                    else {
+                        continue;
+                    };
+                    for item in contract.body.iter() {
+                        if let ast::ItemKind::Using(using) = &item.kind {
+                            let functions = lookup.resolve_using_functions(hir, using);
+                            using_for
+                                .contract_functions
+                                .entry(contract_id)
+                                .or_default()
+                                .extend(functions);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    using_for
+}
+
+impl UsingLookup {
+    fn new(hir: &Hir<'_>) -> Self {
+        let mut this = Self {
+            contracts_by_source_name: HashMap::new(),
+            contracts_by_name: HashMap::new(),
+            free_functions_by_name: HashMap::new(),
+            contract_functions_by_name: HashMap::new(),
+        };
+
+        for contract_id in hir.contract_ids() {
+            let contract = hir.contract(contract_id);
+            this.contracts_by_source_name
+                .insert((contract.source, contract.name.name), contract_id);
+            this.contracts_by_name.entry(contract.name.name).or_default().push(contract_id);
+
+            for function_id in contract.functions() {
+                if let Some(name) = hir.function(function_id).name {
+                    this.contract_functions_by_name
+                        .entry((contract_id, name.name))
+                        .or_default()
+                        .push(function_id);
+                }
+            }
+        }
+
+        for function_id in hir.function_ids() {
+            let function = hir.function(function_id);
+            if function.contract.is_none()
+                && let Some(name) = function.name
+            {
+                this.free_functions_by_name.entry(name.name).or_default().push(function_id);
+            }
+        }
+
+        this
+    }
+
+    fn resolve_using_functions(
+        &self,
+        hir: &Hir<'_>,
+        using: &ast::UsingDirective<'_>,
+    ) -> Vec<FunctionId> {
+        match &using.list {
+            ast::UsingList::Single(path) => self.resolve_using_path(hir, path),
+            ast::UsingList::Multiple(items) => {
+                items.iter().flat_map(|(path, _)| self.resolve_using_path(hir, path)).collect()
+            }
+        }
+    }
+
+    fn resolve_using_path(&self, hir: &Hir<'_>, path: &ast::PathSlice) -> Vec<FunctionId> {
+        match path.segments() {
+            [name] => {
+                let mut functions =
+                    self.free_functions_by_name.get(&name.name).cloned().unwrap_or_default();
+                for &contract_id in self.contracts_by_name.get(&name.name).into_iter().flatten() {
+                    functions.extend(hir.contract(contract_id).functions());
+                }
+                functions
+            }
+            [contract_name, function_name] => self
+                .contracts_by_name
+                .get(&contract_name.name)
+                .into_iter()
+                .flatten()
+                .flat_map(|&contract_id| {
+                    self.contract_functions_by_name
+                        .get(&(contract_id, function_name.name))
+                        .into_iter()
+                        .flatten()
+                        .copied()
+                })
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
 }
 
 fn is_dead_code_candidate(hir: &Hir<'_>, function: &Function<'_>, function_id: FunctionId) -> bool {
@@ -134,13 +276,13 @@ fn is_entry_point(function: &Function<'_>) -> bool {
 
 fn collect_overridden_functions(
     hir: &Hir<'_>,
-    excluded_sources: &HashSet<SourceId>,
+    included_sources: &HashSet<SourceId>,
 ) -> HashSet<FunctionId> {
     let mut overridden = HashSet::new();
 
     for function_id in hir.function_ids() {
         let function = hir.function(function_id);
-        if !function.override_ || excluded_sources.contains(&function.source) {
+        if !function.override_ || !included_sources.contains(&function.source) {
             continue;
         }
 
@@ -155,7 +297,8 @@ fn collect_overridden_functions(
 
         for &base_id in bases {
             for base_function_id in matching_overridden_functions(hir, base_id, function) {
-                if hir.function(base_function_id).virtual_ {
+                let base_function = hir.function(base_function_id);
+                if included_sources.contains(&base_function.source) && base_function.virtual_ {
                     overridden.insert(base_function_id);
                 }
             }
@@ -222,46 +365,107 @@ fn select_matching_functions(
     if !exact.is_empty() { exact } else { possible }
 }
 
+fn select_matching_member_functions(
+    hir: &Hir<'_>,
+    candidates: impl IntoIterator<Item = FunctionId>,
+    receiver: &Expr<'_>,
+    args: CallArgs<'_>,
+) -> Vec<FunctionId> {
+    let mut exact = Vec::new();
+    let mut possible = Vec::new();
+
+    for function_id in candidates {
+        match function_matches_member_args(hir, hir.function(function_id), receiver, args) {
+            Some(MatchQuality::Exact) => exact.push(function_id),
+            Some(MatchQuality::Possible) => possible.push(function_id),
+            None => {}
+        }
+    }
+
+    if !exact.is_empty() { exact } else { possible }
+}
+
 fn function_matches_args(
     hir: &Hir<'_>,
     function: &Function<'_>,
     args: CallArgs<'_>,
 ) -> Option<MatchQuality> {
-    if function.parameters.len() != args.len() {
+    parameters_match_args(hir, function.parameters, args)
+}
+
+fn function_matches_member_args(
+    hir: &Hir<'_>,
+    function: &Function<'_>,
+    receiver: &Expr<'_>,
+    args: CallArgs<'_>,
+) -> Option<MatchQuality> {
+    let Some((&receiver_param, parameters)) = function.parameters.split_first() else {
+        return None;
+    };
+    if parameters.len() != args.len() {
         return None;
     }
 
     let mut quality = MatchQuality::Exact;
-    let mut check_arg = |expr: &Expr<'_>, param: VariableId| match expr_matches_type(
-        hir,
-        expr,
-        &hir.variable(param).ty,
-    ) {
-        Some(MatchQuality::Exact) => Some(()),
-        Some(MatchQuality::Possible) => {
-            quality = MatchQuality::Possible;
-            Some(())
-        }
-        None => None,
-    };
+    check_arg_match(hir, receiver, receiver_param, &mut quality)?;
+    parameters_match_args_with_quality(hir, parameters, args, &mut quality)?;
 
+    Some(quality)
+}
+
+fn parameters_match_args(
+    hir: &Hir<'_>,
+    parameters: &[VariableId],
+    args: CallArgs<'_>,
+) -> Option<MatchQuality> {
+    if parameters.len() != args.len() {
+        return None;
+    }
+
+    let mut quality = MatchQuality::Exact;
+    parameters_match_args_with_quality(hir, parameters, args, &mut quality)?;
+    Some(quality)
+}
+
+fn parameters_match_args_with_quality(
+    hir: &Hir<'_>,
+    parameters: &[VariableId],
+    args: CallArgs<'_>,
+    quality: &mut MatchQuality,
+) -> Option<()> {
     match args.kind {
         solar::sema::hir::CallArgsKind::Unnamed(exprs) => {
-            for (expr, &param) in exprs.iter().zip(function.parameters) {
-                check_arg(expr, param)?;
+            for (expr, &param) in exprs.iter().zip(parameters) {
+                check_arg_match(hir, expr, param, quality)?;
             }
         }
         solar::sema::hir::CallArgsKind::Named(named_args) => {
             for arg in named_args {
-                let param = function.parameters.iter().copied().find(|&param| {
+                let param = parameters.iter().copied().find(|&param| {
                     hir.variable(param).name.is_some_and(|ident| ident.name == arg.name.name)
                 })?;
-                check_arg(&arg.value, param)?;
+                check_arg_match(hir, &arg.value, param, quality)?;
             }
         }
     }
 
-    Some(quality)
+    Some(())
+}
+
+fn check_arg_match(
+    hir: &Hir<'_>,
+    expr: &Expr<'_>,
+    param: VariableId,
+    quality: &mut MatchQuality,
+) -> Option<()> {
+    match expr_matches_type(hir, expr, &hir.variable(param).ty) {
+        Some(MatchQuality::Exact) => Some(()),
+        Some(MatchQuality::Possible) => {
+            *quality = MatchQuality::Possible;
+            Some(())
+        }
+        None => None,
+    }
 }
 
 fn expr_matches_type(hir: &Hir<'_>, expr: &Expr<'_>, ty: &Type<'_>) -> Option<MatchQuality> {
@@ -430,32 +634,39 @@ fn same_lit_kind(lhs: &LitKind<'_>, rhs: &LitKind<'_>) -> bool {
     }
 }
 
-struct Reachability<'hir> {
+struct Reachability<'hir, 'a> {
     hir: &'hir Hir<'hir>,
-    excluded_sources: HashSet<SourceId>,
+    included_sources: HashSet<SourceId>,
+    using_for: &'a UsingFor,
     reachable: HashSet<FunctionId>,
     current_contract: Option<ContractId>,
+    current_source: Option<SourceId>,
 }
 
-impl<'hir> Reachability<'hir> {
-    fn compute(hir: &'hir Hir<'hir>, excluded_sources: &HashSet<SourceId>) -> HashSet<FunctionId> {
+impl<'hir, 'a> Reachability<'hir, 'a> {
+    fn compute(
+        hir: &'hir Hir<'hir>,
+        included_sources: &HashSet<SourceId>,
+        using_for: &'a UsingFor,
+    ) -> HashSet<FunctionId> {
         let mut this = Self {
             hir,
-            excluded_sources: excluded_sources.clone(),
+            included_sources: included_sources.clone(),
+            using_for,
             reachable: HashSet::new(),
             current_contract: None,
+            current_source: None,
         };
 
         for function_id in hir.function_ids() {
-            if !this.is_excluded_function(function_id) && is_entry_point(hir.function(function_id))
-            {
+            if this.is_included_function(function_id) && is_entry_point(hir.function(function_id)) {
                 this.mark_function(function_id);
             }
         }
 
         for variable_id in hir.variable_ids() {
             let variable = hir.variable(variable_id);
-            if !this.is_excluded_source(variable.source)
+            if this.is_included_source(variable.source)
                 && variable.function.is_none()
                 && variable.initializer.is_some()
             {
@@ -466,16 +677,16 @@ impl<'hir> Reachability<'hir> {
         this.reachable
     }
 
-    fn is_excluded_source(&self, source_id: SourceId) -> bool {
-        self.excluded_sources.contains(&source_id)
+    fn is_included_source(&self, source_id: SourceId) -> bool {
+        self.included_sources.contains(&source_id)
     }
 
-    fn is_excluded_function(&self, function_id: FunctionId) -> bool {
-        self.is_excluded_source(self.hir.function(function_id).source)
+    fn is_included_function(&self, function_id: FunctionId) -> bool {
+        self.is_included_source(self.hir.function(function_id).source)
     }
 
     fn mark_function(&mut self, function_id: FunctionId) {
-        if self.is_excluded_function(function_id) {
+        if !self.is_included_function(function_id) {
             return;
         }
         if self.reachable.insert(function_id) {
@@ -511,7 +722,10 @@ impl<'hir> Reachability<'hir> {
             let Some(contract_id) = self.current_contract else { return functions };
             let contract = self.hir.contract(contract_id);
             for &base_id in contract.linearized_bases.iter().skip(1) {
-                functions.extend(matching_functions(self.hir, base_id, member, args));
+                functions = matching_functions(self.hir, base_id, member, args);
+                if !functions.is_empty() {
+                    return functions;
+                }
             }
             return functions;
         }
@@ -519,7 +733,36 @@ impl<'hir> Reachability<'hir> {
         for contract_id in self.resolve_static_contracts(base) {
             functions.extend(matching_functions(self.hir, contract_id, member, args));
         }
+        functions.extend(self.resolve_using_for(base, member, args));
         functions
+    }
+
+    fn resolve_using_for(
+        &self,
+        base: &'hir Expr<'hir>,
+        member: Symbol,
+        args: CallArgs<'hir>,
+    ) -> Vec<FunctionId> {
+        let Some(source_id) = self.current_source else { return Vec::new() };
+        let mut seen = HashSet::new();
+        let candidates = self
+            .using_for
+            .global_functions
+            .iter()
+            .chain(self.using_for.source_functions.get(&source_id).into_iter().flatten())
+            .chain(
+                self.current_contract
+                    .and_then(|contract_id| self.using_for.contract_functions.get(&contract_id))
+                    .into_iter()
+                    .flatten(),
+            )
+            .copied()
+            .filter(|&function_id| seen.insert(function_id))
+            .filter(|&function_id| {
+                self.hir.function(function_id).name.is_some_and(|ident| ident.name == member)
+            });
+
+        select_matching_member_functions(self.hir, candidates, base, args)
     }
 
     fn resolve_static_contracts(&self, expr: &'hir Expr<'hir>) -> Vec<ContractId> {
@@ -554,7 +797,7 @@ fn is_super(expr: &Expr<'_>) -> bool {
     })
 }
 
-impl<'hir> Visit<'hir> for Reachability<'hir> {
+impl<'hir> Visit<'hir> for Reachability<'hir, '_> {
     type BreakValue = Never;
 
     fn hir(&self) -> &'hir Hir<'hir> {
@@ -563,9 +806,12 @@ impl<'hir> Visit<'hir> for Reachability<'hir> {
 
     fn visit_function(&mut self, function: &'hir Function<'hir>) -> ControlFlow<Self::BreakValue> {
         let previous_contract = self.current_contract;
+        let previous_source = self.current_source;
         self.current_contract = function.contract;
+        self.current_source = Some(function.source);
         let result = self.walk_function(function);
         self.current_contract = previous_contract;
+        self.current_source = previous_source;
         result
     }
 
@@ -577,16 +823,19 @@ impl<'hir> Visit<'hir> for Reachability<'hir> {
     }
 
     fn visit_var(&mut self, variable: &'hir Variable<'hir>) -> ControlFlow<Self::BreakValue> {
-        if self.is_excluded_source(variable.source) {
+        if !self.is_included_source(variable.source) {
             return ControlFlow::Continue(());
         }
 
         let previous_contract = self.current_contract;
+        let previous_source = self.current_source;
         if variable.function.is_none() {
             self.current_contract = variable.contract;
         }
+        self.current_source = Some(variable.source);
         let result = self.walk_var(variable);
         self.current_contract = previous_contract;
+        self.current_source = previous_source;
         result
     }
 

--- a/crates/lint/src/sol/codesize/dead_code.rs
+++ b/crates/lint/src/sol/codesize/dead_code.rs
@@ -5,10 +5,17 @@ use crate::{
 };
 use solar::{
     ast::{ContractKind, FunctionKind, Visibility},
-    interface::sym,
-    sema::hir::{self, Visit as _},
+    interface::{Symbol, data_structures::Never, sym},
+    sema::hir::{
+        CallArgs, ContractId, Expr, ExprKind, Function, FunctionId, Hir, ItemId, Modifier, Res,
+        SourceId, Type, TypeKind, Variable, VariableId, Visit,
+    },
 };
-use std::{collections::HashSet, ops::ControlFlow};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::ControlFlow,
+    sync::{Arc, LazyLock, Mutex},
+};
 
 declare_forge_lint!(
     DEAD_CODE,
@@ -21,11 +28,10 @@ impl<'hir> LateLintPass<'hir> for DeadCode {
     fn check_nested_source(
         &mut self,
         ctx: &LintContext,
-        hir: &'hir hir::Hir<'hir>,
-        source_id: hir::SourceId,
+        hir: &'hir Hir<'hir>,
+        source_id: SourceId,
     ) {
-        let reachable = Reachability::compute(hir);
-        let overridden = collect_overridden_functions(hir);
+        let analysis = dead_code_analysis(hir);
 
         for function_id in hir.function_ids() {
             let function = hir.function(function_id);
@@ -33,22 +39,57 @@ impl<'hir> LateLintPass<'hir> for DeadCode {
                 continue;
             }
 
-            if function.virtual_ && overridden.contains(&function_id) {
+            if function.virtual_ && analysis.overridden.contains(&function_id) {
                 continue;
             }
 
-            if !reachable.contains(&function_id) {
+            if !analysis.reachable.contains(&function_id) {
                 ctx.emit(&DEAD_CODE, function.span);
             }
         }
     }
 }
 
-fn is_dead_code_candidate(
-    hir: &hir::Hir<'_>,
-    function: &hir::Function<'_>,
-    function_id: hir::FunctionId,
-) -> bool {
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct AnalysisCacheKey {
+    hir: usize,
+    sources: usize,
+    contracts: usize,
+    functions: usize,
+    variables: usize,
+}
+
+#[derive(Debug)]
+struct DeadCodeAnalysis {
+    reachable: HashSet<FunctionId>,
+    overridden: HashSet<FunctionId>,
+}
+
+static ANALYSIS_CACHE: LazyLock<Mutex<HashMap<AnalysisCacheKey, Arc<DeadCodeAnalysis>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn dead_code_analysis(hir: &Hir<'_>) -> Arc<DeadCodeAnalysis> {
+    let key = AnalysisCacheKey {
+        hir: std::ptr::from_ref(hir).addr(),
+        sources: hir.source_ids().len(),
+        contracts: hir.contract_ids().len(),
+        functions: hir.function_ids().len(),
+        variables: hir.variable_ids().len(),
+    };
+
+    if let Some(analysis) = ANALYSIS_CACHE.lock().unwrap().get(&key).cloned() {
+        return analysis;
+    }
+
+    let analysis = Arc::new(DeadCodeAnalysis {
+        reachable: Reachability::compute(hir),
+        overridden: collect_overridden_functions(hir),
+    });
+
+    ANALYSIS_CACHE.lock().unwrap().entry(key).or_insert_with(|| analysis).clone()
+}
+
+fn is_dead_code_candidate(hir: &Hir<'_>, function: &Function<'_>, function_id: FunctionId) -> bool {
     if function.kind != FunctionKind::Function
         || function.visibility >= Visibility::Public
         || function.body.is_none()
@@ -76,7 +117,7 @@ fn is_dead_code_candidate(
     true
 }
 
-fn is_entry_point(function: &hir::Function<'_>) -> bool {
+fn is_entry_point(function: &Function<'_>) -> bool {
     function.body.is_some()
         && (function.visibility >= Visibility::Public
             || matches!(
@@ -85,7 +126,7 @@ fn is_entry_point(function: &hir::Function<'_>) -> bool {
             ))
 }
 
-fn collect_overridden_functions(hir: &hir::Hir<'_>) -> HashSet<hir::FunctionId> {
+fn collect_overridden_functions(hir: &Hir<'_>) -> HashSet<FunctionId> {
     let mut overridden = HashSet::new();
 
     for function_id in hir.function_ids() {
@@ -95,8 +136,6 @@ fn collect_overridden_functions(hir: &hir::Hir<'_>) -> HashSet<hir::FunctionId> 
         }
 
         let Some(contract_id) = function.contract else { continue };
-        let Some(name) = function.name else { continue };
-        let arity = function.parameters.len();
         let contract = hir.contract(contract_id);
 
         let bases = if function.overrides.is_empty() {
@@ -106,7 +145,7 @@ fn collect_overridden_functions(hir: &hir::Hir<'_>) -> HashSet<hir::FunctionId> 
         };
 
         for &base_id in bases {
-            for base_function_id in matching_functions(hir, base_id, name.name, arity) {
+            for base_function_id in matching_overridden_functions(hir, base_id, function) {
                 if hir.function(base_function_id).virtual_ {
                     overridden.insert(base_function_id);
                 }
@@ -117,12 +156,28 @@ fn collect_overridden_functions(hir: &hir::Hir<'_>) -> HashSet<hir::FunctionId> 
     overridden
 }
 
+fn matching_overridden_functions(
+    hir: &Hir<'_>,
+    contract_id: ContractId,
+    overriding: &Function<'_>,
+) -> Vec<FunctionId> {
+    let Some(name) = overriding.name else { return Vec::new() };
+    hir.contract(contract_id)
+        .all_functions()
+        .filter(|&function_id| {
+            let function = hir.function(function_id);
+            function.name.is_some_and(|ident| ident.name == name.name)
+                && same_parameter_types(hir, function.parameters, overriding.parameters)
+        })
+        .collect()
+}
+
 fn matching_functions(
-    hir: &hir::Hir<'_>,
-    contract_id: hir::ContractId,
-    name: solar::interface::Symbol,
+    hir: &Hir<'_>,
+    contract_id: ContractId,
+    name: Symbol,
     arity: usize,
-) -> Vec<hir::FunctionId> {
+) -> Vec<FunctionId> {
     hir.contract(contract_id)
         .all_functions()
         .filter(|&function_id| {
@@ -133,14 +188,50 @@ fn matching_functions(
         .collect()
 }
 
+fn same_parameter_types(hir: &Hir<'_>, lhs: &[VariableId], rhs: &[VariableId]) -> bool {
+    lhs.len() == rhs.len()
+        && lhs
+            .iter()
+            .zip(rhs)
+            .all(|(&lhs, &rhs)| same_type(hir, &hir.variable(lhs).ty, &hir.variable(rhs).ty))
+}
+
+fn same_type(hir: &Hir<'_>, lhs: &Type<'_>, rhs: &Type<'_>) -> bool {
+    match (&lhs.kind, &rhs.kind) {
+        (TypeKind::Elementary(lhs), TypeKind::Elementary(rhs)) => lhs == rhs,
+        (TypeKind::Array(lhs), TypeKind::Array(rhs)) => {
+            same_type(hir, &lhs.element, &rhs.element)
+                && match (lhs.size, rhs.size) {
+                    (None, None) => true,
+                    (Some(lhs), Some(rhs)) => {
+                        format!("{:?}", lhs.kind) == format!("{:?}", rhs.kind)
+                    }
+                    _ => false,
+                }
+        }
+        (TypeKind::Function(lhs), TypeKind::Function(rhs)) => {
+            lhs.visibility == rhs.visibility
+                && lhs.state_mutability == rhs.state_mutability
+                && same_parameter_types(hir, lhs.parameters, rhs.parameters)
+                && same_parameter_types(hir, lhs.returns, rhs.returns)
+        }
+        (TypeKind::Mapping(lhs), TypeKind::Mapping(rhs)) => {
+            same_type(hir, &lhs.key, &rhs.key) && same_type(hir, &lhs.value, &rhs.value)
+        }
+        (TypeKind::Custom(lhs), TypeKind::Custom(rhs)) => lhs == rhs,
+        (TypeKind::Err(_), TypeKind::Err(_)) => true,
+        _ => false,
+    }
+}
+
 struct Reachability<'hir> {
-    hir: &'hir hir::Hir<'hir>,
-    reachable: HashSet<hir::FunctionId>,
-    current_contract: Option<hir::ContractId>,
+    hir: &'hir Hir<'hir>,
+    reachable: HashSet<FunctionId>,
+    current_contract: Option<ContractId>,
 }
 
 impl<'hir> Reachability<'hir> {
-    fn compute(hir: &'hir hir::Hir<'hir>) -> HashSet<hir::FunctionId> {
+    fn compute(hir: &'hir Hir<'hir>) -> HashSet<FunctionId> {
         let mut this = Self { hir, reachable: HashSet::new(), current_contract: None };
 
         for function_id in hir.function_ids() {
@@ -159,18 +250,19 @@ impl<'hir> Reachability<'hir> {
         this.reachable
     }
 
-    fn mark_function(&mut self, function_id: hir::FunctionId) {
+    fn mark_function(&mut self, function_id: FunctionId) {
         if self.reachable.insert(function_id) {
             let _ = self.visit_nested_function(function_id);
         }
     }
 
-    fn resolve_callee(&self, callee: &'hir hir::Expr<'hir>, arity: usize) -> Vec<hir::FunctionId> {
+    fn resolve_callee(&self, callee: &'hir Expr<'hir>, args: CallArgs<'hir>) -> Vec<FunctionId> {
+        let arity = args.len();
         match &callee.peel_parens().kind {
-            hir::ExprKind::Ident(resolutions) => resolutions
+            ExprKind::Ident(resolutions) => resolutions
                 .iter()
                 .filter_map(|resolution| match resolution {
-                    hir::Res::Item(hir::ItemId::Function(function_id))
+                    Res::Item(ItemId::Function(function_id))
                         if self.hir.function(*function_id).parameters.len() == arity =>
                     {
                         Some(*function_id)
@@ -178,7 +270,7 @@ impl<'hir> Reachability<'hir> {
                     _ => None,
                 })
                 .collect(),
-            hir::ExprKind::Member(base, member) => {
+            ExprKind::Member(base, member) => {
                 self.resolve_member_callee(base.peel_parens(), member.name, arity)
             }
             _ => Vec::new(),
@@ -187,43 +279,56 @@ impl<'hir> Reachability<'hir> {
 
     fn resolve_member_callee(
         &self,
-        base: &'hir hir::Expr<'hir>,
-        member: solar::interface::Symbol,
+        base: &'hir Expr<'hir>,
+        member: Symbol,
         arity: usize,
-    ) -> Vec<hir::FunctionId> {
-        let hir::ExprKind::Ident(resolutions) = &base.kind else { return Vec::new() };
-
+    ) -> Vec<FunctionId> {
         let mut functions = Vec::new();
-        for resolution in *resolutions {
-            match resolution {
-                hir::Res::Item(hir::ItemId::Contract(contract_id)) => {
-                    functions.extend(matching_functions(self.hir, *contract_id, member, arity));
-                }
-                hir::Res::Builtin(builtin) if builtin.name() == sym::super_ => {
-                    let Some(contract_id) = self.current_contract else { continue };
-                    let contract = self.hir.contract(contract_id);
-                    for &base_id in contract.linearized_bases.iter().skip(1) {
-                        functions.extend(matching_functions(self.hir, base_id, member, arity));
-                    }
-                }
-                _ => {}
+        if is_super(base) {
+            let Some(contract_id) = self.current_contract else { return functions };
+            let contract = self.hir.contract(contract_id);
+            for &base_id in contract.linearized_bases.iter().skip(1) {
+                functions.extend(matching_functions(self.hir, base_id, member, arity));
             }
+            return functions;
+        }
+
+        for contract_id in self.resolve_static_contracts(base) {
+            functions.extend(matching_functions(self.hir, contract_id, member, arity));
         }
         functions
     }
+
+    fn resolve_static_contracts(&self, expr: &'hir Expr<'hir>) -> Vec<ContractId> {
+        match &expr.peel_parens().kind {
+            ExprKind::Ident(resolutions) => resolutions
+                .iter()
+                .filter_map(|resolution| match resolution {
+                    Res::Item(ItemId::Contract(contract_id)) => Some(*contract_id),
+                    _ => None,
+                })
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
 }
 
-impl<'hir> hir::Visit<'hir> for Reachability<'hir> {
-    type BreakValue = solar::interface::data_structures::Never;
+fn is_super(expr: &Expr<'_>) -> bool {
+    let ExprKind::Ident(resolutions) = &expr.peel_parens().kind else { return false };
+    resolutions.iter().any(|resolution| match resolution {
+        Res::Builtin(builtin) => builtin.name() == sym::super_,
+        _ => false,
+    })
+}
 
-    fn hir(&self) -> &'hir hir::Hir<'hir> {
+impl<'hir> Visit<'hir> for Reachability<'hir> {
+    type BreakValue = Never;
+
+    fn hir(&self) -> &'hir Hir<'hir> {
         self.hir
     }
 
-    fn visit_function(
-        &mut self,
-        function: &'hir hir::Function<'hir>,
-    ) -> ControlFlow<Self::BreakValue> {
+    fn visit_function(&mut self, function: &'hir Function<'hir>) -> ControlFlow<Self::BreakValue> {
         let previous_contract = self.current_contract;
         self.current_contract = function.contract;
         let result = self.walk_function(function);
@@ -231,17 +336,14 @@ impl<'hir> hir::Visit<'hir> for Reachability<'hir> {
         result
     }
 
-    fn visit_modifier(
-        &mut self,
-        modifier: &'hir hir::Modifier<'hir>,
-    ) -> ControlFlow<Self::BreakValue> {
-        if let hir::ItemId::Function(function_id) = modifier.id {
+    fn visit_modifier(&mut self, modifier: &'hir Modifier<'hir>) -> ControlFlow<Self::BreakValue> {
+        if let ItemId::Function(function_id) = modifier.id {
             self.mark_function(function_id);
         }
         self.walk_modifier(modifier)
     }
 
-    fn visit_var(&mut self, variable: &'hir hir::Variable<'hir>) -> ControlFlow<Self::BreakValue> {
+    fn visit_var(&mut self, variable: &'hir Variable<'hir>) -> ControlFlow<Self::BreakValue> {
         let previous_contract = self.current_contract;
         if variable.function.is_none() {
             self.current_contract = variable.contract;
@@ -251,17 +353,17 @@ impl<'hir> hir::Visit<'hir> for Reachability<'hir> {
         result
     }
 
-    fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
-        if let hir::ExprKind::Call(callee, args, opts) = &expr.kind {
-            for function_id in self.resolve_callee(callee, args.len()) {
+    fn visit_expr(&mut self, expr: &'hir Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+        if let ExprKind::Call(callee, args, opts) = &expr.kind {
+            for function_id in self.resolve_callee(callee, *args) {
                 self.mark_function(function_id);
             }
 
             match &callee.peel_parens().kind {
                 // The call resolver above filters overloaded identifiers by arity, so do not also
                 // visit the callee as a bare function reference and mark every overload reachable.
-                hir::ExprKind::Ident(_) => {}
-                hir::ExprKind::Member(base, _) => self.visit_expr(base)?,
+                ExprKind::Ident(_) => {}
+                ExprKind::Member(base, _) => self.visit_expr(base)?,
                 _ => self.visit_expr(callee)?,
             }
             if let Some(opts) = opts {
@@ -273,9 +375,9 @@ impl<'hir> hir::Visit<'hir> for Reachability<'hir> {
             return ControlFlow::Continue(());
         }
 
-        if let hir::ExprKind::Ident(resolutions) = &expr.kind {
+        if let ExprKind::Ident(resolutions) = &expr.kind {
             for function_id in resolutions.iter().filter_map(|resolution| match resolution {
-                hir::Res::Item(hir::ItemId::Function(function_id)) => Some(*function_id),
+                Res::Item(ItemId::Function(function_id)) => Some(*function_id),
                 _ => None,
             }) {
                 self.mark_function(function_id);

--- a/crates/lint/src/sol/codesize/dead_code.rs
+++ b/crates/lint/src/sol/codesize/dead_code.rs
@@ -1,0 +1,287 @@
+use super::DeadCode;
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::{
+    ast::{ContractKind, FunctionKind, Visibility},
+    interface::sym,
+    sema::hir::{self, Visit as _},
+};
+use std::{collections::HashSet, ops::ControlFlow};
+
+declare_forge_lint!(
+    DEAD_CODE,
+    Severity::CodeSize,
+    "dead-code",
+    "internal or private function is never used"
+);
+
+impl<'hir> LateLintPass<'hir> for DeadCode {
+    fn check_nested_source(
+        &mut self,
+        ctx: &LintContext,
+        hir: &'hir hir::Hir<'hir>,
+        source_id: hir::SourceId,
+    ) {
+        let reachable = Reachability::compute(hir);
+        let overridden = collect_overridden_functions(hir);
+
+        for function_id in hir.function_ids() {
+            let function = hir.function(function_id);
+            if function.source != source_id || !is_dead_code_candidate(hir, function, function_id) {
+                continue;
+            }
+
+            if function.virtual_ && overridden.contains(&function_id) {
+                continue;
+            }
+
+            if !reachable.contains(&function_id) {
+                ctx.emit(&DEAD_CODE, function.span);
+            }
+        }
+    }
+}
+
+fn is_dead_code_candidate(
+    hir: &hir::Hir<'_>,
+    function: &hir::Function<'_>,
+    function_id: hir::FunctionId,
+) -> bool {
+    if function.kind != FunctionKind::Function
+        || function.visibility >= Visibility::Public
+        || function.body.is_none()
+        || function.is_getter()
+    {
+        return false;
+    }
+
+    if let Some(contract_id) = function.contract {
+        let contract = hir.contract(contract_id);
+        if contract.kind == ContractKind::Library {
+            return false;
+        }
+
+        // Constructors/fallback/receive functions are stored separately by the contract, but keep
+        // this defensive check close to the candidate filter.
+        if contract.ctor == Some(function_id)
+            || contract.fallback == Some(function_id)
+            || contract.receive == Some(function_id)
+        {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn is_entry_point(function: &hir::Function<'_>) -> bool {
+    function.body.is_some()
+        && (function.visibility >= Visibility::Public
+            || matches!(
+                function.kind,
+                FunctionKind::Constructor | FunctionKind::Fallback | FunctionKind::Receive
+            ))
+}
+
+fn collect_overridden_functions(hir: &hir::Hir<'_>) -> HashSet<hir::FunctionId> {
+    let mut overridden = HashSet::new();
+
+    for function_id in hir.function_ids() {
+        let function = hir.function(function_id);
+        if !function.override_ {
+            continue;
+        }
+
+        let Some(contract_id) = function.contract else { continue };
+        let Some(name) = function.name else { continue };
+        let arity = function.parameters.len();
+        let contract = hir.contract(contract_id);
+
+        let bases = if function.overrides.is_empty() {
+            contract.linearized_bases.get(1..).unwrap_or_default()
+        } else {
+            function.overrides
+        };
+
+        for &base_id in bases {
+            for base_function_id in matching_functions(hir, base_id, name.name, arity) {
+                if hir.function(base_function_id).virtual_ {
+                    overridden.insert(base_function_id);
+                }
+            }
+        }
+    }
+
+    overridden
+}
+
+fn matching_functions(
+    hir: &hir::Hir<'_>,
+    contract_id: hir::ContractId,
+    name: solar::interface::Symbol,
+    arity: usize,
+) -> Vec<hir::FunctionId> {
+    hir.contract(contract_id)
+        .all_functions()
+        .filter(|&function_id| {
+            let function = hir.function(function_id);
+            function.name.is_some_and(|ident| ident.name == name)
+                && function.parameters.len() == arity
+        })
+        .collect()
+}
+
+struct Reachability<'hir> {
+    hir: &'hir hir::Hir<'hir>,
+    reachable: HashSet<hir::FunctionId>,
+    current_contract: Option<hir::ContractId>,
+}
+
+impl<'hir> Reachability<'hir> {
+    fn compute(hir: &'hir hir::Hir<'hir>) -> HashSet<hir::FunctionId> {
+        let mut this = Self { hir, reachable: HashSet::new(), current_contract: None };
+
+        for function_id in hir.function_ids() {
+            if is_entry_point(hir.function(function_id)) {
+                this.mark_function(function_id);
+            }
+        }
+
+        for variable_id in hir.variable_ids() {
+            let variable = hir.variable(variable_id);
+            if variable.function.is_none() && variable.initializer.is_some() {
+                let _ = this.visit_nested_var(variable_id);
+            }
+        }
+
+        this.reachable
+    }
+
+    fn mark_function(&mut self, function_id: hir::FunctionId) {
+        if self.reachable.insert(function_id) {
+            let _ = self.visit_nested_function(function_id);
+        }
+    }
+
+    fn resolve_callee(&self, callee: &'hir hir::Expr<'hir>, arity: usize) -> Vec<hir::FunctionId> {
+        match &callee.peel_parens().kind {
+            hir::ExprKind::Ident(resolutions) => resolutions
+                .iter()
+                .filter_map(|resolution| match resolution {
+                    hir::Res::Item(hir::ItemId::Function(function_id))
+                        if self.hir.function(*function_id).parameters.len() == arity =>
+                    {
+                        Some(*function_id)
+                    }
+                    _ => None,
+                })
+                .collect(),
+            hir::ExprKind::Member(base, member) => {
+                self.resolve_member_callee(base.peel_parens(), member.name, arity)
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn resolve_member_callee(
+        &self,
+        base: &'hir hir::Expr<'hir>,
+        member: solar::interface::Symbol,
+        arity: usize,
+    ) -> Vec<hir::FunctionId> {
+        let hir::ExprKind::Ident(resolutions) = &base.kind else { return Vec::new() };
+
+        let mut functions = Vec::new();
+        for resolution in *resolutions {
+            match resolution {
+                hir::Res::Item(hir::ItemId::Contract(contract_id)) => {
+                    functions.extend(matching_functions(self.hir, *contract_id, member, arity));
+                }
+                hir::Res::Builtin(builtin) if builtin.name() == sym::super_ => {
+                    let Some(contract_id) = self.current_contract else { continue };
+                    let contract = self.hir.contract(contract_id);
+                    for &base_id in contract.linearized_bases.iter().skip(1) {
+                        functions.extend(matching_functions(self.hir, base_id, member, arity));
+                    }
+                }
+                _ => {}
+            }
+        }
+        functions
+    }
+}
+
+impl<'hir> hir::Visit<'hir> for Reachability<'hir> {
+    type BreakValue = solar::interface::data_structures::Never;
+
+    fn hir(&self) -> &'hir hir::Hir<'hir> {
+        self.hir
+    }
+
+    fn visit_function(
+        &mut self,
+        function: &'hir hir::Function<'hir>,
+    ) -> ControlFlow<Self::BreakValue> {
+        let previous_contract = self.current_contract;
+        self.current_contract = function.contract;
+        let result = self.walk_function(function);
+        self.current_contract = previous_contract;
+        result
+    }
+
+    fn visit_modifier(
+        &mut self,
+        modifier: &'hir hir::Modifier<'hir>,
+    ) -> ControlFlow<Self::BreakValue> {
+        if let hir::ItemId::Function(function_id) = modifier.id {
+            self.mark_function(function_id);
+        }
+        self.walk_modifier(modifier)
+    }
+
+    fn visit_var(&mut self, variable: &'hir hir::Variable<'hir>) -> ControlFlow<Self::BreakValue> {
+        let previous_contract = self.current_contract;
+        if variable.function.is_none() {
+            self.current_contract = variable.contract;
+        }
+        let result = self.walk_var(variable);
+        self.current_contract = previous_contract;
+        result
+    }
+
+    fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+        if let hir::ExprKind::Call(callee, args, opts) = &expr.kind {
+            for function_id in self.resolve_callee(callee, args.len()) {
+                self.mark_function(function_id);
+            }
+
+            match &callee.peel_parens().kind {
+                // The call resolver above filters overloaded identifiers by arity, so do not also
+                // visit the callee as a bare function reference and mark every overload reachable.
+                hir::ExprKind::Ident(_) => {}
+                hir::ExprKind::Member(base, _) => self.visit_expr(base)?,
+                _ => self.visit_expr(callee)?,
+            }
+            if let Some(opts) = opts {
+                for opt in *opts {
+                    self.visit_expr(&opt.value)?;
+                }
+            }
+            self.visit_call_args(args)?;
+            return ControlFlow::Continue(());
+        }
+
+        if let hir::ExprKind::Ident(resolutions) = &expr.kind {
+            for function_id in resolutions.iter().filter_map(|resolution| match resolution {
+                hir::Res::Item(hir::ItemId::Function(function_id)) => Some(*function_id),
+                _ => None,
+            }) {
+                self.mark_function(function_id);
+            }
+        }
+
+        self.walk_expr(expr)
+    }
+}

--- a/crates/lint/src/sol/codesize/dead_code.rs
+++ b/crates/lint/src/sol/codesize/dead_code.rs
@@ -1,11 +1,11 @@
 use super::DeadCode;
 use crate::{
-    linter::{LateLintPass, LintContext},
+    linter::{Lint, ProjectLintEmitter, ProjectLintPass, ProjectSource},
     sol::{Severity, SolLint},
 };
 use solar::{
-    ast::{ContractKind, FunctionKind, LitKind, Visibility},
-    interface::{Symbol, data_structures::Never, sym},
+    ast::{ContractKind, ElementaryType, FunctionKind, LitKind, Visibility},
+    interface::{Symbol, data_structures::Never, source_map::FileName, sym},
     sema::hir::{
         CallArgs, ContractId, Expr, ExprKind, Function, FunctionId, Hir, ItemId, Modifier, Res,
         SourceId, Type, TypeKind, Variable, VariableId, Visit,
@@ -14,7 +14,7 @@ use solar::{
 use std::{
     collections::{HashMap, HashSet},
     ops::ControlFlow,
-    sync::{Arc, LazyLock, Mutex},
+    path::Path,
 };
 
 declare_forge_lint!(
@@ -24,18 +24,26 @@ declare_forge_lint!(
     "internal or private function is never used"
 );
 
-impl<'hir> LateLintPass<'hir> for DeadCode {
-    fn check_nested_source(
-        &mut self,
-        ctx: &LintContext,
-        hir: &'hir Hir<'hir>,
-        source_id: SourceId,
-    ) {
-        let analysis = dead_code_analysis(hir);
+impl<'ast> ProjectLintPass<'ast> for DeadCode {
+    fn check_project(&mut self, ctx: &ProjectLintEmitter<'_, '_>, sources: &[ProjectSource<'ast>]) {
+        if !ctx.is_lint_enabled(DEAD_CODE.id()) {
+            return;
+        }
+
+        let gcx = ctx.gcx();
+        let hir = &gcx.hir;
+        let input_sources = input_sources(hir, sources);
+        if input_sources.emitted.is_empty() {
+            return;
+        }
+
+        let analysis = dead_code_analysis(hir, &input_sources.excluded);
 
         for function_id in hir.function_ids() {
             let function = hir.function(function_id);
-            if function.source != source_id || !is_dead_code_candidate(hir, function, function_id) {
+            let Some(&source_idx) = input_sources.emitted.get(&function.source) else { continue };
+
+            if !is_dead_code_candidate(hir, function, function_id) {
                 continue;
             }
 
@@ -44,19 +52,10 @@ impl<'hir> LateLintPass<'hir> for DeadCode {
             }
 
             if !analysis.reachable.contains(&function_id) {
-                ctx.emit(&DEAD_CODE, function.span);
+                ctx.emit(&sources[source_idx], &DEAD_CODE, function.span);
             }
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct AnalysisCacheKey {
-    hir: usize,
-    sources: usize,
-    contracts: usize,
-    functions: usize,
-    variables: usize,
 }
 
 #[derive(Debug)]
@@ -65,40 +64,35 @@ struct DeadCodeAnalysis {
     overridden: HashSet<FunctionId>,
 }
 
-const ANALYSIS_CACHE_LIMIT: usize = 16;
+fn dead_code_analysis(hir: &Hir<'_>, excluded_sources: &HashSet<SourceId>) -> DeadCodeAnalysis {
+    DeadCodeAnalysis {
+        reachable: Reachability::compute(hir, excluded_sources),
+        overridden: collect_overridden_functions(hir, excluded_sources),
+    }
+}
 
-static ANALYSIS_CACHE: LazyLock<Mutex<HashMap<AnalysisCacheKey, Arc<DeadCodeAnalysis>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+#[derive(Default)]
+struct InputSources {
+    emitted: HashMap<SourceId, usize>,
+    excluded: HashSet<SourceId>,
+}
 
-fn dead_code_analysis(hir: &Hir<'_>) -> Arc<DeadCodeAnalysis> {
-    let key = AnalysisCacheKey {
-        hir: std::ptr::from_ref(hir).addr(),
-        sources: hir.source_ids().len(),
-        contracts: hir.contract_ids().len(),
-        functions: hir.function_ids().len(),
-        variables: hir.variable_ids().len(),
-    };
+fn input_sources<'ast>(hir: &Hir<'_>, sources: &[ProjectSource<'ast>]) -> InputSources {
+    let source_indices_by_path: HashMap<&Path, usize> =
+        sources.iter().enumerate().map(|(idx, source)| (source.path.as_path(), idx)).collect();
 
-    {
-        let cache = ANALYSIS_CACHE.lock().unwrap();
-        if let Some(analysis) = cache.get(&key).cloned() {
-            return analysis;
+    let mut input_sources = InputSources::default();
+    for (source_id, source) in hir.sources_enumerated() {
+        let FileName::Real(path) = &source.file.name else { continue };
+        let Some(&source_idx) = source_indices_by_path.get(path.as_path()) else { continue };
+
+        if sources[source_idx].is_test_or_script {
+            input_sources.excluded.insert(source_id);
+        } else {
+            input_sources.emitted.insert(source_id, source_idx);
         }
     }
-
-    let analysis = Arc::new(DeadCodeAnalysis {
-        reachable: Reachability::compute(hir),
-        overridden: collect_overridden_functions(hir),
-    });
-
-    let mut cache = ANALYSIS_CACHE.lock().unwrap();
-    // `check_nested_source` is called once per source and constructs fresh pass instances each
-    // time, so cache per-HIR analysis across those calls. Keep it bounded for long-running test
-    // processes that lint many independent HIRs in one process.
-    if cache.len() >= ANALYSIS_CACHE_LIMIT {
-        cache.clear();
-    }
-    cache.entry(key).or_insert_with(|| analysis).clone()
+    input_sources
 }
 
 fn is_dead_code_candidate(hir: &Hir<'_>, function: &Function<'_>, function_id: FunctionId) -> bool {
@@ -138,12 +132,15 @@ fn is_entry_point(function: &Function<'_>) -> bool {
             ))
 }
 
-fn collect_overridden_functions(hir: &Hir<'_>) -> HashSet<FunctionId> {
+fn collect_overridden_functions(
+    hir: &Hir<'_>,
+    excluded_sources: &HashSet<SourceId>,
+) -> HashSet<FunctionId> {
     let mut overridden = HashSet::new();
 
     for function_id in hir.function_ids() {
         let function = hir.function(function_id);
-        if !function.override_ {
+        if !function.override_ || excluded_sources.contains(&function.source) {
             continue;
         }
 
@@ -188,16 +185,183 @@ fn matching_functions(
     hir: &Hir<'_>,
     contract_id: ContractId,
     name: Symbol,
-    arity: usize,
+    args: CallArgs<'_>,
 ) -> Vec<FunctionId> {
-    hir.contract(contract_id)
-        .all_functions()
-        .filter(|&function_id| {
+    select_matching_functions(
+        hir,
+        hir.contract(contract_id).all_functions().filter(|&function_id| {
             let function = hir.function(function_id);
             function.name.is_some_and(|ident| ident.name == name)
-                && function.parameters.len() == arity
-        })
-        .collect()
+        }),
+        args,
+    )
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MatchQuality {
+    Exact,
+    Possible,
+}
+
+fn select_matching_functions(
+    hir: &Hir<'_>,
+    candidates: impl IntoIterator<Item = FunctionId>,
+    args: CallArgs<'_>,
+) -> Vec<FunctionId> {
+    let mut exact = Vec::new();
+    let mut possible = Vec::new();
+
+    for function_id in candidates {
+        match function_matches_args(hir, hir.function(function_id), args) {
+            Some(MatchQuality::Exact) => exact.push(function_id),
+            Some(MatchQuality::Possible) => possible.push(function_id),
+            None => {}
+        }
+    }
+
+    if !exact.is_empty() { exact } else { possible }
+}
+
+fn function_matches_args(
+    hir: &Hir<'_>,
+    function: &Function<'_>,
+    args: CallArgs<'_>,
+) -> Option<MatchQuality> {
+    if function.parameters.len() != args.len() {
+        return None;
+    }
+
+    let mut quality = MatchQuality::Exact;
+    let mut check_arg = |expr: &Expr<'_>, param: VariableId| match expr_matches_type(
+        hir,
+        expr,
+        &hir.variable(param).ty,
+    ) {
+        Some(MatchQuality::Exact) => Some(()),
+        Some(MatchQuality::Possible) => {
+            quality = MatchQuality::Possible;
+            Some(())
+        }
+        None => None,
+    };
+
+    match args.kind {
+        solar::sema::hir::CallArgsKind::Unnamed(exprs) => {
+            for (expr, &param) in exprs.iter().zip(function.parameters) {
+                check_arg(expr, param)?;
+            }
+        }
+        solar::sema::hir::CallArgsKind::Named(named_args) => {
+            for arg in named_args {
+                let param = function.parameters.iter().copied().find(|&param| {
+                    hir.variable(param).name.is_some_and(|ident| ident.name == arg.name.name)
+                })?;
+                check_arg(&arg.value, param)?;
+            }
+        }
+    }
+
+    Some(quality)
+}
+
+fn expr_matches_type(hir: &Hir<'_>, expr: &Expr<'_>, ty: &Type<'_>) -> Option<MatchQuality> {
+    let expr = expr.peel_parens();
+    match &expr.kind {
+        ExprKind::Ident(resolutions) => {
+            let mut variables = resolutions.iter().filter_map(|res| match res {
+                Res::Item(ItemId::Variable(variable_id)) => Some(*variable_id),
+                _ => None,
+            });
+            let Some(variable_id) = variables.next() else { return Some(MatchQuality::Possible) };
+            if variables.next().is_some() {
+                return Some(MatchQuality::Possible);
+            }
+            type_matches_param(hir, &hir.variable(variable_id).ty, ty)
+        }
+        ExprKind::Call(callee, ..) => {
+            if let Some(expr_ty) = call_expr_type(callee.peel_parens()) {
+                type_matches_param(hir, expr_ty, ty)
+            } else {
+                Some(MatchQuality::Possible)
+            }
+        }
+        ExprKind::Lit(lit) => lit_matches_type(&lit.kind, ty),
+        ExprKind::New(expr_ty) => type_matches_param(hir, expr_ty, ty),
+        ExprKind::Payable(_) => match ty.kind {
+            TypeKind::Elementary(ElementaryType::Address(true)) => Some(MatchQuality::Exact),
+            TypeKind::Elementary(ElementaryType::Address(false)) => Some(MatchQuality::Possible),
+            _ => None,
+        },
+        ExprKind::Ternary(_, lhs, rhs) => {
+            match (expr_matches_type(hir, lhs, ty)?, expr_matches_type(hir, rhs, ty)?) {
+                (MatchQuality::Exact, MatchQuality::Exact) => Some(MatchQuality::Exact),
+                _ => Some(MatchQuality::Possible),
+            }
+        }
+        ExprKind::Err(_) => Some(MatchQuality::Possible),
+        _ => Some(MatchQuality::Possible),
+    }
+}
+
+fn type_matches_param(
+    hir: &Hir<'_>,
+    arg_ty: &Type<'_>,
+    param_ty: &Type<'_>,
+) -> Option<MatchQuality> {
+    if same_type(hir, arg_ty, param_ty) {
+        return Some(MatchQuality::Exact);
+    }
+
+    match (&arg_ty.kind, &param_ty.kind) {
+        (
+            TypeKind::Elementary(ElementaryType::UInt(arg_size)),
+            TypeKind::Elementary(ElementaryType::UInt(param_size)),
+        )
+        | (
+            TypeKind::Elementary(ElementaryType::Int(arg_size)),
+            TypeKind::Elementary(ElementaryType::Int(param_size)),
+        ) if arg_size.bits() <= param_size.bits() => Some(MatchQuality::Possible),
+        (
+            TypeKind::Elementary(ElementaryType::Address(true)),
+            TypeKind::Elementary(ElementaryType::Address(false)),
+        ) => Some(MatchQuality::Possible),
+        (TypeKind::Err(_), _) | (_, TypeKind::Err(_)) => Some(MatchQuality::Possible),
+        _ => None,
+    }
+}
+
+fn call_expr_type<'hir>(callee: &'hir Expr<'hir>) -> Option<&'hir Type<'hir>> {
+    match &callee.kind {
+        ExprKind::Type(ty) | ExprKind::TypeCall(ty) | ExprKind::New(ty) => Some(ty),
+        _ => None,
+    }
+}
+
+fn lit_matches_type(lit: &LitKind<'_>, ty: &Type<'_>) -> Option<MatchQuality> {
+    let TypeKind::Elementary(elementary) = ty.kind else {
+        return match lit {
+            LitKind::Err(_) => Some(MatchQuality::Possible),
+            _ => None,
+        };
+    };
+
+    match (lit, elementary) {
+        (LitKind::Bool(_), ElementaryType::Bool)
+        | (LitKind::Address(_), ElementaryType::Address(false)) => Some(MatchQuality::Exact),
+        (LitKind::Address(_), ElementaryType::Address(true)) => Some(MatchQuality::Possible),
+        (LitKind::Str(..), ElementaryType::String | ElementaryType::Bytes) => {
+            Some(MatchQuality::Possible)
+        }
+        (
+            LitKind::Number(_) | LitKind::Rational(_),
+            ElementaryType::Int(_)
+            | ElementaryType::UInt(_)
+            | ElementaryType::Fixed(_, _)
+            | ElementaryType::UFixed(_, _),
+        ) => Some(MatchQuality::Possible),
+        (LitKind::Err(_), _) => Some(MatchQuality::Possible),
+        _ => None,
+    }
 }
 
 fn same_parameter_types(hir: &Hir<'_>, lhs: &[VariableId], rhs: &[VariableId]) -> bool {
@@ -268,23 +432,33 @@ fn same_lit_kind(lhs: &LitKind<'_>, rhs: &LitKind<'_>) -> bool {
 
 struct Reachability<'hir> {
     hir: &'hir Hir<'hir>,
+    excluded_sources: HashSet<SourceId>,
     reachable: HashSet<FunctionId>,
     current_contract: Option<ContractId>,
 }
 
 impl<'hir> Reachability<'hir> {
-    fn compute(hir: &'hir Hir<'hir>) -> HashSet<FunctionId> {
-        let mut this = Self { hir, reachable: HashSet::new(), current_contract: None };
+    fn compute(hir: &'hir Hir<'hir>, excluded_sources: &HashSet<SourceId>) -> HashSet<FunctionId> {
+        let mut this = Self {
+            hir,
+            excluded_sources: excluded_sources.clone(),
+            reachable: HashSet::new(),
+            current_contract: None,
+        };
 
         for function_id in hir.function_ids() {
-            if is_entry_point(hir.function(function_id)) {
+            if !this.is_excluded_function(function_id) && is_entry_point(hir.function(function_id))
+            {
                 this.mark_function(function_id);
             }
         }
 
         for variable_id in hir.variable_ids() {
             let variable = hir.variable(variable_id);
-            if variable.function.is_none() && variable.initializer.is_some() {
+            if !this.is_excluded_source(variable.source)
+                && variable.function.is_none()
+                && variable.initializer.is_some()
+            {
                 let _ = this.visit_nested_var(variable_id);
             }
         }
@@ -292,28 +466,35 @@ impl<'hir> Reachability<'hir> {
         this.reachable
     }
 
+    fn is_excluded_source(&self, source_id: SourceId) -> bool {
+        self.excluded_sources.contains(&source_id)
+    }
+
+    fn is_excluded_function(&self, function_id: FunctionId) -> bool {
+        self.is_excluded_source(self.hir.function(function_id).source)
+    }
+
     fn mark_function(&mut self, function_id: FunctionId) {
+        if self.is_excluded_function(function_id) {
+            return;
+        }
         if self.reachable.insert(function_id) {
             let _ = self.visit_nested_function(function_id);
         }
     }
 
     fn resolve_callee(&self, callee: &'hir Expr<'hir>, args: CallArgs<'hir>) -> Vec<FunctionId> {
-        let arity = args.len();
         match &callee.peel_parens().kind {
-            ExprKind::Ident(resolutions) => resolutions
-                .iter()
-                .filter_map(|resolution| match resolution {
-                    Res::Item(ItemId::Function(function_id))
-                        if self.hir.function(*function_id).parameters.len() == arity =>
-                    {
-                        Some(*function_id)
-                    }
+            ExprKind::Ident(resolutions) => select_matching_functions(
+                self.hir,
+                resolutions.iter().filter_map(|resolution| match resolution {
+                    Res::Item(ItemId::Function(function_id)) => Some(*function_id),
                     _ => None,
-                })
-                .collect(),
+                }),
+                args,
+            ),
             ExprKind::Member(base, member) => {
-                self.resolve_member_callee(base.peel_parens(), member.name, arity)
+                self.resolve_member_callee(base.peel_parens(), member.name, args)
             }
             _ => Vec::new(),
         }
@@ -323,20 +504,20 @@ impl<'hir> Reachability<'hir> {
         &self,
         base: &'hir Expr<'hir>,
         member: Symbol,
-        arity: usize,
+        args: CallArgs<'hir>,
     ) -> Vec<FunctionId> {
         let mut functions = Vec::new();
         if is_super(base) {
             let Some(contract_id) = self.current_contract else { return functions };
             let contract = self.hir.contract(contract_id);
             for &base_id in contract.linearized_bases.iter().skip(1) {
-                functions.extend(matching_functions(self.hir, base_id, member, arity));
+                functions.extend(matching_functions(self.hir, base_id, member, args));
             }
             return functions;
         }
 
         for contract_id in self.resolve_static_contracts(base) {
-            functions.extend(matching_functions(self.hir, contract_id, member, arity));
+            functions.extend(matching_functions(self.hir, contract_id, member, args));
         }
         functions
     }
@@ -396,6 +577,10 @@ impl<'hir> Visit<'hir> for Reachability<'hir> {
     }
 
     fn visit_var(&mut self, variable: &'hir Variable<'hir>) -> ControlFlow<Self::BreakValue> {
+        if self.is_excluded_source(variable.source) {
+            return ControlFlow::Continue(());
+        }
+
         let previous_contract = self.current_contract;
         if variable.function.is_none() {
             self.current_contract = variable.contract;
@@ -412,8 +597,8 @@ impl<'hir> Visit<'hir> for Reachability<'hir> {
             }
 
             match &callee.peel_parens().kind {
-                // The call resolver above filters overloaded identifiers by arity, so do not also
-                // visit the callee as a bare function reference and mark every overload reachable.
+                // The call resolver above handles overloaded identifiers, so do not also visit the
+                // callee as a bare function reference and mark every overload reachable.
                 ExprKind::Ident(_) => {}
                 ExprKind::Member(base, _) => self.visit_expr(base)?,
                 _ => self.visit_expr(callee)?,

--- a/crates/lint/src/sol/codesize/dead_code.rs
+++ b/crates/lint/src/sol/codesize/dead_code.rs
@@ -4,7 +4,7 @@ use crate::{
     sol::{Severity, SolLint},
 };
 use solar::{
-    ast::{ContractKind, FunctionKind, Visibility},
+    ast::{ContractKind, FunctionKind, LitKind, Visibility},
     interface::{Symbol, data_structures::Never, sym},
     sema::hir::{
         CallArgs, ContractId, Expr, ExprKind, Function, FunctionId, Hir, ItemId, Modifier, Res,
@@ -65,6 +65,8 @@ struct DeadCodeAnalysis {
     overridden: HashSet<FunctionId>,
 }
 
+const ANALYSIS_CACHE_LIMIT: usize = 16;
+
 static ANALYSIS_CACHE: LazyLock<Mutex<HashMap<AnalysisCacheKey, Arc<DeadCodeAnalysis>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
@@ -77,8 +79,11 @@ fn dead_code_analysis(hir: &Hir<'_>) -> Arc<DeadCodeAnalysis> {
         variables: hir.variable_ids().len(),
     };
 
-    if let Some(analysis) = ANALYSIS_CACHE.lock().unwrap().get(&key).cloned() {
-        return analysis;
+    {
+        let cache = ANALYSIS_CACHE.lock().unwrap();
+        if let Some(analysis) = cache.get(&key).cloned() {
+            return analysis;
+        }
     }
 
     let analysis = Arc::new(DeadCodeAnalysis {
@@ -86,7 +91,14 @@ fn dead_code_analysis(hir: &Hir<'_>) -> Arc<DeadCodeAnalysis> {
         overridden: collect_overridden_functions(hir),
     });
 
-    ANALYSIS_CACHE.lock().unwrap().entry(key).or_insert_with(|| analysis).clone()
+    let mut cache = ANALYSIS_CACHE.lock().unwrap();
+    // `check_nested_source` is called once per source and constructs fresh pass instances each time,
+    // so cache per-HIR analysis across those calls. Keep it bounded for long-running test processes
+    // that lint many independent HIRs in one process.
+    if cache.len() >= ANALYSIS_CACHE_LIMIT {
+        cache.clear();
+    }
+    cache.entry(key).or_insert_with(|| analysis).clone()
 }
 
 fn is_dead_code_candidate(hir: &Hir<'_>, function: &Function<'_>, function_id: FunctionId) -> bool {
@@ -201,13 +213,7 @@ fn same_type(hir: &Hir<'_>, lhs: &Type<'_>, rhs: &Type<'_>) -> bool {
         (TypeKind::Elementary(lhs), TypeKind::Elementary(rhs)) => lhs == rhs,
         (TypeKind::Array(lhs), TypeKind::Array(rhs)) => {
             same_type(hir, &lhs.element, &rhs.element)
-                && match (lhs.size, rhs.size) {
-                    (None, None) => true,
-                    (Some(lhs), Some(rhs)) => {
-                        format!("{:?}", lhs.kind) == format!("{:?}", rhs.kind)
-                    }
-                    _ => false,
-                }
+                && same_array_size(lhs.size.map(Expr::peel_parens), rhs.size.map(Expr::peel_parens))
         }
         (TypeKind::Function(lhs), TypeKind::Function(rhs)) => {
             lhs.visibility == rhs.visibility
@@ -220,6 +226,42 @@ fn same_type(hir: &Hir<'_>, lhs: &Type<'_>, rhs: &Type<'_>) -> bool {
         }
         (TypeKind::Custom(lhs), TypeKind::Custom(rhs)) => lhs == rhs,
         (TypeKind::Err(_), TypeKind::Err(_)) => true,
+        _ => false,
+    }
+}
+
+fn same_array_size(lhs: Option<&Expr<'_>>, rhs: Option<&Expr<'_>>) -> bool {
+    match (lhs, rhs) {
+        (None, None) => true,
+        (Some(lhs), Some(rhs)) => same_expr(lhs, rhs),
+        _ => false,
+    }
+}
+
+fn same_expr(lhs: &Expr<'_>, rhs: &Expr<'_>) -> bool {
+    match (&lhs.peel_parens().kind, &rhs.peel_parens().kind) {
+        (ExprKind::Lit(lhs), ExprKind::Lit(rhs)) => same_lit_kind(&lhs.kind, &rhs.kind),
+        (ExprKind::Ident(lhs), ExprKind::Ident(rhs)) => lhs == rhs,
+        (ExprKind::Unary(lhs_op, lhs), ExprKind::Unary(rhs_op, rhs)) => {
+            lhs_op.kind == rhs_op.kind && same_expr(lhs, rhs)
+        }
+        (ExprKind::Binary(lhs_l, lhs_op, lhs_r), ExprKind::Binary(rhs_l, rhs_op, rhs_r)) => {
+            lhs_op.kind == rhs_op.kind && same_expr(lhs_l, rhs_l) && same_expr(lhs_r, rhs_r)
+        }
+        _ => false,
+    }
+}
+
+fn same_lit_kind(lhs: &LitKind<'_>, rhs: &LitKind<'_>) -> bool {
+    match (lhs, rhs) {
+        (LitKind::Str(lhs_kind, lhs_value, _), LitKind::Str(rhs_kind, rhs_value, _)) => {
+            lhs_kind == rhs_kind && lhs_value == rhs_value
+        }
+        (LitKind::Number(lhs), LitKind::Number(rhs)) => lhs == rhs,
+        (LitKind::Rational(lhs), LitKind::Rational(rhs)) => lhs == rhs,
+        (LitKind::Address(lhs), LitKind::Address(rhs)) => lhs == rhs,
+        (LitKind::Bool(lhs), LitKind::Bool(rhs)) => lhs == rhs,
+        (LitKind::Err(_), LitKind::Err(_)) => true,
         _ => false,
     }
 }
@@ -308,6 +350,16 @@ impl<'hir> Reachability<'hir> {
                     _ => None,
                 })
                 .collect(),
+            ExprKind::Type(Type {
+                kind: TypeKind::Custom(ItemId::Contract(contract_id)), ..
+            })
+            | ExprKind::TypeCall(Type {
+                kind: TypeKind::Custom(ItemId::Contract(contract_id)),
+                ..
+            }) => vec![*contract_id],
+            // Casts like `C(addr).foo()` are instance calls, not static base calls. Resolving them
+            // here would only add false edges for public/external calls, which are not dead-code
+            // candidates.
             _ => Vec::new(),
         }
     }

--- a/crates/lint/src/sol/codesize/dead_code.rs
+++ b/crates/lint/src/sol/codesize/dead_code.rs
@@ -93,10 +93,9 @@ fn input_sources<'ast>(hir: &Hir<'_>, sources: &[ProjectSource<'ast>]) -> InputS
 
         if sources[source_idx].is_test_or_script {
             continue;
-        } else {
-            input_sources.emitted.insert(source_id, source_idx);
-            input_sources.included.insert(source_id);
         }
+        input_sources.emitted.insert(source_id, source_idx);
+        input_sources.included.insert(source_id);
     }
     input_sources
 }
@@ -362,7 +361,7 @@ fn select_matching_functions(
         }
     }
 
-    if !exact.is_empty() { exact } else { possible }
+    if exact.is_empty() { possible } else { exact }
 }
 
 fn select_matching_member_functions(
@@ -382,7 +381,7 @@ fn select_matching_member_functions(
         }
     }
 
-    if !exact.is_empty() { exact } else { possible }
+    if exact.is_empty() { possible } else { exact }
 }
 
 fn function_matches_args(
@@ -399,9 +398,7 @@ fn function_matches_member_args(
     receiver: &Expr<'_>,
     args: CallArgs<'_>,
 ) -> Option<MatchQuality> {
-    let Some((&receiver_param, parameters)) = function.parameters.split_first() else {
-        return None;
-    };
+    let (&receiver_param, parameters) = function.parameters.split_first()?;
     if parameters.len() != args.len() {
         return None;
     }
@@ -534,14 +531,14 @@ fn type_matches_param(
     }
 }
 
-fn call_expr_type<'hir>(callee: &'hir Expr<'hir>) -> Option<&'hir Type<'hir>> {
+const fn call_expr_type<'hir>(callee: &'hir Expr<'hir>) -> Option<&'hir Type<'hir>> {
     match &callee.kind {
         ExprKind::Type(ty) | ExprKind::TypeCall(ty) | ExprKind::New(ty) => Some(ty),
         _ => None,
     }
 }
 
-fn lit_matches_type(lit: &LitKind<'_>, ty: &Type<'_>) -> Option<MatchQuality> {
+const fn lit_matches_type(lit: &LitKind<'_>, ty: &Type<'_>) -> Option<MatchQuality> {
     let TypeKind::Elementary(elementary) = ty.kind else {
         return match lit {
             LitKind::Err(_) => Some(MatchQuality::Possible),

--- a/crates/lint/src/sol/codesize/mod.rs
+++ b/crates/lint/src/sol/codesize/mod.rs
@@ -6,6 +6,6 @@ use dead_code::DEAD_CODE;
 use unwrapped_modifier_logic::UNWRAPPED_MODIFIER_LOGIC;
 
 register_lints!(
-    (DeadCode, late, (DEAD_CODE)),
+    (DeadCode, project, (DEAD_CODE)),
     (UnwrappedModifierLogic, late, (UNWRAPPED_MODIFIER_LOGIC)),
 );

--- a/crates/lint/src/sol/codesize/mod.rs
+++ b/crates/lint/src/sol/codesize/mod.rs
@@ -1,6 +1,11 @@
 use crate::sol::{EarlyLintPass, LateLintPass, SolLint};
 
+mod dead_code;
 mod unwrapped_modifier_logic;
+use dead_code::DEAD_CODE;
 use unwrapped_modifier_logic::UNWRAPPED_MODIFIER_LOGIC;
 
-register_lints!((UnwrappedModifierLogic, late, (UNWRAPPED_MODIFIER_LOGIC)));
+register_lints!(
+    (DeadCode, late, (DEAD_CODE)),
+    (UnwrappedModifierLogic, late, (UNWRAPPED_MODIFIER_LOGIC)),
+);

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -220,7 +220,14 @@ impl<'a> SolidityLinter<'a> {
                 let comments =
                     Comments::new(&source.file, gcx.sess.source_map(), false, false, None);
                 let inline_config = parse_inline_config(gcx.sess, &comments, ast);
-                Some(ProjectSource { path, file: source.file.clone(), ast, inline_config })
+                let is_test_or_script = self.path_config.is_test_or_script(&path);
+                Some(ProjectSource {
+                    path,
+                    file: source.file.clone(),
+                    ast,
+                    inline_config,
+                    is_test_or_script,
+                })
             })
             .collect();
 

--- a/crates/lint/testdata/DeadCode.sol
+++ b/crates/lint/testdata/DeadCode.sol
@@ -18,6 +18,14 @@ contract DeadCode {
         usedFromConstructor();
     }
 
+    receive() external payable {
+        usedFromReceive();
+    }
+
+    fallback() external payable {
+        usedFromFallback();
+    }
+
     modifier usesHelper() {
         usedFromModifier();
         _;
@@ -44,6 +52,10 @@ contract DeadCode {
     }
 
     function usedFromConstructor() private {}
+
+    function usedFromReceive() private {}
+
+    function usedFromFallback() internal {}
 
     function usedFromInitializer() internal pure returns (uint256) {
         return 0;

--- a/crates/lint/testdata/DeadCode.sol
+++ b/crates/lint/testdata/DeadCode.sol
@@ -1,0 +1,89 @@
+//@compile-flags: --only-lint dead-code
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+function unusedFreeFunction() pure returns (uint256) {
+    return 1;
+}
+
+function usedFreeFunction() pure returns (uint256) {
+    return 2;
+}
+
+contract DeadCode {
+    uint256 initialized = usedFromInitializer();
+
+    constructor() {
+        usedFromConstructor();
+    }
+
+    modifier usesHelper() {
+        usedFromModifier();
+        _;
+    }
+
+    function entry(uint256 value) external usesHelper returns (uint256) {
+        return usedDirectly(value) + usedTransitively(value) + usedFreeFunction();
+    }
+
+    function publicEntry() public pure returns (uint256) {
+        return 10;
+    }
+
+    function usedDirectly(uint256 value) internal pure returns (uint256) {
+        return value;
+    }
+
+    function usedTransitively(uint256 value) private pure returns (uint256) {
+        return usedLeaf(value);
+    }
+
+    function usedLeaf(uint256 value) internal pure returns (uint256) {
+        return value + 1;
+    }
+
+    function usedFromConstructor() private {}
+
+    function usedFromInitializer() internal pure returns (uint256) {
+        return 0;
+    }
+
+    function usedFromModifier() private {}
+
+    function unusedInternal() internal pure returns (uint256) {
+        return 3;
+    }
+
+    function unusedPrivate() private pure returns (uint256) {
+        return 4;
+    }
+
+    function unreachableInternal() internal pure returns (uint256) {
+        return unreachablePrivate();
+    }
+
+    function unreachablePrivate() private pure returns (uint256) {
+        return 5;
+    }
+}
+
+abstract contract AbstractDeclarations {
+    function unimplemented() internal virtual returns (uint256);
+}
+
+abstract contract AbstractBase {
+    function hook() internal virtual returns (uint256) {
+        return 1;
+    }
+}
+
+contract Child is AbstractBase {
+    function callHook() external returns (uint256) {
+        return hook();
+    }
+
+    function hook() internal pure override returns (uint256) {
+        return 2;
+    }
+}

--- a/crates/lint/testdata/DeadCode.sol
+++ b/crates/lint/testdata/DeadCode.sol
@@ -99,3 +99,32 @@ contract Child is AbstractBase {
         return 2;
     }
 }
+
+abstract contract ArrayOverrideBase {
+    function fixedArrayHook(uint256[2] memory values) internal virtual returns (uint256) {
+        return values[0];
+    }
+}
+
+contract ArrayOverrideChild is ArrayOverrideBase {
+    function callFixedArrayHook() external pure returns (uint256) {
+        uint256[2] memory values;
+        return fixedArrayHook(values);
+    }
+
+    function fixedArrayHook(uint256[2] memory values) internal pure override returns (uint256) {
+        return values[1];
+    }
+}
+
+contract StaticBase {
+    function usedViaStaticBase() internal pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract StaticChild is StaticBase {
+    function callStaticBase() external pure returns (uint256) {
+        return StaticBase.usedViaStaticBase();
+    }
+}

--- a/crates/lint/testdata/DeadCode.sol
+++ b/crates/lint/testdata/DeadCode.sol
@@ -128,3 +128,105 @@ contract StaticChild is StaticBase {
         return StaticBase.usedViaStaticBase();
     }
 }
+
+contract OverloadedDeadCode {
+    function callAddress(address value) external pure returns (uint256) {
+        return overloaded(value);
+    }
+
+    function callAddressCast() external pure returns (uint256) {
+        return overloadedCast(address(0));
+    }
+
+    function overloaded(address) internal pure returns (uint256) {
+        return 1;
+    }
+
+    function overloaded(uint256) internal pure returns (uint256) {
+        return 2;
+    }
+
+    function overloadedCast(address) internal pure returns (uint256) {
+        return 3;
+    }
+
+    function overloadedCast(uint256) internal pure returns (uint256) {
+        return 4;
+    }
+}
+
+contract StaticOverloadBase {
+    function usedViaStaticOverload(address) internal pure returns (uint256) {
+        return 1;
+    }
+
+    function usedViaStaticOverload(uint256) internal pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract StaticOverloadChild is StaticOverloadBase {
+    function callStaticOverload() external pure returns (uint256) {
+        return StaticOverloadBase.usedViaStaticOverload(address(0));
+    }
+}
+
+contract AmbiguousOverloadReachability {
+    function callFromHelper() external pure returns (uint256) {
+        return ambiguous(makeAddress());
+    }
+
+    function makeAddress() internal pure returns (address) {
+        return address(0);
+    }
+
+    function ambiguous(address) internal pure returns (uint256) {
+        return 1;
+    }
+
+    function ambiguous(uint256) internal pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract ImplicitConversionReachability {
+    function callWidening(uint8 value) external pure returns (uint256) {
+        return widened(value);
+    }
+
+    function widened(uint256 value) internal pure returns (uint256) {
+        return value;
+    }
+}
+
+contract PayableConversionReachability {
+    function callPlain(address value) external pure returns (uint256) {
+        return takesPlain(payable(value));
+    }
+
+    function callPayable(address value) external pure returns (uint256) {
+        return takesPayable(payable(value));
+    }
+
+    function takesPlain(address) internal pure returns (uint256) {
+        return 1;
+    }
+
+    function takesPayable(address payable) internal pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract NamedArgOverload {
+    function callNamed(address who, uint256 amount) external pure returns (uint256) {
+        return named({amount: amount, who: who});
+    }
+
+    function named(address who, uint256 amount) internal pure returns (uint256) {
+        return uint160(who) + amount;
+    }
+
+    function named(uint256 who, address amount) internal pure returns (uint256) {
+        return who + uint160(amount);
+    }
+}

--- a/crates/lint/testdata/DeadCode.sol
+++ b/crates/lint/testdata/DeadCode.sol
@@ -11,6 +11,18 @@ function usedFreeFunction() pure returns (uint256) {
     return 2;
 }
 
+function usedAsAttachedFreeFunction(uint256 value) pure returns (uint256) {
+    return value + 1;
+}
+
+function unusedAttachedFreeFunction(uint256 value) pure returns (uint256) {
+    return value + 2;
+}
+
+function usedByUsingLibrary(uint256 value) pure returns (uint256) {
+    return value * 2;
+}
+
 contract DeadCode {
     uint256 initialized = usedFromInitializer();
 
@@ -126,6 +138,66 @@ contract StaticBase {
 contract StaticChild is StaticBase {
     function callStaticBase() external pure returns (uint256) {
         return StaticBase.usedViaStaticBase();
+    }
+}
+
+contract InheritedBaseInternal {
+    function inheritedHelper() internal pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract InheritedChildCallsBase is InheritedBaseInternal {
+    function callInheritedHelper() external pure returns (uint256) {
+        return inheritedHelper();
+    }
+}
+
+contract SuperRoot {
+    function superHook() internal pure virtual returns (uint256) {
+        return rootOnlyHelper();
+    }
+
+    function rootOnlyHelper() internal pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract SuperMid is SuperRoot {
+    function superHook() internal pure virtual override returns (uint256) {
+        return midOnlyHelper();
+    }
+
+    function midOnlyHelper() internal pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract SuperChild is SuperMid {
+    function callSuperHook() external pure returns (uint256) {
+        return super.superHook();
+    }
+}
+
+contract UsingForFreeFunction {
+    using {usedAsAttachedFreeFunction} for uint256;
+
+    function callAttached(uint256 value) external pure returns (uint256) {
+        return value.usedAsAttachedFreeFunction();
+    }
+}
+
+library UsingForLibrary {
+    function twice(uint256 value) internal pure returns (uint256) {
+        return usedByUsingLibrary(value);
+    }
+}
+
+contract UsingForLibraryCall {
+    using UsingForLibrary for uint256;
+
+    function callLibrary(uint256 value) external pure returns (uint256) {
+        return value.twice();
     }
 }
 

--- a/crates/lint/testdata/DeadCode.stderr
+++ b/crates/lint/testdata/DeadCode.stderr
@@ -1,0 +1,50 @@
+note[dead-code]: internal or private function is never used
+   ╭▸ ROOT/testdata/DeadCode.sol:LL:CC
+   │
+LL │ ┏ function unusedFreeFunction() pure returns (uint256) {
+LL │ ┃     return 1;
+LL │ ┃ }
+   │ ┗━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dead-code
+
+note[dead-code]: internal or private function is never used
+   ╭▸ ROOT/testdata/DeadCode.sol:LL:CC
+   │
+LL │ ┏     function unusedInternal() internal pure returns (uint256) {
+LL │ ┃         return 3;
+LL │ ┃     }
+   │ ┗━━━━━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dead-code
+
+note[dead-code]: internal or private function is never used
+   ╭▸ ROOT/testdata/DeadCode.sol:LL:CC
+   │
+LL │ ┏     function unusedPrivate() private pure returns (uint256) {
+LL │ ┃         return 4;
+LL │ ┃     }
+   │ ┗━━━━━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dead-code
+
+note[dead-code]: internal or private function is never used
+   ╭▸ ROOT/testdata/DeadCode.sol:LL:CC
+   │
+LL │ ┏     function unreachableInternal() internal pure returns (uint256) {
+LL │ ┃         return unreachablePrivate();
+LL │ ┃     }
+   │ ┗━━━━━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dead-code
+
+note[dead-code]: internal or private function is never used
+   ╭▸ ROOT/testdata/DeadCode.sol:LL:CC
+   │
+LL │ ┏     function unreachablePrivate() private pure returns (uint256) {
+LL │ ┃         return 5;
+LL │ ┃     }
+   │ ┗━━━━━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dead-code
+

--- a/crates/lint/testdata/DeadCode.stderr
+++ b/crates/lint/testdata/DeadCode.stderr
@@ -48,3 +48,43 @@ LL │ ┃     }
    │
    ╰ help: https://getfoundry.sh/forge/linting/dead-code
 
+note[dead-code]: internal or private function is never used
+   ╭▸ ROOT/testdata/DeadCode.sol:LL:CC
+   │
+LL │ ┏     function overloaded(uint256) internal pure returns (uint256) {
+LL │ ┃         return 2;
+LL │ ┃     }
+   │ ┗━━━━━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dead-code
+
+note[dead-code]: internal or private function is never used
+   ╭▸ ROOT/testdata/DeadCode.sol:LL:CC
+   │
+LL │ ┏     function overloadedCast(uint256) internal pure returns (uint256) {
+LL │ ┃         return 4;
+LL │ ┃     }
+   │ ┗━━━━━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dead-code
+
+note[dead-code]: internal or private function is never used
+   ╭▸ ROOT/testdata/DeadCode.sol:LL:CC
+   │
+LL │ ┏     function usedViaStaticOverload(uint256) internal pure returns (uint256) {
+LL │ ┃         return 2;
+LL │ ┃     }
+   │ ┗━━━━━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dead-code
+
+note[dead-code]: internal or private function is never used
+   ╭▸ ROOT/testdata/DeadCode.sol:LL:CC
+   │
+LL │ ┏     function named(uint256 who, address amount) internal pure returns (uint256) {
+LL │ ┃         return who + uint160(amount);
+LL │ ┃     }
+   │ ┗━━━━━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dead-code
+

--- a/crates/lint/testdata/DeadCode.stderr
+++ b/crates/lint/testdata/DeadCode.stderr
@@ -11,6 +11,16 @@ LL │ ┃ }
 note[dead-code]: internal or private function is never used
    ╭▸ ROOT/testdata/DeadCode.sol:LL:CC
    │
+LL │ ┏ function unusedAttachedFreeFunction(uint256 value) pure returns (uint256) {
+LL │ ┃     return value + 2;
+LL │ ┃ }
+   │ ┗━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dead-code
+
+note[dead-code]: internal or private function is never used
+   ╭▸ ROOT/testdata/DeadCode.sol:LL:CC
+   │
 LL │ ┏     function unusedInternal() internal pure returns (uint256) {
 LL │ ┃         return 3;
 LL │ ┃     }
@@ -43,6 +53,16 @@ note[dead-code]: internal or private function is never used
    │
 LL │ ┏     function unreachablePrivate() private pure returns (uint256) {
 LL │ ┃         return 5;
+LL │ ┃     }
+   │ ┗━━━━━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dead-code
+
+note[dead-code]: internal or private function is never used
+   ╭▸ ROOT/testdata/DeadCode.sol:LL:CC
+   │
+LL │ ┏     function rootOnlyHelper() internal pure returns (uint256) {
+LL │ ┃         return 1;
 LL │ ┃     }
    │ ┗━━━━━┛
    │

--- a/crates/lint/testdata/UnwrappedModifierLogic.sol
+++ b/crates/lint/testdata/UnwrappedModifierLogic.sol
@@ -1,4 +1,4 @@
-//@compile-flags: --severity code-size
+//@compile-flags: --only-lint unwrapped-modifier-logic
 
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;


### PR DESCRIPTION
## Summary
- Add `dead-code` lint for unreachable internal/private functions.

## Counterpart
- Book PR: https://github.com/foundry-rs/book/pull/1837
