### PR TITLE
ci: skip Tempo and MPP CI on PRs from forks

### DIFF
--- a/.github/workflows/ci-mpp.yml
+++ b/.github/workflows/ci-mpp.yml
@@ -18,6 +18,10 @@ env:
 
 jobs:
   mpp-check:
+    # Skip on PRs from forks (only run for branches in foundry-rs/foundry, i.e. maintainer PRs).
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: depot-ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -39,6 +39,10 @@ env:
 
 jobs:
   tempo-check:
+    # Skip on PRs from forks (only run for branches in foundry-rs/foundry, i.e. maintainer PRs).
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: depot-ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
Repository secrets are not exposed to workflows triggered by `pull_request` from forks, so these jobs cannot do anything useful for external contributor PRs:

- **`ci-tempo.yml` / `tempo-check`** — relies on `TEMPO_*_RPC_URL`, `VERIFIER_URL`, `THROW_AWAY_MAINNET_PKEY`. With empty `ETH_RPC_URL`, every `cast`/`forge --rpc-url` call in [`tempo-check.sh`](.github/scripts/tempo-check.sh) fails immediately, and `tempo::tests::test_fork_schedule_parses_configured_rpcs` fails on empty RPC env vars. Result: the job **fails** for fork PRs.
- **`ci-mpp.yml` / `mpp-check`** — relies on `TEMPO_PRIVATE_KEY`, `TEMPO_KEYS_TOML_B64`, `MPP_API_KEY`. The script already `exit 0`s when both wallet secrets are empty, so the job **passes**, but only after burning runner time building forge/cast/anvil/chisel for a no-op.

Both jobs are now gated to only run on `pull_request` when the head repo is `foundry-rs/foundry` (i.e. maintainer branches). `push` to `master`, the nightly `schedule` (tempo only), and manual `workflow_dispatch` runs are unaffected.