### PR TITLE
ci(tempo): make mainnet check manual-only

### DIFF
--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -71,7 +71,6 @@ jobs:
 
       - name: Run Tempo check on mainnet
         if: |
-          github.event_name == 'schedule' ||
           github.event.inputs.network == 'mainnet' ||
           github.event.inputs.network == 'all'
         env:


### PR DESCRIPTION
## Motivation

The nightly Tempo workflow keeps failing because the scheduled run exercises the real Tempo mainnet which fails for various reasons and the CI scripts are not optimized for.

## Solution

Drop the `github.event_name == 'schedule'` trigger from the "Run Tempo check on mainnet" step. Mainnet now only runs via `workflow_dispatch` (with `network: mainnet` or `network: all`).

The scheduled nightly continues to run:
- the shared `Check Tempo fork schedule compatibility` cargo test, and
- the testnet check.

Closes #14705