### PR TITLE
chore: simplify negated is_some_and checks

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -2133,7 +2133,7 @@ pub fn update_state<DB: Database>(
     persistent_accounts: Option<&HashSet<Address>>,
 ) -> Result<(), DB::Error> {
     for (addr, acc) in state.iter_mut() {
-        if !persistent_accounts.is_some_and(|accounts| accounts.contains(addr)) {
+        if persistent_accounts.is_none_or(|accounts| !accounts.contains(addr)) {
             acc.info = db.basic(*addr)?.unwrap_or_default();
             for (key, val) in &mut acc.storage {
                 val.present_value = db.storage(*addr, *key)?;

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -125,7 +125,7 @@ impl<'a> SolidityLinter<'a> {
     fn include_lint(&self, lint: SolLint) -> bool {
         self.severity.as_ref().is_none_or(|sev| sev.contains(&lint.severity()))
             && self.lints_included.as_ref().is_none_or(|incl| incl.contains(&lint))
-            && !self.lints_excluded.as_ref().is_some_and(|excl| excl.contains(&lint))
+            && self.lints_excluded.as_ref().is_none_or(|excl| !excl.contains(&lint))
     }
 
     fn process_source_ast<'gcx>(

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -399,7 +399,7 @@ impl VerifyBytecodeArgs {
 
         trace!(ignore = ?self.ignore);
         // Check if `--ignore` is set to `creation`.
-        if !self.ignore.is_some_and(|b| b.is_creation()) {
+        if self.ignore.is_none_or(|b| !b.is_creation()) {
             // Compare creation code with locally built bytecode and `maybe_creation_code`.
             let match_type = crate::utils::match_bytecodes(
                 local_bytecode_vec.as_slice(),
@@ -433,7 +433,7 @@ impl VerifyBytecodeArgs {
             }
         }
 
-        if !self.ignore.is_some_and(|b| b.is_runtime()) {
+        if self.ignore.is_none_or(|b| !b.is_runtime()) {
             // Get contract creation block.
             let simulation_block = match self.block {
                 Some(BlockId::Number(BlockNumberOrTag::Number(block))) => block,


### PR DESCRIPTION
## Motivation

Recent clippy cleanup fixed the same `nonminimal_bool` warning in `calls_loop`. A few production code paths still use `!Option::is_some_and(...)`, which clippy reports as a non-minimal boolean expression when warnings are denied.

## Solution

Replace those checks with the equivalent `Option::is_none_or(...)` form in lint filtering, EVM backend state refresh, and verify-bytecode ignore handling.