### PR TITLE
clippy: remove remaining needless for_each calls

### DIFF
--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -235,11 +235,11 @@ impl InMemoryBlockStates {
             .collect::<Vec<_>>();
 
         // Get on-disk state snapshots
-        self.on_disk_states.iter().for_each(|(hash, _)| {
+        for hash in self.on_disk_states.keys() {
             if let Some(state_snapshot) = self.disk_cache.read(*hash) {
                 states.push((*hash, state_snapshot));
             }
-        });
+        }
 
         SerializableHistoricalStates::new(states)
     }

--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -482,18 +482,18 @@ pub struct SelectorImportResponse {
 impl SelectorImportResponse {
     /// Print info about the functions which were uploaded or already known
     pub fn describe(&self) {
-        self.result.function.imported.iter().for_each(|(k, v)| {
+        for (k, v) in &self.result.function.imported {
             let _ = sh_println!("Imported: Function {k}: {v}");
-        });
-        self.result.event.imported.iter().for_each(|(k, v)| {
+        }
+        for (k, v) in &self.result.event.imported {
             let _ = sh_println!("Imported: Event {k}: {v}");
-        });
-        self.result.function.duplicated.iter().for_each(|(k, v)| {
+        }
+        for (k, v) in &self.result.function.duplicated {
             let _ = sh_println!("Duplicated: Function {k}: {v}");
-        });
-        self.result.event.duplicated.iter().for_each(|(k, v)| {
+        }
+        for (k, v) in &self.result.event.duplicated {
             let _ = sh_println!("Duplicated: Event {k}: {v}");
-        });
+        }
 
         let _ = sh_println!("Selectors successfully uploaded to OpenChain");
     }

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -68,29 +68,31 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
 
         // Deploy libraries
         match libraries {
-            ScriptPredeployLibraries::Default(libraries) => libraries.iter().for_each(|code| {
-                let result = self
-                    .executor
-                    .deploy(self.evm_opts.sender, code.clone(), U256::ZERO, None)
-                    .expect("couldn't deploy library")
-                    .raw;
+            ScriptPredeployLibraries::Default(libraries) => {
+                for code in libraries {
+                    let result = self
+                        .executor
+                        .deploy(self.evm_opts.sender, code.clone(), U256::ZERO, None)
+                        .expect("couldn't deploy library")
+                        .raw;
 
-                if let Some(deploy_traces) = result.traces {
-                    traces.push((TraceKind::Deployment, deploy_traces));
+                    if let Some(deploy_traces) = result.traces {
+                        traces.push((TraceKind::Deployment, deploy_traces));
+                    }
+
+                    let mut tx_req = TransactionRequestFor::<FEN>::default()
+                        .with_from(self.evm_opts.sender)
+                        .with_input(code.clone())
+                        .with_nonce(sender_nonce + library_transactions.len() as u64);
+
+                    script_config.tempo.apply::<FEN::Network>(&mut tx_req, None);
+
+                    library_transactions.push_back(BroadcastableTransaction {
+                        rpc: self.evm_opts.fork_url.clone(),
+                        transaction: TransactionMaybeSigned::new(tx_req),
+                    })
                 }
-
-                let mut tx_req = TransactionRequestFor::<FEN>::default()
-                    .with_from(self.evm_opts.sender)
-                    .with_input(code.clone())
-                    .with_nonce(sender_nonce + library_transactions.len() as u64);
-
-                script_config.tempo.apply::<FEN::Network>(&mut tx_req, None);
-
-                library_transactions.push_back(BroadcastableTransaction {
-                    rpc: self.evm_opts.fork_url.clone(),
-                    transaction: TransactionMaybeSigned::new(tx_req),
-                })
-            }),
+            }
             ScriptPredeployLibraries::Create2(libraries, salt) => {
                 let create2_deployer = self.executor.create2_deployer();
                 for library in libraries {


### PR DESCRIPTION
## Motivation

The workspace already warns on `clippy::needless_for_each`, and recent clippy cleanup replaced side-effecting `.for_each(...)` calls with ordinary `for` loops. A few production paths still used `.for_each(...)` for side effects.

## Solution

Replace the remaining production side-effect `.for_each(...)` calls in Anvil state serialization, selector import reporting, and default script library deployment with equivalent `for` loops.