### PR TITLE
fix(chisel): display dynamic bytes memory layout

### DIFF
--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -312,29 +312,18 @@ fn format_token(token: DynSolValue) -> String {
         DynSolValue::Bool(b) => {
             format!("Type: {}\n└ Value: {}", "bool".red(), b.cyan())
         }
-        DynSolValue::String(_) | DynSolValue::Bytes(_) => {
-            let hex = hex::encode(token.abi_encode());
-            let s = token.as_str();
-            format!(
-                "Type: {}\n{}├ Hex (Memory):\n├─ Length ({}): {}\n├─ Contents ({}): {}\n├ Hex (Tuple Encoded):\n├─ Pointer ({}): {}\n├─ Length ({}): {}\n└─ Contents ({}): {}",
-                if s.is_some() { "string" } else { "dynamic bytes" }.red(),
-                if let Some(s) = s {
-                    format!("├ UTF-8: {}\n", s.cyan())
-                } else {
-                    String::default()
-                },
-                "[0x00:0x20]".yellow(),
-                format!("0x{}", &hex[64..128]).cyan(),
-                "[0x20:..]".yellow(),
-                format!("0x{}", &hex[128..]).cyan(),
-                "[0x00:0x20]".yellow(),
-                format!("0x{}", &hex[..64]).cyan(),
-                "[0x20:0x40]".yellow(),
-                format!("0x{}", &hex[64..128]).cyan(),
-                "[0x40:..]".yellow(),
-                format!("0x{}", &hex[128..]).cyan(),
-            )
-        }
+        DynSolValue::String(s) => format_dynamic_token(
+            "string",
+            Some(&s),
+            s.as_bytes(),
+            DynSolValue::String(s.clone()).abi_encode(),
+        ),
+        DynSolValue::Bytes(bytes) => format_dynamic_token(
+            "dynamic bytes",
+            None,
+            &bytes,
+            DynSolValue::Bytes(bytes.clone()).abi_encode(),
+        ),
         DynSolValue::FixedArray(tokens) | DynSolValue::Array(tokens) => {
             let mut out = format!(
                 "{}({}) = {}",
@@ -370,6 +359,35 @@ fn format_token(token: DynSolValue) -> String {
             unimplemented!()
         }
     }
+}
+
+fn format_dynamic_token(
+    kind: &str,
+    utf8: Option<&str>,
+    contents: &[u8],
+    tuple_encoded: Vec<u8>,
+) -> String {
+    let length_hex = hex::encode(U256::from(contents.len()).to_be_bytes::<32>());
+    let mut memory_contents = contents.to_vec();
+    memory_contents.resize(contents.len().next_multiple_of(32), 0);
+    let memory_contents_hex = hex::encode(memory_contents);
+    let tuple_encoded_hex = hex::encode(tuple_encoded);
+
+    format!(
+        "Type: {}\n{}├ Hex (Memory):\n├─ Length ({}): {}\n├─ Contents ({}): {}\n├ Hex (Tuple Encoded):\n├─ Pointer ({}): {}\n├─ Length ({}): {}\n└─ Contents ({}): {}",
+        kind.red(),
+        if let Some(s) = utf8 { format!("├ UTF-8: {}\n", s.cyan()) } else { String::default() },
+        "[0x00:0x20]".yellow(),
+        format!("0x{length_hex}").cyan(),
+        "[0x20:..]".yellow(),
+        format!("0x{memory_contents_hex}").cyan(),
+        "[0x00:0x20]".yellow(),
+        format!("0x{}", &tuple_encoded_hex[..64]).cyan(),
+        "[0x20:0x40]".yellow(),
+        format!("0x{}", &tuple_encoded_hex[64..128]).cyan(),
+        "[0x40:..]".yellow(),
+        format!("0x{}", &tuple_encoded_hex[128..]).cyan(),
+    )
 }
 
 /// Formats an [`Event`] into an inspection message.

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -312,18 +312,8 @@ fn format_token(token: DynSolValue) -> String {
         DynSolValue::Bool(b) => {
             format!("Type: {}\n└ Value: {}", "bool".red(), b.cyan())
         }
-        DynSolValue::String(s) => format_dynamic_token(
-            "string",
-            Some(&s),
-            s.as_bytes(),
-            DynSolValue::String(s.clone()).abi_encode(),
-        ),
-        DynSolValue::Bytes(bytes) => format_dynamic_token(
-            "dynamic bytes",
-            None,
-            &bytes,
-            DynSolValue::Bytes(bytes.clone()).abi_encode(),
-        ),
+        DynSolValue::String(s) => format_dynamic_token("string", Some(&s), s.as_bytes()),
+        DynSolValue::Bytes(bytes) => format_dynamic_token("dynamic bytes", None, &bytes),
         DynSolValue::FixedArray(tokens) | DynSolValue::Array(tokens) => {
             let mut out = format!(
                 "{}({}) = {}",
@@ -361,17 +351,12 @@ fn format_token(token: DynSolValue) -> String {
     }
 }
 
-fn format_dynamic_token(
-    kind: &str,
-    utf8: Option<&str>,
-    contents: &[u8],
-    tuple_encoded: Vec<u8>,
-) -> String {
+fn format_dynamic_token(kind: &str, utf8: Option<&str>, contents: &[u8]) -> String {
+    let pointer_hex = hex::encode(U256::from(32).to_be_bytes::<32>());
     let length_hex = hex::encode(U256::from(contents.len()).to_be_bytes::<32>());
     let mut memory_contents = contents.to_vec();
     memory_contents.resize(contents.len().next_multiple_of(32), 0);
     let memory_contents_hex = hex::encode(memory_contents);
-    let tuple_encoded_hex = hex::encode(tuple_encoded);
 
     format!(
         "Type: {}\n{}├ Hex (Memory):\n├─ Length ({}): {}\n├─ Contents ({}): {}\n├ Hex (Tuple Encoded):\n├─ Pointer ({}): {}\n├─ Length ({}): {}\n└─ Contents ({}): {}",
@@ -382,11 +367,11 @@ fn format_dynamic_token(
         "[0x20:..]".yellow(),
         format!("0x{memory_contents_hex}").cyan(),
         "[0x00:0x20]".yellow(),
-        format!("0x{}", &tuple_encoded_hex[..64]).cyan(),
+        format!("0x{pointer_hex}").cyan(),
         "[0x20:0x40]".yellow(),
-        format!("0x{}", &tuple_encoded_hex[64..128]).cyan(),
+        format!("0x{length_hex}").cyan(),
         "[0x40:..]".yellow(),
-        format!("0x{}", &tuple_encoded_hex[128..]).cyan(),
+        format!("0x{memory_contents_hex}").cyan(),
     )
 }
 

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -40,6 +40,13 @@ repl_test!(abi_encoded_bytes_memory_display, |repl| {
     repl.sendln(r#"bytes memory revertStringOne = abi.encode("Not initialized")"#);
     repl.sendln("bytes memory decoded = abi.decode(revertStringOne, (bytes))");
     repl.sendln(r#"bytes memory revertStringTwo = bytes("Not initialized")"#);
+    repl.sendln("bytes memory emptyBytes = hex\"\"");
+    repl.sendln(
+        "bytes memory exactWord = hex\"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20\"",
+    );
+    repl.sendln(
+        "bytes memory overWord = hex\"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f2021\"",
+    );
 
     repl.sendln("decoded");
     repl.expect(
@@ -55,6 +62,28 @@ repl_test!(abi_encoded_bytes_memory_display, |repl| {
     );
     repl.expect(
         "Contents ([0x20:..]): 0x4e6f7420696e697469616c697a65640000000000000000000000000000000000",
+    );
+
+    repl.sendln("emptyBytes");
+    repl.expect(
+        "Length ([0x00:0x20]): 0x0000000000000000000000000000000000000000000000000000000000000000",
+    );
+    repl.expect("Contents ([0x20:..]): 0x");
+
+    repl.sendln("exactWord");
+    repl.expect(
+        "Length ([0x00:0x20]): 0x0000000000000000000000000000000000000000000000000000000000000020",
+    );
+    repl.expect(
+        "Contents ([0x20:..]): 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+    );
+
+    repl.sendln("overWord");
+    repl.expect(
+        "Length ([0x00:0x20]): 0x0000000000000000000000000000000000000000000000000000000000000021",
+    );
+    repl.expect(
+        "Contents ([0x20:..]): 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202100000000000000000000000000000000000000000000000000000000000000",
     );
 });
 

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -35,6 +35,29 @@ repl_test!(abi_encode_decode, |repl| {
     repl.expect("hello");
 });
 
+// Issue #5253: ABI-encoded bytes should be displayed with their actual memory layout.
+repl_test!(abi_encoded_bytes_memory_display, |repl| {
+    repl.sendln(r#"bytes memory revertStringOne = abi.encode("Not initialized")"#);
+    repl.sendln("bytes memory decoded = abi.decode(revertStringOne, (bytes))");
+    repl.sendln(r#"bytes memory revertStringTwo = bytes("Not initialized")"#);
+
+    repl.sendln("decoded");
+    repl.expect(
+        "Length ([0x00:0x20]): 0x000000000000000000000000000000000000000000000000000000000000000f",
+    );
+    repl.expect(
+        "Contents ([0x20:..]): 0x4e6f7420696e697469616c697a65640000000000000000000000000000000000",
+    );
+
+    repl.sendln("revertStringTwo");
+    repl.expect(
+        "Length ([0x00:0x20]): 0x000000000000000000000000000000000000000000000000000000000000000f",
+    );
+    repl.expect(
+        "Contents ([0x20:..]): 0x4e6f7420696e697469616c697a65640000000000000000000000000000000000",
+    );
+});
+
 // Test 0x prefixed strings.
 repl_test!(hex_string_interpretation, |repl| {
     repl.sendln("string memory s = \"0x1234\"");


### PR DESCRIPTION
## Summary
- derive dynamic bytes/string memory display from the decoded value instead of slicing tuple ABI encoding
- keep tuple-encoded output as a separate section
- add a Chisel regression test for #5253

Closes #5253

## Testing
- cargo fmt --check
- git diff --check
- cargo test -p chisel abi_encoded_bytes_memory_display --test it -- --nocapture *(blocked locally: dependency fetch for ethereum-optimism/optimism failed with `No space left on device`; disk had only ~32MiB free before cleanup)*