### PR TITLE
fix(anvil): preserve detected Tempo fork hardfork

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1490,6 +1490,7 @@ latest block number: {latest_block}"
             provider,
             chain_id,
             override_chain_id,
+            hardfork: self.hardfork,
             timestamp: block.header.timestamp(),
             base_fee: block.header.base_fee_per_gas().map(|g| g as u128),
             timeout: self.fork_request_timeout,

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -26,6 +26,7 @@ use alloy_rpc_types::{
 };
 use alloy_transport::TransportError;
 use foundry_common::provider::{ProviderBuilder, RetryProvider};
+use foundry_evm::hardfork::FoundryHardfork;
 use foundry_primitives::{FoundryTxEnvelope, FoundryTxReceipt};
 use parking_lot::{
     RawRwLock, RwLock,
@@ -672,6 +673,8 @@ pub struct ClientForkConfig<N: Network = AnyNetwork> {
     pub provider: Arc<RetryProvider<N>>,
     pub chain_id: u64,
     pub override_chain_id: Option<u64>,
+    /// The hardfork resolved for the forked block, if known.
+    pub hardfork: Option<FoundryHardfork>,
     /// The timestamp for the forked block
     pub timestamp: u64,
     /// The basefee of the forked block

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -557,8 +557,18 @@ impl<N: Network> Backend<N> {
     }
 
     /// Returns the active hardfork.
-    pub const fn hardfork(&self) -> FoundryHardfork {
+    pub fn hardfork(&self) -> FoundryHardfork {
+        if let Some(hardfork) =
+            self.fork.read().as_ref().and_then(|fork| fork.config.read().hardfork)
+        {
+            return hardfork;
+        }
         self.hardfork
+    }
+
+    /// Returns the active Tempo hardfork.
+    pub fn tempo_hardfork(&self) -> TempoHardfork {
+        TempoHardfork::from(self.hardfork())
     }
 
     /// Returns the precompiles for the current spec.
@@ -1258,7 +1268,7 @@ impl<N: Network> Backend<N> {
         I: Inspector<TempoContext<WrapDatabaseRef<&'db DB>>>,
         WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
     {
-        let hardfork = TempoHardfork::from(self.hardfork);
+        let hardfork = self.tempo_hardfork();
         let tempo_env = EvmEnv::new(
             evm_env.cfg_env.clone().with_spec_and_gas_params(hardfork, tempo_gas_params(hardfork)),
             TempoBlockEnv { inner: evm_env.block_env.clone(), timestamp_millis_part: 0 },
@@ -1332,7 +1342,7 @@ impl<N: Network> Backend<N> {
         }
 
         if self.is_tempo() {
-            let hardfork = TempoHardfork::from(self.hardfork);
+            let hardfork = self.tempo_hardfork();
             let tempo_env = EvmEnv::new(
                 evm_env
                     .cfg_env
@@ -2096,7 +2106,7 @@ impl<N: Network> Backend<N> {
             let chain_id = self.evm_env.read().cfg_env.chain_id;
             let timestamp = self.genesis.timestamp;
             let test_accounts: Vec<Address> = self.genesis.accounts.clone();
-            let hardfork = TempoHardfork::from(self.hardfork);
+            let hardfork = self.tempo_hardfork();
             let mut db = self.db.write().await;
             crate::eth::backend::tempo::initialize_tempo_precompiles(
                 &mut **db,

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -35,6 +35,25 @@ const THETA_USD: Address = address!("0x20C0000000000000000000000000000000000003"
 /// Gas limit for TIP20 transfer calls (precompile interactions need more gas).
 const TIP20_TRANSFER_GAS: u64 = 300_000;
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_fork_detects_hardfork_from_fork_timestamp() {
+    use tempo_chainspec::hardfork::TempoHardfork;
+
+    let fork_timestamp = TempoHardfork::T3.mainnet_activation_timestamp().unwrap();
+    let (_source_api, source_handle) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(4217u64))
+            .with_genesis_timestamp(Some(fork_timestamp)),
+    )
+    .await;
+
+    let (api, _handle) =
+        spawn(NodeConfig::test_tempo().with_eth_rpc_url(Some(source_handle.http_endpoint()))).await;
+
+    let node_info = api.anvil_node_info().await.unwrap();
+    assert_eq!(node_info.hard_fork, "T3");
+}
+
 sol! {
     #[sol(rpc)]
     interface IFeeManagerRpc {


### PR DESCRIPTION
## Summary
- store the hardfork resolved during Anvil fork setup on the fork config
- have backend hardfork lookups prefer the fork-resolved hardfork
- use that resolved Tempo hardfork for Tempo EVM gas params and precompile initialization
- add a local regression test for a Tempo fork source at a T3 activation timestamp

Closes #14865