### PR TITLE
fix(cast): clarify storage missing slot error

### DIFF
--- a/crates/cast/src/cmd/storage.rs
+++ b/crates/cast/src/cmd/storage.rs
@@ -146,9 +146,7 @@ impl StorageArgs {
                 etherscan_config.into_client_with_no_proxy(config.eth_rpc_no_proxy)?
             }
             None => {
-                let api_key = etherscan_api_key.ok_or_else(|| {
-                    eyre::eyre!("You must provide an Etherscan API key if you're fetching a remote contract's storage.")
-                })?;
+                let api_key = etherscan_api_key.ok_or_else(missing_storage_slot_or_key_error)?;
                 foundry_block_explorers::Client::new(chain, api_key)?
             }
         };
@@ -393,6 +391,14 @@ const fn is_storage_layout_empty(storage_layout: &Option<StorageLayout>) -> bool
     if let Some(s) = storage_layout { s.storage.is_empty() } else { true }
 }
 
+fn missing_storage_slot_or_key_error() -> eyre::Report {
+    eyre::eyre!(
+        "No storage slot was provided. To read a raw storage slot, pass a slot argument: \
+         `cast storage <address> <slot>`. To fetch the full storage layout, provide an \
+         Etherscan API key or run from a local project with matching artifacts."
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -420,5 +426,12 @@ mod tests {
     fn parse_solc_version_arg() {
         let args = StorageArgs::parse_from(["foundry-cli", "addr.eth", "--solc-version", "0.8.10"]);
         assert_eq!(args.solc_version, Some(Version::parse("0.8.10").unwrap()));
+    }
+
+    #[test]
+    fn missing_slot_error_explains_raw_storage_usage() {
+        let err = missing_storage_slot_or_key_error().to_string();
+        assert!(err.contains("No storage slot was provided"));
+        assert!(err.contains("cast storage <address> <slot>"));
     }
 }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -2313,6 +2313,28 @@ casttest!(storage, |_prj, cmd| {
 "#]]);
 });
 
+casttest!(storage_missing_slot_without_api_key, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+    cmd.unset_env("ETHERSCAN_API_KEY");
+    cmd.unset_env("HTTP_PROXY");
+    cmd.unset_env("HTTPS_PROXY");
+    cmd.unset_env("ALL_PROXY");
+    cmd.unset_env("http_proxy");
+    cmd.unset_env("https_proxy");
+    cmd.unset_env("all_proxy");
+    cmd.args([
+        "storage",
+        "0x4e59b44847b379578588920ca78fbf26c0b4956c",
+        "--rpc-url",
+        &handle.http_endpoint(),
+    ])
+    .assert_failure()
+    .stderr_eq(str![[r#"
+Error: No storage slot was provided. To read a raw storage slot, pass a slot argument: `cast storage <address> <slot>`. To fetch the full storage layout, provide an Etherscan API key or run from a local project with matching artifacts.
+
+"#]]);
+});
+
 casttest!(flaky_storage_with_valid_solc_version_1, |_prj, cmd| {
     cmd.args([
         "storage",


### PR DESCRIPTION
## Summary

- replace the address-only `cast storage` fallback error with guidance that a raw storage read needs a slot argument
- keep the full storage layout path documented for users who want explorer/project artifact based layout output
- add unit and CLI regression coverage for the no-slot/no-API-key path

## Testing

- `cargo +nightly fmt --check`
- `cargo +nightly test -p cast --lib cmd::storage::tests::missing_slot_error_explains_raw_storage_usage`
- `cargo +nightly test -p cast --test cli storage_missing_slot_without_api_key`