### PR TITLE
feat(cli): adopt envelope output for forge build and cast call

### DIFF
--- a/crates/anvil/bin/main.rs
+++ b/crates/anvil/bin/main.rs
@@ -7,6 +7,10 @@ static ALLOC: foundry_cli::utils::Allocator = foundry_cli::utils::new_allocator(
 
 fn main() {
     if let Err(err) = run() {
+        if foundry_cli::is_machine() {
+            foundry_cli::machine::report_machine_error(&err);
+            std::process::exit(foundry_cli::ExitCode::GenericError.to_i32());
+        }
         let _ = foundry_common::sh_err!("{err:?}");
         std::process::exit(1);
     }

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -9,6 +9,10 @@ static ALLOC: foundry_cli::utils::Allocator = foundry_cli::utils::new_allocator(
 
 fn main() {
     if let Err(err) = run() {
+        if foundry_cli::is_machine() {
+            foundry_cli::machine::report_machine_error(&err);
+            std::process::exit(foundry_cli::ExitCode::GenericError.to_i32());
+        }
         if foundry_common::shell::is_json() {
             // Collect the full error chain into structured error entries.
             let errors = err

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -43,7 +43,7 @@ pub fn run() -> Result<()> {
     // Pre-parse discovery flags run before `setup()` so they cannot be blocked
     // by panic-handler / tracing init failures and avoid that init's cost.
     foundry_cli::machine::check_machine();
-    foundry_cli::opts::GlobalArgs::check_introspect_with(CastArgs::command(), &REGISTRY);
+    foundry_cli::opts::GlobalArgs::check_introspect_with(CastArgs::command, &REGISTRY);
     foundry_cli::opts::GlobalArgs::check_markdown_help::<CastArgs>();
 
     setup()?;

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -1,6 +1,7 @@
 use crate::{
     Cast, SimpleCast,
     cmd::erc20::IERC20,
+    introspect::REGISTRY,
     opts::{Cast as CastArgs, CastSubcommand, ToBaseArgs},
     traces::identifier::SignaturesIdentifier,
     tx::CastTxSender,
@@ -42,7 +43,7 @@ pub fn run() -> Result<()> {
     // Pre-parse discovery flags run before `setup()` so they cannot be blocked
     // by panic-handler / tracing init failures and avoid that init's cost.
     foundry_cli::machine::check_machine();
-    foundry_cli::opts::GlobalArgs::check_introspect::<CastArgs>();
+    foundry_cli::opts::GlobalArgs::check_introspect_with(CastArgs::command(), &REGISTRY);
     foundry_cli::opts::GlobalArgs::check_markdown_help::<CastArgs>();
 
     setup()?;
@@ -944,7 +945,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
 mod tests {
     use super::*;
     use foundry_cli::introspect::{
-        CommandRegistry, INTROSPECT_SCHEMA_ID, IntrospectDocument, build_document,
+        CommandRegistry, INTROSPECT_SCHEMA_ID, IntrospectDocument, OutputMode, build_document,
         capability_violations, duplicate_command_ids, render_introspect_document,
     };
 
@@ -962,7 +963,7 @@ mod tests {
             .stack_size(16 * 1024 * 1024)
             .spawn(|| {
                 let cmd = CastArgs::command();
-                let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+                let doc = build_document(&cmd, &REGISTRY);
                 duplicate_command_ids(&doc)
             })
             .expect("spawn worker thread")
@@ -999,12 +1000,42 @@ mod tests {
             .stack_size(16 * 1024 * 1024)
             .spawn(|| {
                 let cmd = CastArgs::command();
-                let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+                let doc = build_document(&cmd, &REGISTRY);
                 capability_violations(&doc)
             })
             .expect("spawn worker thread")
             .join()
             .expect("worker thread join");
         assert!(v.is_empty(), "cast capability violations: {v:?}");
+    }
+
+    /// Every adopted command (`output_mode = Envelope`) must pin a stable
+    /// `command_id` matching its registry entry.
+    #[test]
+    fn registered_commands_pin_stable_ids() {
+        let ids = std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let cmd = <CastArgs as clap::CommandFactory>::command();
+                let doc = build_document(&cmd, &REGISTRY);
+                fn walk(c: &foundry_cli::introspect::CommandInfo) -> Vec<String> {
+                    let mut out = Vec::new();
+                    if matches!(c.capabilities.output_mode, OutputMode::Envelope) {
+                        out.push(c.command_id.clone());
+                    }
+                    for sub in &c.subcommands {
+                        out.extend(walk(sub));
+                    }
+                    out
+                }
+                doc.commands.iter().flat_map(walk).collect::<Vec<_>>()
+            })
+            .expect("spawn worker thread")
+            .join()
+            .expect("worker thread join");
+        assert!(
+            ids.iter().any(|s| s == "cast.call"),
+            "cast.call missing from envelope ids: {ids:?}"
+        );
     }
 }

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -59,7 +59,7 @@ pub struct CallData {
 }
 
 /// Emit a typed `network.rpc.error` envelope and exit `Network (6)`.
-fn rpc_failure(err: &eyre::Report) -> Result<()> {
+fn rpc_failure(err: &eyre::Report) -> ! {
     let cause_chain: Vec<String> = err.chain().map(ToString::to_string).collect();
     let message = cause_chain.first().cloned().unwrap_or_else(|| err.to_string());
     let envelope = JsonEnvelope::error(
@@ -243,12 +243,19 @@ impl CallArgs {
     pub async fn run(self) -> Result<()> {
         // Reject flags whose stdout shape or interactivity conflicts with the envelope contract.
         if foundry_cli::is_machine() {
+            // `--interactive` and the hardware / cloud signer flags can trigger TTY prompts,
+            // hardware confirmations, or SDK auth output (e.g. AWS SSO device-auth URLs printed
+            // directly to stdout), all of which would corrupt the envelope.
             let unsupported = [
                 ("--trace", self.trace),
                 ("--debug", self.debug),
                 ("--decode-internal", self.decode_internal),
                 ("--curl", self.rpc.curl),
                 ("--interactive", self.wallet.raw.interactive),
+                ("--ledger", self.wallet.ledger),
+                ("--trezor", self.wallet.trezor),
+                ("--aws", self.wallet.aws),
+                ("--gcp", self.wallet.gcp),
             ]
             .into_iter()
             .filter_map(|(name, on)| on.then_some(name))
@@ -259,6 +266,18 @@ impl CallArgs {
                      run without `--machine` or omit those flags.",
                     unsupported.join(", ")
                 ));
+            }
+            // Unlocked keystore: prompts for the password on TTY at signer construction.
+            let has_keystore =
+                self.wallet.keystore_path.is_some() || self.wallet.keystore_account_name.is_some();
+            let has_password = self.wallet.keystore_password.is_some()
+                || self.wallet.keystore_password_file.is_some();
+            if has_keystore && !has_password {
+                foundry_cli::machine::bail_machine_usage(
+                    "`cast call --machine` requires `--password` or `--password-file` when \
+                     `--keystore` / `--account` is set; an unlocked keystore would prompt on \
+                     stdin and corrupt the envelope.",
+                );
             }
         }
 
@@ -325,11 +344,11 @@ impl CallArgs {
 
         // Provider construction (transport setup) is a network operation, so connection /
         // DNS / TCP failures here are typed `network.rpc.error` under `--machine`.
-        let machine_mode_provider = foundry_cli::is_machine();
+        let machine_mode = foundry_cli::is_machine();
         let provider =
             match ProviderBuilder::<FEN::Network>::from_config(&config).and_then(|b| b.build()) {
                 Ok(p) => p,
-                Err(err) if machine_mode_provider => return rpc_failure(&err),
+                Err(err) if machine_mode => rpc_failure(&err),
                 Err(err) => return Err(err),
             };
         let sender = SenderKind::from_wallet_opts(wallet).await?;
@@ -368,7 +387,7 @@ impl CallArgs {
         .await;
         let (tx, func) = match builder_result {
             Ok(v) => v,
-            Err(err) if machine_mode_provider => return rpc_failure(&err),
+            Err(err) if machine_mode => rpc_failure(&err),
             Err(err) => return Err(err),
         };
 
@@ -486,14 +505,13 @@ impl CallArgs {
 
         // Bypass the ABI decoder under `--machine`; the envelope carries raw hex only.
         // Only the eth_call itself maps to `network.rpc.error`; setup/local errors fall through.
-        let machine_mode = foundry_cli::is_machine();
         let decode_func = (!machine_mode).then_some(func.as_ref()).flatten();
         let response = match Cast::new(&provider)
             .call(&tx, decode_func, block, state_overrides, block_overrides)
             .await
         {
             Ok(r) => r,
-            Err(err) if machine_mode => return rpc_failure(&err),
+            Err(err) if machine_mode => rpc_failure(&err),
             Err(err) => return Err(err),
         };
 

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -266,18 +266,6 @@ impl CallArgs {
             return self.run_curl().await;
         }
 
-        // Under `--machine`, any failure past the flag-rejection check is an RPC
-        // interaction failure for `cast call@v1`. Funnel through one typed envelope.
-        let machine_mode = foundry_cli::is_machine();
-        let result = self.run_dispatch().await;
-        match result {
-            Ok(()) => Ok(()),
-            Err(err) if machine_mode => rpc_failure(&err),
-            Err(err) => Err(err),
-        }
-    }
-
-    async fn run_dispatch(self) -> Result<()> {
         if self.tx.tempo.is_tempo() {
             return self.run_with_network::<TempoEvmNetwork>().await;
         }
@@ -478,17 +466,25 @@ impl CallArgs {
         }
 
         // Bypass the ABI decoder under `--machine`; the envelope carries raw hex only.
+        // Only the eth_call itself maps to `network.rpc.error`; setup/local errors fall through.
         let machine_mode = foundry_cli::is_machine();
         let decode_func = (!machine_mode).then_some(func.as_ref()).flatten();
-        let response = Cast::new(&provider)
+        let response = match Cast::new(&provider)
             .call(&tx, decode_func, block, state_overrides, block_overrides)
-            .await?;
+            .await
+        {
+            Ok(r) => r,
+            Err(err) if machine_mode => return rpc_failure(&err),
+            Err(err) => return Err(err),
+        };
 
-        if response == "0x"
+        // Skip the empty-code lookup under `--machine`: it exists only for the human warning.
+        if !machine_mode
+            && response == "0x"
             && let Some(contract_address) = tx.to()
         {
             let code = provider.get_code_at(contract_address).await?;
-            if !machine_mode && code.is_empty() {
+            if code.is_empty() {
                 sh_warn!("Contract code is empty")?;
             }
         }

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -16,7 +16,8 @@ use alloy_rpc_types::{
 use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
-    json::{JsonEnvelope, print_json},
+    ExitCode, diagnostic,
+    json::{JsonEnvelope, JsonMessage, print_json},
     opts::{ChainValueParser, RpcOpts, TransactionOpts},
     utils::{LoadConfig, TraceResult, parse_ether_value},
 };
@@ -53,10 +54,20 @@ use std::{str::FromStr, sync::LazyLock};
 /// Stable payload emitted in the `cast call` envelope under `--machine`.
 #[derive(Clone, Debug, Serialize)]
 pub struct CallData {
-    /// Display string for the call's return value: raw hex when no
-    /// signature was supplied, otherwise the decoded value formatted as
-    /// `cast` would print it. Opaque-by-design at `@v1`.
-    pub result: String,
+    /// Raw `0x`-prefixed hex return data from `eth_call`.
+    pub raw: String,
+}
+
+/// Emit a typed `network.rpc.error` envelope and exit `Network (6)`.
+fn rpc_failure(err: &eyre::Report) -> Result<()> {
+    let cause_chain: Vec<String> = err.chain().map(ToString::to_string).collect();
+    let message = cause_chain.first().cloned().unwrap_or_else(|| err.to_string());
+    let envelope = JsonEnvelope::error(
+        JsonMessage::error(diagnostic::network::RPC_ERROR, message)
+            .with_details(serde_json::json!({ "cause_chain": cause_chain })),
+    );
+    let _ = print_json(&envelope);
+    std::process::exit(ExitCode::Network.to_i32());
 }
 
 // matches override pattern <address>:<slot>:<value>
@@ -254,6 +265,19 @@ impl CallArgs {
         if self.rpc.curl {
             return self.run_curl().await;
         }
+
+        // Under `--machine`, any failure past the flag-rejection check is an RPC
+        // interaction failure for `cast call@v1`. Funnel through one typed envelope.
+        let machine_mode = foundry_cli::is_machine();
+        let result = self.run_dispatch().await;
+        match result {
+            Ok(()) => Ok(()),
+            Err(err) if machine_mode => rpc_failure(&err),
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn run_dispatch(self) -> Result<()> {
         if self.tx.tempo.is_tempo() {
             return self.run_with_network::<TempoEvmNetwork>().await;
         }
@@ -453,21 +477,24 @@ impl CallArgs {
             return Ok(());
         }
 
+        // Bypass the ABI decoder under `--machine`; the envelope carries raw hex only.
+        let machine_mode = foundry_cli::is_machine();
+        let decode_func = (!machine_mode).then_some(func.as_ref()).flatten();
         let response = Cast::new(&provider)
-            .call(&tx, func.as_ref(), block, state_overrides, block_overrides)
+            .call(&tx, decode_func, block, state_overrides, block_overrides)
             .await?;
 
         if response == "0x"
             && let Some(contract_address) = tx.to()
         {
             let code = provider.get_code_at(contract_address).await?;
-            if code.is_empty() {
+            if !machine_mode && code.is_empty() {
                 sh_warn!("Contract code is empty")?;
             }
         }
 
-        if foundry_cli::is_machine() {
-            print_json(&JsonEnvelope::success(CallData { result: response }))?;
+        if machine_mode {
+            print_json(&JsonEnvelope::success(CallData { raw: response }))?;
         } else {
             sh_println!("{}", response)?;
         }

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -270,13 +270,13 @@ impl CallArgs {
             // Unlocked keystore: prompts for the password on TTY at signer construction.
             let has_keystore =
                 self.wallet.keystore_path.is_some() || self.wallet.keystore_account_name.is_some();
-            let has_password = self.wallet.keystore_password.is_some()
+            let has_noninteractive_password = self.wallet.keystore_password.is_some()
                 || self.wallet.keystore_password_file.is_some();
-            if has_keystore && !has_password {
+            if has_keystore && !has_noninteractive_password {
                 foundry_cli::machine::bail_machine_usage(
-                    "`cast call --machine` requires `--password` or `--password-file` when \
-                     `--keystore` / `--account` is set; an unlocked keystore would prompt on \
-                     stdin and corrupt the envelope.",
+                    "`cast call --machine` requires `--password`, `--password-file`, or the \
+                     `ETH_PASSWORD` env var when `--keystore` / `--account` is set; an unlocked \
+                     keystore would prompt on stdin and corrupt the envelope.",
                 );
             }
         }

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -241,13 +241,14 @@ pub enum CallSubcommands {
 
 impl CallArgs {
     pub async fn run(self) -> Result<()> {
-        // Reject flags whose stdout shape conflicts with the envelope contract.
+        // Reject flags whose stdout shape or interactivity conflicts with the envelope contract.
         if foundry_cli::is_machine() {
             let unsupported = [
                 ("--trace", self.trace),
                 ("--debug", self.debug),
                 ("--decode-internal", self.decode_internal),
                 ("--curl", self.rpc.curl),
+                ("--interactive", self.wallet.raw.interactive),
             ]
             .into_iter()
             .filter_map(|(name, on)| on.then_some(name))
@@ -322,7 +323,15 @@ impl CallArgs {
             sig = Some(data);
         }
 
-        let provider = ProviderBuilder::<FEN::Network>::from_config(&config)?.build()?;
+        // Provider construction (transport setup) is a network operation, so connection /
+        // DNS / TCP failures here are typed `network.rpc.error` under `--machine`.
+        let machine_mode_provider = foundry_cli::is_machine();
+        let provider =
+            match ProviderBuilder::<FEN::Network>::from_config(&config).and_then(|b| b.build()) {
+                Ok(p) => p,
+                Err(err) if machine_mode_provider => return rpc_failure(&err),
+                Err(err) => return Err(err),
+            };
         let sender = SenderKind::from_wallet_opts(wallet).await?;
         let from = sender.address();
 
@@ -343,15 +352,25 @@ impl CallArgs {
             None
         };
 
-        let (tx, func) = CastTxBuilder::new(&provider, tx, &config)
-            .await?
-            .with_to(to)
-            .await?
-            .with_code_sig_and_args(code, sig, args)
-            .await?
-            .raw()
-            .build(sender)
-            .await?;
+        // `CastTxBuilder` performs the first RPC pings (chain_id, gas estimation, ENS
+        // resolution); transport/connectivity failures here are typed `network.rpc.error`.
+        let builder_result: Result<_> = async {
+            CastTxBuilder::new(&provider, tx, &config)
+                .await?
+                .with_to(to)
+                .await?
+                .with_code_sig_and_args(code, sig, args)
+                .await?
+                .raw()
+                .build(sender)
+                .await
+        }
+        .await;
+        let (tx, func) = match builder_result {
+            Ok(v) => v,
+            Err(err) if machine_mode_provider => return rpc_failure(&err),
+            Err(err) => return Err(err),
+        };
 
         if trace {
             if let Some(BlockId::Number(BlockNumberOrTag::Number(block_number))) = self.block {

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -16,6 +16,7 @@ use alloy_rpc_types::{
 use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
+    json::{JsonEnvelope, print_json},
     opts::{ChainValueParser, RpcOpts, TransactionOpts},
     utils::{LoadConfig, TraceResult, parse_ether_value},
 };
@@ -46,7 +47,17 @@ use foundry_evm::{
 };
 use foundry_wallets::WalletOpts;
 use regex::Regex;
+use serde::Serialize;
 use std::{str::FromStr, sync::LazyLock};
+
+/// Stable payload emitted in the `cast call` envelope under `--machine`.
+#[derive(Clone, Debug, Serialize)]
+pub struct CallData {
+    /// Display string for the call's return value: raw hex when no
+    /// signature was supplied, otherwise the decoded value formatted as
+    /// `cast` would print it. Opaque-by-design at `@v1`.
+    pub result: String,
+}
 
 // matches override pattern <address>:<slot>:<value>
 // e.g. 0x123:0x1:0x1234
@@ -219,6 +230,26 @@ pub enum CallSubcommands {
 
 impl CallArgs {
     pub async fn run(self) -> Result<()> {
+        // Reject flags whose stdout shape conflicts with the envelope contract.
+        if foundry_cli::is_machine() {
+            let unsupported = [
+                ("--trace", self.trace),
+                ("--debug", self.debug),
+                ("--decode-internal", self.decode_internal),
+                ("--curl", self.rpc.curl),
+            ]
+            .into_iter()
+            .filter_map(|(name, on)| on.then_some(name))
+            .collect::<Vec<_>>();
+            if !unsupported.is_empty() {
+                foundry_cli::machine::bail_machine_usage(format!(
+                    "`cast call` under `--machine` does not yet support {}; \
+                     run without `--machine` or omit those flags.",
+                    unsupported.join(", ")
+                ));
+            }
+        }
+
         // Handle --curl mode early, before any provider interaction
         if self.rpc.curl {
             return self.run_curl().await;
@@ -434,7 +465,12 @@ impl CallArgs {
                 sh_warn!("Contract code is empty")?;
             }
         }
-        sh_println!("{}", response)?;
+
+        if foundry_cli::is_machine() {
+            print_json(&JsonEnvelope::success(CallData { result: response }))?;
+        } else {
+            sh_println!("{}", response)?;
+        }
 
         Ok(())
     }

--- a/crates/cast/src/diagnostic.rs
+++ b/crates/cast/src/diagnostic.rs
@@ -6,9 +6,9 @@
 
 /// Diagnostic codes for read-only RPC commands like `cast call`, `cast tx`.
 pub mod rpc {
-    pub use foundry_cli::diagnostic::network::{RPC_TIMEOUT, RPC_UNAUTHORIZED};
+    pub use foundry_cli::diagnostic::network::{RPC_ERROR, RPC_TIMEOUT, RPC_UNAUTHORIZED};
 
-    pub(crate) const ALL: &[&str] = &[RPC_TIMEOUT, RPC_UNAUTHORIZED];
+    pub(crate) const ALL: &[&str] = &[RPC_ERROR, RPC_TIMEOUT, RPC_UNAUTHORIZED];
 }
 
 /// All diagnostic codes declared by `cast`.

--- a/crates/cast/src/diagnostic.rs
+++ b/crates/cast/src/diagnostic.rs
@@ -1,0 +1,31 @@
+//! Stable, machine-readable diagnostic codes emitted by `cast`.
+//!
+//! See [`docs/agents/diagnostics.md`](../../../docs/agents/diagnostics.md)
+//! for the format and registry rules. Most codes re-export per-domain
+//! constants from [`foundry_cli::diagnostic`].
+
+/// Diagnostic codes for read-only RPC commands like `cast call`, `cast tx`.
+pub mod rpc {
+    pub use foundry_cli::diagnostic::network::{RPC_TIMEOUT, RPC_UNAUTHORIZED};
+
+    pub(crate) const ALL: &[&str] = &[RPC_TIMEOUT, RPC_UNAUTHORIZED];
+}
+
+/// All diagnostic codes declared by `cast`.
+pub fn known_codes() -> Vec<&'static str> {
+    let groups: &[&[&str]] = &[rpc::ALL];
+    groups.iter().flat_map(|g| g.iter().copied()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use foundry_cli::diagnostic::validate;
+
+    #[test]
+    fn every_known_code_validates() {
+        for c in known_codes() {
+            assert!(validate(c).is_ok(), "registered code `{c}` failed validation");
+        }
+    }
+}

--- a/crates/cast/src/introspect.rs
+++ b/crates/cast/src/introspect.rs
@@ -3,13 +3,54 @@
 //! See [`docs/agents/spec.md`](../../../docs/agents/spec.md). The registry
 //! pins `command_id`s and machine-mode capabilities for adopted commands.
 
-use foundry_cli::introspect::{
-    Capabilities, CommandMeta, CommandRegistry, OutputMode, RegistryEntry, SideEffects,
+use foundry_cli::{
+    ExitCode,
+    introspect::{
+        Capabilities, CommandMeta, CommandRegistry, ExitCodeInfo, OutputMode, RegistryEntry,
+        SideEffects,
+    },
 };
 use std::borrow::Cow;
 
 /// Stable schema id for the `cast call` envelope payload.
 pub const CALL_RESULT_SCHEMA: &str = "foundry:cast.call@v1";
+
+/// Exit codes `cast call` may emit under `--machine`. Declared explicitly so
+/// agents don't have to assume "inherits global defaults"; codes not in this
+/// list are not produced by this command.
+static CALL_EXIT_CODES: &[ExitCodeInfo] = &[
+    ExitCodeInfo {
+        code: ExitCode::Success.to_i32(),
+        name: Cow::Borrowed(ExitCode::Success.name()),
+        description: Cow::Borrowed("Call succeeded; envelope `success: true` with raw hex."),
+    },
+    ExitCodeInfo {
+        code: ExitCode::GenericError.to_i32(),
+        name: Cow::Borrowed(ExitCode::GenericError.name()),
+        description: Cow::Borrowed(
+            "Unclassified failure outside the typed paths (envelope `cli.unknown`).",
+        ),
+    },
+    ExitCodeInfo {
+        code: ExitCode::Usage.to_i32(),
+        name: Cow::Borrowed(ExitCode::Usage.name()),
+        description: Cow::Borrowed(
+            "Flag combination rejected under `--machine` (envelope `cli.usage.invalid`).",
+        ),
+    },
+    ExitCodeInfo {
+        code: ExitCode::Network.to_i32(),
+        name: Cow::Borrowed(ExitCode::Network.name()),
+        description: Cow::Borrowed(
+            "Provider construction or `eth_call` failed (envelope `network.rpc.error`).",
+        ),
+    },
+    ExitCodeInfo {
+        code: ExitCode::User.to_i32(),
+        name: Cow::Borrowed(ExitCode::User.name()),
+        description: Cow::Borrowed("Wallet / keystore resolution failed in non-interactive setup."),
+    },
+];
 
 static ENTRIES: &[RegistryEntry] = &[RegistryEntry {
     path: &["call"],
@@ -28,7 +69,7 @@ static ENTRIES: &[RegistryEntry] = &[RegistryEntry {
             stateful: false,
         },
         capabilities_declared: true,
-        exit_codes: &[],
+        exit_codes: CALL_EXIT_CODES,
     },
 }];
 

--- a/crates/cast/src/introspect.rs
+++ b/crates/cast/src/introspect.rs
@@ -1,0 +1,37 @@
+//! Stable, agent-facing metadata for the `cast` command tree.
+//!
+//! See [`docs/agents/spec.md`](../../../docs/agents/spec.md). The registry
+//! pins `command_id`s and machine-mode capabilities for adopted commands.
+
+use foundry_cli::introspect::{
+    Capabilities, CommandMeta, CommandRegistry, OutputMode, RegistryEntry, SideEffects,
+};
+use std::borrow::Cow;
+
+/// Stable schema id for the `cast call` envelope payload.
+pub const CALL_RESULT_SCHEMA: &str = "foundry:cast.call@v1";
+
+static ENTRIES: &[RegistryEntry] = &[RegistryEntry {
+    path: &["call"],
+    meta: CommandMeta {
+        command_id: Some("cast.call"),
+        capabilities: Capabilities {
+            output_mode: OutputMode::Envelope,
+            result_schema_ref: Some(Cow::Borrowed(CALL_RESULT_SCHEMA)),
+            event_schema_ref: None,
+            session_schema_ref: None,
+            reads_stdin: false,
+            supports_output_path: false,
+            requires_project: false,
+            side_effects: SideEffects::Network,
+            long_running: false,
+            stateful: false,
+        },
+        capabilities_declared: true,
+        exit_codes: &[],
+    },
+}];
+
+/// The `cast` command registry. Used by `--introspect` and by adoption code
+/// that needs to look up command metadata.
+pub const REGISTRY: CommandRegistry = CommandRegistry::new(ENTRIES);

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -60,6 +60,8 @@ pub use foundry_evm::*;
 
 pub mod args;
 pub mod cmd;
+pub mod diagnostic;
+pub mod introspect;
 pub mod opts;
 pub mod tempo;
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3464,6 +3464,61 @@ forgetest_async!(cast_call_custom_chain_id, |_prj, cmd| {
         .assert_success();
 });
 
+// `cast --machine call` emits a single envelope on stdout against an
+// empty account, returning the deterministic `0x` result.
+forgetest_async!(cast_call_machine_mode_emits_envelope, |_prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let http_endpoint = handle.http_endpoint();
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "--machine",
+            "call",
+            "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+            "--rpc-url",
+            &http_endpoint,
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout is exactly one JSON envelope");
+
+    assert_eq!(envelope["schema_version"], 1);
+    assert_eq!(envelope["success"], true);
+    assert_eq!(envelope["data"]["result"], "0x");
+    assert_eq!(envelope["errors"], serde_json::json!([]));
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
+});
+
+// `--machine` rejects flags that would corrupt the envelope-only stdout
+// contract. Asserts the stable `code` + exit code, not just message text.
+forgetest_async!(cast_call_machine_mode_rejects_unsupported_flags, |_prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let http_endpoint = handle.http_endpoint();
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "--machine",
+            "call",
+            "--trace",
+            "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+            "--rpc-url",
+            &http_endpoint,
+        ])
+        .assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
+
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("--trace"), "missing --trace mention: {envelope}");
+});
+
 // https://github.com/foundry-rs/foundry/issues/10848
 forgetest_async!(cast_call_disable_labels, |prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test()).await;

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3519,9 +3519,9 @@ forgetest_async!(cast_call_machine_mode_rejects_unsupported_flags, |_prj, cmd| {
     assert!(msg.contains("--trace"), "missing --trace mention: {envelope}");
 });
 
-// Setup-time RPC failures fall through to the generic fallback; only the actual
-// `eth_call` is classified as `network.rpc.error`.
-forgetest_async!(cast_call_machine_mode_setup_failure_falls_through, |_prj, cmd| {
+// Transport/connectivity failures (here: unreachable RPC URL) emit a typed
+// `network.rpc.error` envelope and exit `Network (6)`.
+forgetest_async!(cast_call_machine_mode_rpc_failure_emits_network_envelope, |_prj, cmd| {
     let assert = cmd
         .cast_fuse()
         .args([
@@ -3538,8 +3538,8 @@ forgetest_async!(cast_call_machine_mode_setup_failure_falls_through, |_prj, cmd|
         serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
 
     assert_eq!(envelope["success"], false);
-    assert_eq!(envelope["errors"][0]["code"], "cli.unknown");
-    assert_eq!(assert.get_output().status.code(), Some(1));
+    assert_eq!(envelope["errors"][0]["code"], "network.rpc.error");
+    assert_eq!(assert.get_output().status.code(), Some(6));
 });
 
 // https://github.com/foundry-rs/foundry/issues/10848

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3519,8 +3519,9 @@ forgetest_async!(cast_call_machine_mode_rejects_unsupported_flags, |_prj, cmd| {
     assert!(msg.contains("--trace"), "missing --trace mention: {envelope}");
 });
 
-// RPC failures under `--machine` emit a typed `network.rpc.error` envelope and exit `Network (6)`.
-forgetest_async!(cast_call_machine_mode_rpc_failure_emits_network_envelope, |_prj, cmd| {
+// Setup-time RPC failures fall through to the generic fallback; only the actual
+// `eth_call` is classified as `network.rpc.error`.
+forgetest_async!(cast_call_machine_mode_setup_failure_falls_through, |_prj, cmd| {
     let assert = cmd
         .cast_fuse()
         .args([
@@ -3537,8 +3538,8 @@ forgetest_async!(cast_call_machine_mode_rpc_failure_emits_network_envelope, |_pr
         serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
 
     assert_eq!(envelope["success"], false);
-    assert_eq!(envelope["errors"][0]["code"], "network.rpc.error");
-    assert_eq!(assert.get_output().status.code(), Some(6));
+    assert_eq!(envelope["errors"][0]["code"], "cli.unknown");
+    assert_eq!(assert.get_output().status.code(), Some(1));
 });
 
 // https://github.com/foundry-rs/foundry/issues/10848

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3486,7 +3486,7 @@ forgetest_async!(cast_call_machine_mode_emits_envelope, |_prj, cmd| {
 
     assert_eq!(envelope["schema_version"], 1);
     assert_eq!(envelope["success"], true);
-    assert_eq!(envelope["data"]["result"], "0x");
+    assert_eq!(envelope["data"]["raw"], "0x");
     assert_eq!(envelope["errors"], serde_json::json!([]));
     assert_eq!(envelope["warnings"], serde_json::json!([]));
 });
@@ -3517,6 +3517,28 @@ forgetest_async!(cast_call_machine_mode_rejects_unsupported_flags, |_prj, cmd| {
     assert_eq!(assert.get_output().status.code(), Some(2));
     let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
     assert!(msg.contains("--trace"), "missing --trace mention: {envelope}");
+});
+
+// RPC failures under `--machine` emit a typed `network.rpc.error` envelope and exit `Network (6)`.
+forgetest_async!(cast_call_machine_mode_rpc_failure_emits_network_envelope, |_prj, cmd| {
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "--machine",
+            "call",
+            "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+            "--rpc-url",
+            // Unreachable: port 1 is reserved and nothing accepts here.
+            "http://127.0.0.1:1",
+        ])
+        .assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
+
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "network.rpc.error");
+    assert_eq!(assert.get_output().status.code(), Some(6));
 });
 
 // https://github.com/foundry-rs/foundry/issues/10848

--- a/crates/chisel/bin/main.rs
+++ b/crates/chisel/bin/main.rs
@@ -7,6 +7,10 @@ static ALLOC: foundry_cli::utils::Allocator = foundry_cli::utils::new_allocator(
 
 fn main() {
     if let Err(err) = run() {
+        if foundry_cli::is_machine() {
+            foundry_cli::machine::report_machine_error(&err);
+            std::process::exit(foundry_cli::ExitCode::GenericError.to_i32());
+        }
         let _ = foundry_common::sh_err!("{err:?}");
         std::process::exit(1);
     }

--- a/crates/cli/src/diagnostic.rs
+++ b/crates/cli/src/diagnostic.rs
@@ -129,10 +129,12 @@ pub mod compiler {
 
 /// Network / RPC diagnostic codes.
 pub mod network {
+    /// Generic RPC failure (transport, JSON-RPC error, connectivity).
+    pub const RPC_ERROR: &str = "network.rpc.error";
     pub const RPC_TIMEOUT: &str = "network.rpc.timeout";
     pub const RPC_UNAUTHORIZED: &str = "network.rpc.unauthorized";
 
-    pub(crate) const ALL: &[&str] = &[RPC_TIMEOUT, RPC_UNAUTHORIZED];
+    pub(crate) const ALL: &[&str] = &[RPC_ERROR, RPC_TIMEOUT, RPC_UNAUTHORIZED];
 }
 
 /// `foundry-wallets` diagnostic codes.

--- a/crates/cli/src/introspect/mod.rs
+++ b/crates/cli/src/introspect/mod.rs
@@ -15,7 +15,7 @@ pub use build::{
     render_introspect_document,
 };
 pub use document::*;
-pub use registry::{CommandMeta, CommandRegistry};
+pub use registry::{CommandMeta, CommandRegistry, RegistryEntry};
 
 /// Stable schema id for the introspect document.
 pub const INTROSPECT_SCHEMA_ID: &str = "foundry:introspect@v1";

--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -3,6 +3,7 @@
 use eyre::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, to_string};
+use std::io::Write as _;
 
 /// The current version of Foundry's top-level JSON output envelope.
 pub const JSON_SCHEMA_VERSION: u32 = 1;
@@ -131,10 +132,11 @@ impl JsonMessage {
 
 /// Prints a value as compact, single-line JSON to stdout.
 ///
-/// The trailing newline makes this suitable for NDJSON streams when each call
-/// emits one self-contained JSON record.
+/// Bypasses the shell verbosity layer so `--quiet` cannot suppress structured
+/// output the caller explicitly asked for.
 pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
-    sh_println!("{}", to_string(value)?)?;
+    let mut stdout = std::io::stdout().lock();
+    writeln!(stdout, "{}", to_string(value)?)?;
     Ok(())
 }
 

--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -137,6 +137,7 @@ impl JsonMessage {
 pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
     let mut stdout = std::io::stdout().lock();
     writeln!(stdout, "{}", to_string(value)?)?;
+    stdout.flush()?;
     Ok(())
 }
 

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -26,10 +26,7 @@ use crate::{
 };
 use clap::{CommandFactory, Parser, error::ErrorKind};
 use serde_json::json;
-use std::{
-    fmt::Write,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 static MACHINE_MODE: AtomicBool = AtomicBool::new(false);
 
@@ -144,47 +141,17 @@ pub fn bail_machine_usage(message: impl Into<String>) -> ! {
     std::process::exit(ExitCode::Usage.to_i32());
 }
 
-/// Emit a structured error envelope on stdout for an `eyre::Report`.
-///
-/// Used by binary entry points to wrap an uncaught command failure as a
-/// terminal envelope. The diagnostic code is best-effort, classified from
-/// the report's cause chain via [`diagnostic_code_for_report`]; the process
-/// exit code is the caller's responsibility (typically [`ExitCode::GenericError`]).
+/// Fallback envelope emitter for an untyped `eyre::Report`. Always tags
+/// `cli.unknown` and preserves the eyre cause chain in `details.cause_chain`.
+/// The process exit code is the caller's responsibility.
 pub fn report_machine_error(report: &eyre::Report) {
-    let message = format!("{report}");
-    let envelope =
-        JsonEnvelope::error(JsonMessage::error(diagnostic_code_for_report(report), message));
+    let cause_chain: Vec<String> = report.chain().map(ToString::to_string).collect();
+    let message = cause_chain.first().cloned().unwrap_or_else(|| report.to_string());
+    let envelope = JsonEnvelope::error(
+        JsonMessage::error(diagnostic::cli::UNKNOWN, message)
+            .with_details(json!({ "cause_chain": cause_chain })),
+    );
     let _ = print_json(&envelope);
-}
-
-/// Conservative classification of an `eyre::Report` into a stable diagnostic
-/// code.
-///
-/// Stable codes are part of the agent contract; over-specific
-/// misclassification is worse than the catch-all. Only a small set of
-/// high-confidence keyword matches escape the [`diagnostic::cli::UNKNOWN`]
-/// fallback. Typed call sites should emit specific codes directly rather
-/// than relying on this helper.
-pub fn diagnostic_code_for_report(report: &eyre::Report) -> &'static str {
-    let mut buf = String::new();
-    for cause in report.chain() {
-        let _ = writeln!(buf, "{cause}");
-    }
-    let lower = buf.to_lowercase();
-
-    if lower.contains("interrupted") || lower.contains("sigint") || lower.contains("sigterm") {
-        return diagnostic::cli::INTERRUPTED;
-    }
-    if lower.contains("foundry.toml") {
-        return diagnostic::config::INVALID;
-    }
-    if lower.contains("solc") {
-        return diagnostic::compiler::SOLC_ERROR;
-    }
-    if lower.contains("vyper") {
-        return diagnostic::compiler::VYPER_ERROR;
-    }
-    diagnostic::cli::UNKNOWN
 }
 
 #[cfg(test)]
@@ -240,25 +207,33 @@ mod tests {
         Run,
     }
 
+    /// `report_machine_error` always tags `cli.unknown` and preserves the
+    /// full eyre cause chain in `errors[0].details.cause_chain`.
     #[test]
-    fn diagnostic_classifier_picks_compiler_for_solc_errors() {
-        let r: eyre::Report = eyre::eyre!("solc compilation failed");
-        assert_eq!(diagnostic_code_for_report(&r), diagnostic::compiler::SOLC_ERROR);
-    }
+    fn report_machine_error_uses_cli_unknown_and_preserves_cause_chain() {
+        use eyre::WrapErr as _;
+        let leaf: eyre::Report = eyre::eyre!("solc: missing semicolon");
+        let report: eyre::Report = Result::<(), _>::Err(leaf)
+            .wrap_err("compile failed")
+            .wrap_err("build failed")
+            .unwrap_err();
 
-    #[test]
-    fn diagnostic_classifier_falls_back_to_cli_unknown_for_rpc_failures() {
-        // Generic RPC errors stay `cli.unknown` — typed call sites should
-        // emit `network.rpc.*` codes themselves when they have the context
-        // to classify accurately.
-        let r: eyre::Report = eyre::eyre!("RPC connection timeout");
-        assert_eq!(diagnostic_code_for_report(&r), diagnostic::cli::UNKNOWN);
-    }
+        let cause_chain: Vec<String> = report.chain().map(ToString::to_string).collect();
+        let message = cause_chain.first().cloned().unwrap();
+        let envelope = JsonEnvelope::error(
+            JsonMessage::error(diagnostic::cli::UNKNOWN, message)
+                .with_details(json!({ "cause_chain": cause_chain })),
+        );
 
-    #[test]
-    fn diagnostic_classifier_falls_back_to_cli_unknown() {
-        let r: eyre::Report = eyre::eyre!("something unexpected went wrong");
-        assert_eq!(diagnostic_code_for_report(&r), diagnostic::cli::UNKNOWN);
+        assert!(!envelope.success);
+        assert_eq!(envelope.errors.len(), 1);
+        assert_eq!(envelope.errors[0].code, diagnostic::cli::UNKNOWN);
+        assert_eq!(envelope.errors[0].message, "build failed");
+        let details = envelope.errors[0].details.as_ref().expect("details");
+        let chain = details.get("cause_chain").and_then(|v| v.as_array()).expect("chain");
+        assert_eq!(chain.len(), 3);
+        assert_eq!(chain[0], "build failed");
+        assert_eq!(chain[2], "solc: missing semicolon");
     }
 
     #[test]

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -26,7 +26,10 @@ use crate::{
 };
 use clap::{CommandFactory, Parser, error::ErrorKind};
 use serde_json::json;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::{
+    fmt::Write,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 static MACHINE_MODE: AtomicBool = AtomicBool::new(false);
 
@@ -132,6 +135,58 @@ fn exit_code_for_clap_error(err: &clap::Error) -> ExitCode {
     }
 }
 
+/// Emit a `cli.usage.invalid` envelope on stdout and exit with
+/// [`ExitCode::Usage`] (`2`). Use at call sites that intentionally reject
+/// a flag combination under `--machine`.
+pub fn bail_machine_usage(message: impl Into<String>) -> ! {
+    let envelope = JsonEnvelope::error(JsonMessage::error(diagnostic::cli::USAGE_INVALID, message));
+    let _ = print_json(&envelope);
+    std::process::exit(ExitCode::Usage.to_i32());
+}
+
+/// Emit a structured error envelope on stdout for an `eyre::Report`.
+///
+/// Used by binary entry points to wrap an uncaught command failure as a
+/// terminal envelope. The diagnostic code is best-effort, classified from
+/// the report's cause chain via [`diagnostic_code_for_report`]; the process
+/// exit code is the caller's responsibility (typically [`ExitCode::GenericError`]).
+pub fn report_machine_error(report: &eyre::Report) {
+    let message = format!("{report}");
+    let envelope =
+        JsonEnvelope::error(JsonMessage::error(diagnostic_code_for_report(report), message));
+    let _ = print_json(&envelope);
+}
+
+/// Conservative classification of an `eyre::Report` into a stable diagnostic
+/// code.
+///
+/// Stable codes are part of the agent contract; over-specific
+/// misclassification is worse than the catch-all. Only a small set of
+/// high-confidence keyword matches escape the [`diagnostic::cli::UNKNOWN`]
+/// fallback. Typed call sites should emit specific codes directly rather
+/// than relying on this helper.
+pub fn diagnostic_code_for_report(report: &eyre::Report) -> &'static str {
+    let mut buf = String::new();
+    for cause in report.chain() {
+        let _ = writeln!(buf, "{cause}");
+    }
+    let lower = buf.to_lowercase();
+
+    if lower.contains("interrupted") || lower.contains("sigint") || lower.contains("sigterm") {
+        return diagnostic::cli::INTERRUPTED;
+    }
+    if lower.contains("foundry.toml") {
+        return diagnostic::config::INVALID;
+    }
+    if lower.contains("solc") {
+        return diagnostic::compiler::SOLC_ERROR;
+    }
+    if lower.contains("vyper") {
+        return diagnostic::compiler::VYPER_ERROR;
+    }
+    diagnostic::cli::UNKNOWN
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -183,6 +238,27 @@ mod tests {
     #[derive(Debug, clap::Subcommand)]
     enum StrictSub {
         Run,
+    }
+
+    #[test]
+    fn diagnostic_classifier_picks_compiler_for_solc_errors() {
+        let r: eyre::Report = eyre::eyre!("solc compilation failed");
+        assert_eq!(diagnostic_code_for_report(&r), diagnostic::compiler::SOLC_ERROR);
+    }
+
+    #[test]
+    fn diagnostic_classifier_falls_back_to_cli_unknown_for_rpc_failures() {
+        // Generic RPC errors stay `cli.unknown` — typed call sites should
+        // emit `network.rpc.*` codes themselves when they have the context
+        // to classify accurately.
+        let r: eyre::Report = eyre::eyre!("RPC connection timeout");
+        assert_eq!(diagnostic_code_for_report(&r), diagnostic::cli::UNKNOWN);
+    }
+
+    #[test]
+    fn diagnostic_classifier_falls_back_to_cli_unknown() {
+        let r: eyre::Report = eyre::eyre!("something unexpected went wrong");
+        assert_eq!(diagnostic_code_for_report(&r), diagnostic::cli::UNKNOWN);
     }
 
     #[test]

--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -92,13 +92,14 @@ impl GlobalArgs {
     }
 
     /// Like [`check_introspect`](Self::check_introspect) but uses an explicit
-    /// [`Command`](clap::Command) and [`CommandRegistry`](crate::introspect::CommandRegistry).
+    /// [`CommandRegistry`](crate::introspect::CommandRegistry). The clap command
+    /// is built lazily so normal startup pays nothing when `--introspect` is absent.
     pub fn check_introspect_with(
-        command: clap::Command,
+        make_command: impl FnOnce() -> clap::Command,
         registry: &crate::introspect::CommandRegistry,
     ) {
         if pre_parse_flag_present("--introspect") {
-            emit_introspect_and_exit(command, registry);
+            emit_introspect_and_exit(make_command(), registry);
         }
     }
 

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -8,6 +8,10 @@ static ALLOC: foundry_cli::utils::Allocator = foundry_cli::utils::new_allocator(
 
 fn main() {
     if let Err(err) = run() {
+        if foundry_cli::is_machine() {
+            foundry_cli::machine::report_machine_error(&err);
+            std::process::exit(foundry_cli::ExitCode::GenericError.to_i32());
+        }
         let _ = foundry_common::sh_err!("{err:?}");
         std::process::exit(1);
     }

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -77,6 +77,7 @@ pub fn run_command(args: Forge) -> Result<()> {
         }
         ForgeSubcommand::Bind(cmd) => cmd.run(),
         ForgeSubcommand::Build(cmd) => {
+            cmd.ensure_machine_compatible();
             if cmd.is_watch() {
                 global.block_on(watch::watch_build(cmd))
             } else {

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -15,7 +15,7 @@ pub fn run() -> Result<()> {
     // Pre-parse discovery flags run before `setup()` so they cannot be blocked
     // by panic-handler / tracing init failures and avoid that init's cost.
     foundry_cli::machine::check_machine();
-    foundry_cli::opts::GlobalArgs::check_introspect_with(Forge::command(), &REGISTRY);
+    foundry_cli::opts::GlobalArgs::check_introspect_with(Forge::command, &REGISTRY);
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Forge>();
 
     setup()?;

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -1,5 +1,6 @@
 use crate::{
     cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, watch},
+    introspect::REGISTRY,
     opts::{Forge, ForgeSubcommand},
 };
 use clap::CommandFactory;
@@ -14,7 +15,7 @@ pub fn run() -> Result<()> {
     // Pre-parse discovery flags run before `setup()` so they cannot be blocked
     // by panic-handler / tracing init failures and avoid that init's cost.
     foundry_cli::machine::check_machine();
-    foundry_cli::opts::GlobalArgs::check_introspect::<Forge>();
+    foundry_cli::opts::GlobalArgs::check_introspect_with(Forge::command(), &REGISTRY);
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Forge>();
 
     setup()?;
@@ -151,7 +152,7 @@ pub fn run_command(args: Forge) -> Result<()> {
 mod tests {
     use super::*;
     use foundry_cli::introspect::{
-        CommandRegistry, INTROSPECT_SCHEMA_ID, IntrospectDocument, build_document,
+        CommandRegistry, INTROSPECT_SCHEMA_ID, IntrospectDocument, OutputMode, build_document,
         capability_violations, duplicate_command_ids, render_introspect_document,
     };
 
@@ -162,7 +163,7 @@ mod tests {
     #[test]
     fn introspect_command_ids_are_unique() {
         let cmd = Forge::command();
-        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let doc = build_document(&cmd, &REGISTRY);
         let dups = duplicate_command_ids(&doc);
         assert!(dups.is_empty(), "duplicate forge command_ids: {dups:?}");
     }
@@ -184,8 +185,30 @@ mod tests {
     #[test]
     fn introspect_capabilities_are_consistent() {
         let cmd = Forge::command();
-        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let doc = build_document(&cmd, &REGISTRY);
         let v = capability_violations(&doc);
         assert!(v.is_empty(), "forge capability violations: {v:?}");
+    }
+
+    /// Every adopted command (`output_mode = Envelope`) must pin a stable
+    /// `command_id` matching its registry entry. Catches accidental drift
+    /// between the registry and the clap tree.
+    #[test]
+    fn registered_commands_pin_stable_ids() {
+        let cmd = Forge::command();
+        let doc = build_document(&cmd, &REGISTRY);
+        fn walk(c: &foundry_cli::introspect::CommandInfo) -> Vec<&str> {
+            let mut out = Vec::new();
+            if matches!(c.capabilities.output_mode, OutputMode::Envelope) {
+                out.push(c.command_id.as_str());
+            }
+            for sub in &c.subcommands {
+                out.extend(walk(sub));
+            }
+            out
+        }
+        let mut envelope_ids: Vec<&str> = doc.commands.iter().flat_map(walk).collect();
+        envelope_ids.sort();
+        assert!(envelope_ids.contains(&"forge.build"), "forge.build missing: {envelope_ids:?}");
     }
 }

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -20,7 +20,7 @@ use foundry_compilers::{
     utils::source_files_iter,
 };
 use foundry_config::{
-    Config, SkipBuildFilters,
+    Config, DenyLevel, SkipBuildFilters,
     figment::{
         self, Metadata, Profile, Provider,
         error::Kind::InvalidType,
@@ -121,6 +121,21 @@ impl BuildArgs {
         {
             // need to re-configure here to also catch additional remappings
             config = self.load_config()?;
+        }
+
+        // Lint output isn't modeled in the v1 envelope; refuse configs that would diverge
+        // human and machine success/failure outcomes.
+        if machine_mode
+            && !self.no_lint
+            && config.lint.lint_on_build
+            && config.deny != DenyLevel::Never
+        {
+            foundry_cli::machine::bail_machine_usage(
+                "`forge build` under `--machine` does not model lint diagnostics in the v1 \
+                 envelope; configs with `lint_on_build = true` and `deny != never` would \
+                 produce a false success. Pass `--no-lint` or disable lint-on-build / set \
+                 `deny = never` in foundry.toml.",
+            );
         }
 
         self.check_soldeer_lock_consistency(&config).await;

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -1,9 +1,11 @@
 use super::{install, watch::WatchArgs};
+use crate::diagnostic::build::SOLC_ERROR;
 use clap::Parser;
 use eyre::Result;
 use forge_lint::{linter::Linter, sol::SolidityLinter};
 use foundry_cli::{
-    json::{JsonEnvelope, print_json},
+    ExitCode,
+    json::{JsonEnvelope, JsonMessage, print_json},
     opts::{BuildOpts, configure_pcx_from_solc, get_solar_sources_from_compile_output},
     utils::{Git, LoadConfig, cache_local_signatures},
 };
@@ -84,26 +86,38 @@ pub struct BuildArgs {
 }
 
 impl BuildArgs {
-    pub async fn run(self) -> Result<ProjectCompileOutput> {
-        // Reject flags whose stdout shape conflicts with the envelope contract.
-        if foundry_cli::is_machine() {
-            let unsupported =
-                [("--watch", self.is_watch()), ("--names", self.names), ("--sizes", self.sizes)]
-                    .into_iter()
-                    .filter_map(|(name, on)| on.then_some(name))
-                    .collect::<Vec<_>>();
-            if !unsupported.is_empty() {
-                foundry_cli::machine::bail_machine_usage(format!(
-                    "`forge build` under `--machine` does not yet support {}; \
-                     run without `--machine` or omit those flags.",
-                    unsupported.join(", ")
-                ));
-            }
+    /// Reject flags whose stdout shape conflicts with the envelope contract.
+    /// Must be called before dispatch so `--watch` is caught before the watch
+    /// loop short-circuits past `BuildArgs::run`.
+    pub fn ensure_machine_compatible(&self) {
+        if !foundry_cli::is_machine() {
+            return;
         }
+        let unsupported =
+            [("--watch", self.is_watch()), ("--names", self.names), ("--sizes", self.sizes)]
+                .into_iter()
+                .filter_map(|(name, on)| on.then_some(name))
+                .collect::<Vec<_>>();
+        if !unsupported.is_empty() {
+            foundry_cli::machine::bail_machine_usage(format!(
+                "`forge build` under `--machine` does not yet support {}; \
+                 run without `--machine` or omit those flags.",
+                unsupported.join(", ")
+            ));
+        }
+    }
 
+    pub async fn run(self) -> Result<ProjectCompileOutput> {
+        self.ensure_machine_compatible();
+
+        let machine_mode = foundry_cli::is_machine();
         let mut config = self.load_config()?;
 
-        if install::install_missing_dependencies(&mut config).await && config.auto_detect_remappings
+        // Skip implicit dep install under `--machine`: it writes to stdout and mutates the project
+        // behind the agent's back. Missing deps will surface as a typed compile-error envelope.
+        if !machine_mode
+            && install::install_missing_dependencies(&mut config).await
+            && config.auto_detect_remappings
         {
             // need to re-configure here to also catch additional remappings
             config = self.load_config()?;
@@ -127,12 +141,19 @@ impl BuildArgs {
             }
         }
 
-        let machine_mode = foundry_cli::is_machine();
         let format_json = shell::is_json();
-        // Under `--machine`, only the terminal envelope is allowed on
-        // stdout. Force the compile reporter quiet without overriding the
-        // `--quiet` default in the human path (the builder's default
-        // already picks up `shell::is_quiet()`).
+
+        // Pre-empt the inner `"Nothing to compile" + exit(0)` path so it can't break the
+        // envelope-only stdout contract.
+        if machine_mode && !project.paths.has_input_files() && self.paths.is_none() {
+            let payload = BuildData { artifacts: 0, errors: 0, warnings: 0, unchanged: false };
+            print_json(&JsonEnvelope::success(payload))?;
+            std::process::exit(ExitCode::Success.to_i32());
+        }
+
+        // Under `--machine`: force quiet (envelope-only stdout) and disable `bail` so we can
+        // emit a typed failure envelope instead of a generic eyre error. v1 skips post-build
+        // lint (not yet modeled in the envelope schema).
         let mut compiler = ProjectCompiler::new()
             .files(files)
             .dynamic_test_linking(config.dynamic_test_linking)
@@ -145,7 +166,7 @@ impl BuildArgs {
                     .map(ContractSizeLimits::with_runtime_limit)
                     .unwrap_or_default(),
             )
-            .bail(!format_json);
+            .bail(!format_json && !machine_mode);
         if machine_mode {
             compiler = compiler.quiet(true);
         }
@@ -160,13 +181,25 @@ impl BuildArgs {
         }
 
         if machine_mode {
+            if output.has_compiler_errors() {
+                let errors: Vec<JsonMessage> = output
+                    .output()
+                    .errors
+                    .iter()
+                    .filter(|e| e.is_error())
+                    .map(|e| JsonMessage::error(SOLC_ERROR, e.to_string()))
+                    .collect();
+                print_json(&JsonEnvelope::<()>::failure(errors))?;
+                std::process::exit(ExitCode::Build.to_i32());
+            }
+
             let payload = BuildData::from_output(&output);
             print_json(&JsonEnvelope::success(payload))?;
+            return Ok(output);
         }
 
         // Only run the `SolidityLinter` if lint on build and no compilation errors.
-        if !machine_mode
-            && !self.no_lint
+        if !self.no_lint
             && config.lint.lint_on_build
             && !output.output().errors.iter().any(|e| e.is_error())
             && let Err(err) = self.lint(&project, &config, self.paths.as_deref(), &mut output)
@@ -383,8 +416,9 @@ pub struct BuildData {
     pub errors: usize,
     /// Number of compiler warnings in the output.
     pub warnings: usize,
-    /// Whether the build was a no-op cache hit.
-    pub cache_hit: bool,
+    /// Whether the build was a no-op (no input files changed since the last
+    /// compile). Mirrors `ProjectCompileOutput::is_unchanged`.
+    pub unchanged: bool,
 }
 
 impl BuildData {
@@ -399,7 +433,7 @@ impl BuildData {
                 warnings += 1;
             }
         }
-        Self { artifacts, errors, warnings, cache_hit: output.is_unchanged() }
+        Self { artifacts, errors, warnings, unchanged: output.is_unchanged() }
     }
 }
 

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -129,8 +129,11 @@ impl BuildArgs {
 
         let machine_mode = foundry_cli::is_machine();
         let format_json = shell::is_json();
-        // `--machine` reserves stdout for the terminal envelope.
-        let compiler = ProjectCompiler::new()
+        // Under `--machine`, only the terminal envelope is allowed on
+        // stdout. Force the compile reporter quiet without overriding the
+        // `--quiet` default in the human path (the builder's default
+        // already picks up `shell::is_quiet()`).
+        let mut compiler = ProjectCompiler::new()
             .files(files)
             .dynamic_test_linking(config.dynamic_test_linking)
             .print_names(self.names)
@@ -142,8 +145,10 @@ impl BuildArgs {
                     .map(ContractSizeLimits::with_runtime_limit)
                     .unwrap_or_default(),
             )
-            .quiet(machine_mode)
             .bail(!format_json);
+        if machine_mode {
+            compiler = compiler.quiet(true);
+        }
 
         let mut output = compiler.compile(&project)?;
 

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -123,23 +123,12 @@ impl BuildArgs {
             config = self.load_config()?;
         }
 
-        // Lint output isn't modeled in the v1 envelope; refuse configs that would diverge
-        // human and machine success/failure outcomes.
-        if machine_mode
-            && !self.no_lint
-            && config.lint.lint_on_build
-            && config.deny != DenyLevel::Never
-        {
-            foundry_cli::machine::bail_machine_usage(
-                "`forge build` under `--machine` does not model lint diagnostics in the v1 \
-                 envelope; configs with `lint_on_build = true` and `deny != never` would \
-                 produce a false success. Pass `--no-lint` or disable lint-on-build / set \
-                 `deny = never` in foundry.toml.",
-            );
+        // Lock-consistency checks emit `sh_warn!` to stderr; skip under `--machine` to keep
+        // the agent channel quiet.
+        if !machine_mode {
+            self.check_soldeer_lock_consistency(&config).await;
+            self.check_foundry_lock_consistency(&config);
         }
-
-        self.check_soldeer_lock_consistency(&config).await;
-        self.check_foundry_lock_consistency(&config);
 
         let project = config.project()?;
 
@@ -188,6 +177,20 @@ impl BuildArgs {
 
         let mut output = compiler.compile(&project)?;
 
+        // Under `--machine`, emit the typed envelope *before* `cache_local_signatures` so a
+        // cache-write failure can never mask a compile-error envelope as `cli.unknown`.
+        if machine_mode && output.has_compiler_errors() {
+            let errors: Vec<JsonMessage> = output
+                .output()
+                .errors
+                .iter()
+                .filter(|e| e.is_error())
+                .map(|e| JsonMessage::error(SOLC_ERROR, e.to_string()))
+                .collect();
+            print_json(&JsonEnvelope::<()>::failure(errors))?;
+            std::process::exit(ExitCode::Build.to_i32());
+        }
+
         // Cache project selectors.
         cache_local_signatures(&output)?;
 
@@ -196,16 +199,15 @@ impl BuildArgs {
         }
 
         if machine_mode {
-            if output.has_compiler_errors() {
-                let errors: Vec<JsonMessage> = output
-                    .output()
-                    .errors
-                    .iter()
-                    .filter(|e| e.is_error())
-                    .map(|e| JsonMessage::error(SOLC_ERROR, e.to_string()))
-                    .collect();
-                print_json(&JsonEnvelope::<()>::failure(errors))?;
-                std::process::exit(ExitCode::Build.to_i32());
+            // Lint output isn't modeled in the v1 envelope; refuse configs that would otherwise
+            // diverge human and machine outcomes (deferred until after compile so a failed
+            // build still emits `compiler.solc.error` + `Build (4)`).
+            if !self.no_lint && config.lint.lint_on_build && config.deny != DenyLevel::Never {
+                foundry_cli::machine::bail_machine_usage(
+                    "`forge build --machine` does not model lint diagnostics in v1; \
+                     `lint_on_build = true` with `deny != never` would diverge human and \
+                     machine outcomes. Pass `--no-lint` or set `deny = never`.",
+                );
             }
 
             let payload = BuildData::from_output(&output);

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use eyre::Result;
 use forge_lint::{linter::Linter, sol::SolidityLinter};
 use foundry_cli::{
+    json::{JsonEnvelope, print_json},
     opts::{BuildOpts, configure_pcx_from_solc, get_solar_sources_from_compile_output},
     utils::{Git, LoadConfig, cache_local_signatures},
 };
@@ -84,6 +85,22 @@ pub struct BuildArgs {
 
 impl BuildArgs {
     pub async fn run(self) -> Result<ProjectCompileOutput> {
+        // Reject flags whose stdout shape conflicts with the envelope contract.
+        if foundry_cli::is_machine() {
+            let unsupported =
+                [("--watch", self.is_watch()), ("--names", self.names), ("--sizes", self.sizes)]
+                    .into_iter()
+                    .filter_map(|(name, on)| on.then_some(name))
+                    .collect::<Vec<_>>();
+            if !unsupported.is_empty() {
+                foundry_cli::machine::bail_machine_usage(format!(
+                    "`forge build` under `--machine` does not yet support {}; \
+                     run without `--machine` or omit those flags.",
+                    unsupported.join(", ")
+                ));
+            }
+        }
+
         let mut config = self.load_config()?;
 
         if install::install_missing_dependencies(&mut config).await && config.auto_detect_remappings
@@ -110,7 +127,9 @@ impl BuildArgs {
             }
         }
 
+        let machine_mode = foundry_cli::is_machine();
         let format_json = shell::is_json();
+        // `--machine` reserves stdout for the terminal envelope.
         let compiler = ProjectCompiler::new()
             .files(files)
             .dynamic_test_linking(config.dynamic_test_linking)
@@ -123,6 +142,7 @@ impl BuildArgs {
                     .map(ContractSizeLimits::with_runtime_limit)
                     .unwrap_or_default(),
             )
+            .quiet(machine_mode)
             .bail(!format_json);
 
         let mut output = compiler.compile(&project)?;
@@ -130,12 +150,18 @@ impl BuildArgs {
         // Cache project selectors.
         cache_local_signatures(&output)?;
 
-        if format_json && !self.names && !self.sizes {
+        if format_json && !self.names && !self.sizes && !machine_mode {
             sh_println!("{}", serde_json::to_string_pretty(&output.output())?)?;
         }
 
+        if machine_mode {
+            let payload = BuildData::from_output(&output);
+            print_json(&JsonEnvelope::success(payload))?;
+        }
+
         // Only run the `SolidityLinter` if lint on build and no compilation errors.
-        if !self.no_lint
+        if !machine_mode
+            && !self.no_lint
             && config.lint.lint_on_build
             && !output.output().errors.iter().any(|e| e.is_error())
             && let Err(err) = self.lint(&project, &config, self.paths.as_deref(), &mut output)
@@ -340,6 +366,35 @@ impl BuildArgs {
                 .ok();
             }
         }
+    }
+}
+
+/// Stable payload emitted in the `forge build` envelope under `--machine`.
+#[derive(Clone, Debug, Serialize)]
+pub struct BuildData {
+    /// Total number of compiled artifacts in the project.
+    pub artifacts: usize,
+    /// Number of compiler errors in the output.
+    pub errors: usize,
+    /// Number of compiler warnings in the output.
+    pub warnings: usize,
+    /// Whether the build was a no-op cache hit.
+    pub cache_hit: bool,
+}
+
+impl BuildData {
+    fn from_output(output: &ProjectCompileOutput) -> Self {
+        let artifacts = output.artifact_ids().count();
+        let mut errors = 0usize;
+        let mut warnings = 0usize;
+        for diag in &output.output().errors {
+            if diag.is_error() {
+                errors += 1;
+            } else {
+                warnings += 1;
+            }
+        }
+        Self { artifacts, errors, warnings, cache_hit: output.is_unchanged() }
     }
 }
 

--- a/crates/forge/src/diagnostic.rs
+++ b/crates/forge/src/diagnostic.rs
@@ -1,0 +1,31 @@
+//! Stable, machine-readable diagnostic codes emitted by `forge`.
+//!
+//! See [`docs/agents/diagnostics.md`](../../../docs/agents/diagnostics.md)
+//! for the format and registry rules. Most codes re-export per-domain
+//! constants from [`foundry_cli::diagnostic`].
+
+/// Build-time diagnostic codes (compilation, linking, artifact generation).
+pub mod build {
+    pub use foundry_cli::diagnostic::compiler::SOLC_ERROR;
+
+    pub(crate) const ALL: &[&str] = &[SOLC_ERROR];
+}
+
+/// All diagnostic codes declared by `forge`.
+pub fn known_codes() -> Vec<&'static str> {
+    let groups: &[&[&str]] = &[build::ALL];
+    groups.iter().flat_map(|g| g.iter().copied()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use foundry_cli::diagnostic::validate;
+
+    #[test]
+    fn every_known_code_validates() {
+        for c in known_codes() {
+            assert!(validate(c).is_ok(), "registered code `{c}` failed validation");
+        }
+    }
+}

--- a/crates/forge/src/introspect.rs
+++ b/crates/forge/src/introspect.rs
@@ -1,0 +1,37 @@
+//! Stable, agent-facing metadata for the `forge` command tree.
+//!
+//! See [`docs/agents/spec.md`](../../../docs/agents/spec.md). The registry
+//! pins `command_id`s and machine-mode capabilities for adopted commands.
+
+use foundry_cli::introspect::{
+    Capabilities, CommandMeta, CommandRegistry, OutputMode, RegistryEntry, SideEffects,
+};
+use std::borrow::Cow;
+
+/// Stable schema id for the `forge build` envelope payload.
+pub const BUILD_RESULT_SCHEMA: &str = "foundry:forge.build@v1";
+
+static ENTRIES: &[RegistryEntry] = &[RegistryEntry {
+    path: &["build"],
+    meta: CommandMeta {
+        command_id: Some("forge.build"),
+        capabilities: Capabilities {
+            output_mode: OutputMode::Envelope,
+            result_schema_ref: Some(Cow::Borrowed(BUILD_RESULT_SCHEMA)),
+            event_schema_ref: None,
+            session_schema_ref: None,
+            reads_stdin: false,
+            supports_output_path: false,
+            requires_project: true,
+            side_effects: SideEffects::FsWrite,
+            long_running: false,
+            stateful: false,
+        },
+        capabilities_declared: true,
+        exit_codes: &[],
+    },
+}];
+
+/// The `forge` command registry. Used by `--introspect` and by adoption code
+/// that needs to look up command metadata.
+pub const REGISTRY: CommandRegistry = CommandRegistry::new(ENTRIES);

--- a/crates/forge/src/introspect.rs
+++ b/crates/forge/src/introspect.rs
@@ -3,13 +3,49 @@
 //! See [`docs/agents/spec.md`](../../../docs/agents/spec.md). The registry
 //! pins `command_id`s and machine-mode capabilities for adopted commands.
 
-use foundry_cli::introspect::{
-    Capabilities, CommandMeta, CommandRegistry, OutputMode, RegistryEntry, SideEffects,
+use foundry_cli::{
+    ExitCode,
+    introspect::{
+        Capabilities, CommandMeta, CommandRegistry, ExitCodeInfo, OutputMode, RegistryEntry,
+        SideEffects,
+    },
 };
 use std::borrow::Cow;
 
 /// Stable schema id for the `forge build` envelope payload.
 pub const BUILD_RESULT_SCHEMA: &str = "foundry:forge.build@v1";
+
+/// Exit codes `forge build` may emit under `--machine`. Declared explicitly so
+/// agents don't have to assume "inherits global defaults"; codes not in this
+/// list are not produced by this command.
+static BUILD_EXIT_CODES: &[ExitCodeInfo] = &[
+    ExitCodeInfo {
+        code: ExitCode::Success.to_i32(),
+        name: Cow::Borrowed(ExitCode::Success.name()),
+        description: Cow::Borrowed("Build succeeded; envelope `success: true`."),
+    },
+    ExitCodeInfo {
+        code: ExitCode::GenericError.to_i32(),
+        name: Cow::Borrowed(ExitCode::GenericError.name()),
+        description: Cow::Borrowed(
+            "Unclassified failure outside the typed paths (envelope `cli.unknown`).",
+        ),
+    },
+    ExitCodeInfo {
+        code: ExitCode::Usage.to_i32(),
+        name: Cow::Borrowed(ExitCode::Usage.name()),
+        description: Cow::Borrowed(
+            "Flag combination rejected under `--machine` (envelope `cli.usage.invalid`).",
+        ),
+    },
+    ExitCodeInfo {
+        code: ExitCode::Build.to_i32(),
+        name: Cow::Borrowed(ExitCode::Build.name()),
+        description: Cow::Borrowed(
+            "Solc reported one or more compile errors (envelope `compiler.solc.error`).",
+        ),
+    },
+];
 
 static ENTRIES: &[RegistryEntry] = &[RegistryEntry {
     path: &["build"],
@@ -28,7 +64,7 @@ static ENTRIES: &[RegistryEntry] = &[RegistryEntry {
             stateful: false,
         },
         capabilities_declared: true,
-        exit_codes: &[],
+        exit_codes: BUILD_EXIT_CODES,
     },
 }];
 

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -15,6 +15,8 @@ use foundry_wallets as _;
 
 pub mod args;
 pub mod cmd;
+pub mod diagnostic;
+pub mod introspect;
 pub mod opts;
 
 pub mod coverage;

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -526,7 +526,7 @@ forgetest_init!(machine_mode_emits_envelope, |prj, cmd| {
     assert!(envelope["data"]["artifacts"].as_u64().is_some(), "missing artifacts: {envelope}");
     assert!(envelope["data"]["errors"].as_u64().is_some(), "missing errors: {envelope}");
     assert!(envelope["data"]["warnings"].as_u64().is_some(), "missing warnings: {envelope}");
-    assert!(envelope["data"]["cache_hit"].as_bool().is_some(), "missing cache_hit: {envelope}");
+    assert!(envelope["data"]["unchanged"].as_bool().is_some(), "missing unchanged: {envelope}");
     assert_eq!(envelope["errors"], serde_json::json!([]));
     assert_eq!(envelope["warnings"], serde_json::json!([]));
 });
@@ -544,6 +544,66 @@ forgetest_init!(machine_mode_rejects_unsupported_flags, |prj, cmd| {
     assert_eq!(assert.get_output().status.code(), Some(2));
     let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
     assert!(msg.contains("--names"), "missing --names mention: {envelope}");
+});
+
+// `--machine` rejects `--watch` even though the watch path normally short-circuits before
+// `BuildArgs::run`.
+forgetest_init!(machine_mode_rejects_watch, |prj, cmd| {
+    prj.initialize_default_contracts();
+    let assert = cmd.args(["--machine", "build", "--watch"]).assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
+
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("--watch"), "missing --watch mention: {envelope}");
+});
+
+// Compile failures under `--machine` emit a typed `compiler.solc.error` envelope and exit `Build
+// (4)`.
+forgetest!(machine_mode_compile_failure_emits_typed_envelope, |prj, cmd| {
+    prj.add_source(
+        "BadSyntax",
+        r"
+contract Dummy {
+    uint256 public number;
+    function something(uint256 newNumber) public {
+        number = newnumber;
+    }
+}
+",
+    );
+
+    let assert = cmd.args(["--machine", "build", "--force"]).assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim()).expect("failure envelope on stdout");
+
+    assert_eq!(envelope["schema_version"], 1);
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["data"], serde_json::Value::Null);
+    let errors = envelope["errors"].as_array().expect("errors array");
+    assert!(!errors.is_empty(), "expected at least one error: {envelope}");
+    assert_eq!(errors[0]["code"], "compiler.solc.error");
+    assert_eq!(assert.get_output().status.code(), Some(4));
+});
+
+// Empty project under `--machine` emits a success envelope (artifacts=0), not "Nothing to compile".
+forgetest!(machine_mode_empty_project_emits_envelope, |_prj, cmd| {
+    let assert = cmd.args(["--machine", "build"]).assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stdout.trim()).expect("stdout is exactly one JSON envelope");
+
+    assert_eq!(envelope["schema_version"], 1);
+    assert_eq!(envelope["success"], true);
+    assert_eq!(envelope["data"]["artifacts"], 0);
+    assert_eq!(envelope["data"]["errors"], 0);
+    assert_eq!(envelope["data"]["warnings"], 0);
+    assert_eq!(envelope["errors"], serde_json::json!([]));
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
+    assert_eq!(assert.get_output().status.code(), Some(0));
 });
 
 // tests that build warns when foundry.lock revision differs from actual submodule revision

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -512,12 +512,13 @@ forgetest_init!(build_no_warning_without_foundry_lock, |prj, cmd| {
 "#]]);
 });
 
-// `forge --machine build` emits a single envelope on stdout. Asserts the
-// contract surface, not artifact counts (those drift with templates).
+// `forge --machine build` emits a single envelope on stdout and nothing on stderr.
 forgetest_init!(machine_mode_emits_envelope, |prj, cmd| {
     prj.initialize_default_contracts();
     let assert = cmd.args(["--machine", "build", "--force"]).assert_success();
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "expected empty stderr under --machine, got: {stderr}");
     let envelope: Value =
         serde_json::from_str(stdout.trim()).expect("stdout is exactly one JSON envelope");
 

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -546,6 +546,38 @@ forgetest_init!(machine_mode_rejects_unsupported_flags, |prj, cmd| {
     assert!(msg.contains("--names"), "missing --names mention: {envelope}");
 });
 
+// `--quiet` must not suppress the machine envelope.
+forgetest_init!(machine_mode_envelope_survives_quiet, |prj, cmd| {
+    prj.initialize_default_contracts();
+    let assert = cmd.args(["--machine", "--quiet", "build", "--force"]).assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim())
+        .expect("stdout is exactly one JSON envelope, even under --quiet");
+
+    assert_eq!(envelope["schema_version"], 1);
+    assert_eq!(envelope["success"], true);
+});
+
+// `--machine` refuses configs where lint-on-build + non-`Never` deny would diverge
+// human and machine success outcomes.
+forgetest_init!(machine_mode_rejects_lint_deny_divergence, |prj, cmd| {
+    prj.initialize_default_contracts();
+    let toml = "\
+[profile.default]\n\
+deny = \"warnings\"\n\
+[lint]\n\
+lint_on_build = true\n\
+";
+    std::fs::write(prj.root().join("foundry.toml"), toml).unwrap();
+    let assert = cmd.args(["--machine", "build", "--force"]).assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
+
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(assert.get_output().status.code(), Some(2));
+});
+
 // `--machine` rejects `--watch` even though the watch path normally short-circuits before
 // `BuildArgs::run`.
 forgetest_init!(machine_mode_rejects_watch, |prj, cmd| {

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -1,6 +1,7 @@
 use crate::utils::generate_large_init_contract;
 use foundry_test_utils::{forgetest, forgetest_init, snapbox::IntoData, str};
 use globset::Glob;
+use serde_json::Value;
 use std::fs;
 
 forgetest_init!(can_parse_build_filters, |prj, cmd| {
@@ -509,6 +510,40 @@ forgetest_init!(build_no_warning_without_foundry_lock, |prj, cmd| {
 
     cmd.args(["build"]).assert_success().stderr_eq(str![[r#"
 "#]]);
+});
+
+// `forge --machine build` emits a single envelope on stdout. Asserts the
+// contract surface, not artifact counts (those drift with templates).
+forgetest_init!(machine_mode_emits_envelope, |prj, cmd| {
+    prj.initialize_default_contracts();
+    let assert = cmd.args(["--machine", "build", "--force"]).assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stdout.trim()).expect("stdout is exactly one JSON envelope");
+
+    assert_eq!(envelope["schema_version"], 1);
+    assert_eq!(envelope["success"], true);
+    assert!(envelope["data"]["artifacts"].as_u64().is_some(), "missing artifacts: {envelope}");
+    assert!(envelope["data"]["errors"].as_u64().is_some(), "missing errors: {envelope}");
+    assert!(envelope["data"]["warnings"].as_u64().is_some(), "missing warnings: {envelope}");
+    assert!(envelope["data"]["cache_hit"].as_bool().is_some(), "missing cache_hit: {envelope}");
+    assert_eq!(envelope["errors"], serde_json::json!([]));
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
+});
+
+// `--machine` rejects flags that would corrupt the envelope-only stdout
+// contract. Asserts the stable `code` + exit code, not just message text.
+forgetest_init!(machine_mode_rejects_unsupported_flags, |prj, cmd| {
+    prj.initialize_default_contracts();
+    let assert = cmd.args(["--machine", "build", "--names"]).assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
+
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("--names"), "missing --names mention: {envelope}");
 });
 
 // tests that build warns when foundry.lock revision differs from actual submodule revision


### PR DESCRIPTION
Stacked on #14771. Adopts envelope output for two commands as a proof of the substrate:

- `forge build` — output_mode=envelope, foundry:forge.build@v1, side_effects=fs_write, requires_project
- `cast call` — output_mode=envelope, foundry:cast.call@v1, side_effects=network

Per-binary `CommandRegistry` wired through `check_introspect_with` so `--introspect` reports real metadata. Shape-changing flags are rejected under `--machine` (`--watch`/`--names`/`--sizes` for build; `--trace`/`--debug`/`--decode-internal`/`--curl` for call) with `cli.usage.invalid` + exit `2`. `--watch` is caught before dispatch via `BuildArgs::ensure_machine_compatible()`.

Typed failure envelopes for the primary error modes:

- `forge build --machine` compile failures → `compiler.solc.error` per solc error, exit `Build (4)`.
- `cast call --machine` RPC failures → `network.rpc.error` (new code) with eyre cause chain in `details.cause_chain`, exit `Network (6)`.

`forge build --machine` also skips `install_missing_dependencies`, pre-empts the `"Nothing to compile" + exit(0)` path with an empty envelope, and skips post-build lint at v1. `CallData.raw` replaces `CallData.result` — decoder bypassed, always raw `0x` hex.

All four binary `main.rs` files get a strictly-additive `is_machine()`-guarded handler. `report_machine_error` always tags `cli.unknown` and preserves the cause chain; typed call sites emit specific codes. Legacy `stderr + exit(1)` preserved for the human path. `check_machine()` runs before `setup()` so early failures are enveloped.

Part of OSS-218