### PR TITLE
Fix cast log chunk boundaries

### DIFF
--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -226,7 +226,9 @@ pub trait Db:
 
     /// Deserialize and add all chain data to the backend storage
     fn load_state(&mut self, state: SerializableState) -> DatabaseResult<bool> {
-        for (addr, account) in state.accounts {
+        let SerializableState { accounts, blocks, .. } = state;
+
+        for (addr, account) in accounts {
             let old_account_nonce = DatabaseRef::basic_ref(self, addr)
                 .ok()
                 .and_then(|acc| acc.map(|acc| acc.nonce))
@@ -254,6 +256,15 @@ pub trait Db:
                 self.set_storage_at(addr, k, v)?;
             }
         }
+
+        // Backfill execution-layer block hash cache for imported blocks so BLOCKHASH lookups can
+        // hit local DB data after `anvil_loadState`.
+        for block in blocks {
+            let number = U256::from(block.header.number);
+            let hash = block.header.hash_slow();
+            self.insert_block_hash(number, hash);
+        }
+
         Ok(true)
     }
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3966,14 +3966,17 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
             ));
         }
 
-        if !self.db.write().await.load_state(state.clone())? {
+        let mut state = state;
+        let historical_states = state.historical_states.take();
+
+        if !self.db.write().await.load_state(state)? {
             return Err(RpcError::invalid_params(
                 "Loading state not supported with the current configuration",
             )
             .into());
         }
 
-        if let Some(historical_states) = state.historical_states {
+        if let Some(historical_states) = historical_states {
             self.states.write().load_states(historical_states);
         }
 
@@ -4807,6 +4810,7 @@ pub use foundry_evm::core::evm::IntoInstructionResult;
 #[cfg(test)]
 mod tests {
     use crate::{NodeConfig, spawn};
+    use revm::database::DatabaseRef;
 
     #[tokio::test]
     async fn test_deterministic_block_mining() {
@@ -4860,5 +4864,25 @@ mod tests {
             block_a_1.header.hash, block_a_2.header.hash,
             "Different blocks should have different hashes"
         );
+    }
+
+    #[tokio::test]
+    async fn test_load_state_backfills_block_hash_cache() {
+        let genesis_timestamp = 1743944919u64;
+        let config = NodeConfig::test().with_genesis_timestamp(genesis_timestamp.into());
+
+        let (api_src, _src_handle) = spawn(config.clone()).await;
+        let (api_dst, _dst_handle) = spawn(config).await;
+
+        let mined = api_src.backend.mine_block(vec![]).await;
+        let number = mined.block_number;
+        let mined_block = api_src.block_by_number(number.into()).await.unwrap().unwrap();
+        let expected_hash = mined_block.header.hash;
+
+        let dumped_state = api_src.backend.dump_state(false).await.unwrap();
+        api_dst.backend.load_state_bytes(dumped_state).await.unwrap();
+
+        let loaded_hash = api_dst.backend.db.read().await.block_hash_ref(number).unwrap();
+        assert_eq!(loaded_hash, expected_hash);
     }
 }


### PR DESCRIPTION
 ## Motivation
                                                                                                                                                                                                 
  `anvil_loadState` imported accounts and storage, but it did not repopulate the execution-layer block-hash cache from imported blocks.                                                          
  That can leave `BLOCKHASH`-based reads inconsistent after a state import, even when the block data is present.                                                                                 
                                                                                                                                                                                                 
  ## Solution                                                                                                                                                                                    
                                                                                                                                                                                                 
  This change backfills block hashes during state import and keeps historical snapshots handling intact:                                                                                         
                                                                                                                                                                                                 
  - `Db::load_state` now iterates imported `blocks` and inserts `(block_number, block_hash)` into the local block-hash cache.                                                                    
  - `Backend::load_state` takes `historical_states` before moving `state` into DB loading, avoiding unnecessary cloning and preserving behavior.                                                 
  - Added a regression test (`test_load_state_backfills_block_hash_cache`) that verifies a mined block hash is still available after `dump_state -> load_state_bytes`.                           
                                                                                                                                                                                                 
  ## PR Checklist                                                                                                                                                                                
                                                                                                                                                                                                 
  - [x] Added Tests                                                                                                                                                                              
  - [ ] Added Documentation                                                                                                                                                                      
  - [ ] Breaking changes  