### PR TITLE
fix(forge): default Tempo tests to latest hardfork

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2955,7 +2955,7 @@ mod tests {
         ModelCheckerEngine, YulDetails,
         vyper::{VyperOptimizationLevel, VyperOptimizationMode, VyperVenomSettings},
     };
-    use foundry_evm_hardforks::TempoHardfork;
+    use foundry_evm_hardforks::{TempoHardfork, latest_active_tempo_hardfork};
     use similar_asserts::assert_eq;
     use soldeer_core::remappings::RemappingsLocation;
     use std::{fs::File, io::Write};
@@ -5090,6 +5090,25 @@ mod tests {
         };
 
         assert_eq!(config.evm_spec_id::<TempoHardfork>(), TempoHardfork::T3);
+    }
+
+    #[test]
+    fn tempo_network_defaults_to_latest_tempo_hardfork() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                network = "tempo"
+            "#,
+            )?;
+
+            let config = Config::load().unwrap();
+            assert!(config.networks.is_tempo());
+            assert_eq!(config.evm_spec_id::<TempoHardfork>(), latest_active_tempo_hardfork());
+
+            Ok(())
+        });
     }
 
     #[test]

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -395,7 +395,10 @@ pub fn evm_spec_id<SPEC: FromEvmVersion>(evm_version: EvmVersion) -> SPEC {
 /// Returns the latest Tempo hardfork that has an activation on a known Tempo network.
 pub fn latest_active_tempo_hardfork() -> TempoHardfork {
     // Tempo currently publishes activation timestamps through chain-aware hardfork resolution.
-    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(u64::MAX);
     TempoHardfork::from_chain_and_timestamp(4217, now)
         .or_else(|| TempoHardfork::from_chain_and_timestamp(42431, now))
         .unwrap_or_default()

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -3,7 +3,10 @@
 //! Provides [`FoundryHardfork`], a unified enum over Ethereum, Optimism, and Tempo hardforks
 //! with `FromStr`/`Serialize`/`Deserialize` support for CLI and config usage.
 
-use std::str::FromStr;
+use std::{
+    str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use alloy_chains::Chain;
 use alloy_rpc_types::BlockNumberOrTag;
@@ -392,9 +395,9 @@ pub fn evm_spec_id<SPEC: FromEvmVersion>(evm_version: EvmVersion) -> SPEC {
 /// Returns the latest Tempo hardfork that has an activation on a known Tempo network.
 pub fn latest_active_tempo_hardfork() -> TempoHardfork {
     // Tempo currently publishes activation timestamps through chain-aware hardfork resolution.
-    // Use `u64::MAX` to select the latest scheduled fork while ignoring placeholder variants.
-    TempoHardfork::from_chain_and_timestamp(4217, u64::MAX)
-        .or_else(|| TempoHardfork::from_chain_and_timestamp(42431, u64::MAX))
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+    TempoHardfork::from_chain_and_timestamp(4217, now)
+        .or_else(|| TempoHardfork::from_chain_and_timestamp(42431, now))
         .unwrap_or_default()
 }
 

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -131,9 +131,7 @@ impl FoundryHardfork {
         if let Some(fork) = OpHardfork::from_chain_and_timestamp(chain, timestamp) {
             return Some(Self::Optimism(fork));
         }
-        // TODO: add tempo support after https://github.com/tempoxyz/tempo/pull/3514 release
-        // providing TempoHardfork::from_chain_and_timestamp
-        None
+        TempoHardfork::from_chain_and_timestamp(chain_id, timestamp).map(Self::Tempo)
     }
 }
 
@@ -362,7 +360,7 @@ impl ExecutionSpec for OpSpecId {
 
 impl FromEvmVersion for TempoHardfork {
     fn from_evm_version(_: EvmVersion) -> Self {
-        Self::default()
+        latest_active_tempo_hardfork()
     }
 }
 
@@ -389,6 +387,15 @@ impl ExecutionSpec for TempoHardfork {
 /// Returns the spec id derived from [`EvmVersion`] for a given spec type.
 pub fn evm_spec_id<SPEC: FromEvmVersion>(evm_version: EvmVersion) -> SPEC {
     SPEC::from_evm_version(evm_version)
+}
+
+/// Returns the latest Tempo hardfork that has an activation on a known Tempo network.
+pub fn latest_active_tempo_hardfork() -> TempoHardfork {
+    // Tempo currently publishes activation timestamps through chain-aware hardfork resolution.
+    // Use `u64::MAX` to select the latest scheduled fork while ignoring placeholder variants.
+    TempoHardfork::from_chain_and_timestamp(4217, u64::MAX)
+        .or_else(|| TempoHardfork::from_chain_and_timestamp(42431, u64::MAX))
+        .unwrap_or_default()
 }
 
 // Parses an EVM version or network-specific hardfork into the given spec type.
@@ -437,6 +444,20 @@ mod tests {
     #[test]
     fn test_tempo_spec_id_mapping() {
         assert_eq!(SpecId::from(TempoHardfork::Genesis), SpecId::OSAKA);
+    }
+
+    #[test]
+    fn test_tempo_evm_version_defaults_to_latest_active_hardfork() {
+        assert_eq!(latest_active_tempo_hardfork(), TempoHardfork::T4);
+        assert_eq!(evm_spec_id::<TempoHardfork>(EvmVersion::Osaka), TempoHardfork::T4);
+    }
+
+    #[test]
+    fn test_tempo_hardfork_from_chain_and_timestamp() {
+        assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(4217, u64::MAX),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T4))
+        );
     }
 
     #[test]

--- a/crates/forge/tests/cli/test_cmd/spec.rs
+++ b/crates/forge/tests/cli/test_cmd/spec.rs
@@ -212,3 +212,36 @@ contract TempoEvmVersionTest is Test {
 
     cmd.args(["test", "--network", "tempo", "--mc", "TempoEvmVersionTest"]).assert_success();
 });
+
+forgetest_init!(test_network_tempo_defaults_to_latest_hardfork, |prj, cmd| {
+    prj.update_config(|config| {
+        config.solc = Some(OTHER_SOLC_VERSION.into());
+    });
+
+    let expected =
+        foundry_evm::hardforks::latest_active_tempo_hardfork().to_string().to_lowercase();
+    prj.add_test(
+        "TempoDefaultEvmVersion.t.sol",
+        &format!(
+            r#"
+pragma solidity >=0.8.20;
+
+import {{Test}} from "forge-std/Test.sol";
+
+interface EvmVm {{
+    function getEvmVersion() external pure returns (string memory evm);
+}}
+
+contract TempoDefaultEvmVersionTest is Test {{
+    EvmVm constant evm = EvmVm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    function test_network_tempo_defaults_to_latest_hardfork() public {{
+        assertEq(evm.getEvmVersion(), "{expected}");
+    }}
+}}
+   "#
+        ),
+    );
+
+    cmd.args(["test", "--network", "tempo", "--mc", "TempoDefaultEvmVersionTest"]).assert_success();
+});


### PR DESCRIPTION
## Summary
- default Tempo EVM-version fallback to the latest active Tempo hardfork instead of T0
- include Tempo in chain/timestamp hardfork detection now that the pinned dependency exposes it
- add config and forge CLI regressions for network=tempo / --network tempo

Manual gas check: a temporary 8 fresh-slot storage write test now reports 179,552 gas by default, 2,020,352 gas with --network tempo, and 179,552 gas with --network tempo plus FOUNDRY_HARDFORK=tempo:T0.