### PR TITLE
docs(architecture): add missing punctuation between cheatcodes link and its description

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -7,7 +7,7 @@ This document describes the high-level architecture of Foundry.
 Foundry's EVM tooling. This is built around [`revm`](https://github.com/bluealloy/revm) and has additional
 implementation of:
 
-- [cheatcodes](./cheatcodes.md) a set of solidity calls dedicated to testing which can manipulate the environment in which the execution is run
+- [cheatcodes](./cheatcodes.md): a set of solidity calls dedicated to testing which can manipulate the environment in which the execution is run
 
 ### `config/`
 


### PR DESCRIPTION
The single bullet under `evm/` in `docs/dev/architecture.md` runs the markdown link directly into the definition that follows:

> - [cheatcodes](./cheatcodes.md) a set of solidity calls dedicated to testing which can manipulate the environment in which the execution is run

That reads as a run-on. The parent paragraph ends with `… and has additional implementation of:`, so the bullet is a definition-style entry; a colon between the term and its description matches that setup and reads cleanly.

No semantic change.