### PR TITLE
fix(lint): detect named ERC20 transfer args

### DIFF
--- a/crates/lint/src/sol/high/unchecked_calls.rs
+++ b/crates/lint/src/sol/high/unchecked_calls.rs
@@ -62,7 +62,7 @@ fn is_erc20_transfer_call(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
     // Ensure the expression is a call to a contract member function.
     let hir::ExprKind::Call(
         hir::Expr { kind: hir::ExprKind::Member(contract_expr, func_ident), .. },
-        hir::CallArgs { kind: hir::CallArgsKind::Unnamed(args), .. },
+        call_args,
         ..,
     ) = &expr.kind
     else {
@@ -70,9 +70,10 @@ fn is_erc20_transfer_call(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
     };
 
     // Determine the expected ERC20 signature from the call
+    let arity = call_args.len();
     let (expected_params, expected_returns): (&[&str], &[&str]) = match func_ident.as_str() {
-        "transferFrom" if args.len() == 3 => (&["address", "address", "uint256"], &["bool"]),
-        "transfer" if args.len() == 2 => (&["address", "uint256"], &["bool"]),
+        "transferFrom" if arity == 3 => (&["address", "address", "uint256"], &["bool"]),
+        "transfer" if arity == 2 => (&["address", "uint256"], &["bool"]),
         _ => return false,
     };
 

--- a/crates/lint/testdata/UncheckedTransferERC20.sol
+++ b/crates/lint/testdata/UncheckedTransferERC20.sol
@@ -28,11 +28,13 @@ contract UncheckedTransfer {
     function uncheckedTransfer(address to, uint256 amount) public {
         IERC20(address(token)).transfer(to, amount); //~WARN: ERC20 'transfer' and 'transferFrom' calls should check the return value
         token.transfer(to, amount); //~WARN: ERC20 'transfer' and 'transferFrom' calls should check the return value
+        token.transfer({to: to, amount: amount}); //~WARN: ERC20 'transfer' and 'transferFrom' calls should check the return value
     }
 
     function uncheckedTransferFrom(address from, address to, uint256 amount) public {
         IERC20(address(token)).transferFrom(from, to, amount); //~WARN: ERC20 'transfer' and 'transferFrom' calls should check the return value
         token.transferFrom(from, to, amount); //~WARN: ERC20 'transfer' and 'transferFrom' calls should check the return value
+        token.transferFrom({from: from, to: to, amount: amount}); //~WARN: ERC20 'transfer' and 'transferFrom' calls should check the return value
     }
 
     function uncheckedInLoop(address[] memory recipients, uint256[] memory amounts) public {
@@ -56,6 +58,10 @@ contract UncheckedTransfer {
     // SHOULD PASS: Properly checked transfer calls
     function checkedTransferWithRequire(address to, uint256 amount) public {
         require(token.transfer(to, amount), "Transfer failed");
+    }
+
+    function checkedTransferWithNamedArgs(address to, uint256 amount) public {
+        require(token.transfer({to: to, amount: amount}), "Transfer failed");
     }
 
     function checkedTransferWithVariable(address to, uint256 amount) public {

--- a/crates/lint/testdata/UncheckedTransferERC20.stderr
+++ b/crates/lint/testdata/UncheckedTransferERC20.stderr
@@ -57,6 +57,14 @@ LL │         token.transfer(to, amount);
 warning[erc20-unchecked-transfer]: ERC20 'transfer' and 'transferFrom' calls should check the return value
    ╭▸ ROOT/testdata/UncheckedTransferERC20.sol:LL:CC
    │
+LL │         token.transfer({to: to, amount: amount});
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/erc20-unchecked-transfer
+
+warning[erc20-unchecked-transfer]: ERC20 'transfer' and 'transferFrom' calls should check the return value
+   ╭▸ ROOT/testdata/UncheckedTransferERC20.sol:LL:CC
+   │
 LL │ …     IERC20(address(token)).transferFrom(from, to, amount);
    │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -67,6 +75,14 @@ warning[erc20-unchecked-transfer]: ERC20 'transfer' and 'transferFrom' calls sho
    │
 LL │         token.transferFrom(from, to, amount);
    │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/erc20-unchecked-transfer
+
+warning[erc20-unchecked-transfer]: ERC20 'transfer' and 'transferFrom' calls should check the return value
+   ╭▸ ROOT/testdata/UncheckedTransferERC20.sol:LL:CC
+   │
+LL │ …     token.transferFrom({from: from, to: to, amount: amount});
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/erc20-unchecked-transfer
 


### PR DESCRIPTION
## Summary

Teach the ERC20 unchecked-transfer lint to use the total call argument count instead of matching only positional call arguments. This lets it catch `transfer` and `transferFrom` calls written with Solidity named arguments.

## Details

The `unused-return` lint added in #14785 delegates ERC20 transfer calls to `erc20-unchecked-transfer`, but that lint previously ignored `CallArgsKind::Named`. The fixture now covers unchecked named-argument calls and a checked named-argument call so the behavior stays anchored.