### PR TITLE
feat(cast): add --tempo.sponsor-url for remote fee payer sponsorship

### DIFF
--- a/crates/cli/src/opts/tempo.rs
+++ b/crates/cli/src/opts/tempo.rs
@@ -88,7 +88,7 @@ pub struct TempoOpts {
         long = "tempo.sponsor-signer",
         value_name = "SIGNER",
         requires = "sponsor",
-        conflicts_with = "sponsor_sig"
+        conflicts_with_all = &["sponsor_sig", "sponsor_url"]
     )]
     pub sponsor_signer: Option<String>,
 
@@ -101,9 +101,22 @@ pub struct TempoOpts {
         alias = "tempo.sponsor-signature",
         value_parser = parse_signature,
         requires = "sponsor",
-        conflicts_with = "sponsor_signer"
+        conflicts_with_all = &["sponsor_signer", "sponsor_url"]
     )]
     pub sponsor_sig: Option<Signature>,
+
+    /// URL of a remote sponsor service for Tempo fee payer signatures.
+    ///
+    /// The service must implement the `tempo_signSponsorHash` JSON-RPC method.
+    /// When set, the sponsor address is returned by the service and `--tempo.sponsor`
+    /// is optional (used only as an assertion).
+    #[arg(
+        long = "tempo.sponsor-url",
+        alias = "sponsor-url",
+        value_name = "URL",
+        conflicts_with_all = &["sponsor_signer", "sponsor_sig"]
+    )]
+    pub sponsor_url: Option<String>,
 
     /// Print the sponsor signature hash and exit.
     ///
@@ -111,7 +124,7 @@ pub struct TempoOpts {
     /// knows what hash to sign. The transaction is not sent.
     #[arg(
         long = "tempo.print-sponsor-hash",
-        conflicts_with_all = &["sponsor", "sponsor_signer", "sponsor_sig"]
+        conflicts_with_all = &["sponsor", "sponsor_signer", "sponsor_sig", "sponsor_url"]
     )]
     pub print_sponsor_hash: bool,
 
@@ -154,6 +167,7 @@ impl TempoOpts {
             || self.sponsor.is_some()
             || self.sponsor_signer.is_some()
             || self.sponsor_sig.is_some()
+            || self.sponsor_url.is_some()
             || self.print_sponsor_hash
             || self.key_id.is_some()
             || self.expiring_nonce
@@ -182,11 +196,19 @@ impl TempoOpts {
 
     /// Returns `true` if a sponsor signature should be attached before submission.
     pub const fn has_sponsor_submission(&self) -> bool {
-        self.sponsor.is_some() || self.sponsor_signer.is_some() || self.sponsor_sig.is_some()
+        self.sponsor.is_some()
+            || self.sponsor_signer.is_some()
+            || self.sponsor_sig.is_some()
+            || self.sponsor_url.is_some()
     }
 
     /// Resolves sponsor CLI options into a reusable sponsor config for transaction submission.
     pub async fn sponsor_config(&self) -> Result<Option<TempoSponsor>> {
+        // Remote sponsor URL: sponsor address is optional (returned by the service).
+        if let Some(url) = &self.sponsor_url {
+            return Ok(Some(TempoSponsor::remote(url.clone(), self.sponsor)));
+        }
+
         let Some(sponsor) = self.sponsor else {
             return Ok(None);
         };
@@ -208,7 +230,7 @@ impl TempoOpts {
 
         if signer.is_none() && self.sponsor_sig.is_none() {
             eyre::bail!(
-                "--tempo.sponsor requires either --tempo.sponsor-signer or --tempo.sponsor-sig"
+                "--tempo.sponsor requires either --tempo.sponsor-signer, --tempo.sponsor-sig, or --tempo.sponsor-url"
             );
         }
 
@@ -416,6 +438,76 @@ mod tests {
                 "--tempo.print-sponsor-hash",
                 "--tempo.sponsor",
                 "0x1111111111111111111111111111111111111111",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn parse_sponsor_url() {
+        let opts = TempoOpts::try_parse_from([
+            "",
+            "--tempo.sponsor-url",
+            "https://sponsor.tempo.xyz",
+        ])
+        .unwrap();
+
+        assert_eq!(opts.sponsor_url.as_deref(), Some("https://sponsor.tempo.xyz"));
+        assert!(opts.sponsor.is_none());
+        assert!(opts.is_tempo());
+        assert!(opts.has_sponsor_submission());
+    }
+
+    #[test]
+    fn sponsor_url_alias() {
+        let opts =
+            TempoOpts::try_parse_from(["", "--sponsor-url", "https://sponsor.tempo.xyz"]).unwrap();
+
+        assert_eq!(opts.sponsor_url.as_deref(), Some("https://sponsor.tempo.xyz"));
+    }
+
+    #[test]
+    fn sponsor_url_with_optional_sponsor_address() {
+        let opts = TempoOpts::try_parse_from([
+            "",
+            "--tempo.sponsor-url",
+            "https://sponsor.tempo.xyz",
+            "--tempo.sponsor",
+            "0x1111111111111111111111111111111111111111",
+        ])
+        .unwrap();
+
+        assert_eq!(opts.sponsor_url.as_deref(), Some("https://sponsor.tempo.xyz"));
+        assert_eq!(opts.sponsor, Some(address!("0x1111111111111111111111111111111111111111")));
+    }
+
+    #[test]
+    fn sponsor_url_conflicts_with_sponsor_signer() {
+        assert!(
+            TempoOpts::try_parse_from([
+                "",
+                "--tempo.sponsor-url",
+                "https://sponsor.tempo.xyz",
+                "--tempo.sponsor",
+                "0x1111111111111111111111111111111111111111",
+                "--tempo.sponsor-signer",
+                "env://SPONSOR",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn sponsor_url_conflicts_with_sponsor_sig() {
+        assert!(
+            TempoOpts::try_parse_from([
+                "",
+                "--tempo.sponsor-url",
+                "https://sponsor.tempo.xyz",
+                "--tempo.sponsor",
+                "0x1111111111111111111111111111111111111111",
+                "--tempo.sponsor-sig",
+                "0x0eb96ca19e8a77102767a41fc85a36afd5c61ccb09911cec5d3e86e193d9c5ae3a456401896b1b6055311536bf00a718568c744d8c1f9df59879e8350220ca182b",
             ])
             .is_err()
         );

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Address, B256, Signature};
 use alloy_signer::Signer;
 use eyre::{Context, Result};
 use foundry_wallets::{RawWalletOpts, WalletOpts, WalletSigner};
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
 mod keystore;
 
@@ -36,21 +36,42 @@ pub const TEMPO_BROWSER_GAS_BUFFER: u64 = 7_000;
 /// Gas sponsor configuration for Tempo fee-payer signatures.
 #[derive(Clone, Debug)]
 pub struct TempoSponsor {
-    sponsor: Address,
-    signer: Option<Arc<WalletSigner>>,
-    signature: Option<Signature>,
+    sponsor: Option<Address>,
+    source: SponsorSource,
+}
+
+#[derive(Clone, Debug)]
+enum SponsorSource {
+    /// Pre-signed sponsor signature.
+    Presigned(Signature),
+    /// Local signer that can produce signatures on demand.
+    Local(Arc<WalletSigner>),
+    /// Remote sponsor service URL (JSON-RPC `tempo_signSponsorHash`).
+    Remote(String),
 }
 
 impl TempoSponsor {
-    pub const fn new(
+    pub fn new(
         sponsor: Address,
         signer: Option<Arc<WalletSigner>>,
         signature: Option<Signature>,
     ) -> Self {
-        Self { sponsor, signer, signature }
+        let source = if let Some(sig) = signature {
+            SponsorSource::Presigned(sig)
+        } else if let Some(signer) = signer {
+            SponsorSource::Local(signer)
+        } else {
+            unreachable!("TempoSponsor::new requires either a signer or signature")
+        };
+        Self { sponsor: Some(sponsor), source }
     }
 
-    pub const fn sponsor(&self) -> Address {
+    /// Creates a remote sponsor that fetches signatures from a URL.
+    pub fn remote(url: String, expected_sponsor: Option<Address>) -> Self {
+        Self { sponsor: expected_sponsor, source: SponsorSource::Remote(url) }
+    }
+
+    pub fn sponsor(&self) -> Option<Address> {
         self.sponsor
     }
 
@@ -62,11 +83,13 @@ impl TempoSponsor {
     where
         N::TransactionRequest: FoundryTransactionBuilder<N>,
     {
-        if self.sponsor == sender {
-            eyre::bail!(
-                "invalid Tempo sponsorship: sponsor {} must not equal transaction sender",
-                self.sponsor
-            );
+        if let Some(sponsor) = self.sponsor {
+            if sponsor == sender {
+                eyre::bail!(
+                    "invalid Tempo sponsorship: sponsor {} must not equal transaction sender",
+                    sponsor
+                );
+            }
         }
 
         let digest = tx.compute_sponsor_hash(sender).ok_or_else(|| {
@@ -75,8 +98,27 @@ impl TempoSponsor {
             )
         })?;
 
+        let (sponsor, signature) = match &self.source {
+            SponsorSource::Presigned(sig) => (self.sponsor.expect("presigned requires sponsor"), *sig),
+            SponsorSource::Local(signer) => {
+                let sig = signer.sign_hash(&digest).await.context("failed to sign Tempo sponsor digest")?;
+                (self.sponsor.expect("local signer requires sponsor"), sig)
+            }
+            SponsorSource::Remote(url) => {
+                let (addr, sig) = fetch_remote_sponsor_signature(url, digest, sender).await?;
+                if let Some(expected) = self.sponsor {
+                    if addr != expected {
+                        eyre::bail!(
+                            "remote sponsor returned address {addr}, expected --tempo.sponsor {expected}"
+                        );
+                    }
+                }
+                (addr, sig)
+            }
+        };
+
         let preview = TempoSponsorPreview {
-            sponsor: self.sponsor,
+            sponsor,
             fee_token: tx.fee_token(),
             valid_before: tx.valid_before().map(|v| v.get()),
             valid_after: tx.valid_after().map(|v| v.get()),
@@ -84,19 +126,11 @@ impl TempoSponsor {
         };
         preview.print()?;
 
-        let signature = if let Some(signature) = self.signature {
-            signature
-        } else if let Some(signer) = &self.signer {
-            signer.sign_hash(&digest).await.context("failed to sign Tempo sponsor digest")?
-        } else {
-            eyre::bail!("missing Tempo sponsor signature or signer")
-        };
-
         let recovered = signature
             .recover_address_from_prehash(&digest)
             .context("failed to recover Tempo sponsor signature")?;
-        if recovered != self.sponsor {
-            eyre::bail!("Tempo sponsor signature recovered {recovered}, expected {}", self.sponsor);
+        if recovered != sponsor {
+            eyre::bail!("Tempo sponsor signature recovered {recovered}, expected {sponsor}");
         }
         if recovered == sender {
             eyre::bail!(
@@ -107,6 +141,76 @@ impl TempoSponsor {
         tx.set_fee_payer_signature(signature);
         Ok(preview)
     }
+}
+
+/// Fetches a sponsor signature from a remote JSON-RPC service.
+///
+/// Calls `tempo_signSponsorHash` with the sponsor digest and sender address.
+/// Returns the sponsor address and signature.
+async fn fetch_remote_sponsor_signature(
+    url: &str,
+    digest: B256,
+    sender: Address,
+) -> Result<(Address, Signature)> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .context("failed to build HTTP client for sponsor URL")?;
+
+    let request_body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tempo_signSponsorHash",
+        "params": [{
+            "hash": format!("{digest:?}"),
+            "sender": format!("{sender:?}")
+        }]
+    });
+
+    let response = client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .json(&request_body)
+        .send()
+        .await
+        .context("failed to reach sponsor URL")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        eyre::bail!("sponsor URL returned HTTP {status}: {body}");
+    }
+
+    let body: serde_json::Value =
+        response.json().await.context("sponsor URL returned invalid JSON")?;
+
+    if let Some(error) = body.get("error") {
+        let msg = error
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("unknown error");
+        eyre::bail!("sponsor URL returned JSON-RPC error: {msg}");
+    }
+
+    let result = body
+        .get("result")
+        .ok_or_else(|| eyre::eyre!("sponsor URL response missing 'result' field"))?;
+
+    let sponsor_hex = result
+        .get("sponsor")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| eyre::eyre!("sponsor URL response missing 'result.sponsor' field"))?;
+    let sponsor = Address::from_str(sponsor_hex)
+        .map_err(|e| eyre::eyre!("invalid sponsor address from sponsor URL: {e}"))?;
+
+    let sig_hex = result
+        .get("signature")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| eyre::eyre!("sponsor URL response missing 'result.signature' field"))?;
+    let signature = Signature::from_str(sig_hex)
+        .map_err(|e| eyre::eyre!("invalid signature from sponsor URL: {e}"))?;
+
+    Ok((sponsor, signature))
 }
 
 /// User-visible sponsor digest metadata for a single outgoing Tempo transaction.


### PR DESCRIPTION
Adds `--tempo.sponsor-url` (alias: `--sponsor-url`) to `cast send` and `cast mktx` for fetching Tempo fee payer signatures from a remote JSON-RPC service.

## Usage

```bash
# Simple — sponsor address returned by service
cast send --sponsor-url https://sponsor.tempo.xyz <to> <sig> [args]

# With address assertion
cast send --sponsor-url https://sponsor.tempo.xyz --tempo.sponsor 0x58Aa7... <to> <sig> [args]
```

## Protocol

The service must implement `tempo_signSponsorHash`:

```json
// Request
{"jsonrpc":"2.0","id":1,"method":"tempo_signSponsorHash","params":[{"hash":"0x...","sender":"0x..."}]}

// Response
{"jsonrpc":"2.0","id":1,"result":{"sponsor":"0x...","signature":"0x..."}}
```

## Changes

- **`crates/cli/src/opts/tempo.rs`**: Added `--tempo.sponsor-url` flag with conflicts against `--tempo.sponsor-signer` and `--tempo.sponsor-sig`. Updated `is_tempo()`, `has_sponsor_submission()`, and `sponsor_config()`.
- **`crates/common/src/tempo/mod.rs`**: Refactored `TempoSponsor` to support three source variants (presigned, local signer, remote URL). Added `fetch_remote_sponsor_signature()` for the JSON-RPC call.
- 6 new unit tests for flag parsing and conflict validation.

## Note

The sponsor service (sponsor.tempo.xyz) needs a corresponding update to implement the `tempo_signSponsorHash` method. The existing `eth_signRawTransaction` method is unaffected.