### PR TITLE
fix(verify): honor retry args while watching jobs

### DIFF
--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     VerifierArgs,
     provider::{VerificationContext, VerificationProvider},
-    retry::RETRY_CHECK_ON_VERIFY,
     utils::ensure_solc_build_metadata,
     verify::{ContractLanguage, VerifyArgs, VerifyCheckArgs},
 };
@@ -139,7 +138,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
                 let check_args = VerifyCheckArgs {
                     id: resp.result,
                     etherscan: args.etherscan,
-                    retry: RETRY_CHECK_ON_VERIFY,
+                    retry: args.retry,
                     verifier: args.verifier,
                 };
                 return self.check(check_args).await;

--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -1,6 +1,5 @@
 use crate::{
     provider::{VerificationContext, VerificationProvider},
-    retry::RETRY_CHECK_ON_VERIFY,
     utils::ensure_solc_build_metadata,
     verify::{ContractLanguage, VerifyArgs, VerifyCheckArgs},
 };
@@ -111,7 +110,7 @@ impl VerificationProvider for SourcifyVerificationProvider {
                 let check_args = VerifyCheckArgs {
                     id: resp.verification_id,
                     etherscan: args.etherscan,
-                    retry: RETRY_CHECK_ON_VERIFY,
+                    retry: args.retry,
                     verifier: args.verifier,
                 };
                 return self.check(check_args).await;


### PR DESCRIPTION
## Summary
- pass user-provided `--retries`/`--delay` settings through to verification job status polling
- apply the same behavior to Sourcify and Etherscan verification providers

## Context
The Tempo nightly failure in #14873 timed out while polling a Sourcify verification job. The CI command passed `--retries 10 --delay 10`, but the watch path still used the hard-coded `RETRY_CHECK_ON_VERIFY` value (8 attempts, 15s delay), as shown by the workflow log (`15 seconds ... 7 tries remaining`).

## Test plan
- `cargo fmt --check --package forge-verify`
- `cargo check --locked -p forge-verify`
- `cargo test --locked -p forge-verify retry::tests::test_cli -- --exact`

Fixes #14873