### PR TITLE
docs: fix article usage in comments and messages

### DIFF
--- a/crates/cli/src/opts/rpc.rs
+++ b/crates/cli/src/opts/rpc.rs
@@ -32,7 +32,7 @@ pub struct RpcOpts {
 
     /// JWT Secret for the RPC endpoint.
     ///
-    /// The JWT secret will be used to create a JWT for a RPC. For example, the following can be
+    /// The JWT secret will be used to create a JWT for an RPC. For example, the following can be
     /// used to simulate a CL `engine_forkchoiceUpdated` call:
     ///
     /// cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -453,7 +453,7 @@ pub struct Backend<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     ///
     /// In a way the `JournaledState` is something like a cache that
     /// 1. check if account is already loaded (hot)
-    /// 2. if not load from the `Database` (this will then retrieve the account via RPC in forking
+    /// 2. if not load from the `Database` (this will then retrieve the account vian RPC in forking
     ///    mode)
     ///
     /// To properly initialize we store the `JournaledState` before the first fork is selected

--- a/crates/evm/traces/src/folded_stack_trace.rs
+++ b/crates/evm/traces/src/folded_stack_trace.rs
@@ -30,7 +30,7 @@ impl EvmFoldedStackTraceBuilder {
         self.fst.build()
     }
 
-    /// Creates an entry for a EVM CALL in the folded stack trace. This method recursively processes
+    /// Creates an entry for an EVM CALL in the folded stack trace. This method recursively processes
     /// all the children nodes of the call node and at the end it exits.
     pub fn process_call_node(&mut self, nodes: &[CallTraceNode], idx: usize) {
         let node = &nodes[idx];

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1511,7 +1511,7 @@ Compiler run successful!
 Script ran successfully.
 [GAS]
 
-If you wish to simulate on-chain transactions pass a RPC URL.
+If you wish to simulate on-chain transactions pass an RPC URL.
 
 "#]]);
 });
@@ -1587,7 +1587,7 @@ Script ran successfully.
   0x159E2f2F1C094625A2c6c8bF59526d91454c2F3c
   0x159E2f2F1C094625A2c6c8bF59526d91454c2F3c
 
-If you wish to simulate on-chain transactions pass a RPC URL.
+If you wish to simulate on-chain transactions pass an RPC URL.
 
 "#]]);
 });
@@ -1637,7 +1637,7 @@ Compiler run successful!
 Script ran successfully.
 [GAS]
 
-If you wish to simulate on-chain transactions pass a RPC URL.
+If you wish to simulate on-chain transactions pass an RPC URL.
 
 "#]]);
 });

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -394,7 +394,7 @@ impl ScriptArgs {
             // Check if there are any missing RPCs and exit early to avoid hard error.
             if pre_simulation.execution_artifacts.rpc_data.missing_rpc {
                 if !shell::is_json() {
-                    sh_println!("\nIf you wish to simulate on-chain transactions pass a RPC URL.")?;
+                    sh_println!("\nIf you wish to simulate on-chain transactions pass an RPC URL.")?;
                 }
 
                 return Ok(None);

--- a/crates/test-utils/src/script.rs
+++ b/crates/test-utils/src/script.rs
@@ -278,7 +278,7 @@ pub enum ScriptOutcome {
 impl ScriptOutcome {
     pub const fn as_str(&self) -> &'static str {
         match self {
-            Self::OkNoEndpoint => "If you wish to simulate on-chain transactions pass a RPC URL.",
+            Self::OkNoEndpoint => "If you wish to simulate on-chain transactions pass an RPC URL.",
             Self::OkSimulation => "SIMULATION COMPLETE. To broadcast these",
             Self::OkBroadcast => "ONCHAIN EXECUTION COMPLETE & SUCCESSFUL",
             Self::WarnSpecifyDeployer => {


### PR DESCRIPTION
## Description
Fixed grammatical errors in code comments and user-facing messages for improved readability.

## Changes
- Changed `a RPC` → `an RPC` throughout codebase
- Changed `a EVM` → `an EVM` in trace comments
- Improves grammar consistency in documentation

## Files Modified
- `crates/cli/src/opts/rpc.rs`
- `crates/evm/core/src/backend/mod.rs`
- `crates/evm/traces/src/folded_stack_trace.rs`
- `crates/forge/tests/cli/script.rs`
- `crates/script/src/lib.rs`
- `crates/test-utils/src/script.rs`

## Testing
- Changes are documentation/comments only
- No functional changes