### PR TITLE
feat(lint): add return-bomb lint

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -23,6 +23,7 @@ It helps enforce best practices and improve code quality within Foundry projects
 - **Low Severity:**
   - `block-timestamp`: Warns when `block.timestamp` is used in a comparison, as it may be manipulated by validators.
   - `missing-zero-check`: Address parameter is used in a state write or value transfer without a zero-address check.
+  - `return-bomb`: External calls with a gas limit should not consume unbounded return data.
 - **Informational / Style Guide:**
   - `boolean-equal`: Boolean comparisons to constants should be simplified.
   - `too-many-digits`: Numeric literals with 5+ consecutive zeros are error-prone.

--- a/crates/lint/docs/return-bomb.md
+++ b/crates/lint/docs/return-bomb.md
@@ -3,13 +3,14 @@
 **Severity**: `Low`
 **ID**: `return-bomb`
 
-Flags low-level external calls that set an explicit gas limit while copying unbounded returndata
-into a `bytes` value.
+Flags external calls that set an explicit gas limit while copying unbounded dynamic returndata.
 
 ## What it does
 
 Detects low-level `call`, `delegatecall`, and `staticcall` expressions that specify `{gas: ...}`
-and bind the raw returndata to `bytes memory` or an existing `bytes` variable.
+and bind or return the raw returndata as `bytes`. It also detects high-level external calls with
+`{gas: ...}` that consume dynamically encoded return values such as `bytes`, `string`, dynamic
+arrays, or structs containing dynamic fields.
 
 ## Why is this bad?
 

--- a/crates/lint/docs/return-bomb.md
+++ b/crates/lint/docs/return-bomb.md
@@ -7,10 +7,10 @@ Flags external calls that set an explicit gas limit while copying unbounded dyna
 
 ## What it does
 
-Detects low-level `call`, `delegatecall`, and `staticcall` expressions that specify `{gas: ...}`
-and bind or return the raw returndata as `bytes`. It also detects high-level external calls with
-`{gas: ...}` that consume dynamically encoded return values such as `bytes`, `string`, dynamic
-arrays, or structs containing dynamic fields.
+Detects low-level `call`, `delegatecall`, and `staticcall` expressions that specify `{gas: ...}`.
+Solidity copies the full returndata for these calls even when the second tuple element is ignored.
+It also detects high-level external calls with `{gas: ...}` that consume dynamically encoded return
+values such as `bytes`, `string`, dynamic arrays, or structs containing dynamic fields.
 
 ## Why is this bad?
 
@@ -24,7 +24,7 @@ causing the caller to run out of gas while implicitly copying the result.
 
 ```solidity
 function callTarget(address target, bytes memory payload, uint256 gasLimit) external {
-    (bool ok, bytes memory result) = target.call{gas: gasLimit}(payload);
+    (bool ok, ) = target.call{gas: gasLimit}(payload);
     require(ok);
 }
 ```
@@ -33,10 +33,13 @@ function callTarget(address target, bytes memory payload, uint256 gasLimit) exte
 
 ```solidity
 function callTarget(address target, bytes memory payload, uint256 gasLimit) external {
-    (bool ok, ) = target.call{gas: gasLimit}(payload);
+    bool ok;
+    assembly {
+        ok := call(gasLimit, target, 0, add(payload, 0x20), mload(payload), 0, 0)
+    }
     require(ok);
 }
 ```
 
-If the returndata is needed, copy only a bounded number of bytes with a helper that caps returndata
-size.
+Ignoring the second tuple element does not avoid the copy. If the returndata is needed, copy only a
+bounded number of bytes with a helper that caps returndata size.

--- a/crates/lint/docs/return-bomb.md
+++ b/crates/lint/docs/return-bomb.md
@@ -1,0 +1,41 @@
+# Return bomb
+
+**Severity**: `Low`
+**ID**: `return-bomb`
+
+Flags low-level external calls that set an explicit gas limit while copying unbounded returndata
+into a `bytes` value.
+
+## What it does
+
+Detects low-level `call`, `delegatecall`, and `staticcall` expressions that specify `{gas: ...}`
+and bind the raw returndata to `bytes memory` or an existing `bytes` variable.
+
+## Why is this bad?
+
+The gas option limits gas forwarded to the callee, but copying returndata into memory is paid by
+the caller after the call returns. A malicious callee can return or revert with large returndata,
+causing the caller to run out of gas while implicitly copying the result.
+
+## Example
+
+### Bad
+
+```solidity
+function callTarget(address target, bytes memory payload, uint256 gasLimit) external {
+    (bool ok, bytes memory result) = target.call{gas: gasLimit}(payload);
+    require(ok);
+}
+```
+
+### Good
+
+```solidity
+function callTarget(address target, bytes memory payload, uint256 gasLimit) external {
+    (bool ok, ) = target.call{gas: gasLimit}(payload);
+    require(ok);
+}
+```
+
+If the returndata is needed, copy only a bounded number of bytes with a helper that caps returndata
+size.

--- a/crates/lint/src/sol/calls.rs
+++ b/crates/lint/src/sol/calls.rs
@@ -32,7 +32,7 @@ pub(crate) const fn is_low_level_call(expr: &Expr<'_>) -> bool {
 /// - `target.delegatecall{gas: gasLimit}(...)`
 /// - `target.staticcall{gas: gasLimit}(...)`
 pub(crate) fn is_low_level_call_with_gas_limit(expr: &hir::Expr<'_>) -> bool {
-    let hir::ExprKind::Call(callee, _, Some(opts)) = &expr.kind else {
+    let Some((callee, opts)) = call_with_options(expr) else {
         return false;
     };
 
@@ -45,4 +45,22 @@ pub(crate) fn is_low_level_call_with_gas_limit(expr: &hir::Expr<'_>) -> bool {
     }
 
     opts.iter().any(|opt| opt.name.name == kw::Gas)
+}
+
+/// Checks if a HIR expression is any call with an explicit gas option.
+pub(crate) fn is_call_with_gas_limit(expr: &hir::Expr<'_>) -> bool {
+    let Some((_, opts)) = call_with_options(expr) else {
+        return false;
+    };
+
+    opts.iter().any(|opt| opt.name.name == kw::Gas)
+}
+
+fn call_with_options<'hir>(
+    expr: &'hir hir::Expr<'hir>,
+) -> Option<(&'hir hir::Expr<'hir>, &'hir [hir::NamedArg<'hir>])> {
+    let hir::ExprKind::Call(callee, _, Some(opts)) = &expr.peel_parens().kind else {
+        return None;
+    };
+    Some((callee, opts))
 }

--- a/crates/lint/src/sol/calls.rs
+++ b/crates/lint/src/sol/calls.rs
@@ -1,6 +1,7 @@
 use solar::{
     ast::{Expr, ExprKind},
     interface::kw,
+    sema::hir,
 };
 
 /// Checks if an expression is a low-level call.
@@ -22,4 +23,26 @@ pub(crate) const fn is_low_level_call(expr: &Expr<'_>) -> bool {
         }
     }
     false
+}
+
+/// Checks if a HIR expression is a low-level call with an explicit gas option.
+///
+/// Detects patterns like:
+/// - `target.call{gas: gasLimit}(...)`
+/// - `target.delegatecall{gas: gasLimit}(...)`
+/// - `target.staticcall{gas: gasLimit}(...)`
+pub(crate) fn is_low_level_call_with_gas_limit(expr: &hir::Expr<'_>) -> bool {
+    let hir::ExprKind::Call(callee, _, Some(opts)) = &expr.kind else {
+        return false;
+    };
+
+    if !matches!(
+        &callee.peel_parens().kind,
+        hir::ExprKind::Member(_, member)
+            if matches!(member.name, kw::Call | kw::Delegatecall | kw::Staticcall)
+    ) {
+        return false;
+    }
+
+    opts.iter().any(|opt| opt.name.name == kw::Gas)
 }

--- a/crates/lint/src/sol/calls.rs
+++ b/crates/lint/src/sol/calls.rs
@@ -25,28 +25,6 @@ pub(crate) const fn is_low_level_call(expr: &Expr<'_>) -> bool {
     false
 }
 
-/// Checks if a HIR expression is a low-level call with an explicit gas option.
-///
-/// Detects patterns like:
-/// - `target.call{gas: gasLimit}(...)`
-/// - `target.delegatecall{gas: gasLimit}(...)`
-/// - `target.staticcall{gas: gasLimit}(...)`
-pub(crate) fn is_low_level_call_with_gas_limit(expr: &hir::Expr<'_>) -> bool {
-    let Some((callee, opts)) = call_with_options(expr) else {
-        return false;
-    };
-
-    if !matches!(
-        &callee.peel_parens().kind,
-        hir::ExprKind::Member(_, member)
-            if matches!(member.name, kw::Call | kw::Delegatecall | kw::Staticcall)
-    ) {
-        return false;
-    }
-
-    opts.iter().any(|opt| opt.name.name == kw::Gas)
-}
-
 /// Checks if a HIR expression is any call with an explicit gas option.
 pub(crate) fn is_call_with_gas_limit(expr: &hir::Expr<'_>) -> bool {
     let Some((_, opts)) = call_with_options(expr) else {

--- a/crates/lint/src/sol/low/mod.rs
+++ b/crates/lint/src/sol/low/mod.rs
@@ -6,7 +6,11 @@ use block_timestamp::BLOCK_TIMESTAMP;
 mod missing_zero_check;
 use missing_zero_check::MISSING_ZERO_CHECK;
 
+mod return_bomb;
+use return_bomb::RETURN_BOMB;
+
 register_lints!(
     (BlockTimestamp, early, (BLOCK_TIMESTAMP)),
     (MissingZeroCheck, late, (MISSING_ZERO_CHECK)),
+    (ReturnBomb, late, (RETURN_BOMB)),
 );

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -329,6 +329,10 @@ fn member_is_builtin_address(base: &hir::Expr<'_>, member: Symbol) -> bool {
 
 /// Returns whether an expression can match the expected type, if known.
 fn expr_matches_type(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>, ty: &hir::Type<'_>) -> Option<bool> {
+    if let Some(matches) = bool_expr_matches_type(expr, ty) {
+        return Some(matches);
+    }
+
     if let Some(literal) = integer_literal(expr)
         && let Some(matches) = integer_literal_matches_type(literal, ty)
     {
@@ -342,6 +346,33 @@ fn expr_matches_type(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>, ty: &hir::Type<'_
     }
 
     expr_type(hir, expr).map(|expr_ty| types_match(hir, expr_ty, ty))
+}
+
+/// Returns whether a known boolean expression can match the expected type.
+fn bool_expr_matches_type(expr: &hir::Expr<'_>, ty: &hir::Type<'_>) -> Option<bool> {
+    expr_is_bool(expr).then(|| is_bool_type(ty))
+}
+
+fn expr_is_bool(expr: &hir::Expr<'_>) -> bool {
+    match &expr.peel_parens().kind {
+        ExprKind::Binary(_, op, _) => matches!(
+            op.kind,
+            hir::BinOpKind::Lt
+                | hir::BinOpKind::Le
+                | hir::BinOpKind::Gt
+                | hir::BinOpKind::Ge
+                | hir::BinOpKind::Eq
+                | hir::BinOpKind::Ne
+                | hir::BinOpKind::Or
+                | hir::BinOpKind::And
+        ),
+        ExprKind::Unary(op, _) => op.kind == hir::UnOpKind::Not,
+        _ => false,
+    }
+}
+
+const fn is_bool_type(ty: &hir::Type<'_>) -> bool {
+    matches!(ty.kind, TypeKind::Elementary(ElementaryType::Bool))
 }
 /// Returns the type of simple expressions needed by this lint.
 fn expr_type<'hir>(

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -62,14 +62,16 @@ fn matching_functions_for_callee<'hir>(
     hir: &'hir hir::Hir<'hir>,
     callee: &hir::Expr<'hir>,
     args: &CallArgs<'hir>,
-) -> Option<Vec<hir::FunctionId>> {
+) -> Option<FunctionCandidates<'hir>> {
     match &callee.peel_parens().kind {
         ExprKind::Ident(reses) => {
-            let candidates = reses.iter().filter_map(|res| match res {
-                hir::Res::Item(ItemId::Function(id)) => Some(*id),
-                _ => None,
-            });
-            Some(select_functions_for_args(hir, candidates, args))
+            let candidates = reses.iter().filter_map(res_function_id);
+            let functions = select_functions_for_args(hir, candidates, args);
+            (!functions.is_empty()).then_some(functions).or_else(|| {
+                expr_type(hir, callee)
+                    .and_then(|ty| function_type_returns_for_args(hir, ty, args))
+                    .map(FunctionCandidates::Pointer)
+            })
         }
         ExprKind::Member(base, member) => {
             let contract = expr_contract_id(hir, base)?;
@@ -98,7 +100,7 @@ fn select_functions_for_args<'hir>(
     hir: &'hir hir::Hir<'hir>,
     candidates: impl Iterator<Item = hir::FunctionId>,
     args: &CallArgs<'hir>,
-) -> Vec<hir::FunctionId> {
+) -> FunctionCandidates<'hir> {
     let mut exact = Vec::new();
     let mut maybe = Vec::new();
 
@@ -110,24 +112,61 @@ fn select_functions_for_args<'hir>(
         }
     }
 
-    if exact.is_empty() { maybe } else { exact }
+    if exact.is_empty() {
+        FunctionCandidates::Maybe(maybe)
+    } else {
+        FunctionCandidates::Exact(exact)
+    }
 }
-/// Returns true if the matched functions all return dynamic data.
-fn functions_return_dynamic_data(hir: &hir::Hir<'_>, functions: &[hir::FunctionId]) -> bool {
+/// Returns true if a gas-limited call can return dynamic data.
+fn functions_return_dynamic_data(hir: &hir::Hir<'_>, functions: &FunctionCandidates<'_>) -> bool {
     match functions {
-        [] => false,
-        &[function] => function_returns_dynamic_data(hir, function),
-        [first, rest @ ..] => {
-            let first = function_returns_dynamic_data(hir, *first);
-            rest.iter().all(|&function| function_returns_dynamic_data(hir, function) == first)
-                && first
+        FunctionCandidates::Exact(functions) => match functions.as_slice() {
+            [] => false,
+            [function] => function_returns_dynamic_data(hir, *function),
+            [first, rest @ ..] => {
+                let first = function_returns_dynamic_data(hir, *first);
+                rest.iter().all(|&function| function_returns_dynamic_data(hir, function) == first)
+                    && first
+            }
+        },
+        FunctionCandidates::Maybe(functions) => {
+            functions.iter().any(|&function| function_returns_dynamic_data(hir, function))
         }
+        FunctionCandidates::Pointer(returns) => returns_dynamic_data(hir, returns),
+    }
+}
+
+enum FunctionCandidates<'hir> {
+    Exact(Vec<hir::FunctionId>),
+    Maybe(Vec<hir::FunctionId>),
+    Pointer(&'hir [hir::VariableId]),
+}
+
+impl FunctionCandidates<'_> {
+    const fn is_empty(&self) -> bool {
+        match self {
+            Self::Exact(functions) | Self::Maybe(functions) => functions.is_empty(),
+            Self::Pointer(returns) => returns.is_empty(),
+        }
+    }
+}
+
+/// Returns true if any return variable has a dynamically encoded return type.
+fn returns_dynamic_data(hir: &hir::Hir<'_>, returns: &[hir::VariableId]) -> bool {
+    returns.iter().any(|&var| is_dynamic_type(hir, &hir.variable(var).ty))
+}
+
+const fn res_function_id(res: &hir::Res) -> Option<hir::FunctionId> {
+    match res {
+        hir::Res::Item(ItemId::Function(id)) => Some(*id),
+        _ => None,
     }
 }
 
 /// Returns true if a function has any dynamically encoded return value.
 fn function_returns_dynamic_data(hir: &hir::Hir<'_>, function: hir::FunctionId) -> bool {
-    hir.function(function).returns.iter().any(|&var| is_dynamic_type(hir, &hir.variable(var).ty))
+    returns_dynamic_data(hir, hir.function(function).returns)
 }
 
 enum ArgMatch {
@@ -138,18 +177,27 @@ enum ArgMatch {
 /// Returns how well call arguments match a candidate function signature.
 fn function_arg_match(hir: &hir::Hir<'_>, id: hir::FunctionId, args: &CallArgs<'_>) -> ArgMatch {
     let function = hir.function(id);
-    if args.len() != function.parameters.len() {
+    params_arg_match(hir, function.parameters, args)
+}
+
+/// Returns how well call arguments match the expected parameter types.
+fn params_arg_match(
+    hir: &hir::Hir<'_>,
+    parameters: &[hir::VariableId],
+    args: &CallArgs<'_>,
+) -> ArgMatch {
+    if args.len() != parameters.len() {
         return ArgMatch::No;
     }
 
     match &args.kind {
         CallArgsKind::Unnamed(exprs) => {
-            params_match_args(hir, function.parameters.iter().copied().zip(exprs.iter()))
+            params_match_args(hir, parameters.iter().copied().zip(exprs.iter()))
         }
         CallArgsKind::Named(named_args) => {
             let mut maybe = false;
             for named_arg in *named_args {
-                let Some(param) = function.parameters.iter().copied().find(|&param| {
+                let Some(param) = parameters.iter().copied().find(|&param| {
                     hir.variable(param).name.is_some_and(|name| name.name == named_arg.name.name)
                 }) else {
                     return ArgMatch::No;
@@ -183,16 +231,21 @@ fn params_match_args<'hir>(
 fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::ContractId> {
     match &expr.peel_parens().kind {
         ExprKind::Ident(reses) if is_this(reses) => enclosing_contract(hir, expr),
-        ExprKind::Call(callee, _, _) => match &callee.peel_parens().kind {
-            ExprKind::Ident(reses) => reses.iter().find_map(|res| match res {
-                hir::Res::Item(ItemId::Contract(id)) => Some(*id),
-                _ => None,
-            }),
-            ExprKind::Type(hir::Type { kind: TypeKind::Custom(ItemId::Contract(id)), .. }) => {
-                Some(*id)
-            }
-            _ => None,
-        },
+        ExprKind::Call(callee, _, _) => {
+            expr_type(hir, expr).and_then(type_contract_id).or_else(|| {
+                match &callee.peel_parens().kind {
+                    ExprKind::Ident(reses) => reses.iter().find_map(|res| match res {
+                        hir::Res::Item(ItemId::Contract(id)) => Some(*id),
+                        _ => None,
+                    }),
+                    ExprKind::Type(hir::Type {
+                        kind: TypeKind::Custom(ItemId::Contract(id)),
+                        ..
+                    }) => Some(*id),
+                    _ => None,
+                }
+            })
+        }
         _ => expr_type(hir, expr).and_then(type_contract_id),
     }
 }
@@ -220,13 +273,15 @@ fn expr_is_address(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
     match &expr.peel_parens().kind {
         ExprKind::Lit(lit) => matches!(lit.kind, LitKind::Address(_)),
         ExprKind::Payable(_) => true,
-        ExprKind::Call(callee, _, _) => matches!(
-            &callee.peel_parens().kind,
-            ExprKind::Type(hir::Type {
-                kind: TypeKind::Elementary(ElementaryType::Address(_)),
-                ..
-            })
-        ),
+        ExprKind::Call(callee, _, _) => {
+            matches!(
+                &callee.peel_parens().kind,
+                ExprKind::Type(hir::Type {
+                    kind: TypeKind::Elementary(ElementaryType::Address(_)),
+                    ..
+                })
+            ) || expr_type(hir, expr).is_some_and(is_address_type)
+        }
         ExprKind::Member(base, member) if member_is_builtin_address(base, member.name) => true,
         _ => expr_type(hir, expr).is_some_and(is_address_type),
     }
@@ -276,12 +331,59 @@ fn expr_type<'hir>(
                 (hir.variable(field).name?.name == member.name).then_some(&hir.variable(field).ty)
             })
         }
-        ExprKind::Call(callee, _, _) => match &callee.peel_parens().kind {
+        ExprKind::Call(callee, args, _) => match &callee.peel_parens().kind {
             ExprKind::Type(ty) => Some(ty),
-            _ => None,
+            _ => call_return_type(hir, callee, args),
         },
         _ => None,
     }
+}
+
+/// Returns the single return type for a statically resolved call expression.
+fn call_return_type<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    callee: &hir::Expr<'hir>,
+    args: &CallArgs<'hir>,
+) -> Option<&'hir hir::Type<'hir>> {
+    let functions = match matching_functions_for_callee(hir, callee, args)? {
+        FunctionCandidates::Exact(functions) | FunctionCandidates::Maybe(functions) => functions,
+        FunctionCandidates::Pointer(_) => return None,
+    };
+    let function = single_function(functions.into_iter())?;
+    single_return_type(hir, hir.function(function).returns)
+}
+
+/// Returns exactly one function id from an iterator.
+fn single_function(
+    mut functions: impl Iterator<Item = hir::FunctionId>,
+) -> Option<hir::FunctionId> {
+    let function = functions.next()?;
+    functions.next().is_none().then_some(function)
+}
+
+/// Returns exactly one return type.
+fn single_return_type<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    returns: &[hir::VariableId],
+) -> Option<&'hir hir::Type<'hir>> {
+    let &[ret] = returns else { return None };
+    Some(&hir.variable(ret).ty)
+}
+
+/// Returns external function-type return variables when the arguments can match.
+fn function_type_returns_for_args<'hir>(
+    hir: &hir::Hir<'_>,
+    ty: &'hir hir::Type<'hir>,
+    args: &CallArgs<'_>,
+) -> Option<&'hir [hir::VariableId]> {
+    let TypeKind::Function(function) = ty.kind else { return None };
+    if function.visibility != hir::Visibility::External {
+        return None;
+    }
+    if matches!(params_arg_match(hir, function.parameters, args), ArgMatch::No) {
+        return None;
+    }
+    Some(function.returns)
 }
 
 /// Returns true if the type is an address type

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -1,11 +1,15 @@
 use super::ReturnBomb;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{Severity, SolLint, calls::is_low_level_call_with_gas_limit},
+    sol::{
+        Severity, SolLint,
+        calls::{is_call_with_gas_limit, is_low_level_call_with_gas_limit},
+    },
 };
 use solar::{
     ast::ElementaryType,
-    sema::hir::{self, ExprKind, StmtKind, TypeKind},
+    interface::Symbol,
+    sema::hir::{self, ExprKind, ItemId, StmtKind, TypeKind},
 };
 
 declare_forge_lint!(
@@ -23,9 +27,26 @@ impl<'hir> LateLintPass<'hir> for ReturnBomb {
         stmt: &'hir hir::Stmt<'hir>,
     ) {
         let span = match stmt.kind {
-            StmtKind::DeclMulti(vars, expr) => (is_low_level_call_with_gas_limit(expr)
-                && captures_return_data(hir, vars))
-            .then_some(stmt.span),
+            StmtKind::DeclSingle(var) => {
+                let var = hir.variable(var);
+                var.initializer
+                    .filter(|expr| {
+                        call_with_gas_returns_dynamic_data(hir, expr)
+                            && is_dynamic_type(hir, &var.ty)
+                    })
+                    .map(|_| stmt.span)
+            }
+            StmtKind::DeclMulti(vars, expr) => {
+                if is_low_level_call_with_gas_limit(expr) && captures_return_data(hir, vars) {
+                    Some(stmt.span)
+                } else if call_with_gas_returns_dynamic_data(hir, expr)
+                    && captures_dynamic_return_data(hir, vars)
+                {
+                    Some(stmt.span)
+                } else {
+                    None
+                }
+            }
             StmtKind::Expr(expr) => match expr.kind {
                 ExprKind::Assign(lhs, _, rhs)
                     if is_low_level_call_with_gas_limit(rhs)
@@ -33,8 +54,20 @@ impl<'hir> LateLintPass<'hir> for ReturnBomb {
                 {
                     Some(expr.span)
                 }
+                ExprKind::Assign(lhs, _, rhs)
+                    if call_with_gas_returns_dynamic_data(hir, rhs)
+                        && assignment_captures_dynamic_return_data(hir, lhs) =>
+                {
+                    Some(expr.span)
+                }
                 _ => None,
             },
+            StmtKind::Return(Some(expr)) if is_low_level_call_with_gas_limit(expr) => {
+                Some(stmt.span)
+            }
+            StmtKind::Return(Some(expr)) if call_with_gas_returns_dynamic_data(hir, expr) => {
+                Some(stmt.span)
+            }
             _ => None,
         };
 
@@ -52,17 +85,176 @@ fn captures_return_data(hir: &hir::Hir<'_>, vars: &[Option<hir::VariableId>]) ->
 
 fn assigns_return_data_receiver(hir: &hir::Hir<'_>, lhs: &hir::Expr<'_>) -> bool {
     let ExprKind::Tuple(elements) = &lhs.peel_parens().kind else { return false };
-    elements.get(1).and_then(|element| *element).is_some_and(|expr| is_bytes_variable(hir, expr))
+    elements.get(1).and_then(|element| *element).is_some_and(|expr| is_bytes_lvalue(hir, expr))
 }
 
-fn is_bytes_variable(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
-    let ExprKind::Ident(reses) = &expr.peel_parens().kind else { return false };
-    reses
-        .iter()
-        .filter_map(hir::Res::as_variable)
-        .any(|var| is_dynamic_bytes_type(&hir.variable(var).ty.kind))
+fn is_bytes_lvalue(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    let expr = expr.peel_parens();
+    match &expr.kind {
+        ExprKind::Ident(reses) => reses
+            .iter()
+            .filter_map(hir::Res::as_variable)
+            .any(|var| is_dynamic_bytes_type(&hir.variable(var).ty.kind)),
+        ExprKind::Member(base, member) => {
+            field_type(hir, base, member.name).is_some_and(|ty| is_dynamic_bytes_type(&ty.kind))
+        }
+        ExprKind::Index(base, _) => {
+            indexed_value_type(hir, base).is_some_and(|ty| is_dynamic_bytes_type(&ty.kind))
+        }
+        _ => false,
+    }
 }
 
 const fn is_dynamic_bytes_type(ty: &TypeKind<'_>) -> bool {
     matches!(ty, TypeKind::Elementary(ElementaryType::Bytes))
+}
+
+fn field_type<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    base: &hir::Expr<'hir>,
+    member: Symbol,
+) -> Option<&'hir hir::Type<'hir>> {
+    let base = base.peel_parens();
+    let ExprKind::Ident(reses) = &base.kind else { return None };
+    let var = reses.iter().filter_map(hir::Res::as_variable).next()?;
+    let TypeKind::Custom(ItemId::Struct(struct_id)) = hir.variable(var).ty.kind else {
+        return None;
+    };
+    hir.strukt(struct_id).fields.iter().find_map(|&field| {
+        let field_var = hir.variable(field);
+        (field_var.name?.name == member).then_some(&field_var.ty)
+    })
+}
+
+fn indexed_value_type<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    base: &hir::Expr<'hir>,
+) -> Option<&'hir hir::Type<'hir>> {
+    match &base.peel_parens().kind {
+        ExprKind::Ident(reses) => {
+            let var = reses.iter().filter_map(hir::Res::as_variable).next()?;
+            array_element_type(&hir.variable(var).ty)
+        }
+        ExprKind::Member(inner, member) => {
+            let field = field_type(hir, inner, member.name)?;
+            array_element_type(field)
+        }
+        ExprKind::Index(inner, _) => {
+            let element = indexed_value_type(hir, inner)?;
+            array_element_type(element)
+        }
+        _ => None,
+    }
+}
+
+fn array_element_type<'hir>(ty: &'hir hir::Type<'hir>) -> Option<&'hir hir::Type<'hir>> {
+    let TypeKind::Array(array) = &ty.kind else { return None };
+    Some(&array.element)
+}
+
+fn captures_dynamic_return_data(hir: &hir::Hir<'_>, vars: &[Option<hir::VariableId>]) -> bool {
+    vars.iter().flatten().any(|&var| is_dynamic_type(hir, &hir.variable(var).ty))
+}
+
+fn assignment_captures_dynamic_return_data(hir: &hir::Hir<'_>, lhs: &hir::Expr<'_>) -> bool {
+    let ExprKind::Tuple(elements) = &lhs.peel_parens().kind else {
+        return expr_has_dynamic_type(hir, lhs);
+    };
+    elements.iter().flatten().any(|expr| expr_has_dynamic_type(hir, expr))
+}
+
+fn call_with_gas_returns_dynamic_data(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    is_call_with_gas_limit(expr) && call_returns_dynamic_data(hir, expr)
+}
+
+fn call_returns_dynamic_data(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    let ExprKind::Call(callee, _, _) = &expr.peel_parens().kind else { return false };
+    callee_return_vars(hir, callee).is_some_and(|returns| {
+        returns.iter().any(|&var| is_dynamic_type(hir, &hir.variable(var).ty))
+    })
+}
+
+fn callee_return_vars<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    callee: &hir::Expr<'hir>,
+) -> Option<&'hir [hir::VariableId]> {
+    match &callee.peel_parens().kind {
+        ExprKind::Ident(reses) => reses
+            .iter()
+            .filter_map(|res| match res {
+                hir::Res::Item(ItemId::Function(id)) => Some(hir.function(*id).returns),
+                _ => None,
+            })
+            .next(),
+        ExprKind::Member(base, member) => {
+            let contract = expr_contract_id(hir, base)?;
+            function_returns_for_member(hir, contract, member.name)
+        }
+        _ => None,
+    }
+}
+
+fn function_returns_for_member<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    contract: hir::ContractId,
+    member: Symbol,
+) -> Option<&'hir [hir::VariableId]> {
+    hir.contract_item_ids(contract).find_map(|item| {
+        let ItemId::Function(id) = item else { return None };
+        let function = hir.function(id);
+        (function.name?.name == member).then_some(function.returns)
+    })
+}
+
+fn expr_has_dynamic_type(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    expr_type(hir, expr).is_some_and(|ty| is_dynamic_type(hir, ty))
+}
+
+fn expr_type<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    expr: &hir::Expr<'hir>,
+) -> Option<&'hir hir::Type<'hir>> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) => {
+            let var = reses.iter().filter_map(hir::Res::as_variable).next()?;
+            Some(&hir.variable(var).ty)
+        }
+        ExprKind::Member(base, member) => field_type(hir, base, member.name),
+        ExprKind::Index(base, _) => indexed_value_type(hir, base),
+        _ => None,
+    }
+}
+
+fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::ContractId> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) => {
+            let var = reses.iter().filter_map(hir::Res::as_variable).next()?;
+            type_contract_id(&hir.variable(var).ty)
+        }
+        ExprKind::Call(callee, _, _) => match &callee.peel_parens().kind {
+            ExprKind::Type(hir::Type { kind: TypeKind::Custom(ItemId::Contract(id)), .. }) => {
+                Some(*id)
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn type_contract_id(ty: &hir::Type<'_>) -> Option<hir::ContractId> {
+    let TypeKind::Custom(ItemId::Contract(id)) = ty.kind else { return None };
+    Some(id)
+}
+
+fn is_dynamic_type(hir: &hir::Hir<'_>, ty: &hir::Type<'_>) -> bool {
+    match &ty.kind {
+        TypeKind::Elementary(ElementaryType::Bytes | ElementaryType::String) => true,
+        TypeKind::Array(array) => array.size.is_none() || is_dynamic_type(hir, &array.element),
+        TypeKind::Custom(ItemId::Struct(id)) => hir
+            .strukt(*id)
+            .fields
+            .iter()
+            .any(|&field| is_dynamic_type(hir, &hir.variable(field).ty)),
+        _ => false,
+    }
 }

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -301,11 +301,19 @@ fn expr_is_address(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
                     kind: TypeKind::Elementary(ElementaryType::Address(_)),
                     ..
                 })
-            ) || expr_type(hir, expr).is_some_and(is_address_type)
+            ) || callee_is_address_returning_builtin(callee)
+                || expr_type(hir, expr).is_some_and(is_address_type)
         }
         ExprKind::Member(base, member) if member_is_builtin_address(base, member.name) => true,
         _ => expr_type(hir, expr).is_some_and(is_address_type),
     }
+}
+
+fn callee_is_address_returning_builtin(callee: &hir::Expr<'_>) -> bool {
+    let ExprKind::Ident(reses) = &callee.peel_parens().kind else { return false };
+    reses
+        .iter()
+        .any(|res| matches!(res, hir::Res::Builtin(builtin) if builtin.name() == sym::ecrecover))
 }
 
 fn member_is_builtin_address(base: &hir::Expr<'_>, member: Symbol) -> bool {
@@ -386,7 +394,7 @@ fn call_return_type<'hir>(
 ) -> Option<&'hir hir::Type<'hir>> {
     let functions = match matching_functions_for_callee(hir, callee, args)? {
         FunctionCandidates::Exact(functions) | FunctionCandidates::Maybe(functions) => functions,
-        FunctionCandidates::Pointer(_) => return None,
+        FunctionCandidates::Pointer(returns) => return single_return_type(hir, returns),
     };
     let function = single_function(functions.into_iter())?;
     single_return_type(hir, hir.function(function).returns)

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -23,6 +23,7 @@ impl<'hir> LateLintPass<'hir> for ReturnBomb {
         hir: &'hir hir::Hir<'hir>,
         expr: &'hir hir::Expr<'hir>,
     ) {
+        // Flag gas-limited calls that can force the caller to copy unbounded returndata.
         if low_level_call_with_gas_consumes_unbounded_return_data(hir, expr)
             || call_with_gas_returns_dynamic_data(hir, expr)
         {
@@ -31,16 +32,18 @@ impl<'hir> LateLintPass<'hir> for ReturnBomb {
     }
 }
 
+/// Returns true for gas-limited calls that return dynamic data.
 fn call_with_gas_returns_dynamic_data(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
     is_call_with_gas_limit(expr) && call_returns_dynamic_data(hir, expr)
 }
-
+/// Returns true if a call resolves to functions that return dynamic data.
 fn call_returns_dynamic_data(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
     let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else { return false };
     matching_functions_for_callee(hir, callee, args)
         .is_some_and(|functions| functions_return_dynamic_data(hir, &functions))
 }
 
+/// Returns true for gas-limited low-level calls that copy unbounded returndata.
 fn low_level_call_with_gas_consumes_unbounded_return_data(
     hir: &hir::Hir<'_>,
     expr: &hir::Expr<'_>,
@@ -54,7 +57,7 @@ fn low_level_call_with_gas_consumes_unbounded_return_data(
     matches!(member.name, kw::Call | kw::Delegatecall | kw::Staticcall)
         && expr_is_address(hir, receiver)
 }
-
+/// Returns the function overloads that can match a callee and its arguments.
 fn matching_functions_for_callee<'hir>(
     hir: &'hir hir::Hir<'hir>,
     callee: &hir::Expr<'hir>,
@@ -77,6 +80,7 @@ fn matching_functions_for_callee<'hir>(
     }
 }
 
+/// Returns function candidates with the given member name on a contract.
 fn function_candidates_for_member<'hir>(
     hir: &'hir hir::Hir<'hir>,
     contract: hir::ContractId,
@@ -89,6 +93,7 @@ fn function_candidates_for_member<'hir>(
     })
 }
 
+/// Selects the candidate functions that best match the call arguments.
 fn select_functions_for_args<'hir>(
     hir: &'hir hir::Hir<'hir>,
     candidates: impl Iterator<Item = hir::FunctionId>,
@@ -107,7 +112,7 @@ fn select_functions_for_args<'hir>(
 
     if exact.is_empty() { maybe } else { exact }
 }
-
+/// Returns true if the matched functions all return dynamic data.
 fn functions_return_dynamic_data(hir: &hir::Hir<'_>, functions: &[hir::FunctionId]) -> bool {
     match functions {
         [] => false,
@@ -120,6 +125,7 @@ fn functions_return_dynamic_data(hir: &hir::Hir<'_>, functions: &[hir::FunctionI
     }
 }
 
+/// Returns true if a function has any dynamically encoded return value.
 fn function_returns_dynamic_data(hir: &hir::Hir<'_>, function: hir::FunctionId) -> bool {
     hir.function(function).returns.iter().any(|&var| is_dynamic_type(hir, &hir.variable(var).ty))
 }
@@ -129,7 +135,7 @@ enum ArgMatch {
     Maybe,
     No,
 }
-
+/// Returns how well call arguments match a candidate function signature.
 fn function_arg_match(hir: &hir::Hir<'_>, id: hir::FunctionId, args: &CallArgs<'_>) -> ArgMatch {
     let function = hir.function(id);
     if args.len() != function.parameters.len() {
@@ -158,7 +164,7 @@ fn function_arg_match(hir: &hir::Hir<'_>, id: hir::FunctionId, args: &CallArgs<'
         }
     }
 }
-
+/// Returns how well positional arguments match their expected parameter types.
 fn params_match_args<'hir>(
     hir: &hir::Hir<'hir>,
     params_and_args: impl Iterator<Item = (hir::VariableId, &'hir hir::Expr<'hir>)>,
@@ -173,7 +179,7 @@ fn params_match_args<'hir>(
     }
     if maybe { ArgMatch::Maybe } else { ArgMatch::Exact }
 }
-
+/// Returns the contract id for expressions known to be contract-typed.
 fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::ContractId> {
     match &expr.peel_parens().kind {
         ExprKind::Call(callee, _, _) => match &callee.peel_parens().kind {
@@ -189,12 +195,12 @@ fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::Con
         _ => expr_type(hir, expr).and_then(type_contract_id),
     }
 }
-
+/// Returns the contract id for contract-typed values.
 const fn type_contract_id(ty: &hir::Type<'_>) -> Option<hir::ContractId> {
     let TypeKind::Custom(ItemId::Contract(id)) = ty.kind else { return None };
     Some(id)
 }
-
+/// Returns true if an expression is known to have an address type.
 fn expr_is_address(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
     match &expr.peel_parens().kind {
         ExprKind::Lit(lit) => matches!(lit.kind, LitKind::Address(_)),
@@ -209,7 +215,7 @@ fn expr_is_address(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
         _ => expr_type(hir, expr).is_some_and(is_address_type),
     }
 }
-
+/// Returns whether an expression can match the expected type, if known.
 fn expr_matches_type(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>, ty: &hir::Type<'_>) -> Option<bool> {
     match &expr.peel_parens().kind {
         ExprKind::Lit(lit) => return Some(lit_matches_type(lit, ty)),
@@ -219,7 +225,7 @@ fn expr_matches_type(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>, ty: &hir::Type<'_
 
     expr_type(hir, expr).map(|expr_ty| types_match(hir, expr_ty, ty))
 }
-
+/// Returns the type of simple expressions needed by this lint.
 fn expr_type<'hir>(
     hir: &'hir hir::Hir<'hir>,
     expr: &hir::Expr<'hir>,
@@ -250,10 +256,11 @@ fn expr_type<'hir>(
     }
 }
 
+/// Returns true if the type is an address type
 const fn is_address_type(ty: &hir::Type<'_>) -> bool {
     matches!(ty.kind, TypeKind::Elementary(ElementaryType::Address(_)))
 }
-
+/// Returns true if a literal can be used for a value of the given type.
 const fn lit_matches_type(lit: &solar::ast::Lit<'_>, ty: &hir::Type<'_>) -> bool {
     matches!(
         (&lit.kind, &ty.kind),
@@ -279,6 +286,7 @@ const fn lit_matches_type(lit: &solar::ast::Lit<'_>, ty: &hir::Type<'_>) -> bool
     )
 }
 
+/// Returns true if two types are equivalent for overload resolution.
 fn types_match(hir: &hir::Hir<'_>, a: &hir::Type<'_>, b: &hir::Type<'_>) -> bool {
     match (&a.kind, &b.kind) {
         (
@@ -306,6 +314,7 @@ fn types_match(hir: &hir::Hir<'_>, a: &hir::Type<'_>, b: &hir::Type<'_>) -> bool
     }
 }
 
+/// Returns true if the type contains dynamically encoded ABI data.
 fn is_dynamic_type(hir: &hir::Hir<'_>, ty: &hir::Type<'_>) -> bool {
     match &ty.kind {
         TypeKind::Elementary(ElementaryType::Bytes | ElementaryType::String) => true,

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -105,7 +105,7 @@ fn function_candidates_for_member<'hir>(
 }
 
 /// Returns true if a function can be called through `this.foo()` or `contract.foo()`.
-fn is_externally_callable(function: &hir::Function<'_>) -> bool {
+const fn is_externally_callable(function: &hir::Function<'_>) -> bool {
     matches!(function.visibility, hir::Visibility::Public | hir::Visibility::External)
 }
 
@@ -329,6 +329,12 @@ fn member_is_builtin_address(base: &hir::Expr<'_>, member: Symbol) -> bool {
 
 /// Returns whether an expression can match the expected type, if known.
 fn expr_matches_type(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>, ty: &hir::Type<'_>) -> Option<bool> {
+    if let Some(literal) = integer_literal(expr)
+        && let Some(matches) = integer_literal_matches_type(literal, ty)
+    {
+        return Some(matches);
+    }
+
     match &expr.peel_parens().kind {
         ExprKind::Lit(lit) => return Some(lit_matches_type(lit, ty)),
         ExprKind::Payable(_) => return Some(is_address_type(ty)),
@@ -437,6 +443,56 @@ fn function_type_returns_for_args<'hir>(
 const fn is_address_type(ty: &hir::Type<'_>) -> bool {
     matches!(ty.kind, TypeKind::Elementary(ElementaryType::Address(_)))
 }
+
+#[derive(Clone, Copy)]
+struct IntegerLiteral {
+    negative: bool,
+    bits: usize,
+    is_zero: bool,
+    is_power_of_two: bool,
+}
+
+/// Returns an integer literal's sign and precision, including unary negation.
+fn integer_literal(expr: &hir::Expr<'_>) -> Option<IntegerLiteral> {
+    match &expr.peel_parens().kind {
+        ExprKind::Lit(lit) => match lit.kind {
+            LitKind::Number(value) => Some(IntegerLiteral {
+                negative: false,
+                bits: value.bit_len().max(1),
+                is_zero: value.is_zero(),
+                is_power_of_two: value.is_power_of_two(),
+            }),
+            _ => None,
+        },
+        ExprKind::Unary(op, expr) if op.kind == hir::UnOpKind::Neg => {
+            let mut literal = integer_literal(expr)?;
+            if !literal.is_zero {
+                literal.negative = !literal.negative;
+            }
+            Some(literal)
+        }
+        _ => None,
+    }
+}
+
+/// Returns whether an integer literal fits in an expected integer type.
+fn integer_literal_matches_type(literal: IntegerLiteral, ty: &hir::Type<'_>) -> Option<bool> {
+    match ty.kind {
+        TypeKind::Elementary(ElementaryType::UInt(size)) => {
+            Some(!literal.negative && literal.bits <= usize::from(size.bits()))
+        }
+        TypeKind::Elementary(ElementaryType::Int(size)) => {
+            let bits = usize::from(size.bits());
+            Some(if literal.negative {
+                literal.bits < bits || (literal.bits == bits && literal.is_power_of_two)
+            } else {
+                literal.bits < bits
+            })
+        }
+        _ => None,
+    }
+}
+
 /// Returns true if a literal can be used for a value of the given type.
 const fn lit_matches_type(lit: &solar::ast::Lit<'_>, ty: &hir::Type<'_>) -> bool {
     matches!(
@@ -444,7 +500,11 @@ const fn lit_matches_type(lit: &solar::ast::Lit<'_>, ty: &hir::Type<'_>) -> bool
         (LitKind::Address(_), TypeKind::Elementary(ElementaryType::Address(_)))
             | (LitKind::Bool(_), TypeKind::Elementary(ElementaryType::Bool))
             | (
-                LitKind::Number(_) | LitKind::Rational(_),
+                LitKind::Number(_),
+                TypeKind::Elementary(ElementaryType::Fixed(_, _) | ElementaryType::UFixed(_, _)),
+            )
+            | (
+                LitKind::Rational(_),
                 TypeKind::Elementary(
                     ElementaryType::Int(_)
                         | ElementaryType::UInt(_)

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -423,7 +423,7 @@ fn types_match(hir: &hir::Hir<'_>, a: &hir::Type<'_>, b: &hir::Type<'_>) -> bool
             TypeKind::Elementary(ElementaryType::Address(_)),
             TypeKind::Elementary(ElementaryType::Address(_)),
         ) => true,
-        (TypeKind::Elementary(a), TypeKind::Elementary(b)) => a == b,
+        (TypeKind::Elementary(a), TypeKind::Elementary(b)) => elementary_type_matches(*a, *b),
         (TypeKind::Array(a), TypeKind::Array(b)) => {
             a.size.is_some() == b.size.is_some() && types_match(hir, &a.element, &b.element)
         }
@@ -439,6 +439,25 @@ fn types_match(hir: &hir::Hir<'_>, a: &hir::Type<'_>, b: &hir::Type<'_>) -> bool
                     .iter()
                     .zip(b.returns)
                     .all(|(&a, &b)| types_match(hir, &hir.variable(a).ty, &hir.variable(b).ty))
+        }
+        _ => false,
+    }
+}
+
+/// Returns true if an elementary value can be used for an expected elementary type.
+fn elementary_type_matches(actual: ElementaryType, expected: ElementaryType) -> bool {
+    use ElementaryType::{Address, Bool, Bytes, Fixed, FixedBytes, Int, String, UFixed, UInt};
+
+    match (actual, expected) {
+        (Address(_), Address(false)) => true,
+        (Address(payable), Address(true)) => payable,
+        (UInt(actual), UInt(expected))
+        | (Int(actual), Int(expected))
+        | (FixedBytes(actual), FixedBytes(expected)) => actual.bits() <= expected.bits(),
+        (Bool, Bool) | (String, String) | (Bytes, Bytes) => true,
+        (Fixed(actual_size, actual_scale), Fixed(expected_size, expected_scale))
+        | (UFixed(actual_size, actual_scale), UFixed(expected_size, expected_scale)) => {
+            actual_size == expected_size && actual_scale == expected_scale
         }
         _ => false,
     }

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -271,11 +271,13 @@ fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::Con
 
 /// Returns the contract containing an expression span.
 fn enclosing_contract(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::ContractId> {
-    hir.function_ids().find_map(|id| {
-        let function = hir.function(id);
-        (function.body.is_some() && function.body_span.contains(expr.span))
-            .then_some(function.contract?)
-    })
+    hir.function_ids()
+        .find_map(|id| {
+            let function = hir.function(id);
+            (function.body.is_some() && function.body_span.contains(expr.span))
+                .then_some(function.contract?)
+        })
+        .or_else(|| hir.contract_ids().find(|&id| hir.contract(id).span.contains(expr.span)))
 }
 
 fn is_this(reses: &[hir::Res]) -> bool {
@@ -354,7 +356,25 @@ fn expr_type<'hir>(
             ExprKind::Type(ty) | ExprKind::New(ty) => Some(ty),
             _ => call_return_type(hir, callee, args),
         },
+        ExprKind::Ternary(_, true_, false_) => common_expr_type(hir, true_, false_),
         _ => None,
+    }
+}
+
+/// Returns the common type for a ternary expression when one branch type can accept the other.
+fn common_expr_type<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    true_: &hir::Expr<'hir>,
+    false_: &hir::Expr<'hir>,
+) -> Option<&'hir hir::Type<'hir>> {
+    let true_ty = expr_type(hir, true_)?;
+    let false_ty = expr_type(hir, false_)?;
+    if types_match(hir, true_ty, false_ty) {
+        Some(false_ty)
+    } else if types_match(hir, false_ty, true_ty) {
+        Some(true_ty)
+    } else {
+        None
     }
 }
 
@@ -444,8 +464,12 @@ fn types_match(hir: &hir::Hir<'_>, a: &hir::Type<'_>, b: &hir::Type<'_>) -> bool
         ) => true,
         (TypeKind::Elementary(a), TypeKind::Elementary(b)) => elementary_type_matches(*a, *b),
         (TypeKind::Array(a), TypeKind::Array(b)) => {
-            array_sizes_match(a.size, b.size) && types_match(hir, &a.element, &b.element)
+            array_sizes_match(hir, a.size, b.size) && types_match(hir, &a.element, &b.element)
         }
+        (
+            TypeKind::Custom(ItemId::Contract(actual)),
+            TypeKind::Custom(ItemId::Contract(expected)),
+        ) => contract_type_matches(hir, *actual, *expected),
         (TypeKind::Custom(a), TypeKind::Custom(b)) => a == b,
         (TypeKind::Function(a), TypeKind::Function(b)) => {
             a.parameters.len() == b.parameters.len()
@@ -463,23 +487,115 @@ fn types_match(hir: &hir::Hir<'_>, a: &hir::Type<'_>, b: &hir::Type<'_>) -> bool
     }
 }
 
+/// Returns true if an actual contract type can be used where the expected contract type is needed.
+fn contract_type_matches(
+    hir: &hir::Hir<'_>,
+    actual: hir::ContractId,
+    expected: hir::ContractId,
+) -> bool {
+    actual == expected || hir.contract(actual).linearized_bases.contains(&expected)
+}
+
 /// Returns true if two array sizes are equivalent for overload resolution.
-fn array_sizes_match(a: Option<&hir::Expr<'_>>, b: Option<&hir::Expr<'_>>) -> bool {
+fn array_sizes_match(
+    hir: &hir::Hir<'_>,
+    a: Option<&hir::Expr<'_>>,
+    b: Option<&hir::Expr<'_>>,
+) -> bool {
     match (a, b) {
         (None, None) => true,
-        (Some(a), Some(b)) => fixed_array_sizes_match(a, b),
+        (Some(a), Some(b)) => fixed_array_sizes_match(hir, a, b),
         _ => false,
     }
 }
 
-fn fixed_array_sizes_match(a: &hir::Expr<'_>, b: &hir::Expr<'_>) -> bool {
-    match (&a.peel_parens().kind, &b.peel_parens().kind) {
-        (ExprKind::Lit(a), ExprKind::Lit(b)) => match (&a.kind, &b.kind) {
-            (LitKind::Number(a), LitKind::Number(b)) => a == b,
-            _ => false,
-        },
-        _ => false,
+fn fixed_array_sizes_match(hir: &hir::Hir<'_>, a: &hir::Expr<'_>, b: &hir::Expr<'_>) -> bool {
+    matches!(
+        (const_array_size(hir, a), const_array_size(hir, b)),
+        (Some(LitKind::Number(a)), Some(LitKind::Number(b))) if a == b
+    )
+}
+
+type ConstArraySize = LitKind<'static>;
+
+fn const_array_size(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<ConstArraySize> {
+    const MAX_DEPTH: usize = 64;
+    const_array_size_inner(hir, expr, MAX_DEPTH)
+}
+
+fn const_array_size_inner(
+    hir: &hir::Hir<'_>,
+    expr: &hir::Expr<'_>,
+    depth: usize,
+) -> Option<ConstArraySize> {
+    if depth == 0 {
+        return None;
     }
+
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) => {
+            let var = reses.iter().find_map(hir::Res::as_variable)?;
+            let var = hir.variable(var);
+            if !var.is_constant() {
+                return None;
+            }
+            const_array_size_inner(hir, var.initializer?, depth - 1)
+        }
+        ExprKind::Lit(lit) => match lit.kind {
+            LitKind::Number(value) => Some(LitKind::Number(value)),
+            _ => None,
+        },
+        ExprKind::Unary(op, expr) => {
+            let LitKind::Number(value) = const_array_size_inner(hir, expr, depth - 1)? else {
+                return None;
+            };
+            match op.kind {
+                hir::UnOpKind::BitNot => Some(LitKind::Number(!value)),
+                hir::UnOpKind::Neg => Some(LitKind::Number(value.wrapping_neg())),
+                _ => None,
+            }
+        }
+        ExprKind::Binary(left, op, right) => {
+            let left = const_array_size_inner(hir, left, depth - 1)?;
+            let right = const_array_size_inner(hir, right, depth - 1)?;
+            const_array_size_binary_op(left, op.kind, right)
+        }
+        _ => None,
+    }
+}
+
+fn const_array_size_binary_op(
+    left: ConstArraySize,
+    op: hir::BinOpKind,
+    right: ConstArraySize,
+) -> Option<ConstArraySize> {
+    let (LitKind::Number(left), LitKind::Number(right)) = (left, right) else {
+        return None;
+    };
+
+    let value = match op {
+        hir::BinOpKind::BitOr => left | right,
+        hir::BinOpKind::BitAnd => left & right,
+        hir::BinOpKind::BitXor => left ^ right,
+        hir::BinOpKind::Shr => left.wrapping_shr(right.try_into().unwrap_or(usize::MAX)),
+        hir::BinOpKind::Shl => left.wrapping_shl(right.try_into().unwrap_or(usize::MAX)),
+        hir::BinOpKind::Sar => left.arithmetic_shr(right.try_into().unwrap_or(usize::MAX)),
+        hir::BinOpKind::Add => left.checked_add(right)?,
+        hir::BinOpKind::Sub => left.checked_sub(right)?,
+        hir::BinOpKind::Mul => left.checked_mul(right)?,
+        hir::BinOpKind::Div => left.checked_div(right)?,
+        hir::BinOpKind::Rem => left.checked_rem(right)?,
+        hir::BinOpKind::Pow => left.checked_pow(right)?,
+        hir::BinOpKind::Lt
+        | hir::BinOpKind::Le
+        | hir::BinOpKind::Gt
+        | hir::BinOpKind::Ge
+        | hir::BinOpKind::Eq
+        | hir::BinOpKind::Ne
+        | hir::BinOpKind::Or
+        | hir::BinOpKind::And => return None,
+    };
+    Some(LitKind::Number(value))
 }
 
 /// Returns true if an elementary value can be used for an expected elementary type.

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -1,15 +1,12 @@
 use super::ReturnBomb;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{
-        Severity, SolLint,
-        calls::{is_call_with_gas_limit, is_low_level_call_with_gas_limit},
-    },
+    sol::{Severity, SolLint, calls::is_call_with_gas_limit},
 };
 use solar::{
-    ast::ElementaryType,
-    interface::Symbol,
-    sema::hir::{self, ExprKind, ItemId, StmtKind, TypeKind},
+    ast::{ElementaryType, LitKind, StrKind},
+    interface::{Symbol, kw},
+    sema::hir::{self, CallArgs, CallArgsKind, ExprKind, ItemId, TypeKind},
 };
 
 declare_forge_lint!(
@@ -20,89 +17,17 @@ declare_forge_lint!(
 );
 
 impl<'hir> LateLintPass<'hir> for ReturnBomb {
-    fn check_stmt(
+    fn check_expr(
         &mut self,
         ctx: &LintContext,
         hir: &'hir hir::Hir<'hir>,
-        stmt: &'hir hir::Stmt<'hir>,
+        expr: &'hir hir::Expr<'hir>,
     ) {
-        let span = match stmt.kind {
-            StmtKind::DeclSingle(var) => hir
-                .variable(var)
-                .initializer
-                .filter(|expr| expr_consumes_unbounded_return_data(hir, expr))
-                .map(|_| stmt.span),
-            StmtKind::DeclMulti(_, expr) => {
-                if expr_consumes_unbounded_return_data(hir, expr) {
-                    Some(stmt.span)
-                } else {
-                    None
-                }
-            }
-            StmtKind::Expr(expr) if expr_consumes_unbounded_return_data(hir, expr) => {
-                Some(expr.span)
-            }
-            StmtKind::Return(Some(expr)) if expr_consumes_unbounded_return_data(hir, expr) => {
-                Some(stmt.span)
-            }
-            _ => None,
-        };
-
-        if let Some(span) = span {
-            ctx.emit(&RETURN_BOMB, span);
+        if low_level_call_with_gas_consumes_unbounded_return_data(hir, expr)
+            || call_with_gas_returns_dynamic_data(hir, expr)
+        {
+            ctx.emit(&RETURN_BOMB, expr.span);
         }
-    }
-}
-
-fn expr_consumes_unbounded_return_data(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
-    let expr = expr.peel_parens();
-
-    if is_low_level_call_with_gas_limit(expr) || call_with_gas_returns_dynamic_data(hir, expr) {
-        return true;
-    }
-
-    match &expr.kind {
-        ExprKind::Array(exprs) => {
-            exprs.iter().any(|expr| expr_consumes_unbounded_return_data(hir, expr))
-        }
-        ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {
-            expr_consumes_unbounded_return_data(hir, lhs)
-                || expr_consumes_unbounded_return_data(hir, rhs)
-        }
-        ExprKind::Call(callee, args, opts) => {
-            expr_consumes_unbounded_return_data(hir, callee)
-                || args.exprs().any(|expr| expr_consumes_unbounded_return_data(hir, expr))
-                || opts.is_some_and(|opts| {
-                    opts.iter().any(|opt| expr_consumes_unbounded_return_data(hir, &opt.value))
-                })
-        }
-        ExprKind::Delete(inner) | ExprKind::Payable(inner) | ExprKind::Unary(_, inner) => {
-            expr_consumes_unbounded_return_data(hir, inner)
-        }
-        ExprKind::Index(base, index) => {
-            expr_consumes_unbounded_return_data(hir, base)
-                || index.is_some_and(|index| expr_consumes_unbounded_return_data(hir, index))
-        }
-        ExprKind::Slice(base, start, end) => {
-            expr_consumes_unbounded_return_data(hir, base)
-                || start.is_some_and(|start| expr_consumes_unbounded_return_data(hir, start))
-                || end.is_some_and(|end| expr_consumes_unbounded_return_data(hir, end))
-        }
-        ExprKind::Member(base, _) => expr_consumes_unbounded_return_data(hir, base),
-        ExprKind::Ternary(cond, then_expr, else_expr) => {
-            expr_consumes_unbounded_return_data(hir, cond)
-                || expr_consumes_unbounded_return_data(hir, then_expr)
-                || expr_consumes_unbounded_return_data(hir, else_expr)
-        }
-        ExprKind::Tuple(exprs) => {
-            exprs.iter().flatten().any(|expr| expr_consumes_unbounded_return_data(hir, expr))
-        }
-        ExprKind::Ident(_)
-        | ExprKind::Lit(_)
-        | ExprKind::New(_)
-        | ExprKind::TypeCall(_)
-        | ExprKind::Type(_)
-        | ExprKind::Err(_) => false,
     }
 }
 
@@ -111,51 +36,155 @@ fn call_with_gas_returns_dynamic_data(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) 
 }
 
 fn call_returns_dynamic_data(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
-    let ExprKind::Call(callee, _, _) = &expr.peel_parens().kind else { return false };
-    callee_return_vars(hir, callee).is_some_and(|returns| {
-        returns.iter().any(|&var| is_dynamic_type(hir, &hir.variable(var).ty))
-    })
+    let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else { return false };
+    matching_functions_for_callee(hir, callee, args)
+        .is_some_and(|functions| functions_return_dynamic_data(hir, &functions))
 }
 
-fn callee_return_vars<'hir>(
+fn low_level_call_with_gas_consumes_unbounded_return_data(
+    hir: &hir::Hir<'_>,
+    expr: &hir::Expr<'_>,
+) -> bool {
+    if !is_call_with_gas_limit(expr) {
+        return false;
+    }
+
+    let ExprKind::Call(callee, _, _) = &expr.peel_parens().kind else { return false };
+    let ExprKind::Member(receiver, member) = &callee.peel_parens().kind else { return false };
+    matches!(member.name, kw::Call | kw::Delegatecall | kw::Staticcall)
+        && expr_is_address(hir, receiver)
+}
+
+fn matching_functions_for_callee<'hir>(
     hir: &'hir hir::Hir<'hir>,
     callee: &hir::Expr<'hir>,
-) -> Option<&'hir [hir::VariableId]> {
+    args: &CallArgs<'hir>,
+) -> Option<Vec<hir::FunctionId>> {
     match &callee.peel_parens().kind {
-        ExprKind::Ident(reses) => reses
-            .iter()
-            .filter_map(|res| match res {
-                hir::Res::Item(ItemId::Function(id)) => Some(hir.function(*id).returns),
+        ExprKind::Ident(reses) => {
+            let candidates = reses.iter().filter_map(|res| match res {
+                hir::Res::Item(ItemId::Function(id)) => Some(*id),
                 _ => None,
-            })
-            .next(),
+            });
+            Some(select_functions_for_args(hir, candidates, args))
+        }
         ExprKind::Member(base, member) => {
             let contract = expr_contract_id(hir, base)?;
-            function_returns_for_member(hir, contract, member.name)
+            let candidates = function_candidates_for_member(hir, contract, member.name);
+            Some(select_functions_for_args(hir, candidates, args))
         }
         _ => None,
     }
 }
 
-fn function_returns_for_member<'hir>(
+fn function_candidates_for_member<'hir>(
     hir: &'hir hir::Hir<'hir>,
     contract: hir::ContractId,
     member: Symbol,
-) -> Option<&'hir [hir::VariableId]> {
-    hir.contract_item_ids(contract).find_map(|item| {
+) -> impl Iterator<Item = hir::FunctionId> + Clone + 'hir {
+    hir.contract_item_ids(contract).filter_map(move |item| {
         let ItemId::Function(id) = item else { return None };
         let function = hir.function(id);
-        (function.name?.name == member).then_some(function.returns)
+        (function.name?.name == member).then_some(id)
     })
+}
+
+fn select_functions_for_args<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    candidates: impl Iterator<Item = hir::FunctionId>,
+    args: &CallArgs<'hir>,
+) -> Vec<hir::FunctionId> {
+    let mut exact = Vec::new();
+    let mut maybe = Vec::new();
+
+    for id in candidates {
+        match function_arg_match(hir, id, args) {
+            ArgMatch::Exact => exact.push(id),
+            ArgMatch::Maybe => maybe.push(id),
+            ArgMatch::No => {}
+        }
+    }
+
+    if exact.is_empty() { maybe } else { exact }
+}
+
+fn functions_return_dynamic_data(hir: &hir::Hir<'_>, functions: &[hir::FunctionId]) -> bool {
+    match functions {
+        [] => false,
+        &[function] => function_returns_dynamic_data(hir, function),
+        [first, rest @ ..] => {
+            let first = function_returns_dynamic_data(hir, *first);
+            rest.iter().all(|&function| function_returns_dynamic_data(hir, function) == first)
+                && first
+        }
+    }
+}
+
+fn function_returns_dynamic_data(hir: &hir::Hir<'_>, function: hir::FunctionId) -> bool {
+    hir.function(function).returns.iter().any(|&var| is_dynamic_type(hir, &hir.variable(var).ty))
+}
+
+enum ArgMatch {
+    Exact,
+    Maybe,
+    No,
+}
+
+fn function_arg_match(hir: &hir::Hir<'_>, id: hir::FunctionId, args: &CallArgs<'_>) -> ArgMatch {
+    let function = hir.function(id);
+    if args.len() != function.parameters.len() {
+        return ArgMatch::No;
+    }
+
+    match &args.kind {
+        CallArgsKind::Unnamed(exprs) => {
+            params_match_args(hir, function.parameters.iter().copied().zip(exprs.iter()))
+        }
+        CallArgsKind::Named(named_args) => {
+            let mut maybe = false;
+            for named_arg in *named_args {
+                let Some(param) = function.parameters.iter().copied().find(|&param| {
+                    hir.variable(param).name.is_some_and(|name| name.name == named_arg.name.name)
+                }) else {
+                    return ArgMatch::No;
+                };
+                match expr_matches_type(hir, &named_arg.value, &hir.variable(param).ty) {
+                    Some(true) => {}
+                    Some(false) => return ArgMatch::No,
+                    None => maybe = true,
+                }
+            }
+            if maybe { ArgMatch::Maybe } else { ArgMatch::Exact }
+        }
+    }
+}
+
+fn params_match_args<'hir>(
+    hir: &hir::Hir<'hir>,
+    params_and_args: impl Iterator<Item = (hir::VariableId, &'hir hir::Expr<'hir>)>,
+) -> ArgMatch {
+    let mut maybe = false;
+    for (param, arg) in params_and_args {
+        match expr_matches_type(hir, arg, &hir.variable(param).ty) {
+            Some(true) => {}
+            Some(false) => return ArgMatch::No,
+            None => maybe = true,
+        }
+    }
+    if maybe { ArgMatch::Maybe } else { ArgMatch::Exact }
 }
 
 fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::ContractId> {
     match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => {
-            let var = reses.iter().filter_map(hir::Res::as_variable).next()?;
-            type_contract_id(&hir.variable(var).ty)
-        }
+        ExprKind::Ident(reses) => reses
+            .iter()
+            .find_map(hir::Res::as_variable)
+            .and_then(|var| type_contract_id(&hir.variable(var).ty)),
         ExprKind::Call(callee, _, _) => match &callee.peel_parens().kind {
+            ExprKind::Ident(reses) => reses.iter().find_map(|res| match res {
+                hir::Res::Item(ItemId::Contract(id)) => Some(*id),
+                _ => None,
+            }),
             ExprKind::Type(hir::Type { kind: TypeKind::Custom(ItemId::Contract(id)), .. }) => {
                 Some(*id)
             }
@@ -165,9 +194,119 @@ fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::Con
     }
 }
 
-fn type_contract_id(ty: &hir::Type<'_>) -> Option<hir::ContractId> {
+const fn type_contract_id(ty: &hir::Type<'_>) -> Option<hir::ContractId> {
     let TypeKind::Custom(ItemId::Contract(id)) = ty.kind else { return None };
     Some(id)
+}
+
+fn expr_is_address(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    match &expr.peel_parens().kind {
+        ExprKind::Lit(lit) => matches!(lit.kind, LitKind::Address(_)),
+        ExprKind::Payable(_) => true,
+        ExprKind::Call(callee, _, _) => matches!(
+            &callee.peel_parens().kind,
+            ExprKind::Type(hir::Type {
+                kind: TypeKind::Elementary(ElementaryType::Address(_)),
+                ..
+            })
+        ),
+        _ => expr_type(hir, expr).is_some_and(is_address_type),
+    }
+}
+
+fn expr_matches_type(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>, ty: &hir::Type<'_>) -> Option<bool> {
+    match &expr.peel_parens().kind {
+        ExprKind::Lit(lit) => return Some(lit_matches_type(lit, ty)),
+        ExprKind::Payable(_) => return Some(is_address_type(ty)),
+        _ => {}
+    }
+
+    expr_type(hir, expr).map(|expr_ty| types_match(hir, expr_ty, ty))
+}
+
+fn expr_type<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    expr: &hir::Expr<'hir>,
+) -> Option<&'hir hir::Type<'hir>> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) => {
+            let var = reses.iter().filter_map(hir::Res::as_variable).next()?;
+            Some(&hir.variable(var).ty)
+        }
+        ExprKind::Index(base, _) => {
+            let TypeKind::Array(array) = &expr_type(hir, base)?.kind else { return None };
+            Some(&array.element)
+        }
+        ExprKind::Member(base, member) => {
+            let TypeKind::Custom(ItemId::Struct(id)) = expr_type(hir, base)?.kind else {
+                return None;
+            };
+            hir.strukt(id).fields.iter().find_map(|&field| {
+                (hir.variable(field).name?.name == member.name).then_some(&hir.variable(field).ty)
+            })
+        }
+        ExprKind::Call(callee, _, _) => match &callee.peel_parens().kind {
+            ExprKind::Type(ty) => Some(ty),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+const fn is_address_type(ty: &hir::Type<'_>) -> bool {
+    matches!(ty.kind, TypeKind::Elementary(ElementaryType::Address(_)))
+}
+
+const fn lit_matches_type(lit: &solar::ast::Lit<'_>, ty: &hir::Type<'_>) -> bool {
+    matches!(
+        (&lit.kind, &ty.kind),
+        (LitKind::Address(_), TypeKind::Elementary(ElementaryType::Address(_)))
+            | (LitKind::Bool(_), TypeKind::Elementary(ElementaryType::Bool))
+            | (
+                LitKind::Number(_) | LitKind::Rational(_),
+                TypeKind::Elementary(
+                    ElementaryType::Int(_)
+                        | ElementaryType::UInt(_)
+                        | ElementaryType::Fixed(_, _)
+                        | ElementaryType::UFixed(_, _),
+                ),
+            )
+            | (
+                LitKind::Str(StrKind::Str | StrKind::Unicode, ..),
+                TypeKind::Elementary(ElementaryType::String),
+            )
+            | (
+                LitKind::Str(StrKind::Hex, ..),
+                TypeKind::Elementary(ElementaryType::Bytes | ElementaryType::FixedBytes(_)),
+            )
+    )
+}
+
+fn types_match(hir: &hir::Hir<'_>, a: &hir::Type<'_>, b: &hir::Type<'_>) -> bool {
+    match (&a.kind, &b.kind) {
+        (
+            TypeKind::Elementary(ElementaryType::Address(_)),
+            TypeKind::Elementary(ElementaryType::Address(_)),
+        ) => true,
+        (TypeKind::Elementary(a), TypeKind::Elementary(b)) => a == b,
+        (TypeKind::Array(a), TypeKind::Array(b)) => {
+            a.size.is_some() == b.size.is_some() && types_match(hir, &a.element, &b.element)
+        }
+        (TypeKind::Custom(a), TypeKind::Custom(b)) => a == b,
+        (TypeKind::Function(a), TypeKind::Function(b)) => {
+            a.parameters.len() == b.parameters.len()
+                && a.returns.len() == b.returns.len()
+                && a.parameters
+                    .iter()
+                    .zip(b.parameters)
+                    .all(|(&a, &b)| types_match(hir, &hir.variable(a).ty, &hir.variable(b).ty))
+                && a.returns
+                    .iter()
+                    .zip(b.returns)
+                    .all(|(&a, &b)| types_match(hir, &hir.variable(a).ty, &hir.variable(b).ty))
+        }
+        _ => false,
+    }
 }
 
 fn is_dynamic_type(hir: &hir::Hir<'_>, ty: &hir::Type<'_>) -> bool {

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -63,23 +63,32 @@ fn matching_functions_for_callee<'hir>(
     callee: &hir::Expr<'hir>,
     args: &CallArgs<'hir>,
 ) -> Option<FunctionCandidates<'hir>> {
-    match &callee.peel_parens().kind {
+    let functions = match &callee.peel_parens().kind {
         ExprKind::Ident(reses) => {
             let candidates = reses.iter().filter_map(res_function_id);
-            let functions = select_functions_for_args(hir, candidates, args);
-            (!functions.is_empty()).then_some(functions).or_else(|| {
-                expr_type(hir, callee)
-                    .and_then(|ty| function_type_returns_for_args(hir, ty, args))
-                    .map(FunctionCandidates::Pointer)
-            })
-        }
-        ExprKind::Member(base, member) => {
-            let contract = expr_contract_id(hir, base)?;
-            let candidates = function_candidates_for_member(hir, contract, member.name);
             Some(select_functions_for_args(hir, candidates, args))
         }
+        ExprKind::Member(base, member) => expr_contract_id(hir, base).map(|contract| {
+            let candidates = function_candidates_for_member(hir, contract, member.name);
+            select_functions_for_args(hir, candidates, args)
+        }),
         _ => None,
-    }
+    };
+
+    functions
+        .filter(|functions| !functions.is_empty())
+        .or_else(|| function_pointer_candidates_for_callee(hir, callee, args))
+}
+
+/// Returns an external function pointer callee if its arguments can match.
+fn function_pointer_candidates_for_callee<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    callee: &hir::Expr<'hir>,
+    args: &CallArgs<'_>,
+) -> Option<FunctionCandidates<'hir>> {
+    expr_type(hir, callee)
+        .and_then(|ty| function_type_returns_for_args(hir, ty, args))
+        .map(FunctionCandidates::Pointer)
 }
 
 /// Returns function candidates with the given member name on a contract.
@@ -91,8 +100,13 @@ fn function_candidates_for_member<'hir>(
     hir.contract_item_ids(contract).filter_map(move |item| {
         let ItemId::Function(id) = item else { return None };
         let function = hir.function(id);
-        (function.name?.name == member).then_some(id)
+        (function.name?.name == member && is_externally_callable(function)).then_some(id)
     })
+}
+
+/// Returns true if a function can be called through `this.foo()` or `contract.foo()`.
+fn is_externally_callable(function: &hir::Function<'_>) -> bool {
+    matches!(function.visibility, hir::Visibility::Public | hir::Visibility::External)
 }
 
 /// Selects the candidate functions that best match the call arguments.
@@ -231,6 +245,7 @@ fn params_match_args<'hir>(
 fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::ContractId> {
     match &expr.peel_parens().kind {
         ExprKind::Ident(reses) if is_this(reses) => enclosing_contract(hir, expr),
+        ExprKind::New(hir::Type { kind: TypeKind::Custom(ItemId::Contract(id)), .. }) => Some(*id),
         ExprKind::Call(callee, _, _) => {
             expr_type(hir, expr).and_then(type_contract_id).or_else(|| {
                 match &callee.peel_parens().kind {
@@ -239,6 +254,10 @@ fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::Con
                         _ => None,
                     }),
                     ExprKind::Type(hir::Type {
+                        kind: TypeKind::Custom(ItemId::Contract(id)),
+                        ..
+                    }) => Some(*id),
+                    ExprKind::New(hir::Type {
                         kind: TypeKind::Custom(ItemId::Contract(id)),
                         ..
                     }) => Some(*id),
@@ -332,7 +351,7 @@ fn expr_type<'hir>(
             })
         }
         ExprKind::Call(callee, args, _) => match &callee.peel_parens().kind {
-            ExprKind::Type(ty) => Some(ty),
+            ExprKind::Type(ty) | ExprKind::New(ty) => Some(ty),
             _ => call_return_type(hir, callee, args),
         },
         _ => None,
@@ -425,7 +444,7 @@ fn types_match(hir: &hir::Hir<'_>, a: &hir::Type<'_>, b: &hir::Type<'_>) -> bool
         ) => true,
         (TypeKind::Elementary(a), TypeKind::Elementary(b)) => elementary_type_matches(*a, *b),
         (TypeKind::Array(a), TypeKind::Array(b)) => {
-            a.size.is_some() == b.size.is_some() && types_match(hir, &a.element, &b.element)
+            array_sizes_match(a.size, b.size) && types_match(hir, &a.element, &b.element)
         }
         (TypeKind::Custom(a), TypeKind::Custom(b)) => a == b,
         (TypeKind::Function(a), TypeKind::Function(b)) => {
@@ -440,6 +459,25 @@ fn types_match(hir: &hir::Hir<'_>, a: &hir::Type<'_>, b: &hir::Type<'_>) -> bool
                     .zip(b.returns)
                     .all(|(&a, &b)| types_match(hir, &hir.variable(a).ty, &hir.variable(b).ty))
         }
+        _ => false,
+    }
+}
+
+/// Returns true if two array sizes are equivalent for overload resolution.
+fn array_sizes_match(a: Option<&hir::Expr<'_>>, b: Option<&hir::Expr<'_>>) -> bool {
+    match (a, b) {
+        (None, None) => true,
+        (Some(a), Some(b)) => fixed_array_sizes_match(a, b),
+        _ => false,
+    }
+}
+
+fn fixed_array_sizes_match(a: &hir::Expr<'_>, b: &hir::Expr<'_>) -> bool {
+    match (&a.peel_parens().kind, &b.peel_parens().kind) {
+        (ExprKind::Lit(a), ExprKind::Lit(b)) => match (&a.kind, &b.kind) {
+            (LitKind::Number(a), LitKind::Number(b)) => a == b,
+            _ => false,
+        },
         _ => false,
     }
 }

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -1,0 +1,68 @@
+use super::ReturnBomb;
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{Severity, SolLint, calls::is_low_level_call_with_gas_limit},
+};
+use solar::{
+    ast::ElementaryType,
+    sema::hir::{self, ExprKind, StmtKind, TypeKind},
+};
+
+declare_forge_lint!(
+    RETURN_BOMB,
+    Severity::Low,
+    "return-bomb",
+    "external calls with a gas limit should not consume unbounded return data"
+);
+
+impl<'hir> LateLintPass<'hir> for ReturnBomb {
+    fn check_stmt(
+        &mut self,
+        ctx: &LintContext,
+        hir: &'hir hir::Hir<'hir>,
+        stmt: &'hir hir::Stmt<'hir>,
+    ) {
+        let span = match stmt.kind {
+            StmtKind::DeclMulti(vars, expr) => (is_low_level_call_with_gas_limit(expr)
+                && captures_return_data(hir, vars))
+            .then_some(stmt.span),
+            StmtKind::Expr(expr) => match expr.kind {
+                ExprKind::Assign(lhs, _, rhs)
+                    if is_low_level_call_with_gas_limit(rhs)
+                        && assigns_return_data_receiver(hir, lhs) =>
+                {
+                    Some(expr.span)
+                }
+                _ => None,
+            },
+            _ => None,
+        };
+
+        if let Some(span) = span {
+            ctx.emit(&RETURN_BOMB, span);
+        }
+    }
+}
+
+fn captures_return_data(hir: &hir::Hir<'_>, vars: &[Option<hir::VariableId>]) -> bool {
+    vars.get(1)
+        .and_then(|var| *var)
+        .is_some_and(|var| is_dynamic_bytes_type(&hir.variable(var).ty.kind))
+}
+
+fn assigns_return_data_receiver(hir: &hir::Hir<'_>, lhs: &hir::Expr<'_>) -> bool {
+    let ExprKind::Tuple(elements) = &lhs.peel_parens().kind else { return false };
+    elements.get(1).and_then(|element| *element).is_some_and(|expr| is_bytes_variable(hir, expr))
+}
+
+fn is_bytes_variable(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    let ExprKind::Ident(reses) = &expr.peel_parens().kind else { return false };
+    reses
+        .iter()
+        .filter_map(hir::Res::as_variable)
+        .any(|var| is_dynamic_bytes_type(&hir.variable(var).ty.kind))
+}
+
+const fn is_dynamic_bytes_type(ty: &TypeKind<'_>) -> bool {
+    matches!(ty, TypeKind::Elementary(ElementaryType::Bytes))
+}

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -176,10 +176,6 @@ fn params_match_args<'hir>(
 
 fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::ContractId> {
     match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => reses
-            .iter()
-            .find_map(hir::Res::as_variable)
-            .and_then(|var| type_contract_id(&hir.variable(var).ty)),
         ExprKind::Call(callee, _, _) => match &callee.peel_parens().kind {
             ExprKind::Ident(reses) => reses.iter().find_map(|res| match res {
                 hir::Res::Item(ItemId::Contract(id)) => Some(*id),
@@ -190,7 +186,7 @@ fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::Con
             }
             _ => None,
         },
-        _ => None,
+        _ => expr_type(hir, expr).and_then(type_contract_id),
     }
 }
 
@@ -233,10 +229,11 @@ fn expr_type<'hir>(
             let var = reses.iter().filter_map(hir::Res::as_variable).next()?;
             Some(&hir.variable(var).ty)
         }
-        ExprKind::Index(base, _) => {
-            let TypeKind::Array(array) = &expr_type(hir, base)?.kind else { return None };
-            Some(&array.element)
-        }
+        ExprKind::Index(base, _) => match &expr_type(hir, base)?.kind {
+            TypeKind::Array(array) => Some(&array.element),
+            TypeKind::Mapping(mapping) => Some(&mapping.value),
+            _ => None,
+        },
         ExprKind::Member(base, member) => {
             let TypeKind::Custom(ItemId::Struct(id)) = expr_type(hir, base)?.kind else {
                 return None;

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use solar::{
     ast::{ElementaryType, LitKind, StrKind},
-    interface::{Symbol, kw},
+    interface::{Symbol, kw, sym},
     sema::hir::{self, CallArgs, CallArgsKind, ExprKind, ItemId, TypeKind},
 };
 
@@ -182,6 +182,7 @@ fn params_match_args<'hir>(
 /// Returns the contract id for expressions known to be contract-typed.
 fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::ContractId> {
     match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) if is_this(reses) => enclosing_contract(hir, expr),
         ExprKind::Call(callee, _, _) => match &callee.peel_parens().kind {
             ExprKind::Ident(reses) => reses.iter().find_map(|res| match res {
                 hir::Res::Item(ItemId::Contract(id)) => Some(*id),
@@ -195,6 +196,20 @@ fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::Con
         _ => expr_type(hir, expr).and_then(type_contract_id),
     }
 }
+
+/// Returns the contract containing an expression span.
+fn enclosing_contract(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::ContractId> {
+    hir.function_ids().find_map(|id| {
+        let function = hir.function(id);
+        (function.body.is_some() && function.body_span.contains(expr.span))
+            .then_some(function.contract?)
+    })
+}
+
+fn is_this(reses: &[hir::Res]) -> bool {
+    reses.iter().any(|res| matches!(res, hir::Res::Builtin(builtin) if builtin.name() == sym::this))
+}
+
 /// Returns the contract id for contract-typed values.
 const fn type_contract_id(ty: &hir::Type<'_>) -> Option<hir::ContractId> {
     let TypeKind::Custom(ItemId::Contract(id)) = ty.kind else { return None };
@@ -212,9 +227,22 @@ fn expr_is_address(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
                 ..
             })
         ),
+        ExprKind::Member(base, member) if member_is_builtin_address(base, member.name) => true,
         _ => expr_type(hir, expr).is_some_and(is_address_type),
     }
 }
+
+fn member_is_builtin_address(base: &hir::Expr<'_>, member: Symbol) -> bool {
+    let ExprKind::Ident(reses) = &base.peel_parens().kind else { return false };
+    reses.iter().any(|res| {
+        let hir::Res::Builtin(builtin) = res else { return false };
+        matches!(
+            (builtin.name(), member),
+            (sym::msg, sym::sender) | (sym::block, kw::Coinbase) | (sym::tx, kw::Origin)
+        )
+    })
+}
+
 /// Returns whether an expression can match the expected type, if known.
 fn expr_matches_type(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>, ty: &hir::Type<'_>) -> Option<bool> {
     match &expr.peel_parens().kind {

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -27,45 +27,22 @@ impl<'hir> LateLintPass<'hir> for ReturnBomb {
         stmt: &'hir hir::Stmt<'hir>,
     ) {
         let span = match stmt.kind {
-            StmtKind::DeclSingle(var) => {
-                let var = hir.variable(var);
-                var.initializer
-                    .filter(|expr| {
-                        call_with_gas_returns_dynamic_data(hir, expr)
-                            && is_dynamic_type(hir, &var.ty)
-                    })
-                    .map(|_| stmt.span)
-            }
-            StmtKind::DeclMulti(vars, expr) => {
-                if is_low_level_call_with_gas_limit(expr) && captures_return_data(hir, vars) {
-                    Some(stmt.span)
-                } else if call_with_gas_returns_dynamic_data(hir, expr)
-                    && captures_dynamic_return_data(hir, vars)
-                {
+            StmtKind::DeclSingle(var) => hir
+                .variable(var)
+                .initializer
+                .filter(|expr| expr_consumes_unbounded_return_data(hir, expr))
+                .map(|_| stmt.span),
+            StmtKind::DeclMulti(_, expr) => {
+                if expr_consumes_unbounded_return_data(hir, expr) {
                     Some(stmt.span)
                 } else {
                     None
                 }
             }
-            StmtKind::Expr(expr) => match expr.kind {
-                ExprKind::Assign(lhs, _, rhs)
-                    if is_low_level_call_with_gas_limit(rhs)
-                        && assigns_return_data_receiver(hir, lhs) =>
-                {
-                    Some(expr.span)
-                }
-                ExprKind::Assign(lhs, _, rhs)
-                    if call_with_gas_returns_dynamic_data(hir, rhs)
-                        && assignment_captures_dynamic_return_data(hir, lhs) =>
-                {
-                    Some(expr.span)
-                }
-                _ => None,
-            },
-            StmtKind::Return(Some(expr)) if is_low_level_call_with_gas_limit(expr) => {
-                Some(stmt.span)
+            StmtKind::Expr(expr) if expr_consumes_unbounded_return_data(hir, expr) => {
+                Some(expr.span)
             }
-            StmtKind::Return(Some(expr)) if call_with_gas_returns_dynamic_data(hir, expr) => {
+            StmtKind::Return(Some(expr)) if expr_consumes_unbounded_return_data(hir, expr) => {
                 Some(stmt.span)
             }
             _ => None,
@@ -77,90 +54,56 @@ impl<'hir> LateLintPass<'hir> for ReturnBomb {
     }
 }
 
-fn captures_return_data(hir: &hir::Hir<'_>, vars: &[Option<hir::VariableId>]) -> bool {
-    vars.get(1)
-        .and_then(|var| *var)
-        .is_some_and(|var| is_dynamic_bytes_type(&hir.variable(var).ty.kind))
-}
-
-fn assigns_return_data_receiver(hir: &hir::Hir<'_>, lhs: &hir::Expr<'_>) -> bool {
-    let ExprKind::Tuple(elements) = &lhs.peel_parens().kind else { return false };
-    elements.get(1).and_then(|element| *element).is_some_and(|expr| is_bytes_lvalue(hir, expr))
-}
-
-fn is_bytes_lvalue(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+fn expr_consumes_unbounded_return_data(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
     let expr = expr.peel_parens();
+
+    if is_low_level_call_with_gas_limit(expr) || call_with_gas_returns_dynamic_data(hir, expr) {
+        return true;
+    }
+
     match &expr.kind {
-        ExprKind::Ident(reses) => reses
-            .iter()
-            .filter_map(hir::Res::as_variable)
-            .any(|var| is_dynamic_bytes_type(&hir.variable(var).ty.kind)),
-        ExprKind::Member(base, member) => {
-            field_type(hir, base, member.name).is_some_and(|ty| is_dynamic_bytes_type(&ty.kind))
+        ExprKind::Array(exprs) => {
+            exprs.iter().any(|expr| expr_consumes_unbounded_return_data(hir, expr))
         }
-        ExprKind::Index(base, _) => {
-            indexed_value_type(hir, base).is_some_and(|ty| is_dynamic_bytes_type(&ty.kind))
+        ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {
+            expr_consumes_unbounded_return_data(hir, lhs)
+                || expr_consumes_unbounded_return_data(hir, rhs)
         }
-        _ => false,
+        ExprKind::Call(callee, args, opts) => {
+            expr_consumes_unbounded_return_data(hir, callee)
+                || args.exprs().any(|expr| expr_consumes_unbounded_return_data(hir, expr))
+                || opts.is_some_and(|opts| {
+                    opts.iter().any(|opt| expr_consumes_unbounded_return_data(hir, &opt.value))
+                })
+        }
+        ExprKind::Delete(inner) | ExprKind::Payable(inner) | ExprKind::Unary(_, inner) => {
+            expr_consumes_unbounded_return_data(hir, inner)
+        }
+        ExprKind::Index(base, index) => {
+            expr_consumes_unbounded_return_data(hir, base)
+                || index.is_some_and(|index| expr_consumes_unbounded_return_data(hir, index))
+        }
+        ExprKind::Slice(base, start, end) => {
+            expr_consumes_unbounded_return_data(hir, base)
+                || start.is_some_and(|start| expr_consumes_unbounded_return_data(hir, start))
+                || end.is_some_and(|end| expr_consumes_unbounded_return_data(hir, end))
+        }
+        ExprKind::Member(base, _) => expr_consumes_unbounded_return_data(hir, base),
+        ExprKind::Ternary(cond, then_expr, else_expr) => {
+            expr_consumes_unbounded_return_data(hir, cond)
+                || expr_consumes_unbounded_return_data(hir, then_expr)
+                || expr_consumes_unbounded_return_data(hir, else_expr)
+        }
+        ExprKind::Tuple(exprs) => {
+            exprs.iter().flatten().any(|expr| expr_consumes_unbounded_return_data(hir, expr))
+        }
+        ExprKind::Ident(_)
+        | ExprKind::Lit(_)
+        | ExprKind::New(_)
+        | ExprKind::TypeCall(_)
+        | ExprKind::Type(_)
+        | ExprKind::Err(_) => false,
     }
-}
-
-const fn is_dynamic_bytes_type(ty: &TypeKind<'_>) -> bool {
-    matches!(ty, TypeKind::Elementary(ElementaryType::Bytes))
-}
-
-fn field_type<'hir>(
-    hir: &'hir hir::Hir<'hir>,
-    base: &hir::Expr<'hir>,
-    member: Symbol,
-) -> Option<&'hir hir::Type<'hir>> {
-    let base = base.peel_parens();
-    let ExprKind::Ident(reses) = &base.kind else { return None };
-    let var = reses.iter().filter_map(hir::Res::as_variable).next()?;
-    let TypeKind::Custom(ItemId::Struct(struct_id)) = hir.variable(var).ty.kind else {
-        return None;
-    };
-    hir.strukt(struct_id).fields.iter().find_map(|&field| {
-        let field_var = hir.variable(field);
-        (field_var.name?.name == member).then_some(&field_var.ty)
-    })
-}
-
-fn indexed_value_type<'hir>(
-    hir: &'hir hir::Hir<'hir>,
-    base: &hir::Expr<'hir>,
-) -> Option<&'hir hir::Type<'hir>> {
-    match &base.peel_parens().kind {
-        ExprKind::Ident(reses) => {
-            let var = reses.iter().filter_map(hir::Res::as_variable).next()?;
-            array_element_type(&hir.variable(var).ty)
-        }
-        ExprKind::Member(inner, member) => {
-            let field = field_type(hir, inner, member.name)?;
-            array_element_type(field)
-        }
-        ExprKind::Index(inner, _) => {
-            let element = indexed_value_type(hir, inner)?;
-            array_element_type(element)
-        }
-        _ => None,
-    }
-}
-
-fn array_element_type<'hir>(ty: &'hir hir::Type<'hir>) -> Option<&'hir hir::Type<'hir>> {
-    let TypeKind::Array(array) = &ty.kind else { return None };
-    Some(&array.element)
-}
-
-fn captures_dynamic_return_data(hir: &hir::Hir<'_>, vars: &[Option<hir::VariableId>]) -> bool {
-    vars.iter().flatten().any(|&var| is_dynamic_type(hir, &hir.variable(var).ty))
-}
-
-fn assignment_captures_dynamic_return_data(hir: &hir::Hir<'_>, lhs: &hir::Expr<'_>) -> bool {
-    let ExprKind::Tuple(elements) = &lhs.peel_parens().kind else {
-        return expr_has_dynamic_type(hir, lhs);
-    };
-    elements.iter().flatten().any(|expr| expr_has_dynamic_type(hir, expr))
 }
 
 fn call_with_gas_returns_dynamic_data(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
@@ -204,25 +147,6 @@ fn function_returns_for_member<'hir>(
         let function = hir.function(id);
         (function.name?.name == member).then_some(function.returns)
     })
-}
-
-fn expr_has_dynamic_type(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
-    expr_type(hir, expr).is_some_and(|ty| is_dynamic_type(hir, ty))
-}
-
-fn expr_type<'hir>(
-    hir: &'hir hir::Hir<'hir>,
-    expr: &hir::Expr<'hir>,
-) -> Option<&'hir hir::Type<'hir>> {
-    match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => {
-            let var = reses.iter().filter_map(hir::Res::as_variable).next()?;
-            Some(&hir.variable(var).ty)
-        }
-        ExprKind::Member(base, member) => field_type(hir, base, member.name),
-        ExprKind::Index(base, _) => indexed_value_type(hir, base),
-        _ => None,
-    }
 }
 
 fn expr_contract_id(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::ContractId> {

--- a/crates/lint/testdata/ReturnBomb.sol
+++ b/crates/lint/testdata/ReturnBomb.sol
@@ -87,6 +87,18 @@ contract ReturnBomb {
         require(result.length >= 0);
     }
 
+    function msgSenderCall(bytes memory payload, uint256 gasLimit) public {
+        msg.sender.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
+    function blockCoinbaseCall(bytes memory payload, uint256 gasLimit) public {
+        block.coinbase.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
+    function txOriginCall(bytes memory payload, uint256 gasLimit) public {
+        tx.origin.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
     function existingBytes(address target, bytes memory payload, uint256 gasLimit) public {
         (bool success, bytes memory result) = target.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
         (success, existingData) = target.call{gas: gasLimit}(result); //~WARN: external calls with a gas limit should not consume unbounded return data
@@ -140,6 +152,14 @@ contract ReturnBomb {
     function memberHighLevelDynamicReturn(TargetSlot memory slot, uint256 gasLimit) public {
         bytes memory result = slot.target.fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
         require(result.length >= 0);
+    }
+
+    function ownDynamicReturn() external returns (bytes memory) {
+        return "";
+    }
+
+    function thisHighLevelDynamicReturn(uint256 gasLimit) public {
+        this.ownDynamicReturn{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
     }
 
     function highLevelStaticReturn(IReturnBombTarget target, uint256 gasLimit) public {

--- a/crates/lint/testdata/ReturnBomb.sol
+++ b/crates/lint/testdata/ReturnBomb.sol
@@ -22,6 +22,11 @@ interface IReturnBombOverloadedReverseTarget {
     function fetch(uint256 value) external returns (uint256);
 }
 
+interface IReturnBombAmbiguousOverloadedTarget {
+    function fetch(uint256 value) external returns (bytes memory);
+    function fetch(bool value) external returns (uint256);
+}
+
 contract ReturnBomb {
     event DynamicReturn(bytes result);
 
@@ -39,6 +44,7 @@ contract ReturnBomb {
     bytes[] results;
     Result storedResult;
     mapping(uint256 => IReturnBombTarget) mappedTargets;
+    IReturnBombTarget storedTarget;
 
     // SHOULD PASS: Calls without a gas cap.
     function valueOnlyOption(address payable target, bytes memory payload, uint256 value) public {
@@ -99,6 +105,14 @@ contract ReturnBomb {
         tx.origin.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
     }
 
+    function getAddress() public view returns (address) {
+        return address(this);
+    }
+
+    function returnedAddressLowLevelCall(bytes memory payload, uint256 gasLimit) public {
+        getAddress().call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
     function existingBytes(address target, bytes memory payload, uint256 gasLimit) public {
         (bool success, bytes memory result) = target.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
         (success, existingData) = target.call{gas: gasLimit}(result); //~WARN: external calls with a gas limit should not consume unbounded return data
@@ -151,6 +165,15 @@ contract ReturnBomb {
 
     function memberHighLevelDynamicReturn(TargetSlot memory slot, uint256 gasLimit) public {
         bytes memory result = slot.target.fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function getTarget() public view returns (IReturnBombTarget) {
+        return storedTarget;
+    }
+
+    function returnedTargetHighLevelDynamicReturn(uint256 gasLimit) public {
+        bytes memory result = getTarget().fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
         require(result.length >= 0);
     }
 
@@ -207,6 +230,15 @@ contract ReturnBomb {
         require(result >= 0);
     }
 
+    function overloadedUnknownArgumentDynamicReturn(
+        IReturnBombAmbiguousOverloadedTarget target,
+        uint256 value,
+        uint256 gasLimit
+    ) public {
+        bytes memory result = target.fetch{gas: gasLimit}(value + 1); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
     function castDynamicReturn(address target, uint256 gasLimit) public {
         bytes memory result = IReturnBombTarget(target).fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
         require(result.length >= 0);
@@ -218,6 +250,14 @@ contract ReturnBomb {
         uint256 gasLimit
     ) public {
         bytes memory result = IReturnBombOverloadedTarget(target).fetch{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function externalFunctionPointerDynamicReturn(
+        function() external returns (bytes memory) fetcher,
+        uint256 gasLimit
+    ) public {
+        bytes memory result = fetcher{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
         require(result.length >= 0);
     }
 }

--- a/crates/lint/testdata/ReturnBomb.sol
+++ b/crates/lint/testdata/ReturnBomb.sol
@@ -31,9 +31,14 @@ contract ReturnBomb {
         bytes data;
     }
 
+    struct TargetSlot {
+        IReturnBombTarget target;
+    }
+
     bytes existingData;
     bytes[] results;
     Result storedResult;
+    mapping(uint256 => IReturnBombTarget) mappedTargets;
 
     // SHOULD PASS: Calls without a gas cap.
     function valueOnlyOption(address payable target, bytes memory payload, uint256 value) public {
@@ -120,6 +125,21 @@ contract ReturnBomb {
 
     function directHighLevelDynamicReturn(IReturnBombTarget target, uint256 gasLimit) public returns (bytes memory) {
         return target.fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
+    function indexedHighLevelDynamicReturn(IReturnBombTarget[] memory targets, uint256 index, uint256 gasLimit) public {
+        bytes memory result = targets[index].fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function mappedHighLevelDynamicReturn(uint256 index, uint256 gasLimit) public {
+        bytes memory result = mappedTargets[index].fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function memberHighLevelDynamicReturn(TargetSlot memory slot, uint256 gasLimit) public {
+        bytes memory result = slot.target.fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
     }
 
     function highLevelStaticReturn(IReturnBombTarget target, uint256 gasLimit) public {

--- a/crates/lint/testdata/ReturnBomb.sol
+++ b/crates/lint/testdata/ReturnBomb.sol
@@ -149,6 +149,17 @@ contract ReturnBomb {
         getAddress().call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
     }
 
+    function ecrecoverLowLevelCall(
+        bytes32 h,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes memory payload,
+        uint256 gasLimit
+    ) public {
+        ecrecover(h, v, r, s).call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
     function existingBytes(address target, bytes memory payload, uint256 gasLimit) public {
         (bool success, bytes memory result) = target.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
         (success, existingData) = target.call{gas: gasLimit}(result); //~WARN: external calls with a gas limit should not consume unbounded return data
@@ -389,6 +400,14 @@ contract ReturnBomb {
 
     function returnedExternalFunctionPointerDynamicReturn(uint256 gasLimit) public {
         bytes memory result = getFetcher(){gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function externalFunctionPointerReturnedTargetDynamicReturn(
+        function() external returns (IReturnBombTarget) targetGetter,
+        uint256 gasLimit
+    ) public {
+        bytes memory result = targetGetter().fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
         require(result.length >= 0);
     }
 

--- a/crates/lint/testdata/ReturnBomb.sol
+++ b/crates/lint/testdata/ReturnBomb.sol
@@ -27,6 +27,10 @@ interface IReturnBombAmbiguousOverloadedTarget {
     function fetch(bool value) external returns (uint256);
 }
 
+interface IReturnBombWideningTarget {
+    function fetch(uint256 value) external returns (bytes memory);
+}
+
 contract ReturnBomb {
     event DynamicReturn(bytes result);
 
@@ -236,6 +240,15 @@ contract ReturnBomb {
         uint256 gasLimit
     ) public {
         bytes memory result = target.fetch{gas: gasLimit}(value + 1); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function integerWideningDynamicReturn(
+        IReturnBombWideningTarget target,
+        uint8 value,
+        uint256 gasLimit
+    ) public {
+        bytes memory result = target.fetch{gas: gasLimit}(value); //~WARN: external calls with a gas limit should not consume unbounded return data
         require(result.length >= 0);
     }
 

--- a/crates/lint/testdata/ReturnBomb.sol
+++ b/crates/lint/testdata/ReturnBomb.sol
@@ -31,9 +31,24 @@ interface IReturnBombWideningTarget {
     function fetch(uint256 value) external returns (bytes memory);
 }
 
+contract ReturnBombBaseArgument {}
+
+contract ReturnBombDerivedArgument is ReturnBombBaseArgument {}
+
+interface IReturnBombBaseArgumentTarget {
+    function fetch(ReturnBombBaseArgument value) external returns (bytes memory);
+}
+
 interface IReturnBombFixedArrayOverloadedTarget {
     function fetch(uint256[2] calldata values) external returns (bytes memory);
     function fetch(uint256[3] calldata values) external returns (uint256);
+}
+
+uint256 constant RETURN_BOMB_FIXED_ARRAY_BASE = 1;
+uint256 constant RETURN_BOMB_FIXED_ARRAY_LENGTH = RETURN_BOMB_FIXED_ARRAY_BASE + 1;
+
+interface IReturnBombConstantFixedArrayTarget {
+    function fetch(uint256[RETURN_BOMB_FIXED_ARRAY_LENGTH] calldata values) external returns (bytes memory);
 }
 
 contract ReturnBombCreatedTarget {
@@ -46,6 +61,8 @@ contract ReturnBomb {
     event DynamicReturn(bytes result);
 
     error DynamicReturnError(bytes result);
+
+    bytes initializedData = this.ownDynamicReturn{gas: 10_000}(); //~WARN: external calls with a gas limit should not consume unbounded return data
 
     struct Result {
         bytes data;
@@ -212,6 +229,15 @@ contract ReturnBomb {
         this.ownDynamicReturn{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
     }
 
+    modifier withDynamicReturn(bytes memory) {
+        _;
+    }
+
+    function thisHighLevelDynamicReturnInModifierArgument(uint256 gasLimit)
+        public
+        withDynamicReturn(this.ownDynamicReturn{gas: gasLimit}()) //~WARN: external calls with a gas limit should not consume unbounded return data
+    {}
+
     function thisExternalStaticOverloadIgnoresInternal(uint256 value, uint256 gasLimit) public {
         uint256 result = this.externalStaticOverload{gas: gasLimit}(value + 1);
         require(result >= 0);
@@ -280,6 +306,15 @@ contract ReturnBomb {
         require(result.length >= 0);
     }
 
+    function derivedContractArgumentDynamicReturn(
+        IReturnBombBaseArgumentTarget target,
+        ReturnBombDerivedArgument value,
+        uint256 gasLimit
+    ) public {
+        bytes memory result = target.fetch{gas: gasLimit}(value); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
     function fixedArrayOverloadDynamicReturn(
         IReturnBombFixedArrayOverloadedTarget target,
         uint256[2] calldata values,
@@ -287,6 +322,35 @@ contract ReturnBomb {
     ) public {
         bytes memory result = target.fetch{gas: gasLimit}(values); //~WARN: external calls with a gas limit should not consume unbounded return data
         require(result.length >= 0);
+    }
+
+    function constantFixedArrayLengthDynamicReturn(
+        IReturnBombConstantFixedArrayTarget target,
+        uint256[RETURN_BOMB_FIXED_ARRAY_BASE + 1] calldata values,
+        uint256 gasLimit
+    ) public {
+        bytes memory result = target.fetch{gas: gasLimit}(values); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function ternaryHighLevelDynamicReturn(
+        IReturnBombTarget first,
+        IReturnBombTarget second,
+        bool useFirst,
+        uint256 gasLimit
+    ) public {
+        bytes memory result = (useFirst ? first : second).fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function ternaryLowLevelCall(
+        address first,
+        address second,
+        bool useFirst,
+        bytes memory payload,
+        uint256 gasLimit
+    ) public {
+        (useFirst ? first : second).call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
     }
 
     function castDynamicReturn(address target, uint256 gasLimit) public {

--- a/crates/lint/testdata/ReturnBomb.sol
+++ b/crates/lint/testdata/ReturnBomb.sol
@@ -31,6 +31,16 @@ interface IReturnBombWideningTarget {
     function fetch(uint256 value) external returns (bytes memory);
 }
 
+interface IReturnBombLiteralRangeTarget {
+    function fetch(uint8 value) external returns (uint256);
+    function fetch(uint256 value) external returns (bytes memory);
+}
+
+interface IReturnBombNegativeLiteralTarget {
+    function fetch(int8 value) external returns (uint256);
+    function fetch(uint256 value) external returns (bytes memory);
+}
+
 contract ReturnBombBaseArgument {}
 
 contract ReturnBombDerivedArgument is ReturnBombBaseArgument {}
@@ -315,6 +325,22 @@ contract ReturnBomb {
     ) public {
         bytes memory result = target.fetch{gas: gasLimit}(value); //~WARN: external calls with a gas limit should not consume unbounded return data
         require(result.length >= 0);
+    }
+
+    function overloadedLiteralRangeDynamicReturn(
+        IReturnBombLiteralRangeTarget target,
+        uint256 gasLimit
+    ) public {
+        bytes memory result = target.fetch{gas: gasLimit}(300); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function overloadedNegativeLiteralStaticReturn(
+        IReturnBombNegativeLiteralTarget target,
+        uint256 gasLimit
+    ) public {
+        uint256 result = target.fetch{gas: gasLimit}(-1);
+        require(result >= 0);
     }
 
     function derivedContractArgumentDynamicReturn(

--- a/crates/lint/testdata/ReturnBomb.sol
+++ b/crates/lint/testdata/ReturnBomb.sol
@@ -3,8 +3,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
+interface IReturnBombTarget {
+    function fetch() external returns (bytes memory);
+    function value() external returns (uint256);
+}
+
 contract ReturnBomb {
+    struct Result {
+        bytes data;
+    }
+
     bytes existingData;
+    bytes[] results;
+    Result storedResult;
 
     // SHOULD PASS: Gas-capped calls that do not bind returndata.
     function ignoresReturnData(address target, bytes memory payload, uint256 gasLimit) public {
@@ -53,5 +64,36 @@ contract ReturnBomb {
         (bool success, bytes memory result) = target.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
         (success, existingData) = target.call{gas: gasLimit}(result); //~WARN: external calls with a gas limit should not consume unbounded return data
         require(success, "Call failed");
+    }
+
+    function directReturn(address target, bytes memory payload, uint256 gasLimit) public returns (bool, bytes memory) {
+        return target.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
+    function memberBytes(address target, bytes memory payload, uint256 gasLimit) public {
+        bool success;
+        (success, storedResult.data) = target.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(success, "Call failed");
+    }
+
+    function indexedBytes(address target, bytes memory payload, uint256 gasLimit) public {
+        bool success;
+        results.push();
+        (success, results[0]) = target.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(success, "Call failed");
+    }
+
+    function highLevelDynamicReturn(IReturnBombTarget target, uint256 gasLimit) public {
+        bytes memory result = target.fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function directHighLevelDynamicReturn(IReturnBombTarget target, uint256 gasLimit) public returns (bytes memory) {
+        return target.fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
+    function highLevelStaticReturn(IReturnBombTarget target, uint256 gasLimit) public {
+        uint256 result = target.value{gas: gasLimit}();
+        require(result >= 0);
     }
 }

--- a/crates/lint/testdata/ReturnBomb.sol
+++ b/crates/lint/testdata/ReturnBomb.sol
@@ -17,19 +17,23 @@ contract ReturnBomb {
     bytes[] results;
     Result storedResult;
 
-    // SHOULD PASS: Gas-capped calls that do not bind returndata.
-    function ignoresReturnData(address target, bytes memory payload, uint256 gasLimit) public {
-        (bool success, ) = target.call{gas: gasLimit}(payload);
-        require(success, "Call failed");
-    }
-
+    // SHOULD PASS: Calls without a gas cap.
     function valueOnlyOption(address payable target, bytes memory payload, uint256 value) public {
         (bool success, bytes memory result) = target.call{value: value}(payload);
         require(success, "Call failed");
         require(result.length >= 0);
     }
 
-    // SHOULD FAIL: Gas-capped calls that bind unbounded returndata.
+    // SHOULD FAIL: Gas-capped low-level calls that copy unbounded returndata.
+    function ignoresReturnData(address target, bytes memory payload, uint256 gasLimit) public {
+        (bool success, ) = target.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(success, "Call failed");
+    }
+
+    function standaloneLowLevelCall(address target, bytes memory payload, uint256 gasLimit) public {
+        target.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
     function lowLevelCall(address target, bytes memory payload, uint256 gasLimit) public {
         (bool success, bytes memory result) = target.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
         require(success, "Call failed");
@@ -86,6 +90,14 @@ contract ReturnBomb {
     function highLevelDynamicReturn(IReturnBombTarget target, uint256 gasLimit) public {
         bytes memory result = target.fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
         require(result.length >= 0);
+    }
+
+    function standaloneHighLevelDynamicReturn(IReturnBombTarget target, uint256 gasLimit) public {
+        target.fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
+    function nestedHighLevelDynamicReturn(IReturnBombTarget target, uint256 gasLimit) public {
+        require(target.fetch{gas: gasLimit}().length >= 0); //~WARN: external calls with a gas limit should not consume unbounded return data
     }
 
     function directHighLevelDynamicReturn(IReturnBombTarget target, uint256 gasLimit) public returns (bytes memory) {

--- a/crates/lint/testdata/ReturnBomb.sol
+++ b/crates/lint/testdata/ReturnBomb.sol
@@ -8,7 +8,25 @@ interface IReturnBombTarget {
     function value() external returns (uint256);
 }
 
+interface IReturnBombFalsePositiveTarget {
+    function call(bytes calldata payload) external returns (uint256);
+}
+
+interface IReturnBombOverloadedTarget {
+    function fetch(uint256 value) external returns (uint256);
+    function fetch(bytes calldata payload) external returns (bytes memory);
+}
+
+interface IReturnBombOverloadedReverseTarget {
+    function fetch(bytes calldata payload) external returns (bytes memory);
+    function fetch(uint256 value) external returns (uint256);
+}
+
 contract ReturnBomb {
+    event DynamicReturn(bytes result);
+
+    error DynamicReturnError(bytes result);
+
     struct Result {
         bytes data;
     }
@@ -107,5 +125,59 @@ contract ReturnBomb {
     function highLevelStaticReturn(IReturnBombTarget target, uint256 gasLimit) public {
         uint256 result = target.value{gas: gasLimit}();
         require(result >= 0);
+    }
+
+    function highLevelDynamicReturnInIf(IReturnBombTarget target, uint256 gasLimit) public {
+        if (target.fetch{gas: gasLimit}().length > 0) {} //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
+    function highLevelDynamicReturnInEmit(IReturnBombTarget target, uint256 gasLimit) public {
+        emit DynamicReturn(target.fetch{gas: gasLimit}()); //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
+    function highLevelDynamicReturnInRevert(IReturnBombTarget target, uint256 gasLimit) public {
+        revert DynamicReturnError(target.fetch{gas: gasLimit}()); //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
+    function highLevelDynamicReturnInTry(IReturnBombTarget target, uint256 gasLimit) public {
+        try target.fetch{gas: gasLimit}() returns (bytes memory) { //~WARN: external calls with a gas limit should not consume unbounded return data
+        } catch {}
+    }
+
+    function highLevelMethodNamedCall(IReturnBombFalsePositiveTarget target, bytes calldata payload, uint256 gasLimit) public {
+        uint256 result = target.call{gas: gasLimit}(payload);
+        require(result >= 0);
+    }
+
+    function overloadedDynamicReturn(
+        IReturnBombOverloadedTarget target,
+        bytes calldata payload,
+        uint256 gasLimit
+    ) public {
+        bytes memory result = target.fetch{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function overloadedStaticReturn(
+        IReturnBombOverloadedReverseTarget target,
+        uint256 value,
+        uint256 gasLimit
+    ) public {
+        uint256 result = target.fetch{gas: gasLimit}(value);
+        require(result >= 0);
+    }
+
+    function castDynamicReturn(address target, uint256 gasLimit) public {
+        bytes memory result = IReturnBombTarget(target).fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function castOverloadedDynamicReturn(
+        address target,
+        bytes calldata payload,
+        uint256 gasLimit
+    ) public {
+        bytes memory result = IReturnBombOverloadedTarget(target).fetch{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
     }
 }

--- a/crates/lint/testdata/ReturnBomb.sol
+++ b/crates/lint/testdata/ReturnBomb.sol
@@ -31,6 +31,17 @@ interface IReturnBombWideningTarget {
     function fetch(uint256 value) external returns (bytes memory);
 }
 
+interface IReturnBombFixedArrayOverloadedTarget {
+    function fetch(uint256[2] calldata values) external returns (bytes memory);
+    function fetch(uint256[3] calldata values) external returns (uint256);
+}
+
+contract ReturnBombCreatedTarget {
+    function fetch() external returns (bytes memory) {
+        return "";
+    }
+}
+
 contract ReturnBomb {
     event DynamicReturn(bytes result);
 
@@ -42,6 +53,10 @@ contract ReturnBomb {
 
     struct TargetSlot {
         IReturnBombTarget target;
+    }
+
+    struct FunctionPointerSlot {
+        function() external returns (bytes memory) fetcher;
     }
 
     bytes existingData;
@@ -185,8 +200,21 @@ contract ReturnBomb {
         return "";
     }
 
+    function externalStaticOverload(uint256 value) external returns (uint256) {
+        return value;
+    }
+
+    function externalStaticOverload(bool) internal returns (bytes memory) {
+        return "";
+    }
+
     function thisHighLevelDynamicReturn(uint256 gasLimit) public {
         this.ownDynamicReturn{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+    }
+
+    function thisExternalStaticOverloadIgnoresInternal(uint256 value, uint256 gasLimit) public {
+        uint256 result = this.externalStaticOverload{gas: gasLimit}(value + 1);
+        require(result >= 0);
     }
 
     function highLevelStaticReturn(IReturnBombTarget target, uint256 gasLimit) public {
@@ -252,6 +280,15 @@ contract ReturnBomb {
         require(result.length >= 0);
     }
 
+    function fixedArrayOverloadDynamicReturn(
+        IReturnBombFixedArrayOverloadedTarget target,
+        uint256[2] calldata values,
+        uint256 gasLimit
+    ) public {
+        bytes memory result = target.fetch{gas: gasLimit}(values); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
     function castDynamicReturn(address target, uint256 gasLimit) public {
         bytes memory result = IReturnBombTarget(target).fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
         require(result.length >= 0);
@@ -271,6 +308,28 @@ contract ReturnBomb {
         uint256 gasLimit
     ) public {
         bytes memory result = fetcher{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function externalFunctionPointerMemberDynamicReturn(
+        FunctionPointerSlot memory slot,
+        uint256 gasLimit
+    ) public {
+        bytes memory result = slot.fetcher{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function getFetcher() public view returns (function() external returns (bytes memory)) {
+        return this.ownDynamicReturn;
+    }
+
+    function returnedExternalFunctionPointerDynamicReturn(uint256 gasLimit) public {
+        bytes memory result = getFetcher(){gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(result.length >= 0);
+    }
+
+    function newTargetDynamicReturn(uint256 gasLimit) public {
+        bytes memory result = (new ReturnBombCreatedTarget()).fetch{gas: gasLimit}(); //~WARN: external calls with a gas limit should not consume unbounded return data
         require(result.length >= 0);
     }
 }

--- a/crates/lint/testdata/ReturnBomb.sol
+++ b/crates/lint/testdata/ReturnBomb.sol
@@ -327,6 +327,15 @@ contract ReturnBomb {
         require(result.length >= 0);
     }
 
+    function overloadedBooleanExpressionStaticReturn(
+        IReturnBombAmbiguousOverloadedTarget target,
+        uint256 value,
+        uint256 gasLimit
+    ) public {
+        uint256 result = target.fetch{gas: gasLimit}(value > 0);
+        require(result >= 0);
+    }
+
     function overloadedLiteralRangeDynamicReturn(
         IReturnBombLiteralRangeTarget target,
         uint256 gasLimit

--- a/crates/lint/testdata/ReturnBomb.sol
+++ b/crates/lint/testdata/ReturnBomb.sol
@@ -1,0 +1,57 @@
+//@compile-flags: --only-lint return-bomb
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+contract ReturnBomb {
+    bytes existingData;
+
+    // SHOULD PASS: Gas-capped calls that do not bind returndata.
+    function ignoresReturnData(address target, bytes memory payload, uint256 gasLimit) public {
+        (bool success, ) = target.call{gas: gasLimit}(payload);
+        require(success, "Call failed");
+    }
+
+    function valueOnlyOption(address payable target, bytes memory payload, uint256 value) public {
+        (bool success, bytes memory result) = target.call{value: value}(payload);
+        require(success, "Call failed");
+        require(result.length >= 0);
+    }
+
+    // SHOULD FAIL: Gas-capped calls that bind unbounded returndata.
+    function lowLevelCall(address target, bytes memory payload, uint256 gasLimit) public {
+        (bool success, bytes memory result) = target.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(success, "Call failed");
+        require(result.length >= 0);
+    }
+
+    function lowLevelCallLiteralGas(address target, bytes memory payload) public {
+        (bool success, bytes memory result) = target.call{gas: 10_000}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(success, "Call failed");
+        require(result.length >= 0);
+    }
+
+    function lowLevelCallWithValue(address payable target, bytes memory payload, uint256 gasLimit, uint256 value) public {
+        (bool success, bytes memory result) = target.call{value: value, gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(success, "Call failed");
+        require(result.length >= 0);
+    }
+
+    function delegateCall(address target, bytes memory payload, uint256 gasLimit) public {
+        (bool success, bytes memory result) = target.delegatecall{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(success, "Delegatecall failed");
+        require(result.length >= 0);
+    }
+
+    function staticCall(address target, bytes memory payload, uint256 gasLimit) public view {
+        (bool success, bytes memory result) = target.staticcall{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(success, "Staticcall failed");
+        require(result.length >= 0);
+    }
+
+    function existingBytes(address target, bytes memory payload, uint256 gasLimit) public {
+        (bool success, bytes memory result) = target.call{gas: gasLimit}(payload); //~WARN: external calls with a gas limit should not consume unbounded return data
+        (success, existingData) = target.call{gas: gasLimit}(result); //~WARN: external calls with a gas limit should not consume unbounded return data
+        require(success, "Call failed");
+    }
+}

--- a/crates/lint/testdata/ReturnBomb.stderr
+++ b/crates/lint/testdata/ReturnBomb.stderr
@@ -257,6 +257,14 @@ LL │ …     bytes memory result = target.fetch{gas: gasLimit}(value);
 warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
+LL │ …     bytes memory result = target.fetch{gas: gasLimit}(values);
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
 LL │ …     bytes memory result = IReturnBombTarget(target).fetch{gas: gasLimit}();
    │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -275,6 +283,30 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    │
 LL │ …     bytes memory result = fetcher{gas: gasLimit}();
    │                             ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     bytes memory result = slot.fetcher{gas: gasLimit}();
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     bytes memory result = getFetcher(){gas: gasLimit}();
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     bytes memory result = (new ReturnBombCreatedTarget()).fetch{gas: gasLimit}();
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 

--- a/crates/lint/testdata/ReturnBomb.stderr
+++ b/crates/lint/testdata/ReturnBomb.stderr
@@ -1,0 +1,56 @@
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     (bool success, bytes memory result) = target.call{gas: gasLimit}(payload);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     (bool success, bytes memory result) = target.call{gas: 10_000}(payload);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     (bool success, bytes memory result) = target.call{value: value, gas: gasLimit}(payload);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     (bool success, bytes memory result) = target.delegatecall{gas: gasLimit}(payload);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     (bool success, bytes memory result) = target.staticcall{gas: gasLimit}(payload);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     (bool success, bytes memory result) = target.call{gas: gasLimit}(payload);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     (success, existingData) = target.call{gas: gasLimit}(result);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+

--- a/crates/lint/testdata/ReturnBomb.stderr
+++ b/crates/lint/testdata/ReturnBomb.stderr
@@ -249,6 +249,14 @@ LL │ …     bytes memory result = target.fetch{gas: gasLimit}(value + 1);
 warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
+LL │ …     bytes memory result = target.fetch{gas: gasLimit}(value);
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
 LL │ …     bytes memory result = IReturnBombTarget(target).fetch{gas: gasLimit}();
    │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/ReturnBomb.stderr
+++ b/crates/lint/testdata/ReturnBomb.stderr
@@ -57,6 +57,30 @@ LL │ …     (bool success, bytes memory result) = target.staticcall{gas: gasL
 warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
+LL │         msg.sender.call{gas: gasLimit}(payload);
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │         block.coinbase.call{gas: gasLimit}(payload);
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │         tx.origin.call{gas: gasLimit}(payload);
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
 LL │ …     (bool success, bytes memory result) = target.call{gas: gasLimit}(payload);
    │                                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -147,6 +171,14 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    │
 LL │ …     bytes memory result = slot.target.fetch{gas: gasLimit}();
    │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │         this.ownDynamicReturn{gas: gasLimit}();
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 

--- a/crates/lint/testdata/ReturnBomb.stderr
+++ b/crates/lint/testdata/ReturnBomb.stderr
@@ -2,7 +2,7 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │ …     (bool success, ) = target.call{gas: gasLimit}(payload);
-   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │                          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
@@ -18,7 +18,7 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │ …     (bool success, bytes memory result) = target.call{gas: gasLimit}(payload);
-   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │                                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
@@ -26,7 +26,7 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │ …     (bool success, bytes memory result) = target.call{gas: 10_000}(payload);
-   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │                                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
@@ -34,7 +34,7 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │ …     (bool success, bytes memory result) = target.call{value: value, gas: gasLimit}(payload);
-   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │                                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
@@ -42,7 +42,7 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │ …     (bool success, bytes memory result) = target.delegatecall{gas: gasLimit}(payload);
-   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │                                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
@@ -50,7 +50,7 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │ …     (bool success, bytes memory result) = target.staticcall{gas: gasLimit}(payload);
-   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │                                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
@@ -58,7 +58,7 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │ …     (bool success, bytes memory result) = target.call{gas: gasLimit}(payload);
-   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │                                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
@@ -66,7 +66,7 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │ …     (success, existingData) = target.call{gas: gasLimit}(result);
-   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │                                 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
@@ -74,7 +74,7 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │         return target.call{gas: gasLimit}(payload);
-   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
@@ -82,7 +82,7 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │ …     (success, storedResult.data) = target.call{gas: gasLimit}(payload);
-   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │                                      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
@@ -90,7 +90,7 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │ …     (success, results[0]) = target.call{gas: gasLimit}(payload);
-   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │                               ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
@@ -98,7 +98,7 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │ …     bytes memory result = target.fetch{gas: gasLimit}();
-   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
@@ -114,7 +114,7 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │ …     require(target.fetch{gas: gasLimit}().length >= 0);
-   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │               ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
@@ -122,7 +122,63 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
 LL │         return target.fetch{gas: gasLimit}();
-   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     if (target.fetch{gas: gasLimit}().length > 0) {}
+   │           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     emit DynamicReturn(target.fetch{gas: gasLimit}());
+   │                          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     revert DynamicReturnError(target.fetch{gas: gasLimit}());
+   │                                 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     try target.fetch{gas: gasLimit}() returns (bytes memory) {
+   │           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     bytes memory result = target.fetch{gas: gasLimit}(payload);
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     bytes memory result = IReturnBombTarget(target).fetch{gas: gasLimit}();
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     bytes memory result = IReturnBombOverloadedTarget(target).fetch{gas: gasLimit}(payload);
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 

--- a/crates/lint/testdata/ReturnBomb.stderr
+++ b/crates/lint/testdata/ReturnBomb.stderr
@@ -97,6 +97,14 @@ LL │         getAddress().call{gas: gasLimit}(payload);
 warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
+LL │ …     ecrecover(h, v, r, s).call{gas: gasLimit}(payload);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
 LL │ …     (bool success, bytes memory result) = target.call{gas: gasLimit}(payload);
    │                                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -347,6 +355,14 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    │
 LL │ …     bytes memory result = getFetcher(){gas: gasLimit}();
    │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     bytes memory result = targetGetter().fetch{gas: gasLimit}();
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 

--- a/crates/lint/testdata/ReturnBomb.stderr
+++ b/crates/lint/testdata/ReturnBomb.stderr
@@ -81,6 +81,14 @@ LL │         tx.origin.call{gas: gasLimit}(payload);
 warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
+LL │         getAddress().call{gas: gasLimit}(payload);
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
 LL │ …     (bool success, bytes memory result) = target.call{gas: gasLimit}(payload);
    │                                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -177,6 +185,14 @@ LL │ …     bytes memory result = slot.target.fetch{gas: gasLimit}();
 warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
+LL │ …     bytes memory result = getTarget().fetch{gas: gasLimit}();
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
 LL │         this.ownDynamicReturn{gas: gasLimit}();
    │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -225,6 +241,14 @@ LL │ …     bytes memory result = target.fetch{gas: gasLimit}(payload);
 warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
+LL │ …     bytes memory result = target.fetch{gas: gasLimit}(value + 1);
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
 LL │ …     bytes memory result = IReturnBombTarget(target).fetch{gas: gasLimit}();
    │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -235,6 +259,14 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    │
 LL │ …     bytes memory result = IReturnBombOverloadedTarget(target).fetch{gas: gasLimit}(payload);
    │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     bytes memory result = fetcher{gas: gasLimit}();
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 

--- a/crates/lint/testdata/ReturnBomb.stderr
+++ b/crates/lint/testdata/ReturnBomb.stderr
@@ -281,6 +281,14 @@ LL │ …     bytes memory result = target.fetch{gas: gasLimit}(value);
 warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
+LL │ …     bytes memory result = target.fetch{gas: gasLimit}(300);
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
 LL │ …     bytes memory result = target.fetch{gas: gasLimit}(value);
    │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/ReturnBomb.stderr
+++ b/crates/lint/testdata/ReturnBomb.stderr
@@ -1,6 +1,22 @@
 warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
+LL │ …     (bool success, ) = target.call{gas: gasLimit}(payload);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │         target.call{gas: gasLimit}(payload);
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
 LL │ …     (bool success, bytes memory result) = target.call{gas: gasLimit}(payload);
    │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -83,6 +99,22 @@ warning[return-bomb]: external calls with a gas limit should not consume unbound
    │
 LL │ …     bytes memory result = target.fetch{gas: gasLimit}();
    │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │         target.fetch{gas: gasLimit}();
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     require(target.fetch{gas: gasLimit}().length >= 0);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 

--- a/crates/lint/testdata/ReturnBomb.stderr
+++ b/crates/lint/testdata/ReturnBomb.stderr
@@ -129,6 +129,30 @@ LL │         return target.fetch{gas: gasLimit}();
 warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
+LL │ …     bytes memory result = targets[index].fetch{gas: gasLimit}();
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     bytes memory result = mappedTargets[index].fetch{gas: gasLimit}();
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     bytes memory result = slot.target.fetch{gas: gasLimit}();
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
 LL │ …     if (target.fetch{gas: gasLimit}().length > 0) {}
    │           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/ReturnBomb.stderr
+++ b/crates/lint/testdata/ReturnBomb.stderr
@@ -1,6 +1,14 @@
 warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
+LL │     bytes initializedData = this.ownDynamicReturn{gas: 10_000}();
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
 LL │ …     (bool success, ) = target.call{gas: gasLimit}(payload);
    │                          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -201,6 +209,14 @@ LL │         this.ownDynamicReturn{gas: gasLimit}();
 warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
+LL │ …     withDynamicReturn(this.ownDynamicReturn{gas: gasLimit}())
+   │                         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
 LL │ …     if (target.fetch{gas: gasLimit}().length > 0) {}
    │           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -257,8 +273,40 @@ LL │ …     bytes memory result = target.fetch{gas: gasLimit}(value);
 warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
    ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
    │
+LL │ …     bytes memory result = target.fetch{gas: gasLimit}(value);
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
 LL │ …     bytes memory result = target.fetch{gas: gasLimit}(values);
    │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     bytes memory result = target.fetch{gas: gasLimit}(values);
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     bytes memory result = (useFirst ? first : second).fetch{gas: gasLimit}();
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     (useFirst ? first : second).call{gas: gasLimit}(payload);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 

--- a/crates/lint/testdata/ReturnBomb.stderr
+++ b/crates/lint/testdata/ReturnBomb.stderr
@@ -54,3 +54,43 @@ LL │ …     (success, existingData) = target.call{gas: gasLimit}(result);
    │
    ╰ help: https://getfoundry.sh/forge/linting/return-bomb
 
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │         return target.call{gas: gasLimit}(payload);
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     (success, storedResult.data) = target.call{gas: gasLimit}(payload);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     (success, results[0]) = target.call{gas: gasLimit}(payload);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │ …     bytes memory result = target.fetch{gas: gasLimit}();
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+
+warning[return-bomb]: external calls with a gas limit should not consume unbounded return data
+   ╭▸ ROOT/testdata/ReturnBomb.sol:LL:CC
+   │
+LL │         return target.fetch{gas: gasLimit}();
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/return-bomb
+


### PR DESCRIPTION
## Motivation
Gas-capped external calls can still force the caller to copy unbounded dynamic returndata after the call returns, which can cause the caller to run out of gas.

## Solution
- Adds a low-severity `return-bomb` lint that flags gas-limited low-level calls and high-level external calls that consume dynamic return data. Includes documentation and lint test coverage for low-level calls, ignored returndata, overloads, and dynamic high-level returns.

cc @mattsse  @mablr @stevencartavia  @figtracer 