### PR TITLE
fix(traces): prefer contract ABI for decoding

### DIFF
--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -7,7 +7,7 @@ use alloy_dyn_abi::{DecodedEvent, DynSolValue, EventExt, FunctionExt, JsonAbiExt
 use alloy_json_abi::{Error, Event, Function, JsonAbi};
 use alloy_primitives::{
     Address, B256, LogData, Selector,
-    map::{HashMap, HashSet, hash_map::Entry},
+    map::{HashMap, HashSet},
 };
 use foundry_common::{
     ContractsByArtifact, SELECTOR_LEN, abi::get_indexed_event, fmt::format_token,
@@ -149,6 +149,8 @@ pub struct CallTraceDecoder {
 
     /// All known functions.
     pub functions: HashMap<Selector, Vec<Function>>,
+    /// Functions identified for a specific contract address.
+    pub functions_by_address: HashMap<Address, HashMap<Selector, Vec<Function>>>,
     /// All known events.
     ///
     /// Key is: `(topics[0], topics.len() - 1)`.
@@ -239,6 +241,7 @@ impl CallTraceDecoder {
                 .flatten()
                 .map(|func| (func.selector(), vec![func]))
                 .collect(),
+            functions_by_address: Default::default(),
             events: console::ds::abi::events()
                 .into_values()
                 // Tempo
@@ -278,6 +281,7 @@ impl CallTraceDecoder {
         self.receive_contracts.clear();
         self.fallback_contracts.clear();
         self.non_fallback_contracts.clear();
+        self.functions_by_address.clear();
     }
 
     /// Identify unknown addresses in the specified call trace using the specified identifier.
@@ -315,24 +319,49 @@ impl CallTraceDecoder {
 
     /// Adds a single function to the decoder.
     pub fn push_function(&mut self, function: Function) {
-        match self.functions.entry(function.selector()) {
-            Entry::Occupied(entry) => {
-                // This shouldn't happen that often.
-                if entry.get().contains(&function) {
-                    return;
-                }
-                trace!(target: "evm::traces", selector=%entry.key(), new=%function.signature(), "duplicate function selector");
-                entry.into_mut().push(function);
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(vec![function]);
-            }
+        let selector = function.selector();
+        let functions = self.functions.entry(selector).or_default();
+
+        if Self::push_function_to(functions, function) && functions.len() > 1 {
+            let function = functions.last().expect("function was just inserted");
+            let signature = function.signature();
+            trace!(target: "evm::traces", %selector, new=%signature, "duplicate function selector");
         }
     }
 
-    /// Selects the appropriate function from a list of functions with the same selector
-    /// by checking which one belongs to the contract being called, this avoids collisions
-    /// where multiple different functions across different contracts have the same selector.
+    /// Adds a single function to the decoder for a specific contract address.
+    pub fn push_address_function(&mut self, address: Address, function: Function) {
+        let functions = self
+            .functions_by_address
+            .entry(address)
+            .or_default()
+            .entry(function.selector())
+            .or_default();
+        Self::push_function_to(functions, function);
+    }
+
+    fn push_function_to(functions: &mut Vec<Function>, function: Function) -> bool {
+        if functions.contains(&function) {
+            false
+        } else {
+            functions.push(function);
+            true
+        }
+    }
+
+    fn functions_for_selector(&self, address: Address, selector: &Selector) -> Option<&[Function]> {
+        self.functions_by_address
+            .get(&address)
+            .and_then(|functions| functions.get(selector))
+            .or_else(|| self.functions.get(selector))
+            .map(Vec::as_slice)
+    }
+
+    /// Selects the appropriate function from a list of functions with the same selector by
+    /// checking which one decodes the calldata.
+    ///
+    /// Address-scoped function lookup should happen before this to avoid using ABI metadata from a
+    /// different contract when multiple functions have the same input types.
     fn select_contract_function<'a>(
         &self,
         functions: &'a [Function],
@@ -394,6 +423,9 @@ impl CallTraceDecoder {
         }
         trace!(target: "evm::traces", len, ?address, "collecting ABI");
         for function in abi.functions() {
+            if let Some(address) = address {
+                self.push_address_function(address, function.clone());
+            }
             self.push_function(function.clone());
         }
         for event in abi.events() {
@@ -459,16 +491,16 @@ impl CallTraceDecoder {
 
         if is_abi_call_data(cdata) {
             let selector = Selector::try_from(&cdata[..SELECTOR_LEN]).unwrap();
-            let mut functions = Vec::new();
-            let functions = match self.functions.get(&selector) {
-                Some(fs) => fs,
+            let mut identified_functions = Vec::new();
+            let functions = match self.functions_for_selector(trace.address, &selector) {
+                Some(functions) => functions,
                 None => {
                     if let Some(identifier) = &self.signature_identifier
                         && let Some(function) = identifier.identify_function(selector).await
                     {
-                        functions.push(function);
+                        identified_functions.push(function);
                     }
-                    &functions
+                    &identified_functions
                 }
             };
 

--- a/crates/forge/tests/cli/test_cmd/trace.rs
+++ b/crates/forge/tests/cli/test_cmd/trace.rs
@@ -1,6 +1,6 @@
 //! Tests for tracing functionality
 
-use foundry_test_utils::{str, util::OutputExt};
+use foundry_test_utils::str;
 
 forgetest_init!(conflicting_signatures, |prj, cmd| {
     prj.add_test(
@@ -143,16 +143,25 @@ contract TraceStructOutputsTest is Test {
 "#,
     );
 
-    let stdout = cmd
-        .args(["test", "--mt", "testStructTracesUseContractAbi", "-vvvv"])
+    cmd.args(["test", "--mt", "testStructTracesUseContractAbi", "-vvvv"])
         .assert_success()
-        .get_output()
-        .stdout_lossy();
+        .stdout_eq(str![[r#"
+...
+Ran 1 test for test/TraceStructOutputs.t.sol:TraceStructOutputsTest
+[PASS] testStructTracesUseContractAbi() ([GAS])
+Traces:
+  [..] TraceStructOutputsTest::testStructTracesUseContractAbi()
+    ├─ [..] ZWow::item(1) [staticcall]
+    │   └─ ← [Return] WowStruct({ a: 1, b: 2 })
+    ├─ [..] AAAMuchWow::item(2) [staticcall]
+    │   └─ ← [Return] MuchWowStruct({ c: 3, d: 4 })
+    └─ ← [Stop]
 
-    assert!(stdout.contains("ZWow::item(1) [staticcall]"), "{stdout}");
-    assert!(stdout.contains("← [Return] WowStruct({ a: 1, b: 2 })"), "{stdout}");
-    assert!(stdout.contains("AAAMuchWow::item(2) [staticcall]"), "{stdout}");
-    assert!(stdout.contains("← [Return] MuchWowStruct({ c: 3, d: 4 })"), "{stdout}");
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]);
 });
 
 #[cfg(not(feature = "isolate-by-default"))]

--- a/crates/forge/tests/cli/test_cmd/trace.rs
+++ b/crates/forge/tests/cli/test_cmd/trace.rs
@@ -1,6 +1,6 @@
 //! Tests for tracing functionality
 
-use foundry_test_utils::str;
+use foundry_test_utils::{str, util::OutputExt};
 
 forgetest_init!(conflicting_signatures, |prj, cmd| {
     prj.add_test(
@@ -77,6 +77,82 @@ Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 
 "#]]);
+});
+
+forgetest_init!(trace_struct_outputs_use_called_contract_abi, |prj, cmd| {
+    prj.add_test(
+        "TraceStructOutputs.t.sol",
+        r#"
+pragma solidity ^0.8.18;
+
+import "forge-std/Test.sol";
+
+contract AAAMuchWow {
+    struct MuchWowStruct {
+        uint256 c;
+        uint256 d;
+    }
+
+    mapping(uint256 => MuchWowStruct) internal items;
+
+    constructor() {
+        items[2] = MuchWowStruct({ c: 3, d: 4 });
+    }
+
+    function item(uint256 id) public view returns (MuchWowStruct memory) {
+        return items[id];
+    }
+}
+
+contract ZWow {
+    struct WowStruct {
+        uint256 a;
+        uint256 b;
+    }
+
+    mapping(uint256 => WowStruct) internal items;
+
+    constructor() {
+        items[1] = WowStruct({ a: 1, b: 2 });
+    }
+
+    function item(uint256 id) public view returns (WowStruct memory) {
+        return items[id];
+    }
+}
+
+contract TraceStructOutputsTest is Test {
+    AAAMuchWow muchWow;
+    ZWow wow;
+
+    function setUp() public {
+        muchWow = new AAAMuchWow();
+        wow = new ZWow();
+    }
+
+    function testStructTracesUseContractAbi() public view {
+        ZWow.WowStruct memory wowItem = wow.item(1);
+        AAAMuchWow.MuchWowStruct memory muchWowItem = muchWow.item(2);
+
+        assertEq(wowItem.a, 1);
+        assertEq(wowItem.b, 2);
+        assertEq(muchWowItem.c, 3);
+        assertEq(muchWowItem.d, 4);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--mt", "testStructTracesUseContractAbi", "-vvvv"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(stdout.contains("ZWow::item(1) [staticcall]"), "{stdout}");
+    assert!(stdout.contains("← [Return] WowStruct({ a: 1, b: 2 })"), "{stdout}");
+    assert!(stdout.contains("AAAMuchWow::item(2) [staticcall]"), "{stdout}");
+    assert!(stdout.contains("← [Return] MuchWowStruct({ c: 3, d: 4 })"), "{stdout}");
 });
 
 #[cfg(not(feature = "isolate-by-default"))]

--- a/crates/forge/tests/cli/test_cmd/trace.rs
+++ b/crates/forge/tests/cli/test_cmd/trace.rs
@@ -67,9 +67,9 @@ Traces:
     ├─ [..] ReturnsNothing::func() [staticcall]
     │   └─ ← [Stop]
     ├─ [..] ReturnsString::func() [staticcall]
-    │   └─ ← [Return] 0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000006737472696e670000000000000000000000000000000000000000000000000000
+    │   └─ ← [Return] "string"
     ├─ [..] ReturnsUint::func() [staticcall]
-    │   └─ ← [Return] 0x0000000000000000000000000000000000000000000000000000000000000001
+    │   └─ ← [Return] 1
     └─ ← [Stop]
 
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]


### PR DESCRIPTION
Trace decoding collected every known function ABI into a selector-wide cache, so calls with the same selector and input types could be decoded with ABI metadata from another contract. That made returned struct values render with the wrong struct and field names even though the underlying bytes were correct.

This keeps functions identified for a concrete address in an address-scoped cache and prefers that cache during trace decoding before falling back to global selector lookup. The regression uses Forge test source with two contracts that return different structs from the same selector and asserts the rendered trace uses each called contract ABI.

Reference: https://t.me/foundry_rs/42434
