### PR TITLE
fix(anvil): preserve network detected from chain id

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -638,7 +638,7 @@ impl NodeConfig {
     pub fn set_chain_id(&mut self, chain_id: Option<impl Into<u64>>) {
         self.chain_id = chain_id.map(Into::into);
         let chain_id = self.get_chain_id();
-        self.networks.with_chain_id(chain_id);
+        self.networks = self.networks.with_chain_id(chain_id);
         self.genesis_accounts.iter_mut().for_each(|wallet| {
             *wallet = wallet.clone().with_chain_id(Some(chain_id));
         });
@@ -1773,5 +1773,14 @@ mod tests {
         assert!(!config.is_state_history_supported());
         let config = PruneStateHistoryConfig::from_args(Some(Some(10)));
         assert!(config.is_state_history_supported());
+    }
+
+    #[cfg(feature = "optimism")]
+    #[test]
+    fn set_chain_id_updates_network_config() {
+        let mut config = NodeConfig::test();
+        config.set_chain_id(Some(10u64));
+
+        assert!(config.networks.is_optimism());
     }
 }


### PR DESCRIPTION
## Motivation

`NodeConfig::set_chain_id` calls `NetworkConfigs::with_chain_id()` so Anvil can infer network-specific configuration from known chain IDs. The returned `NetworkConfigs` value was ignored, so chain IDs such as Optimism mainnet did not update the node config's active network.

## Solution

Store the inferred `NetworkConfigs` value back on `NodeConfig` when the chain ID changes. Add coverage for the Optimism chain ID path so the config-level inference is preserved.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes