### PR TITLE
refactor(symbolic): consolidate constants into a `consts` module

### DIFF
--- a/crates/evm/symbolic/src/consts.rs
+++ b/crates/evm/symbolic/src/consts.rs
@@ -1,0 +1,45 @@
+use alloy_primitives::{Address, U256, address};
+use std::time::Duration;
+
+// HD wallet key derivation
+pub(crate) const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/60'/0'/0/";
+pub(crate) const MAX_REMEMBER_KEYS: u32 = 64;
+pub(crate) const SYMBOLIC_VM_COMPAT_ADDRESS: Address =
+    address!("0xF3993A62377BCd56AE39D773740A5390411E8BC9");
+
+// EVM execution limits
+pub(crate) const EVM_STACK_LIMIT: usize = 1024;
+pub(crate) const CALL_VALUE_STIPEND: u64 = 2300;
+
+// Symbolic exponentiation limits
+pub(crate) const SYMBOLIC_EXP_CONCRETE_EXPONENT_LIMIT: u64 = 32;
+pub(crate) const CONCRETE_BASE_SYMBOLIC_EXPONENT_LIMIT: u64 = 256;
+
+// Revert selectors and assertion constants
+pub(crate) const PANIC_SELECTOR: [u8; 4] = [0x4e, 0x48, 0x7b, 0x71];
+pub(crate) const ERROR_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
+pub(crate) const ASSERT_PANIC_CODE: U256 = U256::from_limbs([1, 0, 0, 0]);
+pub(crate) const ASSERTION_FAILED_PREFIX: &str = "assertion failed";
+
+// ABI encoding lengths
+pub(crate) const ABI_SELECTOR_PLUS_WORD_LEN: usize = 36; // selector (4) + one ABI word (32)
+pub(crate) const ERROR_DATA_MIN_LEN: usize = 68; // selector (4) + offset (32) + length (32)
+
+// Precompile address layout
+pub(crate) const PRECOMPILE_ADDRESS_LEADING_ZEROS: usize = 19;
+
+// Solver polling backoff
+pub(crate) const INITIAL_SOLVER_POLL_BACKOFF: Duration = Duration::from_micros(200);
+pub(crate) const MAX_SOLVER_POLL_BACKOFF: Duration = Duration::from_millis(50);
+pub(crate) const SECOND_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(100);
+pub(crate) const RESCUE_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(500);
+
+// Portfolio scheduler tuning
+pub(crate) const PORTFOLIO_SCHEDULER_HISTORY: usize = 8;
+pub(crate) const PORTFOLIO_SCHEDULER_MIN_RECENCY_WEIGHT: i64 = 1;
+pub(crate) const PORTFOLIO_SCHEDULER_SPEED_BONUS_CAP_MS: u128 = 100;
+pub(crate) const PORTFOLIO_SCHEDULER_MAX_SPEED_BONUS: i64 = 100;
+
+/// Symbolic solver names with built-in command-line mappings.
+pub const BUILTIN_SYMBOLIC_SOLVERS: &[&str] =
+    &["z3", "yices", "cvc5", "cvc5-int", "bitwuzla", "bitwuzla-abs"];

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -4,7 +4,7 @@
 
 use alloy_dyn_abi::{DynSolType, DynSolValue, JsonAbiExt};
 use alloy_json_abi::Function;
-use alloy_primitives::{Address, B256, Bytes, I256, U256, address, hex, keccak256};
+use alloy_primitives::{Address, B256, Bytes, I256, U256, hex, keccak256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::{
     MnemonicBuilder, PrivateKeySigner,
@@ -53,19 +53,15 @@ macro_rules! selector {
     }};
 }
 
+mod consts;
+pub use consts::BUILTIN_SYMBOLIC_SOLVERS;
+pub(crate) use consts::*;
+
 mod abi;
 mod executor;
 mod runtime;
 
 pub use runtime::{PortfolioDiagnostics, SymbolicError, SymbolicRunInput};
-
-/// Symbolic solver names with built-in command-line mappings.
-pub const BUILTIN_SYMBOLIC_SOLVERS: &[&str] =
-    &["z3", "yices", "cvc5", "cvc5-int", "bitwuzla", "bitwuzla-abs"];
-
-const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/60'/0'/0/";
-const MAX_REMEMBER_KEYS: u32 = 64;
-const SYMBOLIC_VM_COMPAT_ADDRESS: Address = address!("0xF3993A62377BCd56AE39D773740A5390411E8BC9");
 
 /// Returns whether `solver` is one of Foundry's semantic symbolic solver names.
 pub fn symbolic_solver_is_builtin(solver: &str) -> bool {
@@ -222,9 +218,6 @@ pub struct SymbolicExecutor {
     config: SymbolicConfig,
     solver: Box<dyn runtime::SymbolicSolver>,
 }
-
-const SYMBOLIC_EXP_CONCRETE_EXPONENT_LIMIT: u64 = 32;
-const CONCRETE_BASE_SYMBOLIC_EXPONENT_LIMIT: u64 = 256;
 
 #[cfg(test)]
 mod tests;

--- a/crates/evm/symbolic/src/runtime.rs
+++ b/crates/evm/symbolic/src/runtime.rs
@@ -20,14 +20,14 @@ pub(crate) use expressions::*;
 pub(crate) use memory::*;
 pub(crate) use precompiles::*;
 pub use solver::PortfolioDiagnostics;
-#[cfg(test)]
-pub(crate) use solver::{
-    PORTFOLIO_SCHEDULER_HISTORY, SolverCommand, SolverOutcome, SolverRunSummary,
-    fallback_single_var_model, named_solver_command, parse_model, solver_commands_for_config,
-    split_solver_command, validate_solver_model_output,
-};
 pub(crate) use solver::{
     SmtLibSubprocessSolver, SymbolicSolver, solver_portfolio_availability_warning,
+};
+#[cfg(test)]
+pub(crate) use solver::{
+    SolverCommand, SolverOutcome, SolverRunSummary, fallback_single_var_model,
+    named_solver_command, parse_model, solver_commands_for_config, split_solver_command,
+    validate_solver_model_output,
 };
 pub(crate) use state::*;
 

--- a/crates/evm/symbolic/src/runtime/evm.rs
+++ b/crates/evm/symbolic/src/runtime/evm.rs
@@ -285,11 +285,6 @@ pub(crate) fn ensure_jumpdest(
     if jumpdests.contains(&dest) { Ok(()) } else { Err(SymbolicError::InvalidJump(dest)) }
 }
 
-pub(crate) const PANIC_SELECTOR: [u8; 4] = [0x4e, 0x48, 0x7b, 0x71];
-pub(crate) const ERROR_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
-const ASSERT_PANIC_CODE: U256 = U256::from_limbs([1, 0, 0, 0]);
-const ASSERTION_FAILED_PREFIX: &str = "assertion failed";
-
 /// Returns whether `is_assertion_revert` holds.
 pub(crate) fn is_assertion_revert(data: &[u8]) -> bool {
     is_assert_panic(data) || is_revert_assertion_failure(data)
@@ -297,18 +292,19 @@ pub(crate) fn is_assertion_revert(data: &[u8]) -> bool {
 
 /// Returns whether `is_assert_panic` holds.
 pub(crate) fn is_assert_panic(data: &[u8]) -> bool {
-    data.len() >= 36
+    data.len() >= ABI_SELECTOR_PLUS_WORD_LEN
         && data.starts_with(&PANIC_SELECTOR)
-        && abi_word(&data[4..36]).is_some_and(|code| code == ASSERT_PANIC_CODE)
+        && abi_word(&data[4..ABI_SELECTOR_PLUS_WORD_LEN])
+            .is_some_and(|code| code == ASSERT_PANIC_CODE)
 }
 
 /// Returns whether `is_revert_assertion_failure` holds.
 pub(crate) fn is_revert_assertion_failure(data: &[u8]) -> bool {
-    if data.len() < 68 || !data.starts_with(&ERROR_SELECTOR) {
+    if data.len() < ERROR_DATA_MIN_LEN || !data.starts_with(&ERROR_SELECTOR) {
         return false;
     }
 
-    let Some(offset) = abi_word_usize(&data[4..36]) else {
+    let Some(offset) = abi_word_usize(&data[4..ABI_SELECTOR_PLUS_WORD_LEN]) else {
         return false;
     };
     let Some(length_offset) = 4usize.checked_add(offset) else {

--- a/crates/evm/symbolic/src/runtime/memory.rs
+++ b/crates/evm/symbolic/src/runtime/memory.rs
@@ -6,7 +6,7 @@ pub(crate) struct SymStack(Vec<SymWord>);
 impl SymStack {
     /// Implements the `push` symbolic memory helper.
     pub(crate) fn push(&mut self, value: SymWord) -> Result<(), SymbolicError> {
-        if self.0.len() >= 1024 {
+        if self.0.len() >= EVM_STACK_LIMIT {
             return Err(SymbolicError::StackOverflow);
         }
         self.0.push(value);

--- a/crates/evm/symbolic/src/runtime/precompiles.rs
+++ b/crates/evm/symbolic/src/runtime/precompiles.rs
@@ -13,11 +13,11 @@ pub(crate) fn is_console(address: Address) -> bool {
 /// Returns the `precompile_number` precompile helper result.
 pub(crate) fn precompile_number(address: Address) -> Option<u8> {
     let bytes = address.as_slice();
-    if bytes[..19].iter().any(|byte| *byte != 0) {
+    if bytes[..PRECOMPILE_ADDRESS_LEADING_ZEROS].iter().any(|byte| *byte != 0) {
         return None;
     }
-    match bytes[19] {
-        1..=9 => Some(bytes[19]),
+    match bytes[PRECOMPILE_ADDRESS_LEADING_ZEROS] {
+        1..=9 => Some(bytes[PRECOMPILE_ADDRESS_LEADING_ZEROS]),
         _ => None,
     }
 }
@@ -25,7 +25,7 @@ pub(crate) fn precompile_number(address: Address) -> Option<u8> {
 /// Returns the `precompile_address` precompile helper result.
 pub(crate) fn precompile_address(number: u8) -> Address {
     let mut bytes = [0u8; 20];
-    bytes[19] = number;
+    bytes[PRECOMPILE_ADDRESS_LEADING_ZEROS] = number;
     Address::from(bytes)
 }
 

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -1,14 +1,5 @@
 use super::*;
 
-const INITIAL_SOLVER_POLL_BACKOFF: Duration = Duration::from_micros(200);
-const MAX_SOLVER_POLL_BACKOFF: Duration = Duration::from_millis(50);
-const SECOND_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(100);
-const RESCUE_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(500);
-pub(crate) const PORTFOLIO_SCHEDULER_HISTORY: usize = 8;
-const PORTFOLIO_SCHEDULER_MIN_RECENCY_WEIGHT: i64 = 1;
-const PORTFOLIO_SCHEDULER_SPEED_BONUS_CAP_MS: u128 = 100;
-const PORTFOLIO_SCHEDULER_MAX_SPEED_BONUS: i64 = 100;
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum SolverOutcome {
     Cancelled,

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -616,10 +616,9 @@ pub(crate) fn adjust_expected_call_gas_for_value(
     min_gas: Option<u64>,
 ) -> (Option<u64>, Option<u64>) {
     if value.is_some_and(|value| !value.is_zero()) {
-        const POSITIVE_VALUE_STIPEND: u64 = 2300;
         (
-            gas.map(|gas| gas.saturating_add(POSITIVE_VALUE_STIPEND)),
-            min_gas.map(|gas| gas.saturating_add(POSITIVE_VALUE_STIPEND)),
+            gas.map(|gas| gas.saturating_add(CALL_VALUE_STIPEND)),
+            min_gas.map(|gas| gas.saturating_add(CALL_VALUE_STIPEND)),
         )
     } else {
         (gas, min_gas)
@@ -695,7 +694,7 @@ impl ExpectedCall {
         }
         let mut gas = gas.clone().into_concrete("symbolic expected call gas")?;
         if value.is_some_and(|value| !value.is_zero()) {
-            gas = gas.saturating_add(U256::from(2300));
+            gas = gas.saturating_add(U256::from(CALL_VALUE_STIPEND));
         }
         Ok(self.gas.is_none_or(|expected| gas == U256::from(expected))
             && self.min_gas.is_none_or(|expected| gas >= U256::from(expected)))


### PR DESCRIPTION

## Motivation

Promotes scattered magic numbers and named constants spread across executor.rs, solver.rs, evm.rs, memory.rs, state.rs and precompiles.rs into a single `crates/evm/symbolic/src/consts.rs` module. 

All previous call-sites pick the constants up through the existing use `super::*` / `pub(crate) use consts::*` re-export chain, so no public API changes.


