### PR TITLE
fix(forge): preserve configured evm_version across fork selection

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1229,8 +1229,12 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
 
         self.active_fork_ids = Some((id, idx));
         // Update current environment with environment of newly selected fork.
+        // Preserve the configured spec (evm_version) from the current environment — the fork's
+        // evm_env is built with SPEC::default() and must not override the user's hardfork setting.
+        let preserved_spec = evm_env.cfg_env.spec;
         tx_env.set_chain_id(Some(fork_evm_env.cfg_env.chain_id));
         *evm_env = fork_evm_env;
+        evm_env.cfg_env.set_spec_and_mainnet_gas_params(preserved_spec);
 
         Ok(())
     }
@@ -1256,7 +1260,9 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
             if active_id == id {
                 // need to update the block's env settings right away, which is otherwise set when
                 // forks are selected `select_fork`
+                let preserved_spec = evm_env.cfg_env.spec;
                 *evm_env = fork_env;
+                evm_env.cfg_env.set_spec_and_mainnet_gas_params(preserved_spec);
 
                 // we also need to update the journaled_state right away, this has essentially the
                 // same effect as selecting (`select_fork`) by discarding

--- a/crates/forge/tests/cli/test_cmd/spec.rs
+++ b/crates/forge/tests/cli/test_cmd/spec.rs
@@ -1,3 +1,4 @@
+use foundry_compilers::artifacts::EvmVersion;
 use foundry_test_utils::{rpc, util::OTHER_SOLC_VERSION};
 
 // Test evm version switch during tests / scripts.
@@ -244,4 +245,34 @@ contract TempoDefaultEvmVersionTest is Test {{
     );
 
     cmd.args(["test", "--network", "tempo", "--mc", "TempoDefaultEvmVersionTest"]).assert_success();
+});
+
+// Regression test for <https://github.com/foundry-rs/foundry/issues/13040>:
+// configured evm_version must be preserved after createSelectFork / rollFork.
+forgetest_init!(test_fork_preserves_evm_version, |prj, cmd| {
+    let endpoint = rpc::next_http_archive_rpc_url();
+
+    prj.update_config(|config| {
+        config.evm_version = EvmVersion::Cancun;
+    });
+
+    prj.add_test(
+        "ForkEvmVersion.t.sol",
+        &r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ForkEvmVersionTest is Test {
+    function test_evm_version_preserved_after_fork() public {
+        assertEq(vm.getEvmVersion(), "cancun", "before fork");
+        uint256 forkId = vm.createSelectFork("<rpc>", 21000000);
+        assertEq(vm.getEvmVersion(), "cancun", "after createSelectFork");
+        vm.rollFork(21000001);
+        assertEq(vm.getEvmVersion(), "cancun", "after rollFork");
+    }
+}
+   "#
+        .replace("<rpc>", &endpoint),
+    );
+
+    cmd.args(["test", "--mc", "ForkEvmVersionTest", "-vvvv"]).assert_success();
 });


### PR DESCRIPTION
## Motivation

Close #13040

When selecting or rolling a fork, the entire `evm_env` was overwritten with the fork's environment, which was built with `SPEC::default()`, silently resetting the user-configured `evm_version` hardfork. Fix by preserving the current spec across `select_fork` and `roll_fork`, and restoring it (including gas-schedule params) after the overwrite.


## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
