### PR TITLE
fix(npm): propagate wrapper exit codes

### DIFF
--- a/npm/scripts/test-bin-exit.mjs
+++ b/npm/scripts/test-bin-exit.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+import * as NodeAssert from 'node:assert/strict'
+import * as NodeChildProcess from 'node:child_process'
+import * as NodeFS from 'node:fs/promises'
+import * as NodeOS from 'node:os'
+import * as NodePath from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { BINARY_NAME, PLATFORM_SPECIFIC_PACKAGE_NAME } from '#const.mjs'
+
+const __dirname = NodePath.dirname(fileURLToPath(import.meta.url))
+const tool = 'forge'
+const binaryName = BINARY_NAME(tool)
+const maybePlatformPackage = PLATFORM_SPECIFIC_PACKAGE_NAME(tool)
+
+if (!maybePlatformPackage)
+  throw new Error(`Unsupported platform for ${tool}: ${process.platform}/${process.arch}`)
+
+const platformPackage = maybePlatformPackage
+const tempDir = await NodeFS.mkdtemp(NodePath.join(NodeOS.tmpdir(), 'foundry-npm-bin-'))
+
+try {
+  await stageFakeBinary()
+  assertExitCode(0)
+  assertExitCode(7)
+} finally {
+  await NodeFS.rm(tempDir, { recursive: true, force: true })
+}
+
+async function stageFakeBinary() {
+  const packageDir = NodePath.join(tempDir, 'node_modules', ...platformPackage.split('/'))
+  const binDir = NodePath.join(packageDir, 'bin')
+  const binaryPath = NodePath.join(binDir, binaryName)
+
+  await NodeFS.mkdir(binDir, { recursive: true })
+  await NodeFS.writeFile(
+    NodePath.join(packageDir, 'package.json'),
+    JSON.stringify({ name: platformPackage, version: '0.0.0-test' }, null, 2) + '\n'
+  )
+  await NodeFS.writeFile(
+    binaryPath,
+    [
+      '#!/usr/bin/env node',
+      'process.exit(Number(process.argv[2]))',
+      ''
+    ].join('\n'),
+    { mode: 0o755 }
+  )
+  await NodeFS.chmod(binaryPath, 0o755)
+}
+
+/**
+ * @param {number} expected
+ */
+function assertExitCode(expected) {
+  const result = NodeChildProcess.spawnSync(
+    process.execPath,
+    ['./src/bin.mjs', String(expected)],
+    {
+      cwd: NodePath.resolve(__dirname, '..'),
+      env: {
+        ...process.env,
+        NODE_PATH: NodePath.join(tempDir, 'node_modules'),
+        TARGET_TOOL: tool
+      },
+      encoding: 'utf8'
+    }
+  )
+
+  NodeAssert.equal(result.status, expected, result.stderr || result.stdout)
+}

--- a/npm/src/bin.mjs
+++ b/npm/src/bin.mjs
@@ -45,6 +45,23 @@ const signalHandlers = {
 for (const [signal, handler] of Object.entries(signalHandlers))
   process.on(signal, handler)
 
+child.on('error', error => {
+  cleanupSignalHandlers()
+  console.error(error)
+  process.exit(1)
+})
+
+child.on('exit', (code, signal) => {
+  cleanupSignalHandlers()
+
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+
+  process.exit(code ?? 1)
+})
+
 /**
  * Determines which tool wrapper is executing.
  * @returns {Tool}
@@ -149,4 +166,9 @@ function forwardSignal(signal) {
 
   process.off(signal, signalHandlers[signal])
   process.kill(process.pid, signal)
+}
+
+function cleanupSignalHandlers() {
+  for (const [signal, handler] of Object.entries(signalHandlers))
+    process.off(signal, handler)
 }


### PR DESCRIPTION
Closes #14781

## Motivation

The npm meta package wrapper currently spawns the platform-specific Foundry binary, but it does not handle the child process exit result. That means the wrapper can exit with status `0` even when the underlying `forge`, `cast`, `anvil`, or `chisel` binary exits with a non-zero status.

For commands such as `forge test`, this can make CI continue after Foundry already printed failing tests.

## Solution

This PR updates `npm/src/bin.mjs` so the wrapper:

- exits with the same code as the child binary
- exits with `1` if the child result has no code
- preserves signal behavior when the child exits due to a signal
- cleans up installed signal handlers when the child exits or fails to spawn

I kept the focused regression test because `CONTRIBUTING.md` asks code fixes to include tests.

## Tests

```sh
cd npm
bun install --frozen-lockfile
bun tsc --project tsconfig.json --noEmit
node ./scripts/test-bin-exit.mjs
```

I also verified the wrapper against a real installed `forge` binary:

```sh
forge definitely-not-a-command
echo $?
# 2

NODE_PATH=/private/tmp/foundry-real-node-path/node_modules TARGET_TOOL=forge node ./src/bin.mjs definitely-not-a-command
echo $?
# 2
```

## AI disclosure

This PR was prepared with AI assistance. I used Codex to inspect the npm wrapper, reproduce the exit-code behavior, implement the patch, and draft the test and PR text. I reviewed the resulting change and validation steps.
