### PR TITLE
feat(anvil): enable js-tracer by default

### DIFF
--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -124,7 +124,7 @@ tokio = { workspace = true, features = ["full"] }
 tempo-alloy.workspace = true
 
 [features]
-default = ["cli", "jemalloc", "asm-keccak", "optimism"]
+default = ["cli", "jemalloc", "asm-keccak", "optimism", "js-tracer"]
 optimism = [
     "dep:op-alloy-consensus",
     "dep:op-alloy-rpc-types",


### PR DESCRIPTION
`js-tracer` is shipped in release and docker builds (`release.yml` and `docker-publish.yml` both list it in `RUST_FEATURES`), but it is not in anvil's default feature set, so:

- `cargo test --workspace` skips the JS-tracer integration tests (gated behind `#[cfg(feature = "js-tracer")]`)
- `cargo build` does not exercise the `boa_engine` code path

Add `js-tracer` to anvil's default features so the local development experience matches what we ship.

This also matches [Reth's pattern](https://github.com/paradigmxyz/reth/blob/main/bin/reth/Cargo.toml), where `js-tracer` is enabled by default in the `reth` binary.