### PR TITLE
fix(anvil): reuse spec blob params for fee history

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -105,7 +105,7 @@ use foundry_evm::{
     },
     utils::{
         block_env_from_header, get_blob_base_fee_update_fraction,
-        get_blob_base_fee_update_fraction_by_spec_id,
+        get_blob_base_fee_update_fraction_by_spec_id, get_blob_params_by_spec_id,
     },
 };
 use foundry_evm_networks::NetworkConfigs;
@@ -602,17 +602,7 @@ impl<N: Network> Backend<N> {
 
     /// Returns [`BlobParams`] corresponding to the current spec.
     pub fn blob_params(&self) -> BlobParams {
-        let spec_id = self.spec_id();
-
-        if spec_id >= SpecId::OSAKA {
-            return BlobParams::osaka();
-        }
-
-        if spec_id >= SpecId::PRAGUE {
-            return BlobParams::prague();
-        }
-
-        BlobParams::cancun()
+        get_blob_params_by_spec_id(self.spec_id())
     }
 
     /// Returns an error if EIP1559 is not active (pre Berlin)

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -22,7 +22,6 @@ use crate::{
     shutdown::Signal,
     tasks::TaskManager,
 };
-use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::{Address, U256};
 use alloy_signer_local::PrivateKeySigner;
 use eth::backend::fork::ClientFork;
@@ -32,7 +31,6 @@ pub use foundry_evm::hardfork::EthereumHardfork;
 use foundry_primitives::FoundryNetwork;
 use futures::{FutureExt, TryFutureExt};
 use parking_lot::Mutex;
-use revm::primitives::hardfork::SpecId;
 use server::try_spawn_ipc;
 use std::{
     net::SocketAddr,
@@ -211,11 +209,7 @@ pub async fn try_spawn(mut config: NodeConfig) -> Result<(EthApi<FoundryNetwork>
 
     let fee_history_cache = Arc::new(Mutex::new(Default::default()));
     let fee_history_service = FeeHistoryService::new(
-        match backend.spec_id() {
-            SpecId::OSAKA => BlobParams::osaka(),
-            SpecId::PRAGUE => BlobParams::prague(),
-            _ => BlobParams::cancun(),
-        },
+        backend.blob_params(),
         backend.new_block_notifications(),
         Arc::clone(&fee_history_cache),
         StorageInfo::new(Arc::clone(&backend)),

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -7,10 +7,7 @@ use alloy_primitives::{B256, ChainId, Selector, U256};
 use alloy_provider::{Network, network::BlockResponse};
 use foundry_config::NamedChain;
 use foundry_evm_networks::NetworkConfigs;
-use revm::primitives::{
-    eip4844::{BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE},
-    hardfork::SpecId,
-};
+use revm::primitives::hardfork::SpecId;
 pub use revm::state::EvmState as StateChangeset;
 
 /// Hints to the compiler that this is a cold path, i.e. unlikely to be taken.
@@ -136,13 +133,22 @@ pub fn get_blob_base_fee_update_fraction(chain_id: ChainId, timestamp: u64) -> u
     get_blob_params(chain_id, timestamp).update_fraction as u64
 }
 
+/// Returns the blob params based on the spec id.
+pub fn get_blob_params_by_spec_id(spec: SpecId) -> BlobParams {
+    if spec >= SpecId::AMSTERDAM {
+        BlobParams::bpo2()
+    } else if spec >= SpecId::OSAKA {
+        BlobParams::osaka()
+    } else if spec >= SpecId::PRAGUE {
+        BlobParams::prague()
+    } else {
+        BlobParams::cancun()
+    }
+}
+
 /// Returns the blob base fee update fraction based on the spec id.
 pub fn get_blob_base_fee_update_fraction_by_spec_id(spec: SpecId) -> u64 {
-    if spec >= SpecId::PRAGUE {
-        BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE
-    } else {
-        BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN
-    }
+    get_blob_params_by_spec_id(spec).update_fraction as u64
 }
 
 /// Given an ABI and selector, it tries to find the respective function.
@@ -154,4 +160,21 @@ pub fn get_function<'a>(
     abi.functions()
         .find(|func| func.selector() == selector)
         .ok_or_else(|| eyre::eyre!("{contract_name} does not have the selector {selector}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blob_params_by_spec_id_tracks_latest_known_blob_schedule() {
+        assert_eq!(get_blob_params_by_spec_id(SpecId::CANCUN), BlobParams::cancun());
+        assert_eq!(get_blob_params_by_spec_id(SpecId::PRAGUE), BlobParams::prague());
+        assert_eq!(get_blob_params_by_spec_id(SpecId::OSAKA), BlobParams::osaka());
+        assert_eq!(get_blob_params_by_spec_id(SpecId::AMSTERDAM), BlobParams::bpo2());
+        assert_eq!(
+            get_blob_base_fee_update_fraction_by_spec_id(SpecId::AMSTERDAM),
+            BlobParams::bpo2().update_fraction as u64
+        );
+    }
 }


### PR DESCRIPTION
## Motivation

`FeeHistoryService` duplicated spec-to-blob-params logic and only matched `OSAKA` and `PRAGUE`. Newer specs such as `AMSTERDAM` therefore fell back to Cancun params even though the core blob-param mapping already exposes the
Amsterdam `bpo2` schedule.

## Solution

Add a shared `get_blob_params_by_spec_id` helper, make the update-fraction helper delegate to it, and initialize fee history from the backend's current blob params. Add coverage for the Cancun, Prague, Osaka, and Amsterdam schedules.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes