### PR TITLE
feat(cli): adopt NDJSON streaming for forge test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5221,6 +5221,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-signer",
  "cfg-if",
+ "chrono",
  "clap",
  "clap_complete",
  "clap_complete_nushell",

--- a/crates/anvil/tests/it/machine.rs
+++ b/crates/anvil/tests/it/machine.rs
@@ -14,15 +14,8 @@ fn sigint(pid: u32) {
     assert!(status.success(), "failed to deliver SIGINT to pid {pid}");
 }
 
-/// Spawns `anvil` with `--port 0` and the given extra args, waits for the
-/// startup handshake, then returns the running child.
-///
-/// In normal mode anvil emits a human-readable "Listening on" banner on
-/// stdout, which is the handshake we wait for. Under `--machine` the shell
-/// is forced to `Quiet` (no human prints reach stdout) and the structured
-/// `session_start` record is a follow-up PR, so there is no on-stdout
-/// handshake to wait for: we fall back to a fixed grace period long enough
-/// for the bind to complete.
+/// Spawns `anvil --port 0` with extra args and waits for the startup
+/// handshake before returning the running child.
 fn spawn_anvil(extra: &[&str]) -> (Child, BufReader<std::process::ChildStdout>) {
     let bin = env!("CARGO_BIN_EXE_anvil");
     let mut cmd = Command::new(bin);
@@ -31,11 +24,9 @@ fn spawn_anvil(extra: &[&str]) -> (Child, BufReader<std::process::ChildStdout>) 
     let stdout = BufReader::new(child.stdout.take().unwrap());
 
     if extra.contains(&"--machine") {
-        // No on-stdout startup record yet under `--machine`; give anvil time
-        // to bind AND register its ctrlc handler before returning so the
-        // SIGINT lands on the installed handler rather than the default
-        // termination handler. 5s is generous but matches the upper bound
-        // of cold-start under a debug build on a busy CI runner.
+        // `--machine` silences the "Listening on" banner and the structured
+        // `session_start` handshake is not yet implemented; fall back to a
+        // fixed grace period for bind + ctrlc-handler registration.
         std::thread::sleep(Duration::from_secs(5));
         return (child, stdout);
     }

--- a/crates/anvil/tests/it/machine.rs
+++ b/crates/anvil/tests/it/machine.rs
@@ -15,14 +15,32 @@ fn sigint(pid: u32) {
 }
 
 /// Spawns `anvil` with `--port 0` and the given extra args, waits for the
-/// "Listening on" handshake on stdout, then returns the running child.
+/// startup handshake, then returns the running child.
+///
+/// In normal mode anvil emits a human-readable "Listening on" banner on
+/// stdout, which is the handshake we wait for. Under `--machine` the shell
+/// is forced to `Quiet` (no human prints reach stdout) and the structured
+/// `session_start` record is a follow-up PR, so there is no on-stdout
+/// handshake to wait for: we fall back to a fixed grace period long enough
+/// for the bind to complete.
 fn spawn_anvil(extra: &[&str]) -> (Child, BufReader<std::process::ChildStdout>) {
     let bin = env!("CARGO_BIN_EXE_anvil");
     let mut cmd = Command::new(bin);
     cmd.args(["--port", "0"]).args(extra).stdout(Stdio::piped()).stderr(Stdio::piped());
     let mut child = cmd.spawn().expect("anvil spawn");
-    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    let stdout = BufReader::new(child.stdout.take().unwrap());
 
+    if extra.contains(&"--machine") {
+        // No on-stdout startup record yet under `--machine`; give anvil time
+        // to bind AND register its ctrlc handler before returning so the
+        // SIGINT lands on the installed handler rather than the default
+        // termination handler. 5s is generous but matches the upper bound
+        // of cold-start under a debug build on a busy CI runner.
+        std::thread::sleep(Duration::from_secs(5));
+        return (child, stdout);
+    }
+
+    let mut stdout = stdout;
     let deadline = Instant::now() + Duration::from_secs(30);
     loop {
         if Instant::now() > deadline {

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -261,11 +261,14 @@ impl CallArgs {
             .filter_map(|(name, on)| on.then_some(name))
             .collect::<Vec<_>>();
             if !unsupported.is_empty() {
-                foundry_cli::machine::bail_machine_usage(format!(
-                    "`cast call` under `--machine` does not yet support {}; \
-                     run without `--machine` or omit those flags.",
-                    unsupported.join(", ")
-                ));
+                foundry_cli::machine::bail_machine_usage_with_details(
+                    format!(
+                        "`cast call` under `--machine` does not yet support {}; \
+                         run without `--machine` or omit those flags.",
+                        unsupported.join(", ")
+                    ),
+                    serde_json::json!({ "unsupported_flags": unsupported }),
+                );
             }
             // Unlocked keystore: prompts for the password on TTY at signer construction.
             let has_keystore =

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3517,6 +3517,11 @@ forgetest_async!(cast_call_machine_mode_rejects_unsupported_flags, |_prj, cmd| {
     assert_eq!(assert.get_output().status.code(), Some(2));
     let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
     assert!(msg.contains("--trace"), "missing --trace mention: {envelope}");
+    assert_eq!(
+        envelope["errors"][0]["details"]["unsupported_flags"],
+        serde_json::json!(["--trace"]),
+        "missing structured unsupported_flags details: {envelope}"
+    );
 });
 
 // Transport/connectivity failures (here: unreachable RPC URL) emit a typed

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -37,6 +37,7 @@ alloy-chains.workspace = true
 alloy-ens = { workspace = true, features = ["provider"] }
 
 cfg-if = "1.0"
+chrono.workspace = true
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_complete.workspace = true
 clap_complete_nushell.workspace = true

--- a/crates/cli/src/diagnostic.rs
+++ b/crates/cli/src/diagnostic.rs
@@ -149,8 +149,10 @@ pub mod wallet {
 pub mod test {
     pub const FAILED: &str = "test.failed";
     pub const SETUP_FAILED: &str = "test.setup_failed";
+    /// Non-fatal advisory surfaced by a test suite.
+    pub const WARNING: &str = "test.warning";
 
-    pub(crate) const ALL: &[&str] = &[FAILED, SETUP_FAILED];
+    pub(crate) const ALL: &[&str] = &[FAILED, SETUP_FAILED, WARNING];
 }
 
 /// `forge script` diagnostic codes.

--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -3,7 +3,6 @@
 use eyre::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, to_string};
-use std::io::Write as _;
 
 /// The current version of Foundry's top-level JSON output envelope.
 pub const JSON_SCHEMA_VERSION: u32 = 1;
@@ -132,13 +131,56 @@ impl JsonMessage {
 
 /// Prints a value as compact, single-line JSON to stdout.
 ///
-/// Bypasses the shell verbosity layer so `--quiet` cannot suppress structured
-/// output the caller explicitly asked for.
+/// Bypasses the shell verbosity layer so neither `--quiet` nor the
+/// `--machine`-induced Quiet mode can suppress structured output the
+/// caller explicitly asked for. Always flushes before returning so that
+/// callers which immediately `std::process::exit` cannot drop the record
+/// on a piped stdout. The trailing newline makes this suitable for
+/// NDJSON streams when each call emits one self-contained JSON record.
 pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
-    let mut stdout = std::io::stdout().lock();
-    writeln!(stdout, "{}", to_string(value)?)?;
-    stdout.flush()?;
+    let s = to_string(value)?;
+    let mut shell = foundry_common::shell::Shell::get();
+    writeln!(shell.out(), "{s}")?;
+    shell.out().flush()?;
     Ok(())
+}
+
+/// One NDJSON record emitted on the stream of a long-running command.
+///
+/// Carries the per-record fields required by `docs/agents/spec.md` §6
+/// (`schema_id`, `command_id`, `kind`, `ts`) and flattens the kind-specific
+/// payload into the same object.
+#[derive(Clone, Debug, Serialize)]
+pub struct StreamRecord<T> {
+    pub schema_id: &'static str,
+    pub command_id: &'static str,
+    pub kind: &'static str,
+    /// RFC 3339 timestamp.
+    pub ts: String,
+    #[serde(flatten)]
+    pub payload: T,
+}
+
+impl<T: Serialize> StreamRecord<T> {
+    /// Build a record stamped with the current UTC time.
+    pub fn new(
+        schema_id: &'static str,
+        command_id: &'static str,
+        kind: &'static str,
+        payload: T,
+    ) -> Self {
+        Self { schema_id, command_id, kind, ts: chrono::Utc::now().to_rfc3339(), payload }
+    }
+}
+
+/// Emits a single NDJSON record on stdout for a streaming command.
+pub fn print_stream_record<T: Serialize>(
+    schema_id: &'static str,
+    command_id: &'static str,
+    kind: &'static str,
+    payload: T,
+) -> Result<()> {
+    print_json(&StreamRecord::new(schema_id, command_id, kind, payload))
 }
 
 /// Prints a successful JSON envelope to stdout.
@@ -189,6 +231,32 @@ mod tests {
         assert_eq!(value["warnings"][0]["level"], "warning");
         assert_eq!(value["warnings"][0]["code"], "compiler.remappings");
         assert_eq!(value["warnings"][0]["details"]["count"], 3);
+    }
+
+    #[test]
+    fn stream_record_includes_required_fields_and_flattens_payload() {
+        #[derive(Serialize)]
+        struct TestEvent {
+            contract: String,
+            passed: usize,
+        }
+        let payload = TestEvent { contract: "Counter.t.sol:CounterTest".into(), passed: 3 };
+        let rec = StreamRecord::new(
+            "foundry:forge.test.event@v1",
+            "forge.test",
+            "suite_finished",
+            payload,
+        );
+        let json = to_string(&rec).unwrap();
+        // Compact, no pretty-printing.
+        assert!(!json.contains('\n'), "expected compact json, got: {json}");
+        let v = serde_json::from_str::<Value>(&json).unwrap();
+        assert_eq!(v["schema_id"], "foundry:forge.test.event@v1");
+        assert_eq!(v["command_id"], "forge.test");
+        assert_eq!(v["kind"], "suite_finished");
+        assert!(v["ts"].is_string());
+        assert_eq!(v["contract"], "Counter.t.sol:CounterTest");
+        assert_eq!(v["passed"], 3);
     }
 
     #[test]

--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -141,8 +141,11 @@ impl JsonMessage {
 pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
     let s = to_string(value)?;
     let mut shell = foundry_common::shell::Shell::get();
-    writeln!(shell.out(), "{s}")?;
-    shell.out().flush()?;
+    // Bind `out()` once so write and flush target the same writer; defensive
+    // against any future `out()` impl that returns a fresh wrapper.
+    let out = shell.out();
+    writeln!(out, "{s}")?;
+    out.flush()?;
     Ok(())
 }
 
@@ -151,18 +154,23 @@ pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
 /// Carries the per-record fields required by `docs/agents/spec.md` §6
 /// (`schema_id`, `command_id`, `kind`, `ts`) and flattens the kind-specific
 /// payload into the same object.
+///
+/// Fields are crate-private so the only construction paths are
+/// [`StreamRecord::new`] and [`print_stream_record`], which guarantee the
+/// `ts` invariant (RFC 3339 with millisecond precision).
 #[derive(Clone, Debug, Serialize)]
 pub struct StreamRecord<T> {
-    pub schema_id: &'static str,
-    pub command_id: &'static str,
-    pub kind: &'static str,
-    /// RFC 3339 timestamp.
-    pub ts: String,
+    pub(crate) schema_id: &'static str,
+    pub(crate) command_id: &'static str,
+    pub(crate) kind: &'static str,
+    /// RFC 3339 timestamp with millisecond precision, UTC. Fixed-width
+    /// substring keeps stream parsers and log search regexes stable.
+    pub(crate) ts: String,
     #[serde(flatten)]
-    pub payload: T,
+    pub(crate) payload: T,
 }
 
-impl<T: Serialize> StreamRecord<T> {
+impl<T> StreamRecord<T> {
     /// Build a record stamped with the current UTC time.
     pub fn new(
         schema_id: &'static str,
@@ -170,7 +178,13 @@ impl<T: Serialize> StreamRecord<T> {
         kind: &'static str,
         payload: T,
     ) -> Self {
-        Self { schema_id, command_id, kind, ts: chrono::Utc::now().to_rfc3339(), payload }
+        Self {
+            schema_id,
+            command_id,
+            kind,
+            ts: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            payload,
+        }
     }
 }
 

--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -131,12 +131,13 @@ impl JsonMessage {
 
 /// Prints a value as compact, single-line JSON to stdout.
 ///
-/// Bypasses the shell verbosity layer so neither `--quiet` nor the
-/// `--machine`-induced Quiet mode can suppress structured output the
-/// caller explicitly asked for. Always flushes before returning so that
-/// callers which immediately `std::process::exit` cannot drop the record
-/// on a piped stdout. The trailing newline makes this suitable for
-/// NDJSON streams when each call emits one self-contained JSON record.
+/// Bypasses the shell verbosity layer (see
+/// [`foundry_common::shell::Shell::is_quiet`]) so neither `--quiet` nor the
+/// `--machine`-induced Quiet mode can suppress structured output the caller
+/// explicitly asked for. Always flushes before returning so that callers
+/// which immediately `std::process::exit` cannot drop the record on a piped
+/// stdout. The trailing newline makes this suitable for NDJSON streams when
+/// each call emits one self-contained JSON record.
 pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
     let s = to_string(value)?;
     let mut shell = foundry_common::shell::Shell::get();

--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -129,42 +129,28 @@ impl JsonMessage {
     }
 }
 
-/// Prints a value as compact, single-line JSON to stdout.
+/// Prints a value as one compact JSON line on stdout and flushes.
 ///
-/// Bypasses the shell verbosity layer (see
-/// [`foundry_common::shell::Shell::is_quiet`]) so neither `--quiet` nor the
-/// `--machine`-induced Quiet mode can suppress structured output the caller
-/// explicitly asked for. Always flushes before returning so that callers
-/// which immediately `std::process::exit` cannot drop the record on a piped
-/// stdout. The trailing newline makes this suitable for NDJSON streams when
-/// each call emits one self-contained JSON record.
+/// Bypasses the shell verbosity layer so `--quiet` cannot suppress structured
+/// output the caller explicitly asked for.
 pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
     let s = to_string(value)?;
     let mut shell = foundry_common::shell::Shell::get();
-    // Bind `out()` once so write and flush target the same writer; defensive
-    // against any future `out()` impl that returns a fresh wrapper.
     let out = shell.out();
     writeln!(out, "{s}")?;
     out.flush()?;
     Ok(())
 }
 
-/// One NDJSON record emitted on the stream of a long-running command.
-///
-/// Carries the per-record fields required by `docs/agents/spec.md` §6
-/// (`schema_id`, `command_id`, `kind`, `ts`) and flattens the kind-specific
-/// payload into the same object.
-///
-/// Fields are crate-private so the only construction paths are
-/// [`StreamRecord::new`] and [`print_stream_record`], which guarantee the
-/// `ts` invariant (RFC 3339 with millisecond precision).
+/// One NDJSON record on a long-running command's stream. The kind-specific
+/// `payload` is flattened into the same object alongside the spec fields
+/// (`schema_id`, `command_id`, `kind`, `ts`).
 #[derive(Clone, Debug, Serialize)]
 pub struct StreamRecord<T> {
     pub(crate) schema_id: &'static str,
     pub(crate) command_id: &'static str,
     pub(crate) kind: &'static str,
-    /// RFC 3339 timestamp with millisecond precision, UTC. Fixed-width
-    /// substring keeps stream parsers and log search regexes stable.
+    /// RFC 3339 UTC with millisecond precision.
     pub(crate) ts: String,
     #[serde(flatten)]
     pub(crate) payload: T,

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -141,10 +141,8 @@ pub fn bail_machine_usage(message: impl Into<String>) -> ! {
     std::process::exit(ExitCode::Usage.to_i32());
 }
 
-/// Like [`bail_machine_usage`] but attaches structured `details` to the
-/// emitted [`JsonMessage`]. Use when the rejection carries machine-parseable
-/// context (e.g. a list of conflicting flag names) so agents do not have
-/// to parse the prose `message` to react.
+/// Like [`bail_machine_usage`] but attaches structured `details` so agents
+/// can react without parsing the prose `message`.
 pub fn bail_machine_usage_with_details(
     message: impl Into<String>,
     details: serde_json::Value,

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -141,6 +141,21 @@ pub fn bail_machine_usage(message: impl Into<String>) -> ! {
     std::process::exit(ExitCode::Usage.to_i32());
 }
 
+/// Like [`bail_machine_usage`] but attaches structured `details` to the
+/// emitted [`JsonMessage`]. Use when the rejection carries machine-parseable
+/// context (e.g. a list of conflicting flag names) so agents do not have
+/// to parse the prose `message` to react.
+pub fn bail_machine_usage_with_details(
+    message: impl Into<String>,
+    details: serde_json::Value,
+) -> ! {
+    let envelope = JsonEnvelope::error(
+        JsonMessage::error(diagnostic::cli::USAGE_INVALID, message).with_details(details),
+    );
+    let _ = print_json(&envelope);
+    std::process::exit(ExitCode::Usage.to_i32());
+}
+
 /// Fallback envelope emitter for an untyped `eyre::Report`. Always tags
 /// `cli.unknown` and preserves the eyre cause chain in `details.cause_chain`.
 /// The process exit code is the caller's responsibility.

--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -140,18 +140,8 @@ impl GlobalArgs {
 
     /// Create a new shell instance.
     pub fn shell(&self) -> Shell {
-        // `--machine` owns stdout; force the global shell to Quiet so every
-        // `sh_println!` / `sh_warn!` / `sh_err!` site becomes a no-op.
-        // Explicit machine output (envelopes, NDJSON records) goes through
+        // `--machine` forces Quiet; structured output goes through
         // `print_json` / `print_stream_record`, which bypass the quiet check.
-        //
-        // Consequence: any binary or subcommand that has NOT been adopted
-        // into the agent contract will produce zero stdout and zero stderr
-        // under `--machine` — appearing completely silent / hung from the
-        // agent's perspective. Adoption work for a new command MUST wire up
-        // a session_start record, NDJSON stream events, and/or a terminal
-        // envelope so the agent has something to observe. See
-        // `docs/agents/spec.md` for the per-mode contract.
         let mode = match self.quiet || self.machine {
             true => OutputMode::Quiet,
             false => OutputMode::Normal,

--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -140,7 +140,11 @@ impl GlobalArgs {
 
     /// Create a new shell instance.
     pub fn shell(&self) -> Shell {
-        let mode = match self.quiet {
+        // `--machine` owns stdout; force the global shell to Quiet so all
+        // `sh_println!`/`sh_warn!` sites become no-ops. Explicit machine
+        // output (envelopes, NDJSON records) goes through `print_json`,
+        // which bypasses the quiet check.
+        let mode = match self.quiet || self.machine {
             true => OutputMode::Quiet,
             false => OutputMode::Normal,
         };

--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -140,10 +140,18 @@ impl GlobalArgs {
 
     /// Create a new shell instance.
     pub fn shell(&self) -> Shell {
-        // `--machine` owns stdout; force the global shell to Quiet so all
-        // `sh_println!`/`sh_warn!` sites become no-ops. Explicit machine
-        // output (envelopes, NDJSON records) goes through `print_json`,
-        // which bypasses the quiet check.
+        // `--machine` owns stdout; force the global shell to Quiet so every
+        // `sh_println!` / `sh_warn!` / `sh_err!` site becomes a no-op.
+        // Explicit machine output (envelopes, NDJSON records) goes through
+        // `print_json` / `print_stream_record`, which bypass the quiet check.
+        //
+        // Consequence: any binary or subcommand that has NOT been adopted
+        // into the agent contract will produce zero stdout and zero stderr
+        // under `--machine` — appearing completely silent / hung from the
+        // agent's perspective. Adoption work for a new command MUST wire up
+        // a session_start record, NDJSON stream events, and/or a terminal
+        // envelope so the agent has something to observe. See
+        // `docs/agents/spec.md` for the per-mode contract.
         let mode = match self.quiet || self.machine {
             true => OutputMode::Quiet,
             false => OutputMode::Normal,

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -63,9 +63,7 @@ pub fn run_command(args: Forge) -> Result<()> {
     // Run the subcommand.
     match args.cmd {
         ForgeSubcommand::Test(cmd) => {
-            // Preflight runs before the watcher dispatch so `--watch` (and
-            // every other unsupported flag) is rejected at the top level
-            // rather than swallowed by the watch loop.
+            // Preflight before watcher dispatch so `--watch` is rejected too.
             cmd.reject_machine_unsupported_flags()?;
             if cmd.is_watch() {
                 global.block_on(watch::watch_test(cmd))
@@ -163,26 +161,17 @@ pub fn run_command(args: Forge) -> Result<()> {
 }
 
 /// Emit the terminal `forge test` envelope and exit appropriately under
-/// `--machine`. Bypasses [`TestOutcome::ensure_ok`]'s human output entirely;
-/// the agent stream owns stdout for the run.
+/// `--machine`. Bypasses [`TestOutcome::ensure_ok`]'s human output.
 fn finalize_test_machine_mode(outcome: TestOutcome, wall_clock: std::time::Duration) -> Result<()> {
     let summary = TestSummaryData::from_outcome(&outcome, wall_clock);
     let warnings = aggregate_test_warnings(&outcome);
 
-    // `--allow-failure` opts into "test failures don't fail the command".
-    // Preserve that legacy contract under `--machine`: emit a success
-    // envelope and exit 0 even if `summary.failed > 0`. Agents that need to
-    // detect tolerated failures inspect `data.failed` on the success
-    // envelope; the contract is documented on `ExitCode::Success` in
-    // `crates/forge/src/introspect.rs`.
+    // `--allow-failure`: success envelope + exit 0 even if `summary.failed > 0`.
     if outcome.allow_failure || outcome.failed() == 0 {
         print_json(&JsonEnvelope::success_with_warnings(summary, warnings))?;
         return Ok(());
     }
-    // `TestSummaryData` is `usize` + `u128`; serialization is infallible.
-    // Use `expect` so any future shape change that breaks this invariant
-    // fails loudly instead of silently dropping the details to null.
-    let details = serde_json::to_value(&summary).expect("TestSummaryData serialization");
+    let details = serde_json::to_value(&summary).expect("TestSummaryData is plain scalar fields");
     let failing_suites = outcome.results.values().filter(|s| s.failed() > 0).count();
     let message = format!(
         "{} test(s) failed across {} failing suite(s) (out of {} ran)",
@@ -198,8 +187,7 @@ fn finalize_test_machine_mode(outcome: TestOutcome, wall_clock: std::time::Durat
     std::process::exit(foundry_cli::ExitCode::TestFailure.to_i32());
 }
 
-/// Collect every `SuiteResult.warnings` string into structured envelope
-/// messages keyed by the stable `test.warning` code.
+/// Flatten per-suite warnings into envelope messages keyed by `test.warning`.
 fn aggregate_test_warnings(outcome: &TestOutcome) -> Vec<JsonMessage> {
     outcome
         .results

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -1,12 +1,16 @@
 use crate::{
-    cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, watch},
+    cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, test::TestSummaryData, watch},
     introspect::REGISTRY,
     opts::{Forge, ForgeSubcommand},
+    result::TestOutcome,
 };
 use clap::CommandFactory;
 use clap_complete::generate;
 use eyre::Result;
-use foundry_cli::utils;
+use foundry_cli::{
+    json::{JsonEnvelope, JsonMessage, print_json},
+    utils,
+};
 use foundry_common::{sh_warn, shell};
 use foundry_evm::inspectors::cheatcodes::{ForgeContext, set_execution_context};
 
@@ -59,11 +63,20 @@ pub fn run_command(args: Forge) -> Result<()> {
     // Run the subcommand.
     match args.cmd {
         ForgeSubcommand::Test(cmd) => {
+            // Preflight runs before the watcher dispatch so `--watch` (and
+            // every other unsupported flag) is rejected at the top level
+            // rather than swallowed by the watch loop.
+            cmd.reject_machine_unsupported_flags()?;
             if cmd.is_watch() {
                 global.block_on(watch::watch_test(cmd))
             } else {
-                let silent = cmd.junit || shell::is_json();
+                let machine_mode = foundry_cli::is_machine();
+                let silent = machine_mode || cmd.junit || shell::is_json();
+                let started = std::time::Instant::now();
                 let outcome = global.block_on(cmd.run())?;
+                if machine_mode {
+                    return finalize_test_machine_mode(outcome, started.elapsed());
+                }
                 outcome.ensure_ok(silent)
             }
         }
@@ -149,6 +162,43 @@ pub fn run_command(args: Forge) -> Result<()> {
     }
 }
 
+/// Emit the terminal `forge test` envelope and exit appropriately under
+/// `--machine`. Bypasses [`TestOutcome::ensure_ok`]'s human output entirely;
+/// the agent stream owns stdout for the run.
+fn finalize_test_machine_mode(outcome: TestOutcome, wall_clock: std::time::Duration) -> Result<()> {
+    let summary = TestSummaryData::from_outcome(&outcome, wall_clock);
+    let warnings = aggregate_test_warnings(&outcome);
+
+    if outcome.allow_failure || outcome.failed() == 0 {
+        print_json(&JsonEnvelope::success_with_warnings(summary, warnings))?;
+        return Ok(());
+    }
+    let details = serde_json::to_value(&summary).unwrap_or(serde_json::Value::Null);
+    let message =
+        format!("{} test(s) failed across {} suite(s)", outcome.failed(), outcome.results.len());
+    let mut envelope = JsonEnvelope::error(
+        JsonMessage::error(foundry_cli::diagnostic::test::FAILED, message).with_details(details),
+    );
+    envelope.warnings = warnings;
+    print_json(&envelope)?;
+    std::process::exit(foundry_cli::ExitCode::TestFailure.to_i32());
+}
+
+/// Collect every `SuiteResult.warnings` string into structured envelope
+/// messages keyed by the stable `test.warning` code.
+fn aggregate_test_warnings(outcome: &TestOutcome) -> Vec<JsonMessage> {
+    outcome
+        .results
+        .iter()
+        .flat_map(|(suite, sr)| {
+            sr.warnings.iter().map(move |w| {
+                JsonMessage::warning(foundry_cli::diagnostic::test::WARNING, w.clone())
+                    .with_details(serde_json::json!({ "suite": suite }))
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -191,25 +241,31 @@ mod tests {
         assert!(v.is_empty(), "forge capability violations: {v:?}");
     }
 
-    /// Every adopted command (`output_mode = Envelope`) must pin a stable
-    /// `command_id` matching its registry entry. Catches accidental drift
-    /// between the registry and the clap tree.
+    /// Every adopted command must pin a stable `command_id` matching its
+    /// registry entry. Catches accidental drift between the registry and the
+    /// clap tree across both envelope- and stream-mode commands.
     #[test]
     fn registered_commands_pin_stable_ids() {
         let cmd = Forge::command();
         let doc = build_document(&cmd, &REGISTRY);
-        fn walk(c: &foundry_cli::introspect::CommandInfo) -> Vec<&str> {
+        fn walk(c: &foundry_cli::introspect::CommandInfo) -> Vec<(&str, OutputMode)> {
             let mut out = Vec::new();
-            if matches!(c.capabilities.output_mode, OutputMode::Envelope) {
-                out.push(c.command_id.as_str());
+            if !matches!(c.capabilities.output_mode, OutputMode::None) {
+                out.push((c.command_id.as_str(), c.capabilities.output_mode));
             }
             for sub in &c.subcommands {
                 out.extend(walk(sub));
             }
             out
         }
-        let mut envelope_ids: Vec<&str> = doc.commands.iter().flat_map(walk).collect();
-        envelope_ids.sort();
-        assert!(envelope_ids.contains(&"forge.build"), "forge.build missing: {envelope_ids:?}");
+        let pinned: Vec<(&str, OutputMode)> = doc.commands.iter().flat_map(walk).collect();
+        let pinned_ids: Vec<&str> = pinned.iter().map(|(id, _)| *id).collect();
+        for id in ["forge.build", "forge.test"] {
+            assert!(pinned_ids.contains(&id), "{id} missing from pinned ids: {pinned_ids:?}");
+        }
+        assert!(
+            pinned.iter().any(|(id, m)| *id == "forge.test" && matches!(m, OutputMode::Stream)),
+            "forge.test must be Stream: {pinned:?}"
+        );
     }
 }

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -169,13 +169,27 @@ fn finalize_test_machine_mode(outcome: TestOutcome, wall_clock: std::time::Durat
     let summary = TestSummaryData::from_outcome(&outcome, wall_clock);
     let warnings = aggregate_test_warnings(&outcome);
 
+    // `--allow-failure` opts into "test failures don't fail the command".
+    // Preserve that legacy contract under `--machine`: emit a success
+    // envelope and exit 0 even if `summary.failed > 0`. Agents that need to
+    // detect tolerated failures inspect `data.failed` on the success
+    // envelope; the contract is documented on `ExitCode::Success` in
+    // `crates/forge/src/introspect.rs`.
     if outcome.allow_failure || outcome.failed() == 0 {
         print_json(&JsonEnvelope::success_with_warnings(summary, warnings))?;
         return Ok(());
     }
-    let details = serde_json::to_value(&summary).unwrap_or(serde_json::Value::Null);
-    let message =
-        format!("{} test(s) failed across {} suite(s)", outcome.failed(), outcome.results.len());
+    // `TestSummaryData` is `usize` + `u128`; serialization is infallible.
+    // Use `expect` so any future shape change that breaks this invariant
+    // fails loudly instead of silently dropping the details to null.
+    let details = serde_json::to_value(&summary).expect("TestSummaryData serialization");
+    let failing_suites = outcome.results.values().filter(|s| s.failed() > 0).count();
+    let message = format!(
+        "{} test(s) failed across {} failing suite(s) (out of {} ran)",
+        outcome.failed(),
+        failing_suites,
+        outcome.results.len(),
+    );
     let mut envelope = JsonEnvelope::error(
         JsonMessage::error(foundry_cli::diagnostic::test::FAILED, message).with_details(details),
     );

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -181,7 +181,7 @@ pub fn run_command(args: Forge) -> Result<()> {
 }
 
 /// Human-readable subcommand name (e.g. `"snapshot"`) for diagnostics.
-fn subcommand_name(cmd: &ForgeSubcommand) -> &'static str {
+const fn subcommand_name(cmd: &ForgeSubcommand) -> &'static str {
     match cmd {
         ForgeSubcommand::Test(_) => "test",
         ForgeSubcommand::Script(_) => "script",

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -60,6 +60,26 @@ pub fn run_command(args: Forge) -> Result<()> {
 
     let global = &args.global;
 
+    // Reject `--machine` for forge subcommands not declared adopted in the
+    // introspect registry. Without this, embedders that wrap `TestArgs` (e.g.
+    // `snapshot`, `coverage`) would emit `forge.test` stream events on the
+    // process-global `is_machine()` flag without ever emitting a terminal
+    // envelope — spoofing `command_id` and leaving the stream unterminated.
+    if foundry_cli::is_machine() {
+        let adopted = matches!(args.cmd, ForgeSubcommand::Build(_) | ForgeSubcommand::Test(_));
+        if !adopted {
+            let name = subcommand_name(&args.cmd);
+            foundry_cli::machine::bail_machine_usage_with_details(
+                format!(
+                    "`forge {name}` is not yet adopted for `--machine`; only \
+                     `forge build` and `forge test` are. Run without `--machine` \
+                     or use an adopted subcommand."
+                ),
+                serde_json::json!({ "subcommand": name }),
+            );
+        }
+    }
+
     // Run the subcommand.
     match args.cmd {
         ForgeSubcommand::Test(cmd) => {
@@ -157,6 +177,45 @@ pub fn run_command(args: Forge) -> Result<()> {
         ForgeSubcommand::Eip712(cmd) => cmd.run(),
         ForgeSubcommand::BindJson(cmd) => cmd.run(),
         ForgeSubcommand::Lint(cmd) => cmd.run(),
+    }
+}
+
+/// Human-readable subcommand name (e.g. `"snapshot"`) for diagnostics.
+fn subcommand_name(cmd: &ForgeSubcommand) -> &'static str {
+    match cmd {
+        ForgeSubcommand::Test(_) => "test",
+        ForgeSubcommand::Script(_) => "script",
+        ForgeSubcommand::Coverage(_) => "coverage",
+        ForgeSubcommand::Bind(_) => "bind",
+        ForgeSubcommand::Build(_) => "build",
+        ForgeSubcommand::VerifyContract(_) => "verify-contract",
+        ForgeSubcommand::VerifyCheck(_) => "verify-check",
+        ForgeSubcommand::VerifyBytecode(_) => "verify-bytecode",
+        ForgeSubcommand::Clone(_) => "clone",
+        ForgeSubcommand::Cache(_) => "cache",
+        ForgeSubcommand::Create(_) => "create",
+        ForgeSubcommand::Update(_) => "update",
+        ForgeSubcommand::Install(_) => "install",
+        ForgeSubcommand::Remove(_) => "remove",
+        ForgeSubcommand::Remappings(_) => "remappings",
+        ForgeSubcommand::Init(_) => "init",
+        ForgeSubcommand::Completions { .. } => "completions",
+        ForgeSubcommand::Clean { .. } => "clean",
+        ForgeSubcommand::Snapshot(_) => "snapshot",
+        ForgeSubcommand::Fmt(_) => "fmt",
+        ForgeSubcommand::Config(_) => "config",
+        ForgeSubcommand::Flatten(_) => "flatten",
+        ForgeSubcommand::Inspect(_) => "inspect",
+        ForgeSubcommand::Tree(_) => "tree",
+        ForgeSubcommand::Geiger(_) => "geiger",
+        ForgeSubcommand::Doc(_) => "doc",
+        ForgeSubcommand::Selectors { .. } => "selectors",
+        ForgeSubcommand::Generate(_) => "generate",
+        ForgeSubcommand::Compiler(_) => "compiler",
+        ForgeSubcommand::Soldeer(_) => "soldeer",
+        ForgeSubcommand::Eip712(_) => "eip712",
+        ForgeSubcommand::BindJson(_) => "bind-json",
+        ForgeSubcommand::Lint(_) => "lint",
     }
 }
 

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -99,11 +99,14 @@ impl BuildArgs {
                 .filter_map(|(name, on)| on.then_some(name))
                 .collect::<Vec<_>>();
         if !unsupported.is_empty() {
-            foundry_cli::machine::bail_machine_usage(format!(
-                "`forge build` under `--machine` does not yet support {}; \
-                 run without `--machine` or omit those flags.",
-                unsupported.join(", ")
-            ));
+            foundry_cli::machine::bail_machine_usage_with_details(
+                format!(
+                    "`forge build` under `--machine` does not yet support {}; \
+                     run without `--machine` or omit those flags.",
+                    unsupported.join(", ")
+                ),
+                serde_json::json!({ "unsupported_flags": unsupported }),
+            );
         }
     }
 

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -190,7 +190,9 @@ impl BuildArgs {
                 .filter(|e| e.is_error())
                 .map(|e| JsonMessage::error(SOLC_ERROR, e.to_string()))
                 .collect();
-            print_json(&JsonEnvelope::<()>::failure(errors))?;
+            // Best-effort: bubbling via `?` on a broken stdout would demote
+            // the canonical `Build (4)` exit to `GenericError (1)`.
+            let _ = print_json(&JsonEnvelope::<()>::failure(errors));
             std::process::exit(ExitCode::Build.to_i32());
         }
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -324,8 +324,8 @@ impl TestArgs {
     }
 
     /// Reject flags whose stdout shape conflicts with the NDJSON stream
-    /// contract under `--machine`. Called from the binary entry point
-    /// before any subcommand dispatch so `--watch` is also rejected.
+    /// contract under `--machine`. Called from the binary entry point so
+    /// `--watch` is also rejected.
     pub(crate) fn reject_machine_unsupported_flags(&self) -> Result<()> {
         if !foundry_cli::is_machine() {
             return Ok(());
@@ -340,10 +340,9 @@ impl TestArgs {
             ("--list", self.list),
             ("--junit", self.junit),
             ("--show-progress", self.show_progress),
-            // `--live-logs` prints console.log output directly to stdout from
-            // the EVM log inspector, which would interleave with the NDJSON
-            // stream. The same risk via `live_logs = true` in foundry.toml is
-            // silently overridden in `compile_and_run` (see `machine_mode`).
+            // `--live-logs` writes console.log straight to stdout; the
+            // `live_logs = true` config equivalent is overridden in
+            // `compile_and_run`.
             ("--live-logs", self.evm.live_logs),
         ]
         .into_iter()
@@ -388,9 +387,8 @@ impl TestArgs {
         });
         let output = project.compile()?;
         if output.has_compiler_errors() {
-            // Under `--machine` the precompile path emits the same typed
-            // `compiler.solc.error` + `Build (4)` envelope as the main compile
-            // path, so agents don't see this surface as `cli.unknown`/exit 1.
+            // Mirror the main-compile typed envelope so agents don't see this
+            // path as `cli.unknown` + exit 1.
             if foundry_cli::is_machine() {
                 emit_machine_compile_error(&output);
             }
@@ -420,20 +418,16 @@ impl TestArgs {
         // Merge all configs.
         let (mut config, evm_opts) = self.load_config_and_evm_opts()?;
 
-        // Under `--machine`, neutralize config-driven knobs that would print to
-        // stdout outside the NDJSON contract. CLI equivalents are rejected in
-        // `reject_machine_unsupported_flags`; this catches the foundry.toml
-        // side that the CLI preflight cannot see.
+        // Override foundry.toml knobs that would print outside the NDJSON
+        // stream; the CLI equivalents are rejected in
+        // `reject_machine_unsupported_flags`.
         if machine_mode {
             config.show_progress = false;
             config.live_logs = false;
         }
 
-        // Install missing dependencies. `install_missing_dependencies` prints
-        // "Missing dependencies found. Installing now..." to stdout, which would
-        // corrupt the NDJSON stream. Under `--machine`, skip it: a missing dep
-        // surfaces as a typed `compiler.solc.error` envelope from the compile
-        // path below, which is exactly what agents need.
+        // Skip implicit dep install: it prints to stdout. A missing dep then
+        // surfaces as a typed `compiler.solc.error` from the compile below.
         if !machine_mode
             && install::install_missing_dependencies(&mut config).await
             && config.auto_detect_remappings
@@ -452,9 +446,8 @@ impl TestArgs {
             .dynamic_test_linking(config.dynamic_test_linking)
             .quiet(shell::is_json() || self.junit || machine_mode)
             .files(self.get_sources_to_compile(&config, &filter)?);
-        // Under `--machine`, disable the inner `bail` so a compile error
-        // returns the output and we can emit a typed envelope instead of an
-        // untyped eyre error mapped to `cli.unknown`.
+        // Disable inner `bail` so a compile error returns the output and we
+        // can emit a typed envelope instead of an untyped `cli.unknown`.
         if machine_mode {
             compiler = compiler.bail(false);
         }
@@ -844,7 +837,7 @@ impl TestArgs {
         }
 
         // Run tests in a non-streaming fashion and collect results for serialization.
-        // `--machine` takes precedence over `--json`; the agent stream wins.
+        // Agent stream wins over `--json`.
         if !machine_mode && !self.gas_report && !self.summary && shell::is_json() {
             let mut results = runner.test_collect(filter)?;
             for suite_result in results.values_mut() {
@@ -1280,10 +1273,8 @@ impl TestArgs {
     }
 }
 
-/// Stable payload emitted in the terminal `forge test` envelope under `--machine`.
-///
-/// See `docs/agents/spec.md` §6 for the contract: counts are aggregated across
-/// every suite that ran. Times are reported in milliseconds.
+/// Terminal `forge test` envelope payload under `--machine`. Counts are
+/// aggregated across every suite; times are in milliseconds.
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct TestSummaryData {
     pub suites: usize,
@@ -1385,12 +1376,8 @@ fn emit_warning_event(contract: &str, message: &str) -> Result<()> {
     Ok(())
 }
 
-/// Emit a `compiler.solc.error` envelope from a [`ProjectCompileOutput`] that
-/// reported errors, then exit with [`ExitCode::Build`]. Used by both the
-/// precompile and main-compile sites under `--machine` so agents see the
-/// same typed failure regardless of where the error was caught.
-///
-/// Mirrors the shape of `forge build`'s machine-mode compile-error path.
+/// Emit a `compiler.solc.error` envelope and exit `Build (4)`. Shared by the
+/// precompile and main-compile sites under `--machine`.
 fn emit_machine_compile_error(output: &ProjectCompileOutput) -> ! {
     let errors: Vec<JsonMessage> = output
         .output()
@@ -1399,6 +1386,7 @@ fn emit_machine_compile_error(output: &ProjectCompileOutput) -> ! {
         .filter(|e| e.is_error())
         .map(|e| JsonMessage::error(SOLC_ERROR, e.to_string()))
         .collect();
+    // Best-effort: bubbling on a broken stdout would demote exit `4` to `1`.
     let _ = print_json(&JsonEnvelope::<()>::failure(errors));
     std::process::exit(ExitCode::Build.to_i32());
 }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -350,11 +350,14 @@ impl TestArgs {
         .filter_map(|(name, on)| on.then_some(name))
         .collect::<Vec<_>>();
         if !unsupported.is_empty() {
-            foundry_cli::machine::bail_machine_usage(format!(
-                "`forge test` under `--machine` does not yet support {}; \
-                 run without `--machine` or omit those flags.",
-                unsupported.join(", ")
-            ));
+            foundry_cli::machine::bail_machine_usage_with_details(
+                format!(
+                    "`forge test` under `--machine` does not yet support {}; \
+                     run without `--machine` or omit those flags.",
+                    unsupported.join(", ")
+                ),
+                serde_json::json!({ "unsupported_flags": unsupported }),
+            );
         }
         Ok(())
     }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -346,6 +346,9 @@ impl TestArgs {
             ("--live-logs", self.evm.live_logs),
             // Bails mid-suite on diff; config equivalent overridden in `compile_and_run`.
             ("--gas-snapshot-check", self.gas_snapshot_check.unwrap_or(false)),
+            // Writes mid-suite to disk and can fail between test_result and
+            // suite_finished; config equivalent overridden in `compile_and_run`.
+            ("--gas-snapshot-emit", self.gas_snapshot_emit == Some(true)),
         ]
         .into_iter()
         .filter_map(|(name, on)| on.then_some(name))
@@ -427,6 +430,7 @@ impl TestArgs {
             config.show_progress = false;
             config.live_logs = false;
             config.gas_snapshot_check = false;
+            config.gas_snapshot_emit = false;
         }
 
         // Skip implicit dep install: it prints to stdout. A missing dep then

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -344,6 +344,8 @@ impl TestArgs {
             // `live_logs = true` config equivalent is overridden in
             // `compile_and_run`.
             ("--live-logs", self.evm.live_logs),
+            // Bails mid-suite on diff; config equivalent overridden in `compile_and_run`.
+            ("--gas-snapshot-check", self.gas_snapshot_check.unwrap_or(false)),
         ]
         .into_iter()
         .filter_map(|(name, on)| on.then_some(name))
@@ -419,11 +421,12 @@ impl TestArgs {
         let (mut config, evm_opts) = self.load_config_and_evm_opts()?;
 
         // Override foundry.toml knobs that would print outside the NDJSON
-        // stream; the CLI equivalents are rejected in
+        // stream or bail mid-suite; the CLI equivalents are rejected in
         // `reject_machine_unsupported_flags`.
         if machine_mode {
             config.show_progress = false;
             config.live_logs = false;
+            config.gas_snapshot_check = false;
         }
 
         // Skip implicit dep install: it prints to stdout. A missing dep then
@@ -520,6 +523,21 @@ impl TestArgs {
         // Parse inline config early to detect per-test network annotations.
         let inline_config = InlineConfig::new_parsed(output, &config)?;
         let override_networks = inline_config.referenced_override_networks(&config.profile);
+
+        // Multi-pass would emit `test_result*` + `suite_finished` once per
+        // pass for the same suite, violating "exactly one terminator per group".
+        if foundry_cli::is_machine() && !override_networks.is_empty() {
+            let networks: Vec<String> = override_networks.iter().map(|n| n.to_string()).collect();
+            foundry_cli::machine::bail_machine_usage_with_details(
+                "`forge test` under `--machine` does not yet support inline network \
+                 overrides; run without `--machine` or remove the inline `network` \
+                 annotations.",
+                serde_json::json!({
+                    "unsupported_features": ["inline_network_overrides"],
+                    "networks": networks,
+                }),
+            );
+        }
 
         let (libraries, mut outcome) = if override_networks.is_empty() {
             // Single-pass: no per-test network overrides, use global network setting.
@@ -1191,7 +1209,9 @@ impl TestArgs {
                 for warning in &suite_result.warnings {
                     emit_warning_event(&contract_name, warning)?;
                 }
-                if has_tests {
+                // Terminator follows any record for the group; warning-only
+                // suites get a zero-count `suite_finished`.
+                if has_tests || !suite_result.warnings.is_empty() {
                     emit_suite_finished_event(&contract_name, &suite_result)?;
                 }
             }
@@ -1298,7 +1318,7 @@ impl TestSummaryData {
 
 #[derive(serde::Serialize)]
 struct TestResultEvent<'a> {
-    contract: &'a str,
+    suite: &'a str,
     name: &'a str,
     status: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1308,7 +1328,7 @@ struct TestResultEvent<'a> {
 
 #[derive(serde::Serialize)]
 struct SuiteFinishedEvent<'a> {
-    contract: &'a str,
+    suite: &'a str,
     passed: usize,
     failed: usize,
     skipped: usize,
@@ -1317,7 +1337,7 @@ struct SuiteFinishedEvent<'a> {
 
 #[derive(serde::Serialize)]
 struct WarningEvent<'a> {
-    contract: &'a str,
+    suite: &'a str,
     code: &'static str,
     message: &'a str,
 }
@@ -1331,7 +1351,7 @@ const fn status_str(status: TestStatus) -> &'static str {
 }
 
 fn emit_test_result_event(
-    contract: &str,
+    suite: &str,
     name: &str,
     result: &crate::result::TestResult,
 ) -> Result<()> {
@@ -1340,7 +1360,7 @@ fn emit_test_result_event(
         "forge.test",
         "test_result",
         TestResultEvent {
-            contract,
+            suite,
             name,
             status: status_str(result.status),
             reason: result.reason.as_deref(),
@@ -1350,28 +1370,28 @@ fn emit_test_result_event(
     Ok(())
 }
 
-fn emit_suite_finished_event(contract: &str, suite: &SuiteResult) -> Result<()> {
+fn emit_suite_finished_event(suite: &str, result: &SuiteResult) -> Result<()> {
     foundry_cli::json::print_stream_record(
         crate::introspect::TEST_EVENT_SCHEMA,
         "forge.test",
         "suite_finished",
         SuiteFinishedEvent {
-            contract,
-            passed: suite.passed(),
-            failed: suite.failed(),
-            skipped: suite.skipped(),
-            duration_ms: suite.duration.as_millis(),
+            suite,
+            passed: result.passed(),
+            failed: result.failed(),
+            skipped: result.skipped(),
+            duration_ms: result.duration.as_millis(),
         },
     )?;
     Ok(())
 }
 
-fn emit_warning_event(contract: &str, message: &str) -> Result<()> {
+fn emit_warning_event(suite: &str, message: &str) -> Result<()> {
     foundry_cli::json::print_stream_record(
         crate::introspect::TEST_EVENT_SCHEMA,
         "forge.test",
         "warning",
-        WarningEvent { contract, code: foundry_cli::diagnostic::test::WARNING, message },
+        WarningEvent { suite, code: foundry_cli::diagnostic::test::WARNING, message },
     )?;
     Ok(())
 }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -2,6 +2,7 @@ use super::{install, test::filter::ProjectPathsAwareFilter, watch::WatchArgs};
 use crate::{
     MultiContractRunner, MultiContractRunnerBuilder,
     decode::decode_console_logs,
+    diagnostic::build::SOLC_ERROR,
     gas_report::GasReport,
     multi_runner::{MultiNetworkConfig, ShowmapConfig, matches_artifact},
     result::{SuiteResult, TestKindReport, TestOutcome, TestResult, TestStatus},
@@ -17,12 +18,14 @@ use chrono::Utc;
 use clap::{Parser, ValueEnum, ValueHint};
 use eyre::{Context, OptionExt, Result, bail};
 use foundry_cli::{
+    ExitCode,
+    json::{JsonEnvelope, JsonMessage, print_json},
     opts::{BuildOpts, EvmArgs, GlobalArgs},
     utils::{self, LoadConfig},
 };
 use foundry_common::{EmptyTestFilter, TestFunctionExt, compile::ProjectCompiler, fs, shell};
 use foundry_compilers::{
-    ProjectCompileOutput,
+    CompilationError, ProjectCompileOutput,
     artifacts::{Libraries, output_selection::OutputSelection},
     compilers::{
         Language,
@@ -337,6 +340,11 @@ impl TestArgs {
             ("--list", self.list),
             ("--junit", self.junit),
             ("--show-progress", self.show_progress),
+            // `--live-logs` prints console.log output directly to stdout from
+            // the EVM log inspector, which would interleave with the NDJSON
+            // stream. The same risk via `live_logs = true` in foundry.toml is
+            // silently overridden in `compile_and_run` (see `machine_mode`).
+            ("--live-logs", self.evm.live_logs),
         ]
         .into_iter()
         .filter_map(|(name, on)| on.then_some(name))
@@ -377,6 +385,12 @@ impl TestArgs {
         });
         let output = project.compile()?;
         if output.has_compiler_errors() {
+            // Under `--machine` the precompile path emits the same typed
+            // `compiler.solc.error` + `Build (4)` envelope as the main compile
+            // path, so agents don't see this surface as `cli.unknown`/exit 1.
+            if foundry_cli::is_machine() {
+                emit_machine_compile_error(&output);
+            }
             sh_println!("{output}")?;
             eyre::bail!("Compilation failed");
         }
@@ -398,11 +412,28 @@ impl TestArgs {
     ///
     /// Returns the test results for all matching tests.
     pub async fn compile_and_run(&mut self) -> Result<TestOutcome> {
+        let machine_mode = foundry_cli::is_machine();
+
         // Merge all configs.
         let (mut config, evm_opts) = self.load_config_and_evm_opts()?;
 
-        // Install missing dependencies.
-        if install::install_missing_dependencies(&mut config).await && config.auto_detect_remappings
+        // Under `--machine`, neutralize config-driven knobs that would print to
+        // stdout outside the NDJSON contract. CLI equivalents are rejected in
+        // `reject_machine_unsupported_flags`; this catches the foundry.toml
+        // side that the CLI preflight cannot see.
+        if machine_mode {
+            config.show_progress = false;
+            config.live_logs = false;
+        }
+
+        // Install missing dependencies. `install_missing_dependencies` prints
+        // "Missing dependencies found. Installing now..." to stdout, which would
+        // corrupt the NDJSON stream. Under `--machine`, skip it: a missing dep
+        // surfaces as a typed `compiler.solc.error` envelope from the compile
+        // path below, which is exactly what agents need.
+        if !machine_mode
+            && install::install_missing_dependencies(&mut config).await
+            && config.auto_detect_remappings
         {
             // need to re-configure here to also catch additional remappings
             config = self.load_config()?;
@@ -414,11 +445,21 @@ impl TestArgs {
         let filter = self.filter(&config)?;
         trace!(target: "forge::test", ?filter, "using filter");
 
-        let compiler = ProjectCompiler::new()
+        let mut compiler = ProjectCompiler::new()
             .dynamic_test_linking(config.dynamic_test_linking)
-            .quiet(shell::is_json() || self.junit || foundry_cli::is_machine())
+            .quiet(shell::is_json() || self.junit || machine_mode)
             .files(self.get_sources_to_compile(&config, &filter)?);
+        // Under `--machine`, disable the inner `bail` so a compile error
+        // returns the output and we can emit a typed envelope instead of an
+        // untyped eyre error mapped to `cli.unknown`.
+        if machine_mode {
+            compiler = compiler.bail(false);
+        }
         let output = compiler.compile(&project)?;
+
+        if machine_mode && output.has_compiler_errors() {
+            emit_machine_compile_error(&output);
+        }
 
         self.run_tests(&project.paths.root, config, evm_opts, &output, &filter, false).await
     }
@@ -1339,6 +1380,24 @@ fn emit_warning_event(contract: &str, message: &str) -> Result<()> {
         WarningEvent { contract, code: foundry_cli::diagnostic::test::WARNING, message },
     )?;
     Ok(())
+}
+
+/// Emit a `compiler.solc.error` envelope from a [`ProjectCompileOutput`] that
+/// reported errors, then exit with [`ExitCode::Build`]. Used by both the
+/// precompile and main-compile sites under `--machine` so agents see the
+/// same typed failure regardless of where the error was caught.
+///
+/// Mirrors the shape of `forge build`'s machine-mode compile-error path.
+fn emit_machine_compile_error(output: &ProjectCompileOutput) -> ! {
+    let errors: Vec<JsonMessage> = output
+        .output()
+        .errors
+        .iter()
+        .filter(|e| e.is_error())
+        .map(|e| JsonMessage::error(SOLC_ERROR, e.to_string()))
+        .collect();
+    let _ = print_json(&JsonEnvelope::<()>::failure(errors));
+    std::process::exit(ExitCode::Build.to_i32());
 }
 
 impl Provider for TestArgs {

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -320,6 +320,37 @@ impl TestArgs {
         })
     }
 
+    /// Reject flags whose stdout shape conflicts with the NDJSON stream
+    /// contract under `--machine`. Called from the binary entry point
+    /// before any subcommand dispatch so `--watch` is also rejected.
+    pub(crate) fn reject_machine_unsupported_flags(&self) -> Result<()> {
+        if !foundry_cli::is_machine() {
+            return Ok(());
+        }
+        let unsupported = [
+            ("--watch", self.is_watch()),
+            ("--debug", self.debug),
+            ("--flamegraph", self.flamegraph),
+            ("--flamechart", self.flamechart),
+            ("--gas-report", self.gas_report),
+            ("--summary", self.summary),
+            ("--list", self.list),
+            ("--junit", self.junit),
+            ("--show-progress", self.show_progress),
+        ]
+        .into_iter()
+        .filter_map(|(name, on)| on.then_some(name))
+        .collect::<Vec<_>>();
+        if !unsupported.is_empty() {
+            foundry_cli::machine::bail_machine_usage(format!(
+                "`forge test` under `--machine` does not yet support {}; \
+                 run without `--machine` or omit those flags.",
+                unsupported.join(", ")
+            ));
+        }
+        Ok(())
+    }
+
     /// Returns a list of files that need to be compiled in order to run all the tests that match
     /// the given filter.
     ///
@@ -385,7 +416,7 @@ impl TestArgs {
 
         let compiler = ProjectCompiler::new()
             .dynamic_test_linking(config.dynamic_test_linking)
-            .quiet(shell::is_json() || self.junit)
+            .quiet(shell::is_json() || self.junit || foundry_cli::is_machine())
             .files(self.get_sources_to_compile(&config, &filter)?);
         let output = compiler.compile(&project)?;
 
@@ -514,10 +545,11 @@ impl TestArgs {
             }
 
             // Print the merged summary (per-pass summaries are suppressed in `run_tests_inner`).
-            if !self.summary && !shell::is_json() {
+            // Machine mode emits a terminal envelope from the binary entry point instead.
+            if !self.summary && !shell::is_json() && !foundry_cli::is_machine() {
                 sh_println!("{}", outcome.summary(multi_pass_timer.elapsed()))?;
             }
-            if self.summary && !outcome.results.is_empty() {
+            if self.summary && !outcome.results.is_empty() && !foundry_cli::is_machine() {
                 let summary_report = TestSummaryReport::new(self.detailed, outcome.clone());
                 sh_println!("{}", &summary_report)?;
             }
@@ -706,8 +738,12 @@ impl TestArgs {
 
         trace!(target: "forge::test", "running all tests");
 
+        let machine_mode = foundry_cli::is_machine();
+
         // If we need to render to a serialized format, we should not print anything else to stdout.
-        let silent = self.gas_report && shell::is_json() || self.summary && shell::is_json();
+        // Machine mode is also a structured stream and must not interleave human output.
+        let silent =
+            machine_mode || self.gas_report && shell::is_json() || self.summary && shell::is_json();
 
         let num_filtered = runner.matching_test_functions(filter).count();
 
@@ -717,22 +753,24 @@ impl TestArgs {
             } else {
                 runner.matching_test_functions(&EmptyTestFilter::default()).count()
             };
-            if total_tests == 0 {
-                sh_println!(
-                    "No tests found in project! Forge looks for functions that start with `test`"
-                )?;
-            } else {
-                let mut msg = format!("no tests match the provided pattern:\n{filter}");
-                // Try to suggest a test when there's no match.
-                if let Some(test_pattern) = &filter.args().test_pattern {
-                    let test_name = test_pattern.as_str();
-                    // Filter contracts but not test functions.
-                    let candidates = runner.all_test_functions(filter).map(|f| &f.name);
-                    if let Some(suggestion) = utils::did_you_mean(test_name, candidates).pop() {
-                        write!(msg, "\nDid you mean `{suggestion}`?")?;
+            if !machine_mode {
+                if total_tests == 0 {
+                    sh_println!(
+                        "No tests found in project! Forge looks for functions that start with `test`"
+                    )?;
+                } else {
+                    let mut msg = format!("no tests match the provided pattern:\n{filter}");
+                    // Try to suggest a test when there's no match.
+                    if let Some(test_pattern) = &filter.args().test_pattern {
+                        let test_name = test_pattern.as_str();
+                        // Filter contracts but not test functions.
+                        let candidates = runner.all_test_functions(filter).map(|f| &f.name);
+                        if let Some(suggestion) = utils::did_you_mean(test_name, candidates).pop() {
+                            write!(msg, "\nDid you mean `{suggestion}`?")?;
+                        }
                     }
+                    sh_warn!("{msg}")?;
                 }
-                sh_warn!("{msg}")?;
             }
             return Ok(TestOutcome::empty(Some(runner.known_contracts.clone()), false));
         }
@@ -762,7 +800,8 @@ impl TestArgs {
         }
 
         // Run tests in a non-streaming fashion and collect results for serialization.
-        if !self.gas_report && !self.summary && shell::is_json() {
+        // `--machine` takes precedence over `--json`; the agent stream wins.
+        if !machine_mode && !self.gas_report && !self.summary && shell::is_json() {
             let mut results = runner.test_collect(filter)?;
             for suite_result in results.values_mut() {
                 for test_result in suite_result.test_results.values_mut() {
@@ -911,6 +950,10 @@ impl TestArgs {
                             sh_println!()?;
                         }
                     }
+                }
+
+                if machine_mode {
+                    emit_test_result_event(&contract_name, name, result)?;
                 }
 
                 // We shouldn't break out of the outer loop directly here so that we finish
@@ -1107,6 +1150,15 @@ impl TestArgs {
                 sh_println!("{}", suite_result.summary())?;
             }
 
+            if machine_mode {
+                for warning in &suite_result.warnings {
+                    emit_warning_event(&contract_name, warning)?;
+                }
+                if has_tests {
+                    emit_suite_finished_event(&contract_name, &suite_result)?;
+                }
+            }
+
             // Add the suite result to the outcome.
             outcome.results.insert(contract_name, suite_result);
 
@@ -1126,11 +1178,11 @@ impl TestArgs {
             outcome.gas_report = Some(finalized);
         }
 
-        if !is_multi_pass && !self.summary && !shell::is_json() {
+        if !is_multi_pass && !self.summary && !shell::is_json() && !machine_mode {
             sh_println!("{}", outcome.summary(duration))?;
         }
 
-        if !is_multi_pass && self.summary && !outcome.results.is_empty() {
+        if !is_multi_pass && self.summary && !outcome.results.is_empty() && !machine_mode {
             let summary_report = TestSummaryReport::new(self.detailed, outcome.clone());
             sh_println!("{summary_report}")?;
         }
@@ -1182,6 +1234,111 @@ impl TestArgs {
             Ok([config.src, config.test])
         })
     }
+}
+
+/// Stable payload emitted in the terminal `forge test` envelope under `--machine`.
+///
+/// See `docs/agents/spec.md` §6 for the contract: counts are aggregated across
+/// every suite that ran. Times are reported in milliseconds.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct TestSummaryData {
+    pub suites: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub duration_ms: u128,
+}
+
+impl TestSummaryData {
+    pub fn from_outcome(outcome: &TestOutcome, wall_clock: Duration) -> Self {
+        Self {
+            suites: outcome.results.len(),
+            passed: outcome.passed(),
+            failed: outcome.failed(),
+            skipped: outcome.skipped(),
+            duration_ms: wall_clock.as_millis(),
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct TestResultEvent<'a> {
+    contract: &'a str,
+    name: &'a str,
+    status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'a str>,
+    duration_ms: u128,
+}
+
+#[derive(serde::Serialize)]
+struct SuiteFinishedEvent<'a> {
+    contract: &'a str,
+    passed: usize,
+    failed: usize,
+    skipped: usize,
+    duration_ms: u128,
+}
+
+#[derive(serde::Serialize)]
+struct WarningEvent<'a> {
+    contract: &'a str,
+    code: &'static str,
+    message: &'a str,
+}
+
+const fn status_str(status: TestStatus) -> &'static str {
+    match status {
+        TestStatus::Success => "passed",
+        TestStatus::Failure => "failed",
+        TestStatus::Skipped => "skipped",
+    }
+}
+
+fn emit_test_result_event(
+    contract: &str,
+    name: &str,
+    result: &crate::result::TestResult,
+) -> Result<()> {
+    foundry_cli::json::print_stream_record(
+        crate::introspect::TEST_EVENT_SCHEMA,
+        "forge.test",
+        "test_result",
+        TestResultEvent {
+            contract,
+            name,
+            status: status_str(result.status),
+            reason: result.reason.as_deref(),
+            duration_ms: result.duration.as_millis(),
+        },
+    )?;
+    Ok(())
+}
+
+fn emit_suite_finished_event(contract: &str, suite: &SuiteResult) -> Result<()> {
+    foundry_cli::json::print_stream_record(
+        crate::introspect::TEST_EVENT_SCHEMA,
+        "forge.test",
+        "suite_finished",
+        SuiteFinishedEvent {
+            contract,
+            passed: suite.passed(),
+            failed: suite.failed(),
+            skipped: suite.skipped(),
+            duration_ms: suite.duration.as_millis(),
+        },
+    )?;
+    Ok(())
+}
+
+fn emit_warning_event(contract: &str, message: &str) -> Result<()> {
+    foundry_cli::json::print_stream_record(
+        crate::introspect::TEST_EVENT_SCHEMA,
+        "forge.test",
+        "warning",
+        WarningEvent { contract, code: foundry_cli::diagnostic::test::WARNING, message },
+    )?;
+    Ok(())
 }
 
 impl Provider for TestArgs {

--- a/crates/forge/src/diagnostic.rs
+++ b/crates/forge/src/diagnostic.rs
@@ -11,9 +11,16 @@ pub mod build {
     pub(crate) const ALL: &[&str] = &[SOLC_ERROR];
 }
 
+/// `forge test` diagnostic codes.
+pub mod test {
+    pub use foundry_cli::diagnostic::test::{FAILED, SETUP_FAILED, WARNING};
+
+    pub(crate) const ALL: &[&str] = &[FAILED, SETUP_FAILED, WARNING];
+}
+
 /// All diagnostic codes declared by `forge`.
 pub fn known_codes() -> Vec<&'static str> {
-    let groups: &[&[&str]] = &[build::ALL];
+    let groups: &[&[&str]] = &[build::ALL, test::ALL];
     groups.iter().flat_map(|g| g.iter().copied()).collect()
 }
 

--- a/crates/forge/src/introspect.rs
+++ b/crates/forge/src/introspect.rs
@@ -15,6 +15,11 @@ use std::borrow::Cow;
 /// Stable schema id for the `forge build` envelope payload.
 pub const BUILD_RESULT_SCHEMA: &str = "foundry:forge.build@v1";
 
+/// Stable schema id for `forge test` stream event records.
+pub const TEST_EVENT_SCHEMA: &str = "foundry:forge.test.event@v1";
+/// Stable schema id for the terminal `forge test` envelope payload.
+pub const TEST_RESULT_SCHEMA: &str = "foundry:forge.test@v1";
+
 /// Exit codes `forge build` may emit under `--machine`. Declared explicitly so
 /// agents don't have to assume "inherits global defaults"; codes not in this
 /// list are not produced by this command.
@@ -47,26 +52,81 @@ static BUILD_EXIT_CODES: &[ExitCodeInfo] = &[
     },
 ];
 
-static ENTRIES: &[RegistryEntry] = &[RegistryEntry {
-    path: &["build"],
-    meta: CommandMeta {
-        command_id: Some("forge.build"),
-        capabilities: Capabilities {
-            output_mode: OutputMode::Envelope,
-            result_schema_ref: Some(Cow::Borrowed(BUILD_RESULT_SCHEMA)),
-            event_schema_ref: None,
-            session_schema_ref: None,
-            reads_stdin: false,
-            supports_output_path: false,
-            requires_project: true,
-            side_effects: SideEffects::FsWrite,
-            long_running: false,
-            stateful: false,
-        },
-        capabilities_declared: true,
-        exit_codes: BUILD_EXIT_CODES,
+/// Exit codes `forge test` may emit under `--machine`. `TestFailure` is the
+/// canonical "tests ran cleanly but at least one failed" signal that lets
+/// agents distinguish a test failure from an infrastructure error without
+/// parsing the envelope.
+static TEST_EXIT_CODES: &[ExitCodeInfo] = &[
+    ExitCodeInfo {
+        code: ExitCode::Success.to_i32(),
+        name: Cow::Borrowed(ExitCode::Success.name()),
+        description: Cow::Borrowed("All tests passed; envelope `success: true`."),
     },
-}];
+    ExitCodeInfo {
+        code: ExitCode::GenericError.to_i32(),
+        name: Cow::Borrowed(ExitCode::GenericError.name()),
+        description: Cow::Borrowed(
+            "Unclassified failure outside the typed paths (envelope `cli.unknown`).",
+        ),
+    },
+    ExitCodeInfo {
+        code: ExitCode::Usage.to_i32(),
+        name: Cow::Borrowed(ExitCode::Usage.name()),
+        description: Cow::Borrowed(
+            "Flag combination rejected under `--machine` (envelope `cli.usage.invalid`).",
+        ),
+    },
+    ExitCodeInfo {
+        code: ExitCode::TestFailure.to_i32(),
+        name: Cow::Borrowed(ExitCode::TestFailure.name()),
+        description: Cow::Borrowed(
+            "Test suite ran but at least one test failed (envelope `test.failed`).",
+        ),
+    },
+];
+
+static ENTRIES: &[RegistryEntry] = &[
+    RegistryEntry {
+        path: &["build"],
+        meta: CommandMeta {
+            command_id: Some("forge.build"),
+            capabilities: Capabilities {
+                output_mode: OutputMode::Envelope,
+                result_schema_ref: Some(Cow::Borrowed(BUILD_RESULT_SCHEMA)),
+                event_schema_ref: None,
+                session_schema_ref: None,
+                reads_stdin: false,
+                supports_output_path: false,
+                requires_project: true,
+                side_effects: SideEffects::FsWrite,
+                long_running: false,
+                stateful: false,
+            },
+            capabilities_declared: true,
+            exit_codes: BUILD_EXIT_CODES,
+        },
+    },
+    RegistryEntry {
+        path: &["test"],
+        meta: CommandMeta {
+            command_id: Some("forge.test"),
+            capabilities: Capabilities {
+                output_mode: OutputMode::Stream,
+                result_schema_ref: Some(Cow::Borrowed(TEST_RESULT_SCHEMA)),
+                event_schema_ref: Some(Cow::Borrowed(TEST_EVENT_SCHEMA)),
+                session_schema_ref: None,
+                reads_stdin: false,
+                supports_output_path: false,
+                requires_project: true,
+                side_effects: SideEffects::None,
+                long_running: true,
+                stateful: false,
+            },
+            capabilities_declared: true,
+            exit_codes: TEST_EXIT_CODES,
+        },
+    },
+];
 
 /// The `forge` command registry. Used by `--introspect` and by adoption code
 /// that needs to look up command metadata.

--- a/crates/forge/src/introspect.rs
+++ b/crates/forge/src/introspect.rs
@@ -52,10 +52,7 @@ static BUILD_EXIT_CODES: &[ExitCodeInfo] = &[
     },
 ];
 
-/// Exit codes `forge test` may emit under `--machine`. `TestFailure` is the
-/// canonical "tests ran cleanly but at least one failed" signal that lets
-/// agents distinguish a test failure from an infrastructure error without
-/// parsing the envelope.
+/// Exit codes `forge test` may emit under `--machine`.
 static TEST_EXIT_CODES: &[ExitCodeInfo] = &[
     ExitCodeInfo {
         code: ExitCode::Success.to_i32(),
@@ -130,12 +127,8 @@ static ENTRIES: &[RegistryEntry] = &[
                 reads_stdin: false,
                 supports_output_path: false,
                 requires_project: true,
-                // `forge test` writes artifacts, run-failure state, and gas
-                // snapshots, and routinely performs network reads (`--fork-url`,
-                // configured `eth_rpc_url`, trace lookups). `Capabilities`
-                // reports only the highest-impact side effect, so we declare
-                // `Network` to subsume the always-present `FsWrite`. Not
-                // `ChainWrite`: `forge test` does not broadcast user txs.
+                // `Network` subsumes the always-present `FsWrite`; `forge
+                // test` does not broadcast user txs, so not `ChainWrite`.
                 side_effects: SideEffects::Network,
                 long_running: true,
                 stateful: false,

--- a/crates/forge/src/introspect.rs
+++ b/crates/forge/src/introspect.rs
@@ -60,7 +60,10 @@ static TEST_EXIT_CODES: &[ExitCodeInfo] = &[
     ExitCodeInfo {
         code: ExitCode::Success.to_i32(),
         name: Cow::Borrowed(ExitCode::Success.name()),
-        description: Cow::Borrowed("All tests passed; envelope `success: true`."),
+        description: Cow::Borrowed(
+            "All tests passed, or failures were tolerated by `--allow-failure`; envelope \
+             `success: true`. When `--allow-failure` is set, `data.failed` may be non-zero.",
+        ),
     },
     ExitCodeInfo {
         code: ExitCode::GenericError.to_i32(),
@@ -77,10 +80,19 @@ static TEST_EXIT_CODES: &[ExitCodeInfo] = &[
         ),
     },
     ExitCodeInfo {
+        code: ExitCode::Build.to_i32(),
+        name: Cow::Borrowed(ExitCode::Build.name()),
+        description: Cow::Borrowed(
+            "Solc reported one or more compile errors before tests could run \
+             (envelope `compiler.solc.error`).",
+        ),
+    },
+    ExitCodeInfo {
         code: ExitCode::TestFailure.to_i32(),
         name: Cow::Borrowed(ExitCode::TestFailure.name()),
         description: Cow::Borrowed(
-            "Test suite ran but at least one test failed (envelope `test.failed`).",
+            "Test suite ran and at least one test failed without `--allow-failure` \
+             (envelope `test.failed`).",
         ),
     },
 ];
@@ -118,7 +130,13 @@ static ENTRIES: &[RegistryEntry] = &[
                 reads_stdin: false,
                 supports_output_path: false,
                 requires_project: true,
-                side_effects: SideEffects::None,
+                // `forge test` writes artifacts, run-failure state, and gas
+                // snapshots, and routinely performs network reads (`--fork-url`,
+                // configured `eth_rpc_url`, trace lookups). `Capabilities`
+                // reports only the highest-impact side effect, so we declare
+                // `Network` to subsume the always-present `FsWrite`. Not
+                // `ChainWrite`: `forge test` does not broadcast user txs.
+                side_effects: SideEffects::Network,
                 long_running: true,
                 stateful: false,
             },

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -545,6 +545,11 @@ forgetest_init!(machine_mode_rejects_unsupported_flags, |prj, cmd| {
     assert_eq!(assert.get_output().status.code(), Some(2));
     let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
     assert!(msg.contains("--names"), "missing --names mention: {envelope}");
+    assert_eq!(
+        envelope["errors"][0]["details"]["unsupported_flags"],
+        serde_json::json!(["--names"]),
+        "missing structured unsupported_flags details: {envelope}"
+    );
 });
 
 // `--quiet` must not suppress the machine envelope.

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -97,12 +97,8 @@ Tip: Run `forge test --rerun` to retry only the 2 failed tests
 "#]]);
 });
 
-// `forge --machine test` emits NDJSON: per-test events, suite_finished
-// events, terminating in a success envelope. Exercises the canonical
-// passing-tests path with a small fixture suite and asserts the contract
-// shape (schema_id / command_id / RFC 3339 ts), per-suite ordering
-// (`test_result*` then `suite_finished` then no more `test_result` for
-// that suite), and the terminal envelope payload.
+// `forge --machine test` on passing tests: NDJSON stream + success envelope.
+// Asserts record shape, per-suite ordering, and envelope payload.
 forgetest_init!(machine_mode_emits_ndjson_stream, |prj, cmd| {
     use std::collections::HashSet;
     prj.add_test(
@@ -121,10 +117,7 @@ contract MachinePassTest is Test {
     let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
     assert!(lines.len() >= 2, "expected stream + envelope lines, got: {stdout}");
 
-    // Every record parses as JSON and stream events carry the spec fields.
-    // Per-suite ordering: `test_result`s for a suite all precede that
-    // suite's `suite_finished`. Once `suite_finished` for a contract has
-    // fired, no further `test_result` may target that contract.
+    // Per-suite ordering: no `test_result` for a suite after its `suite_finished`.
     let mut saw_test_result = false;
     let mut saw_suite_finished = false;
     let mut closed_suites: HashSet<String> = HashSet::new();
@@ -133,7 +126,6 @@ contract MachinePassTest is Test {
             .unwrap_or_else(|e| panic!("non-json stream line: {line}: {e}"));
         assert_eq!(v["schema_id"], "foundry:forge.test.event@v1");
         assert_eq!(v["command_id"], "forge.test");
-        // `ts` must round-trip through RFC 3339 — agents pin this contract.
         let ts = v["ts"].as_str().unwrap_or_else(|| panic!("missing ts on line: {line}"));
         chrono::DateTime::parse_from_rfc3339(ts)
             .unwrap_or_else(|e| panic!("ts `{ts}` not RFC 3339 on line {line}: {e}"));
@@ -153,7 +145,6 @@ contract MachinePassTest is Test {
                 );
                 saw_suite_finished = true;
             }
-            // `warning` is allowed inter-test under the spec; nothing to assert here.
             "warning" => {}
             other => panic!("unexpected event kind `{other}` on line: {line}"),
         }
@@ -170,8 +161,7 @@ contract MachinePassTest is Test {
     assert!(envelope["data"]["suites"].as_u64().is_some(), "missing suites: {envelope}");
 });
 
-// On a failing test, `forge --machine test` ends with an error envelope and
-// exits with `ExitCode::TestFailure` (5).
+// Failing test → error envelope + exit `TestFailure (5)`.
 forgetest_init!(machine_mode_failing_test_emits_error_envelope, |prj, cmd| {
     prj.add_test(
         "MachineFail.t.sol",
@@ -194,7 +184,7 @@ contract MachineFailTest is Test {
     assert!(failed >= 1, "expected at least one failed test in details: {envelope}");
 });
 
-// `--machine` rejects flags that would corrupt the NDJSON stream contract.
+// Rejection envelope: stable `code`, exit code, structured `details.unsupported_flags`.
 forgetest_init!(machine_mode_rejects_unsupported_flags, |_prj, cmd| {
     let assert = cmd.args(["--machine", "test", "--gas-report"]).assert_failure();
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
@@ -205,12 +195,37 @@ forgetest_init!(machine_mode_rejects_unsupported_flags, |_prj, cmd| {
     assert_eq!(assert.get_output().status.code(), Some(2));
     let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
     assert!(msg.contains("--gas-report"), "missing --gas-report mention: {envelope}");
+    assert_eq!(
+        envelope["errors"][0]["details"]["unsupported_flags"],
+        serde_json::json!(["--gas-report"]),
+        "missing structured unsupported_flags details: {envelope}"
+    );
 });
 
-// Compile errors at the main compile site (empty filter → precompile is
-// skipped) must surface as `compiler.solc.error` + `Build (4)` under
-// `--machine`, not as the generic `cli.unknown` + exit `1` that an
-// untyped `eyre::bail!("Compilation failed")` would produce.
+// `--allow-failure`: success envelope with `data.failed > 0` and exit 0.
+forgetest_init!(machine_mode_allow_failure_emits_success_envelope, |prj, cmd| {
+    prj.add_test(
+        "MachineAllowFailure.t.sol",
+        r#"
+import "forge-std/Test.sol";
+contract MachineAllowFailureTest is Test {
+    function testAlwaysFails() public { assertTrue(false); }
+}
+"#,
+    );
+    let assert = cmd.args(["--machine", "test", "--allow-failure"]).assert_success();
+    assert_eq!(assert.get_output().status.code(), Some(0));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    let envelope: Value = serde_json::from_str(lines.last().unwrap())
+        .unwrap_or_else(|e| panic!("trailing line not envelope: {stdout}: {e}"));
+    assert_eq!(envelope["success"], true);
+    assert_eq!(envelope["errors"], serde_json::json!([]));
+    let failed = envelope["data"]["failed"].as_u64().unwrap_or(0);
+    assert!(failed >= 1, "expected at least one tolerated failure in data: {envelope}");
+});
+
+// Main-compile errors → `compiler.solc.error` + `Build (4)`, not `cli.unknown`.
 forgetest_init!(machine_mode_compile_failure_emits_typed_envelope, |prj, cmd| {
     prj.add_test(
         "BadCompile.t.sol",
@@ -230,9 +245,7 @@ contract BadCompileTest is Test {
     assert_eq!(envelope["errors"][0]["code"], "compiler.solc.error");
 });
 
-// Same contract but with a filter set so `get_sources_to_compile` runs the
-// precompile path before the main compile. Both sites must emit the same
-// typed envelope, not the generic `cli.unknown` path.
+// Same contract with a filter so the precompile path runs; same typed envelope.
 forgetest_init!(machine_mode_precompile_failure_emits_typed_envelope, |prj, cmd| {
     prj.add_test(
         "BadCompilePrecompile.t.sol",
@@ -253,10 +266,7 @@ contract BadCompilePrecompileTest is Test {
     assert_eq!(envelope["errors"][0]["code"], "compiler.solc.error");
 });
 
-// `live_logs = true` in foundry.toml would normally print console.log output
-// straight to stdout, corrupting the NDJSON stream. Under `--machine` the
-// config knob must be silently neutralized (the CLI equivalent `--live-logs`
-// is rejected separately in `machine_mode_rejects_unsupported_flags`).
+// `live_logs = true` in foundry.toml is silently overridden under `--machine`.
 forgetest_init!(machine_mode_overrides_live_logs_config, |prj, cmd| {
     prj.update_config(|c| c.live_logs = true);
     prj.add_test(
@@ -275,16 +285,13 @@ contract LiveLogsTest is Test {
         !stdout.contains("HUMAN_PROSE_LINE"),
         "raw console.log leaked to stdout under --machine: {stdout}"
     );
-    // Every stdout line is valid JSON; no human prose survived.
     for line in stdout.lines().filter(|l| !l.is_empty()) {
         serde_json::from_str::<Value>(line)
             .unwrap_or_else(|e| panic!("non-json stdout line `{line}`: {e}"));
     }
 });
 
-// `show_progress = true` in foundry.toml would enable progress mode in
-// `multi_runner`, which batches results and prints progress UI — neither
-// compatible with real-time NDJSON streaming. Override must be silent.
+// `show_progress = true` in foundry.toml is silently overridden under `--machine`.
 forgetest_init!(machine_mode_overrides_show_progress_config, |prj, cmd| {
     prj.update_config(|c| c.show_progress = true);
     prj.add_test(
@@ -299,16 +306,13 @@ contract ProgressTest is Test {
     );
     let assert = cmd.args(["--machine", "test"]).assert_success();
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
-    // Every stdout line must be valid JSON; progress bars and human text would not be.
     for line in stdout.lines().filter(|l| !l.is_empty()) {
         serde_json::from_str::<Value>(line)
             .unwrap_or_else(|e| panic!("non-json stdout line `{line}`: {e}"));
     }
 });
 
-// `--watch` is dispatched separately from `cmd.run()`, so the rejection
-// preflight has to live at the top-level entry. This regression guards
-// against the dispatch boundary moving back under the rejection path.
+// `--watch` is dispatched before `cmd.run()`; guards the top-level preflight.
 forgetest_init!(machine_mode_rejects_watch, |_prj, cmd| {
     let assert = cmd.args(["--machine", "test", "--watch"]).assert_failure();
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -328,6 +328,25 @@ forgetest_init!(machine_mode_rejects_watch, |_prj, cmd| {
     assert!(msg.contains("--watch"), "missing --watch mention: {envelope}");
 });
 
+// Unadopted forge subcommands (snapshot, coverage, ...) must reject `--machine`
+// at the top level — otherwise they'd inherit TestArgs's stream emission and
+// spoof `command_id: forge.test` without ever emitting a terminal envelope.
+forgetest_init!(machine_mode_rejects_unadopted_subcommand, |_prj, cmd| {
+    let assert = cmd.args(["--machine", "snapshot"]).assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single-envelope error stdout: {stdout}: {e}"));
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    assert_eq!(envelope["errors"][0]["details"]["subcommand"], "snapshot");
+    // No spurious stream events leaked before the rejection envelope.
+    assert!(
+        !stdout.contains("forge.test.event"),
+        "unadopted subcommand emitted stream events: {stdout}"
+    );
+});
+
 // Warning duality: same `code`/`message`/`suite` on stream + envelope surfaces.
 forgetest_init!(machine_mode_warning_appears_in_stream_and_envelope, |prj, cmd| {
     // Mis-cased `setup()` triggers a SuiteResult warning.

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -99,8 +99,12 @@ Tip: Run `forge test --rerun` to retry only the 2 failed tests
 
 // `forge --machine test` emits NDJSON: per-test events, suite_finished
 // events, terminating in a success envelope. Exercises the canonical
-// passing-tests path with a small fixture suite.
+// passing-tests path with a small fixture suite and asserts the contract
+// shape (schema_id / command_id / RFC 3339 ts), per-suite ordering
+// (`test_result*` then `suite_finished` then no more `test_result` for
+// that suite), and the terminal envelope payload.
 forgetest_init!(machine_mode_emits_ndjson_stream, |prj, cmd| {
+    use std::collections::HashSet;
     prj.add_test(
         "MachinePass.t.sol",
         r#"
@@ -118,17 +122,39 @@ contract MachinePassTest is Test {
     assert!(lines.len() >= 2, "expected stream + envelope lines, got: {stdout}");
 
     // Every record parses as JSON and stream events carry the spec fields.
+    // Per-suite ordering: `test_result`s for a suite all precede that
+    // suite's `suite_finished`. Once `suite_finished` for a contract has
+    // fired, no further `test_result` may target that contract.
     let mut saw_test_result = false;
     let mut saw_suite_finished = false;
+    let mut closed_suites: HashSet<String> = HashSet::new();
     for line in &lines[..lines.len() - 1] {
         let v: Value = serde_json::from_str(line)
             .unwrap_or_else(|e| panic!("non-json stream line: {line}: {e}"));
         assert_eq!(v["schema_id"], "foundry:forge.test.event@v1");
         assert_eq!(v["command_id"], "forge.test");
-        assert!(v["ts"].is_string());
+        // `ts` must round-trip through RFC 3339 — agents pin this contract.
+        let ts = v["ts"].as_str().unwrap_or_else(|| panic!("missing ts on line: {line}"));
+        chrono::DateTime::parse_from_rfc3339(ts)
+            .unwrap_or_else(|e| panic!("ts `{ts}` not RFC 3339 on line {line}: {e}"));
+        let contract = v["contract"].as_str().unwrap_or_else(|| panic!("missing contract: {line}"));
         match v["kind"].as_str().unwrap_or("") {
-            "test_result" => saw_test_result = true,
-            "suite_finished" => saw_suite_finished = true,
+            "test_result" => {
+                assert!(
+                    !closed_suites.contains(contract),
+                    "test_result for `{contract}` after its suite_finished: {line}"
+                );
+                saw_test_result = true;
+            }
+            "suite_finished" => {
+                assert!(
+                    closed_suites.insert(contract.to_string()),
+                    "duplicate suite_finished for `{contract}`: {line}"
+                );
+                saw_suite_finished = true;
+            }
+            // `warning` is allowed inter-test under the spec; nothing to assert here.
+            "warning" => {}
             other => panic!("unexpected event kind `{other}` on line: {line}"),
         }
     }

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -181,6 +181,105 @@ forgetest_init!(machine_mode_rejects_unsupported_flags, |_prj, cmd| {
     assert!(msg.contains("--gas-report"), "missing --gas-report mention: {envelope}");
 });
 
+// Compile errors at the main compile site (empty filter → precompile is
+// skipped) must surface as `compiler.solc.error` + `Build (4)` under
+// `--machine`, not as the generic `cli.unknown` + exit `1` that an
+// untyped `eyre::bail!("Compilation failed")` would produce.
+forgetest_init!(machine_mode_compile_failure_emits_typed_envelope, |prj, cmd| {
+    prj.add_test(
+        "BadCompile.t.sol",
+        r#"
+import "forge-std/Test.sol";
+contract BadCompileTest is Test {
+    function testWillNotCompile() public { this is not valid solidity; }
+}
+"#,
+    );
+    let assert = cmd.args(["--machine", "test"]).assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(4));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single-envelope error stdout: {stdout}: {e}"));
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "compiler.solc.error");
+});
+
+// Same contract but with a filter set so `get_sources_to_compile` runs the
+// precompile path before the main compile. Both sites must emit the same
+// typed envelope, not the generic `cli.unknown` path.
+forgetest_init!(machine_mode_precompile_failure_emits_typed_envelope, |prj, cmd| {
+    prj.add_test(
+        "BadCompilePrecompile.t.sol",
+        r#"
+import "forge-std/Test.sol";
+contract BadCompilePrecompileTest is Test {
+    function testWillNotCompile() public { this is not valid solidity; }
+}
+"#,
+    );
+    let assert =
+        cmd.args(["--machine", "test", "--match-test", "testWillNotCompile"]).assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(4));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single-envelope error stdout: {stdout}: {e}"));
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "compiler.solc.error");
+});
+
+// `live_logs = true` in foundry.toml would normally print console.log output
+// straight to stdout, corrupting the NDJSON stream. Under `--machine` the
+// config knob must be silently neutralized (the CLI equivalent `--live-logs`
+// is rejected separately in `machine_mode_rejects_unsupported_flags`).
+forgetest_init!(machine_mode_overrides_live_logs_config, |prj, cmd| {
+    prj.update_config(|c| c.live_logs = true);
+    prj.add_test(
+        "LiveLogs.t.sol",
+        r#"
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+contract LiveLogsTest is Test {
+    function testLogs() public { console.log("HUMAN_PROSE_LINE"); assertTrue(true); }
+}
+"#,
+    );
+    let assert = cmd.args(["--machine", "test"]).assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        !stdout.contains("HUMAN_PROSE_LINE"),
+        "raw console.log leaked to stdout under --machine: {stdout}"
+    );
+    // Every stdout line is valid JSON; no human prose survived.
+    for line in stdout.lines().filter(|l| !l.is_empty()) {
+        serde_json::from_str::<Value>(line)
+            .unwrap_or_else(|e| panic!("non-json stdout line `{line}`: {e}"));
+    }
+});
+
+// `show_progress = true` in foundry.toml would enable progress mode in
+// `multi_runner`, which batches results and prints progress UI — neither
+// compatible with real-time NDJSON streaming. Override must be silent.
+forgetest_init!(machine_mode_overrides_show_progress_config, |prj, cmd| {
+    prj.update_config(|c| c.show_progress = true);
+    prj.add_test(
+        "Progress.t.sol",
+        r#"
+import "forge-std/Test.sol";
+contract ProgressTest is Test {
+    function testOne() public { assertTrue(true); }
+    function testTwo() public { assertTrue(true); }
+}
+"#,
+    );
+    let assert = cmd.args(["--machine", "test"]).assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    // Every stdout line must be valid JSON; progress bars and human text would not be.
+    for line in stdout.lines().filter(|l| !l.is_empty()) {
+        serde_json::from_str::<Value>(line)
+            .unwrap_or_else(|e| panic!("non-json stdout line `{line}`: {e}"));
+    }
+});
+
 // `--watch` is dispatched separately from `cmd.run()`, so the rejection
 // preflight has to live at the top-level entry. This regression guards
 // against the dispatch boundary moving back under the rejection path.

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -1,6 +1,7 @@
 //! Core test functionality tests
 
 use foundry_test_utils::str;
+use serde_json::Value;
 
 forgetest_init!(failing_test_after_failed_setup, |prj, cmd| {
     prj.add_test(
@@ -94,6 +95,105 @@ Encountered a total of 2 failing tests, 1 tests succeeded
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
 
 "#]]);
+});
+
+// `forge --machine test` emits NDJSON: per-test events, suite_finished
+// events, terminating in a success envelope. Exercises the canonical
+// passing-tests path with a small fixture suite.
+forgetest_init!(machine_mode_emits_ndjson_stream, |prj, cmd| {
+    prj.add_test(
+        "MachinePass.t.sol",
+        r#"
+import "forge-std/Test.sol";
+contract MachinePassTest is Test {
+    function testAlwaysPasses() public { assertTrue(true); }
+    function testAlsoPasses() public { assertEq(uint256(1), uint256(1)); }
+}
+"#,
+    );
+    let assert = cmd.args(["--machine", "test"]).assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert!(lines.len() >= 2, "expected stream + envelope lines, got: {stdout}");
+
+    // Every record parses as JSON and stream events carry the spec fields.
+    let mut saw_test_result = false;
+    let mut saw_suite_finished = false;
+    for line in &lines[..lines.len() - 1] {
+        let v: Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("non-json stream line: {line}: {e}"));
+        assert_eq!(v["schema_id"], "foundry:forge.test.event@v1");
+        assert_eq!(v["command_id"], "forge.test");
+        assert!(v["ts"].is_string());
+        match v["kind"].as_str().unwrap_or("") {
+            "test_result" => saw_test_result = true,
+            "suite_finished" => saw_suite_finished = true,
+            other => panic!("unexpected event kind `{other}` on line: {line}"),
+        }
+    }
+    assert!(saw_test_result, "missing any test_result event in: {stdout}");
+    assert!(saw_suite_finished, "missing any suite_finished event in: {stdout}");
+
+    // Terminal envelope.
+    let envelope: Value = serde_json::from_str(lines.last().unwrap()).unwrap();
+    assert_eq!(envelope["schema_version"], 1);
+    assert_eq!(envelope["success"], true);
+    assert!(envelope["data"]["passed"].as_u64().is_some(), "missing passed: {envelope}");
+    assert!(envelope["data"]["failed"].as_u64().is_some(), "missing failed: {envelope}");
+    assert!(envelope["data"]["suites"].as_u64().is_some(), "missing suites: {envelope}");
+});
+
+// On a failing test, `forge --machine test` ends with an error envelope and
+// exits with `ExitCode::TestFailure` (5).
+forgetest_init!(machine_mode_failing_test_emits_error_envelope, |prj, cmd| {
+    prj.add_test(
+        "MachineFail.t.sol",
+        r#"
+import "forge-std/Test.sol";
+contract MachineFailTest is Test {
+    function testAlwaysFails() public { assertTrue(false); }
+}
+"#,
+    );
+    let assert = cmd.args(["--machine", "test"]).assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(5));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    let envelope: Value = serde_json::from_str(lines.last().unwrap())
+        .unwrap_or_else(|e| panic!("trailing line not envelope: {stdout}: {e}"));
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "test.failed");
+    let failed = envelope["errors"][0]["details"]["failed"].as_u64().unwrap_or(0);
+    assert!(failed >= 1, "expected at least one failed test in details: {envelope}");
+});
+
+// `--machine` rejects flags that would corrupt the NDJSON stream contract.
+forgetest_init!(machine_mode_rejects_unsupported_flags, |_prj, cmd| {
+    let assert = cmd.args(["--machine", "test", "--gas-report"]).assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single-envelope error stdout: {stdout}: {e}"));
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("--gas-report"), "missing --gas-report mention: {envelope}");
+});
+
+// `--watch` is dispatched separately from `cmd.run()`, so the rejection
+// preflight has to live at the top-level entry. This regression guards
+// against the dispatch boundary moving back under the rejection path.
+forgetest_init!(machine_mode_rejects_watch, |_prj, cmd| {
+    let assert = cmd.args(["--machine", "test", "--watch"]).assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single-envelope error stdout: {stdout}: {e}"));
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("--watch"), "missing --watch mention: {envelope}");
 });
 
 forgetest_init!(payment_failure, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -129,19 +129,19 @@ contract MachinePassTest is Test {
         let ts = v["ts"].as_str().unwrap_or_else(|| panic!("missing ts on line: {line}"));
         chrono::DateTime::parse_from_rfc3339(ts)
             .unwrap_or_else(|e| panic!("ts `{ts}` not RFC 3339 on line {line}: {e}"));
-        let contract = v["contract"].as_str().unwrap_or_else(|| panic!("missing contract: {line}"));
+        let suite = v["suite"].as_str().unwrap_or_else(|| panic!("missing suite: {line}"));
         match v["kind"].as_str().unwrap_or("") {
             "test_result" => {
                 assert!(
-                    !closed_suites.contains(contract),
-                    "test_result for `{contract}` after its suite_finished: {line}"
+                    !closed_suites.contains(suite),
+                    "test_result for `{suite}` after its suite_finished: {line}"
                 );
                 saw_test_result = true;
             }
             "suite_finished" => {
                 assert!(
-                    closed_suites.insert(contract.to_string()),
-                    "duplicate suite_finished for `{contract}`: {line}"
+                    closed_suites.insert(suite.to_string()),
+                    "duplicate suite_finished for `{suite}`: {line}"
                 );
                 saw_suite_finished = true;
             }
@@ -323,6 +323,45 @@ forgetest_init!(machine_mode_rejects_watch, |_prj, cmd| {
     assert_eq!(assert.get_output().status.code(), Some(2));
     let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
     assert!(msg.contains("--watch"), "missing --watch mention: {envelope}");
+});
+
+// Warning duality: same `code`/`message`/`suite` on stream + envelope surfaces.
+forgetest_init!(machine_mode_warning_appears_in_stream_and_envelope, |prj, cmd| {
+    // Mis-cased `setup()` triggers a SuiteResult warning.
+    prj.add_test(
+        "MachineWarning.t.sol",
+        r#"
+import "forge-std/Test.sol";
+contract MachineWarningTest is Test {
+    function setup() public {}
+    function testPasses() public { assertTrue(true); }
+}
+"#,
+    );
+    let assert = cmd.args(["--machine", "test"]).assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+
+    let mut stream_warning: Option<Value> = None;
+    for line in &lines[..lines.len() - 1] {
+        let v: Value = serde_json::from_str(line).unwrap();
+        if v["kind"] == "warning" {
+            stream_warning = Some(v);
+            break;
+        }
+    }
+    let stream_warning = stream_warning.expect("no stream warning event emitted");
+    assert_eq!(stream_warning["code"], "test.warning");
+    let stream_message = stream_warning["message"].as_str().unwrap();
+    let stream_suite = stream_warning["suite"].as_str().unwrap();
+
+    let envelope: Value = serde_json::from_str(lines.last().unwrap()).unwrap();
+    let envelope_warning = envelope["warnings"]
+        .as_array()
+        .and_then(|ws| ws.iter().find(|w| w["code"] == "test.warning"))
+        .expect("envelope warnings[] missing test.warning entry");
+    assert_eq!(envelope_warning["message"].as_str().unwrap(), stream_message);
+    assert_eq!(envelope_warning["details"]["suite"].as_str().unwrap(), stream_suite);
 });
 
 forgetest_init!(payment_failure, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -117,9 +117,10 @@ contract MachinePassTest is Test {
     let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
     assert!(lines.len() >= 2, "expected stream + envelope lines, got: {stdout}");
 
-    // Per-suite ordering: no `test_result` for a suite after its `suite_finished`.
+    // Per-suite lifecycle: every opened suite is closed exactly once, and no
+    // record of any kind targets a suite after its `suite_finished`.
     let mut saw_test_result = false;
-    let mut saw_suite_finished = false;
+    let mut opened_suites: HashSet<String> = HashSet::new();
     let mut closed_suites: HashSet<String> = HashSet::new();
     for line in &lines[..lines.len() - 1] {
         let v: Value = serde_json::from_str(line)
@@ -130,27 +131,29 @@ contract MachinePassTest is Test {
         chrono::DateTime::parse_from_rfc3339(ts)
             .unwrap_or_else(|e| panic!("ts `{ts}` not RFC 3339 on line {line}: {e}"));
         let suite = v["suite"].as_str().unwrap_or_else(|| panic!("missing suite: {line}"));
-        match v["kind"].as_str().unwrap_or("") {
-            "test_result" => {
-                assert!(
-                    !closed_suites.contains(suite),
-                    "test_result for `{suite}` after its suite_finished: {line}"
-                );
-                saw_test_result = true;
-            }
+        let kind = v["kind"].as_str().unwrap_or("");
+        assert!(
+            !closed_suites.contains(suite),
+            "`{kind}` for `{suite}` after its suite_finished: {line}"
+        );
+        opened_suites.insert(suite.to_string());
+        match kind {
+            "test_result" => saw_test_result = true,
             "suite_finished" => {
                 assert!(
                     closed_suites.insert(suite.to_string()),
                     "duplicate suite_finished for `{suite}`: {line}"
                 );
-                saw_suite_finished = true;
             }
             "warning" => {}
             other => panic!("unexpected event kind `{other}` on line: {line}"),
         }
     }
     assert!(saw_test_result, "missing any test_result event in: {stdout}");
-    assert!(saw_suite_finished, "missing any suite_finished event in: {stdout}");
+    assert_eq!(
+        opened_suites, closed_suites,
+        "every opened suite must be terminated by a suite_finished"
+    );
 
     // Terminal envelope.
     let envelope: Value = serde_json::from_str(lines.last().unwrap()).unwrap();

--- a/docs/agents/diagnostics.md
+++ b/docs/agents/diagnostics.md
@@ -26,7 +26,13 @@ Examples:
 - `wallet.signature.rejected`
 - `test.failed`
 - `test.setup_failed`
+- `test.warning`
 - `script.broadcast_failed`
+
+Stream-event `code` fields (e.g. the `code` carried on `kind: "warning"`
+records under `foundry:forge.test.event@v1`) draw from this same
+registry: any code mirrored from a stream event into a terminal envelope
+`warnings[]` entry is identical.
 
 ## Reserved domains
 
@@ -36,7 +42,7 @@ Examples:
 | `compiler` | `foundry-compilers`, `forge`    | `compiler.solc.error`                     |
 | `network`  | RPC / HTTP layers               | `network.rpc.timeout`                     |
 | `wallet`   | `foundry-wallets`               | `wallet.key.missing`                      |
-| `test`     | `forge test`                    | `test.failed`, `test.setup_failed`        |
+| `test`     | `forge test`                    | `test.failed`, `test.setup_failed`, `test.warning` |
 | `script`   | `forge script`                  | `script.broadcast_failed`                 |
 | `cast`     | `cast`                          | `cast.tx.not_found`                       |
 | `anvil`    | `anvil`                         | `anvil.fork.unreachable`                  |

--- a/docs/agents/spec.md
+++ b/docs/agents/spec.md
@@ -229,8 +229,8 @@ each grouping unit (suite for `forge.test`, simulation phase for
 
 After a group's terminator, no more records targeting that group may be
 emitted. Groups themselves are not ordered against each other; agents
-should key on the group identifier in the payload (e.g. `contract`) when
-correlating per-group records.
+should key on the group identifier in the payload (e.g. `suite` for
+`forge.test`) when correlating per-group records.
 
 ### Warning duality
 
@@ -242,12 +242,21 @@ outcome, the warning is emitted **twice**:
 2. as an entry in the terminal envelope's `warnings[]` — for the
    end-of-run summary
 
-Both surfaces carry the same `code` and `message` for the same logical
-warning. The grouping identifier differs by surface: the stream event
-identifies the suite via the top-level `contract` field; the terminal
-envelope warning identifies it via `details.suite`. Agents consuming
-both surfaces should de-duplicate by `(suite, message)`. The terminal
-envelope's `warnings[]` is the authoritative aggregated set.
+Both surfaces carry the same `code` and `message` and identify the suite
+via the same `suite` key — `suite` as a top-level field on the stream
+event, and `details.suite` on the terminal envelope warning. Agents
+consuming both surfaces should de-duplicate by `(suite, message)`. The
+terminal envelope's `warnings[]` is the authoritative aggregated set.
+
+### Failure-envelope conventions
+
+A command's `result_schema_ref` describes the envelope `data` payload
+when present. Failure envelopes may set `data: null` and surface
+structured failure context inside `errors[].details`. Agents that need
+to detect failure key on the combination of exit code, `success: false`,
+and `errors[].code`; per-command spec sections document where additional
+context lives on failure (for `forge.test`, the summary appears under
+`errors[0].details` and is the same shape as `data` on success).
 
 ### Concrete shapes (informative, `@v1`)
 
@@ -256,15 +265,22 @@ command in [`crates/forge/src/introspect.rs`](../../crates/forge/src/introspect.
 and the equivalent registry files. The current `forge.test` event payloads
 under `foundry:forge.test.event@v1`:
 
-- `kind: "test_result"` — `{ contract, name, status, reason?, duration_ms }`
+- `kind: "test_result"` — `{ suite, name, status, reason?, duration_ms }`
   with `status ∈ { "passed", "failed", "skipped" }`.
-- `kind: "warning"` — `{ contract, code, message }`.
-- `kind: "suite_finished"` — `{ contract, passed, failed, skipped, duration_ms }`.
+- `kind: "warning"` — `{ suite, code, message }`.
+- `kind: "suite_finished"` — `{ suite, passed, failed, skipped, duration_ms }`.
+
+`suite` is the full suite identifier (e.g. `test/Counter.t.sol:CounterTest`).
+A `suite_finished` record terminates the group for that suite; no further
+records targeting that suite are emitted. Warning-only suites still emit a
+`suite_finished` (with zero counts) so the group lifecycle is honest.
 
 The terminal envelope payload under `foundry:forge.test@v1`:
 `{ suites, passed, failed, skipped, duration_ms }`. When `--allow-failure`
 tolerated failures, `success: true` and `data.failed` may be non-zero — see
-the `Success` exit-code description on the per-command introspection.
+the `Success` exit-code description on the per-command introspection. On
+test failure (`success: false`, `errors[0].code: test.failed`), the same
+payload appears under `errors[0].details`.
 
 ---
 

--- a/docs/agents/spec.md
+++ b/docs/agents/spec.md
@@ -208,12 +208,61 @@ Stream commands write one JSON object per line on stdout. Each record carries:
 - `schema_id` — the event-schema id (e.g. `foundry:forge.test.event@v1`)
 - `command_id` — the emitting command (e.g. `forge.test`)
 - `kind` — record kind (per-event-schema enum)
-- `ts` — RFC 3339 timestamp
+- `ts` — RFC 3339 timestamp, UTC, millisecond precision (e.g.
+  `2026-05-28T17:15:42.123Z`). Fixed-width substring; safe for regex pinning
+  and log search.
 - additional kind-specific fields
 
 A stream may end with a single terminal `JsonEnvelope` record on the same
 stream. Consumers MUST tolerate streams that end without it (e.g. on signal
 termination).
+
+### Per-command event ordering
+
+For each per-command event schema (e.g. `foundry:forge.test.event@v1`),
+each grouping unit (suite for `forge.test`, simulation phase for
+`forge.script`, etc.) emits records in this order:
+
+1. zero or more child records (e.g. `test_result`)
+2. zero or more non-terminal annotations on that group (e.g. `warning`)
+3. exactly one terminator record for the group (e.g. `suite_finished`)
+
+After a group's terminator, no more records targeting that group may be
+emitted. Groups themselves are not ordered against each other; agents
+should key on the group identifier in the payload (e.g. `contract`) when
+correlating per-group records.
+
+### Warning duality
+
+When a command surfaces a warning that is also relevant to the terminal
+outcome, the warning is emitted **twice**:
+
+1. as a per-suite `warning` stream event with `kind: "warning"` and the
+   per-event `code` (e.g. `test.warning`) — for real-time visibility
+2. as an entry in the terminal envelope's `warnings[]` — for the
+   end-of-run summary
+
+Both surfaces carry the same `code`/`message`/`details` for the same logical
+warning. Agents consuming both surfaces should de-duplicate by
+`(suite, message)`. The terminal envelope's `warnings[]` is the
+authoritative aggregated set.
+
+### Concrete shapes (informative, `@v1`)
+
+The wire contract is the schema id and the field set documented per
+command in [`crates/forge/src/introspect.rs`](../../crates/forge/src/introspect.rs)
+and the equivalent registry files. The current `forge.test` event payloads
+under `foundry:forge.test.event@v1`:
+
+- `kind: "test_result"` — `{ contract, name, status, reason?, duration_ms }`
+  with `status ∈ { "passed", "failed", "skipped" }`.
+- `kind: "warning"` — `{ contract, code, message }`.
+- `kind: "suite_finished"` — `{ contract, passed, failed, skipped, duration_ms }`.
+
+The terminal envelope payload under `foundry:forge.test@v1`:
+`{ suites, passed, failed, skipped, duration_ms }`. When `--allow-failure`
+tolerated failures, `success: true` and `data.failed` may be non-zero — see
+the `Success` exit-code description on the per-command introspection.
 
 ---
 

--- a/docs/agents/spec.md
+++ b/docs/agents/spec.md
@@ -242,10 +242,12 @@ outcome, the warning is emitted **twice**:
 2. as an entry in the terminal envelope's `warnings[]` — for the
    end-of-run summary
 
-Both surfaces carry the same `code`/`message`/`details` for the same logical
-warning. Agents consuming both surfaces should de-duplicate by
-`(suite, message)`. The terminal envelope's `warnings[]` is the
-authoritative aggregated set.
+Both surfaces carry the same `code` and `message` for the same logical
+warning. The grouping identifier differs by surface: the stream event
+identifies the suite via the top-level `contract` field; the terminal
+envelope warning identifies it via `details.suite`. Agents consuming
+both surfaces should de-duplicate by `(suite, message)`. The terminal
+envelope's `warnings[]` is the authoritative aggregated set.
 
 ### Concrete shapes (informative, `@v1`)
 


### PR DESCRIPTION
Stacked on #14774. Ships `forge.test` as the first streaming command in the agent contract.

- `forge.test` → `output_mode=stream`, `event_schema_ref=foundry:forge.test.event@v1`, `result_schema_ref=foundry:forge.test@v1`
- NDJSON events on stdout: `test_result`, `suite_finished`, `warning`
- Terminal envelope with `{ suites, passed, failed, skipped, duration_ms }`
- Failure path: error envelope `code=test.failed`, exit `5`

Adds `StreamRecord<T>` + `print_stream_record()` to `foundry_cli::json`. Under `--machine`, the global shell is forced to `Quiet` so existing human prints no-op; `print_json` bypasses quiet only in machine mode. Stream-incompatible flags (`--watch`, `--debug`, `--flamegraph`, `--flamechart`, `--gas-report`, `--summary`, `--list`, `--junit`, `--show-progress`) are rejected with `cli.usage.invalid` + exit `2`.

Part of OSS-218