### PR TITLE
feat: add `reentrancy-events` lint

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -32,6 +32,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `calls-loop`: External calls inside loops can cause denial-of-service if a call reverts or exhausts gas.
   - `delegatecall-loop`: Payable functions should not use `delegatecall` inside a loop.
   - `missing-zero-check`: Address parameter is used in a state write or value transfer without a zero-address check.
+  - `reentrancy-events`: Events emitted after external calls can be reordered or fabricated by a reentrant callee and mislead off-chain consumers.
   - `return-bomb`: External calls with a gas limit should not consume unbounded return data.
 - **Informational / Style Guide:**
   - `boolean-equal`: Boolean comparisons to constants should be simplified.

--- a/crates/lint/docs/reentrancy-events.md
+++ b/crates/lint/docs/reentrancy-events.md
@@ -15,7 +15,7 @@ For every function body, the lint performs a control-flow analysis that tracks w
 - High-level state-mutating external calls on interface or contract types (e.g. `IERC20(token).transfer(...)`). `view` and `pure` callees are not tracked.
 - Contract deployments via `new Foo(...)` (the constructor runs as an external interaction).
 
-External calls reached through internal/private/public helper functions and modifiers are tracked transitively when the helper is invoked by a bare identifier (e.g. `_helper()`). Member-form internal dispatch such as `Lib.f(...)`, `using for` syntax, and `super.f(...)` is **not** yet followed; external calls hidden behind those forms may go undetected.
+External calls reached through internal/private/public helper functions, modifiers, and `super.f(...)` base-chain dispatch are tracked transitively when the helper is invoked by a bare identifier (e.g. `_helper()`) or via `super.`. Member-form internal dispatch such as `Lib.f(...)` and `using for` syntax is **not** yet followed; external calls hidden behind those forms may go undetected.
 
 When the analysis encounters an `emit` statement reachable from a path that already executed a tracked external call, the statement is flagged.
 

--- a/crates/lint/docs/reentrancy-events.md
+++ b/crates/lint/docs/reentrancy-events.md
@@ -7,14 +7,17 @@ Flags `emit` statements that appear after an external call within the same funct
 
 ## What it does
 
-For every function body, the lint performs a control-flow analysis that tracks whether an external call has occurred on the path leading to each statement. External calls include:
+For every function body, the lint performs a control-flow analysis that tracks whether an external call has occurred on the path leading to each statement. Only calls that can plausibly affect log ordering or observable state are considered — `staticcall` and high-level `view` / `pure` external calls are excluded. Tracked calls include:
 
-- Low-level calls: `address.call(...)`, `delegatecall(...)`, `staticcall(...)` (with or without `{value: ...}` / `{gas: ...}` options).
+- Low-level calls: `address.call(...)` and `address.delegatecall(...)` (with or without `{value: ...}` / `{gas: ...}` options).
 - ETH sends: `address.transfer(...)`, `address.send(...)`.
 - `this.method(...)` self-external calls.
-- High-level external calls on interface or contract types (e.g. `IERC20(token).transfer(...)`).
+- High-level state-mutating external calls on interface or contract types (e.g. `IERC20(token).transfer(...)`). `view` and `pure` callees are not tracked.
+- Contract deployments via `new Foo(...)` (the constructor runs as an external interaction).
 
-External calls reached through internal/private/public helper functions and modifiers are also tracked transitively. When the analysis encounters an `emit` statement reachable from a path that already executed an external call, the statement is flagged.
+External calls reached through internal/private/public helper functions and modifiers are tracked transitively when the helper is invoked by a bare identifier (e.g. `_helper()`). Member-form internal dispatch such as `Lib.f(...)`, `using for` syntax, and `super.f(...)` is **not** yet followed; external calls hidden behind those forms may go undetected.
+
+When the analysis encounters an `emit` statement reachable from a path that already executed a tracked external call, the statement is flagged.
 
 ## Why is this bad?
 

--- a/crates/lint/docs/reentrancy-events.md
+++ b/crates/lint/docs/reentrancy-events.md
@@ -1,0 +1,58 @@
+# Reentrancy Events
+
+**Severity**: `Low`
+**ID**: `reentrancy-events`
+
+Flags `emit` statements that appear after an external call within the same function (or any internal helper it transitively calls). Emitting state-change events only after the external call returns can mislead off-chain consumers — including indexers, subgraphs, monitoring tools, and bridges — that rely on log ordering to reconstruct contract state.
+
+## What it does
+
+For every function body, the lint performs a control-flow analysis that tracks whether an external call has occurred on the path leading to each statement. External calls include:
+
+- Low-level calls: `address.call(...)`, `delegatecall(...)`, `staticcall(...)` (with or without `{value: ...}` / `{gas: ...}` options).
+- ETH sends: `address.transfer(...)`, `address.send(...)`.
+- `this.method(...)` self-external calls.
+- High-level external calls on interface or contract types (e.g. `IERC20(token).transfer(...)`).
+
+External calls reached through internal/private/public helper functions and modifiers are also tracked transitively. When the analysis encounters an `emit` statement reachable from a path that already executed an external call, the statement is flagged.
+
+## Why is this bad?
+
+Reentrancy and off-chain ordering both depend on event sequence:
+
+- A reentrant callee can observe (or trigger another contract to observe) events in an order that no longer reflects the final state of the calling contract.
+- Indexers, bridges, and monitoring tools that consume logs in emission order may apply state transitions incorrectly when events are not emitted alongside the writes they describe.
+
+Emitting the event **before** the external call ensures the log is anchored to the local state change, regardless of what the callee does.
+
+## Example
+
+### Bad
+
+```solidity
+contract BadCounter {
+    uint256 public counter;
+    event Counter(uint256 value);
+
+    function count(IExternal d) external {
+        counter += 1;
+        d.notify();             // external call first ...
+        emit Counter(counter);  // ... then the event (may be reordered by reentrancy)
+    }
+}
+```
+
+### Good
+
+```solidity
+contract GoodCounter {
+    uint256 public counter;
+    event Counter(uint256 value);
+
+    function count(IExternal d) external {
+        counter += 1;
+        emit Counter(counter);  // emit event right after the state change
+        d.notify();             // then perform the external call
+    }
+}
+```

--- a/crates/lint/src/sol/low/calls_loop.rs
+++ b/crates/lint/src/sol/low/calls_loop.rs
@@ -272,20 +272,30 @@ pub(super) fn is_external_call<'gcx>(
         return true;
     }
 
+    // `super.<member>(...)` is internal base-chain dispatch, not an external call.
+    // Short-circuit before any code that would ask Solar for `super`'s type (panics).
+    if is_super(base) {
+        return false;
+    }
+
     if resolves_to_internal_library_extension(gcx, hir, base, *member, explicit_arg_count) {
         return false;
     }
 
-    matches!(semantic_member_ty(gcx, hir, base, member.name).map(|ty| ty.kind), Some(TyKind::FnPtr(func)) if func.visibility >= Visibility::Public)
+    // Iterate matching members so overloads aren't dropped by a unique-name lookup.
+    external_member_signatures(gcx, hir, base, member.name, explicit_arg_count)
+        .into_iter()
+        .any(|(vis, _)| vis >= Visibility::Public)
 }
 
 /// Like [`is_external_call`], but excludes calls that cannot affect log ordering or
-/// observable state: low-level `staticcall` and high-level `view`/`pure` callees.
+/// observable state: `staticcall` and high-level `view`/`pure` callees (including `this.*`).
 pub(super) fn is_state_mutating_external_call<'gcx>(
     gcx: Gcx<'gcx>,
     hir: &Hir<'gcx>,
     callee: &Expr<'gcx>,
     explicit_arg_count: usize,
+    enclosing_contract: Option<ContractId>,
 ) -> bool {
     // Contract deployment: the constructor runs arbitrary code and can emit logs.
     if matches!(callee.peel_parens().kind, ExprKind::New(_)) {
@@ -307,19 +317,58 @@ pub(super) fn is_state_mutating_external_call<'gcx>(
     }
 
     if is_this(base) {
-        return true;
+        // `this.<view|pure>()` compiles to a STATICCALL and cannot reorder events; only
+        // taint when the resolved self-call is state-mutating.
+        return self_call_is_state_mutating(hir, enclosing_contract, member.name);
+    }
+
+    // `super.<member>(...)` is internal dispatch — not an external call.
+    if is_super(base) {
+        return false;
     }
 
     if resolves_to_internal_library_extension(gcx, hir, base, *member, explicit_arg_count) {
         return false;
     }
 
-    matches!(
-        semantic_member_ty(gcx, hir, base, member.name).map(|ty| ty.kind),
-        Some(TyKind::FnPtr(func))
-            if func.visibility >= Visibility::Public
-                && !matches!(func.state_mutability, StateMutability::View | StateMutability::Pure)
+    // Iterate overloads: conservatively flag if any matching public/external member is
+    // not `view`/`pure` (rather than silently dropping overloaded names).
+    external_member_signatures(gcx, hir, base, member.name, explicit_arg_count).into_iter().any(
+        |(vis, mut_)| {
+            vis >= Visibility::Public
+                && !matches!(mut_, StateMutability::View | StateMutability::Pure)
+        },
     )
+}
+
+/// Returns `true` when a `this.<member>(...)` call may emit logs or mutate state.
+/// Conservative on unresolved/overloaded names (avoids `gcx.type_of_res` for the `this` builtin,
+/// which panics).
+fn self_call_is_state_mutating(
+    hir: &Hir<'_>,
+    enclosing_contract: Option<ContractId>,
+    member_name: solar::interface::Symbol,
+) -> bool {
+    let Some(contract_id) = enclosing_contract else { return true };
+
+    let mut matched = false;
+    for item_id in hir.contract_item_ids(contract_id) {
+        let Some(func_id) = item_id.as_function() else { continue };
+        let func = hir.function(func_id);
+        if func.name.is_none_or(|name| name.name != member_name) {
+            continue;
+        }
+        // Only externally-callable functions can appear in a `this.<member>(...)` call.
+        if func.visibility < Visibility::Public {
+            continue;
+        }
+        matched = true;
+        if !matches!(func.state_mutability, StateMutability::View | StateMutability::Pure) {
+            return true;
+        }
+    }
+    // No public/external match resolved → conservatively taint.
+    !matched
 }
 
 fn resolves_to_internal_library_extension<'gcx>(
@@ -356,6 +405,42 @@ fn member_function_ids<'gcx>(
         .collect()
 }
 
+/// `(visibility, state_mutability)` for every callable member named `member_name`.
+/// When `explicit_arg_count` matches one or more overloads, narrows to those; otherwise
+/// returns the full set. Preserves overloads (no `unique` collapse).
+fn external_member_signatures<'gcx>(
+    gcx: Gcx<'gcx>,
+    hir: &Hir<'gcx>,
+    base: &Expr<'gcx>,
+    member_name: solar::interface::Symbol,
+    explicit_arg_count: usize,
+) -> Vec<(Visibility, StateMutability)> {
+    let Some(base_ty) = semantic_expr_ty(gcx, hir, base) else { return Vec::new() };
+
+    // (visibility, state_mutability, arity) for every matching callable member.
+    let all: Vec<(Visibility, StateMutability, usize)> = gcx
+        .members_of(base_ty, base_item_source(hir, base), base_contract(hir, base))
+        .iter()
+        .filter(|member| member.name == member_name)
+        .filter_map(|member| match (member.res, member.ty.kind) {
+            (Some(Res::Item(ItemId::Function(func_id))), _) => {
+                let f = hir.function(func_id);
+                Some((f.visibility, f.state_mutability, f.parameters.len()))
+            }
+            (_, TyKind::FnPtr(func)) => {
+                Some((func.visibility, func.state_mutability, func.parameters.len()))
+            }
+            _ => None,
+        })
+        .collect();
+
+    // Prefer arity-matched overloads; fall back to the full set when none match.
+    let arity_matched: Vec<_> =
+        all.iter().filter(|(_, _, n)| *n == explicit_arg_count).copied().collect();
+    let chosen = if arity_matched.is_empty() { all } else { arity_matched };
+    chosen.into_iter().map(|(v, m, _)| (v, m)).collect()
+}
+
 pub(super) fn resolved_internal_function_ids<'hir>(
     hir: &'hir Hir<'hir>,
     callee: &'hir Expr<'hir>,
@@ -373,6 +458,35 @@ pub(super) fn resolved_internal_function_ids<'hir>(
     })
 }
 
+/// Resolves `super.<member>(...)` to the matching base-chain function(s) — for transitive
+/// analysis of external calls reached through C3 super dispatch.
+pub(super) fn resolved_super_function_ids<'hir>(
+    hir: &'hir Hir<'hir>,
+    enclosing_contract: Option<ContractId>,
+    callee: &'hir Expr<'hir>,
+) -> Vec<FunctionId> {
+    let ExprKind::Member(base, member) = &callee.peel_parens().kind else { return Vec::new() };
+    if !is_super(base) {
+        return Vec::new();
+    }
+    let Some(contract_id) = enclosing_contract else { return Vec::new() };
+
+    let mut out = Vec::new();
+    // Skip the contract itself; super dispatch starts at the next base in linearization order.
+    for base_id in hir.contract(contract_id).linearized_bases.iter().skip(1).copied() {
+        for item_id in hir.contract(base_id).items {
+            let Some(func_id) = item_id.as_function() else { continue };
+            let func = hir.function(func_id);
+            if func.name.is_some_and(|name| name.name == member.name)
+                && matches!(func.visibility, Visibility::Internal | Visibility::Public)
+            {
+                out.push(func_id);
+            }
+        }
+    }
+    out
+}
+
 const fn is_internal_callable(func: &Function<'_>) -> bool {
     func.kind.is_function()
         && matches!(
@@ -387,6 +501,17 @@ fn is_this(expr: &Expr<'_>) -> bool {
         ExprKind::Ident(reses)
             if reses.iter().any(|res| {
                 matches!(res, Res::Builtin(builtin) if builtin.name() == sym::this)
+            })
+    )
+}
+
+/// `super` is the C3-linearized base-chain dispatch builtin; `gcx.type_of_res` panics on it.
+fn is_super(expr: &Expr<'_>) -> bool {
+    matches!(
+        &expr.peel_parens().kind,
+        ExprKind::Ident(reses)
+            if reses.iter().any(|res| {
+                matches!(res, Res::Builtin(builtin) if builtin.name() == sym::super_)
             })
     )
 }

--- a/crates/lint/src/sol/low/calls_loop.rs
+++ b/crates/lint/src/sol/low/calls_loop.rs
@@ -246,7 +246,7 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
     }
 }
 
-fn is_external_call<'gcx>(
+pub(super) fn is_external_call<'gcx>(
     gcx: Gcx<'gcx>,
     hir: &Hir<'gcx>,
     callee: &Expr<'gcx>,
@@ -309,7 +309,7 @@ fn member_function_ids<'gcx>(
         .collect()
 }
 
-fn resolved_internal_function_ids<'hir>(
+pub(super) fn resolved_internal_function_ids<'hir>(
     hir: &'hir Hir<'hir>,
     callee: &'hir Expr<'hir>,
 ) -> impl Iterator<Item = FunctionId> + 'hir {

--- a/crates/lint/src/sol/low/calls_loop.rs
+++ b/crates/lint/src/sol/low/calls_loop.rs
@@ -252,6 +252,10 @@ pub(super) fn is_external_call<'gcx>(
     callee: &Expr<'gcx>,
     explicit_arg_count: usize,
 ) -> bool {
+    // `new Foo(...)` runs the deployed contract's constructor — an external interaction.
+    if matches!(callee.peel_parens().kind, ExprKind::New(_)) {
+        return true;
+    }
     let ExprKind::Member(base, member) = &callee.peel_parens().kind else { return false };
 
     if matches!(member.name, kw::Call | kw::Delegatecall | kw::Staticcall)
@@ -283,6 +287,10 @@ pub(super) fn is_state_mutating_external_call<'gcx>(
     callee: &Expr<'gcx>,
     explicit_arg_count: usize,
 ) -> bool {
+    // Contract deployment: the constructor runs arbitrary code and can emit logs.
+    if matches!(callee.peel_parens().kind, ExprKind::New(_)) {
+        return true;
+    }
     let ExprKind::Member(base, member) = &callee.peel_parens().kind else { return false };
 
     // Low-level address calls: `call` and `delegatecall` are in scope; `staticcall` is not.

--- a/crates/lint/src/sol/low/calls_loop.rs
+++ b/crates/lint/src/sol/low/calls_loop.rs
@@ -4,7 +4,7 @@ use crate::{
     sol::{Severity, SolLint},
 };
 use solar::{
-    ast::{DataLocation, ElementaryType, Visibility},
+    ast::{DataLocation, ElementaryType, StateMutability, Visibility},
     interface::{kw, sym},
     sema::{
         Gcx, Ty,
@@ -273,6 +273,45 @@ pub(super) fn is_external_call<'gcx>(
     }
 
     matches!(semantic_member_ty(gcx, hir, base, member.name).map(|ty| ty.kind), Some(TyKind::FnPtr(func)) if func.visibility >= Visibility::Public)
+}
+
+/// Like [`is_external_call`], but excludes calls that cannot affect log ordering or
+/// observable state: low-level `staticcall` and high-level `view`/`pure` callees.
+pub(super) fn is_state_mutating_external_call<'gcx>(
+    gcx: Gcx<'gcx>,
+    hir: &Hir<'gcx>,
+    callee: &Expr<'gcx>,
+    explicit_arg_count: usize,
+) -> bool {
+    let ExprKind::Member(base, member) = &callee.peel_parens().kind else { return false };
+
+    // Low-level address calls: `call` and `delegatecall` are in scope; `staticcall` is not.
+    if matches!(member.name, kw::Call | kw::Delegatecall) && is_address_like(hir, base) {
+        return true;
+    }
+
+    if member.name == kw::Staticcall && is_address_like(hir, base) {
+        return false;
+    }
+
+    if matches!(member.name, sym::send | sym::transfer) && is_address_like(hir, base) {
+        return true;
+    }
+
+    if is_this(base) {
+        return true;
+    }
+
+    if resolves_to_internal_library_extension(gcx, hir, base, *member, explicit_arg_count) {
+        return false;
+    }
+
+    matches!(
+        semantic_member_ty(gcx, hir, base, member.name).map(|ty| ty.kind),
+        Some(TyKind::FnPtr(func))
+            if func.visibility >= Visibility::Public
+                && !matches!(func.state_mutability, StateMutability::View | StateMutability::Pure)
+    )
 }
 
 fn resolves_to_internal_library_extension<'gcx>(

--- a/crates/lint/src/sol/low/calls_loop.rs
+++ b/crates/lint/src/sol/low/calls_loop.rs
@@ -319,7 +319,12 @@ pub(super) fn is_state_mutating_external_call<'gcx>(
     if is_this(base) {
         // `this.<view|pure>()` compiles to a STATICCALL and cannot reorder events; only
         // taint when the resolved self-call is state-mutating.
-        return self_call_is_state_mutating(hir, enclosing_contract, member.name);
+        return self_call_is_state_mutating(
+            hir,
+            enclosing_contract,
+            member.name,
+            explicit_arg_count,
+        );
     }
 
     // `super.<member>(...)` is internal dispatch — not an external call.
@@ -348,6 +353,7 @@ fn self_call_is_state_mutating(
     hir: &Hir<'_>,
     enclosing_contract: Option<ContractId>,
     member_name: solar::interface::Symbol,
+    explicit_arg_count: usize,
 ) -> bool {
     let Some(contract_id) = enclosing_contract else { return true };
 
@@ -356,6 +362,9 @@ fn self_call_is_state_mutating(
         let Some(func_id) = item_id.as_function() else { continue };
         let func = hir.function(func_id);
         if func.name.is_none_or(|name| name.name != member_name) {
+            continue;
+        }
+        if func.parameters.len() != explicit_arg_count {
             continue;
         }
         // Only externally-callable functions can appear in a `this.<member>(...)` call.
@@ -464,6 +473,7 @@ pub(super) fn resolved_super_function_ids<'hir>(
     hir: &'hir Hir<'hir>,
     enclosing_contract: Option<ContractId>,
     callee: &'hir Expr<'hir>,
+    explicit_arg_count: usize,
 ) -> Vec<FunctionId> {
     let ExprKind::Member(base, member) = &callee.peel_parens().kind else { return Vec::new() };
     if !is_super(base) {
@@ -478,9 +488,11 @@ pub(super) fn resolved_super_function_ids<'hir>(
             let Some(func_id) = item_id.as_function() else { continue };
             let func = hir.function(func_id);
             if func.name.is_some_and(|name| name.name == member.name)
+                && func.parameters.len() == explicit_arg_count
                 && matches!(func.visibility, Visibility::Internal | Visibility::Public)
             {
                 out.push(func_id);
+                return out;
             }
         }
     }

--- a/crates/lint/src/sol/low/mod.rs
+++ b/crates/lint/src/sol/low/mod.rs
@@ -15,10 +15,14 @@ use missing_zero_check::MISSING_ZERO_CHECK;
 mod return_bomb;
 use return_bomb::RETURN_BOMB;
 
+mod reentrancy_events;
+use reentrancy_events::REENTRANCY_EVENTS;
+
 register_lints!(
     (BlockTimestamp, early, (BLOCK_TIMESTAMP)),
     (CallsLoop, late, (CALLS_LOOP)),
     (DelegatecallLoop, late, (DELEGATECALL_LOOP)),
     (MissingZeroCheck, late, (MISSING_ZERO_CHECK)),
     (ReturnBomb, late, (RETURN_BOMB)),
+    (ReentrancyEvents, late, (REENTRANCY_EVENTS)),
 );

--- a/crates/lint/src/sol/low/reentrancy_events.rs
+++ b/crates/lint/src/sol/low/reentrancy_events.rs
@@ -172,7 +172,12 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
         };
 
         for arg in modifier.args.exprs() {
+            self.expr_aborted = false;
             self.analyze_expr(arg, &mut entry);
+            // An aborting arg means the modifier (and therefore its body) is never entered.
+            if self.expr_aborted {
+                return Exits::abort();
+            }
         }
 
         let Some(modifier_id) = modifier.id.as_function() else {
@@ -224,9 +229,11 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
         placeholder: Placeholder<'hir>,
         mut entry: FlowState,
     ) -> Exits {
+        // Reset once per statement so each branch can read `expr_aborted` after analyzing
+        // its top-level expressions without leaking state from a previous statement.
+        self.expr_aborted = false;
         match stmt.kind {
             StmtKind::DeclSingle(var_id) => {
-                self.expr_aborted = false;
                 if let Some(init) = self.hir.variable(var_id).initializer {
                     self.analyze_expr(init, &mut entry);
                 }
@@ -236,7 +243,6 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                 Exits::fallthrough(entry)
             }
             StmtKind::DeclMulti(_, expr) | StmtKind::Expr(expr) => {
-                self.expr_aborted = false;
                 self.analyze_expr(expr, &mut entry);
                 // Aborts via builtins (`revert()`, `selfdestruct(...)`, `require(false, …)`,
                 // `assert(false)`) or via an inlined helper with no normal exit.
@@ -252,6 +258,11 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                 // Solidity evaluates event arguments before emitting, so an external call inside
                 // the arguments also taints this emit. Analyze the args first, then check state.
                 self.analyze_expr(expr, &mut entry);
+                // If an argument aborts (e.g. `emit E(helperThatAlwaysReverts())`), the emit
+                // itself is unreachable, so it must not be reported and the path aborts.
+                if self.expr_aborted {
+                    return Exits::abort();
+                }
                 if entry.external_call_seen
                     && !self.suppress_inline_reports
                     && self.emitted.insert(stmt.span)
@@ -267,6 +278,10 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
             StmtKind::Return(expr) => {
                 if let Some(expr) = expr {
                     self.analyze_expr(expr, &mut entry);
+                }
+                // If the return value computation aborts, the `return` itself never runs.
+                if self.expr_aborted {
+                    return Exits::abort();
                 }
                 Exits::return_(entry)
             }
@@ -317,6 +332,11 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
             }
             StmtKind::If(cond, then_stmt, else_stmt) => {
                 self.analyze_expr(cond, &mut entry);
+                // If the condition aborts (e.g. `if (helperThatAlwaysReverts())`), neither
+                // branch is reachable.
+                if self.expr_aborted {
+                    return Exits::abort();
+                }
 
                 let then_exits = self.analyze_stmt(then_stmt, placeholder, entry.clone());
                 let else_exits = if let Some(else_stmt) = else_stmt {
@@ -331,6 +351,11 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
             }
             StmtKind::Try(try_stmt) => {
                 self.analyze_expr(&try_stmt.expr, &mut entry);
+                // If evaluating the try-call expression aborts before the call itself runs
+                // (e.g. an aborting arg), no clause can execute.
+                if self.expr_aborted {
+                    return Exits::abort();
+                }
 
                 let mut summary = Exits::default();
                 for clause in try_stmt.clauses {
@@ -388,6 +413,28 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                     resolved_super_function_ids(self.hir, self.enclosing_contract, callee)
                 {
                     self.analyze_internal_call(func_id, state);
+                }
+            }
+            ExprKind::Binary(lhs, op, rhs)
+                if matches!(op.kind, hir::BinOpKind::And | hir::BinOpKind::Or) =>
+            {
+                // Short-circuiting `&&`/`||`: LHS always runs, RHS is conditional. Model RHS
+                // on a forked state so its taint only reaches the merged result when the
+                // short-circuit path is also possible, and so an aborting RHS does not kill
+                // the whole expression (the short-circuit path still falls through).
+                self.analyze_expr(lhs, state);
+                let lhs_aborted = std::mem::replace(&mut self.expr_aborted, false);
+
+                let mut rhs_state = state.clone();
+                self.analyze_expr(rhs, &mut rhs_state);
+                let rhs_aborted = self.expr_aborted;
+
+                // The expression aborts iff LHS aborts (then no path survives); an
+                // RHS-only abort just drops the non-short-circuit path.
+                self.expr_aborted = lhs_aborted;
+
+                if !lhs_aborted && !rhs_aborted {
+                    state.merge(&rhs_state);
                 }
             }
             ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {

--- a/crates/lint/src/sol/low/reentrancy_events.rs
+++ b/crates/lint/src/sol/low/reentrancy_events.rs
@@ -1,6 +1,9 @@
 use super::{
     ReentrancyEvents,
-    calls_loop::{is_state_mutating_external_call, resolved_internal_function_ids},
+    calls_loop::{
+        is_state_mutating_external_call, resolved_internal_function_ids,
+        resolved_super_function_ids,
+    },
 };
 use crate::{
     linter::{LateLintPass, LintContext},
@@ -11,7 +14,9 @@ use solar::{
     interface::{Span, kw, sym},
     sema::{
         Gcx,
-        hir::{self, Block, Expr, ExprKind, Function, FunctionId, Hir, Res, Stmt, StmtKind},
+        hir::{
+            self, Block, ContractId, Expr, ExprKind, Function, FunctionId, Hir, Res, Stmt, StmtKind,
+        },
     },
 };
 use std::collections::HashSet;
@@ -33,7 +38,7 @@ impl<'hir> LateLintPass<'hir> for ReentrancyEvents {
     ) {
         let Some(body) = func.body else { return };
 
-        let mut analyzer = Analyzer::new(ctx, gcx, hir);
+        let mut analyzer = Analyzer::new(ctx, gcx, hir, func.contract);
         let _ = analyzer.analyze_callable(func, body, FlowState::default());
     }
 }
@@ -112,6 +117,9 @@ struct Analyzer<'ctx, 's, 'c, 'hir> {
     ctx: &'ctx LintContext<'s, 'c>,
     gcx: Gcx<'hir>,
     hir: &'hir Hir<'hir>,
+    /// Top-level analyzed contract; used to resolve `this.<method>` without consulting
+    /// Solar for the `this` builtin. Held fixed across inlined helpers (runtime `this`).
+    enclosing_contract: Option<ContractId>,
     /// Call stack to break recursion when inlining internal helpers and modifiers.
     call_stack: Vec<FunctionId>,
     /// Spans already reported, to dedupe diagnostics across paths/iterations.
@@ -125,11 +133,17 @@ struct Analyzer<'ctx, 's, 'c, 'hir> {
 }
 
 impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
-    fn new(ctx: &'ctx LintContext<'s, 'c>, gcx: Gcx<'hir>, hir: &'hir Hir<'hir>) -> Self {
+    fn new(
+        ctx: &'ctx LintContext<'s, 'c>,
+        gcx: Gcx<'hir>,
+        hir: &'hir Hir<'hir>,
+        enclosing_contract: Option<ContractId>,
+    ) -> Self {
         Self {
             ctx,
             gcx,
             hir,
+            enclosing_contract,
             call_stack: Vec::new(),
             emitted: HashSet::new(),
             suppress_inline_reports: false,
@@ -354,13 +368,25 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                     self.analyze_expr(arg, state);
                 }
 
-                if is_state_mutating_external_call(self.gcx, self.hir, callee, args.len()) {
+                if is_state_mutating_external_call(
+                    self.gcx,
+                    self.hir,
+                    callee,
+                    args.len(),
+                    self.enclosing_contract,
+                ) {
                     state.external_call_seen = true;
                 }
 
                 // Follow internal/private/public helpers transitively so external calls in
                 // helpers also taint the caller's flow state.
                 for func_id in resolved_internal_function_ids(self.hir, callee) {
+                    self.analyze_internal_call(func_id, state);
+                }
+                // Same for `super.<member>(...)` base-chain dispatch.
+                for func_id in
+                    resolved_super_function_ids(self.hir, self.enclosing_contract, callee)
+                {
                     self.analyze_internal_call(func_id, state);
                 }
             }
@@ -388,15 +414,30 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
             }
             ExprKind::Ternary(cond, then_expr, else_expr) => {
                 self.analyze_expr(cond, state);
+                // Sample `expr_aborted` per branch so an aborting branch can't poison the
+                // sibling. The ternary aborts iff `cond` aborts OR both branches abort.
+                let outer_aborted = std::mem::replace(&mut self.expr_aborted, false);
 
                 let mut then_state = state.clone();
                 self.analyze_expr(then_expr, &mut then_state);
+                let then_aborted = std::mem::replace(&mut self.expr_aborted, false);
 
                 let mut else_state = state.clone();
                 self.analyze_expr(else_expr, &mut else_state);
+                let else_aborted = self.expr_aborted;
 
-                *state = then_state;
-                state.merge(&else_state);
+                self.expr_aborted = outer_aborted || (then_aborted && else_aborted);
+
+                // Aborting branches drop their state; only surviving branches contribute.
+                match (then_aborted, else_aborted) {
+                    (true, true) => {}
+                    (true, false) => *state = else_state,
+                    (false, true) => *state = then_state,
+                    (false, false) => {
+                        *state = then_state;
+                        state.merge(&else_state);
+                    }
+                }
             }
             ExprKind::Array(exprs) => {
                 for expr in *exprs {

--- a/crates/lint/src/sol/low/reentrancy_events.rs
+++ b/crates/lint/src/sol/low/reentrancy_events.rs
@@ -1,0 +1,451 @@
+use super::{
+    ReentrancyEvents,
+    calls_loop::{is_external_call, resolved_internal_function_ids},
+};
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::{
+    ast::LitKind,
+    interface::{Span, kw, sym},
+    sema::{
+        Gcx,
+        hir::{self, Block, Expr, ExprKind, Function, FunctionId, Hir, Res, Stmt, StmtKind},
+    },
+};
+use std::collections::HashSet;
+
+declare_forge_lint!(
+    REENTRANCY_EVENTS,
+    Severity::Low,
+    "reentrancy-events",
+    "event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on"
+);
+
+impl<'hir> LateLintPass<'hir> for ReentrancyEvents {
+    fn check_function_with_gcx(
+        &mut self,
+        ctx: &LintContext,
+        gcx: Gcx<'hir>,
+        hir: &'hir Hir<'hir>,
+        func: &'hir Function<'hir>,
+    ) {
+        let Some(body) = func.body else { return };
+
+        let mut analyzer = Analyzer::new(ctx, gcx, hir);
+        let _ = analyzer.analyze_callable(func, body, FlowState::default());
+    }
+}
+
+type Placeholder<'hir> = Option<(&'hir [hir::Modifier<'hir>], usize, Block<'hir>)>;
+
+/// Per-path state tracked by the may-analysis.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct FlowState {
+    /// True iff an external call has occurred on the path leading to the current program point.
+    external_call_seen: bool,
+}
+
+impl FlowState {
+    const fn merge(&mut self, other: &Self) {
+        self.external_call_seen |= other.external_call_seen;
+    }
+}
+
+/// Summarises how a piece of code can exit, with the [`FlowState`] reaching each exit kind.
+/// `None` means no path produces that exit; `Some(_)` means some path does.
+///
+/// Aborting paths (`revert`/`require(false)`/etc.) drop their state — they are simply absent
+/// from every bucket, so they cannot taint subsequent statements.
+#[derive(Clone, Debug, Default)]
+struct Exits {
+    /// Control falls through to the next statement of the enclosing block.
+    fallthrough: Option<FlowState>,
+    /// Control exits the enclosing function via `return`.
+    return_: Option<FlowState>,
+    /// Control exits the enclosing loop via `break`.
+    break_: Option<FlowState>,
+    /// Control goes back to the loop header via `continue`.
+    continue_: Option<FlowState>,
+}
+
+impl Exits {
+    fn fallthrough(state: FlowState) -> Self {
+        Self { fallthrough: Some(state), ..Default::default() }
+    }
+
+    fn return_(state: FlowState) -> Self {
+        Self { return_: Some(state), ..Default::default() }
+    }
+
+    fn break_(state: FlowState) -> Self {
+        Self { break_: Some(state), ..Default::default() }
+    }
+
+    fn continue_(state: FlowState) -> Self {
+        Self { continue_: Some(state), ..Default::default() }
+    }
+
+    /// Aborting exit (`revert`, infinite loop, panic): no paths flow out.
+    fn abort() -> Self {
+        Self::default()
+    }
+
+    const fn merge(&mut self, other: Self) {
+        merge_opt(&mut self.fallthrough, other.fallthrough);
+        merge_opt(&mut self.return_, other.return_);
+        merge_opt(&mut self.break_, other.break_);
+        merge_opt(&mut self.continue_, other.continue_);
+    }
+}
+
+const fn merge_opt(dst: &mut Option<FlowState>, src: Option<FlowState>) {
+    match (dst.as_mut(), src) {
+        (None, src) => *dst = src,
+        (Some(_), None) => {}
+        (Some(d), Some(s)) => d.merge(&s),
+    }
+}
+
+struct Analyzer<'ctx, 's, 'c, 'hir> {
+    ctx: &'ctx LintContext<'s, 'c>,
+    gcx: Gcx<'hir>,
+    hir: &'hir Hir<'hir>,
+    /// Call stack to break recursion when inlining internal helpers and modifiers.
+    call_stack: Vec<FunctionId>,
+    /// Spans already reported, to dedupe diagnostics across paths/iterations.
+    emitted: HashSet<Span>,
+}
+
+impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
+    fn new(ctx: &'ctx LintContext<'s, 'c>, gcx: Gcx<'hir>, hir: &'hir Hir<'hir>) -> Self {
+        Self { ctx, gcx, hir, call_stack: Vec::new(), emitted: HashSet::new() }
+    }
+
+    fn analyze_callable(
+        &mut self,
+        func: &'hir Function<'hir>,
+        body: Block<'hir>,
+        entry: FlowState,
+    ) -> Exits {
+        self.analyze_modifier_chain(func.modifiers, 0, body, entry)
+    }
+
+    fn analyze_modifier_chain(
+        &mut self,
+        modifiers: &'hir [hir::Modifier<'hir>],
+        index: usize,
+        body: Block<'hir>,
+        mut entry: FlowState,
+    ) -> Exits {
+        let Some(modifier) = modifiers.get(index) else {
+            return self.analyze_block(body, None, entry);
+        };
+
+        for arg in modifier.args.exprs() {
+            self.analyze_expr(arg, &mut entry);
+        }
+
+        let Some(modifier_id) = modifier.id.as_function() else {
+            return self.analyze_modifier_chain(modifiers, index + 1, body, entry);
+        };
+
+        // Note: we deliberately do NOT skip duplicate modifier IDs here. A modifier may
+        // legitimately appear at multiple indices in the chain (e.g. `f() m(false) m(true)`),
+        // and the chain itself cannot recurse infinitely because `index` strictly increases.
+        // True recursion through internal calls is still handled by `analyze_internal_call`.
+
+        let modifier_func = self.hir.function(modifier_id);
+        let Some(modifier_body) = modifier_func.body else {
+            return self.analyze_modifier_chain(modifiers, index + 1, body, entry);
+        };
+
+        self.call_stack.push(modifier_id);
+        let summary = self.analyze_block(modifier_body, Some((modifiers, index + 1, body)), entry);
+        self.call_stack.pop();
+        summary
+    }
+
+    fn analyze_block(
+        &mut self,
+        block: Block<'hir>,
+        placeholder: Placeholder<'hir>,
+        mut entry: FlowState,
+    ) -> Exits {
+        let mut summary = Exits::default();
+        for stmt in block.stmts {
+            let stmt_exits = self.analyze_stmt(stmt, placeholder, entry);
+            // Non-fallthrough exits propagate up out of the block.
+            merge_opt(&mut summary.return_, stmt_exits.return_);
+            merge_opt(&mut summary.break_, stmt_exits.break_);
+            merge_opt(&mut summary.continue_, stmt_exits.continue_);
+            // Only the fallthrough state reaches the next statement.
+            match stmt_exits.fallthrough {
+                Some(next) => entry = next,
+                None => return summary, // Subsequent statements are dead.
+            }
+        }
+        summary.fallthrough = Some(entry);
+        summary
+    }
+
+    fn analyze_stmt(
+        &mut self,
+        stmt: &'hir Stmt<'hir>,
+        placeholder: Placeholder<'hir>,
+        mut entry: FlowState,
+    ) -> Exits {
+        match stmt.kind {
+            StmtKind::DeclSingle(var_id) => {
+                if let Some(init) = self.hir.variable(var_id).initializer {
+                    self.analyze_expr(init, &mut entry);
+                }
+                Exits::fallthrough(entry)
+            }
+            StmtKind::DeclMulti(_, expr) | StmtKind::Expr(expr) => {
+                self.analyze_expr(expr, &mut entry);
+                // Several Solidity builtins terminate execution but lower to plain expression
+                // statements rather than `StmtKind::Revert`: `revert()`/`revert("msg")`,
+                // `selfdestruct(...)`, `require(false, ...)`, and `assert(false)`. Treat them
+                // as aborts so following statements are not misanalysed as reachable.
+                if is_aborting_call(expr) {
+                    return Exits::abort();
+                }
+                Exits::fallthrough(entry)
+            }
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
+                self.analyze_block(block, placeholder, entry)
+            }
+            StmtKind::Emit(expr) => {
+                // Solidity evaluates event arguments before emitting, so an external call inside
+                // the arguments also taints this emit. Analyze the args first, then check state.
+                self.analyze_expr(expr, &mut entry);
+                if entry.external_call_seen && self.emitted.insert(stmt.span) {
+                    self.ctx.emit(&REENTRANCY_EVENTS, stmt.span);
+                }
+                Exits::fallthrough(entry)
+            }
+            StmtKind::Revert(expr) => {
+                self.analyze_expr(expr, &mut entry);
+                Exits::abort()
+            }
+            StmtKind::Return(expr) => {
+                if let Some(expr) = expr {
+                    self.analyze_expr(expr, &mut entry);
+                }
+                Exits::return_(entry)
+            }
+            StmtKind::Break => Exits::break_(entry),
+            StmtKind::Continue => Exits::continue_(entry),
+            StmtKind::Loop(block, _) => {
+                // Single-pass may-analysis: matches `reentrancy.rs`. May miss cases where the
+                // second iteration would taint earlier emits via the back-edge.
+                let body = self.analyze_block(block, placeholder, entry.clone());
+                // Post-loop state combines the entry (zero iterations), fallthrough at end of
+                // body, plus any `break` or `continue` exits. Aborting paths are absent and
+                // therefore drop out.
+                let mut post = entry;
+                if let Some(ft) = body.fallthrough {
+                    post.merge(&ft);
+                }
+                if let Some(b) = body.break_ {
+                    post.merge(&b);
+                }
+                if let Some(c) = body.continue_ {
+                    post.merge(&c);
+                }
+                Exits {
+                    fallthrough: Some(post),
+                    return_: body.return_,
+                    break_: None,
+                    continue_: None,
+                }
+            }
+            StmtKind::If(cond, then_stmt, else_stmt) => {
+                self.analyze_expr(cond, &mut entry);
+
+                let then_exits = self.analyze_stmt(then_stmt, placeholder, entry.clone());
+                let else_exits = if let Some(else_stmt) = else_stmt {
+                    self.analyze_stmt(else_stmt, placeholder, entry)
+                } else {
+                    Exits::fallthrough(entry)
+                };
+
+                let mut merged = then_exits;
+                merged.merge(else_exits);
+                merged
+            }
+            StmtKind::Try(try_stmt) => {
+                self.analyze_expr(&try_stmt.expr, &mut entry);
+
+                let mut summary = Exits::default();
+                for clause in try_stmt.clauses {
+                    let clause_exits = self.analyze_block(clause.block, placeholder, entry.clone());
+                    summary.merge(clause_exits);
+                }
+                summary
+            }
+            StmtKind::Placeholder => {
+                if let Some((modifiers, index, body)) = placeholder {
+                    self.analyze_modifier_chain(modifiers, index, body, entry)
+                } else {
+                    Exits::fallthrough(entry)
+                }
+            }
+            StmtKind::Err(_) => Exits::fallthrough(entry),
+        }
+    }
+
+    fn analyze_expr(&mut self, expr: &'hir Expr<'hir>, state: &mut FlowState) {
+        match &expr.kind {
+            ExprKind::Call(callee, args, opts) => {
+                self.analyze_expr(callee, state);
+                if let Some(opts) = opts {
+                    for opt in *opts {
+                        self.analyze_expr(&opt.value, state);
+                    }
+                }
+                for arg in args.exprs() {
+                    self.analyze_expr(arg, state);
+                }
+
+                if is_external_call(self.gcx, self.hir, callee, args.len())
+                    || is_new_expression(callee)
+                {
+                    // Deploying a contract (`new Foo(args)`) executes that contract's
+                    // constructor, which is an external interaction that may emit events
+                    // or call back into this contract.
+                    state.external_call_seen = true;
+                }
+
+                // Follow internal/private/public helpers transitively so external calls in
+                // helpers also taint the caller's flow state.
+                for func_id in resolved_internal_function_ids(self.hir, callee) {
+                    self.analyze_internal_call(func_id, state);
+                }
+            }
+            ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {
+                self.analyze_expr(lhs, state);
+                self.analyze_expr(rhs, state);
+            }
+            ExprKind::Unary(_, inner) | ExprKind::Delete(inner) | ExprKind::Payable(inner) => {
+                self.analyze_expr(inner, state);
+            }
+            ExprKind::Index(base, index) => {
+                self.analyze_expr(base, state);
+                if let Some(index) = index {
+                    self.analyze_expr(index, state);
+                }
+            }
+            ExprKind::Slice(base, start, end) => {
+                self.analyze_expr(base, state);
+                if let Some(start) = start {
+                    self.analyze_expr(start, state);
+                }
+                if let Some(end) = end {
+                    self.analyze_expr(end, state);
+                }
+            }
+            ExprKind::Ternary(cond, then_expr, else_expr) => {
+                self.analyze_expr(cond, state);
+
+                let mut then_state = state.clone();
+                self.analyze_expr(then_expr, &mut then_state);
+
+                let mut else_state = state.clone();
+                self.analyze_expr(else_expr, &mut else_state);
+
+                *state = then_state;
+                state.merge(&else_state);
+            }
+            ExprKind::Array(exprs) => {
+                for expr in *exprs {
+                    self.analyze_expr(expr, state);
+                }
+            }
+            ExprKind::Tuple(exprs) => {
+                for expr in exprs.iter().copied().flatten() {
+                    self.analyze_expr(expr, state);
+                }
+            }
+            ExprKind::Member(base, _) => self.analyze_expr(base, state),
+            ExprKind::Ident(_)
+            | ExprKind::Lit(_)
+            | ExprKind::New(_)
+            | ExprKind::TypeCall(_)
+            | ExprKind::Type(_)
+            | ExprKind::Err(_) => {}
+        }
+    }
+
+    fn analyze_internal_call(&mut self, func_id: FunctionId, state: &mut FlowState) {
+        if self.call_stack.contains(&func_id) {
+            return;
+        }
+
+        let func = self.hir.function(func_id);
+        let Some(body) = func.body else { return };
+
+        self.call_stack.push(func_id);
+        let summary = self.analyze_callable(func, body, state.clone());
+        self.call_stack.pop();
+
+        // Caller only inherits the state of paths that return normally to it (implicit
+        // fallthrough at the end of the body, or explicit `return`). If every path inside the
+        // callee aborts (e.g. always `revert`s), the caller's state is left unchanged here —
+        // post-call code is technically dead, but we cannot signal that through the expression
+        // visitor. This is a documented limitation.
+        let any_normal = summary.fallthrough.is_some() || summary.return_.is_some();
+        if any_normal {
+            let mut after = FlowState::default();
+            if let Some(ft) = summary.fallthrough {
+                after.merge(&ft);
+            }
+            if let Some(rt) = summary.return_ {
+                after.merge(&rt);
+            }
+            *state = after;
+        }
+    }
+}
+
+/// Returns `true` when the expression-statement is a builtin call that always terminates
+/// execution: `revert()` / `revert("msg")`, `selfdestruct(...)`, `require(false, ...)`, or
+/// `assert(false)`.
+fn is_aborting_call(expr: &Expr<'_>) -> bool {
+    let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else {
+        return false;
+    };
+    let ExprKind::Ident(reses) = &callee.peel_parens().kind else {
+        return false;
+    };
+    for res in *reses {
+        let Res::Builtin(b) = res else { continue };
+        let name = b.name();
+        if name == kw::Revert || name == kw::Selfdestruct {
+            return true;
+        }
+        if (name == sym::require || name == sym::assert)
+            && args.exprs().next().is_some_and(literal_false)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Returns `true` if `expr` is the boolean literal `false`.
+fn literal_false(expr: &Expr<'_>) -> bool {
+    matches!(
+        &expr.peel_parens().kind,
+        ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Bool(false))
+    )
+}
+
+/// Returns `true` if `callee` is a `new` expression — i.e. the call is a contract deployment
+/// (`new Foo(args)`), which executes the deployed contract's constructor and is an external
+/// interaction for our purposes.
+fn is_new_expression(callee: &Expr<'_>) -> bool {
+    matches!(callee.peel_parens().kind, ExprKind::New(_))
+}

--- a/crates/lint/src/sol/low/reentrancy_events.rs
+++ b/crates/lint/src/sol/low/reentrancy_events.rs
@@ -409,9 +409,12 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                     self.analyze_internal_call(func_id, state);
                 }
                 // Same for `super.<member>(...)` base-chain dispatch.
-                for func_id in
-                    resolved_super_function_ids(self.hir, self.enclosing_contract, callee)
-                {
+                for func_id in resolved_super_function_ids(
+                    self.hir,
+                    self.enclosing_contract,
+                    callee,
+                    args.len(),
+                ) {
                     self.analyze_internal_call(func_id, state);
                 }
             }

--- a/crates/lint/src/sol/low/reentrancy_events.rs
+++ b/crates/lint/src/sol/low/reentrancy_events.rs
@@ -116,11 +116,25 @@ struct Analyzer<'ctx, 's, 'c, 'hir> {
     call_stack: Vec<FunctionId>,
     /// Spans already reported, to dedupe diagnostics across paths/iterations.
     emitted: HashSet<Span>,
+    /// When `true`, suppress emit diagnostics: we are inside an inlined helper that was
+    /// entered with a clean state, so the helper's own self-pass will catch any taint.
+    suppress_inline_reports: bool,
+    /// Set by `analyze_internal_call` when the inlined callee has no normal exits, so the
+    /// enclosing statement can treat itself as aborting.
+    expr_aborted: bool,
 }
 
 impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
     fn new(ctx: &'ctx LintContext<'s, 'c>, gcx: Gcx<'hir>, hir: &'hir Hir<'hir>) -> Self {
-        Self { ctx, gcx, hir, call_stack: Vec::new(), emitted: HashSet::new() }
+        Self {
+            ctx,
+            gcx,
+            hir,
+            call_stack: Vec::new(),
+            emitted: HashSet::new(),
+            suppress_inline_reports: false,
+            expr_aborted: false,
+        }
     }
 
     fn analyze_callable(
@@ -198,18 +212,21 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
     ) -> Exits {
         match stmt.kind {
             StmtKind::DeclSingle(var_id) => {
+                self.expr_aborted = false;
                 if let Some(init) = self.hir.variable(var_id).initializer {
                     self.analyze_expr(init, &mut entry);
+                }
+                if self.expr_aborted {
+                    return Exits::abort();
                 }
                 Exits::fallthrough(entry)
             }
             StmtKind::DeclMulti(_, expr) | StmtKind::Expr(expr) => {
+                self.expr_aborted = false;
                 self.analyze_expr(expr, &mut entry);
-                // Several Solidity builtins terminate execution but lower to plain expression
-                // statements rather than `StmtKind::Revert`: `revert()`/`revert("msg")`,
-                // `selfdestruct(...)`, `require(false, ...)`, and `assert(false)`. Treat them
-                // as aborts so following statements are not misanalysed as reachable.
-                if is_aborting_call(expr) {
+                // Aborts via builtins (`revert()`, `selfdestruct(...)`, `require(false, …)`,
+                // `assert(false)`) or via an inlined helper with no normal exit.
+                if is_aborting_call(expr) || self.expr_aborted {
                     return Exits::abort();
                 }
                 Exits::fallthrough(entry)
@@ -221,7 +238,10 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                 // Solidity evaluates event arguments before emitting, so an external call inside
                 // the arguments also taints this emit. Analyze the args first, then check state.
                 self.analyze_expr(expr, &mut entry);
-                if entry.external_call_seen && self.emitted.insert(stmt.span) {
+                if entry.external_call_seen
+                    && !self.suppress_inline_reports
+                    && self.emitted.insert(stmt.span)
+                {
                     self.ctx.emit(&REENTRANCY_EVENTS, stmt.span);
                 }
                 Exits::fallthrough(entry)
@@ -312,7 +332,12 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                     Exits::fallthrough(entry)
                 }
             }
-            StmtKind::Err(_) => Exits::fallthrough(entry),
+            StmtKind::Err(_) => {
+                // Inline assembly lowers to `StmtKind::Err`; it can perform external
+                // interactions (call/delegatecall/create, logs). Conservatively taint.
+                entry.external_call_seen = true;
+                Exits::fallthrough(entry)
+            }
         }
     }
 
@@ -329,12 +354,7 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                     self.analyze_expr(arg, state);
                 }
 
-                if is_state_mutating_external_call(self.gcx, self.hir, callee, args.len())
-                    || is_new_expression(callee)
-                {
-                    // Deploying a contract (`new Foo(args)`) executes that contract's
-                    // constructor, which is an external interaction that may emit events
-                    // or call back into this contract.
+                if is_state_mutating_external_call(self.gcx, self.hir, callee, args.len()) {
                     state.external_call_seen = true;
                 }
 
@@ -406,15 +426,20 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
         let func = self.hir.function(func_id);
         let Some(body) = func.body else { return };
 
+        // Suppress diagnostics inside helpers entered with a clean state — the helper's
+        // own self-pass will independently catch any intra-helper taint, avoiding
+        // duplicate reports across callers.
+        let prev_suppress = self.suppress_inline_reports;
+        self.suppress_inline_reports = prev_suppress || !state.external_call_seen;
+
         self.call_stack.push(func_id);
         let summary = self.analyze_callable(func, body, state.clone());
         self.call_stack.pop();
 
-        // Caller only inherits the state of paths that return normally to it (implicit
-        // fallthrough at the end of the body, or explicit `return`). If every path inside the
-        // callee aborts (e.g. always `revert`s), the caller's state is left unchanged here —
-        // post-call code is technically dead, but we cannot signal that through the expression
-        // visitor. This is a documented limitation.
+        self.suppress_inline_reports = prev_suppress;
+
+        // Caller inherits the state of paths that return normally. If the callee has no
+        // normal exits (always aborts), signal abort to the enclosing statement.
         let any_normal = summary.fallthrough.is_some() || summary.return_.is_some();
         if any_normal {
             let mut after = FlowState::default();
@@ -425,6 +450,8 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                 after.merge(&rt);
             }
             *state = after;
+        } else {
+            self.expr_aborted = true;
         }
     }
 }
@@ -460,11 +487,4 @@ fn literal_false(expr: &Expr<'_>) -> bool {
         &expr.peel_parens().kind,
         ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Bool(false))
     )
-}
-
-/// Returns `true` if `callee` is a `new` expression — i.e. the call is a contract deployment
-/// (`new Foo(args)`), which executes the deployed contract's constructor and is an external
-/// interaction for our purposes.
-fn is_new_expression(callee: &Expr<'_>) -> bool {
-    matches!(callee.peel_parens().kind, ExprKind::New(_))
 }

--- a/crates/lint/src/sol/low/reentrancy_events.rs
+++ b/crates/lint/src/sol/low/reentrancy_events.rs
@@ -1,6 +1,6 @@
 use super::{
     ReentrancyEvents,
-    calls_loop::{is_external_call, resolved_internal_function_ids},
+    calls_loop::{is_state_mutating_external_call, resolved_internal_function_ids},
 };
 use crate::{
     linter::{LateLintPass, LintContext},
@@ -239,9 +239,28 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
             StmtKind::Break => Exits::break_(entry),
             StmtKind::Continue => Exits::continue_(entry),
             StmtKind::Loop(block, _) => {
-                // Single-pass may-analysis: matches `reentrancy.rs`. May miss cases where the
-                // second iteration would taint earlier emits via the back-edge.
-                let body = self.analyze_block(block, placeholder, entry.clone());
+                // Two-pass fixpoint: with a 1-bit state the back-edge can only strengthen
+                // `external_call_seen` from false to true, so a second pass with the merged
+                // entry suffices to catch emits tainted only on iterations 2..N. Duplicate
+                // diagnostics from the first pass are deduped via `self.emitted`.
+                let first = self.analyze_block(block, placeholder, entry.clone());
+
+                // Back-edge entry: pre-loop entry merged with anything that loops back
+                // (fallthrough at the end of the body, or an explicit `continue`).
+                let mut back_edge = entry.clone();
+                if let Some(ft) = &first.fallthrough {
+                    back_edge.merge(ft);
+                }
+                if let Some(c) = &first.continue_ {
+                    back_edge.merge(c);
+                }
+
+                let body = if back_edge == entry {
+                    first
+                } else {
+                    self.analyze_block(block, placeholder, back_edge)
+                };
+
                 // Post-loop state combines the entry (zero iterations), fallthrough at end of
                 // body, plus any `break` or `continue` exits. Aborting paths are absent and
                 // therefore drop out.
@@ -310,7 +329,7 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                     self.analyze_expr(arg, state);
                 }
 
-                if is_external_call(self.gcx, self.hir, callee, args.len())
+                if is_state_mutating_external_call(self.gcx, self.hir, callee, args.len())
                     || is_new_expression(callee)
                 {
                     // Deploying a contract (`new Foo(args)`) executes that contract's

--- a/crates/lint/testdata/ReentrancyEvents.sol
+++ b/crates/lint/testdata/ReentrancyEvents.sol
@@ -171,7 +171,7 @@ contract ReentrancyEvents {
         emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
     }
 
-    // Known limitation: member-form internal calls (`Lib.f(...)`, `using for`, `super.f()`)
+    // Known limitation: member-form internal calls (`Lib.f(...)`, `using for`)
     // are not yet followed because Solar's `members_of` for `TyKind::Type(Contract)` is a
     // TODO. The external call inside `staticHelper` is therefore missed and no warning fires.
     function emitAfterLibraryStaticCall() external {
@@ -334,6 +334,13 @@ contract ReentrancyEvents {
         emit Counter(v);
     }
 
+    // Only the selected overload matters: the zero-arg self-call is pure, even though a
+    // one-arg overload below is state-mutating.
+    function emitAfterSelfPureOverloadCall() external {
+        uint256 v = this.overloadedSelf();
+        emit Counter(v);
+    }
+
     // Mutating self-external call still taints subsequent emits.
     function emitAfterSelfMutatingCall() external {
         counter += 1;
@@ -372,6 +379,15 @@ contract ReentrancyEvents {
 
     function pureSelf(uint256 a) public pure returns (uint256) {
         return a + 1;
+    }
+
+    function overloadedSelf() public pure returns (uint256) {
+        return 1;
+    }
+
+    function overloadedSelf(uint256 a) public returns (uint256) {
+        counter += a;
+        return counter;
     }
 
     function _doExternalWork() internal {
@@ -458,5 +474,42 @@ contract Child is Base {
     function emitAfterSuperTaintingCall() external {
         super.doExt();
         emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+}
+
+contract SuperBaseWithTaint {
+    IExternal internal ext__;
+    event Tick();
+
+    function overridden() internal virtual {
+        ext__.notify(0);
+    }
+
+    function arity(uint256) internal {
+        ext__.notify(0);
+    }
+}
+
+contract SuperPureOverride is SuperBaseWithTaint {
+    function overridden() internal pure override {}
+
+    function arity() internal pure {}
+}
+
+contract SuperChild is SuperPureOverride {
+    event Counter(uint256 value);
+
+    // Clean: `super.overridden()` dispatches to the immediate pure override, not the
+    // older base implementation with the same signature that performs an external call.
+    function emitAfterSuperPureOverrideCall() external {
+        super.overridden();
+        emit Tick();
+    }
+
+    // Clean: `super.arity()` dispatches to the zero-arg overload only; the mutating
+    // one-arg overload in the older base must not taint this call.
+    function emitAfterSuperPureArityCall() external {
+        super.arity();
+        emit Counter(0);
     }
 }

--- a/crates/lint/testdata/ReentrancyEvents.sol
+++ b/crates/lint/testdata/ReentrancyEvents.sol
@@ -1,0 +1,276 @@
+//@compile-flags: --only-lint reentrancy-events
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+interface IExternal {
+    function notify(uint256 value) external returns (bool);
+}
+
+contract Other {
+    function action(uint256) external returns (bool) {
+        return true;
+    }
+}
+
+library NotifyLib {
+    function notifyVia(IExternal d, uint256 v) internal {
+        d.notify(v);
+    }
+
+    function staticHelper(IExternal d) internal {
+        d.notify(0);
+    }
+}
+
+contract ReentrancyEvents {
+    using NotifyLib for IExternal;
+
+    event Counter(uint256 value);
+    event Paid(address indexed to, uint256 amount);
+    event Tick();
+
+    uint256 public counter;
+    address payable public recipient;
+    IExternal public ext;
+    Other public other;
+
+    // --- Bad cases ----------------------------------------------------------
+
+    function emitAfterHighLevelCall(IExternal d) external {
+        counter += 1;
+        d.notify(counter);
+        emit Counter(counter); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    function emitAfterLowLevelCall(address target) external {
+        counter += 1;
+        // forge-lint: disable-next-line(unchecked-call)
+        target.call("");
+        emit Counter(counter); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    function emitAfterTransfer() external {
+        counter += 1;
+        recipient.transfer(1 wei);
+        emit Counter(counter); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    function emitAfterSend() external {
+        counter += 1;
+        // forge-lint: disable-next-line(unchecked-call)
+        recipient.send(1 wei);
+        emit Counter(counter); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    function emitAfterSelfExternalCall() external {
+        counter += 1;
+        this.publicHelper();
+        emit Counter(counter); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    function emitInIfBranch(IExternal d, bool flag) external {
+        d.notify(0);
+        if (flag) {
+            emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+        }
+    }
+
+    function emitAfterCallInBranch(IExternal d, bool flag) external {
+        if (flag) {
+            d.notify(1);
+        }
+        // The "if" branch may have made an external call before reaching this emit.
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    function emitInLoopAfterCall(IExternal d, uint256 n) external {
+        d.notify(0);
+        for (uint256 i; i < n; ++i) {
+            emit Counter(i); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+        }
+    }
+
+    function emitAfterLoopWithCall(IExternal d, uint256 n) external {
+        for (uint256 i; i < n; ++i) {
+            d.notify(i);
+        }
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    function emitAfterTryCall(IExternal d) external {
+        try d.notify(1) returns (bool) {} catch {}
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    function emitAfterHelperWithCall() external {
+        _doExternalWork();
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    function emitAfterChainedCall() external {
+        counter += 1;
+        Other(other).action(counter);
+        emit Counter(counter); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    // External call inside the emit's arguments (Solidity evaluates args before emitting).
+    function emitWithExternalCallInArgs(IExternal d) external {
+        emit Counter(d.notify(1) ? 1 : 0); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    // Internal helper returns early after an external call: caller should still see the taint.
+    function emitAfterHelperEarlyReturn(bool flag) external {
+        _maybeNotify(flag);
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    // External call in one loop iteration must taint the post-loop state via `break`.
+    function emitAfterBreakWithCall(IExternal d, bool flag) external {
+        for (uint256 i; i < 10; ++i) {
+            if (flag) {
+                d.notify(i);
+                break;
+            }
+        }
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    // `new Foo(...)` deploys and runs a constructor — an external interaction.
+    function emitAfterNew() external {
+        new Other();
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    // Same modifier listed twice — the second instance must not be silently dropped.
+    modifier maybeNotify(bool b) {
+        if (b) ext.notify(1);
+        _;
+    }
+
+    function emitAfterDuplicateModifier() external maybeNotify(false) maybeNotify(true) {
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    // Known limitation: member-form internal calls (`Lib.f(...)`, `using for`, `super.f()`)
+    // are not yet followed because Solar's `members_of` for `TyKind::Type(Contract)` is a
+    // TODO. The external call inside `staticHelper` is therefore missed and no warning fires.
+    function emitAfterLibraryStaticCall() external {
+        NotifyLib.staticHelper(ext);
+        emit Tick();
+    }
+
+    function emitAfterUsingForCall() external {
+        ext.notifyVia(1);
+        emit Tick();
+    }
+
+    // --- Good cases ---------------------------------------------------------
+
+    function emitBeforeExternalCall(IExternal d) external {
+        counter += 1;
+        emit Counter(counter);
+        d.notify(counter);
+    }
+
+    function emitOnlyNoCalls() external {
+        counter += 1;
+        emit Counter(counter);
+    }
+
+    function emitAfterInternalOnly() external {
+        _internalHelper();
+        emit Tick();
+    }
+
+    function emitAfterPureInternalCall() external {
+        uint256 x = _pureHelper(1);
+        emit Counter(x);
+    }
+
+    function bothBranchesEmitBeforeCall(IExternal d, bool flag) external {
+        if (flag) {
+            emit Tick();
+        } else {
+            emit Counter(0);
+        }
+        d.notify(1);
+    }
+
+    // Internal helper that always reverts: caller's post-call code is unreachable, no warning.
+    function emitAfterAlwaysAbortingHelper() external {
+        _alwaysReverts();
+        emit Tick();
+    }
+
+    // External call inside a loop body followed by a `revert` in the same iteration:
+    // post-loop state must not be tainted because every body path aborts.
+    function emitAfterLoopThatAlwaysReverts(IExternal d) external {
+        for (uint256 i; i < 1; ++i) {
+            d.notify(i);
+            revert("oops");
+        }
+        emit Tick();
+    }
+
+    // External call only on a branch that itself returns early: the function's caller
+    // sees the call, but within this function the post-if fallthrough state is clean,
+    // so an emit on the fallthrough path is fine.
+    function emitOnUntaintedBranch(IExternal d, bool flag) external {
+        if (flag) {
+            d.notify(0);
+            return;
+        }
+        emit Tick();
+    }
+
+    // `selfdestruct(...)` terminates execution; post-statements are unreachable.
+    function emitAfterSelfdestruct(IExternal d) external {
+        d.notify(0);
+        selfdestruct(payable(msg.sender));
+        emit Tick();
+    }
+
+    // `require(false, ...)` and `assert(false)` also abort unconditionally.
+    function emitAfterRequireFalse(IExternal d) external {
+        d.notify(0);
+        require(false, "no");
+        emit Tick();
+    }
+
+    function emitAfterAssertFalse(IExternal d) external {
+        d.notify(0);
+        assert(false);
+        emit Tick();
+    }
+
+    // --- Helpers ------------------------------------------------------------
+
+    function publicHelper() public {
+        counter += 1;
+    }
+
+    function _doExternalWork() internal {
+        ext.notify(counter);
+    }
+
+    function _maybeNotify(bool flag) internal {
+        if (flag) {
+            ext.notify(1);
+            return;
+        }
+    }
+
+    function _alwaysReverts() internal {
+        ext.notify(0);
+        revert("nope");
+    }
+
+    function _internalHelper() internal {
+        counter += 1;
+    }
+
+    function _pureHelper(uint256 a) internal pure returns (uint256) {
+        return a + 1;
+    }
+}

--- a/crates/lint/testdata/ReentrancyEvents.sol
+++ b/crates/lint/testdata/ReentrancyEvents.sol
@@ -9,6 +9,14 @@ interface IExternal {
     function compute(uint256 x) external pure returns (uint256);
 }
 
+// Overloaded interface methods exercise the multi-match member lookup.
+interface IBus {
+    function notify(uint256) external returns (bool);
+    function notify(uint256, bytes calldata) external returns (bool);
+    function peek(uint256) external view returns (uint256);
+    function peek(uint256, uint256) external view returns (uint256);
+}
+
 contract Other {
     function action(uint256) external returns (bool) {
         return true;
@@ -214,6 +222,24 @@ contract ReentrancyEvents {
         emit Tick();
     }
 
+    // Ternary with one aborting branch: per-branch abort tracking must let the live
+    // branch's taint survive so the subsequent emit is still flagged.
+    function emitAfterTernaryAbortingElse(IExternal d, bool flag) external {
+        uint256 x = flag ? _peeker(d) : _alwaysRevertsU();
+        emit Counter(x); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    function emitAfterTernaryAbortingThen(IExternal d, bool flag) external {
+        uint256 x = flag ? _alwaysRevertsU() : _peeker(d);
+        emit Counter(x); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    // Both ternary branches abort: the post-ternary emit is genuinely unreachable.
+    function emitAfterTernaryBothAbort(bool flag) external {
+        uint256 x = flag ? _alwaysRevertsU() : _alwaysRevertsU2();
+        emit Counter(x);
+    }
+
     // External call inside a loop body followed by a `revert` in the same iteration:
     // post-loop state must not be tainted because every body path aborts.
     function emitAfterLoopThatAlwaysReverts(IExternal d) external {
@@ -274,6 +300,47 @@ contract ReentrancyEvents {
         emit Counter(v);
     }
 
+    // Overloaded mutating external method: must flag despite the name collision in
+    // the interface (member lookup used to drop overloads via a unique-name filter).
+    function emitAfterOverloadedMutatingCall(IBus b) external {
+        b.notify(0);
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    function emitAfterOverloadedMutatingCallTwoArgs(IBus b) external {
+        b.notify(0, "");
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    // Overloaded but all overloads are `view` — must NOT flag.
+    function emitAfterOverloadedViewCall(IBus b) external {
+        uint256 v = b.peek(0);
+        emit Counter(v);
+    }
+
+    function emitAfterOverloadedViewCallTwoArgs(IBus b) external {
+        uint256 v = b.peek(0, 1);
+        emit Counter(v);
+    }
+
+    // `this.<view|pure>()` compiles to STATICCALL — cannot reorder events.
+    function emitAfterSelfViewCall() external {
+        uint256 v = this.viewSelf();
+        emit Counter(v);
+    }
+
+    function emitAfterSelfPureCall() external {
+        uint256 v = this.pureSelf(1);
+        emit Counter(v);
+    }
+
+    // Mutating self-external call still taints subsequent emits.
+    function emitAfterSelfMutatingCall() external {
+        counter += 1;
+        this.publicHelper();
+        emit Counter(counter); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
     // Caller is already tainted, then calls a helper that always reverts. The post-call
     // emit is unreachable and must NOT be flagged.
     function emitAfterTaintedAlwaysRevertsHelper(IExternal d) external {
@@ -299,6 +366,14 @@ contract ReentrancyEvents {
         counter += 1;
     }
 
+    function viewSelf() public view returns (uint256) {
+        return counter;
+    }
+
+    function pureSelf(uint256 a) public pure returns (uint256) {
+        return a + 1;
+    }
+
     function _doExternalWork() internal {
         ext.notify(counter);
     }
@@ -315,6 +390,19 @@ contract ReentrancyEvents {
         revert("nope");
     }
 
+    function _alwaysRevertsU() internal pure returns (uint256) {
+        revert("nope");
+    }
+
+    function _alwaysRevertsU2() internal pure returns (uint256) {
+        revert("nope2");
+    }
+
+    function _peeker(IExternal d) internal returns (uint256) {
+        d.notify(0);
+        return 0;
+    }
+
     function _internalHelper() internal {
         counter += 1;
     }
@@ -327,6 +415,48 @@ contract ReentrancyEvents {
     // own self-pass), not once per caller.
     function _helperEmitAfterCall() internal {
         ext.notify(0);
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+}
+
+// `super.<member>(...)` is internal base-chain dispatch — must not panic the linter and
+// must not be treated as an external call by itself, but external calls inside the
+// resolved base function must still taint the caller.
+contract Base {
+    IExternal internal ext_;
+    event Tick();
+
+    function doExt() internal {
+        ext_.notify(0);
+    }
+
+    function viewBase() internal view returns (uint256) {
+        return 0;
+    }
+
+    function pureBase() internal pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract Child is Base {
+    event Counter(uint256 value);
+
+    // Clean: super resolves to a base function with no external call.
+    function emitAfterSuperViewCall() external {
+        uint256 v = super.viewBase();
+        emit Counter(v);
+    }
+
+    function emitAfterSuperPureCall() external {
+        uint256 v = super.pureBase();
+        emit Counter(v);
+    }
+
+    // Transitive: the base function makes an external call, so the post-super emit is
+    // tainted exactly like a direct `_helper()` call would be.
+    function emitAfterSuperTaintingCall() external {
+        super.doExt();
         emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
     }
 }

--- a/crates/lint/testdata/ReentrancyEvents.sol
+++ b/crates/lint/testdata/ReentrancyEvents.sol
@@ -5,6 +5,8 @@ pragma solidity ^0.8.15;
 
 interface IExternal {
     function notify(uint256 value) external returns (bool);
+    function peek() external view returns (uint256);
+    function compute(uint256 x) external pure returns (uint256);
 }
 
 contract Other {
@@ -96,6 +98,15 @@ contract ReentrancyEvents {
             d.notify(i);
         }
         emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    // Loop back-edge: the emit is clean on iteration 1 but tainted by the call from the
+    // previous iteration on iterations 2..N. The two-pass fixpoint must catch this.
+    function emitInLoopBeforeCall(IExternal d, uint256 n) external {
+        for (uint256 i; i < n; ++i) {
+            emit Counter(i); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+            d.notify(i);
+        }
     }
 
     function emitAfterTryCall(IExternal d) external {
@@ -242,6 +253,25 @@ contract ReentrancyEvents {
         d.notify(0);
         assert(false);
         emit Tick();
+    }
+
+    // `staticcall` cannot emit logs or perform state-changing reentrancy.
+    function emitAfterStaticcall(address target) external {
+        // forge-lint: disable-next-line(unchecked-call)
+        target.staticcall("");
+        emit Tick();
+    }
+
+    // High-level `view` external calls are read-only and cannot reorder events.
+    function emitAfterViewCall(IExternal d) external {
+        uint256 v = d.peek();
+        emit Counter(v);
+    }
+
+    // High-level `pure` external calls likewise cannot reorder events.
+    function emitAfterPureCall(IExternal d) external {
+        uint256 v = d.compute(1);
+        emit Counter(v);
     }
 
     // --- Helpers ------------------------------------------------------------

--- a/crates/lint/testdata/ReentrancyEvents.sol
+++ b/crates/lint/testdata/ReentrancyEvents.sol
@@ -274,6 +274,25 @@ contract ReentrancyEvents {
         emit Counter(v);
     }
 
+    // Caller is already tainted, then calls a helper that always reverts. The post-call
+    // emit is unreachable and must NOT be flagged.
+    function emitAfterTaintedAlwaysRevertsHelper(IExternal d) external {
+        d.notify(0);
+        _alwaysReverts();
+        emit Tick();
+    }
+
+    // The shared helper `_helperEmitAfterCall` is invoked from two callers. Its tainted
+    // emit must be reported exactly once (in the helper's self-pass), not duplicated per
+    // caller.
+    function callsSharedHelperA() external {
+        _helperEmitAfterCall();
+    }
+
+    function callsSharedHelperB() external {
+        _helperEmitAfterCall();
+    }
+
     // --- Helpers ------------------------------------------------------------
 
     function publicHelper() public {
@@ -302,5 +321,12 @@ contract ReentrancyEvents {
 
     function _pureHelper(uint256 a) internal pure returns (uint256) {
         return a + 1;
+    }
+
+    // Tainted emit inside a shared helper. The lint reports this once (in the helper's
+    // own self-pass), not once per caller.
+    function _helperEmitAfterCall() internal {
+        ext.notify(0);
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
     }
 }

--- a/crates/lint/testdata/ReentrancyEvents.stderr
+++ b/crates/lint/testdata/ReentrancyEvents.stderr
@@ -73,6 +73,14 @@ LL │ …     emit Tick();
 warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
    ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
    │
+LL │ …     emit Counter(i);
+   │       ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
 LL │ …     emit Tick();
    │       ━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/ReentrancyEvents.stderr
+++ b/crates/lint/testdata/ReentrancyEvents.stderr
@@ -145,6 +145,54 @@ LL │ …     emit Tick();
 warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
    ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
    │
+LL │ …     emit Counter(x);
+   │       ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Counter(x);
+   │       ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Counter(counter);
+   │       ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
 LL │ …     emit Tick();
    │       ━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/ReentrancyEvents.stderr
+++ b/crates/lint/testdata/ReentrancyEvents.stderr
@@ -142,3 +142,11 @@ LL │ …     emit Tick();
    │
    ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
 
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+

--- a/crates/lint/testdata/ReentrancyEvents.stderr
+++ b/crates/lint/testdata/ReentrancyEvents.stderr
@@ -1,0 +1,136 @@
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Counter(counter);
+   │       ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Counter(counter);
+   │       ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Counter(counter);
+   │       ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Counter(counter);
+   │       ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Counter(counter);
+   │       ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Counter(i);
+   │       ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Counter(counter);
+   │       ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Counter(d.notify(1) ? 1 : 0);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+


### PR DESCRIPTION
Low-severity Solidity lint `reentrancy-events`: flags emit statements reachable after an external call on any control-flow path (matches Slither's reentrancy-events).