### PR TITLE
feat(script): agent-substrate streaming for forge script

### DIFF
--- a/crates/cli/src/diagnostic.rs
+++ b/crates/cli/src/diagnostic.rs
@@ -158,8 +158,15 @@ pub mod test {
 /// `forge script` diagnostic codes.
 pub mod script {
     pub const BROADCAST_FAILED: &str = "script.broadcast_failed";
+    /// `--broadcast` was requested but the script produced no transactions.
+    pub const NO_TRANSACTIONS: &str = "script.no_transactions";
+    /// On-chain simulation was skipped because no `--rpc-url` was provided.
+    pub const MISSING_RPC_URL: &str = "script.missing_rpc_url";
+    /// Script contains a transaction whose target address has no contract code.
+    pub const NOOP_TARGET: &str = "script.noop_target";
 
-    pub(crate) const ALL: &[&str] = &[BROADCAST_FAILED];
+    pub(crate) const ALL: &[&str] =
+        &[BROADCAST_FAILED, NO_TRANSACTIONS, MISSING_RPC_URL, NOOP_TARGET];
 }
 
 /// `cast` diagnostic codes.

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -66,14 +66,17 @@ pub fn run_command(args: Forge) -> Result<()> {
     // process-global `is_machine()` flag without ever emitting a terminal
     // envelope — spoofing `command_id` and leaving the stream unterminated.
     if foundry_cli::is_machine() {
-        let adopted = matches!(args.cmd, ForgeSubcommand::Build(_) | ForgeSubcommand::Test(_));
+        let adopted = matches!(
+            args.cmd,
+            ForgeSubcommand::Build(_) | ForgeSubcommand::Test(_) | ForgeSubcommand::Script(_)
+        );
         if !adopted {
             let name = subcommand_name(&args.cmd);
             foundry_cli::machine::bail_machine_usage_with_details(
                 format!(
                     "`forge {name}` is not yet adopted for `--machine`; only \
-                     `forge build` and `forge test` are. Run without `--machine` \
-                     or use an adopted subcommand."
+                     `forge build`, `forge test`, and `forge script` are. Run without \
+                     `--machine` or use an adopted subcommand."
                 ),
                 serde_json::json!({ "subcommand": name }),
             );
@@ -321,12 +324,14 @@ mod tests {
         }
         let pinned: Vec<(&str, OutputMode)> = doc.commands.iter().flat_map(walk).collect();
         let pinned_ids: Vec<&str> = pinned.iter().map(|(id, _)| *id).collect();
-        for id in ["forge.build", "forge.test"] {
+        for id in ["forge.build", "forge.test", "forge.script"] {
             assert!(pinned_ids.contains(&id), "{id} missing from pinned ids: {pinned_ids:?}");
         }
-        assert!(
-            pinned.iter().any(|(id, m)| *id == "forge.test" && matches!(m, OutputMode::Stream)),
-            "forge.test must be Stream: {pinned:?}"
-        );
+        for id in ["forge.test", "forge.script"] {
+            assert!(
+                pinned.iter().any(|(p, m)| *p == id && matches!(m, OutputMode::Stream)),
+                "{id} must be Stream: {pinned:?}"
+            );
+        }
     }
 }

--- a/crates/forge/src/diagnostic.rs
+++ b/crates/forge/src/diagnostic.rs
@@ -18,9 +18,19 @@ pub mod test {
     pub(crate) const ALL: &[&str] = &[FAILED, SETUP_FAILED, WARNING];
 }
 
+/// `forge script` diagnostic codes.
+pub mod script {
+    pub use foundry_cli::diagnostic::script::{
+        BROADCAST_FAILED, MISSING_RPC_URL, NO_TRANSACTIONS, NOOP_TARGET,
+    };
+
+    pub(crate) const ALL: &[&str] =
+        &[BROADCAST_FAILED, NO_TRANSACTIONS, MISSING_RPC_URL, NOOP_TARGET];
+}
+
 /// All diagnostic codes declared by `forge`.
 pub fn known_codes() -> Vec<&'static str> {
-    let groups: &[&[&str]] = &[build::ALL, test::ALL];
+    let groups: &[&[&str]] = &[build::ALL, test::ALL, script::ALL];
     groups.iter().flat_map(|g| g.iter().copied()).collect()
 }
 

--- a/crates/forge/src/introspect.rs
+++ b/crates/forge/src/introspect.rs
@@ -20,6 +20,11 @@ pub const TEST_EVENT_SCHEMA: &str = "foundry:forge.test.event@v1";
 /// Stable schema id for the terminal `forge test` envelope payload.
 pub const TEST_RESULT_SCHEMA: &str = "foundry:forge.test@v1";
 
+/// Stable schema id for `forge script` stream event records.
+pub const SCRIPT_EVENT_SCHEMA: &str = "foundry:forge.script.event@v1";
+/// Stable schema id for the terminal `forge script` envelope payload.
+pub const SCRIPT_RESULT_SCHEMA: &str = "foundry:forge.script@v1";
+
 /// Exit codes `forge build` may emit under `--machine`. Declared explicitly so
 /// agents don't have to assume "inherits global defaults"; codes not in this
 /// list are not produced by this command.
@@ -93,6 +98,33 @@ static TEST_EXIT_CODES: &[ExitCodeInfo] = &[
         ),
     },
 ];
+/// Exit codes `forge script` may emit under `--machine`.
+static SCRIPT_EXIT_CODES: &[ExitCodeInfo] = &[
+    ExitCodeInfo {
+        code: ExitCode::Success.to_i32(),
+        name: Cow::Borrowed(ExitCode::Success.name()),
+        description: Cow::Borrowed(
+            "Script ran (dry-run or broadcast accepted). Advisories in `warnings[]`.",
+        ),
+    },
+    ExitCodeInfo {
+        code: ExitCode::GenericError.to_i32(),
+        name: Cow::Borrowed(ExitCode::GenericError.name()),
+        description: Cow::Borrowed(
+            "`script.broadcast_failed` or unclassified failure (`cli.unknown`).",
+        ),
+    },
+    ExitCodeInfo {
+        code: ExitCode::Usage.to_i32(),
+        name: Cow::Borrowed(ExitCode::Usage.name()),
+        description: Cow::Borrowed("Flag combination rejected (`cli.usage.invalid`)."),
+    },
+    ExitCodeInfo {
+        code: ExitCode::Build.to_i32(),
+        name: Cow::Borrowed(ExitCode::Build.name()),
+        description: Cow::Borrowed("Solc compile errors (`compiler.solc.error`)."),
+    },
+];
 
 static ENTRIES: &[RegistryEntry] = &[
     RegistryEntry {
@@ -135,6 +167,26 @@ static ENTRIES: &[RegistryEntry] = &[
             },
             capabilities_declared: true,
             exit_codes: TEST_EXIT_CODES,
+        },
+    },
+    RegistryEntry {
+        path: &["script"],
+        meta: CommandMeta {
+            command_id: Some("forge.script"),
+            capabilities: Capabilities {
+                output_mode: OutputMode::Stream,
+                result_schema_ref: Some(Cow::Borrowed(SCRIPT_RESULT_SCHEMA)),
+                event_schema_ref: Some(Cow::Borrowed(SCRIPT_EVENT_SCHEMA)),
+                session_schema_ref: None,
+                reads_stdin: false,
+                supports_output_path: false,
+                requires_project: true,
+                side_effects: SideEffects::ChainWrite,
+                long_running: true,
+                stateful: false,
+            },
+            capabilities_declared: true,
+            exit_codes: SCRIPT_EXIT_CODES,
         },
     },
 ];

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3927,7 +3927,8 @@ contract Demo {
     assert_eq!(envelope["success"], true);
     assert_eq!(envelope["data"]["mode"], "dry_run");
     assert_eq!(envelope["data"]["tx_count"], 0);
-    assert!(envelope["data"]["tx_hashes"].as_array().unwrap().is_empty());
+    assert!(envelope["data"]["transactions"].as_array().unwrap().is_empty());
+    assert!(envelope["data"].get("broadcast").is_none(), "broadcast must be dropped: {envelope}");
 
     // Warning duality: same `(code, message)` on the stream record and in `warnings[]`.
     let stream_warning =
@@ -3984,19 +3985,27 @@ contract DeployScript is Script {
     let envelope: Value =
         serde_json::from_str(stdout.lines().rfind(|l| !l.is_empty()).unwrap()).unwrap();
     assert_eq!(envelope["success"], false);
-    // `data: null` (key present + explicitly Null); `is_null()` alone also passes when absent.
     assert_eq!(envelope.get("data"), Some(&Value::Null), "{envelope}");
-    assert_eq!(envelope["errors"][0]["code"], "script.broadcast_failed");
-    assert!(
-        !envelope["errors"][0]["details"]["cause_chain"].as_array().unwrap().is_empty(),
-        "{envelope}"
-    );
+    let err = &envelope["errors"][0];
+    assert_eq!(err["code"], "script.broadcast_failed");
+    let details = &err["details"];
+    assert!(!details["cause_chain"].as_array().unwrap().is_empty(), "{envelope}");
+    // Typed fields agents can react to without parsing prose.
+    assert!(details["kind"].is_string(), "{envelope}");
+    assert!(details["retryable"].is_boolean(), "{envelope}");
+    // Recovery context: --resume is the v1 recovery primitive.
+    let recovery = &details["recovery"];
+    assert_eq!(recovery["resume_supported"], true, "{envelope}");
+    assert!(recovery["sequence_paths"].is_array(), "{envelope}");
+    assert!(recovery["submitted_count"].is_u64(), "{envelope}");
+    // Warning duality survives the failure path.
     let warnings = envelope["warnings"].as_array().unwrap();
     assert!(warnings.iter().any(|w| w["code"] == "script.noop_target"), "{envelope}");
 });
 
 // Reject flags whose stdout would corrupt the stream or whose runtime would
-// block on user/device input. One representative per class.
+// block on user/device input. Covers each rejected flag in the v1 list.
+// `--resume` is allowed under `--machine` (it's the documented recovery primitive).
 forgetest!(machine_mode_rejects_unsupported_flags, |prj, cmd| {
     let script = prj.add_source(
         "Foo",
@@ -4007,18 +4016,69 @@ contract Demo {
    "#,
     );
 
-    for flag in ["--debug", "--interactive", "--ledger"] {
-        cmd.forge_fuse().arg("--machine").arg("script").arg(&script).arg(flag);
+    let cases: &[&[&str]] = &[
+        &["--debug"],
+        &["--verify", "--broadcast"], // `--verify` requires `--broadcast` in clap.
+        &["--interactive"],
+        &["--ledger"],
+        &["--trezor"],
+        &["--browser"],
+        // Keystore without `--password`/`--password-file` would prompt for a passphrase.
+        &["--keystore", "/tmp/nonexistent.json"],
+    ];
+    for args in cases {
+        cmd.forge_fuse().arg("--machine").arg("script").arg(&script).args(*args);
         let assert = cmd.assert_failure();
         let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
         let envelope: Value = serde_json::from_str(stdout.trim()).unwrap();
-        assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
-        assert_eq!(assert.get_output().status.code(), Some(2));
-        assert!(
-            envelope["errors"][0]["message"].as_str().unwrap().contains(flag),
-            "missing {flag} mention: {envelope}"
-        );
+        assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid", "{args:?}: {envelope}");
+        assert_eq!(assert.get_output().status.code(), Some(2), "{args:?}");
+        let msg = envelope["errors"][0]["message"].as_str().unwrap();
+        // `--keystore <PATH>` is reported as `--keystore/--account ...`; match
+        // the bare flag rather than the full literal arg.
+        let token = args[0];
+        assert!(msg.contains(token), "missing {token} mention for {args:?}: {envelope}");
     }
+});
+
+// `script.missing_rpc_url` warning duality: stream record + terminal `warnings[]`
+// carry the same `(code, message)` when on-chain simulation is skipped (script
+// produces broadcast txs but no `--rpc-url` is provided).
+forgetest_init!(machine_mode_missing_rpc_url_warning_duality, |prj, cmd| {
+    let script = prj.add_source(
+        "NoRpc",
+        r#"
+import "forge-std/Script.sol";
+contract Hello {}
+contract NoRpcScript is Script {
+    function run() external {
+        vm.startBroadcast();
+        new Hello();
+        vm.stopBroadcast();
+    }
+}
+   "#,
+    );
+
+    let assert =
+        cmd.arg("--machine").arg("script").arg(script).arg("--target-contract").arg("NoRpcScript");
+    let assert = assert.assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    let stream: Vec<Value> =
+        lines[..lines.len() - 1].iter().map(|l| serde_json::from_str(l).unwrap()).collect();
+    let envelope: Value = serde_json::from_str(lines.last().unwrap()).unwrap();
+
+    let stream_warning = stream
+        .iter()
+        .find(|r| r["kind"] == "warning" && r["code"] == "script.missing_rpc_url")
+        .expect("missing_rpc_url stream record");
+    let warnings = envelope["warnings"].as_array().unwrap();
+    let env_warning = warnings
+        .iter()
+        .find(|w| w["code"] == "script.missing_rpc_url")
+        .expect("missing_rpc_url envelope warning");
+    assert_eq!(stream_warning["message"], env_warning["message"]);
 });
 
 // Happy-path broadcast pins the `@v1` payload shape (mode, tx hashes, CREATEs).
@@ -4065,18 +4125,23 @@ contract DeployScript is Script {
     let data = &envelope["data"];
     assert_eq!(envelope["success"], true, "{envelope}");
     assert_eq!(data["mode"], "broadcast", "{envelope}");
+    assert!(data.get("broadcast").is_none(), "broadcast must be dropped: {envelope}");
     assert!(data["tx_count"].as_u64().unwrap_or(0) >= 1, "{envelope}");
-    let tx_hashes = data["tx_hashes"].as_array().unwrap();
+    // `transactions[]` carries per-tx outcome (hash + status + optional block_number).
+    let transactions = data["transactions"].as_array().unwrap();
+    assert!(!transactions.is_empty(), "{envelope}");
+    for tx in transactions {
+        assert!(tx["hash"].as_str().unwrap().starts_with("0x"), "{tx}");
+        let status = tx["status"].as_str().unwrap();
+        assert!(matches!(status, "success" | "failed" | "pending"), "bad status `{status}`");
+    }
+    // `created_contracts[].tx_hash` links each entry to the creating tx.
+    let creates = data["created_contracts"].as_array().unwrap();
+    assert!(creates.iter().any(|c| c["address"].as_str().unwrap().starts_with("0x")), "{envelope}");
     assert!(
-        !tx_hashes.is_empty() && tx_hashes.iter().all(|h| h.as_str().unwrap().starts_with("0x")),
-        "{envelope}"
-    );
-    assert!(
-        data["created_contracts"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|c| c["address"].as_str().unwrap().starts_with("0x")),
+        creates.iter().all(|c| c
+            .get("tx_hash")
+            .is_none_or(|h| h.as_str().is_some_and(|s| s.starts_with("0x")))),
         "{envelope}"
     );
 });

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3892,3 +3892,255 @@ forgetest_async!(script_check_contract_sizes_honors_config_limit, |prj, cmd| {
         .assert_success()
         .stderr_eq(str![[r#""#]]);
 });
+
+// Stream + envelope shape on a no-tx `--broadcast`: phases, dry-run payload,
+// and `script.no_transactions` warning duality.
+forgetest!(machine_mode_emits_ndjson_stream_and_aggregates_warnings, |prj, cmd| {
+    let script = prj.add_source(
+        "Foo",
+        r#"
+contract Demo {
+    function run() external {}
+}
+   "#,
+    );
+
+    let assert = cmd.arg("--machine").arg("script").arg(script).arg("--broadcast").assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert!(lines.len() >= 2, "expected stream + envelope, got: {stdout}");
+
+    let stream: Vec<Value> =
+        lines[..lines.len() - 1].iter().map(|l| serde_json::from_str(l).unwrap()).collect();
+    for rec in &stream {
+        assert_eq!(rec["schema_id"], "foundry:forge.script.event@v1");
+        assert_eq!(rec["command_id"], "forge.script");
+        assert!(rec["ts"].is_string());
+    }
+    assert!(
+        stream.iter().any(|r| r["kind"] == "phase" && r["phase"] == "compile"),
+        "missing compile phase: {stream:?}"
+    );
+
+    let envelope: Value = serde_json::from_str(lines.last().unwrap()).unwrap();
+    assert_eq!(envelope["schema_version"], 1);
+    assert_eq!(envelope["success"], true);
+    assert_eq!(envelope["data"]["mode"], "dry_run");
+    assert_eq!(envelope["data"]["tx_count"], 0);
+    assert!(envelope["data"]["tx_hashes"].as_array().unwrap().is_empty());
+
+    // Warning duality: same `(code, message)` on the stream record and in `warnings[]`.
+    let stream_warning =
+        stream.iter().find(|r| r["kind"] == "warning").expect("stream warning record");
+    let warnings = envelope["warnings"].as_array().unwrap();
+    assert_eq!(stream_warning["code"], "script.no_transactions");
+    assert_eq!(warnings[0]["code"], "script.no_transactions");
+    assert_eq!(stream_warning["message"], warnings[0]["message"]);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// Broadcast failure: `script.broadcast_failed` with `data: null`, cause chain,
+// and prior `script.noop_target` warning preserved in `warnings[]`.
+forgetest_async!(machine_mode_broadcast_failed_emits_typed_envelope, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+
+    // 0-value call to an empty-code address triggers `script.noop_target` during simulation;
+    // the unfunded sender then fails the broadcast.
+    let script = prj.add_source(
+        "Deploy",
+        r#"
+import "forge-std/Script.sol";
+contract DeployScript is Script {
+    function run() external {
+        vm.startBroadcast();
+        (bool ok, ) = address(0xdEaD).call("");
+        ok;
+        vm.stopBroadcast();
+    }
+}
+   "#,
+    );
+    let unfunded_pk = "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+    let assert = cmd
+        .args([
+            "--machine",
+            "script",
+            script.to_str().unwrap(),
+            "--target-contract",
+            "DeployScript",
+            "--broadcast",
+            "--rpc-url",
+            &handle.http_endpoint(),
+            "--private-key",
+            unfunded_pk,
+        ])
+        .assert_failure();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stdout.lines().rfind(|l| !l.is_empty()).unwrap()).unwrap();
+    assert_eq!(envelope["success"], false);
+    // `data: null` (key present + explicitly Null); `is_null()` alone also passes when absent.
+    assert_eq!(envelope.get("data"), Some(&Value::Null), "{envelope}");
+    assert_eq!(envelope["errors"][0]["code"], "script.broadcast_failed");
+    assert!(
+        !envelope["errors"][0]["details"]["cause_chain"].as_array().unwrap().is_empty(),
+        "{envelope}"
+    );
+    let warnings = envelope["warnings"].as_array().unwrap();
+    assert!(warnings.iter().any(|w| w["code"] == "script.noop_target"), "{envelope}");
+});
+
+// Reject flags whose stdout would corrupt the stream or whose runtime would
+// block on user/device input. One representative per class.
+forgetest!(machine_mode_rejects_unsupported_flags, |prj, cmd| {
+    let script = prj.add_source(
+        "Foo",
+        r#"
+contract Demo {
+    function run() external {}
+}
+   "#,
+    );
+
+    for flag in ["--debug", "--interactive", "--ledger"] {
+        cmd.forge_fuse().arg("--machine").arg("script").arg(&script).arg(flag);
+        let assert = cmd.assert_failure();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        let envelope: Value = serde_json::from_str(stdout.trim()).unwrap();
+        assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+        assert_eq!(assert.get_output().status.code(), Some(2));
+        assert!(
+            envelope["errors"][0]["message"].as_str().unwrap().contains(flag),
+            "missing {flag} mention: {envelope}"
+        );
+    }
+});
+
+// Happy-path broadcast pins the `@v1` payload shape (mode, tx hashes, CREATEs).
+forgetest_async!(machine_mode_broadcast_success_emits_payload, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    let deploy_script = prj.add_source(
+        "Deploy",
+        r#"
+import "forge-std/Script.sol";
+contract Deployed {}
+contract DeployScript is Script {
+    function run() external {
+        vm.startBroadcast();
+        new Deployed();
+        vm.stopBroadcast();
+    }
+}
+   "#,
+    );
+    let deploy_contract = deploy_script.display().to_string() + ":DeployScript";
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    // Anvil's standard prefunded dev account #0.
+    let private_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    cmd.set_current_dir(prj.root());
+
+    let assert = cmd
+        .args([
+            "--machine",
+            "script",
+            &deploy_contract,
+            "--root",
+            prj.root().to_str().unwrap(),
+            "--rpc-url",
+            &handle.http_endpoint(),
+            "--broadcast",
+            "--private-key",
+            private_key,
+        ])
+        .assert_success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stdout.lines().rfind(|l| !l.is_empty()).unwrap()).unwrap();
+    let data = &envelope["data"];
+    assert_eq!(envelope["success"], true, "{envelope}");
+    assert_eq!(data["mode"], "broadcast", "{envelope}");
+    assert!(data["tx_count"].as_u64().unwrap_or(0) >= 1, "{envelope}");
+    let tx_hashes = data["tx_hashes"].as_array().unwrap();
+    assert!(
+        !tx_hashes.is_empty() && tx_hashes.iter().all(|h| h.as_str().unwrap().starts_with("0x")),
+        "{envelope}"
+    );
+    assert!(
+        data["created_contracts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|c| c["address"].as_str().unwrap().starts_with("0x")),
+        "{envelope}"
+    );
+});
+
+// Compile errors emit `compiler.solc.error` with exit `Build (4)`.
+forgetest!(machine_mode_compile_error_emits_typed_envelope, |prj, cmd| {
+    let script = prj.add_source(
+        "Bad",
+        r#"
+contract Bad {
+    function run() external { this is not solidity }
+}
+"#,
+    );
+
+    let assert = cmd.arg("--machine").arg("script").arg(script).assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stdout.lines().rfind(|l| !l.is_empty()).unwrap()).unwrap();
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "compiler.solc.error");
+    assert_eq!(assert.get_output().status.code(), Some(4));
+});
+
+// Noop-target tx must not prompt; emits the warning and proceeds. Regressions hang.
+forgetest_async!(machine_mode_noop_tx_does_not_prompt, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let script = prj.add_source(
+        "Noop",
+        r#"
+import "forge-std/Script.sol";
+contract NoopScript is Script {
+    function run() external {
+        vm.startBroadcast();
+        (bool ok,) = address(0xdEaD).call("");
+        require(ok);
+        vm.stopBroadcast();
+    }
+}
+"#,
+    );
+
+    let assert = cmd
+        .args([
+            "--machine",
+            "script",
+            script.to_str().unwrap(),
+            "--target-contract",
+            "NoopScript",
+            "--broadcast",
+            "--rpc-url",
+            &handle.http_endpoint(),
+            "--private-key",
+            "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        ])
+        .assert_success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stdout.lines().rfind(|l| !l.is_empty()).unwrap()).unwrap();
+    assert_eq!(envelope["success"], true, "{envelope}");
+    assert!(
+        envelope["warnings"].as_array().unwrap().iter().any(|w| w["code"] == "script.noop_target"),
+        "{envelope}"
+    );
+});

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -18,7 +18,7 @@ use foundry_common::{
     ContractData, ContractsByArtifact, compile::ProjectCompiler, provider::ProviderBuilder,
 };
 use foundry_compilers::{
-    ArtifactId, ProjectCompileOutput,
+    ArtifactId, CompilationError, ProjectCompileOutput,
     artifacts::{BytecodeObject, Libraries},
     compilers::{Language, multi::MultiCompilerLanguage},
     info::ContractInfo,
@@ -229,7 +229,32 @@ impl<FEN: FoundryEvmNetwork> PreprocessedState<FEN> {
         )
         .chain([target_path.clone()]);
 
-        let output = ProjectCompiler::new().files(sources_to_compile).compile(&project)?;
+        // Under `--machine`: emit typed `compiler.solc.error` with exit `Build (4)`.
+        let machine_mode = foundry_cli::is_machine();
+        let mut compiler = ProjectCompiler::new().files(sources_to_compile);
+        if machine_mode {
+            compiler = compiler.bail(false).quiet(true);
+        }
+        let output = compiler.compile(&project)?;
+
+        if machine_mode && output.has_compiler_errors() {
+            let errors = output
+                .output()
+                .errors
+                .iter()
+                .filter(|e| e.is_error())
+                .map(|e| {
+                    foundry_cli::json::JsonMessage::error(
+                        foundry_cli::diagnostic::compiler::SOLC_ERROR,
+                        e.to_string(),
+                    )
+                })
+                .collect();
+            let _ = foundry_cli::json::print_json(&foundry_cli::json::JsonEnvelope::<()>::failure(
+                errors,
+            ));
+            std::process::exit(foundry_cli::ExitCode::Build.to_i32());
+        }
 
         let mut target_id: Option<ArtifactId> = None;
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -303,10 +303,27 @@ impl ScriptArgs {
     }
 
     /// Executes the script
-    #[allow(clippy::large_stack_frames)]
     pub async fn run_script(self) -> Result<()> {
         trace!(target: "script", "executing script command");
 
+        self.reject_machine_unsupported_flags()?;
+        let machine_mode = foundry_cli::is_machine();
+        if machine_mode {
+            // Avoid leaking warnings from a prior in-process invocation.
+            reset_machine_warnings();
+        }
+
+        match self.run_script_inner().await {
+            Ok(()) => Ok(()),
+            // Preserve recorded stream warnings in the terminal envelope.
+            Err(e) if machine_mode => bail_script_unknown(e),
+            Err(e) => Err(e),
+        }
+    }
+
+    #[allow(clippy::large_stack_frames)]
+    async fn run_script_inner(self) -> Result<()> {
+        let machine_mode = foundry_cli::is_machine();
         let (config, evm_opts) = self.resolved_evm_opts().await?;
 
         let is_tempo = evm_opts.networks.is_tempo();
@@ -322,27 +339,75 @@ impl ScriptArgs {
         if is_tempo {
             let batch = self.batch;
             let bundled = match self.prepare_bundled::<TempoEvmNetwork>(config, evm_opts).await? {
-                Some(bundled) => bundled,
-                None => return Ok(()),
+                Some(b) => b,
+                None => return emit_machine_success(None),
             };
-            // batch mode owns its own pending recovery inside broadcast_batch(); running the
-            // generic wait_for_pending() first would race with that and could double-process
-            // an already-confirmed batch hash.
+            // batch mode owns its own pending recovery; skip the generic
+            // wait_for_pending() to avoid double-processing.
             let bundled = if batch { bundled } else { bundled.wait_for_pending().await? };
-            let broadcasted =
-                if batch { bundled.broadcast_batch().await? } else { bundled.broadcast().await? };
+            emit_phase("broadcast")?;
+            let res =
+                if batch { bundled.broadcast_batch().await } else { bundled.broadcast().await };
+            let broadcasted = match res {
+                Ok(b) => b,
+                Err(e) if machine_mode => bail_broadcast_failed(e),
+                Err(e) => return Err(e),
+            };
+            // Build payload before `verify` consumes `broadcasted`.
+            let payload =
+                machine_mode.then(|| ScriptResultData::from_sequence(&broadcasted.sequence));
             if broadcasted.args.verify {
                 broadcasted.verify().await?;
             }
-            return Ok(());
+            return emit_machine_success(payload);
         }
 
         #[cfg(feature = "optimism")]
         if evm_opts.networks.is_optimism() {
-            return self.run_generic_script::<OpEvmNetwork>(config, evm_opts).await;
+            let p = self.run_generic_script::<OpEvmNetwork>(config, evm_opts).await?;
+            return emit_machine_success(p);
         }
 
-        self.run_generic_script::<EthEvmNetwork>(config, evm_opts).await
+        let p = self.run_generic_script::<EthEvmNetwork>(config, evm_opts).await?;
+        emit_machine_success(p)
+    }
+
+    /// Reject flags under `--machine` that would corrupt stdout or block on input.
+    fn reject_machine_unsupported_flags(&self) -> Result<()> {
+        if !foundry_cli::is_machine() {
+            return Ok(());
+        }
+        // `MultiWalletOpts::keystores()` zips passwords/password_files per entry, so
+        // coverage is `max(...)`, not the sum. `--keystore`/`--account` conflict in clap.
+        let len = |v: &Option<Vec<String>>| v.as_ref().map_or(0, Vec::len);
+        let keystore_count =
+            len(&self.wallets.keystore_paths) + len(&self.wallets.keystore_account_names);
+        let password_count =
+            len(&self.wallets.keystore_passwords).max(len(&self.wallets.keystore_password_files));
+        let keystore_unprotected = keystore_count > 0 && password_count < keystore_count;
+
+        let unsupported: Vec<&'static str> = [
+            ("--debug", self.debug),
+            ("--resume", self.resume),
+            ("--verify", self.verify),
+            ("--interactive", self.wallets.interactive || self.wallets.interactives > 0),
+            ("--ledger", self.wallets.ledger),
+            ("--trezor", self.wallets.trezor),
+            ("--browser", self.wallets.browser.browser),
+            ("--keystore/--account without --password or --password-file", keystore_unprotected),
+        ]
+        .into_iter()
+        .filter_map(|(name, on)| on.then_some(name))
+        .collect();
+
+        if !unsupported.is_empty() {
+            foundry_cli::machine::bail_machine_usage(format!(
+                "`forge script` under `--machine` does not support {}; \
+                 run without `--machine` or omit those flags.",
+                unsupported.join(", ")
+            ));
+        }
+        Ok(())
     }
 
     /// Prepares the bundled state (compile, simulate, bundle) and returns it
@@ -356,6 +421,7 @@ impl ScriptArgs {
     ) -> Result<Option<BundledState<FEN>>> {
         let state = self.preprocess::<FEN>(config, evm_opts).await?;
         let create2_deployer = state.script_config.evm_opts.create2_deployer;
+        emit_phase("compile")?;
         let compiled = state.compile()?;
 
         // Move from `CompiledState` to `BundledState` either by resuming or executing and
@@ -373,6 +439,8 @@ impl ScriptArgs {
                 .await?
                 .prepare_simulation()
                 .await?;
+
+            emit_phase("simulate")?;
 
             if pre_simulation.args.debug {
                 return match pre_simulation.args.dump.clone() {
@@ -397,6 +465,12 @@ impl ScriptArgs {
             {
                 if pre_simulation.args.broadcast {
                     sh_warn!("No transactions to broadcast.")?;
+                    if foundry_cli::is_machine() {
+                        record_machine_warning(
+                            foundry_cli::diagnostic::script::NO_TRANSACTIONS,
+                            "--broadcast requested but the script produced no transactions",
+                        )?;
+                    }
                 }
 
                 return Ok(None);
@@ -406,6 +480,12 @@ impl ScriptArgs {
             if pre_simulation.execution_artifacts.rpc_data.missing_rpc {
                 if !shell::is_json() {
                     sh_println!("\nIf you wish to simulate on-chain transactions pass a RPC URL.")?;
+                }
+                if foundry_cli::is_machine() {
+                    record_machine_warning(
+                        foundry_cli::diagnostic::script::MISSING_RPC_URL,
+                        "no --rpc-url provided; on-chain simulation skipped",
+                    )?;
                 }
 
                 return Ok(None);
@@ -454,20 +534,29 @@ impl ScriptArgs {
         self,
         config: Config,
         evm_opts: EvmOpts,
-    ) -> Result<()> {
+    ) -> Result<Option<ScriptResultData>> {
+        let machine_mode = foundry_cli::is_machine();
         let bundled = match self.prepare_bundled::<FEN>(config, evm_opts).await? {
             Some(bundled) => bundled,
-            None => return Ok(()),
+            None => return Ok(machine_mode.then(ScriptResultData::dry_run)),
         };
 
         // Wait for pending txes and broadcast others.
-        let broadcasted = bundled.wait_for_pending().await?.broadcast().await?;
+        let bundled = bundled.wait_for_pending().await?;
+        emit_phase("broadcast")?;
+        let broadcasted = match bundled.broadcast().await {
+            Ok(b) => b,
+            Err(e) if machine_mode => bail_broadcast_failed(e),
+            Err(e) => return Err(e),
+        };
 
+        // Build payload before `verify` (which consumes `broadcasted`).
+        let payload = machine_mode.then(|| ScriptResultData::from_sequence(&broadcasted.sequence));
         if broadcasted.args.verify {
             broadcasted.verify().await?;
         }
 
-        Ok(())
+        Ok(payload)
     }
 
     /// In case the user has loaded *only* one private-key or a single remote signer (e.g.,
@@ -607,8 +696,10 @@ impl ScriptArgs {
         }
 
         // Only prompt if we're broadcasting and we've not disabled interactivity.
+        // `--machine` is implicitly non-interactive: never block on user input.
         if prompt_user
             && !self.non_interactive
+            && !foundry_cli::is_machine()
             && !Confirm::new().with_prompt("Do you wish to continue?".to_string()).interact()?
         {
             eyre::bail!("User canceled the script.");
@@ -620,6 +711,176 @@ impl ScriptArgs {
     /// We only broadcast transactions if --broadcast, --resume, or --verify was passed.
     const fn should_broadcast(&self) -> bool {
         self.broadcast || self.resume || self.verify
+    }
+}
+
+/// Mirrors `forge::introspect::SCRIPT_EVENT_SCHEMA` (pinned by registry test).
+const SCRIPT_EVENT_SCHEMA: &str = "foundry:forge.script.event@v1";
+
+#[derive(Serialize)]
+struct PhaseEvent {
+    phase: &'static str,
+}
+
+/// No-op outside of `--machine`; otherwise emits a `kind: "phase"` stream record.
+fn emit_phase(phase: &'static str) -> Result<()> {
+    if !foundry_cli::is_machine() {
+        return Ok(());
+    }
+    foundry_cli::json::print_stream_record(
+        SCRIPT_EVENT_SCHEMA,
+        "forge.script",
+        "phase",
+        PhaseEvent { phase },
+    )
+}
+
+#[derive(Serialize)]
+struct ScriptWarningEvent<'a> {
+    code: &'static str,
+    message: &'a str,
+}
+
+/// Per-invocation warning collector. Process-global (not `thread_local!`)
+/// because Tokio may migrate record/drain tasks across worker threads.
+static MACHINE_WARNINGS: std::sync::LazyLock<std::sync::Mutex<Vec<(&'static str, String)>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(Vec::new()));
+
+fn machine_warnings_lock() -> std::sync::MutexGuard<'static, Vec<(&'static str, String)>> {
+    MACHINE_WARNINGS.lock().unwrap_or_else(|p| p.into_inner())
+}
+
+fn reset_machine_warnings() {
+    machine_warnings_lock().clear();
+}
+
+fn record_machine_warning(code: &'static str, message: &str) -> Result<()> {
+    foundry_cli::json::print_stream_record(
+        SCRIPT_EVENT_SCHEMA,
+        "forge.script",
+        "warning",
+        ScriptWarningEvent { code, message },
+    )?;
+    machine_warnings_lock().push((code, message.to_string()));
+    Ok(())
+}
+
+/// Noop-target advisory under `--machine` (called from `simulate.rs`).
+pub(crate) fn record_machine_warning_noop_target(to: alloy_primitives::Address) -> Result<()> {
+    record_machine_warning(
+        foundry_cli::diagnostic::script::NOOP_TARGET,
+        &format!("transaction target {to:#x} has no contract code"),
+    )
+}
+
+/// Bail with a typed code, attaching the eyre cause chain and draining recorded
+/// stream warnings into `warnings[]` so the terminal envelope stays authoritative.
+fn bail_machine_failure(code: &'static str, message: String, e: eyre::Report) -> ! {
+    let cause_chain: Vec<String> = e.chain().map(ToString::to_string).collect();
+    let mut envelope = foundry_cli::json::JsonEnvelope::error(
+        foundry_cli::json::JsonMessage::error(code, message)
+            .with_details(serde_json::json!({ "cause_chain": cause_chain })),
+    );
+    envelope.warnings = drain_machine_warnings();
+    let _ = foundry_cli::json::print_json(&envelope);
+    std::process::exit(foundry_cli::ExitCode::GenericError.to_i32());
+}
+
+fn bail_broadcast_failed(e: eyre::Report) -> ! {
+    let first = e.chain().next().map(ToString::to_string).unwrap_or_else(|| e.to_string());
+    bail_machine_failure(
+        foundry_cli::diagnostic::script::BROADCAST_FAILED,
+        format!("broadcast failed: {first}"),
+        e,
+    )
+}
+
+/// Generic fallback: `cli.unknown` with prior warnings preserved.
+fn bail_script_unknown(e: eyre::Report) -> ! {
+    let first = e.chain().next().map(ToString::to_string).unwrap_or_else(|| e.to_string());
+    bail_machine_failure(foundry_cli::diagnostic::cli::UNKNOWN, first, e)
+}
+
+/// Emit the terminal success envelope with drained warnings. No-op outside `--machine`.
+fn emit_machine_success(payload: Option<ScriptResultData>) -> Result<()> {
+    if !foundry_cli::is_machine() {
+        return Ok(());
+    }
+    let warnings = drain_machine_warnings();
+    let payload = payload.unwrap_or_else(ScriptResultData::dry_run);
+    foundry_cli::json::print_json(&foundry_cli::json::JsonEnvelope::success_with_warnings(
+        payload, warnings,
+    ))
+}
+
+fn drain_machine_warnings() -> Vec<foundry_cli::json::JsonMessage> {
+    std::mem::take(&mut *machine_warnings_lock())
+        .into_iter()
+        .map(|(code, message)| foundry_cli::json::JsonMessage::warning(code, message))
+        .collect()
+}
+
+/// Terminal `forge.script@v1` payload. Documented in `docs/agents/spec.md`.
+#[derive(Serialize)]
+struct ScriptResultData {
+    mode: &'static str,
+    broadcast: bool,
+    tx_count: usize,
+    tx_hashes: Vec<String>,
+    created_contracts: Vec<CreatedContract>,
+}
+
+#[derive(Serialize)]
+struct CreatedContract {
+    address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    contract_name: Option<String>,
+}
+
+impl ScriptResultData {
+    /// Empty payload for the dry-run / no-broadcast case.
+    const fn dry_run() -> Self {
+        Self {
+            mode: "dry_run",
+            broadcast: false,
+            tx_count: 0,
+            tx_hashes: vec![],
+            created_contracts: vec![],
+        }
+    }
+
+    fn from_sequence<N: alloy_network::Network>(
+        sequence: &crate::sequence::ScriptSequenceKind<N>,
+    ) -> Self
+    where
+        N::TxEnvelope: for<'d> serde::Deserialize<'d> + Serialize,
+    {
+        let (mut tx_count, mut tx_hashes, mut created_contracts) = (0, vec![], vec![]);
+        let name = |n: &Option<String>| n.clone().filter(|s| !s.is_empty());
+        for seq in sequence.sequences() {
+            for tx in &seq.transactions {
+                tx_count += 1;
+                if let Some(h) = tx.hash {
+                    tx_hashes.push(format!("{h:#x}"));
+                }
+                // `contract_address` is also populated for ordinary CALLs; gate on `call_kind`.
+                if tx.call_kind.is_any_create()
+                    && let Some(addr) = tx.contract_address
+                {
+                    created_contracts.push(CreatedContract {
+                        address: format!("{addr:#x}"),
+                        contract_name: name(&tx.contract_name),
+                    });
+                }
+                for c in &tx.additional_contracts {
+                    created_contracts.push(CreatedContract {
+                        address: format!("{:#x}", c.address),
+                        contract_name: name(&c.contract_name),
+                    });
+                }
+            }
+        }
+        Self { mode: "broadcast", broadcast: true, tx_count, tx_hashes, created_contracts }
     }
 }
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -346,11 +346,13 @@ impl ScriptArgs {
             // wait_for_pending() to avoid double-processing.
             let bundled = if batch { bundled } else { bundled.wait_for_pending().await? };
             emit_phase("broadcast")?;
+            // Snapshot recovery context before `.broadcast()` consumes `bundled`.
+            let recovery = machine_mode.then(|| RecoveryInfo::from_sequence(&bundled.sequence));
             let res =
                 if batch { bundled.broadcast_batch().await } else { bundled.broadcast().await };
             let broadcasted = match res {
                 Ok(b) => b,
-                Err(e) if machine_mode => bail_broadcast_failed(e),
+                Err(e) if machine_mode => bail_broadcast_failed(e, recovery.unwrap()),
                 Err(e) => return Err(e),
             };
             // Build payload before `verify` consumes `broadcasted`.
@@ -388,7 +390,6 @@ impl ScriptArgs {
 
         let unsupported: Vec<&'static str> = [
             ("--debug", self.debug),
-            ("--resume", self.resume),
             ("--verify", self.verify),
             ("--interactive", self.wallets.interactive || self.wallets.interactives > 0),
             ("--ledger", self.wallets.ledger),
@@ -544,9 +545,11 @@ impl ScriptArgs {
         // Wait for pending txes and broadcast others.
         let bundled = bundled.wait_for_pending().await?;
         emit_phase("broadcast")?;
+        // Snapshot recovery context before `.broadcast()` consumes `bundled`.
+        let recovery = machine_mode.then(|| RecoveryInfo::from_sequence(&bundled.sequence));
         let broadcasted = match bundled.broadcast().await {
             Ok(b) => b,
-            Err(e) if machine_mode => bail_broadcast_failed(e),
+            Err(e) if machine_mode => bail_broadcast_failed(e, recovery.unwrap()),
             Err(e) => return Err(e),
         };
 
@@ -786,13 +789,74 @@ fn bail_machine_failure(code: &'static str, message: String, e: eyre::Report) ->
     std::process::exit(foundry_cli::ExitCode::GenericError.to_i32());
 }
 
-fn bail_broadcast_failed(e: eyre::Report) -> ! {
-    let first = e.chain().next().map(ToString::to_string).unwrap_or_else(|| e.to_string());
-    bail_machine_failure(
-        foundry_cli::diagnostic::script::BROADCAST_FAILED,
-        format!("broadcast failed: {first}"),
-        e,
-    )
+/// `script.broadcast_failed` with typed recovery context so agents can decide
+/// whether to retry, resume, or escalate without parsing prose.
+fn bail_broadcast_failed(e: eyre::Report, recovery: RecoveryInfo) -> ! {
+    let cause_chain: Vec<String> = e.chain().map(ToString::to_string).collect();
+    let first = cause_chain.first().cloned().unwrap_or_else(|| e.to_string());
+    let kind = classify_broadcast_error(&cause_chain);
+    let details = serde_json::json!({
+        "kind": kind,
+        // Only `rpc.timeout` is treated as transient; other failures need `--resume`.
+        "retryable": kind == "rpc.timeout",
+        "cause_chain": cause_chain,
+        "recovery": recovery,
+    });
+    let mut envelope = foundry_cli::json::JsonEnvelope::error(
+        foundry_cli::json::JsonMessage::error(
+            foundry_cli::diagnostic::script::BROADCAST_FAILED,
+            format!("broadcast failed: {first}"),
+        )
+        .with_details(details),
+    );
+    envelope.warnings = drain_machine_warnings();
+    let _ = foundry_cli::json::print_json(&envelope);
+    std::process::exit(foundry_cli::ExitCode::GenericError.to_i32());
+}
+
+/// Heuristic classification of broadcast errors using dotted codes from the
+/// `script.broadcast_failed.kind` enum. Conservative: anything unrecognised
+/// is `"unknown"` so `retryable` defaults to `false`.
+fn classify_broadcast_error(cause_chain: &[String]) -> &'static str {
+    let joined = cause_chain.join("\n").to_ascii_lowercase();
+    if joined.contains("nonce") {
+        "nonce.too_low"
+    } else if joined.contains("timeout") {
+        "rpc.timeout"
+    } else if joined.contains("signer") || joined.contains("sign") {
+        "signer.failed"
+    } else {
+        "unknown"
+    }
+}
+
+/// Recovery context attached to `script.broadcast_failed`. `sequence_paths`
+/// points at the on-disk `run-latest.json` files that agents can pass to
+/// `forge script --resume`. Empty when no sequence was persisted.
+#[derive(Serialize)]
+struct RecoveryInfo {
+    resume_supported: bool,
+    sequence_paths: Vec<String>,
+    submitted_count: usize,
+}
+
+impl RecoveryInfo {
+    fn from_sequence<N: alloy_network::Network>(
+        sequence: &crate::sequence::ScriptSequenceKind<N>,
+    ) -> Self
+    where
+        N::TxEnvelope: for<'d> serde::Deserialize<'d> + Serialize,
+    {
+        let mut sequence_paths = Vec::new();
+        let mut submitted_count = 0usize;
+        for seq in sequence.sequences() {
+            if let Some((path, _)) = seq.paths.as_ref() {
+                sequence_paths.push(path.display().to_string());
+            }
+            submitted_count += seq.transactions.iter().filter(|t| t.hash.is_some()).count();
+        }
+        Self { resume_supported: true, sequence_paths, submitted_count }
+    }
 }
 
 /// Generic fallback: `cli.unknown` with prior warnings preserved.
@@ -824,10 +888,18 @@ fn drain_machine_warnings() -> Vec<foundry_cli::json::JsonMessage> {
 #[derive(Serialize)]
 struct ScriptResultData {
     mode: &'static str,
-    broadcast: bool,
     tx_count: usize,
-    tx_hashes: Vec<String>,
+    transactions: Vec<TxOutcome>,
     created_contracts: Vec<CreatedContract>,
+}
+
+#[derive(Serialize)]
+struct TxOutcome {
+    hash: String,
+    /// `"success" | "failed" | "pending"` — pending until a receipt is recorded.
+    status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    block_number: Option<u64>,
 }
 
 #[derive(Serialize)]
@@ -835,18 +907,15 @@ struct CreatedContract {
     address: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     contract_name: Option<String>,
+    /// Hash of the tx that created this contract (when known).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tx_hash: Option<String>,
 }
 
 impl ScriptResultData {
     /// Empty payload for the dry-run / no-broadcast case.
     const fn dry_run() -> Self {
-        Self {
-            mode: "dry_run",
-            broadcast: false,
-            tx_count: 0,
-            tx_hashes: vec![],
-            created_contracts: vec![],
-        }
+        Self { mode: "dry_run", tx_count: 0, transactions: vec![], created_contracts: vec![] }
     }
 
     fn from_sequence<N: alloy_network::Network>(
@@ -855,13 +924,24 @@ impl ScriptResultData {
     where
         N::TxEnvelope: for<'d> serde::Deserialize<'d> + Serialize,
     {
-        let (mut tx_count, mut tx_hashes, mut created_contracts) = (0, vec![], vec![]);
+        use alloy_network::ReceiptResponse;
+        let (mut tx_count, mut transactions, mut created_contracts) = (0, vec![], vec![]);
         let name = |n: &Option<String>| n.clone().filter(|s| !s.is_empty());
         for seq in sequence.sequences() {
+            // Index receipts by tx hash so we can fill status/block_number per tx.
+            let receipt_by_hash: std::collections::HashMap<_, _> =
+                seq.receipts.iter().map(|r| (r.transaction_hash(), r)).collect();
             for tx in &seq.transactions {
                 tx_count += 1;
+                let tx_hash_str = tx.hash.map(|h| format!("{h:#x}"));
                 if let Some(h) = tx.hash {
-                    tx_hashes.push(format!("{h:#x}"));
+                    let (status, block_number) = match receipt_by_hash.get(&h) {
+                        Some(r) => {
+                            (if r.status() { "success" } else { "failed" }, r.block_number())
+                        }
+                        None => ("pending", None),
+                    };
+                    transactions.push(TxOutcome { hash: format!("{h:#x}"), status, block_number });
                 }
                 // `contract_address` is also populated for ordinary CALLs; gate on `call_kind`.
                 if tx.call_kind.is_any_create()
@@ -870,17 +950,19 @@ impl ScriptResultData {
                     created_contracts.push(CreatedContract {
                         address: format!("{addr:#x}"),
                         contract_name: name(&tx.contract_name),
+                        tx_hash: tx_hash_str.clone(),
                     });
                 }
                 for c in &tx.additional_contracts {
                     created_contracts.push(CreatedContract {
                         address: format!("{:#x}", c.address),
                         contract_name: name(&c.contract_name),
+                        tx_hash: tx_hash_str.clone(),
                     });
                 }
             }
         }
-        Self { mode: "broadcast", broadcast: true, tx_count, tx_hashes, created_contracts }
+        Self { mode: "broadcast", tx_count, transactions, created_contracts }
     }
 }
 
@@ -1695,5 +1777,60 @@ mod tests {
         ]);
         // priority (200) > max_fee (100) — broadcast should reject this at runtime
         assert!(args.priority_gas_price.unwrap() > args.with_gas_price.unwrap());
+    }
+
+    /// Synthetic fixture covering the `ScriptSequenceKind::Multi` payload path
+    /// (used by Tempo `broadcast_batch` and multi-chain scripts). Asserts that
+    /// `ScriptResultData::from_sequence` aggregates txs and created contracts
+    /// across child sequences. Live Tempo nodes are not in the test harness; the
+    /// `Single` path is covered by `machine_mode_broadcast_success_emits_payload`.
+    #[test]
+    fn script_result_from_multi_sequence_aggregates_children() {
+        use crate::{multi_sequence::MultiChainSequence, sequence::ScriptSequenceKind};
+        use alloy_rpc_types::TransactionRequest;
+        use forge_script_sequence::{ScriptSequence, TransactionWithMetadata};
+        use foundry_common::transactions::TransactionMaybeSigned;
+        use revm_inspectors::tracing::types::CallKind;
+
+        let make_create_tx = |hash_byte: u8, addr_byte: u8, name: &str| {
+            let mut tx = TransactionWithMetadata::<Ethereum>::from_tx_request(
+                TransactionMaybeSigned::new(TransactionRequest::default()),
+            );
+            tx.hash = Some(B256::from([hash_byte; 32]));
+            tx.call_kind = CallKind::Create;
+            tx.contract_address = Some(Address::from([addr_byte; 20]));
+            tx.contract_name = Some(name.to_string());
+            tx
+        };
+
+        let mut seq_a = ScriptSequence::<Ethereum>::default();
+        seq_a.transactions.push_back(make_create_tx(0xaa, 0xa1, "ChainAContract"));
+        let mut seq_b = ScriptSequence::<Ethereum>::default();
+        seq_b.transactions.push_back(make_create_tx(0xbb, 0xb1, "ChainBContract"));
+        seq_b.transactions.push_back(make_create_tx(0xbc, 0xb2, "ChainBContract2"));
+
+        // Use a tempdir because `ScriptSequenceKind`'s `Drop` saves to these paths.
+        let tmp = tempdir().unwrap();
+        let kind = ScriptSequenceKind::Multi(MultiChainSequence::<Ethereum> {
+            deployments: vec![seq_a, seq_b],
+            path: tmp.path().join("multi.json"),
+            sensitive_path: tmp.path().join("multi.sensitive.json"),
+            timestamp: 0,
+        });
+
+        let payload = ScriptResultData::from_sequence(&kind);
+        assert_eq!(payload.mode, "broadcast");
+        assert_eq!(payload.tx_count, 3);
+        assert_eq!(payload.transactions.len(), 3);
+        // No receipts attached → all `pending`.
+        for tx in &payload.transactions {
+            assert_eq!(tx.status, "pending");
+            assert!(tx.block_number.is_none());
+        }
+        // Each CREATE produced one entry, each linked to its tx_hash.
+        assert_eq!(payload.created_contracts.len(), 3);
+        for c in &payload.created_contracts {
+            assert!(c.tx_hash.as_deref().is_some_and(|h| h.starts_with("0x")));
+        }
     }
 }

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -192,10 +192,14 @@ impl<FEN: FoundryEvmNetwork> PreSimulationState<FEN> {
                     sh_warn!(
                         "Script contains a transaction to {to} which does not contain any code."
                     )?;
+                    if foundry_cli::is_machine() {
+                        crate::record_machine_warning_noop_target(to)?;
+                    }
 
-                    // Only prompt if we're broadcasting and we've not disabled interactivity.
+                    // `--machine` is implicitly non-interactive: never block on user input.
                     if self.args.should_broadcast()
                         && !self.args.non_interactive
+                        && !foundry_cli::is_machine()
                         && !Confirm::new()
                             .with_prompt("Do you wish to continue?".to_string())
                             .interact()?

--- a/docs/agents/diagnostics.md
+++ b/docs/agents/diagnostics.md
@@ -28,6 +28,9 @@ Examples:
 - `test.setup_failed`
 - `test.warning`
 - `script.broadcast_failed`
+- `script.no_transactions`
+- `script.missing_rpc_url`
+- `script.noop_target`
 
 Stream-event `code` fields (e.g. the `code` carried on `kind: "warning"`
 records under `foundry:forge.test.event@v1`) draw from this same
@@ -43,7 +46,7 @@ registry: any code mirrored from a stream event into a terminal envelope
 | `network`  | RPC / HTTP layers               | `network.rpc.timeout`                     |
 | `wallet`   | `foundry-wallets`               | `wallet.key.missing`                      |
 | `test`     | `forge test`                    | `test.failed`, `test.setup_failed`, `test.warning` |
-| `script`   | `forge script`                  | `script.broadcast_failed`                 |
+| `script`   | `forge script`                  | `script.broadcast_failed`, `script.no_transactions`, `script.missing_rpc_url`, `script.noop_target` |
 | `cast`     | `cast`                          | `cast.tx.not_found`                       |
 | `anvil`    | `anvil`                         | `anvil.fork.unreachable`                  |
 | `chisel`   | `chisel`                        | `chisel.session.invalid`                  |

--- a/docs/agents/spec.md
+++ b/docs/agents/spec.md
@@ -300,15 +300,43 @@ Terminal envelope under `foundry:forge.script@v1`:
 ```
 {
   "mode":              "dry_run" | "broadcast",
-  "broadcast":         bool,
   "tx_count":          uint,
-  "tx_hashes":         [String],            // 0x-prefixed, in order
-  "created_contracts": [{ "address": String, "contract_name"?: String }]
+  "transactions":      [{
+    "hash":           String,                // 0x-prefixed
+    "status":         "success" | "failed" | "pending",
+    "block_number"?:  uint
+  }],
+  "created_contracts": [{
+    "address":         String,               // 0x-prefixed
+    "contract_name"?:  String,
+    "tx_hash"?:        String                // 0x-prefixed; the creating tx
+  }]
 }
 ```
 
 On broadcast failure (`script.broadcast_failed`), `data` is `null` and
-`errors[0].details.cause_chain` is `[String]` (the eyre cause chain).
+`errors[0].details` carries typed recovery context:
+
+```
+{
+  "kind":         "rpc.timeout" | "nonce.too_low" | "signer.failed" | "unknown",
+  "retryable":    bool,                       // true only for "rpc.timeout"
+  "cause_chain":  [String],                   // eyre chain, outermost first
+  "recovery": {
+    "resume_supported": bool,                 // true in v1
+    "sequence_paths":   [String],             // run-latest.json paths
+    "submitted_count":  uint                  // txs with a known hash
+  }
+}
+```
+
+Agents should branch on `details.kind`/`details.retryable` and, when
+`recovery.sequence_paths` is non-empty, re-invoke `forge script --resume`
+to continue the partial broadcast. Plain retries are not idempotent.
+
+`--verify` is rejected under `--machine` for v1. To verify after a
+successful broadcast, parse `created_contracts[].address` from the
+envelope and call `forge verify-contract` per entry.
 
 ---
 

--- a/docs/agents/spec.md
+++ b/docs/agents/spec.md
@@ -219,34 +219,40 @@ termination).
 
 ### Per-command event ordering
 
-For each per-command event schema (e.g. `foundry:forge.test.event@v1`),
-each grouping unit (suite for `forge.test`, simulation phase for
-`forge.script`, etc.) emits records in this order:
+Stream records come in two shapes:
 
-1. zero or more child records (e.g. `test_result`)
-2. zero or more non-terminal annotations on that group (e.g. `warning`)
-3. exactly one terminator record for the group (e.g. `suite_finished`)
+- **Group records** — the command emits a grouped lifecycle per unit
+  (e.g. one suite per group for `forge.test`). For each group:
 
-After a group's terminator, no more records targeting that group may be
-emitted. Groups themselves are not ordered against each other; agents
-should key on the group identifier in the payload (e.g. `suite` for
-`forge.test`) when correlating per-group records.
+  1. zero or more child records (e.g. `test_result`)
+  2. zero or more non-terminal annotations on that group (e.g. `warning`)
+  3. exactly one terminator record for the group (e.g. `suite_finished`)
+
+  After a group's terminator, no more records targeting that group may be
+  emitted. Groups themselves are not ordered against each other; agents
+  should key on the group identifier in the payload (e.g. `suite` for
+  `forge.test`) when correlating per-group records.
+
+- **Progress records** — standalone, no per-group lifecycle (e.g. `phase`
+  records for `forge.script`). No terminators; treat as point-in-time
+  signals between stream start and the terminal envelope.
+
+Each event schema documents its shape in "Concrete shapes" below.
 
 ### Warning duality
 
 When a command surfaces a warning that is also relevant to the terminal
-outcome, the warning is emitted **twice**:
+outcome, the warning may be emitted **twice**:
 
-1. as a per-suite `warning` stream event with `kind: "warning"` and the
-   per-event `code` (e.g. `test.warning`) — for real-time visibility
+1. as a command-specific `kind: "warning"` stream event — for real-time
+   visibility
 2. as an entry in the terminal envelope's `warnings[]` — for the
    end-of-run summary
 
-Both surfaces carry the same `code` and `message` and identify the suite
-via the same `suite` key — `suite` as a top-level field on the stream
-event, and `details.suite` on the terminal envelope warning. Agents
-consuming both surfaces should de-duplicate by `(suite, message)`. The
-terminal envelope's `warnings[]` is the authoritative aggregated set.
+Both surfaces carry the same `code` and `message`. Additional correlation
+fields are command-specific: `forge.test` keys on `(suite, code, message)`
+(`suite` on the stream, `details.suite` on the envelope); `forge.script`
+keys on `(code, message)`. The terminal `warnings[]` is authoritative.
 
 ### Failure-envelope conventions
 
@@ -281,6 +287,28 @@ tolerated failures, `success: true` and `data.failed` may be non-zero — see
 the `Success` exit-code description on the per-command introspection. On
 test failure (`success: false`, `errors[0].code: test.failed`), the same
 payload appears under `errors[0].details`.
+
+The `forge.script` event payloads under `foundry:forge.script.event@v1`
+(progress-record shape — no terminators):
+
+- `kind: "phase"` — `{ phase }`, `phase ∈ { "compile", "simulate", "broadcast" }`.
+- `kind: "warning"` — `{ code, message }`, `code` in the `script.*` domain
+  (see [diagnostics.md](diagnostics.md)). Mirrored into terminal `warnings[]`.
+
+Terminal envelope under `foundry:forge.script@v1`:
+
+```
+{
+  "mode":              "dry_run" | "broadcast",
+  "broadcast":         bool,
+  "tx_count":          uint,
+  "tx_hashes":         [String],            // 0x-prefixed, in order
+  "created_contracts": [{ "address": String, "contract_name"?: String }]
+}
+```
+
+On broadcast failure (`script.broadcast_failed`), `data` is `null` and
+`errors[0].details.cause_chain` is `[String]` (the eyre cause chain).
 
 ---
 


### PR DESCRIPTION
Stacked on #14775.

Adopts --machine for forge script:

- `output_mode=stream`, `event_schema_ref=foundry:forge.script.event@v1`, `result_schema_ref=foundry:forge.script@v1`, `side_effects=ChainWrite`, `long_running=true`.
- NDJSON phase events (`compile`, `simulate`, `broadcast`) and structured warnings on stdout; terminal envelope summarizes the on-chain effect (mode, tx hashes, created contracts).
- Broadcast failures emit a typed `script.broadcast_failed envelope`.

Part of OSS-218