### PR TITLE
feat(lint): add `unprotected-initializer`

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -13,6 +13,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `erc20-unchecked-transfer`: ERC20 `transfer` and `transferFrom` calls should check the return value.
   - `rtlo`: Flags Unicode bidirectional override characters ("Trojan Source", CVE-2021-42574) that can hide malicious code.
   - `reentrancy-unlimited-gas`: Flags uncapped ETH-transferring low-level calls followed by writes to state that was read before the call.
+  - `unprotected-initializer`: Upgradeable initializers should not be callable on the implementation contract.
 - **Medium Severity:**
   - `assert-state-change`: Flags state-modifying expressions inside `assert()` arguments.
   - `boolean-cst`: Flags misuse of boolean constants.

--- a/crates/lint/docs/unprotected-initializer.md
+++ b/crates/lint/docs/unprotected-initializer.md
@@ -10,8 +10,7 @@ This lint reports initializer-like functions that:
 - are public or external;
 - are marked with `initializer` or `reinitializer`;
 - write state directly or through an internal helper; and
-- are in an implementation whose constructor does not call `_disableInitializers()` and is not
-  itself marked `initializer`; and
+- are in an implementation whose constructor does not call `_disableInitializers()`; and
 - are in a contract with a public or external `delegatecall`, `callcode`, or `selfdestruct` path
   that is not restricted to proxy calls with `onlyProxy`.
 

--- a/crates/lint/docs/unprotected-initializer.md
+++ b/crates/lint/docs/unprotected-initializer.md
@@ -10,7 +10,7 @@ This lint reports initializer-like functions that:
 - are public or external;
 - are marked with `initializer` or `reinitializer`;
 - write state directly or through an internal helper; and
-- are in an implementation whose constructor does not call `_disableInitializers()`; and
+- are in an implementation whose constructor does not call an inherited `_disableInitializers()`; and
 - are in a contract with a public or external `delegatecall`, `callcode`, or `selfdestruct` path
   that is not restricted to proxy calls with `onlyProxy`.
 

--- a/crates/lint/docs/unprotected-initializer.md
+++ b/crates/lint/docs/unprotected-initializer.md
@@ -1,17 +1,19 @@
 # Unprotected initializer
 
 `unprotected-initializer` flags upgradeable contracts whose public or external initializer can
-still be called directly on the implementation contract.
+still be called directly on an implementation contract that exposes a destructive entry point.
 
 ## What it detects
 
 This lint reports initializer-like functions that:
 
 - are public or external;
-- are marked with `initializer` or `reinitializer`, or are named like `initialize`;
+- are marked with `initializer` or `reinitializer`;
 - write state directly or through an internal helper; and
 - are in an implementation whose constructor does not call `_disableInitializers()` and is not
-  itself marked `initializer`.
+  itself marked `initializer`; and
+- are in a contract with a public or external `delegatecall`, `callcode`, or `selfdestruct` path
+  that is not restricted to proxy calls with `onlyProxy`.
 
 ## Examples
 
@@ -21,6 +23,11 @@ contract Vault is Initializable {
 
     function initialize(address owner_) public initializer {
         owner = owner_;
+    }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
     }
 }
 ```
@@ -48,4 +55,7 @@ This lint has no additional configuration.
 ## Notes
 
 The lint is intentionally local: it does not inspect deployment scripts to prove whether a proxy is
-initialized atomically. It focuses on implementation contracts that remain directly initializable.
+initialized atomically. It focuses on implementation contracts that remain directly initializable
+and can reach code paths that may destroy or replace implementation state.
+
+The `onlyProxy` exemption is a name-based heuristic for common UUPS implementations.

--- a/crates/lint/docs/unprotected-initializer.md
+++ b/crates/lint/docs/unprotected-initializer.md
@@ -1,0 +1,51 @@
+# Unprotected initializer
+
+`unprotected-initializer` flags upgradeable contracts whose public or external initializer can
+still be called directly on the implementation contract.
+
+## What it detects
+
+This lint reports initializer-like functions that:
+
+- are public or external;
+- are marked with `initializer` or `reinitializer`, or are named like `initialize`;
+- write state directly or through an internal helper; and
+- are in an implementation whose constructor does not call `_disableInitializers()` and is not
+  itself marked `initializer`.
+
+## Examples
+
+```solidity
+contract Vault is Initializable {
+    address public owner;
+
+    function initialize(address owner_) public initializer {
+        owner = owner_;
+    }
+}
+```
+
+Prefer locking the implementation contract during deployment:
+
+```solidity
+contract Vault is Initializable {
+    address public owner;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address owner_) public initializer {
+        owner = owner_;
+    }
+}
+```
+
+## Configuration
+
+This lint has no additional configuration.
+
+## Notes
+
+The lint is intentionally local: it does not inspect deployment scripts to prove whether a proxy is
+initialized atomically. It focuses on implementation contracts that remain directly initializable.

--- a/crates/lint/src/sol/high/mod.rs
+++ b/crates/lint/src/sol/high/mod.rs
@@ -4,16 +4,19 @@ mod incorrect_shift;
 mod reentrancy;
 mod rtlo;
 mod unchecked_calls;
+mod unprotected_initializer;
 
 use incorrect_shift::INCORRECT_SHIFT;
 use reentrancy::REENTRANCY_UNLIMITED_GAS;
 use rtlo::RTLO;
 use unchecked_calls::{ERC20_UNCHECKED_TRANSFER, UNCHECKED_CALL};
+use unprotected_initializer::UNPROTECTED_INITIALIZER;
 
 register_lints!(
     (IncorrectShift, early, (INCORRECT_SHIFT)),
     (ReentrancyUnlimitedGas, late, (REENTRANCY_UNLIMITED_GAS)),
     (UncheckedCall, early, (UNCHECKED_CALL)),
     (UncheckedTransferERC20, late, (ERC20_UNCHECKED_TRANSFER)),
+    (UnprotectedInitializer, late, (UNPROTECTED_INITIALIZER)),
     (Rtlo, early, (RTLO))
 );

--- a/crates/lint/src/sol/high/unprotected_initializer.rs
+++ b/crates/lint/src/sol/high/unprotected_initializer.rs
@@ -4,7 +4,7 @@ use crate::{
     sol::{Severity, SolLint},
 };
 use solar::{
-    ast::{ContractKind, FunctionKind, StateMutability, Visibility},
+    ast::{ContractKind, DataLocation, FunctionKind, StateMutability, Visibility},
     interface::{Symbol, kw, sym},
     sema::{
         builtins::Builtin,
@@ -36,8 +36,9 @@ impl<'hir> LateLintPass<'hir> for UnprotectedInitializer {
             .linearized_bases
             .iter()
             .any(|&base_id| hir.contract(base_id).name.as_str() == "Initializable");
+        let runtime_entries = effective_runtime_dispatch_surface(hir, contract.linearized_bases);
         if !upgradeable
-            && !contract.functions().any(|fid| has_initializer_modifier(hir, hir.function(fid)))
+            && !runtime_entries.iter().any(|&fid| has_initializer_modifier(hir, hir.function(fid)))
         {
             return;
         }
@@ -46,11 +47,11 @@ impl<'hir> LateLintPass<'hir> for UnprotectedInitializer {
             return;
         }
 
-        if !has_destructive_entrypoint(hir, contract) {
+        if !has_destructive_entrypoint(hir, contract, &runtime_entries) {
             return;
         }
 
-        for fid in contract.functions() {
+        for fid in runtime_entries {
             let func = hir.function(fid);
             if !is_public_initializer(hir, func) || has_modifier_named(hir, func, "onlyProxy") {
                 continue;
@@ -80,8 +81,12 @@ fn initializers_disabled_in_constructor(hir: &hir::Hir<'_>, contract: &hir::Cont
     })
 }
 
-fn has_destructive_entrypoint(hir: &hir::Hir<'_>, contract: &hir::Contract<'_>) -> bool {
-    effective_runtime_dispatch_surface(hir, contract.linearized_bases).into_iter().any(|fid| {
+fn has_destructive_entrypoint(
+    hir: &hir::Hir<'_>,
+    contract: &hir::Contract<'_>,
+    runtime_entries: &[FunctionId],
+) -> bool {
+    runtime_entries.iter().copied().any(|fid| {
         let func = hir.function(fid);
         if has_modifier_named(hir, func, "onlyProxy") {
             return false;
@@ -462,17 +467,15 @@ impl<'hir> StateWriteAnalyzer<'hir> {
     fn expr_writes_state(&mut self, expr: &'hir hir::Expr<'hir>) -> bool {
         match &expr.kind {
             ExprKind::Assign(lhs, _, rhs) => {
-                state_write_lhs_vars(self.hir, lhs).next().is_some()
+                lhs_writes_state(self.hir, lhs)
                     || self.expr_writes_state(lhs)
                     || self.expr_writes_state(rhs)
             }
             ExprKind::Delete(inner) => {
-                state_write_lhs_vars(self.hir, inner).next().is_some()
-                    || self.expr_writes_state(inner)
+                lhs_writes_state(self.hir, inner) || self.expr_writes_state(inner)
             }
             ExprKind::Unary(op, inner) => {
-                (op.kind.has_side_effects()
-                    && state_write_lhs_vars(self.hir, inner).next().is_some())
+                (op.kind.has_side_effects() && lhs_writes_state(self.hir, inner))
                     || self.expr_writes_state(inner)
             }
             ExprKind::Call(callee, args, opts) => {
@@ -540,43 +543,38 @@ impl<'hir> StateWriteAnalyzer<'hir> {
 
 fn member_call_writes_state(hir: &hir::Hir<'_>, callee: &hir::Expr<'_>) -> bool {
     let ExprKind::Member(base, member) = &callee.peel_parens().kind else { return false };
-    matches!(member.as_str(), "push" | "pop") && state_write_lhs_vars(hir, base).next().is_some()
+    matches!(member.as_str(), "push" | "pop") && lhs_writes_state(hir, base)
 }
 
-fn state_write_lhs_vars<'hir>(
-    hir: &'hir hir::Hir<'hir>,
-    expr: &'hir hir::Expr<'hir>,
-) -> impl Iterator<Item = VariableId> + 'hir {
-    let mut vars = HashSet::new();
-    collect_state_write_lhs_vars(hir, expr, &mut vars);
-    vars.into_iter()
-}
-
-fn collect_state_write_lhs_vars(
-    hir: &hir::Hir<'_>,
-    expr: &hir::Expr<'_>,
-    vars: &mut HashSet<VariableId>,
-) {
+fn lhs_writes_state(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
     match &expr.peel_parens().kind {
         ExprKind::Ident(resolutions) => {
-            for res in *resolutions {
-                if let Res::Item(ItemId::Variable(var_id)) = res
-                    && hir.variable(*var_id).kind.is_state()
-                {
-                    vars.insert(*var_id);
-                }
-            }
+            resolutions.iter().any(|res| matches!(res, Res::Item(ItemId::Variable(var_id)) if hir.variable(*var_id).kind.is_state()))
         }
         ExprKind::Index(base, _) | ExprKind::Slice(base, _, _) | ExprKind::Member(base, _) => {
-            collect_state_write_lhs_vars(hir, base, vars);
+            expr_references_storage(hir, base)
         }
         ExprKind::Tuple(exprs) => {
-            for expr in exprs.iter().flatten() {
-                collect_state_write_lhs_vars(hir, expr, vars);
-            }
+            exprs.iter().flatten().any(|expr| lhs_writes_state(hir, expr))
         }
-        _ => {}
+        _ => false,
     }
+}
+
+fn expr_references_storage(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(resolutions) => resolutions.iter().any(|res| {
+            matches!(res, Res::Item(ItemId::Variable(var_id)) if variable_references_storage(hir.variable(*var_id)))
+        }),
+        ExprKind::Index(base, _) | ExprKind::Slice(base, _, _) | ExprKind::Member(base, _) => {
+            expr_references_storage(hir, base)
+        }
+        _ => false,
+    }
+}
+
+fn variable_references_storage(var: &hir::Variable<'_>) -> bool {
+    var.kind.is_state() || var.data_location == Some(DataLocation::Storage)
 }
 
 fn resolved_internal_function_ids(

--- a/crates/lint/src/sol/high/unprotected_initializer.rs
+++ b/crates/lint/src/sol/high/unprotected_initializer.rs
@@ -1,0 +1,451 @@
+use super::UnprotectedInitializer;
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::{
+    ast::{ContractKind, StateMutability, Visibility},
+    interface::sym,
+    sema::hir::{self, ContractId, ExprKind, FunctionId, ItemId, Res, StmtKind, VariableId},
+};
+use std::collections::HashSet;
+
+declare_forge_lint!(
+    UNPROTECTED_INITIALIZER,
+    Severity::High,
+    "unprotected-initializer",
+    "upgradeable initializer is not protected against direct implementation calls"
+);
+
+impl<'hir> LateLintPass<'hir> for UnprotectedInitializer {
+    fn check_nested_contract(
+        &mut self,
+        ctx: &LintContext,
+        hir: &'hir hir::Hir<'hir>,
+        contract_id: ContractId,
+    ) {
+        let contract = hir.contract(contract_id);
+        if !matches!(contract.kind, ContractKind::Contract) || contract.linearization_failed() {
+            return;
+        }
+
+        let upgradeable = contract
+            .linearized_bases
+            .iter()
+            .any(|&base_id| hir.contract(base_id).name.as_str() == "Initializable");
+        if !upgradeable
+            && !contract.functions().any(|fid| has_initializer_modifier(hir, hir.function(fid)))
+        {
+            return;
+        }
+
+        if initializers_disabled_in_constructor(hir, contract) {
+            return;
+        }
+
+        for fid in contract.functions() {
+            let func = hir.function(fid);
+            if !is_public_initializer(hir, func, upgradeable)
+                || has_modifier_named(hir, func, "onlyProxy")
+            {
+                continue;
+            }
+
+            let Some(body) = func.body else { continue };
+            let mut analyzer =
+                StateWriteAnalyzer { hir, bases: contract.linearized_bases, stack: Vec::new() };
+            if analyzer.block_writes_state(body) {
+                ctx.emit(&UNPROTECTED_INITIALIZER, func.name.map_or(func.span, |name| name.span));
+            }
+        }
+    }
+}
+
+fn is_public_initializer(hir: &hir::Hir<'_>, func: &hir::Function<'_>, upgradeable: bool) -> bool {
+    if !func.kind.is_function()
+        || !matches!(func.visibility, Visibility::Public | Visibility::External)
+        || matches!(func.state_mutability, StateMutability::Pure | StateMutability::View)
+    {
+        return false;
+    }
+
+    has_initializer_modifier(hir, func)
+        || (upgradeable && func.name.is_some_and(|name| is_initializer_name(name.as_str())))
+}
+
+fn is_initializer_name(name: &str) -> bool {
+    if matches!(name, "initialize" | "reinitialize") {
+        return true;
+    }
+
+    name.strip_prefix("initialize").is_some_and(|suffix| {
+        suffix
+            .chars()
+            .next()
+            .is_some_and(|c| c == '_' || c.is_ascii_digit() || c.is_ascii_uppercase())
+    }) || name.strip_prefix("reinitialize").is_some_and(|suffix| {
+        suffix
+            .chars()
+            .next()
+            .is_some_and(|c| c == '_' || c.is_ascii_digit() || c.is_ascii_uppercase())
+    })
+}
+
+fn initializers_disabled_in_constructor(hir: &hir::Hir<'_>, contract: &hir::Contract<'_>) -> bool {
+    contract.linearized_bases.iter().filter_map(|&cid| hir.contract(cid).ctor).any(|ctor_id| {
+        let ctor = hir.function(ctor_id);
+        has_modifier_named(hir, ctor, "initializer")
+            || function_calls_named(hir, ctor, "_disableInitializers")
+    })
+}
+
+fn has_initializer_modifier(hir: &hir::Hir<'_>, func: &hir::Function<'_>) -> bool {
+    has_modifier_named(hir, func, "initializer") || has_modifier_named(hir, func, "reinitializer")
+}
+
+fn has_modifier_named(hir: &hir::Hir<'_>, func: &hir::Function<'_>, name: &str) -> bool {
+    func.modifiers.iter().any(|modifier| modifier_name_is(hir, modifier, name))
+}
+
+fn modifier_name_is(hir: &hir::Hir<'_>, modifier: &hir::Modifier<'_>, name: &str) -> bool {
+    match modifier.id {
+        ItemId::Function(fid) => hir.function(fid).name.is_some_and(|ident| ident.as_str() == name),
+        ItemId::Contract(cid) => hir.contract(cid).name.as_str() == name,
+        _ => false,
+    }
+}
+
+fn function_calls_named(hir: &hir::Hir<'_>, func: &hir::Function<'_>, name: &str) -> bool {
+    let Some(body) = func.body else { return false };
+    let mut finder = CallNameFinder { hir, name, bases: &[], stack: vec![] };
+    finder.block_calls_named(body)
+}
+
+struct CallNameFinder<'a, 'hir> {
+    hir: &'hir hir::Hir<'hir>,
+    name: &'a str,
+    bases: &'hir [ContractId],
+    stack: Vec<FunctionId>,
+}
+
+impl<'hir> CallNameFinder<'_, 'hir> {
+    fn block_calls_named(&mut self, block: hir::Block<'hir>) -> bool {
+        block.stmts.iter().any(|stmt| self.stmt_calls_named(stmt))
+    }
+
+    fn stmt_calls_named(&mut self, stmt: &'hir hir::Stmt<'hir>) -> bool {
+        match &stmt.kind {
+            StmtKind::DeclSingle(var_id) => self
+                .hir
+                .variable(*var_id)
+                .initializer
+                .is_some_and(|init| self.expr_calls_named(init)),
+            StmtKind::DeclMulti(_, expr)
+            | StmtKind::Emit(expr)
+            | StmtKind::Revert(expr)
+            | StmtKind::Return(Some(expr))
+            | StmtKind::Expr(expr) => self.expr_calls_named(expr),
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
+                self.block_calls_named(*block)
+            }
+            StmtKind::If(condition, then_stmt, else_stmt) => {
+                self.expr_calls_named(condition)
+                    || self.stmt_calls_named(then_stmt)
+                    || else_stmt.is_some_and(|stmt| self.stmt_calls_named(stmt))
+            }
+            StmtKind::Try(stmt_try) => {
+                self.expr_calls_named(&stmt_try.expr)
+                    || stmt_try.clauses.iter().any(|clause| self.block_calls_named(clause.block))
+            }
+            StmtKind::Return(None)
+            | StmtKind::Break
+            | StmtKind::Continue
+            | StmtKind::Placeholder
+            | StmtKind::Err(_) => false,
+        }
+    }
+
+    fn expr_calls_named(&mut self, expr: &'hir hir::Expr<'hir>) -> bool {
+        match &expr.kind {
+            ExprKind::Call(callee, args, opts) => {
+                if callee_name_is(self.hir, callee, self.name) {
+                    return true;
+                }
+
+                if let Some(opts) = opts
+                    && opts.iter().any(|opt| self.expr_calls_named(&opt.value))
+                {
+                    return true;
+                }
+
+                if args.exprs().any(|arg| self.expr_calls_named(arg)) {
+                    return true;
+                }
+
+                resolved_internal_function_ids(self.hir, callee, self.bases)
+                    .into_iter()
+                    .any(|func_id| self.function_calls_named(func_id))
+            }
+            ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {
+                self.expr_calls_named(lhs) || self.expr_calls_named(rhs)
+            }
+            ExprKind::Unary(_, inner) | ExprKind::Delete(inner) | ExprKind::Payable(inner) => {
+                self.expr_calls_named(inner)
+            }
+            ExprKind::Index(base, index) => {
+                self.expr_calls_named(base)
+                    || index.is_some_and(|index| self.expr_calls_named(index))
+            }
+            ExprKind::Slice(base, start, end) => {
+                self.expr_calls_named(base)
+                    || start.is_some_and(|start| self.expr_calls_named(start))
+                    || end.is_some_and(|end| self.expr_calls_named(end))
+            }
+            ExprKind::Member(base, _) => self.expr_calls_named(base),
+            ExprKind::Ternary(condition, if_true, if_false) => {
+                self.expr_calls_named(condition)
+                    || self.expr_calls_named(if_true)
+                    || self.expr_calls_named(if_false)
+            }
+            ExprKind::Array(exprs) => exprs.iter().any(|expr| self.expr_calls_named(expr)),
+            ExprKind::Tuple(exprs) => {
+                exprs.iter().flatten().any(|expr| self.expr_calls_named(expr))
+            }
+            ExprKind::Lit(_)
+            | ExprKind::Ident(_)
+            | ExprKind::New(_)
+            | ExprKind::TypeCall(_)
+            | ExprKind::Type(_)
+            | ExprKind::Err(_) => false,
+        }
+    }
+
+    fn function_calls_named(&mut self, func_id: FunctionId) -> bool {
+        if self.stack.contains(&func_id) {
+            return false;
+        }
+
+        let func = self.hir.function(func_id);
+        let Some(body) = func.body else { return false };
+        self.stack.push(func_id);
+        let found = self.block_calls_named(body);
+        self.stack.pop();
+        found
+    }
+}
+
+fn callee_name_is(hir: &hir::Hir<'_>, callee: &hir::Expr<'_>, name: &str) -> bool {
+    match &callee.peel_parens().kind {
+        ExprKind::Ident(resolutions) => resolutions.iter().any(|res| {
+            matches!(res, Res::Item(ItemId::Function(fid)) if hir.function(*fid).name.is_some_and(|ident| ident.as_str() == name))
+        }),
+        ExprKind::Member(_, member) => member.as_str() == name,
+        _ => false,
+    }
+}
+
+struct StateWriteAnalyzer<'hir> {
+    hir: &'hir hir::Hir<'hir>,
+    bases: &'hir [ContractId],
+    stack: Vec<FunctionId>,
+}
+
+impl<'hir> StateWriteAnalyzer<'hir> {
+    fn block_writes_state(&mut self, block: hir::Block<'hir>) -> bool {
+        block.stmts.iter().any(|stmt| self.stmt_writes_state(stmt))
+    }
+
+    fn stmt_writes_state(&mut self, stmt: &'hir hir::Stmt<'hir>) -> bool {
+        match &stmt.kind {
+            StmtKind::DeclSingle(var_id) => self
+                .hir
+                .variable(*var_id)
+                .initializer
+                .is_some_and(|init| self.expr_writes_state(init)),
+            StmtKind::DeclMulti(_, expr)
+            | StmtKind::Emit(expr)
+            | StmtKind::Revert(expr)
+            | StmtKind::Return(Some(expr))
+            | StmtKind::Expr(expr) => self.expr_writes_state(expr),
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
+                self.block_writes_state(*block)
+            }
+            StmtKind::If(condition, then_stmt, else_stmt) => {
+                self.expr_writes_state(condition)
+                    || self.stmt_writes_state(then_stmt)
+                    || else_stmt.is_some_and(|stmt| self.stmt_writes_state(stmt))
+            }
+            StmtKind::Try(stmt_try) => {
+                self.expr_writes_state(&stmt_try.expr)
+                    || stmt_try.clauses.iter().any(|clause| self.block_writes_state(clause.block))
+            }
+            StmtKind::Return(None)
+            | StmtKind::Break
+            | StmtKind::Continue
+            | StmtKind::Placeholder
+            | StmtKind::Err(_) => false,
+        }
+    }
+
+    fn expr_writes_state(&mut self, expr: &'hir hir::Expr<'hir>) -> bool {
+        match &expr.kind {
+            ExprKind::Assign(lhs, _, rhs) => {
+                state_write_lhs_vars(self.hir, lhs).next().is_some()
+                    || self.expr_writes_state(lhs)
+                    || self.expr_writes_state(rhs)
+            }
+            ExprKind::Delete(inner) => {
+                state_write_lhs_vars(self.hir, inner).next().is_some()
+                    || self.expr_writes_state(inner)
+            }
+            ExprKind::Unary(op, inner) => {
+                (op.kind.has_side_effects()
+                    && state_write_lhs_vars(self.hir, inner).next().is_some())
+                    || self.expr_writes_state(inner)
+            }
+            ExprKind::Call(callee, args, opts) => {
+                if member_call_writes_state(self.hir, callee) {
+                    return true;
+                }
+
+                if self.expr_writes_state(callee)
+                    || opts.is_some_and(|opts| {
+                        opts.iter().any(|opt| self.expr_writes_state(&opt.value))
+                    })
+                    || args.exprs().any(|arg| self.expr_writes_state(arg))
+                {
+                    return true;
+                }
+
+                resolved_internal_function_ids(self.hir, callee, self.bases)
+                    .into_iter()
+                    .any(|func_id| self.function_writes_state(func_id))
+            }
+            ExprKind::Binary(lhs, _, rhs) => {
+                self.expr_writes_state(lhs) || self.expr_writes_state(rhs)
+            }
+            ExprKind::Index(base, index) => {
+                self.expr_writes_state(base)
+                    || index.is_some_and(|index| self.expr_writes_state(index))
+            }
+            ExprKind::Slice(base, start, end) => {
+                self.expr_writes_state(base)
+                    || start.is_some_and(|start| self.expr_writes_state(start))
+                    || end.is_some_and(|end| self.expr_writes_state(end))
+            }
+            ExprKind::Member(base, _) | ExprKind::Payable(base) => self.expr_writes_state(base),
+            ExprKind::Ternary(condition, if_true, if_false) => {
+                self.expr_writes_state(condition)
+                    || self.expr_writes_state(if_true)
+                    || self.expr_writes_state(if_false)
+            }
+            ExprKind::Array(exprs) => exprs.iter().any(|expr| self.expr_writes_state(expr)),
+            ExprKind::Tuple(exprs) => {
+                exprs.iter().flatten().any(|expr| self.expr_writes_state(expr))
+            }
+            ExprKind::Lit(_)
+            | ExprKind::Ident(_)
+            | ExprKind::New(_)
+            | ExprKind::TypeCall(_)
+            | ExprKind::Type(_)
+            | ExprKind::Err(_) => false,
+        }
+    }
+
+    fn function_writes_state(&mut self, func_id: FunctionId) -> bool {
+        if self.stack.contains(&func_id) {
+            return false;
+        }
+
+        let func = self.hir.function(func_id);
+        let Some(body) = func.body else { return false };
+        self.stack.push(func_id);
+        let writes = self.block_writes_state(body);
+        self.stack.pop();
+        writes
+    }
+}
+
+fn member_call_writes_state(hir: &hir::Hir<'_>, callee: &hir::Expr<'_>) -> bool {
+    let ExprKind::Member(base, member) = &callee.peel_parens().kind else { return false };
+    matches!(member.as_str(), "push" | "pop") && state_write_lhs_vars(hir, base).next().is_some()
+}
+
+fn state_write_lhs_vars<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    expr: &'hir hir::Expr<'hir>,
+) -> impl Iterator<Item = VariableId> + 'hir {
+    let mut vars = HashSet::new();
+    collect_state_write_lhs_vars(hir, expr, &mut vars);
+    vars.into_iter()
+}
+
+fn collect_state_write_lhs_vars(
+    hir: &hir::Hir<'_>,
+    expr: &hir::Expr<'_>,
+    vars: &mut HashSet<VariableId>,
+) {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(resolutions) => {
+            for res in *resolutions {
+                if let Res::Item(ItemId::Variable(var_id)) = res
+                    && hir.variable(*var_id).kind.is_state()
+                {
+                    vars.insert(*var_id);
+                }
+            }
+        }
+        ExprKind::Index(base, _) | ExprKind::Slice(base, _, _) | ExprKind::Member(base, _) => {
+            collect_state_write_lhs_vars(hir, base, vars);
+        }
+        ExprKind::Tuple(exprs) => {
+            for expr in exprs.iter().flatten() {
+                collect_state_write_lhs_vars(hir, expr, vars);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn resolved_internal_function_ids(
+    hir: &hir::Hir<'_>,
+    callee: &hir::Expr<'_>,
+    bases: &[ContractId],
+) -> Vec<FunctionId> {
+    match &callee.peel_parens().kind {
+        ExprKind::Ident(resolutions) => resolutions
+            .iter()
+            .filter_map(|res| match res {
+                Res::Item(ItemId::Function(func_id)) => Some(*func_id),
+                _ => None,
+            })
+            .collect(),
+        ExprKind::Member(base, method) => {
+            let ExprKind::Ident(resolutions) = &base.peel_parens().kind else { return vec![] };
+            let is_super = resolutions
+                .iter()
+                .any(|res| matches!(res, Res::Builtin(builtin) if builtin.name() == sym::super_));
+
+            let contracts: Vec<_> = if is_super {
+                bases.get(1..).unwrap_or_default().to_vec()
+            } else {
+                resolutions
+                    .iter()
+                    .filter_map(|res| match res {
+                        Res::Item(ItemId::Contract(cid)) => Some(*cid),
+                        _ => None,
+                    })
+                    .collect()
+            };
+
+            contracts
+                .into_iter()
+                .flat_map(|cid| hir.contract(cid).all_functions())
+                .filter(|&fid| {
+                    hir.function(fid).name.is_some_and(|name| name.as_str() == method.as_str())
+                })
+                .collect()
+        }
+        _ => vec![],
+    }
+}

--- a/crates/lint/src/sol/high/unprotected_initializer.rs
+++ b/crates/lint/src/sol/high/unprotected_initializer.rs
@@ -345,7 +345,12 @@ impl<'hir> CallNameFinder<'_, 'hir> {
     fn expr_calls_named(&mut self, expr: &'hir hir::Expr<'hir>) -> bool {
         match &expr.kind {
             ExprKind::Call(callee, args, opts) => {
-                if callee_name_is(self.hir, callee, self.name) {
+                let called_functions = resolved_internal_function_ids(self.hir, callee, self.bases);
+                if called_functions
+                    .iter()
+                    .copied()
+                    .any(|func_id| self.function_matches_name(func_id))
+                {
                     return true;
                 }
 
@@ -359,9 +364,14 @@ impl<'hir> CallNameFinder<'_, 'hir> {
                     return true;
                 }
 
-                resolved_internal_function_ids(self.hir, callee, self.bases)
-                    .into_iter()
-                    .any(|func_id| self.function_calls_named(func_id))
+                for func_id in called_functions {
+                    if self.function_belongs_to_bases(func_id) && self.function_calls_named(func_id)
+                    {
+                        return true;
+                    }
+                }
+
+                false
             }
             ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {
                 self.expr_calls_named(lhs) || self.expr_calls_named(rhs)
@@ -409,15 +419,17 @@ impl<'hir> CallNameFinder<'_, 'hir> {
         self.stack.pop();
         found
     }
-}
 
-fn callee_name_is(hir: &hir::Hir<'_>, callee: &hir::Expr<'_>, name: &str) -> bool {
-    match &callee.peel_parens().kind {
-        ExprKind::Ident(resolutions) => resolutions.iter().any(|res| {
-            matches!(res, Res::Item(ItemId::Function(fid)) if hir.function(*fid).name.is_some_and(|ident| ident.as_str() == name))
-        }),
-        ExprKind::Member(_, member) => member.as_str() == name,
-        _ => false,
+    fn function_matches_name(&self, func_id: FunctionId) -> bool {
+        self.function_belongs_to_bases(func_id)
+            && self.hir.function(func_id).name.is_some_and(|ident| ident.as_str() == self.name)
+    }
+
+    fn function_belongs_to_bases(&self, func_id: FunctionId) -> bool {
+        self.hir
+            .function(func_id)
+            .contract
+            .is_some_and(|contract_id| self.bases.iter().any(|&base_id| base_id == contract_id))
     }
 }
 

--- a/crates/lint/src/sol/high/unprotected_initializer.rs
+++ b/crates/lint/src/sol/high/unprotected_initializer.rs
@@ -429,7 +429,7 @@ impl<'hir> CallNameFinder<'_, 'hir> {
         self.hir
             .function(func_id)
             .contract
-            .is_some_and(|contract_id| self.bases.iter().any(|&base_id| base_id == contract_id))
+            .is_some_and(|contract_id| self.bases.contains(&contract_id))
     }
 }
 

--- a/crates/lint/src/sol/high/unprotected_initializer.rs
+++ b/crates/lint/src/sol/high/unprotected_initializer.rs
@@ -4,9 +4,12 @@ use crate::{
     sol::{Severity, SolLint},
 };
 use solar::{
-    ast::{ContractKind, StateMutability, Visibility},
-    interface::sym,
-    sema::hir::{self, ContractId, ExprKind, FunctionId, ItemId, Res, StmtKind, VariableId},
+    ast::{ContractKind, FunctionKind, StateMutability, Visibility},
+    interface::{Symbol, kw, sym},
+    sema::{
+        builtins::Builtin,
+        hir::{self, ContractId, ExprKind, FunctionId, ItemId, Res, StmtKind, VariableId},
+    },
 };
 use std::collections::HashSet;
 
@@ -43,11 +46,13 @@ impl<'hir> LateLintPass<'hir> for UnprotectedInitializer {
             return;
         }
 
+        if !has_destructive_entrypoint(hir, contract) {
+            return;
+        }
+
         for fid in contract.functions() {
             let func = hir.function(fid);
-            if !is_public_initializer(hir, func, upgradeable)
-                || has_modifier_named(hir, func, "onlyProxy")
-            {
+            if !is_public_initializer(hir, func) || has_modifier_named(hir, func, "onlyProxy") {
                 continue;
             }
 
@@ -61,42 +66,205 @@ impl<'hir> LateLintPass<'hir> for UnprotectedInitializer {
     }
 }
 
-fn is_public_initializer(hir: &hir::Hir<'_>, func: &hir::Function<'_>, upgradeable: bool) -> bool {
-    if !func.kind.is_function()
-        || !matches!(func.visibility, Visibility::Public | Visibility::External)
-        || matches!(func.state_mutability, StateMutability::Pure | StateMutability::View)
-    {
-        return false;
-    }
-
-    has_initializer_modifier(hir, func)
-        || (upgradeable && func.name.is_some_and(|name| is_initializer_name(name.as_str())))
-}
-
-fn is_initializer_name(name: &str) -> bool {
-    if matches!(name, "initialize" | "reinitialize") {
-        return true;
-    }
-
-    name.strip_prefix("initialize").is_some_and(|suffix| {
-        suffix
-            .chars()
-            .next()
-            .is_some_and(|c| c == '_' || c.is_ascii_digit() || c.is_ascii_uppercase())
-    }) || name.strip_prefix("reinitialize").is_some_and(|suffix| {
-        suffix
-            .chars()
-            .next()
-            .is_some_and(|c| c == '_' || c.is_ascii_digit() || c.is_ascii_uppercase())
-    })
+fn is_public_initializer(hir: &hir::Hir<'_>, func: &hir::Function<'_>) -> bool {
+    func.kind.is_function()
+        && matches!(func.visibility, Visibility::Public | Visibility::External)
+        && !matches!(func.state_mutability, StateMutability::Pure | StateMutability::View)
+        && has_initializer_modifier(hir, func)
 }
 
 fn initializers_disabled_in_constructor(hir: &hir::Hir<'_>, contract: &hir::Contract<'_>) -> bool {
     contract.linearized_bases.iter().filter_map(|&cid| hir.contract(cid).ctor).any(|ctor_id| {
         let ctor = hir.function(ctor_id);
         has_modifier_named(hir, ctor, "initializer")
-            || function_calls_named(hir, ctor, "_disableInitializers")
+            || function_calls_named(hir, ctor, contract.linearized_bases, "_disableInitializers")
     })
+}
+
+fn has_destructive_entrypoint(hir: &hir::Hir<'_>, contract: &hir::Contract<'_>) -> bool {
+    effective_runtime_dispatch_surface(hir, contract.linearized_bases).into_iter().any(|fid| {
+        let func = hir.function(fid);
+        if has_modifier_named(hir, func, "onlyProxy") {
+            return false;
+        }
+
+        let Some(body) = func.body else { return false };
+        let mut finder =
+            DestructiveSinkFinder { hir, bases: contract.linearized_bases, stack: vec![fid] };
+        finder.block_has_destructive_sink(body)
+    })
+}
+
+fn effective_runtime_dispatch_surface(hir: &hir::Hir<'_>, bases: &[ContractId]) -> Vec<FunctionId> {
+    let mut seen_functions: HashSet<(Symbol, String)> = HashSet::new();
+    let mut seen_fallback = false;
+    let mut seen_receive = false;
+    let mut entries = Vec::new();
+
+    for &cid in bases {
+        for fid in hir.contract(cid).all_functions() {
+            let func = hir.function(fid);
+            match func.kind {
+                FunctionKind::Function => {
+                    if !matches!(func.visibility, Visibility::Public | Visibility::External) {
+                        continue;
+                    }
+                    let Some(name) = func.name else { continue };
+                    if seen_functions.insert((name.name, parameter_signature(hir, func.parameters)))
+                    {
+                        entries.push(fid);
+                    }
+                }
+                FunctionKind::Fallback => {
+                    if !seen_fallback {
+                        seen_fallback = true;
+                        entries.push(fid);
+                    }
+                }
+                FunctionKind::Receive => {
+                    if !seen_receive {
+                        seen_receive = true;
+                        entries.push(fid);
+                    }
+                }
+                FunctionKind::Constructor | FunctionKind::Modifier => {}
+            }
+        }
+    }
+
+    entries
+}
+
+fn parameter_signature(hir: &hir::Hir<'_>, params: &[VariableId]) -> String {
+    params
+        .iter()
+        .map(|&param| format!("{:?}", hir.variable(param).ty.kind))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+struct DestructiveSinkFinder<'hir> {
+    hir: &'hir hir::Hir<'hir>,
+    bases: &'hir [ContractId],
+    stack: Vec<FunctionId>,
+}
+
+impl<'hir> DestructiveSinkFinder<'hir> {
+    fn block_has_destructive_sink(&mut self, block: hir::Block<'hir>) -> bool {
+        block.stmts.iter().any(|stmt| self.stmt_has_destructive_sink(stmt))
+    }
+
+    fn stmt_has_destructive_sink(&mut self, stmt: &'hir hir::Stmt<'hir>) -> bool {
+        match &stmt.kind {
+            StmtKind::DeclSingle(var_id) => self
+                .hir
+                .variable(*var_id)
+                .initializer
+                .is_some_and(|init| self.expr_has_destructive_sink(init)),
+            StmtKind::DeclMulti(_, expr)
+            | StmtKind::Emit(expr)
+            | StmtKind::Revert(expr)
+            | StmtKind::Return(Some(expr))
+            | StmtKind::Expr(expr) => self.expr_has_destructive_sink(expr),
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
+                self.block_has_destructive_sink(*block)
+            }
+            StmtKind::If(condition, then_stmt, else_stmt) => {
+                self.expr_has_destructive_sink(condition)
+                    || self.stmt_has_destructive_sink(then_stmt)
+                    || else_stmt.is_some_and(|stmt| self.stmt_has_destructive_sink(stmt))
+            }
+            StmtKind::Try(stmt_try) => {
+                self.expr_has_destructive_sink(&stmt_try.expr)
+                    || stmt_try
+                        .clauses
+                        .iter()
+                        .any(|clause| self.block_has_destructive_sink(clause.block))
+            }
+            StmtKind::Return(None)
+            | StmtKind::Break
+            | StmtKind::Continue
+            | StmtKind::Placeholder
+            | StmtKind::Err(_) => false,
+        }
+    }
+
+    fn expr_has_destructive_sink(&mut self, expr: &'hir hir::Expr<'hir>) -> bool {
+        match &expr.kind {
+            ExprKind::Call(callee, args, opts) => {
+                if is_destructive_call(callee) {
+                    return true;
+                }
+
+                if self.expr_has_destructive_sink(callee)
+                    || opts.is_some_and(|opts| {
+                        opts.iter().any(|opt| self.expr_has_destructive_sink(&opt.value))
+                    })
+                    || args.exprs().any(|arg| self.expr_has_destructive_sink(arg))
+                {
+                    return true;
+                }
+
+                resolved_internal_function_ids(self.hir, callee, self.bases)
+                    .into_iter()
+                    .any(|func_id| self.function_has_destructive_sink(func_id))
+            }
+            ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {
+                self.expr_has_destructive_sink(lhs) || self.expr_has_destructive_sink(rhs)
+            }
+            ExprKind::Unary(_, inner) | ExprKind::Delete(inner) | ExprKind::Payable(inner) => {
+                self.expr_has_destructive_sink(inner)
+            }
+            ExprKind::Index(base, index) => {
+                self.expr_has_destructive_sink(base)
+                    || index.is_some_and(|index| self.expr_has_destructive_sink(index))
+            }
+            ExprKind::Slice(base, start, end) => {
+                self.expr_has_destructive_sink(base)
+                    || start.is_some_and(|start| self.expr_has_destructive_sink(start))
+                    || end.is_some_and(|end| self.expr_has_destructive_sink(end))
+            }
+            ExprKind::Member(base, _) => self.expr_has_destructive_sink(base),
+            ExprKind::Ternary(condition, if_true, if_false) => {
+                self.expr_has_destructive_sink(condition)
+                    || self.expr_has_destructive_sink(if_true)
+                    || self.expr_has_destructive_sink(if_false)
+            }
+            ExprKind::Array(exprs) => exprs.iter().any(|expr| self.expr_has_destructive_sink(expr)),
+            ExprKind::Tuple(exprs) => {
+                exprs.iter().flatten().any(|expr| self.expr_has_destructive_sink(expr))
+            }
+            ExprKind::Lit(_)
+            | ExprKind::Ident(_)
+            | ExprKind::New(_)
+            | ExprKind::TypeCall(_)
+            | ExprKind::Type(_)
+            | ExprKind::Err(_) => false,
+        }
+    }
+
+    fn function_has_destructive_sink(&mut self, func_id: FunctionId) -> bool {
+        if self.stack.contains(&func_id) {
+            return false;
+        }
+
+        let func = self.hir.function(func_id);
+        let Some(body) = func.body else { return false };
+        self.stack.push(func_id);
+        let found = self.block_has_destructive_sink(body);
+        self.stack.pop();
+        found
+    }
+}
+
+fn is_destructive_call(callee: &hir::Expr<'_>) -> bool {
+    match &callee.peel_parens().kind {
+        ExprKind::Member(_, member) => matches!(member.name, kw::Delegatecall | kw::Callcode),
+        ExprKind::Ident(resolutions) => {
+            resolutions.iter().any(|res| matches!(res, Res::Builtin(Builtin::Selfdestruct)))
+        }
+        _ => false,
+    }
 }
 
 fn has_initializer_modifier(hir: &hir::Hir<'_>, func: &hir::Function<'_>) -> bool {
@@ -115,9 +283,14 @@ fn modifier_name_is(hir: &hir::Hir<'_>, modifier: &hir::Modifier<'_>, name: &str
     }
 }
 
-fn function_calls_named(hir: &hir::Hir<'_>, func: &hir::Function<'_>, name: &str) -> bool {
+fn function_calls_named(
+    hir: &hir::Hir<'_>,
+    func: &hir::Function<'_>,
+    bases: &[ContractId],
+    name: &str,
+) -> bool {
     let Some(body) = func.body else { return false };
-    let mut finder = CallNameFinder { hir, name, bases: &[], stack: vec![] };
+    let mut finder = CallNameFinder { hir, name, bases, stack: vec![] };
     finder.block_calls_named(body)
 }
 

--- a/crates/lint/src/sol/high/unprotected_initializer.rs
+++ b/crates/lint/src/sol/high/unprotected_initializer.rs
@@ -76,8 +76,7 @@ fn is_public_initializer(hir: &hir::Hir<'_>, func: &hir::Function<'_>) -> bool {
 fn initializers_disabled_in_constructor(hir: &hir::Hir<'_>, contract: &hir::Contract<'_>) -> bool {
     contract.linearized_bases.iter().filter_map(|&cid| hir.contract(cid).ctor).any(|ctor_id| {
         let ctor = hir.function(ctor_id);
-        has_modifier_named(hir, ctor, "initializer")
-            || function_calls_named(hir, ctor, contract.linearized_bases, "_disableInitializers")
+        function_calls_named(hir, ctor, contract.linearized_bases, "_disableInitializers")
     })
 }
 

--- a/crates/lint/testdata/UnprotectedInitializer.sol
+++ b/crates/lint/testdata/UnprotectedInitializer.sol
@@ -143,6 +143,27 @@ contract ProtectedThroughHelper is Initializable {
     }
 }
 
+library UnrelatedInitializerLock {
+    function _disableInitializers() internal pure {}
+}
+
+contract UnrelatedInitializerLockCall is Initializable {
+    address public owner;
+
+    constructor() {
+        UnrelatedInitializerLock._disableInitializers();
+    }
+
+    function initialize(address owner_) public initializer { //~WARN: upgradeable initializer is not protected against direct implementation calls
+        owner = owner_;
+    }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
+    }
+}
+
 contract OnlyProxyInitializer is Initializable {
     address public owner;
 

--- a/crates/lint/testdata/UnprotectedInitializer.sol
+++ b/crates/lint/testdata/UnprotectedInitializer.sol
@@ -224,3 +224,43 @@ contract NonUpgradeableInitializeName {
         owner = owner_;
     }
 }
+
+contract InheritedInitializerBase is Initializable {
+    address public owner;
+
+    function initialize(address owner_) public initializer { //~WARN: upgradeable initializer is not protected against direct implementation calls
+        owner = owner_;
+    }
+}
+
+contract InheritedInitializerDerived is InheritedInitializerBase {
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
+    }
+}
+
+contract StorageAliasInitializer is Initializable {
+    struct Layout {
+        address owner;
+    }
+
+    bytes32 private constant SLOT = keccak256("foundry.storage.alias.initializer");
+
+    function _getLayout() private pure returns (Layout storage s) {
+        bytes32 slot = SLOT;
+        assembly {
+            s.slot := slot
+        }
+    }
+
+    function initialize(address owner_) public initializer { //~WARN: upgradeable initializer is not protected against direct implementation calls
+        Layout storage s = _getLayout();
+        s.owner = owner_;
+    }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
+    }
+}

--- a/crates/lint/testdata/UnprotectedInitializer.sol
+++ b/crates/lint/testdata/UnprotectedInitializer.sol
@@ -1,0 +1,134 @@
+//@compile-flags: --only-lint unprotected-initializer
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+abstract contract Initializable {
+    bool private _initialized;
+
+    modifier initializer() {
+        _;
+    }
+
+    modifier reinitializer(uint64) {
+        _;
+    }
+
+    modifier onlyInitializing() {
+        _;
+    }
+
+    function _disableInitializers() internal {
+        _initialized = true;
+    }
+}
+
+contract UnprotectedInitializer is Initializable {
+    address public owner;
+
+    function initialize(address owner_) public initializer { //~WARN: upgradeable initializer is not protected against direct implementation calls
+        owner = owner_;
+    }
+}
+
+contract UnprotectedReinitializer is Initializable {
+    uint256 public fee;
+
+    function initializeV2(uint256 fee_) external reinitializer(2) { //~WARN: upgradeable initializer is not protected against direct implementation calls
+        fee = fee_;
+    }
+}
+
+contract UnprotectedNamedInitialize is Initializable {
+    address public admin;
+
+    function initialize(address admin_) external { //~WARN: upgradeable initializer is not protected against direct implementation calls
+        admin = admin_;
+    }
+}
+
+contract UnprotectedInternalWrite is Initializable {
+    address public owner;
+
+    function initialize(address owner_) public initializer { //~WARN: upgradeable initializer is not protected against direct implementation calls
+        _setOwner(owner_);
+    }
+
+    function _setOwner(address owner_) internal {
+        owner = owner_;
+    }
+}
+
+contract UnprotectedArrayWrite is Initializable {
+    address[] public owners;
+
+    function initialize(address owner_) public initializer { //~WARN: upgradeable initializer is not protected against direct implementation calls
+        owners.push(owner_);
+    }
+}
+
+contract ProtectedDisableInitializers is Initializable {
+    address public owner;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address owner_) public initializer {
+        owner = owner_;
+    }
+}
+
+contract ProtectedConstructorInitializer is Initializable {
+    address public owner;
+
+    constructor() initializer {}
+
+    function initialize(address owner_) public initializer {
+        owner = owner_;
+    }
+}
+
+contract ProtectedThroughHelper is Initializable {
+    address public owner;
+
+    constructor() {
+        _lockImplementation();
+    }
+
+    function _lockImplementation() internal {
+        _disableInitializers();
+    }
+
+    function initialize(address owner_) public initializer {
+        owner = owner_;
+    }
+}
+
+contract OnlyProxyInitializer is Initializable {
+    address public owner;
+
+    modifier onlyProxy() {
+        _;
+    }
+
+    function initialize(address owner_) external initializer onlyProxy {
+        owner = owner_;
+    }
+}
+
+contract NoStateWriteInitializer is Initializable {
+    event Initialized(address indexed account);
+
+    function initialize(address account) external initializer {
+        emit Initialized(account);
+    }
+}
+
+contract NonUpgradeableInitializeName {
+    address public owner;
+
+    function initialize(address owner_) external {
+        owner = owner_;
+    }
+}

--- a/crates/lint/testdata/UnprotectedInitializer.sol
+++ b/crates/lint/testdata/UnprotectedInitializer.sol
@@ -112,13 +112,18 @@ contract ProtectedDisableInitializers is Initializable {
     }
 }
 
-contract ProtectedConstructorInitializer is Initializable {
-    address public owner;
+contract ConstructorInitializerReinitializer is Initializable {
+    uint256 public fee;
 
     constructor() initializer {}
 
-    function initialize(address owner_) public initializer {
-        owner = owner_;
+    function initializeV2(uint256 fee_) external reinitializer(2) { //~WARN: upgradeable initializer is not protected against direct implementation calls
+        fee = fee_;
+    }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
     }
 }
 

--- a/crates/lint/testdata/UnprotectedInitializer.sol
+++ b/crates/lint/testdata/UnprotectedInitializer.sol
@@ -29,6 +29,11 @@ contract UnprotectedInitializer is Initializable {
     function initialize(address owner_) public initializer { //~WARN: upgradeable initializer is not protected against direct implementation calls
         owner = owner_;
     }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
+    }
 }
 
 contract UnprotectedReinitializer is Initializable {
@@ -37,13 +42,23 @@ contract UnprotectedReinitializer is Initializable {
     function initializeV2(uint256 fee_) external reinitializer(2) { //~WARN: upgradeable initializer is not protected against direct implementation calls
         fee = fee_;
     }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
+    }
 }
 
 contract UnprotectedNamedInitialize is Initializable {
     address public admin;
 
-    function initialize(address admin_) external { //~WARN: upgradeable initializer is not protected against direct implementation calls
+    function initialize(address admin_) external {
         admin = admin_;
+    }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
     }
 }
 
@@ -57,6 +72,11 @@ contract UnprotectedInternalWrite is Initializable {
     function _setOwner(address owner_) internal {
         owner = owner_;
     }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
+    }
 }
 
 contract UnprotectedArrayWrite is Initializable {
@@ -64,6 +84,19 @@ contract UnprotectedArrayWrite is Initializable {
 
     function initialize(address owner_) public initializer { //~WARN: upgradeable initializer is not protected against direct implementation calls
         owners.push(owner_);
+    }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
+    }
+}
+
+contract NoDestructiveSink is Initializable {
+    address public owner;
+
+    function initialize(address owner_) public initializer {
+        owner = owner_;
     }
 }
 
@@ -115,6 +148,55 @@ contract OnlyProxyInitializer is Initializable {
     function initialize(address owner_) external initializer onlyProxy {
         owner = owner_;
     }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
+    }
+}
+
+contract OnlyProxySink is Initializable {
+    address public owner;
+
+    modifier onlyProxy() {
+        _;
+    }
+
+    function initialize(address owner_) external initializer {
+        owner = owner_;
+    }
+
+    function execute(address target, bytes calldata data) external onlyProxy {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
+    }
+}
+
+contract DangerousBase {
+    function execute(address target, bytes calldata data) external virtual {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
+    }
+}
+
+contract OverridesDangerousBase is Initializable, DangerousBase {
+    address public owner;
+
+    function initialize(address owner_) external initializer {
+        owner = owner_;
+    }
+
+    function execute(address, bytes calldata) external pure override {}
+}
+
+contract OverloadedDangerousBase is Initializable, DangerousBase {
+    address public owner;
+
+    function initialize(address owner_) external initializer { //~WARN: upgradeable initializer is not protected against direct implementation calls
+        owner = owner_;
+    }
+
+    function execute(uint256, bytes calldata) external pure {}
 }
 
 contract NoStateWriteInitializer is Initializable {
@@ -122,6 +204,11 @@ contract NoStateWriteInitializer is Initializable {
 
     function initialize(address account) external initializer {
         emit Initialized(account);
+    }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
     }
 }
 

--- a/crates/lint/testdata/UnprotectedInitializer.stderr
+++ b/crates/lint/testdata/UnprotectedInitializer.stderr
@@ -1,0 +1,40 @@
+warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
+   ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
+   │
+LL │     function initialize(address owner_) public initializer {
+   │              ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
+
+warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
+   ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
+   │
+LL │     function initializeV2(uint256 fee_) external reinitializer(2) {
+   │              ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
+
+warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
+   ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
+   │
+LL │     function initialize(address admin_) external {
+   │              ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
+
+warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
+   ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
+   │
+LL │     function initialize(address owner_) public initializer {
+   │              ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
+
+warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
+   ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
+   │
+LL │     function initialize(address owner_) public initializer {
+   │              ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
+

--- a/crates/lint/testdata/UnprotectedInitializer.stderr
+++ b/crates/lint/testdata/UnprotectedInitializer.stderr
@@ -41,6 +41,14 @@ LL │     function initializeV2(uint256 fee_) external reinitializer(2) {
 warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
    ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
    │
+LL │     function initialize(address owner_) public initializer {
+   │              ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
+
+warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
+   ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
+   │
 LL │     function initialize(address owner_) external initializer {
    │              ━━━━━━━━━━
    │

--- a/crates/lint/testdata/UnprotectedInitializer.stderr
+++ b/crates/lint/testdata/UnprotectedInitializer.stderr
@@ -33,6 +33,14 @@ LL │     function initialize(address owner_) public initializer {
 warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
    ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
    │
+LL │     function initializeV2(uint256 fee_) external reinitializer(2) {
+   │              ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
+
+warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
+   ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
+   │
 LL │     function initialize(address owner_) external initializer {
    │              ━━━━━━━━━━
    │

--- a/crates/lint/testdata/UnprotectedInitializer.stderr
+++ b/crates/lint/testdata/UnprotectedInitializer.stderr
@@ -46,3 +46,19 @@ LL │     function initialize(address owner_) external initializer {
    │
    ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
 
+warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
+   ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
+   │
+LL │     function initialize(address owner_) public initializer {
+   │              ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
+
+warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
+   ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
+   │
+LL │     function initialize(address owner_) public initializer {
+   │              ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
+

--- a/crates/lint/testdata/UnprotectedInitializer.stderr
+++ b/crates/lint/testdata/UnprotectedInitializer.stderr
@@ -17,14 +17,6 @@ LL │     function initializeV2(uint256 fee_) external reinitializer(2) {
 warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
    ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
    │
-LL │     function initialize(address admin_) external {
-   │              ━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
-
-warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
-   ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
-   │
 LL │     function initialize(address owner_) public initializer {
    │              ━━━━━━━━━━
    │
@@ -34,6 +26,14 @@ warning[unprotected-initializer]: upgradeable initializer is not protected again
    ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
    │
 LL │     function initialize(address owner_) public initializer {
+   │              ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
+
+warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
+   ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
+   │
+LL │     function initialize(address owner_) external initializer {
    │              ━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer


### PR DESCRIPTION
## Summary
- add a high-severity `unprotected-initializer` lint for upgradeable implementations
- flag public/external initializer-like functions that write state when the implementation constructor does not lock initializers
- add lint docs/book counterpart and UI fixture coverage