### PR TITLE
feat(cli): agent-machine runtime — --machine, ExitCode, diagnostics, capability guard

### DIFF
--- a/crates/anvil/src/args.rs
+++ b/crates/anvil/src/args.rs
@@ -87,7 +87,7 @@ mod tests {
     #[test]
     fn introspect_command_ids_are_unique() {
         use foundry_cli::introspect::{CommandRegistry, build_document, duplicate_command_ids};
-        let cmd = <Anvil as clap::CommandFactory>::command();
+        let cmd = Anvil::command();
         let doc = build_document(&cmd, &CommandRegistry::EMPTY);
         let dups = duplicate_command_ids(&doc);
         assert!(dups.is_empty(), "duplicate anvil command_ids: {dups:?}");
@@ -100,7 +100,7 @@ mod tests {
         use foundry_cli::introspect::{
             CommandRegistry, INTROSPECT_SCHEMA_ID, IntrospectDocument, render_introspect_document,
         };
-        let cmd = <Anvil as clap::CommandFactory>::command();
+        let cmd = Anvil::command();
         let json = render_introspect_document(&cmd, &CommandRegistry::EMPTY);
         let doc: IntrospectDocument = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(doc.schema_id, INTROSPECT_SCHEMA_ID);
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn introspect_capabilities_are_consistent() {
         use foundry_cli::introspect::{CommandRegistry, build_document, capability_violations};
-        let cmd = <Anvil as clap::CommandFactory>::command();
+        let cmd = Anvil::command();
         let doc = build_document(&cmd, &CommandRegistry::EMPTY);
         let v = capability_violations(&doc);
         assert!(v.is_empty(), "anvil capability violations: {v:?}");

--- a/crates/anvil/src/args.rs
+++ b/crates/anvil/src/args.rs
@@ -1,5 +1,5 @@
 use crate::opts::{Anvil, AnvilSubcommand};
-use clap::{CommandFactory, Parser};
+use clap::CommandFactory;
 use eyre::Result;
 use foundry_cli::utils;
 
@@ -7,12 +7,13 @@ use foundry_cli::utils;
 pub fn run() -> Result<()> {
     // Pre-parse discovery flags run before `setup()` so they cannot be blocked
     // by panic-handler / tracing init failures and avoid that init's cost.
+    foundry_cli::machine::check_machine();
     foundry_cli::opts::GlobalArgs::check_introspect::<Anvil>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Anvil>();
 
     setup()?;
 
-    let mut args = Anvil::parse();
+    let mut args = foundry_cli::parse_or_exit::<Anvil>();
     args.global.init()?;
     args.node.evm.resolve_rpc_alias();
 
@@ -49,6 +50,7 @@ pub fn run_command(args: Anvil) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
 
     #[test]
     fn verify_cli() {
@@ -103,5 +105,15 @@ mod tests {
         let doc: IntrospectDocument = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(doc.schema_id, INTROSPECT_SCHEMA_ID);
         assert_eq!(doc.binary.name, "anvil");
+    }
+
+    /// Capability self-consistency for every `anvil` command.
+    #[test]
+    fn introspect_capabilities_are_consistent() {
+        use foundry_cli::introspect::{CommandRegistry, build_document, capability_violations};
+        let cmd = <Anvil as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let v = capability_violations(&doc);
+        assert!(v.is_empty(), "anvil capability violations: {v:?}");
     }
 }

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -441,7 +441,16 @@ impl NodeArgs {
                 // cleaning up and shutting down
                 // this will make sure that the fork RPC cache is flushed if caching is configured
             }
-            std::process::exit(0);
+            // Triggered by SIGINT / SIGTERM after a clean cache flush. Under
+            // the agent contract this is `Interrupted` (8); legacy human
+            // invocations preserve the historical exit-0 contract for
+            // backward compatibility.
+            let code = if foundry_cli::is_machine() {
+                foundry_cli::ExitCode::Interrupted.to_i32()
+            } else {
+                0
+            };
+            std::process::exit(code);
         });
 
         ctrlc::set_handler(move || {

--- a/crates/anvil/tests/it/machine.rs
+++ b/crates/anvil/tests/it/machine.rs
@@ -1,0 +1,77 @@
+//! Binary-level contract tests for the `--machine` agent runtime in anvil.
+
+#![cfg(unix)]
+
+use std::{
+    io::{BufRead, BufReader, Read},
+    process::{Child, Command, Stdio},
+    time::{Duration, Instant},
+};
+
+/// Sends `SIGINT` to a child PID via `/bin/kill -INT`.
+fn sigint(pid: u32) {
+    let status = Command::new("kill").args(["-INT", &pid.to_string()]).status().unwrap();
+    assert!(status.success(), "failed to deliver SIGINT to pid {pid}");
+}
+
+/// Spawns `anvil` with `--port 0` and the given extra args, waits for the
+/// "Listening on" handshake on stdout, then returns the running child.
+fn spawn_anvil(extra: &[&str]) -> (Child, BufReader<std::process::ChildStdout>) {
+    let bin = env!("CARGO_BIN_EXE_anvil");
+    let mut cmd = Command::new(bin);
+    cmd.args(["--port", "0"]).args(extra).stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("anvil spawn");
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            panic!("anvil did not start within 30s");
+        }
+        let mut line = String::new();
+        if stdout.read_line(&mut line).unwrap_or(0) == 0 {
+            std::thread::sleep(Duration::from_millis(20));
+            continue;
+        }
+        if line.contains("Listening on") {
+            break;
+        }
+    }
+    (child, stdout)
+}
+
+/// Waits up to 10s for the child to exit and returns its numeric exit code.
+fn wait_for_exit(mut child: Child) -> i32 {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            // Drain residual output so the pipe never blocks the child.
+            if let Some(mut s) = child.stdout.take() {
+                let _ = s.read_to_string(&mut String::new());
+            }
+            return status.code().unwrap_or(-1);
+        }
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            panic!("anvil did not exit within 10s of SIGINT");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+// Legacy `anvil` exits 0 on SIGINT — the historical contract.
+#[test]
+fn anvil_sigint_legacy_exits_zero() {
+    let (child, _stdout) = spawn_anvil(&[]);
+    sigint(child.id());
+    assert_eq!(wait_for_exit(child), 0);
+}
+
+// `anvil --machine` maps SIGINT to `ExitCode::Interrupted` (8).
+#[test]
+fn anvil_sigint_machine_exits_eight() {
+    let (child, _stdout) = spawn_anvil(&["--machine"]);
+    sigint(child.id());
+    assert_eq!(wait_for_exit(child), 8);
+}

--- a/crates/anvil/tests/it/main.rs
+++ b/crates/anvil/tests/it/main.rs
@@ -11,6 +11,8 @@ mod gas;
 mod genesis;
 mod ipc;
 mod logs;
+#[cfg(feature = "cli")]
+mod machine;
 #[cfg(feature = "optimism")]
 mod optimism;
 mod otterscan;

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -12,7 +12,7 @@ use alloy_network::Ethereum;
 use alloy_primitives::{Address, B256, eip191_hash_message, hex, keccak256};
 use alloy_provider::Provider;
 use alloy_rpc_types::{BlockId, BlockNumberOrTag::Latest};
-use clap::{CommandFactory, Parser};
+use clap::CommandFactory;
 use clap_complete::generate;
 use eyre::{Result, WrapErr};
 use foundry_cli::utils::{self, LoadConfig};
@@ -38,12 +38,13 @@ use tempo_alloy::TempoNetwork;
 pub fn run() -> Result<()> {
     // Pre-parse discovery flags run before `setup()` so they cannot be blocked
     // by panic-handler / tracing init failures and avoid that init's cost.
+    foundry_cli::machine::check_machine();
     foundry_cli::opts::GlobalArgs::check_introspect::<CastArgs>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<CastArgs>();
 
     setup()?;
 
-    let args = CastArgs::parse();
+    let args = foundry_cli::parse_or_exit::<CastArgs>();
     args.global.init()?;
     args.global.tokio_runtime().block_on(run_command(args))
 }
@@ -854,7 +855,7 @@ mod tests {
     use super::*;
     use foundry_cli::introspect::{
         CommandRegistry, INTROSPECT_SCHEMA_ID, IntrospectDocument, build_document,
-        duplicate_command_ids, render_introspect_document,
+        capability_violations, duplicate_command_ids, render_introspect_document,
     };
 
     /// Every `command_id` exposed by `cast --introspect` MUST be unique.
@@ -897,5 +898,23 @@ mod tests {
         let doc: IntrospectDocument = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(doc.schema_id, INTROSPECT_SCHEMA_ID);
         assert_eq!(doc.binary.name, "cast");
+    }
+
+    /// Capability self-consistency: any command declaring an output mode
+    /// must wire the matching schema reference. See
+    /// [`capability_violations`].
+    #[test]
+    fn introspect_capabilities_are_consistent() {
+        let v = std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let cmd = <CastArgs as clap::CommandFactory>::command();
+                let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+                capability_violations(&doc)
+            })
+            .expect("spawn worker thread")
+            .join()
+            .expect("worker thread join");
+        assert!(v.is_empty(), "cast capability violations: {v:?}");
     }
 }

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -871,7 +871,7 @@ mod tests {
         let dups = std::thread::Builder::new()
             .stack_size(16 * 1024 * 1024)
             .spawn(|| {
-                let cmd = <CastArgs as clap::CommandFactory>::command();
+                let cmd = CastArgs::command();
                 let doc = build_document(&cmd, &CommandRegistry::EMPTY);
                 duplicate_command_ids(&doc)
             })
@@ -889,7 +889,7 @@ mod tests {
         let json = std::thread::Builder::new()
             .stack_size(16 * 1024 * 1024)
             .spawn(|| {
-                let cmd = <CastArgs as clap::CommandFactory>::command();
+                let cmd = CastArgs::command();
                 render_introspect_document(&cmd, &CommandRegistry::EMPTY)
             })
             .expect("spawn worker thread")
@@ -908,7 +908,7 @@ mod tests {
         let v = std::thread::Builder::new()
             .stack_size(16 * 1024 * 1024)
             .spawn(|| {
-                let cmd = <CastArgs as clap::CommandFactory>::command();
+                let cmd = CastArgs::command();
                 let doc = build_document(&cmd, &CommandRegistry::EMPTY);
                 capability_violations(&doc)
             })

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -84,9 +84,11 @@ Display options:
           Format log messages as JSON
 
       --machine
-          Activate the agent contract: emit declared output mode only, no color, no progress,
-          structured early-exit. Implies no color. Mutually exclusive with `--json` and `--md` to
-          keep machine-mode output unambiguous
+          Activate the agent contract: disables color and wraps CLI-runtime exits (parse / usage /
+          help / version) in a structured envelope. Per-command machine output (declared
+          `output_mode`, progress and prompt suppression, canonical exit codes) is adopted
+          incrementally — see `docs/agents/spec.md` §10. Mutually exclusive with `--json` and `--md`
+          to keep machine-mode output unambiguous
 
       --md
           Format log messages as Markdown

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -83,6 +83,11 @@ Display options:
       --json
           Format log messages as JSON
 
+      --machine
+          Activate the agent contract: emit declared output mode only, no color, no progress,
+          structured early-exit. Implies no color. Mutually exclusive with `--json` and `--md` to
+          keep machine-mode output unambiguous
+
       --md
           Format log messages as Markdown
 

--- a/crates/chisel/src/args.rs
+++ b/crates/chisel/src/args.rs
@@ -2,7 +2,6 @@ use crate::{
     opts::{Chisel, ChiselSubcommand},
     prelude::{ChiselCommand, ChiselDispatcher, SolidityHelper},
 };
-use clap::Parser;
 use eyre::{Context, Result};
 use foundry_cli::utils::{self, LoadConfig};
 use foundry_common::fs;
@@ -14,12 +13,13 @@ use yansi::Paint;
 pub fn run() -> Result<()> {
     // Pre-parse discovery flags run before `setup()` so they cannot be blocked
     // by panic-handler / tracing init failures and avoid that init's cost.
+    foundry_cli::machine::check_machine();
     foundry_cli::opts::GlobalArgs::check_introspect::<Chisel>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Chisel>();
 
     setup()?;
 
-    let args = Chisel::parse();
+    let args = foundry_cli::parse_or_exit::<Chisel>();
     args.global.init()?;
     args.global.tokio_runtime().block_on(run_command(args))
 }
@@ -209,5 +209,15 @@ mod tests {
         let doc: IntrospectDocument = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(doc.schema_id, INTROSPECT_SCHEMA_ID);
         assert_eq!(doc.binary.name, "chisel");
+    }
+
+    /// Capability self-consistency for every `chisel` command.
+    #[test]
+    fn introspect_capabilities_are_consistent() {
+        use foundry_cli::introspect::{CommandRegistry, build_document, capability_violations};
+        let cmd = Chisel::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let v = capability_violations(&doc);
+        assert!(v.is_empty(), "chisel capability violations: {v:?}");
     }
 }

--- a/crates/cli/src/diagnostic.rs
+++ b/crates/cli/src/diagnostic.rs
@@ -1,0 +1,249 @@
+//! Stable, machine-readable diagnostic codes.
+//!
+//! Codes attach to [`JsonMessage`](crate::json::JsonMessage) entries inside
+//! [`JsonEnvelope`](crate::json::JsonEnvelope) `errors[]` and `warnings[]`.
+//!
+//! See [`docs/agents/diagnostics.md`](../../../docs/agents/diagnostics.md) for
+//! the format and registry rules. Codes are namespaced strings of the form
+//! `^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$`.
+//!
+//! # Implementation choice
+//!
+//! Codes are exposed as `&'static str` constants, organised in per-domain
+//! modules colocated with this crate (or, for adoption PRs, with the owning
+//! crate). [`JsonMessage::error`](crate::json::JsonMessage::error) accepts
+//! `impl Into<String>`, so call sites pass the constant directly. The
+//! [`DiagnosticCode`] newtype is available when callers want a parsed,
+//! validated value.
+
+use std::{fmt, sync::OnceLock};
+
+/// Validation error returned by [`DiagnosticCode::new`] / [`validate`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidDiagnosticCode {
+    code: String,
+}
+
+impl fmt::Display for InvalidDiagnosticCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid diagnostic code `{}`: must match `^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$`",
+            self.code
+        )
+    }
+}
+
+impl std::error::Error for InvalidDiagnosticCode {}
+
+/// Validate that `s` matches the diagnostic-code grammar.
+pub fn validate(s: &str) -> Result<(), InvalidDiagnosticCode> {
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(r"^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$")
+            .expect("diagnostic-code regex compiles")
+    });
+    if re.is_match(s) { Ok(()) } else { Err(InvalidDiagnosticCode { code: s.to_string() }) }
+}
+
+/// Stable, machine-readable diagnostic code attached to a structured message.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct DiagnosticCode(String);
+
+impl DiagnosticCode {
+    /// Create a new code, validating against the registry grammar.
+    pub fn new(code: impl Into<String>) -> Result<Self, InvalidDiagnosticCode> {
+        let code = code.into();
+        validate(&code)?;
+        Ok(Self(code))
+    }
+
+    /// Borrow the underlying code as a `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume and return the underlying owned `String`.
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for DiagnosticCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for DiagnosticCode {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<DiagnosticCode> for String {
+    fn from(code: DiagnosticCode) -> Self {
+        code.0
+    }
+}
+
+impl std::str::FromStr for DiagnosticCode {
+    type Err = InvalidDiagnosticCode;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+/// CLI-layer diagnostic codes (argument parsing, global flags).
+pub mod cli {
+    /// Command-line usage was invalid (parse error, missing subcommand,
+    /// invalid flag combination).
+    pub const USAGE_INVALID: &str = "cli.usage.invalid";
+    /// `--help` was requested.
+    pub const HELP: &str = "cli.help";
+    /// `--version` was requested.
+    pub const VERSION: &str = "cli.version";
+    /// Process was interrupted (`SIGINT` / `SIGTERM`).
+    pub const INTERRUPTED: &str = "cli.interrupted";
+    /// Catch-all for failures that do not fit a more specific domain.
+    pub const UNKNOWN: &str = "cli.unknown";
+
+    pub(crate) const ALL: &[&str] = &[USAGE_INVALID, HELP, VERSION, INTERRUPTED, UNKNOWN];
+}
+
+/// `foundry-config` diagnostic codes.
+pub mod config {
+    pub const INVALID: &str = "config.invalid";
+    pub const MISSING_FIELD: &str = "config.missing_field";
+
+    pub(crate) const ALL: &[&str] = &[INVALID, MISSING_FIELD];
+}
+
+/// Compiler diagnostic codes (`foundry-compilers`, `forge`).
+pub mod compiler {
+    pub const SOLC_ERROR: &str = "compiler.solc.error";
+    pub const VYPER_ERROR: &str = "compiler.vyper.error";
+
+    pub(crate) const ALL: &[&str] = &[SOLC_ERROR, VYPER_ERROR];
+}
+
+/// Network / RPC diagnostic codes.
+pub mod network {
+    pub const RPC_TIMEOUT: &str = "network.rpc.timeout";
+    pub const RPC_UNAUTHORIZED: &str = "network.rpc.unauthorized";
+
+    pub(crate) const ALL: &[&str] = &[RPC_TIMEOUT, RPC_UNAUTHORIZED];
+}
+
+/// `foundry-wallets` diagnostic codes.
+pub mod wallet {
+    pub const KEY_MISSING: &str = "wallet.key.missing";
+    pub const SIGNATURE_REJECTED: &str = "wallet.signature.rejected";
+
+    pub(crate) const ALL: &[&str] = &[KEY_MISSING, SIGNATURE_REJECTED];
+}
+
+/// `forge test` diagnostic codes.
+pub mod test {
+    pub const FAILED: &str = "test.failed";
+    pub const SETUP_FAILED: &str = "test.setup_failed";
+
+    pub(crate) const ALL: &[&str] = &[FAILED, SETUP_FAILED];
+}
+
+/// `forge script` diagnostic codes.
+pub mod script {
+    pub const BROADCAST_FAILED: &str = "script.broadcast_failed";
+
+    pub(crate) const ALL: &[&str] = &[BROADCAST_FAILED];
+}
+
+/// `cast` diagnostic codes.
+pub mod cast {
+    pub const TX_NOT_FOUND: &str = "cast.tx.not_found";
+
+    pub(crate) const ALL: &[&str] = &[TX_NOT_FOUND];
+}
+
+/// `anvil` diagnostic codes.
+pub mod anvil {
+    pub const FORK_UNREACHABLE: &str = "anvil.fork.unreachable";
+
+    pub(crate) const ALL: &[&str] = &[FORK_UNREACHABLE];
+}
+
+/// `chisel` diagnostic codes.
+pub mod chisel {
+    pub const SESSION_INVALID: &str = "chisel.session.invalid";
+
+    pub(crate) const ALL: &[&str] = &[SESSION_INVALID];
+}
+
+/// All diagnostic codes declared in this crate.
+///
+/// Useful for repo-wide validation tests.
+pub fn known_codes() -> Vec<&'static str> {
+    let groups: &[&[&str]] = &[
+        cli::ALL,
+        config::ALL,
+        compiler::ALL,
+        network::ALL,
+        wallet::ALL,
+        test::ALL,
+        script::ALL,
+        cast::ALL,
+        anvil::ALL,
+        chisel::ALL,
+    ];
+    groups.iter().flat_map(|g| g.iter().copied()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_codes_round_trip() {
+        for c in &["cli.usage.invalid", "config.invalid", "network.rpc.timeout", "a.b.c.d.e"] {
+            let code = DiagnosticCode::new(*c).unwrap();
+            assert_eq!(code.as_str(), *c);
+        }
+    }
+
+    #[test]
+    fn invalid_codes_rejected() {
+        for c in &[
+            "",
+            "no_dot",
+            "Cli.usage",         // uppercase
+            ".cli.usage",        // leading dot
+            "cli.usage.",        // trailing dot
+            "cli..usage",        // empty segment
+            "1cli.usage",        // segment must start with [a-z]
+            "cli.1usage",        // segment must start with [a-z]
+            "cli.usage-invalid", // dash not allowed
+            "cli.usage invalid", // space not allowed
+        ] {
+            assert!(DiagnosticCode::new(*c).is_err(), "expected `{c}` to be rejected");
+        }
+    }
+
+    #[test]
+    fn every_known_code_validates() {
+        for c in known_codes() {
+            assert!(validate(c).is_ok(), "registered code `{c}` failed validation");
+        }
+    }
+
+    #[test]
+    fn known_codes_are_unique() {
+        let mut seen = std::collections::BTreeSet::new();
+        let mut dups = Vec::new();
+        for c in known_codes() {
+            if !seen.insert(c) {
+                dups.push(c);
+            }
+        }
+        assert!(dups.is_empty(), "duplicate diagnostic codes: {dups:?}");
+    }
+}

--- a/crates/cli/src/exit_code.rs
+++ b/crates/cli/src/exit_code.rs
@@ -3,7 +3,7 @@
 //! See [`docs/agents/exit-codes.md`](../../../docs/agents/exit-codes.md) for the
 //! contract these codes implement.
 
-use std::fmt;
+use std::{fmt, fmt::Write};
 
 /// Canonical exit codes emitted by Foundry binaries.
 ///
@@ -78,7 +78,6 @@ impl From<&eyre::Report> for ExitCode {
     fn from(report: &eyre::Report) -> Self {
         let mut buf = String::new();
         for cause in report.chain() {
-            use std::fmt::Write;
             let _ = writeln!(buf, "{cause}");
         }
         let lower = buf.to_lowercase();
@@ -89,12 +88,14 @@ impl From<&eyre::Report> for ExitCode {
         if lower.contains("interrupted") || lower.contains("sigint") || lower.contains("sigterm") {
             return Self::Interrupted;
         }
+
         if lower.contains("foundry.toml")
             || (lower.contains("config")
                 && (lower.contains("invalid") || lower.contains("missing")))
         {
             return Self::Config;
         }
+
         if lower.contains("unauthorized")
             || lower.contains("forbidden")
             || lower.contains("authentication")
@@ -107,6 +108,7 @@ impl From<&eyre::Report> for ExitCode {
         {
             return Self::User;
         }
+
         if lower.contains("rpc")
             || lower.contains("timeout")
             || lower.contains("timed out")
@@ -115,9 +117,11 @@ impl From<&eyre::Report> for ExitCode {
         {
             return Self::Network;
         }
+
         if lower.contains("compil") || lower.contains("solc") || lower.contains("vyper") {
             return Self::Build;
         }
+
         Self::GenericError
     }
 }

--- a/crates/cli/src/exit_code.rs
+++ b/crates/cli/src/exit_code.rs
@@ -1,0 +1,195 @@
+//! Canonical process exit codes for the Foundry agent contract.
+//!
+//! See [`docs/agents/exit-codes.md`](../../../docs/agents/exit-codes.md) for the
+//! contract these codes implement.
+
+use std::fmt;
+
+/// Canonical exit codes emitted by Foundry binaries.
+///
+/// Only the variants below are guaranteed by the agent contract. Commands MAY
+/// document additional, command-specific codes via
+/// [`ExitCodeInfo`](crate::introspect::ExitCodeInfo); those codes MUST NOT
+/// collide with this global table.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(i32)]
+pub enum ExitCode {
+    /// Command completed successfully.
+    Success = 0,
+    /// Unclassified failure.
+    GenericError = 1,
+    /// Argument parse error, missing subcommand, or invalid flag combination.
+    Usage = 2,
+    /// Foundry config invalid or missing required value.
+    Config = 3,
+    /// Compilation, linking, or artifact generation failed.
+    Build = 4,
+    /// Tests ran but at least one failed (distinct from a build/setup failure).
+    TestFailure = 5,
+    /// RPC, HTTP, or chain-connectivity failure.
+    Network = 6,
+    /// Authentication, authorization, or wallet/key-related failure.
+    User = 7,
+    /// Command terminated by `SIGINT` / `SIGTERM`.
+    Interrupted = 8,
+}
+
+impl ExitCode {
+    /// Returns the numeric process exit code.
+    pub const fn to_i32(self) -> i32 {
+        self as i32
+    }
+
+    /// Returns the stable, human-readable variant name.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Success => "Success",
+            Self::GenericError => "GenericError",
+            Self::Usage => "Usage",
+            Self::Config => "Config",
+            Self::Build => "Build",
+            Self::TestFailure => "TestFailure",
+            Self::Network => "Network",
+            Self::User => "User",
+            Self::Interrupted => "Interrupted",
+        }
+    }
+}
+
+impl fmt::Display for ExitCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ({})", self.name(), self.to_i32())
+    }
+}
+
+impl From<ExitCode> for i32 {
+    fn from(code: ExitCode) -> Self {
+        code.to_i32()
+    }
+}
+
+impl From<&eyre::Report> for ExitCode {
+    /// Best-effort classification of a report.
+    ///
+    /// Walks the error chain looking for keywords characteristic of common
+    /// failure categories; falls back to [`ExitCode::GenericError`] when no
+    /// category matches. The mapping is intentionally conservative — adoption
+    /// PRs will tighten it as commands return typed errors.
+    fn from(report: &eyre::Report) -> Self {
+        let mut buf = String::new();
+        for cause in report.chain() {
+            use std::fmt::Write;
+            let _ = writeln!(buf, "{cause}");
+        }
+        let lower = buf.to_lowercase();
+
+        // Order matters: classify auth/user signals before network so a 401
+        // from an RPC provider doesn't get misfiled as a transient network
+        // error.
+        if lower.contains("interrupted") || lower.contains("sigint") || lower.contains("sigterm") {
+            return Self::Interrupted;
+        }
+        if lower.contains("foundry.toml")
+            || (lower.contains("config")
+                && (lower.contains("invalid") || lower.contains("missing")))
+        {
+            return Self::Config;
+        }
+        if lower.contains("unauthorized")
+            || lower.contains("forbidden")
+            || lower.contains("authentication")
+            || lower.contains("authorization")
+            || lower.contains("api key")
+            || lower.contains("private key")
+            || lower.contains("keystore")
+            || lower.contains("wallet")
+            || lower.contains("signer")
+        {
+            return Self::User;
+        }
+        if lower.contains("rpc")
+            || lower.contains("timeout")
+            || lower.contains("timed out")
+            || lower.contains("connection refused")
+            || lower.contains("dns")
+        {
+            return Self::Network;
+        }
+        if lower.contains("compil") || lower.contains("solc") || lower.contains("vyper") {
+            return Self::Build;
+        }
+        Self::GenericError
+    }
+}
+
+impl From<eyre::Report> for ExitCode {
+    fn from(report: eyre::Report) -> Self {
+        (&report).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn numeric_codes_match_spec() {
+        assert_eq!(ExitCode::Success.to_i32(), 0);
+        assert_eq!(ExitCode::GenericError.to_i32(), 1);
+        assert_eq!(ExitCode::Usage.to_i32(), 2);
+        assert_eq!(ExitCode::Config.to_i32(), 3);
+        assert_eq!(ExitCode::Build.to_i32(), 4);
+        assert_eq!(ExitCode::TestFailure.to_i32(), 5);
+        assert_eq!(ExitCode::Network.to_i32(), 6);
+        assert_eq!(ExitCode::User.to_i32(), 7);
+        assert_eq!(ExitCode::Interrupted.to_i32(), 8);
+    }
+
+    #[test]
+    fn report_classifies_config() {
+        let r: eyre::Report = eyre::eyre!("could not parse foundry.toml: invalid value");
+        assert_eq!(ExitCode::from(&r), ExitCode::Config);
+    }
+
+    #[test]
+    fn report_classifies_network() {
+        let r: eyre::Report = eyre::eyre!("RPC connection timeout");
+        assert_eq!(ExitCode::from(&r), ExitCode::Network);
+    }
+
+    #[test]
+    fn report_classifies_wallet() {
+        let r: eyre::Report = eyre::eyre!("wallet: missing private key");
+        assert_eq!(ExitCode::from(&r), ExitCode::User);
+    }
+
+    #[test]
+    fn report_classifies_compiler() {
+        let r: eyre::Report = eyre::eyre!("solc compilation failed");
+        assert_eq!(ExitCode::from(&r), ExitCode::Build);
+    }
+
+    #[test]
+    fn report_falls_back_to_generic() {
+        let r: eyre::Report = eyre::eyre!("something unexpected went wrong");
+        assert_eq!(ExitCode::from(&r), ExitCode::GenericError);
+    }
+
+    #[test]
+    fn auth_classified_before_network() {
+        let r: eyre::Report = eyre::eyre!("RPC call failed: 401 unauthorized");
+        assert_eq!(ExitCode::from(&r), ExitCode::User);
+    }
+
+    #[test]
+    fn dns_failure_is_network() {
+        let r: eyre::Report = eyre::eyre!("dns lookup failed for mainnet.alchemy.com");
+        assert_eq!(ExitCode::from(&r), ExitCode::Network);
+    }
+
+    #[test]
+    fn interrupt_classification() {
+        let r: eyre::Report = eyre::eyre!("interrupted by SIGINT");
+        assert_eq!(ExitCode::from(&r), ExitCode::Interrupted);
+    }
+}

--- a/crates/cli/src/exit_code.rs
+++ b/crates/cli/src/exit_code.rs
@@ -3,7 +3,7 @@
 //! See [`docs/agents/exit-codes.md`](../../../docs/agents/exit-codes.md) for the
 //! contract these codes implement.
 
-use std::{fmt, fmt::Write};
+use std::fmt;
 
 /// Canonical exit codes emitted by Foundry binaries.
 ///
@@ -68,70 +68,6 @@ impl From<ExitCode> for i32 {
     }
 }
 
-impl From<&eyre::Report> for ExitCode {
-    /// Best-effort classification of a report.
-    ///
-    /// Walks the error chain looking for keywords characteristic of common
-    /// failure categories; falls back to [`ExitCode::GenericError`] when no
-    /// category matches. The mapping is intentionally conservative — adoption
-    /// PRs will tighten it as commands return typed errors.
-    fn from(report: &eyre::Report) -> Self {
-        let mut buf = String::new();
-        for cause in report.chain() {
-            let _ = writeln!(buf, "{cause}");
-        }
-        let lower = buf.to_lowercase();
-
-        // Order matters: classify auth/user signals before network so a 401
-        // from an RPC provider doesn't get misfiled as a transient network
-        // error.
-        if lower.contains("interrupted") || lower.contains("sigint") || lower.contains("sigterm") {
-            return Self::Interrupted;
-        }
-
-        if lower.contains("foundry.toml")
-            || (lower.contains("config")
-                && (lower.contains("invalid") || lower.contains("missing")))
-        {
-            return Self::Config;
-        }
-
-        if lower.contains("unauthorized")
-            || lower.contains("forbidden")
-            || lower.contains("authentication")
-            || lower.contains("authorization")
-            || lower.contains("api key")
-            || lower.contains("private key")
-            || lower.contains("keystore")
-            || lower.contains("wallet")
-            || lower.contains("signer")
-        {
-            return Self::User;
-        }
-
-        if lower.contains("rpc")
-            || lower.contains("timeout")
-            || lower.contains("timed out")
-            || lower.contains("connection refused")
-            || lower.contains("dns")
-        {
-            return Self::Network;
-        }
-
-        if lower.contains("compil") || lower.contains("solc") || lower.contains("vyper") {
-            return Self::Build;
-        }
-
-        Self::GenericError
-    }
-}
-
-impl From<eyre::Report> for ExitCode {
-    fn from(report: eyre::Report) -> Self {
-        (&report).into()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -147,53 +83,5 @@ mod tests {
         assert_eq!(ExitCode::Network.to_i32(), 6);
         assert_eq!(ExitCode::User.to_i32(), 7);
         assert_eq!(ExitCode::Interrupted.to_i32(), 8);
-    }
-
-    #[test]
-    fn report_classifies_config() {
-        let r: eyre::Report = eyre::eyre!("could not parse foundry.toml: invalid value");
-        assert_eq!(ExitCode::from(&r), ExitCode::Config);
-    }
-
-    #[test]
-    fn report_classifies_network() {
-        let r: eyre::Report = eyre::eyre!("RPC connection timeout");
-        assert_eq!(ExitCode::from(&r), ExitCode::Network);
-    }
-
-    #[test]
-    fn report_classifies_wallet() {
-        let r: eyre::Report = eyre::eyre!("wallet: missing private key");
-        assert_eq!(ExitCode::from(&r), ExitCode::User);
-    }
-
-    #[test]
-    fn report_classifies_compiler() {
-        let r: eyre::Report = eyre::eyre!("solc compilation failed");
-        assert_eq!(ExitCode::from(&r), ExitCode::Build);
-    }
-
-    #[test]
-    fn report_falls_back_to_generic() {
-        let r: eyre::Report = eyre::eyre!("something unexpected went wrong");
-        assert_eq!(ExitCode::from(&r), ExitCode::GenericError);
-    }
-
-    #[test]
-    fn auth_classified_before_network() {
-        let r: eyre::Report = eyre::eyre!("RPC call failed: 401 unauthorized");
-        assert_eq!(ExitCode::from(&r), ExitCode::User);
-    }
-
-    #[test]
-    fn dns_failure_is_network() {
-        let r: eyre::Report = eyre::eyre!("dns lookup failed for mainnet.alchemy.com");
-        assert_eq!(ExitCode::from(&r), ExitCode::Network);
-    }
-
-    #[test]
-    fn interrupt_classification() {
-        let r: eyre::Report = eyre::eyre!("interrupted by SIGINT");
-        assert_eq!(ExitCode::from(&r), ExitCode::Interrupted);
     }
 }

--- a/crates/cli/src/introspect/build.rs
+++ b/crates/cli/src/introspect/build.rs
@@ -1,9 +1,10 @@
 //! Build an [`IntrospectDocument`] from a `clap::Command` tree.
 
 use clap::{Arg, ArgAction, Command};
+use std::sync::OnceLock;
 
 use super::{
-    INTROSPECT_SCHEMA_ID, INTROSPECT_SCHEMA_VERSION,
+    INTROSPECT_SCHEMA_ID, INTROSPECT_SCHEMA_VERSION, OutputMode,
     document::{
         ArgInfo, ArgKind, BinaryInfo, Capabilities, CommandInfo, IntrospectDocument, ValueType,
     },
@@ -26,6 +27,124 @@ pub fn collect_command_ids(doc: &IntrospectDocument) -> Vec<String> {
     let mut out = Vec::new();
     for cmd in &doc.commands {
         cmd.collect_ids_into(&mut out);
+    }
+    out
+}
+
+/// Assert capability self-consistency for every command in `doc`.
+///
+/// Returns one error message per offending command. Static repo-wide check
+/// that catches commands declaring an output mode without wiring the
+/// supporting schema metadata, or vice versa.
+///
+/// Per-mode rules (see also spec §3, §4, §8):
+///
+/// - [`OutputMode::None`](super::OutputMode::None) and
+///   [`OutputMode::LegacyJson`](super::OutputMode::LegacyJson) MUST NOT carry schema refs.
+/// - [`OutputMode::Envelope`](super::OutputMode::Envelope) requires `result_schema_ref`; MUST NOT
+///   carry `event_schema_ref` or `session_schema_ref`.
+/// - [`OutputMode::Stream`](super::OutputMode::Stream) requires `event_schema_ref`; implies
+///   `long_running = true`. `result_schema_ref` MAY also be set when the stream ends with a
+///   terminal envelope.
+/// - [`OutputMode::Session`](super::OutputMode::Session) requires `session_schema_ref`; implies
+///   `stateful = true` and `long_running = true`.
+///
+/// Schema refs, when present, must be non-empty and match
+/// `^foundry:[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*(\.event|\.session)?@v\d+$`.
+pub fn capability_violations(doc: &IntrospectDocument) -> Vec<String> {
+    static SCHEMA_REF_RE: OnceLock<regex::Regex> = OnceLock::new();
+    let schema_re = SCHEMA_REF_RE.get_or_init(|| {
+        regex::Regex::new(r"^foundry:[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*(\.event|\.session)?@v\d+$")
+            .expect("schema-ref regex compiles")
+    });
+
+    fn check_ref(
+        out: &mut Vec<String>,
+        id: &str,
+        name: &str,
+        val: Option<&str>,
+        re: &regex::Regex,
+    ) {
+        if let Some(v) = val {
+            if v.is_empty() {
+                out.push(format!("{id}: capabilities.{name} must not be empty"));
+            } else if !re.is_match(v) {
+                out.push(format!(
+                    "{id}: capabilities.{name} = `{v}` does not match `foundry:<id>@vN`"
+                ));
+            }
+        }
+    }
+
+    fn walk(cmd: &CommandInfo, out: &mut Vec<String>, re: &regex::Regex) {
+        let caps = &cmd.capabilities;
+        let id = cmd.command_id.as_str();
+
+        // Format check on every present ref, regardless of mode.
+        check_ref(out, id, "result_schema_ref", caps.result_schema_ref.as_deref(), re);
+        check_ref(out, id, "event_schema_ref", caps.event_schema_ref.as_deref(), re);
+        check_ref(out, id, "session_schema_ref", caps.session_schema_ref.as_deref(), re);
+
+        match caps.output_mode {
+            OutputMode::None | OutputMode::LegacyJson => {
+                if caps.result_schema_ref.is_some()
+                    || caps.event_schema_ref.is_some()
+                    || caps.session_schema_ref.is_some()
+                {
+                    out.push(format!(
+                        "{id}: output_mode={:?} must not carry any schema refs",
+                        caps.output_mode
+                    ));
+                }
+            }
+            OutputMode::Envelope => {
+                if caps.result_schema_ref.is_none() {
+                    out.push(format!(
+                        "{id}: output_mode=envelope requires capabilities.result_schema_ref"
+                    ));
+                }
+                if caps.event_schema_ref.is_some() {
+                    out.push(format!("{id}: output_mode=envelope must not carry event_schema_ref"));
+                }
+                if caps.session_schema_ref.is_some() {
+                    out.push(format!(
+                        "{id}: output_mode=envelope must not carry session_schema_ref"
+                    ));
+                }
+            }
+            OutputMode::Stream => {
+                if caps.event_schema_ref.is_none() {
+                    out.push(format!(
+                        "{id}: output_mode=stream requires capabilities.event_schema_ref"
+                    ));
+                }
+                if !caps.long_running {
+                    out.push(format!("{id}: output_mode=stream implies long_running = true"));
+                }
+            }
+            OutputMode::Session => {
+                if caps.session_schema_ref.is_none() {
+                    out.push(format!(
+                        "{id}: output_mode=session requires capabilities.session_schema_ref"
+                    ));
+                }
+                if !caps.stateful {
+                    out.push(format!("{id}: output_mode=session implies stateful = true"));
+                }
+                if !caps.long_running {
+                    out.push(format!("{id}: output_mode=session implies long_running = true"));
+                }
+            }
+        }
+
+        for sub in &cmd.subcommands {
+            walk(sub, out, re);
+        }
+    }
+
+    let mut out = Vec::new();
+    for cmd in &doc.commands {
+        walk(cmd, &mut out, schema_re);
     }
     out
 }
@@ -457,6 +576,130 @@ mod tests {
         for arg in &build.args {
             assert!(arg.name != "help" && arg.name != "version", "got {arg:?}");
         }
+    }
+
+    /// Helper: build a registry with one entry pinned at `["build"]` whose
+    /// capabilities overlay `caps` (with `capabilities_declared = true`).
+    fn registry_with_capabilities(caps: Capabilities) -> CommandRegistry {
+        let entry: &'static super::super::registry::RegistryEntry =
+            Box::leak(Box::new(super::super::registry::RegistryEntry {
+                path: &["build"],
+                meta: CommandMeta {
+                    command_id: None,
+                    capabilities: caps,
+                    capabilities_declared: true,
+                    exit_codes: &[],
+                },
+            }));
+        CommandRegistry::new(std::slice::from_ref(entry))
+    }
+
+    #[test]
+    fn capability_violations_detects_envelope_without_schema_ref() {
+        let registry = registry_with_capabilities(Capabilities {
+            output_mode: OutputMode::Envelope,
+            ..Capabilities::NONE
+        });
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let violations = capability_violations(&doc);
+        assert_eq!(violations.len(), 1, "got {violations:?}");
+        assert!(violations[0].contains("envelope requires capabilities.result_schema_ref"));
+    }
+
+    #[test]
+    fn capability_violations_passes_for_well_formed_envelope() {
+        let registry = registry_with_capabilities(Capabilities {
+            output_mode: OutputMode::Envelope,
+            result_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:demo.build@v1")),
+            ..Capabilities::NONE
+        });
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let violations = capability_violations(&doc);
+        assert!(violations.is_empty(), "unexpected violations: {violations:?}");
+    }
+
+    #[test]
+    fn capability_violations_rejects_empty_schema_ref() {
+        let registry = registry_with_capabilities(Capabilities {
+            output_mode: OutputMode::Envelope,
+            result_schema_ref: Some(std::borrow::Cow::Borrowed("")),
+            ..Capabilities::NONE
+        });
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(v.iter().any(|s| s.contains("must not be empty")), "got {v:?}");
+    }
+
+    #[test]
+    fn capability_violations_rejects_malformed_schema_ref() {
+        let registry = registry_with_capabilities(Capabilities {
+            output_mode: OutputMode::Envelope,
+            result_schema_ref: Some(std::borrow::Cow::Borrowed("not-a-foundry-ref")),
+            ..Capabilities::NONE
+        });
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(v.iter().any(|s| s.contains("does not match")), "got {v:?}");
+    }
+
+    #[test]
+    fn capability_violations_rejects_envelope_with_event_ref() {
+        let registry = registry_with_capabilities(Capabilities {
+            output_mode: OutputMode::Envelope,
+            result_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:demo.build@v1")),
+            event_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:demo.build.event@v1")),
+            ..Capabilities::NONE
+        });
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(v.iter().any(|s| s.contains("must not carry event_schema_ref")), "got {v:?}");
+    }
+
+    #[test]
+    fn capability_violations_rejects_none_with_schema_ref() {
+        let registry = registry_with_capabilities(Capabilities {
+            output_mode: OutputMode::None,
+            result_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:demo.build@v1")),
+            ..Capabilities::NONE
+        });
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(v.iter().any(|s| s.contains("must not carry any schema refs")), "got {v:?}");
+    }
+
+    #[test]
+    fn capability_violations_session_requires_stateful() {
+        let registry = registry_with_capabilities(Capabilities {
+            output_mode: OutputMode::Session,
+            session_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:demo.session@v1")),
+            long_running: true,
+            stateful: false,
+            ..Capabilities::NONE
+        });
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(v.iter().any(|s| s.contains("implies stateful")), "got {v:?}");
+    }
+
+    #[test]
+    fn capability_violations_stream_requires_long_running() {
+        let registry = registry_with_capabilities(Capabilities {
+            output_mode: OutputMode::Stream,
+            event_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:demo.event@v1")),
+            long_running: false,
+            ..Capabilities::NONE
+        });
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(v.iter().any(|s| s.contains("implies long_running")), "got {v:?}");
     }
 
     #[test]

--- a/crates/cli/src/introspect/build.rs
+++ b/crates/cli/src/introspect/build.rs
@@ -47,30 +47,55 @@ pub fn collect_command_ids(doc: &IntrospectDocument) -> Vec<String> {
 /// - [`OutputMode::Session`] requires `session_schema_ref`; implies `stateful = true` and
 ///   `long_running = true`.
 ///
-/// Schema refs, when present, must be non-empty and match
-/// `^foundry:[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*(\.event|\.session)?@v\d+$`.
+/// Per-field stem rules (spec §8): every present ref MUST take the exact
+/// shape `foundry:<stem>@v<N>` where `<stem>` is the emitting command's
+/// `command_id` for `result_schema_ref`, the same id suffixed with
+/// `.event` for `event_schema_ref`, and `.session` for `session_schema_ref`.
+/// This makes payload/event/session schemas mechanically derivable from
+/// `command_id` so agents can pin against them without trusting the
+/// registry to map them.
 pub fn capability_violations(doc: &IntrospectDocument) -> Vec<String> {
     static SCHEMA_REF_RE: OnceLock<regex::Regex> = OnceLock::new();
     let schema_re = SCHEMA_REF_RE.get_or_init(|| {
-        regex::Regex::new(r"^foundry:[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*(\.event|\.session)?@v\d+$")
+        regex::Regex::new(r"^foundry:([a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*)@v\d+$")
             .expect("schema-ref regex compiles")
     });
 
+    /// Validate format and exact-stem equality.
+    ///
+    /// `expected_stem` is `command_id` (for result), `command_id.event`
+    /// (for event), or `command_id.session` (for session). The ref MUST
+    /// match `foundry:<expected_stem>@v<digits>`.
     fn check_ref(
         out: &mut Vec<String>,
         id: &str,
         name: &str,
         val: Option<&str>,
+        expected_stem: &str,
         re: &regex::Regex,
     ) {
-        if let Some(v) = val {
-            if v.is_empty() {
-                out.push(format!("{id}: capabilities.{name} must not be empty"));
-            } else if !re.is_match(v) {
-                out.push(format!(
-                    "{id}: capabilities.{name} = `{v}` does not match `foundry:<id>@vN`"
-                ));
-            }
+        let Some(v) = val else { return };
+        if v.is_empty() {
+            out.push(format!("{id}: capabilities.{name} must not be empty"));
+            return;
+        }
+        let Some(caps) = re.captures(v) else {
+            out.push(format!(
+                "{id}: capabilities.{name} = `{v}` does not match `foundry:<stem>@vN`"
+            ));
+            return;
+        };
+        let stem = &caps[1];
+        if stem != expected_stem {
+            out.push(format!(
+                "{id}: capabilities.{name} = `{v}` stem `{stem}` does not match expected \
+                 `{expected_stem}` (per spec §8: stem must equal `command_id`{suffix})",
+                suffix = match name {
+                    "event_schema_ref" => " + `.event`",
+                    "session_schema_ref" => " + `.session`",
+                    _ => "",
+                },
+            ));
         }
     }
 
@@ -78,10 +103,24 @@ pub fn capability_violations(doc: &IntrospectDocument) -> Vec<String> {
         let caps = &cmd.capabilities;
         let id = cmd.command_id.as_str();
 
-        // Format check on every present ref, regardless of mode.
-        check_ref(out, id, "result_schema_ref", caps.result_schema_ref.as_deref(), re);
-        check_ref(out, id, "event_schema_ref", caps.event_schema_ref.as_deref(), re);
-        check_ref(out, id, "session_schema_ref", caps.session_schema_ref.as_deref(), re);
+        // Format + stem check on every present ref, regardless of mode.
+        check_ref(out, id, "result_schema_ref", caps.result_schema_ref.as_deref(), id, re);
+        check_ref(
+            out,
+            id,
+            "event_schema_ref",
+            caps.event_schema_ref.as_deref(),
+            &format!("{id}.event"),
+            re,
+        );
+        check_ref(
+            out,
+            id,
+            "session_schema_ref",
+            caps.session_schema_ref.as_deref(),
+            &format!("{id}.session"),
+            re,
+        );
 
         match caps.output_mode {
             OutputMode::None | OutputMode::LegacyJson => {
@@ -675,7 +714,7 @@ mod tests {
     fn capability_violations_session_requires_stateful() {
         let registry = registry_with_capabilities(Capabilities {
             output_mode: OutputMode::Session,
-            session_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:demo.session@v1")),
+            session_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:demo.build.session@v1")),
             long_running: true,
             stateful: false,
             ..Capabilities::NONE
@@ -690,7 +729,7 @@ mod tests {
     fn capability_violations_stream_requires_long_running() {
         let registry = registry_with_capabilities(Capabilities {
             output_mode: OutputMode::Stream,
-            event_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:demo.event@v1")),
+            event_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:demo.build.event@v1")),
             long_running: false,
             ..Capabilities::NONE
         });
@@ -698,6 +737,81 @@ mod tests {
         let doc = build_document(&cmd, &registry);
         let v = capability_violations(&doc);
         assert!(v.iter().any(|s| s.contains("implies long_running")), "got {v:?}");
+    }
+
+    /// Spec §8: `result_schema_ref` stem MUST equal `command_id`. A ref
+    /// whose stem drifts away from `command_id` (e.g. `foundry:test-result@v1`
+    /// for `demo.build`) breaks discoverability and must be rejected.
+    #[test]
+    fn capability_violations_rejects_result_ref_stem_mismatch() {
+        let registry = registry_with_capabilities(Capabilities {
+            output_mode: OutputMode::Envelope,
+            result_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:test_result@v1")),
+            ..Capabilities::NONE
+        });
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(
+            v.iter().any(|s| s.contains("stem `test_result` does not match expected `demo.build`")),
+            "got {v:?}"
+        );
+    }
+
+    /// Spec §8: `event_schema_ref` stem MUST equal `<command_id>.event`. A
+    /// missing or wrong `.event` suffix must be rejected.
+    #[test]
+    fn capability_violations_rejects_event_ref_without_event_suffix() {
+        let registry = registry_with_capabilities(Capabilities {
+            output_mode: OutputMode::Stream,
+            event_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:demo.build@v1")),
+            long_running: true,
+            ..Capabilities::NONE
+        });
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(
+            v.iter().any(|s| s.contains("does not match expected `demo.build.event`")),
+            "got {v:?}"
+        );
+    }
+
+    /// Spec §8: `session_schema_ref` stem MUST equal `<command_id>.session`.
+    #[test]
+    fn capability_violations_rejects_session_ref_without_session_suffix() {
+        let registry = registry_with_capabilities(Capabilities {
+            output_mode: OutputMode::Session,
+            session_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:demo.build@v1")),
+            long_running: true,
+            stateful: true,
+            ..Capabilities::NONE
+        });
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(
+            v.iter().any(|s| s.contains("does not match expected `demo.build.session`")),
+            "got {v:?}"
+        );
+    }
+
+    /// Suffix on the wrong field must be rejected:
+    /// `result_schema_ref` MUST NOT end in `.event` or `.session`.
+    #[test]
+    fn capability_violations_rejects_result_ref_with_event_suffix() {
+        let registry = registry_with_capabilities(Capabilities {
+            output_mode: OutputMode::Envelope,
+            result_schema_ref: Some(std::borrow::Cow::Borrowed("foundry:demo.build.event@v1")),
+            ..Capabilities::NONE
+        });
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(
+            v.iter().any(|s| s.contains("stem `demo.build.event` does not match expected `demo.build`")),
+            "got {v:?}"
+        );
     }
 
     #[test]

--- a/crates/cli/src/introspect/build.rs
+++ b/crates/cli/src/introspect/build.rs
@@ -57,7 +57,8 @@ pub fn collect_command_ids(doc: &IntrospectDocument) -> Vec<String> {
 pub fn capability_violations(doc: &IntrospectDocument) -> Vec<String> {
     static SCHEMA_REF_RE: OnceLock<regex::Regex> = OnceLock::new();
     let schema_re = SCHEMA_REF_RE.get_or_init(|| {
-        regex::Regex::new(r"^foundry:([a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*)@v\d+$")
+        // Versions are canonical, start at 1, and have no leading zeros.
+        regex::Regex::new(r"^foundry:([a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*)@v[1-9][0-9]*$")
             .expect("schema-ref regex compiles")
     });
 
@@ -681,6 +682,28 @@ mod tests {
         let doc = build_document(&cmd, &registry);
         let v = capability_violations(&doc);
         assert!(v.iter().any(|s| s.contains("does not match")), "got {v:?}");
+    }
+
+    /// Schema versions are canonical: start at 1, no leading zeros.
+    /// `@v0`, `@v01`, `@v007` must all be rejected.
+    #[test]
+    fn capability_violations_rejects_non_canonical_version() {
+        for ref_str in
+            ["foundry:demo.build@v0", "foundry:demo.build@v01", "foundry:demo.build@v007"]
+        {
+            let registry = registry_with_capabilities(Capabilities {
+                output_mode: OutputMode::Envelope,
+                result_schema_ref: Some(std::borrow::Cow::Owned(ref_str.to_string())),
+                ..Capabilities::NONE
+            });
+            let cmd = <Demo as clap::CommandFactory>::command();
+            let doc = build_document(&cmd, &registry);
+            let v = capability_violations(&doc);
+            assert!(
+                v.iter().any(|s| s.contains("does not match")),
+                "expected rejection of `{ref_str}`, got {v:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/cli/src/introspect/build.rs
+++ b/crates/cli/src/introspect/build.rs
@@ -39,15 +39,13 @@ pub fn collect_command_ids(doc: &IntrospectDocument) -> Vec<String> {
 ///
 /// Per-mode rules (see also spec §3, §4, §8):
 ///
-/// - [`OutputMode::None`](super::OutputMode::None) and
-///   [`OutputMode::LegacyJson`](super::OutputMode::LegacyJson) MUST NOT carry schema refs.
-/// - [`OutputMode::Envelope`](super::OutputMode::Envelope) requires `result_schema_ref`; MUST NOT
-///   carry `event_schema_ref` or `session_schema_ref`.
-/// - [`OutputMode::Stream`](super::OutputMode::Stream) requires `event_schema_ref`; implies
-///   `long_running = true`. `result_schema_ref` MAY also be set when the stream ends with a
-///   terminal envelope.
-/// - [`OutputMode::Session`](super::OutputMode::Session) requires `session_schema_ref`; implies
-///   `stateful = true` and `long_running = true`.
+/// - [`OutputMode::None`] and [`OutputMode::LegacyJson`] MUST NOT carry schema refs.
+/// - [`OutputMode::Envelope`] requires `result_schema_ref`; MUST NOT carry `event_schema_ref` or
+///   `session_schema_ref`.
+/// - [`OutputMode::Stream`] requires `event_schema_ref`; implies `long_running = true`.
+///   `result_schema_ref` MAY also be set when the stream ends with a terminal envelope.
+/// - [`OutputMode::Session`] requires `session_schema_ref`; implies `stateful = true` and
+///   `long_running = true`.
 ///
 /// Schema refs, when present, must be non-empty and match
 /// `^foundry:[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*(\.event|\.session)?@v\d+$`.

--- a/crates/cli/src/introspect/mod.rs
+++ b/crates/cli/src/introspect/mod.rs
@@ -11,7 +11,8 @@ mod document;
 mod registry;
 
 pub use build::{
-    build_document, collect_command_ids, duplicate_command_ids, render_introspect_document,
+    build_document, capability_violations, collect_command_ids, duplicate_command_ids,
+    render_introspect_document,
 };
 pub use document::*;
 pub use registry::{CommandMeta, CommandRegistry};

--- a/crates/cli/src/introspect/registry.rs
+++ b/crates/cli/src/introspect/registry.rs
@@ -95,7 +95,7 @@ impl CommandRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::introspect::document::OutputMode;
+    use crate::introspect::document::{OutputMode, SideEffects};
     use std::borrow::Cow;
 
     fn fixture_registry() -> CommandRegistry {
@@ -105,13 +105,13 @@ mod tests {
                 command_id: Some("forge.build"),
                 capabilities: Capabilities {
                     output_mode: OutputMode::Envelope,
-                    result_schema_ref: None,
+                    result_schema_ref: Some(Cow::Borrowed("foundry:forge.build@v1")),
                     event_schema_ref: None,
                     session_schema_ref: None,
                     reads_stdin: false,
                     supports_output_path: false,
                     requires_project: true,
-                    side_effects: super::super::document::SideEffects::FsWrite,
+                    side_effects: SideEffects::FsWrite,
                     long_running: false,
                     stateful: false,
                 },
@@ -179,7 +179,7 @@ mod tests {
                     reads_stdin: false,
                     supports_output_path: false,
                     requires_project: true,
-                    side_effects: super::super::document::SideEffects::None,
+                    side_effects: SideEffects::None,
                     long_running: false,
                     stateful: false,
                 },

--- a/crates/cli/src/introspect/registry.rs
+++ b/crates/cli/src/introspect/registry.rs
@@ -160,12 +160,19 @@ mod tests {
 
     /// A registry with real strings (schema refs, exit-code names) must be
     /// authorable in a plain `static` without lazy allocation.
+    ///
+    /// The example pins values that comply with the agent contract:
+    ///
+    /// - the exit code (`10`) is outside the global table (codes 0..=8 per
+    ///   `docs/agents/exit-codes.md`), so it does not collide;
+    /// - the `result_schema_ref` stem (`forge.test`) matches `command_id`, the rule enforced by
+    ///   `capability_violations` per spec §8.
     #[test]
     fn static_registry_supports_real_strings() {
         static EXITS: &[ExitCodeInfo] = &[ExitCodeInfo {
-            code: 2,
-            name: Cow::Borrowed("TestFailure"),
-            description: Cow::Borrowed("at least one test failed"),
+            code: 10,
+            name: Cow::Borrowed("CompilationFailed"),
+            description: Cow::Borrowed("test-only command-specific code (non-colliding)"),
         }];
         static ENTRIES: &[RegistryEntry] = &[RegistryEntry {
             path: &["test"],
@@ -173,7 +180,7 @@ mod tests {
                 command_id: Some("forge.test"),
                 capabilities: Capabilities {
                     output_mode: OutputMode::Envelope,
-                    result_schema_ref: Some(Cow::Borrowed("foundry:test-result@v1")),
+                    result_schema_ref: Some(Cow::Borrowed("foundry:forge.test@v1")),
                     event_schema_ref: None,
                     session_schema_ref: None,
                     reads_stdin: false,
@@ -190,7 +197,7 @@ mod tests {
         let registry = CommandRegistry::new(ENTRIES);
 
         let meta = registry.lookup(&["test"]).unwrap();
-        assert_eq!(meta.capabilities.result_schema_ref.as_deref(), Some("foundry:test-result@v1"));
-        assert_eq!(meta.exit_codes[0].name, "TestFailure");
+        assert_eq!(meta.capabilities.result_schema_ref.as_deref(), Some("foundry:forge.test@v1"));
+        assert_eq!(meta.exit_codes[0].name, "CompilationFailed");
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -12,11 +12,17 @@ extern crate foundry_common;
 extern crate tracing;
 
 pub mod clap;
+pub mod diagnostic;
+pub mod exit_code;
 pub mod handler;
 pub mod introspect;
 pub mod json;
+pub mod machine;
 pub mod opts;
 pub mod utils;
+
+pub use exit_code::ExitCode;
+pub use machine::{check_machine, is_machine, parse_or_exit};
 
 #[cfg(feature = "tracy")]
 tracing_tracy::client::register_demangler!();

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -1,0 +1,165 @@
+//! Machine mode (`--machine`) — agent-contract output selector.
+//!
+//! See [`docs/agents/spec.md`](../../../docs/agents/spec.md) §10. When a
+//! command is invoked with `--machine`:
+//!
+//! - it emits its declared [`output_mode`](crate::introspect::OutputMode) only,
+//! - it never writes color, progress bars, or interactive prompts to stdout,
+//! - parse, usage, version, and help failures are structured as envelopes,
+//! - process-exit failures map to the canonical [`ExitCode`] enum.
+//!
+//! The flag is detected before clap parsing — see [`check_machine`] — so the
+//! mode is known by the time clap errors need to be intercepted.
+//!
+//! Adoption of machine-mode output by individual commands lands in follow-up
+//! PRs. PR 2 wires the runtime infrastructure (flag detection, error
+//! interception, exit-code mapping); per-command envelope emission is
+//! deferred.
+
+use crate::{
+    diagnostic,
+    exit_code::ExitCode,
+    json::{JsonEnvelope, JsonMessage, print_json},
+};
+use clap::{CommandFactory, Parser, error::ErrorKind};
+use serde_json::json;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static MACHINE_MODE: AtomicBool = AtomicBool::new(false);
+
+/// Returns whether `--machine` was set on the current invocation.
+///
+/// Only meaningful after [`check_machine`] has run.
+pub fn is_machine() -> bool {
+    MACHINE_MODE.load(Ordering::Relaxed)
+}
+
+/// Force machine mode on. Intended for tests and for [`check_machine`].
+#[doc(hidden)]
+pub fn set_machine(on: bool) {
+    MACHINE_MODE.store(on, Ordering::Relaxed);
+}
+
+/// Pre-parse scan for `--machine`.
+///
+/// Mirrors `check_introspect` / `check_markdown_help`: runs before clap
+/// parsing so the flag is visible while intercepting parse errors. Does NOT
+/// exit — machine mode persists for the rest of the run.
+pub fn check_machine() {
+    if std::env::args().any(|a| a == "--machine") {
+        set_machine(true);
+    }
+}
+
+/// Parse arguments, intercepting clap errors when machine mode is on.
+///
+/// Replaces `T::parse()` at binary entry points. Under `--machine`, parse
+/// errors and `--help` / `--version` are converted into a structured
+/// [`JsonEnvelope`] on stdout and the process exits with the appropriate
+/// [`ExitCode`]. Without `--machine`, behaves exactly like
+/// [`Parser::parse`].
+pub fn parse_or_exit<T: Parser + CommandFactory>() -> T {
+    match T::try_parse() {
+        Ok(t) => t,
+        Err(err) => {
+            if is_machine() {
+                handle_machine_clap_error::<T>(err)
+            } else {
+                err.exit()
+            }
+        }
+    }
+}
+
+fn handle_machine_clap_error<T: CommandFactory>(err: clap::Error) -> ! {
+    let kind = err.kind();
+    match kind {
+        ErrorKind::DisplayHelp | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+            let mut cmd = T::command();
+            let help = cmd.render_help().to_string();
+            let envelope = JsonEnvelope::success(json!({ "help": help }));
+            let _ = print_json(&envelope);
+            std::process::exit(ExitCode::Success.to_i32());
+        }
+        ErrorKind::DisplayVersion => {
+            let cmd = T::command();
+            let envelope = JsonEnvelope::success(json!({
+                "version": cmd.get_version().unwrap_or(""),
+                "long_version": cmd.get_long_version().unwrap_or(""),
+            }));
+            let _ = print_json(&envelope);
+            std::process::exit(ExitCode::Success.to_i32());
+        }
+        _ => {
+            let message = err.to_string();
+            let envelope = JsonEnvelope::error(
+                JsonMessage::error(diagnostic::cli::USAGE_INVALID, message)
+                    .with_details(json!({ "clap_error_kind": format!("{kind:?}") })),
+            );
+            let _ = print_json(&envelope);
+            std::process::exit(ExitCode::Usage.to_i32());
+        }
+    }
+}
+
+/// Exit code that maps a clap error kind to the canonical table.
+///
+/// Useful for callers that have a `clap::Error` they want to classify
+/// without going through [`parse_or_exit`].
+pub fn exit_code_for_clap_error(err: &clap::Error) -> ExitCode {
+    match err.kind() {
+        ErrorKind::DisplayHelp
+        | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+        | ErrorKind::DisplayVersion => ExitCode::Success,
+        _ => ExitCode::Usage,
+    }
+}
+
+/// Emit a structured error envelope on stdout for an `eyre::Report`.
+///
+/// Adoption PRs use this at command-execution failure sites under
+/// `--machine`. PR 2 ships the helper but does not yet route command-error
+/// failures through it; that is part of per-command envelope adoption.
+pub fn report_machine_error(report: &eyre::Report) {
+    let message = format!("{report}");
+    let envelope = JsonEnvelope::error(JsonMessage::error(diagnostic::cli::UNKNOWN, message));
+    let _ = print_json(&envelope);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn machine_flag_default_off() {
+        set_machine(false);
+        assert!(!is_machine());
+    }
+
+    #[test]
+    fn machine_flag_can_be_toggled() {
+        set_machine(true);
+        assert!(is_machine());
+        set_machine(false);
+        assert!(!is_machine());
+    }
+
+    #[derive(Debug, Parser)]
+    #[command(name = "demo", version = "0.1.0")]
+    struct Demo {
+        #[arg(long)]
+        name: Option<String>,
+    }
+
+    #[test]
+    fn clap_error_kinds_map_to_exit_codes() {
+        let bad = Demo::try_parse_from(["demo", "--unknown"]).unwrap_err();
+        assert_eq!(exit_code_for_clap_error(&bad), ExitCode::Usage);
+
+        let help = Demo::try_parse_from(["demo", "--help"]).unwrap_err();
+        assert_eq!(exit_code_for_clap_error(&help), ExitCode::Success);
+
+        let version = Demo::try_parse_from(["demo", "--version"]).unwrap_err();
+        assert_eq!(exit_code_for_clap_error(&version), ExitCode::Success);
+    }
+}

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -11,10 +11,10 @@
 //! The flag is detected before clap parsing — see [`check_machine`] — so the
 //! mode is known by the time clap errors need to be intercepted.
 //!
-//! Adoption of machine-mode output by individual commands lands in follow-up
-//! PRs. PR 2 wires the runtime infrastructure (flag detection, error
-//! interception, exit-code mapping); per-command envelope emission is
-//! deferred.
+//! This module ships the runtime infrastructure (flag detection, error
+//! interception, exit-code mapping). Adoption of machine-mode output by
+//! individual commands lands in follow-up work; per-command envelope
+//! emission is deferred.
 
 use crate::{
     diagnostic,

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -47,9 +47,8 @@ pub(crate) fn set_machine(on: bool) {
 /// Pre-parse scan for `--machine`.
 ///
 /// Runs before clap parsing so the flag is visible while intercepting parse
-/// errors. Honors the `global = true` declaration on
-/// [`crate::opts::GlobalArgs::machine`], so `cast call --machine --help`
-/// also flips the mode. See [`crate::opts::pre_parse_global_flag_present`].
+/// errors. Honors `--machine`'s clap-global declaration, so `cast call
+/// --machine --help` also flips the mode.
 pub fn check_machine() {
     if crate::opts::pre_parse_global_flag_present("--machine") {
         set_machine(true);

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -46,13 +46,12 @@ pub(crate) fn set_machine(on: bool) {
 
 /// Pre-parse scan for `--machine`.
 ///
-/// Mirrors `check_introspect` / `check_markdown_help`: runs before clap
-/// parsing so the flag is visible while intercepting parse errors. Uses the
-/// same shared top-level scanner so `--machine` after `--`, after a
-/// subcommand/positional, or as a value to another flag does **not** flip
-/// the mode. Non-UTF-8 argv is handled gracefully (no panic).
+/// Runs before clap parsing so the flag is visible while intercepting parse
+/// errors. Honors the `global = true` declaration on
+/// [`crate::opts::GlobalArgs::machine`], so `cast call --machine --help`
+/// also flips the mode. See [`crate::opts::pre_parse_global_flag_present`].
 pub fn check_machine() {
-    if crate::opts::pre_parse_flag_present("--machine") {
+    if crate::opts::pre_parse_global_flag_present("--machine") {
         set_machine(true);
     }
 }
@@ -65,14 +64,23 @@ pub fn check_machine() {
 /// [`ExitCode`]. Without `--machine`, behaves exactly like
 /// [`Parser::parse`].
 pub fn parse_or_exit<T: Parser + CommandFactory>() -> T {
-    match T::try_parse() {
-        Ok(t) => t,
-        Err(err) => {
-            if is_machine() {
-                handle_machine_clap_error(err)
-            } else {
-                err.exit()
-            }
+    if is_machine() {
+        // `GlobalArgs::init()` (which calls `yansi::disable()`) hasn't run
+        // yet; force `ColorChoice::Never` on the command so clap's rendered
+        // help / error text never embeds ANSI escapes in the envelope.
+        let mut cmd = T::command().color(clap::ColorChoice::Never);
+        let mut matches = match cmd.try_get_matches_from_mut(std::env::args_os()) {
+            Ok(m) => m,
+            Err(err) => handle_machine_clap_error(err),
+        };
+        match T::from_arg_matches_mut(&mut matches) {
+            Ok(t) => t,
+            Err(err) => handle_machine_clap_error(err),
+        }
+    } else {
+        match T::try_parse() {
+            Ok(t) => t,
+            Err(err) => err.exit(),
         }
     }
 }

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -1,20 +1,23 @@
 //! Machine mode (`--machine`) — agent-contract output selector.
 //!
-//! See [`docs/agents/spec.md`](../../../docs/agents/spec.md) §10. When a
-//! command is invoked with `--machine`:
+//! See [`docs/agents/spec.md`](../../../docs/agents/spec.md) §10. This
+//! module ships the **runtime layer** of `--machine`: pre-parse detection,
+//! clap-error interception, and the canonical [`ExitCode`] mapping for
+//! pre-command exits.
 //!
-//! - it emits its declared [`output_mode`](crate::introspect::OutputMode) only,
-//! - it never writes color, progress bars, or interactive prompts to stdout,
-//! - parse, usage, version, and help failures are structured as envelopes,
-//! - process-exit failures map to the canonical [`ExitCode`] enum.
+//! Runtime guarantees, regardless of which command is invoked:
 //!
-//! The flag is detected before clap parsing — see [`check_machine`] — so the
-//! mode is known by the time clap errors need to be intercepted.
+//! - color is disabled (wired through [`crate::opts::GlobalArgs::shell`]),
+//! - parse / usage failures are wrapped in an error envelope (`cli.usage.invalid`, exit `2`),
+//! - `--help` / `--version` are wrapped in a success envelope (exit `0`).
 //!
-//! This module ships the runtime infrastructure (flag detection, error
-//! interception, exit-code mapping). Adoption of machine-mode output by
-//! individual commands lands in follow-up work; per-command envelope
-//! emission is deferred.
+//! Per-command behavior — emitting only the declared
+//! [`output_mode`](crate::introspect::OutputMode), suppressing progress
+//! bars and interactive prompts, returning the canonical [`ExitCode`] for
+//! the failure category — is opt-in and adopted incrementally.
+//!
+//! The flag is detected before clap parsing — see [`check_machine`] — so
+//! the mode is known by the time clap errors need to be intercepted.
 
 use crate::{
     diagnostic,

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -34,19 +34,22 @@ pub fn is_machine() -> bool {
     MACHINE_MODE.load(Ordering::Relaxed)
 }
 
-/// Force machine mode on. Intended for tests and for [`check_machine`].
-#[doc(hidden)]
-pub fn set_machine(on: bool) {
+/// Force machine mode on or off. Intentionally crate-private: production
+/// activation goes through [`check_machine`] (pre-parse) or
+/// [`crate::opts::GlobalArgs::init`] (post-parse re-sync).
+pub(crate) fn set_machine(on: bool) {
     MACHINE_MODE.store(on, Ordering::Relaxed);
 }
 
 /// Pre-parse scan for `--machine`.
 ///
 /// Mirrors `check_introspect` / `check_markdown_help`: runs before clap
-/// parsing so the flag is visible while intercepting parse errors. Does NOT
-/// exit — machine mode persists for the rest of the run.
+/// parsing so the flag is visible while intercepting parse errors. Uses the
+/// same shared top-level scanner so `--machine` after `--`, after a
+/// subcommand/positional, or as a value to another flag does **not** flip
+/// the mode. Non-UTF-8 argv is handled gracefully (no panic).
 pub fn check_machine() {
-    if std::env::args().any(|a| a == "--machine") {
+    if crate::opts::pre_parse_flag_present("--machine") {
         set_machine(true);
     }
 }
@@ -63,7 +66,7 @@ pub fn parse_or_exit<T: Parser + CommandFactory>() -> T {
         Ok(t) => t,
         Err(err) => {
             if is_machine() {
-                handle_machine_clap_error::<T>(err)
+                handle_machine_clap_error(err)
             } else {
                 err.exit()
             }
@@ -71,59 +74,52 @@ pub fn parse_or_exit<T: Parser + CommandFactory>() -> T {
     }
 }
 
-fn handle_machine_clap_error<T: CommandFactory>(err: clap::Error) -> ! {
-    let kind = err.kind();
-    match kind {
-        ErrorKind::DisplayHelp | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
-            let mut cmd = T::command();
-            let help = cmd.render_help().to_string();
-            let envelope = JsonEnvelope::success(json!({ "help": help }));
+/// Convert a clap error into a structured machine-mode envelope and exit.
+///
+/// - `DisplayHelp` / `DisplayVersion` (explicit `--help` / `--version`) → success envelope wrapping
+///   clap's already-rendered, context-aware text (so e.g. `cast call --help` yields `cast call`
+///   help, not root help), exit `0`.
+/// - Everything else (parse errors, missing subcommand, missing required arg, conflict, including
+///   `DisplayHelpOnMissingArgumentOrSubcommand`, which is clap's "render help because args were
+///   missing" — i.e. a usage failure, not a help request) → error envelope with
+///   `cli.usage.invalid`, exit `2`.
+fn handle_machine_clap_error(err: clap::Error) -> ! {
+    let exit = exit_code_for_clap_error(&err);
+    match err.kind() {
+        ErrorKind::DisplayHelp => {
+            let rendered = err.render().to_string();
+            let envelope = JsonEnvelope::success(json!({ "help": rendered }));
             let _ = print_json(&envelope);
-            std::process::exit(ExitCode::Success.to_i32());
         }
         ErrorKind::DisplayVersion => {
-            let cmd = T::command();
-            let envelope = JsonEnvelope::success(json!({
-                "version": cmd.get_version().unwrap_or(""),
-                "long_version": cmd.get_long_version().unwrap_or(""),
-            }));
+            let rendered = err.render().to_string();
+            let envelope = JsonEnvelope::success(json!({ "version": rendered }));
             let _ = print_json(&envelope);
-            std::process::exit(ExitCode::Success.to_i32());
         }
         _ => {
+            // Includes `DisplayHelpOnMissingArgumentOrSubcommand`: clap
+            // rendered help text, but the underlying cause is a missing
+            // required arg or subcommand — a usage failure by contract.
             let message = err.to_string();
-            let envelope = JsonEnvelope::error(
-                JsonMessage::error(diagnostic::cli::USAGE_INVALID, message)
-                    .with_details(json!({ "clap_error_kind": format!("{kind:?}") })),
-            );
+            let envelope =
+                JsonEnvelope::error(JsonMessage::error(diagnostic::cli::USAGE_INVALID, message));
             let _ = print_json(&envelope);
-            std::process::exit(ExitCode::Usage.to_i32());
         }
     }
+    std::process::exit(exit.to_i32());
 }
 
-/// Exit code that maps a clap error kind to the canonical table.
+/// Maps a clap error kind to the canonical [`ExitCode`].
 ///
-/// Useful for callers that have a `clap::Error` they want to classify
-/// without going through [`parse_or_exit`].
-pub fn exit_code_for_clap_error(err: &clap::Error) -> ExitCode {
+/// Only `DisplayHelp` and `DisplayVersion` (explicit `--help` / `--version`)
+/// are successes; everything else (parse errors, missing subcommand,
+/// missing required arg, conflict, `DisplayHelpOnMissingArgumentOrSubcommand`)
+/// is `Usage`.
+fn exit_code_for_clap_error(err: &clap::Error) -> ExitCode {
     match err.kind() {
-        ErrorKind::DisplayHelp
-        | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
-        | ErrorKind::DisplayVersion => ExitCode::Success,
+        ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => ExitCode::Success,
         _ => ExitCode::Usage,
     }
-}
-
-/// Emit a structured error envelope on stdout for an `eyre::Report`.
-///
-/// Adoption PRs use this at command-execution failure sites under
-/// `--machine`. PR 2 ships the helper but does not yet route command-error
-/// failures through it; that is part of per-command envelope adoption.
-pub fn report_machine_error(report: &eyre::Report) {
-    let message = format!("{report}");
-    let envelope = JsonEnvelope::error(JsonMessage::error(diagnostic::cli::UNKNOWN, message));
-    let _ = print_json(&envelope);
 }
 
 #[cfg(test)]
@@ -149,6 +145,34 @@ mod tests {
     struct Demo {
         #[arg(long)]
         name: Option<String>,
+        #[command(subcommand)]
+        cmd: Option<DemoSub>,
+    }
+
+    #[derive(Debug, clap::Subcommand)]
+    enum DemoSub {
+        /// Build the project.
+        Build {
+            #[arg(long)]
+            path: Option<String>,
+        },
+    }
+
+    #[derive(Debug, Parser)]
+    #[command(
+        name = "strict",
+        version = "0.1.0",
+        subcommand_required = true,
+        arg_required_else_help = true
+    )]
+    struct Strict {
+        #[command(subcommand)]
+        cmd: StrictSub,
+    }
+
+    #[derive(Debug, clap::Subcommand)]
+    enum StrictSub {
+        Run,
     }
 
     #[test]
@@ -161,5 +185,34 @@ mod tests {
 
         let version = Demo::try_parse_from(["demo", "--version"]).unwrap_err();
         assert_eq!(exit_code_for_clap_error(&version), ExitCode::Success);
+    }
+
+    /// `DisplayHelpOnMissingArgumentOrSubcommand` is clap's "render help
+    /// because args were missing" — a usage failure, not a help request.
+    /// The agent contract maps it to [`ExitCode::Usage`], not `Success`.
+    #[test]
+    fn missing_required_subcommand_classifies_as_usage() {
+        let err = Strict::try_parse_from(["strict"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand);
+        assert_eq!(exit_code_for_clap_error(&err), ExitCode::Usage);
+    }
+
+    /// Subcommand `--help` must surface the **subcommand's** help, not the
+    /// root help. This is the contract test for the I3 fix: rendering
+    /// flows through `err.render()` instead of `T::command().render_help()`.
+    #[test]
+    fn subcommand_help_preserves_command_context() {
+        let err = Demo::try_parse_from(["demo", "build", "--help"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::DisplayHelp);
+        let rendered = err.render().to_string();
+        assert!(
+            rendered.contains("Build the project"),
+            "subcommand help should mention the subcommand description, got: {rendered}"
+        );
+        // Root-only subcommand list MUST NOT appear in subcommand help.
+        assert!(
+            !rendered.contains("Usage: demo [OPTIONS]"),
+            "subcommand help leaked root usage: {rendered}"
+        );
     }
 }

--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -201,7 +201,10 @@ fn emit_introspect_and_exit(
 /// the ASCII flags this helper supports). Values of known value-taking
 /// global options are skipped, so e.g. `forge --color always --introspect`
 /// and `forge -j 4 --introspect` still match.
-fn pre_parse_flag_present(flag: &str) -> bool {
+///
+/// Shared by every pre-parse flag detector (`--introspect`,
+/// `--markdown-help`, `--machine`) so the activation surface stays uniform.
+pub(crate) fn pre_parse_flag_present(flag: &str) -> bool {
     pre_parse_flag_present_in(std::env::args_os().skip(1), flag)
 }
 
@@ -211,7 +214,7 @@ fn pre_parse_flag_present(flag: &str) -> bool {
 /// declarations above.
 const VALUE_TAKING_GLOBAL_OPTIONS: &[&str] = &["--color", "-j", "--threads", "--jobs"];
 
-fn pre_parse_flag_present_in<I>(args: I, flag: &str) -> bool
+pub(crate) fn pre_parse_flag_present_in<I>(args: I, flag: &str) -> bool
 where
     I: IntoIterator<Item = std::ffi::OsString>,
 {
@@ -281,5 +284,45 @@ mod tests {
         ] {
             assert!(!pre_parse_flag_present_in(argv(case), "--introspect"), "case: {case:?}");
         }
+    }
+
+    /// Regression for the agent-substrate `--machine` pre-parse detector:
+    /// the same scanner discipline applies. `--machine` after a `--`
+    /// separator or after a positional / subcommand boundary must NOT
+    /// flip machine mode, even though it appears in argv.
+    #[test]
+    fn pre_parse_flag_present_machine_boundary_cases() {
+        // Positive: leading top-level flag, with and without other globals.
+        for case in
+            [&["--machine"][..], &["--color", "always", "--machine"], &["-j", "4", "--machine"]]
+        {
+            assert!(pre_parse_flag_present_in(argv(case), "--machine"), "expected match: {case:?}");
+        }
+
+        // Negative: out-of-band positions must not match.
+        for case in [
+            &["--", "--machine"][..],
+            &["test", "--machine"],
+            &["call", "ADDR", "sig(string)", "--data", "--machine"],
+            // `--machine` consumed as a positional value to a known
+            // value-taking global must not match.
+            &["--color", "--machine"],
+        ] {
+            assert!(
+                !pre_parse_flag_present_in(argv(case), "--machine"),
+                "expected NO match: {case:?}"
+            );
+        }
+    }
+
+    /// Non-UTF-8 argv must not panic the scanner; it must short-circuit
+    /// to `false` at the offending token.
+    #[test]
+    #[cfg(unix)]
+    fn pre_parse_flag_present_handles_non_utf8() {
+        use std::os::unix::ffi::OsStringExt;
+        let bad = OsString::from_vec(vec![0xff, 0xfe]);
+        let args = vec![bad, OsString::from("--machine")];
+        assert!(!pre_parse_flag_present_in(args, "--machine"));
     }
 }

--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -31,10 +31,12 @@ pub struct GlobalArgs {
     #[arg(help_heading = "Display options", global = true, long, alias = "format-json", conflicts_with_all = &["quiet", "color", "machine"])]
     json: bool,
 
-    /// Activate the agent contract: emit declared output mode only, no color,
-    /// no progress, structured early-exit. Implies no color. Mutually
-    /// exclusive with `--json` and `--md` to keep machine-mode output
-    /// unambiguous.
+    /// Activate the agent contract: disables color and wraps CLI-runtime
+    /// exits (parse / usage / help / version) in a structured envelope.
+    /// Per-command machine output (declared `output_mode`, progress and
+    /// prompt suppression, canonical exit codes) is adopted incrementally
+    /// — see `docs/agents/spec.md` §10. Mutually exclusive with `--json`
+    /// and `--md` to keep machine-mode output unambiguous.
     #[arg(help_heading = "Display options", global = true, long, conflicts_with_all = &["color", "md"])]
     machine: bool,
 

--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -28,8 +28,15 @@ pub struct GlobalArgs {
     quiet: bool,
 
     /// Format log messages as JSON.
-    #[arg(help_heading = "Display options", global = true, long, alias = "format-json", conflicts_with_all = &["quiet", "color"])]
+    #[arg(help_heading = "Display options", global = true, long, alias = "format-json", conflicts_with_all = &["quiet", "color", "machine"])]
     json: bool,
+
+    /// Activate the agent contract: emit declared output mode only, no color,
+    /// no progress, structured early-exit. Implies no color. Mutually
+    /// exclusive with `--json` and `--md` to keep machine-mode output
+    /// unambiguous.
+    #[arg(help_heading = "Display options", global = true, long, conflicts_with_all = &["color", "md"])]
+    machine: bool,
 
     /// Format log messages as Markdown.
     #[arg(
@@ -95,6 +102,12 @@ impl GlobalArgs {
 
     /// Initialize the global options.
     pub fn init(&self) -> eyre::Result<()> {
+        // Keep the runtime machine-mode flag in sync with what clap parsed.
+        // `check_machine` runs pre-parse on the binary entry point; this
+        // covers callers that construct `GlobalArgs` programmatically and
+        // ensures the flag never goes stale.
+        crate::machine::set_machine(self.machine);
+
         // Set the global shell.
         let shell = self.shell();
         // Argument takes precedence over the env var global color choice.
@@ -113,6 +126,7 @@ impl GlobalArgs {
         // Display a warning message if the current version is not stable.
         if IS_NIGHTLY_VERSION
             && !self.json
+            && !self.machine
             && std::env::var_os("FOUNDRY_DISABLE_NIGHTLY_WARNING").is_none()
         {
             let _ = sh_warn!("{}", NIGHTLY_VERSION_WARNING_MESSAGE);
@@ -127,7 +141,11 @@ impl GlobalArgs {
             true => OutputMode::Quiet,
             false => OutputMode::Normal,
         };
-        let color = self.json.then_some(ColorChoice::Never).or(self.color).unwrap_or_default();
+        // `--machine` forces no-color; `--json` already forces no-color.
+        let color = (self.json || self.machine)
+            .then_some(ColorChoice::Never)
+            .or(self.color)
+            .unwrap_or_default();
         let format = if self.json {
             OutputFormat::Json
         } else if self.md {

--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -37,7 +37,7 @@ pub struct GlobalArgs {
     /// prompt suppression, canonical exit codes) is adopted incrementally
     /// — see `docs/agents/spec.md` §10. Mutually exclusive with `--json`
     /// and `--md` to keep machine-mode output unambiguous.
-    #[arg(help_heading = "Display options", global = true, long, conflicts_with_all = &["color", "md"])]
+    #[arg(help_heading = "Display options", global = true, long, conflicts_with_all = &["color", "md", "json"])]
     machine: bool,
 
     /// Format log messages as Markdown.
@@ -204,10 +204,17 @@ fn emit_introspect_and_exit(
 /// global options are skipped, so e.g. `forge --color always --introspect`
 /// and `forge -j 4 --introspect` still match.
 ///
-/// Shared by every pre-parse flag detector (`--introspect`,
-/// `--markdown-help`, `--machine`) so the activation surface stays uniform.
+/// Use for non-clap-global pre-parse flags (`--introspect`, `--markdown-help`).
+/// For clap-globals like `--machine`, use [`pre_parse_global_flag_present`].
 pub(crate) fn pre_parse_flag_present(flag: &str) -> bool {
     pre_parse_flag_present_in(std::env::args_os().skip(1), flag)
+}
+
+/// Like [`pre_parse_flag_present`] but scans past subcommands/positionals,
+/// honoring `clap`'s `global = true` placement (e.g. `cast call --machine --help`).
+/// Still stops at `--` and skips values of known value-taking globals.
+pub(crate) fn pre_parse_global_flag_present(flag: &str) -> bool {
+    pre_parse_global_flag_present_in(std::env::args_os().skip(1), flag)
 }
 
 /// Value-taking global options declared on [`GlobalArgs`]; their following
@@ -238,6 +245,27 @@ where
         }
         // Skip the value of `--opt VALUE` form; `--opt=VALUE` is one token.
         if !s.contains('=') && VALUE_TAKING_GLOBAL_OPTIONS.contains(&s) {
+            iter.next();
+        }
+    }
+    false
+}
+
+pub(crate) fn pre_parse_global_flag_present_in<I>(args: I, flag: &str) -> bool
+where
+    I: IntoIterator<Item = std::ffi::OsString>,
+{
+    let mut iter = args.into_iter();
+    while let Some(a) = iter.next() {
+        if a == "--" {
+            return false;
+        }
+        // Non-UTF-8 token: skip but keep scanning.
+        let Some(s) = a.to_str() else { continue };
+        if s == flag {
+            return true;
+        }
+        if s.starts_with('-') && !s.contains('=') && VALUE_TAKING_GLOBAL_OPTIONS.contains(&s) {
             iter.next();
         }
     }
@@ -288,30 +316,26 @@ mod tests {
         }
     }
 
-    /// Regression for the agent-substrate `--machine` pre-parse detector:
-    /// the same scanner discipline applies. `--machine` after a `--`
-    /// separator or after a positional / subcommand boundary must NOT
-    /// flip machine mode, even though it appears in argv.
+    /// Clap-global scanner: matches `--machine` anywhere except after `--`
+    /// or as the value of a known value-taking global.
     #[test]
-    fn pre_parse_flag_present_machine_boundary_cases() {
-        // Positive: leading top-level flag, with and without other globals.
-        for case in
-            [&["--machine"][..], &["--color", "always", "--machine"], &["-j", "4", "--machine"]]
-        {
-            assert!(pre_parse_flag_present_in(argv(case), "--machine"), "expected match: {case:?}");
-        }
-
-        // Negative: out-of-band positions must not match.
+    fn pre_parse_global_flag_present_machine_cases() {
         for case in [
-            &["--", "--machine"][..],
-            &["test", "--machine"],
-            &["call", "ADDR", "sig(string)", "--data", "--machine"],
-            // `--machine` consumed as a positional value to a known
-            // value-taking global must not match.
-            &["--color", "--machine"],
+            &["--machine"][..],
+            &["--color", "always", "--machine"],
+            &["-j", "4", "--machine"],
+            &["build", "--machine"],
+            &["build", "--machine", "--help"],
+            &["call", "ADDR", "sig(string)", "--data", "0x00", "--machine"],
         ] {
             assert!(
-                !pre_parse_flag_present_in(argv(case), "--machine"),
+                pre_parse_global_flag_present_in(argv(case), "--machine"),
+                "expected match: {case:?}"
+            );
+        }
+        for case in [&["--", "--machine"][..], &["--color", "--machine"]] {
+            assert!(
+                !pre_parse_global_flag_present_in(argv(case), "--machine"),
                 "expected NO match: {case:?}"
             );
         }
@@ -326,5 +350,15 @@ mod tests {
         let bad = OsString::from_vec(vec![0xff, 0xfe]);
         let args = vec![bad, OsString::from("--machine")];
         assert!(!pre_parse_flag_present_in(args, "--machine"));
+    }
+
+    /// Non-UTF-8 token must not block a later `--machine` from matching.
+    #[test]
+    #[cfg(unix)]
+    fn pre_parse_global_flag_present_handles_non_utf8() {
+        use std::os::unix::ffi::OsStringExt;
+        let bad = OsString::from_vec(vec![0xff, 0xfe]);
+        let args = vec![bad, OsString::from("--machine")];
+        assert!(pre_parse_global_flag_present_in(args, "--machine"));
     }
 }

--- a/crates/cli/src/opts/mod.rs
+++ b/crates/cli/src/opts/mod.rs
@@ -12,6 +12,7 @@ pub use build::*;
 pub use chain::*;
 pub use dependency::*;
 pub use evm::*;
+pub(crate) use global::pre_parse_flag_present;
 pub use global::*;
 pub use rpc::*;
 pub use rpc_common::*;

--- a/crates/cli/src/opts/mod.rs
+++ b/crates/cli/src/opts/mod.rs
@@ -12,7 +12,7 @@ pub use build::*;
 pub use chain::*;
 pub use dependency::*;
 pub use evm::*;
-pub(crate) use global::pre_parse_flag_present;
+pub(crate) use global::pre_parse_global_flag_present;
 pub use global::*;
 pub use rpc::*;
 pub use rpc_common::*;

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -161,7 +161,7 @@ mod tests {
     /// downstream tooling.
     #[test]
     fn introspect_command_ids_are_unique() {
-        let cmd = <Forge as clap::CommandFactory>::command();
+        let cmd = Forge::command();
         let doc = build_document(&cmd, &CommandRegistry::EMPTY);
         let dups = duplicate_command_ids(&doc);
         assert!(dups.is_empty(), "duplicate forge command_ids: {dups:?}");
@@ -171,7 +171,7 @@ mod tests {
     /// the canonical `IntrospectDocument` shape.
     #[test]
     fn introspect_document_is_valid_json() {
-        let cmd = <Forge as clap::CommandFactory>::command();
+        let cmd = Forge::command();
         let json = render_introspect_document(&cmd, &CommandRegistry::EMPTY);
         let doc: IntrospectDocument = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(doc.schema_id, INTROSPECT_SCHEMA_ID);
@@ -183,7 +183,7 @@ mod tests {
     /// [`capability_violations`].
     #[test]
     fn introspect_capabilities_are_consistent() {
-        let cmd = <Forge as clap::CommandFactory>::command();
+        let cmd = Forge::command();
         let doc = build_document(&cmd, &CommandRegistry::EMPTY);
         let v = capability_violations(&doc);
         assert!(v.is_empty(), "forge capability violations: {v:?}");

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -2,7 +2,7 @@ use crate::{
     cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, watch},
     opts::{Forge, ForgeSubcommand},
 };
-use clap::{CommandFactory, Parser};
+use clap::CommandFactory;
 use clap_complete::generate;
 use eyre::Result;
 use foundry_cli::utils;
@@ -13,12 +13,13 @@ use foundry_evm::inspectors::cheatcodes::{ForgeContext, set_execution_context};
 pub fn run() -> Result<()> {
     // Pre-parse discovery flags run before `setup()` so they cannot be blocked
     // by panic-handler / tracing init failures and avoid that init's cost.
+    foundry_cli::machine::check_machine();
     foundry_cli::opts::GlobalArgs::check_introspect::<Forge>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Forge>();
 
     setup()?;
 
-    let args = Forge::parse();
+    let args = foundry_cli::parse_or_exit::<Forge>();
     args.global.init()?;
 
     run_command(args)
@@ -151,7 +152,7 @@ mod tests {
     use super::*;
     use foundry_cli::introspect::{
         CommandRegistry, INTROSPECT_SCHEMA_ID, IntrospectDocument, build_document,
-        duplicate_command_ids, render_introspect_document,
+        capability_violations, duplicate_command_ids, render_introspect_document,
     };
 
     /// Every `command_id` exposed by `forge --introspect` MUST be unique.
@@ -175,5 +176,16 @@ mod tests {
         let doc: IntrospectDocument = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(doc.schema_id, INTROSPECT_SCHEMA_ID);
         assert_eq!(doc.binary.name, "forge");
+    }
+
+    /// Capability self-consistency: any command declaring an output mode
+    /// must wire the matching schema reference. See
+    /// [`capability_violations`].
+    #[test]
+    fn introspect_capabilities_are_consistent() {
+        let cmd = <Forge as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let v = capability_violations(&doc);
+        assert!(v.is_empty(), "forge capability violations: {v:?}");
     }
 }

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -173,6 +173,10 @@ impl TestOutcome {
     }
 
     /// Checks if there are any failures and failures are disallowed.
+    //
+    // Exit-code policy: under `--machine` we honor the agent contract
+    // ([`ExitCode::TestFailure`]); legacy invocations preserve the
+    // historical exit-1 contract that scripts and CIs already depend on.
     pub fn ensure_ok(&self, silent: bool) -> eyre::Result<()> {
         let outcome = self;
         let failures = outcome.failures().count();
@@ -181,7 +185,7 @@ impl TestOutcome {
         }
 
         if shell::is_quiet() || silent {
-            std::process::exit(1);
+            std::process::exit(test_failure_exit_code());
         }
 
         sh_println!("\nFailing tests:")?;
@@ -225,7 +229,7 @@ impl TestOutcome {
             )?;
         }
 
-        std::process::exit(1);
+        std::process::exit(test_failure_exit_code());
     }
 
     /// Removes first test result, if any.
@@ -239,6 +243,11 @@ impl TestOutcome {
             }
         })
     }
+}
+
+/// Process exit code emitted when at least one test failed.
+fn test_failure_exit_code() -> i32 {
+    if foundry_cli::is_machine() { foundry_cli::ExitCode::TestFailure.to_i32() } else { 1 }
 }
 
 /// A set of test results for a single test suite, which is all the tests in a single contract.

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -54,9 +54,11 @@ Display options:
           Format log messages as JSON
 
       --machine
-          Activate the agent contract: emit declared output mode only, no color, no progress,
-          structured early-exit. Implies no color. Mutually exclusive with `--json` and `--md` to
-          keep machine-mode output unambiguous
+          Activate the agent contract: disables color and wraps CLI-runtime exits (parse / usage /
+          help / version) in a structured envelope. Per-command machine output (declared
+          `output_mode`, progress and prompt suppression, canonical exit codes) is adopted
+          incrementally — see `docs/agents/spec.md` §10. Mutually exclusive with `--json` and `--md`
+          to keep machine-mode output unambiguous
 
       --md
           Format log messages as Markdown

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -53,6 +53,11 @@ Display options:
       --json
           Format log messages as JSON
 
+      --machine
+          Activate the agent contract: emit declared output mode only, no color, no progress,
+          structured early-exit. Implies no color. Mutually exclusive with `--json` and `--md` to
+          keep machine-mode output unambiguous
+
       --md
           Format log messages as Markdown
 

--- a/crates/forge/tests/cli/machine.rs
+++ b/crates/forge/tests/cli/machine.rs
@@ -38,11 +38,20 @@ forgetest!(machine_unknown_flag_emits_usage_envelope, |_prj, cmd| {
 });
 
 // `<subcommand> --help` under `--machine` must surface the subcommand's own help text.
-// `--machine` must lead, since the pre-parse scanner only honors top-level flags.
 forgetest!(machine_subcommand_help_preserves_context, |_prj, cmd| {
     let out =
         cmd.args(["--machine", "build", "--help"]).assert_success().get_output().stdout.clone();
     let env = parse_envelope(&out);
+    let help = env["data"]["help"].as_str().expect("help is a string");
+    assert!(help.contains("Build the project's smart contracts"), "leaked root help: {help}");
+});
+
+// `--machine` after a subcommand must also flip machine mode (clap-global).
+forgetest!(machine_flag_honored_after_subcommand, |_prj, cmd| {
+    let out =
+        cmd.args(["build", "--machine", "--help"]).assert_success().get_output().stdout.clone();
+    let env = parse_envelope(&out);
+    assert_eq!(env["success"], true);
     let help = env["data"]["help"].as_str().expect("help is a string");
     assert!(help.contains("Build the project's smart contracts"), "leaked root help: {help}");
 });

--- a/crates/forge/tests/cli/machine.rs
+++ b/crates/forge/tests/cli/machine.rs
@@ -1,0 +1,78 @@
+//! Binary-level contract tests for the `--machine` agent runtime.
+
+use foundry_test_utils::{forgetest, forgetest_init};
+use serde_json::Value;
+
+/// Returns true if the byte slice contains a CSI escape (`ESC [`).
+fn has_ansi(bytes: &[u8]) -> bool {
+    bytes.windows(2).any(|w| w == [0x1b, b'['])
+}
+
+/// Parses the stdout as a top-level envelope and asserts no ANSI escapes leaked.
+fn parse_envelope(stdout: &[u8]) -> Value {
+    assert!(!has_ansi(stdout), "envelope leaked ANSI escapes");
+    serde_json::from_slice(stdout).unwrap_or_else(|e| {
+        panic!("stdout was not JSON: {e}\n----\n{}\n----", String::from_utf8_lossy(stdout))
+    })
+}
+
+forgetest!(machine_version_emits_success_envelope, |_prj, cmd| {
+    let out = cmd.args(["--machine", "--version"]).assert_success().get_output().stdout.clone();
+    let env = parse_envelope(&out);
+    assert_eq!(env["success"], true);
+    assert!(env["data"]["version"].is_string());
+});
+
+forgetest!(machine_help_emits_success_envelope, |_prj, cmd| {
+    let out = cmd.args(["--machine", "--help"]).assert_success().get_output().stdout.clone();
+    let env = parse_envelope(&out);
+    assert_eq!(env["success"], true);
+    assert!(env["data"]["help"].is_string());
+});
+
+forgetest!(machine_unknown_flag_emits_usage_envelope, |_prj, cmd| {
+    let out = cmd.args(["--machine", "--badflag"]).assert_code(2).get_output().stdout.clone();
+    let env = parse_envelope(&out);
+    assert_eq!(env["success"], false);
+    assert_eq!(env["errors"][0]["code"], "cli.usage.invalid");
+});
+
+// `<subcommand> --help` under `--machine` must surface the subcommand's own help text.
+// `--machine` must lead, since the pre-parse scanner only honors top-level flags.
+forgetest!(machine_subcommand_help_preserves_context, |_prj, cmd| {
+    let out =
+        cmd.args(["--machine", "build", "--help"]).assert_success().get_output().stdout.clone();
+    let env = parse_envelope(&out);
+    let help = env["data"]["help"].as_str().expect("help is a string");
+    assert!(help.contains("Build the project's smart contracts"), "leaked root help: {help}");
+});
+
+forgetest!(machine_conflicts_with_json, |_prj, cmd| {
+    let out = cmd.args(["--machine", "--json", "build"]).assert_code(2).get_output().stdout.clone();
+    let env = parse_envelope(&out);
+    assert_eq!(env["errors"][0]["code"], "cli.usage.invalid");
+});
+
+forgetest!(machine_conflicts_with_md, |_prj, cmd| {
+    let out = cmd.args(["--machine", "--md", "build"]).assert_code(2).get_output().stdout.clone();
+    let env = parse_envelope(&out);
+    assert_eq!(env["errors"][0]["code"], "cli.usage.invalid");
+});
+
+static FAILING_TEST: &str = r#"
+import "forge-std/Test.sol";
+
+contract MachineFailingTest is Test {
+    function testShouldFail() public {
+        assertTrue(false);
+    }
+}
+"#;
+
+// Failing tests: legacy exits 1, `--machine` exits 5 (`ExitCode::TestFailure`).
+forgetest_init!(machine_test_failure_uses_canonical_exit_code, |prj, cmd| {
+    prj.add_source("machine_failing_test", FAILING_TEST);
+
+    cmd.forge_fuse().args(["test"]).assert_code(1);
+    cmd.forge_fuse().args(["--machine", "test"]).assert_code(5);
+});

--- a/crates/forge/tests/cli/main.rs
+++ b/crates/forge/tests/cli/main.rs
@@ -24,6 +24,7 @@ mod install;
 
 mod json;
 mod lint;
+mod machine;
 mod multi_script;
 mod precompiles;
 mod script;

--- a/docs/agents/diagnostics.md
+++ b/docs/agents/diagnostics.md
@@ -55,8 +55,12 @@ are allowed:
 2. **per-domain enums** (`ConfigDiagnostic`, `NetworkDiagnostic`, …) that
    serialize to namespaced strings.
 
-A repo-wide test asserts every emitted code matches the format above and
-appears in this document.
+The `foundry-cli` crate exposes a `known_codes()` registry and a
+`DiagnosticCode::new` validator; per-crate tests assert that codes
+declared in `foundry-cli` round-trip through the validator and are
+unique. A truly repo-wide assertion (every emitted code, in every crate)
+is **aspirational** — it requires downstream adopter PRs to register
+their codes with the central list before it can be enforced.
 
 ## Versioning
 

--- a/docs/agents/exit-codes.md
+++ b/docs/agents/exit-codes.md
@@ -3,9 +3,12 @@
 This document defines the canonical exit-code contract for Foundry binaries.
 Exit codes are part of the agent contract — agents may switch on them.
 
-The table below reflects the target contract. Until the `ExitCode` enum is
-in place, binaries continue to emit `0` on success and a non-zero code on
-failure without further guarantees.
+The table below is the canonical contract. The [`ExitCode`] enum encodes
+it for use in code. Adoption is incremental: commands return the
+appropriate variant as they migrate; until then, callers should expect a
+non-zero exit but may not get the specific code listed here.
+
+[`ExitCode`]: ../../crates/cli/src/exit_code.rs
 
 | Code | Name             | Meaning                                                                        |
 | ---- | ---------------- | ------------------------------------------------------------------------------ |
@@ -44,8 +47,11 @@ combination, `--help`, `--version`):
   wrapping the rendered text (schemas `foundry:cli.help@v1` /
   `foundry:cli.version@v1`; see [`spec.md`](./spec.md) §10)
 
-Command-local non-zero exits adopt structured envelopes incrementally
-according to each command's declared
-[`output_mode`](./spec.md#4-output-modes). Until a command opts in, it
-exits with the canonical [`ExitCode`](#) for its failure category but does
-not emit an envelope.
+Command-local exit-code and envelope adoption is incremental. Each
+command migrates to its canonical [`ExitCode`] and to envelope output
+per its declared [`output_mode`](./spec.md#4-output-modes) as part of
+follow-up work; until a command opts in, it exits `1` on failure (the
+existing `main` fallback) and does not emit an envelope. The two
+exit-code adoptions wired in the runtime layer today are `forge test`
+failure → `TestFailure` (5) and `anvil` signal exit → `Interrupted` (8)
+under `--machine`.

--- a/docs/agents/exit-codes.md
+++ b/docs/agents/exit-codes.md
@@ -34,8 +34,18 @@ codes MUST NOT collide with this global table.
 
 ## Machine-mode interaction
 
-Under `--machine`, the binary always emits a JSON envelope on stdout when
-exiting with a non-zero code, including for parse and usage errors — these
-are emitted as `JsonEnvelope::error` with the appropriate diagnostic code.
-Help and version requests are not failures: they exit `0` and are emitted as
-a success envelope wrapping the rendered text.
+Under `--machine`, the CLI runtime guarantees structured envelopes for
+**pre-command exits** (parse errors, missing subcommand, invalid flag
+combination, `--help`, `--version`):
+
+- parse / usage failures exit `2` and emit `JsonEnvelope::error` with
+  diagnostic code `cli.usage.invalid`
+- `--help` / `--version` exit `0` and emit `JsonEnvelope::success`
+  wrapping the rendered text (schemas `foundry:cli.help@v1` /
+  `foundry:cli.version@v1`; see [`spec.md`](./spec.md) §10)
+
+Command-local non-zero exits adopt structured envelopes incrementally
+according to each command's declared
+[`output_mode`](./spec.md#4-output-modes). Until a command opts in, it
+exits with the canonical [`ExitCode`](#) for its failure category but does
+not emit an envelope.

--- a/docs/agents/spec.md
+++ b/docs/agents/spec.md
@@ -271,6 +271,11 @@ Where the schema id appears:
   `capabilities.result_schema_ref` in introspection. This avoids forcing
   every successful envelope to carry version metadata that is already
   pinned by the `command_id` + introspection contract.
+- **Global (non-command) machine-mode payloads** — a small fixed set of
+  envelopes is emitted by the CLI runtime itself, before any command is
+  resolved (see §10 below). Their payload schemas are listed by name in
+  this document rather than discovered via introspection, because no
+  `command_id` exists at the point of emission.
 
 ---
 
@@ -299,6 +304,37 @@ introspection no longer lists it.
 
 Agents may also rely on `--introspect` for discovery and on the existing
 `--json` flag for legacy machine-readable output.
+
+### Global machine-mode payload schemas
+
+Two payloads are emitted by the CLI runtime itself (before any command is
+resolved) and therefore cannot be discovered via
+`capabilities.result_schema_ref` on a command. Their wire shapes are
+fixed and listed here as part of the contract:
+
+- **`foundry:cli.help@v1`** — emitted as the `data` of a success envelope
+  when `--help` / `-h` is requested under `--machine`. Exit code: `0`.
+
+  ```json
+  { "help": "<clap-rendered help text for the actual command context>" }
+  ```
+
+  The `help` string is clap's own rendered help for the precise
+  subcommand requested (e.g. `cast call --machine --help` carries
+  `cast call` help, not `cast` root help).
+
+- **`foundry:cli.version@v1`** — emitted as the `data` of a success
+  envelope when `--version` / `-V` is requested under `--machine`.
+  Exit code: `0`.
+
+  ```json
+  { "version": "<clap-rendered version text>" }
+  ```
+
+Usage failures (missing subcommand, missing required arg, conflict,
+unknown flag, including clap's `DisplayHelpOnMissingArgumentOrSubcommand`
+case which renders help on missing input) are emitted as an error
+envelope with diagnostic code `cli.usage.invalid` and exit code `2`.
 
 ---
 

--- a/docs/agents/spec.md
+++ b/docs/agents/spec.md
@@ -294,12 +294,20 @@ introspection no longer lists it.
 
 ## 10. Machine mode (`--machine`)
 
-`--machine` is the stable agent-contract selector. When set, a command:
+`--machine` is the stable agent-contract selector. The selector itself is
+shipped by the CLI runtime; per-command behavior is adopted incrementally.
 
-- emits its declared `output_mode` only
-- never writes color, progress bars, or interactive prompts to stdout
-- wraps parse and usage failures in an error envelope, and wraps help/version
-  output in a success envelope (instead of plain text on stderr/stdout)
+The runtime guarantees today, regardless of which command is invoked:
+
+- color is disabled (`ColorChoice::Never`)
+- parse and usage failures are wrapped in an error envelope
+  (`cli.usage.invalid`, exit `2`)
+- `--help` / `--version` are wrapped in a success envelope (exit `0`)
+
+The per-command guarantees a command opts into, once adopted, are:
+
+- emits its declared `output_mode` only on stdout
+- suppresses progress bars and interactive prompts
 - maps process-exit failures to the canonical `ExitCode` enum
 
 Agents may also rely on `--introspect` for discovery and on the existing


### PR DESCRIPTION
Stacked on #14770. Adds the runtime substrate the agent contract executes against.

## What this adds

- `--machine` global flag — the agent-contract opt-in. Pre-parse detected (via a shared `pre_parse_flag_present` scanner that handles `--`, subcommand boundary, value-taking globals, and non-UTF-8 argv). Forces no color. Mutually exclusive with `--json` and `--md`.
- `ExitCode` enum matching `docs/agents/exit-codes.md` (9 variants), with a conservative `From<eyre::Report>` heuristic.
- `DiagnosticCode` newtype + per-domain `&'static str` constants colocated by domain (`cli`, `config`, `compiler`, `network`, `wallet`, `test`, `script`, `cast`, `anvil`, `chisel`).
- Structured JSON envelopes for clap parse / usage / version / help under `--machine`. Subcommand `--help` preserves its own context (e.g. `cast call --machine --help` returns cast-call help, not root). Global runtime payload schemas `foundry:cli.help@v1` / `foundry:cli.version@v1` documented in `docs/agents/spec.md` §10.
- Hardened `capability_violations` static check — per-mode schema-ref rules (envelope/stream/session), `foundry:<stem>@vN` format, and stem-equality (`result` = `command_id`, `event` = `command_id.event`, `session` = `command_id.session`). Run per-binary in CI.
- Adopts canonical exit codes for `forge test` failure (`5`) and `anvil` Ctrl-C (`8`) — both gated on `--machine`. Legacy invocations remain `exit 1` and `exit 0`.

No command emits envelope/stream/session output yet — per-command adoption lands in follow-up PRs.

## Backward compatibility

Strictly additive. `main.rs` files unchanged. `--json` semantics unchanged. Every behavior change is gated on `--machine`.

## Manual sanity

- `forge --machine --version` → success envelope, exit `0`
- `forge --machine bogus` → error envelope with `cli.usage.invalid`, exit `2`
- `forge --machine --help` → success envelope wrapping help text, exit `0`
- `forge --json --machine build` → ArgumentConflict envelope, exit `2`
- `forge --version`, `forge bogus`, `forge test`: legacy paths unchanged

Part of OSS-218