### PR TITLE
ci(ext): disable invariant assert_all in ExtTester

### DIFF
--- a/crates/test-utils/src/ext.rs
+++ b/crates/test-utils/src/ext.rs
@@ -176,6 +176,13 @@ impl ExtTester {
             test_cmd.env("FOUNDRY_FORK_BLOCK_NUMBER", fork_block.to_string());
         }
         test_cmd.env("FOUNDRY_INVARIANT_DEPTH", "15");
+        // Restore pre-#12587/#14482 short-circuit behavior for the ext_integration
+        // suite. External repos (e.g. mds1/convex-shutdown-simulation, hexonaut/guni-lev)
+        // pin specific commits and don't carry `assert_all = false` in their
+        // foundry.toml, so the new continuous-campaign default makes the
+        // invariant runs ~30-100× slower in CI (convex 10s → ~660s, gunilev
+        // 3s → ~320s). Force the legacy behavior here to keep the suite fast.
+        test_cmd.env("FOUNDRY_INVARIANT_ASSERT_ALL", "false");
         test_cmd.env("FOUNDRY_ALLOW_INTERNAL_EXPECT_REVERT", "true");
 
         test_cmd.assert_success();


### PR DESCRIPTION
Force `assert_all = false` for the `ext_integration` suite to undo the runtime regression introduced by #12587 / #14482 on external repos that don't carry the new default in their `foundry.toml`.

Per-commit CI timings (`nextest / test external (aarch64-unknown-linux-gnu)`):

| sha | convex | gunilev |
|---|---|---|
| `f369bce7d` | 8.3s | 3.0s |
| `5f5838d33` | 22.4s | 9.3s |
| **`0d3c40e59`** (#14482) | **439.7s** | **90.7s** |
| `2e66fff05` | 661.8s | 321.7s |

Only invariant-style fork tests (`convex_shutdown_simulation`, `gunilev`) regress — `solady`, `forge_std`, etc. are unaffected. Same root cause as #14746; same workaround pcaversaccio applied in [snekmate@0b06a1f6](https://github.com/pcaversaccio/snekmate/commit/0b06a1f62e71fa9e98685117089506799f39843f).

Co-Authored-By: grandizzy <38490174+grandizzy@users.noreply.github.com>

Prompted by: george