### PR TITLE
fix(symbolic): defer diagnostics during progress output

### DIFF
--- a/crates/evm/symbolic/src/executor.rs
+++ b/crates/evm/symbolic/src/executor.rs
@@ -18,6 +18,16 @@ impl SymbolicExecutor {
         self.solver.portfolio_diagnostics().cloned()
     }
 
+    /// Defers verbose solver diagnostics until the caller explicitly takes them.
+    pub fn capture_diagnostics(&mut self) {
+        self.solver.capture_diagnostics();
+    }
+
+    /// Returns and clears deferred verbose solver diagnostics.
+    pub fn take_diagnostics(&mut self) -> Option<String> {
+        self.solver.take_diagnostics()
+    }
+
     /// Executes one function symbolically against an already-deployed test contract.
     ///
     /// The input executor supplies the deployed bytecode, storage backend, caller, and

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -60,6 +60,12 @@ pub(crate) trait SymbolicSolver {
     /// Returns aggregate staged-portfolio diagnostics collected by this backend.
     fn portfolio_diagnostics(&self) -> Option<&PortfolioDiagnostics>;
 
+    /// Captures verbose diagnostics for later rendering instead of writing them live.
+    fn capture_diagnostics(&mut self);
+
+    /// Takes any captured verbose diagnostics collected by this backend.
+    fn take_diagnostics(&mut self) -> Option<String>;
+
     /// Verifies that the configured solver can be invoked before exploration starts.
     ///
     /// Backends should keep this check lightweight and return a [`SymbolicError`] with
@@ -111,6 +117,7 @@ pub(crate) struct SmtLibSubprocessSolver {
     pub(crate) queries: usize,
     pub(crate) dump_smt: bool,
     portfolio_diagnostics: PortfolioDiagnostics,
+    captured_diagnostics: Option<String>,
 }
 
 impl SmtLibSubprocessSolver {
@@ -128,6 +135,7 @@ impl SmtLibSubprocessSolver {
             queries: 0,
             dump_smt,
             portfolio_diagnostics: PortfolioDiagnostics::default(),
+            captured_diagnostics: None,
         }
     }
 
@@ -151,6 +159,16 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
     /// Returns staged-portfolio diagnostics collected by this solver.
     fn portfolio_diagnostics(&self) -> Option<&PortfolioDiagnostics> {
         (!self.portfolio_diagnostics.is_empty()).then_some(&self.portfolio_diagnostics)
+    }
+
+    /// Enables deferred diagnostic rendering for verbose symbolic solver output.
+    fn capture_diagnostics(&mut self) {
+        self.captured_diagnostics.get_or_insert_with(String::new);
+    }
+
+    /// Returns and clears deferred diagnostic rendering output.
+    fn take_diagnostics(&mut self) -> Option<String> {
+        self.captured_diagnostics.take().filter(|diagnostics| !diagnostics.is_empty())
     }
 
     /// Validates the `check_available` solver helper.
@@ -219,6 +237,16 @@ impl SmtLibSubprocessSolver {
         self.commands.as_ref().map(Vec::as_slice).map_err(|err| SymbolicError::Solver(err.clone()))
     }
 
+    /// Emits one verbose solver diagnostic either live or into the deferred buffer.
+    fn emit_diagnostic(&mut self, diagnostic: fmt::Arguments<'_>) {
+        if let Some(captured_diagnostics) = &mut self.captured_diagnostics {
+            let _ = captured_diagnostics.write_fmt(diagnostic);
+        } else {
+            let mut stderr = std::io::stderr().lock();
+            let _ = stderr.write_fmt(diagnostic);
+        }
+    }
+
     /// Validates the `reserve_query` solver helper.
     pub(crate) const fn reserve_query(&self) -> Result<(), SymbolicError> {
         if self.queries >= self.max_queries {
@@ -238,7 +266,7 @@ impl SmtLibSubprocessSolver {
             constraint.collect_vars(&mut vars);
         }
 
-        let commands = self.commands()?;
+        let commands = self.commands()?.to_vec();
 
         let mut smt = String::new();
         smt.push_str("(set-logic QF_BV)\n");
@@ -258,19 +286,20 @@ impl SmtLibSubprocessSolver {
             smt.push_str("(get-model)\n");
         }
         if self.dump_smt {
-            let mut stderr = std::io::stderr().lock();
-            let _ = writeln!(stderr, "--- symbolic SMT query {} ---\n{smt}", self.queries);
+            let query = self.queries;
+            self.emit_diagnostic(format_args!("--- symbolic SMT query {query} ---\n{smt}\n"));
         }
 
-        let result = run_solver_commands(
-            commands,
-            &smt,
-            self.timeout,
-            model.then_some(constraints),
-            self.dump_smt,
-        );
+        let result =
+            run_solver_commands(&commands, &smt, self.timeout, model.then_some(constraints));
         if self.dump_smt {
             self.portfolio_diagnostics.record(&result.summaries);
+            if !result.summaries.is_empty() {
+                self.emit_diagnostic(format_args!(
+                    "{}",
+                    format_solver_portfolio_summaries(&result.summaries)
+                ));
+            }
         }
         result.output
     }
@@ -604,7 +633,6 @@ fn run_solver_commands(
     smt: &str,
     timeout: Option<u32>,
     model_constraints: Option<&[BoolExpr]>,
-    dump_diagnostics: bool,
 ) -> SolverCommandRun {
     if commands.is_empty() {
         return SolverCommandRun {
@@ -784,10 +812,6 @@ fn run_solver_commands(
             summary.winner = true;
         }
 
-        if dump_diagnostics {
-            dump_solver_portfolio_summaries(&summaries);
-        }
-
         let output = if let Some(output) = decisive {
             Ok(output)
         } else if saw_invalid_sat_model {
@@ -879,10 +903,10 @@ fn summary_for_cancelled_solver_result(
     summary.with_schedule(index, scheduled_after, Some(started_after))
 }
 
-/// Writes solver portfolio outcome diagnostics to stderr.
-fn dump_solver_portfolio_summaries(summaries: &[SolverRunSummary]) {
-    let mut stderr = std::io::stderr().lock();
-    let _ = writeln!(stderr, "--- symbolic solver portfolio outcomes ---");
+/// Formats solver portfolio outcome diagnostics.
+fn format_solver_portfolio_summaries(summaries: &[SolverRunSummary]) -> String {
+    let mut output = String::new();
+    let _ = writeln!(output, "--- symbolic solver portfolio outcomes ---");
     for summary in summaries {
         let marker = if summary.winner { " winner" } else { "" };
         let schedule = summary.index.zip(summary.scheduled_after).map(|(index, delay)| {
@@ -893,7 +917,7 @@ fn dump_solver_portfolio_summaries(summaries: &[SolverRunSummary]) {
             format!("#{} scheduled +{delay:.3?}{started} ", index + 1)
         });
         let _ = write!(
-            stderr,
+            output,
             "{}{}: {} in {:.3?}{}",
             schedule.as_deref().unwrap_or_default(),
             summary.display,
@@ -902,10 +926,11 @@ fn dump_solver_portfolio_summaries(summaries: &[SolverRunSummary]) {
             marker
         );
         if let Some(detail) = summary.detail.as_deref().filter(|detail| !detail.is_empty()) {
-            let _ = write!(stderr, " ({detail})");
+            let _ = write!(output, " ({detail})");
         }
-        let _ = writeln!(stderr);
+        let _ = writeln!(output);
     }
+    output
 }
 
 /// Runs one solver process to completion, timeout, or cooperative cancellation.

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2092,6 +2092,32 @@ fn portfolio_delayed_solver_can_rescue_stalled_leader() {
     assert!(started_at.elapsed() >= Duration::from_millis(100));
 }
 
+#[cfg(unix)]
+#[test]
+/// Regression coverage for deferring SMT and portfolio diagnostics during progress rendering.
+fn solver_capture_diagnostics_buffers_dump_smt_output() {
+    let commands = vec![
+        SolverCommand::new(vec!["/bin/echo".to_string(), "sat".to_string()], false).unwrap(),
+        SolverCommand::new(
+            vec!["/bin/sh".to_string(), "-c".to_string(), "printf 'sat\n'".to_string()],
+            false,
+        )
+        .unwrap(),
+    ];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 1, true);
+
+    solver.capture_diagnostics();
+
+    assert!(solver.is_sat(&[]).unwrap());
+    let diagnostics = solver.take_diagnostics().unwrap();
+
+    assert!(diagnostics.contains("--- symbolic SMT query 1 ---"));
+    assert!(diagnostics.contains("(check-sat)"));
+    assert!(diagnostics.contains("--- symbolic solver portfolio outcomes ---"));
+    assert!(diagnostics.contains("winner"));
+    assert!(solver.take_diagnostics().is_none());
+}
+
 #[test]
 /// Regression coverage for `PortfolioDiagnostics::record`.
 fn portfolio_diagnostics_counts_staged_outcomes() {

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -896,6 +896,13 @@ impl TestArgs {
                     !self.suppress_successful_traces || result.status == TestStatus::Failure;
                 if !silent {
                     sh_println!("{}", result.short_result(name))?;
+                    if let Some(diagnostics) = result
+                        .symbolic_diagnostics
+                        .take()
+                        .filter(|diagnostics| !diagnostics.is_empty())
+                    {
+                        sh_print!("{diagnostics}")?;
+                    }
 
                     // Display invariant metrics if invariant kind.
                     if let TestKind::Invariant { metrics, .. } = &result.kind

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -570,6 +570,10 @@ pub struct TestResult {
     /// Staged solver portfolio diagnostics collected during symbolic execution.
     #[serde(skip)]
     pub symbolic_portfolio_diagnostics: Option<PortfolioDiagnostics>,
+
+    /// Verbose symbolic solver diagnostics deferred until test output rendering.
+    #[serde(skip)]
+    pub symbolic_diagnostics: Option<String>,
 }
 
 impl fmt::Display for TestResult {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -644,6 +644,11 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         &self.cr.mcr.revert_decoder
     }
 
+    /// Returns whether verbose symbolic diagnostics should be rendered after progress clears.
+    fn should_defer_symbolic_diagnostics(&self) -> bool {
+        self.cr.progress.is_some() && self.config.symbolic.dump_smt
+    }
+
     /// Configures this runner with the inline configuration for the contract.
     fn apply_function_inline_config(&mut self, func: &Function) -> Result<()> {
         if self.inline_config.contains_function(self.cr.name, &func.name) {
@@ -741,6 +746,9 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         }
 
         let mut symbolic = SymbolicExecutor::new(self.config.symbolic.clone());
+        if self.should_defer_symbolic_diagnostics() {
+            symbolic.capture_diagnostics();
+        }
         let result = symbolic.run(SymbolicRunInput {
             executor: self.executor.as_ref(),
             target: self.address,
@@ -750,6 +758,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             ffi_enabled: self.config.ffi,
         });
         let portfolio_diagnostics = symbolic.portfolio_diagnostics();
+        let symbolic_diagnostics = symbolic.take_diagnostics();
 
         match result {
             SymbolicRunResult::Safe(stats) => {
@@ -778,6 +787,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     Err(EvmError::Skip(reason)) => {
                         self.result.single_skip(reason);
                         self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
+                        self.result.symbolic_diagnostics = symbolic_diagnostics;
                         return self.result;
                     }
                     Err(err) => {
@@ -789,6 +799,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                             stats.solver_queries,
                         );
                         self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
+                        self.result.symbolic_diagnostics = symbolic_diagnostics;
                         return self.result;
                     }
                 };
@@ -819,6 +830,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         }
 
         self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
+        self.result.symbolic_diagnostics = symbolic_diagnostics;
         self.result
     }
 
@@ -886,6 +898,9 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             .unwrap_or(self.config.invariant.fail_on_revert);
 
         let mut symbolic = SymbolicExecutor::new(self.config.symbolic.clone());
+        if self.should_defer_symbolic_diagnostics() {
+            symbolic.capture_diagnostics();
+        }
         let result = symbolic.run_invariant(SymbolicInvariantRunInput {
             executor: self.executor.as_ref(),
             invariant_address: self.address,
@@ -899,6 +914,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             ffi_enabled: self.config.ffi,
         });
         let portfolio_diagnostics = symbolic.portfolio_diagnostics();
+        let symbolic_diagnostics = symbolic.take_diagnostics();
 
         match result {
             SymbolicInvariantRunResult::Safe(stats) => {
@@ -931,6 +947,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         }
 
         self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
+        self.result.symbolic_diagnostics = symbolic_diagnostics;
         self.result
     }
 


### PR DESCRIPTION
## Summary
- capture verbose symbolic SMT dumps / per-query portfolio diagnostics while `--show-progress` is active
- render captured diagnostics with each test result after progress output is cleared
- keep live stderr diagnostics unchanged when progress is not active