### PR TITLE
fix(lint): preserve variable locations in loop lints

### DIFF
--- a/crates/lint/src/sol/low/calls_loop.rs
+++ b/crates/lint/src/sol/low/calls_loop.rs
@@ -4,7 +4,7 @@ use crate::{
     sol::{Severity, SolLint},
 };
 use solar::{
-    ast::{ElementaryType, Visibility},
+    ast::{DataLocation, ElementaryType, Visibility},
     interface::{kw, sym},
     sema::{
         Gcx, Ty,
@@ -484,7 +484,13 @@ fn semantic_expr_ty<'gcx>(gcx: Gcx<'gcx>, hir: &Hir<'gcx>, expr: &Expr<'gcx>) ->
                         res.as_variable().map(|var_id| Res::Item(ItemId::Variable(var_id)))
                     }))
                 })?;
-            Some(gcx.type_of_res(res))
+            let ty = gcx.type_of_res(res);
+            Some(match res {
+                Res::Item(ItemId::Variable(var_id)) => {
+                    ty.with_loc_if_ref_opt(gcx, variable_data_location(hir, var_id))
+                }
+                _ => ty,
+            })
         }
         ExprKind::Index(base, _) => semantic_index_ty(gcx, hir, base),
         ExprKind::Member(base, member) => semantic_member_ty(gcx, hir, base, member.name),
@@ -506,10 +512,19 @@ fn semantic_expr_ty<'gcx>(gcx: Gcx<'gcx>, hir: &Hir<'gcx>, expr: &Expr<'gcx>) ->
 
 fn semantic_index_ty<'gcx>(gcx: Gcx<'gcx>, hir: &Hir<'gcx>, base: &Expr<'gcx>) -> Option<Ty<'gcx>> {
     let base_ty = semantic_expr_ty(gcx, hir, base)?;
+    let loc = indexed_base_data_location(base_ty);
     match base_ty.peel_refs().kind {
-        TyKind::Mapping(_, value) => Some(value),
+        TyKind::Mapping(_, value) => Some(value.with_loc_if_ref_opt(gcx, loc)),
         _ => base_ty.base_type(gcx),
     }
+}
+
+fn indexed_base_data_location(ty: Ty<'_>) -> Option<DataLocation> {
+    ty.loc().or_else(|| {
+        // Mappings can only live in storage, but Solar does not model `TyKind::Mapping`
+        // itself as a reference type.
+        matches!(ty.kind, TyKind::Mapping(..)).then_some(DataLocation::Storage)
+    })
 }
 
 fn semantic_member_ty<'gcx>(
@@ -550,6 +565,13 @@ fn referenced_item(expr: &Expr<'_>) -> Option<ItemId> {
         ExprKind::Ident([Res::Item(id), ..]) => Some(*id),
         _ => None,
     }
+}
+
+fn variable_data_location(hir: &Hir<'_>, var_id: hir::VariableId) -> Option<DataLocation> {
+    let var = hir.variable(var_id);
+    var.data_location.or_else(|| {
+        (var.function.is_none() && var.contract.is_some()).then_some(DataLocation::Storage)
+    })
 }
 
 fn unique<T>(mut iter: impl Iterator<Item = T>) -> Option<T> {

--- a/crates/lint/src/sol/low/delegatecall_loop.rs
+++ b/crates/lint/src/sol/low/delegatecall_loop.rs
@@ -4,7 +4,7 @@ use crate::{
     sol::{Severity, SolLint},
 };
 use solar::{
-    ast::{ElementaryType, LitKind, StateMutability, StrKind, TypeSize, Visibility},
+    ast::{DataLocation, ElementaryType, LitKind, StateMutability, StrKind, TypeSize, Visibility},
     interface::{Span, kw, sym},
     sema::{
         Gcx, Ty,
@@ -409,6 +409,10 @@ fn expr_ty<'gcx>(gcx: Gcx<'gcx>, hir: &Hir<'gcx>, expr: &Expr<'gcx>) -> Option<T
                 {
                     None
                 }
+                Res::Item(ItemId::Variable(var_id)) => Some(
+                    gcx.type_of_res(res)
+                        .with_loc_if_ref_opt(gcx, variable_data_location(hir, var_id)),
+                ),
                 _ => Some(gcx.type_of_res(res)),
             }
         }
@@ -419,7 +423,7 @@ fn expr_ty<'gcx>(gcx: Gcx<'gcx>, hir: &Hir<'gcx>, expr: &Expr<'gcx>) -> Option<T
             {
                 return None;
             }
-            lhs_ty.base_type(gcx)
+            index_ty(gcx, lhs_ty)
         }
         ExprKind::Lit(lit) => Some(match &lit.kind {
             LitKind::Str(StrKind::Hex, s, _) => {
@@ -493,6 +497,22 @@ fn explicit_cast_ty<'gcx>(gcx: Gcx<'gcx>, to: Ty<'gcx>, args: &CallArgs<'gcx>) -
     }
 }
 
+fn index_ty<'gcx>(gcx: Gcx<'gcx>, base_ty: Ty<'gcx>) -> Option<Ty<'gcx>> {
+    let loc = indexed_base_data_location(base_ty);
+    match base_ty.peel_refs().kind {
+        TyKind::Mapping(_, value) => Some(value.with_loc_if_ref_opt(gcx, loc)),
+        _ => base_ty.base_type(gcx),
+    }
+}
+
+fn indexed_base_data_location(ty: Ty<'_>) -> Option<DataLocation> {
+    ty.loc().or_else(|| {
+        // Mappings can only live in storage, but Solar does not model `TyKind::Mapping`
+        // itself as a reference type.
+        matches!(ty.kind, TyKind::Mapping(..)).then_some(DataLocation::Storage)
+    })
+}
+
 fn member_ty<'gcx>(
     gcx: Gcx<'gcx>,
     hir: &Hir<'gcx>,
@@ -531,6 +551,13 @@ fn referenced_item(expr: &Expr<'_>) -> Option<ItemId> {
         ExprKind::Ident([Res::Item(id), ..]) => Some(*id),
         _ => None,
     }
+}
+
+fn variable_data_location(hir: &Hir<'_>, var_id: VariableId) -> Option<DataLocation> {
+    let var = hir.variable(var_id);
+    var.data_location.or_else(|| {
+        (var.function.is_none() && var.contract.is_some()).then_some(DataLocation::Storage)
+    })
 }
 
 fn is_address_ty(ty: Ty<'_>) -> bool {

--- a/crates/lint/testdata/CallsLoop.sol
+++ b/crates/lint/testdata/CallsLoop.sol
@@ -73,6 +73,8 @@ contract CallsLoop {
     mapping(address => IReceiver) internal receiverByAddress;
     Target internal target;
     LocalLib.Box[] internal boxes;
+    address[] internal scratchTargets;
+    mapping(address => address[]) internal targetLists;
 
     modifier loopedPlaceholder() {
         for (uint256 i; i < 1; ++i) {
@@ -191,6 +193,18 @@ contract CallsLoop {
     function localInternalCallsAreIgnored() external {
         for (uint256 i; i < boxes.length; ++i) {
             _local(i);
+        }
+    }
+
+    function arrayBuiltinsAreIgnored(address targetAddress) external {
+        for (uint256 i; i < receivers.length; ++i) {
+            scratchTargets.push(targetAddress);
+        }
+    }
+
+    function mappingArrayBuiltinsAreIgnored(address targetKey, address targetAddress) external {
+        for (uint256 i; i < receivers.length; ++i) {
+            targetLists[targetKey].push(targetAddress);
         }
     }
 


### PR DESCRIPTION
## Summary
- preserve HIR variable data locations when reconstructing semantic types in calls-loop and delegatecall-loop
- add a calls-loop regression case for storage array builtins inside loops
- prevents Solar member resolution from receiving bare dynamic array reference types and panicking

Context: seen in tempoxyz/tempo CI where forge build --sizes on nightly crashed in calls-loop with `native_members: type DynArray(Elementary(Address)) should be wrapped in Ref`.