### PR TITLE
feat(symbolic): summarize portfolio diagnostics

### DIFF
--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -231,7 +231,31 @@ For latency-sensitive local runs, start with a small portfolio such as
 can still use more CPU and be slower when one fast solver already handles most
 queries. `--symbolic-dump-smt` prints each solver's configured order and launch
 delay with the per-query portfolio outcomes so solver mixes can be compared
-without changing execution semantics.
+without changing execution semantics. It also prints an aggregate portfolio
+summary at the end of the run, for example:
+
+```text
+--- symbolic solver portfolio summary ---
+queries: 48
+solver runs: 64
+rescue solver runs: 0
+not-started solver runs: 32
+non-primary wins: 0
+rescue wins: 0
+cancelled after winner: 0
+invalid models: 0
+solver errors: 0
+winner counts:
+  yices-smt2 --bvconst-in-decimal: 48
+launch counts:
+  yices-smt2 --bvconst-in-decimal: 48
+  z3 -in -smt2: 16
+outcome counts:
+  not-started: 32
+  sat-valid: 32
+  unsat: 32
+```
+
 Forge warns when a configured portfolio is degraded because one or more solver
 entries are not available, but it still uses the entries that can be invoked.
 

--- a/crates/evm/symbolic/src/executor.rs
+++ b/crates/evm/symbolic/src/executor.rs
@@ -13,6 +13,11 @@ impl SymbolicExecutor {
         Self { config, solver: Box::new(solver) }
     }
 
+    /// Returns staged solver portfolio diagnostics collected by this executor.
+    pub fn portfolio_diagnostics(&self) -> Option<PortfolioDiagnostics> {
+        self.solver.portfolio_diagnostics().cloned()
+    }
+
     /// Executes one function symbolically against an already-deployed test contract.
     ///
     /// The input executor supplies the deployed bytecode, storage backend, caller, and

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -55,7 +55,7 @@ mod abi;
 mod executor;
 mod runtime;
 
-pub use runtime::{SymbolicError, SymbolicRunInput};
+pub use runtime::{PortfolioDiagnostics, SymbolicError, SymbolicRunInput};
 
 /// Symbolic solver names with built-in command-line mappings.
 pub const BUILTIN_SYMBOLIC_SOLVERS: &[&str] =

--- a/crates/evm/symbolic/src/runtime.rs
+++ b/crates/evm/symbolic/src/runtime.rs
@@ -19,6 +19,7 @@ pub(crate) use evm::*;
 pub(crate) use expressions::*;
 pub(crate) use memory::*;
 pub(crate) use precompiles::*;
+pub use solver::PortfolioDiagnostics;
 pub(crate) use solver::*;
 pub(crate) use state::*;
 

--- a/crates/evm/symbolic/src/runtime.rs
+++ b/crates/evm/symbolic/src/runtime.rs
@@ -20,7 +20,14 @@ pub(crate) use expressions::*;
 pub(crate) use memory::*;
 pub(crate) use precompiles::*;
 pub use solver::PortfolioDiagnostics;
-pub(crate) use solver::*;
+pub(crate) use solver::{
+    SmtLibSubprocessSolver, SymbolicSolver, solver_portfolio_availability_warning,
+};
+#[cfg(test)]
+pub(crate) use solver::{
+    SolverCommand, SolverRunSummary, fallback_single_var_model, named_solver_command, parse_model,
+    solver_commands_for_config, split_solver_command, validate_solver_model_output,
+};
 pub(crate) use state::*;
 
 pub struct SymbolicRunInput<'a, FEN: FoundryEvmNetwork> {

--- a/crates/evm/symbolic/src/runtime.rs
+++ b/crates/evm/symbolic/src/runtime.rs
@@ -25,8 +25,9 @@ pub(crate) use solver::{
 };
 #[cfg(test)]
 pub(crate) use solver::{
-    SolverCommand, SolverRunSummary, fallback_single_var_model, named_solver_command, parse_model,
-    solver_commands_for_config, split_solver_command, validate_solver_model_output,
+    SolverCommand, SolverOutcome, SolverRunSummary, fallback_single_var_model,
+    named_solver_command, parse_model, solver_commands_for_config, split_solver_command,
+    validate_solver_model_output,
 };
 pub(crate) use state::*;
 

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -5,18 +5,47 @@ const MAX_SOLVER_POLL_BACKOFF: Duration = Duration::from_millis(50);
 const SECOND_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(100);
 const RESCUE_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(500);
 
-const OUTCOME_CANCELLED: &str = "cancelled";
-const OUTCOME_ERROR: &str = "error";
-const OUTCOME_NOT_STARTED: &str = "not-started";
-const OUTCOME_SAT_AFTER_WINNER: &str = "sat-after-winner";
-const OUTCOME_SAT_INVALID: &str = "sat-invalid";
-const OUTCOME_SAT_VALID: &str = "sat-valid";
-const OUTCOME_TIMEOUT_OR_UNKNOWN: &str = "timeout-or-unknown";
-const OUTCOME_UNKNOWN: &str = "unknown";
-const OUTCOME_UNKNOWN_AFTER_WINNER: &str = "unknown-after-winner";
-const OUTCOME_UNSAT: &str = "unsat";
-const OUTCOME_UNSAT_AFTER_WINNER: &str = "unsat-after-winner";
-const OUTCOME_UNEXPECTED: &str = "unexpected";
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum SolverOutcome {
+    Cancelled,
+    Error,
+    NotStarted,
+    SatAfterWinner,
+    SatInvalid,
+    SatValid,
+    TimeoutOrUnknown,
+    Unknown,
+    UnknownAfterWinner,
+    Unsat,
+    UnsatAfterWinner,
+    Unexpected,
+}
+
+impl SolverOutcome {
+    /// Returns the diagnostic label for this solver outcome.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cancelled => "cancelled",
+            Self::Error => "error",
+            Self::NotStarted => "not-started",
+            Self::SatAfterWinner => "sat-after-winner",
+            Self::SatInvalid => "sat-invalid",
+            Self::SatValid => "sat-valid",
+            Self::TimeoutOrUnknown => "timeout-or-unknown",
+            Self::Unknown => "unknown",
+            Self::UnknownAfterWinner => "unknown-after-winner",
+            Self::Unsat => "unsat",
+            Self::UnsatAfterWinner => "unsat-after-winner",
+            Self::Unexpected => "unexpected",
+        }
+    }
+}
+
+impl fmt::Display for SolverOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 /// Minimal solver backend interface used by the symbolic executor.
 ///
@@ -402,14 +431,14 @@ pub(crate) struct SolverRunSummary {
     scheduled_after: Option<Duration>,
     started_after: Option<Duration>,
     elapsed: Duration,
-    outcome: &'static str,
+    outcome: SolverOutcome,
     detail: Option<String>,
     winner: bool,
 }
 
 impl SolverRunSummary {
     /// Builds a portfolio run summary with no detail or winner marker.
-    pub(crate) const fn new(display: String, elapsed: Duration, outcome: &'static str) -> Self {
+    pub(crate) const fn new(display: String, elapsed: Duration, outcome: SolverOutcome) -> Self {
         Self {
             index: None,
             display,
@@ -461,7 +490,7 @@ pub struct PortfolioDiagnostics {
     pub(crate) solver_errors: usize,
     pub(crate) winner_counts: BTreeMap<String, usize>,
     pub(crate) launch_counts: BTreeMap<String, usize>,
-    pub(crate) outcome_counts: BTreeMap<&'static str, usize>,
+    pub(crate) outcome_counts: BTreeMap<SolverOutcome, usize>,
 }
 
 impl PortfolioDiagnostics {
@@ -488,13 +517,13 @@ impl PortfolioDiagnostics {
             }
 
             match summary.outcome {
-                OUTCOME_NOT_STARTED => self.not_started += 1,
-                OUTCOME_CANCELLED
-                | OUTCOME_SAT_AFTER_WINNER
-                | OUTCOME_UNSAT_AFTER_WINNER
-                | OUTCOME_UNKNOWN_AFTER_WINNER => self.cancelled_after_winner += 1,
-                OUTCOME_SAT_INVALID => self.invalid_models += 1,
-                OUTCOME_ERROR => self.solver_errors += 1,
+                SolverOutcome::NotStarted => self.not_started += 1,
+                SolverOutcome::Cancelled
+                | SolverOutcome::SatAfterWinner
+                | SolverOutcome::UnsatAfterWinner
+                | SolverOutcome::UnknownAfterWinner => self.cancelled_after_winner += 1,
+                SolverOutcome::SatInvalid => self.invalid_models += 1,
+                SolverOutcome::Error => self.solver_errors += 1,
                 _ => {}
             }
 
@@ -677,16 +706,20 @@ fn run_solver_commands(
                         && let Err(err) = validate_solver_model_output(&output, constraints)
                     {
                         summaries.push(
-                            SolverRunSummary::new(display.clone(), elapsed, OUTCOME_SAT_INVALID)
-                                .with_schedule(index, scheduled_after, Some(started_after))
-                                .with_detail(err.to_string()),
+                            SolverRunSummary::new(
+                                display.clone(),
+                                elapsed,
+                                SolverOutcome::SatInvalid,
+                            )
+                            .with_schedule(index, scheduled_after, Some(started_after))
+                            .with_detail(err.to_string()),
                         );
                         saw_invalid_sat_model = true;
                         errors.push(format!("{display}: {err}"));
                         continue;
                     }
                     summaries.push(
-                        SolverRunSummary::new(display, elapsed, OUTCOME_SAT_VALID)
+                        SolverRunSummary::new(display, elapsed, SolverOutcome::SatValid)
                             .with_schedule(index, scheduled_after, Some(started_after))
                             .winner(),
                     );
@@ -698,28 +731,22 @@ fn run_solver_commands(
                 }
                 SolverProcessOutcome::Output(output) if solver_output_is_unsat(&output) => {
                     summaries.push(
-                        SolverRunSummary::new(display, elapsed, OUTCOME_UNSAT).with_schedule(
-                            index,
-                            scheduled_after,
-                            Some(started_after),
-                        ),
+                        SolverRunSummary::new(display, elapsed, SolverOutcome::Unsat)
+                            .with_schedule(index, scheduled_after, Some(started_after)),
                     );
                     saw_unsat = true;
                 }
                 SolverProcessOutcome::Output(output) if solver_output_is_unknown(&output) => {
                     summaries.push(
-                        SolverRunSummary::new(display, elapsed, OUTCOME_UNKNOWN).with_schedule(
-                            index,
-                            scheduled_after,
-                            Some(started_after),
-                        ),
+                        SolverRunSummary::new(display, elapsed, SolverOutcome::Unknown)
+                            .with_schedule(index, scheduled_after, Some(started_after)),
                     );
                     saw_unknown = true;
                 }
                 SolverProcessOutcome::Output(output) => {
                     let first_line = first_solver_line(&output).to_string();
                     summaries.push(
-                        SolverRunSummary::new(display.clone(), elapsed, OUTCOME_UNEXPECTED)
+                        SolverRunSummary::new(display.clone(), elapsed, SolverOutcome::Unexpected)
                             .with_schedule(index, scheduled_after, Some(started_after))
                             .with_detail(first_line.clone()),
                     );
@@ -727,23 +754,20 @@ fn run_solver_commands(
                 }
                 SolverProcessOutcome::Unknown => {
                     summaries.push(
-                        SolverRunSummary::new(display, elapsed, OUTCOME_TIMEOUT_OR_UNKNOWN)
+                        SolverRunSummary::new(display, elapsed, SolverOutcome::TimeoutOrUnknown)
                             .with_schedule(index, scheduled_after, Some(started_after)),
                     );
                     saw_unknown = true;
                 }
                 SolverProcessOutcome::Cancelled => {
                     summaries.push(
-                        SolverRunSummary::new(display, elapsed, OUTCOME_CANCELLED).with_schedule(
-                            index,
-                            scheduled_after,
-                            Some(started_after),
-                        ),
+                        SolverRunSummary::new(display, elapsed, SolverOutcome::Cancelled)
+                            .with_schedule(index, scheduled_after, Some(started_after)),
                     );
                 }
                 SolverProcessOutcome::Error(err) => {
                     summaries.push(
-                        SolverRunSummary::new(display.clone(), elapsed, OUTCOME_ERROR)
+                        SolverRunSummary::new(display.clone(), elapsed, SolverOutcome::Error)
                             .with_schedule(index, scheduled_after, Some(started_after))
                             .with_detail(err.clone()),
                     );
@@ -755,7 +779,7 @@ fn run_solver_commands(
         if decisive.is_none()
             && saw_unsat
             && let Some(summary) =
-                summaries.iter_mut().find(|summary| summary.outcome == OUTCOME_UNSAT)
+                summaries.iter_mut().find(|summary| summary.outcome == SolverOutcome::Unsat)
         {
             summary.winner = true;
         }
@@ -815,7 +839,7 @@ fn next_portfolio_launch_wait(
 
 /// Summarizes a solver that was never launched because the portfolio already won.
 fn summary_for_unstarted_solver(solver: ScheduledSolver) -> SolverRunSummary {
-    SolverRunSummary::new(solver.command.display, Duration::ZERO, OUTCOME_NOT_STARTED)
+    SolverRunSummary::new(solver.command.display, Duration::ZERO, SolverOutcome::NotStarted)
         .with_schedule(solver.index, solver.launch_after, None)
 }
 
@@ -830,26 +854,26 @@ fn summary_for_cancelled_solver_result(
 ) -> SolverRunSummary {
     let summary = match outcome {
         SolverProcessOutcome::Output(output) if solver_output_is_sat(&output) => {
-            SolverRunSummary::new(display, elapsed, OUTCOME_SAT_AFTER_WINNER)
+            SolverRunSummary::new(display, elapsed, SolverOutcome::SatAfterWinner)
         }
         SolverProcessOutcome::Output(output) if solver_output_is_unsat(&output) => {
-            SolverRunSummary::new(display, elapsed, OUTCOME_UNSAT_AFTER_WINNER)
+            SolverRunSummary::new(display, elapsed, SolverOutcome::UnsatAfterWinner)
         }
         SolverProcessOutcome::Output(output) if solver_output_is_unknown(&output) => {
-            SolverRunSummary::new(display, elapsed, OUTCOME_UNKNOWN_AFTER_WINNER)
+            SolverRunSummary::new(display, elapsed, SolverOutcome::UnknownAfterWinner)
         }
         SolverProcessOutcome::Output(output) => {
-            SolverRunSummary::new(display, elapsed, OUTCOME_UNEXPECTED)
+            SolverRunSummary::new(display, elapsed, SolverOutcome::Unexpected)
                 .with_detail(first_solver_line(&output).to_string())
         }
         SolverProcessOutcome::Unknown => {
-            SolverRunSummary::new(display, elapsed, OUTCOME_TIMEOUT_OR_UNKNOWN)
+            SolverRunSummary::new(display, elapsed, SolverOutcome::TimeoutOrUnknown)
         }
         SolverProcessOutcome::Cancelled => {
-            SolverRunSummary::new(display, elapsed, OUTCOME_CANCELLED)
+            SolverRunSummary::new(display, elapsed, SolverOutcome::Cancelled)
         }
         SolverProcessOutcome::Error(err) => {
-            SolverRunSummary::new(display, elapsed, OUTCOME_ERROR).with_detail(err)
+            SolverRunSummary::new(display, elapsed, SolverOutcome::Error).with_detail(err)
         }
     };
     summary.with_schedule(index, scheduled_after, Some(started_after))

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -5,6 +5,19 @@ const MAX_SOLVER_POLL_BACKOFF: Duration = Duration::from_millis(50);
 const SECOND_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(100);
 const RESCUE_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(500);
 
+const OUTCOME_CANCELLED: &str = "cancelled";
+const OUTCOME_ERROR: &str = "error";
+const OUTCOME_NOT_STARTED: &str = "not-started";
+const OUTCOME_SAT_AFTER_WINNER: &str = "sat-after-winner";
+const OUTCOME_SAT_INVALID: &str = "sat-invalid";
+const OUTCOME_SAT_VALID: &str = "sat-valid";
+const OUTCOME_TIMEOUT_OR_UNKNOWN: &str = "timeout-or-unknown";
+const OUTCOME_UNKNOWN: &str = "unknown";
+const OUTCOME_UNKNOWN_AFTER_WINNER: &str = "unknown-after-winner";
+const OUTCOME_UNSAT: &str = "unsat";
+const OUTCOME_UNSAT_AFTER_WINNER: &str = "unsat-after-winner";
+const OUTCOME_UNEXPECTED: &str = "unexpected";
+
 /// Minimal solver backend interface used by the symbolic executor.
 ///
 /// Implementations are responsible for translating accumulated symbolic constraints
@@ -14,6 +27,9 @@ const RESCUE_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(500);
 pub(crate) trait SymbolicSolver {
     /// Returns solver counters collected by this backend.
     fn stats(&self) -> SymbolicStats;
+
+    /// Returns aggregate staged-portfolio diagnostics collected by this backend.
+    fn portfolio_diagnostics(&self) -> Option<&PortfolioDiagnostics>;
 
     /// Verifies that the configured solver can be invoked before exploration starts.
     ///
@@ -103,6 +119,11 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
         SymbolicStats { paths: 0, solver_queries: self.queries }
     }
 
+    /// Returns staged-portfolio diagnostics collected by this solver.
+    fn portfolio_diagnostics(&self) -> Option<&PortfolioDiagnostics> {
+        (!self.portfolio_diagnostics.is_empty()).then_some(&self.portfolio_diagnostics)
+    }
+
     /// Validates the `check_available` solver helper.
     fn check_available(&self) -> Result<(), SymbolicError> {
         let commands = self.commands()?;
@@ -188,15 +209,14 @@ impl SmtLibSubprocessSolver {
             constraint.collect_vars(&mut vars);
         }
 
+        let commands = self.commands()?;
+
         let mut smt = String::new();
         smt.push_str("(set-logic QF_BV)\n");
+        if commands.iter().all(|command| command.smt_timeout)
+            && let Some(timeout) = self.timeout.filter(|timeout| *timeout > 0)
         {
-            let commands = self.commands()?;
-            if commands.iter().all(|command| command.smt_timeout)
-                && let Some(timeout) = self.timeout.filter(|timeout| *timeout > 0)
-            {
-                let _ = writeln!(smt, "(set-option :timeout {})", timeout.saturating_mul(1000));
-            }
+            let _ = writeln!(smt, "(set-option :timeout {})", timeout.saturating_mul(1000));
         }
         for var in vars {
             let _ = writeln!(smt, "(declare-fun {var} () (_ BitVec 256))");
@@ -213,16 +233,13 @@ impl SmtLibSubprocessSolver {
             let _ = writeln!(stderr, "--- symbolic SMT query {} ---\n{smt}", self.queries);
         }
 
-        let result = {
-            let commands = self.commands()?;
-            run_solver_commands(
-                commands,
-                &smt,
-                self.timeout,
-                model.then_some(constraints),
-                self.dump_smt,
-            )
-        };
+        let result = run_solver_commands(
+            commands,
+            &smt,
+            self.timeout,
+            model.then_some(constraints),
+            self.dump_smt,
+        );
         if self.dump_smt {
             self.portfolio_diagnostics.record(&result.summaries);
         }
@@ -431,8 +448,8 @@ impl SolverRunSummary {
     }
 }
 
-#[derive(Debug, Default)]
-pub(crate) struct PortfolioDiagnostics {
+#[derive(Clone, Debug, Default)]
+pub struct PortfolioDiagnostics {
     pub(crate) queries: usize,
     pub(crate) solver_runs: usize,
     pub(crate) rescue_runs: usize,
@@ -448,6 +465,11 @@ pub(crate) struct PortfolioDiagnostics {
 }
 
 impl PortfolioDiagnostics {
+    /// Returns whether this diagnostic set is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.queries == 0
+    }
+
     /// Records one portfolio query's per-solver summaries.
     pub(crate) fn record(&mut self, summaries: &[SolverRunSummary]) {
         if summaries.len() <= 1 {
@@ -466,13 +488,13 @@ impl PortfolioDiagnostics {
             }
 
             match summary.outcome {
-                "not-started" => self.not_started += 1,
-                "cancelled"
-                | "sat-after-winner"
-                | "unsat-after-winner"
-                | "unknown-after-winner" => self.cancelled_after_winner += 1,
-                "sat-invalid" => self.invalid_models += 1,
-                "error" => self.solver_errors += 1,
+                OUTCOME_NOT_STARTED => self.not_started += 1,
+                OUTCOME_CANCELLED
+                | OUTCOME_SAT_AFTER_WINNER
+                | OUTCOME_UNSAT_AFTER_WINNER
+                | OUTCOME_UNKNOWN_AFTER_WINNER => self.cancelled_after_winner += 1,
+                OUTCOME_SAT_INVALID => self.invalid_models += 1,
+                OUTCOME_ERROR => self.solver_errors += 1,
                 _ => {}
             }
 
@@ -488,47 +510,62 @@ impl PortfolioDiagnostics {
         }
     }
 
-    /// Writes the aggregate portfolio summary to stderr.
-    fn dump(&self) {
-        if self.queries == 0 {
-            return;
-        }
-
-        let mut stderr = std::io::stderr().lock();
-        let _ = writeln!(stderr, "--- symbolic solver portfolio summary ---");
-        let _ = writeln!(stderr, "queries: {}", self.queries);
-        let _ = writeln!(stderr, "solver runs: {}", self.solver_runs);
-        let _ = writeln!(stderr, "rescue solver runs: {}", self.rescue_runs);
-        let _ = writeln!(stderr, "not-started solver runs: {}", self.not_started);
-        let _ = writeln!(stderr, "non-primary wins: {}", self.non_primary_wins);
-        let _ = writeln!(stderr, "rescue wins: {}", self.rescue_wins);
-        let _ = writeln!(stderr, "cancelled after winner: {}", self.cancelled_after_winner);
-        let _ = writeln!(stderr, "invalid models: {}", self.invalid_models);
-        let _ = writeln!(stderr, "solver errors: {}", self.solver_errors);
-        if !self.winner_counts.is_empty() {
-            let _ = writeln!(stderr, "winner counts:");
-            for (solver, count) in &self.winner_counts {
-                let _ = writeln!(stderr, "  {solver}: {count}");
-            }
-        }
-        if !self.launch_counts.is_empty() {
-            let _ = writeln!(stderr, "launch counts:");
-            for (solver, count) in &self.launch_counts {
-                let _ = writeln!(stderr, "  {solver}: {count}");
-            }
-        }
-        let _ = writeln!(stderr, "outcome counts:");
-        for (outcome, count) in &self.outcome_counts {
-            let _ = writeln!(stderr, "  {outcome}: {count}");
-        }
+    /// Merges another aggregate portfolio summary into this one.
+    pub fn merge(&mut self, other: &Self) {
+        self.queries += other.queries;
+        self.solver_runs += other.solver_runs;
+        self.rescue_runs += other.rescue_runs;
+        self.non_primary_wins += other.non_primary_wins;
+        self.rescue_wins += other.rescue_wins;
+        self.not_started += other.not_started;
+        self.cancelled_after_winner += other.cancelled_after_winner;
+        self.invalid_models += other.invalid_models;
+        self.solver_errors += other.solver_errors;
+        merge_counts(&mut self.winner_counts, &other.winner_counts);
+        merge_counts(&mut self.launch_counts, &other.launch_counts);
+        merge_counts(&mut self.outcome_counts, &other.outcome_counts);
     }
 }
 
-impl Drop for SmtLibSubprocessSolver {
-    fn drop(&mut self) {
-        if self.dump_smt {
-            self.portfolio_diagnostics.dump();
+impl fmt::Display for PortfolioDiagnostics {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_empty() {
+            return Ok(());
         }
+
+        writeln!(f, "--- symbolic solver portfolio summary ---")?;
+        writeln!(f, "queries: {}", self.queries)?;
+        writeln!(f, "solver runs: {}", self.solver_runs)?;
+        writeln!(f, "rescue solver runs: {}", self.rescue_runs)?;
+        writeln!(f, "not-started solver runs: {}", self.not_started)?;
+        writeln!(f, "non-primary wins: {}", self.non_primary_wins)?;
+        writeln!(f, "rescue wins: {}", self.rescue_wins)?;
+        writeln!(f, "cancelled after winner: {}", self.cancelled_after_winner)?;
+        writeln!(f, "invalid models: {}", self.invalid_models)?;
+        writeln!(f, "solver errors: {}", self.solver_errors)?;
+        if !self.winner_counts.is_empty() {
+            writeln!(f, "winner counts:")?;
+            for (solver, count) in &self.winner_counts {
+                writeln!(f, "  {solver}: {count}")?;
+            }
+        }
+        if !self.launch_counts.is_empty() {
+            writeln!(f, "launch counts:")?;
+            for (solver, count) in &self.launch_counts {
+                writeln!(f, "  {solver}: {count}")?;
+            }
+        }
+        writeln!(f, "outcome counts:")?;
+        for (outcome, count) in &self.outcome_counts {
+            writeln!(f, "  {outcome}: {count}")?;
+        }
+        Ok(())
+    }
+}
+
+fn merge_counts<K: Ord + Clone>(base: &mut BTreeMap<K, usize>, other: &BTreeMap<K, usize>) {
+    for (key, count) in other {
+        *base.entry(key.clone()).or_default() += count;
     }
 }
 
@@ -640,7 +677,7 @@ fn run_solver_commands(
                         && let Err(err) = validate_solver_model_output(&output, constraints)
                     {
                         summaries.push(
-                            SolverRunSummary::new(display.clone(), elapsed, "sat-invalid")
+                            SolverRunSummary::new(display.clone(), elapsed, OUTCOME_SAT_INVALID)
                                 .with_schedule(index, scheduled_after, Some(started_after))
                                 .with_detail(err.to_string()),
                         );
@@ -649,7 +686,7 @@ fn run_solver_commands(
                         continue;
                     }
                     summaries.push(
-                        SolverRunSummary::new(display, elapsed, "sat-valid")
+                        SolverRunSummary::new(display, elapsed, OUTCOME_SAT_VALID)
                             .with_schedule(index, scheduled_after, Some(started_after))
                             .winner(),
                     );
@@ -660,16 +697,18 @@ fn run_solver_commands(
                     }
                 }
                 SolverProcessOutcome::Output(output) if solver_output_is_unsat(&output) => {
-                    summaries.push(SolverRunSummary::new(display, elapsed, "unsat").with_schedule(
-                        index,
-                        scheduled_after,
-                        Some(started_after),
-                    ));
+                    summaries.push(
+                        SolverRunSummary::new(display, elapsed, OUTCOME_UNSAT).with_schedule(
+                            index,
+                            scheduled_after,
+                            Some(started_after),
+                        ),
+                    );
                     saw_unsat = true;
                 }
                 SolverProcessOutcome::Output(output) if solver_output_is_unknown(&output) => {
                     summaries.push(
-                        SolverRunSummary::new(display, elapsed, "unknown").with_schedule(
+                        SolverRunSummary::new(display, elapsed, OUTCOME_UNKNOWN).with_schedule(
                             index,
                             scheduled_after,
                             Some(started_after),
@@ -680,7 +719,7 @@ fn run_solver_commands(
                 SolverProcessOutcome::Output(output) => {
                     let first_line = first_solver_line(&output).to_string();
                     summaries.push(
-                        SolverRunSummary::new(display.clone(), elapsed, "unexpected")
+                        SolverRunSummary::new(display.clone(), elapsed, OUTCOME_UNEXPECTED)
                             .with_schedule(index, scheduled_after, Some(started_after))
                             .with_detail(first_line.clone()),
                     );
@@ -688,14 +727,14 @@ fn run_solver_commands(
                 }
                 SolverProcessOutcome::Unknown => {
                     summaries.push(
-                        SolverRunSummary::new(display, elapsed, "timeout-or-unknown")
+                        SolverRunSummary::new(display, elapsed, OUTCOME_TIMEOUT_OR_UNKNOWN)
                             .with_schedule(index, scheduled_after, Some(started_after)),
                     );
                     saw_unknown = true;
                 }
                 SolverProcessOutcome::Cancelled => {
                     summaries.push(
-                        SolverRunSummary::new(display, elapsed, "cancelled").with_schedule(
+                        SolverRunSummary::new(display, elapsed, OUTCOME_CANCELLED).with_schedule(
                             index,
                             scheduled_after,
                             Some(started_after),
@@ -704,7 +743,7 @@ fn run_solver_commands(
                 }
                 SolverProcessOutcome::Error(err) => {
                     summaries.push(
-                        SolverRunSummary::new(display.clone(), elapsed, "error")
+                        SolverRunSummary::new(display.clone(), elapsed, OUTCOME_ERROR)
                             .with_schedule(index, scheduled_after, Some(started_after))
                             .with_detail(err.clone()),
                     );
@@ -715,7 +754,8 @@ fn run_solver_commands(
 
         if decisive.is_none()
             && saw_unsat
-            && let Some(summary) = summaries.iter_mut().find(|summary| summary.outcome == "unsat")
+            && let Some(summary) =
+                summaries.iter_mut().find(|summary| summary.outcome == OUTCOME_UNSAT)
         {
             summary.winner = true;
         }
@@ -775,11 +815,8 @@ fn next_portfolio_launch_wait(
 
 /// Summarizes a solver that was never launched because the portfolio already won.
 fn summary_for_unstarted_solver(solver: ScheduledSolver) -> SolverRunSummary {
-    SolverRunSummary::new(solver.command.display, Duration::ZERO, "not-started").with_schedule(
-        solver.index,
-        solver.launch_after,
-        None,
-    )
+    SolverRunSummary::new(solver.command.display, Duration::ZERO, OUTCOME_NOT_STARTED)
+        .with_schedule(solver.index, solver.launch_after, None)
 }
 
 /// Summarizes a solver result received after a portfolio winner was chosen.
@@ -793,24 +830,26 @@ fn summary_for_cancelled_solver_result(
 ) -> SolverRunSummary {
     let summary = match outcome {
         SolverProcessOutcome::Output(output) if solver_output_is_sat(&output) => {
-            SolverRunSummary::new(display, elapsed, "sat-after-winner")
+            SolverRunSummary::new(display, elapsed, OUTCOME_SAT_AFTER_WINNER)
         }
         SolverProcessOutcome::Output(output) if solver_output_is_unsat(&output) => {
-            SolverRunSummary::new(display, elapsed, "unsat-after-winner")
+            SolverRunSummary::new(display, elapsed, OUTCOME_UNSAT_AFTER_WINNER)
         }
         SolverProcessOutcome::Output(output) if solver_output_is_unknown(&output) => {
-            SolverRunSummary::new(display, elapsed, "unknown-after-winner")
+            SolverRunSummary::new(display, elapsed, OUTCOME_UNKNOWN_AFTER_WINNER)
         }
         SolverProcessOutcome::Output(output) => {
-            SolverRunSummary::new(display, elapsed, "unexpected")
+            SolverRunSummary::new(display, elapsed, OUTCOME_UNEXPECTED)
                 .with_detail(first_solver_line(&output).to_string())
         }
         SolverProcessOutcome::Unknown => {
-            SolverRunSummary::new(display, elapsed, "timeout-or-unknown")
+            SolverRunSummary::new(display, elapsed, OUTCOME_TIMEOUT_OR_UNKNOWN)
         }
-        SolverProcessOutcome::Cancelled => SolverRunSummary::new(display, elapsed, "cancelled"),
+        SolverProcessOutcome::Cancelled => {
+            SolverRunSummary::new(display, elapsed, OUTCOME_CANCELLED)
+        }
         SolverProcessOutcome::Error(err) => {
-            SolverRunSummary::new(display, elapsed, "error").with_detail(err)
+            SolverRunSummary::new(display, elapsed, OUTCOME_ERROR).with_detail(err)
         }
     };
     summary.with_schedule(index, scheduled_after, Some(started_after))

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -65,17 +65,25 @@ pub(crate) struct SmtLibSubprocessSolver {
     pub(crate) max_queries: usize,
     pub(crate) queries: usize,
     pub(crate) dump_smt: bool,
+    portfolio_diagnostics: PortfolioDiagnostics,
 }
 
 impl SmtLibSubprocessSolver {
     /// Constructs a new instance.
-    pub(crate) const fn new(
+    pub(crate) fn new(
         commands: Result<Vec<SolverCommand>, String>,
         timeout: Option<u32>,
         max_queries: usize,
         dump_smt: bool,
     ) -> Self {
-        Self { commands, timeout, max_queries, queries: 0, dump_smt }
+        Self {
+            commands,
+            timeout,
+            max_queries,
+            queries: 0,
+            dump_smt,
+            portfolio_diagnostics: PortfolioDiagnostics::default(),
+        }
     }
 
     /// Constructs a subprocess solver from Foundry symbolic config.
@@ -171,7 +179,7 @@ impl SmtLibSubprocessSolver {
 
     /// Implements the `query` solver helper.
     pub(crate) fn query(
-        &self,
+        &mut self,
         constraints: &[BoolExpr],
         model: bool,
     ) -> Result<String, SymbolicError> {
@@ -180,13 +188,15 @@ impl SmtLibSubprocessSolver {
             constraint.collect_vars(&mut vars);
         }
 
-        let commands = self.commands()?;
         let mut smt = String::new();
         smt.push_str("(set-logic QF_BV)\n");
-        if commands.iter().all(|command| command.smt_timeout)
-            && let Some(timeout) = self.timeout.filter(|timeout| *timeout > 0)
         {
-            let _ = writeln!(smt, "(set-option :timeout {})", timeout.saturating_mul(1000));
+            let commands = self.commands()?;
+            if commands.iter().all(|command| command.smt_timeout)
+                && let Some(timeout) = self.timeout.filter(|timeout| *timeout > 0)
+            {
+                let _ = writeln!(smt, "(set-option :timeout {})", timeout.saturating_mul(1000));
+            }
         }
         for var in vars {
             let _ = writeln!(smt, "(declare-fun {var} () (_ BitVec 256))");
@@ -203,13 +213,20 @@ impl SmtLibSubprocessSolver {
             let _ = writeln!(stderr, "--- symbolic SMT query {} ---\n{smt}", self.queries);
         }
 
-        run_solver_commands(
-            commands,
-            &smt,
-            self.timeout,
-            model.then_some(constraints),
-            self.dump_smt,
-        )
+        let result = {
+            let commands = self.commands()?;
+            run_solver_commands(
+                commands,
+                &smt,
+                self.timeout,
+                model.then_some(constraints),
+                self.dump_smt,
+            )
+        };
+        if self.dump_smt {
+            self.portfolio_diagnostics.record(&result.summaries);
+        }
+        result.output
     }
 }
 
@@ -356,7 +373,13 @@ struct ScheduledSolver {
 }
 
 #[derive(Debug)]
-struct SolverRunSummary {
+struct SolverCommandRun {
+    output: Result<String, SymbolicError>,
+    summaries: Vec<SolverRunSummary>,
+}
+
+#[derive(Debug)]
+pub(crate) struct SolverRunSummary {
     index: Option<usize>,
     display: String,
     scheduled_after: Option<Duration>,
@@ -369,7 +392,7 @@ struct SolverRunSummary {
 
 impl SolverRunSummary {
     /// Builds a portfolio run summary with no detail or winner marker.
-    const fn new(display: String, elapsed: Duration, outcome: &'static str) -> Self {
+    pub(crate) const fn new(display: String, elapsed: Duration, outcome: &'static str) -> Self {
         Self {
             index: None,
             display,
@@ -383,7 +406,7 @@ impl SolverRunSummary {
     }
 
     /// Attaches the configured portfolio order and launch delay to this summary.
-    const fn with_schedule(
+    pub(crate) const fn with_schedule(
         mut self,
         index: usize,
         scheduled_after: Duration,
@@ -402,9 +425,110 @@ impl SolverRunSummary {
     }
 
     /// Marks this solver run as the portfolio result winner.
-    const fn winner(mut self) -> Self {
+    pub(crate) const fn winner(mut self) -> Self {
         self.winner = true;
         self
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PortfolioDiagnostics {
+    pub(crate) queries: usize,
+    pub(crate) solver_runs: usize,
+    pub(crate) rescue_runs: usize,
+    pub(crate) non_primary_wins: usize,
+    pub(crate) rescue_wins: usize,
+    pub(crate) not_started: usize,
+    pub(crate) cancelled_after_winner: usize,
+    pub(crate) invalid_models: usize,
+    pub(crate) solver_errors: usize,
+    pub(crate) winner_counts: BTreeMap<String, usize>,
+    pub(crate) launch_counts: BTreeMap<String, usize>,
+    pub(crate) outcome_counts: BTreeMap<&'static str, usize>,
+}
+
+impl PortfolioDiagnostics {
+    /// Records one portfolio query's per-solver summaries.
+    pub(crate) fn record(&mut self, summaries: &[SolverRunSummary]) {
+        if summaries.len() <= 1 {
+            return;
+        }
+
+        self.queries += 1;
+        for summary in summaries {
+            *self.outcome_counts.entry(summary.outcome).or_default() += 1;
+            if summary.started_after.is_some() {
+                self.solver_runs += 1;
+                *self.launch_counts.entry(summary.display.clone()).or_default() += 1;
+                if summary.index.is_some_and(|index| index >= 2) {
+                    self.rescue_runs += 1;
+                }
+            }
+
+            match summary.outcome {
+                "not-started" => self.not_started += 1,
+                "cancelled"
+                | "sat-after-winner"
+                | "unsat-after-winner"
+                | "unknown-after-winner" => self.cancelled_after_winner += 1,
+                "sat-invalid" => self.invalid_models += 1,
+                "error" => self.solver_errors += 1,
+                _ => {}
+            }
+
+            if summary.winner {
+                *self.winner_counts.entry(summary.display.clone()).or_default() += 1;
+                if summary.index.is_some_and(|index| index > 0) {
+                    self.non_primary_wins += 1;
+                }
+                if summary.index.is_some_and(|index| index >= 2) {
+                    self.rescue_wins += 1;
+                }
+            }
+        }
+    }
+
+    /// Writes the aggregate portfolio summary to stderr.
+    fn dump(&self) {
+        if self.queries == 0 {
+            return;
+        }
+
+        let mut stderr = std::io::stderr().lock();
+        let _ = writeln!(stderr, "--- symbolic solver portfolio summary ---");
+        let _ = writeln!(stderr, "queries: {}", self.queries);
+        let _ = writeln!(stderr, "solver runs: {}", self.solver_runs);
+        let _ = writeln!(stderr, "rescue solver runs: {}", self.rescue_runs);
+        let _ = writeln!(stderr, "not-started solver runs: {}", self.not_started);
+        let _ = writeln!(stderr, "non-primary wins: {}", self.non_primary_wins);
+        let _ = writeln!(stderr, "rescue wins: {}", self.rescue_wins);
+        let _ = writeln!(stderr, "cancelled after winner: {}", self.cancelled_after_winner);
+        let _ = writeln!(stderr, "invalid models: {}", self.invalid_models);
+        let _ = writeln!(stderr, "solver errors: {}", self.solver_errors);
+        if !self.winner_counts.is_empty() {
+            let _ = writeln!(stderr, "winner counts:");
+            for (solver, count) in &self.winner_counts {
+                let _ = writeln!(stderr, "  {solver}: {count}");
+            }
+        }
+        if !self.launch_counts.is_empty() {
+            let _ = writeln!(stderr, "launch counts:");
+            for (solver, count) in &self.launch_counts {
+                let _ = writeln!(stderr, "  {solver}: {count}");
+            }
+        }
+        let _ = writeln!(stderr, "outcome counts:");
+        for (outcome, count) in &self.outcome_counts {
+            let _ = writeln!(stderr, "  {outcome}: {count}");
+        }
+    }
+}
+
+impl Drop for SmtLibSubprocessSolver {
+    fn drop(&mut self) {
+        if self.dump_smt {
+            self.portfolio_diagnostics.dump();
+        }
     }
 }
 
@@ -415,12 +539,15 @@ fn run_solver_commands(
     timeout: Option<u32>,
     model_constraints: Option<&[BoolExpr]>,
     dump_diagnostics: bool,
-) -> Result<String, SymbolicError> {
+) -> SolverCommandRun {
     if commands.is_empty() {
-        return Err(SymbolicError::Solver("symbolic solver portfolio is empty".to_string()));
+        return SolverCommandRun {
+            output: Err(SymbolicError::Solver("symbolic solver portfolio is empty".to_string())),
+            summaries: Vec::new(),
+        };
     }
     if commands.len() == 1 {
-        return match run_solver_process(&commands[0], smt, timeout, &AtomicBool::new(false)) {
+        let output = match run_solver_process(&commands[0], smt, timeout, &AtomicBool::new(false)) {
             SolverProcessOutcome::Output(output) => Ok(output),
             SolverProcessOutcome::Unknown => Err(SymbolicError::SolverUnknown),
             SolverProcessOutcome::Cancelled => {
@@ -428,6 +555,7 @@ fn run_solver_commands(
             }
             SolverProcessOutcome::Error(err) => Err(SymbolicError::Solver(err)),
         };
+        return SolverCommandRun { output, summaries: Vec::new() };
     }
 
     let cancel = Arc::new(AtomicBool::new(false));
@@ -596,7 +724,7 @@ fn run_solver_commands(
             dump_solver_portfolio_summaries(&summaries);
         }
 
-        if let Some(output) = decisive {
+        let output = if let Some(output) = decisive {
             Ok(output)
         } else if saw_invalid_sat_model {
             Err(SymbolicError::Solver(errors.join("; ")))
@@ -606,7 +734,9 @@ fn run_solver_commands(
             Err(SymbolicError::SolverUnknown)
         } else {
             Err(SymbolicError::Solver(errors.join("; ")))
-        }
+        };
+
+        SolverCommandRun { output, summaries }
     })
 }
 

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2096,17 +2096,33 @@ fn portfolio_delayed_solver_can_rescue_stalled_leader() {
 /// Regression coverage for `PortfolioDiagnostics::record`.
 fn portfolio_diagnostics_counts_staged_outcomes() {
     let summaries = vec![
-        SolverRunSummary::new("primary".to_string(), Duration::from_millis(3), "sat-valid")
-            .with_schedule(0, Duration::ZERO, Some(Duration::ZERO))
-            .winner(),
-        SolverRunSummary::new("secondary".to_string(), Duration::ZERO, "not-started")
+        SolverRunSummary::new(
+            "primary".to_string(),
+            Duration::from_millis(3),
+            SolverOutcome::SatValid,
+        )
+        .with_schedule(0, Duration::ZERO, Some(Duration::ZERO))
+        .winner(),
+        SolverRunSummary::new("secondary".to_string(), Duration::ZERO, SolverOutcome::NotStarted)
             .with_schedule(1, Duration::from_millis(100), None),
-        SolverRunSummary::new("rescue".to_string(), Duration::from_millis(5), "cancelled")
-            .with_schedule(2, Duration::from_millis(500), Some(Duration::from_millis(500))),
-        SolverRunSummary::new("bad".to_string(), Duration::from_millis(1), "sat-invalid")
-            .with_schedule(3, Duration::from_millis(1000), Some(Duration::from_millis(1000))),
-        SolverRunSummary::new("missing".to_string(), Duration::from_millis(1), "error")
-            .with_schedule(4, Duration::from_millis(1500), Some(Duration::from_millis(1500))),
+        SolverRunSummary::new(
+            "rescue".to_string(),
+            Duration::from_millis(5),
+            SolverOutcome::Cancelled,
+        )
+        .with_schedule(2, Duration::from_millis(500), Some(Duration::from_millis(500))),
+        SolverRunSummary::new(
+            "bad".to_string(),
+            Duration::from_millis(1),
+            SolverOutcome::SatInvalid,
+        )
+        .with_schedule(3, Duration::from_millis(1000), Some(Duration::from_millis(1000))),
+        SolverRunSummary::new(
+            "missing".to_string(),
+            Duration::from_millis(1),
+            SolverOutcome::Error,
+        )
+        .with_schedule(4, Duration::from_millis(1500), Some(Duration::from_millis(1500))),
     ];
     let mut diagnostics = PortfolioDiagnostics::default();
 
@@ -2125,11 +2141,11 @@ fn portfolio_diagnostics_counts_staged_outcomes() {
     assert_eq!(diagnostics.launch_counts.get("primary"), Some(&1));
     assert_eq!(diagnostics.launch_counts.get("secondary"), None);
     assert_eq!(diagnostics.launch_counts.get("rescue"), Some(&1));
-    assert_eq!(diagnostics.outcome_counts.get("sat-valid"), Some(&1));
-    assert_eq!(diagnostics.outcome_counts.get("not-started"), Some(&1));
-    assert_eq!(diagnostics.outcome_counts.get("cancelled"), Some(&1));
-    assert_eq!(diagnostics.outcome_counts.get("sat-invalid"), Some(&1));
-    assert_eq!(diagnostics.outcome_counts.get("error"), Some(&1));
+    assert_eq!(diagnostics.outcome_counts.get(&SolverOutcome::SatValid), Some(&1));
+    assert_eq!(diagnostics.outcome_counts.get(&SolverOutcome::NotStarted), Some(&1));
+    assert_eq!(diagnostics.outcome_counts.get(&SolverOutcome::Cancelled), Some(&1));
+    assert_eq!(diagnostics.outcome_counts.get(&SolverOutcome::SatInvalid), Some(&1));
+    assert_eq!(diagnostics.outcome_counts.get(&SolverOutcome::Error), Some(&1));
 }
 
 #[test]

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2093,6 +2093,46 @@ fn portfolio_delayed_solver_can_rescue_stalled_leader() {
 }
 
 #[test]
+/// Regression coverage for `PortfolioDiagnostics::record`.
+fn portfolio_diagnostics_counts_staged_outcomes() {
+    let summaries = vec![
+        SolverRunSummary::new("primary".to_string(), Duration::from_millis(3), "sat-valid")
+            .with_schedule(0, Duration::ZERO, Some(Duration::ZERO))
+            .winner(),
+        SolverRunSummary::new("secondary".to_string(), Duration::ZERO, "not-started")
+            .with_schedule(1, Duration::from_millis(100), None),
+        SolverRunSummary::new("rescue".to_string(), Duration::from_millis(5), "cancelled")
+            .with_schedule(2, Duration::from_millis(500), Some(Duration::from_millis(500))),
+        SolverRunSummary::new("bad".to_string(), Duration::from_millis(1), "sat-invalid")
+            .with_schedule(3, Duration::from_millis(1000), Some(Duration::from_millis(1000))),
+        SolverRunSummary::new("missing".to_string(), Duration::from_millis(1), "error")
+            .with_schedule(4, Duration::from_millis(1500), Some(Duration::from_millis(1500))),
+    ];
+    let mut diagnostics = PortfolioDiagnostics::default();
+
+    diagnostics.record(&summaries);
+
+    assert_eq!(diagnostics.queries, 1);
+    assert_eq!(diagnostics.solver_runs, 4);
+    assert_eq!(diagnostics.rescue_runs, 3);
+    assert_eq!(diagnostics.not_started, 1);
+    assert_eq!(diagnostics.cancelled_after_winner, 1);
+    assert_eq!(diagnostics.invalid_models, 1);
+    assert_eq!(diagnostics.solver_errors, 1);
+    assert_eq!(diagnostics.non_primary_wins, 0);
+    assert_eq!(diagnostics.rescue_wins, 0);
+    assert_eq!(diagnostics.winner_counts.get("primary"), Some(&1));
+    assert_eq!(diagnostics.launch_counts.get("primary"), Some(&1));
+    assert_eq!(diagnostics.launch_counts.get("secondary"), None);
+    assert_eq!(diagnostics.launch_counts.get("rescue"), Some(&1));
+    assert_eq!(diagnostics.outcome_counts.get("sat-valid"), Some(&1));
+    assert_eq!(diagnostics.outcome_counts.get("not-started"), Some(&1));
+    assert_eq!(diagnostics.outcome_counts.get("cancelled"), Some(&1));
+    assert_eq!(diagnostics.outcome_counts.get("sat-invalid"), Some(&1));
+    assert_eq!(diagnostics.outcome_counts.get("error"), Some(&1));
+}
+
+#[test]
 /// Regression coverage for `assertion_revert_classifies_assert_panic_only`.
 fn assertion_revert_classifies_assert_panic_only() {
     let mut assert_payload = PANIC_SELECTOR.to_vec();

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -54,6 +54,7 @@ use revm::context::Transaction;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Write,
+    io::Write as IoWrite,
     path::{Path, PathBuf},
     sync::{Arc, mpsc::channel},
     time::{Duration, Instant},
@@ -519,6 +520,7 @@ impl TestArgs {
                 let summary_report = TestSummaryReport::new(self.detailed, outcome.clone());
                 sh_println!("{}", &summary_report)?;
             }
+            print_symbolic_portfolio_summary(&outcome);
 
             (libraries, outcome)
         };
@@ -757,6 +759,10 @@ impl TestArgs {
             runner.decode_internal = InternalTraceMode::Full;
         }
 
+        // In multi-pass mode, suppress per-pass portfolio summaries and print the merged summary
+        // once after all network passes complete.
+        let is_multi_pass = !runner.tcfg.multi_network.all_override_networks.is_empty();
+
         // Run tests in a non-streaming fashion and collect results for serialization.
         if !self.gas_report && !self.summary && shell::is_json() {
             let mut results = runner.test_collect(filter)?;
@@ -773,14 +779,22 @@ impl TestArgs {
             }
             sh_println!("{}", serde_json::to_string(&results)?)?;
             let kc = runner.known_contracts.clone();
-            return Ok(TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed));
+            let outcome = TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed);
+            if !is_multi_pass {
+                print_symbolic_portfolio_summary(&outcome);
+            }
+            return Ok(outcome);
         }
 
         if self.junit {
             let results = runner.test_collect(filter)?;
             sh_println!("{}", junit_xml_report(&results, verbosity).to_string()?)?;
             let kc = runner.known_contracts.clone();
-            return Ok(TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed));
+            let outcome = TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed);
+            if !is_multi_pass {
+                print_symbolic_portfolio_summary(&outcome);
+            }
+            return Ok(outcome);
         }
 
         let remote_chain =
@@ -788,11 +802,6 @@ impl TestArgs {
         let known_contracts = runner.known_contracts.clone();
 
         let libraries = runner.libraries.clone();
-
-        // Capture multi-pass state before moving `runner` into the spawn task.
-        // In multi-pass mode the per-pass summary is suppressed; the merged summary is
-        // printed once by the caller after all passes complete.
-        let is_multi_pass = !runner.tcfg.multi_network.all_override_networks.is_empty();
 
         // Run tests in a streaming fashion.
         let (tx, rx) = channel::<(String, SuiteResult)>();
@@ -1143,6 +1152,10 @@ impl TestArgs {
             },
         }
 
+        if !is_multi_pass {
+            print_symbolic_portfolio_summary(&outcome);
+        }
+
         // Persist test run failures to enable replaying.
         persist_run_failures(&config, &outcome);
 
@@ -1303,6 +1316,14 @@ fn list<FEN: FoundryEvmNetwork>(
         }
     }
     Ok(TestOutcome::empty(Some(runner.known_contracts), false))
+}
+
+/// Prints merged symbolic portfolio diagnostics for a completed test outcome.
+fn print_symbolic_portfolio_summary(outcome: &TestOutcome) {
+    if let Some(diagnostics) = outcome.symbolic_portfolio_diagnostics() {
+        let mut stderr = std::io::stderr().lock();
+        let _ = write!(stderr, "{diagnostics}");
+    }
 }
 
 /// Merges `other` into `base` by extending suite results.

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -18,6 +18,7 @@ use foundry_evm::{
     fuzz::{CounterExample, FuzzCase, FuzzFixtures, FuzzTestResult},
     traces::{CallTraceArena, CallTraceDecoder, TraceKind, Traces},
 };
+use foundry_evm_symbolic::PortfolioDiagnostics;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap as Map},
@@ -90,6 +91,17 @@ impl TestOutcome {
     /// Returns an iterator over all individual tests and their names.
     pub fn tests(&self) -> impl Iterator<Item = (&String, &TestResult)> {
         self.results.values().flat_map(|suite| suite.tests())
+    }
+
+    /// Returns merged symbolic solver portfolio diagnostics across all tests in this outcome.
+    pub fn symbolic_portfolio_diagnostics(&self) -> Option<PortfolioDiagnostics> {
+        let mut diagnostics = PortfolioDiagnostics::default();
+        for (_, result) in self.tests() {
+            if let Some(result_diagnostics) = &result.symbolic_portfolio_diagnostics {
+                diagnostics.merge(result_diagnostics);
+            }
+        }
+        (!diagnostics.is_empty()).then_some(diagnostics)
     }
 
     /// Flattens the test outcome into a list of individual tests.
@@ -554,6 +566,10 @@ pub struct TestResult {
     /// Deprecated cheatcodes (mapped to their replacements, if any) used in current test.
     #[serde(skip)]
     pub deprecated_cheatcodes: HashMap<&'static str, Option<&'static str>>,
+
+    /// Staged solver portfolio diagnostics collected during symbolic execution.
+    #[serde(skip)]
+    pub symbolic_portfolio_diagnostics: Option<PortfolioDiagnostics>,
 }
 
 impl fmt::Display for TestResult {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -749,6 +749,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             value: U256::ZERO,
             ffi_enabled: self.config.ffi,
         });
+        let portfolio_diagnostics = symbolic.portfolio_diagnostics();
 
         match result {
             SymbolicRunResult::Safe(stats) => {
@@ -776,6 +777,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     Err(EvmError::Execution(err)) => (err.raw, Some(err.reason)),
                     Err(EvmError::Skip(reason)) => {
                         self.result.single_skip(reason);
+                        self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
                         return self.result;
                     }
                     Err(err) => {
@@ -786,6 +788,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                             stats.paths,
                             stats.solver_queries,
                         );
+                        self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
                         return self.result;
                     }
                 };
@@ -815,6 +818,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             }
         }
 
+        self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
         self.result
     }
 
@@ -894,6 +898,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             fail_on_revert,
             ffi_enabled: self.config.ffi,
         });
+        let portfolio_diagnostics = symbolic.portfolio_diagnostics();
 
         match result {
             SymbolicInvariantRunResult::Safe(stats) => {
@@ -925,6 +930,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             }
         }
 
+        self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
         self.result
     }
 

--- a/crates/primitives/src/transaction/request.rs
+++ b/crates/primitives/src/transaction/request.rs
@@ -29,6 +29,7 @@ use crate::FoundryNetwork;
 ///   `DEPOSIT_TX_TYPE_ID`
 /// - **Tempo**: When `feeToken` or `nonceKey` fields are present, or transaction type is
 ///   `TEMPO_TX_TYPE_ID`
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FoundryTransactionRequest {
     Ethereum(TransactionRequest),

--- a/crates/primitives/src/transaction/request.rs
+++ b/crates/primitives/src/transaction/request.rs
@@ -31,9 +31,9 @@ use crate::FoundryNetwork;
 ///   `TEMPO_TX_TYPE_ID`
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FoundryTransactionRequest {
-    Ethereum(TransactionRequest),
+    Ethereum(Box<TransactionRequest>),
     #[cfg(feature = "optimism")]
-    Op(WithOtherFields<TransactionRequest>),
+    Op(Box<WithOtherFields<TransactionRequest>>),
     Tempo(Box<TempoTransactionRequest>),
 }
 
@@ -48,7 +48,7 @@ impl FoundryTransactionRequest {
     /// Consume the [`FoundryTransactionRequest`] and return the inner transaction request.
     pub fn into_inner(self) -> TransactionRequest {
         match self {
-            Self::Ethereum(tx) => tx,
+            Self::Ethereum(tx) => *tx,
             #[cfg(feature = "optimism")]
             Self::Op(tx) => tx.inner,
             Self::Tempo(tx) => tx.inner,
@@ -176,11 +176,12 @@ impl FoundryTransactionRequest {
             // format), try to build to eip4844 without sidecar
             self.into_inner()
                 .build_4844_without_sidecar()
-                .map_err(|e| Self::Ethereum(e.into_value()))
+                .map_err(|e| Self::Ethereum(Box::new(e.into_value())))
                 .map(|tx| FoundryTypedTx::Eip4844(tx.into()))
         } else {
             // Use the inner transaction request to build EthereumTypedTransaction
-            let typed_tx = self.into_inner().build_typed_tx().map_err(Self::Ethereum)?;
+            let typed_tx =
+                self.into_inner().build_typed_tx().map_err(|tx| Self::Ethereum(Box::new(tx)))?;
             // Convert EthereumTypedTransaction to FoundryTypedTx
             Ok(match typed_tx {
                 EthereumTypedTransaction::Legacy(tx) => FoundryTypedTx::Legacy(tx),
@@ -195,7 +196,7 @@ impl FoundryTransactionRequest {
 
 impl Default for FoundryTransactionRequest {
     fn default() -> Self {
-        Self::Ethereum(TransactionRequest::default())
+        Self::Ethereum(Box::<TransactionRequest>::default())
     }
 }
 
@@ -268,20 +269,20 @@ impl From<WithOtherFields<TransactionRequest>> for FoundryTransactionRequest {
             || tx.transaction_type == Some(POST_EXEC_TX_TYPE_ID)
             || get_deposit_tx_parts(&tx.other).is_ok()
         {
-            return Self::Op(tx);
+            return Self::Op(Box::new(tx));
         }
-        Self::Ethereum(tx.into_inner())
+        Self::Ethereum(Box::new(tx.into_inner()))
     }
 }
 
 impl From<FoundryTypedTx> for FoundryTransactionRequest {
     fn from(tx: FoundryTypedTx) -> Self {
         match tx {
-            FoundryTypedTx::Legacy(tx) => Self::Ethereum(Into::<TransactionRequest>::into(tx)),
-            FoundryTypedTx::Eip2930(tx) => Self::Ethereum(Into::<TransactionRequest>::into(tx)),
-            FoundryTypedTx::Eip1559(tx) => Self::Ethereum(Into::<TransactionRequest>::into(tx)),
-            FoundryTypedTx::Eip4844(tx) => Self::Ethereum(Into::<TransactionRequest>::into(tx)),
-            FoundryTypedTx::Eip7702(tx) => Self::Ethereum(Into::<TransactionRequest>::into(tx)),
+            FoundryTypedTx::Legacy(tx) => Self::Ethereum(Box::new(tx.into())),
+            FoundryTypedTx::Eip2930(tx) => Self::Ethereum(Box::new(tx.into())),
+            FoundryTypedTx::Eip1559(tx) => Self::Ethereum(Box::new(tx.into())),
+            FoundryTypedTx::Eip4844(tx) => Self::Ethereum(Box::new(tx.into())),
+            FoundryTypedTx::Eip7702(tx) => Self::Ethereum(Box::new(tx.into())),
             #[cfg(feature = "optimism")]
             FoundryTypedTx::Deposit(tx) => {
                 let other = OtherFields::from_iter([

--- a/crates/primitives/src/transaction/request.rs
+++ b/crates/primitives/src/transaction/request.rs
@@ -31,9 +31,9 @@ use crate::FoundryNetwork;
 ///   `TEMPO_TX_TYPE_ID`
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FoundryTransactionRequest {
-    Ethereum(Box<TransactionRequest>),
+    Ethereum(TransactionRequest),
     #[cfg(feature = "optimism")]
-    Op(Box<WithOtherFields<TransactionRequest>>),
+    Op(WithOtherFields<TransactionRequest>),
     Tempo(Box<TempoTransactionRequest>),
 }
 
@@ -48,7 +48,7 @@ impl FoundryTransactionRequest {
     /// Consume the [`FoundryTransactionRequest`] and return the inner transaction request.
     pub fn into_inner(self) -> TransactionRequest {
         match self {
-            Self::Ethereum(tx) => *tx,
+            Self::Ethereum(tx) => tx,
             #[cfg(feature = "optimism")]
             Self::Op(tx) => tx.inner,
             Self::Tempo(tx) => tx.inner,
@@ -176,12 +176,11 @@ impl FoundryTransactionRequest {
             // format), try to build to eip4844 without sidecar
             self.into_inner()
                 .build_4844_without_sidecar()
-                .map_err(|e| Self::Ethereum(Box::new(e.into_value())))
+                .map_err(|e| Self::Ethereum(e.into_value()))
                 .map(|tx| FoundryTypedTx::Eip4844(tx.into()))
         } else {
             // Use the inner transaction request to build EthereumTypedTransaction
-            let typed_tx =
-                self.into_inner().build_typed_tx().map_err(|tx| Self::Ethereum(Box::new(tx)))?;
+            let typed_tx = self.into_inner().build_typed_tx().map_err(Self::Ethereum)?;
             // Convert EthereumTypedTransaction to FoundryTypedTx
             Ok(match typed_tx {
                 EthereumTypedTransaction::Legacy(tx) => FoundryTypedTx::Legacy(tx),
@@ -196,7 +195,7 @@ impl FoundryTransactionRequest {
 
 impl Default for FoundryTransactionRequest {
     fn default() -> Self {
-        Self::Ethereum(Box::<TransactionRequest>::default())
+        Self::Ethereum(TransactionRequest::default())
     }
 }
 
@@ -269,20 +268,20 @@ impl From<WithOtherFields<TransactionRequest>> for FoundryTransactionRequest {
             || tx.transaction_type == Some(POST_EXEC_TX_TYPE_ID)
             || get_deposit_tx_parts(&tx.other).is_ok()
         {
-            return Self::Op(Box::new(tx));
+            return Self::Op(tx);
         }
-        Self::Ethereum(Box::new(tx.into_inner()))
+        Self::Ethereum(tx.into_inner())
     }
 }
 
 impl From<FoundryTypedTx> for FoundryTransactionRequest {
     fn from(tx: FoundryTypedTx) -> Self {
         match tx {
-            FoundryTypedTx::Legacy(tx) => Self::Ethereum(Box::new(tx.into())),
-            FoundryTypedTx::Eip2930(tx) => Self::Ethereum(Box::new(tx.into())),
-            FoundryTypedTx::Eip1559(tx) => Self::Ethereum(Box::new(tx.into())),
-            FoundryTypedTx::Eip4844(tx) => Self::Ethereum(Box::new(tx.into())),
-            FoundryTypedTx::Eip7702(tx) => Self::Ethereum(Box::new(tx.into())),
+            FoundryTypedTx::Legacy(tx) => Self::Ethereum(Into::<TransactionRequest>::into(tx)),
+            FoundryTypedTx::Eip2930(tx) => Self::Ethereum(Into::<TransactionRequest>::into(tx)),
+            FoundryTypedTx::Eip1559(tx) => Self::Ethereum(Into::<TransactionRequest>::into(tx)),
+            FoundryTypedTx::Eip4844(tx) => Self::Ethereum(Into::<TransactionRequest>::into(tx)),
+            FoundryTypedTx::Eip7702(tx) => Self::Ethereum(Into::<TransactionRequest>::into(tx)),
             #[cfg(feature = "optimism")]
             FoundryTypedTx::Deposit(tx) => {
                 let other = OtherFields::from_iter([


### PR DESCRIPTION
## Summary

- add an aggregate `--symbolic-dump-smt` portfolio summary for staged portfolios
- report query count, solver launches, rescue launches/wins, skipped launches, cancellation/error/model-invalid counts, and per-solver winner/launch/outcome totals
- keep solver execution semantics unchanged; this only makes the staged policy easier to measure
- document the summary output and add focused regression coverage for the aggregation logic

## Example

```text
--- symbolic solver portfolio summary ---
queries: 48
solver runs: 64
rescue solver runs: 0
not-started solver runs: 32
non-primary wins: 0
rescue wins: 0
cancelled after winner: 0
invalid models: 0
solver errors: 0
winner counts:
  yices-smt2 --bvconst-in-decimal: 48
launch counts:
  yices-smt2 --bvconst-in-decimal: 48
  z3 -in -smt2: 16
outcome counts:
  not-started: 32
  sat-valid: 32
  unsat: 32
```
