### PR TITLE
fix(lint): cover delegatecall-loop followups

### DIFF
--- a/crates/lint/src/sol/low/delegatecall_loop.rs
+++ b/crates/lint/src/sol/low/delegatecall_loop.rs
@@ -5,12 +5,12 @@ use crate::{
 };
 use solar::{
     ast::{ElementaryType, LitKind, StateMutability, StrKind, TypeSize, Visibility},
-    interface::{Span, kw},
+    interface::{Span, kw, sym},
     sema::{
         Gcx, Ty,
         hir::{
-            Block, CallArgs, CallArgsKind, Expr, ExprKind, Function, FunctionId, Hir, ItemId,
-            Modifier, Res, Stmt, StmtKind, VariableId, Visit,
+            Block, CallArgs, CallArgsKind, ContractId, Expr, ExprKind, Function, FunctionId, Hir,
+            ItemId, Modifier, Res, Stmt, StmtKind, VariableId, Visit,
         },
         ty::TyKind,
     },
@@ -48,8 +48,9 @@ impl<'hir> LateLintPass<'hir> for DelegatecallLoop {
             placeholder: None,
             modifier_stack: Vec::new(),
             call_stack: Vec::new(),
+            current_contract: func.contract,
         };
-        checker.visit_modifier_chain(func.modifiers, 0, body);
+        checker.visit_modifier_chain(func.modifiers, 0, body, func.contract);
     }
 }
 
@@ -68,9 +69,10 @@ struct DelegatecallLoopChecker<'a, 's, 'hir> {
     placeholder: Option<ModifierContinuation<'hir>>,
     modifier_stack: Vec<FunctionId>,
     call_stack: Vec<FunctionId>,
+    current_contract: Option<ContractId>,
 }
 
-type ModifierContinuation<'hir> = (&'hir [Modifier<'hir>], usize, Block<'hir>);
+type ModifierContinuation<'hir> = (&'hir [Modifier<'hir>], usize, Block<'hir>, Option<ContractId>);
 
 impl<'a, 's, 'hir> DelegatecallLoopChecker<'a, 's, 'hir> {
     fn visit_modifier_chain(
@@ -78,33 +80,38 @@ impl<'a, 's, 'hir> DelegatecallLoopChecker<'a, 's, 'hir> {
         modifiers: &'hir [Modifier<'hir>],
         index: usize,
         body: Block<'hir>,
+        body_contract: Option<ContractId>,
     ) {
         // Walk modifiers as wrappers; `_` resumes the remaining modifiers and function body.
         let Some(modifier) = modifiers.get(index) else {
-            self.visit_block_with_placeholder(body, None);
+            self.visit_block_with_placeholder(body, None, body_contract);
             return;
         };
 
         let _ = self.visit_call_args(&modifier.args);
 
         let Some(modifier_id) = modifier.id.as_function() else {
-            self.visit_modifier_chain(modifiers, index + 1, body);
+            self.visit_modifier_chain(modifiers, index + 1, body, body_contract);
             return;
         };
 
         if self.modifier_stack.contains(&modifier_id) {
-            self.visit_modifier_chain(modifiers, index + 1, body);
+            self.visit_modifier_chain(modifiers, index + 1, body, body_contract);
             return;
         }
 
         let modifier_func = self.hir.function(modifier_id);
         let Some(modifier_body) = modifier_func.body else {
-            self.visit_modifier_chain(modifiers, index + 1, body);
+            self.visit_modifier_chain(modifiers, index + 1, body, body_contract);
             return;
         };
 
         self.modifier_stack.push(modifier_id);
-        self.visit_block_with_placeholder(modifier_body, Some((modifiers, index + 1, body)));
+        self.visit_block_with_placeholder(
+            modifier_body,
+            Some((modifiers, index + 1, body, body_contract)),
+            modifier_func.contract,
+        );
         self.modifier_stack.pop();
     }
 
@@ -118,10 +125,14 @@ impl<'a, 's, 'hir> DelegatecallLoopChecker<'a, 's, 'hir> {
         &mut self,
         block: Block<'hir>,
         placeholder: Option<ModifierContinuation<'hir>>,
+        current_contract: Option<ContractId>,
     ) {
         let previous = self.placeholder;
+        let previous_contract = self.current_contract;
         self.placeholder = placeholder;
+        self.current_contract = current_contract;
         self.visit_block_stmts(block);
+        self.current_contract = previous_contract;
         self.placeholder = previous;
     }
 }
@@ -140,8 +151,8 @@ impl<'hir> Visit<'hir> for DelegatecallLoopChecker<'_, '_, 'hir> {
             StmtKind::Loop(block, _) => self.visit_loop_block(block),
             // Modifier `_` executes at this statement, preserving the current loop context.
             StmtKind::Placeholder => {
-                if let Some((modifiers, index, body)) = self.placeholder {
-                    self.visit_modifier_chain(modifiers, index, body);
+                if let Some((modifiers, index, body, body_contract)) = self.placeholder {
+                    self.visit_modifier_chain(modifiers, index, body, body_contract);
                 }
                 ControlFlow::Continue(())
             }
@@ -189,7 +200,7 @@ impl<'hir> DelegatecallLoopChecker<'_, '_, 'hir> {
         let Some(body) = func.body else { return };
 
         self.call_stack.push(func_id);
-        self.visit_modifier_chain(func.modifiers, 0, body);
+        self.visit_modifier_chain(func.modifiers, 0, body, func.contract);
         self.call_stack.pop();
     }
 
@@ -244,17 +255,46 @@ impl<'hir> DelegatecallLoopChecker<'_, '_, 'hir> {
             return Vec::new();
         };
 
+        if is_builtin(base, sym::super_) {
+            return self.super_function_ids(member_name);
+        }
+
         reses
             .iter()
             .filter_map(|res| match res {
                 Res::Item(ItemId::Contract(contract_id)) => Some(*contract_id),
                 _ => None,
             })
-            .flat_map(|contract_id| {
-                self.hir.contract(contract_id).functions().filter(move |&func_id| {
-                    let func = self.hir.function(func_id);
-                    func.name.is_some_and(|name| name.name == member_name)
-                })
+            .flat_map(|contract_id| self.contract_function_ids(contract_id, member_name))
+            .collect()
+    }
+
+    fn super_function_ids(&self, member_name: solar::interface::Symbol) -> Vec<FunctionId> {
+        let Some(contract_id) = self.current_contract else {
+            return Vec::new();
+        };
+
+        for &base_id in self.hir.contract(contract_id).linearized_bases.iter().skip(1) {
+            let funcs = self.contract_function_ids(base_id, member_name);
+            if !funcs.is_empty() {
+                return funcs;
+            }
+        }
+
+        Vec::new()
+    }
+
+    fn contract_function_ids(
+        &self,
+        contract_id: ContractId,
+        member_name: solar::interface::Symbol,
+    ) -> Vec<FunctionId> {
+        self.hir
+            .contract(contract_id)
+            .functions()
+            .filter(|&func_id| {
+                let func = self.hir.function(func_id);
+                func.name.is_some_and(|name| name.name == member_name)
             })
             .collect()
     }
@@ -279,18 +319,15 @@ fn is_current_context_helper(func: &Function<'_>) -> bool {
 }
 
 fn is_this_or_super(expr: &Expr<'_>) -> bool {
+    is_builtin(expr, sym::this) || is_builtin(expr, sym::super_)
+}
+
+fn is_builtin(expr: &Expr<'_>, symbol: solar::interface::Symbol) -> bool {
     matches!(
         &expr.peel_parens().kind,
         ExprKind::Ident(reses)
             if reses.iter().any(|res| {
-                matches!(
-                    res,
-                    Res::Builtin(builtin)
-                        if matches!(
-                            builtin.name(),
-                            solar::interface::sym::this | solar::interface::sym::super_
-                        )
-                )
+                matches!(res, Res::Builtin(builtin) if builtin.name() == symbol)
             })
     )
 }
@@ -407,16 +444,31 @@ fn expr_ty<'gcx>(gcx: Gcx<'gcx>, hir: &Hir<'gcx>, expr: &Expr<'gcx>) -> Option<T
                 .collect::<Option<Vec<_>>>()?;
             Some(gcx.mk_ty_tuple(gcx.mk_tys(&tys)))
         }
+        ExprKind::Ternary(cond, true_expr, false_expr) => {
+            if !expr_ty(gcx, hir, cond)?.convert_implicit_to(gcx.types.bool, gcx) {
+                return None;
+            }
+
+            let true_ty = expr_ty(gcx, hir, true_expr)?;
+            let false_ty = expr_ty(gcx, hir, false_expr)?;
+            common_ty(gcx, true_ty, false_ty)
+        }
         ExprKind::Type(ty) | ExprKind::TypeCall(ty) => {
             let ty = gcx.type_of_hir_ty(ty);
             Some(gcx.mk_ty(TyKind::Type(ty)))
         }
         ExprKind::Unary(_, inner) => expr_ty(gcx, hir, inner),
-        ExprKind::Assign(..)
-        | ExprKind::Binary(..)
-        | ExprKind::Delete(..)
-        | ExprKind::Ternary(..)
-        | ExprKind::Err(_) => None,
+        ExprKind::Assign(..) | ExprKind::Binary(..) | ExprKind::Delete(..) | ExprKind::Err(_) => {
+            None
+        }
+    }
+}
+
+fn common_ty<'gcx>(gcx: Gcx<'gcx>, lhs: Ty<'gcx>, rhs: Ty<'gcx>) -> Option<Ty<'gcx>> {
+    if lhs.convert_implicit_to(rhs, gcx) {
+        Some(rhs)
+    } else {
+        rhs.convert_implicit_to(lhs, gcx).then_some(lhs)
     }
 }
 
@@ -444,18 +496,7 @@ fn member_ty<'gcx>(
     // Resolve `base.member` through semantic members while keeping `this`/`super`
     // out of address-builtin detection.
     let base_ty = match &base.peel_parens().kind {
-        ExprKind::Ident(reses)
-            if reses.iter().any(|res| {
-                matches!(
-                    res,
-                    Res::Builtin(builtin)
-                        if matches!(
-                            builtin.name(),
-                            solar::interface::sym::this | solar::interface::sym::super_
-                        )
-                )
-            }) =>
-        {
+        ExprKind::Ident(_) if is_this_or_super(base) => {
             return None;
         }
         _ => expr_ty(gcx, hir, base)?,

--- a/crates/lint/src/sol/low/delegatecall_loop.rs
+++ b/crates/lint/src/sol/low/delegatecall_loop.rs
@@ -48,6 +48,7 @@ impl<'hir> LateLintPass<'hir> for DelegatecallLoop {
             placeholder: None,
             modifier_stack: Vec::new(),
             call_stack: Vec::new(),
+            dispatch_contract: func.contract,
             current_contract: func.contract,
         };
         checker.visit_modifier_chain(func.modifiers, 0, body, func.contract);
@@ -69,6 +70,7 @@ struct DelegatecallLoopChecker<'a, 's, 'hir> {
     placeholder: Option<ModifierContinuation<'hir>>,
     modifier_stack: Vec<FunctionId>,
     call_stack: Vec<FunctionId>,
+    dispatch_contract: Option<ContractId>,
     current_contract: Option<ContractId>,
 }
 
@@ -270,11 +272,19 @@ impl<'hir> DelegatecallLoopChecker<'_, '_, 'hir> {
     }
 
     fn super_function_ids(&self, member_name: solar::interface::Symbol) -> Vec<FunctionId> {
-        let Some(contract_id) = self.current_contract else {
+        let (Some(dispatch_contract), Some(current_contract)) =
+            (self.dispatch_contract, self.current_contract)
+        else {
             return Vec::new();
         };
 
-        for &base_id in self.hir.contract(contract_id).linearized_bases.iter().skip(1) {
+        let linearized_bases = self.hir.contract(dispatch_contract).linearized_bases;
+        let Some(current_index) = linearized_bases.iter().position(|&id| id == current_contract)
+        else {
+            return Vec::new();
+        };
+
+        for &base_id in linearized_bases.iter().skip(current_index + 1) {
             let funcs = self.contract_function_ids(base_id, member_name);
             if !funcs.is_empty() {
                 return funcs;
@@ -444,11 +454,7 @@ fn expr_ty<'gcx>(gcx: Gcx<'gcx>, hir: &Hir<'gcx>, expr: &Expr<'gcx>) -> Option<T
                 .collect::<Option<Vec<_>>>()?;
             Some(gcx.mk_ty_tuple(gcx.mk_tys(&tys)))
         }
-        ExprKind::Ternary(cond, true_expr, false_expr) => {
-            if !expr_ty(gcx, hir, cond)?.convert_implicit_to(gcx.types.bool, gcx) {
-                return None;
-            }
-
+        ExprKind::Ternary(_, true_expr, false_expr) => {
             let true_ty = expr_ty(gcx, hir, true_expr)?;
             let false_ty = expr_ty(gcx, hir, false_expr)?;
             common_ty(gcx, true_ty, false_ty)

--- a/crates/lint/testdata/DelegatecallLoop.sol
+++ b/crates/lint/testdata/DelegatecallLoop.sol
@@ -29,7 +29,34 @@ contract ParentDelegatecallHelper {
     }
 }
 
-contract DelegatecallLoop is ParentOrdinaryDelegatecall, ParentDelegatecallHelper {
+contract LinearizedSuperBase {
+    function next(bytes calldata) internal virtual {}
+}
+
+contract LinearizedSuperDelegate is LinearizedSuperBase {
+    function next(bytes calldata payload) internal virtual override {
+        address target = address(this);
+        (bool ok,) = target.delegatecall(payload); //~WARN: payable functions should not use `delegatecall` inside a loop
+        require(ok);
+    }
+}
+
+contract LinearizedSuperCaller is LinearizedSuperBase {
+    function callNext(bytes calldata payload) internal {
+        super.next(payload);
+    }
+}
+
+contract DelegatecallLoop is
+    ParentOrdinaryDelegatecall,
+    ParentDelegatecallHelper,
+    LinearizedSuperDelegate,
+    LinearizedSuperCaller
+{
+    function next(bytes calldata payload) internal override(LinearizedSuperBase, LinearizedSuperDelegate) {
+        super.next(payload);
+    }
+
     function payableForLoop(bytes[] calldata payloads) external payable {
         address target = address(this);
         for (uint256 i = 0; i < payloads.length; ++i) {
@@ -149,6 +176,12 @@ contract DelegatecallLoop is ParentOrdinaryDelegatecall, ParentDelegatecallHelpe
         }
     }
 
+    function payableLoopWithLinearizedSuperDelegatecall(bytes[] calldata payloads) external payable {
+        for (uint256 i = 0; i < payloads.length; ++i) {
+            callNext(payloads[i]);
+        }
+    }
+
     function payableLoopWithCallAndStaticcall(bytes[] calldata payloads) external payable {
         address target = address(this);
         for (uint256 i = 0; i < payloads.length; ++i) {
@@ -212,6 +245,15 @@ contract DelegatecallLoop is ParentOrdinaryDelegatecall, ParentDelegatecallHelpe
         address targetB = address(0xBEEF);
         for (uint256 i = 0; i < payloads.length; ++i) {
             (bool ok,) = (flag ? targetA : targetB).delegatecall(payloads[i]); //~WARN: payable functions should not use `delegatecall` inside a loop
+            require(ok);
+        }
+    }
+
+    function payableLoopCallsConditionalDelegatecallWithBinaryCondition(bytes[] calldata payloads) external payable {
+        address targetA = address(this);
+        address targetB = address(0xBEEF);
+        for (uint256 i = 0; i < payloads.length; ++i) {
+            (bool ok,) = (payloads[i].length != 0 ? targetA : targetB).delegatecall(payloads[i]); //~WARN: payable functions should not use `delegatecall` inside a loop
             require(ok);
         }
     }

--- a/crates/lint/testdata/DelegatecallLoop.sol
+++ b/crates/lint/testdata/DelegatecallLoop.sol
@@ -21,7 +21,15 @@ contract ParentOrdinaryDelegatecall {
     }
 }
 
-contract DelegatecallLoop is ParentOrdinaryDelegatecall {
+contract ParentDelegatecallHelper {
+    function superDelegate(bytes calldata payload) internal {
+        address target = address(this);
+        (bool ok,) = target.delegatecall(payload); //~WARN: payable functions should not use `delegatecall` inside a loop
+        require(ok);
+    }
+}
+
+contract DelegatecallLoop is ParentOrdinaryDelegatecall, ParentDelegatecallHelper {
     function payableForLoop(bytes[] calldata payloads) external payable {
         address target = address(this);
         for (uint256 i = 0; i < payloads.length; ++i) {
@@ -135,6 +143,12 @@ contract DelegatecallLoop is ParentOrdinaryDelegatecall {
         require(ok);
     }
 
+    function payableLoopWithSuperInternalDelegatecall(bytes[] calldata payloads) external payable {
+        for (uint256 i = 0; i < payloads.length; ++i) {
+            super.superDelegate(payloads[i]);
+        }
+    }
+
     function payableLoopWithCallAndStaticcall(bytes[] calldata payloads) external payable {
         address target = address(this);
         for (uint256 i = 0; i < payloads.length; ++i) {
@@ -190,6 +204,15 @@ contract DelegatecallLoop is ParentOrdinaryDelegatecall {
     function payableLoopCallsSuperDelegatecall(bytes[] calldata payloads) external payable {
         for (uint256 i = 0; i < payloads.length; ++i) {
             require(super.delegatecall(payloads[i]));
+        }
+    }
+
+    function payableLoopCallsConditionalDelegatecall(bytes[] calldata payloads, bool flag) external payable {
+        address targetA = address(this);
+        address targetB = address(0xBEEF);
+        for (uint256 i = 0; i < payloads.length; ++i) {
+            (bool ok,) = (flag ? targetA : targetB).delegatecall(payloads[i]); //~WARN: payable functions should not use `delegatecall` inside a loop
+            require(ok);
         }
     }
 

--- a/crates/lint/testdata/DelegatecallLoop.stderr
+++ b/crates/lint/testdata/DelegatecallLoop.stderr
@@ -86,3 +86,19 @@ LL │         (bool ok,) = target.delegatecall(payload);
    │
    ╰ help: https://getfoundry.sh/forge/linting/delegatecall-loop
 
+warning[delegatecall-loop]: payable functions should not use `delegatecall` inside a loop
+   ╭▸ ROOT/testdata/DelegatecallLoop.sol:LL:CC
+   │
+LL │         (bool ok,) = target.delegatecall(payload);
+   │                      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/delegatecall-loop
+
+warning[delegatecall-loop]: payable functions should not use `delegatecall` inside a loop
+   ╭▸ ROOT/testdata/DelegatecallLoop.sol:LL:CC
+   │
+LL │ …     (bool ok,) = (flag ? targetA : targetB).delegatecall(payloads[i]);
+   │                    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/delegatecall-loop
+

--- a/crates/lint/testdata/DelegatecallLoop.stderr
+++ b/crates/lint/testdata/DelegatecallLoop.stderr
@@ -97,8 +97,24 @@ LL │         (bool ok,) = target.delegatecall(payload);
 warning[delegatecall-loop]: payable functions should not use `delegatecall` inside a loop
    ╭▸ ROOT/testdata/DelegatecallLoop.sol:LL:CC
    │
+LL │         (bool ok,) = target.delegatecall(payload);
+   │                      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/delegatecall-loop
+
+warning[delegatecall-loop]: payable functions should not use `delegatecall` inside a loop
+   ╭▸ ROOT/testdata/DelegatecallLoop.sol:LL:CC
+   │
 LL │ …     (bool ok,) = (flag ? targetA : targetB).delegatecall(payloads[i]);
    │                    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/delegatecall-loop
+
+warning[delegatecall-loop]: payable functions should not use `delegatecall` inside a loop
+   ╭▸ ROOT/testdata/DelegatecallLoop.sol:LL:CC
+   │
+LL │ …     (bool ok,) = (payloads[i].length != 0 ? targetA : targetB).delegatecall(payloads[i]);
+   │                    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/delegatecall-loop
 


### PR DESCRIPTION
## Summary
- infer a conservative common type for ternary expressions used as delegatecall receivers
- resolve `super.<helper>(...)` internal calls while tracking the active contract during helper and modifier traversal
- add delegatecall-loop UI coverage for conditional address receivers and inherited `super` helpers

## Context
Follow-up to #14752 and the review notes in https://github.com/foundry-rs/foundry/pull/14752#pullrequestreview-4318566533.