### PR TITLE
fix(cast): support tempo sponsors in erc20 commands

### DIFF
--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -11,7 +11,7 @@ use alloy_ens::NameOrAddress;
 use alloy_network::{Ethereum, EthereumWallet, Network, TransactionBuilder};
 use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, fillers::RecommendedFillers};
-use alloy_signer::Signature;
+use alloy_signer::{Signature, Signer};
 use alloy_sol_types::sol;
 use clap::Parser;
 use foundry_cli::{
@@ -363,7 +363,11 @@ impl Erc20Subcommand {
                 $build_tx:expr
             ) => {{
                 let mut tx_opts = $tx_opts;
+                let print_sponsor_hash = tx_opts.tempo.print_sponsor_hash;
                 let expires_at = tx_opts.tempo.resolve_expires();
+                let tempo_sponsor =
+                    if print_sponsor_hash { None } else { tx_opts.tempo.sponsor_config().await? };
+                let needs_sponsor_payload = print_sponsor_hash || tempo_sponsor.is_some();
                 if let Some(ts) = expires_at {
                     sh_println!("Transaction expires at unix timestamp {ts}")?;
                 }
@@ -377,10 +381,38 @@ impl Erc20Subcommand {
                         ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
                     let $erc20 = IERC20::new($token.resolve(&$provider).await?, &$provider);
                     let mut tx = { $build_tx }.into_transaction_request();
-                    tx_opts.apply::<TempoNetwork>(
-                        &mut tx,
-                        get_chain(config.chain, &$provider).await?.is_legacy(),
-                    );
+                    let chain = get_chain(config.chain, &$provider).await?;
+                    tx_opts.apply::<TempoNetwork>(&mut tx, chain.is_legacy());
+                    if needs_sponsor_payload {
+                        tx.set_key_id(access_key.key_address);
+                        tx.prepare_access_key_authorization(
+                            &$provider,
+                            access_key.wallet_address,
+                            access_key.key_address,
+                            access_key.key_authorization.as_ref(),
+                        )
+                        .await?;
+                        fill_tx(&$provider, &mut tx, access_key.wallet_address, chain).await?;
+                        if print_sponsor_hash {
+                            let hash = tx
+                                .compute_sponsor_hash(access_key.wallet_address)
+                                .ok_or_else(|| {
+                                    eyre::eyre!(
+                                        "This network does not support sponsored transactions"
+                                    )
+                                })?;
+                            sh_println!("{hash:?}")?;
+                            return Ok(());
+                        }
+                        if let Some(sponsor) = &tempo_sponsor {
+                            sponsor
+                                .attach_and_print::<TempoNetwork>(
+                                    &mut tx,
+                                    access_key.wallet_address,
+                                )
+                                .await?;
+                        }
+                    }
                     cast_send_with_access_key(
                         &$provider,
                         tx,
@@ -404,6 +436,16 @@ impl Erc20Subcommand {
                         tx.set_fee_token(PATH_USD_ADDRESS);
                     }
                     fill_tx(&$provider, &mut tx, browser.address(), chain).await?;
+                    if print_sponsor_hash {
+                        let hash = tx.compute_sponsor_hash(browser.address()).ok_or_else(|| {
+                            eyre::eyre!("This network does not support sponsored transactions")
+                        })?;
+                        sh_println!("{hash:?}")?;
+                        return Ok(());
+                    }
+                    if let Some(sponsor) = &tempo_sponsor {
+                        sponsor.attach_and_print::<N>(&mut tx, browser.address()).await?;
+                    }
                     let tx_hash = browser.send_transaction_via_browser(tx).await?;
                     CastTxSender::new(&$provider)
                         .print_tx_result(
@@ -415,13 +457,25 @@ impl Erc20Subcommand {
                         .await?
                 } else {
                     let signer = pre_resolved_signer.unwrap_or($send_tx.eth.wallet.signer().await?);
+                    let from = signer.address();
                     let $provider = build_provider_with_signer::<N>(&$send_tx, signer)?;
                     let $erc20 = IERC20::new($token.resolve(&$provider).await?, &$provider);
                     let mut tx = { $build_tx }.into_transaction_request();
-                    tx_opts.apply::<N>(
-                        &mut tx,
-                        get_chain(config.chain, &$provider).await?.is_legacy(),
-                    );
+                    let chain = get_chain(config.chain, &$provider).await?;
+                    tx_opts.apply::<N>(&mut tx, chain.is_legacy());
+                    if needs_sponsor_payload {
+                        fill_tx(&$provider, &mut tx, from, chain).await?;
+                        if print_sponsor_hash {
+                            let hash = tx.compute_sponsor_hash(from).ok_or_else(|| {
+                                eyre::eyre!("This network does not support sponsored transactions")
+                            })?;
+                            sh_println!("{hash:?}")?;
+                            return Ok(());
+                        }
+                        if let Some(sponsor) = &tempo_sponsor {
+                            sponsor.attach_and_print::<N>(&mut tx, from).await?;
+                        }
+                    }
                     cast_send(
                         $provider,
                         tx,

--- a/crates/cast/tests/cli/erc20.rs
+++ b/crates/cast/tests/cli/erc20.rs
@@ -512,6 +512,40 @@ casttest!(erc20_transfer_help_includes_tempo_expires, |_prj, cmd| {
     );
 });
 
+forgetest_async!(erc20_transfer_prints_tempo_sponsor_hash, |_prj, cmd| {
+    let (_, _handle) = anvil::spawn(NodeConfig::test()).await;
+    let rpc = _handle.http_endpoint();
+
+    let output = cmd
+        .cast_fuse()
+        .args([
+            "erc20",
+            "transfer",
+            anvil_const::TOKEN,
+            anvil_const::ADDR2,
+            "1",
+            "--rpc-url",
+            &rpc,
+            "--private-key",
+            anvil_const::PK1,
+            "--tempo.print-sponsor-hash",
+            "--nonce",
+            "0",
+            "--gas-limit",
+            "100000",
+            "--gas-price",
+            "1",
+            "--priority-gas-price",
+            "1",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    let hash = output.trim();
+    assert!(hash.starts_with("0x") && hash.len() == 66, "expected sponsor hash, got:\n{output}",);
+});
+
 // tests that `balance` command works correctly with --json flag
 forgetest_async!(erc20_balance_json, |prj, cmd| {
     let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;


### PR DESCRIPTION
## Summary
Adds Tempo sponsor handling to state-changing `cast erc20` helpers so their Tempo transaction behavior matches `cast send`.

## Details
`cast erc20` already accepts the shared Tempo transaction options, but the ERC20 send helper was not resolving sponsor configuration, printing sponsor hashes, or attaching fee-payer signatures before submission.

This change wires `sponsor_config()` into the ERC20 send macro, supports `--tempo.print-sponsor-hash`, and attaches sponsor signatures across access-key, browser, and local-signer paths. Access-key sponsor handling prepares key authorization before the sponsor digest is computed, matching the `cast send` ordering.