### PR TITLE
feat(tempo): resolve live session signers

### DIFF
--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -268,6 +268,7 @@ pub fn resolve_live_session_signer(
     Ok(Some(ResolvedSessionSigner { session, signer, access_key }))
 }
 
+/// Ensures a session key authorization matches the stored key, chain, root signer, and policy.
 fn validate_session_key_authorization(
     session: &SessionEntry,
     key: &SessionKeyMaterial,
@@ -313,6 +314,7 @@ fn validate_session_key_authorization(
     Ok(())
 }
 
+/// Ensures a session authorization does not outlive or exceed the stored session policy.
 fn validate_session_authorization_policy(
     session: &SessionEntry,
     authorization: &SignedKeyAuthorization,
@@ -363,6 +365,7 @@ fn validate_session_authorization_policy(
     Ok(())
 }
 
+/// Canonical spending limit used for order-independent policy comparisons.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct CanonicalTokenLimit {
     token: Address,
@@ -370,18 +373,21 @@ struct CanonicalTokenLimit {
     period: u64,
 }
 
+/// Canonical target scope used for order-independent policy comparisons.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct CanonicalCallScope {
     target: Address,
     selector_rules: Vec<CanonicalSelectorRule>,
 }
 
+/// Canonical selector rule used for order-independent policy comparisons.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct CanonicalSelectorRule {
     selector: [u8; 4],
     recipients: Vec<Address>,
 }
 
+/// Converts stored session limits into canonical form for authorization comparison.
 fn session_authorization_limits(session: &SessionEntry) -> eyre::Result<Vec<CanonicalTokenLimit>> {
     let mut limits = session
         .limits
@@ -398,6 +404,7 @@ fn session_authorization_limits(session: &SessionEntry) -> eyre::Result<Vec<Cano
     Ok(limits)
 }
 
+/// Converts signed authorization limits into canonical form for session comparison.
 fn authorization_limits(
     limits: &[tempo_primitives::transaction::TokenLimit],
 ) -> Vec<CanonicalTokenLimit> {
@@ -413,12 +420,14 @@ fn authorization_limits(
     limits
 }
 
+/// Parses a stored session spending limit from decimal or 0x-prefixed hex.
 fn parse_session_limit(raw: &str) -> eyre::Result<U256> {
     let raw = raw.trim();
     if let Some(hex) = raw.strip_prefix("0x") { U256::from_str_radix(hex, 16) } else { raw.parse() }
         .map_err(|err| eyre::eyre!("invalid session spending limit `{raw}`: {err}"))
 }
 
+/// Converts stored session scope into canonical form for authorization comparison.
 fn session_authorization_scope(session: &SessionEntry) -> Vec<CanonicalCallScope> {
     let mut scope = session
         .scope
@@ -432,6 +441,7 @@ fn session_authorization_scope(session: &SessionEntry) -> Vec<CanonicalCallScope
     scope
 }
 
+/// Converts signed authorization scope into canonical form for session comparison.
 fn authorization_scope(
     scope: &[tempo_primitives::transaction::CallScope],
 ) -> Vec<CanonicalCallScope> {
@@ -446,6 +456,7 @@ fn authorization_scope(
     scope
 }
 
+/// Converts stored selector rules into canonical form for authorization comparison.
 fn session_authorization_selector_rules(
     rules: &[SessionSelectorRule],
 ) -> Vec<CanonicalSelectorRule> {
@@ -461,6 +472,7 @@ fn session_authorization_selector_rules(
     rules
 }
 
+/// Converts signed authorization selector rules into canonical form for session comparison.
 fn authorization_selector_rules(
     rules: &[tempo_primitives::transaction::SelectorRule],
 ) -> Vec<CanonicalSelectorRule> {
@@ -476,6 +488,7 @@ fn authorization_selector_rules(
     rules
 }
 
+/// Maps stored session key types to Tempo authorization signature types.
 const fn key_type_to_signature_type(
     key_type: KeyType,
 ) -> tempo_primitives::transaction::SignatureType {
@@ -575,6 +588,7 @@ mod tests {
         }
     }
 
+    /// Builds a session entry with matching root and session key material.
     fn sample_entry_with_valid_key(
         session_id: B256,
         expiry: u64,
@@ -595,10 +609,12 @@ mod tests {
         }
     }
 
+    /// Encodes a signed key authorization that matches the supplied session entry.
     fn signed_key_authorization_hex(entry: &SessionEntry) -> String {
         signed_key_authorization_hex_with(entry, std::convert::identity)
     }
 
+    /// Encodes a signed key authorization after applying a test-specific mutation.
     fn signed_key_authorization_hex_with(
         entry: &SessionEntry,
         update: impl FnOnce(KeyAuthorization) -> KeyAuthorization,
@@ -612,6 +628,7 @@ mod tests {
         hex::encode_prefixed(buf)
     }
 
+    /// Builds a key authorization that mirrors the session entry policy.
     fn session_key_authorization(entry: &SessionEntry) -> KeyAuthorization {
         KeyAuthorization::unrestricted(entry.chain_id, SignatureType::Secp256k1, entry.key_address)
             .with_expiry(entry.expiry)

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -2,8 +2,11 @@
 
 use super::{KeyType, registry::*, tempo_home};
 use alloy_primitives::{Address, B256, Selector};
+use alloy_signer::Signer;
+use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use tempo_primitives::transaction::SignedKeyAuthorization;
 
 /// Relative path from Tempo home to the session registry file.
 pub const WALLET_SESSIONS_PATH: &str = "wallet/sessions.toml";
@@ -183,6 +186,14 @@ impl SessionRecord {
     }
 }
 
+/// A live session key resolved into the signer and Tempo access-key metadata.
+#[derive(Debug)]
+pub struct ResolvedSessionSigner {
+    pub session: SessionEntry,
+    pub signer: WalletSigner,
+    pub access_key: TempoAccessKeyConfig,
+}
+
 /// Returns the path to the Tempo session registry file.
 pub fn session_registry_path() -> Option<PathBuf> {
     tempo_home().map(|home| home.join(WALLET_SESSIONS_PATH))
@@ -206,6 +217,109 @@ pub fn read_session_record() -> Option<SessionRecord> {
 /// Read a live session-scoped key entry by session id.
 pub fn read_live_session_key(session_id: B256, now: u64) -> Option<SessionEntry> {
     read_session_record()?.live_key(session_id, now).cloned()
+}
+
+/// Resolve a live session key into a signer and access-key configuration.
+pub fn resolve_live_session_signer(
+    session_id: B256,
+    now: u64,
+) -> eyre::Result<Option<ResolvedSessionSigner>> {
+    mark_expired_session_entries(now)?;
+
+    let path =
+        session_registry_path().ok_or_else(|| eyre::eyre!("could not resolve tempo home"))?;
+    let Some(record) = read_toml_file::<SessionRecord>(&path, "tempo sessions")? else {
+        return Ok(None);
+    };
+    let Some(session) = record.live_key(session_id, now).cloned() else {
+        return Ok(None);
+    };
+    let key =
+        session.key.as_ref().ok_or_else(|| eyre::eyre!("live session has no key material"))?;
+
+    let signer = foundry_wallets::utils::create_private_key_signer(&key.key)?;
+    let signer_address = signer.address();
+    if signer_address != session.key_address {
+        eyre::bail!(
+            "session {} key material resolves to {}, expected {}",
+            session.session_id,
+            signer_address,
+            session.key_address
+        );
+    }
+
+    let key_authorization = key
+        .key_authorization
+        .as_deref()
+        .map(|raw| {
+            super::decode_key_authorization::<SignedKeyAuthorization>(raw)
+                .map_err(|err| eyre::eyre!("failed to decode session key_authorization: {err}"))
+        })
+        .transpose()?;
+    if let Some(auth) = &key_authorization {
+        validate_session_key_authorization(&session, key, auth)?;
+    }
+    let access_key = TempoAccessKeyConfig {
+        wallet_address: session.root_account,
+        key_address: session.key_address,
+        key_authorization,
+    };
+
+    Ok(Some(ResolvedSessionSigner { session, signer, access_key }))
+}
+
+fn validate_session_key_authorization(
+    session: &SessionEntry,
+    key: &SessionKeyMaterial,
+    authorization: &SignedKeyAuthorization,
+) -> eyre::Result<()> {
+    if authorization.authorization.key_id != session.key_address {
+        eyre::bail!(
+            "session {} key_authorization key_id is {}, expected {}",
+            session.session_id,
+            authorization.authorization.key_id,
+            session.key_address
+        );
+    }
+    if authorization.authorization.chain_id != session.chain_id {
+        eyre::bail!(
+            "session {} key_authorization chain_id is {}, expected {}",
+            session.session_id,
+            authorization.authorization.chain_id,
+            session.chain_id
+        );
+    }
+    let expected_key_type = key_type_to_signature_type(key.key_type);
+    if authorization.authorization.key_type != expected_key_type {
+        eyre::bail!(
+            "session {} key_authorization key_type is {:?}, expected {:?}",
+            session.session_id,
+            authorization.authorization.key_type,
+            expected_key_type
+        );
+    }
+    let recovered = authorization
+        .recover_signer()
+        .map_err(|err| eyre::eyre!("failed to recover session key_authorization signer: {err}"))?;
+    if recovered != session.root_account {
+        eyre::bail!(
+            "session {} key_authorization signer is {}, expected {}",
+            session.session_id,
+            recovered,
+            session.root_account
+        );
+    }
+    Ok(())
+}
+
+const fn key_type_to_signature_type(
+    key_type: KeyType,
+) -> tempo_primitives::transaction::SignatureType {
+    match key_type {
+        KeyType::Secp256k1 => tempo_primitives::transaction::SignatureType::Secp256k1,
+        KeyType::P256 => tempo_primitives::transaction::SignatureType::P256,
+        KeyType::WebAuthn => tempo_primitives::transaction::SignatureType::WebAuthn,
+    }
 }
 
 /// Atomically upsert a [`SessionEntry`] into the session registry.
@@ -249,7 +363,17 @@ pub fn mark_expired_session_entries(now: u64) -> eyre::Result<usize> {
 mod tests {
     use super::*;
     use crate::tempo::with_tempo_home;
+    use alloy_primitives::hex;
+    use alloy_rlp::Encodable;
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
     use std::{fs, str::FromStr};
+    use tempo_primitives::transaction::{KeyAuthorization, PrimitiveSignature, SignatureType};
+
+    const ROOT_PRIVATE_KEY: &str =
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    const SESSION_PRIVATE_KEY: &str =
+        "0x59c6995e998f97a5a004497e5da3b5d2b2b66a87f064d39c44da0b6d6e4f8ff0";
 
     fn sample_entry(session_id: B256, expiry: u64, status: SessionStatus) -> SessionEntry {
         SessionEntry {
@@ -283,6 +407,41 @@ mod tests {
             }),
             ..sample_entry(session_id, expiry, status)
         }
+    }
+
+    fn sample_entry_with_valid_key(
+        session_id: B256,
+        expiry: u64,
+        status: SessionStatus,
+    ) -> SessionEntry {
+        let root_signer: PrivateKeySigner = ROOT_PRIVATE_KEY.parse().unwrap();
+        let signer = foundry_wallets::utils::create_private_key_signer(SESSION_PRIVATE_KEY)
+            .expect("valid test private key");
+        SessionEntry {
+            root_account: root_signer.address(),
+            key_address: signer.address(),
+            key: Some(SessionKeyMaterial {
+                key_type: KeyType::Secp256k1,
+                key: SESSION_PRIVATE_KEY.to_string(),
+                key_authorization: None,
+            }),
+            ..sample_entry(session_id, expiry, status)
+        }
+    }
+
+    fn signed_key_authorization_hex(entry: &SessionEntry) -> String {
+        let root_signer: PrivateKeySigner = ROOT_PRIVATE_KEY.parse().unwrap();
+        let auth = KeyAuthorization::unrestricted(
+            entry.chain_id,
+            SignatureType::Secp256k1,
+            entry.key_address,
+        )
+        .with_expiry(entry.expiry);
+        let signature = root_signer.sign_hash_sync(&auth.signature_hash()).unwrap();
+        let signed = auth.into_signed(PrimitiveSignature::Secp256k1(signature));
+        let mut buf = Vec::new();
+        signed.encode(&mut buf);
+        hex::encode_prefixed(buf)
     }
 
     #[test]
@@ -379,6 +538,121 @@ mod tests {
         assert!(record.live_key(revoked_id, 100).is_none());
         assert!(record.live_key(no_key_id, 100).is_none());
         assert!(record.live_key(pending_id, 100).is_none());
+    }
+
+    #[test]
+    fn resolve_live_session_signer_returns_signer_and_access_key_config() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x06; 32]);
+            let entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            upsert_session_entry(entry.clone()).unwrap();
+
+            let resolved = resolve_live_session_signer(session_id, 100).unwrap().unwrap();
+
+            assert_eq!(resolved.session, entry);
+            assert_eq!(Signer::address(&resolved.signer), entry.key_address);
+            assert_eq!(resolved.access_key.wallet_address, entry.root_account);
+            assert_eq!(resolved.access_key.key_address, entry.key_address);
+            assert!(resolved.access_key.key_authorization.is_none());
+        });
+    }
+
+    #[test]
+    fn resolve_live_session_signer_rejects_mismatched_private_key() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x07; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            entry.key_address =
+                Address::from_str("0x0000000000000000000000000000000000000abc").unwrap();
+            upsert_session_entry(entry).unwrap();
+
+            let error = resolve_live_session_signer(session_id, 100).unwrap_err();
+
+            assert!(error.to_string().contains("key material resolves to"));
+        });
+    }
+
+    #[test]
+    fn resolve_live_session_signer_expires_stale_entries_before_resolving() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x08; 32]);
+            upsert_session_entry(sample_entry_with_valid_key(
+                session_id,
+                100,
+                SessionStatus::Active,
+            ))
+            .unwrap();
+
+            assert!(resolve_live_session_signer(session_id, 100).unwrap().is_none());
+
+            let record = read_session_record().unwrap();
+            let session = record.get(session_id).unwrap();
+            assert_eq!(session.status, SessionStatus::Expired);
+            assert!(session.key.is_none());
+        });
+    }
+
+    #[test]
+    fn resolve_live_session_signer_decodes_and_validates_key_authorization() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x09; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            let auth = signed_key_authorization_hex(&entry);
+            entry.key.as_mut().unwrap().key_authorization = Some(auth);
+            upsert_session_entry(entry.clone()).unwrap();
+
+            let resolved = resolve_live_session_signer(session_id, 100).unwrap().unwrap();
+            let key_authorization = resolved.access_key.key_authorization.unwrap();
+
+            assert_eq!(key_authorization.authorization.key_id, entry.key_address);
+            assert_eq!(key_authorization.authorization.chain_id, entry.chain_id);
+            assert_eq!(key_authorization.authorization.key_type, SignatureType::Secp256k1);
+            assert_eq!(key_authorization.recover_signer().unwrap(), entry.root_account);
+        });
+    }
+
+    #[test]
+    fn resolve_live_session_signer_rejects_invalid_key_authorization() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x0a; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            entry.key.as_mut().unwrap().key_authorization = Some("0xdeadbeef".to_string());
+            upsert_session_entry(entry).unwrap();
+
+            let error = resolve_live_session_signer(session_id, 100).unwrap_err();
+
+            assert!(error.to_string().contains("key_authorization"));
+        });
+    }
+
+    #[test]
+    fn resolve_live_session_signer_rejects_authorization_for_wrong_chain() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x0b; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            let mut auth_entry = entry.clone();
+            auth_entry.chain_id += 1;
+            entry.key.as_mut().unwrap().key_authorization =
+                Some(signed_key_authorization_hex(&auth_entry));
+            upsert_session_entry(entry).unwrap();
+
+            let error = resolve_live_session_signer(session_id, 100).unwrap_err();
+
+            assert!(error.to_string().contains("chain_id"));
+        });
+    }
+
+    #[test]
+    fn resolve_live_session_signer_fails_closed_when_session_file_is_corrupt() {
+        with_tempo_home(|| {
+            let path = session_registry_path().unwrap();
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, "sessions = [").unwrap();
+            let original = fs::read_to_string(&path).unwrap();
+
+            assert!(resolve_live_session_signer(B256::from([0x0c; 32]), 100).is_err());
+            assert_eq!(fs::read_to_string(&path).unwrap(), original);
+        });
     }
 
     #[test]

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -1,11 +1,11 @@
 //! Tempo session registry and local lifecycle metadata.
 
 use super::{KeyType, registry::*, tempo_home};
-use alloy_primitives::{Address, B256, Selector};
+use alloy_primitives::{Address, B256, Selector, U256};
 use alloy_signer::Signer;
 use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{num::NonZeroU64, path::PathBuf};
 use tempo_primitives::transaction::SignedKeyAuthorization;
 
 /// Relative path from Tempo home to the session registry file.
@@ -309,7 +309,171 @@ fn validate_session_key_authorization(
             session.root_account
         );
     }
+    validate_session_authorization_policy(session, authorization)?;
     Ok(())
+}
+
+fn validate_session_authorization_policy(
+    session: &SessionEntry,
+    authorization: &SignedKeyAuthorization,
+) -> eyre::Result<()> {
+    let auth = &authorization.authorization;
+
+    let expected_expiry = NonZeroU64::new(session.expiry)
+        .ok_or_else(|| eyre::eyre!("session {} has invalid zero expiry", session.session_id))?;
+    if auth.expiry != Some(expected_expiry) {
+        eyre::bail!(
+            "session {} key_authorization expiry is {:?}, expected {}",
+            session.session_id,
+            auth.expiry.map(NonZeroU64::get),
+            session.expiry
+        );
+    }
+
+    let Some(auth_limits) = auth.limits.as_deref() else {
+        eyre::bail!(
+            "session {} key_authorization limits are unrestricted, expected session limits",
+            session.session_id
+        );
+    };
+    let expected_limits = session_authorization_limits(session)?;
+    let actual_limits = authorization_limits(auth_limits);
+    if actual_limits != expected_limits {
+        eyre::bail!(
+            "session {} key_authorization limits do not match session limits",
+            session.session_id
+        );
+    }
+
+    let Some(auth_allowed_calls) = auth.allowed_calls.as_deref() else {
+        eyre::bail!(
+            "session {} key_authorization allowed_calls are unrestricted, expected session scope",
+            session.session_id
+        );
+    };
+    let expected_scope = session_authorization_scope(session);
+    let actual_scope = authorization_scope(auth_allowed_calls);
+    if actual_scope != expected_scope {
+        eyre::bail!(
+            "session {} key_authorization allowed_calls do not match session scope",
+            session.session_id
+        );
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct CanonicalTokenLimit {
+    token: Address,
+    limit: U256,
+    period: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct CanonicalCallScope {
+    target: Address,
+    selector_rules: Vec<CanonicalSelectorRule>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct CanonicalSelectorRule {
+    selector: [u8; 4],
+    recipients: Vec<Address>,
+}
+
+fn session_authorization_limits(session: &SessionEntry) -> eyre::Result<Vec<CanonicalTokenLimit>> {
+    let mut limits = session
+        .limits
+        .iter()
+        .map(|limit| {
+            Ok(CanonicalTokenLimit {
+                token: limit.currency,
+                limit: parse_session_limit(&limit.limit)?,
+                period: 0,
+            })
+        })
+        .collect::<eyre::Result<Vec<_>>>()?;
+    limits.sort_by_key(|limit| (limit.token, limit.limit, limit.period));
+    Ok(limits)
+}
+
+fn authorization_limits(
+    limits: &[tempo_primitives::transaction::TokenLimit],
+) -> Vec<CanonicalTokenLimit> {
+    let mut limits = limits
+        .iter()
+        .map(|limit| CanonicalTokenLimit {
+            token: limit.token,
+            limit: limit.limit,
+            period: limit.period,
+        })
+        .collect::<Vec<_>>();
+    limits.sort();
+    limits
+}
+
+fn parse_session_limit(raw: &str) -> eyre::Result<U256> {
+    let raw = raw.trim();
+    if let Some(hex) = raw.strip_prefix("0x") { U256::from_str_radix(hex, 16) } else { raw.parse() }
+        .map_err(|err| eyre::eyre!("invalid session spending limit `{raw}`: {err}"))
+}
+
+fn session_authorization_scope(session: &SessionEntry) -> Vec<CanonicalCallScope> {
+    let mut scope = session
+        .scope
+        .iter()
+        .map(|scope| CanonicalCallScope {
+            target: scope.target,
+            selector_rules: session_authorization_selector_rules(&scope.selector_rules),
+        })
+        .collect::<Vec<_>>();
+    scope.sort();
+    scope
+}
+
+fn authorization_scope(
+    scope: &[tempo_primitives::transaction::CallScope],
+) -> Vec<CanonicalCallScope> {
+    let mut scope = scope
+        .iter()
+        .map(|scope| CanonicalCallScope {
+            target: scope.target,
+            selector_rules: authorization_selector_rules(&scope.selector_rules),
+        })
+        .collect::<Vec<_>>();
+    scope.sort();
+    scope
+}
+
+fn session_authorization_selector_rules(
+    rules: &[SessionSelectorRule],
+) -> Vec<CanonicalSelectorRule> {
+    let mut rules = rules
+        .iter()
+        .map(|rule| {
+            let mut recipients = rule.recipients.clone();
+            recipients.sort();
+            CanonicalSelectorRule { selector: rule.selector.into(), recipients }
+        })
+        .collect::<Vec<_>>();
+    rules.sort();
+    rules
+}
+
+fn authorization_selector_rules(
+    rules: &[tempo_primitives::transaction::SelectorRule],
+) -> Vec<CanonicalSelectorRule> {
+    let mut rules = rules
+        .iter()
+        .map(|rule| {
+            let mut recipients = rule.recipients.clone();
+            recipients.sort();
+            CanonicalSelectorRule { selector: rule.selector, recipients }
+        })
+        .collect::<Vec<_>>();
+    rules.sort();
+    rules
 }
 
 const fn key_type_to_signature_type(
@@ -368,7 +532,9 @@ mod tests {
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use std::{fs, str::FromStr};
-    use tempo_primitives::transaction::{KeyAuthorization, PrimitiveSignature, SignatureType};
+    use tempo_primitives::transaction::{
+        CallScope, KeyAuthorization, PrimitiveSignature, SelectorRule, SignatureType, TokenLimit,
+    };
 
     const ROOT_PRIVATE_KEY: &str =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
@@ -430,18 +596,53 @@ mod tests {
     }
 
     fn signed_key_authorization_hex(entry: &SessionEntry) -> String {
+        signed_key_authorization_hex_with(entry, std::convert::identity)
+    }
+
+    fn signed_key_authorization_hex_with(
+        entry: &SessionEntry,
+        update: impl FnOnce(KeyAuthorization) -> KeyAuthorization,
+    ) -> String {
         let root_signer: PrivateKeySigner = ROOT_PRIVATE_KEY.parse().unwrap();
-        let auth = KeyAuthorization::unrestricted(
-            entry.chain_id,
-            SignatureType::Secp256k1,
-            entry.key_address,
-        )
-        .with_expiry(entry.expiry);
+        let auth = update(session_key_authorization(entry));
         let signature = root_signer.sign_hash_sync(&auth.signature_hash()).unwrap();
         let signed = auth.into_signed(PrimitiveSignature::Secp256k1(signature));
         let mut buf = Vec::new();
         signed.encode(&mut buf);
         hex::encode_prefixed(buf)
+    }
+
+    fn session_key_authorization(entry: &SessionEntry) -> KeyAuthorization {
+        KeyAuthorization::unrestricted(entry.chain_id, SignatureType::Secp256k1, entry.key_address)
+            .with_expiry(entry.expiry)
+            .with_limits(
+                entry
+                    .limits
+                    .iter()
+                    .map(|limit| TokenLimit {
+                        token: limit.currency,
+                        limit: parse_session_limit(&limit.limit).unwrap(),
+                        period: 0,
+                    })
+                    .collect(),
+            )
+            .with_allowed_calls(
+                entry
+                    .scope
+                    .iter()
+                    .map(|scope| CallScope {
+                        target: scope.target,
+                        selector_rules: scope
+                            .selector_rules
+                            .iter()
+                            .map(|rule| SelectorRule {
+                                selector: rule.selector.into(),
+                                recipients: rule.recipients.clone(),
+                            })
+                            .collect(),
+                    })
+                    .collect(),
+            )
     }
 
     #[test]
@@ -607,6 +808,9 @@ mod tests {
             assert_eq!(key_authorization.authorization.key_id, entry.key_address);
             assert_eq!(key_authorization.authorization.chain_id, entry.chain_id);
             assert_eq!(key_authorization.authorization.key_type, SignatureType::Secp256k1);
+            assert_eq!(key_authorization.authorization.expiry.unwrap().get(), entry.expiry);
+            assert!(key_authorization.authorization.limits.is_some());
+            assert!(key_authorization.authorization.allowed_calls.is_some());
             assert_eq!(key_authorization.recover_signer().unwrap(), entry.root_account);
         });
     }
@@ -639,6 +843,96 @@ mod tests {
             let error = resolve_live_session_signer(session_id, 100).unwrap_err();
 
             assert!(error.to_string().contains("chain_id"));
+        });
+    }
+
+    #[test]
+    fn resolve_live_session_signer_rejects_authorization_without_session_expiry() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x0d; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            entry.key.as_mut().unwrap().key_authorization =
+                Some(signed_key_authorization_hex_with(&entry, |mut auth| {
+                    auth.expiry = None;
+                    auth
+                }));
+            upsert_session_entry(entry).unwrap();
+
+            let error = resolve_live_session_signer(session_id, 100).unwrap_err();
+
+            assert!(error.to_string().contains("expiry"));
+        });
+    }
+
+    #[test]
+    fn resolve_live_session_signer_rejects_authorization_without_session_limits() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x0e; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            entry.key.as_mut().unwrap().key_authorization =
+                Some(signed_key_authorization_hex_with(&entry, |mut auth| {
+                    auth.limits = None;
+                    auth
+                }));
+            upsert_session_entry(entry).unwrap();
+
+            let error = resolve_live_session_signer(session_id, 100).unwrap_err();
+
+            assert!(error.to_string().contains("limits"));
+        });
+    }
+
+    #[test]
+    fn resolve_live_session_signer_rejects_authorization_without_session_scope() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x0f; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            entry.key.as_mut().unwrap().key_authorization =
+                Some(signed_key_authorization_hex_with(&entry, |mut auth| {
+                    auth.allowed_calls = None;
+                    auth
+                }));
+            upsert_session_entry(entry).unwrap();
+
+            let error = resolve_live_session_signer(session_id, 100).unwrap_err();
+
+            assert!(error.to_string().contains("allowed_calls"));
+        });
+    }
+
+    #[test]
+    fn resolve_live_session_signer_rejects_authorization_with_wider_session_limit() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x10; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            entry.key.as_mut().unwrap().key_authorization =
+                Some(signed_key_authorization_hex_with(&entry, |mut auth| {
+                    auth.limits.as_mut().unwrap()[0].limit = U256::from(1);
+                    auth
+                }));
+            upsert_session_entry(entry).unwrap();
+
+            let error = resolve_live_session_signer(session_id, 100).unwrap_err();
+
+            assert!(error.to_string().contains("limits"));
+        });
+    }
+
+    #[test]
+    fn resolve_live_session_signer_rejects_authorization_with_wider_session_scope() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x12; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            entry.key.as_mut().unwrap().key_authorization =
+                Some(signed_key_authorization_hex_with(&entry, |mut auth| {
+                    auth.allowed_calls.as_mut().unwrap()[0].selector_rules.clear();
+                    auth
+                }));
+            upsert_session_entry(entry).unwrap();
+
+            let error = resolve_live_session_signer(session_id, 100).unwrap_err();
+
+            assert!(error.to_string().contains("allowed_calls"));
         });
     }
 

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -99,10 +99,14 @@ pub struct SessionEntry {
     /// Tempo sessions are always bounded-lifetime. `0` is not a "never
     /// expires" sentinel; it is already expired.
     pub expiry: u64,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub scope: Vec<SessionCallScope>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub limits: Vec<SessionTokenLimit>,
+    /// Call scope policy for the session key. `None` means unrestricted;
+    /// `Some([])` means no calls are allowed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<Vec<SessionCallScope>>,
+    /// Spending limit policy for the session key. `None` means unrestricted;
+    /// `Some([])` means no token spending is allowed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limits: Option<Vec<SessionTokenLimit>>,
     #[serde(default)]
     pub status: SessionStatus,
     /// Session-scoped key material. This is intentionally separate from
@@ -274,42 +278,38 @@ fn validate_session_key_authorization(
     key: &SessionKeyMaterial,
     authorization: &SignedKeyAuthorization,
 ) -> eyre::Result<()> {
-    if authorization.authorization.key_id != session.key_address {
-        eyre::bail!(
-            "session {} key_authorization key_id is {}, expected {}",
-            session.session_id,
-            authorization.authorization.key_id,
-            session.key_address
-        );
-    }
-    if authorization.authorization.chain_id != session.chain_id {
-        eyre::bail!(
-            "session {} key_authorization chain_id is {}, expected {}",
-            session.session_id,
-            authorization.authorization.chain_id,
-            session.chain_id
-        );
-    }
+    eyre::ensure!(
+        authorization.authorization.key_id == session.key_address,
+        "session {} key_authorization key_id is {}, expected {}",
+        session.session_id,
+        authorization.authorization.key_id,
+        session.key_address
+    );
+    eyre::ensure!(
+        authorization.authorization.chain_id == session.chain_id,
+        "session {} key_authorization chain_id is {}, expected {}",
+        session.session_id,
+        authorization.authorization.chain_id,
+        session.chain_id
+    );
     let expected_key_type = key_type_to_signature_type(key.key_type);
-    if authorization.authorization.key_type != expected_key_type {
-        eyre::bail!(
-            "session {} key_authorization key_type is {:?}, expected {:?}",
-            session.session_id,
-            authorization.authorization.key_type,
-            expected_key_type
-        );
-    }
+    eyre::ensure!(
+        authorization.authorization.key_type == expected_key_type,
+        "session {} key_authorization key_type is {:?}, expected {:?}",
+        session.session_id,
+        authorization.authorization.key_type,
+        expected_key_type
+    );
     let recovered = authorization
         .recover_signer()
         .map_err(|err| eyre::eyre!("failed to recover session key_authorization signer: {err}"))?;
-    if recovered != session.root_account {
-        eyre::bail!(
-            "session {} key_authorization signer is {}, expected {}",
-            session.session_id,
-            recovered,
-            session.root_account
-        );
-    }
+    eyre::ensure!(
+        recovered == session.root_account,
+        "session {} key_authorization signer is {}, expected {}",
+        session.session_id,
+        recovered,
+        session.root_account
+    );
     validate_session_authorization_policy(session, authorization)?;
     Ok(())
 }
@@ -323,44 +323,29 @@ fn validate_session_authorization_policy(
 
     let expected_expiry = NonZeroU64::new(session.expiry)
         .ok_or_else(|| eyre::eyre!("session {} has invalid zero expiry", session.session_id))?;
-    if auth.expiry != Some(expected_expiry) {
-        eyre::bail!(
-            "session {} key_authorization expiry is {:?}, expected {}",
-            session.session_id,
-            auth.expiry.map(NonZeroU64::get),
-            session.expiry
-        );
-    }
+    eyre::ensure!(
+        auth.expiry == Some(expected_expiry),
+        "session {} key_authorization expiry is {:?}, expected {}",
+        session.session_id,
+        auth.expiry.map(NonZeroU64::get),
+        session.expiry
+    );
 
-    let Some(auth_limits) = auth.limits.as_deref() else {
-        eyre::bail!(
-            "session {} key_authorization limits are unrestricted, expected session limits",
-            session.session_id
-        );
-    };
     let expected_limits = session_authorization_limits(session)?;
-    let actual_limits = authorization_limits(auth_limits);
-    if actual_limits != expected_limits {
-        eyre::bail!(
-            "session {} key_authorization limits do not match session limits",
-            session.session_id
-        );
-    }
+    let actual_limits = auth.limits.as_deref().map(authorization_limits);
+    eyre::ensure!(
+        actual_limits == expected_limits,
+        "session {} key_authorization limits do not match session limits",
+        session.session_id
+    );
 
-    let Some(auth_allowed_calls) = auth.allowed_calls.as_deref() else {
-        eyre::bail!(
-            "session {} key_authorization allowed_calls are unrestricted, expected session scope",
-            session.session_id
-        );
-    };
     let expected_scope = session_authorization_scope(session);
-    let actual_scope = authorization_scope(auth_allowed_calls);
-    if actual_scope != expected_scope {
-        eyre::bail!(
-            "session {} key_authorization allowed_calls do not match session scope",
-            session.session_id
-        );
-    }
+    let actual_scope = auth.allowed_calls.as_deref().map(authorization_scope);
+    eyre::ensure!(
+        actual_scope == expected_scope,
+        "session {} key_authorization allowed_calls do not match session scope",
+        session.session_id
+    );
 
     Ok(())
 }
@@ -388,20 +373,27 @@ struct CanonicalSelectorRule {
 }
 
 /// Converts stored session limits into canonical form for authorization comparison.
-fn session_authorization_limits(session: &SessionEntry) -> eyre::Result<Vec<CanonicalTokenLimit>> {
-    let mut limits = session
+fn session_authorization_limits(
+    session: &SessionEntry,
+) -> eyre::Result<Option<Vec<CanonicalTokenLimit>>> {
+    session
         .limits
-        .iter()
-        .map(|limit| {
-            Ok(CanonicalTokenLimit {
-                token: limit.currency,
-                limit: parse_session_limit(&limit.limit)?,
-                period: 0,
-            })
+        .as_deref()
+        .map(|limits| {
+            let mut limits = limits
+                .iter()
+                .map(|limit| {
+                    Ok(CanonicalTokenLimit {
+                        token: limit.currency,
+                        limit: parse_session_limit(&limit.limit)?,
+                        period: 0,
+                    })
+                })
+                .collect::<eyre::Result<Vec<_>>>()?;
+            limits.sort();
+            Ok(limits)
         })
-        .collect::<eyre::Result<Vec<_>>>()?;
-    limits.sort_by_key(|limit| (limit.token, limit.limit, limit.period));
-    Ok(limits)
+        .transpose()
 }
 
 /// Converts signed authorization limits into canonical form for session comparison.
@@ -428,17 +420,18 @@ fn parse_session_limit(raw: &str) -> eyre::Result<U256> {
 }
 
 /// Converts stored session scope into canonical form for authorization comparison.
-fn session_authorization_scope(session: &SessionEntry) -> Vec<CanonicalCallScope> {
-    let mut scope = session
-        .scope
-        .iter()
-        .map(|scope| CanonicalCallScope {
-            target: scope.target,
-            selector_rules: session_authorization_selector_rules(&scope.selector_rules),
-        })
-        .collect::<Vec<_>>();
-    scope.sort();
-    scope
+fn session_authorization_scope(session: &SessionEntry) -> Option<Vec<CanonicalCallScope>> {
+    session.scope.as_deref().map(|scope| {
+        let mut scope = scope
+            .iter()
+            .map(|scope| CanonicalCallScope {
+                target: scope.target,
+                selector_rules: session_authorization_selector_rules(&scope.selector_rules),
+            })
+            .collect::<Vec<_>>();
+        scope.sort();
+        scope
+    })
 }
 
 /// Converts signed authorization scope into canonical form for session comparison.
@@ -561,17 +554,17 @@ mod tests {
             chain_id: 4217,
             key_address: Address::from_str("0x0000000000000000000000000000000000000abc").unwrap(),
             expiry,
-            scope: vec![SessionCallScope {
+            scope: Some(vec![SessionCallScope {
                 target: Address::from_str("0x00000000000000000000000000000000000000aa").unwrap(),
                 selector_rules: vec![SessionSelectorRule {
                     selector: Selector::from_slice(&[0x12, 0x34, 0x56, 0x78]),
                     recipients: vec![],
                 }],
-            }],
-            limits: vec![SessionTokenLimit {
+            }]),
+            limits: Some(vec![SessionTokenLimit {
                 currency: Address::from_str("0x00000000000000000000000000000000000000ff").unwrap(),
                 limit: "0".to_string(),
-            }],
+            }]),
             status,
             key: None,
         }
@@ -630,11 +623,15 @@ mod tests {
 
     /// Builds a key authorization that mirrors the session entry policy.
     fn session_key_authorization(entry: &SessionEntry) -> KeyAuthorization {
-        KeyAuthorization::unrestricted(entry.chain_id, SignatureType::Secp256k1, entry.key_address)
-            .with_expiry(entry.expiry)
-            .with_limits(
-                entry
-                    .limits
+        let mut authorization = KeyAuthorization::unrestricted(
+            entry.chain_id,
+            SignatureType::Secp256k1,
+            entry.key_address,
+        )
+        .with_expiry(entry.expiry);
+        if let Some(limits) = &entry.limits {
+            authorization = authorization.with_limits(
+                limits
                     .iter()
                     .map(|limit| TokenLimit {
                         token: limit.currency,
@@ -642,10 +639,11 @@ mod tests {
                         period: 0,
                     })
                     .collect(),
-            )
-            .with_allowed_calls(
-                entry
-                    .scope
+            );
+        }
+        if let Some(scope) = &entry.scope {
+            authorization = authorization.with_allowed_calls(
+                scope
                     .iter()
                     .map(|scope| CallScope {
                         target: scope.target,
@@ -659,7 +657,9 @@ mod tests {
                             .collect(),
                     })
                     .collect(),
-            )
+            );
+        }
+        authorization
     }
 
     #[test]
@@ -725,8 +725,8 @@ mod tests {
         let decoded: SessionEntry = toml::from_str(&toml).unwrap();
 
         assert_eq!(decoded.session_id, entry.session_id);
-        assert_eq!(decoded.scope.len(), 1);
-        assert_eq!(decoded.limits.len(), 1);
+        assert_eq!(decoded.scope.as_ref().unwrap().len(), 1);
+        assert_eq!(decoded.limits.as_ref().unwrap().len(), 1);
         assert_eq!(decoded.status, SessionStatus::Revoking);
         assert_eq!(decoded.key.as_ref().unwrap().key, "0xdeadbeef");
         assert!(decoded.has_inline_key());
@@ -829,6 +829,45 @@ mod tests {
             assert!(key_authorization.authorization.limits.is_some());
             assert!(key_authorization.authorization.allowed_calls.is_some());
             assert_eq!(key_authorization.recover_signer().unwrap(), entry.root_account);
+        });
+    }
+
+    #[test]
+    fn resolve_live_session_signer_accepts_unrestricted_authorization_when_policy_is_omitted() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x13; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            entry.limits = None;
+            entry.scope = None;
+            entry.key.as_mut().unwrap().key_authorization =
+                Some(signed_key_authorization_hex(&entry));
+            upsert_session_entry(entry.clone()).unwrap();
+
+            let resolved = resolve_live_session_signer(session_id, 100).unwrap().unwrap();
+            let key_authorization = resolved.access_key.key_authorization.unwrap();
+
+            assert!(key_authorization.authorization.limits.is_none());
+            assert!(key_authorization.authorization.allowed_calls.is_none());
+        });
+    }
+
+    #[test]
+    fn resolve_live_session_signer_rejects_unrestricted_authorization_when_policy_is_empty() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x14; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            let mut auth_entry = entry.clone();
+            auth_entry.limits = None;
+            auth_entry.scope = None;
+            entry.limits = Some(vec![]);
+            entry.scope = Some(vec![]);
+            entry.key.as_mut().unwrap().key_authorization =
+                Some(signed_key_authorization_hex(&auth_entry));
+            upsert_session_entry(entry).unwrap();
+
+            let error = resolve_live_session_signer(session_id, 100).unwrap_err();
+
+            assert!(error.to_string().contains("limits"));
         });
     }
 

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -268,7 +268,7 @@ pub fn resolve_live_session_signer(
     Ok(Some(ResolvedSessionSigner { session, signer, access_key }))
 }
 
-/// Ensures a session key authorization matches the stored key, chain, root signer, and policy.
+/// Ensures a session key authorization matches the stored key, chain, and root signer.
 fn validate_session_key_authorization(
     session: &SessionEntry,
     key: &SessionKeyMaterial,
@@ -314,7 +314,7 @@ fn validate_session_key_authorization(
     Ok(())
 }
 
-/// Ensures a session authorization does not outlive or exceed the stored session policy.
+/// Ensures authorization expiry, limits, and call scope match the stored session policy.
 fn validate_session_authorization_policy(
     session: &SessionEntry,
     authorization: &SignedKeyAuthorization,


### PR DESCRIPTION
### Summary
Follow-up to #14827 and #14878 for OSS-162.

#14827 added the initial Tempo session registry scaffold: session metadata, wallet/sessions.toml, atomic upsert/removal, expiry tracking, and shared TOML registry helpers. #14878 made the storage semantics explicit by keeping temporary session key material inside session entries instead of the persistent wallet/keys.toml access-key store.

This PR adds the next resolver layer: 
it loads a live session-scoped key from the local session registry, expires stale entries before use, validates that the stored key material matches the recorded session key address, and returns the WalletSigner plus TempoAccessKeyConfig needed to use that session key for outgoing transactions.

It also decodes and validates inline key_authorization data, ensuring the authorization belongs to the stored key, chain, and root signer, and that its expiry, spending limits, and call scope match the stored session policy.