### PR TITLE
feat(symbolic): adapt portfolio scheduling

### DIFF
--- a/crates/evm/symbolic/src/runtime.rs
+++ b/crates/evm/symbolic/src/runtime.rs
@@ -20,14 +20,14 @@ pub(crate) use expressions::*;
 pub(crate) use memory::*;
 pub(crate) use precompiles::*;
 pub use solver::PortfolioDiagnostics;
-pub(crate) use solver::{
-    SmtLibSubprocessSolver, SymbolicSolver, solver_portfolio_availability_warning,
-};
 #[cfg(test)]
 pub(crate) use solver::{
-    SolverCommand, SolverOutcome, SolverRunSummary, fallback_single_var_model,
-    named_solver_command, parse_model, solver_commands_for_config, split_solver_command,
-    validate_solver_model_output,
+    PORTFOLIO_SCHEDULER_HISTORY, SolverCommand, SolverOutcome, SolverRunSummary,
+    fallback_single_var_model, named_solver_command, parse_model, solver_commands_for_config,
+    split_solver_command, validate_solver_model_output,
+};
+pub(crate) use solver::{
+    SmtLibSubprocessSolver, SymbolicSolver, solver_portfolio_availability_warning,
 };
 pub(crate) use state::*;
 

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -4,7 +4,7 @@ const INITIAL_SOLVER_POLL_BACKOFF: Duration = Duration::from_micros(200);
 const MAX_SOLVER_POLL_BACKOFF: Duration = Duration::from_millis(50);
 const SECOND_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(100);
 const RESCUE_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(500);
-const PORTFOLIO_SCHEDULER_HISTORY: usize = 8;
+pub(crate) const PORTFOLIO_SCHEDULER_HISTORY: usize = 8;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum SolverOutcome {
@@ -334,7 +334,7 @@ impl SmtLibSubprocessSolver {
 
 #[derive(Clone, Debug, Default)]
 struct PortfolioScheduler {
-    history: Vec<VecDeque<SolverRunSummary>>,
+    history: Vec<VecDeque<i64>>,
 }
 
 impl PortfolioScheduler {
@@ -360,7 +360,11 @@ impl PortfolioScheduler {
             let Some(run_index) = summary.index else { continue };
             let Some((configured_index, _)) = ordered_commands.get(run_index) else { continue };
             let Some(history) = self.history.get_mut(*configured_index) else { continue };
-            history.push_back(summary.clone());
+            let score = portfolio_summary_score(summary);
+            if score == 0 {
+                continue;
+            }
+            history.push_back(score);
             if history.len() > PORTFOLIO_SCHEDULER_HISTORY {
                 history.pop_front();
             }
@@ -380,9 +384,9 @@ impl PortfolioScheduler {
             .flatten()
             .rev()
             .enumerate()
-            .map(|(age, summary)| {
+            .map(|(age, score)| {
                 let recency = PORTFOLIO_SCHEDULER_HISTORY.saturating_sub(age).max(1) as i64;
-                recency * portfolio_summary_score(summary)
+                recency * score
             })
             .sum()
     }
@@ -548,7 +552,7 @@ struct SolverCommandRun {
     summaries: Vec<SolverRunSummary>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct SolverRunSummary {
     index: Option<usize>,
     display: String,

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -5,6 +5,9 @@ const MAX_SOLVER_POLL_BACKOFF: Duration = Duration::from_millis(50);
 const SECOND_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(100);
 const RESCUE_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(500);
 pub(crate) const PORTFOLIO_SCHEDULER_HISTORY: usize = 8;
+const PORTFOLIO_SCHEDULER_MIN_RECENCY_WEIGHT: i64 = 1;
+const PORTFOLIO_SCHEDULER_SPEED_BONUS_CAP_MS: u128 = 100;
+const PORTFOLIO_SCHEDULER_MAX_SPEED_BONUS: i64 = 100;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum SolverOutcome {
@@ -334,7 +337,48 @@ impl SmtLibSubprocessSolver {
 
 #[derive(Clone, Debug, Default)]
 struct PortfolioScheduler {
-    history: Vec<VecDeque<i64>>,
+    history: Vec<VecDeque<PortfolioSchedulerSignal>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PortfolioSchedulerSignal {
+    Winner { speed_bonus: i64 },
+    InvalidModel,
+    Error,
+    Unknown,
+    Neutral,
+}
+
+impl PortfolioSchedulerSignal {
+    /// Returns the scheduler signal represented by one solver run summary.
+    fn from_summary(summary: &SolverRunSummary) -> Self {
+        let speed_bonus = PORTFOLIO_SCHEDULER_MAX_SPEED_BONUS.saturating_sub(
+            summary.elapsed.as_millis().min(PORTFOLIO_SCHEDULER_SPEED_BONUS_CAP_MS) as i64,
+        );
+        match (summary.winner, summary.outcome) {
+            (true, SolverOutcome::SatValid | SolverOutcome::Unsat) => Self::Winner { speed_bonus },
+            (_, SolverOutcome::SatInvalid) => Self::InvalidModel,
+            (_, SolverOutcome::Error | SolverOutcome::Unexpected) => Self::Error,
+            (_, SolverOutcome::Unknown | SolverOutcome::TimeoutOrUnknown) => Self::Unknown,
+            _ => Self::Neutral,
+        }
+    }
+
+    /// Returns whether this signal should affect later portfolio scheduling.
+    const fn is_neutral(self) -> bool {
+        matches!(self, Self::Neutral)
+    }
+
+    /// Returns the numeric score contribution for adaptive portfolio ordering.
+    const fn score(self) -> i64 {
+        match self {
+            Self::Winner { speed_bonus } => 1_000 + speed_bonus,
+            Self::InvalidModel => -1_000,
+            Self::Error => -750,
+            Self::Unknown => -250,
+            Self::Neutral => 0,
+        }
+    }
 }
 
 impl PortfolioScheduler {
@@ -360,11 +404,11 @@ impl PortfolioScheduler {
             let Some(run_index) = summary.index else { continue };
             let Some((configured_index, _)) = ordered_commands.get(run_index) else { continue };
             let Some(history) = self.history.get_mut(*configured_index) else { continue };
-            let score = portfolio_summary_score(summary);
-            if score == 0 {
+            let signal = PortfolioSchedulerSignal::from_summary(summary);
+            if signal.is_neutral() {
                 continue;
             }
-            history.push_back(score);
+            history.push_back(signal);
             if history.len() > PORTFOLIO_SCHEDULER_HISTORY {
                 history.pop_front();
             }
@@ -384,23 +428,14 @@ impl PortfolioScheduler {
             .flatten()
             .rev()
             .enumerate()
-            .map(|(age, score)| {
-                let recency = PORTFOLIO_SCHEDULER_HISTORY.saturating_sub(age).max(1) as i64;
-                recency * score
+            .map(|(age, signal)| {
+                let recency = PORTFOLIO_SCHEDULER_HISTORY
+                    .saturating_sub(age)
+                    .max(PORTFOLIO_SCHEDULER_MIN_RECENCY_WEIGHT as usize)
+                    as i64;
+                recency * signal.score()
             })
             .sum()
-    }
-}
-
-/// Scores one solver run summary for adaptive portfolio ordering.
-fn portfolio_summary_score(summary: &SolverRunSummary) -> i64 {
-    let speed_bonus = 100i64.saturating_sub(summary.elapsed.as_millis().min(100) as i64);
-    match (summary.winner, summary.outcome) {
-        (true, SolverOutcome::SatValid | SolverOutcome::Unsat) => 1_000 + speed_bonus,
-        (_, SolverOutcome::SatInvalid) => -1_000,
-        (_, SolverOutcome::Error | SolverOutcome::Unexpected) => -750,
-        (_, SolverOutcome::Unknown | SolverOutcome::TimeoutOrUnknown) => -250,
-        _ => 0,
     }
 }
 

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -4,6 +4,7 @@ const INITIAL_SOLVER_POLL_BACKOFF: Duration = Duration::from_micros(200);
 const MAX_SOLVER_POLL_BACKOFF: Duration = Duration::from_millis(50);
 const SECOND_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(100);
 const RESCUE_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(500);
+const PORTFOLIO_SCHEDULER_HISTORY: usize = 8;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum SolverOutcome {
@@ -122,6 +123,7 @@ pub(crate) struct SmtLibSubprocessSolver {
     pub(crate) queries: usize,
     query_observer: Option<QueryObserver>,
     pub(crate) dump_smt: bool,
+    portfolio_scheduler: PortfolioScheduler,
     portfolio_diagnostics: PortfolioDiagnostics,
     captured_diagnostics: Option<String>,
 }
@@ -141,6 +143,7 @@ impl SmtLibSubprocessSolver {
             queries: 0,
             query_observer: None,
             dump_smt,
+            portfolio_scheduler: PortfolioScheduler::default(),
             portfolio_diagnostics: PortfolioDiagnostics::default(),
             captured_diagnostics: None,
         }
@@ -286,7 +289,10 @@ impl SmtLibSubprocessSolver {
             constraint.collect_vars(&mut vars);
         }
 
-        let commands = self.commands()?.to_vec();
+        let configured_commands = self.commands()?.to_vec();
+        let ordered_commands = self.portfolio_scheduler.ordered_commands(&configured_commands);
+        let commands =
+            ordered_commands.iter().map(|(_, command)| command.clone()).collect::<Vec<_>>();
 
         let mut smt = String::new();
         smt.push_str("(set-logic QF_BV)\n");
@@ -312,6 +318,7 @@ impl SmtLibSubprocessSolver {
 
         let result =
             run_solver_commands(&commands, &smt, self.timeout, model.then_some(constraints));
+        self.portfolio_scheduler.record(&ordered_commands, &result.summaries);
         if self.dump_smt {
             self.portfolio_diagnostics.record(&result.summaries);
             if !result.summaries.is_empty() {
@@ -322,6 +329,74 @@ impl SmtLibSubprocessSolver {
             }
         }
         result.output
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct PortfolioScheduler {
+    history: Vec<VecDeque<SolverRunSummary>>,
+}
+
+impl PortfolioScheduler {
+    /// Returns configured commands ordered by recent portfolio performance.
+    fn ordered_commands(&mut self, commands: &[SolverCommand]) -> Vec<(usize, SolverCommand)> {
+        self.ensure_len(commands.len());
+        let mut ordered = commands.iter().cloned().enumerate().collect::<Vec<_>>();
+        ordered.sort_by(|(left_index, _), (right_index, _)| {
+            self.score(*right_index)
+                .cmp(&self.score(*left_index))
+                .then_with(|| left_index.cmp(right_index))
+        });
+        ordered
+    }
+
+    /// Records one query's portfolio summaries against original configured solver indexes.
+    fn record(
+        &mut self,
+        ordered_commands: &[(usize, SolverCommand)],
+        summaries: &[SolverRunSummary],
+    ) {
+        for summary in summaries {
+            let Some(run_index) = summary.index else { continue };
+            let Some((configured_index, _)) = ordered_commands.get(run_index) else { continue };
+            let Some(history) = self.history.get_mut(*configured_index) else { continue };
+            history.push_back(summary.clone());
+            if history.len() > PORTFOLIO_SCHEDULER_HISTORY {
+                history.pop_front();
+            }
+        }
+    }
+
+    /// Ensures the scheduler has one history slot per configured solver.
+    fn ensure_len(&mut self, len: usize) {
+        self.history.resize_with(len, VecDeque::new);
+    }
+
+    /// Returns the recent-performance score for one configured solver index.
+    fn score(&self, index: usize) -> i64 {
+        self.history
+            .get(index)
+            .into_iter()
+            .flatten()
+            .rev()
+            .enumerate()
+            .map(|(age, summary)| {
+                let recency = PORTFOLIO_SCHEDULER_HISTORY.saturating_sub(age).max(1) as i64;
+                recency * portfolio_summary_score(summary)
+            })
+            .sum()
+    }
+}
+
+/// Scores one solver run summary for adaptive portfolio ordering.
+fn portfolio_summary_score(summary: &SolverRunSummary) -> i64 {
+    let speed_bonus = 100i64.saturating_sub(summary.elapsed.as_millis().min(100) as i64);
+    match (summary.winner, summary.outcome) {
+        (true, SolverOutcome::SatValid | SolverOutcome::Unsat) => 1_000 + speed_bonus,
+        (_, SolverOutcome::SatInvalid) => -1_000,
+        (_, SolverOutcome::Error | SolverOutcome::Unexpected) => -750,
+        (_, SolverOutcome::Unknown | SolverOutcome::TimeoutOrUnknown) => -250,
+        _ => 0,
     }
 }
 
@@ -473,7 +548,7 @@ struct SolverCommandRun {
     summaries: Vec<SolverRunSummary>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct SolverRunSummary {
     index: Option<usize>,
     display: String,

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2014,6 +2014,16 @@ fn solver_portfolio_availability_warning_reports_missing_entries() {
 }
 
 #[cfg(unix)]
+/// Returns a unique marker path for solver portfolio tests.
+fn portfolio_test_marker(name: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "foundry-symbolic-{name}-{}-{}",
+        std::process::id(),
+        SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+    ))
+}
+
+#[cfg(unix)]
 #[test]
 /// Regression coverage for `portfolio_sat_beats_early_unsat`.
 fn portfolio_sat_beats_early_unsat() {
@@ -2037,13 +2047,81 @@ fn portfolio_sat_beats_early_unsat() {
 
 #[cfg(unix)]
 #[test]
+/// Regression coverage for adaptive portfolio scheduling promoting recent winners.
+fn portfolio_scheduler_promotes_recent_sat_winner() {
+    let marker = portfolio_test_marker("adaptive-slow-leader");
+    let marker_arg = marker.display().to_string();
+    let commands = vec![
+        SolverCommand::new(
+            vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "printf started > \"$1\"; sleep 0.3; printf 'unknown\n'".to_string(),
+                "sh".to_string(),
+                marker_arg,
+            ],
+            false,
+        )
+        .unwrap(),
+        SolverCommand::new(
+            vec!["/bin/sh".to_string(), "-c".to_string(), "printf 'sat\n'".to_string()],
+            false,
+        )
+        .unwrap(),
+    ];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 2, false);
+
+    assert!(solver.is_sat(&[]).unwrap());
+    assert!(marker.exists());
+    let _ = std::fs::remove_file(&marker);
+
+    assert!(solver.is_sat(&[]).unwrap());
+    assert!(!marker.exists());
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for adaptive portfolio scheduling penalizing invalid models.
+fn portfolio_scheduler_penalizes_invalid_models() {
+    let marker = portfolio_test_marker("adaptive-invalid-model");
+    let marker_arg = marker.display().to_string();
+    let invalid_model = "sat\n((define-fun calldata_0 () (_ BitVec 256) #x0000000000000000000000000000000000000000000000000000000000000000))\n";
+    let valid_model = "sat\n((define-fun calldata_0 () (_ BitVec 256) #x0000000000000000000000000000000000000000000000000000000000000001))\n";
+    let commands = vec![
+        SolverCommand::new(
+            vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                format!("printf started > \"$1\"; printf '{}'", invalid_model),
+                "sh".to_string(),
+                marker_arg,
+            ],
+            false,
+        )
+        .unwrap(),
+        SolverCommand::new(
+            vec!["/bin/sh".to_string(), "-c".to_string(), format!("printf '{}'", valid_model)],
+            false,
+        )
+        .unwrap(),
+    ];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 2, false);
+    let constraints =
+        vec![BoolExpr::eq(Expr::Var("calldata_0".to_string()), Expr::Const(U256::from(1)))];
+
+    assert_eq!(solver.model(&constraints).unwrap().get("calldata_0"), Some(&U256::from(1)));
+    assert!(marker.exists());
+    let _ = std::fs::remove_file(&marker);
+
+    assert_eq!(solver.model(&constraints).unwrap().get("calldata_0"), Some(&U256::from(1)));
+    assert!(!marker.exists());
+}
+
+#[cfg(unix)]
+#[test]
 /// Regression coverage for `run_solver_commands` staged portfolio launching.
 fn portfolio_winner_skips_delayed_solver() {
-    let marker = std::env::temp_dir().join(format!(
-        "foundry-symbolic-delayed-solver-{}-{}",
-        std::process::id(),
-        SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-    ));
+    let marker = portfolio_test_marker("delayed-solver");
     let marker_arg = marker.display().to_string();
     let commands = vec![
         SolverCommand::new(vec!["/bin/echo".to_string(), "sat".to_string()], false).unwrap(),

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2081,6 +2081,36 @@ fn portfolio_scheduler_promotes_recent_sat_winner() {
 
 #[cfg(unix)]
 #[test]
+/// Regression coverage for adaptive portfolio scheduling promoting unsat winners.
+fn portfolio_scheduler_promotes_recent_unsat_winner() {
+    let commands = vec![
+        SolverCommand::new(
+            vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "sleep 0.3; printf 'unknown\n'".to_string(),
+            ],
+            false,
+        )
+        .unwrap(),
+        SolverCommand::new(vec!["/bin/echo".to_string(), "unsat".to_string()], false).unwrap(),
+    ];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 2, true);
+
+    solver.capture_diagnostics();
+
+    assert!(!solver.is_sat(&[]).unwrap());
+    assert!(!solver.is_sat(&[]).unwrap());
+
+    let diagnostics = solver.take_diagnostics().unwrap();
+    let last_outcomes =
+        diagnostics.rsplit("--- symbolic solver portfolio outcomes ---").next().unwrap_or_default();
+    assert!(last_outcomes.contains("#1 scheduled +0.000ns"));
+    assert!(last_outcomes.contains("/bin/echo unsat: unsat"));
+}
+
+#[cfg(unix)]
+#[test]
 /// Regression coverage for adaptive portfolio scheduling penalizing invalid models.
 fn portfolio_scheduler_penalizes_invalid_models() {
     let marker = portfolio_test_marker("adaptive-invalid-model");
@@ -2105,16 +2135,19 @@ fn portfolio_scheduler_penalizes_invalid_models() {
         )
         .unwrap(),
     ];
-    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 2, false);
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 16, false);
     let constraints =
         vec![BoolExpr::eq(Expr::Var("calldata_0".to_string()), Expr::Const(U256::from(1)))];
 
-    assert_eq!(solver.model(&constraints).unwrap().get("calldata_0"), Some(&U256::from(1)));
-    assert!(marker.exists());
-    let _ = std::fs::remove_file(&marker);
-
-    assert_eq!(solver.model(&constraints).unwrap().get("calldata_0"), Some(&U256::from(1)));
-    assert!(!marker.exists());
+    for query in 0..=PORTFOLIO_SCHEDULER_HISTORY {
+        assert_eq!(solver.model(&constraints).unwrap().get("calldata_0"), Some(&U256::from(1)));
+        if query == 0 {
+            assert!(marker.exists());
+            let _ = std::fs::remove_file(&marker);
+        } else {
+            assert!(!marker.exists());
+        }
+    }
 }
 
 #[cfg(unix)]

--- a/crates/forge/src/progress.rs
+++ b/crates/forge/src/progress.rs
@@ -102,7 +102,7 @@ impl TestsProgressState {
                 self.multi.insert_after(suite_progress, ProgressBar::new(max_queries as u64));
             symbolic_progress.set_style(
                 indicatif::ProgressStyle::with_template(
-                    "    ↪ {prefix:.bold.dim}: [{pos}/{len}] SMT queries {msg}",
+                    "    ↪ {prefix:.bold.dim}: SMT queries: {pos} {msg}",
                 )
                 .unwrap()
                 .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ "),


### PR DESCRIPTION
Stacked on #14862.

Adds an internal adaptive scheduler for symbolic solver portfolios: later queries prefer solvers that recently produced valid `sat`/`unsat` answers and deprioritize invalid models, errors, and unknown/timeouts.
