### PR TITLE
fix(anvil): align CLI mining default with NodeConfig

### DIFF
--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -180,9 +180,10 @@ pub async fn try_spawn(mut config: NodeConfig) -> Result<(EthApi<FoundryNetwork>
     } else if no_mining {
         MiningMode::None
     } else {
-        // get a listener for ready transactions
-        let listener = pool.add_ready_listener();
-        MiningMode::instant(max_transactions, listener)
+        // Default to manual mining (no auto-mine)
+        // This aligns CLI behavior with NodeConfig::default() expectations
+        // Users can enable auto-mining via --block-time or evm_setAutomine RPC
+        MiningMode::None
     };
 
     let miner = match &fork {


### PR DESCRIPTION
## Summary

Fixes #14867 

Aligns the CLI binary's default mining mode with `NodeConfig::default()` by changing from instant auto-mining to manual mining (`MiningMode::None`).

## Root Cause

The divergence occurred in `crates/anvil/src/lib.rs` (lines 182-186). When neither `block_time` nor `no_mining` was set, the CLI defaulted to `MiningMode::instant()`, which mined a new block per transaction.

## Changes

- Changed default mining mode from `MiningMode::instant(max_transactions, listener)` to `MiningMode::None`
- Added clarifying comments explaining the behavior

## Testing

Manual testing confirms:
- **Before:** TX 1 → Block N, TX 2 → Block N+1 (instant mining)
- **After:** TX 1 + TX 2 queued, `evm_mine` → Both in Block N ✅

## Breaking Change

This is a **breaking change** for users who relied on auto-mining. Migration options:

1. Use `--block-time` for interval mining:
```bash
   anvil --block-time 1
```

2. Enable auto-mine via RPC:
```bash
   curl -X POST http://localhost:8545 \
     -d '{"jsonrpc":"2.0","method":"evm_setAutomine","params":[true],"id":1}'
```

3. Use `evm_mine` manually after transactions

## Checklist

- [x] Code change implemented
- [x] Manual testing completed
- [ ] CHANGELOG entry (will add after approval)