### PR TITLE
feat: Add Tempo session registry scaffold

### DIFF
--- a/crates/common/src/tempo/keystore.rs
+++ b/crates/common/src/tempo/keystore.rs
@@ -6,7 +6,9 @@
 use alloy_primitives::{Address, hex};
 use alloy_rlp::Decodable;
 use serde::{Deserialize, Serialize};
-use std::{env, fs, io::Write, path::PathBuf};
+use std::{env, path::PathBuf};
+
+use super::registry::{read_toml_file, write_toml_file_atomic};
 
 /// Environment variable for an ephemeral Tempo private key.
 pub const TEMPO_PRIVATE_KEY_ENV: &str = "TEMPO_PRIVATE_KEY";
@@ -127,26 +129,7 @@ pub fn tempo_keys_path() -> Option<PathBuf> {
 /// Errors are logged as warnings.
 pub fn read_tempo_keys_file() -> Option<KeysFile> {
     let keys_path = tempo_keys_path()?;
-    if !keys_path.exists() {
-        tracing::trace!(?keys_path, "tempo keys file not found");
-        return None;
-    }
-
-    let contents = match fs::read_to_string(&keys_path) {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::warn!(?keys_path, %e, "failed to read tempo keys file");
-            return None;
-        }
-    };
-
-    match toml::from_str(&contents) {
-        Ok(f) => Some(f),
-        Err(e) => {
-            tracing::warn!(?keys_path, %e, "failed to parse tempo keys file");
-            None
-        }
-    }
+    read_toml_file(&keys_path, "tempo keys")
 }
 
 /// Decodes a hex-encoded, RLP-encoded key authorization.
@@ -168,25 +151,16 @@ pub fn decode_key_authorization<T: Decodable>(hex_str: &str) -> eyre::Result<T> 
 /// temp file + rename so a crash mid-write cannot corrupt the file.
 pub(crate) fn upsert_key_entry(entry: KeyEntry) -> eyre::Result<()> {
     let path = tempo_keys_path().ok_or_else(|| eyre::eyre!("could not resolve tempo home"))?;
-    let dir = path.parent().ok_or_else(|| eyre::eyre!("invalid keys path: {}", path.display()))?;
-    fs::create_dir_all(dir)?;
-
     let mut file = read_tempo_keys_file().unwrap_or_default();
     file.keys
         .retain(|k| !(k.wallet_address == entry.wallet_address && k.chain_id == entry.chain_id));
     file.keys.push(entry);
 
-    let body = toml::to_string_pretty(&file)?;
-    let contents = format!(
-        "# Tempo wallet keys — managed by Foundry / Tempo CLI.\n# Do not edit manually.\n\n{body}"
-    );
-
-    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
-    tmp.write_all(contents.as_bytes())?;
-    tmp.flush()?;
-    tmp.persist(&path).map_err(|e| eyre::eyre!("failed to persist keys.toml: {e}"))?;
-
-    Ok(())
+    write_toml_file_atomic(
+        &path,
+        &file,
+        "# Tempo wallet keys — managed by Foundry / Tempo CLI.\n# Do not edit manually.",
+    )
 }
 
 #[cfg(test)]

--- a/crates/common/src/tempo/keystore.rs
+++ b/crates/common/src/tempo/keystore.rs
@@ -98,16 +98,6 @@ pub struct KeysFile {
     pub keys: Vec<KeyEntry>,
 }
 
-/// Process-wide mutex used by tests that mutate `TEMPO_HOME`.
-///
-/// Returns a [`tokio::sync::Mutex`] so async tests can hold it across `.await`
-/// points without tripping `clippy::await_holding_lock`.
-#[cfg(test)]
-pub(crate) fn test_env_mutex() -> &'static tokio::sync::Mutex<()> {
-    static M: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
-    M.get_or_init(|| tokio::sync::Mutex::new(()))
-}
-
 /// Resolve the Tempo home directory.
 ///
 /// Uses `TEMPO_HOME` env var if set, otherwise `~/.tempo`.
@@ -129,7 +119,13 @@ pub fn tempo_keys_path() -> Option<PathBuf> {
 /// Errors are logged as warnings.
 pub fn read_tempo_keys_file() -> Option<KeysFile> {
     let keys_path = tempo_keys_path()?;
-    read_toml_file(&keys_path, "tempo keys")
+    match read_toml_file(&keys_path, "tempo keys") {
+        Ok(value) => value,
+        Err(e) => {
+            tracing::warn!(?keys_path, %e, "failed to load tempo keys file");
+            None
+        }
+    }
 }
 
 /// Decodes a hex-encoded, RLP-encoded key authorization.
@@ -151,7 +147,7 @@ pub fn decode_key_authorization<T: Decodable>(hex_str: &str) -> eyre::Result<T> 
 /// temp file + rename so a crash mid-write cannot corrupt the file.
 pub(crate) fn upsert_key_entry(entry: KeyEntry) -> eyre::Result<()> {
     let path = tempo_keys_path().ok_or_else(|| eyre::eyre!("could not resolve tempo home"))?;
-    let mut file = read_tempo_keys_file().unwrap_or_default();
+    let mut file = read_toml_file::<KeysFile>(&path, "tempo keys")?.unwrap_or_default();
     file.keys
         .retain(|k| !(k.wallet_address == entry.wallet_address && k.chain_id == entry.chain_id));
     file.keys.push(entry);
@@ -166,16 +162,8 @@ pub(crate) fn upsert_key_entry(entry: KeyEntry) -> eyre::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
-
-    fn with_tempo_home<F: FnOnce()>(f: F) {
-        let tmp = tempfile::tempdir().unwrap();
-        // SAFETY: process-global env access is serialized via the shared mutex.
-        let _g = test_env_mutex().blocking_lock();
-        unsafe { std::env::set_var(TEMPO_HOME_ENV, tmp.path()) };
-        f();
-        unsafe { std::env::remove_var(TEMPO_HOME_ENV) };
-    }
+    use crate::tempo::with_tempo_home;
+    use std::{fs, str::FromStr};
 
     #[test]
     fn upsert_replaces_matching_entry_atomically() {
@@ -238,6 +226,34 @@ mod tests {
             let file = read_tempo_keys_file().unwrap();
             assert_eq!(file.keys.len(), 1, "old entry must be replaced, not duplicated");
             assert_eq!(file.keys[0].key_address, Some(new_key));
+        });
+    }
+
+    #[test]
+    fn upsert_fails_closed_when_keys_file_is_corrupt() {
+        with_tempo_home(|| {
+            let path = tempo_keys_path().unwrap();
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, "keys = [").unwrap();
+            let original = fs::read_to_string(&path).unwrap();
+
+            let wallet = Address::from_str("0x0000000000000000000000000000000000000001").unwrap();
+            let key = Address::from_str("0x0000000000000000000000000000000000000abc").unwrap();
+            let entry = KeyEntry {
+                wallet_type: WalletType::Passkey,
+                wallet_address: wallet,
+                chain_id: 4217,
+                key_type: KeyType::Secp256k1,
+                key_address: Some(key),
+                key: Some("0xdead".to_string()),
+                key_authorization: Some("0xbeef".to_string()),
+                expiry: Some(100),
+                limits: vec![],
+            };
+
+            assert!(read_tempo_keys_file().is_none());
+            assert!(upsert_key_entry(entry).is_err());
+            assert_eq!(fs::read_to_string(&path).unwrap(), original);
         });
     }
 }

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 mod keystore;
 mod registry;
 mod session;
+#[cfg(test)]
+mod test_utils;
 
 pub(crate) use auth::is_known_tempo_endpoint;
 pub use auth::{AccessKeyOutcome, EnsureAccessKeyConfig, ensure_access_key};
@@ -20,7 +22,7 @@ pub use keystore::*;
 pub use session::*;
 
 #[cfg(test)]
-pub(crate) use keystore::test_env_mutex;
+pub(crate) use test_utils::{test_env_mutex, with_tempo_home};
 
 #[cfg(test)]
 mod tests;

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -11,10 +11,13 @@ use foundry_wallets::{RawWalletOpts, WalletOpts, WalletSigner};
 use std::sync::Arc;
 
 mod keystore;
+mod registry;
+mod session;
 
 pub(crate) use auth::is_known_tempo_endpoint;
 pub use auth::{AccessKeyOutcome, EnsureAccessKeyConfig, ensure_access_key};
 pub use keystore::*;
+pub use session::*;
 
 #[cfg(test)]
 pub(crate) use keystore::test_env_mutex;

--- a/crates/common/src/tempo/registry.rs
+++ b/crates/common/src/tempo/registry.rs
@@ -1,4 +1,4 @@
-use eyre::Result;
+use eyre::{Result, WrapErr};
 use serde::{Serialize, de::DeserializeOwned};
 use std::{fs, io::Write, path::Path};
 
@@ -7,33 +7,33 @@ use std::{fs, io::Write, path::Path};
 /// We keep the read/parse and atomic write logic here so `keys.toml`,
 /// `sessions.toml`, and any future Tempo registry files all use the same
 /// persistence semantics instead of duplicating the same boilerplate.
-pub(crate) fn read_toml_file<T: DeserializeOwned>(path: &Path, label: &str) -> Option<T> {
-    if !path.exists() {
-        tracing::trace!(?path, "{label} file not found");
-        return None;
-    }
-
+///
+/// Strict readers return `Ok(None)` only when the file is missing.
+/// Corruption and I/O failures bubble up so mutating paths can fail closed.
+pub(crate) fn read_toml_file<T: DeserializeOwned>(path: &Path, label: &str) -> Result<Option<T>> {
     let contents = match fs::read_to_string(path) {
         Ok(contents) => contents,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::trace!(?path, "{label} file not found");
+            return Ok(None);
+        }
         Err(e) => {
-            tracing::warn!(?path, %e, "failed to read {label} file");
-            return None;
+            return Err(e)
+                .wrap_err_with(|| format!("failed to read {label} file {}", path.display()));
         }
     };
 
-    match toml::from_str(&contents) {
-        Ok(value) => Some(value),
-        Err(e) => {
-            tracing::warn!(?path, %e, "failed to parse {label} file");
-            None
-        }
-    }
+    let value = toml::from_str(&contents)
+        .wrap_err_with(|| format!("failed to parse {label} file {}", path.display()))?;
+    Ok(Some(value))
 }
 
 /// Write a Tempo registry file atomically via temp file + rename.
 ///
 /// This keeps every registry on the same durability path and avoids repeating
 /// the same create-dir / serialize / flush / persist sequence in each caller.
+/// The temp file and parent directory are synced so rename is much closer to a
+/// crash-safe durable write.
 pub(crate) fn write_toml_file_atomic<T: Serialize>(
     path: &Path,
     value: &T,
@@ -49,7 +49,20 @@ pub(crate) fn write_toml_file_atomic<T: Serialize>(
     let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
     tmp.write_all(contents.as_bytes())?;
     tmp.flush()?;
+    tmp.as_file().sync_all()?;
     tmp.persist(path).map_err(|e| eyre::eyre!("failed to persist {}: {e}", path.display()))?;
+    sync_parent_dir(dir)?;
 
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_parent_dir(dir: &Path) -> Result<()> {
+    fs::File::open(dir)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_dir: &Path) -> Result<()> {
     Ok(())
 }

--- a/crates/common/src/tempo/registry.rs
+++ b/crates/common/src/tempo/registry.rs
@@ -2,6 +2,11 @@ use eyre::Result;
 use serde::{Serialize, de::DeserializeOwned};
 use std::{fs, io::Write, path::Path};
 
+/// Shared TOML registry helpers for Tempo local state.
+///
+/// We keep the read/parse and atomic write logic here so `keys.toml`,
+/// `sessions.toml`, and any future Tempo registry files all use the same
+/// persistence semantics instead of duplicating the same boilerplate.
 pub(crate) fn read_toml_file<T: DeserializeOwned>(path: &Path, label: &str) -> Option<T> {
     if !path.exists() {
         tracing::trace!(?path, "{label} file not found");
@@ -25,6 +30,10 @@ pub(crate) fn read_toml_file<T: DeserializeOwned>(path: &Path, label: &str) -> O
     }
 }
 
+/// Write a Tempo registry file atomically via temp file + rename.
+///
+/// This keeps every registry on the same durability path and avoids repeating
+/// the same create-dir / serialize / flush / persist sequence in each caller.
 pub(crate) fn write_toml_file_atomic<T: Serialize>(
     path: &Path,
     value: &T,

--- a/crates/common/src/tempo/registry.rs
+++ b/crates/common/src/tempo/registry.rs
@@ -1,6 +1,10 @@
 use eyre::{Result, WrapErr};
 use serde::{Serialize, de::DeserializeOwned};
-use std::{fs, io::Write, path::Path};
+use std::{
+    fs,
+    io::{ErrorKind, Write},
+    path::Path,
+};
 
 /// Shared TOML registry helpers for Tempo local state.
 ///
@@ -13,7 +17,7 @@ use std::{fs, io::Write, path::Path};
 pub(crate) fn read_toml_file<T: DeserializeOwned>(path: &Path, label: &str) -> Result<Option<T>> {
     let contents = match fs::read_to_string(path) {
         Ok(contents) => contents,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+        Err(e) if e.kind() == ErrorKind::NotFound => {
             tracing::trace!(?path, "{label} file not found");
             return Ok(None);
         }

--- a/crates/common/src/tempo/registry.rs
+++ b/crates/common/src/tempo/registry.rs
@@ -1,0 +1,46 @@
+use eyre::Result;
+use serde::{Serialize, de::DeserializeOwned};
+use std::{fs, io::Write, path::Path};
+
+pub(crate) fn read_toml_file<T: DeserializeOwned>(path: &Path, label: &str) -> Option<T> {
+    if !path.exists() {
+        tracing::trace!(?path, "{label} file not found");
+        return None;
+    }
+
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(e) => {
+            tracing::warn!(?path, %e, "failed to read {label} file");
+            return None;
+        }
+    };
+
+    match toml::from_str(&contents) {
+        Ok(value) => Some(value),
+        Err(e) => {
+            tracing::warn!(?path, %e, "failed to parse {label} file");
+            None
+        }
+    }
+}
+
+pub(crate) fn write_toml_file_atomic<T: Serialize>(
+    path: &Path,
+    value: &T,
+    header: &str,
+) -> Result<()> {
+    let dir =
+        path.parent().ok_or_else(|| eyre::eyre!("invalid registry path: {}", path.display()))?;
+    fs::create_dir_all(dir)?;
+
+    let body = toml::to_string_pretty(value)?;
+    let contents = if header.trim().is_empty() { body } else { format!("{header}\n\n{body}") };
+
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    tmp.write_all(contents.as_bytes())?;
+    tmp.flush()?;
+    tmp.persist(path).map_err(|e| eyre::eyre!("failed to persist {}: {e}", path.display()))?;
+
+    Ok(())
+}

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -8,6 +8,9 @@ use std::path::PathBuf;
 /// Relative path from Tempo home to the session registry file.
 pub const WALLET_SESSIONS_PATH: &str = "wallet/sessions.toml";
 
+const SESSIONS_HEADER: &str =
+    "# Tempo session registry — managed by Foundry / Tempo CLI.\n# Do not edit manually.";
+
 /// Status of a local session entry.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -64,6 +67,10 @@ pub struct SessionEntry {
     pub root_account: Address,
     pub chain_id: u64,
     pub key_address: Address,
+    /// Unix timestamp in seconds when the session expires.
+    ///
+    /// Tempo sessions are always bounded-lifetime. `0` is not a "never
+    /// expires" sentinel; it is already expired.
     pub expiry: u64,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub scope: Vec<SessionCallScope>,
@@ -130,35 +137,33 @@ pub fn session_registry_path() -> Option<PathBuf> {
 /// Errors are logged as warnings.
 pub fn read_session_record() -> Option<SessionRecord> {
     let path = session_registry_path()?;
-    read_toml_file(&path, "tempo sessions")
+    match read_toml_file(&path, "tempo sessions") {
+        Ok(value) => value,
+        Err(e) => {
+            tracing::warn!(?path, %e, "failed to load tempo sessions file");
+            None
+        }
+    }
 }
 
 /// Atomically upsert a [`SessionEntry`] into the session registry.
 pub fn upsert_session_entry(entry: SessionEntry) -> eyre::Result<()> {
     let path =
         session_registry_path().ok_or_else(|| eyre::eyre!("could not resolve tempo home"))?;
-    let mut record = read_session_record().unwrap_or_default();
+    let mut record = read_toml_file::<SessionRecord>(&path, "tempo sessions")?.unwrap_or_default();
     record.upsert(entry);
 
-    write_toml_file_atomic(
-        &path,
-        &record,
-        "# Tempo session registry — managed by Foundry / Tempo CLI.\n# Do not edit manually.",
-    )
+    write_toml_file_atomic(&path, &record, SESSIONS_HEADER)
 }
 
 /// Atomically remove a session from the registry.
 pub fn remove_session_entry(session_id: B256) -> eyre::Result<bool> {
     let path =
         session_registry_path().ok_or_else(|| eyre::eyre!("could not resolve tempo home"))?;
-    let mut record = read_session_record().unwrap_or_default();
+    let mut record = read_toml_file::<SessionRecord>(&path, "tempo sessions")?.unwrap_or_default();
     let removed = record.remove(session_id);
     if removed {
-        write_toml_file_atomic(
-            &path,
-            &record,
-            "# Tempo session registry — managed by Foundry / Tempo CLI.\n# Do not edit manually.",
-        )?;
+        write_toml_file_atomic(&path, &record, SESSIONS_HEADER)?;
     }
     Ok(removed)
 }
@@ -166,16 +171,8 @@ pub fn remove_session_entry(session_id: B256) -> eyre::Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tempo::{TEMPO_HOME_ENV, test_env_mutex};
-    use std::str::FromStr;
-
-    fn with_tempo_home<F: FnOnce()>(f: F) {
-        let tmp = tempfile::tempdir().unwrap();
-        let _g = test_env_mutex().blocking_lock();
-        unsafe { std::env::set_var(TEMPO_HOME_ENV, tmp.path()) };
-        f();
-        unsafe { std::env::remove_var(TEMPO_HOME_ENV) };
-    }
+    use crate::tempo::with_tempo_home;
+    use std::{fs, str::FromStr};
 
     fn sample_entry(session_id: B256, expiry: u64, status: SessionStatus) -> SessionEntry {
         SessionEntry {
@@ -266,5 +263,35 @@ mod tests {
         assert_eq!(decoded.limits.len(), 1);
         assert_eq!(decoded.status, SessionStatus::Revoking);
         assert!(decoded.is_expired_at(1234));
+    }
+
+    #[test]
+    fn upsert_fails_closed_when_session_file_is_corrupt() {
+        with_tempo_home(|| {
+            let path = session_registry_path().unwrap();
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, "sessions = [").unwrap();
+            let original = fs::read_to_string(&path).unwrap();
+
+            let session_id = B256::from([0x77; 32]);
+            let entry = sample_entry(session_id, 100, SessionStatus::Pending);
+
+            assert!(read_session_record().is_none());
+            assert!(upsert_session_entry(entry).is_err());
+            assert_eq!(fs::read_to_string(&path).unwrap(), original);
+        });
+    }
+
+    #[test]
+    fn remove_fails_closed_when_session_file_is_corrupt() {
+        with_tempo_home(|| {
+            let path = session_registry_path().unwrap();
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, "sessions = [").unwrap();
+            let original = fs::read_to_string(&path).unwrap();
+
+            assert!(remove_session_entry(B256::from([0x88; 32])).is_err());
+            assert_eq!(fs::read_to_string(&path).unwrap(), original);
+        });
     }
 }

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -89,7 +89,7 @@ pub struct SessionRecord {
 
 impl SessionRecord {
     /// Returns `true` if the registry has no session entries.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.sessions.is_empty()
     }
 

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -1,0 +1,270 @@
+//! Tempo session registry and local lifecycle metadata.
+
+use super::{registry::*, tempo_home};
+use alloy_primitives::{Address, B256, Selector};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Relative path from Tempo home to the session registry file.
+pub const WALLET_SESSIONS_PATH: &str = "wallet/sessions.toml";
+
+/// Status of a local session entry.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    #[default]
+    Pending,
+    Active,
+    Revoking,
+    Revoked,
+    Expired,
+    Failed,
+}
+
+impl SessionStatus {
+    /// Returns `true` if the session is no longer expected to be usable.
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Revoked | Self::Expired | Self::Failed)
+    }
+
+    /// Returns `true` if the session is still in-flight or usable.
+    pub const fn is_live(self) -> bool {
+        !self.is_terminal()
+    }
+}
+
+/// Spending limit stored for a session entry.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct SessionTokenLimit {
+    pub currency: Address,
+    pub limit: String,
+}
+
+/// A single selector rule in a session scope.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct SessionSelectorRule {
+    pub selector: Selector,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recipients: Vec<Address>,
+}
+
+/// A single target scope in a session entry.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct SessionCallScope {
+    pub target: Address,
+    /// Empty selector list means wildcard access for the target.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub selector_rules: Vec<SessionSelectorRule>,
+}
+
+/// Persisted metadata for one temporary session.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct SessionEntry {
+    pub session_id: B256,
+    pub root_account: Address,
+    pub chain_id: u64,
+    pub key_address: Address,
+    pub expiry: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scope: Vec<SessionCallScope>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub limits: Vec<SessionTokenLimit>,
+    #[serde(default)]
+    pub status: SessionStatus,
+}
+
+impl SessionEntry {
+    /// Returns `true` if the session has passed its expiry timestamp.
+    pub const fn is_expired_at(&self, now: u64) -> bool {
+        now >= self.expiry
+    }
+}
+
+/// Top-level registry persisted in `wallet/sessions.toml`.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct SessionRecord {
+    #[serde(default)]
+    pub sessions: Vec<SessionEntry>,
+}
+
+impl SessionRecord {
+    /// Returns `true` if the registry has no session entries.
+    pub fn is_empty(&self) -> bool {
+        self.sessions.is_empty()
+    }
+
+    /// Insert or replace a session by `session_id`.
+    pub fn upsert(&mut self, entry: SessionEntry) {
+        self.sessions.retain(|session| session.session_id != entry.session_id);
+        self.sessions.push(entry);
+    }
+
+    /// Remove a session by `session_id`. Returns `true` if an entry was removed.
+    pub fn remove(&mut self, session_id: B256) -> bool {
+        let before = self.sessions.len();
+        self.sessions.retain(|session| session.session_id != session_id);
+        self.sessions.len() != before
+    }
+
+    /// Mark expired live entries as expired. Returns the number updated.
+    pub fn mark_expired(&mut self, now: u64) -> usize {
+        let mut updated = 0;
+        for session in &mut self.sessions {
+            if session.status.is_live() && session.is_expired_at(now) {
+                session.status = SessionStatus::Expired;
+                updated += 1;
+            }
+        }
+        updated
+    }
+}
+
+/// Returns the path to the Tempo session registry file.
+pub fn session_registry_path() -> Option<PathBuf> {
+    tempo_home().map(|home| home.join(WALLET_SESSIONS_PATH))
+}
+
+/// Read and parse the Tempo session registry.
+///
+/// Returns `None` if the file doesn't exist or can't be read/parsed.
+/// Errors are logged as warnings.
+pub fn read_session_record() -> Option<SessionRecord> {
+    let path = session_registry_path()?;
+    read_toml_file(&path, "tempo sessions")
+}
+
+/// Atomically upsert a [`SessionEntry`] into the session registry.
+pub fn upsert_session_entry(entry: SessionEntry) -> eyre::Result<()> {
+    let path =
+        session_registry_path().ok_or_else(|| eyre::eyre!("could not resolve tempo home"))?;
+    let mut record = read_session_record().unwrap_or_default();
+    record.upsert(entry);
+
+    write_toml_file_atomic(
+        &path,
+        &record,
+        "# Tempo session registry — managed by Foundry / Tempo CLI.\n# Do not edit manually.",
+    )
+}
+
+/// Atomically remove a session from the registry.
+pub fn remove_session_entry(session_id: B256) -> eyre::Result<bool> {
+    let path =
+        session_registry_path().ok_or_else(|| eyre::eyre!("could not resolve tempo home"))?;
+    let mut record = read_session_record().unwrap_or_default();
+    let removed = record.remove(session_id);
+    if removed {
+        write_toml_file_atomic(
+            &path,
+            &record,
+            "# Tempo session registry — managed by Foundry / Tempo CLI.\n# Do not edit manually.",
+        )?;
+    }
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tempo::{TEMPO_HOME_ENV, test_env_mutex};
+    use std::str::FromStr;
+
+    fn with_tempo_home<F: FnOnce()>(f: F) {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = test_env_mutex().blocking_lock();
+        unsafe { std::env::set_var(TEMPO_HOME_ENV, tmp.path()) };
+        f();
+        unsafe { std::env::remove_var(TEMPO_HOME_ENV) };
+    }
+
+    fn sample_entry(session_id: B256, expiry: u64, status: SessionStatus) -> SessionEntry {
+        SessionEntry {
+            session_id,
+            root_account: Address::from_str("0x0000000000000000000000000000000000000001").unwrap(),
+            chain_id: 4217,
+            key_address: Address::from_str("0x0000000000000000000000000000000000000abc").unwrap(),
+            expiry,
+            scope: vec![SessionCallScope {
+                target: Address::from_str("0x00000000000000000000000000000000000000aa").unwrap(),
+                selector_rules: vec![SessionSelectorRule {
+                    selector: Selector::from_slice(&[0x12, 0x34, 0x56, 0x78]),
+                    recipients: vec![],
+                }],
+            }],
+            limits: vec![SessionTokenLimit {
+                currency: Address::from_str("0x00000000000000000000000000000000000000ff").unwrap(),
+                limit: "0".to_string(),
+            }],
+            status,
+        }
+    }
+
+    #[test]
+    fn session_registry_is_separate_from_keys_registry() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x11; 32]);
+            upsert_session_entry(sample_entry(session_id, 100, SessionStatus::Pending)).unwrap();
+
+            let session_path = session_registry_path().unwrap();
+            let keys_path = crate::tempo::tempo_keys_path().unwrap();
+            assert_eq!(session_path.file_name().and_then(|s| s.to_str()), Some("sessions.toml"));
+            assert_eq!(keys_path.file_name().and_then(|s| s.to_str()), Some("keys.toml"));
+            assert_ne!(session_path, keys_path);
+
+            let record = read_session_record().unwrap();
+            assert_eq!(record.sessions.len(), 1);
+            assert_eq!(record.sessions[0].session_id, session_id);
+        });
+    }
+
+    #[test]
+    fn session_registry_upsert_replaces_matching_session_id() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x22; 32]);
+            upsert_session_entry(sample_entry(session_id, 100, SessionStatus::Pending)).unwrap();
+            upsert_session_entry(sample_entry(session_id, 200, SessionStatus::Active)).unwrap();
+
+            let record = read_session_record().unwrap();
+            assert_eq!(record.sessions.len(), 1);
+            assert_eq!(record.sessions[0].expiry, 200);
+            assert_eq!(record.sessions[0].status, SessionStatus::Active);
+        });
+    }
+
+    #[test]
+    fn session_registry_remove_deletes_entry() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x33; 32]);
+            upsert_session_entry(sample_entry(session_id, 100, SessionStatus::Active)).unwrap();
+            assert!(remove_session_entry(session_id).unwrap());
+            assert!(read_session_record().unwrap().is_empty());
+        });
+    }
+
+    #[test]
+    fn session_record_marks_expired_live_entries() {
+        let mut record = SessionRecord {
+            sessions: vec![
+                sample_entry(B256::from([0x44; 32]), 10, SessionStatus::Pending),
+                sample_entry(B256::from([0x55; 32]), 10, SessionStatus::Revoked),
+            ],
+        };
+
+        assert_eq!(record.mark_expired(11), 1);
+        assert_eq!(record.sessions[0].status, SessionStatus::Expired);
+        assert_eq!(record.sessions[1].status, SessionStatus::Revoked);
+    }
+
+    #[test]
+    fn session_entry_roundtrips_scope_limits_and_status() {
+        let entry = sample_entry(B256::from([0x66; 32]), 1234, SessionStatus::Revoking);
+        let toml = toml::to_string(&entry).unwrap();
+        let decoded: SessionEntry = toml::from_str(&toml).unwrap();
+
+        assert_eq!(decoded.session_id, entry.session_id);
+        assert_eq!(decoded.scope.len(), 1);
+        assert_eq!(decoded.limits.len(), 1);
+        assert_eq!(decoded.status, SessionStatus::Revoking);
+        assert!(decoded.is_expired_at(1234));
+    }
+}

--- a/crates/common/src/tempo/test_utils.rs
+++ b/crates/common/src/tempo/test_utils.rs
@@ -1,0 +1,20 @@
+use super::TEMPO_HOME_ENV;
+
+/// Process-wide mutex used by tests that mutate `TEMPO_HOME`.
+///
+/// Returns a [`tokio::sync::Mutex`] so async tests can hold it across `.await`
+/// points without tripping `clippy::await_holding_lock`.
+pub(crate) fn test_env_mutex() -> &'static tokio::sync::Mutex<()> {
+    static M: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    M.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+pub(crate) fn with_tempo_home<F: FnOnce()>(f: F) {
+    let tmp = tempfile::tempdir().unwrap();
+    let _g = test_env_mutex().blocking_lock();
+    // SAFETY: tests serialize all `TEMPO_HOME` mutation through the mutex.
+    unsafe { std::env::set_var(TEMPO_HOME_ENV, tmp.path()) };
+    f();
+    // SAFETY: tests serialize all `TEMPO_HOME` mutation through the mutex.
+    unsafe { std::env::remove_var(TEMPO_HOME_ENV) };
+}


### PR DESCRIPTION
On the first step of OSS-162 

### Summary 
This PR introduces the initial Tempo session registry layer, separate from the long-lived access key store.

  - adds `SessionEntry`, `SessionRecord`, and `SessionStatus`
  - persists session metadata under `~/.tempo/wallet/sessions.toml`
  - supports atomic upsert, removal, and expiry tracking
  - extracts shared TOML read/write helpers for Tempo registries
  - keeps the existing `keys.toml` access key behavior unchanged
  
cc @mattsse  @mablr  