### PR TITLE
feat(symbolic): configure exploration order

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -114,7 +114,7 @@ mod invariant;
 pub use invariant::InvariantConfig;
 
 mod symbolic;
-pub use symbolic::{SymbolicConfig, SymbolicStorageLayout};
+pub use symbolic::{SymbolicConfig, SymbolicExplorationOrder, SymbolicStorageLayout};
 
 mod inline;
 pub use inline::{InlineConfig, InlineConfigError, NatSpec};
@@ -7328,6 +7328,7 @@ mod tests {
                 loop = 4
                 depth = 100
                 width = 8
+                exploration_order = "dfs"
                 dynamic_lengths = { payload = [1], values = [2, 3] }
                 default_array_lengths = [0, 2]
                 default_bytes_lengths = [1, 3]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -7351,6 +7351,7 @@ mod tests {
                 symbolic_warnings.is_empty(),
                 "Valid symbolic keys should not trigger warnings, got: {symbolic_warnings:?}"
             );
+            assert_eq!(cfg.symbolic.exploration_order, SymbolicExplorationOrder::Dfs);
 
             Ok(())
         });

--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -59,6 +59,7 @@ const SYMBOLIC_KEYS: &[&str] = &[
     "max_depth",
     "max_paths",
     "invariant_depth",
+    "exploration_order",
     "max_solver_queries",
     "default_dynamic_length",
     "max_dynamic_length",

--- a/crates/config/src/symbolic.rs
+++ b/crates/config/src/symbolic.rs
@@ -56,6 +56,7 @@ pub struct SymbolicConfig {
     /// Maximum number of calls in a bounded symbolic invariant sequence.
     pub invariant_depth: u32,
     /// Order used to select the next pending symbolic path.
+    #[serde(default)]
     pub exploration_order: SymbolicExplorationOrder,
     /// Maximum number of solver queries.
     pub max_solver_queries: u32,
@@ -129,5 +130,34 @@ impl SymbolicConfig {
     /// configuration spellings feed the same path exploration budget.
     pub fn path_width(&self) -> u32 {
         self.width.unwrap_or(self.max_paths)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_exploration_order_defaults_to_bfs() {
+        let value = serde_json::json!({
+            "enabled": false,
+            "solver": "z3",
+            "timeout": 30,
+            "max_depth": 10000,
+            "max_paths": 1024,
+            "invariant_depth": 10,
+            "max_solver_queries": 10000,
+            "default_dynamic_length": 2,
+            "max_dynamic_length": 256,
+            "array_lengths": [],
+            "max_calldata_bytes": 4096,
+            "symbolic_call_targets": false,
+            "dump_smt": false,
+            "storage_layout": "solidity"
+        });
+
+        let config: SymbolicConfig = serde_json::from_value(value).unwrap();
+
+        assert_eq!(config.exploration_order, SymbolicExplorationOrder::Bfs);
     }
 }

--- a/crates/config/src/symbolic.rs
+++ b/crates/config/src/symbolic.rs
@@ -14,6 +14,17 @@ pub enum SymbolicStorageLayout {
     Generic,
 }
 
+/// Pending symbolic path exploration order.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SymbolicExplorationOrder {
+    /// Explore pending paths in first-in, first-out order.
+    #[default]
+    Bfs,
+    /// Explore pending paths in last-in, first-out order.
+    Dfs,
+}
+
 /// Configuration for symbolic testing.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SymbolicConfig {
@@ -44,6 +55,8 @@ pub struct SymbolicConfig {
     pub max_paths: u32,
     /// Maximum number of calls in a bounded symbolic invariant sequence.
     pub invariant_depth: u32,
+    /// Order used to select the next pending symbolic path.
+    pub exploration_order: SymbolicExplorationOrder,
     /// Maximum number of solver queries.
     pub max_solver_queries: u32,
     /// Default bounded length for dynamic ABI inputs.
@@ -85,6 +98,7 @@ impl Default for SymbolicConfig {
             max_depth: 10_000,
             max_paths: 1_024,
             invariant_depth: 10,
+            exploration_order: SymbolicExplorationOrder::default(),
             max_solver_queries: 10_000,
             default_dynamic_length: 2,
             max_dynamic_length: 256,

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -107,6 +107,11 @@ product implied by the selected outer lengths. Eager calldata expansion is cappe
 by the effective symbolic path width (`symbolic.width` / `symbolic.max_paths`).
 Extra positional `array_lengths` entries are rejected as config errors.
 
+Pending symbolic paths are explored in breadth-first order by default. Set
+`symbolic.exploration_order = "dfs"` to use depth-first ordering instead. This
+only changes which queued path is explored next; it does not change path limits,
+solver query limits, or solver portfolio scheduling.
+
 Supported ABI shapes include:
 
 - integers, booleans, addresses, fixed bytes, and dynamic bytes
@@ -157,6 +162,7 @@ solver = "z3"
 timeout = 30
 max_depth = 10000
 max_paths = 1024
+exploration_order = "bfs"
 max_solver_queries = 10000
 default_dynamic_length = 2
 max_dynamic_length = 256
@@ -178,6 +184,7 @@ The same values can be set inline with NatSpec:
 /// forge-config: default.symbolic.array_lengths = [2, 4]
 /// forge-config: default.symbolic.dynamic_lengths = { data = [3] }
 /// forge-config: default.symbolic.default_bytes_lengths = [8]
+/// forge-config: default.symbolic.exploration_order = "dfs"
 /// forge-config: default.symbolic.invariant_depth = 6
 function check_with_bounds(bytes memory data, uint256[] memory b) external {
     // ...

--- a/crates/evm/symbolic/src/executor.rs
+++ b/crates/evm/symbolic/src/executor.rs
@@ -1,5 +1,16 @@
 use super::{abi::*, runtime::*, *};
 
+/// Pops the next pending path according to the configured exploration order.
+pub(crate) fn pop_worklist<T>(
+    worklist: &mut VecDeque<T>,
+    order: SymbolicExplorationOrder,
+) -> Option<T> {
+    match order {
+        SymbolicExplorationOrder::Bfs => worklist.pop_front(),
+        SymbolicExplorationOrder::Dfs => worklist.pop_back(),
+    }
+}
+
 impl SymbolicExecutor {
     /// Creates a symbolic executor from Foundry's symbolic configuration.
     ///
@@ -134,7 +145,7 @@ impl SymbolicExecutor {
         let path_limit = self.config.path_width() as usize;
         let depth_limit = self.config.execution_depth() as usize;
 
-        while let Some(mut state) = worklist.pop_front() {
+        while let Some(mut state) = pop_worklist(&mut worklist, self.config.exploration_order) {
             if completed_paths >= path_limit {
                 return Ok(SymbolicRunResult::Incomplete {
                     kind: SymbolicStopReason::Stuck,
@@ -532,7 +543,7 @@ impl SymbolicExecutor {
         let path_limit = self.config.path_width() as usize;
         let depth_limit = self.config.execution_depth() as usize;
 
-        while let Some(mut state) = worklist.pop_front() {
+        while let Some(mut state) = pop_worklist(&mut worklist, self.config.exploration_order) {
             if *completed_paths >= path_limit {
                 return Err(SymbolicError::Unsupported("symbolic path limit exceeded"));
             }
@@ -3028,7 +3039,7 @@ impl SymbolicExecutor {
         let path_limit = self.config.path_width() as usize;
         let depth_limit = self.config.execution_depth() as usize;
 
-        while let Some(mut state) = worklist.pop_front() {
+        while let Some(mut state) = pop_worklist(&mut worklist, self.config.exploration_order) {
             if *completed_paths >= path_limit {
                 return Err(SymbolicError::Unsupported("symbolic path limit exceeded"));
             }

--- a/crates/evm/symbolic/src/executor.rs
+++ b/crates/evm/symbolic/src/executor.rs
@@ -5,9 +5,31 @@ pub(crate) fn pop_worklist<T>(
     worklist: &mut VecDeque<T>,
     order: SymbolicExplorationOrder,
 ) -> Option<T> {
+    pop_batch(worklist, order)
+}
+
+/// Pops the current path from a local batch according to the configured exploration order.
+pub(crate) fn pop_batch<T>(batch: &mut VecDeque<T>, order: SymbolicExplorationOrder) -> Option<T> {
     match order {
-        SymbolicExplorationOrder::Bfs => worklist.pop_front(),
-        SymbolicExplorationOrder::Dfs => worklist.pop_back(),
+        SymbolicExplorationOrder::Bfs => batch.pop_front(),
+        SymbolicExplorationOrder::Dfs => batch.pop_back(),
+    }
+}
+
+/// Spills the remaining local batch onto the global worklist in scheduler order.
+pub(crate) fn spill_batch<T>(
+    batch: VecDeque<T>,
+    worklist: &mut VecDeque<T>,
+    order: SymbolicExplorationOrder,
+) {
+    match order {
+        SymbolicExplorationOrder::Bfs => worklist.extend(batch),
+        SymbolicExplorationOrder::Dfs => {
+            worklist.reserve(batch.len());
+            for path in batch {
+                worklist.push_back(path);
+            }
+        }
     }
 }
 
@@ -2475,7 +2497,7 @@ impl SymbolicExecutor {
             return Ok(StepOutcome::AssumeRejected);
         };
 
-        let mut parents = Vec::with_capacity(outcomes.len());
+        let mut parents = VecDeque::with_capacity(outcomes.len());
         for outcome in std::iter::once(first).chain(rest.iter()) {
             let mut parent = state.clone();
             parent.constraints = outcome.state.constraints.clone();
@@ -2528,7 +2550,7 @@ impl SymbolicExecutor {
                             &return_data,
                         )?;
                         parent.stack.push(SymWord::Concrete(U256::from(1)))?;
-                        parents.push(parent);
+                        parents.push_back(parent);
                         continue;
                     }
                 }
@@ -2563,15 +2585,14 @@ impl SymbolicExecutor {
                 outcome.status,
                 TopLevelCallStatus::Success
             ))))?;
-            parents.push(parent);
+            parents.push_back(parent);
         }
 
-        let mut iter = parents.into_iter();
-        let Some(first) = iter.next() else {
+        let Some(first) = pop_batch(&mut parents, self.config.exploration_order) else {
             return Ok(StepOutcome::AssumeRejected);
         };
         *state = first;
-        worklist.extend(iter);
+        spill_batch(parents, worklist, self.config.exploration_order);
         Ok(StepOutcome::Continue)
     }
 
@@ -2806,18 +2827,18 @@ impl SymbolicExecutor {
             )? {
                 StepOutcome::Continue => {
                     parents.push_back(branch);
-                    parents.extend(branch_worklist);
+                    spill_batch(branch_worklist, &mut parents, self.config.exploration_order);
                 }
                 StepOutcome::AssumeRejected => {}
                 outcome => return Ok(outcome),
             }
         }
 
-        let Some(first) = parents.pop_front() else {
+        let Some(first) = pop_batch(&mut parents, self.config.exploration_order) else {
             return Ok(StepOutcome::AssumeRejected);
         };
         *state = first;
-        worklist.extend(parents);
+        spill_batch(parents, worklist, self.config.exploration_order);
         Ok(StepOutcome::Continue)
     }
 
@@ -2929,7 +2950,7 @@ impl SymbolicExecutor {
             return Ok(StepOutcome::AssumeRejected);
         };
 
-        let mut parents = Vec::with_capacity(outcomes.len());
+        let mut parents = VecDeque::with_capacity(outcomes.len());
         for outcome in std::iter::once(first).chain(rest.iter()) {
             let mut parent = state.clone();
             parent.constraints = outcome.state.constraints.clone();
@@ -2976,7 +2997,7 @@ impl SymbolicExecutor {
                         parent.function_mocks = outcome.state.function_mocks.clone();
                         parent.world = failure_world.clone();
                         parent.stack.push(created_word.clone())?;
-                        parents.push(parent);
+                        parents.push_back(parent);
                         continue;
                     }
                 }
@@ -3013,15 +3034,14 @@ impl SymbolicExecutor {
                 }
             }
 
-            parents.push(parent);
+            parents.push_back(parent);
         }
 
-        let mut iter = parents.into_iter();
-        let Some(first) = iter.next() else {
+        let Some(first) = pop_batch(&mut parents, self.config.exploration_order) else {
             return Ok(StepOutcome::AssumeRejected);
         };
         *state = first;
-        worklist.extend(iter);
+        spill_batch(parents, worklist, self.config.exploration_order);
         Ok(StepOutcome::Continue)
     }
 
@@ -3335,11 +3355,11 @@ impl SymbolicExecutor {
             branches.push_back(branch);
         }
 
-        let Some(first_branch) = branches.pop_front() else {
+        let Some(first_branch) = pop_batch(&mut branches, self.config.exploration_order) else {
             return Ok(Some(StepOutcome::AssumeRejected));
         };
         *state = first_branch;
-        worklist.extend(branches);
+        spill_batch(branches, worklist, self.config.exploration_order);
         Ok(Some(StepOutcome::Continue))
     }
 

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -14,7 +14,9 @@ use alloy_signer_local::{
     },
 };
 use base64::prelude::*;
-use foundry_config::{SymbolicConfig, SymbolicStorageLayout, split_quoted_args};
+use foundry_config::{
+    SymbolicConfig, SymbolicExplorationOrder, SymbolicStorageLayout, split_quoted_args,
+};
 use foundry_evm::{
     constants::{CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, HARDHAT_CONSOLE_ADDRESS},
     core::{backend::DatabaseExt, evm::FoundryEvmNetwork},

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -29,6 +29,30 @@ fn precompile_address(index: u8) -> Address {
 }
 
 #[test]
+/// Regression coverage for `pop_worklist` respecting configured exploration order.
+fn pop_worklist_respects_exploration_order() {
+    let mut bfs_worklist = VecDeque::from([1, 2, 3]);
+    assert_eq!(
+        super::executor::pop_worklist(&mut bfs_worklist, SymbolicExplorationOrder::Bfs),
+        Some(1)
+    );
+    assert_eq!(
+        super::executor::pop_worklist(&mut bfs_worklist, SymbolicExplorationOrder::Bfs),
+        Some(2)
+    );
+
+    let mut dfs_worklist = VecDeque::from([1, 2, 3]);
+    assert_eq!(
+        super::executor::pop_worklist(&mut dfs_worklist, SymbolicExplorationOrder::Dfs),
+        Some(3)
+    );
+    assert_eq!(
+        super::executor::pop_worklist(&mut dfs_worklist, SymbolicExplorationOrder::Dfs),
+        Some(2)
+    );
+}
+
+#[test]
 /// Regression coverage for `binary_helpers_use_evm_operand_order`.
 fn binary_helpers_use_evm_operand_order() {
     let mut state = empty_state();

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -53,6 +53,36 @@ fn pop_worklist_respects_exploration_order() {
 }
 
 #[test]
+/// Regression coverage for local batches respecting configured exploration order.
+fn local_batches_respect_exploration_order() {
+    let mut bfs_batch = VecDeque::from([1, 2, 3]);
+    let mut bfs_worklist = VecDeque::from([10]);
+    assert_eq!(super::executor::pop_batch(&mut bfs_batch, SymbolicExplorationOrder::Bfs), Some(1));
+    super::executor::spill_batch(bfs_batch, &mut bfs_worklist, SymbolicExplorationOrder::Bfs);
+    assert_eq!(
+        super::executor::pop_worklist(&mut bfs_worklist, SymbolicExplorationOrder::Bfs),
+        Some(10)
+    );
+    assert_eq!(
+        super::executor::pop_worklist(&mut bfs_worklist, SymbolicExplorationOrder::Bfs),
+        Some(2)
+    );
+
+    let mut dfs_batch = VecDeque::from([1, 2, 3]);
+    let mut dfs_worklist = VecDeque::from([10]);
+    assert_eq!(super::executor::pop_batch(&mut dfs_batch, SymbolicExplorationOrder::Dfs), Some(3));
+    super::executor::spill_batch(dfs_batch, &mut dfs_worklist, SymbolicExplorationOrder::Dfs);
+    assert_eq!(
+        super::executor::pop_worklist(&mut dfs_worklist, SymbolicExplorationOrder::Dfs),
+        Some(2)
+    );
+    assert_eq!(
+        super::executor::pop_worklist(&mut dfs_worklist, SymbolicExplorationOrder::Dfs),
+        Some(1)
+    );
+}
+
+#[test]
 /// Regression coverage for `binary_helpers_use_evm_operand_order`.
 fn binary_helpers_use_evm_operand_order() {
     let mut state = empty_state();

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -8,7 +8,7 @@ use foundry_compilers::{
 };
 use foundry_config::{
     CompilationRestrictions, Config, FsPermissions, FuzzConfig, FuzzCorpusConfig, InvariantConfig,
-    SettingsOverrides, SolcReq, SymbolicConfig, SymbolicStorageLayout,
+    SettingsOverrides, SolcReq, SymbolicConfig, SymbolicExplorationOrder, SymbolicStorageLayout,
     cache::{CachedChains, CachedEndpoints, StorageCachingConfig},
     filter::GlobMatcher,
     fs_permissions::{FsAccessPermission, PathPermission},
@@ -125,6 +125,7 @@ timeout = 30
 max_depth = 10000
 max_paths = 1024
 invariant_depth = 10
+exploration_order = "bfs"
 max_solver_queries = 10000
 default_dynamic_length = 2
 max_dynamic_length = 256
@@ -335,6 +336,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
             max_depth: 123,
             max_paths: 456,
             invariant_depth: 5,
+            exploration_order: SymbolicExplorationOrder::Dfs,
             max_solver_queries: 789,
             default_dynamic_length: 3,
             max_dynamic_length: 99,
@@ -1396,6 +1398,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "max_depth": 10000,
     "max_paths": 1024,
     "invariant_depth": 10,
+    "exploration_order": "bfs",
     "max_solver_queries": 10000,
     "default_dynamic_length": 2,
     "max_dynamic_length": 256,


### PR DESCRIPTION
Adds a small `symbolic.exploration_order` config knob for pending symbolic path selection:

- `bfs` keeps today's FIFO behavior and remains the default
- `dfs` explores the newest queued path first

This only changes the local pending-path frontier order. It does not change solver portfolios, query limits, path limits, pruning, or invariant sequence-depth scheduling.