### PR TITLE
fix(evm-core): wait for `pending_tasks` before completing `MultiForkHandler`

### DIFF
--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -490,7 +490,7 @@ impl<
             }
         }
 
-        if this.handlers.is_empty() && this.incoming.is_done() {
+        if this.handlers.is_empty() && this.pending_tasks.is_empty() && this.incoming.is_done() {
             trace!(target: "fork::multi", "completed");
             return Poll::Ready(());
         }


### PR DESCRIPTION
`MultiForkHandler::poll` returned `Poll::Ready(())` as soon as `handlers` was empty and `incoming` was closed, even when `pending_tasks` still held in-flight `ForkTask::Create` futures. Those tasks register their handler only after they resolve, so an early exit dropped them and left the requesting `sender` waiting forever. Added `pending_tasks.is_empty()` to the exit condition so the future stays alive until every queued fork creation has settled.