### PR TITLE
feat(config): expose extended Vyper settings

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1845,9 +1845,14 @@ impl Config {
     /// Returns the configured [VyperSettings] that includes:
     /// - evm version
     pub fn vyper_settings(&self) -> Result<VyperSettings, SolcError> {
+        // Let `opt_level` override `optimize` so child profiles can switch away from an
+        // inherited optimization mode without sending both mutually exclusive settings to Vyper.
+        let optimize = if self.vyper.opt_level.is_some() { None } else { self.vyper.optimize };
+
         Ok(VyperSettings {
             evm_version: Some(self.evm_version),
-            optimize: self.vyper.optimize,
+            optimize,
+            opt_level: self.vyper.opt_level,
             bytecode_metadata: None,
             // TODO: We don't yet have a way to deserialize other outputs correctly, so request only
             // those for now. It should be enough to run tests and deploy contracts.
@@ -1858,7 +1863,10 @@ impl Config {
             ]),
             search_paths: None,
             experimental_codegen: self.vyper.experimental_codegen,
-            ..Default::default()
+            debug: self.vyper.debug,
+            enable_decimals: self.vyper.enable_decimals,
+            venom_experimental: self.vyper.venom_experimental,
+            venom: self.vyper.venom.clone(),
         })
     }
 
@@ -2942,7 +2950,8 @@ mod tests {
     use endpoints::{RpcAuth, RpcEndpointConfig};
     use figment::error::Kind::InvalidType;
     use foundry_compilers::artifacts::{
-        ModelCheckerEngine, YulDetails, vyper::VyperOptimizationMode,
+        ModelCheckerEngine, YulDetails,
+        vyper::{VyperOptimizationLevel, VyperOptimizationMode, VyperVenomSettings},
     };
     use foundry_evm_hardforks::TempoHardfork;
     use similar_asserts::assert_eq;
@@ -5422,9 +5431,26 @@ mod tests {
                 "foundry.toml",
                 r#"
                 [vyper]
-                optimize = "codesize"
+                optimize = "O1"
                 path = "/path/to/vyper"
                 experimental_codegen = true
+                venom_experimental = false
+                debug = true
+                enable_decimals = true
+
+                [vyper.venom]
+                disable_inlining = true
+                disable_cse = true
+                disable_sccp = false
+                disable_load_elimination = true
+                disable_dead_store_elimination = false
+                disable_algebraic_optimization = true
+                disable_branch_optimization = false
+                disable_assert_elimination = true
+                disable_mem2var = false
+                disable_simplify_cfg = true
+                disable_remove_unused_variables = false
+                inline_threshold = 15
             "#,
             )?;
 
@@ -5432,14 +5458,84 @@ mod tests {
             assert_eq!(
                 config.vyper,
                 VyperConfig {
-                    optimize: Some(VyperOptimizationMode::Codesize),
+                    optimize: Some(VyperOptimizationMode::O1),
+                    opt_level: None,
                     path: Some("/path/to/vyper".into()),
                     experimental_codegen: Some(true),
+                    venom_experimental: Some(false),
+                    debug: Some(true),
+                    enable_decimals: Some(true),
+                    venom: Some(VyperVenomSettings {
+                        disable_inlining: Some(true),
+                        disable_cse: Some(true),
+                        disable_sccp: Some(false),
+                        disable_load_elimination: Some(true),
+                        disable_dead_store_elimination: Some(false),
+                        disable_algebraic_optimization: Some(true),
+                        disable_branch_optimization: Some(false),
+                        disable_assert_elimination: Some(true),
+                        disable_mem2var: Some(false),
+                        disable_simplify_cfg: Some(true),
+                        disable_remove_unused_variables: Some(false),
+                        inline_threshold: Some(15),
+                    }),
                 }
             );
 
             Ok(())
         });
+    }
+
+    #[test]
+    fn test_vyper_settings_include_extended_config() {
+        let config = Config {
+            vyper: VyperConfig {
+                opt_level: Some(VyperOptimizationLevel::O3),
+                experimental_codegen: Some(true),
+                venom_experimental: Some(false),
+                debug: Some(true),
+                enable_decimals: Some(true),
+                venom: Some(VyperVenomSettings {
+                    disable_cse: Some(true),
+                    inline_threshold: Some(15),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ..Config::default().normalized_optimizer_settings()
+        };
+
+        let settings = config.vyper_settings().unwrap();
+        assert_eq!(settings.optimize, None);
+        assert_eq!(settings.opt_level, Some(VyperOptimizationLevel::O3));
+        assert_eq!(settings.experimental_codegen, Some(true));
+        assert_eq!(settings.venom_experimental, Some(false));
+        assert_eq!(settings.debug, Some(true));
+        assert_eq!(settings.enable_decimals, Some(true));
+        assert_eq!(
+            settings.venom,
+            Some(VyperVenomSettings {
+                disable_cse: Some(true),
+                inline_threshold: Some(15),
+                ..Default::default()
+            })
+        );
+    }
+
+    #[test]
+    fn vyper_opt_level_overrides_optimize() {
+        let config = Config {
+            vyper: VyperConfig {
+                optimize: Some(VyperOptimizationMode::Gas),
+                opt_level: Some(VyperOptimizationLevel::O3),
+                ..Default::default()
+            },
+            ..Config::default().normalized_optimizer_settings()
+        };
+
+        let settings = config.vyper_settings().unwrap();
+        assert_eq!(settings.optimize, None);
+        assert_eq!(settings.opt_level, Some(VyperOptimizationLevel::O3));
     }
 
     #[test]
@@ -7132,9 +7228,16 @@ mod tests {
                 src = "src"
 
                 [vyper]
-                optimize = "gas"
+                optimize = "O1"
                 path = "/usr/bin/vyper"
                 experimental_codegen = true
+                venom_experimental = false
+                debug = true
+                enable_decimals = true
+
+                [vyper.venom]
+                disable_cse = true
+                inline_threshold = 15
                 "#,
             )?;
 
@@ -7171,9 +7274,12 @@ mod tests {
                 src = "src"
 
                 [profile.default.vyper]
-                optimize = "codesize"
+                opt_level = "s"
                 path = "/opt/vyper/bin/vyper"
                 experimental_codegen = false
+                debug = true
+                enable_decimals = true
+                venom = { disable_sccp = true, disable_mem2var = false }
                 "#,
             )?;
 
@@ -7209,13 +7315,13 @@ mod tests {
                 r#"
                 [profile.default]
                 src = "src"
-                vyper = { optimize = "gas" }
+                vyper = { optimize = "gas", debug = true }
 
                 [profile.default-venom]
-                vyper = { experimental_codegen = true }
+                vyper = { opt_level = "O2", experimental_codegen = true, venom = { disable_cse = true } }
 
                 [profile.ci-venom]
-                vyper = { experimental_codegen = true }
+                vyper = { venom_experimental = true, enable_decimals = true }
                 "#,
             )?;
 

--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -27,7 +27,17 @@ const SETTINGS_OVERRIDES_KEYS: &[&str] =
 /// Allowed keys for VyperConfig.
 /// Required because VyperConfig uses `skip_serializing_if = "Option::is_none"` on all fields,
 /// causing the default serialization to produce an empty dict.
-const VYPER_KEYS: &[&str] = &["optimize", "path", "experimental_codegen"];
+const VYPER_KEYS: &[&str] = &[
+    "optimize",
+    "opt_level",
+    "optLevel",
+    "path",
+    "experimental_codegen",
+    "venom_experimental",
+    "debug",
+    "enable_decimals",
+    "venom",
+];
 
 /// Allowed keys for DocConfig.
 /// Required because DocConfig uses `skip_serializing_if = "Option::is_none"` on some fields

--- a/crates/config/src/vyper.rs
+++ b/crates/config/src/vyper.rs
@@ -1,18 +1,35 @@
 //! Vyper specific configuration types.
 
-use foundry_compilers::artifacts::vyper::VyperOptimizationMode;
+use foundry_compilers::artifacts::vyper::{
+    VyperOptimizationLevel, VyperOptimizationMode, VyperVenomSettings,
+};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VyperConfig {
-    /// Vyper optimization mode. "gas", "none" or "codesize"
+    /// Vyper optimization mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub optimize: Option<VyperOptimizationMode>,
+    /// Vyper numeric optimization level.
+    #[serde(default, alias = "optLevel", skip_serializing_if = "Option::is_none")]
+    pub opt_level: Option<VyperOptimizationLevel>,
     /// The Vyper instance to use if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
-    /// Optionally enables experimental Venom pipeline
+    /// Enables Vyper's experimental code generation pipeline.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub experimental_codegen: Option<bool>,
+    /// Enables Vyper's Venom pipeline through the `venomExperimental` standard-json setting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub venom_experimental: Option<bool>,
+    /// Compile in debug mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub debug: Option<bool>,
+    /// Re-enable the Vyper decimal type.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enable_decimals: Option<bool>,
+    /// Fine-grained Venom optimizer settings.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub venom: Option<VyperVenomSettings>,
 }


### PR DESCRIPTION
## Summary
- expose new Vyper standard-json settings in foundry.toml config: opt_level, debug, enable_decimals, venom_experimental, and venom pass toggles + allow new optimization values like O1/O2/O3/Os through the existing optimize field