### PR TITLE
chore: bump tempo version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9039,7 +9039,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9089,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9103,7 +9103,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9127,7 +9127,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9141,7 +9141,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9154,7 +9154,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9190,7 +9190,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9242,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9312,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9360,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9398,7 +9398,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9416,7 +9416,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11195,7 +11195,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.7.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=020bc28785f40fb1625e4e38b43db807b2bebee6#020bc28785f40fb1625e4e38b43db807b2bebee6"
+source = "git+https://github.com/tempoxyz/tempo?rev=341cb39febd5d88bb6e691b287c5dc12a95ce1f4#341cb39febd5d88bb6e691b287c5dc12a95ce1f4"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11222,7 +11222,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.5.4"
-source = "git+https://github.com/tempoxyz/tempo?rev=020bc28785f40fb1625e4e38b43db807b2bebee6#020bc28785f40fb1625e4e38b43db807b2bebee6"
+source = "git+https://github.com/tempoxyz/tempo?rev=341cb39febd5d88bb6e691b287c5dc12a95ce1f4#341cb39febd5d88bb6e691b287c5dc12a95ce1f4"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-evm",
@@ -11241,7 +11241,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.7.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=020bc28785f40fb1625e4e38b43db807b2bebee6#020bc28785f40fb1625e4e38b43db807b2bebee6"
+source = "git+https://github.com/tempoxyz/tempo?rev=341cb39febd5d88bb6e691b287c5dc12a95ce1f4#341cb39febd5d88bb6e691b287c5dc12a95ce1f4"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11251,8 +11251,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.7.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=020bc28785f40fb1625e4e38b43db807b2bebee6#020bc28785f40fb1625e4e38b43db807b2bebee6"
+version = "1.7.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=341cb39febd5d88bb6e691b287c5dc12a95ce1f4#341cb39febd5d88bb6e691b287c5dc12a95ce1f4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11277,8 +11277,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.7.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=020bc28785f40fb1625e4e38b43db807b2bebee6#020bc28785f40fb1625e4e38b43db807b2bebee6"
+version = "1.7.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=341cb39febd5d88bb6e691b287c5dc12a95ce1f4#341cb39febd5d88bb6e691b287c5dc12a95ce1f4"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11297,8 +11297,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.7.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=020bc28785f40fb1625e4e38b43db807b2bebee6#020bc28785f40fb1625e4e38b43db807b2bebee6"
+version = "1.7.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=341cb39febd5d88bb6e691b287c5dc12a95ce1f4#341cb39febd5d88bb6e691b287c5dc12a95ce1f4"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11309,7 +11309,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.7.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=020bc28785f40fb1625e4e38b43db807b2bebee6#020bc28785f40fb1625e4e38b43db807b2bebee6"
+source = "git+https://github.com/tempoxyz/tempo?rev=341cb39febd5d88bb6e691b287c5dc12a95ce1f4#341cb39febd5d88bb6e691b287c5dc12a95ce1f4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -11339,8 +11339,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.7.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=020bc28785f40fb1625e4e38b43db807b2bebee6#020bc28785f40fb1625e4e38b43db807b2bebee6"
+version = "1.7.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=341cb39febd5d88bb6e691b287c5dc12a95ce1f4#341cb39febd5d88bb6e691b287c5dc12a95ce1f4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -515,17 +515,17 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "554d20112eb014bd223d5
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "020bc28785f40fb1625e4e38b43db807b2bebee6", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "020bc28785f40fb1625e4e38b43db807b2bebee6", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "341cb39febd5d88bb6e691b287c5dc12a95ce1f4", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "341cb39febd5d88bb6e691b287c5dc12a95ce1f4", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "020bc28785f40fb1625e4e38b43db807b2bebee6", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "020bc28785f40fb1625e4e38b43db807b2bebee6", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "020bc28785f40fb1625e4e38b43db807b2bebee6", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "341cb39febd5d88bb6e691b287c5dc12a95ce1f4", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "341cb39febd5d88bb6e691b287c5dc12a95ce1f4", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "341cb39febd5d88bb6e691b287c5dc12a95ce1f4", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "020bc28785f40fb1625e4e38b43db807b2bebee6" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "020bc28785f40fb1625e4e38b43db807b2bebee6" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "341cb39febd5d88bb6e691b287c5dc12a95ce1f4" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "341cb39febd5d88bb6e691b287c5dc12a95ce1f4" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -601,9 +601,9 @@ alloy-op-hardforks = { git = "https://github.com/ethereum-optimism/optimism", re
 # foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "2f90eb86d4549fa15a8cc2d99bfc1039bc083977" }
 
 ## tempo — unify crates.io versions (pulled by mpp) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "020bc28785f40fb1625e4e38b43db807b2bebee6" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "020bc28785f40fb1625e4e38b43db807b2bebee6" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "020bc28785f40fb1625e4e38b43db807b2bebee6" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "341cb39febd5d88bb6e691b287c5dc12a95ce1f4" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "341cb39febd5d88bb6e691b287c5dc12a95ce1f4" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "341cb39febd5d88bb6e691b287c5dc12a95ce1f4" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }


### PR DESCRIPTION
this PR (de)bumps tempo to v1.7.0

necessary so that tempo's foundry smoke tests pass
