### PR TITLE
Add JSON warning envelope for forge config --fix

### DIFF
--- a/crates/forge/src/cmd/config.rs
+++ b/crates/forge/src/cmd/config.rs
@@ -1,7 +1,11 @@
 use super::build::BuildArgs;
 use clap::Parser;
 use eyre::Result;
-use foundry_cli::{opts::EvmArgs, utils::LoadConfig};
+use foundry_cli::{
+    json::{JsonMessage, print_json_success_with_warnings},
+    opts::EvmArgs,
+    utils::LoadConfig,
+};
 use foundry_common::shell;
 use foundry_config::fix::fix_tomls;
 
@@ -29,8 +33,26 @@ pub struct ConfigArgs {
 impl ConfigArgs {
     pub fn run(self) -> Result<()> {
         if self.fix {
-            for warning in fix_tomls() {
-                sh_warn!("{warning}")?;
+            let warnings = fix_tomls();
+            if shell::is_json() {
+                let warnings = warnings
+                    .into_iter()
+                    .map(|warning| {
+                        let details = serde_json::to_value(&warning).ok();
+                        let message = warning.to_string();
+                        let warning = JsonMessage::warning("config.fix", message);
+                        if let Some(details) = details {
+                            warning.with_details(details)
+                        } else {
+                            warning
+                        }
+                    })
+                    .collect();
+                print_json_success_with_warnings((), warnings)?;
+            } else {
+                for warning in warnings {
+                    sh_warn!("{warning}")?;
+                }
             }
             return Ok(());
         }

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1018,6 +1018,42 @@ Please use [profile.default] instead or run `forge config --fix`.
 "#]]);
 });
 
+forgetest_init!(config_fix_json_envelope_contains_structured_warnings, |prj, _cmd| {
+    prj.initialize_default_contracts();
+
+    let mut cmd = prj.forge_bin();
+    cmd.arg("config")
+        .arg("--fix")
+        .arg("--json")
+        .arg("--root")
+        .arg(prj.root())
+        .env("FOUNDRY_CONFIG", "missing-foundry.toml");
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "forge config --fix --json failed\nstdout:\n{}\nstderr:\n{}",
+        output.stdout_lossy(),
+        output.stderr_lossy()
+    );
+
+    let envelope: Value = serde_json::from_str(&output.stdout_lossy()).unwrap();
+    assert_eq!(envelope["schema_version"], 1);
+    assert_eq!(envelope["success"], true);
+    assert_eq!(envelope["data"], Value::Null);
+    assert_eq!(envelope["errors"], Value::Array(Vec::new()));
+
+    let warnings = envelope["warnings"].as_array().unwrap();
+    assert!(!warnings.is_empty(), "expected structured warnings in JSON envelope");
+    assert_eq!(warnings[0]["level"], "warning");
+    assert_eq!(warnings[0]["code"], "config.fix");
+    assert!(warnings[0]["message"].as_str().unwrap().contains("No local TOML found to fix"));
+    assert!(
+        warnings[0].get("details").is_none() || warnings[0]["details"].is_null(),
+        "unexpected details payload for NoLocalToml warning"
+    );
+});
+
 forgetest_init!(can_skip_remappings_auto_detection, |prj, cmd| {
     prj.initialize_default_contracts();
     // explicitly set remapping and libraries


### PR DESCRIPTION
## Motivation
                                                                                                                                                                                                 
  `forge config --fix --json` was still emitting warnings through `stderr` text output, so JSON consumers could not reliably parse warnings from the command result. This is inconsistent with the new JSON envelope direction and makes automation harder.                                                                                                                                   
                                                                                                                                                                                                 
  ## Solution                                                                                                                                                                                    
                                                                                                                                                                                                 
  This change makes the `--json` path return warnings inside the standard JSON success envelope (`warnings[]`) using structured `JsonMessage` entries (`code: config.fix`), while keeping non-JSON behavior unchanged (`sh_warn!`).                                                                                                                                                          
  It also adds a CLI test, `config_fix_json_envelope_contains_structured_warnings`, to verify the envelope shape and warning fields.                                                             
                                                                                                                                                                                                 
  ## PR Checklist                                                                                                                                                                                
                                                                                                                                                                                                 
  - [x] Added Tests                                                                                                                                                                              
  - [ ] Added Documentation                                                                                                                                                                      
  - [ ] Breaking changes