### PR TITLE
feat(cast): adopt cast send into --machine envelope contract

### DIFF
--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -1031,17 +1031,24 @@ mod tests {
                     }
                     None
                 }
-                ["cast.call", "cast.abi-encode", "cast.abi-decode", "cast.keccak", "cast.4byte"]
-                    .into_iter()
-                    .map(|id| {
-                        let pinned = doc
-                            .commands
-                            .iter()
-                            .find_map(|c| find(c, id))
-                            .unwrap_or_else(|| panic!("{id} missing from cast introspect"));
-                        (id, pinned)
-                    })
-                    .collect()
+                [
+                    "cast.call",
+                    "cast.abi-encode",
+                    "cast.abi-decode",
+                    "cast.keccak",
+                    "cast.4byte",
+                    "cast.send",
+                ]
+                .into_iter()
+                .map(|id| {
+                    let pinned = doc
+                        .commands
+                        .iter()
+                        .find_map(|c| find(c, id))
+                        .unwrap_or_else(|| panic!("{id} missing from cast introspect"));
+                    (id, pinned)
+                })
+                .collect()
             })
             .expect("spawn worker thread")
             .join()
@@ -1082,6 +1089,12 @@ mod tests {
                 id: "cast.4byte",
                 schema: "foundry:cast.4byte@v1",
                 side_effects: SideEffects::Network,
+                reads_stdin: false,
+            },
+            Expected {
+                id: "cast.send",
+                schema: "foundry:cast.send@v1",
+                side_effects: SideEffects::ChainWrite,
                 reads_stdin: false,
             },
         ];

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -2,13 +2,16 @@ use std::{path::PathBuf, str::FromStr, time::Duration};
 
 use alloy_consensus::{SignableTransaction, Signed};
 use alloy_ens::NameOrAddress;
-use alloy_network::{Ethereum, EthereumWallet, Network, TransactionBuilder};
-use alloy_primitives::Address;
-use alloy_provider::{Provider, ProviderBuilder as AlloyProviderBuilder};
+use alloy_network::{Ethereum, EthereumWallet, Network, ReceiptResponse, TransactionBuilder};
+use alloy_primitives::{Address, B256};
+use alloy_provider::{
+    PendingTransactionBuilder, Provider, ProviderBuilder as AlloyProviderBuilder,
+};
 use alloy_signer::{Signature, Signer};
 use clap::Parser;
 use eyre::{Result, eyre};
 use foundry_cli::{
+    json::{JsonEnvelope, print_json},
     opts::TransactionOpts,
     utils::{LoadConfig, maybe_print_resolved_lane, resolve_lane},
 };
@@ -19,6 +22,7 @@ use foundry_common::{
     tempo::TEMPO_BROWSER_GAS_BUFFER,
 };
 use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
+use serde::Serialize;
 use tempo_alloy::TempoNetwork;
 
 use crate::{
@@ -26,6 +30,56 @@ use crate::{
     tx::{self, CastTxBuilder, CastTxSender, SendTxOpts},
 };
 use tempo_contracts::precompiles::{TIP20_FACTORY_ADDRESS, is_iso4217_currency};
+
+/// `cast send --machine` payload.
+#[derive(Clone, Debug, Serialize)]
+struct SendData {
+    broadcast: bool,
+    tx_hash: String,
+    from: String,
+    to: Option<String>,
+    contract_address: Option<String>,
+    status: Option<bool>,
+    block_number: Option<String>,
+    gas_used: Option<String>,
+    effective_gas_price: Option<String>,
+}
+
+impl SendData {
+    /// Payload for `--async`: only the submitted transaction hash is known.
+    fn async_only(tx_hash: B256, from: Address, to: Option<Address>) -> Self {
+        Self {
+            broadcast: true,
+            tx_hash: format!("{tx_hash:#x}"),
+            from: from.to_string(),
+            to: to.map(|a| a.to_string()),
+            contract_address: None,
+            status: None,
+            block_number: None,
+            gas_used: None,
+            effective_gas_price: None,
+        }
+    }
+
+    /// Payload built from an observed receipt.
+    fn from_receipt<N: Network>(
+        receipt: &N::ReceiptResponse,
+        from: Address,
+        to: Option<Address>,
+    ) -> Self {
+        Self {
+            broadcast: true,
+            tx_hash: format!("{:#x}", receipt.transaction_hash()),
+            from: from.to_string(),
+            to: to.map(|a| a.to_string()),
+            contract_address: receipt.contract_address().map(|a| a.to_string()),
+            status: Some(receipt.status()),
+            block_number: receipt.block_number().map(|b| b.to_string()),
+            gas_used: Some(receipt.gas_used().to_string()),
+            effective_gas_price: Some(receipt.effective_gas_price().to_string()),
+        }
+    }
+}
 
 /// CLI arguments for `cast send`.
 #[derive(Debug, Parser)]
@@ -96,7 +150,31 @@ pub enum SendTxSubcommands {
 }
 
 impl SendTxArgs {
+    /// Rejects flags whose stdout shape conflicts with the envelope contract.
+    pub fn reject_machine_unsupported_flags(&self) -> Result<()> {
+        if !foundry_cli::is_machine() {
+            return Ok(());
+        }
+        let unsupported = [
+            ("--browser", self.send_tx.browser.browser),
+            ("--tempo.print-sponsor-hash", self.tx.tempo.print_sponsor_hash),
+        ]
+        .into_iter()
+        .filter_map(|(name, on)| on.then_some(name))
+        .collect::<Vec<_>>();
+        if !unsupported.is_empty() {
+            foundry_cli::machine::bail_machine_usage(format!(
+                "`cast send` under `--machine` does not yet support {}; \
+                 run without `--machine` or omit those flags.",
+                unsupported.join(", ")
+            ));
+        }
+        Ok(())
+    }
+
     pub async fn run(self) -> Result<()> {
+        self.reject_machine_unsupported_flags()?;
+
         // Resolve the signer early so we know if it's a Tempo access key.
         let (signer, tempo_access_key) = self.send_tx.eth.wallet.maybe_signer().await?;
 
@@ -176,6 +254,12 @@ impl SendTxArgs {
                 && let Some(currency) = args.get(2)
                 && !is_iso4217_currency(currency)
             {
+                if foundry_cli::is_machine() {
+                    foundry_cli::machine::bail_machine_usage(
+                        "`cast send` would prompt to confirm a non-ISO4217 currency code; \
+                         pass `--force` to skip the prompt under `--machine`.",
+                    );
+                }
                 sh_warn!("{}", iso4217_warning_message(currency))?;
                 let response: String = foundry_common::prompt!("\nContinue anyway? [y/N] ")?;
                 if !matches!(response.trim(), "y" | "Y") {
@@ -229,7 +313,9 @@ impl SendTxArgs {
             return Ok(());
         }
 
-        if let Some(ts) = expires_at {
+        if let Some(ts) = expires_at
+            && !foundry_cli::is_machine()
+        {
             sh_println!("Transaction expires at unix timestamp {ts}")?;
         }
 
@@ -237,6 +323,8 @@ impl SendTxArgs {
 
         // Launch browser signer if `--browser` flag is set
         let browser = send_tx.browser.run::<N>().await?;
+
+        let machine = foundry_cli::is_machine();
 
         // Case 1:
         // Default to sending via eth_sendTransaction if the --unlocked flag is passed.
@@ -250,7 +338,9 @@ impl SendTxArgs {
                 // switch chain if current chain id is not the same as the one specified in the
                 // config
                 if config_chain_id != current_chain_id {
-                    sh_warn!("Switching to chain {}", config_chain)?;
+                    if !machine {
+                        sh_warn!("Switching to chain {}", config_chain)?;
+                    }
                     provider
                         .raw_request::<_, ()>(
                             "wallet_switchEthereumChain".into(),
@@ -263,32 +353,39 @@ impl SendTxArgs {
             }
 
             let (mut tx_request, _) = builder.build(config.sender).await?;
-            maybe_print_resolved_lane(
-                resolved_lane.as_ref(),
-                tx_request.nonce().unwrap_or_default(),
-            )?;
-            if let Some(sponsor) = &tempo_sponsor {
-                sponsor.attach_and_print::<N>(&mut tx_request, config.sender).await?;
-            }
+            machine_or_print_lane::<N>(machine, resolved_lane.as_ref(), &tx_request)?;
+            attach_sponsor::<N>(machine, &tempo_sponsor, &mut tx_request, config.sender).await?;
 
-            cast_send(
-                provider,
-                tx_request,
-                send_tx.cast_async,
-                send_tx.sync,
-                send_tx.confirmations,
-                timeout,
-            )
-            .await
+            if machine {
+                let to = tx_request.to();
+                machine_send_via_provider::<N, _>(
+                    &provider,
+                    tx_request,
+                    config.sender,
+                    to,
+                    send_tx.cast_async,
+                    send_tx.sync,
+                    send_tx.confirmations,
+                    timeout,
+                )
+                .await
+            } else {
+                cast_send(
+                    provider,
+                    tx_request,
+                    send_tx.cast_async,
+                    send_tx.sync,
+                    send_tx.confirmations,
+                    timeout,
+                )
+                .await
+            }
         // Case 2:
         // Browser wallet signs and sends the transaction in one step.
         } else if let Some(browser) = browser {
             let chain = builder.chain();
             let (mut tx_request, _) = builder.build(browser.address()).await?;
-            maybe_print_resolved_lane(
-                resolved_lane.as_ref(),
-                tx_request.nonce().unwrap_or_default(),
-            )?;
+            machine_or_print_lane::<N>(machine, resolved_lane.as_ref(), &tx_request)?;
 
             // Browser wallets may sign with P256/WebAuthn instead of secp256k1, which
             // costs more gas for signature verification on Tempo chains. Add a
@@ -298,14 +395,28 @@ impl SendTxArgs {
             {
                 tx_request.set_gas_limit(gas + TEMPO_BROWSER_GAS_BUFFER);
             }
-            if let Some(sponsor) = &tempo_sponsor {
-                sponsor.attach_and_print::<N>(&mut tx_request, browser.address()).await?;
-            }
+            attach_sponsor::<N>(machine, &tempo_sponsor, &mut tx_request, browser.address())
+                .await?;
 
+            let to = tx_request.to();
             let tx_hash = browser.send_transaction_via_browser(tx_request).await?;
 
-            let cast = CastTxSender::new(&provider);
-            cast.print_tx_result(tx_hash, send_tx.cast_async, send_tx.confirmations, timeout).await
+            if machine {
+                machine_send_after_tx_hash::<N, _>(
+                    &provider,
+                    tx_hash,
+                    browser.address(),
+                    to,
+                    send_tx.cast_async,
+                    send_tx.confirmations,
+                    timeout,
+                )
+                .await
+            } else {
+                let cast = CastTxSender::new(&provider);
+                cast.print_tx_result(tx_hash, send_tx.cast_async, send_tx.confirmations, timeout)
+                    .await
+            }
         // Case 3:
         // Tempo access key (keychain) signing. Uses `sign_with_access_key` which
         // handles the provisioning check and embeds `key_authorization` when needed.
@@ -315,23 +426,35 @@ impl SendTxArgs {
                 None => send_tx.eth.wallet.signer().await?,
             };
             let (mut tx_request, _) = builder.build_with_access_key(ak.wallet_address, &ak).await?;
-            maybe_print_resolved_lane(
-                resolved_lane.as_ref(),
-                tx_request.nonce().unwrap_or_default(),
-            )?;
-            if let Some(sponsor) = &tempo_sponsor {
-                sponsor.attach_and_print::<N>(&mut tx_request, ak.wallet_address).await?;
+            machine_or_print_lane::<N>(machine, resolved_lane.as_ref(), &tx_request)?;
+            attach_sponsor::<N>(machine, &tempo_sponsor, &mut tx_request, ak.wallet_address)
+                .await?;
+
+            if machine {
+                let to = tx_request.to();
+                machine_send_with_access_key::<N, _>(
+                    &provider,
+                    tx_request,
+                    &signer,
+                    &ak,
+                    to,
+                    send_tx.cast_async,
+                    send_tx.confirmations,
+                    timeout,
+                )
+                .await
+            } else {
+                cast_send_with_access_key(
+                    &provider,
+                    tx_request,
+                    &signer,
+                    &ak,
+                    send_tx.cast_async,
+                    send_tx.confirmations,
+                    timeout,
+                )
+                .await
             }
-            cast_send_with_access_key(
-                &provider,
-                tx_request,
-                &signer,
-                &ak,
-                send_tx.cast_async,
-                send_tx.confirmations,
-                timeout,
-            )
-            .await
         // Case 4:
         // An option to use a local signer was provided.
         // If we cannot successfully instantiate a local signer, then we will assume we don't have
@@ -346,29 +469,38 @@ impl SendTxArgs {
             tx::validate_from_address(send_tx.eth.wallet.from, from)?;
 
             let (mut tx_request, _) = builder.build(&signer).await?;
-            maybe_print_resolved_lane(
-                resolved_lane.as_ref(),
-                tx_request.nonce().unwrap_or_default(),
-            )?;
-
-            if let Some(sponsor) = &tempo_sponsor {
-                sponsor.attach_and_print::<N>(&mut tx_request, from).await?;
-            }
+            machine_or_print_lane::<N>(machine, resolved_lane.as_ref(), &tx_request)?;
+            attach_sponsor::<N>(machine, &tempo_sponsor, &mut tx_request, from).await?;
 
             let wallet = EthereumWallet::from(signer);
             let provider = AlloyProviderBuilder::<_, _, N>::default()
                 .wallet(wallet)
                 .connect_provider(&provider);
 
-            cast_send(
-                provider,
-                tx_request,
-                send_tx.cast_async,
-                send_tx.sync,
-                send_tx.confirmations,
-                timeout,
-            )
-            .await
+            if machine {
+                let to = tx_request.to();
+                machine_send_via_provider::<N, _>(
+                    &provider,
+                    tx_request,
+                    from,
+                    to,
+                    send_tx.cast_async,
+                    send_tx.sync,
+                    send_tx.confirmations,
+                    timeout,
+                )
+                .await
+            } else {
+                cast_send(
+                    provider,
+                    tx_request,
+                    send_tx.cast_async,
+                    send_tx.sync,
+                    send_tx.confirmations,
+                    timeout,
+                )
+                .await
+            }
         }
     }
 }
@@ -432,4 +564,251 @@ where
         .await?;
     let tx_hash = *provider.send_raw_transaction(&raw_tx).await?.tx_hash();
     CastTxSender::new(provider).print_tx_result(tx_hash, cast_async, confirmations, timeout).await
+}
+
+/// Print the resolved lane preview unless `--machine` owns stdout/stderr.
+fn machine_or_print_lane<N: Network>(
+    machine: bool,
+    resolved_lane: Option<&foundry_cli::utils::ResolvedLane>,
+    tx_request: &N::TransactionRequest,
+) -> Result<()>
+where
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+{
+    if machine {
+        return Ok(());
+    }
+    maybe_print_resolved_lane(resolved_lane, tx_request.nonce().unwrap_or_default())
+}
+
+/// Attach Tempo sponsorship, choosing the silent variant under `--machine`.
+async fn attach_sponsor<N: Network>(
+    machine: bool,
+    tempo_sponsor: &Option<foundry_common::tempo::TempoSponsor>,
+    tx_request: &mut N::TransactionRequest,
+    sender: Address,
+) -> Result<()>
+where
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+{
+    let Some(sponsor) = tempo_sponsor else { return Ok(()) };
+    if machine {
+        sponsor.attach_silent::<N>(tx_request, sender).await?;
+    } else {
+        sponsor.attach_and_print::<N>(tx_request, sender).await?;
+    }
+    Ok(())
+}
+
+/// `--machine` send via `provider.send_transaction[_sync]`. Captures
+/// `tx_hash` after broadcast so receipt-wait failures preserve it.
+#[expect(clippy::too_many_arguments)]
+async fn machine_send_via_provider<N: Network, P: Provider<N>>(
+    provider: &P,
+    tx: N::TransactionRequest,
+    from: Address,
+    to: Option<Address>,
+    cast_async: bool,
+    sync: bool,
+    confs: u64,
+    timeout: u64,
+) -> Result<()>
+where
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+{
+    if sync {
+        let receipt_result: Result<N::ReceiptResponse> =
+            provider.send_transaction_sync(tx).await.map_err(Into::into);
+        return finish_machine_send::<N>(receipt_result.map(|r| (r, from, to)), None, from, to);
+    }
+    let pending_tx = match provider.send_transaction(tx).await {
+        Ok(p) => p,
+        Err(e) => bail_machine_send_error(e.into(), None, from, to),
+    };
+    let tx_hash = *pending_tx.inner().tx_hash();
+    if cast_async {
+        return emit_machine_send_success(SendData::async_only(tx_hash, from, to));
+    }
+    let receipt_result: Result<N::ReceiptResponse> = pending_tx
+        .with_required_confirmations(confs)
+        .with_timeout(Some(Duration::from_secs(timeout)))
+        .get_receipt()
+        .await
+        .map_err(Into::into);
+    finish_machine_send::<N>(receipt_result.map(|r| (r, from, to)), Some(tx_hash), from, to)
+}
+
+/// `--machine` send path for already-broadcast transactions (browser flow).
+async fn machine_send_after_tx_hash<N: Network, P: Provider<N>>(
+    provider: &P,
+    tx_hash: B256,
+    from: Address,
+    to: Option<Address>,
+    cast_async: bool,
+    confs: u64,
+    timeout: u64,
+) -> Result<()>
+where
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+{
+    if cast_async {
+        return emit_machine_send_success(SendData::async_only(tx_hash, from, to));
+    }
+    let receipt_result: Result<N::ReceiptResponse> =
+        PendingTransactionBuilder::<N>::new(provider.root().clone(), tx_hash)
+            .with_required_confirmations(confs)
+            .with_timeout(Some(Duration::from_secs(timeout)))
+            .get_receipt()
+            .await
+            .map_err(Into::into);
+    finish_machine_send::<N>(receipt_result.map(|r| (r, from, to)), Some(tx_hash), from, to)
+}
+
+/// `--machine` send path for Tempo access-key signing.
+#[expect(clippy::too_many_arguments)]
+async fn machine_send_with_access_key<N: Network, P: Provider<N>>(
+    provider: &P,
+    mut tx: N::TransactionRequest,
+    signer: &WalletSigner,
+    access_key: &TempoAccessKeyConfig,
+    to: Option<Address>,
+    cast_async: bool,
+    confs: u64,
+    timeout: u64,
+) -> Result<()>
+where
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+{
+    let from = access_key.wallet_address;
+    tx.set_from(from);
+    tx.set_key_id(access_key.key_address);
+    let raw_tx = match tx
+        .sign_with_access_key(
+            provider,
+            signer,
+            access_key.wallet_address,
+            access_key.key_address,
+            access_key.key_authorization.as_ref(),
+        )
+        .await
+    {
+        Ok(raw) => raw,
+        Err(e) => bail_machine_send_error(e, None, from, to),
+    };
+    let pending_tx = match provider.send_raw_transaction(&raw_tx).await {
+        Ok(p) => p,
+        Err(e) => bail_machine_send_error(e.into(), None, from, to),
+    };
+    let tx_hash = *pending_tx.tx_hash();
+    if cast_async {
+        return emit_machine_send_success(SendData::async_only(tx_hash, from, to));
+    }
+    let receipt_result: Result<N::ReceiptResponse> = pending_tx
+        .with_required_confirmations(confs)
+        .with_timeout(Some(Duration::from_secs(timeout)))
+        .get_receipt()
+        .await
+        .map_err(Into::into);
+    finish_machine_send::<N>(receipt_result.map(|r| (r, from, to)), Some(tx_hash), from, to)
+}
+
+/// Emit a success envelope, or reclassify a reverted receipt as
+/// `chain.broadcast_failed` with the receipt fields kept in `details`.
+fn finish_machine_send<N: Network>(
+    receipt: Result<(N::ReceiptResponse, Address, Option<Address>)>,
+    known_tx_hash: Option<B256>,
+    from: Address,
+    to: Option<Address>,
+) -> Result<()> {
+    match receipt {
+        Ok((receipt, rfrom, rto)) => {
+            let data = SendData::from_receipt::<N>(&receipt, rfrom, rto);
+            if data.status == Some(false) {
+                // Reverted: keep receipt fields so agents can debug.
+                let details = serde_json::json!({
+                    "tx_hash": data.tx_hash,
+                    "from": data.from,
+                    "to": data.to,
+                    "contract_address": data.contract_address,
+                    "block_number": data.block_number,
+                    "gas_used": data.gas_used,
+                    "effective_gas_price": data.effective_gas_price,
+                    "broadcast": true,
+                    "receipt_observed": true,
+                });
+                foundry_cli::machine::bail_machine_diagnostic_with_details(
+                    foundry_cli::diagnostic::chain::BROADCAST_FAILED,
+                    foundry_cli::exit_code::ExitCode::GenericError,
+                    format!("transaction reverted (receipt status 0): {}", data.tx_hash),
+                    details,
+                );
+            }
+            emit_machine_send_success(data)
+        }
+        Err(e) => bail_machine_send_error(e, known_tx_hash, from, to),
+    }
+}
+
+/// Emit a successful `cast send` envelope on stdout.
+fn emit_machine_send_success(data: SendData) -> Result<()> {
+    print_json(&JsonEnvelope::success(data))?;
+    Ok(())
+}
+
+/// Bail with a typed error envelope. When `known_tx_hash` is `Some`, the
+/// broadcast happened; preserve the hash in `details`.
+fn bail_machine_send_error(
+    err: eyre::Report,
+    known_tx_hash: Option<B256>,
+    from: Address,
+    to: Option<Address>,
+) -> ! {
+    let code = classify_send_error(&err);
+    let message = format!("{err:#}");
+    match known_tx_hash {
+        Some(tx_hash) => {
+            let details = serde_json::json!({
+                "tx_hash": format!("{tx_hash:#x}"),
+                "from": from.to_string(),
+                "to": to.map(|a| a.to_string()),
+                "broadcast": true,
+                "receipt_observed": false,
+            });
+            foundry_cli::machine::bail_machine_diagnostic_with_details(
+                code,
+                foundry_cli::exit_code::ExitCode::GenericError,
+                message,
+                details,
+            )
+        }
+        None => foundry_cli::machine::bail_machine_diagnostic(
+            code,
+            foundry_cli::exit_code::ExitCode::GenericError,
+            message,
+        ),
+    }
+}
+
+/// Map a send failure's cause chain to a typed diagnostic code, falling
+/// back to `chain.broadcast_failed` when no keyword matches.
+fn classify_send_error(err: &eyre::Report) -> &'static str {
+    use std::fmt::Write;
+    let mut buf = String::new();
+    for cause in err.chain() {
+        let _ = writeln!(buf, "{cause}");
+    }
+    let lower = buf.to_lowercase();
+
+    if lower.contains("timed out") || lower.contains("timeout") {
+        return foundry_cli::diagnostic::network::RPC_TIMEOUT;
+    }
+    if lower.contains("unauthorized") || lower.contains("401") {
+        return foundry_cli::diagnostic::network::RPC_UNAUTHORIZED;
+    }
+    if (lower.contains("signature") || lower.contains("sign"))
+        && (lower.contains("reject") || lower.contains("denied"))
+    {
+        return foundry_cli::diagnostic::wallet::SIGNATURE_REJECTED;
+    }
+    foundry_cli::diagnostic::chain::BROADCAST_FAILED
 }

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -619,7 +619,7 @@ where
     if sync {
         let receipt_result: Result<N::ReceiptResponse> =
             provider.send_transaction_sync(tx).await.map_err(Into::into);
-        return finish_machine_send::<N>(receipt_result.map(|r| (r, from, to)), None, from, to);
+        return finish_machine_send::<N>(receipt_result, None, from, to);
     }
     let pending_tx = match provider.send_transaction(tx).await {
         Ok(p) => p,
@@ -635,7 +635,7 @@ where
         .get_receipt()
         .await
         .map_err(Into::into);
-    finish_machine_send::<N>(receipt_result.map(|r| (r, from, to)), Some(tx_hash), from, to)
+    finish_machine_send::<N>(receipt_result, Some(tx_hash), from, to)
 }
 
 /// `--machine` send path for already-broadcast transactions (browser flow).
@@ -661,7 +661,7 @@ where
             .get_receipt()
             .await
             .map_err(Into::into);
-    finish_machine_send::<N>(receipt_result.map(|r| (r, from, to)), Some(tx_hash), from, to)
+    finish_machine_send::<N>(receipt_result, Some(tx_hash), from, to)
 }
 
 /// `--machine` send path for Tempo access-key signing.
@@ -709,20 +709,20 @@ where
         .get_receipt()
         .await
         .map_err(Into::into);
-    finish_machine_send::<N>(receipt_result.map(|r| (r, from, to)), Some(tx_hash), from, to)
+    finish_machine_send::<N>(receipt_result, Some(tx_hash), from, to)
 }
 
 /// Emit a success envelope, or reclassify a reverted receipt as
 /// `chain.broadcast_failed` with the receipt fields kept in `details`.
 fn finish_machine_send<N: Network>(
-    receipt: Result<(N::ReceiptResponse, Address, Option<Address>)>,
+    receipt: Result<N::ReceiptResponse>,
     known_tx_hash: Option<B256>,
     from: Address,
     to: Option<Address>,
 ) -> Result<()> {
     match receipt {
-        Ok((receipt, rfrom, rto)) => {
-            let data = SendData::from_receipt::<N>(&receipt, rfrom, rto);
+        Ok(receipt) => {
+            let data = SendData::from_receipt::<N>(&receipt, from, to);
             if data.status == Some(false) {
                 // Reverted: keep receipt fields so agents can debug.
                 let details = serde_json::json!({

--- a/crates/cast/src/introspect.rs
+++ b/crates/cast/src/introspect.rs
@@ -22,6 +22,9 @@ pub const KECCAK_RESULT_SCHEMA: &str = "foundry:cast.keccak@v1";
 /// Schema id for the `cast 4byte` envelope payload.
 pub const FOUR_BYTE_RESULT_SCHEMA: &str = "foundry:cast.4byte@v1";
 
+/// Schema id for the `cast send` envelope payload.
+pub const SEND_RESULT_SCHEMA: &str = "foundry:cast.send@v1";
+
 static ENTRIES: &[RegistryEntry] = &[
     RegistryEntry {
         path: &["call"],
@@ -86,6 +89,19 @@ static ENTRIES: &[RegistryEntry] = &[
                 side_effects: SideEffects::Network,
                 // `--machine` requires argv; stdin is human-only.
                 reads_stdin: false,
+                ..CapabilityMeta::NONE
+            },
+            exit_codes: &[],
+        },
+    },
+    RegistryEntry {
+        path: &["send"],
+        meta: CommandMeta {
+            command_id: Some("cast.send"),
+            capabilities: CapabilityMeta {
+                output_mode: OutputMode::Envelope,
+                result_schema_ref: Some(SEND_RESULT_SCHEMA),
+                side_effects: SideEffects::ChainWrite,
                 ..CapabilityMeta::NONE
             },
             exit_codes: &[],

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3524,6 +3524,343 @@ forgetest_async!(cast_call_machine_mode_rejects_unsupported_flags, |_prj, cmd| {
     assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
 });
 
+// `cast --machine send` against an EOA emits a single envelope on stdout
+// with the receipt-derived fields populated.
+forgetest_async!(cast_send_machine_mode_emits_envelope, |_prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let pk = hex::encode(wallet.credential().to_bytes());
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "--machine",
+            "send",
+            "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+            "--value",
+            "1",
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &endpoint,
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout is exactly one JSON envelope");
+
+    assert_eq!(envelope["success"], true);
+    assert_eq!(envelope["data"]["broadcast"], true);
+    assert_eq!(envelope["data"]["status"], true);
+    assert_eq!(envelope["data"]["contract_address"], serde_json::Value::Null);
+    let tx_hash = envelope["data"]["tx_hash"].as_str().expect("tx_hash is a string");
+    let from = envelope["data"]["from"].as_str().expect("from is a string");
+    let to = envelope["data"]["to"].as_str().expect("to is a string");
+    assert!(tx_hash.starts_with("0x") && tx_hash.len() == 66, "{tx_hash}");
+    assert!(from.starts_with("0x") && from.len() == 42, "{from}");
+    assert!(to.starts_with("0x") && to.len() == 42, "{to}");
+    foundry_test_utils::agent_schema::validate_envelope_data(&envelope, "foundry:cast.send@v1");
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// `cast --machine send --async` emits the envelope as soon as the hash is
+// known, leaving every receipt field null.
+forgetest_async!(cast_send_machine_mode_async_emits_envelope, |_prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let pk = hex::encode(wallet.credential().to_bytes());
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "--machine",
+            "send",
+            "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+            "--value",
+            "1",
+            "--async",
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &endpoint,
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout is exactly one JSON envelope");
+
+    assert_eq!(envelope["success"], true);
+    assert_eq!(envelope["data"]["broadcast"], true);
+    assert_eq!(envelope["data"]["status"], serde_json::Value::Null);
+    assert_eq!(envelope["data"]["block_number"], serde_json::Value::Null);
+    assert_eq!(envelope["data"]["gas_used"], serde_json::Value::Null);
+    assert_eq!(envelope["data"]["effective_gas_price"], serde_json::Value::Null);
+    let tx_hash = envelope["data"]["tx_hash"].as_str().expect("tx_hash is a string");
+    assert!(tx_hash.starts_with("0x") && tx_hash.len() == 66, "{tx_hash}");
+    foundry_test_utils::agent_schema::validate_envelope_data(&envelope, "foundry:cast.send@v1");
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// `cast --machine send --create` emits an envelope with `to: null` and the
+// deployed contract address from the receipt.
+forgetest_async!(cast_send_machine_mode_create_emits_envelope, |_prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let pk = hex::encode(wallet.credential().to_bytes());
+
+    // Minimal runtime-returning constructor that simply returns 0-length code.
+    let bytecode = "0x6000600055";
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "--machine",
+            "send",
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &endpoint,
+            "--create",
+            bytecode,
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout is exactly one JSON envelope");
+
+    assert_eq!(envelope["success"], true);
+    assert_eq!(envelope["data"]["broadcast"], true);
+    assert_eq!(envelope["data"]["status"], true);
+    assert_eq!(envelope["data"]["to"], serde_json::Value::Null);
+    let contract_address =
+        envelope["data"]["contract_address"].as_str().expect("contract_address is a string");
+    assert!(
+        contract_address.starts_with("0x") && contract_address.len() == 42,
+        "{contract_address}"
+    );
+    foundry_test_utils::agent_schema::validate_envelope_data(&envelope, "foundry:cast.send@v1");
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// `cast --machine send` against a reverting constructor emits a typed
+// `chain.broadcast_failed` envelope with the receipt fields kept in
+// `errors[0].details`.
+forgetest_async!(flaky_cast_send_machine_mode_broadcast_failed_emits_envelope, |_prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let pk = hex::encode(wallet.credential().to_bytes());
+
+    // Constructor that immediately reverts: PUSH1 0x00 PUSH1 0x00 REVERT.
+    let bytecode = "0x60006000fd";
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "--machine",
+            "send",
+            "--gas-limit",
+            "1000000",
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &endpoint,
+            "--create",
+            bytecode,
+        ])
+        .assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(1));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
+
+    assert_eq!(envelope["success"], false);
+    assert!(envelope["data"].is_null(), "data must be null: {envelope}");
+    assert_eq!(envelope["warnings"], serde_json::json!([]));
+    assert_eq!(envelope["errors"][0]["code"], "chain.broadcast_failed");
+
+    // Reverted-receipt path: receipt fields must be preserved in `details`.
+    let details = &envelope["errors"][0]["details"];
+    assert_eq!(details["broadcast"], true, "details.broadcast must be true: {envelope}");
+    assert_eq!(
+        details["receipt_observed"], true,
+        "details.receipt_observed must be true (revert path): {envelope}"
+    );
+    let tx_hash = details["tx_hash"].as_str().expect("details.tx_hash is a string");
+    assert!(tx_hash.starts_with("0x") && tx_hash.len() == 66, "{tx_hash}");
+    assert!(details["gas_used"].is_string(), "details.gas_used missing: {envelope}");
+    assert!(details["block_number"].is_string(), "details.block_number missing: {envelope}");
+    assert!(
+        details["effective_gas_price"].is_string(),
+        "details.effective_gas_price missing: {envelope}"
+    );
+
+    foundry_test_utils::agent_schema::validate("foundry:envelope@v1", &envelope);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// `cast --machine send --sync` exercises the `send_transaction_sync` path
+// and emits an envelope with the receipt-derived fields.
+forgetest_async!(cast_send_machine_mode_sync_emits_envelope, |_prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let pk = hex::encode(wallet.credential().to_bytes());
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "--machine",
+            "send",
+            "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+            "--value",
+            "1",
+            "--sync",
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &endpoint,
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout is exactly one JSON envelope");
+
+    assert_eq!(envelope["success"], true);
+    assert_eq!(envelope["data"]["broadcast"], true);
+    assert_eq!(envelope["data"]["status"], true);
+    let tx_hash = envelope["data"]["tx_hash"].as_str().expect("tx_hash is a string");
+    assert!(tx_hash.starts_with("0x") && tx_hash.len() == 66, "{tx_hash}");
+    foundry_test_utils::agent_schema::validate_envelope_data(&envelope, "foundry:cast.send@v1");
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// `cast --machine send --browser` is rejected with a typed `cli.usage.invalid`
+// envelope and exit code 2, before any browser session is opened.
+forgetest_async!(cast_send_machine_mode_rejects_browser, |_prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "--machine",
+            "send",
+            "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+            "--value",
+            "1",
+            "--browser",
+            "--rpc-url",
+            &endpoint,
+        ])
+        .assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
+
+    assert_eq!(envelope["success"], false);
+    assert!(envelope["data"].is_null(), "data must be null on failure: {envelope}");
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("--browser"), "missing --browser mention: {envelope}");
+    foundry_test_utils::agent_schema::validate("foundry:envelope@v1", &envelope);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// `cast --machine send` with an unfunded key surfaces the underlying RPC
+// "insufficient funds" cause through the typed envelope message.
+forgetest_async!(flaky_cast_send_machine_mode_insufficient_funds_envelope, |_prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+
+    // Random unfunded key.
+    let pk = "0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318";
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "--machine",
+            "send",
+            "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+            "--value",
+            "1",
+            "--private-key",
+            pk,
+            "--rpc-url",
+            &endpoint,
+        ])
+        .assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(1));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
+
+    assert_eq!(envelope["success"], false);
+    assert!(envelope["data"].is_null(), "data must be null: {envelope}");
+    assert_eq!(envelope["errors"][0]["code"], "chain.broadcast_failed");
+    let msg = envelope["errors"][0]["message"].as_str().unwrap_or("").to_ascii_lowercase();
+    assert!(msg.contains("insufficient funds"), "missing cause-chain detail: {envelope}");
+    foundry_test_utils::agent_schema::validate("foundry:envelope@v1", &envelope);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
+// `cast --machine send --tempo.print-sponsor-hash` is rejected with a typed
+// `cli.usage.invalid` envelope and exit code 2.
+forgetest_async!(cast_send_machine_mode_rejects_unsupported_flags, |_prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let pk = hex::encode(wallet.credential().to_bytes());
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "--machine",
+            "send",
+            "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+            "--value",
+            "1",
+            "--tempo.print-sponsor-hash",
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &endpoint,
+        ])
+        .assert_failure();
+    assert_eq!(assert.get_output().status.code(), Some(2));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("error envelope on stdout");
+
+    assert_eq!(envelope["success"], false);
+    assert!(envelope["data"].is_null(), "data must be null on failure: {envelope}");
+    assert_eq!(envelope["errors"][0]["code"], "cli.usage.invalid");
+    let msg = envelope["errors"][0]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("--tempo.print-sponsor-hash"), "{envelope}");
+    foundry_test_utils::agent_schema::validate("foundry:envelope@v1", &envelope);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.is_empty(), "stderr must be empty under --machine, got: {stderr}");
+});
+
 // https://github.com/foundry-rs/foundry/issues/10848
 forgetest_async!(cast_call_disable_labels, |prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test()).await;

--- a/crates/cli/src/machine.rs
+++ b/crates/cli/src/machine.rs
@@ -143,6 +143,19 @@ pub fn bail_machine_diagnostic(
     std::process::exit(exit_code.to_i32());
 }
 
+/// Same as [`bail_machine_diagnostic`] but attaches a structured `details`
+/// object to the emitted error message.
+pub fn bail_machine_diagnostic_with_details(
+    code: &'static str,
+    exit_code: ExitCode,
+    message: impl Into<String>,
+    details: serde_json::Value,
+) -> ! {
+    let envelope = JsonEnvelope::error(JsonMessage::error(code, message).with_details(details));
+    let _ = print_json(&envelope);
+    std::process::exit(exit_code.to_i32());
+}
+
 /// Emit a structured error envelope on stdout for an `eyre::Report`.
 ///
 /// Used by binary entry points to wrap an uncaught command failure as a

--- a/crates/test-utils/src/agent_schema.rs
+++ b/crates/test-utils/src/agent_schema.rs
@@ -25,6 +25,7 @@ const SCHEMA_FILES: &[(&str, &str)] = &[
     ("foundry:cast.abi-decode@v1", "cast.abi-decode.v1.json"),
     ("foundry:cast.keccak@v1", "cast.keccak.v1.json"),
     ("foundry:cast.4byte@v1", "cast.4byte.v1.json"),
+    ("foundry:cast.send@v1", "cast.send.v1.json"),
     ("foundry:forge.build@v1", "forge.build.v1.json"),
     ("foundry:forge.create@v1", "forge.create.v1.json"),
     ("foundry:forge.test@v1", "forge.test.v1.json"),

--- a/docs/agents/schemas/cast.send.v1.json
+++ b/docs/agents/schemas/cast.send.v1.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "foundry:cast.send@v1",
+  "title": "cast send result payload",
+  "description": "Shape of the `data` field in the `cast send --machine` terminal envelope.",
+  "type": "object",
+  "required": [
+    "broadcast",
+    "tx_hash",
+    "from",
+    "to",
+    "contract_address",
+    "status",
+    "block_number",
+    "gas_used",
+    "effective_gas_price"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "broadcast": {
+      "type": "boolean",
+      "description": "Always true for `cast send` under `--machine`; the command never dry-runs."
+    },
+    "tx_hash": {
+      "type": "string",
+      "description": "0x-prefixed transaction hash.",
+      "pattern": "^0x[0-9a-fA-F]{64}$"
+    },
+    "from": {
+      "type": "string",
+      "description": "0x-prefixed sender address.",
+      "pattern": "^0x[0-9a-fA-F]{40}$"
+    },
+    "to": {
+      "type": ["string", "null"],
+      "description": "0x-prefixed recipient address. Null when the transaction has no recipient (for example contract creation).",
+      "pattern": "^0x[0-9a-fA-F]{40}$"
+    },
+    "contract_address": {
+      "type": ["string", "null"],
+      "description": "0x-prefixed contract address for create transactions. Null otherwise or when no receipt was observed.",
+      "pattern": "^0x[0-9a-fA-F]{40}$"
+    },
+    "status": {
+      "enum": [true, null],
+      "description": "Receipt success bit. `true` when mined successfully, `null` when no receipt was observed (`--async`). Reverted receipts are reclassified into a `chain.broadcast_failed` error envelope; `false` is reserved."
+    },
+    "block_number": {
+      "type": ["string", "null"],
+      "description": "Decimal-encoded block number of the receipt. Null when no receipt was observed."
+    },
+    "gas_used": {
+      "type": ["string", "null"],
+      "description": "Decimal-encoded gas used reported by the receipt. Null when no receipt was observed."
+    },
+    "effective_gas_price": {
+      "type": ["string", "null"],
+      "description": "Decimal-encoded effective gas price reported by the receipt. Null when no receipt was observed."
+    }
+  }
+}


### PR DESCRIPTION
Stacked on #14821.

`cast send --machine` emits a single `foundry:cast.send@v1` envelope across all modes (`default` / `--sync` / `--async` / `--create`), rejects `--browser` and `--tempo.print-sponsor-hash`, and on failure emits a typed envelope (`chain.broadcast_failed` / `network.rpc.*` / `wallet.signature.rejected`) with the eyre cause chain and post-broadcast recovery metadata (`tx_hash`, `receipt_observed`, receipt fields) preserved in `errors[0].details`. Non-machine output is unchanged.