### PR TITLE
Use TUI fallback for debugger in non-interactive mode

### DIFF
--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -59,7 +59,7 @@ fn non_interactive_debugger_message(reason: TuiFallbackReason) -> String {
     )
 }
 
-fn debugger_dump_hint() -> &'static str {
+const fn debugger_dump_hint() -> &'static str {
     "Pass `--dump <PATH>` to export debugger steps."
 }
 

--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -66,6 +66,32 @@ fn debugger_dump_hint() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{TuiFallbackReason, debugger_dump_hint, non_interactive_debugger_message};
+    use crate::{DebugNode, Debugger};
+    use std::{env, ffi::OsString};
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = env::var_os(key);
+            unsafe { env::set_var(key, value) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => env::set_var(self.key, value),
+                    None => env::remove_var(self.key),
+                }
+            }
+        }
+    }
 
     #[test]
     fn fallback_message_includes_reason() {
@@ -77,5 +103,21 @@ mod tests {
     #[test]
     fn dump_hint_includes_dump_flag() {
         assert!(debugger_dump_hint().contains("--dump <PATH>"));
+    }
+
+    #[test]
+    fn debugger_tui_falls_back_in_ci_with_dump_hint() {
+        let _ci = EnvVarGuard::set("CI", "1");
+        let mut debugger = Debugger::new(
+            vec![DebugNode::default()],
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        );
+
+        let message = debugger.try_run_tui().unwrap_err().to_string();
+
+        assert!(message.contains("running in CI"));
+        assert!(message.contains("--dump <PATH>"));
     }
 }

--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -1,7 +1,7 @@
 //! The debugger TUI.
 
 use eyre::Result;
-use foundry_tui::run_app;
+use foundry_tui::{TuiFallbackReason, TuiMode, run_app_if_interactive, tui_mode};
 
 mod context;
 use crate::debugger::DebuggerContext;
@@ -36,6 +36,38 @@ impl<'a> TUI<'a> {
     fn run_inner(&mut self) -> Result<ExitReason> {
         let mut cx = TUIContext::new(self.debugger_context);
         cx.init();
-        Ok(run_app(&mut cx)?)
+        match run_app_if_interactive(&mut cx)? {
+            Some(exit_reason) => Ok(exit_reason),
+            None => {
+                let message = match tui_mode() {
+                    TuiMode::Fallback(reason) => non_interactive_debugger_message(reason),
+                    TuiMode::Interactive => String::from(
+                        "Cannot open the debugger TUI in this environment. Re-run in an \
+                         interactive terminal, or pass `--dump <PATH>` to export debugger steps.",
+                    ),
+                };
+                eyre::bail!("{message}");
+            }
+        }
+    }
+}
+
+fn non_interactive_debugger_message(reason: TuiFallbackReason) -> String {
+    format!(
+        "Cannot open the debugger TUI because {}. Re-run in an interactive terminal, or pass \
+         `--dump <PATH>` to export debugger steps.",
+        reason.as_str()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TuiFallbackReason, non_interactive_debugger_message};
+
+    #[test]
+    fn fallback_message_includes_reason_and_dump_hint() {
+        let msg = non_interactive_debugger_message(TuiFallbackReason::Ci);
+        assert!(msg.contains("running in CI"));
+        assert!(msg.contains("--dump <PATH>"));
     }
 }

--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -43,10 +43,10 @@ impl<'a> TUI<'a> {
                     TuiMode::Fallback(reason) => non_interactive_debugger_message(reason),
                     TuiMode::Interactive => String::from(
                         "Cannot open the debugger TUI in this environment. Re-run in an \
-                         interactive terminal, or pass `--dump <PATH>` to export debugger steps.",
+                         interactive terminal.",
                     ),
                 };
-                eyre::bail!("{message}");
+                eyre::bail!("{message} {}", debugger_dump_hint());
             }
         }
     }
@@ -54,20 +54,28 @@ impl<'a> TUI<'a> {
 
 fn non_interactive_debugger_message(reason: TuiFallbackReason) -> String {
     format!(
-        "Cannot open the debugger TUI because {}. Re-run in an interactive terminal, or pass \
-         `--dump <PATH>` to export debugger steps.",
+        "Cannot open the debugger TUI because {}. Re-run in an interactive terminal.",
         reason.as_str()
     )
 }
 
+fn debugger_dump_hint() -> &'static str {
+    "Pass `--dump <PATH>` to export debugger steps."
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{TuiFallbackReason, non_interactive_debugger_message};
+    use super::{TuiFallbackReason, debugger_dump_hint, non_interactive_debugger_message};
 
     #[test]
-    fn fallback_message_includes_reason_and_dump_hint() {
+    fn fallback_message_includes_reason() {
         let msg = non_interactive_debugger_message(TuiFallbackReason::Ci);
         assert!(msg.contains("running in CI"));
-        assert!(msg.contains("--dump <PATH>"));
+        assert!(!msg.contains("--dump <PATH>"));
+    }
+
+    #[test]
+    fn dump_hint_includes_dump_flag() {
+        assert!(debugger_dump_hint().contains("--dump <PATH>"));
     }
 }


### PR DESCRIPTION
## Motivation
                                                                                                                                                                                                 
  `foundry-tui` now supports non-interactive fallback detection, but the debugger path was still always calling interactive `run_app`.                                                           
  In CI or non-TTY environments, `--debug` could fail without a clear, actionable fallback path.                                                                                                 
                                                                                                                                                                                                 
  ## Solution
                                                                                                                                                                                                 
  This PR updates the debugger TUI entrypoint to use `run_app_if_interactive` so behavior matches the shared TUI runtime contract.
  Interactive environments are unchanged; non-interactive environments now return a clear reasoned error message and suggest `--dump <PATH>` as the fallback workflow.                           
  A unit test was added to verify the fallback message includes both the reason and the dump hint.                                                                                               
                                                                                                                                                                                                 
  ## PR Checklist                                                                                                                                                                                

  - [x] Added Tests                                                                                                                                                                              
  - [ ] Added Documentation                                                                                                                                                                      
  - [ ] Breaking changes  