### PR TITLE
fix(cast): resolve tempo expiry in helper commands

### DIFF
--- a/crates/cast/src/cmd/batch_mktx.rs
+++ b/crates/cast/src/cmd/batch_mktx.rs
@@ -55,6 +55,7 @@ impl BatchMakeTxArgs {
     pub async fn run(self) -> Result<()> {
         let Self { calls, mut tx, eth, raw_unsigned, ethsign } = self;
         let has_nonce = tx.nonce.is_some();
+        let expires_at = tx.tempo.resolve_expires();
 
         if calls.is_empty() {
             return Err(eyre!("No calls specified. Use --call to specify at least one call."));
@@ -95,6 +96,7 @@ impl BatchMakeTxArgs {
         }
 
         sh_println!("Building batch transaction with {} call(s)...", tempo_calls.len())?;
+        tx::print_tempo_expires(expires_at)?;
 
         // Preserve key_id for modes that do not call build_with_access_key, such as raw unsigned.
         if let Some(ref access_key) = tempo_access_key {

--- a/crates/cast/src/cmd/batch_mktx.rs
+++ b/crates/cast/src/cmd/batch_mktx.rs
@@ -5,6 +5,7 @@
 
 use crate::{
     call_spec::CallSpec,
+    tempo,
     tx::{self, CastTxBuilder},
 };
 use alloy_consensus::SignableTransaction;
@@ -96,7 +97,7 @@ impl BatchMakeTxArgs {
         }
 
         sh_println!("Building batch transaction with {} call(s)...", tempo_calls.len())?;
-        tx::print_tempo_expires(expires_at)?;
+        tempo::print_expires(expires_at)?;
 
         // Preserve key_id for modes that do not call build_with_access_key, such as raw unsigned.
         if let Some(ref access_key) = tempo_access_key {

--- a/crates/cast/src/cmd/batch_send.rs
+++ b/crates/cast/src/cmd/batch_send.rs
@@ -51,6 +51,7 @@ pub struct BatchSendArgs {
 impl BatchSendArgs {
     pub async fn run(self) -> Result<()> {
         let Self { calls, send_tx, mut tx, unlocked } = self;
+        let expires_at = tx.tempo.resolve_expires();
 
         if calls.is_empty() {
             return Err(eyre!("No calls specified. Use --call to specify at least one call."));
@@ -96,6 +97,7 @@ impl BatchSendArgs {
         }
 
         sh_println!("Building batch transaction with {} call(s)...", tempo_calls.len())?;
+        tx::print_tempo_expires(expires_at)?;
 
         // Preserve key_id for modes that do not call build_with_access_key, such as unlocked.
         if let Some(ref access_key) = tempo_access_key {

--- a/crates/cast/src/cmd/batch_send.rs
+++ b/crates/cast/src/cmd/batch_send.rs
@@ -7,6 +7,7 @@
 use crate::{
     call_spec::CallSpec,
     cmd::send::{cast_send, cast_send_with_access_key},
+    tempo,
     tx::{self, CastTxBuilder, SendTxOpts},
 };
 use alloy_network::{EthereumWallet, TransactionBuilder};
@@ -97,7 +98,7 @@ impl BatchSendArgs {
         }
 
         sh_println!("Building batch transaction with {} call(s)...", tempo_calls.len())?;
-        tx::print_tempo_expires(expires_at)?;
+        tempo::print_expires(expires_at)?;
 
         // Preserve key_id for modes that do not call build_with_access_key, such as unlocked.
         if let Some(ref access_key) = tempo_access_key {

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -41,7 +41,7 @@ use foundry_cli::utils::{maybe_print_resolved_lane, resolve_lane};
 
 use crate::{
     cmd::send::cast_send,
-    tx::{self, CastTxBuilder, CastTxSender, SendTxOpts},
+    tx::{CastTxBuilder, CastTxSender, SendTxOpts},
 };
 
 /// Tempo keychain management commands.
@@ -1180,7 +1180,7 @@ async fn send_keychain_tx(
         return Ok(());
     }
 
-    tx::print_tempo_expires(expires_at)?;
+    crate::tempo::print_expires(expires_at)?;
 
     if let Some(browser) = browser {
         let chain = builder.chain();

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -41,7 +41,7 @@ use foundry_cli::utils::{maybe_print_resolved_lane, resolve_lane};
 
 use crate::{
     cmd::send::cast_send,
-    tx::{CastTxBuilder, CastTxSender, SendTxOpts},
+    tx::{self, CastTxBuilder, CastTxSender, SendTxOpts},
 };
 
 /// Tempo keychain management commands.
@@ -1126,6 +1126,7 @@ async fn send_keychain_tx(
 ) -> Result<()> {
     let (signer, tempo_access_key) = send_tx.eth.wallet.maybe_signer().await?;
     let print_sponsor_hash = tx_opts.tempo.print_sponsor_hash;
+    let expires_at = tx_opts.tempo.resolve_expires();
     let tempo_sponsor =
         if print_sponsor_hash { None } else { tx_opts.tempo.sponsor_config().await? };
 
@@ -1178,6 +1179,8 @@ async fn send_keychain_tx(
         }
         return Ok(());
     }
+
+    tx::print_tempo_expires(expires_at)?;
 
     if let Some(browser) = browser {
         let chain = builder.chain();

--- a/crates/cast/src/cmd/tip20/create.rs
+++ b/crates/cast/src/cmd/tip20/create.rs
@@ -3,7 +3,7 @@ use crate::{
         erc20::build_provider_with_signer,
         send::{cast_send, cast_send_with_access_key},
     },
-    tx::{SendTxOpts, TxParams},
+    tx::{self, SendTxOpts, TxParams},
 };
 use alloy_ens::NameOrAddress;
 use alloy_primitives::B256;
@@ -60,7 +60,7 @@ pub(super) async fn run(
     salt: B256,
     force: bool,
     send_tx: SendTxOpts,
-    tx_opts: TxParams,
+    mut tx_opts: TxParams,
 ) -> eyre::Result<()> {
     let (signer, tempo_access_key) = if send_tx.eth.wallet.from.is_some() {
         send_tx.eth.wallet.maybe_signer().await?
@@ -88,6 +88,8 @@ pub(super) async fn run(
         .createToken(name, symbol, currency, quote_token_addr, admin_addr, salt)
         .into_transaction_request();
 
+    let expires_at = tx_opts.tempo.resolve_expires();
+    tx::print_tempo_expires(expires_at)?;
     tx_opts.apply::<TempoNetwork>(&mut tx, get_chain(config.chain, &provider).await?.is_legacy());
 
     if let Some(ref access_key) = tempo_access_key {

--- a/crates/cast/src/cmd/tip20/create.rs
+++ b/crates/cast/src/cmd/tip20/create.rs
@@ -3,7 +3,8 @@ use crate::{
         erc20::build_provider_with_signer,
         send::{cast_send, cast_send_with_access_key},
     },
-    tx::{self, SendTxOpts, TxParams},
+    tempo,
+    tx::{SendTxOpts, TxParams},
 };
 use alloy_ens::NameOrAddress;
 use alloy_primitives::B256;
@@ -89,7 +90,7 @@ pub(super) async fn run(
         .into_transaction_request();
 
     let expires_at = tx_opts.tempo.resolve_expires();
-    tx::print_tempo_expires(expires_at)?;
+    tempo::print_expires(expires_at)?;
     tx_opts.apply::<TempoNetwork>(&mut tx, get_chain(config.chain, &provider).await?.is_legacy());
 
     if let Some(ref access_key) = tempo_access_key {

--- a/crates/cast/src/cmd/tip20/mine.rs
+++ b/crates/cast/src/cmd/tip20/mine.rs
@@ -3,7 +3,7 @@ use crate::{
         erc20::build_provider_with_signer,
         send::{cast_send, cast_send_with_access_key},
     },
-    tx::{SendTxOpts, TxParams},
+    tx::{self, SendTxOpts, TxParams},
 };
 use alloy_primitives::{Address, B256, keccak256};
 use alloy_signer::Signer;
@@ -78,7 +78,7 @@ pub(super) async fn register(
     master: Address,
     salt: B256,
     send_tx: SendTxOpts,
-    tx_opts: TxParams,
+    mut tx_opts: TxParams,
 ) -> Result<()> {
     let (signer, tempo_access_key) = send_tx.eth.wallet.maybe_signer().await?;
     let signer = signer.ok_or_else(|| {
@@ -103,6 +103,8 @@ pub(super) async fn register(
     let mut tx = IAddressRegistry::new(ADDRESS_REGISTRY_ADDRESS, &provider)
         .registerVirtualMaster(salt)
         .into_transaction_request();
+    let expires_at = tx_opts.tempo.resolve_expires();
+    tx::print_tempo_expires(expires_at)?;
     tx_opts.apply::<TempoNetwork>(&mut tx, get_chain(config.chain, &provider).await?.is_legacy());
 
     sh_println!("Submitting registerVirtualMaster({salt}) on Tempo...")?;

--- a/crates/cast/src/cmd/tip20/mine.rs
+++ b/crates/cast/src/cmd/tip20/mine.rs
@@ -3,7 +3,8 @@ use crate::{
         erc20::build_provider_with_signer,
         send::{cast_send, cast_send_with_access_key},
     },
-    tx::{self, SendTxOpts, TxParams},
+    tempo,
+    tx::{SendTxOpts, TxParams},
 };
 use alloy_primitives::{Address, B256, keccak256};
 use alloy_signer::Signer;
@@ -104,7 +105,7 @@ pub(super) async fn register(
         .registerVirtualMaster(salt)
         .into_transaction_request();
     let expires_at = tx_opts.tempo.resolve_expires();
-    tx::print_tempo_expires(expires_at)?;
+    tempo::print_expires(expires_at)?;
     tx_opts.apply::<TempoNetwork>(&mut tx, get_chain(config.chain, &provider).await?.is_legacy());
 
     sh_println!("Submitting registerVirtualMaster({salt}) on Tempo...")?;

--- a/crates/cast/src/cmd/vaddr/create.rs
+++ b/crates/cast/src/cmd/vaddr/create.rs
@@ -4,7 +4,8 @@ use crate::{
         send::{cast_send, cast_send_with_access_key},
         tip20::mine,
     },
-    tx::{self, SendTxOpts, TxParams},
+    tempo,
+    tx::{SendTxOpts, TxParams},
 };
 use alloy_primitives::{Address, B256};
 use alloy_signer::Signer;
@@ -157,7 +158,7 @@ async fn register(
         .registerVirtualMaster(salt)
         .into_transaction_request();
     let expires_at = tx_opts.tempo.resolve_expires();
-    tx::print_tempo_expires(expires_at)?;
+    tempo::print_expires(expires_at)?;
     tx_opts.apply::<TempoNetwork>(&mut tx, get_chain(config.chain, &provider).await?.is_legacy());
 
     sh_println!("Submitting registerVirtualMaster({salt})...")?;

--- a/crates/cast/src/cmd/vaddr/create.rs
+++ b/crates/cast/src/cmd/vaddr/create.rs
@@ -4,7 +4,7 @@ use crate::{
         send::{cast_send, cast_send_with_access_key},
         tip20::mine,
     },
-    tx::{SendTxOpts, TxParams},
+    tx::{self, SendTxOpts, TxParams},
 };
 use alloy_primitives::{Address, B256};
 use alloy_signer::Signer;
@@ -133,7 +133,7 @@ async fn register(
     owner: Address,
     salt: B256,
     send_tx: SendTxOpts,
-    tx_opts: TxParams,
+    mut tx_opts: TxParams,
 ) -> Result<()> {
     let (signer, tempo_access_key) = send_tx.eth.wallet.maybe_signer().await?;
     let signer = signer.ok_or_else(|| {
@@ -156,6 +156,8 @@ async fn register(
     let mut tx = IAddressRegistry::new(ADDRESS_REGISTRY_ADDRESS, &provider)
         .registerVirtualMaster(salt)
         .into_transaction_request();
+    let expires_at = tx_opts.tempo.resolve_expires();
+    tx::print_tempo_expires(expires_at)?;
     tx_opts.apply::<TempoNetwork>(&mut tx, get_chain(config.chain, &provider).await?.is_legacy());
 
     sh_println!("Submitting registerVirtualMaster({salt})...")?;

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -1,3 +1,12 @@
 //! Tempo transaction helpers used by Cast-facing commands.
 
+use eyre::Result;
+
 pub use foundry_common::tempo::{TempoSponsor, TempoSponsorPreview, resolve_tempo_sponsor_signer};
+
+pub(crate) fn print_expires(expires_at: Option<u64>) -> Result<()> {
+    if let Some(ts) = expires_at {
+        sh_println!("Transaction expires at unix timestamp {ts}")?;
+    }
+    Ok(())
+}

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -106,13 +106,6 @@ impl TxParams {
     }
 }
 
-pub(crate) fn print_tempo_expires(expires_at: Option<u64>) -> Result<()> {
-    if let Some(ts) = expires_at {
-        sh_println!("Transaction expires at unix timestamp {ts}")?;
-    }
-    Ok(())
-}
-
 /// Different sender kinds used by [`CastTxBuilder`].
 pub enum SenderKind<'a> {
     /// An address without signer. Used for read-only calls and transactions sent through unlocked

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -106,6 +106,13 @@ impl TxParams {
     }
 }
 
+pub(crate) fn print_tempo_expires(expires_at: Option<u64>) -> Result<()> {
+    if let Some(ts) = expires_at {
+        sh_println!("Transaction expires at unix timestamp {ts}")?;
+    }
+    Ok(())
+}
+
 /// Different sender kinds used by [`CastTxBuilder`].
 pub enum SenderKind<'a> {
     /// An address without signer. Used for read-only calls and transactions sent through unlocked

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -30,6 +30,7 @@ extern crate foundry_test_utils;
 mod erc20;
 mod keychain;
 mod selectors;
+mod tempo;
 
 casttest!(print_short_version, |_prj, cmd| {
     cmd.arg("-V").assert_success().stdout_eq(str![[r#"

--- a/crates/cast/tests/cli/tempo.rs
+++ b/crates/cast/tests/cli/tempo.rs
@@ -1,0 +1,22 @@
+//! CLI tests for shared Tempo transaction options.
+
+use foundry_test_utils::util::OutputExt;
+
+casttest!(tempo_state_changing_help_includes_expires, |_prj, cmd| {
+    let cases: &[(&str, &[&str])] = &[
+        ("batch-mktx", &["batch-mktx", "--help"]),
+        ("batch-send", &["batch-send", "--help"]),
+        ("keychain authorize", &["keychain", "authorize", "--help"]),
+        ("tip20 create", &["tip20", "create", "--help"]),
+        ("tip20 mine", &["tip20", "mine", "--help"]),
+        ("vaddr create", &["vaddr", "create", "--help"]),
+    ];
+
+    for (name, args) in cases {
+        let output = cmd.cast_fuse().args(*args).assert_success().get_output().stdout_lossy();
+        assert!(
+            output.contains("--tempo.expires <SECONDS>"),
+            "expected {name} help to expose --tempo.expires, got:\n{output}",
+        );
+    }
+});


### PR DESCRIPTION
## Motivation

Some Tempo-specific `cast` helpers accept `--tempo.expires` but apply the shared transaction options directly when building their requests. That leaves the relative expiry to be materialized at the application point instead of resolving it once up front, unlike `cast send`, `cast mktx`, and `cast erc20`.

## Solution

Resolve `--tempo.expires` before building transactions for the batch, keychain, TIP20, and virtual-address flows, then print the materialized unix timestamp through a shared helper before submission.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes