### PR TITLE
fix(cast): resolve tempo expiry for erc20 commands

### DIFF
--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -362,6 +362,12 @@ impl Erc20Subcommand {
                 $provider:ident |
                 $build_tx:expr
             ) => {{
+                let mut tx_opts = $tx_opts;
+                let expires_at = tx_opts.tempo.resolve_expires();
+                if let Some(ts) = expires_at {
+                    sh_println!("Transaction expires at unix timestamp {ts}")?;
+                }
+
                 let timeout = $send_tx.timeout.unwrap_or(config.transaction_timeout);
                 if let Some(ref access_key) = tempo_keychain {
                     let signer = pre_resolved_signer
@@ -371,7 +377,7 @@ impl Erc20Subcommand {
                         ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
                     let $erc20 = IERC20::new($token.resolve(&$provider).await?, &$provider);
                     let mut tx = { $build_tx }.into_transaction_request();
-                    $tx_opts.apply::<TempoNetwork>(
+                    tx_opts.apply::<TempoNetwork>(
                         &mut tx,
                         get_chain(config.chain, &$provider).await?.is_legacy(),
                     );
@@ -393,7 +399,7 @@ impl Erc20Subcommand {
                     let $erc20 = IERC20::new($token.resolve(&$provider).await?, &$provider);
                     let mut tx = { $build_tx }.into_transaction_request();
                     let chain = get_chain(config.chain, &$provider).await?;
-                    $tx_opts.apply::<N>(&mut tx, chain.is_legacy());
+                    tx_opts.apply::<N>(&mut tx, chain.is_legacy());
                     if chain.is_tempo() && tx.fee_token().is_none() {
                         tx.set_fee_token(PATH_USD_ADDRESS);
                     }
@@ -412,7 +418,7 @@ impl Erc20Subcommand {
                     let $provider = build_provider_with_signer::<N>(&$send_tx, signer)?;
                     let $erc20 = IERC20::new($token.resolve(&$provider).await?, &$provider);
                     let mut tx = { $build_tx }.into_transaction_request();
-                    $tx_opts.apply::<N>(
+                    tx_opts.apply::<N>(
                         &mut tx,
                         get_chain(config.chain, &$provider).await?.is_legacy(),
                     );

--- a/crates/cast/tests/cli/erc20.rs
+++ b/crates/cast/tests/cli/erc20.rs
@@ -502,6 +502,16 @@ casttest!(erc20_curl_total_supply, |_prj, cmd| {
     assert!(output.contains(rpc));
 });
 
+casttest!(erc20_transfer_help_includes_tempo_expires, |_prj, cmd| {
+    let output =
+        cmd.args(["erc20", "transfer", "--help"]).assert_success().get_output().stdout_lossy();
+
+    assert!(
+        output.contains("--tempo.expires <SECONDS>"),
+        "expected erc20 transfer help to expose --tempo.expires, got:\n{output}",
+    );
+});
+
 // tests that `balance` command works correctly with --json flag
 forgetest_async!(erc20_balance_json, |prj, cmd| {
     let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;


### PR DESCRIPTION
## Summary
Aligns state-changing `cast erc20` helpers with the `cast send` Tempo expiry flow by resolving `--tempo.expires` once before building and signing the ERC20 transaction.

## Details
`cast erc20` already flattens the shared Tempo transaction options, but its send helper applied the options directly without materializing the relative expiry into a stable `valid_before` timestamp. This made the ERC20 helper less consistent with `cast send` and `cast mktx`, which resolve and print the expiry timestamp before submission.

This change resolves `--tempo.expires` in the ERC20 send macro, reuses the materialized options across access-key, browser, and signer paths, and adds a CLI regression check that `erc20 transfer` exposes the convenience flag.