### PR TITLE
fix(anvil): track Amsterdam block gas accounting

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1132,8 +1132,8 @@ impl NodeConfig {
     {
         // configure the revm environment
 
-        let mut cfg = CfgEnv::default();
-        cfg.spec = self.get_hardfork().into();
+        let spec_id = self.get_hardfork().into();
+        let mut cfg = CfgEnv::new_with_spec(spec_id);
 
         cfg.chain_id = self.get_chain_id();
         cfg.limit_contract_code_size = self.code_size_limit;
@@ -1151,7 +1151,6 @@ impl NodeConfig {
             cfg.memory_limit = value;
         }
 
-        let spec_id = cfg.spec;
         let mut evm_env = EvmEnv::new(
             cfg,
             BlockEnv {
@@ -1384,7 +1383,7 @@ latest block number: {latest_block}"
             && let Some(hardfork) =
                 FoundryHardfork::from_chain_and_timestamp(chain_id, block.header.timestamp())
         {
-            evm_env.cfg_env.spec = SpecId::from(hardfork);
+            evm_env.cfg_env.set_spec_and_mainnet_gas_params(SpecId::from(hardfork));
             self.hardfork = Some(hardfork);
         }
 

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -39,7 +39,7 @@ use revm::{
     primitives::hardfork::SpecId,
     state::AccountInfo,
 };
-use std::{fmt, fmt::Debug, mem::take, sync::Arc};
+use std::{cmp::min, fmt, fmt::Debug, mem::take, sync::Arc};
 
 /// Receipt builder for Foundry/Anvil that handles all transaction types
 #[derive(Debug, Default, Clone, Copy)]
@@ -115,8 +115,12 @@ pub struct AnvilBlockExecutor<E> {
     receipt_builder: FoundryReceiptBuilder,
     /// Receipts of executed transactions.
     receipts: Vec<FoundryReceiptEnvelope>,
-    /// Total gas used by transactions in this block.
+    /// Cumulative gas used by transactions in receipts.
     gas_used: u64,
+    /// Regular gas used by transactions in this block.
+    block_regular_gas_used: u64,
+    /// State gas used by transactions in this block.
+    block_state_gas_used: u64,
     /// Blob gas used by the block.
     blob_gas_used: u64,
     /// Optional state change hook.
@@ -146,8 +150,19 @@ impl<E> AnvilBlockExecutor<E> {
             receipt_builder: FoundryReceiptBuilder,
             receipts: Vec::new(),
             gas_used: 0,
+            block_regular_gas_used: 0,
+            block_state_gas_used: 0,
             blob_gas_used: 0,
             state_hook: None,
+        }
+    }
+
+    /// Returns the maximum of regular and state gas used by transactions in this block.
+    const fn max_block_gas_used(&self) -> u64 {
+        if self.block_regular_gas_used > self.block_state_gas_used {
+            self.block_regular_gas_used
+        } else {
+            self.block_state_gas_used
         }
     }
 }
@@ -193,8 +208,19 @@ where
     ) -> Result<Self::Result, BlockExecutionError> {
         let (tx_env, tx) = tx.into_parts();
 
-        let block_available_gas = self.evm.block().gas_limit() - self.gas_used;
-        if tx.tx().gas_limit() > block_available_gas {
+        let block_gas_used = if self.evm.cfg_env().enable_amsterdam_eip8037 {
+            self.block_regular_gas_used
+        } else {
+            self.gas_used
+        };
+        let block_available_gas = self.evm.block().gas_limit() - block_gas_used;
+
+        let mut max_tx_gas_usage = tx.tx().gas_limit();
+        if let Some(tx_gas_limit_cap) = self.evm.cfg_env().tx_gas_limit_cap {
+            max_tx_gas_usage = min(max_tx_gas_usage, tx_gas_limit_cap);
+        }
+
+        if max_tx_gas_usage > block_available_gas {
             return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
                 transaction_gas_limit: tx.tx().gas_limit(),
                 block_available_gas,
@@ -230,8 +256,12 @@ where
             hook.on_state(StateChangeSource::Transaction(self.receipts.len()), &state);
         }
 
-        let gas_used = result.tx_gas_used();
-        self.gas_used += gas_used;
+        let tx_gas_used = result.gas().tx_gas_used();
+        let regular_gas_used = result.gas().block_regular_gas_used();
+        let state_gas_used = result.gas().block_state_gas_used();
+        self.gas_used += tx_gas_used;
+        self.block_regular_gas_used += regular_gas_used;
+        self.block_state_gas_used += state_gas_used;
 
         if self.spec_id >= SpecId::CANCUN {
             self.blob_gas_used = self.blob_gas_used.saturating_add(blob_gas_used);
@@ -275,19 +305,25 @@ where
         self.receipts.push(receipt);
         self.evm.db_mut().commit(state);
 
-        GasOutput::new(gas_used)
+        GasOutput::with_state_gas(tx_gas_used, state_gas_used)
     }
 
     fn finish(
         self,
     ) -> Result<(Self::Evm, BlockExecutionResult<FoundryReceiptEnvelope>), BlockExecutionError>
     {
+        let gas_used = if self.evm.cfg_env().enable_amsterdam_eip8037 {
+            self.max_block_gas_used()
+        } else {
+            self.gas_used
+        };
+
         Ok((
             self.evm,
             BlockExecutionResult {
                 receipts: self.receipts,
                 requests: Default::default(),
-                gas_used: self.gas_used,
+                gas_used,
                 blob_gas_used: self.blob_gas_used,
             },
         ))

--- a/crates/anvil/tests/it/gas.rs
+++ b/crates/anvil/tests/it/gas.rs
@@ -1,12 +1,13 @@
 //! Gas related tests
 
 use crate::utils::http_provider_with_signer;
-use alloy_network::{EthereumWallet, TransactionBuilder};
-use alloy_primitives::{Address, U64, U256, uint};
+use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder};
+use alloy_primitives::{Address, U64, U256, bytes, uint};
 use alloy_provider::Provider;
 use alloy_rpc_types::{BlockId, TransactionRequest};
 use alloy_serde::WithOtherFields;
 use anvil::{NodeConfig, eth::fees::INITIAL_BASE_FEE, spawn};
+use foundry_evm::hardfork::EthereumHardfork;
 
 const GAS_TRANSFER: u64 = 21_000;
 
@@ -23,6 +24,40 @@ async fn test_gas_limit_disabled_from_config() {
 
     // see https://github.com/foundry-rs/foundry/pull/8933
     assert_eq!(api.gas_limit(), U256::from(U64::MAX));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_amsterdam_block_gas_uses_state_gas_accounting() {
+    let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Amsterdam.into()));
+    let (_api, handle) = spawn(node_config).await;
+    let provider = handle.http_provider();
+    let from = handle.dev_wallets().next().unwrap().address();
+
+    let eip1559_est = provider.estimate_eip1559_fees().await.unwrap();
+    let tx = TransactionRequest::default()
+        .with_from(from)
+        .into_create()
+        .with_max_fee_per_gas(eip1559_est.max_fee_per_gas)
+        .with_max_priority_fee_per_gas(eip1559_est.max_priority_fee_per_gas)
+        .with_input(bytes!("66365f5f37365fa05f5260076019f3"));
+
+    let receipt = provider
+        .send_transaction(WithOtherFields::new(tx))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert!(receipt.status());
+
+    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+
+    assert!(
+        block.header.gas_used < receipt.gas_used,
+        "Amsterdam block gas should use split block gas accounting instead of receipt gas: block={}, receipt={}",
+        block.header.gas_used,
+        receipt.gas_used,
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Motivation

`AnvilBlockExecutor` still accumulated `tx_gas_used()` as both the receipt cumulative gas and the block gas total. After Amsterdam/EIP-8037, revm splits regular gas and state gas, and the block header should use the maximum of the block regular gas and block state gas while receipts keep cumulative transaction gas.

Anvil's node setup also set the hardfork directly on a default `CfgEnv`, which left spec-dependent gas params and the Amsterdam EIP-8037 flag stale for explicit and auto-detected hardforks.

## Solution

Initialize and update Anvil's `CfgEnv` through revm's spec-aware gas parameter APIs. Track receipt cumulative gas separately from regular/state block gas in `AnvilBlockExecutor`. Use the Amsterdam-aware gas accumulator for block availability and final `BlockExecutionResult::gas_used`, and return `GasOutput::with_state_gas` so downstream executor consumers preserve both gas components.

Add an Amsterdam integration test that mines a contract creation transaction and checks the block header gas uses split block gas accounting instead of receipt cumulative gas.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes