### PR TITLE
fix(cheatcodes): fix expectRevert with internal reverts for non-contract calls

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1421,15 +1421,6 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             }
 
             let curr_depth = ecx.journal().depth();
-            let selector = call.input.bytes(ecx);
-            let selector = selector.get(..SELECTOR_LEN);
-            let process_cheatcode_revert = cheatcode_call
-                && call_failed
-                && selector.is_some_and(|selector| {
-                    selector == Vm::createSelectFork_0Call::SELECTOR
-                        || selector == Vm::createSelectFork_1Call::SELECTOR
-                        || selector == Vm::createSelectFork_2Call::SELECTOR
-                });
             if curr_depth <= expected_revert.depth {
                 let needs_processing = match expected_revert.kind {
                     ExpectedRevertKind::Default => {
@@ -1451,9 +1442,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         // the expectRevert even though the call succeeded, preventing the actual
                         // Solidity-generated revert (from extcodesize/returndata check) from
                         // satisfying the expectation.
-                        if process_cheatcode_revert {
-                            true
-                        } else if cheatcode_call {
+                        if cheatcode_call {
                             false
                         } else if call_failed {
                             // Call failed - should process

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1422,54 +1422,36 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
 
             let curr_depth = ecx.journal().depth();
             if curr_depth <= expected_revert.depth {
+                // Decide whether this `call_end` should consume the pending `expectRevert`.
+                // With `internal_expect_revert` enabled, a same-depth revert can satisfy it, but
+                // we must not consume it for external calls that succeed (e.g. calls to
+                // non-contract addresses that return `Stop` before Solidity's own revert).
+                let internal = self.config.internal_expect_revert;
+                let went_deeper = expected_revert.max_depth > expected_revert.depth;
                 let needs_processing = match expected_revert.kind {
-                    ExpectedRevertKind::Default => {
-                        // For non-cheatcode calls, we need to decide if this call_end should
-                        // consume the expectRevert.
-                        //
-                        // When internal_expect_revert is enabled, the expectation can be
-                        // satisfied by a revert at the same depth (internal revert). However,
-                        // we should NOT consume the expectation for external calls that succeed
-                        // (e.g., calls to non-contract addresses that return Stop).
-                        //
-                        // Only process if:
-                        // 1. It's not a cheatcode call, AND
-                        // 2. Either the call failed, OR, when internal expect reverts are
-                        //    disabled, we made an external call (max_depth > depth), OR we're at
-                        //    the root call (depth 0)
-                        //
-                        // This fixes the bug where calling a non-contract address would consume
-                        // the expectRevert even though the call succeeded, preventing the actual
-                        // Solidity-generated revert (from extcodesize/returndata check) from
-                        // satisfying the expectation.
+                    ExpectedRevertKind::Default => (|| {
+                        // Cheatcode reverts propagate up; let the outer frame catch them.
                         if cheatcode_call {
-                            false
-                        } else if call_failed {
-                            // Call failed - should process
-                            true
-                        } else if !self.config.internal_expect_revert
-                            && expected_revert.max_depth > expected_revert.depth
-                        {
-                            // Call succeeded but we went to a deeper depth (external call was made)
-                            // This is the traditional expectRevert case
-                            true
-                        } else if curr_depth == 0 {
-                            // Root call (test function) ended - must process any pending
-                            // expectation to catch "dangling"
-                            // expectReverts
-                            true
-                        } else if !self.config.internal_expect_revert {
-                            // Call succeeded, no deeper call was made, internal_expect_revert is
-                            // disabled - this is an error (call should have reverted)
-                            true
-                        } else {
-                            // Call succeeded, no deeper call was made, internal_expect_revert is
-                            // enabled - don't consume the expectation yet, wait for a revert
-                            false
+                            return false;
                         }
-                    }
-                    // `pending_processing` == true means that we're in the `call_end` hook for
-                    // `vm.expectCheatcodeRevert` and shouldn't expect revert here
+                        // Any failure satisfies the expectation.
+                        if call_failed {
+                            return true;
+                        }
+                        // Traditional expectRevert: succeeded external call went deeper.
+                        if !internal && went_deeper {
+                            return true;
+                        }
+                        // Test function returned: catch dangling expectations.
+                        if curr_depth == 0 {
+                            return true;
+                        }
+                        // Same-depth success with internal mode off is an error; with it on,
+                        // keep waiting for the actual revert.
+                        !internal
+                    })(),
+                    // `pending_processing == true` means we're in the `call_end` hook for
+                    // `vm.expectCheatcodeRevert` and shouldn't expect a revert here.
                     ExpectedRevertKind::Cheatcode { pending_processing } => {
                         cheatcode_call && !pending_processing
                     }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1421,7 +1421,42 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             let curr_depth = ecx.journal().depth();
             if curr_depth <= expected_revert.depth {
                 let needs_processing = match expected_revert.kind {
-                    ExpectedRevertKind::Default => !cheatcode_call,
+                    ExpectedRevertKind::Default => {
+                        // For non-cheatcode calls, we need to decide if this call_end should
+                        // consume the expectRevert.
+                        //
+                        // When internal_expect_revert is enabled, the expectation can be
+                        // satisfied by a revert at the same depth (internal revert). However,
+                        // we should NOT consume the expectation for external calls that succeed
+                        // (e.g., calls to non-contract addresses that return Stop).
+                        //
+                        // Only process if:
+                        // 1. It's not a cheatcode call, AND
+                        // 2. Either the call reverted, OR we made an external call (max_depth > depth)
+                        //
+                        // This fixes the bug where calling a non-contract address would consume
+                        // the expectRevert even though the call succeeded, preventing the actual
+                        // Solidity-generated revert (from extcodesize/returndata check) from
+                        // satisfying the expectation.
+                        if cheatcode_call {
+                            false
+                        } else if outcome.result.is_revert() {
+                            // Call reverted - should process
+                            true
+                        } else if expected_revert.max_depth > expected_revert.depth {
+                            // Call succeeded but we went to a deeper depth (external call was made)
+                            // This is the traditional expectRevert case
+                            true
+                        } else if !self.config.internal_expect_revert {
+                            // Call succeeded, no deeper call was made, internal_expect_revert is
+                            // disabled - this is an error (call should have reverted)
+                            true
+                        } else {
+                            // Call succeeded, no deeper call was made, internal_expect_revert is
+                            // enabled - don't consume the expectation yet, wait for a revert
+                            false
+                        }
+                    }
                     // `pending_processing` == true means that we're in the `call_end` hook for
                     // `vm.expectCheatcodeRevert` and shouldn't expect revert here
                     ExpectedRevertKind::Cheatcode { pending_processing } => {

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1432,7 +1432,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         //
                         // Only process if:
                         // 1. It's not a cheatcode call, AND
-                        // 2. Either the call reverted, OR we made an external call (max_depth > depth)
+                        // 2. Either the call reverted, OR we made an external call (max_depth >
+                        //    depth)
                         //
                         // This fixes the bug where calling a non-contract address would consume
                         // the expectRevert even though the call succeeded, preventing the actual

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1433,7 +1433,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         // Only process if:
                         // 1. It's not a cheatcode call, AND
                         // 2. Either the call reverted, OR we made an external call (max_depth >
-                        //    depth)
+                        //    depth), OR we're at the root call (depth 0)
                         //
                         // This fixes the bug where calling a non-contract address would consume
                         // the expectRevert even though the call succeeded, preventing the actual
@@ -1447,6 +1447,11 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         } else if expected_revert.max_depth > expected_revert.depth {
                             // Call succeeded but we went to a deeper depth (external call was made)
                             // This is the traditional expectRevert case
+                            true
+                        } else if curr_depth == 0 {
+                            // Root call (test function) ended - must process any pending
+                            // expectation to catch "dangling"
+                            // expectReverts
                             true
                         } else if !self.config.internal_expect_revert {
                             // Call succeeded, no deeper call was made, internal_expect_revert is

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1431,24 +1431,23 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         // (e.g., calls to non-contract addresses that return Stop).
                         //
                         // Only process if:
-                        // 1. It's not a cheatcode call (unless internal_expect_revert is enabled
-                        //    and the cheatcode reverted), AND
-                        // 2. Either the call reverted, OR we made an external call (max_depth >
-                        //    depth), OR we're at the root call (depth 0)
+                        // 1. It's not a cheatcode call, AND
+                        // 2. Either the call reverted, OR, when internal expect reverts are
+                        //    disabled, we made an external call (max_depth > depth), OR we're at
+                        //    the root call (depth 0)
                         //
                         // This fixes the bug where calling a non-contract address would consume
                         // the expectRevert even though the call succeeded, preventing the actual
                         // Solidity-generated revert (from extcodesize/returndata check) from
                         // satisfying the expectation.
                         if cheatcode_call {
-                            // For cheatcode calls, only process if internal_expect_revert is
-                            // enabled AND the cheatcode reverted. This allows catching cheatcode
-                            // reverts with expectRevert when the flag is set.
-                            self.config.internal_expect_revert && outcome.result.is_revert()
+                            false
                         } else if outcome.result.is_revert() {
                             // Call reverted - should process
                             true
-                        } else if expected_revert.max_depth > expected_revert.depth {
+                        } else if !self.config.internal_expect_revert
+                            && expected_revert.max_depth > expected_revert.depth
+                        {
                             // Call succeeded but we went to a deeper depth (external call was made)
                             // This is the traditional expectRevert case
                             true

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1431,7 +1431,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         // (e.g., calls to non-contract addresses that return Stop).
                         //
                         // Only process if:
-                        // 1. It's not a cheatcode call, AND
+                        // 1. It's not a cheatcode call (unless internal_expect_revert is enabled
+                        //    and the cheatcode reverted), AND
                         // 2. Either the call reverted, OR we made an external call (max_depth >
                         //    depth), OR we're at the root call (depth 0)
                         //
@@ -1440,7 +1441,10 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         // Solidity-generated revert (from extcodesize/returndata check) from
                         // satisfying the expectation.
                         if cheatcode_call {
-                            false
+                            // For cheatcode calls, only process if internal_expect_revert is
+                            // enabled AND the cheatcode reverted. This allows catching cheatcode
+                            // reverts with expectRevert when the flag is set.
+                            self.config.internal_expect_revert && outcome.result.is_revert()
                         } else if outcome.result.is_revert() {
                             // Call reverted - should process
                             true

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1421,6 +1421,15 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             }
 
             let curr_depth = ecx.journal().depth();
+            let selector = call.input.bytes(ecx);
+            let selector = selector.get(..SELECTOR_LEN);
+            let process_cheatcode_revert = cheatcode_call
+                && call_failed
+                && selector.is_some_and(|selector| {
+                    selector == Vm::createSelectFork_0Call::SELECTOR
+                        || selector == Vm::createSelectFork_1Call::SELECTOR
+                        || selector == Vm::createSelectFork_2Call::SELECTOR
+                });
             if curr_depth <= expected_revert.depth {
                 let needs_processing = match expected_revert.kind {
                     ExpectedRevertKind::Default => {
@@ -1442,7 +1451,9 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         // the expectRevert even though the call succeeded, preventing the actual
                         // Solidity-generated revert (from extcodesize/returndata check) from
                         // satisfying the expectation.
-                        if cheatcode_call {
+                        if process_cheatcode_revert {
+                            true
+                        } else if cheatcode_call {
                             false
                         } else if call_failed {
                             // Call failed - should process

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -61,6 +61,7 @@ use revm::{
         CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, FrameInput, Gas,
         InstructionResult, Interpreter, InterpreterAction, InterpreterResult,
         interpreter_types::{Jumps, LoopControl, MemoryTr},
+        return_ok,
     },
 };
 use serde_json::Value;
@@ -1407,7 +1408,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         if let Some(expected_revert) = &mut self.expected_revert {
             // Record current reverter address and call scheme before processing the expect revert
             // if call reverted.
-            if outcome.result.is_revert() {
+            let call_failed = !matches!(outcome.result.result, return_ok!());
+            if call_failed {
                 // Record current reverter address if expect revert is set with expected reverter
                 // address and no actual reverter was set yet or if we're expecting more than one
                 // revert.
@@ -1432,7 +1434,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         //
                         // Only process if:
                         // 1. It's not a cheatcode call, AND
-                        // 2. Either the call reverted, OR, when internal expect reverts are
+                        // 2. Either the call failed, OR, when internal expect reverts are
                         //    disabled, we made an external call (max_depth > depth), OR we're at
                         //    the root call (depth 0)
                         //
@@ -1442,8 +1444,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         // satisfying the expectation.
                         if cheatcode_call {
                             false
-                        } else if outcome.result.is_revert() {
-                            // Call reverted - should process
+                        } else if call_failed {
+                            // Call failed - should process
                             true
                         } else if !self.config.internal_expect_revert
                             && expected_revert.max_depth > expected_revert.depth

--- a/testdata/default/repros/Issue11559.t.sol
+++ b/testdata/default/repros/Issue11559.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "utils/Test.sol";
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+}
+
+// https://github.com/foundry-rs/foundry/issues/11559
+contract Issue11559Test is Test {
+    // When allow_internal_expect_revert is enabled, expectRevert should work with calls to
+    // non-contract addresses. Solidity 0.8+ automatically reverts after calling an address
+    // with no code due to return data validation, and this revert should satisfy the expectation.
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testExpectRevertCallToNonContractAddress() public {
+        vm.expectRevert();
+        IERC20(address(0)).totalSupply();
+    }
+
+    // Same test but with a specific revert message check
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testExpectRevertCallToNonContractAddressWithMessage() public {
+        // The revert message is injected by the RevertDiagnostic inspector
+        vm.expectRevert("call to non-contract address 0x0000000000000000000000000000000000000000");
+        IERC20(address(0)).totalSupply();
+    }
+}

--- a/testdata/default/repros/Issue7481.t.sol
+++ b/testdata/default/repros/Issue7481.t.sol
@@ -8,8 +8,10 @@ import "utils/Test.sol";
 contract Issue7481Test is Test {
     /// forge-config: default.allow_internal_expect_revert = true
     function testRevertTransact() public {
-        vm.expectRevert("vm.createSelectFork: invalid rpc url: mainnet");
-        vm.createSelectFork("mainnet", 19514903);
+        // Use a literal invalid URL (not an alias) so the failure is deterministic and not
+        // dependent on `[rpc_endpoints]` / RPC_MAINNET in the test environment.
+        vm.expectRevert("vm.createSelectFork: invalid rpc url: not-a-real-rpc");
+        vm.createSelectFork("not-a-real-rpc", 19514903);
 
         // Transfer some funds to sender of tx being transacted to ensure that it appears in journaled state
         (bool success,) = payable(address(0x5C60cD7a3D50877Bfebd484750FBeb245D936dAD)).call{value: 1}("");


### PR DESCRIPTION
## Summary

Fixes #11559.

When `allow_internal_expect_revert = true`, calling a non-contract address (e.g. `IERC20(address(0)).totalSupply()`) inside `expectRevert` would fail with *"next call did not revert as expected"*.

## Root cause

Calls to addresses with no code return immediately with `Stop`. The previous `call_end` logic consumed the `expectRevert` on this success, so when Solidity's generated extcodesize/returndata check then reverted, the expectation was already gone.

## Fix

In `call_end`, only consume the `expectRevert` when one of these holds:
1. the call actually failed, or
2. an external call went deeper (`max_depth > depth`), or
3. we're at the test function's root frame (catches dangling expectations), or
4. `internal_expect_revert` is disabled (preserves prior behavior).

With `internal_expect_revert` on, a same-depth success no longer eats the expectation, so Solidity's follow-up revert can satisfy it. The new repro lives in [`testdata/default/repros/Issue11559.t.sol`](testdata/default/repros/Issue11559.t.sol).

## Note on `Issue7481.t.sol`

The dangling-at-root processing (point 3 above) surfaces a latent issue in the existing `testRevertTransact` repro: it asserts the literal string `"vm.createSelectFork: invalid rpc url: mainnet"`, which only matched when CI's `RPC_MAINNET` happened to be unset/invalid. On master the dangling expectation was silently swallowed, hiding the brittleness. This PR makes the test deterministic by using a literal invalid URL instead of the `mainnet` alias.

The original #7481 panic (looped `vm.transact` on a real fork) was not actually exercised by that test before and is still not exercised after this change.