### PR TITLE
feat(cli): freeze agent-substrate @v1 schemas and contract tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -2582,6 +2583,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +2650,12 @@ name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -4174,6 +4187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4407,6 +4429,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4556,6 +4589,17 @@ checksum = "7bffafbd079d520191c7c2779ae9cf757601266cf4167d3f659ff09617ff8483"
 dependencies = [
  "cfg-if",
  "rustc_version 0.2.3",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -5555,6 +5599,7 @@ dependencies = [
  "foundry-compilers",
  "foundry-config",
  "idna_adapter",
+ "jsonschema",
  "parking_lot",
  "rand 0.9.4",
  "regex",
@@ -5617,6 +5662,16 @@ dependencies = [
  "tracing",
  "uuid 1.23.1",
  "webbrowser",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -6791,6 +6846,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
+dependencies = [
+ "ahash",
+ "base64 0.22.1",
+ "bytecount",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "uuid-simd",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7539,6 +7620,12 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -8896,6 +8983,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "referencing"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8eff4fa778b5c2a57e85c5f2fe3a709c52f0e60d23146e2151cbef5893f420e"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -12338,6 +12439,17 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid 1.23.1",
+ "vsimd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4955,6 +4955,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-signer",
  "cfg-if",
+ "chrono",
  "clap",
  "clap_complete",
  "clap_complete_nushell",

--- a/crates/anvil/bin/main.rs
+++ b/crates/anvil/bin/main.rs
@@ -7,6 +7,10 @@ static ALLOC: foundry_cli::utils::Allocator = foundry_cli::utils::new_allocator(
 
 fn main() {
     if let Err(err) = run() {
+        if foundry_cli::is_machine() {
+            foundry_cli::machine::report_machine_error(&err);
+            std::process::exit(foundry_cli::ExitCode::from(&err).to_i32());
+        }
         let _ = foundry_common::sh_err!("{err:?}");
         std::process::exit(1);
     }

--- a/crates/anvil/src/args.rs
+++ b/crates/anvil/src/args.rs
@@ -1,5 +1,5 @@
 use crate::opts::{Anvil, AnvilSubcommand};
-use clap::{CommandFactory, Parser};
+use clap::CommandFactory;
 use eyre::Result;
 use foundry_cli::utils;
 
@@ -7,10 +7,11 @@ use foundry_cli::utils;
 pub fn run() -> Result<()> {
     setup()?;
 
+    foundry_cli::machine::check_machine();
     foundry_cli::opts::GlobalArgs::check_introspect::<Anvil>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Anvil>();
 
-    let mut args = Anvil::parse();
+    let mut args = foundry_cli::parse_or_exit::<Anvil>();
     args.global.init()?;
     args.node.evm.resolve_rpc_alias();
 
@@ -47,6 +48,7 @@ pub fn run_command(args: Anvil) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
 
     #[test]
     fn verify_cli() {
@@ -87,5 +89,15 @@ mod tests {
         let doc = build_document(&cmd, &CommandRegistry::EMPTY);
         let dups = duplicate_command_ids(&doc);
         assert!(dups.is_empty(), "duplicate anvil command_ids: {dups:?}");
+    }
+
+    /// Capability self-consistency for every `anvil` command.
+    #[test]
+    fn introspect_capabilities_are_consistent() {
+        use foundry_cli::introspect::{CommandRegistry, build_document, capability_violations};
+        let cmd = <Anvil as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let v = capability_violations(&doc);
+        assert!(v.is_empty(), "anvil capability violations: {v:?}");
     }
 }

--- a/crates/anvil/src/args.rs
+++ b/crates/anvil/src/args.rs
@@ -7,6 +7,7 @@ use foundry_cli::utils;
 pub fn run() -> Result<()> {
     setup()?;
 
+    foundry_cli::opts::GlobalArgs::check_introspect::<Anvil>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Anvil>();
 
     let mut args = Anvil::parse();
@@ -76,5 +77,15 @@ mod tests {
                 shell: foundry_cli::clap::Shell::ClapCompleteShell(clap_complete::Shell::Bash)
             })
         ));
+    }
+
+    /// Every `command_id` exposed by `anvil --introspect` MUST be unique.
+    #[test]
+    fn introspect_command_ids_are_unique() {
+        use foundry_cli::introspect::{CommandRegistry, build_document, duplicate_command_ids};
+        let cmd = <Anvil as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let dups = duplicate_command_ids(&doc);
+        assert!(dups.is_empty(), "duplicate anvil command_ids: {dups:?}");
     }
 }

--- a/crates/anvil/src/args.rs
+++ b/crates/anvil/src/args.rs
@@ -5,9 +5,10 @@ use foundry_cli::utils;
 
 /// Run the `anvil` command line interface.
 pub fn run() -> Result<()> {
+    // Pre-setup so setup failures land in the machine envelope path.
+    foundry_cli::machine::check_machine();
     setup()?;
 
-    foundry_cli::machine::check_machine();
     foundry_cli::opts::GlobalArgs::check_introspect::<Anvil>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Anvil>();
 

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -441,7 +441,16 @@ impl NodeArgs {
                 // cleaning up and shutting down
                 // this will make sure that the fork RPC cache is flushed if caching is configured
             }
-            std::process::exit(0);
+            // Triggered by SIGINT / SIGTERM after a clean cache flush. Under
+            // the agent contract this is `Interrupted` (8); legacy human
+            // invocations preserve the historical exit-0 contract for
+            // backward compatibility.
+            let code = if foundry_cli::is_machine() {
+                foundry_cli::ExitCode::Interrupted.to_i32()
+            } else {
+                0
+            };
+            std::process::exit(code);
         });
 
         ctrlc::set_handler(move || {

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -8,6 +8,10 @@ static ALLOC: foundry_cli::utils::Allocator = foundry_cli::utils::new_allocator(
 
 fn main() {
     if let Err(err) = run() {
+        if foundry_cli::is_machine() {
+            foundry_cli::machine::report_machine_error(&err);
+            std::process::exit(foundry_cli::ExitCode::from(&err).to_i32());
+        }
         let _ = foundry_common::sh_err!("{err:?}");
         std::process::exit(1);
     }

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -12,7 +12,7 @@ use alloy_network::Ethereum;
 use alloy_primitives::{Address, B256, eip191_hash_message, hex, keccak256};
 use alloy_provider::Provider;
 use alloy_rpc_types::{BlockId, BlockNumberOrTag::Latest};
-use clap::{CommandFactory, Parser};
+use clap::CommandFactory;
 use clap_complete::generate;
 use eyre::{Result, WrapErr};
 use foundry_cli::utils::{self, LoadConfig};
@@ -38,10 +38,11 @@ use tempo_alloy::TempoNetwork;
 pub fn run() -> Result<()> {
     setup()?;
 
+    foundry_cli::machine::check_machine();
     foundry_cli::opts::GlobalArgs::check_introspect::<CastArgs>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<CastArgs>();
 
-    let args = CastArgs::parse();
+    let args = foundry_cli::parse_or_exit::<CastArgs>();
     args.global.init()?;
     args.global.tokio_runtime().block_on(run_command(args))
 }
@@ -850,7 +851,9 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use foundry_cli::introspect::{CommandRegistry, build_document, duplicate_command_ids};
+    use foundry_cli::introspect::{
+        CommandRegistry, build_document, capability_violations, duplicate_command_ids,
+    };
 
     /// Every `command_id` exposed by `cast --introspect` MUST be unique.
     /// This is the foundation of the agent contract — agents key on
@@ -873,5 +876,23 @@ mod tests {
             .join()
             .expect("worker thread join");
         assert!(dups.is_empty(), "duplicate cast command_ids: {dups:?}");
+    }
+
+    /// Capability self-consistency: any command declaring an output mode
+    /// must wire the matching schema reference. See
+    /// [`capability_violations`].
+    #[test]
+    fn introspect_capabilities_are_consistent() {
+        let v = std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let cmd = <CastArgs as clap::CommandFactory>::command();
+                let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+                capability_violations(&doc)
+            })
+            .expect("spawn worker thread")
+            .join()
+            .expect("worker thread join");
+        assert!(v.is_empty(), "cast capability violations: {v:?}");
     }
 }

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -38,6 +38,7 @@ use tempo_alloy::TempoNetwork;
 pub fn run() -> Result<()> {
     setup()?;
 
+    foundry_cli::opts::GlobalArgs::check_introspect::<CastArgs>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<CastArgs>();
 
     let args = CastArgs::parse();
@@ -844,4 +845,33 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use foundry_cli::introspect::{CommandRegistry, build_document, duplicate_command_ids};
+
+    /// Every `command_id` exposed by `cast --introspect` MUST be unique.
+    /// This is the foundation of the agent contract — agents key on
+    /// `command_id` to identify commands, and duplicates would silently break
+    /// downstream tooling.
+    ///
+    /// Cast's clap tree is large and exhausts the default test-thread stack
+    /// (2 MiB) when constructed in debug builds, so we spawn a worker thread
+    /// with an explicit, generous stack size.
+    #[test]
+    fn introspect_command_ids_are_unique() {
+        let dups = std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let cmd = <CastArgs as clap::CommandFactory>::command();
+                let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+                duplicate_command_ids(&doc)
+            })
+            .expect("spawn worker thread")
+            .join()
+            .expect("worker thread join");
+        assert!(dups.is_empty(), "duplicate cast command_ids: {dups:?}");
+    }
 }

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -1,6 +1,7 @@
 use crate::{
     Cast, SimpleCast,
     cmd::erc20::IERC20,
+    introspect::REGISTRY,
     opts::{Cast as CastArgs, CastSubcommand, ToBaseArgs},
     traces::identifier::SignaturesIdentifier,
     tx::CastTxSender,
@@ -36,10 +37,11 @@ use tempo_alloy::TempoNetwork;
 
 /// Run the `cast` command-line interface.
 pub fn run() -> Result<()> {
+    // Pre-setup so setup failures land in the machine envelope path.
+    foundry_cli::machine::check_machine();
     setup()?;
 
-    foundry_cli::machine::check_machine();
-    foundry_cli::opts::GlobalArgs::check_introspect::<CastArgs>();
+    foundry_cli::opts::GlobalArgs::check_introspect_with(CastArgs::command(), &REGISTRY);
     foundry_cli::opts::GlobalArgs::check_markdown_help::<CastArgs>();
 
     let args = foundry_cli::parse_or_exit::<CastArgs>();
@@ -852,7 +854,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
 mod tests {
     use super::*;
     use foundry_cli::introspect::{
-        CommandRegistry, build_document, capability_violations, duplicate_command_ids,
+        OutputMode, build_document, capability_violations, duplicate_command_ids,
     };
 
     /// Every `command_id` exposed by `cast --introspect` MUST be unique.
@@ -869,7 +871,7 @@ mod tests {
             .stack_size(16 * 1024 * 1024)
             .spawn(|| {
                 let cmd = <CastArgs as clap::CommandFactory>::command();
-                let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+                let doc = build_document(&cmd, &REGISTRY);
                 duplicate_command_ids(&doc)
             })
             .expect("spawn worker thread")
@@ -887,12 +889,42 @@ mod tests {
             .stack_size(16 * 1024 * 1024)
             .spawn(|| {
                 let cmd = <CastArgs as clap::CommandFactory>::command();
-                let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+                let doc = build_document(&cmd, &REGISTRY);
                 capability_violations(&doc)
             })
             .expect("spawn worker thread")
             .join()
             .expect("worker thread join");
         assert!(v.is_empty(), "cast capability violations: {v:?}");
+    }
+
+    /// Every adopted command (`output_mode = Envelope`) must pin a stable
+    /// `command_id` matching its registry entry.
+    #[test]
+    fn registered_commands_pin_stable_ids() {
+        let ids = std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let cmd = <CastArgs as clap::CommandFactory>::command();
+                let doc = build_document(&cmd, &REGISTRY);
+                fn walk(c: &foundry_cli::introspect::CommandInfo) -> Vec<String> {
+                    let mut out = Vec::new();
+                    if matches!(c.capabilities.output_mode, OutputMode::Envelope) {
+                        out.push(c.command_id.clone());
+                    }
+                    for sub in &c.subcommands {
+                        out.extend(walk(sub));
+                    }
+                    out
+                }
+                doc.commands.iter().flat_map(walk).collect::<Vec<_>>()
+            })
+            .expect("spawn worker thread")
+            .join()
+            .expect("worker thread join");
+        assert!(
+            ids.iter().any(|s| s == "cast.call"),
+            "cast.call missing from envelope ids: {ids:?}"
+        );
     }
 }

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -898,33 +898,100 @@ mod tests {
         assert!(v.is_empty(), "cast capability violations: {v:?}");
     }
 
-    /// Every adopted command (`output_mode = Envelope`) must pin a stable
-    /// `command_id` matching its registry entry.
+    /// Every `*_schema_ref` exposed by `cast --introspect` MUST point at a
+    /// committed JSON Schema file under `docs/agents/schemas/`. Guards
+    /// against typos and ref bumps that would leave agent tooling with
+    /// dangling pointers.
     #[test]
-    fn registered_commands_pin_stable_ids() {
-        let ids = std::thread::Builder::new()
+    fn introspect_schema_refs_resolve_to_committed_schemas() {
+        let errs = std::thread::Builder::new()
             .stack_size(16 * 1024 * 1024)
             .spawn(|| {
+                use foundry_test_utils::agent_schema;
+                let known: std::collections::BTreeSet<&'static str> =
+                    agent_schema::known_schema_ids().collect();
                 let cmd = <CastArgs as clap::CommandFactory>::command();
                 let doc = build_document(&cmd, &REGISTRY);
-                fn walk(c: &foundry_cli::introspect::CommandInfo) -> Vec<String> {
-                    let mut out = Vec::new();
-                    if matches!(c.capabilities.output_mode, OutputMode::Envelope) {
-                        out.push(c.command_id.clone());
+
+                fn walk(
+                    c: &foundry_cli::introspect::CommandInfo,
+                    known: &std::collections::BTreeSet<&'static str>,
+                    errs: &mut Vec<String>,
+                ) {
+                    let caps = &c.capabilities;
+                    for (name, v) in [
+                        ("result_schema_ref", caps.result_schema_ref.as_deref()),
+                        ("event_schema_ref", caps.event_schema_ref.as_deref()),
+                        ("session_schema_ref", caps.session_schema_ref.as_deref()),
+                    ] {
+                        if let Some(id) = v
+                            && !known.contains(id)
+                        {
+                            errs.push(format!(
+                                "{}: {name} points to unknown schema `{id}`",
+                                c.command_id
+                            ));
+                        }
                     }
                     for sub in &c.subcommands {
-                        out.extend(walk(sub));
+                        walk(sub, known, errs);
                     }
-                    out
                 }
-                doc.commands.iter().flat_map(walk).collect::<Vec<_>>()
+
+                let mut errs = Vec::new();
+                for c in &doc.commands {
+                    walk(c, &known, &mut errs);
+                }
+                errs
             })
             .expect("spawn worker thread")
             .join()
             .expect("worker thread join");
-        assert!(
-            ids.iter().any(|s| s == "cast.call"),
-            "cast.call missing from envelope ids: {ids:?}"
+        assert!(errs.is_empty(), "dangling cast schema refs: {errs:?}");
+    }
+
+    /// Every adopted command must pin its exact `command_id`, output mode,
+    /// and schema refs. A drift in any of those is an agent-contract break.
+    #[test]
+    fn registered_commands_pin_stable_ids() {
+        let pinned = std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let cmd = <CastArgs as clap::CommandFactory>::command();
+                let doc = build_document(&cmd, &REGISTRY);
+                fn find(
+                    c: &foundry_cli::introspect::CommandInfo,
+                    id: &str,
+                ) -> Option<(OutputMode, Option<String>, Option<String>)> {
+                    if c.command_id == id {
+                        return Some((
+                            c.capabilities.output_mode,
+                            c.capabilities.result_schema_ref.clone(),
+                            c.capabilities.event_schema_ref.clone(),
+                        ));
+                    }
+                    for sub in &c.subcommands {
+                        if let Some(v) = find(sub, id) {
+                            return Some(v);
+                        }
+                    }
+                    None
+                }
+                doc.commands
+                    .iter()
+                    .find_map(|c| find(c, "cast.call"))
+                    .expect("cast.call missing from cast introspect")
+            })
+            .expect("spawn worker thread")
+            .join()
+            .expect("worker thread join");
+        let (mode, result_ref, event_ref) = pinned;
+        assert_eq!(mode, OutputMode::Envelope, "cast.call output_mode drift");
+        assert_eq!(
+            result_ref.as_deref(),
+            Some("foundry:cast.call@v1"),
+            "cast.call result_schema_ref drift"
         );
+        assert_eq!(event_ref, None, "cast.call must not declare event_schema_ref");
     }
 }

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -16,6 +16,7 @@ use alloy_rpc_types::{
 use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
+    json::{JsonEnvelope, print_json},
     opts::{ChainValueParser, RpcOpts, TransactionOpts},
     utils::{LoadConfig, TraceResult, parse_ether_value},
 };
@@ -46,7 +47,17 @@ use foundry_evm::{
 };
 use foundry_wallets::WalletOpts;
 use regex::Regex;
+use serde::Serialize;
 use std::{str::FromStr, sync::LazyLock};
+
+/// Stable payload emitted in the `cast call` envelope under `--machine`.
+#[derive(Clone, Debug, Serialize)]
+pub struct CallData {
+    /// Display string for the call's return value: raw hex when no
+    /// signature was supplied, otherwise the decoded value formatted as
+    /// `cast` would print it. Opaque-by-design at `@v1`.
+    pub result: String,
+}
 
 // matches override pattern <address>:<slot>:<value>
 // e.g. 0x123:0x1:0x1234
@@ -219,6 +230,26 @@ pub enum CallSubcommands {
 
 impl CallArgs {
     pub async fn run(self) -> Result<()> {
+        // Reject flags whose stdout shape conflicts with the envelope contract.
+        if foundry_cli::is_machine() {
+            let unsupported = [
+                ("--trace", self.trace),
+                ("--debug", self.debug),
+                ("--decode-internal", self.decode_internal),
+                ("--curl", self.rpc.curl),
+            ]
+            .into_iter()
+            .filter_map(|(name, on)| on.then_some(name))
+            .collect::<Vec<_>>();
+            if !unsupported.is_empty() {
+                foundry_cli::machine::bail_machine_usage(format!(
+                    "`cast call` under `--machine` does not yet support {}; \
+                     run without `--machine` or omit those flags.",
+                    unsupported.join(", ")
+                ));
+            }
+        }
+
         // Handle --curl mode early, before any provider interaction
         if self.rpc.curl {
             return self.run_curl().await;
@@ -434,7 +465,12 @@ impl CallArgs {
                 sh_warn!("Contract code is empty")?;
             }
         }
-        sh_println!("{}", response)?;
+
+        if foundry_cli::is_machine() {
+            print_json(&JsonEnvelope::success(CallData { result: response }))?;
+        } else {
+            sh_println!("{}", response)?;
+        }
 
         Ok(())
     }

--- a/crates/cast/src/diagnostic.rs
+++ b/crates/cast/src/diagnostic.rs
@@ -1,0 +1,31 @@
+//! Stable, machine-readable diagnostic codes emitted by `cast`.
+//!
+//! See [`docs/agents/diagnostics.md`](../../../docs/agents/diagnostics.md)
+//! for the format and registry rules. Most codes re-export per-domain
+//! constants from [`foundry_cli::diagnostic`].
+
+/// Diagnostic codes for read-only RPC commands like `cast call`, `cast tx`.
+pub mod rpc {
+    pub use foundry_cli::diagnostic::network::{RPC_TIMEOUT, RPC_UNAUTHORIZED};
+
+    pub(crate) const ALL: &[&str] = &[RPC_TIMEOUT, RPC_UNAUTHORIZED];
+}
+
+/// All diagnostic codes declared by `cast`.
+pub fn known_codes() -> Vec<&'static str> {
+    let groups: &[&[&str]] = &[rpc::ALL];
+    groups.iter().flat_map(|g| g.iter().copied()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use foundry_cli::diagnostic::validate;
+
+    #[test]
+    fn every_known_code_validates() {
+        for c in known_codes() {
+            assert!(validate(c).is_ok(), "registered code `{c}` failed validation");
+        }
+    }
+}

--- a/crates/cast/src/introspect.rs
+++ b/crates/cast/src/introspect.rs
@@ -1,0 +1,29 @@
+//! Stable, agent-facing metadata for the `cast` command tree.
+//!
+//! See [`docs/agents/spec.md`](../../../docs/agents/spec.md). The registry
+//! pins `command_id`s and machine-mode capabilities for adopted commands.
+
+use foundry_cli::introspect::{
+    CapabilityMeta, CommandMeta, CommandRegistry, OutputMode, RegistryEntry, SideEffects,
+};
+
+/// Stable schema id for the `cast call` envelope payload.
+pub const CALL_RESULT_SCHEMA: &str = "foundry:cast.call@v1";
+
+static ENTRIES: &[RegistryEntry] = &[RegistryEntry {
+    path: &["call"],
+    meta: CommandMeta {
+        command_id: Some("cast.call"),
+        capabilities: CapabilityMeta {
+            output_mode: OutputMode::Envelope,
+            result_schema_ref: Some(CALL_RESULT_SCHEMA),
+            side_effects: SideEffects::Network,
+            ..CapabilityMeta::NONE
+        },
+        exit_codes: &[],
+    },
+}];
+
+/// The `cast` command registry. Used by `--introspect` and by adoption code
+/// that needs to look up command metadata.
+pub const REGISTRY: CommandRegistry = CommandRegistry::new(ENTRIES);

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -60,6 +60,8 @@ pub use foundry_evm::*;
 
 pub mod args;
 pub mod cmd;
+pub mod diagnostic;
+pub mod introspect;
 pub mod opts;
 pub mod tempo;
 

--- a/crates/cast/tests/cli/agent_contract.rs
+++ b/crates/cast/tests/cli/agent_contract.rs
@@ -1,0 +1,58 @@
+//! Binary-level agent-contract tests for `cast`.
+//!
+//! Pins the cross-cutting guarantees agents depend on: `--introspect`
+//! produces a document conforming to `foundry:introspect@v1`, and under
+//! `--machine` the help / parse-error paths emit a `foundry:envelope@v1`
+//! envelope on stdout (never raw clap text).
+
+use foundry_test_utils::agent_schema;
+use serde_json::Value;
+
+// `cast --introspect` returns valid JSON conforming to
+// `foundry:introspect@v1`.
+casttest!(introspect_document_matches_v1_schema, |_prj, cmd| {
+    let assert = cmd.arg("--introspect").assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let doc: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single JSON document on stdout: {stdout}: {e}"));
+    agent_schema::validate("foundry:introspect@v1", &doc);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --introspect, got: {stderr}");
+});
+
+// `cast --machine --help` emits a success envelope on stdout (not raw clap
+// help text).
+casttest!(machine_mode_help_emits_success_envelope, |_prj, cmd| {
+    let assert = cmd.args(["--machine", "--help"]).assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single envelope on stdout: {stdout}: {e}"));
+    assert_eq!(envelope["success"], true);
+    assert!(envelope["data"]["help"].is_string(), "missing data.help: {envelope}");
+    assert_eq!(envelope["errors"], serde_json::json!([]));
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
+    agent_schema::validate("foundry:envelope@v1", &envelope);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// `cast --machine <bad-flag>` emits a typed `cli.usage.invalid` error
+// envelope and exits with `ExitCode::Usage` (2) — never raw clap text.
+casttest!(machine_mode_unknown_flag_emits_typed_envelope, |_prj, cmd| {
+    let assert = cmd.args(["--machine", "--this-flag-does-not-exist"]).assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single envelope on stdout: {stdout}: {e}"));
+    assert_eq!(envelope["success"], false);
+    assert!(envelope["data"].is_null(), "data must be null on failure: {envelope}");
+    assert_eq!(envelope["errors"].as_array().map(Vec::len), Some(1));
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
+    agent_schema::validate("foundry:envelope@v1", &envelope);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -82,6 +82,11 @@ Display options:
       --json
           Format log messages as JSON
 
+      --machine
+          Activate the agent contract: emit declared output mode only, no color, no progress,
+          structured early-exit. Implies no color. Mutually exclusive with `--json` and `--md` to
+          keep machine-mode output unambiguous
+
       --md
           Format log messages as Markdown
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -27,6 +27,7 @@ use tempo_primitives::TempoTxEnvelope;
 #[macro_use]
 extern crate foundry_test_utils;
 
+mod agent_contract;
 mod erc20;
 mod keychain;
 mod selectors;
@@ -3481,11 +3482,12 @@ forgetest_async!(cast_call_machine_mode_emits_envelope, |_prj, cmd| {
     let envelope: serde_json::Value =
         serde_json::from_str(stdout.trim()).expect("stdout is exactly one JSON envelope");
 
-    assert_eq!(envelope["schema_version"], 1);
     assert_eq!(envelope["success"], true);
     assert_eq!(envelope["data"]["result"], "0x");
-    assert_eq!(envelope["errors"], serde_json::json!([]));
-    assert_eq!(envelope["warnings"], serde_json::json!([]));
+    foundry_test_utils::agent_schema::validate_envelope_data(&envelope, "foundry:cast.call@v1");
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
 });
 
 // `--machine` rejects flags that would corrupt the envelope-only stdout
@@ -3505,15 +3507,21 @@ forgetest_async!(cast_call_machine_mode_rejects_unsupported_flags, |_prj, cmd| {
             &http_endpoint,
         ])
         .assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(2));
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     let envelope: serde_json::Value =
         serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
 
     assert_eq!(envelope["success"], false);
+    assert!(envelope["data"].is_null(), "data must be null on failure: {envelope}");
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
     assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
-    assert_eq!(assert.get_output().status.code(), Some(2));
     let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
     assert!(msg.contains("--trace"), "missing --trace mention: {envelope}");
+    foundry_test_utils::agent_schema::validate("foundry:envelope@v1", &envelope);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
 });
 
 // https://github.com/foundry-rs/foundry/issues/10848

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3461,6 +3461,61 @@ forgetest_async!(cast_call_custom_chain_id, |_prj, cmd| {
         .assert_success();
 });
 
+// `cast --machine call` emits a single envelope on stdout against an
+// empty account, returning the deterministic `0x` result.
+forgetest_async!(cast_call_machine_mode_emits_envelope, |_prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let http_endpoint = handle.http_endpoint();
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "--machine",
+            "call",
+            "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+            "--rpc-url",
+            &http_endpoint,
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout is exactly one JSON envelope");
+
+    assert_eq!(envelope["schema_version"], 1);
+    assert_eq!(envelope["success"], true);
+    assert_eq!(envelope["data"]["result"], "0x");
+    assert_eq!(envelope["errors"], serde_json::json!([]));
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
+});
+
+// `--machine` rejects flags that would corrupt the envelope-only stdout
+// contract. Asserts the stable `code` + exit code, not just message text.
+forgetest_async!(cast_call_machine_mode_rejects_unsupported_flags, |_prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let http_endpoint = handle.http_endpoint();
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "--machine",
+            "call",
+            "--trace",
+            "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+            "--rpc-url",
+            &http_endpoint,
+        ])
+        .assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
+
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("--trace"), "missing --trace mention: {envelope}");
+});
+
 // https://github.com/foundry-rs/foundry/issues/10848
 forgetest_async!(cast_call_disable_labels, |prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test()).await;

--- a/crates/chisel/bin/main.rs
+++ b/crates/chisel/bin/main.rs
@@ -7,6 +7,10 @@ static ALLOC: foundry_cli::utils::Allocator = foundry_cli::utils::new_allocator(
 
 fn main() {
     if let Err(err) = run() {
+        if foundry_cli::is_machine() {
+            foundry_cli::machine::report_machine_error(&err);
+            std::process::exit(foundry_cli::ExitCode::from(&err).to_i32());
+        }
         let _ = foundry_common::sh_err!("{err:?}");
         std::process::exit(1);
     }

--- a/crates/chisel/src/args.rs
+++ b/crates/chisel/src/args.rs
@@ -11,9 +11,10 @@ use yansi::Paint;
 
 /// Run the `chisel` command line interface.
 pub fn run() -> Result<()> {
+    // Pre-setup so setup failures land in the machine envelope path.
+    foundry_cli::machine::check_machine();
     setup()?;
 
-    foundry_cli::machine::check_machine();
     foundry_cli::opts::GlobalArgs::check_introspect::<Chisel>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Chisel>();
 

--- a/crates/chisel/src/args.rs
+++ b/crates/chisel/src/args.rs
@@ -2,7 +2,6 @@ use crate::{
     opts::{Chisel, ChiselSubcommand},
     prelude::{ChiselCommand, ChiselDispatcher, SolidityHelper},
 };
-use clap::Parser;
 use eyre::{Context, Result};
 use foundry_cli::utils::{self, LoadConfig};
 use foundry_common::fs;
@@ -14,10 +13,11 @@ use yansi::Paint;
 pub fn run() -> Result<()> {
     setup()?;
 
+    foundry_cli::machine::check_machine();
     foundry_cli::opts::GlobalArgs::check_introspect::<Chisel>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Chisel>();
 
-    let args = Chisel::parse();
+    let args = foundry_cli::parse_or_exit::<Chisel>();
     args.global.init()?;
     args.global.tokio_runtime().block_on(run_command(args))
 }
@@ -193,5 +193,15 @@ mod tests {
         let doc = build_document(&cmd, &CommandRegistry::EMPTY);
         let dups = duplicate_command_ids(&doc);
         assert!(dups.is_empty(), "duplicate chisel command_ids: {dups:?}");
+    }
+
+    /// Capability self-consistency for every `chisel` command.
+    #[test]
+    fn introspect_capabilities_are_consistent() {
+        use foundry_cli::introspect::{CommandRegistry, build_document, capability_violations};
+        let cmd = Chisel::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let v = capability_violations(&doc);
+        assert!(v.is_empty(), "chisel capability violations: {v:?}");
     }
 }

--- a/crates/chisel/src/args.rs
+++ b/crates/chisel/src/args.rs
@@ -14,6 +14,7 @@ use yansi::Paint;
 pub fn run() -> Result<()> {
     setup()?;
 
+    foundry_cli::opts::GlobalArgs::check_introspect::<Chisel>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Chisel>();
 
     let args = Chisel::parse();
@@ -182,5 +183,15 @@ mod tests {
     #[test]
     fn verify_cli() {
         Chisel::command().debug_assert();
+    }
+
+    /// Every `command_id` exposed by `chisel --introspect` MUST be unique.
+    #[test]
+    fn introspect_command_ids_are_unique() {
+        use foundry_cli::introspect::{CommandRegistry, build_document, duplicate_command_ids};
+        let cmd = Chisel::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let dups = duplicate_command_ids(&doc);
+        assert!(dups.is_empty(), "duplicate chisel command_ids: {dups:?}");
     }
 }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -37,6 +37,7 @@ alloy-chains.workspace = true
 alloy-ens = { workspace = true, features = ["provider"] }
 
 cfg-if = "1.0"
+chrono.workspace = true
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_complete.workspace = true
 clap_complete_nushell.workspace = true

--- a/crates/cli/src/diagnostic.rs
+++ b/crates/cli/src/diagnostic.rs
@@ -147,8 +147,10 @@ pub mod wallet {
 pub mod test {
     pub const FAILED: &str = "test.failed";
     pub const SETUP_FAILED: &str = "test.setup_failed";
+    /// Non-fatal advisory surfaced by a test suite.
+    pub const WARNING: &str = "test.warning";
 
-    pub(crate) const ALL: &[&str] = &[FAILED, SETUP_FAILED];
+    pub(crate) const ALL: &[&str] = &[FAILED, SETUP_FAILED, WARNING];
 }
 
 /// `forge script` diagnostic codes.

--- a/crates/cli/src/diagnostic.rs
+++ b/crates/cli/src/diagnostic.rs
@@ -156,8 +156,10 @@ pub mod test {
 /// `forge script` diagnostic codes.
 pub mod script {
     pub const BROADCAST_FAILED: &str = "script.broadcast_failed";
+    /// Non-fatal advisory surfaced by `forge script`.
+    pub const WARNING: &str = "script.warning";
 
-    pub(crate) const ALL: &[&str] = &[BROADCAST_FAILED];
+    pub(crate) const ALL: &[&str] = &[BROADCAST_FAILED, WARNING];
 }
 
 /// `cast` diagnostic codes.

--- a/crates/cli/src/diagnostic.rs
+++ b/crates/cli/src/diagnostic.rs
@@ -10,8 +10,7 @@
 //! # Implementation choice
 //!
 //! Codes are exposed as `&'static str` constants, organised in per-domain
-//! modules colocated with this crate (or, for adoption PRs, with the owning
-//! crate). [`JsonMessage::error`](crate::json::JsonMessage::error) accepts
+//! modules. [`JsonMessage::error`](crate::json::JsonMessage::error) accepts
 //! `impl Into<String>`, so call sites pass the constant directly. The
 //! [`DiagnosticCode`] newtype is available when callers want a parsed,
 //! validated value.
@@ -162,6 +161,19 @@ pub mod script {
     pub(crate) const ALL: &[&str] = &[BROADCAST_FAILED, WARNING];
 }
 
+/// Shared chain-write diagnostic codes.
+///
+/// Used by commands whose `side_effects` are `chain_write` and that submit
+/// transactions outside the `forge script` pipeline (e.g. `forge create`,
+/// `cast send`). `forge script` continues to emit `script.broadcast_failed`
+/// for compatibility with the already-frozen `foundry:forge.script@v1`
+/// contract.
+pub mod chain {
+    pub const BROADCAST_FAILED: &str = "chain.broadcast_failed";
+
+    pub(crate) const ALL: &[&str] = &[BROADCAST_FAILED];
+}
+
 /// `cast` diagnostic codes.
 pub mod cast {
     pub const TX_NOT_FOUND: &str = "cast.tx.not_found";
@@ -195,6 +207,7 @@ pub fn known_codes() -> Vec<&'static str> {
         wallet::ALL,
         test::ALL,
         script::ALL,
+        chain::ALL,
         cast::ALL,
         anvil::ALL,
         chisel::ALL,

--- a/crates/cli/src/diagnostic.rs
+++ b/crates/cli/src/diagnostic.rs
@@ -1,0 +1,249 @@
+//! Stable, machine-readable diagnostic codes.
+//!
+//! Codes attach to [`JsonMessage`](crate::json::JsonMessage) entries inside
+//! [`JsonEnvelope`](crate::json::JsonEnvelope) `errors[]` and `warnings[]`.
+//!
+//! See [`docs/agents/diagnostics.md`](../../../docs/agents/diagnostics.md) for
+//! the format and registry rules. Codes are namespaced strings of the form
+//! `^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$`.
+//!
+//! # Implementation choice
+//!
+//! Codes are exposed as `&'static str` constants, organised in per-domain
+//! modules colocated with this crate (or, for adoption PRs, with the owning
+//! crate). [`JsonMessage::error`](crate::json::JsonMessage::error) accepts
+//! `impl Into<String>`, so call sites pass the constant directly. The
+//! [`DiagnosticCode`] newtype is available when callers want a parsed,
+//! validated value.
+
+use std::{fmt, sync::OnceLock};
+
+/// Validation error returned by [`DiagnosticCode::new`] / [`validate`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidDiagnosticCode {
+    code: String,
+}
+
+impl fmt::Display for InvalidDiagnosticCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid diagnostic code `{}`: must match `^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$`",
+            self.code
+        )
+    }
+}
+
+impl std::error::Error for InvalidDiagnosticCode {}
+
+/// Validate that `s` matches the diagnostic-code grammar.
+pub fn validate(s: &str) -> Result<(), InvalidDiagnosticCode> {
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(r"^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$")
+            .expect("diagnostic-code regex compiles")
+    });
+    if re.is_match(s) { Ok(()) } else { Err(InvalidDiagnosticCode { code: s.to_string() }) }
+}
+
+/// Stable, machine-readable diagnostic code attached to a structured message.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct DiagnosticCode(String);
+
+impl DiagnosticCode {
+    /// Create a new code, validating against the registry grammar.
+    pub fn new(code: impl Into<String>) -> Result<Self, InvalidDiagnosticCode> {
+        let code = code.into();
+        validate(&code)?;
+        Ok(Self(code))
+    }
+
+    /// Borrow the underlying code as a `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume and return the underlying owned `String`.
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for DiagnosticCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for DiagnosticCode {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<DiagnosticCode> for String {
+    fn from(code: DiagnosticCode) -> Self {
+        code.0
+    }
+}
+
+impl std::str::FromStr for DiagnosticCode {
+    type Err = InvalidDiagnosticCode;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+/// CLI-layer diagnostic codes (argument parsing, global flags).
+pub mod cli {
+    /// Command-line usage was invalid (parse error, missing subcommand,
+    /// invalid flag combination).
+    pub const USAGE_INVALID: &str = "cli.usage.invalid";
+    /// `--help` was requested.
+    pub const HELP: &str = "cli.help";
+    /// `--version` was requested.
+    pub const VERSION: &str = "cli.version";
+    /// Process was interrupted (`SIGINT` / `SIGTERM`).
+    pub const INTERRUPTED: &str = "cli.interrupted";
+    /// Catch-all for failures that do not fit a more specific domain.
+    pub const UNKNOWN: &str = "cli.unknown";
+
+    pub(crate) const ALL: &[&str] = &[USAGE_INVALID, HELP, VERSION, INTERRUPTED, UNKNOWN];
+}
+
+/// `foundry-config` diagnostic codes.
+pub mod config {
+    pub const INVALID: &str = "config.invalid";
+    pub const MISSING_FIELD: &str = "config.missing_field";
+
+    pub(crate) const ALL: &[&str] = &[INVALID, MISSING_FIELD];
+}
+
+/// Compiler diagnostic codes (`foundry-compilers`, `forge`).
+pub mod compiler {
+    pub const SOLC_ERROR: &str = "compiler.solc.error";
+    pub const VYPER_ERROR: &str = "compiler.vyper.error";
+
+    pub(crate) const ALL: &[&str] = &[SOLC_ERROR, VYPER_ERROR];
+}
+
+/// Network / RPC diagnostic codes.
+pub mod network {
+    pub const RPC_TIMEOUT: &str = "network.rpc.timeout";
+    pub const RPC_UNAUTHORIZED: &str = "network.rpc.unauthorized";
+
+    pub(crate) const ALL: &[&str] = &[RPC_TIMEOUT, RPC_UNAUTHORIZED];
+}
+
+/// `foundry-wallets` diagnostic codes.
+pub mod wallet {
+    pub const KEY_MISSING: &str = "wallet.key.missing";
+    pub const SIGNATURE_REJECTED: &str = "wallet.signature.rejected";
+
+    pub(crate) const ALL: &[&str] = &[KEY_MISSING, SIGNATURE_REJECTED];
+}
+
+/// `forge test` diagnostic codes.
+pub mod test {
+    pub const FAILED: &str = "test.failed";
+    pub const SETUP_FAILED: &str = "test.setup_failed";
+
+    pub(crate) const ALL: &[&str] = &[FAILED, SETUP_FAILED];
+}
+
+/// `forge script` diagnostic codes.
+pub mod script {
+    pub const BROADCAST_FAILED: &str = "script.broadcast_failed";
+
+    pub(crate) const ALL: &[&str] = &[BROADCAST_FAILED];
+}
+
+/// `cast` diagnostic codes.
+pub mod cast {
+    pub const TX_NOT_FOUND: &str = "cast.tx.not_found";
+
+    pub(crate) const ALL: &[&str] = &[TX_NOT_FOUND];
+}
+
+/// `anvil` diagnostic codes.
+pub mod anvil {
+    pub const FORK_UNREACHABLE: &str = "anvil.fork.unreachable";
+
+    pub(crate) const ALL: &[&str] = &[FORK_UNREACHABLE];
+}
+
+/// `chisel` diagnostic codes.
+pub mod chisel {
+    pub const SESSION_INVALID: &str = "chisel.session.invalid";
+
+    pub(crate) const ALL: &[&str] = &[SESSION_INVALID];
+}
+
+/// All diagnostic codes declared in this crate.
+///
+/// Useful for repo-wide validation tests.
+pub fn known_codes() -> Vec<&'static str> {
+    let groups: &[&[&str]] = &[
+        cli::ALL,
+        config::ALL,
+        compiler::ALL,
+        network::ALL,
+        wallet::ALL,
+        test::ALL,
+        script::ALL,
+        cast::ALL,
+        anvil::ALL,
+        chisel::ALL,
+    ];
+    groups.iter().flat_map(|g| g.iter().copied()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_codes_round_trip() {
+        for c in &["cli.usage.invalid", "config.invalid", "network.rpc.timeout", "a.b.c.d.e"] {
+            let code = DiagnosticCode::new(*c).unwrap();
+            assert_eq!(code.as_str(), *c);
+        }
+    }
+
+    #[test]
+    fn invalid_codes_rejected() {
+        for c in &[
+            "",
+            "no_dot",
+            "Cli.usage",         // uppercase
+            ".cli.usage",        // leading dot
+            "cli.usage.",        // trailing dot
+            "cli..usage",        // empty segment
+            "1cli.usage",        // segment must start with [a-z]
+            "cli.1usage",        // segment must start with [a-z]
+            "cli.usage-invalid", // dash not allowed
+            "cli.usage invalid", // space not allowed
+        ] {
+            assert!(DiagnosticCode::new(*c).is_err(), "expected `{c}` to be rejected");
+        }
+    }
+
+    #[test]
+    fn every_known_code_validates() {
+        for c in known_codes() {
+            assert!(validate(c).is_ok(), "registered code `{c}` failed validation");
+        }
+    }
+
+    #[test]
+    fn known_codes_are_unique() {
+        let mut seen = std::collections::BTreeSet::new();
+        let mut dups = Vec::new();
+        for c in known_codes() {
+            if !seen.insert(c) {
+                dups.push(c);
+            }
+        }
+        assert!(dups.is_empty(), "duplicate diagnostic codes: {dups:?}");
+    }
+}

--- a/crates/cli/src/exit_code.rs
+++ b/crates/cli/src/exit_code.rs
@@ -1,0 +1,195 @@
+//! Canonical process exit codes for the Foundry agent contract.
+//!
+//! See [`docs/agents/exit-codes.md`](../../../docs/agents/exit-codes.md) for the
+//! contract these codes implement.
+
+use std::fmt;
+
+/// Canonical exit codes emitted by Foundry binaries.
+///
+/// Only the variants below are guaranteed by the agent contract. Commands MAY
+/// document additional, command-specific codes via
+/// [`ExitCodeInfo`](crate::introspect::ExitCodeInfo); those codes MUST NOT
+/// collide with this global table.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(i32)]
+pub enum ExitCode {
+    /// Command completed successfully.
+    Success = 0,
+    /// Unclassified failure.
+    GenericError = 1,
+    /// Argument parse error, missing subcommand, or invalid flag combination.
+    Usage = 2,
+    /// Foundry config invalid or missing required value.
+    Config = 3,
+    /// Compilation, linking, or artifact generation failed.
+    Build = 4,
+    /// Tests ran but at least one failed (distinct from a build/setup failure).
+    TestFailure = 5,
+    /// RPC, HTTP, or chain-connectivity failure.
+    Network = 6,
+    /// Authentication, authorization, or wallet/key-related failure.
+    User = 7,
+    /// Command terminated by `SIGINT` / `SIGTERM`.
+    Interrupted = 8,
+}
+
+impl ExitCode {
+    /// Returns the numeric process exit code.
+    pub const fn to_i32(self) -> i32 {
+        self as i32
+    }
+
+    /// Returns the stable, human-readable variant name.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Success => "Success",
+            Self::GenericError => "GenericError",
+            Self::Usage => "Usage",
+            Self::Config => "Config",
+            Self::Build => "Build",
+            Self::TestFailure => "TestFailure",
+            Self::Network => "Network",
+            Self::User => "User",
+            Self::Interrupted => "Interrupted",
+        }
+    }
+}
+
+impl fmt::Display for ExitCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ({})", self.name(), self.to_i32())
+    }
+}
+
+impl From<ExitCode> for i32 {
+    fn from(code: ExitCode) -> Self {
+        code.to_i32()
+    }
+}
+
+impl From<&eyre::Report> for ExitCode {
+    /// Best-effort classification of a report.
+    ///
+    /// Walks the error chain looking for keywords characteristic of common
+    /// failure categories; falls back to [`ExitCode::GenericError`] when no
+    /// category matches. The mapping is intentionally conservative — adoption
+    /// PRs will tighten it as commands return typed errors.
+    fn from(report: &eyre::Report) -> Self {
+        let mut buf = String::new();
+        for cause in report.chain() {
+            use std::fmt::Write;
+            let _ = writeln!(buf, "{cause}");
+        }
+        let lower = buf.to_lowercase();
+
+        // Order matters: classify auth/user signals before network so a 401
+        // from an RPC provider doesn't get misfiled as a transient network
+        // error.
+        if lower.contains("interrupted") || lower.contains("sigint") || lower.contains("sigterm") {
+            return Self::Interrupted;
+        }
+        if lower.contains("foundry.toml")
+            || (lower.contains("config")
+                && (lower.contains("invalid") || lower.contains("missing")))
+        {
+            return Self::Config;
+        }
+        if lower.contains("unauthorized")
+            || lower.contains("forbidden")
+            || lower.contains("authentication")
+            || lower.contains("authorization")
+            || lower.contains("api key")
+            || lower.contains("private key")
+            || lower.contains("keystore")
+            || lower.contains("wallet")
+            || lower.contains("signer")
+        {
+            return Self::User;
+        }
+        if lower.contains("rpc")
+            || lower.contains("timeout")
+            || lower.contains("timed out")
+            || lower.contains("connection refused")
+            || lower.contains("dns")
+        {
+            return Self::Network;
+        }
+        if lower.contains("compil") || lower.contains("solc") || lower.contains("vyper") {
+            return Self::Build;
+        }
+        Self::GenericError
+    }
+}
+
+impl From<eyre::Report> for ExitCode {
+    fn from(report: eyre::Report) -> Self {
+        (&report).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn numeric_codes_match_spec() {
+        assert_eq!(ExitCode::Success.to_i32(), 0);
+        assert_eq!(ExitCode::GenericError.to_i32(), 1);
+        assert_eq!(ExitCode::Usage.to_i32(), 2);
+        assert_eq!(ExitCode::Config.to_i32(), 3);
+        assert_eq!(ExitCode::Build.to_i32(), 4);
+        assert_eq!(ExitCode::TestFailure.to_i32(), 5);
+        assert_eq!(ExitCode::Network.to_i32(), 6);
+        assert_eq!(ExitCode::User.to_i32(), 7);
+        assert_eq!(ExitCode::Interrupted.to_i32(), 8);
+    }
+
+    #[test]
+    fn report_classifies_config() {
+        let r: eyre::Report = eyre::eyre!("could not parse foundry.toml: invalid value");
+        assert_eq!(ExitCode::from(&r), ExitCode::Config);
+    }
+
+    #[test]
+    fn report_classifies_network() {
+        let r: eyre::Report = eyre::eyre!("RPC connection timeout");
+        assert_eq!(ExitCode::from(&r), ExitCode::Network);
+    }
+
+    #[test]
+    fn report_classifies_wallet() {
+        let r: eyre::Report = eyre::eyre!("wallet: missing private key");
+        assert_eq!(ExitCode::from(&r), ExitCode::User);
+    }
+
+    #[test]
+    fn report_classifies_compiler() {
+        let r: eyre::Report = eyre::eyre!("solc compilation failed");
+        assert_eq!(ExitCode::from(&r), ExitCode::Build);
+    }
+
+    #[test]
+    fn report_falls_back_to_generic() {
+        let r: eyre::Report = eyre::eyre!("something unexpected went wrong");
+        assert_eq!(ExitCode::from(&r), ExitCode::GenericError);
+    }
+
+    #[test]
+    fn auth_classified_before_network() {
+        let r: eyre::Report = eyre::eyre!("RPC call failed: 401 unauthorized");
+        assert_eq!(ExitCode::from(&r), ExitCode::User);
+    }
+
+    #[test]
+    fn dns_failure_is_network() {
+        let r: eyre::Report = eyre::eyre!("dns lookup failed for mainnet.alchemy.com");
+        assert_eq!(ExitCode::from(&r), ExitCode::Network);
+    }
+
+    #[test]
+    fn interrupt_classification() {
+        let r: eyre::Report = eyre::eyre!("interrupted by SIGINT");
+        assert_eq!(ExitCode::from(&r), ExitCode::Interrupted);
+    }
+}

--- a/crates/cli/src/introspect/build.rs
+++ b/crates/cli/src/introspect/build.rs
@@ -1,13 +1,15 @@
 //! Build an [`IntrospectDocument`] from a `clap::Command` tree.
 
 use clap::{Arg, ArgAction, Command};
+use std::sync::OnceLock;
 
 use super::{
-    INTROSPECT_SCHEMA_ID, INTROSPECT_SCHEMA_VERSION,
+    INTROSPECT_SCHEMA_ID, INTROSPECT_SCHEMA_VERSION, OutputMode,
     document::{
-        ArgInfo, ArgKind, BinaryInfo, Capabilities, CommandInfo, IntrospectDocument, ValueType,
+        ArgInfo, ArgKind, BinaryInfo, Capabilities, CommandInfo, ExitCodeInfo, IntrospectDocument,
+        ValueType,
     },
-    registry::{CommandMeta, CommandRegistry},
+    registry::{CapabilityMeta, CommandMeta, CommandRegistry, ExitCodeMeta},
 };
 
 /// Collect every `command_id` (recursively) emitted by an
@@ -22,6 +24,124 @@ pub fn collect_command_ids(doc: &IntrospectDocument) -> Vec<String> {
     let mut out = Vec::new();
     for cmd in &doc.commands {
         walk(cmd, &mut out);
+    }
+    out
+}
+
+/// Assert capability self-consistency for every command in `doc`.
+///
+/// Returns one error message per offending command. Static repo-wide check
+/// that catches commands declaring an output mode without wiring the
+/// supporting schema metadata, or vice versa.
+///
+/// Per-mode rules (see also spec §3, §4, §8):
+///
+/// - [`OutputMode::None`](super::OutputMode::None) and
+///   [`OutputMode::LegacyJson`](super::OutputMode::LegacyJson) MUST NOT carry schema refs.
+/// - [`OutputMode::Envelope`](super::OutputMode::Envelope) requires `result_schema_ref`; MUST NOT
+///   carry `event_schema_ref` or `session_schema_ref`.
+/// - [`OutputMode::Stream`](super::OutputMode::Stream) requires `event_schema_ref`; implies
+///   `long_running = true`. `result_schema_ref` MAY also be set when the stream ends with a
+///   terminal envelope.
+/// - [`OutputMode::Session`](super::OutputMode::Session) requires `session_schema_ref`; implies
+///   `stateful = true` and `long_running = true`.
+///
+/// Schema refs, when present, must be non-empty and match
+/// `^foundry:[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*(\.event|\.session)?@v\d+$`.
+pub fn capability_violations(doc: &IntrospectDocument) -> Vec<String> {
+    static SCHEMA_REF_RE: OnceLock<regex::Regex> = OnceLock::new();
+    let schema_re = SCHEMA_REF_RE.get_or_init(|| {
+        regex::Regex::new(r"^foundry:[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*(\.event|\.session)?@v\d+$")
+            .expect("schema-ref regex compiles")
+    });
+
+    fn check_ref(
+        out: &mut Vec<String>,
+        id: &str,
+        name: &str,
+        val: Option<&str>,
+        re: &regex::Regex,
+    ) {
+        if let Some(v) = val {
+            if v.is_empty() {
+                out.push(format!("{id}: capabilities.{name} must not be empty"));
+            } else if !re.is_match(v) {
+                out.push(format!(
+                    "{id}: capabilities.{name} = `{v}` does not match `foundry:<id>@vN`"
+                ));
+            }
+        }
+    }
+
+    fn walk(cmd: &CommandInfo, out: &mut Vec<String>, re: &regex::Regex) {
+        let caps = &cmd.capabilities;
+        let id = cmd.command_id.as_str();
+
+        // Format check on every present ref, regardless of mode.
+        check_ref(out, id, "result_schema_ref", caps.result_schema_ref.as_deref(), re);
+        check_ref(out, id, "event_schema_ref", caps.event_schema_ref.as_deref(), re);
+        check_ref(out, id, "session_schema_ref", caps.session_schema_ref.as_deref(), re);
+
+        match caps.output_mode {
+            OutputMode::None | OutputMode::LegacyJson => {
+                if caps.result_schema_ref.is_some()
+                    || caps.event_schema_ref.is_some()
+                    || caps.session_schema_ref.is_some()
+                {
+                    out.push(format!(
+                        "{id}: output_mode={:?} must not carry any schema refs",
+                        caps.output_mode
+                    ));
+                }
+            }
+            OutputMode::Envelope => {
+                if caps.result_schema_ref.is_none() {
+                    out.push(format!(
+                        "{id}: output_mode=envelope requires capabilities.result_schema_ref"
+                    ));
+                }
+                if caps.event_schema_ref.is_some() {
+                    out.push(format!("{id}: output_mode=envelope must not carry event_schema_ref"));
+                }
+                if caps.session_schema_ref.is_some() {
+                    out.push(format!(
+                        "{id}: output_mode=envelope must not carry session_schema_ref"
+                    ));
+                }
+            }
+            OutputMode::Stream => {
+                if caps.event_schema_ref.is_none() {
+                    out.push(format!(
+                        "{id}: output_mode=stream requires capabilities.event_schema_ref"
+                    ));
+                }
+                if !caps.long_running {
+                    out.push(format!("{id}: output_mode=stream implies long_running = true"));
+                }
+            }
+            OutputMode::Session => {
+                if caps.session_schema_ref.is_none() {
+                    out.push(format!(
+                        "{id}: output_mode=session requires capabilities.session_schema_ref"
+                    ));
+                }
+                if !caps.stateful {
+                    out.push(format!("{id}: output_mode=session implies stateful = true"));
+                }
+                if !caps.long_running {
+                    out.push(format!("{id}: output_mode=session implies long_running = true"));
+                }
+            }
+        }
+
+        for sub in &cmd.subcommands {
+            walk(sub, out, re);
+        }
+    }
+
+    let mut out = Vec::new();
+    for cmd in &doc.commands {
+        walk(cmd, &mut out, schema_re);
     }
     out
 }
@@ -86,8 +206,10 @@ fn build_command_info(
     let meta = registry.lookup(&lookup_path);
 
     let command_id = derive_command_id(&path, meta);
-    let capabilities = meta.map_or_else(Capabilities::default, |m| m.capabilities.clone());
-    let exit_codes = meta.map_or_else(Vec::new, |m| m.exit_codes.to_vec());
+    let capabilities =
+        meta.map_or_else(Capabilities::default, |m| capabilities_from(&m.capabilities));
+    let exit_codes =
+        meta.map_or_else(Vec::new, |m| m.exit_codes.iter().map(exit_code_from).collect());
 
     let aliases = command.get_visible_aliases().map(str::to_string).collect::<Vec<_>>();
 
@@ -114,6 +236,33 @@ fn build_command_info(
         capabilities,
         exit_codes,
         hidden: command.is_hide_set(),
+    }
+}
+
+/// Convert const-friendly registry [`CapabilityMeta`] to the owned
+/// serialized [`Capabilities`] form emitted in introspection.
+fn capabilities_from(meta: &CapabilityMeta) -> Capabilities {
+    Capabilities {
+        output_mode: meta.output_mode,
+        result_schema_ref: meta.result_schema_ref.map(String::from),
+        event_schema_ref: meta.event_schema_ref.map(String::from),
+        session_schema_ref: meta.session_schema_ref.map(String::from),
+        reads_stdin: meta.reads_stdin,
+        supports_output_path: meta.supports_output_path,
+        requires_project: meta.requires_project,
+        side_effects: meta.side_effects,
+        long_running: meta.long_running,
+        stateful: meta.stateful,
+    }
+}
+
+/// Convert const-friendly registry [`ExitCodeMeta`] to the owned serialized
+/// [`ExitCodeInfo`] form emitted in introspection.
+fn exit_code_from(meta: &ExitCodeMeta) -> ExitCodeInfo {
+    ExitCodeInfo {
+        code: meta.code,
+        name: meta.name.to_string(),
+        description: meta.description.to_string(),
     }
 }
 
@@ -269,7 +418,7 @@ mod tests {
                 path: &["build"],
                 meta: CommandMeta {
                     command_id: Some("demo.compile"),
-                    capabilities: Capabilities::NONE,
+                    capabilities: CapabilityMeta::NONE,
                     exit_codes: &[],
                 },
             }];
@@ -314,6 +463,168 @@ mod tests {
         for arg in &build.args {
             assert!(arg.name != "help" && arg.name != "version", "got {arg:?}");
         }
+    }
+
+    /// Helper: build a registry with one entry pinned at `["build"]`.
+    fn registry_with_one_build_entry(meta: &'static CommandMeta) -> CommandRegistry {
+        let entry: &'static super::super::registry::RegistryEntry =
+            Box::leak(Box::new(super::super::registry::RegistryEntry {
+                path: &["build"],
+                meta: *meta,
+            }));
+        CommandRegistry::new(std::slice::from_ref(entry))
+    }
+
+    #[test]
+    fn capability_violations_detects_envelope_without_schema_ref() {
+        static META: CommandMeta = CommandMeta {
+            command_id: None,
+            capabilities: CapabilityMeta {
+                output_mode: OutputMode::Envelope,
+                ..CapabilityMeta::NONE
+            },
+            exit_codes: &[],
+        };
+        static ENTRIES: &[super::super::registry::RegistryEntry] =
+            &[super::super::registry::RegistryEntry { path: &["build"], meta: META }];
+        let registry = CommandRegistry::new(ENTRIES);
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let violations = capability_violations(&doc);
+        assert_eq!(violations.len(), 1, "got {violations:?}");
+        assert!(violations[0].contains("envelope requires capabilities.result_schema_ref"));
+    }
+
+    #[test]
+    fn capability_violations_passes_for_well_formed_envelope() {
+        static META: CommandMeta = CommandMeta {
+            command_id: None,
+            capabilities: CapabilityMeta {
+                output_mode: OutputMode::Envelope,
+                result_schema_ref: Some("foundry:demo.build@v1"),
+                ..CapabilityMeta::NONE
+            },
+            exit_codes: &[],
+        };
+        static ENTRIES: &[super::super::registry::RegistryEntry] =
+            &[super::super::registry::RegistryEntry { path: &["build"], meta: META }];
+        let registry = CommandRegistry::new(ENTRIES);
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let violations = capability_violations(&doc);
+        assert!(violations.is_empty(), "unexpected violations: {violations:?}");
+    }
+
+    #[test]
+    fn capability_violations_rejects_empty_schema_ref() {
+        static META: CommandMeta = CommandMeta {
+            command_id: None,
+            capabilities: CapabilityMeta {
+                output_mode: OutputMode::Envelope,
+                result_schema_ref: Some(""),
+                ..CapabilityMeta::NONE
+            },
+            exit_codes: &[],
+        };
+        let registry = registry_with_one_build_entry(&META);
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(v.iter().any(|s| s.contains("must not be empty")), "got {v:?}");
+    }
+
+    #[test]
+    fn capability_violations_rejects_malformed_schema_ref() {
+        static META: CommandMeta = CommandMeta {
+            command_id: None,
+            capabilities: CapabilityMeta {
+                output_mode: OutputMode::Envelope,
+                result_schema_ref: Some("not-a-foundry-ref"),
+                ..CapabilityMeta::NONE
+            },
+            exit_codes: &[],
+        };
+        let registry = registry_with_one_build_entry(&META);
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(v.iter().any(|s| s.contains("does not match")), "got {v:?}");
+    }
+
+    #[test]
+    fn capability_violations_rejects_envelope_with_event_ref() {
+        static META: CommandMeta = CommandMeta {
+            command_id: None,
+            capabilities: CapabilityMeta {
+                output_mode: OutputMode::Envelope,
+                result_schema_ref: Some("foundry:demo.build@v1"),
+                event_schema_ref: Some("foundry:demo.build.event@v1"),
+                ..CapabilityMeta::NONE
+            },
+            exit_codes: &[],
+        };
+        let registry = registry_with_one_build_entry(&META);
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(v.iter().any(|s| s.contains("must not carry event_schema_ref")), "got {v:?}");
+    }
+
+    #[test]
+    fn capability_violations_rejects_none_with_schema_ref() {
+        static META: CommandMeta = CommandMeta {
+            command_id: None,
+            capabilities: CapabilityMeta {
+                output_mode: OutputMode::None,
+                result_schema_ref: Some("foundry:demo.build@v1"),
+                ..CapabilityMeta::NONE
+            },
+            exit_codes: &[],
+        };
+        let registry = registry_with_one_build_entry(&META);
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(v.iter().any(|s| s.contains("must not carry any schema refs")), "got {v:?}");
+    }
+
+    #[test]
+    fn capability_violations_session_requires_stateful() {
+        static META: CommandMeta = CommandMeta {
+            command_id: None,
+            capabilities: CapabilityMeta {
+                output_mode: OutputMode::Session,
+                session_schema_ref: Some("foundry:demo.session@v1"),
+                long_running: true,
+                stateful: false,
+                ..CapabilityMeta::NONE
+            },
+            exit_codes: &[],
+        };
+        let registry = registry_with_one_build_entry(&META);
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(v.iter().any(|s| s.contains("implies stateful")), "got {v:?}");
+    }
+
+    #[test]
+    fn capability_violations_stream_requires_long_running() {
+        static META: CommandMeta = CommandMeta {
+            command_id: None,
+            capabilities: CapabilityMeta {
+                output_mode: OutputMode::Stream,
+                event_schema_ref: Some("foundry:demo.event@v1"),
+                long_running: false,
+                ..CapabilityMeta::NONE
+            },
+            exit_codes: &[],
+        };
+        let registry = registry_with_one_build_entry(&META);
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+        let v = capability_violations(&doc);
+        assert!(v.iter().any(|s| s.contains("implies long_running")), "got {v:?}");
     }
 
     #[test]

--- a/crates/cli/src/introspect/build.rs
+++ b/crates/cli/src/introspect/build.rs
@@ -36,15 +36,13 @@ pub fn collect_command_ids(doc: &IntrospectDocument) -> Vec<String> {
 ///
 /// Per-mode rules (see also spec §3, §4, §8):
 ///
-/// - [`OutputMode::None`](super::OutputMode::None) and
-///   [`OutputMode::LegacyJson`](super::OutputMode::LegacyJson) MUST NOT carry schema refs.
-/// - [`OutputMode::Envelope`](super::OutputMode::Envelope) requires `result_schema_ref`; MUST NOT
-///   carry `event_schema_ref` or `session_schema_ref`.
-/// - [`OutputMode::Stream`](super::OutputMode::Stream) requires `event_schema_ref`; implies
-///   `long_running = true`. `result_schema_ref` MAY also be set when the stream ends with a
-///   terminal envelope.
-/// - [`OutputMode::Session`](super::OutputMode::Session) requires `session_schema_ref`; implies
-///   `stateful = true` and `long_running = true`.
+/// - [`OutputMode::None`] and [`OutputMode::LegacyJson`] MUST NOT carry schema refs.
+/// - [`OutputMode::Envelope`] requires `result_schema_ref`; MUST NOT carry `event_schema_ref` or
+///   `session_schema_ref`.
+/// - [`OutputMode::Stream`] requires `event_schema_ref`; implies `long_running = true`.
+///   `result_schema_ref` MAY also be set when the stream ends with a terminal envelope.
+/// - [`OutputMode::Session`] requires `session_schema_ref`; implies `stateful = true` and
+///   `long_running = true`.
 ///
 /// Schema refs, when present, must be non-empty and match
 /// `^foundry:[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*(\.event|\.session)?@v\d+$`.

--- a/crates/cli/src/introspect/build.rs
+++ b/crates/cli/src/introspect/build.rs
@@ -1,0 +1,327 @@
+//! Build an [`IntrospectDocument`] from a `clap::Command` tree.
+
+use clap::{Arg, ArgAction, Command};
+
+use super::{
+    INTROSPECT_SCHEMA_ID, INTROSPECT_SCHEMA_VERSION,
+    document::{
+        ArgInfo, ArgKind, BinaryInfo, Capabilities, CommandInfo, IntrospectDocument, ValueType,
+    },
+    registry::{CommandMeta, CommandRegistry},
+};
+
+/// Collect every `command_id` (recursively) emitted by an
+/// [`IntrospectDocument`].
+pub fn collect_command_ids(doc: &IntrospectDocument) -> Vec<String> {
+    fn walk(cmd: &CommandInfo, out: &mut Vec<String>) {
+        out.push(cmd.command_id.clone());
+        for sub in &cmd.subcommands {
+            walk(sub, out);
+        }
+    }
+    let mut out = Vec::new();
+    for cmd in &doc.commands {
+        walk(cmd, &mut out);
+    }
+    out
+}
+
+/// Assert that every `command_id` in `doc` is unique.
+///
+/// Returns the duplicate ids on failure (one entry per duplicate `command_id`,
+/// in the order they were first encountered). On success returns an empty vec.
+///
+/// This is the canonical uniqueness check the agent contract relies on; each
+/// binary calls it from a unit test to enforce the invariant in CI.
+pub fn duplicate_command_ids(doc: &IntrospectDocument) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut dups = Vec::new();
+    for id in collect_command_ids(doc) {
+        if !seen.insert(id.clone()) && !dups.contains(&id) {
+            dups.push(id);
+        }
+    }
+    dups
+}
+
+/// Build an [`IntrospectDocument`] for `command` overlaid with metadata from
+/// `registry`.
+pub fn build_document(command: &Command, registry: &CommandRegistry) -> IntrospectDocument {
+    let binary = build_binary_info(command);
+    let mut commands = Vec::new();
+
+    let root_path = vec![command.get_name().to_string()];
+    for sub in command.get_subcommands() {
+        commands.push(build_command_info(sub, &root_path, registry));
+    }
+
+    IntrospectDocument {
+        schema_id: INTROSPECT_SCHEMA_ID.to_string(),
+        schema_version: INTROSPECT_SCHEMA_VERSION,
+        binary,
+        commands,
+    }
+}
+
+fn build_binary_info(command: &Command) -> BinaryInfo {
+    BinaryInfo {
+        name: command.get_name().to_string(),
+        version: command.get_version().unwrap_or("").to_string(),
+        long_version: command.get_long_version().map(str::to_string),
+        description: command.get_about().map(|s| s.to_string()),
+    }
+}
+
+fn build_command_info(
+    command: &Command,
+    parent_path: &[String],
+    registry: &CommandRegistry,
+) -> CommandInfo {
+    // Path components for this command, including the binary name at index 0.
+    let mut path = parent_path.to_vec();
+    path.push(command.get_name().to_string());
+
+    // Registry lookup uses the path **without** the binary name.
+    let lookup_path: Vec<&str> = path.iter().skip(1).map(String::as_str).collect();
+    let meta = registry.lookup(&lookup_path);
+
+    let command_id = derive_command_id(&path, meta);
+    let capabilities = meta.map_or_else(Capabilities::default, |m| m.capabilities.clone());
+    let exit_codes = meta.map_or_else(Vec::new, |m| m.exit_codes.to_vec());
+
+    let aliases = command.get_visible_aliases().map(str::to_string).collect::<Vec<_>>();
+
+    let summary = command.get_about().map(|s| s.to_string());
+    let description = command
+        .get_long_about()
+        .map(|s| s.to_string())
+        .filter(|d| Some(d.as_str()) != summary.as_deref());
+
+    let args =
+        command.get_arguments().filter(|a| !is_help_or_version(a)).map(build_arg_info).collect();
+
+    let subcommands =
+        command.get_subcommands().map(|sub| build_command_info(sub, &path, registry)).collect();
+
+    CommandInfo {
+        command_id,
+        path,
+        aliases,
+        summary,
+        description,
+        args,
+        subcommands,
+        capabilities,
+        exit_codes,
+        hidden: command.is_hide_set(),
+    }
+}
+
+/// Derive the stable command id.
+///
+/// If the registry pins an explicit `command_id`, use it. Otherwise, derive
+/// the id by joining the path components with `.` (e.g. `forge.build`).
+fn derive_command_id(path: &[String], meta: Option<&CommandMeta>) -> String {
+    if let Some(id) = meta.and_then(|m| m.command_id) {
+        return id.to_string();
+    }
+    path.join(".")
+}
+
+fn build_arg_info(arg: &Arg) -> ArgInfo {
+    let kind = arg_kind(arg);
+    let value_type = arg_value_type(arg);
+
+    let aliases = arg
+        .get_visible_aliases()
+        .map(|a| a.into_iter().map(String::from).collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    let possible_values = arg
+        .get_possible_values()
+        .iter()
+        .filter(|p| !p.is_hide_set())
+        .map(|p| p.get_name().to_string())
+        .collect();
+
+    // Clap does not expose conflict relationships through a public API on `Arg`;
+    // these would have to be threaded through annotations on a per-binary basis.
+    // Reserved here so the schema field is always present and stable.
+    let conflicts_with: Vec<String> = Vec::new();
+
+    let default = arg.get_default_values().first().map(|v| v.to_string_lossy().into_owned());
+
+    ArgInfo {
+        name: arg.get_id().to_string(),
+        kind,
+        value_type,
+        help: arg.get_help().map(|h| h.to_string()),
+        long: arg.get_long().map(String::from),
+        short: arg.get_short(),
+        aliases,
+        env: arg.get_env().map(|e| e.to_string_lossy().into_owned()),
+        default,
+        possible_values,
+        required: arg.is_required_set(),
+        repeatable: matches!(arg.get_action(), ArgAction::Count | ArgAction::Append),
+        conflicts_with,
+        help_heading: arg.get_help_heading().map(String::from),
+        hidden: arg.is_hide_set(),
+    }
+}
+
+fn arg_kind(arg: &Arg) -> ArgKind {
+    if arg.is_positional() {
+        return ArgKind::Positional;
+    }
+    match arg.get_action() {
+        ArgAction::SetTrue
+        | ArgAction::SetFalse
+        | ArgAction::Count
+        | ArgAction::Help
+        | ArgAction::HelpShort
+        | ArgAction::HelpLong
+        | ArgAction::Version => ArgKind::Flag,
+        _ => ArgKind::Option,
+    }
+}
+
+fn arg_value_type(arg: &Arg) -> ValueType {
+    match arg.get_action() {
+        ArgAction::SetTrue | ArgAction::SetFalse => return ValueType::Bool,
+        ArgAction::Count => return ValueType::Integer,
+        _ => {}
+    }
+
+    let name = arg.get_value_names().and_then(|v| v.first()).map(|s| s.as_str()).unwrap_or("");
+    match name.to_ascii_lowercase().as_str() {
+        "" => ValueType::Other,
+        "path" | "file" | "dir" | "directory" => ValueType::Path,
+        "url" | "rpc_url" | "rpc-url" => ValueType::Url,
+        "address" | "addr" => ValueType::Address,
+        "selector" | "sig" => ValueType::Selector,
+        "hex" | "bytes" | "bytecode" | "calldata" => ValueType::Hex,
+        "json" => ValueType::Json,
+        "int" | "integer" | "u64" | "u256" | "i64" | "i256" | "number" | "n" => ValueType::Integer,
+        "string" | "str" | "name" => ValueType::String,
+        _ => ValueType::Other,
+    }
+}
+
+fn is_help_or_version(arg: &Arg) -> bool {
+    matches!(
+        arg.get_action(),
+        ArgAction::Help | ArgAction::HelpShort | ArgAction::HelpLong | ArgAction::Version
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    #[command(name = "demo", version = "0.1.0")]
+    struct Demo {
+        #[command(subcommand)]
+        cmd: DemoSub,
+    }
+
+    #[derive(clap::Subcommand)]
+    enum DemoSub {
+        /// Build the project.
+        #[command(visible_alias = "b")]
+        Build {
+            /// Number of jobs.
+            #[arg(short, long)]
+            jobs: Option<u32>,
+        },
+        /// Group of cache subcommands.
+        Cache {
+            #[command(subcommand)]
+            cmd: CacheSub,
+        },
+    }
+
+    #[derive(clap::Subcommand)]
+    enum CacheSub {
+        /// Clean cache.
+        Clean,
+    }
+
+    #[test]
+    fn builds_document_with_default_command_ids() {
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+
+        assert_eq!(doc.schema_id, INTROSPECT_SCHEMA_ID);
+        assert_eq!(doc.binary.name, "demo");
+
+        let build = doc.commands.iter().find(|c| c.path.last().unwrap() == "build").unwrap();
+        assert_eq!(build.command_id, "demo.build");
+        assert_eq!(build.aliases, vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn registry_overrides_command_id() {
+        static ENTRIES: &[super::super::registry::RegistryEntry] =
+            &[super::super::registry::RegistryEntry {
+                path: &["build"],
+                meta: CommandMeta {
+                    command_id: Some("demo.compile"),
+                    capabilities: Capabilities::NONE,
+                    exit_codes: &[],
+                },
+            }];
+        let registry = CommandRegistry::new(ENTRIES);
+
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &registry);
+
+        let build = doc.commands.iter().find(|c| c.path.last().unwrap() == "build").unwrap();
+        assert_eq!(build.command_id, "demo.compile");
+    }
+
+    #[test]
+    fn nested_subcommands_have_dotted_ids() {
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+
+        let cache = doc.commands.iter().find(|c| c.path.last().unwrap() == "cache").unwrap();
+        let clean = cache.subcommands.iter().find(|c| c.path.last().unwrap() == "clean").unwrap();
+        assert_eq!(clean.command_id, "demo.cache.clean");
+        assert_eq!(clean.path, vec!["demo", "cache", "clean"]);
+    }
+
+    #[test]
+    fn args_are_described() {
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let build = doc.commands.iter().find(|c| c.path.last().unwrap() == "build").unwrap();
+
+        let jobs = build.args.iter().find(|a| a.name == "jobs").unwrap();
+        assert!(matches!(jobs.kind, ArgKind::Option));
+        assert_eq!(jobs.long.as_deref(), Some("jobs"));
+        assert_eq!(jobs.short, Some('j'));
+        assert!(!jobs.required);
+    }
+
+    #[test]
+    fn help_and_version_args_are_excluded() {
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let build = doc.commands.iter().find(|c| c.path.last().unwrap() == "build").unwrap();
+        for arg in &build.args {
+            assert!(arg.name != "help" && arg.name != "version", "got {arg:?}");
+        }
+    }
+
+    #[test]
+    fn document_round_trips_through_serde() {
+        let cmd = <Demo as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let json = serde_json::to_string(&doc).unwrap();
+        let parsed: IntrospectDocument = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, doc);
+    }
+}

--- a/crates/cli/src/introspect/document.rs
+++ b/crates/cli/src/introspect/document.rs
@@ -1,0 +1,230 @@
+//! Serializable types describing a Foundry binary's command surface.
+//!
+//! See [`docs/agents/spec.md`](../../../../docs/agents/spec.md) for the
+//! contract these types implement.
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level introspection document.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IntrospectDocument {
+    /// Stable logical schema id, e.g. `foundry:introspect@v1`.
+    pub schema_id: String,
+    /// Schema version for the introspect document.
+    pub schema_version: u32,
+    /// Information about the binary being introspected.
+    pub binary: BinaryInfo,
+    /// Tree of commands exposed by the binary.
+    pub commands: Vec<CommandInfo>,
+}
+
+/// Information about the binary itself.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BinaryInfo {
+    /// Binary name (`forge`, `cast`, `anvil`, `chisel`).
+    pub name: String,
+    /// Short version string.
+    pub version: String,
+    /// Long version string with build metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub long_version: Option<String>,
+    /// Description of the binary.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Information about a single command (or group) in the CLI tree.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandInfo {
+    /// Stable machine identifier (e.g. `forge.build`).
+    pub command_id: String,
+    /// Clap path components (e.g. `["forge", "build"]`).
+    pub path: Vec<String>,
+    /// Visible aliases for this command.
+    pub aliases: Vec<String>,
+    /// Short, single-line summary.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    /// Long description (multi-line allowed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Arguments declared directly on this command.
+    pub args: Vec<ArgInfo>,
+    /// Subcommands of this command.
+    pub subcommands: Vec<Self>,
+    /// Capabilities reported for agent consumers.
+    pub capabilities: Capabilities,
+    /// Command-specific exit codes (in addition to the global table).
+    pub exit_codes: Vec<ExitCodeInfo>,
+    /// Whether this command is hidden in the human-facing help.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub hidden: bool,
+}
+
+/// Capability flags exposed for agent consumers.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Capabilities {
+    /// What the command emits when run in machine mode.
+    pub output_mode: OutputMode,
+    /// Stable schema id for the envelope payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_schema_ref: Option<String>,
+    /// Stable schema id for stream event records.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_schema_ref: Option<String>,
+    /// Stable schema id for session-record startup/state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_schema_ref: Option<String>,
+    /// Whether the command can take input on stdin via `--input -`.
+    pub reads_stdin: bool,
+    /// Whether the command supports `--output PATH`.
+    pub supports_output_path: bool,
+    /// Whether the command requires a Foundry project to run.
+    pub requires_project: bool,
+    /// Coarse classification of the command's side effects.
+    pub side_effects: SideEffects,
+    /// Whether the command can stream output for an extended period.
+    pub long_running: bool,
+    /// Whether the command opens a session that persists beyond a single call.
+    pub stateful: bool,
+}
+
+impl Capabilities {
+    /// Const-constructible default suitable for use in `static` registries.
+    pub const NONE: Self = Self {
+        output_mode: OutputMode::None,
+        result_schema_ref: None,
+        event_schema_ref: None,
+        session_schema_ref: None,
+        reads_stdin: false,
+        supports_output_path: false,
+        requires_project: false,
+        side_effects: SideEffects::None,
+        long_running: false,
+        stateful: false,
+    };
+}
+
+impl Default for Capabilities {
+    fn default() -> Self {
+        Self::NONE
+    }
+}
+
+/// Output mode under machine mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputMode {
+    /// No machine-mode contract yet; output is human-only.
+    None,
+    /// Pre-existing `--json` shape predating this contract.
+    LegacyJson,
+    /// Single terminal `JsonEnvelope<T>` on stdout.
+    Envelope,
+    /// Newline-delimited JSON event records on stdout.
+    Stream,
+    /// Long-running session (e.g. `anvil`); emits a `session_start` record.
+    Session,
+}
+
+/// Coarse classification of a command's side effects.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SideEffects {
+    /// Pure: reads only (e.g. `cast tx`).
+    None,
+    /// Writes files on the local filesystem.
+    FsWrite,
+    /// Performs network reads (RPC, HTTP).
+    Network,
+    /// Submits transactions or otherwise mutates chain state.
+    ChainWrite,
+    /// Spawns a long-running server (e.g. `anvil`).
+    SpawnServer,
+}
+
+/// Information about a single command argument.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArgInfo {
+    /// Argument identifier (clap arg id).
+    pub name: String,
+    /// Argument kind.
+    pub kind: ArgKind,
+    /// Best-effort classification of the value type.
+    pub value_type: ValueType,
+    /// Help text, when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help: Option<String>,
+    /// Long form (`--foo`), if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub long: Option<String>,
+    /// Short form (`-f`), if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub short: Option<char>,
+    /// All visible aliases.
+    pub aliases: Vec<String>,
+    /// Bound environment variable, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<String>,
+    /// Default value, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+    /// Permitted values for value-enum arguments.
+    pub possible_values: Vec<String>,
+    /// Whether the argument is required.
+    pub required: bool,
+    /// Whether the argument can be supplied multiple times.
+    pub repeatable: bool,
+    /// Other arguments this argument conflicts with.
+    pub conflicts_with: Vec<String>,
+    /// Help heading the argument is grouped under.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_heading: Option<String>,
+    /// Whether the argument is hidden in human help.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub hidden: bool,
+}
+
+/// Argument shape.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArgKind {
+    /// Boolean flag (`--quiet`).
+    Flag,
+    /// Option that takes a value (`--rpc-url URL`).
+    Option,
+    /// Positional argument.
+    Positional,
+}
+
+/// Best-effort classification of an argument's value type, for agent UI hints.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValueType {
+    Bool,
+    String,
+    Integer,
+    Path,
+    Url,
+    Address,
+    Selector,
+    Hex,
+    Json,
+    Other,
+}
+
+/// Documented exit code for a command, beyond the global table.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExitCodeInfo {
+    /// Numeric process exit code.
+    pub code: i32,
+    /// Stable name (e.g. `TestFailure`).
+    pub name: String,
+    /// Description of when this code is emitted.
+    pub description: String,
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+const fn is_false(b: &bool) -> bool {
+    !*b
+}

--- a/crates/cli/src/introspect/mod.rs
+++ b/crates/cli/src/introspect/mod.rs
@@ -1,0 +1,21 @@
+//! Machine-readable introspection for Foundry CLIs.
+//!
+//! This module implements the `--introspect` flag described in
+//! [`docs/agents/spec.md`](../../../../docs/agents/spec.md). It walks a
+//! `clap::Command` tree, merges in metadata from a per-binary
+//! [`CommandRegistry`], and emits an [`IntrospectDocument`] suitable for
+//! agent consumption.
+
+mod build;
+mod document;
+mod registry;
+
+pub use build::{build_document, collect_command_ids, duplicate_command_ids};
+pub use document::*;
+pub use registry::{CommandMeta, CommandRegistry};
+
+/// Stable schema id for the introspect document.
+pub const INTROSPECT_SCHEMA_ID: &str = "foundry:introspect@v1";
+
+/// Schema version for the introspect document.
+pub const INTROSPECT_SCHEMA_VERSION: u32 = 1;

--- a/crates/cli/src/introspect/mod.rs
+++ b/crates/cli/src/introspect/mod.rs
@@ -10,7 +10,9 @@ mod build;
 mod document;
 mod registry;
 
-pub use build::{build_document, collect_command_ids, duplicate_command_ids};
+pub use build::{
+    build_document, capability_violations, collect_command_ids, duplicate_command_ids,
+};
 pub use document::*;
 pub use registry::{CommandMeta, CommandRegistry};
 

--- a/crates/cli/src/introspect/mod.rs
+++ b/crates/cli/src/introspect/mod.rs
@@ -14,7 +14,7 @@ pub use build::{
     build_document, capability_violations, collect_command_ids, duplicate_command_ids,
 };
 pub use document::*;
-pub use registry::{CommandMeta, CommandRegistry};
+pub use registry::{CapabilityMeta, CommandMeta, CommandRegistry, ExitCodeMeta, RegistryEntry};
 
 /// Stable schema id for the introspect document.
 pub const INTROSPECT_SCHEMA_ID: &str = "foundry:introspect@v1";

--- a/crates/cli/src/introspect/registry.rs
+++ b/crates/cli/src/introspect/registry.rs
@@ -1,0 +1,131 @@
+//! Per-binary registry of stable command metadata.
+//!
+//! The registry overlays metadata that cannot be expressed via clap
+//! attributes onto the command tree: the stable `command_id`, capability
+//! flags, and any command-specific exit codes.
+//!
+//! Each binary owns and ships its own [`CommandRegistry`]. Entries are keyed
+//! by the **clap path** (e.g. `["forge", "build"]`). When no entry is found
+//! for a command, the [`build_document`](super::build_document) helper fills
+//! in safe defaults: a derived `command_id` (path joined by `.`) and no
+//! machine-mode contract.
+//!
+//! Only commands intended to be referenced by stable identifiers need to be
+//! registered explicitly. Once a command is registered, its `command_id` is
+//! considered frozen and CI uniqueness checks ensure it cannot collide.
+
+use super::document::{Capabilities, ExitCodeInfo};
+
+/// Per-leaf metadata that overlays the clap-derived defaults.
+#[derive(Clone, Debug)]
+pub struct CommandMeta {
+    /// Stable machine identifier, e.g. `"forge.build"`.
+    ///
+    /// When set, this overrides the path-derived default.
+    pub command_id: Option<&'static str>,
+    /// Capabilities reported for agent consumers.
+    pub capabilities: Capabilities,
+    /// Command-specific exit codes, in addition to the global table.
+    pub exit_codes: &'static [ExitCodeInfo],
+}
+
+impl CommandMeta {
+    /// Const-constructible default suitable for use in `static` registries.
+    pub const DEFAULT: Self =
+        Self { command_id: None, capabilities: Capabilities::NONE, exit_codes: &[] };
+}
+
+impl Default for CommandMeta {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// A binary's command registry.
+///
+/// Implemented as a thin wrapper over a `&'static` slice of (path, metadata) pairs to keep the call
+/// sites declarative without pulling in a hash map at startup.
+#[derive(Clone, Copy, Debug)]
+pub struct CommandRegistry {
+    entries: &'static [RegistryEntry],
+}
+
+/// A single registry entry.
+#[derive(Clone, Debug)]
+pub struct RegistryEntry {
+    /// Clap path components, e.g. `&["build"]` for `forge build`.
+    ///
+    /// The binary name (`forge`, `cast`, …) is not included; it is implicit
+    /// from which binary owns the registry.
+    pub path: &'static [&'static str],
+    /// Metadata overlay for the command at `path`.
+    pub meta: CommandMeta,
+}
+
+impl CommandRegistry {
+    /// Construct a new registry from a static slice of entries.
+    pub const fn new(entries: &'static [RegistryEntry]) -> Self {
+        Self { entries }
+    }
+
+    /// An empty registry. Every command falls back to defaults.
+    pub const EMPTY: Self = Self::new(&[]);
+
+    /// Look up metadata for the command at `path` (clap path, excluding the
+    /// binary name).
+    pub fn lookup(&self, path: &[&str]) -> Option<&CommandMeta> {
+        self.entries.iter().find(|e| e.path == path).map(|e| &e.meta)
+    }
+
+    /// Iterate over all entries.
+    pub fn entries(&self) -> impl Iterator<Item = &RegistryEntry> {
+        self.entries.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::introspect::document::OutputMode;
+
+    fn fixture_registry() -> CommandRegistry {
+        static ENTRIES: &[RegistryEntry] = &[RegistryEntry {
+            path: &["build"],
+            meta: CommandMeta {
+                command_id: Some("forge.build"),
+                capabilities: Capabilities {
+                    output_mode: OutputMode::Envelope,
+                    result_schema_ref: None,
+                    event_schema_ref: None,
+                    session_schema_ref: None,
+                    reads_stdin: false,
+                    supports_output_path: false,
+                    requires_project: true,
+                    side_effects: super::super::document::SideEffects::FsWrite,
+                    long_running: false,
+                    stateful: false,
+                },
+                exit_codes: &[],
+            },
+        }];
+        CommandRegistry::new(ENTRIES)
+    }
+
+    #[test]
+    fn lookup_returns_registered_meta() {
+        let r = fixture_registry();
+        let meta = r.lookup(&["build"]).expect("registered");
+        assert_eq!(meta.command_id, Some("forge.build"));
+        assert!(matches!(meta.capabilities.output_mode, OutputMode::Envelope));
+    }
+
+    #[test]
+    fn lookup_returns_none_for_unregistered_path() {
+        assert!(fixture_registry().lookup(&["unknown"]).is_none());
+    }
+
+    #[test]
+    fn empty_registry_yields_no_entries() {
+        assert_eq!(CommandRegistry::EMPTY.entries().count(), 0);
+    }
+}

--- a/crates/cli/src/introspect/registry.rs
+++ b/crates/cli/src/introspect/registry.rs
@@ -14,31 +14,88 @@
 //! registered explicitly. Once a command is registered, its `command_id` is
 //! considered frozen and CI uniqueness checks ensure it cannot collide.
 
-use super::document::{Capabilities, ExitCodeInfo};
+use super::document::{OutputMode, SideEffects};
 
 /// Per-leaf metadata that overlays the clap-derived defaults.
-#[derive(Clone, Debug)]
+///
+/// All fields are `&'static`-friendly so each binary can declare its
+/// registry as a `static` slice without heap allocation. The serialized
+/// [`Capabilities`](super::Capabilities) / [`ExitCodeInfo`](super::ExitCodeInfo)
+/// types use owned `String`s; conversion happens in
+/// [`build_document`](super::build_document).
+#[derive(Clone, Copy, Debug)]
 pub struct CommandMeta {
     /// Stable machine identifier, e.g. `"forge.build"`.
     ///
     /// When set, this overrides the path-derived default.
     pub command_id: Option<&'static str>,
     /// Capabilities reported for agent consumers.
-    pub capabilities: Capabilities,
+    pub capabilities: CapabilityMeta,
     /// Command-specific exit codes, in addition to the global table.
-    pub exit_codes: &'static [ExitCodeInfo],
+    pub exit_codes: &'static [ExitCodeMeta],
 }
 
 impl CommandMeta {
     /// Const-constructible default suitable for use in `static` registries.
     pub const DEFAULT: Self =
-        Self { command_id: None, capabilities: Capabilities::NONE, exit_codes: &[] };
+        Self { command_id: None, capabilities: CapabilityMeta::NONE, exit_codes: &[] };
 }
 
 impl Default for CommandMeta {
     fn default() -> Self {
         Self::DEFAULT
     }
+}
+
+/// Const-friendly capability metadata stored in a static registry.
+///
+/// Mirrors [`Capabilities`](super::Capabilities) but with `&'static str` in
+/// place of `String` so the whole struct can live in a `static`. Converted to
+/// owned form during introspection rendering.
+#[derive(Clone, Copy, Debug)]
+pub struct CapabilityMeta {
+    pub output_mode: OutputMode,
+    pub result_schema_ref: Option<&'static str>,
+    pub event_schema_ref: Option<&'static str>,
+    pub session_schema_ref: Option<&'static str>,
+    pub reads_stdin: bool,
+    pub supports_output_path: bool,
+    pub requires_project: bool,
+    pub side_effects: SideEffects,
+    pub long_running: bool,
+    pub stateful: bool,
+}
+
+impl CapabilityMeta {
+    /// Default with no machine-mode contract.
+    pub const NONE: Self = Self {
+        output_mode: OutputMode::None,
+        result_schema_ref: None,
+        event_schema_ref: None,
+        session_schema_ref: None,
+        reads_stdin: false,
+        supports_output_path: false,
+        requires_project: false,
+        side_effects: SideEffects::None,
+        long_running: false,
+        stateful: false,
+    };
+}
+
+impl Default for CapabilityMeta {
+    fn default() -> Self {
+        Self::NONE
+    }
+}
+
+/// Const-friendly exit-code entry stored in a static registry.
+///
+/// Mirrors [`ExitCodeInfo`](super::ExitCodeInfo) with borrowed strings.
+#[derive(Clone, Copy, Debug)]
+pub struct ExitCodeMeta {
+    pub code: i32,
+    pub name: &'static str,
+    pub description: &'static str,
 }
 
 /// A binary's command registry.
@@ -51,7 +108,7 @@ pub struct CommandRegistry {
 }
 
 /// A single registry entry.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct RegistryEntry {
     /// Clap path components, e.g. `&["build"]` for `forge build`.
     ///
@@ -86,24 +143,18 @@ impl CommandRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::introspect::document::OutputMode;
 
     fn fixture_registry() -> CommandRegistry {
         static ENTRIES: &[RegistryEntry] = &[RegistryEntry {
             path: &["build"],
             meta: CommandMeta {
                 command_id: Some("forge.build"),
-                capabilities: Capabilities {
+                capabilities: CapabilityMeta {
                     output_mode: OutputMode::Envelope,
-                    result_schema_ref: None,
-                    event_schema_ref: None,
-                    session_schema_ref: None,
-                    reads_stdin: false,
-                    supports_output_path: false,
+                    result_schema_ref: Some("foundry:forge.build@v1"),
                     requires_project: true,
                     side_effects: super::super::document::SideEffects::FsWrite,
-                    long_running: false,
-                    stateful: false,
+                    ..CapabilityMeta::NONE
                 },
                 exit_codes: &[],
             },

--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -134,10 +134,10 @@ impl JsonMessage {
 /// The trailing newline makes this suitable for NDJSON streams when each call
 /// emits one self-contained JSON record.
 ///
-/// Under `--machine` this bypasses [`Shell::is_quiet`] so the agent contract
-/// remains visible even when the global shell is flipped to `Quiet` to
-/// silence human prints. Outside machine mode, behaves like the legacy
-/// `sh_println!` path and respects quiet.
+/// Under `--machine` this bypasses [`foundry_common::shell::Shell::is_quiet`]
+/// so the agent contract remains visible even when the global shell is
+/// flipped to `Quiet` to silence human prints. Outside machine mode, behaves
+/// like the legacy `sh_println!` path and respects quiet.
 pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
     let s = to_string(value)?;
     if crate::machine::is_machine() {

--- a/crates/cli/src/json.rs
+++ b/crates/cli/src/json.rs
@@ -133,9 +133,58 @@ impl JsonMessage {
 ///
 /// The trailing newline makes this suitable for NDJSON streams when each call
 /// emits one self-contained JSON record.
+///
+/// Under `--machine` this bypasses [`Shell::is_quiet`] so the agent contract
+/// remains visible even when the global shell is flipped to `Quiet` to
+/// silence human prints. Outside machine mode, behaves like the legacy
+/// `sh_println!` path and respects quiet.
 pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
-    sh_println!("{}", to_string(value)?)?;
+    let s = to_string(value)?;
+    if crate::machine::is_machine() {
+        let mut shell = foundry_common::shell::Shell::get();
+        writeln!(shell.out(), "{s}")?;
+    } else {
+        sh_println!("{s}")?;
+    }
     Ok(())
+}
+
+/// One NDJSON record emitted on the stream of a long-running command.
+///
+/// Carries the per-record fields required by `docs/agents/spec.md` §6
+/// (`schema_id`, `command_id`, `kind`, `ts`) and flattens the kind-specific
+/// payload into the same object.
+#[derive(Clone, Debug, Serialize)]
+pub struct StreamRecord<T> {
+    pub schema_id: &'static str,
+    pub command_id: &'static str,
+    pub kind: &'static str,
+    /// RFC 3339 timestamp.
+    pub ts: String,
+    #[serde(flatten)]
+    pub payload: T,
+}
+
+impl<T: Serialize> StreamRecord<T> {
+    /// Build a record stamped with the current UTC time.
+    pub fn new(
+        schema_id: &'static str,
+        command_id: &'static str,
+        kind: &'static str,
+        payload: T,
+    ) -> Self {
+        Self { schema_id, command_id, kind, ts: chrono::Utc::now().to_rfc3339(), payload }
+    }
+}
+
+/// Emits a single NDJSON record on stdout for a streaming command.
+pub fn print_stream_record<T: Serialize>(
+    schema_id: &'static str,
+    command_id: &'static str,
+    kind: &'static str,
+    payload: T,
+) -> Result<()> {
+    print_json(&StreamRecord::new(schema_id, command_id, kind, payload))
 }
 
 /// Prints a successful JSON envelope to stdout.
@@ -186,6 +235,32 @@ mod tests {
         assert_eq!(value["warnings"][0]["level"], "warning");
         assert_eq!(value["warnings"][0]["code"], "compiler.remappings");
         assert_eq!(value["warnings"][0]["details"]["count"], 3);
+    }
+
+    #[test]
+    fn stream_record_includes_required_fields_and_flattens_payload() {
+        #[derive(Serialize)]
+        struct TestEvent {
+            contract: String,
+            passed: usize,
+        }
+        let payload = TestEvent { contract: "Counter.t.sol:CounterTest".into(), passed: 3 };
+        let rec = StreamRecord::new(
+            "foundry:forge.test.event@v1",
+            "forge.test",
+            "suite_finished",
+            payload,
+        );
+        let json = to_string(&rec).unwrap();
+        // Compact, no pretty-printing.
+        assert!(!json.contains('\n'), "expected compact json, got: {json}");
+        let v = serde_json::from_str::<Value>(&json).unwrap();
+        assert_eq!(v["schema_id"], "foundry:forge.test.event@v1");
+        assert_eq!(v["command_id"], "forge.test");
+        assert_eq!(v["kind"], "suite_finished");
+        assert!(v["ts"].is_string());
+        assert_eq!(v["contract"], "Counter.t.sol:CounterTest");
+        assert_eq!(v["passed"], 3);
     }
 
     #[test]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -13,6 +13,7 @@ extern crate tracing;
 
 pub mod clap;
 pub mod handler;
+pub mod introspect;
 pub mod json;
 pub mod opts;
 pub mod utils;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -12,11 +12,17 @@ extern crate foundry_common;
 extern crate tracing;
 
 pub mod clap;
+pub mod diagnostic;
+pub mod exit_code;
 pub mod handler;
 pub mod introspect;
 pub mod json;
+pub mod machine;
 pub mod opts;
 pub mod utils;
+
+pub use exit_code::ExitCode;
+pub use machine::{check_machine, is_machine, parse_or_exit};
 
 #[cfg(feature = "tracy")]
 tracing_tracy::client::register_demangler!();

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -1,0 +1,165 @@
+//! Machine mode (`--machine`) — agent-contract output selector.
+//!
+//! See [`docs/agents/spec.md`](../../../docs/agents/spec.md) §10. When a
+//! command is invoked with `--machine`:
+//!
+//! - it emits its declared [`output_mode`](crate::introspect::OutputMode) only,
+//! - it never writes color, progress bars, or interactive prompts to stdout,
+//! - parse, usage, version, and help failures are structured as envelopes,
+//! - process-exit failures map to the canonical [`ExitCode`] enum.
+//!
+//! The flag is detected before clap parsing — see [`check_machine`] — so the
+//! mode is known by the time clap errors need to be intercepted.
+//!
+//! Adoption of machine-mode output by individual commands lands in follow-up
+//! PRs. PR 2 wires the runtime infrastructure (flag detection, error
+//! interception, exit-code mapping); per-command envelope emission is
+//! deferred.
+
+use crate::{
+    diagnostic,
+    exit_code::ExitCode,
+    json::{JsonEnvelope, JsonMessage, print_json},
+};
+use clap::{CommandFactory, Parser, error::ErrorKind};
+use serde_json::json;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static MACHINE_MODE: AtomicBool = AtomicBool::new(false);
+
+/// Returns whether `--machine` was set on the current invocation.
+///
+/// Only meaningful after [`check_machine`] has run.
+pub fn is_machine() -> bool {
+    MACHINE_MODE.load(Ordering::Relaxed)
+}
+
+/// Force machine mode on. Intended for tests and for [`check_machine`].
+#[doc(hidden)]
+pub fn set_machine(on: bool) {
+    MACHINE_MODE.store(on, Ordering::Relaxed);
+}
+
+/// Pre-parse scan for `--machine`.
+///
+/// Mirrors `check_introspect` / `check_markdown_help`: runs before clap
+/// parsing so the flag is visible while intercepting parse errors. Does NOT
+/// exit — machine mode persists for the rest of the run.
+pub fn check_machine() {
+    if std::env::args().any(|a| a == "--machine") {
+        set_machine(true);
+    }
+}
+
+/// Parse arguments, intercepting clap errors when machine mode is on.
+///
+/// Replaces `T::parse()` at binary entry points. Under `--machine`, parse
+/// errors and `--help` / `--version` are converted into a structured
+/// [`JsonEnvelope`] on stdout and the process exits with the appropriate
+/// [`ExitCode`]. Without `--machine`, behaves exactly like
+/// [`Parser::parse`].
+pub fn parse_or_exit<T: Parser + CommandFactory>() -> T {
+    match T::try_parse() {
+        Ok(t) => t,
+        Err(err) => {
+            if is_machine() {
+                handle_machine_clap_error::<T>(err)
+            } else {
+                err.exit()
+            }
+        }
+    }
+}
+
+fn handle_machine_clap_error<T: CommandFactory>(err: clap::Error) -> ! {
+    let kind = err.kind();
+    match kind {
+        ErrorKind::DisplayHelp | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+            let mut cmd = T::command();
+            let help = cmd.render_help().to_string();
+            let envelope = JsonEnvelope::success(json!({ "help": help }));
+            let _ = print_json(&envelope);
+            std::process::exit(ExitCode::Success.to_i32());
+        }
+        ErrorKind::DisplayVersion => {
+            let cmd = T::command();
+            let envelope = JsonEnvelope::success(json!({
+                "version": cmd.get_version().unwrap_or(""),
+                "long_version": cmd.get_long_version().unwrap_or(""),
+            }));
+            let _ = print_json(&envelope);
+            std::process::exit(ExitCode::Success.to_i32());
+        }
+        _ => {
+            let message = err.to_string();
+            let envelope = JsonEnvelope::error(
+                JsonMessage::error(diagnostic::cli::USAGE_INVALID, message)
+                    .with_details(json!({ "clap_error_kind": format!("{kind:?}") })),
+            );
+            let _ = print_json(&envelope);
+            std::process::exit(ExitCode::Usage.to_i32());
+        }
+    }
+}
+
+/// Exit code that maps a clap error kind to the canonical table.
+///
+/// Useful for callers that have a `clap::Error` they want to classify
+/// without going through [`parse_or_exit`].
+pub fn exit_code_for_clap_error(err: &clap::Error) -> ExitCode {
+    match err.kind() {
+        ErrorKind::DisplayHelp
+        | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+        | ErrorKind::DisplayVersion => ExitCode::Success,
+        _ => ExitCode::Usage,
+    }
+}
+
+/// Emit a structured error envelope on stdout for an `eyre::Report`.
+///
+/// Adoption PRs use this at command-execution failure sites under
+/// `--machine`. PR 2 ships the helper but does not yet route command-error
+/// failures through it; that is part of per-command envelope adoption.
+pub fn report_machine_error(report: &eyre::Report) {
+    let message = format!("{report}");
+    let envelope = JsonEnvelope::error(JsonMessage::error(diagnostic::cli::UNKNOWN, message));
+    let _ = print_json(&envelope);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn machine_flag_default_off() {
+        set_machine(false);
+        assert!(!is_machine());
+    }
+
+    #[test]
+    fn machine_flag_can_be_toggled() {
+        set_machine(true);
+        assert!(is_machine());
+        set_machine(false);
+        assert!(!is_machine());
+    }
+
+    #[derive(Debug, Parser)]
+    #[command(name = "demo", version = "0.1.0")]
+    struct Demo {
+        #[arg(long)]
+        name: Option<String>,
+    }
+
+    #[test]
+    fn clap_error_kinds_map_to_exit_codes() {
+        let bad = Demo::try_parse_from(["demo", "--unknown"]).unwrap_err();
+        assert_eq!(exit_code_for_clap_error(&bad), ExitCode::Usage);
+
+        let help = Demo::try_parse_from(["demo", "--help"]).unwrap_err();
+        assert_eq!(exit_code_for_clap_error(&help), ExitCode::Success);
+
+        let version = Demo::try_parse_from(["demo", "--version"]).unwrap_err();
+        assert_eq!(exit_code_for_clap_error(&version), ExitCode::Success);
+    }
+}

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -127,6 +127,22 @@ pub fn bail_machine_usage(message: impl Into<String>) -> ! {
     std::process::exit(ExitCode::Usage.to_i32());
 }
 
+/// Emit a typed error envelope on stdout and exit with `exit_code`.
+///
+/// Use at call sites that have enough context to classify a failure
+/// precisely (e.g. broadcast / RPC / wallet) and want the agent contract
+/// to reflect the typed code rather than the generic
+/// [`report_machine_error`] heuristic in the binary entry point.
+pub fn bail_machine_diagnostic(
+    code: &'static str,
+    exit_code: ExitCode,
+    message: impl Into<String>,
+) -> ! {
+    let envelope = JsonEnvelope::error(JsonMessage::error(code, message));
+    let _ = print_json(&envelope);
+    std::process::exit(exit_code.to_i32());
+}
+
 /// Emit a structured error envelope on stdout for an `eyre::Report`.
 ///
 /// Used by binary entry points to wrap an uncaught command failure as a

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -23,7 +23,10 @@ use crate::{
 };
 use clap::{CommandFactory, Parser, error::ErrorKind};
 use serde_json::json;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::{
+    fmt::Write,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 static MACHINE_MODE: AtomicBool = AtomicBool::new(false);
 
@@ -115,15 +118,57 @@ pub fn exit_code_for_clap_error(err: &clap::Error) -> ExitCode {
     }
 }
 
+/// Emit a `cli.usage.invalid` envelope on stdout and exit with
+/// [`ExitCode::Usage`] (`2`). Use at call sites that intentionally reject
+/// a flag combination under `--machine`.
+pub fn bail_machine_usage(message: impl Into<String>) -> ! {
+    let envelope = JsonEnvelope::error(JsonMessage::error(diagnostic::cli::USAGE_INVALID, message));
+    let _ = print_json(&envelope);
+    std::process::exit(ExitCode::Usage.to_i32());
+}
+
 /// Emit a structured error envelope on stdout for an `eyre::Report`.
 ///
-/// Adoption PRs use this at command-execution failure sites under
-/// `--machine`. PR 2 ships the helper but does not yet route command-error
-/// failures through it; that is part of per-command envelope adoption.
+/// Used by binary entry points to wrap an uncaught command failure as a
+/// terminal envelope. The diagnostic code is best-effort, classified from
+/// the report's cause chain; the [`ExitCode`] returned by
+/// [`ExitCode::from`] uses the same signals.
 pub fn report_machine_error(report: &eyre::Report) {
     let message = format!("{report}");
-    let envelope = JsonEnvelope::error(JsonMessage::error(diagnostic::cli::UNKNOWN, message));
+    let envelope =
+        JsonEnvelope::error(JsonMessage::error(diagnostic_code_for_report(report), message));
     let _ = print_json(&envelope);
+}
+
+/// Conservative classification of an `eyre::Report` into a stable diagnostic
+/// code.
+///
+/// Stable codes are part of the agent contract; over-specific
+/// misclassification is worse than the catch-all. Only a small set of
+/// high-confidence keyword matches escape the [`diagnostic::cli::UNKNOWN`]
+/// fallback. Typed call sites should emit specific codes directly rather
+/// than relying on this helper. [`ExitCode::from`] uses a coarser, separate
+/// heuristic for process exit codes.
+pub fn diagnostic_code_for_report(report: &eyre::Report) -> &'static str {
+    let mut buf = String::new();
+    for cause in report.chain() {
+        let _ = writeln!(buf, "{cause}");
+    }
+    let lower = buf.to_lowercase();
+
+    if lower.contains("interrupted") || lower.contains("sigint") || lower.contains("sigterm") {
+        return diagnostic::cli::INTERRUPTED;
+    }
+    if lower.contains("foundry.toml") {
+        return diagnostic::config::INVALID;
+    }
+    if lower.contains("solc") {
+        return diagnostic::compiler::SOLC_ERROR;
+    }
+    if lower.contains("vyper") {
+        return diagnostic::compiler::VYPER_ERROR;
+    }
+    diagnostic::cli::UNKNOWN
 }
 
 #[cfg(test)]
@@ -149,6 +194,27 @@ mod tests {
     struct Demo {
         #[arg(long)]
         name: Option<String>,
+    }
+
+    #[test]
+    fn diagnostic_classifier_picks_compiler_for_solc_errors() {
+        let r: eyre::Report = eyre::eyre!("solc compilation failed");
+        assert_eq!(diagnostic_code_for_report(&r), diagnostic::compiler::SOLC_ERROR);
+    }
+
+    #[test]
+    fn diagnostic_classifier_falls_back_to_cli_unknown_for_rpc_failures() {
+        // Generic RPC errors stay `cli.unknown` — typed call sites should
+        // emit `network.rpc.*` codes themselves when they have the context
+        // to classify accurately.
+        let r: eyre::Report = eyre::eyre!("RPC connection timeout");
+        assert_eq!(diagnostic_code_for_report(&r), diagnostic::cli::UNKNOWN);
+    }
+
+    #[test]
+    fn diagnostic_classifier_falls_back_to_cli_unknown() {
+        let r: eyre::Report = eyre::eyre!("something unexpected went wrong");
+        assert_eq!(diagnostic_code_for_report(&r), diagnostic::cli::UNKNOWN);
     }
 
     #[test]

--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -28,8 +28,15 @@ pub struct GlobalArgs {
     quiet: bool,
 
     /// Format log messages as JSON.
-    #[arg(help_heading = "Display options", global = true, long, alias = "format-json", conflicts_with_all = &["quiet", "color"])]
+    #[arg(help_heading = "Display options", global = true, long, alias = "format-json", conflicts_with_all = &["quiet", "color", "machine"])]
     json: bool,
+
+    /// Activate the agent contract: emit declared output mode only, no color,
+    /// no progress, structured early-exit. Implies no color. Mutually
+    /// exclusive with `--json` and `--md` to keep machine-mode output
+    /// unambiguous.
+    #[arg(help_heading = "Display options", global = true, long, conflicts_with_all = &["color", "md"])]
+    machine: bool,
 
     /// Format log messages as Markdown.
     #[arg(
@@ -102,6 +109,12 @@ impl GlobalArgs {
 
     /// Initialize the global options.
     pub fn init(&self) -> eyre::Result<()> {
+        // Keep the runtime machine-mode flag in sync with what clap parsed.
+        // `check_machine` runs pre-parse on the binary entry point; this
+        // covers callers that construct `GlobalArgs` programmatically and
+        // ensures the flag never goes stale.
+        crate::machine::set_machine(self.machine);
+
         // Set the global shell.
         let shell = self.shell();
         // Argument takes precedence over the env var global color choice.
@@ -120,6 +133,7 @@ impl GlobalArgs {
         // Display a warning message if the current version is not stable.
         if IS_NIGHTLY_VERSION
             && !self.json
+            && !self.machine
             && std::env::var_os("FOUNDRY_DISABLE_NIGHTLY_WARNING").is_none()
         {
             let _ = sh_warn!("{}", NIGHTLY_VERSION_WARNING_MESSAGE);
@@ -134,7 +148,11 @@ impl GlobalArgs {
             true => OutputMode::Quiet,
             false => OutputMode::Normal,
         };
-        let color = self.json.then_some(ColorChoice::Never).or(self.color).unwrap_or_default();
+        // `--machine` forces no-color; `--json` already forces no-color.
+        let color = (self.json || self.machine)
+            .then_some(ColorChoice::Never)
+            .or(self.color)
+            .unwrap_or_default();
         let format = if self.json {
             OutputFormat::Json
         } else if self.md {

--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -144,7 +144,11 @@ impl GlobalArgs {
 
     /// Create a new shell instance.
     pub fn shell(&self) -> Shell {
-        let mode = match self.quiet {
+        // `--machine` owns stdout; force the global shell to Quiet so all
+        // `sh_println!`/`sh_warn!` sites become no-ops. Explicit machine
+        // output (envelopes, NDJSON records) goes through `print_json`,
+        // which bypasses the quiet check.
+        let mode = match self.quiet || self.machine {
             true => OutputMode::Quiet,
             false => OutputMode::Normal,
         };

--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -55,9 +55,47 @@ impl GlobalArgs {
     ///
     /// This must be called **before** parsing arguments, since commands with required
     /// subcommands would fail parsing before the flag is checked.
+    ///
+    /// Agents should prefer `--introspect`, which emits a stable machine-readable
+    /// document. A deprecation notice is written to stderr to steer that migration;
+    /// the rendered Markdown itself is unchanged from previous releases.
     pub fn check_markdown_help<C: clap::CommandFactory>() {
         if std::env::args().any(|arg| arg == "--markdown-help") {
+            // Pre-parse: `Shell` is not initialized yet, so `sh_*` is unavailable.
+            #[allow(clippy::disallowed_macros)]
+            {
+                eprintln!(
+                    "warning: `--markdown-help` is intended for human documentation; \
+                     agents should use `--introspect` for machine-readable command discovery",
+                );
+            }
             foundry_cli_markdown::print_help_markdown::<C>();
+            std::process::exit(0);
+        }
+    }
+
+    /// Check if `--introspect` was passed and print the introspection document as JSON, then exit.
+    ///
+    /// Must run **before** clap parsing so required subcommands or args don't block discovery.
+    pub fn check_introspect<C: clap::CommandFactory>() {
+        Self::check_introspect_with(C::command(), &crate::introspect::CommandRegistry::EMPTY)
+    }
+
+    /// Like [`check_introspect`](Self::check_introspect) but uses an explicit
+    /// [`Command`](clap::Command) and [`CommandRegistry`](crate::introspect::CommandRegistry).
+    pub fn check_introspect_with(
+        command: clap::Command,
+        registry: &crate::introspect::CommandRegistry,
+    ) {
+        if std::env::args().any(|arg| arg == "--introspect") {
+            let doc = crate::introspect::build_document(&command, registry);
+            let json =
+                serde_json::to_string(&doc).expect("introspect document must be serializable");
+            // Pre-parse: `Shell` is not initialized yet, so `sh_*` is unavailable.
+            #[allow(clippy::disallowed_macros)]
+            {
+                println!("{json}");
+            }
             std::process::exit(0);
         }
     }

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -8,6 +8,10 @@ static ALLOC: foundry_cli::utils::Allocator = foundry_cli::utils::new_allocator(
 
 fn main() {
     if let Err(err) = run() {
+        if foundry_cli::is_machine() {
+            foundry_cli::machine::report_machine_error(&err);
+            std::process::exit(foundry_cli::ExitCode::from(&err).to_i32());
+        }
         let _ = foundry_common::sh_err!("{err:?}");
         std::process::exit(1);
     }

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -2,7 +2,7 @@ use crate::{
     cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, watch},
     opts::{Forge, ForgeSubcommand},
 };
-use clap::{CommandFactory, Parser};
+use clap::CommandFactory;
 use clap_complete::generate;
 use eyre::Result;
 use foundry_cli::utils;
@@ -13,10 +13,11 @@ use foundry_evm::inspectors::cheatcodes::{ForgeContext, set_execution_context};
 pub fn run() -> Result<()> {
     setup()?;
 
+    foundry_cli::machine::check_machine();
     foundry_cli::opts::GlobalArgs::check_introspect::<Forge>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Forge>();
 
-    let args = Forge::parse();
+    let args = foundry_cli::parse_or_exit::<Forge>();
     args.global.init()?;
 
     run_command(args)
@@ -147,7 +148,9 @@ pub fn run_command(args: Forge) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use foundry_cli::introspect::{CommandRegistry, build_document, duplicate_command_ids};
+    use foundry_cli::introspect::{
+        CommandRegistry, build_document, capability_violations, duplicate_command_ids,
+    };
 
     /// Every `command_id` exposed by `forge --introspect` MUST be unique.
     /// This is the foundation of the agent contract — agents key on
@@ -159,5 +162,16 @@ mod tests {
         let doc = build_document(&cmd, &CommandRegistry::EMPTY);
         let dups = duplicate_command_ids(&doc);
         assert!(dups.is_empty(), "duplicate forge command_ids: {dups:?}");
+    }
+
+    /// Capability self-consistency: any command declaring an output mode
+    /// must wire the matching schema reference. See
+    /// [`capability_violations`].
+    #[test]
+    fn introspect_capabilities_are_consistent() {
+        let cmd = <Forge as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let v = capability_violations(&doc);
+        assert!(v.is_empty(), "forge capability violations: {v:?}");
     }
 }

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -1,5 +1,6 @@
 use crate::{
     cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, watch},
+    introspect::REGISTRY,
     opts::{Forge, ForgeSubcommand},
 };
 use clap::CommandFactory;
@@ -11,10 +12,11 @@ use foundry_evm::inspectors::cheatcodes::{ForgeContext, set_execution_context};
 
 /// Run the `forge` command line interface.
 pub fn run() -> Result<()> {
+    // Pre-setup so setup failures land in the machine envelope path.
+    foundry_cli::machine::check_machine();
     setup()?;
 
-    foundry_cli::machine::check_machine();
-    foundry_cli::opts::GlobalArgs::check_introspect::<Forge>();
+    foundry_cli::opts::GlobalArgs::check_introspect_with(Forge::command(), &REGISTRY);
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Forge>();
 
     let args = foundry_cli::parse_or_exit::<Forge>();
@@ -149,7 +151,7 @@ pub fn run_command(args: Forge) -> Result<()> {
 mod tests {
     use super::*;
     use foundry_cli::introspect::{
-        CommandRegistry, build_document, capability_violations, duplicate_command_ids,
+        OutputMode, build_document, capability_violations, duplicate_command_ids,
     };
 
     /// Every `command_id` exposed by `forge --introspect` MUST be unique.
@@ -159,7 +161,7 @@ mod tests {
     #[test]
     fn introspect_command_ids_are_unique() {
         let cmd = <Forge as clap::CommandFactory>::command();
-        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let doc = build_document(&cmd, &REGISTRY);
         let dups = duplicate_command_ids(&doc);
         assert!(dups.is_empty(), "duplicate forge command_ids: {dups:?}");
     }
@@ -170,8 +172,30 @@ mod tests {
     #[test]
     fn introspect_capabilities_are_consistent() {
         let cmd = <Forge as clap::CommandFactory>::command();
-        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let doc = build_document(&cmd, &REGISTRY);
         let v = capability_violations(&doc);
         assert!(v.is_empty(), "forge capability violations: {v:?}");
+    }
+
+    /// Every adopted command (`output_mode = Envelope`) must pin a stable
+    /// `command_id` matching its registry entry. Catches accidental drift
+    /// between the registry and the clap tree.
+    #[test]
+    fn registered_commands_pin_stable_ids() {
+        let cmd = <Forge as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &REGISTRY);
+        fn walk(c: &foundry_cli::introspect::CommandInfo) -> Vec<&str> {
+            let mut out = Vec::new();
+            if matches!(c.capabilities.output_mode, OutputMode::Envelope) {
+                out.push(c.command_id.as_str());
+            }
+            for sub in &c.subcommands {
+                out.extend(walk(sub));
+            }
+            out
+        }
+        let mut envelope_ids: Vec<&str> = doc.commands.iter().flat_map(walk).collect();
+        envelope_ids.sort();
+        assert!(envelope_ids.contains(&"forge.build"), "forge.build missing: {envelope_ids:?}");
     }
 }

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -1,12 +1,16 @@
 use crate::{
-    cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, watch},
+    cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, test::TestSummaryData, watch},
     introspect::REGISTRY,
     opts::{Forge, ForgeSubcommand},
+    result::TestOutcome,
 };
 use clap::CommandFactory;
 use clap_complete::generate;
 use eyre::Result;
-use foundry_cli::utils;
+use foundry_cli::{
+    json::{JsonEnvelope, JsonMessage, print_json},
+    utils,
+};
 use foundry_common::{sh_warn, shell};
 use foundry_evm::inspectors::cheatcodes::{ForgeContext, set_execution_context};
 
@@ -58,11 +62,20 @@ pub fn run_command(args: Forge) -> Result<()> {
     // Run the subcommand.
     match args.cmd {
         ForgeSubcommand::Test(cmd) => {
+            // Preflight runs before the watcher dispatch so `--watch` (and
+            // every other unsupported flag) is rejected at the top level
+            // rather than swallowed by the watch loop.
+            cmd.reject_machine_unsupported_flags()?;
             if cmd.is_watch() {
                 global.block_on(watch::watch_test(cmd))
             } else {
-                let silent = cmd.junit || shell::is_json();
+                let machine_mode = foundry_cli::is_machine();
+                let silent = machine_mode || cmd.junit || shell::is_json();
+                let started = std::time::Instant::now();
                 let outcome = global.block_on(cmd.run())?;
+                if machine_mode {
+                    return finalize_test_machine_mode(outcome, started.elapsed());
+                }
                 outcome.ensure_ok(silent)
             }
         }
@@ -147,6 +160,43 @@ pub fn run_command(args: Forge) -> Result<()> {
     }
 }
 
+/// Emit the terminal `forge test` envelope and exit appropriately under
+/// `--machine`. Bypasses [`TestOutcome::ensure_ok`]'s human output entirely;
+/// the agent stream owns stdout for the run.
+fn finalize_test_machine_mode(outcome: TestOutcome, wall_clock: std::time::Duration) -> Result<()> {
+    let summary = TestSummaryData::from_outcome(&outcome, wall_clock);
+    let warnings = aggregate_test_warnings(&outcome);
+
+    if outcome.allow_failure || outcome.failed() == 0 {
+        print_json(&JsonEnvelope::success_with_warnings(summary, warnings))?;
+        return Ok(());
+    }
+    let details = serde_json::to_value(&summary).unwrap_or(serde_json::Value::Null);
+    let message =
+        format!("{} test(s) failed across {} suite(s)", outcome.failed(), outcome.results.len());
+    let mut envelope = JsonEnvelope::error(
+        JsonMessage::error(foundry_cli::diagnostic::test::FAILED, message).with_details(details),
+    );
+    envelope.warnings = warnings;
+    print_json(&envelope)?;
+    std::process::exit(foundry_cli::ExitCode::TestFailure.to_i32());
+}
+
+/// Collect every `SuiteResult.warnings` string into structured envelope
+/// messages keyed by the stable `test.warning` code.
+fn aggregate_test_warnings(outcome: &TestOutcome) -> Vec<JsonMessage> {
+    outcome
+        .results
+        .iter()
+        .flat_map(|(suite, sr)| {
+            sr.warnings.iter().map(move |w| {
+                JsonMessage::warning(foundry_cli::diagnostic::test::WARNING, w.clone())
+                    .with_details(serde_json::json!({ "suite": suite }))
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,25 +227,31 @@ mod tests {
         assert!(v.is_empty(), "forge capability violations: {v:?}");
     }
 
-    /// Every adopted command (`output_mode = Envelope`) must pin a stable
-    /// `command_id` matching its registry entry. Catches accidental drift
-    /// between the registry and the clap tree.
+    /// Every adopted command must pin a stable `command_id` matching its
+    /// registry entry. Catches accidental drift between the registry and the
+    /// clap tree across both envelope- and stream-mode commands.
     #[test]
     fn registered_commands_pin_stable_ids() {
         let cmd = <Forge as clap::CommandFactory>::command();
         let doc = build_document(&cmd, &REGISTRY);
-        fn walk(c: &foundry_cli::introspect::CommandInfo) -> Vec<&str> {
+        fn walk(c: &foundry_cli::introspect::CommandInfo) -> Vec<(&str, OutputMode)> {
             let mut out = Vec::new();
-            if matches!(c.capabilities.output_mode, OutputMode::Envelope) {
-                out.push(c.command_id.as_str());
+            if !matches!(c.capabilities.output_mode, OutputMode::None) {
+                out.push((c.command_id.as_str(), c.capabilities.output_mode));
             }
             for sub in &c.subcommands {
                 out.extend(walk(sub));
             }
             out
         }
-        let mut envelope_ids: Vec<&str> = doc.commands.iter().flat_map(walk).collect();
-        envelope_ids.sort();
-        assert!(envelope_ids.contains(&"forge.build"), "forge.build missing: {envelope_ids:?}");
+        let pinned: Vec<(&str, OutputMode)> = doc.commands.iter().flat_map(walk).collect();
+        let pinned_ids: Vec<&str> = pinned.iter().map(|(id, _)| *id).collect();
+        for id in ["forge.build", "forge.test"] {
+            assert!(pinned_ids.contains(&id), "{id} missing from pinned ids: {pinned_ids:?}");
+        }
+        assert!(
+            pinned.iter().any(|(id, m)| *id == "forge.test" && matches!(m, OutputMode::Stream)),
+            "forge.test must be Stream: {pinned:?}"
+        );
     }
 }

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -227,32 +227,108 @@ mod tests {
         assert!(v.is_empty(), "forge capability violations: {v:?}");
     }
 
-    /// Every adopted command must pin a stable `command_id` matching its
-    /// registry entry. Catches accidental drift between the registry and the
-    /// clap tree across both envelope- and stream-mode commands.
+    /// Every `*_schema_ref` exposed by `forge --introspect` MUST point at a
+    /// committed JSON Schema file under `docs/agents/schemas/`. Guards
+    /// against typos and ref bumps that would leave agent tooling with
+    /// dangling pointers.
+    #[test]
+    fn introspect_schema_refs_resolve_to_committed_schemas() {
+        use foundry_test_utils::agent_schema;
+        let known: std::collections::BTreeSet<&'static str> =
+            agent_schema::known_schema_ids().collect();
+        let cmd = <Forge as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &REGISTRY);
+
+        fn walk(
+            c: &foundry_cli::introspect::CommandInfo,
+            known: &std::collections::BTreeSet<&'static str>,
+            errs: &mut Vec<String>,
+        ) {
+            let caps = &c.capabilities;
+            for (name, v) in [
+                ("result_schema_ref", caps.result_schema_ref.as_deref()),
+                ("event_schema_ref", caps.event_schema_ref.as_deref()),
+                ("session_schema_ref", caps.session_schema_ref.as_deref()),
+            ] {
+                if let Some(id) = v
+                    && !known.contains(id)
+                {
+                    errs.push(format!("{}: {name} points to unknown schema `{id}`", c.command_id));
+                }
+            }
+            for sub in &c.subcommands {
+                walk(sub, known, errs);
+            }
+        }
+
+        let mut errs = Vec::new();
+        for c in &doc.commands {
+            walk(c, &known, &mut errs);
+        }
+        assert!(errs.is_empty(), "dangling forge schema refs: {errs:?}");
+    }
+
+    /// Every adopted command must pin its exact `command_id`, output mode,
+    /// and schema refs. A drift in any of those is an agent-contract break.
     #[test]
     fn registered_commands_pin_stable_ids() {
         let cmd = <Forge as clap::CommandFactory>::command();
         let doc = build_document(&cmd, &REGISTRY);
-        fn walk(c: &foundry_cli::introspect::CommandInfo) -> Vec<(&str, OutputMode)> {
-            let mut out = Vec::new();
-            if !matches!(c.capabilities.output_mode, OutputMode::None) {
-                out.push((c.command_id.as_str(), c.capabilities.output_mode));
+        fn find<'a>(
+            c: &'a foundry_cli::introspect::CommandInfo,
+            id: &str,
+        ) -> Option<&'a foundry_cli::introspect::CommandInfo> {
+            if c.command_id == id {
+                return Some(c);
             }
             for sub in &c.subcommands {
-                out.extend(walk(sub));
+                if let Some(found) = find(sub, id) {
+                    return Some(found);
+                }
             }
-            out
+            None
         }
-        let pinned: Vec<(&str, OutputMode)> = doc.commands.iter().flat_map(walk).collect();
-        let pinned_ids: Vec<&str> = pinned.iter().map(|(id, _)| *id).collect();
-        for id in ["forge.build", "forge.test", "forge.script"] {
-            assert!(pinned_ids.contains(&id), "{id} missing from pinned ids: {pinned_ids:?}");
-        }
-        for id in ["forge.test", "forge.script"] {
-            assert!(
-                pinned.iter().any(|(p, m)| *p == id && matches!(m, OutputMode::Stream)),
-                "{id} must be Stream: {pinned:?}"
+        let lookup = |id: &str| -> &foundry_cli::introspect::CommandInfo {
+            doc.commands
+                .iter()
+                .find_map(|c| find(c, id))
+                .unwrap_or_else(|| panic!("{id} missing from forge introspect"))
+        };
+
+        // (command_id, expected output_mode, expected result_schema_ref,
+        // expected event_schema_ref). `session_schema_ref` must be absent
+        // for every adopted command in this PR.
+        let pins: &[(&str, OutputMode, &str, Option<&str>)] = &[
+            ("forge.build", OutputMode::Envelope, "foundry:forge.build@v1", None),
+            (
+                "forge.test",
+                OutputMode::Stream,
+                "foundry:forge.test@v1",
+                Some("foundry:forge.test.event@v1"),
+            ),
+            (
+                "forge.script",
+                OutputMode::Stream,
+                "foundry:forge.script@v1",
+                Some("foundry:forge.script.event@v1"),
+            ),
+        ];
+        for (id, mode, result_ref, event_ref) in pins {
+            let info = lookup(id);
+            assert_eq!(info.capabilities.output_mode, *mode, "{id} output_mode drift");
+            assert_eq!(
+                info.capabilities.result_schema_ref.as_deref(),
+                Some(*result_ref),
+                "{id} result_schema_ref drift"
+            );
+            assert_eq!(
+                info.capabilities.event_schema_ref.as_deref(),
+                *event_ref,
+                "{id} event_schema_ref drift"
+            );
+            assert_eq!(
+                info.capabilities.session_schema_ref, None,
+                "{id} must not declare session_schema_ref"
             );
         }
     }

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -13,6 +13,7 @@ use foundry_evm::inspectors::cheatcodes::{ForgeContext, set_execution_context};
 pub fn run() -> Result<()> {
     setup()?;
 
+    foundry_cli::opts::GlobalArgs::check_introspect::<Forge>();
     foundry_cli::opts::GlobalArgs::check_markdown_help::<Forge>();
 
     let args = Forge::parse();
@@ -140,5 +141,23 @@ pub fn run_command(args: Forge) -> Result<()> {
         ForgeSubcommand::Eip712(cmd) => cmd.run(),
         ForgeSubcommand::BindJson(cmd) => cmd.run(),
         ForgeSubcommand::Lint(cmd) => cmd.run(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use foundry_cli::introspect::{CommandRegistry, build_document, duplicate_command_ids};
+
+    /// Every `command_id` exposed by `forge --introspect` MUST be unique.
+    /// This is the foundation of the agent contract — agents key on
+    /// `command_id` to identify commands, and duplicates would silently break
+    /// downstream tooling.
+    #[test]
+    fn introspect_command_ids_are_unique() {
+        let cmd = <Forge as clap::CommandFactory>::command();
+        let doc = build_document(&cmd, &CommandRegistry::EMPTY);
+        let dups = duplicate_command_ids(&doc);
+        assert!(dups.is_empty(), "duplicate forge command_ids: {dups:?}");
     }
 }

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -246,12 +246,14 @@ mod tests {
         }
         let pinned: Vec<(&str, OutputMode)> = doc.commands.iter().flat_map(walk).collect();
         let pinned_ids: Vec<&str> = pinned.iter().map(|(id, _)| *id).collect();
-        for id in ["forge.build", "forge.test"] {
+        for id in ["forge.build", "forge.test", "forge.script"] {
             assert!(pinned_ids.contains(&id), "{id} missing from pinned ids: {pinned_ids:?}");
         }
-        assert!(
-            pinned.iter().any(|(id, m)| *id == "forge.test" && matches!(m, OutputMode::Stream)),
-            "forge.test must be Stream: {pinned:?}"
-        );
+        for id in ["forge.test", "forge.script"] {
+            assert!(
+                pinned.iter().any(|(p, m)| *p == id && matches!(m, OutputMode::Stream)),
+                "{id} must be Stream: {pinned:?}"
+            );
+        }
     }
 }

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -126,15 +126,20 @@ impl BuildArgs {
 
         let machine_mode = foundry_cli::is_machine();
         let format_json = shell::is_json();
-        // `--machine` reserves stdout for the terminal envelope.
-        let compiler = ProjectCompiler::new()
+        // Under `--machine`, only the terminal envelope is allowed on
+        // stdout. Force the compile reporter quiet without overriding the
+        // `--quiet` default in the human path (the builder's default
+        // already picks up `shell::is_quiet()`).
+        let mut compiler = ProjectCompiler::new()
             .files(files)
             .dynamic_test_linking(config.dynamic_test_linking)
             .print_names(self.names)
             .print_sizes(self.sizes)
             .ignore_eip_3860(self.ignore_eip_3860)
-            .quiet(machine_mode)
             .bail(!format_json);
+        if machine_mode {
+            compiler = compiler.quiet(true);
+        }
 
         let mut output = compiler.compile(&project)?;
 

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use eyre::Result;
 use forge_lint::{linter::Linter, sol::SolidityLinter};
 use foundry_cli::{
+    json::{JsonEnvelope, print_json},
     opts::{BuildOpts, configure_pcx_from_solc, get_solar_sources_from_compile_output},
     utils::{Git, LoadConfig, cache_local_signatures},
 };
@@ -81,6 +82,22 @@ pub struct BuildArgs {
 
 impl BuildArgs {
     pub async fn run(self) -> Result<ProjectCompileOutput> {
+        // Reject flags whose stdout shape conflicts with the envelope contract.
+        if foundry_cli::is_machine() {
+            let unsupported =
+                [("--watch", self.is_watch()), ("--names", self.names), ("--sizes", self.sizes)]
+                    .into_iter()
+                    .filter_map(|(name, on)| on.then_some(name))
+                    .collect::<Vec<_>>();
+            if !unsupported.is_empty() {
+                foundry_cli::machine::bail_machine_usage(format!(
+                    "`forge build` under `--machine` does not yet support {}; \
+                     run without `--machine` or omit those flags.",
+                    unsupported.join(", ")
+                ));
+            }
+        }
+
         let mut config = self.load_config()?;
 
         if install::install_missing_dependencies(&mut config).await && config.auto_detect_remappings
@@ -107,13 +124,16 @@ impl BuildArgs {
             }
         }
 
+        let machine_mode = foundry_cli::is_machine();
         let format_json = shell::is_json();
+        // `--machine` reserves stdout for the terminal envelope.
         let compiler = ProjectCompiler::new()
             .files(files)
             .dynamic_test_linking(config.dynamic_test_linking)
             .print_names(self.names)
             .print_sizes(self.sizes)
             .ignore_eip_3860(self.ignore_eip_3860)
+            .quiet(machine_mode)
             .bail(!format_json);
 
         let mut output = compiler.compile(&project)?;
@@ -121,12 +141,18 @@ impl BuildArgs {
         // Cache project selectors.
         cache_local_signatures(&output)?;
 
-        if format_json && !self.names && !self.sizes {
+        if format_json && !self.names && !self.sizes && !machine_mode {
             sh_println!("{}", serde_json::to_string_pretty(&output.output())?)?;
         }
 
+        if machine_mode {
+            let payload = BuildData::from_output(&output);
+            print_json(&JsonEnvelope::success(payload))?;
+        }
+
         // Only run the `SolidityLinter` if lint on build and no compilation errors.
-        if !self.no_lint
+        if !machine_mode
+            && !self.no_lint
             && config.lint.lint_on_build
             && !output.output().errors.iter().any(|e| e.is_error())
             && let Err(err) = self.lint(&project, &config, self.paths.as_deref(), &mut output)
@@ -331,6 +357,35 @@ impl BuildArgs {
                 .ok();
             }
         }
+    }
+}
+
+/// Stable payload emitted in the `forge build` envelope under `--machine`.
+#[derive(Clone, Debug, Serialize)]
+pub struct BuildData {
+    /// Total number of compiled artifacts in the project.
+    pub artifacts: usize,
+    /// Number of compiler errors in the output.
+    pub errors: usize,
+    /// Number of compiler warnings in the output.
+    pub warnings: usize,
+    /// Whether the build was a no-op cache hit.
+    pub cache_hit: bool,
+}
+
+impl BuildData {
+    fn from_output(output: &ProjectCompileOutput) -> Self {
+        let artifacts = output.artifact_ids().count();
+        let mut errors = 0usize;
+        let mut warnings = 0usize;
+        for diag in &output.output().errors {
+            if diag.is_error() {
+                errors += 1;
+            } else {
+                warnings += 1;
+            }
+        }
+        Self { artifacts, errors, warnings, cache_hit: output.is_unchanged() }
     }
 }
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -226,6 +226,37 @@ impl TestArgs {
         self.compile_and_run().await
     }
 
+    /// Reject flags whose stdout shape conflicts with the NDJSON stream
+    /// contract under `--machine`. Called from the binary entry point
+    /// before any subcommand dispatch so `--watch` is also rejected.
+    pub(crate) fn reject_machine_unsupported_flags(&self) -> Result<()> {
+        if !foundry_cli::is_machine() {
+            return Ok(());
+        }
+        let unsupported = [
+            ("--watch", self.is_watch()),
+            ("--debug", self.debug),
+            ("--flamegraph", self.flamegraph),
+            ("--flamechart", self.flamechart),
+            ("--gas-report", self.gas_report),
+            ("--summary", self.summary),
+            ("--list", self.list),
+            ("--junit", self.junit),
+            ("--show-progress", self.show_progress),
+        ]
+        .into_iter()
+        .filter_map(|(name, on)| on.then_some(name))
+        .collect::<Vec<_>>();
+        if !unsupported.is_empty() {
+            foundry_cli::machine::bail_machine_usage(format!(
+                "`forge test` under `--machine` does not yet support {}; \
+                 run without `--machine` or omit those flags.",
+                unsupported.join(", ")
+            ));
+        }
+        Ok(())
+    }
+
     /// Returns a list of files that need to be compiled in order to run all the tests that match
     /// the given filter.
     ///
@@ -291,7 +322,7 @@ impl TestArgs {
 
         let compiler = ProjectCompiler::new()
             .dynamic_test_linking(config.dynamic_test_linking)
-            .quiet(shell::is_json() || self.junit)
+            .quiet(shell::is_json() || self.junit || foundry_cli::is_machine())
             .files(self.get_sources_to_compile(&config, &filter)?);
         let output = compiler.compile(&project)?;
 
@@ -420,10 +451,11 @@ impl TestArgs {
             }
 
             // Print the merged summary (per-pass summaries are suppressed in `run_tests_inner`).
-            if !self.summary && !shell::is_json() {
+            // Machine mode emits a terminal envelope from the binary entry point instead.
+            if !self.summary && !shell::is_json() && !foundry_cli::is_machine() {
                 sh_println!("{}", outcome.summary(multi_pass_timer.elapsed()))?;
             }
-            if self.summary && !outcome.results.is_empty() {
+            if self.summary && !outcome.results.is_empty() && !foundry_cli::is_machine() {
                 let summary_report = TestSummaryReport::new(self.detailed, outcome.clone());
                 sh_println!("{}", &summary_report)?;
             }
@@ -610,8 +642,12 @@ impl TestArgs {
 
         trace!(target: "forge::test", "running all tests");
 
+        let machine_mode = foundry_cli::is_machine();
+
         // If we need to render to a serialized format, we should not print anything else to stdout.
-        let silent = self.gas_report && shell::is_json() || self.summary && shell::is_json();
+        // Machine mode is also a structured stream and must not interleave human output.
+        let silent =
+            machine_mode || self.gas_report && shell::is_json() || self.summary && shell::is_json();
 
         let num_filtered = runner.matching_test_functions(filter).count();
 
@@ -621,22 +657,24 @@ impl TestArgs {
             } else {
                 runner.matching_test_functions(&EmptyTestFilter::default()).count()
             };
-            if total_tests == 0 {
-                sh_println!(
-                    "No tests found in project! Forge looks for functions that start with `test`"
-                )?;
-            } else {
-                let mut msg = format!("no tests match the provided pattern:\n{filter}");
-                // Try to suggest a test when there's no match.
-                if let Some(test_pattern) = &filter.args().test_pattern {
-                    let test_name = test_pattern.as_str();
-                    // Filter contracts but not test functions.
-                    let candidates = runner.all_test_functions(filter).map(|f| &f.name);
-                    if let Some(suggestion) = utils::did_you_mean(test_name, candidates).pop() {
-                        write!(msg, "\nDid you mean `{suggestion}`?")?;
+            if !machine_mode {
+                if total_tests == 0 {
+                    sh_println!(
+                        "No tests found in project! Forge looks for functions that start with `test`"
+                    )?;
+                } else {
+                    let mut msg = format!("no tests match the provided pattern:\n{filter}");
+                    // Try to suggest a test when there's no match.
+                    if let Some(test_pattern) = &filter.args().test_pattern {
+                        let test_name = test_pattern.as_str();
+                        // Filter contracts but not test functions.
+                        let candidates = runner.all_test_functions(filter).map(|f| &f.name);
+                        if let Some(suggestion) = utils::did_you_mean(test_name, candidates).pop() {
+                            write!(msg, "\nDid you mean `{suggestion}`?")?;
+                        }
                     }
+                    sh_warn!("{msg}")?;
                 }
-                sh_warn!("{msg}")?;
             }
             return Ok(TestOutcome::empty(Some(runner.known_contracts.clone()), false));
         }
@@ -666,7 +704,8 @@ impl TestArgs {
         }
 
         // Run tests in a non-streaming fashion and collect results for serialization.
-        if !self.gas_report && !self.summary && shell::is_json() {
+        // `--machine` takes precedence over `--json`; the agent stream wins.
+        if !machine_mode && !self.gas_report && !self.summary && shell::is_json() {
             let mut results = runner.test_collect(filter)?;
             for suite_result in results.values_mut() {
                 for test_result in suite_result.test_results.values_mut() {
@@ -815,6 +854,10 @@ impl TestArgs {
                             sh_println!()?;
                         }
                     }
+                }
+
+                if machine_mode {
+                    emit_test_result_event(&contract_name, name, result)?;
                 }
 
                 // We shouldn't break out of the outer loop directly here so that we finish
@@ -1011,6 +1054,15 @@ impl TestArgs {
                 sh_println!("{}", suite_result.summary())?;
             }
 
+            if machine_mode {
+                for warning in &suite_result.warnings {
+                    emit_warning_event(&contract_name, warning)?;
+                }
+                if has_tests {
+                    emit_suite_finished_event(&contract_name, &suite_result)?;
+                }
+            }
+
             // Add the suite result to the outcome.
             outcome.results.insert(contract_name, suite_result);
 
@@ -1030,11 +1082,11 @@ impl TestArgs {
             outcome.gas_report = Some(finalized);
         }
 
-        if !is_multi_pass && !self.summary && !shell::is_json() {
+        if !is_multi_pass && !self.summary && !shell::is_json() && !machine_mode {
             sh_println!("{}", outcome.summary(duration))?;
         }
 
-        if !is_multi_pass && self.summary && !outcome.results.is_empty() {
+        if !is_multi_pass && self.summary && !outcome.results.is_empty() && !machine_mode {
             let summary_report = TestSummaryReport::new(self.detailed, outcome.clone());
             sh_println!("{summary_report}")?;
         }
@@ -1086,6 +1138,111 @@ impl TestArgs {
             Ok([config.src, config.test])
         })
     }
+}
+
+/// Stable payload emitted in the terminal `forge test` envelope under `--machine`.
+///
+/// See `docs/agents/spec.md` §6 for the contract: counts are aggregated across
+/// every suite that ran. Times are reported in milliseconds.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct TestSummaryData {
+    pub suites: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub duration_ms: u128,
+}
+
+impl TestSummaryData {
+    pub fn from_outcome(outcome: &TestOutcome, wall_clock: Duration) -> Self {
+        Self {
+            suites: outcome.results.len(),
+            passed: outcome.passed(),
+            failed: outcome.failed(),
+            skipped: outcome.skipped(),
+            duration_ms: wall_clock.as_millis(),
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct TestResultEvent<'a> {
+    contract: &'a str,
+    name: &'a str,
+    status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'a str>,
+    duration_ms: u128,
+}
+
+#[derive(serde::Serialize)]
+struct SuiteFinishedEvent<'a> {
+    contract: &'a str,
+    passed: usize,
+    failed: usize,
+    skipped: usize,
+    duration_ms: u128,
+}
+
+#[derive(serde::Serialize)]
+struct WarningEvent<'a> {
+    contract: &'a str,
+    code: &'static str,
+    message: &'a str,
+}
+
+const fn status_str(status: TestStatus) -> &'static str {
+    match status {
+        TestStatus::Success => "passed",
+        TestStatus::Failure => "failed",
+        TestStatus::Skipped => "skipped",
+    }
+}
+
+fn emit_test_result_event(
+    contract: &str,
+    name: &str,
+    result: &crate::result::TestResult,
+) -> Result<()> {
+    foundry_cli::json::print_stream_record(
+        crate::introspect::TEST_EVENT_SCHEMA,
+        "forge.test",
+        "test_result",
+        TestResultEvent {
+            contract,
+            name,
+            status: status_str(result.status),
+            reason: result.reason.as_deref(),
+            duration_ms: result.duration.as_millis(),
+        },
+    )?;
+    Ok(())
+}
+
+fn emit_suite_finished_event(contract: &str, suite: &SuiteResult) -> Result<()> {
+    foundry_cli::json::print_stream_record(
+        crate::introspect::TEST_EVENT_SCHEMA,
+        "forge.test",
+        "suite_finished",
+        SuiteFinishedEvent {
+            contract,
+            passed: suite.passed(),
+            failed: suite.failed(),
+            skipped: suite.skipped(),
+            duration_ms: suite.duration.as_millis(),
+        },
+    )?;
+    Ok(())
+}
+
+fn emit_warning_event(contract: &str, message: &str) -> Result<()> {
+    foundry_cli::json::print_stream_record(
+        crate::introspect::TEST_EVENT_SCHEMA,
+        "forge.test",
+        "warning",
+        WarningEvent { contract, code: foundry_cli::diagnostic::test::WARNING, message },
+    )?;
+    Ok(())
 }
 
 impl Provider for TestArgs {

--- a/crates/forge/src/diagnostic.rs
+++ b/crates/forge/src/diagnostic.rs
@@ -11,9 +11,16 @@ pub mod build {
     pub(crate) const ALL: &[&str] = &[SOLC_ERROR];
 }
 
+/// `forge test` diagnostic codes.
+pub mod test {
+    pub use foundry_cli::diagnostic::test::{FAILED, SETUP_FAILED, WARNING};
+
+    pub(crate) const ALL: &[&str] = &[FAILED, SETUP_FAILED, WARNING];
+}
+
 /// All diagnostic codes declared by `forge`.
 pub fn known_codes() -> Vec<&'static str> {
-    let groups: &[&[&str]] = &[build::ALL];
+    let groups: &[&[&str]] = &[build::ALL, test::ALL];
     groups.iter().flat_map(|g| g.iter().copied()).collect()
 }
 

--- a/crates/forge/src/diagnostic.rs
+++ b/crates/forge/src/diagnostic.rs
@@ -1,0 +1,31 @@
+//! Stable, machine-readable diagnostic codes emitted by `forge`.
+//!
+//! See [`docs/agents/diagnostics.md`](../../../docs/agents/diagnostics.md)
+//! for the format and registry rules. Most codes re-export per-domain
+//! constants from [`foundry_cli::diagnostic`].
+
+/// Build-time diagnostic codes (compilation, linking, artifact generation).
+pub mod build {
+    pub use foundry_cli::diagnostic::compiler::SOLC_ERROR;
+
+    pub(crate) const ALL: &[&str] = &[SOLC_ERROR];
+}
+
+/// All diagnostic codes declared by `forge`.
+pub fn known_codes() -> Vec<&'static str> {
+    let groups: &[&[&str]] = &[build::ALL];
+    groups.iter().flat_map(|g| g.iter().copied()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use foundry_cli::diagnostic::validate;
+
+    #[test]
+    fn every_known_code_validates() {
+        for c in known_codes() {
+            assert!(validate(c).is_ok(), "registered code `{c}` failed validation");
+        }
+    }
+}

--- a/crates/forge/src/diagnostic.rs
+++ b/crates/forge/src/diagnostic.rs
@@ -18,9 +18,16 @@ pub mod test {
     pub(crate) const ALL: &[&str] = &[FAILED, SETUP_FAILED, WARNING];
 }
 
+/// `forge script` diagnostic codes.
+pub mod script {
+    pub use foundry_cli::diagnostic::script::{BROADCAST_FAILED, WARNING};
+
+    pub(crate) const ALL: &[&str] = &[BROADCAST_FAILED, WARNING];
+}
+
 /// All diagnostic codes declared by `forge`.
 pub fn known_codes() -> Vec<&'static str> {
-    let groups: &[&[&str]] = &[build::ALL, test::ALL];
+    let groups: &[&[&str]] = &[build::ALL, test::ALL, script::ALL];
     groups.iter().flat_map(|g| g.iter().copied()).collect()
 }
 

--- a/crates/forge/src/introspect.rs
+++ b/crates/forge/src/introspect.rs
@@ -10,20 +10,43 @@ use foundry_cli::introspect::{
 /// Stable schema id for the `forge build` envelope payload.
 pub const BUILD_RESULT_SCHEMA: &str = "foundry:forge.build@v1";
 
-static ENTRIES: &[RegistryEntry] = &[RegistryEntry {
-    path: &["build"],
-    meta: CommandMeta {
-        command_id: Some("forge.build"),
-        capabilities: CapabilityMeta {
-            output_mode: OutputMode::Envelope,
-            result_schema_ref: Some(BUILD_RESULT_SCHEMA),
-            requires_project: true,
-            side_effects: SideEffects::FsWrite,
-            ..CapabilityMeta::NONE
+/// Stable schema id for `forge test` stream event records.
+pub const TEST_EVENT_SCHEMA: &str = "foundry:forge.test.event@v1";
+/// Stable schema id for the terminal `forge test` envelope payload.
+pub const TEST_RESULT_SCHEMA: &str = "foundry:forge.test@v1";
+
+static ENTRIES: &[RegistryEntry] = &[
+    RegistryEntry {
+        path: &["build"],
+        meta: CommandMeta {
+            command_id: Some("forge.build"),
+            capabilities: CapabilityMeta {
+                output_mode: OutputMode::Envelope,
+                result_schema_ref: Some(BUILD_RESULT_SCHEMA),
+                requires_project: true,
+                side_effects: SideEffects::FsWrite,
+                ..CapabilityMeta::NONE
+            },
+            exit_codes: &[],
         },
-        exit_codes: &[],
     },
-}];
+    RegistryEntry {
+        path: &["test"],
+        meta: CommandMeta {
+            command_id: Some("forge.test"),
+            capabilities: CapabilityMeta {
+                output_mode: OutputMode::Stream,
+                event_schema_ref: Some(TEST_EVENT_SCHEMA),
+                result_schema_ref: Some(TEST_RESULT_SCHEMA),
+                requires_project: true,
+                side_effects: SideEffects::None,
+                long_running: true,
+                ..CapabilityMeta::NONE
+            },
+            exit_codes: &[],
+        },
+    },
+];
 
 /// The `forge` command registry. Used by `--introspect` and by adoption code
 /// that needs to look up command metadata.

--- a/crates/forge/src/introspect.rs
+++ b/crates/forge/src/introspect.rs
@@ -1,0 +1,30 @@
+//! Stable, agent-facing metadata for the `forge` command tree.
+//!
+//! See [`docs/agents/spec.md`](../../../docs/agents/spec.md). The registry
+//! pins `command_id`s and machine-mode capabilities for adopted commands.
+
+use foundry_cli::introspect::{
+    CapabilityMeta, CommandMeta, CommandRegistry, OutputMode, RegistryEntry, SideEffects,
+};
+
+/// Stable schema id for the `forge build` envelope payload.
+pub const BUILD_RESULT_SCHEMA: &str = "foundry:forge.build@v1";
+
+static ENTRIES: &[RegistryEntry] = &[RegistryEntry {
+    path: &["build"],
+    meta: CommandMeta {
+        command_id: Some("forge.build"),
+        capabilities: CapabilityMeta {
+            output_mode: OutputMode::Envelope,
+            result_schema_ref: Some(BUILD_RESULT_SCHEMA),
+            requires_project: true,
+            side_effects: SideEffects::FsWrite,
+            ..CapabilityMeta::NONE
+        },
+        exit_codes: &[],
+    },
+}];
+
+/// The `forge` command registry. Used by `--introspect` and by adoption code
+/// that needs to look up command metadata.
+pub const REGISTRY: CommandRegistry = CommandRegistry::new(ENTRIES);

--- a/crates/forge/src/introspect.rs
+++ b/crates/forge/src/introspect.rs
@@ -15,6 +15,11 @@ pub const TEST_EVENT_SCHEMA: &str = "foundry:forge.test.event@v1";
 /// Stable schema id for the terminal `forge test` envelope payload.
 pub const TEST_RESULT_SCHEMA: &str = "foundry:forge.test@v1";
 
+/// Stable schema id for `forge script` stream event records.
+pub const SCRIPT_EVENT_SCHEMA: &str = "foundry:forge.script.event@v1";
+/// Stable schema id for the terminal `forge script` envelope payload.
+pub const SCRIPT_RESULT_SCHEMA: &str = "foundry:forge.script@v1";
+
 static ENTRIES: &[RegistryEntry] = &[
     RegistryEntry {
         path: &["build"],
@@ -40,6 +45,22 @@ static ENTRIES: &[RegistryEntry] = &[
                 result_schema_ref: Some(TEST_RESULT_SCHEMA),
                 requires_project: true,
                 side_effects: SideEffects::None,
+                long_running: true,
+                ..CapabilityMeta::NONE
+            },
+            exit_codes: &[],
+        },
+    },
+    RegistryEntry {
+        path: &["script"],
+        meta: CommandMeta {
+            command_id: Some("forge.script"),
+            capabilities: CapabilityMeta {
+                output_mode: OutputMode::Stream,
+                event_schema_ref: Some(SCRIPT_EVENT_SCHEMA),
+                result_schema_ref: Some(SCRIPT_RESULT_SCHEMA),
+                requires_project: true,
+                side_effects: SideEffects::ChainWrite,
                 long_running: true,
                 ..CapabilityMeta::NONE
             },

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -15,6 +15,8 @@ use foundry_wallets as _;
 
 pub mod args;
 pub mod cmd;
+pub mod diagnostic;
+pub mod introspect;
 pub mod opts;
 
 pub mod coverage;

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -173,6 +173,10 @@ impl TestOutcome {
     }
 
     /// Checks if there are any failures and failures are disallowed.
+    //
+    // Exit-code policy: under `--machine` we honor the agent contract
+    // ([`ExitCode::TestFailure`]); legacy invocations preserve the
+    // historical exit-1 contract that scripts and CIs already depend on.
     pub fn ensure_ok(&self, silent: bool) -> eyre::Result<()> {
         let outcome = self;
         let failures = outcome.failures().count();
@@ -181,7 +185,7 @@ impl TestOutcome {
         }
 
         if shell::is_quiet() || silent {
-            std::process::exit(1);
+            std::process::exit(test_failure_exit_code());
         }
 
         sh_println!("\nFailing tests:")?;
@@ -225,7 +229,7 @@ impl TestOutcome {
             )?;
         }
 
-        std::process::exit(1);
+        std::process::exit(test_failure_exit_code());
     }
 
     /// Removes first test result, if any.
@@ -239,6 +243,11 @@ impl TestOutcome {
             }
         })
     }
+}
+
+/// Process exit code emitted when at least one test failed.
+fn test_failure_exit_code() -> i32 {
+    if foundry_cli::is_machine() { foundry_cli::ExitCode::TestFailure.to_i32() } else { 1 }
 }
 
 /// A set of test results for a single test suite, which is all the tests in a single contract.

--- a/crates/forge/tests/cli/agent_contract.rs
+++ b/crates/forge/tests/cli/agent_contract.rs
@@ -1,0 +1,58 @@
+//! Binary-level agent-contract tests for `forge`.
+//!
+//! Pins the cross-cutting guarantees agents depend on: `--introspect`
+//! produces a document conforming to `foundry:introspect@v1`, and under
+//! `--machine` the help / parse-error paths emit a `foundry:envelope@v1`
+//! envelope on stdout (never raw clap text).
+
+use foundry_test_utils::agent_schema;
+use serde_json::Value;
+
+// `forge --introspect` returns valid JSON conforming to
+// `foundry:introspect@v1`.
+forgetest!(introspect_document_matches_v1_schema, |_prj, cmd| {
+    let assert = cmd.arg("--introspect").assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let doc: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single JSON document on stdout: {stdout}: {e}"));
+    agent_schema::validate("foundry:introspect@v1", &doc);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --introspect, got: {stderr}");
+});
+
+// `forge --machine --help` emits a success envelope on stdout (not raw clap
+// help text).
+forgetest!(machine_mode_help_emits_success_envelope, |_prj, cmd| {
+    let assert = cmd.args(["--machine", "--help"]).assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single envelope on stdout: {stdout}: {e}"));
+    assert_eq!(envelope["success"], true);
+    assert!(envelope["data"]["help"].is_string(), "missing data.help: {envelope}");
+    assert_eq!(envelope["errors"], serde_json::json!([]));
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
+    agent_schema::validate("foundry:envelope@v1", &envelope);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// `forge --machine <bad-flag>` emits a typed `cli.usage.invalid` error
+// envelope and exits with `ExitCode::Usage` (2) — never raw clap text.
+forgetest!(machine_mode_unknown_flag_emits_typed_envelope, |_prj, cmd| {
+    let assert = cmd.args(["--machine", "--this-flag-does-not-exist"]).assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single envelope on stdout: {stdout}: {e}"));
+    assert_eq!(envelope["success"], false);
+    assert!(envelope["data"].is_null(), "data must be null on failure: {envelope}");
+    assert_eq!(envelope["errors"].as_array().map(Vec::len), Some(1));
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
+    agent_schema::validate("foundry:envelope@v1", &envelope);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -500,14 +500,11 @@ forgetest_init!(machine_mode_emits_envelope, |prj, cmd| {
     let envelope: Value =
         serde_json::from_str(stdout.trim()).expect("stdout is exactly one JSON envelope");
 
-    assert_eq!(envelope["schema_version"], 1);
     assert_eq!(envelope["success"], true);
-    assert!(envelope["data"]["artifacts"].as_u64().is_some(), "missing artifacts: {envelope}");
-    assert!(envelope["data"]["errors"].as_u64().is_some(), "missing errors: {envelope}");
-    assert!(envelope["data"]["warnings"].as_u64().is_some(), "missing warnings: {envelope}");
-    assert!(envelope["data"]["cache_hit"].as_bool().is_some(), "missing cache_hit: {envelope}");
-    assert_eq!(envelope["errors"], serde_json::json!([]));
-    assert_eq!(envelope["warnings"], serde_json::json!([]));
+    foundry_test_utils::agent_schema::validate_envelope_data(&envelope, "foundry:forge.build@v1");
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
 });
 
 // `--machine` rejects flags that would corrupt the envelope-only stdout
@@ -515,14 +512,20 @@ forgetest_init!(machine_mode_emits_envelope, |prj, cmd| {
 forgetest_init!(machine_mode_rejects_unsupported_flags, |prj, cmd| {
     prj.initialize_default_contracts();
     let assert = cmd.args(["--machine", "build", "--names"]).assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(2));
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     let envelope: Value = serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
 
     assert_eq!(envelope["success"], false);
+    assert!(envelope["data"].is_null(), "data must be null on failure: {envelope}");
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
     assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
-    assert_eq!(assert.get_output().status.code(), Some(2));
     let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
     assert!(msg.contains("--names"), "missing --names mention: {envelope}");
+    foundry_test_utils::agent_schema::validate("foundry:envelope@v1", &envelope);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
 });
 
 // tests that build warns when foundry.lock revision differs from actual submodule revision

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -1,6 +1,7 @@
 use crate::utils::generate_large_init_contract;
 use foundry_test_utils::{forgetest, forgetest_init, snapbox::IntoData, str};
 use globset::Glob;
+use serde_json::Value;
 use std::fs;
 
 forgetest_init!(can_parse_build_filters, |prj, cmd| {
@@ -488,6 +489,40 @@ forgetest_init!(build_no_warning_without_foundry_lock, |prj, cmd| {
 
     cmd.args(["build"]).assert_success().stderr_eq(str![[r#"
 "#]]);
+});
+
+// `forge --machine build` emits a single envelope on stdout. Asserts the
+// contract surface, not artifact counts (those drift with templates).
+forgetest_init!(machine_mode_emits_envelope, |prj, cmd| {
+    prj.initialize_default_contracts();
+    let assert = cmd.args(["--machine", "build", "--force"]).assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stdout.trim()).expect("stdout is exactly one JSON envelope");
+
+    assert_eq!(envelope["schema_version"], 1);
+    assert_eq!(envelope["success"], true);
+    assert!(envelope["data"]["artifacts"].as_u64().is_some(), "missing artifacts: {envelope}");
+    assert!(envelope["data"]["errors"].as_u64().is_some(), "missing errors: {envelope}");
+    assert!(envelope["data"]["warnings"].as_u64().is_some(), "missing warnings: {envelope}");
+    assert!(envelope["data"]["cache_hit"].as_bool().is_some(), "missing cache_hit: {envelope}");
+    assert_eq!(envelope["errors"], serde_json::json!([]));
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
+});
+
+// `--machine` rejects flags that would corrupt the envelope-only stdout
+// contract. Asserts the stable `code` + exit code, not just message text.
+forgetest_init!(machine_mode_rejects_unsupported_flags, |prj, cmd| {
+    prj.initialize_default_contracts();
+    let assert = cmd.args(["--machine", "build", "--names"]).assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
+
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("--names"), "missing --names mention: {envelope}");
 });
 
 // tests that build warns when foundry.lock revision differs from actual submodule revision

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -53,6 +53,11 @@ Display options:
       --json
           Format log messages as JSON
 
+      --machine
+          Activate the agent contract: emit declared output mode only, no color, no progress,
+          structured early-exit. Implies no color. Mutually exclusive with `--json` and `--md` to
+          keep machine-mode output unambiguous
+
       --md
           Format log messages as Markdown
 

--- a/crates/forge/tests/cli/main.rs
+++ b/crates/forge/tests/cli/main.rs
@@ -4,6 +4,7 @@ extern crate foundry_test_utils;
 pub mod constants;
 pub mod utils;
 
+mod agent_contract;
 mod backtrace;
 mod bind;
 mod bind_json;

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3706,3 +3706,240 @@ forgetest!(can_execute_script_command_with_tempo, |prj, cmd| {
         .arg(prj.root())
         .assert_success();
 });
+
+// `forge --machine script <Foo>` emits NDJSON phase events terminating in a
+// success envelope. Uses a tiny no-broadcast script.
+forgetest!(machine_mode_emits_ndjson_stream, |prj, cmd| {
+    let script = prj.add_source(
+        "Foo",
+        r#"
+contract Demo {
+    function run() external {}
+}
+   "#,
+    );
+
+    let assert = cmd.arg("--machine").arg("script").arg(script).assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert!(lines.len() >= 2, "expected stream + envelope, got: {stdout}");
+
+    let mut phases = Vec::new();
+    for line in &lines[..lines.len() - 1] {
+        let v: Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("non-json stream line: {line}: {e}"));
+        assert_eq!(v["schema_id"], "foundry:forge.script.event@v1");
+        assert_eq!(v["command_id"], "forge.script");
+        assert!(v["ts"].is_string());
+        if v["kind"] == "phase" {
+            phases.push(v["phase"].as_str().unwrap_or("").to_string());
+        }
+    }
+    assert!(phases.iter().any(|p| p == "compile"), "missing compile phase: {phases:?}");
+
+    let envelope: Value = serde_json::from_str(lines.last().unwrap()).unwrap();
+    assert_eq!(envelope["schema_version"], 1);
+    assert_eq!(envelope["success"], true);
+    assert_eq!(envelope["data"]["mode"], "dry_run");
+    assert_eq!(envelope["data"]["broadcast"], false);
+    assert_eq!(envelope["data"]["tx_count"], 0);
+    assert!(envelope["data"]["tx_hashes"].as_array().unwrap().is_empty());
+    assert!(envelope["data"]["created_contracts"].as_array().unwrap().is_empty());
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// `forge --machine script <Foo> --broadcast` on a script with no transactions
+// emits a `warning` stream event AND aggregates the warning into the terminal
+// envelope's `warnings[]` so machine consumers don't lose what the silenced
+// human path would have printed.
+forgetest!(machine_mode_aggregates_warnings_into_envelope, |prj, cmd| {
+    let script = prj.add_source(
+        "Foo",
+        r#"
+contract Demo {
+    function run() external {}
+}
+   "#,
+    );
+
+    let assert = cmd.arg("--machine").arg("script").arg(script).arg("--broadcast").assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert!(lines.len() >= 2, "expected stream + envelope, got: {stdout}");
+
+    // Last line is the terminal envelope; preceding lines are stream records.
+    let envelope: Value = serde_json::from_str(lines.last().unwrap()).unwrap();
+    assert_eq!(envelope["success"], true);
+    assert_eq!(envelope["data"]["broadcast"], false);
+    let warnings = envelope["warnings"].as_array().expect("warnings must be an array");
+    assert!(!warnings.is_empty(), "expected warnings in envelope, got: {envelope}");
+    assert_eq!(warnings[0]["level"], "warning");
+    assert_eq!(warnings[0]["code"], "script.warning");
+    assert!(
+        warnings[0]["message"].as_str().unwrap_or("").contains("no transactions"),
+        "unexpected warning: {}",
+        warnings[0]
+    );
+
+    // The same warning must also appear as a stream `warning` record.
+    let saw_stream_warning = lines[..lines.len() - 1].iter().any(|l| {
+        let v: Value = serde_json::from_str(l).unwrap();
+        v["kind"] == "warning"
+    });
+    assert!(saw_stream_warning, "expected a `warning` stream record, got: {stdout}");
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// A broadcast failure under `--machine` emits a typed error envelope keyed
+// by `script.broadcast_failed` instead of falling through to the generic
+// `cli.unknown` heuristic in the binary entry point.
+//
+// Trigger: anvil running, but the broadcast key is not in anvil's
+// pre-funded set so `eth_sendRawTransaction` rejects with insufficient
+// funds at the broadcast step (simulation against the fork still
+// succeeds).
+forgetest_async!(machine_mode_broadcast_failed_emits_typed_envelope, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let http_endpoint = handle.http_endpoint();
+
+    let script = prj.add_source(
+        "Deploy",
+        r#"
+import "forge-std/Script.sol";
+contract Empty {}
+contract DeployScript is Script {
+    function run() external {
+        vm.startBroadcast();
+        new Empty();
+        vm.stopBroadcast();
+    }
+}
+   "#,
+    );
+
+    // Private key for an address with zero anvil balance.
+    let unfunded_pk = "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+    let assert = cmd
+        .arg("--machine")
+        .arg("script")
+        .arg(script)
+        .arg("--target-contract")
+        .arg("DeployScript")
+        .arg("--broadcast")
+        .arg("--rpc-url")
+        .arg(&http_endpoint)
+        .arg("--private-key")
+        .arg(unfunded_pk)
+        .assert_failure();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    let envelope: Value = serde_json::from_str(lines.last().unwrap())
+        .unwrap_or_else(|e| panic!("trailing line not envelope: {stdout}: {e}"));
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "script.broadcast_failed");
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// `--machine` rejects flags whose stdout shape would corrupt the NDJSON
+// stream contract (`--debug`, `--resume`, `--verify`).
+forgetest!(machine_mode_rejects_unsupported_flags, |prj, cmd| {
+    let script = prj.add_source(
+        "Foo",
+        r#"
+contract Demo {
+    function run() external {}
+}
+   "#,
+    );
+
+    let assert = cmd.arg("--machine").arg("script").arg(script).arg("--debug").assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single-envelope error: {stdout}: {e}"));
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("--debug"), "missing --debug mention: {envelope}");
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// Happy-path broadcast: `--machine script ... --broadcast` against anvil
+// emits the `@v1` envelope with mode=broadcast, real tx hashes, and the
+// CREATE'd contract address. Pins the v1 payload shape.
+forgetest_async!(machine_mode_broadcast_success_emits_payload, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    let deploy_script = prj.add_source(
+        "Deploy",
+        r#"
+import "forge-std/Script.sol";
+contract Deployed {}
+contract DeployScript is Script {
+    function run() external {
+        vm.startBroadcast();
+        new Deployed();
+        vm.stopBroadcast();
+    }
+}
+   "#,
+    );
+    let deploy_contract = deploy_script.display().to_string() + ":DeployScript";
+
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    // Anvil's standard prefunded dev account #0.
+    let private_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    cmd.set_current_dir(prj.root());
+
+    let assert = cmd
+        .args([
+            "--machine",
+            "script",
+            &deploy_contract,
+            "--root",
+            prj.root().to_str().unwrap(),
+            "--rpc-url",
+            &handle.http_endpoint(),
+            "--broadcast",
+            "--private-key",
+            private_key,
+        ])
+        .assert_success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    let envelope: Value = serde_json::from_str(lines.last().unwrap())
+        .unwrap_or_else(|e| panic!("trailing line not envelope: {stdout}: {e}"));
+
+    assert_eq!(envelope["success"], true, "envelope: {envelope}");
+    let data = &envelope["data"];
+    assert_eq!(data["mode"], "broadcast", "envelope: {envelope}");
+    assert_eq!(data["broadcast"], true, "envelope: {envelope}");
+    let tx_count = data["tx_count"].as_u64().unwrap_or(0);
+    assert!(tx_count >= 1, "expected tx_count >= 1, got {tx_count}: {envelope}");
+    let tx_hashes = data["tx_hashes"].as_array().expect("tx_hashes array");
+    assert!(!tx_hashes.is_empty(), "tx_hashes empty: {envelope}");
+    for h in tx_hashes {
+        assert!(h.as_str().unwrap_or("").starts_with("0x"), "tx hash not 0x-prefixed: {h}");
+    }
+    let created = data["created_contracts"].as_array().expect("created_contracts array");
+    assert!(!created.is_empty(), "created_contracts empty: {envelope}");
+    assert!(
+        created.iter().any(|c| c["address"].as_str().unwrap_or("").starts_with("0x")),
+        "no created_contracts entry with 0x address: {envelope}"
+    );
+    assert!(data.get("verified").is_none(), "verified should be absent: {envelope}");
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3728,23 +3728,23 @@ contract Demo {
     for line in &lines[..lines.len() - 1] {
         let v: Value = serde_json::from_str(line)
             .unwrap_or_else(|e| panic!("non-json stream line: {line}: {e}"));
-        assert_eq!(v["schema_id"], "foundry:forge.script.event@v1");
-        assert_eq!(v["command_id"], "forge.script");
-        assert!(v["ts"].is_string());
+        foundry_test_utils::agent_schema::validate("foundry:forge.script.event@v1", &v);
         if v["kind"] == "phase" {
             phases.push(v["phase"].as_str().unwrap_or("").to_string());
         }
     }
+    // Dry-run must emit both `compile` and `simulate` phases; the
+    // `broadcast` phase is dry-run-suppressed.
     assert!(phases.iter().any(|p| p == "compile"), "missing compile phase: {phases:?}");
+    assert!(phases.iter().any(|p| p == "simulate"), "missing simulate phase: {phases:?}");
+    assert!(!phases.iter().any(|p| p == "broadcast"), "unexpected broadcast phase: {phases:?}");
 
     let envelope: Value = serde_json::from_str(lines.last().unwrap()).unwrap();
-    assert_eq!(envelope["schema_version"], 1);
     assert_eq!(envelope["success"], true);
     assert_eq!(envelope["data"]["mode"], "dry_run");
-    assert_eq!(envelope["data"]["broadcast"], false);
     assert_eq!(envelope["data"]["tx_count"], 0);
-    assert!(envelope["data"]["tx_hashes"].as_array().unwrap().is_empty());
     assert!(envelope["data"]["created_contracts"].as_array().unwrap().is_empty());
+    foundry_test_utils::agent_schema::validate_envelope_data(&envelope, "foundry:forge.script@v1");
 
     let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
     assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
@@ -3783,12 +3783,19 @@ contract Demo {
         warnings[0]
     );
 
-    // The same warning must also appear as a stream `warning` record.
-    let saw_stream_warning = lines[..lines.len() - 1].iter().any(|l| {
-        let v: Value = serde_json::from_str(l).unwrap();
-        v["kind"] == "warning"
-    });
-    assert!(saw_stream_warning, "expected a `warning` stream record, got: {stdout}");
+    // The same warning must appear in the stream and be the one aggregated
+    // into the terminal envelope — not just any warning.
+    let stream_warning = lines[..lines.len() - 1]
+        .iter()
+        .find_map(|l| {
+            let v: Value = serde_json::from_str(l).unwrap();
+            foundry_test_utils::agent_schema::validate("foundry:forge.script.event@v1", &v);
+            (v["kind"] == "warning").then_some(v)
+        })
+        .unwrap_or_else(|| panic!("expected a `warning` stream record, got: {stdout}"));
+    assert_eq!(stream_warning["code"], "script.warning");
+    assert_eq!(stream_warning["message"], warnings[0]["message"]);
+    foundry_test_utils::agent_schema::validate_envelope_data(&envelope, "foundry:forge.script@v1");
 
     let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
     assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
@@ -3843,7 +3850,10 @@ contract DeployScript is Script {
     let envelope: Value = serde_json::from_str(lines.last().unwrap())
         .unwrap_or_else(|e| panic!("trailing line not envelope: {stdout}: {e}"));
     assert_eq!(envelope["success"], false);
+    assert!(envelope["data"].is_null(), "data must be null on failure: {envelope}");
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
     assert_eq!(envelope["errors"][0]["code"], "script.broadcast_failed");
+    foundry_test_utils::agent_schema::validate("foundry:envelope@v1", &envelope);
 
     let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
     assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
@@ -3862,14 +3872,17 @@ contract Demo {
     );
 
     let assert = cmd.arg("--machine").arg("script").arg(script).arg("--debug").assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(2));
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     let envelope: Value = serde_json::from_str(stdout.trim())
         .unwrap_or_else(|e| panic!("expected single-envelope error: {stdout}: {e}"));
     assert_eq!(envelope["success"], false);
+    assert!(envelope["data"].is_null(), "data must be null on failure: {envelope}");
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
     assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
-    assert_eq!(assert.get_output().status.code(), Some(2));
     let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
     assert!(msg.contains("--debug"), "missing --debug mention: {envelope}");
+    foundry_test_utils::agent_schema::validate("foundry:envelope@v1", &envelope);
 
     let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
     assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
@@ -3924,21 +3937,16 @@ contract DeployScript is Script {
     assert_eq!(envelope["success"], true, "envelope: {envelope}");
     let data = &envelope["data"];
     assert_eq!(data["mode"], "broadcast", "envelope: {envelope}");
-    assert_eq!(data["broadcast"], true, "envelope: {envelope}");
     let tx_count = data["tx_count"].as_u64().unwrap_or(0);
     assert!(tx_count >= 1, "expected tx_count >= 1, got {tx_count}: {envelope}");
-    let tx_hashes = data["tx_hashes"].as_array().expect("tx_hashes array");
-    assert!(!tx_hashes.is_empty(), "tx_hashes empty: {envelope}");
-    for h in tx_hashes {
-        assert!(h.as_str().unwrap_or("").starts_with("0x"), "tx hash not 0x-prefixed: {h}");
-    }
-    let created = data["created_contracts"].as_array().expect("created_contracts array");
-    assert!(!created.is_empty(), "created_contracts empty: {envelope}");
+    assert!(!data["tx_hashes"].as_array().unwrap().is_empty(), "tx_hashes empty: {envelope}");
     assert!(
-        created.iter().any(|c| c["address"].as_str().unwrap_or("").starts_with("0x")),
-        "no created_contracts entry with 0x address: {envelope}"
+        !data["created_contracts"].as_array().unwrap().is_empty(),
+        "created_contracts empty: {envelope}"
     );
-    assert!(data.get("verified").is_none(), "verified should be absent: {envelope}");
+    // `--verify` is rejected under `--machine`, so this field must not appear.
+    assert!(data.get("verified").is_none(), "verified must be absent under @v1: {envelope}");
+    foundry_test_utils::agent_schema::validate_envelope_data(&envelope, "foundry:forge.script@v1");
 
     let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
     assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -123,9 +123,7 @@ contract MachinePassTest is Test {
     for line in &lines[..lines.len() - 1] {
         let v: Value = serde_json::from_str(line)
             .unwrap_or_else(|e| panic!("non-json stream line: {line}: {e}"));
-        assert_eq!(v["schema_id"], "foundry:forge.test.event@v1");
-        assert_eq!(v["command_id"], "forge.test");
-        assert!(v["ts"].is_string());
+        foundry_test_utils::agent_schema::validate("foundry:forge.test.event@v1", &v);
         match v["kind"].as_str().unwrap_or("") {
             "test_result" => saw_test_result = true,
             "suite_finished" => saw_suite_finished = true,
@@ -135,13 +133,16 @@ contract MachinePassTest is Test {
     assert!(saw_test_result, "missing any test_result event in: {stdout}");
     assert!(saw_suite_finished, "missing any suite_finished event in: {stdout}");
 
-    // Terminal envelope.
+    // Terminal envelope: 2-test, 1-suite fixture pinned exactly.
     let envelope: Value = serde_json::from_str(lines.last().unwrap()).unwrap();
-    assert_eq!(envelope["schema_version"], 1);
     assert_eq!(envelope["success"], true);
-    assert!(envelope["data"]["passed"].as_u64().is_some(), "missing passed: {envelope}");
-    assert!(envelope["data"]["failed"].as_u64().is_some(), "missing failed: {envelope}");
-    assert!(envelope["data"]["suites"].as_u64().is_some(), "missing suites: {envelope}");
+    assert_eq!(envelope["data"]["passed"].as_u64(), Some(2));
+    assert_eq!(envelope["data"]["failed"].as_u64(), Some(0));
+    assert_eq!(envelope["data"]["suites"].as_u64(), Some(1));
+    foundry_test_utils::agent_schema::validate_envelope_data(&envelope, "foundry:forge.test@v1");
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
 });
 
 // On a failing test, `forge --machine test` ends with an error envelope and
@@ -166,19 +167,29 @@ contract MachineFailTest is Test {
     assert_eq!(envelope["errors"][0]["code"], "test.failed");
     let failed = envelope["errors"][0]["details"]["failed"].as_u64().unwrap_or(0);
     assert!(failed >= 1, "expected at least one failed test in details: {envelope}");
+    foundry_test_utils::agent_schema::validate("foundry:envelope@v1", &envelope);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
 });
 
 // `--machine` rejects flags that would corrupt the NDJSON stream contract.
 forgetest_init!(machine_mode_rejects_unsupported_flags, |_prj, cmd| {
     let assert = cmd.args(["--machine", "test", "--gas-report"]).assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(2));
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     let envelope: Value = serde_json::from_str(stdout.trim())
         .unwrap_or_else(|e| panic!("expected single-envelope error stdout: {stdout}: {e}"));
     assert_eq!(envelope["success"], false);
+    assert!(envelope["data"].is_null(), "data must be null on failure: {envelope}");
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
     assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
-    assert_eq!(assert.get_output().status.code(), Some(2));
     let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
     assert!(msg.contains("--gas-report"), "missing --gas-report mention: {envelope}");
+    foundry_test_utils::agent_schema::validate("foundry:envelope@v1", &envelope);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
 });
 
 // `--watch` is dispatched separately from `cmd.run()`, so the rejection
@@ -186,14 +197,20 @@ forgetest_init!(machine_mode_rejects_unsupported_flags, |_prj, cmd| {
 // against the dispatch boundary moving back under the rejection path.
 forgetest_init!(machine_mode_rejects_watch, |_prj, cmd| {
     let assert = cmd.args(["--machine", "test", "--watch"]).assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(2));
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     let envelope: Value = serde_json::from_str(stdout.trim())
         .unwrap_or_else(|e| panic!("expected single-envelope error stdout: {stdout}: {e}"));
     assert_eq!(envelope["success"], false);
+    assert!(envelope["data"].is_null(), "data must be null on failure: {envelope}");
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
     assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
-    assert_eq!(assert.get_output().status.code(), Some(2));
     let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
     assert!(msg.contains("--watch"), "missing --watch mention: {envelope}");
+    foundry_test_utils::agent_schema::validate("foundry:envelope@v1", &envelope);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
 });
 
 forgetest_init!(payment_failure, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -1,6 +1,7 @@
 //! Core test functionality tests
 
 use foundry_test_utils::str;
+use serde_json::Value;
 
 forgetest_init!(failing_test_after_failed_setup, |prj, cmd| {
     prj.add_test(
@@ -94,6 +95,105 @@ Encountered a total of 2 failing tests, 1 tests succeeded
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
 
 "#]]);
+});
+
+// `forge --machine test` emits NDJSON: per-test events, suite_finished
+// events, terminating in a success envelope. Exercises the canonical
+// passing-tests path with a small fixture suite.
+forgetest_init!(machine_mode_emits_ndjson_stream, |prj, cmd| {
+    prj.add_test(
+        "MachinePass.t.sol",
+        r#"
+import "forge-std/Test.sol";
+contract MachinePassTest is Test {
+    function testAlwaysPasses() public { assertTrue(true); }
+    function testAlsoPasses() public { assertEq(uint256(1), uint256(1)); }
+}
+"#,
+    );
+    let assert = cmd.args(["--machine", "test"]).assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert!(lines.len() >= 2, "expected stream + envelope lines, got: {stdout}");
+
+    // Every record parses as JSON and stream events carry the spec fields.
+    let mut saw_test_result = false;
+    let mut saw_suite_finished = false;
+    for line in &lines[..lines.len() - 1] {
+        let v: Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("non-json stream line: {line}: {e}"));
+        assert_eq!(v["schema_id"], "foundry:forge.test.event@v1");
+        assert_eq!(v["command_id"], "forge.test");
+        assert!(v["ts"].is_string());
+        match v["kind"].as_str().unwrap_or("") {
+            "test_result" => saw_test_result = true,
+            "suite_finished" => saw_suite_finished = true,
+            other => panic!("unexpected event kind `{other}` on line: {line}"),
+        }
+    }
+    assert!(saw_test_result, "missing any test_result event in: {stdout}");
+    assert!(saw_suite_finished, "missing any suite_finished event in: {stdout}");
+
+    // Terminal envelope.
+    let envelope: Value = serde_json::from_str(lines.last().unwrap()).unwrap();
+    assert_eq!(envelope["schema_version"], 1);
+    assert_eq!(envelope["success"], true);
+    assert!(envelope["data"]["passed"].as_u64().is_some(), "missing passed: {envelope}");
+    assert!(envelope["data"]["failed"].as_u64().is_some(), "missing failed: {envelope}");
+    assert!(envelope["data"]["suites"].as_u64().is_some(), "missing suites: {envelope}");
+});
+
+// On a failing test, `forge --machine test` ends with an error envelope and
+// exits with `ExitCode::TestFailure` (5).
+forgetest_init!(machine_mode_failing_test_emits_error_envelope, |prj, cmd| {
+    prj.add_test(
+        "MachineFail.t.sol",
+        r#"
+import "forge-std/Test.sol";
+contract MachineFailTest is Test {
+    function testAlwaysFails() public { assertTrue(false); }
+}
+"#,
+    );
+    let assert = cmd.args(["--machine", "test"]).assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(5));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    let envelope: Value = serde_json::from_str(lines.last().unwrap())
+        .unwrap_or_else(|e| panic!("trailing line not envelope: {stdout}: {e}"));
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "test.failed");
+    let failed = envelope["errors"][0]["details"]["failed"].as_u64().unwrap_or(0);
+    assert!(failed >= 1, "expected at least one failed test in details: {envelope}");
+});
+
+// `--machine` rejects flags that would corrupt the NDJSON stream contract.
+forgetest_init!(machine_mode_rejects_unsupported_flags, |_prj, cmd| {
+    let assert = cmd.args(["--machine", "test", "--gas-report"]).assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single-envelope error stdout: {stdout}: {e}"));
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("--gas-report"), "missing --gas-report mention: {envelope}");
+});
+
+// `--watch` is dispatched separately from `cmd.run()`, so the rejection
+// preflight has to live at the top-level entry. This regression guards
+// against the dispatch boundary moving back under the rejection path.
+forgetest_init!(machine_mode_rejects_watch, |_prj, cmd| {
+    let assert = cmd.args(["--machine", "test", "--watch"]).assert_failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected single-envelope error stdout: {stdout}: {e}"));
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("--watch"), "missing --watch mention: {envelope}");
 });
 
 forgetest_init!(payment_failure, |prj, cmd| {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -303,6 +303,9 @@ impl ScriptArgs {
     pub async fn run_script(self) -> Result<()> {
         trace!(target: "script", "executing script command");
 
+        self.reject_machine_unsupported_flags()?;
+        let machine_mode = foundry_cli::is_machine();
+
         let (config, evm_opts) = self.resolved_evm_opts().await?;
 
         let is_tempo = evm_opts.networks.is_tempo();
@@ -311,27 +314,97 @@ impl ScriptArgs {
             eyre::bail!("--batch mode is only supported on Tempo networks");
         }
 
-        if is_tempo {
+        let machine_payload: Option<ScriptResultData> = if is_tempo {
             let batch = self.batch;
-            let bundled = match self.prepare_bundled::<TempoEvmNetwork>(config, evm_opts).await? {
-                Some(bundled) => bundled,
-                None => return Ok(()),
-            };
-            let bundled = bundled.wait_for_pending().await?;
-            let broadcasted =
-                if batch { bundled.broadcast_batch().await? } else { bundled.broadcast().await? };
-            if broadcasted.args.verify {
-                broadcasted.verify().await?;
+            match self.prepare_bundled::<TempoEvmNetwork>(config, evm_opts).await? {
+                Some(bundled) => {
+                    let bundled = bundled.wait_for_pending().await?;
+                    if machine_mode {
+                        emit_phase("broadcast")?;
+                    }
+                    let broadcasted = match if batch {
+                        bundled.broadcast_batch().await
+                    } else {
+                        bundled.broadcast().await
+                    } {
+                        Ok(b) => b,
+                        Err(e) if machine_mode => foundry_cli::machine::bail_machine_diagnostic(
+                            foundry_cli::diagnostic::script::BROADCAST_FAILED,
+                            foundry_cli::ExitCode::GenericError,
+                            format!("broadcast failed: {e}"),
+                        ),
+                        Err(e) => return Err(e),
+                    };
+                    let verify_requested = broadcasted.args.verify;
+                    let payload = machine_mode
+                        .then(|| ScriptResultData::from_sequence(&broadcasted.sequence, None));
+                    let verified = if verify_requested {
+                        match broadcasted.verify().await {
+                            Ok(()) => Some(true),
+                            Err(e) if machine_mode => {
+                                let _ =
+                                    record_machine_warning(&format!("verification failed: {e}"));
+                                Some(false)
+                            }
+                            Err(e) => return Err(e),
+                        }
+                    } else {
+                        None
+                    };
+                    payload.map(|mut p| {
+                        p.verified = verified;
+                        p
+                    })
+                }
+                None => machine_mode.then(ScriptResultData::dry_run),
             }
+        } else {
+            #[cfg(feature = "optimism")]
+            {
+                if evm_opts.networks.is_optimism() {
+                    self.run_generic_script::<OpEvmNetwork>(config, evm_opts).await?
+                } else {
+                    self.run_generic_script::<EthEvmNetwork>(config, evm_opts).await?
+                }
+            }
+            #[cfg(not(feature = "optimism"))]
+            {
+                self.run_generic_script::<EthEvmNetwork>(config, evm_opts).await?
+            }
+        };
+
+        if machine_mode {
+            let warnings = drain_machine_warnings();
+            let payload = machine_payload.unwrap_or_else(ScriptResultData::dry_run);
+            foundry_cli::json::print_json(
+                &foundry_cli::json::JsonEnvelope::success_with_warnings(payload, warnings),
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Reject flags whose stdout shape conflicts with the NDJSON stream
+    /// contract under `--machine`. `--debug` opens a TUI that can't share
+    /// stdout with the agent stream; `--resume` and `--verify` drive
+    /// state-machine paths whose envelope shape is not part of `@v1`.
+    fn reject_machine_unsupported_flags(&self) -> Result<()> {
+        if !foundry_cli::is_machine() {
             return Ok(());
         }
-
-        #[cfg(feature = "optimism")]
-        if evm_opts.networks.is_optimism() {
-            return self.run_generic_script::<OpEvmNetwork>(config, evm_opts).await;
+        let unsupported =
+            [("--debug", self.debug), ("--resume", self.resume), ("--verify", self.verify)]
+                .into_iter()
+                .filter_map(|(name, on)| on.then_some(name))
+                .collect::<Vec<_>>();
+        if !unsupported.is_empty() {
+            foundry_cli::machine::bail_machine_usage(format!(
+                "`forge script` under `--machine` does not support {}; \
+                 run without `--machine` or omit those flags.",
+                unsupported.join(", ")
+            ));
         }
-
-        self.run_generic_script::<EthEvmNetwork>(config, evm_opts).await
+        Ok(())
     }
 
     /// Prepares the bundled state (compile, simulate, bundle) and returns it
@@ -345,6 +418,9 @@ impl ScriptArgs {
     ) -> Result<Option<BundledState<FEN>>> {
         let state = self.preprocess::<FEN>(config, evm_opts).await?;
         let create2_deployer = state.script_config.evm_opts.create2_deployer;
+        if foundry_cli::is_machine() {
+            emit_phase("compile")?;
+        }
         let compiled = state.compile()?;
 
         // Move from `CompiledState` to `BundledState` either by resuming or executing and
@@ -362,6 +438,10 @@ impl ScriptArgs {
                 .await?
                 .prepare_simulation()
                 .await?;
+
+            if foundry_cli::is_machine() {
+                emit_phase("simulate")?;
+            }
 
             if pre_simulation.args.debug {
                 return match pre_simulation.args.dump.clone() {
@@ -386,6 +466,9 @@ impl ScriptArgs {
             {
                 if pre_simulation.args.broadcast {
                     sh_warn!("No transactions to broadcast.")?;
+                    if foundry_cli::is_machine() {
+                        record_machine_warning("no transactions to broadcast")?;
+                    }
                 }
 
                 return Ok(None);
@@ -395,6 +478,11 @@ impl ScriptArgs {
             if pre_simulation.execution_artifacts.rpc_data.missing_rpc {
                 if !shell::is_json() {
                     sh_println!("\nIf you wish to simulate on-chain transactions pass a RPC URL.")?;
+                }
+                if foundry_cli::is_machine() {
+                    record_machine_warning(
+                        "missing RPC URL: pass --rpc-url to enable on-chain simulation",
+                    )?;
                 }
 
                 return Ok(None);
@@ -436,20 +524,48 @@ impl ScriptArgs {
         self,
         config: Config,
         evm_opts: EvmOpts,
-    ) -> Result<()> {
+    ) -> Result<Option<ScriptResultData>> {
+        let machine_mode = foundry_cli::is_machine();
         let bundled = match self.prepare_bundled::<FEN>(config, evm_opts).await? {
             Some(bundled) => bundled,
-            None => return Ok(()),
+            None => return Ok(machine_mode.then(ScriptResultData::dry_run)),
         };
 
         // Wait for pending txes and broadcast others.
-        let broadcasted = bundled.wait_for_pending().await?.broadcast().await?;
-
-        if broadcasted.args.verify {
-            broadcasted.verify().await?;
+        let bundled = bundled.wait_for_pending().await?;
+        if machine_mode {
+            emit_phase("broadcast")?;
         }
+        let broadcasted = match bundled.broadcast().await {
+            Ok(b) => b,
+            Err(e) if machine_mode => foundry_cli::machine::bail_machine_diagnostic(
+                foundry_cli::diagnostic::script::BROADCAST_FAILED,
+                foundry_cli::ExitCode::GenericError,
+                format!("broadcast failed: {e}"),
+            ),
+            Err(e) => return Err(e),
+        };
 
-        Ok(())
+        let verify_requested = broadcasted.args.verify;
+        let payload =
+            machine_mode.then(|| ScriptResultData::from_sequence(&broadcasted.sequence, None));
+        let verified = if verify_requested {
+            match broadcasted.verify().await {
+                Ok(()) => Some(true),
+                Err(e) if machine_mode => {
+                    let _ = record_machine_warning(&format!("verification failed: {e}"));
+                    Some(false)
+                }
+                Err(e) => return Err(e),
+            }
+        } else {
+            None
+        };
+
+        Ok(payload.map(|mut p| {
+            p.verified = verified;
+            p
+        }))
     }
 
     /// In case the user has loaded *only* one private-key or a single remote signer (e.g.,
@@ -591,8 +707,10 @@ impl ScriptArgs {
         }
 
         // Only prompt if we're broadcasting and we've not disabled interactivity.
+        // `--machine` is implicitly non-interactive: never block on user input.
         if prompt_user
             && !self.non_interactive
+            && !foundry_cli::is_machine()
             && !Confirm::new().with_prompt("Do you wish to continue?".to_string()).interact()?
         {
             eyre::bail!("User canceled the script.");
@@ -604,6 +722,159 @@ impl ScriptArgs {
     /// We only broadcast transactions if --broadcast, --resume, or --verify was passed.
     const fn should_broadcast(&self) -> bool {
         self.broadcast || self.resume || self.verify
+    }
+}
+
+/// Stable schema id for `forge script` stream event records.
+/// Must match `crate::introspect::SCRIPT_EVENT_SCHEMA` in the `forge` crate;
+/// the registered_commands_pin_stable_ids test pins the registry side.
+const SCRIPT_EVENT_SCHEMA: &str = "foundry:forge.script.event@v1";
+
+#[derive(Serialize)]
+struct PhaseEvent {
+    phase: &'static str,
+}
+
+fn emit_phase(phase: &'static str) -> Result<()> {
+    foundry_cli::json::print_stream_record(
+        SCRIPT_EVENT_SCHEMA,
+        "forge.script",
+        "phase",
+        PhaseEvent { phase },
+    )?;
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct ScriptWarningEvent<'a> {
+    code: &'static str,
+    message: &'a str,
+}
+
+thread_local! {
+    /// Per-invocation collector of structured warnings; drained into the
+    /// terminal envelope's `warnings[]` so machine consumers see what the
+    /// silenced human path would have printed.
+    static MACHINE_WARNINGS: std::cell::RefCell<Vec<String>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Emit a warning event on the stream and stash it for the terminal envelope.
+fn record_machine_warning(message: &str) -> Result<()> {
+    foundry_cli::json::print_stream_record(
+        SCRIPT_EVENT_SCHEMA,
+        "forge.script",
+        "warning",
+        ScriptWarningEvent { code: foundry_cli::diagnostic::script::WARNING, message },
+    )?;
+    MACHINE_WARNINGS.with(|w| w.borrow_mut().push(message.to_string()));
+    Ok(())
+}
+
+fn drain_machine_warnings() -> Vec<foundry_cli::json::JsonMessage> {
+    MACHINE_WARNINGS
+        .with(|w| std::mem::take(&mut *w.borrow_mut()))
+        .into_iter()
+        .map(|m| {
+            foundry_cli::json::JsonMessage::warning(foundry_cli::diagnostic::script::WARNING, m)
+        })
+        .collect()
+}
+
+/// Stable payload emitted in the terminal `forge script` envelope under `--machine`.
+///
+/// Carries enough to reason about the script's on-chain effect (mode, tx
+/// count, hashes, created contracts) without reading the saved sequence file.
+#[derive(Serialize)]
+struct ScriptResultData {
+    /// `"dry_run"` when no transactions were submitted on-chain, `"broadcast"`
+    /// when at least one transaction was sent.
+    mode: &'static str,
+    /// Whether at least one transaction was submitted on-chain.
+    broadcast: bool,
+    /// Number of transactions in the script's sequence(s).
+    tx_count: usize,
+    /// Submitted transaction hashes, in order. Empty in dry-run.
+    tx_hashes: Vec<String>,
+    /// Contracts created by the script (best-effort; depends on metadata).
+    created_contracts: Vec<CreatedContract>,
+    /// `Some(true)` if `--verify` ran and reported success; `Some(false)` if
+    /// it ran and reported failure; `None` if `--verify` was not requested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    verified: Option<bool>,
+}
+
+#[derive(Serialize)]
+struct CreatedContract {
+    /// 0x-prefixed deployed address.
+    address: String,
+    /// Best-effort contract name (may be missing for unlinked / dynamic deploys).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    contract_name: Option<String>,
+}
+
+impl ScriptResultData {
+    /// Empty payload for the dry-run / no-broadcast case.
+    const fn dry_run() -> Self {
+        Self {
+            mode: "dry_run",
+            broadcast: false,
+            tx_count: 0,
+            tx_hashes: Vec::new(),
+            created_contracts: Vec::new(),
+            verified: None,
+        }
+    }
+
+    /// Build the broadcast-mode payload from a finished sequence.
+    fn from_sequence<N: alloy_network::Network>(
+        sequence: &crate::sequence::ScriptSequenceKind<N>,
+        verified: Option<bool>,
+    ) -> Self
+    where
+        N::TxEnvelope: for<'d> serde::Deserialize<'d> + Serialize,
+    {
+        let mut tx_count = 0usize;
+        let mut tx_hashes = Vec::new();
+        let mut created_contracts = Vec::new();
+        for seq in sequence.sequences() {
+            for tx in &seq.transactions {
+                tx_count += 1;
+
+                if let Some(h) = tx.hash {
+                    tx_hashes.push(format!("{h:#x}"));
+                }
+
+                // Top-level CREATE / CREATE2: `contract_address` is also populated for
+                // ordinary CALLs, so gate on `call_kind` to avoid reporting callees as
+                // newly-created contracts.
+                if tx.call_kind.is_any_create()
+                    && let Some(addr) = tx.contract_address
+                {
+                    created_contracts.push(CreatedContract {
+                        address: format!("{addr:#x}"),
+                        contract_name: tx.contract_name.clone().filter(|s| !s.is_empty()),
+                    });
+                }
+
+                // Nested contracts created during the tx's execution (recorded in
+                // sequence metadata at simulation time).
+                for c in &tx.additional_contracts {
+                    created_contracts.push(CreatedContract {
+                        address: format!("{:#x}", c.address),
+                        contract_name: c.contract_name.clone().filter(|s| !s.is_empty()),
+                    });
+                }
+            }
+        }
+        Self {
+            mode: "broadcast",
+            broadcast: true,
+            tx_count,
+            tx_hashes,
+            created_contracts,
+            verified,
+        }
     }
 }
 

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -26,6 +26,7 @@ alloy-provider.workspace = true
 
 eyre.workspace = true
 fd-lock = "4.0"
+jsonschema = { version = "0.30", default-features = false }
 parking_lot.workspace = true
 regex.workspace = true
 serde_json.workspace = true

--- a/crates/test-utils/src/agent_schema.rs
+++ b/crates/test-utils/src/agent_schema.rs
@@ -1,0 +1,210 @@
+//! JSON Schema validation for agent-substrate `@v1` payloads.
+//!
+//! Loads the schema files committed under `docs/agents/schemas/` and exposes a
+//! single [`validate`] entry point keyed by schema id. Test helpers wrap the
+//! existing `machine_mode_*` snapshot assertions so envelope / stream payloads
+//! are checked against the same schemas external agent tooling depends on.
+
+use jsonschema::Validator;
+use parking_lot::Mutex;
+use serde_json::Value;
+use std::{collections::HashMap, path::PathBuf, sync::OnceLock};
+
+/// Returns the absolute path to `docs/agents/schemas/` in the workspace.
+fn schemas_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../docs/agents/schemas")
+}
+
+/// Map of `schema_id` -> committed JSON Schema file name (relative to
+/// `docs/agents/schemas/`).
+const SCHEMA_FILES: &[(&str, &str)] = &[
+    ("foundry:envelope@v1", "envelope.v1.json"),
+    ("foundry:introspect@v1", "introspect.v1.json"),
+    ("foundry:cast.call@v1", "cast.call.v1.json"),
+    ("foundry:forge.build@v1", "forge.build.v1.json"),
+    ("foundry:forge.test@v1", "forge.test.v1.json"),
+    ("foundry:forge.test.event@v1", "forge.test.event.v1.json"),
+    ("foundry:forge.script@v1", "forge.script.v1.json"),
+    ("foundry:forge.script.event@v1", "forge.script.event.v1.json"),
+];
+
+/// The list of `@v1` schema ids covered by the agent-substrate freeze.
+pub fn known_schema_ids() -> impl Iterator<Item = &'static str> {
+    SCHEMA_FILES.iter().map(|(id, _)| *id)
+}
+
+fn validator_for(schema_id: &str) -> &'static Validator {
+    static CACHE: OnceLock<Mutex<HashMap<&'static str, &'static Validator>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+
+    let (id, file) = SCHEMA_FILES
+        .iter()
+        .find(|(id, _)| *id == schema_id)
+        .unwrap_or_else(|| panic!("unknown agent schema id: {schema_id}"));
+
+    if let Some(v) = cache.lock().get(id) {
+        return v;
+    }
+
+    let path = schemas_dir().join(file);
+    let raw =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let schema_value: Value =
+        serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+    // `should_validate_formats(true)` opts in to hard-failing on bad
+    // `format` values (e.g. `date-time`); the Draft 2020-12 default is
+    // annotation-only.
+    let validator: Validator = jsonschema::draft202012::options()
+        .should_validate_formats(true)
+        .build(&schema_value)
+        .unwrap_or_else(|e| panic!("compile {}: {e}", path.display()));
+
+    // `Validator` owns its compiled schema once built, so a single Box leak
+    // is enough to give it a `'static` lifetime for the cache. The test
+    // process exits clean these up.
+    let leaked_validator: &'static Validator = Box::leak(Box::new(validator));
+    cache.lock().insert(id, leaked_validator);
+    leaked_validator
+}
+
+/// Validate `instance` against the committed schema for `schema_id`.
+///
+/// Panics with a descriptive message on validation failure. Use in tests to
+/// pin emitted payloads to the same `@v1` contract external agent tooling
+/// consumes.
+pub fn validate(schema_id: &str, instance: &Value) {
+    let validator = validator_for(schema_id);
+    if let Err(error) = validator.validate(instance) {
+        panic!(
+            "schema `{schema_id}` validation failed: {error}\n\
+             instance was:\n{}",
+            serde_json::to_string_pretty(instance).unwrap_or_default()
+        );
+    }
+}
+
+/// Validate the `data` payload of an envelope-mode terminal envelope against
+/// the per-command schema.
+///
+/// `envelope` is the parsed terminal envelope value (the last NDJSON line
+/// under `--machine` stream mode, or the only line under envelope mode).
+/// `data_schema_id` is the `result_schema_ref` reported in the introspect
+/// registry for the command.
+pub fn validate_envelope_data(envelope: &Value, data_schema_id: &str) {
+    validate("foundry:envelope@v1", envelope);
+    let data = envelope.get("data").unwrap_or_else(|| {
+        panic!("envelope has no `data` field:\n{}", serde_json::to_string_pretty(envelope).unwrap())
+    });
+    assert!(!data.is_null(), "envelope `data` is null; cannot validate against {data_schema_id}");
+    validate(data_schema_id, data);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Every committed schema must be a valid JSON Schema Draft 2020-12 document.
+    #[test]
+    fn all_committed_schemas_compile() {
+        for id in known_schema_ids() {
+            let _ = validator_for(id);
+        }
+    }
+
+    #[test]
+    fn envelope_minimal_success_validates() {
+        let v = json!({
+            "schema_version": 1,
+            "success": true,
+            "data": {},
+            "errors": [],
+            "warnings": []
+        });
+        validate("foundry:envelope@v1", &v);
+    }
+
+    #[test]
+    fn envelope_failure_with_typed_error_validates() {
+        let v = json!({
+            "schema_version": 1,
+            "success": false,
+            "data": null,
+            "errors": [{
+                "level": "error",
+                "code": "script.broadcast_failed",
+                "message": "broadcast failed: insufficient funds",
+            }],
+            "warnings": []
+        });
+        validate("foundry:envelope@v1", &v);
+    }
+
+    #[test]
+    fn envelope_rejects_malformed_diagnostic_code() {
+        let v = json!({
+            "schema_version": 1,
+            "success": false,
+            "data": null,
+            "errors": [{ "level": "error", "code": "NotADotted", "message": "x" }],
+            "warnings": []
+        });
+        let validator = validator_for("foundry:envelope@v1");
+        assert!(validator.validate(&v).is_err());
+    }
+
+    #[test]
+    fn forge_script_payload_validates() {
+        let data = json!({
+            "mode": "broadcast",
+            "broadcast": true,
+            "tx_count": 1,
+            "tx_hashes": [
+                "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            ],
+            "created_contracts": [{
+                "address": "0x000000000000000000000000000000000000beef",
+                "contract_name": "Deployed",
+            }]
+        });
+        validate("foundry:forge.script@v1", &data);
+    }
+
+    #[test]
+    fn forge_test_event_oneof_kinds_validate() {
+        for v in [
+            json!({
+                "schema_id": "foundry:forge.test.event@v1",
+                "command_id": "forge.test",
+                "kind": "test_result",
+                "ts": "2025-01-01T00:00:00Z",
+                "contract": "C.t.sol:CT",
+                "name": "test_x",
+                "status": "passed",
+                "duration_ms": 1,
+            }),
+            json!({
+                "schema_id": "foundry:forge.test.event@v1",
+                "command_id": "forge.test",
+                "kind": "suite_finished",
+                "ts": "2025-01-01T00:00:00Z",
+                "contract": "C.t.sol:CT",
+                "passed": 1,
+                "failed": 0,
+                "skipped": 0,
+                "duration_ms": 1,
+            }),
+            json!({
+                "schema_id": "foundry:forge.test.event@v1",
+                "command_id": "forge.test",
+                "kind": "warning",
+                "ts": "2025-01-01T00:00:00Z",
+                "contract": "C.t.sol:CT",
+                "code": "test.warning",
+                "message": "x",
+            }),
+        ] {
+            validate("foundry:forge.test.event@v1", &v);
+        }
+    }
+}

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -14,6 +14,7 @@ extern crate tracing;
 #[macro_use]
 mod macros;
 
+pub mod agent_schema;
 pub mod etherscan;
 pub mod rpc;
 

--- a/deny.toml
+++ b/deny.toml
@@ -71,6 +71,8 @@ exceptions = [
     { allow = ["CC0-1.0"], name = "aurora-engine-modexp" },
     # Rendered mdBook HTML source code includes attribution as required by CC-BY-4.0
     { allow = ["CC-BY-4.0", "MIT"], name = "font-awesome-as-a-crate" },
+    # MIT No Attribution; transitive dep of `jsonschema` (foundry-test-utils only).
+    { allow = ["MIT-0"], name = "borrow-or-share" },
 ]
 # copyleft = "deny"
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,34 @@
+# Foundry agent-facing substrate
+
+This directory contains the specification for Foundry's agent-facing surface:
+the stable, machine-readable contract that downstream tooling, automation, and
+AI agents can rely on across `forge`, `cast`, `anvil`, and `chisel`.
+
+The agent surface is layered on top of the existing CLIs. It is opt-in,
+additive, and explicitly versioned. It does not replace the human-facing CLI;
+it complements it so that the human interface can evolve without breaking
+machine consumers.
+
+## Documents
+
+- [`spec.md`](./spec.md) — the contract (introspection, machine mode,
+  envelope, streaming, sessions, versioning, deprecation policy)
+- [`exit-codes.md`](./exit-codes.md) — the canonical exit-code table
+- [`diagnostics.md`](./diagnostics.md) — diagnostic-code namespacing
+
+## Schema identifiers
+
+Every machine-readable artifact has a stable logical identifier of the
+form `foundry:<name>@vN` (e.g. `foundry:envelope@v1`,
+`foundry:introspect@v1`). The identifier is the contract — agents pin
+against it, not against the in-memory shape of any particular release.
+
+Identifiers appear inline as a `schema_id` field on the introspect
+document and on stream/session records. Envelope payload schemas are
+discovered via the emitting command's `capabilities.result_schema_ref`
+in introspection (see [`spec.md`](./spec.md) §8).
+
+Concrete JSON Schemas describing each identifier are introduced alongside
+the commands that adopt them.
+
+

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -15,6 +15,8 @@ machine consumers.
   envelope, streaming, sessions, versioning, deprecation policy)
 - [`exit-codes.md`](./exit-codes.md) — the canonical exit-code table
 - [`diagnostics.md`](./diagnostics.md) — diagnostic-code namespacing
+- [`schemas/`](./schemas/) — JSON Schema files for every committed `@v1`
+  identifier
 
 ## Schema identifiers
 
@@ -28,7 +30,30 @@ document and on stream/session records. Envelope payload schemas are
 discovered via the emitting command's `capabilities.result_schema_ref`
 in introspection (see [`spec.md`](./spec.md) §8).
 
-Concrete JSON Schemas describing each identifier are introduced alongside
-the commands that adopt them.
+The [`schemas/`](./schemas/) directory carries a JSON Schema (Draft
+2020-12) for every `@v1` identifier currently shipped. They are the
+source of truth for downstream tooling; the in-repo `foundry-test-utils`
+crate validates real emitted payloads against them on every CI run.
+
+## Relationship to legacy flags
+
+- `--markdown-help` is **deprecated for agent use**. It targets human
+  readers and predates the agent contract; use `--introspect` instead.
+- `--json` predates this contract and remains supported for backward
+  compatibility with existing scripts. It is **not part of the agent
+  surface** — its shape varies by command and is not pinned by any
+  `foundry:*@vN` identifier. Use `--machine` to opt in to the contract.
+
+## Retry safety for chain-write commands
+
+Under `--machine`, commands declared with `side_effects: chain_write`
+(e.g. `forge script`) submit real transactions. Network errors,
+interrupted processes, and lost terminal envelopes can leave
+on-chain state ahead of what the envelope reports. **`@v1` does not
+guarantee idempotency or safe retries.** The terminal envelope's
+`tx_hashes` / `created_contracts` are emitted only on a clean exit;
+if the process is killed mid-broadcast, consumers must reconcile
+chain state directly (e.g. `cast nonce`, `cast receipt`) before
+re-issuing the call.
 
 

--- a/docs/agents/diagnostics.md
+++ b/docs/agents/diagnostics.md
@@ -1,0 +1,66 @@
+# Diagnostic codes
+
+Every `JsonMessage` carried in an envelope's `errors[]` or `warnings[]`
+includes a stable, machine-readable `code`. Codes are strings drawn from a
+namespaced registry. They are part of the agent contract — agents may switch
+on them.
+
+## Format
+
+A diagnostic code is a dot-separated, lowercase, ASCII-only string of the
+form:
+
+```
+<domain>.<subdomain>[.<subdomain>...]
+```
+
+Examples:
+
+- `config.invalid`
+- `config.missing_field`
+- `compiler.solc.error`
+- `compiler.vyper.error`
+- `network.rpc.timeout`
+- `network.rpc.unauthorized`
+- `wallet.key.missing`
+- `wallet.signature.rejected`
+- `test.failed`
+- `test.setup_failed`
+- `script.broadcast_failed`
+
+## Reserved domains
+
+| Domain     | Owner crate / area              | Examples                                  |
+| ---------- | ------------------------------- | ----------------------------------------- |
+| `config`   | `foundry-config`                | `config.invalid`, `config.missing_field`  |
+| `compiler` | `foundry-compilers`, `forge`    | `compiler.solc.error`                     |
+| `network`  | RPC / HTTP layers               | `network.rpc.timeout`                     |
+| `wallet`   | `foundry-wallets`               | `wallet.key.missing`                      |
+| `test`     | `forge test`                    | `test.failed`, `test.setup_failed`        |
+| `script`   | `forge script`                  | `script.broadcast_failed`                 |
+| `cast`     | `cast`                          | `cast.tx.not_found`                       |
+| `anvil`    | `anvil`                         | `anvil.fork.unreachable`                  |
+| `chisel`   | `chisel`                        | `chisel.session.invalid`                  |
+| `cli`      | argument parsing / global flags | `cli.usage.invalid`                       |
+
+New domains require a PR that updates this table.
+
+## Implementation shape
+
+Codes are **not** modeled as one monolithic repo-wide enum. Two patterns
+are allowed:
+
+1. **`DiagnosticCode` newtype over `String`** with namespaced `pub const`
+   declarations colocated with each owning crate, or
+2. **per-domain enums** (`ConfigDiagnostic`, `NetworkDiagnostic`, …) that
+   serialize to namespaced strings.
+
+A repo-wide test asserts every emitted code matches the format above and
+appears in this document.
+
+## Versioning
+
+Codes are part of the schema they appear in. Removing or renaming a code
+requires bumping the affected schema id (envelope `@vN` for global codes;
+per-command `@vN` for command-local codes), following the deprecation
+policy in [`spec.md`](./spec.md) §9.

--- a/docs/agents/diagnostics.md
+++ b/docs/agents/diagnostics.md
@@ -38,6 +38,7 @@ Examples:
 | `wallet`   | `foundry-wallets`               | `wallet.key.missing`                      |
 | `test`     | `forge test`                    | `test.failed`, `test.setup_failed`        |
 | `script`   | `forge script`                  | `script.broadcast_failed`                 |
+| `chain`    | shared chain-write commands     | `chain.broadcast_failed`                  |
 | `cast`     | `cast`                          | `cast.tx.not_found`                       |
 | `anvil`    | `anvil`                         | `anvil.fork.unreachable`                  |
 | `chisel`   | `chisel`                        | `chisel.session.invalid`                  |
@@ -55,8 +56,9 @@ are allowed:
 2. **per-domain enums** (`ConfigDiagnostic`, `NetworkDiagnostic`, …) that
    serialize to namespaced strings.
 
-A repo-wide test asserts every emitted code matches the format above and
-appears in this document.
+A unit test in `foundry-cli` asserts every code declared via the
+in-crate registry validates against the format above. Domain-table
+sync with this document is enforced by review.
 
 ## Versioning
 

--- a/docs/agents/exit-codes.md
+++ b/docs/agents/exit-codes.md
@@ -1,0 +1,40 @@
+# Foundry exit-code table
+
+This document defines the canonical exit-code contract for Foundry binaries.
+Exit codes are part of the agent contract — agents may switch on them.
+
+The table below reflects the target contract. Until the `ExitCode` enum is
+in place, binaries continue to emit `0` on success and a non-zero code on
+failure without further guarantees.
+
+| Code | Name             | Meaning                                                                        |
+| ---- | ---------------- | ------------------------------------------------------------------------------ |
+| `0`  | `Success`        | Command completed successfully                                                 |
+| `1`  | `GenericError`   | Unclassified failure                                                           |
+| `2`  | `Usage`          | Argument parse error, missing subcommand, invalid flag combination             |
+| `3`  | `Config`         | Foundry config invalid or missing required value                               |
+| `4`  | `Build`          | Compilation, linking, or artifact generation failed                            |
+| `5`  | `TestFailure`    | Tests ran but at least one failed (distinct from a build/setup failure)        |
+| `6`  | `Network`        | RPC, HTTP, or chain-connectivity failure                                       |
+| `7`  | `User`           | Authentication, authorization, or wallet/key-related failure                   |
+| `8`  | `Interrupted`    | Command terminated by `SIGINT` / `SIGTERM`                                     |
+
+Codes outside this set are reserved. Commands MAY document additional
+command-specific codes in `CommandInfo.exit_codes` (introspection); those
+codes MUST NOT collide with this global table.
+
+## Mapping rules
+
+- A failure to parse `--json` / `--machine` output flags themselves is `Usage`.
+- A failure to load `foundry.toml` is `Config`.
+- A test that compiled and ran but reverted is `TestFailure`, not `Build`.
+- A network timeout during `cast call` is `Network`.
+- A signed-message rejection or missing key is `User`.
+- A build failure during `forge test` setup is `Build`, not `TestFailure`.
+
+## Machine-mode interaction
+
+Under `--machine`, the binary always emits a JSON envelope on stdout when
+exiting with a non-zero code. Parse, usage, and help failures are no
+exception — they are emitted as `JsonEnvelope::error` with the appropriate
+diagnostic code.

--- a/docs/agents/schemas/cast.call.v1.json
+++ b/docs/agents/schemas/cast.call.v1.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "foundry:cast.call@v1",
+  "title": "cast call result payload",
+  "description": "Shape of the `data` field in the `cast call --machine` terminal envelope.",
+  "type": "object",
+  "required": ["result"],
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "type": "string",
+      "description": "Raw hex when no signature was supplied; otherwise the decoded return value formatted as `cast` would print it."
+    }
+  }
+}

--- a/docs/agents/schemas/envelope.v1.json
+++ b/docs/agents/schemas/envelope.v1.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "foundry:envelope@v1",
+  "title": "Foundry agent envelope",
+  "description": "Terminal command outcome emitted on stdout under `--machine`. Per-command result payloads (e.g. `foundry:forge.build@v1`) define the shape of the `data` field; this schema describes the envelope itself.",
+  "type": "object",
+  "required": ["schema_version", "success", "data", "errors", "warnings"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Envelope schema version."
+    },
+    "success": {
+      "type": "boolean",
+      "description": "Whether the command completed successfully."
+    },
+    "data": {
+      "description": "Command-specific payload on success; `null` on failure. See `result_schema_ref` in the introspect document for the per-command success shape.",
+      "type": ["object", "null"]
+    },
+    "errors": {
+      "type": "array",
+      "description": "Structured errors emitted by the command.",
+      "items": { "$ref": "#/$defs/JsonMessage" }
+    },
+    "warnings": {
+      "type": "array",
+      "description": "Structured warnings emitted by the command.",
+      "items": { "$ref": "#/$defs/JsonMessage" }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "success": { "const": true } } },
+      "then": {
+        "properties": {
+          "data": { "type": "object" },
+          "errors": { "maxItems": 0 }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "success": { "const": false } } },
+      "then": {
+        "properties": {
+          "data": { "type": "null" },
+          "errors": { "minItems": 1 }
+        }
+      }
+    },
+    {
+      "properties": {
+        "errors": { "items": { "properties": { "level": { "const": "error" } } } },
+        "warnings": { "items": { "properties": { "level": { "const": "warning" } } } }
+      }
+    }
+  ],
+  "$defs": {
+    "JsonMessage": {
+      "type": "object",
+      "required": ["level", "code", "message"],
+      "additionalProperties": false,
+      "properties": {
+        "level": {
+          "type": "string",
+          "enum": ["error", "warning"]
+        },
+        "code": {
+          "type": "string",
+          "description": "Stable diagnostic code (see `docs/agents/diagnostics.md`).",
+          "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "description": "Optional structured context.",
+          "type": ["object", "array", "string", "number", "boolean", "null"]
+        }
+      }
+    }
+  }
+}

--- a/docs/agents/schemas/forge.build.v1.json
+++ b/docs/agents/schemas/forge.build.v1.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "foundry:forge.build@v1",
+  "title": "forge build result payload",
+  "description": "Shape of the `data` field in the `forge build --machine` terminal envelope.",
+  "type": "object",
+  "required": ["artifacts", "errors", "warnings", "cache_hit"],
+  "additionalProperties": false,
+  "properties": {
+    "artifacts": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total number of artifacts written to disk."
+    },
+    "errors": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of compiler errors."
+    },
+    "warnings": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of compiler warnings."
+    },
+    "cache_hit": {
+      "type": "boolean",
+      "description": "Whether the build was a no-op cache hit."
+    }
+  }
+}

--- a/docs/agents/schemas/forge.script.event.v1.json
+++ b/docs/agents/schemas/forge.script.event.v1.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "foundry:forge.script.event@v1",
+  "title": "forge script stream event record",
+  "description": "One NDJSON line emitted on stdout by `forge script --machine` before the terminal envelope. Per-record meta fields (`schema_id`, `command_id`, `kind`, `ts`) are flattened together with kind-specific payload fields.",
+  "type": "object",
+  "required": ["schema_id", "command_id", "kind", "ts"],
+  "unevaluatedProperties": false,
+  "properties": {
+    "schema_id": { "type": "string", "const": "foundry:forge.script.event@v1" },
+    "command_id": { "type": "string", "const": "forge.script" },
+    "kind": { "type": "string", "enum": ["phase", "warning"] },
+    "ts": { "type": "string", "format": "date-time" }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "kind": { "const": "phase" },
+        "phase": { "type": "string", "enum": ["compile", "simulate", "broadcast"] }
+      },
+      "required": ["phase"]
+    },
+    {
+      "properties": {
+        "kind": { "const": "warning" },
+        "code": { "type": "string", "const": "script.warning" },
+        "message": { "type": "string", "minLength": 1 }
+      },
+      "required": ["code", "message"]
+    }
+  ]
+}

--- a/docs/agents/schemas/forge.script.v1.json
+++ b/docs/agents/schemas/forge.script.v1.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "foundry:forge.script@v1",
+  "title": "forge script result payload",
+  "description": "Shape of the `data` field in the `forge script --machine` terminal envelope.",
+  "type": "object",
+  "required": ["mode", "broadcast", "tx_count", "tx_hashes", "created_contracts"],
+  "additionalProperties": false,
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["dry_run", "broadcast"],
+      "description": "`dry_run` if no transactions were submitted on-chain; `broadcast` if at least one was sent."
+    },
+    "broadcast": {
+      "type": "boolean",
+      "description": "Whether the script reached the broadcast step. `true` iff `mode == \"broadcast\"`."
+    },
+    "tx_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of transactions in the script's sequence(s)."
+    },
+    "tx_hashes": {
+      "type": "array",
+      "description": "Submitted transaction hashes, in order. Empty in dry-run.",
+      "items": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" }
+    },
+    "created_contracts": {
+      "type": "array",
+      "description": "Contracts created by the script (top-level CREATEs and nested deploys).",
+      "items": { "$ref": "#/$defs/CreatedContract" }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "mode": { "const": "broadcast" } } },
+      "then": { "properties": { "broadcast": { "const": true } } }
+    },
+    {
+      "if": { "properties": { "mode": { "const": "dry_run" } } },
+      "then": {
+        "properties": {
+          "broadcast": { "const": false },
+          "tx_hashes": { "maxItems": 0 }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "CreatedContract": {
+      "type": "object",
+      "required": ["address"],
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "type": "string",
+          "pattern": "^0x[0-9a-fA-F]{40}$",
+          "description": "0x-prefixed deployed address."
+        },
+        "contract_name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Best-effort contract name."
+        }
+      }
+    }
+  }
+}

--- a/docs/agents/schemas/forge.test.event.v1.json
+++ b/docs/agents/schemas/forge.test.event.v1.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "foundry:forge.test.event@v1",
+  "title": "forge test stream event record",
+  "description": "One NDJSON line emitted on stdout by `forge test --machine` before the terminal envelope. Per-record meta fields (`schema_id`, `command_id`, `kind`, `ts`) are flattened together with kind-specific payload fields.",
+  "type": "object",
+  "required": ["schema_id", "command_id", "kind", "ts"],
+  "unevaluatedProperties": false,
+  "properties": {
+    "schema_id": { "type": "string", "const": "foundry:forge.test.event@v1" },
+    "command_id": { "type": "string", "const": "forge.test" },
+    "kind": { "type": "string", "enum": ["test_result", "suite_finished", "warning"] },
+    "ts": { "type": "string", "format": "date-time" }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "kind": { "const": "test_result" },
+        "contract": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "status": { "type": "string", "enum": ["passed", "failed", "skipped"] },
+        "reason": { "type": "string" },
+        "duration_ms": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["contract", "name", "status", "duration_ms"]
+    },
+    {
+      "properties": {
+        "kind": { "const": "suite_finished" },
+        "contract": { "type": "string", "minLength": 1 },
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "duration_ms": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["contract", "passed", "failed", "skipped", "duration_ms"]
+    },
+    {
+      "properties": {
+        "kind": { "const": "warning" },
+        "contract": { "type": "string", "minLength": 1 },
+        "code": { "type": "string", "const": "test.warning" },
+        "message": { "type": "string", "minLength": 1 }
+      },
+      "required": ["contract", "code", "message"]
+    }
+  ]
+}

--- a/docs/agents/schemas/forge.test.v1.json
+++ b/docs/agents/schemas/forge.test.v1.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "foundry:forge.test@v1",
+  "title": "forge test result payload",
+  "description": "Shape of the `data` field in the `forge test --machine` terminal envelope.",
+  "type": "object",
+  "required": ["suites", "passed", "failed", "skipped", "duration_ms"],
+  "additionalProperties": false,
+  "properties": {
+    "suites": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total number of test suites executed."
+    },
+    "passed": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total tests that passed."
+    },
+    "failed": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total tests that failed."
+    },
+    "skipped": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total tests skipped."
+    },
+    "duration_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total wall-clock execution time in milliseconds."
+    }
+  }
+}

--- a/docs/agents/schemas/introspect.v1.json
+++ b/docs/agents/schemas/introspect.v1.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "foundry:introspect@v1",
+  "title": "Foundry binary introspection document",
+  "description": "Emitted on stdout by `<binary> --introspect`. Describes the binary's command tree and per-command agent capabilities.",
+  "type": "object",
+  "required": ["schema_id", "schema_version", "binary", "commands"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_id": {
+      "type": "string",
+      "const": "foundry:introspect@v1"
+    },
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "binary": { "$ref": "#/$defs/BinaryInfo" },
+    "commands": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/CommandInfo" }
+    }
+  },
+  "$defs": {
+    "BinaryInfo": {
+      "type": "object",
+      "required": ["name", "version"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "long_version": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "CommandInfo": {
+      "type": "object",
+      "required": [
+        "command_id",
+        "path",
+        "aliases",
+        "args",
+        "subcommands",
+        "capabilities",
+        "exit_codes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "command_id": {
+          "type": "string",
+          "description": "Stable, non-empty machine identifier scoped under the binary name (e.g. `forge.build`, `cast.4byte-event`). Uniqueness across the document is enforced by binary-side tests.",
+          "minLength": 1
+        },
+        "path": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "aliases": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "summary": { "type": "string" },
+        "description": { "type": "string" },
+        "args": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ArgInfo" }
+        },
+        "subcommands": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/CommandInfo" }
+        },
+        "capabilities": { "$ref": "#/$defs/Capabilities" },
+        "exit_codes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ExitCodeInfo" }
+        },
+        "hidden": { "type": "boolean" }
+      }
+    },
+    "Capabilities": {
+      "type": "object",
+      "required": [
+        "output_mode",
+        "reads_stdin",
+        "supports_output_path",
+        "requires_project",
+        "side_effects",
+        "long_running",
+        "stateful"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "output_mode": {
+          "type": "string",
+          "enum": ["none", "legacy_json", "envelope", "stream", "session"]
+        },
+        "result_schema_ref": {
+          "type": "string",
+          "description": "Per-command success-payload schema id. Must NOT carry an `.event` or `.session` suffix.",
+          "pattern": "^foundry:[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*@v\\d+$"
+        },
+        "event_schema_ref": {
+          "type": "string",
+          "description": "Per-record stream schema id. Must carry an `.event` suffix.",
+          "pattern": "^foundry:[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*\\.event@v\\d+$"
+        },
+        "session_schema_ref": {
+          "type": "string",
+          "description": "Per-record session schema id. Must carry a `.session` suffix.",
+          "pattern": "^foundry:[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*\\.session@v\\d+$"
+        },
+        "reads_stdin": { "type": "boolean" },
+        "supports_output_path": { "type": "boolean" },
+        "requires_project": { "type": "boolean" },
+        "side_effects": {
+          "type": "string",
+          "enum": ["none", "fs_write", "network", "chain_write", "spawn_server"]
+        },
+        "long_running": { "type": "boolean" },
+        "stateful": { "type": "boolean" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "output_mode": { "const": "envelope" } } },
+          "then": { "required": ["result_schema_ref"] }
+        },
+        {
+          "if": { "properties": { "output_mode": { "const": "stream" } } },
+          "then": { "required": ["result_schema_ref", "event_schema_ref"] }
+        },
+        {
+          "if": { "properties": { "output_mode": { "const": "session" } } },
+          "then": { "required": ["session_schema_ref"] }
+        }
+      ]
+    },
+    "ArgInfo": {
+      "type": "object",
+      "required": [
+        "name",
+        "kind",
+        "value_type",
+        "aliases",
+        "possible_values",
+        "required",
+        "repeatable",
+        "conflicts_with"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "kind": {
+          "type": "string",
+          "enum": ["flag", "option", "positional"]
+        },
+        "value_type": {
+          "type": "string",
+          "enum": [
+            "bool",
+            "string",
+            "integer",
+            "path",
+            "url",
+            "address",
+            "selector",
+            "hex",
+            "json",
+            "other"
+          ]
+        },
+        "help": { "type": "string" },
+        "long": { "type": "string" },
+        "short": { "type": "string", "maxLength": 1 },
+        "aliases": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "env": { "type": "string" },
+        "default": { "type": "string" },
+        "possible_values": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "required": { "type": "boolean" },
+        "repeatable": { "type": "boolean" },
+        "conflicts_with": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "help_heading": { "type": "string" },
+        "hidden": { "type": "boolean" }
+      }
+    },
+    "ExitCodeInfo": {
+      "type": "object",
+      "required": ["code", "name", "description"],
+      "additionalProperties": false,
+      "properties": {
+        "code": { "type": "integer" },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" }
+      }
+    }
+  }
+}

--- a/docs/agents/spec.md
+++ b/docs/agents/spec.md
@@ -1,0 +1,251 @@
+# Foundry agent contract
+
+This document defines the agent-facing contract for Foundry. It applies to
+the `forge`, `cast`, `anvil`, and `chisel` binaries.
+
+The contract is layered on top of the existing CLIs and does **not** change
+the behavior of legacy `--json` users. New agent semantics are opt-in via
+`--machine` and via the discovery flag `--introspect`.
+
+---
+
+## 1. Discovery — `--introspect`
+
+Every binary supports a top-level `--introspect` flag. When passed, the
+binary emits a single JSON document on stdout describing itself and exits
+with code `0`.
+
+`--introspect` is detected **before** clap argument parsing, so it works
+even when the binary's required arguments or subcommands are missing.
+
+The document is identified by `foundry:introspect@v1` and is the same shape
+emitted by every Foundry binary.
+
+Top-level shape:
+
+```json
+{
+  "schema_id": "foundry:introspect@v1",
+  "schema_version": 1,
+  "binary": {
+    "name": "forge",
+    "version": "<short>",
+    "long_version": "<long>",
+    "description": "..."
+  },
+  "commands": [ /* CommandInfo */ ]
+}
+```
+
+`CommandInfo` exposes, per command:
+
+- `command_id` — stable machine identifier (e.g. `forge.build`)
+- `path` — clap path components (e.g. `["forge", "build"]`)
+- `aliases` — visible aliases for the command name
+- `summary`, `description`
+- `args[]` — each with `name`, `kind` (`flag`/`option`/`positional`),
+  `value_type`, `help`, `long`, `short`, `aliases`, `env`, `default`,
+  `possible_values`, `required`, `repeatable`, `conflicts_with`,
+  `help_heading`. The `conflicts_with` field is **best-effort and may be
+  empty**: clap's public API does not expose conflict relationships from
+  an `Arg`, so populating this field requires per-binary annotations.
+  When non-empty, it is authoritative; when empty, agents MUST NOT assume
+  the absence of conflicts.
+- `subcommands[]` — recursive `CommandInfo`
+- `capabilities` — see §3
+- `exit_codes[]` — command-specific exit codes (in addition to the global set)
+
+---
+
+## 2. Command identifiers
+
+Every leaf and group command has a `command_id`. The default is the clap path
+joined by `.` (e.g. the command at `forge` → `build` has `command_id`
+`forge.build`).
+
+For commands promoted to `stable`, the `command_id` is **frozen** in the
+in-binary registry so subsequent renames or reorganizations of the human-
+facing CLI do not move the machine identifier.
+
+`command_id` values are unique within a binary. CI enforces uniqueness.
+
+---
+
+## 3. Command capabilities
+
+Each `CommandInfo.capabilities` block exposes machine-relevant behavior:
+
+| Field                  | Type                                                                | Meaning                                                                  |
+| ---------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `output_mode`          | `none` \| `legacy_json` \| `envelope` \| `stream` \| `session`      | What the command emits when run in machine mode                          |
+| `result_schema_ref`    | string \| null                                                      | Stable schema id for the envelope payload (e.g. `foundry:forge.build@v1`) |
+| `event_schema_ref`     | string \| null                                                      | Stable schema id for stream event records                                |
+| `session_schema_ref`   | string \| null                                                      | Stable schema id for session-record startup/state                        |
+| `reads_stdin`          | bool                                                                | Whether the command can take input via `--input -`                       |
+| `supports_output_path` | bool                                                                | Whether the command supports `--output PATH`                             |
+| `requires_project`     | bool                                                                | Whether the command needs a Foundry project                              |
+| `side_effects`         | `none` \| `fs_write` \| `network` \| `chain_write` \| `spawn_server`| Coarse classification of what the command does                           |
+| `long_running`         | bool                                                                | Whether the command can stream output for an extended period             |
+| `stateful`             | bool                                                                | Whether the command opens a session that persists beyond a single call   |
+
+These fields let agents decide how to consume each command without parsing
+prose help text.
+
+---
+
+## 4. Output modes
+
+Output mode is reported per command in `capabilities.output_mode`.
+
+- **`none`** — no machine-mode contract yet; output is human-only.
+- **`legacy_json`** — pre-existing `--json` shape predating this contract.
+  Not part of the agent contract; preserved for backward compatibility only.
+- **`envelope`** — single terminal `JsonEnvelope<T>` on stdout; payload `T`
+  is described by `result_schema_ref`.
+- **`stream`** — newline-delimited JSON event records on stdout, optionally
+  ending with a final terminal record. Event shape is described by
+  `event_schema_ref`. Consumers must tolerate a missing final record on
+  `SIGINT` / `SIGKILL`.
+- **`session`** — long-running session command (e.g. `anvil`). Emits a
+  `session_start` record on startup; subsequent records may follow. Not a
+  terminal envelope.
+
+`--json` continues to mean what it means today (legacy single-object output
+for read commands; pre-existing JSON shapes elsewhere). The new agent
+contract activates under `--machine`.
+
+---
+
+## 5. Envelope
+
+The terminal-result envelope is identified by `foundry:envelope@v1` and
+implemented by [`JsonEnvelope<T>`](../../crates/cli/src/json.rs):
+
+```json
+{
+  "schema_version": 1,
+  "success": true,
+  "data": { /* per-command payload */ },
+  "errors": [],
+  "warnings": []
+}
+```
+
+Diagnostics inside `errors[]` and `warnings[]` carry a stable `code`
+(`JsonMessage.code`) drawn from the diagnostic registry — see
+[`diagnostics.md`](./diagnostics.md).
+
+---
+
+## 6. Streaming events
+
+Stream commands write one JSON object per line on stdout. Each record carries:
+
+- `schema_id` — the event-schema id (e.g. `foundry:forge.test.event@v1`)
+- `command_id` — the emitting command (e.g. `forge.test`)
+- `kind` — record kind (per-event-schema enum)
+- `ts` — RFC 3339 timestamp
+- additional kind-specific fields
+
+A stream may end with a single terminal `JsonEnvelope` record on the same
+stream. Consumers MUST tolerate streams that end without it (e.g. on signal
+termination).
+
+---
+
+## 7. Sessions
+
+`anvil` and other long-running, stateful commands emit a `session_start`
+record on startup carrying:
+
+- `rpc_url`
+- `chain_id`
+- `accounts`
+- `fork_url` (optional)
+- `block`
+
+This is **not** a terminal envelope. Subsequent session records may follow.
+The session-record schema is `foundry:anvil.session@v1`.
+
+### Anvil introspection limitation
+
+`anvil --introspect` reports only the explicit subcommands declared on the
+binary (today: `completions`). The default "no subcommand → start server"
+mode is **not** yet exposed as a discoverable `command_id` because clap
+models it as the absence of a subcommand. An explicit `anvil.start`
+`command_id` and the `session_start` record described above are tracked as
+follow-up work.
+
+Until then, agents should treat `anvil --introspect` as a discovery surface
+for tooling subcommands only and rely on the existing `anvil` flags for
+server startup.
+
+---
+
+## 8. Versioning
+
+Versions are tracked on **four independent axes**:
+
+1. **Envelope** — `foundry:envelope@vN`
+2. **Per-command result** — `foundry:<command_id>@vN`
+3. **Per-stream event** — `foundry:<command_id>.event@vN`
+4. **Per-session record** — `foundry:<command_id>.session@vN`
+
+A bump on one axis does not imply bumps on others.
+
+Where the schema id appears:
+
+- **Introspect document** — top-level `schema_id` field
+- **Stream event records** — top-level `schema_id` per record
+- **Session records** — top-level `schema_id` on the `session_start` record
+- **Envelope payloads** — the envelope itself does not carry a `schema_id`;
+  the payload's schema is discovered via the emitting command's
+  `capabilities.result_schema_ref` in introspection. This avoids forcing
+  every successful envelope to carry version metadata that is already
+  pinned by the `command_id` + introspection contract.
+
+---
+
+## 9. Deprecation policy
+
+Breaking changes to a schema's wire format require bumping the affected
+schema id (`foundry:envelope@v1` → `foundry:envelope@v2`). Both versions
+SHOULD be emitted in parallel for at least one minor release before the
+older identifier is removed, giving consumers time to migrate.
+
+Removing a `command_id` follows the same rule: the command should remain
+functional through one minor release after the announcement, after which
+introspection no longer lists it.
+
+---
+
+## 10. Machine mode (`--machine`)
+
+`--machine` is the stable agent-contract selector. When set, a command:
+
+- emits its declared `output_mode` only
+- never writes color, progress bars, or interactive prompts to stdout
+- structures parse, usage, version, and help failures as envelopes
+- maps process-exit failures to the canonical `ExitCode` enum
+
+Agents may also rely on `--introspect` for discovery and on the existing
+`--json` flag for legacy machine-readable output.
+
+---
+
+## 11. I/O conventions
+
+- `--input -` reads from stdin; `--input PATH` reads from a file
+- `--output -` writes to stdout (default); `--output PATH` writes to a file
+- Compact JSON (no pretty-printing) on every machine-mode output
+
+---
+
+## 12. Out of scope
+
+- Cancellation tokens / idempotency keys
+- Output paging or chunked file protocols
+- Bidirectional RPC sessions for `anvil`/`chisel`
+- A general agent transport beyond CLI stdout/stderr
+
+These remain for future versions if real consumers need them.


### PR DESCRIPTION
Update (deny.toml):** the new `jsonschema` test dep transitively pulls in `borrow-or-share`, which is licensed `MIT-0` (MIT No Attribution). 

Stacked on #14791.

Commits a JSON Schema (Draft 2020-12) for every shipped foundry:*@v1 identifier under docs/agents/schemas/ and wires schema validation into the existing machine-mode tests so the production code paths are pinned against the committed contract.

Also adds:

binary-level agent_contract.rs tests for forge and cast covering --introspect, --machine --help, and --machine <bad-flag>
CI guards that prevent dangling schema refs and pin exact result_schema_ref / event_schema_ref per adopted command
additive chain.broadcast_failed diagnostic for upcoming chain-write commands (script.broadcast_failed is untouched)
docs updates for --markdown-help deprecation, --json clarification, and chain-write retry-safety
No new commands are adopted; this PR locks down the contract already shipped by the previous PRs.
