### PR TITLE
chore(traces): simplify trace status option check

### DIFF
--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -800,7 +800,7 @@ impl CallTraceDecoder {
         // This is due to trace.status is derived from the revm_interpreter::InstructionResult in
         // revm-inspectors status will `None` post revm 27, as `InstructionResult::Continue` does
         // not exists anymore.
-        if trace.status.is_none() || trace.status.is_some_and(|s| s.is_ok()) {
+        if trace.status.is_none_or(|s| s.is_ok()) {
             return None;
         }
         (!trace.success).then(|| self.revert_decoder.decode(&trace.output, trace.status))


### PR DESCRIPTION
## Motivation

Recent cleanup simplified non-minimal option boolean checks with `Option::is_none_or(...)`. The trace decoder still had the same shape when deciding whether return data should skip revert decoding.

## Solution

Use `trace.status.is_none_or(|s| s.is_ok())` in the default return-data path, preserving the existing behavior while making the condition direct.