### PR TITLE
ci: add stale PR workflow

### DIFF
--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -44,16 +44,6 @@ jobs:
             "$close_marker" \
             "Closing this pull request because it had no activity for ${CLOSE_AFTER_DAYS} days after being marked stale. Please reopen it or open a new pull request if it is still relevant."
 
-          gh label create "$STALE_LABEL" \
-            --color BFDADC \
-            --description "Pull requests pending stale closure" \
-            --force
-
-          gh label create "$STOP_STALE_LABEL" \
-            --color 0E8A16 \
-            --description "Prevent stale automation from closing this pull request" \
-            --force
-
           stale_cutoff_ts="$(date -u -d "${STALE_AFTER_DAYS} days ago" +%s)"
           close_after_seconds="$((CLOSE_AFTER_DAYS * 24 * 60 * 60))"
 

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -10,7 +10,7 @@ on:
 permissions: {}
 
 jobs:
-  close-prs:
+  stale-prs:
     if: github.repository == 'foundry-rs/foundry'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: stale-prs
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   stale-prs:

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,157 @@
+name: stale-prs
+
+permissions: {}
+
+on:
+  schedule:
+    - cron: "15 4 * * *" # Run daily at 4:15 AM UTC.
+  workflow_dispatch:
+
+concurrency:
+  group: stale-prs
+  cancel-in-progress: true
+
+jobs:
+  stale-prs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      STALE_AFTER_DAYS: "14"
+      CLOSE_AFTER_DAYS: "7"
+      STALE_LABEL: stale
+      STOP_STALE_LABEL: stop-stale
+    steps:
+      - name: Mark and close stale PRs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          stale_marker="<!-- foundry-stale-pr -->"
+          close_marker="<!-- foundry-stale-pr-close -->"
+          activity_grace_seconds=600
+
+          printf -v stale_body '%s\n%s\n\n%s' \
+            "$stale_marker" \
+            "This pull request has been open for more than ${STALE_AFTER_DAYS} days, so it has been marked as stale." \
+            "It will be closed in ${CLOSE_AFTER_DAYS} days if there is no further activity. Further activity will add the \`${STOP_STALE_LABEL}\` label and keep it open."
+
+          printf -v close_body '%s\n%s' \
+            "$close_marker" \
+            "Closing this pull request because it had no activity for ${CLOSE_AFTER_DAYS} days after being marked stale. Please reopen it or open a new pull request if it is still relevant."
+
+          gh label create "$STALE_LABEL" \
+            --color BFDADC \
+            --description "Pull requests pending stale closure" \
+            --force
+
+          gh label create "$STOP_STALE_LABEL" \
+            --color 0E8A16 \
+            --description "Prevent stale automation from closing this pull request" \
+            --force
+
+          stale_cutoff_ts="$(date -u -d "${STALE_AFTER_DAYS} days ago" +%s)"
+          close_after_seconds="$((CLOSE_AFTER_DAYS * 24 * 60 * 60))"
+
+          has_label() {
+            local pr_json="$1"
+            local label="$2"
+
+            jq -e --arg label "$label" 'any(.labels[].name; . == $label)' <<< "$pr_json" > /dev/null
+          }
+
+          latest_stale_comment_at() {
+            local number="$1"
+
+            gh api --paginate "repos/${GH_REPO}/issues/${number}/comments?per_page=100" \
+              --jq '.[] | select(.body | contains("'"${stale_marker}"'")) | .created_at' \
+              | tail -n 1
+          }
+
+          mark_stale() {
+            local number="$1"
+            local url="$2"
+            local created_at="$3"
+
+            echo "Marking PR #${number} as stale, created at ${created_at}: ${url}"
+            gh issue edit "$number" --add-label "$STALE_LABEL"
+            gh issue comment "$number" --body "$stale_body"
+          }
+
+          close_stale() {
+            local number="$1"
+            local url="$2"
+
+            echo "Closing stale PR #${number}: ${url}"
+            gh issue comment "$number" --body "$close_body"
+            gh api -X PATCH "repos/${GH_REPO}/issues/${number}" -f state=closed
+          }
+
+          stop_stale() {
+            local number="$1"
+            local url="$2"
+
+            echo "PR #${number} had activity after stale warning, adding ${STOP_STALE_LABEL}: ${url}"
+            gh issue edit "$number" --remove-label "$STALE_LABEL" --add-label "$STOP_STALE_LABEL"
+          }
+
+          found=false
+
+          while read -r encoded_pr; do
+            found=true
+            pr_json="$(base64 --decode <<< "$encoded_pr")"
+            number="$(jq -r '.number' <<< "$pr_json")"
+            url="$(jq -r '.html_url' <<< "$pr_json")"
+            created_at="$(jq -r '.created_at' <<< "$pr_json")"
+            updated_at="$(jq -r '.updated_at' <<< "$pr_json")"
+            created_ts="$(date -u -d "$created_at" +%s)"
+
+            if has_label "$pr_json" "$STOP_STALE_LABEL"; then
+              if has_label "$pr_json" "$STALE_LABEL"; then
+                echo "Removing ${STALE_LABEL} from PR #${number}; ${STOP_STALE_LABEL} is present: ${url}"
+                gh issue edit "$number" --remove-label "$STALE_LABEL"
+              fi
+
+              echo "Skipping PR #${number}; it already has ${STOP_STALE_LABEL}: ${url}"
+              continue
+            fi
+
+            if ! has_label "$pr_json" "$STALE_LABEL"; then
+              if (( created_ts <= stale_cutoff_ts )); then
+                mark_stale "$number" "$url" "$created_at"
+              else
+                echo "Skipping PR #${number}; it is not older than ${STALE_AFTER_DAYS} days: ${url}"
+              fi
+
+              continue
+            fi
+
+            marked_at="$(latest_stale_comment_at "$number")"
+            if [[ -z "$marked_at" ]]; then
+              mark_stale "$number" "$url" "$created_at"
+              continue
+            fi
+
+            marked_ts="$(date -u -d "$marked_at" +%s)"
+            updated_ts="$(date -u -d "$updated_at" +%s)"
+
+            if (( updated_ts > marked_ts + activity_grace_seconds )); then
+              stop_stale "$number" "$url"
+              continue
+            fi
+
+            if (( $(date -u +%s) >= marked_ts + close_after_seconds )); then
+              close_stale "$number" "$url"
+              continue
+            fi
+
+            echo "PR #${number} is stale but still within the ${CLOSE_AFTER_DAYS}-day close window: ${url}"
+          done < <(gh api --paginate "repos/${GH_REPO}/pulls?state=open&sort=created&direction=asc&per_page=100" --jq '.[] | @base64')
+
+          if [[ "$found" == false ]]; then
+            echo "No open pull requests found."
+          fi

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,147 +1,33 @@
-name: stale-prs
+# Marks pull requests as stale.
+
+name: stale PRs
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "30 1 * * *"
 
 permissions: {}
 
-on:
-  schedule:
-    - cron: "15 4 * * *" # Run daily at 4:15 AM UTC.
-  workflow_dispatch:
-
-concurrency:
-  group: stale-prs
-  cancel-in-progress: false
-
 jobs:
-  stale-prs:
+  close-prs:
+    if: github.repository == 'foundry-rs/foundry'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     permissions:
       issues: write
       pull-requests: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-      GH_REPO: ${{ github.repository }}
-      STALE_AFTER_DAYS: "14"
-      CLOSE_AFTER_DAYS: "7"
-      STALE_LABEL: stale
-      STOP_STALE_LABEL: stop-stale
     steps:
-      - name: Mark and close stale PRs
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          stale_marker="<!-- foundry-stale-pr -->"
-          close_marker="<!-- foundry-stale-pr-close -->"
-          activity_grace_seconds=600
-
-          printf -v stale_body '%s\n%s\n\n%s' \
-            "$stale_marker" \
-            "This pull request has been open for more than ${STALE_AFTER_DAYS} days, so it has been marked as stale." \
-            "It will be closed in ${CLOSE_AFTER_DAYS} days if there is no further activity. Further activity will add the \`${STOP_STALE_LABEL}\` label and keep it open."
-
-          printf -v close_body '%s\n%s' \
-            "$close_marker" \
-            "Closing this pull request because it had no activity for ${CLOSE_AFTER_DAYS} days after being marked stale. Please reopen it or open a new pull request if it is still relevant."
-
-          stale_cutoff_ts="$(date -u -d "${STALE_AFTER_DAYS} days ago" +%s)"
-          close_after_seconds="$((CLOSE_AFTER_DAYS * 24 * 60 * 60))"
-
-          has_label() {
-            local pr_json="$1"
-            local label="$2"
-
-            jq -e --arg label "$label" 'any(.labels[].name; . == $label)' <<< "$pr_json" > /dev/null
-          }
-
-          latest_stale_comment_at() {
-            local number="$1"
-
-            gh api --paginate "repos/${GH_REPO}/issues/${number}/comments?per_page=100" \
-              --jq '.[] | select(.body | contains("'"${stale_marker}"'")) | .created_at' \
-              | tail -n 1
-          }
-
-          mark_stale() {
-            local number="$1"
-            local url="$2"
-            local created_at="$3"
-
-            echo "Marking PR #${number} as stale, created at ${created_at}: ${url}"
-            gh issue edit "$number" --add-label "$STALE_LABEL"
-            gh issue comment "$number" --body "$stale_body"
-          }
-
-          close_stale() {
-            local number="$1"
-            local url="$2"
-
-            echo "Closing stale PR #${number}: ${url}"
-            gh issue comment "$number" --body "$close_body"
-            gh api -X PATCH "repos/${GH_REPO}/issues/${number}" -f state=closed
-          }
-
-          stop_stale() {
-            local number="$1"
-            local url="$2"
-
-            echo "PR #${number} had activity after stale warning, adding ${STOP_STALE_LABEL}: ${url}"
-            gh issue edit "$number" --remove-label "$STALE_LABEL" --add-label "$STOP_STALE_LABEL"
-          }
-
-          found=false
-
-          while read -r encoded_pr; do
-            found=true
-            pr_json="$(base64 --decode <<< "$encoded_pr")"
-            number="$(jq -r '.number' <<< "$pr_json")"
-            url="$(jq -r '.html_url' <<< "$pr_json")"
-            created_at="$(jq -r '.created_at' <<< "$pr_json")"
-            updated_at="$(jq -r '.updated_at' <<< "$pr_json")"
-            created_ts="$(date -u -d "$created_at" +%s)"
-
-            if has_label "$pr_json" "$STOP_STALE_LABEL"; then
-              if has_label "$pr_json" "$STALE_LABEL"; then
-                echo "Removing ${STALE_LABEL} from PR #${number}; ${STOP_STALE_LABEL} is present: ${url}"
-                gh issue edit "$number" --remove-label "$STALE_LABEL"
-              fi
-
-              echo "Skipping PR #${number}; it already has ${STOP_STALE_LABEL}: ${url}"
-              continue
-            fi
-
-            if ! has_label "$pr_json" "$STALE_LABEL"; then
-              if (( created_ts <= stale_cutoff_ts )); then
-                mark_stale "$number" "$url" "$created_at"
-              else
-                echo "Skipping PR #${number}; it is not older than ${STALE_AFTER_DAYS} days: ${url}"
-              fi
-
-              continue
-            fi
-
-            marked_at="$(latest_stale_comment_at "$number")"
-            if [[ -z "$marked_at" ]]; then
-              mark_stale "$number" "$url" "$created_at"
-              continue
-            fi
-
-            marked_ts="$(date -u -d "$marked_at" +%s)"
-            updated_ts="$(date -u -d "$updated_at" +%s)"
-
-            if (( updated_ts > marked_ts + activity_grace_seconds )); then
-              stop_stale "$number" "$url"
-              continue
-            fi
-
-            if (( $(date -u +%s) >= marked_ts + close_after_seconds )); then
-              close_stale "$number" "$url"
-              continue
-            fi
-
-            echo "PR #${number} is stale but still within the ${CLOSE_AFTER_DAYS}-day close window: ${url}"
-          done < <(gh api --paginate "repos/${GH_REPO}/pulls?state=open&sort=created&direction=asc&per_page=100" --jq '.[] | @base64')
-
-          if [[ "$found" == false ]]; then
-            echo "No open pull requests found."
-          fi
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          stale-pr-label: "stale"
+          exempt-pr-labels: "stop-stale"
+          stale-pr-message: "This pull request is stale because it has been open for 14 days with no activity. It will be closed in 7 days if there is no further activity."
+          close-pr-message: "This pull request was closed because it has been inactive for 7 days since being marked as stale."
+          labels-to-add-when-unstale: "stop-stale"
+          exempt-all-milestones: true
+          exempt-all-assignees: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -30,4 +30,3 @@ jobs:
           labels-to-add-when-unstale: "stop-stale"
           exempt-all-milestones: true
           exempt-all-assignees: true
-          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add a scheduled `stale-prs` workflow that runs daily and can be triggered manually.
- Mark PRs as `stale` after they have been open for 14 days.
- Close stale PRs after 7 more days with no activity, and add `stop-stale` when activity happens after the stale warning.

## Testing

- Parsed the workflow YAML with Ruby.
- Ran `bash -n` against the embedded shell script.
- Ran `shellcheck` against the embedded shell script.