### PR TITLE
feat(symbolic): add solver selection plumbing

### DIFF
--- a/crates/config/src/inline/natspec.rs
+++ b/crates/config/src/inline/natspec.rs
@@ -145,10 +145,10 @@ impl NatSpec {
 }
 
 fn translate_halmos_config(args: &str, values: &mut Vec<String>) -> Result<(), String> {
-    let tokens = args.split_whitespace().collect::<Vec<_>>();
+    let tokens = split_halmos_args(args)?;
     let mut idx = 0;
     while idx < tokens.len() {
-        let token = tokens[idx];
+        let token = tokens[idx].as_str();
         if token == "--array-lengths" {
             idx += 1;
             let Some(value) = tokens.get(idx) else {
@@ -193,6 +193,22 @@ fn translate_halmos_config(args: &str, values: &mut Vec<String>) -> Result<(), S
             push_halmos_u32(values, "timeout", value, "--solver-timeout-branching")?;
         } else if let Some(value) = token.strip_prefix("--solver-timeout-assertion=") {
             push_halmos_u32(values, "timeout", value, "--solver-timeout-assertion")?;
+        } else if token == "--solver" {
+            idx += 1;
+            let Some(value) = tokens.get(idx) else {
+                return Err("missing value for --solver".to_string());
+            };
+            push_halmos_string(values, "solver", value);
+        } else if let Some(value) = token.strip_prefix("--solver=") {
+            push_halmos_string(values, "solver", value);
+        } else if token == "--solver-command" {
+            idx += 1;
+            let Some(value) = tokens.get(idx) else {
+                return Err("missing value for --solver-command".to_string());
+            };
+            push_halmos_string(values, "solver_command", value);
+        } else if let Some(value) = token.strip_prefix("--solver-command=") {
+            push_halmos_string(values, "solver_command", value);
         } else if token.starts_with("--")
             && tokens.get(idx + 1).is_some_and(|next| !next.starts_with("--"))
         {
@@ -201,6 +217,54 @@ fn translate_halmos_config(args: &str, values: &mut Vec<String>) -> Result<(), S
         idx += 1;
     }
     Ok(())
+}
+
+fn split_halmos_args(args: &str) -> Result<Vec<String>, String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+
+    for ch in args.chars() {
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if let Some(quote_ch) = quote {
+            if ch == quote_ch {
+                quote = None;
+            } else {
+                current.push(ch);
+            }
+            continue;
+        }
+        if matches!(ch, '"' | '\'') {
+            quote = Some(ch);
+        } else if ch.is_whitespace() {
+            if !current.is_empty() {
+                tokens.push(std::mem::take(&mut current));
+            }
+        } else {
+            current.push(ch);
+        }
+    }
+
+    if let Some(quote_ch) = quote {
+        return Err(format!("unterminated {quote_ch} quote in @custom:halmos config"));
+    }
+    if escaped {
+        current.push('\\');
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    Ok(tokens)
 }
 
 fn halmos_numeric_symbolic_field(flag: &str) -> Option<&'static str> {
@@ -258,6 +322,14 @@ fn push_halmos_u32(
 ) -> Result<(), String> {
     values.push(format!("default.symbolic.{field} = {}", parse_halmos_u32(value, flag)?));
     Ok(())
+}
+
+fn push_halmos_string(values: &mut Vec<String>, field: &str, value: &str) {
+    values.push(format!("default.symbolic.{field} = {}", toml_string(value)));
+}
+
+fn toml_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
 fn parse_halmos_u32(value: &str, flag: &str) -> Result<u32, String> {
@@ -921,6 +993,25 @@ contract FuzzInlineConf is DSTest {
                 "default.symbolic.width = 32",
                 "default.symbolic.depth = 128",
                 "default.symbolic.timeout = 5",
+            ]
+        );
+    }
+
+    #[test]
+    fn translates_legacy_halmos_solver_selection() {
+        let natspec = NatSpec {
+            contract: "dir/TestContract.t.sol:SymbolicContract".to_string(),
+            function: Some("check_solver".to_string()),
+            line: "10:1".to_string(),
+            docs: "@custom:halmos --solver cvc5 --solver-command \"bitwuzla --produce-models\""
+                .to_string(),
+        };
+
+        assert_eq!(
+            natspec.halmos_config_values().unwrap(),
+            vec![
+                "default.symbolic.solver = \"cvc5\"",
+                "default.symbolic.solver_command = \"bitwuzla --produce-models\"",
             ]
         );
     }

--- a/crates/config/src/inline/natspec.rs
+++ b/crates/config/src/inline/natspec.rs
@@ -1,4 +1,5 @@
 use super::{INLINE_CONFIG_PREFIX, InlineConfigError, InlineConfigErrorKind};
+use crate::split_quoted_args;
 use figment::Profile;
 use foundry_compilers::{
     ProjectCompileOutput,
@@ -220,51 +221,7 @@ fn translate_halmos_config(args: &str, values: &mut Vec<String>) -> Result<(), S
 }
 
 fn split_halmos_args(args: &str) -> Result<Vec<String>, String> {
-    let mut tokens = Vec::new();
-    let mut current = String::new();
-    let mut quote = None;
-    let mut escaped = false;
-
-    for ch in args.chars() {
-        if escaped {
-            current.push(ch);
-            escaped = false;
-            continue;
-        }
-        if ch == '\\' {
-            escaped = true;
-            continue;
-        }
-        if let Some(quote_ch) = quote {
-            if ch == quote_ch {
-                quote = None;
-            } else {
-                current.push(ch);
-            }
-            continue;
-        }
-        if matches!(ch, '"' | '\'') {
-            quote = Some(ch);
-        } else if ch.is_whitespace() {
-            if !current.is_empty() {
-                tokens.push(std::mem::take(&mut current));
-            }
-        } else {
-            current.push(ch);
-        }
-    }
-
-    if let Some(quote_ch) = quote {
-        return Err(format!("unterminated {quote_ch} quote in @custom:halmos config"));
-    }
-    if escaped {
-        current.push('\\');
-    }
-    if !current.is_empty() {
-        tokens.push(current);
-    }
-
-    Ok(tokens)
+    split_quoted_args(args, "@custom:halmos config")
 }
 
 fn halmos_numeric_symbolic_field(flag: &str) -> Option<&'static str> {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -7323,6 +7323,8 @@ mod tests {
                 src = "src"
 
                 [profile.default.symbolic]
+                solver_command = "z3 -in -smt2"
+                solver_portfolio = ["z3", "cvc5"]
                 loop = 4
                 depth = 100
                 width = 8

--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -50,6 +50,8 @@ const DOC_KEYS: &[&str] = &["out", "title", "book", "homepage", "repository", "p
 const SYMBOLIC_KEYS: &[&str] = &[
     "enabled",
     "solver",
+    "solver_command",
+    "solver_portfolio",
     "timeout",
     "loop",
     "depth",

--- a/crates/config/src/symbolic.rs
+++ b/crates/config/src/symbolic.rs
@@ -21,6 +21,12 @@ pub struct SymbolicConfig {
     pub enabled: bool,
     /// Solver executable to invoke.
     pub solver: String,
+    /// Exact solver command to invoke. When set, this overrides `solver`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub solver_command: Option<String>,
+    /// Solver names or exact commands to race in parallel. Ignored when `solver_command` is set.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub solver_portfolio: Vec<String>,
     /// Optional timeout in seconds for solver-backed symbolic execution.
     pub timeout: Option<u32>,
     /// Halmos-compatible loop bound accepted by config and annotations.
@@ -70,6 +76,8 @@ impl Default for SymbolicConfig {
         Self {
             enabled: false,
             solver: "z3".to_string(),
+            solver_command: None,
+            solver_portfolio: Vec::new(),
             timeout: Some(30),
             loop_bound: None,
             depth: None,

--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -118,6 +118,67 @@ pub fn to_array_value(val: &str) -> Result<Value, figment::Error> {
     Ok(value)
 }
 
+/// Splits a shell-like argument string into argv parts without invoking a shell.
+///
+/// This supports whitespace separation, single and double quotes, and backslash escaping. It is
+/// intentionally smaller than a shell parser: expansions, redirection, pipelines, and command
+/// separators are treated as plain argument text by callers.
+pub fn split_quoted_args(args: &str, context: &str) -> Result<Vec<String>, String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+    let mut token_started = false;
+
+    for ch in args.chars() {
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            token_started = true;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            token_started = true;
+            continue;
+        }
+        if let Some(quote_ch) = quote {
+            if ch == quote_ch {
+                quote = None;
+            } else {
+                current.push(ch);
+            }
+            token_started = true;
+            continue;
+        }
+        if matches!(ch, '"' | '\'') {
+            quote = Some(ch);
+            token_started = true;
+        } else if ch.is_whitespace() {
+            if token_started {
+                parts.push(std::mem::take(&mut current));
+                token_started = false;
+            }
+        } else {
+            current.push(ch);
+            token_started = true;
+        }
+    }
+
+    if let Some(quote_ch) = quote {
+        return Err(format!("unterminated {quote_ch} quote in {context}"));
+    }
+    if escaped {
+        current.push('\\');
+        token_started = true;
+    }
+    if token_started {
+        parts.push(current);
+    }
+
+    Ok(parts)
+}
+
 /// Returns a list of _unique_ paths to all folders under `root` that contain a `foundry.toml` file
 ///
 /// This will also resolve symlinks

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -207,28 +207,33 @@ FOUNDRY_SYMBOLIC_TIMEOUT=120 forge test --symbolic
 ```
 
 Known solver names are `z3`, `yices`, `cvc5`, `cvc5-int`, `bitwuzla`, and
-`bitwuzla-abs`. Unknown `symbolic.solver` values are treated as z3-compatible
+`bitwuzla-abs`. Versioned aliases are provided for the solver versions this
+backend has been checked against, including `yices-2.7.0`, `cvc5-1.3.4`, and
+`bitwuzla-0.9.0`. Unknown `symbolic.solver` values are treated as z3-compatible
 executables and are invoked with `-in -smt2` to preserve the old
 `symbolic.solver = "/path/to/z3"` behavior. Use `symbolic.solver_command` for
 non-z3-compatible command lines or wrapper tools.
 
-`symbolic.solver_portfolio` runs multiple solvers in parallel for each SMT query
-and uses the first `sat` or `unsat` response. `unknown` results only win if no
-configured solver returns a decisive response. A nonempty `symbolic.solver_command`
-overrides both `symbolic.solver_portfolio` and `symbolic.solver`; otherwise a
-nonempty portfolio overrides `symbolic.solver`. Portfolio entries without
-whitespace, quotes, or backslashes are resolved like `symbolic.solver` values.
-Entries with whitespace, quotes, or backslashes are split into argv parts like
+`symbolic.solver_portfolio` runs multiple solvers in parallel for each SMT query.
+The first `sat` response wins after its model is validated for model-producing
+queries. `unsat` responses are used only if no configured solver returns `sat`,
+and `unknown` results only win if no configured solver returns a decisive
+response. A nonempty `symbolic.solver_command` overrides both
+`symbolic.solver_portfolio` and `symbolic.solver`; otherwise a nonempty
+portfolio overrides `symbolic.solver`. Portfolio entries without whitespace,
+quotes, or backslashes are resolved like `symbolic.solver` values. Entries with
+whitespace, quotes, or backslashes are split into argv parts like
 `symbolic.solver_command`; they are not executed through a shell.
 For latency-sensitive local runs, start with a small portfolio such as
 `["yices", "z3"]`. Broader portfolios can help on solver-diverse workloads but
 use more CPU and can be slower when one fast solver already handles most
 queries.
 
-Security note: `symbolic.solver_command` and `symbolic.solver_portfolio` execute
-local programs when symbolic tests run. This also applies when these values come
-from inline `forge-config:` or translated legacy `@custom:halmos` annotations.
-Review solver settings before running symbolic tests from untrusted projects.
+Security note: `symbolic.solver_command`, custom `symbolic.solver` values, and
+custom or command-like `symbolic.solver_portfolio` entries execute local programs
+when symbolic tests run. This also applies when these values come from inline
+`forge-config:` or translated legacy `@custom:halmos` annotations. Review solver
+settings before running symbolic tests from untrusted projects.
 Timeouts and portfolio cancellation terminate only the direct solver child
 process. Wrapper commands should forward termination to any subprocesses they
 spawn and close inherited stdout/stderr so descendant solvers do not outlive the

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -153,7 +153,7 @@ solver = "z3"
 # Optional solver names or commands to race in parallel. Ignored when
 # `solver_command` is set. Entries with spaces/quotes/backslashes are parsed as
 # argv strings, not shell snippets.
-# solver_portfolio = ["z3", "cvc5", "bitwuzla"]
+# solver_portfolio = ["yices", "z3"]
 timeout = 30
 max_depth = 10000
 max_paths = 1024
@@ -192,7 +192,7 @@ forge test --symbolic --symbolic-solver yices
 forge test --symbolic --symbolic-solver cvc5
 forge test --symbolic --symbolic-solver bitwuzla
 forge test --symbolic --symbolic-solver-command "z3 -in -smt2"
-forge test --symbolic --symbolic-solver-portfolio z3,cvc5,bitwuzla
+forge test --symbolic --symbolic-solver-portfolio yices,z3
 forge test --symbolic --symbolic-timeout 120
 forge test --symbolic --symbolic-array-lengths 2,4
 forge test --symbolic --symbolic-invariant-depth 6
@@ -202,7 +202,7 @@ forge test --symbolic --symbolic-dump-smt
 FOUNDRY_SYMBOLIC=true forge test
 FOUNDRY_SYMBOLIC_SOLVER=z3 forge test --symbolic
 FOUNDRY_SYMBOLIC_SOLVER_COMMAND="z3 -in -smt2" forge test --symbolic
-FOUNDRY_SYMBOLIC_SOLVER_PORTFOLIO="z3,cvc5,bitwuzla" forge test --symbolic
+FOUNDRY_SYMBOLIC_SOLVER_PORTFOLIO="yices,z3" forge test --symbolic
 FOUNDRY_SYMBOLIC_TIMEOUT=120 forge test --symbolic
 ```
 
@@ -220,6 +220,10 @@ nonempty portfolio overrides `symbolic.solver`. Portfolio entries without
 whitespace, quotes, or backslashes are resolved like `symbolic.solver` values.
 Entries with whitespace, quotes, or backslashes are split into argv parts like
 `symbolic.solver_command`; they are not executed through a shell.
+For latency-sensitive local runs, start with a small portfolio such as
+`["yices", "z3"]`. Broader portfolios can help on solver-diverse workloads but
+use more CPU and can be slower when one fast solver already handles most
+queries.
 
 Security note: `symbolic.solver_command` and `symbolic.solver_portfolio` execute
 local programs when symbolic tests run. This also applies when these values come

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -148,6 +148,12 @@ The primary configuration path is native Foundry config.
 ```toml
 [profile.default.symbolic]
 solver = "z3"
+# Optional exact command. When set, this overrides `solver`.
+# solver_command = "z3 -in -smt2"
+# Optional solver names or commands to race in parallel. Ignored when
+# `solver_command` is set. Entries with spaces/quotes/backslashes are parsed as
+# argv strings, not shell snippets.
+# solver_portfolio = ["z3", "cvc5", "bitwuzla"]
 timeout = 30
 max_depth = 10000
 max_paths = 1024
@@ -182,6 +188,11 @@ Common CLI and environment overrides:
 
 ```sh
 forge test --symbolic
+forge test --symbolic --symbolic-solver yices
+forge test --symbolic --symbolic-solver cvc5
+forge test --symbolic --symbolic-solver bitwuzla
+forge test --symbolic --symbolic-solver-command "z3 -in -smt2"
+forge test --symbolic --symbolic-solver-portfolio z3,cvc5,bitwuzla
 forge test --symbolic --symbolic-timeout 120
 forge test --symbolic --symbolic-array-lengths 2,4
 forge test --symbolic --symbolic-invariant-depth 6
@@ -190,8 +201,30 @@ forge test --symbolic --symbolic-dump-smt
 
 FOUNDRY_SYMBOLIC=true forge test
 FOUNDRY_SYMBOLIC_SOLVER=z3 forge test --symbolic
+FOUNDRY_SYMBOLIC_SOLVER_COMMAND="z3 -in -smt2" forge test --symbolic
+FOUNDRY_SYMBOLIC_SOLVER_PORTFOLIO="z3,cvc5,bitwuzla" forge test --symbolic
 FOUNDRY_SYMBOLIC_TIMEOUT=120 forge test --symbolic
 ```
+
+Known solver names are `z3`, `yices`, `cvc5`, `cvc5-int`, `bitwuzla`, and
+`bitwuzla-abs`. Unknown `symbolic.solver` values are treated as z3-compatible
+executables and are invoked with `-in -smt2` to preserve the old
+`symbolic.solver = "/path/to/z3"` behavior. Use `symbolic.solver_command` for
+non-z3-compatible command lines or wrapper tools.
+
+`symbolic.solver_portfolio` runs multiple solvers in parallel for each SMT query
+and uses the first `sat` or `unsat` response. `unknown` results only win if no
+configured solver returns a decisive response. A nonempty `symbolic.solver_command`
+overrides both `symbolic.solver_portfolio` and `symbolic.solver`; otherwise a
+nonempty portfolio overrides `symbolic.solver`. Portfolio entries without
+whitespace, quotes, or backslashes are resolved like `symbolic.solver` values.
+Entries with whitespace, quotes, or backslashes are split into argv parts like
+`symbolic.solver_command`; they are not executed through a shell.
+
+Security note: `symbolic.solver_command` and `symbolic.solver_portfolio` execute
+local programs when symbolic tests run. This also applies when these values come
+from inline `forge-config:` or translated legacy `@custom:halmos` annotations.
+Review solver settings before running symbolic tests from untrusted projects.
 
 Halmos-style annotations are accepted as compatibility input and translated into
 the same internal config:
@@ -213,6 +246,8 @@ Supported compatibility flags are:
 - `--solver-timeout`
 - `--solver-timeout-branching`
 - `--solver-timeout-assertion`
+- `--solver`
+- `--solver-command`
 
 Native `forge-config:` values win when both native and compatibility annotations
 set the same symbolic option.

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -225,6 +225,10 @@ Security note: `symbolic.solver_command` and `symbolic.solver_portfolio` execute
 local programs when symbolic tests run. This also applies when these values come
 from inline `forge-config:` or translated legacy `@custom:halmos` annotations.
 Review solver settings before running symbolic tests from untrusted projects.
+Timeouts and portfolio cancellation terminate only the direct solver child
+process. Wrapper commands should forward termination to any subprocesses they
+spawn and close inherited stdout/stderr so descendant solvers do not outlive the
+cancelled query.
 
 Halmos-style annotations are accepted as compatibility input and translated into
 the same internal config:
@@ -317,8 +321,9 @@ Important internal pieces:
   storage, logs, returndata, snapshots, and account lifecycle changes.
 - `CallFrame` tracks address, code address, storage address, caller, call value,
   static context, calldata, stack, memory, and returndata.
-- `SymbolicSolver` is the small internal trait used by the default Z3 subprocess
-  backend.
+- `SymbolicSolver` is the small internal trait used by the default SMT-LIB
+  subprocess backend, which resolves named solvers (z3, cvc5, yices, bitwuzla,
+  etc.) into solver-specific argv via `solver_commands_for_config`.
 
 ## EVM And World Semantics
 

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -207,9 +207,7 @@ FOUNDRY_SYMBOLIC_TIMEOUT=120 forge test --symbolic
 ```
 
 Known solver names are `z3`, `yices`, `cvc5`, `cvc5-int`, `bitwuzla`, and
-`bitwuzla-abs`. Versioned aliases are provided for the solver versions this
-backend has been checked against, including `yices-2.7.0`, `cvc5-1.3.4`, and
-`bitwuzla-0.9.0`. Unknown `symbolic.solver` values are treated as z3-compatible
+`bitwuzla-abs`. Unknown `symbolic.solver` values are treated as z3-compatible
 executables and are invoked with `-in -smt2` to preserve the old
 `symbolic.solver = "/path/to/z3"` behavior. Use `symbolic.solver_command` for
 non-z3-compatible command lines or wrapper tools.

--- a/crates/evm/symbolic/src/executor.rs
+++ b/crates/evm/symbolic/src/executor.rs
@@ -9,12 +9,7 @@ impl SymbolicExecutor {
     /// The executor owns an isolated solver backend and symbolic world overlay. Create
     /// a fresh executor when a caller needs independent solver query accounting.
     pub fn new(config: SymbolicConfig) -> Self {
-        let solver = Z3SubprocessSolver::new(
-            config.solver.clone(),
-            config.timeout,
-            config.max_solver_queries as usize,
-            config.dump_smt,
-        );
+        let solver = SmtLibSubprocessSolver::from_config(&config);
         Self { config, solver: Box::new(solver) }
     }
 

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -14,7 +14,7 @@ use alloy_signer_local::{
     },
 };
 use base64::prelude::*;
-use foundry_config::{SymbolicConfig, SymbolicStorageLayout};
+use foundry_config::{SymbolicConfig, SymbolicStorageLayout, split_quoted_args};
 use foundry_evm::{
     constants::{CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, HARDHAT_CONSOLE_ADDRESS},
     core::{backend::DatabaseExt, evm::FoundryEvmNetwork},
@@ -196,7 +196,7 @@ pub struct SymbolicStats {
     pub solver_queries: usize,
 }
 
-/// Z3-backed symbolic executor.
+/// SMT-LIB-backed symbolic executor.
 ///
 /// This executor is intentionally separate from the concrete revm executor used by
 /// Foundry. It consumes bytecode and state from an existing [`Executor`], explores

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -30,11 +30,17 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     fmt::{self, Write as _},
-    io::Write,
+    io::{Read, Write},
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    time::{SystemTime, UNIX_EPOCH},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
+    thread,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
 

--- a/crates/evm/symbolic/src/runtime/expressions.rs
+++ b/crates/evm/symbolic/src/runtime/expressions.rs
@@ -223,6 +223,12 @@ pub(crate) fn storage_select(
 pub(crate) fn storage_key_eq(read_key: SymWord, write_key: SymWord) -> BoolExpr {
     let read_key = read_key.into_expr();
     let write_key = write_key.into_expr();
+    if let (Some(read_root), Some(write_root)) =
+        (storage_mapping_root_slot(&read_key), storage_mapping_root_slot(&write_key))
+        && read_root != write_root
+    {
+        return BoolExpr::Const(false);
+    }
     match (storage_layout_key(&read_key), storage_layout_key(&write_key)) {
         (Some((read_base, read_offset)), Some((write_base, write_offset))) => BoolExpr::and(vec![
             BoolExpr::eq(read_base, write_base),
@@ -231,6 +237,25 @@ pub(crate) fn storage_key_eq(read_key: SymWord, write_key: SymWord) -> BoolExpr 
         (Some(_), None) if matches!(write_key, Expr::Const(_)) => BoolExpr::Const(false),
         (None, Some(_)) if matches!(read_key, Expr::Const(_)) => BoolExpr::Const(false),
         _ => BoolExpr::eq(read_key, write_key),
+    }
+}
+
+/// Returns the root Solidity storage slot for a mapping-style keccak key.
+pub(crate) fn storage_mapping_root_slot(key: &Expr) -> Option<U256> {
+    let Expr::Keccak { len, bytes, .. } = key else { return None };
+    if !matches!(len.as_ref(), Expr::Const(value) if *value == U256::from(64)) || bytes.len() < 64 {
+        return None;
+    }
+
+    let slot = word_from_bytes(bytes[32..64].iter().cloned().map(|expr| match expr {
+        Expr::Const(value) => SymWord::Concrete(value),
+        expr => SymWord::Expr(expr),
+    }))
+    .into_expr();
+    match slot {
+        Expr::Const(slot) => Some(slot),
+        Expr::Keccak { .. } => storage_mapping_root_slot(&slot),
+        _ => None,
     }
 }
 
@@ -638,9 +663,8 @@ pub(crate) fn eval_expr(
     Ok(match expr {
         Expr::Const(value) => *value,
         Expr::Var(var) => model.get(var).copied().unwrap_or_default(),
-        Expr::Keccak { name, .. } | Expr::Hash { name, .. } => {
-            model.get(name).copied().unwrap_or_default()
-        }
+        Expr::Keccak { len, bytes, .. } => eval_keccak_expr(len, bytes, model)?,
+        Expr::Hash { name, .. } => model.get(name).copied().unwrap_or_default(),
         Expr::Not(value) => !eval_expr(value, model)?,
         Expr::Op(op, left, right) => {
             let left = eval_expr(left, model)?;
@@ -655,6 +679,27 @@ pub(crate) fn eval_expr(
             }
         }
     })
+}
+
+/// Returns the concrete keccak value implied by a solver model.
+pub(crate) fn eval_keccak_expr(
+    len: &Expr,
+    bytes: &[Expr],
+    model: &BTreeMap<String, U256>,
+) -> Result<U256, SymbolicError> {
+    let len = eval_expr(len, model)?;
+    if len > U256::from(bytes.len()) {
+        return Err(SymbolicError::Solver(
+            "solver model uses an invalid keccak length".to_string(),
+        ));
+    }
+
+    let mut input = Vec::with_capacity(len.to::<usize>());
+    for byte in bytes.iter().take(len.to::<usize>()) {
+        input.push((eval_expr(byte, model)? & U256::from(0xff)).to::<u8>());
+    }
+
+    Ok(U256::from_be_bytes(keccak256(input).0))
 }
 
 /// Returns the `eval_expr_op` symbolic expression helper result.

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -230,10 +230,8 @@ pub(crate) fn solver_commands_for_config(
 pub(crate) fn named_solver_command(solver: &str) -> Result<SolverCommand, String> {
     let (parts, smt_timeout) = match solver {
         "z3" => (vec!["z3", "-in", "-smt2"], true),
-        "yices" | "yices-2.6.4" | "yices-2.6.5" => {
-            (vec!["yices-smt2", "--bvconst-in-decimal"], false)
-        }
-        "cvc5" | "cvc5-1.2.1" => (
+        "yices" => (vec!["yices-smt2", "--bvconst-in-decimal"], false),
+        "cvc5" => (
             vec![
                 "cvc5",
                 "--produce-models",
@@ -255,7 +253,7 @@ pub(crate) fn named_solver_command(solver: &str) -> Result<SolverCommand, String
             ],
             false,
         ),
-        "bitwuzla" | "bitwuzla-0.8.1" => (vec!["bitwuzla", "--produce-models"], false),
+        "bitwuzla" => (vec!["bitwuzla", "--produce-models"], false),
         "bitwuzla-abs" => (vec!["bitwuzla", "--produce-models", "--abstraction"], false),
         // Preserve existing behavior for custom z3-compatible executable names/paths.
         custom => (vec![custom, "-in", "-smt2"], true),

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -142,19 +142,7 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
         let output = self.query(constraints, true)?;
         let mut lines = output.lines();
         match lines.next().unwrap_or_default().trim() {
-            "sat" => {
-                let model = parse_model(&output)?;
-                if constraints
-                    .iter()
-                    .all(|constraint| eval_bool_expr(constraint, &model).unwrap_or(false))
-                {
-                    Ok(model)
-                } else {
-                    Err(SymbolicError::Solver(
-                        "solver model does not satisfy path constraints".to_string(),
-                    ))
-                }
-            }
+            "sat" => parse_and_validate_model(&output, constraints),
             "unsat" => Err(SymbolicError::Solver("counterexample path became unsat".to_string())),
             "unknown" => fallback_single_var_model(constraints).ok_or(SymbolicError::SolverUnknown),
             other => Err(SymbolicError::Solver(format!("unexpected solver response `{other}`"))),
@@ -210,7 +198,7 @@ impl SmtLibSubprocessSolver {
             let _ = writeln!(stderr, "--- symbolic SMT query {} ---\n{smt}", self.queries);
         }
 
-        run_solver_commands(commands, &smt, self.timeout)
+        run_solver_commands(commands, &smt, self.timeout, model.then_some(constraints))
     }
 }
 
@@ -284,50 +272,7 @@ pub(crate) fn solver_command_for_portfolio_entry(entry: &str) -> Result<SolverCo
 
 /// Splits a shell-like solver command into argv parts.
 pub(crate) fn split_solver_command(command: &str) -> Result<Vec<String>, String> {
-    let mut parts = Vec::new();
-    let mut current = String::new();
-    let mut quote = None;
-    let mut escaped = false;
-
-    for ch in command.chars() {
-        if escaped {
-            current.push(ch);
-            escaped = false;
-            continue;
-        }
-        if ch == '\\' {
-            escaped = true;
-            continue;
-        }
-        if let Some(quote_ch) = quote {
-            if ch == quote_ch {
-                quote = None;
-            } else {
-                current.push(ch);
-            }
-            continue;
-        }
-        if matches!(ch, '"' | '\'') {
-            quote = Some(ch);
-        } else if ch.is_whitespace() {
-            if !current.is_empty() {
-                parts.push(std::mem::take(&mut current));
-            }
-        } else {
-            current.push(ch);
-        }
-    }
-
-    if let Some(quote_ch) = quote {
-        return Err(format!("unterminated {quote_ch} quote in symbolic solver command"));
-    }
-    if escaped {
-        current.push('\\');
-    }
-    if !current.is_empty() {
-        parts.push(current);
-    }
-
+    let parts = split_quoted_args(command, "symbolic solver command")?;
     if parts.is_empty() {
         return Err("symbolic solver command is empty".to_string());
     }
@@ -348,6 +293,7 @@ fn run_solver_commands(
     commands: &[SolverCommand],
     smt: &str,
     timeout: Option<u32>,
+    model_constraints: Option<&[BoolExpr]>,
 ) -> Result<String, SymbolicError> {
     if commands.is_empty() {
         return Err(SymbolicError::Solver("symbolic solver portfolio is empty".to_string()));
@@ -382,6 +328,13 @@ fn run_solver_commands(
         while let Ok((display, outcome)) = rx.recv() {
             match outcome {
                 SolverProcessOutcome::Output(output) if solver_output_is_decisive(&output) => {
+                    if let Some(constraints) = model_constraints
+                        && solver_output_is_sat(&output)
+                        && let Err(err) = validate_solver_model_output(&output, constraints)
+                    {
+                        errors.push(format!("{display}: {err}"));
+                        continue;
+                    }
                     decisive = Some(output);
                     cancel.store(true, Ordering::SeqCst);
                     break;
@@ -450,6 +403,8 @@ fn run_solver_process(
     let deadline = timeout
         .filter(|seconds| *seconds > 0)
         .map(|seconds| Instant::now() + Duration::from_secs(seconds.into()));
+    let mut backoff = Duration::from_micros(200);
+    const MAX_BACKOFF: Duration = Duration::from_millis(50);
     let status = loop {
         if cancel.load(Ordering::SeqCst) {
             kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
@@ -461,7 +416,10 @@ fn run_solver_process(
         }
         match child.try_wait() {
             Ok(Some(status)) => break status,
-            Ok(None) => thread::sleep(Duration::from_millis(10)),
+            Ok(None) => {
+                thread::sleep(backoff);
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+            }
             Err(err) => {
                 kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
                 return SolverProcessOutcome::Error(format!("failed to read solver output: {err}"));
@@ -510,6 +468,8 @@ fn kill_and_reap_solver_process(
     stdout_reader: Option<thread::JoinHandle<Result<String, String>>>,
     stderr_reader: Option<thread::JoinHandle<Result<String, String>>>,
 ) {
+    // This only terminates the direct child. Wrapper commands should forward termination and close
+    // inherited pipes so descendant solver processes do not outlive cancelled queries.
     let _ = child.kill();
     let _ = child.wait();
     let _ = join_pipe_output(stdout_reader, "stdout");
@@ -538,12 +498,35 @@ fn solver_output_is_decisive(output: &str) -> bool {
     matches!(first_solver_line(output), "sat" | "unsat")
 }
 
+fn solver_output_is_sat(output: &str) -> bool {
+    first_solver_line(output) == "sat"
+}
+
 fn solver_output_is_unknown(output: &str) -> bool {
     first_solver_line(output) == "unknown"
 }
 
 fn first_solver_line(output: &str) -> &str {
     output.lines().next().unwrap_or_default().trim()
+}
+
+pub(crate) fn parse_and_validate_model(
+    output: &str,
+    constraints: &[BoolExpr],
+) -> Result<BTreeMap<String, U256>, SymbolicError> {
+    let model = parse_model(output)?;
+    if constraints.iter().all(|constraint| eval_bool_expr(constraint, &model).unwrap_or(false)) {
+        Ok(model)
+    } else {
+        Err(SymbolicError::Solver("solver model does not satisfy path constraints".to_string()))
+    }
+}
+
+pub(crate) fn validate_solver_model_output(
+    output: &str,
+    constraints: &[BoolExpr],
+) -> Result<(), SymbolicError> {
+    parse_and_validate_model(output, constraints).map(|_| ())
 }
 
 /// Implements the `constraints_prefer_fallback_first` solver helper.

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -230,10 +230,10 @@ pub(crate) fn solver_commands_for_config(
 pub(crate) fn named_solver_command(solver: &str) -> Result<SolverCommand, String> {
     let (parts, smt_timeout) = match solver {
         "z3" => (vec!["z3", "-in", "-smt2"], true),
-        "yices" | "yices-2.6.4" | "yices-2.6.5" => {
+        "yices" | "yices-2.6.4" | "yices-2.6.5" | "yices-2.7.0" => {
             (vec!["yices-smt2", "--bvconst-in-decimal"], false)
         }
-        "cvc5" | "cvc5-1.2.1" => (
+        "cvc5" | "cvc5-1.2.1" | "cvc5-1.3.4" => (
             vec![
                 "cvc5",
                 "--produce-models",
@@ -255,7 +255,9 @@ pub(crate) fn named_solver_command(solver: &str) -> Result<SolverCommand, String
             ],
             false,
         ),
-        "bitwuzla" | "bitwuzla-0.8.1" => (vec!["bitwuzla", "--produce-models"], false),
+        "bitwuzla" | "bitwuzla-0.8.1" | "bitwuzla-0.9.0" => {
+            (vec!["bitwuzla", "--produce-models"], false)
+        }
         "bitwuzla-abs" => (vec!["bitwuzla", "--produce-models", "--abstraction"], false),
         // Preserve existing behavior for custom z3-compatible executable names/paths.
         custom => (vec![custom, "-in", "-smt2"], true),
@@ -326,21 +328,26 @@ fn run_solver_commands(
         drop(tx);
 
         let mut saw_unknown = false;
+        let mut saw_unsat = false;
+        let mut saw_invalid_sat_model = false;
         let mut errors = Vec::new();
         let mut decisive = None;
         while let Ok((display, outcome)) = rx.recv() {
             match outcome {
-                SolverProcessOutcome::Output(output) if solver_output_is_decisive(&output) => {
+                SolverProcessOutcome::Output(output) if solver_output_is_sat(&output) => {
                     if let Some(constraints) = model_constraints
-                        && solver_output_is_sat(&output)
                         && let Err(err) = validate_solver_model_output(&output, constraints)
                     {
+                        saw_invalid_sat_model = true;
                         errors.push(format!("{display}: {err}"));
                         continue;
                     }
                     decisive = Some(output);
                     cancel.store(true, Ordering::SeqCst);
                     break;
+                }
+                SolverProcessOutcome::Output(output) if solver_output_is_unsat(&output) => {
+                    saw_unsat = true;
                 }
                 SolverProcessOutcome::Output(output) if solver_output_is_unknown(&output) => {
                     saw_unknown = true;
@@ -363,6 +370,10 @@ fn run_solver_commands(
 
         if let Some(output) = decisive {
             Ok(output)
+        } else if saw_invalid_sat_model {
+            Err(SymbolicError::Solver(errors.join("; ")))
+        } else if saw_unsat {
+            Ok("unsat\n".to_string())
         } else if saw_unknown {
             Err(SymbolicError::SolverUnknown)
         } else {
@@ -496,12 +507,12 @@ fn solver_exit_error(
     message
 }
 
-fn solver_output_is_decisive(output: &str) -> bool {
-    matches!(first_solver_line(output), "sat" | "unsat")
-}
-
 fn solver_output_is_sat(output: &str) -> bool {
     first_solver_line(output) == "sat"
+}
+
+fn solver_output_is_unsat(output: &str) -> bool {
+    first_solver_line(output) == "unsat"
 }
 
 fn solver_output_is_unknown(output: &str) -> bool {

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+const INITIAL_SOLVER_POLL_BACKOFF: Duration = Duration::from_micros(200);
+const MAX_SOLVER_POLL_BACKOFF: Duration = Duration::from_millis(50);
+
 /// Minimal solver backend interface used by the symbolic executor.
 ///
 /// Implementations are responsible for translating accumulated symbolic constraints
@@ -228,7 +231,7 @@ pub(crate) fn named_solver_command(solver: &str) -> Result<SolverCommand, String
     let (parts, smt_timeout) = match solver {
         "z3" => (vec!["z3", "-in", "-smt2"], true),
         "yices" | "yices-2.6.4" | "yices-2.6.5" => {
-            (vec!["yices-smt2", "--smt2-model-format", "--bvconst-in-decimal"], false)
+            (vec!["yices-smt2", "--bvconst-in-decimal"], false)
         }
         "cvc5" | "cvc5-1.2.1" => (
             vec![
@@ -403,8 +406,7 @@ fn run_solver_process(
     let deadline = timeout
         .filter(|seconds| *seconds > 0)
         .map(|seconds| Instant::now() + Duration::from_secs(seconds.into()));
-    let mut backoff = Duration::from_micros(200);
-    const MAX_BACKOFF: Duration = Duration::from_millis(50);
+    let mut backoff = INITIAL_SOLVER_POLL_BACKOFF;
     let status = loop {
         if cancel.load(Ordering::SeqCst) {
             kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
@@ -418,7 +420,7 @@ fn run_solver_process(
             Ok(Some(status)) => break status,
             Ok(None) => {
                 thread::sleep(backoff);
-                backoff = (backoff * 2).min(MAX_BACKOFF);
+                backoff = (backoff * 2).min(MAX_SOLVER_POLL_BACKOFF);
             }
             Err(err) => {
                 kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -30,27 +30,61 @@ pub(crate) trait SymbolicSolver {
     fn model(&mut self, constraints: &[BoolExpr]) -> Result<BTreeMap<String, U256>, SymbolicError>;
 }
 
-pub(crate) struct Z3SubprocessSolver {
-    pub(crate) command: String,
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SolverCommand {
+    pub(crate) program: String,
+    pub(crate) args: Vec<String>,
+    pub(crate) display: String,
+    pub(crate) smt_timeout: bool,
+}
+
+impl SolverCommand {
+    /// Constructs a solver command from a program plus arguments.
+    pub(crate) fn new(parts: Vec<String>, smt_timeout: bool) -> Result<Self, String> {
+        let mut parts = parts.into_iter();
+        let Some(program) = parts.next().filter(|part| !part.is_empty()) else {
+            return Err("symbolic solver command is empty".to_string());
+        };
+        let args = parts.collect::<Vec<_>>();
+        let display = std::iter::once(program.as_str())
+            .chain(args.iter().map(String::as_str))
+            .collect::<Vec<_>>()
+            .join(" ");
+        Ok(Self { program, args, display, smt_timeout })
+    }
+}
+
+pub(crate) struct SmtLibSubprocessSolver {
+    pub(crate) commands: Result<Vec<SolverCommand>, String>,
     pub(crate) timeout: Option<u32>,
     pub(crate) max_queries: usize,
     pub(crate) queries: usize,
     pub(crate) dump_smt: bool,
 }
 
-impl Z3SubprocessSolver {
+impl SmtLibSubprocessSolver {
     /// Constructs a new instance.
     pub(crate) const fn new(
-        command: String,
+        commands: Result<Vec<SolverCommand>, String>,
         timeout: Option<u32>,
         max_queries: usize,
         dump_smt: bool,
     ) -> Self {
-        Self { command, timeout, max_queries, queries: 0, dump_smt }
+        Self { commands, timeout, max_queries, queries: 0, dump_smt }
+    }
+
+    /// Constructs a subprocess solver from Foundry symbolic config.
+    pub(crate) fn from_config(config: &SymbolicConfig) -> Self {
+        Self::new(
+            solver_commands_for_config(config),
+            config.timeout,
+            config.max_solver_queries as usize,
+            config.dump_smt,
+        )
     }
 }
 
-impl SymbolicSolver for Z3SubprocessSolver {
+impl SymbolicSolver for SmtLibSubprocessSolver {
     /// Implements the `stats` solver helper.
     fn stats(&self) -> SymbolicStats {
         SymbolicStats { paths: 0, solver_queries: self.queries }
@@ -58,14 +92,22 @@ impl SymbolicSolver for Z3SubprocessSolver {
 
     /// Validates the `check_available` solver helper.
     fn check_available(&self) -> Result<(), SymbolicError> {
-        let output = Command::new(&self.command).arg("--version").output().map_err(|err| {
-            SymbolicError::Solver(format!("failed to execute `{}`: {err}", self.command))
-        })?;
-        if output.status.success() {
-            Ok(())
-        } else {
-            Err(SymbolicError::Solver(format!("`{}` is not a usable z3 executable", self.command)))
+        let commands = self.commands()?;
+        let mut errors = Vec::new();
+        for command in commands {
+            let output = match Command::new(&command.program).arg("--version").output() {
+                Ok(output) => output,
+                Err(err) => {
+                    errors.push(format!("failed to execute `{}`: {err}", command.program));
+                    continue;
+                }
+            };
+            if output.status.success() {
+                return Ok(());
+            }
+            errors.push(format!("`{}` is not a usable SMT solver executable", command.program));
         }
+        Err(SymbolicError::Solver(errors.join("; ")))
     }
 
     /// Returns whether `is_sat` holds.
@@ -84,7 +126,7 @@ impl SymbolicSolver for Z3SubprocessSolver {
             "unknown" => fallback_single_var_model(constraints)
                 .map(|_| true)
                 .ok_or(SymbolicError::SolverUnknown),
-            other => Err(SymbolicError::Solver(format!("unexpected z3 response `{other}`"))),
+            other => Err(SymbolicError::Solver(format!("unexpected solver response `{other}`"))),
         }
     }
 
@@ -100,15 +142,32 @@ impl SymbolicSolver for Z3SubprocessSolver {
         let output = self.query(constraints, true)?;
         let mut lines = output.lines();
         match lines.next().unwrap_or_default().trim() {
-            "sat" => parse_model(&output),
+            "sat" => {
+                let model = parse_model(&output)?;
+                if constraints
+                    .iter()
+                    .all(|constraint| eval_bool_expr(constraint, &model).unwrap_or(false))
+                {
+                    Ok(model)
+                } else {
+                    Err(SymbolicError::Solver(
+                        "solver model does not satisfy path constraints".to_string(),
+                    ))
+                }
+            }
             "unsat" => Err(SymbolicError::Solver("counterexample path became unsat".to_string())),
             "unknown" => fallback_single_var_model(constraints).ok_or(SymbolicError::SolverUnknown),
-            other => Err(SymbolicError::Solver(format!("unexpected z3 response `{other}`"))),
+            other => Err(SymbolicError::Solver(format!("unexpected solver response `{other}`"))),
         }
     }
 }
 
-impl Z3SubprocessSolver {
+impl SmtLibSubprocessSolver {
+    /// Returns the resolved commands or the stored config error.
+    pub(crate) fn commands(&self) -> Result<&[SolverCommand], SymbolicError> {
+        self.commands.as_ref().map(Vec::as_slice).map_err(|err| SymbolicError::Solver(err.clone()))
+    }
+
     /// Validates the `reserve_query` solver helper.
     pub(crate) const fn reserve_query(&self) -> Result<(), SymbolicError> {
         if self.queries >= self.max_queries {
@@ -128,9 +187,12 @@ impl Z3SubprocessSolver {
             constraint.collect_vars(&mut vars);
         }
 
+        let commands = self.commands()?;
         let mut smt = String::new();
         smt.push_str("(set-logic QF_BV)\n");
-        if let Some(timeout) = self.timeout {
+        if commands.iter().all(|command| command.smt_timeout)
+            && let Some(timeout) = self.timeout.filter(|timeout| *timeout > 0)
+        {
             let _ = writeln!(smt, "(set-option :timeout {})", timeout.saturating_mul(1000));
         }
         for var in vars {
@@ -148,29 +210,340 @@ impl Z3SubprocessSolver {
             let _ = writeln!(stderr, "--- symbolic SMT query {} ---\n{smt}", self.queries);
         }
 
-        let mut child = Command::new(&self.command)
-            .args(["-in", "-smt2"])
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|err| {
-                SymbolicError::Solver(format!("failed to spawn `{}`: {err}", self.command))
-            })?;
-        child
-            .stdin
-            .as_mut()
-            .expect("stdin configured")
-            .write_all(smt.as_bytes())
-            .map_err(|err| SymbolicError::Solver(format!("failed to write z3 query: {err}")))?;
-        let output = child
-            .wait_with_output()
-            .map_err(|err| SymbolicError::Solver(format!("failed to read z3 output: {err}")))?;
-        if !output.status.success() {
-            return Err(SymbolicError::Solver(String::from_utf8_lossy(&output.stderr).to_string()));
-        }
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        run_solver_commands(commands, &smt, self.timeout)
     }
+}
+
+/// Returns the subprocess commands for the configured SMT solver setup.
+pub(crate) fn solver_commands_for_config(
+    config: &SymbolicConfig,
+) -> Result<Vec<SolverCommand>, String> {
+    if let Some(command) = config.solver_command.as_deref().filter(|command| !command.is_empty()) {
+        return Ok(vec![SolverCommand::new(split_solver_command(command)?, false)?]);
+    }
+
+    let portfolio = config
+        .solver_portfolio
+        .iter()
+        .map(|entry| entry.trim())
+        .filter(|entry| !entry.is_empty())
+        .collect::<Vec<_>>();
+    if !portfolio.is_empty() {
+        return portfolio.into_iter().map(solver_command_for_portfolio_entry).collect();
+    }
+
+    Ok(vec![named_solver_command(&config.solver)?])
+}
+
+/// Returns the default command for a known solver name.
+pub(crate) fn named_solver_command(solver: &str) -> Result<SolverCommand, String> {
+    let (parts, smt_timeout) = match solver {
+        "z3" => (vec!["z3", "-in", "-smt2"], true),
+        "yices" | "yices-2.6.4" | "yices-2.6.5" => {
+            (vec!["yices-smt2", "--smt2-model-format", "--bvconst-in-decimal"], false)
+        }
+        "cvc5" | "cvc5-1.2.1" => (
+            vec![
+                "cvc5",
+                "--produce-models",
+                "--lang",
+                "smt2",
+                "--bv-print-consts-as-indexed-symbols",
+            ],
+            false,
+        ),
+        "cvc5-int" => (
+            vec![
+                "cvc5",
+                "--produce-models",
+                "--lang",
+                "smt2",
+                "--bv-print-consts-as-indexed-symbols",
+                "--solve-bv-as-int=iand",
+                "--iand-mode=bitwise",
+            ],
+            false,
+        ),
+        "bitwuzla" | "bitwuzla-0.8.1" => (vec!["bitwuzla", "--produce-models"], false),
+        "bitwuzla-abs" => (vec!["bitwuzla", "--produce-models", "--abstraction"], false),
+        // Preserve existing behavior for custom z3-compatible executable names/paths.
+        custom => (vec![custom, "-in", "-smt2"], true),
+    };
+    let parts = parts.into_iter().map(str::to_string).collect::<Vec<_>>();
+    SolverCommand::new(parts, smt_timeout)
+}
+
+/// Returns the command for one configured portfolio entry.
+pub(crate) fn solver_command_for_portfolio_entry(entry: &str) -> Result<SolverCommand, String> {
+    if entry.chars().any(|ch| ch.is_whitespace() || matches!(ch, '"' | '\'' | '\\')) {
+        SolverCommand::new(split_solver_command(entry)?, false)
+    } else {
+        named_solver_command(entry)
+    }
+}
+
+/// Splits a shell-like solver command into argv parts.
+pub(crate) fn split_solver_command(command: &str) -> Result<Vec<String>, String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+
+    for ch in command.chars() {
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if let Some(quote_ch) = quote {
+            if ch == quote_ch {
+                quote = None;
+            } else {
+                current.push(ch);
+            }
+            continue;
+        }
+        if matches!(ch, '"' | '\'') {
+            quote = Some(ch);
+        } else if ch.is_whitespace() {
+            if !current.is_empty() {
+                parts.push(std::mem::take(&mut current));
+            }
+        } else {
+            current.push(ch);
+        }
+    }
+
+    if let Some(quote_ch) = quote {
+        return Err(format!("unterminated {quote_ch} quote in symbolic solver command"));
+    }
+    if escaped {
+        current.push('\\');
+    }
+    if !current.is_empty() {
+        parts.push(current);
+    }
+
+    if parts.is_empty() {
+        return Err("symbolic solver command is empty".to_string());
+    }
+
+    Ok(parts)
+}
+
+#[derive(Debug)]
+enum SolverProcessOutcome {
+    Output(String),
+    Unknown,
+    Cancelled,
+    Error(String),
+}
+
+/// Runs one or more solver commands and returns the first decisive SMT-LIB response.
+fn run_solver_commands(
+    commands: &[SolverCommand],
+    smt: &str,
+    timeout: Option<u32>,
+) -> Result<String, SymbolicError> {
+    if commands.is_empty() {
+        return Err(SymbolicError::Solver("symbolic solver portfolio is empty".to_string()));
+    }
+    if commands.len() == 1 {
+        return match run_solver_process(&commands[0], smt, timeout, &AtomicBool::new(false)) {
+            SolverProcessOutcome::Output(output) => Ok(output),
+            SolverProcessOutcome::Unknown => Err(SymbolicError::SolverUnknown),
+            SolverProcessOutcome::Cancelled => {
+                Err(SymbolicError::Solver("solver query was cancelled".to_string()))
+            }
+            SolverProcessOutcome::Error(err) => Err(SymbolicError::Solver(err)),
+        };
+    }
+
+    let cancel = Arc::new(AtomicBool::new(false));
+    let (tx, rx) = mpsc::channel();
+    thread::scope(|scope| {
+        for command in commands.iter().cloned() {
+            let tx = tx.clone();
+            let cancel = Arc::clone(&cancel);
+            scope.spawn(move || {
+                let outcome = run_solver_process(&command, smt, timeout, &cancel);
+                let _ = tx.send((command.display, outcome));
+            });
+        }
+        drop(tx);
+
+        let mut saw_unknown = false;
+        let mut errors = Vec::new();
+        let mut decisive = None;
+        while let Ok((display, outcome)) = rx.recv() {
+            match outcome {
+                SolverProcessOutcome::Output(output) if solver_output_is_decisive(&output) => {
+                    decisive = Some(output);
+                    cancel.store(true, Ordering::SeqCst);
+                    break;
+                }
+                SolverProcessOutcome::Output(output) if solver_output_is_unknown(&output) => {
+                    saw_unknown = true;
+                }
+                SolverProcessOutcome::Output(output) => {
+                    errors.push(format!(
+                        "{display}: unexpected solver response `{}`",
+                        first_solver_line(&output)
+                    ));
+                }
+                SolverProcessOutcome::Unknown => saw_unknown = true,
+                SolverProcessOutcome::Cancelled => {}
+                SolverProcessOutcome::Error(err) => errors.push(format!("{display}: {err}")),
+            }
+        }
+
+        if decisive.is_some() {
+            while rx.recv().is_ok() {}
+        }
+
+        if let Some(output) = decisive {
+            Ok(output)
+        } else if saw_unknown {
+            Err(SymbolicError::SolverUnknown)
+        } else {
+            Err(SymbolicError::Solver(errors.join("; ")))
+        }
+    })
+}
+
+/// Runs one solver process to completion, timeout, or cooperative cancellation.
+fn run_solver_process(
+    command: &SolverCommand,
+    smt: &str,
+    timeout: Option<u32>,
+    cancel: &AtomicBool,
+) -> SolverProcessOutcome {
+    let mut child = match Command::new(&command.program)
+        .args(&command.args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(err) => {
+            return SolverProcessOutcome::Error(format!(
+                "failed to spawn `{}`: {err}",
+                command.display
+            ));
+        }
+    };
+    let stdout_reader = child.stdout.take().map(read_pipe_to_string);
+    let stderr_reader = child.stderr.take().map(read_pipe_to_string);
+
+    if let Some(mut stdin) = child.stdin.take()
+        && let Err(err) = stdin.write_all(smt.as_bytes())
+    {
+        kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
+        return SolverProcessOutcome::Error(format!("failed to write solver query: {err}"));
+    }
+
+    let deadline = timeout
+        .filter(|seconds| *seconds > 0)
+        .map(|seconds| Instant::now() + Duration::from_secs(seconds.into()));
+    let status = loop {
+        if cancel.load(Ordering::SeqCst) {
+            kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
+            return SolverProcessOutcome::Cancelled;
+        }
+        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
+            return SolverProcessOutcome::Unknown;
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => thread::sleep(Duration::from_millis(10)),
+            Err(err) => {
+                kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
+                return SolverProcessOutcome::Error(format!("failed to read solver output: {err}"));
+            }
+        }
+    };
+
+    let stdout = match join_pipe_output(stdout_reader, "stdout") {
+        Ok(stdout) => stdout,
+        Err(err) => return SolverProcessOutcome::Error(err),
+    };
+    let stderr = match join_pipe_output(stderr_reader, "stderr") {
+        Ok(stderr) => stderr,
+        Err(err) => return SolverProcessOutcome::Error(err),
+    };
+    if !status.success() {
+        return SolverProcessOutcome::Error(solver_exit_error(command, status, &stdout, &stderr));
+    }
+    SolverProcessOutcome::Output(stdout)
+}
+
+fn read_pipe_to_string<R>(mut pipe: R) -> thread::JoinHandle<Result<String, String>>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut output = Vec::new();
+        pipe.read_to_end(&mut output)
+            .map_err(|err| format!("failed to read solver output: {err}"))?;
+        Ok(String::from_utf8_lossy(&output).to_string())
+    })
+}
+
+fn join_pipe_output(
+    reader: Option<thread::JoinHandle<Result<String, String>>>,
+    stream: &str,
+) -> Result<String, String> {
+    match reader {
+        Some(reader) => reader.join().map_err(|_| format!("solver {stream} reader panicked"))?,
+        None => Ok(String::new()),
+    }
+}
+
+fn kill_and_reap_solver_process(
+    child: &mut std::process::Child,
+    stdout_reader: Option<thread::JoinHandle<Result<String, String>>>,
+    stderr_reader: Option<thread::JoinHandle<Result<String, String>>>,
+) {
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = join_pipe_output(stdout_reader, "stdout");
+    let _ = join_pipe_output(stderr_reader, "stderr");
+}
+
+fn solver_exit_error(
+    command: &SolverCommand,
+    status: std::process::ExitStatus,
+    stdout: &str,
+    stderr: &str,
+) -> String {
+    let mut message = format!("`{}` exited with {status}", command.display);
+    if !stderr.trim().is_empty() {
+        message.push_str(": ");
+        message.push_str(stderr.trim());
+    }
+    if !stdout.trim().is_empty() {
+        message.push_str("; stdout: ");
+        message.push_str(stdout.trim());
+    }
+    message
+}
+
+fn solver_output_is_decisive(output: &str) -> bool {
+    matches!(first_solver_line(output), "sat" | "unsat")
+}
+
+fn solver_output_is_unknown(output: &str) -> bool {
+    first_solver_line(output) == "unknown"
+}
+
+fn first_solver_line(output: &str) -> &str {
+    output.lines().next().unwrap_or_default().trim()
 }
 
 /// Implements the `constraints_prefer_fallback_first` solver helper.
@@ -407,20 +780,37 @@ pub(crate) fn parse_model(output: &str) -> Result<BTreeMap<String, U256>, Symbol
             let Some(name) = tokens.next() else { continue };
             while let Some(value) = tokens.next() {
                 if let Some(hex) = value.strip_prefix("#x") {
+                    if hex.len() > 64 {
+                        return Err(SymbolicError::Solver(
+                            "solver hex model value exceeds 256 bits".to_string(),
+                        ));
+                    }
                     let mut bytes = [0u8; 32];
                     let decoded = alloy_primitives::hex::decode(hex).map_err(|err| {
-                        SymbolicError::Solver(format!("invalid z3 hex model value: {err}"))
+                        SymbolicError::Solver(format!("invalid solver hex model value: {err}"))
                     })?;
                     let start = 32usize.saturating_sub(decoded.len());
                     bytes[start..start + decoded.len()].copy_from_slice(&decoded);
                     values.insert(name.to_string(), U256::from_be_bytes(bytes));
                     break;
                 }
+                if let Some(binary) = value.strip_prefix("#b") {
+                    if binary.len() > 256 {
+                        return Err(SymbolicError::Solver(
+                            "solver binary model value exceeds 256 bits".to_string(),
+                        ));
+                    }
+                    let parsed = U256::from_str_radix(binary, 2).map_err(|err| {
+                        SymbolicError::Solver(format!("invalid solver binary model value: {err}"))
+                    })?;
+                    values.insert(name.to_string(), parsed);
+                    break;
+                }
                 if value == "_"
                     && let Some(bv) = tokens.next().and_then(|v| v.strip_prefix("bv"))
                 {
                     let parsed = U256::from_str_radix(bv, 10).map_err(|err| {
-                        SymbolicError::Solver(format!("invalid z3 decimal model value: {err}"))
+                        SymbolicError::Solver(format!("invalid solver decimal model value: {err}"))
                     })?;
                     values.insert(name.to_string(), parsed);
                     break;

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -230,10 +230,10 @@ pub(crate) fn solver_commands_for_config(
 pub(crate) fn named_solver_command(solver: &str) -> Result<SolverCommand, String> {
     let (parts, smt_timeout) = match solver {
         "z3" => (vec!["z3", "-in", "-smt2"], true),
-        "yices" | "yices-2.6.4" | "yices-2.6.5" | "yices-2.7.0" => {
+        "yices" | "yices-2.6.4" | "yices-2.6.5" => {
             (vec!["yices-smt2", "--bvconst-in-decimal"], false)
         }
-        "cvc5" | "cvc5-1.2.1" | "cvc5-1.3.4" => (
+        "cvc5" | "cvc5-1.2.1" => (
             vec![
                 "cvc5",
                 "--produce-models",
@@ -255,9 +255,7 @@ pub(crate) fn named_solver_command(solver: &str) -> Result<SolverCommand, String
             ],
             false,
         ),
-        "bitwuzla" | "bitwuzla-0.8.1" | "bitwuzla-0.9.0" => {
-            (vec!["bitwuzla", "--produce-models"], false)
-        }
+        "bitwuzla" | "bitwuzla-0.8.1" => (vec!["bitwuzla", "--produce-models"], false),
         "bitwuzla-abs" => (vec!["bitwuzla", "--produce-models", "--abstraction"], false),
         // Preserve existing behavior for custom z3-compatible executable names/paths.
         custom => (vec![custom, "-in", "-smt2"], true),

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1840,7 +1840,7 @@ fn known_solver_names_resolve_to_smtlib_commands() {
     let command = &commands[0];
 
     assert_eq!(command.program, "yices-smt2");
-    assert_eq!(command.args, vec!["--smt2-model-format", "--bvconst-in-decimal"]);
+    assert_eq!(command.args, vec!["--bvconst-in-decimal"]);
     assert!(!command.smt_timeout);
 
     let commands = solver_commands_for_config(&SymbolicConfig {

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1706,8 +1706,8 @@ fn symbolic_signextend_uses_sign_bit_ite() {
 }
 
 #[test]
-/// Regression coverage for `parse_z3_hex_model_values`.
-fn parse_z3_hex_model_values() {
+/// Regression coverage for `parse_smt_hex_model_values`.
+fn parse_smt_hex_model_values() {
     let output = "\
 sat
 (
@@ -1719,6 +1719,33 @@ sat
     let model = parse_model(output).unwrap();
 
     assert_eq!(model.get("calldata_0"), Some(&U256::from(42)));
+}
+
+#[test]
+/// Regression coverage for `parse_smt_binary_model_values`.
+fn parse_smt_binary_model_values() {
+    let output = "\
+sat
+(
+  (define-fun calldata_0 () (_ BitVec 8)
+    #b00101010)
+)
+";
+
+    let model = parse_model(output).unwrap();
+
+    assert_eq!(model.get("calldata_0"), Some(&U256::from(42)));
+}
+
+#[test]
+/// Regression coverage for `parse_model_rejects_oversized_bitvector_literals`.
+fn parse_model_rejects_oversized_bitvector_literals() {
+    let output =
+        format!("sat\n((define-fun calldata_0 () (_ BitVec 257) #b{}))\n", "1".repeat(257));
+
+    let err = parse_model(&output).unwrap_err();
+
+    assert!(err.to_string().contains("exceeds 256 bits"));
 }
 
 #[test]
@@ -1771,12 +1798,113 @@ fn concrete_dynamic_array_return_uses_raw_abi_encoding() {
 #[test]
 /// Regression coverage for `query_limit_is_enforced_before_spawning_solver`.
 fn query_limit_is_enforced_before_spawning_solver() {
-    let mut solver = Z3SubprocessSolver::new("missing-z3".to_string(), None, 0, false);
+    let mut solver = SmtLibSubprocessSolver::new(
+        Ok(vec![SolverCommand::new(vec!["missing-z3".to_string()], false).unwrap()]),
+        None,
+        0,
+        false,
+    );
 
     let err = solver.is_sat(&[]).unwrap_err();
 
     assert!(matches!(err, SymbolicError::SolverQueryLimit(0)));
     assert_eq!(solver.stats().solver_queries, 0);
+}
+
+#[test]
+/// Regression coverage for `known_solver_names_resolve_to_smtlib_commands`.
+fn known_solver_names_resolve_to_smtlib_commands() {
+    let commands = solver_commands_for_config(&SymbolicConfig {
+        solver: "yices".to_string(),
+        ..Default::default()
+    })
+    .unwrap();
+    let command = &commands[0];
+
+    assert_eq!(command.program, "yices-smt2");
+    assert_eq!(command.args, vec!["--smt2-model-format", "--bvconst-in-decimal"]);
+    assert!(!command.smt_timeout);
+
+    let commands = solver_commands_for_config(&SymbolicConfig {
+        solver: "cvc5-int".to_string(),
+        ..Default::default()
+    })
+    .unwrap();
+    let command = &commands[0];
+
+    assert_eq!(command.program, "cvc5");
+    assert!(command.args.contains(&"--bv-print-consts-as-indexed-symbols".to_string()));
+    assert!(!command.smt_timeout);
+
+    let commands = solver_commands_for_config(&SymbolicConfig {
+        solver: "bitwuzla-abs".to_string(),
+        ..Default::default()
+    })
+    .unwrap();
+    let command = &commands[0];
+
+    assert_eq!(command.program, "bitwuzla");
+    assert_eq!(command.args, vec!["--produce-models", "--abstraction"]);
+    assert!(!command.smt_timeout);
+}
+
+#[test]
+/// Regression coverage for `solver_command_overrides_solver_name`.
+fn solver_command_overrides_solver_name() {
+    let commands = solver_commands_for_config(&SymbolicConfig {
+        solver: "z3".to_string(),
+        solver_command: Some("custom-solver --flag 'two words'".to_string()),
+        solver_portfolio: vec!["cvc5".to_string(), "bitwuzla".to_string()],
+        ..Default::default()
+    })
+    .unwrap();
+    let command = &commands[0];
+
+    assert_eq!(commands.len(), 1);
+    assert_eq!(command.program, "custom-solver");
+    assert_eq!(command.args, vec!["--flag", "two words"]);
+    assert!(!command.smt_timeout);
+}
+
+#[test]
+/// Regression coverage for `custom_solver_names_remain_z3_compatible`.
+fn custom_solver_names_remain_z3_compatible() {
+    let commands = solver_commands_for_config(&SymbolicConfig {
+        solver: "/opt/solvers/z3-nightly".to_string(),
+        ..Default::default()
+    })
+    .unwrap();
+    let command = &commands[0];
+
+    assert_eq!(command.program, "/opt/solvers/z3-nightly");
+    assert_eq!(command.args, vec!["-in", "-smt2"]);
+    assert!(command.smt_timeout);
+}
+
+#[test]
+/// Regression coverage for `solver_portfolio_resolves_parallel_commands`.
+fn solver_portfolio_resolves_parallel_commands() {
+    let commands = solver_commands_for_config(&SymbolicConfig {
+        solver: "z3".to_string(),
+        solver_portfolio: vec![
+            "z3".to_string(),
+            "cvc5".to_string(),
+            "custom-wrapper --stdin".to_string(),
+            "  ".to_string(),
+        ],
+        ..Default::default()
+    })
+    .unwrap();
+
+    assert_eq!(commands.len(), 3);
+    assert_eq!(commands[0].program, "z3");
+    assert_eq!(commands[0].args, vec!["-in", "-smt2"]);
+    assert!(commands[0].smt_timeout);
+    assert_eq!(commands[1].program, "cvc5");
+    assert!(commands[1].args.contains(&"--bv-print-consts-as-indexed-symbols".to_string()));
+    assert_eq!(commands[2].program, "custom-wrapper");
+    assert_eq!(commands[2].args, vec!["--stdin"]);
+    assert!(!commands[2].smt_timeout);
 }
 
 #[test]

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1893,13 +1893,6 @@ fn known_solver_names_resolve_to_smtlib_commands() {
     assert!(!command.smt_timeout);
 
     let commands = solver_commands_for_config(&SymbolicConfig {
-        solver: "yices-2.7.0".to_string(),
-        ..Default::default()
-    })
-    .unwrap();
-    assert_eq!(commands[0].program, "yices-smt2");
-
-    let commands = solver_commands_for_config(&SymbolicConfig {
         solver: "cvc5-int".to_string(),
         ..Default::default()
     })
@@ -1911,13 +1904,6 @@ fn known_solver_names_resolve_to_smtlib_commands() {
     assert!(!command.smt_timeout);
 
     let commands = solver_commands_for_config(&SymbolicConfig {
-        solver: "cvc5-1.3.4".to_string(),
-        ..Default::default()
-    })
-    .unwrap();
-    assert_eq!(commands[0].program, "cvc5");
-
-    let commands = solver_commands_for_config(&SymbolicConfig {
         solver: "bitwuzla-abs".to_string(),
         ..Default::default()
     })
@@ -1927,13 +1913,6 @@ fn known_solver_names_resolve_to_smtlib_commands() {
     assert_eq!(command.program, "bitwuzla");
     assert_eq!(command.args, vec!["--produce-models", "--abstraction"]);
     assert!(!command.smt_timeout);
-
-    let commands = solver_commands_for_config(&SymbolicConfig {
-        solver: "bitwuzla-0.9.0".to_string(),
-        ..Default::default()
-    })
-    .unwrap();
-    assert_eq!(commands[0].program, "bitwuzla");
 }
 
 #[test]

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1408,6 +1408,24 @@ fn symbolic_keccak_tracks_symbolic_length() {
 }
 
 #[test]
+/// Regression coverage for `model_word_computes_symbolic_keccak_from_model`.
+fn model_word_computes_symbolic_keccak_from_model() {
+    let owner = Address::from([0x11; 20]);
+    let slot = U256::from(1);
+    let mut bytes = word_bytes(SymWord::Expr(Expr::Var("owner".to_string())));
+    bytes.extend(word_bytes(SymWord::Concrete(slot)));
+    let word = keccak_word(bytes);
+
+    let mut input = Vec::new();
+    input.extend(address_word(owner).to_be_bytes::<32>());
+    input.extend(slot.to_be_bytes::<32>());
+    let expected = U256::from_be_bytes(keccak256(input).0);
+    let model = BTreeMap::from([("owner".to_string(), address_word(owner))]);
+
+    assert_eq!(model_word(&word, &model).unwrap(), expected);
+}
+
+#[test]
 /// Regression coverage for `symbolic_hash_precompiles_are_deterministic_for_same_symbolic_input`.
 fn symbolic_hash_precompiles_are_deterministic_for_same_symbolic_input() {
     let input = vec![
@@ -1599,6 +1617,37 @@ fn symbolic_storage_key_equality_rejects_concrete_plain_slot_alias() {
     let layout_key = add_words(keccak_word(word_bytes(owner)), SymWord::Concrete(U256::ZERO));
 
     assert_eq!(storage_key_eq(layout_key, SymWord::Concrete(U256::ZERO)), BoolExpr::Const(false));
+}
+
+#[test]
+/// Regression coverage for `nested_mapping_key_does_not_alias_plain_mapping_key_under_model`.
+fn nested_mapping_key_does_not_alias_plain_mapping_key_under_model() {
+    let owner = SymWord::Expr(Expr::Var("owner".to_string()));
+    let spender = SymWord::Expr(Expr::Var("spender".to_string()));
+    let recipient = SymWord::Expr(Expr::Var("recipient".to_string()));
+
+    let mut balance_key_bytes = word_bytes(recipient);
+    balance_key_bytes.extend(word_bytes(SymWord::Concrete(U256::ZERO)));
+    let balance_key = keccak_word(balance_key_bytes);
+
+    let mut inner_key_bytes = word_bytes(owner);
+    inner_key_bytes.extend(word_bytes(SymWord::Concrete(U256::from(1))));
+    let inner_key = keccak_word(inner_key_bytes);
+
+    let mut allowance_key_bytes = word_bytes(spender);
+    allowance_key_bytes.extend(word_bytes(inner_key));
+    let allowance_key = keccak_word(allowance_key_bytes);
+
+    let same_address = precompile_address(0x60);
+    let model = BTreeMap::from([
+        ("owner".to_string(), address_word(Address::from([0x11; 20]))),
+        ("spender".to_string(), address_word(same_address)),
+        ("recipient".to_string(), address_word(same_address)),
+    ]);
+    let condition = storage_key_eq(balance_key, allowance_key);
+
+    assert_eq!(condition, BoolExpr::Const(false));
+    assert!(!eval_bool_expr(&condition, &model).unwrap());
 }
 
 #[test]

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1844,6 +1844,13 @@ fn known_solver_names_resolve_to_smtlib_commands() {
     assert!(!command.smt_timeout);
 
     let commands = solver_commands_for_config(&SymbolicConfig {
+        solver: "yices-2.7.0".to_string(),
+        ..Default::default()
+    })
+    .unwrap();
+    assert_eq!(commands[0].program, "yices-smt2");
+
+    let commands = solver_commands_for_config(&SymbolicConfig {
         solver: "cvc5-int".to_string(),
         ..Default::default()
     })
@@ -1855,6 +1862,13 @@ fn known_solver_names_resolve_to_smtlib_commands() {
     assert!(!command.smt_timeout);
 
     let commands = solver_commands_for_config(&SymbolicConfig {
+        solver: "cvc5-1.3.4".to_string(),
+        ..Default::default()
+    })
+    .unwrap();
+    assert_eq!(commands[0].program, "cvc5");
+
+    let commands = solver_commands_for_config(&SymbolicConfig {
         solver: "bitwuzla-abs".to_string(),
         ..Default::default()
     })
@@ -1864,6 +1878,13 @@ fn known_solver_names_resolve_to_smtlib_commands() {
     assert_eq!(command.program, "bitwuzla");
     assert_eq!(command.args, vec!["--produce-models", "--abstraction"]);
     assert!(!command.smt_timeout);
+
+    let commands = solver_commands_for_config(&SymbolicConfig {
+        solver: "bitwuzla-0.9.0".to_string(),
+        ..Default::default()
+    })
+    .unwrap();
+    assert_eq!(commands[0].program, "bitwuzla");
 }
 
 #[test]
@@ -1931,6 +1952,28 @@ fn solver_portfolio_resolves_parallel_commands() {
     assert_eq!(commands[2].program, "custom-wrapper");
     assert_eq!(commands[2].args, vec!["--stdin"]);
     assert!(!commands[2].smt_timeout);
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for `portfolio_sat_beats_early_unsat`.
+fn portfolio_sat_beats_early_unsat() {
+    let commands = vec![
+        SolverCommand::new(
+            vec!["/bin/sh".to_string(), "-c".to_string(), "printf 'unsat\n'".to_string()],
+            false,
+        )
+        .unwrap(),
+        SolverCommand::new(
+            vec!["/bin/sh".to_string(), "-c".to_string(), "sleep 0.1; printf 'sat\n'".to_string()],
+            false,
+        )
+        .unwrap(),
+    ];
+
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 1, false);
+
+    assert!(solver.is_sat(&[]).unwrap());
 }
 
 #[test]

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1749,6 +1749,24 @@ fn parse_model_rejects_oversized_bitvector_literals() {
 }
 
 #[test]
+/// Regression coverage for `validate_solver_model_output_rejects_unsatisfied_models`.
+fn validate_solver_model_output_rejects_unsatisfied_models() {
+    let output = "\
+sat
+(
+  (define-fun calldata_0 () (_ BitVec 8)
+    #x00)
+)
+";
+    let constraints =
+        vec![BoolExpr::eq(Expr::Var("calldata_0".to_string()), Expr::Const(U256::from(1)))];
+
+    let err = validate_solver_model_output(output, &constraints).unwrap_err();
+
+    assert!(err.to_string().contains("does not satisfy path constraints"));
+}
+
+#[test]
 /// Regression coverage for `fallback_model_finds_wrapping_arithmetic_riddle_candidate`.
 fn fallback_model_finds_wrapping_arithmetic_riddle_candidate() {
     let var = Expr::Var("calldata_0".to_string());
@@ -1864,6 +1882,14 @@ fn solver_command_overrides_solver_name() {
     assert_eq!(command.program, "custom-solver");
     assert_eq!(command.args, vec!["--flag", "two words"]);
     assert!(!command.smt_timeout);
+}
+
+#[test]
+/// Regression coverage for `split_solver_command_preserves_empty_quoted_args`.
+fn split_solver_command_preserves_empty_quoted_args() {
+    let parts = split_solver_command(r#"custom-solver "" arg ''"#).unwrap();
+
+    assert_eq!(parts, vec!["custom-solver", "", "arg", ""]);
 }
 
 #[test]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -194,6 +194,19 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_SYMBOLIC_SOLVER", value_name = "PATH_OR_NAME")]
     pub symbolic_solver: Option<String>,
 
+    /// Exact solver command used for symbolic tests.
+    #[arg(long, env = "FOUNDRY_SYMBOLIC_SOLVER_COMMAND", value_name = "COMMAND")]
+    pub symbolic_solver_command: Option<String>,
+
+    /// Comma-separated SMT solver names or commands to race in parallel for symbolic tests.
+    #[arg(
+        long,
+        env = "FOUNDRY_SYMBOLIC_SOLVER_PORTFOLIO",
+        value_delimiter = ',',
+        value_name = "SOLVER_OR_COMMAND,..."
+    )]
+    pub symbolic_solver_portfolio: Option<Vec<String>>,
+
     /// Timeout for symbolic execution in seconds.
     #[arg(long, env = "FOUNDRY_SYMBOLIC_TIMEOUT", value_name = "SECONDS")]
     pub symbolic_timeout: Option<u32>,
@@ -1202,6 +1215,12 @@ impl Provider for TestArgs {
         }
         if let Some(solver) = self.symbolic_solver.clone() {
             symbolic_dict.insert("solver".to_string(), solver.into());
+        }
+        if let Some(solver_command) = self.symbolic_solver_command.clone() {
+            symbolic_dict.insert("solver_command".to_string(), solver_command.into());
+        }
+        if let Some(solver_portfolio) = self.symbolic_solver_portfolio.clone() {
+            symbolic_dict.insert("solver_portfolio".to_string(), solver_portfolio.into());
         }
         if let Some(timeout) = self.symbolic_timeout {
             symbolic_dict.insert("timeout".to_string(), timeout.into());

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -62,18 +62,8 @@ use tracing::Span;
 /// `address(uint160(uint256(keccak256("foundry library deployer"))))`
 pub const LIBRARY_DEPLOYER: Address = address!("0x1F95D37F27EA0dEA9C252FC09D5A6eaA97647353");
 
-const BUILTIN_SYMBOLIC_SOLVERS: &[&str] = &[
-    "z3",
-    "yices",
-    "yices-2.6.4",
-    "yices-2.6.5",
-    "cvc5",
-    "cvc5-1.2.1",
-    "cvc5-int",
-    "bitwuzla",
-    "bitwuzla-0.8.1",
-    "bitwuzla-abs",
-];
+const BUILTIN_SYMBOLIC_SOLVERS: &[&str] =
+    &["z3", "yices", "cvc5", "cvc5-int", "bitwuzla", "bitwuzla-abs"];
 
 pub(crate) fn is_symbolic_entrypoint(func: &Function) -> bool {
     func.name.starts_with("check") || func.name.starts_with("prove")

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -67,14 +67,11 @@ const BUILTIN_SYMBOLIC_SOLVERS: &[&str] = &[
     "yices",
     "yices-2.6.4",
     "yices-2.6.5",
-    "yices-2.7.0",
     "cvc5",
     "cvc5-1.2.1",
-    "cvc5-1.3.4",
     "cvc5-int",
     "bitwuzla",
     "bitwuzla-0.8.1",
-    "bitwuzla-0.9.0",
     "bitwuzla-abs",
 ];
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -14,7 +14,7 @@ use alloy_primitives::{Address, Bytes, Selector, U256, address, map::HashMap};
 use eyre::Result;
 use foundry_common::{TestFunctionExt, TestFunctionKind, contracts::ContractsByAddress};
 use foundry_compilers::utils::canonicalized;
-use foundry_config::{Config, FuzzCorpusConfig, InvariantConfig};
+use foundry_config::{Config, FuzzCorpusConfig, InvariantConfig, SymbolicConfig};
 use foundry_evm::{
     constants::CALLER,
     core::evm::FoundryEvmNetwork,
@@ -450,6 +450,9 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             self.contract.abi.functions().count(),
             find_timer.elapsed(),
         );
+        if let Some(warning) = self.symbolic_solver_command_warning(&functions) {
+            warnings.push(warning);
+        }
 
         let identified_contracts = has_invariants.then(|| {
             load_contracts(setup.traces.iter().map(|(_, t)| &t.arena), &self.mcr.known_contracts)
@@ -528,6 +531,44 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
         let duration = start.elapsed();
         SuiteResult::new(duration, test_results, warnings)
     }
+
+    fn symbolic_solver_command_warning(&self, functions: &[&Function]) -> Option<String> {
+        if !self.config.symbolic.enabled
+            || !functions.iter().copied().any(|func| {
+                is_symbolic_entrypoint(func)
+                    && self.effective_symbolic_config(func).is_some_and(|symbolic| {
+                        symbolic_solver_config_executes_custom_command(&symbolic)
+                    })
+            })
+        {
+            return None;
+        }
+
+        Some(
+            "Symbolic solver command configuration can execute arbitrary local programs. \
+             Review `symbolic.solver_command`, command-like `symbolic.solver_portfolio` entries, \
+             and inline `forge-config:` or `@custom:halmos` annotations before running symbolic \
+             tests from untrusted projects."
+                .to_string(),
+        )
+    }
+
+    fn effective_symbolic_config(&self, func: &Function) -> Option<SymbolicConfig> {
+        if self.inline_config.contains_function(self.name, &func.name) {
+            self.inline_config(Some(func)).ok().map(|config| config.symbolic)
+        } else {
+            Some(self.config.symbolic.clone())
+        }
+    }
+}
+
+fn symbolic_solver_config_executes_custom_command(symbolic: &SymbolicConfig) -> bool {
+    symbolic.solver_command.as_deref().is_some_and(|command| !command.trim().is_empty())
+        || symbolic.solver_portfolio.iter().any(|entry| {
+            let entry = entry.trim();
+            !entry.is_empty()
+                && entry.chars().any(|ch| ch.is_whitespace() || matches!(ch, '"' | '\'' | '\\'))
+        })
 }
 
 /// Executes a single test function, returning a [`TestResult`].

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -62,6 +62,22 @@ use tracing::Span;
 /// `address(uint160(uint256(keccak256("foundry library deployer"))))`
 pub const LIBRARY_DEPLOYER: Address = address!("0x1F95D37F27EA0dEA9C252FC09D5A6eaA97647353");
 
+const BUILTIN_SYMBOLIC_SOLVERS: &[&str] = &[
+    "z3",
+    "yices",
+    "yices-2.6.4",
+    "yices-2.6.5",
+    "yices-2.7.0",
+    "cvc5",
+    "cvc5-1.2.1",
+    "cvc5-1.3.4",
+    "cvc5-int",
+    "bitwuzla",
+    "bitwuzla-0.8.1",
+    "bitwuzla-0.9.0",
+    "bitwuzla-abs",
+];
+
 pub(crate) fn is_symbolic_entrypoint(func: &Function) -> bool {
     func.name.starts_with("check") || func.name.starts_with("prove")
 }
@@ -535,9 +551,9 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
     fn symbolic_solver_command_warning(&self, functions: &[&Function]) -> Option<String> {
         if !self.config.symbolic.enabled
             || !functions.iter().copied().any(|func| {
-                is_symbolic_entrypoint(func)
+                (is_symbolic_entrypoint(func) || func.is_invariant_test())
                     && self.effective_symbolic_config(func).is_some_and(|symbolic| {
-                        symbolic_solver_config_executes_custom_command(&symbolic)
+                        symbolic_solver_config_executes_custom_program(&symbolic)
                     })
             })
         {
@@ -546,9 +562,10 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
 
         Some(
             "Symbolic solver command configuration can execute arbitrary local programs. \
-             Review `symbolic.solver_command`, command-like `symbolic.solver_portfolio` entries, \
-             and inline `forge-config:` or `@custom:halmos` annotations before running symbolic \
-             tests from untrusted projects."
+             Review `symbolic.solver_command`, custom `symbolic.solver` values, \
+             command-like or custom `symbolic.solver_portfolio` entries, and inline \
+             `forge-config:` or `@custom:halmos` annotations before running symbolic tests from \
+             untrusted projects."
                 .to_string(),
         )
     }
@@ -562,13 +579,19 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
     }
 }
 
-fn symbolic_solver_config_executes_custom_command(symbolic: &SymbolicConfig) -> bool {
-    symbolic.solver_command.as_deref().is_some_and(|command| !command.trim().is_empty())
-        || symbolic.solver_portfolio.iter().any(|entry| {
+fn symbolic_solver_config_executes_custom_program(symbolic: &SymbolicConfig) -> bool {
+    if symbolic.solver_command.as_deref().is_some_and(|command| !command.trim().is_empty()) {
+        return true;
+    }
+    if symbolic.solver_portfolio.iter().any(|entry| !entry.trim().is_empty()) {
+        return symbolic.solver_portfolio.iter().any(|entry| {
             let entry = entry.trim();
             !entry.is_empty()
-                && entry.chars().any(|ch| ch.is_whitespace() || matches!(ch, '"' | '\'' | '\\'))
-        })
+                && (entry.chars().any(|ch| ch.is_whitespace() || matches!(ch, '"' | '\'' | '\\'))
+                    || !BUILTIN_SYMBOLIC_SOLVERS.contains(&entry))
+        });
+    }
+    !BUILTIN_SYMBOLIC_SOLVERS.contains(&symbolic.solver.trim())
 }
 
 /// Executes a single test function, returning a [`TestResult`].

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -326,6 +326,8 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         symbolic: SymbolicConfig {
             enabled: true,
             solver: "custom-z3".to_string(),
+            solver_command: None,
+            solver_portfolio: Vec::new(),
             timeout: Some(7),
             loop_bound: Some(64),
             depth: Some(222),

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -4213,19 +4213,14 @@ contract SymbolicErc20TransferFromStorage {
 "#,
     );
 
-    let stdout = cmd
-        .args(["test", "--symbolic", "--match-test", "checkTransferFromStorage"])
-        .assert_success()
-        .get_output()
-        .stdout_lossy();
-
-    assert!(
-        stdout.contains(
-            "[PASS] checkTransferFromStorage(address,address,address,uint96,uint96,uint96)"
-        ),
-        "{stdout}"
-    );
-    assert!(!stdout.contains("symbolic counterexample did not replay"), "{stdout}");
+    assert_symbolic(cmd.args(["test", "--symbolic", "--match-test", "checkTransferFromStorage"]))
+        .success()
+        .stdout_eq(str![[r#"
+...
+Ran 1 test for test/SymbolicErc20TransferFromStorage.t.sol:SymbolicErc20TransferFromStorage
+[PASS] checkTransferFromStorage(address,address,address,uint96,uint96,uint96) ([METRICS])
+...
+"#]]);
 });
 
 forgetest_init!(symbolic_svm_storage_helpers_are_supported, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -4173,6 +4173,61 @@ contract SymbolicErc20Storage {
     assert!(!stdout.contains("symbolic SLOAD key"), "{stdout}");
 });
 
+forgetest_init!(symbolic_erc20_transfer_from_storage_paths_do_not_alias, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_erc20_transfer_from_storage_paths_do_not_alias because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicErc20TransferFromStorage.t.sol",
+        r#"
+contract SymbolicErc20TransferFromStorage {
+    mapping(address => uint256) balanceOf;
+    mapping(address => mapping(address => uint256)) allowance;
+
+    function checkTransferFromStorage(
+        address owner,
+        address spender,
+        address recipient,
+        uint96 balance,
+        uint96 approval,
+        uint96 amount
+    ) public {
+        balanceOf[owner] = balance;
+        allowance[owner][spender] = approval;
+
+        uint256 beforeTotal = balanceOf[owner] + balanceOf[recipient];
+        if (owner != recipient && amount <= balanceOf[owner] && amount <= allowance[owner][spender]) {
+            allowance[owner][spender] -= amount;
+            balanceOf[owner] -= amount;
+            balanceOf[recipient] += amount;
+
+            assert(balanceOf[owner] + balanceOf[recipient] == beforeTotal);
+            assert(allowance[owner][spender] == uint256(approval) - amount);
+        }
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkTransferFromStorage"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(
+        stdout.contains(
+            "[PASS] checkTransferFromStorage(address,address,address,uint96,uint96,uint96)"
+        ),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("symbolic counterexample did not replay"), "{stdout}");
+});
+
 forgetest_init!(symbolic_svm_storage_helpers_are_supported, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(

--- a/crates/forge/tests/cli/test_cmd/symbolic_helpers.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_helpers.rs
@@ -15,12 +15,12 @@ macro_rules! skip_unless_z3 {
     };
 }
 
-/// Run a symbolic test with redactions that mask Z3-dependent / wall-clock
+/// Run a symbolic test with redactions that mask solver-dependent / wall-clock
 /// noise so the snapshot is stable across solver versions and runs.
 ///
 /// - `[METRICS]` — `paths: N, queries: M` line suffix (engine internal metrics change with solver
 ///   heuristic / engine path-pruning changes).
-/// - `[SENDER]` — `sender=0x...` symbolic invariant senders, which Z3 picks freely from an
+/// - `[SENDER]` — `sender=0x...` symbolic invariant senders, which the solver picks freely from an
 ///   unconstrained address pool.
 pub fn assert_symbolic(cmd: &mut TestCommand) -> OutputAssert {
     cmd.assert_with(&[


### PR DESCRIPTION
## Summary
- add `symbolic.solver_command`, `--symbolic-solver-command`, and `FOUNDRY_SYMBOLIC_SOLVER_COMMAND`
- add `symbolic.solver_portfolio`, `--symbolic-solver-portfolio`, and `FOUNDRY_SYMBOLIC_SOLVER_PORTFOLIO` to race multiple SMT subprocesses in parallel
- resolve known SMT-LIB solver names (`z3`, `yices`, `cvc5`, `cvc5-int`, `bitwuzla`, `bitwuzla-abs`) into solver-specific argv/model-output commands while preserving custom z3-compatible executable paths
- translate Halmos `@custom:halmos --solver` and `--solver-command` annotations into native symbolic config
- parse solver models from decimal, hex, and binary bit-vector values, validate returned models against path constraints, and document the local-command trust boundary

This keeps install/download/cache policy out of the first PR. Follow-up directions:
- evaluate jsi-style portfolio orchestration for richer cancellation/scoring once we have performance data: https://github.com/a16z/jsi
- keep exploration strategy/performance work separate; Greed DFS/prioritizer docs are useful references for matching exhaustive verification vs bug-finding search modes: https://ucsb-seclab.github.io/greed/modules/greed.exploration_techniques.dfs/