### PR TITLE
fix(anvil): coalesce concurrent txs into one block

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -126,9 +126,9 @@ pub struct NodeConfig {
     pub genesis_block_number: Option<u64>,
     /// Signer accounts that can sign messages/transactions from the EVM node
     pub signer_accounts: Vec<PrivateKeySigner>,
-    /// Configured block time for the EVM chain. Use `None` to mine a new block for every tx
+    /// Configured block time for the EVM chain. Use `None` for instant/auto mining.
     pub block_time: Option<Duration>,
-    /// Disable auto, interval mining mode uns use `MiningMode::None` instead
+    /// Disable auto and interval mining mode and use `MiningMode::None` instead.
     pub no_mining: bool,
     /// Enables auto and interval mining mode
     pub mixed_mining: bool,

--- a/crates/anvil/src/eth/miner.rs
+++ b/crates/anvil/src/eth/miner.rs
@@ -10,11 +10,16 @@ use futures::{
 use parking_lot::{RawRwLock, RwLock, lock_api::RwLockWriteGuard};
 use std::{
     fmt,
+    pin::Pin,
     sync::Arc,
     task::{Context, Poll},
     time::Duration,
 };
-use tokio::time::{Interval, MissedTickBehavior};
+use tokio::time::{Interval, MissedTickBehavior, Sleep};
+
+/// Window for grouping concurrently-submitted transactions into one instant-mined block.
+/// Scoped to batch/in-process concurrency; not a guarantee for independent external clients.
+const INSTANT_COALESCE_WINDOW: Duration = Duration::from_millis(5);
 
 pub struct Miner<T> {
     /// The mode this miner currently operates in
@@ -163,6 +168,7 @@ impl MiningMode {
             max_transactions,
             has_pending_txs: None,
             rx: listener.fuse(),
+            coalesce: None,
         })
     }
 
@@ -172,7 +178,12 @@ impl MiningMode {
 
     pub fn mixed(max_transactions: usize, listener: Receiver<TxHash>, duration: Duration) -> Self {
         Self::Mixed(
-            ReadyTransactionMiner { max_transactions, has_pending_txs: None, rx: listener.fuse() },
+            ReadyTransactionMiner {
+                max_transactions,
+                has_pending_txs: None,
+                rx: listener.fuse(),
+                coalesce: None,
+            },
             FixedBlockTimeMiner::new(duration),
         )
     }
@@ -262,6 +273,8 @@ pub struct ReadyTransactionMiner {
     has_pending_txs: Option<bool>,
     /// Receives hashes of transactions that are ready
     rx: Fuse<Receiver<TxHash>>,
+    /// Active [`INSTANT_COALESCE_WINDOW`] timer; while pending, ready txs are accumulated.
+    coalesce: Option<Pin<Box<Sleep>>>,
 }
 
 impl ReadyTransactionMiner {
@@ -271,13 +284,30 @@ impl ReadyTransactionMiner {
         cx: &mut Context<'_>,
     ) -> Poll<Vec<Arc<PoolTransaction<T>>>> {
         // always drain the notification stream so that we're woken up as soon as there's a new tx
+        let mut saw_new_ready = false;
         while let Poll::Ready(Some(_hash)) = self.rx.poll_next_unpin(cx) {
+            saw_new_ready = true;
+        }
+
+        // Arm the coalescing window only on fresh notifications to avoid delaying
+        // consecutive chunks when draining a backlog larger than `max_transactions`.
+        if saw_new_ready {
             self.has_pending_txs = Some(true);
+            if self.coalesce.is_none() {
+                self.coalesce = Some(Box::pin(tokio::time::sleep(INSTANT_COALESCE_WINDOW)));
+            }
         }
 
         if self.has_pending_txs == Some(false) {
             return Poll::Pending;
         }
+
+        if let Some(sleep) = self.coalesce.as_mut()
+            && sleep.as_mut().poll(cx).is_pending()
+        {
+            return Poll::Pending;
+        }
+        self.coalesce = None;
 
         let transactions =
             pool.ready_transactions().take(self.max_transactions).collect::<Vec<_>>();
@@ -286,6 +316,7 @@ impl ReadyTransactionMiner {
         self.has_pending_txs = Some(transactions.len() >= self.max_transactions);
 
         if transactions.is_empty() {
+            self.has_pending_txs = Some(false);
             return Poll::Pending;
         }
 

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -669,8 +669,8 @@ async fn flaky_test_reorg() {
 
     let accounts = handle.dev_wallets().collect::<Vec<_>>();
 
-    // Test calls
-    // Populate chain
+    // Populate with deterministic block boundaries: disable automine, batch 2 txs, mine.
+    api.anvil_set_auto_mine(false).await.unwrap();
     for i in 0..10 {
         let tx = TransactionRequest::default()
             .to(accounts[0].address())
@@ -685,7 +685,10 @@ async fn flaky_test_reorg() {
             .from(accounts[2].address());
         let tx = WithOtherFields::new(tx);
         api.send_transaction(tx).await.unwrap();
+
+        api.evm_mine(None).await.unwrap();
     }
+    api.anvil_set_auto_mine(true).await.unwrap();
 
     // Define transactions
     let mut txs = vec![];
@@ -699,20 +702,22 @@ async fn flaky_test_reorg() {
     }
 
     let prev_height = provider.get_block_number().await.unwrap();
-    api.anvil_reorg(ReorgOptions { depth: 7, tx_block_pairs: txs }).await.unwrap();
+    let depth = 7u64;
+    api.anvil_reorg(ReorgOptions { depth, tx_block_pairs: txs }).await.unwrap();
 
     let reorged_height = provider.get_block_number().await.unwrap();
     assert_eq!(reorged_height, prev_height);
 
-    // The first 3 reorged blocks should have 5 transactions each
-    for num in 14..17 {
+    // The 3 reorged blocks (one per `tx_block_pairs` group) should each hold 5 txs.
+    let first_reorged = prev_height - depth + 1;
+    for num in first_reorged..first_reorged + 3 {
         let block = provider.get_block_by_number(num.into()).full().await.unwrap();
         let block = block.unwrap();
         assert_eq!(block.transactions.len(), 5);
     }
 
-    // Verify that historic blocks are still accessible
-    for num in (0..14).rev() {
+    // Verify that historic blocks below the reorged range are still accessible
+    for num in (0..first_reorged).rev() {
         let block = provider.get_block_by_number(num.into()).full().await.unwrap();
         assert!(block.is_some(), "Historic block {num} should be accessible after reorg");
     }

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -18,7 +18,10 @@ use eyre::Ok;
 use foundry_evm::hardfork::EthereumHardfork;
 use futures::{FutureExt, StreamExt, future::join_all};
 use revm::primitives::eip7825::TX_GAS_LIMIT_CAP;
-use std::{str::FromStr, time::Duration};
+use std::{
+    str::FromStr,
+    time::{Duration, Instant},
+};
 use tokio::time::timeout;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1551,4 +1554,148 @@ async fn can_get_tx_by_sender_and_nonce() {
     assert!(result.is_some());
     let found_tx = result.unwrap();
     assert_eq!(found_tx.inner.nonce(), 4);
+}
+
+// Instant-mine coalescing regression tests.
+
+/// Polls `eth_getTransactionReceipt` until a block number is available.
+async fn poll_receipt_block(client: &reqwest::Client, endpoint: &str, tx_hash: &str) -> u64 {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let payload = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_getTransactionReceipt",
+            "params": [tx_hash],
+        });
+        let resp: serde_json::Value =
+            client.post(endpoint).json(&payload).send().await.unwrap().json().await.unwrap();
+        if let Some(receipt) = resp.get("result").and_then(|r| r.as_object())
+            && let Some(block_hex) = receipt.get("blockNumber").and_then(|b| b.as_str())
+        {
+            return u64::from_str_radix(block_hex.trim_start_matches("0x"), 16).unwrap();
+        }
+        assert!(Instant::now() < deadline, "timed out waiting for receipt of {tx_hash}");
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// Txs in one JSON-RPC batch POST must share a block.
+#[tokio::test(flavor = "multi_thread")]
+async fn instant_mine_groups_json_rpc_batch_in_one_block() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    let from1 = accounts[1].address();
+    let from2 = accounts[2].address();
+    let to = accounts[0].address();
+
+    let batch = serde_json::json!([
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_sendTransaction",
+            "params": [{"from": from1, "to": to, "value": "0x1"}]
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "eth_sendTransaction",
+            "params": [{"from": from2, "to": to, "value": "0x1"}]
+        }
+    ]);
+
+    let client = reqwest::Client::new();
+    let resp: serde_json::Value =
+        client.post(&endpoint).json(&batch).send().await.unwrap().json().await.unwrap();
+
+    let arr = resp.as_array().expect("expected JSON-RPC batch response");
+    assert_eq!(arr.len(), 2);
+    let hashes: Vec<String> = arr
+        .iter()
+        .map(|r| r.get("result").expect("expected result").as_str().unwrap().to_owned())
+        .collect();
+
+    let mut blocks = Vec::new();
+    for hash in &hashes {
+        let block = poll_receipt_block(&client, &endpoint, hash).await;
+        blocks.push(block);
+    }
+
+    assert_eq!(
+        blocks[0], blocks[1],
+        "batched eth_sendTransaction txs landed in different blocks ({blocks:?})"
+    );
+}
+
+/// Txs from in-process parallel HTTP requests must share a block.
+#[tokio::test(flavor = "multi_thread")]
+async fn instant_mine_groups_in_process_parallel_http_in_one_block() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    let from1 = accounts[1].address();
+    let from2 = accounts[2].address();
+    let to = accounts[0].address();
+
+    let client = reqwest::Client::new();
+
+    let send = |from: Address, id: u64| {
+        let client = client.clone();
+        let endpoint = endpoint.clone();
+        async move {
+            let payload = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "eth_sendTransaction",
+                "params": [{"from": from, "to": to, "value": "0x1"}],
+            });
+            let resp: serde_json::Value =
+                client.post(&endpoint).json(&payload).send().await.unwrap().json().await.unwrap();
+            resp.get("result").unwrap().as_str().unwrap().to_owned()
+        }
+    };
+
+    let (h1, h2) = tokio::join!(send(from1, 1), send(from2, 2));
+
+    let b1 = poll_receipt_block(&client, &endpoint, &h1).await;
+    let b2 = poll_receipt_block(&client, &endpoint, &h2).await;
+
+    assert_eq!(b1, b2, "parallel-HTTP txs landed in different blocks (b1={b1}, b2={b2})");
+}
+
+/// Sends spaced beyond the coalescing window must still mine in separate blocks.
+#[tokio::test(flavor = "multi_thread")]
+async fn instant_mine_does_not_group_sequential_sends_beyond_window() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    let from1 = accounts[1].address();
+    let from2 = accounts[2].address();
+    let to = accounts[0].address();
+    let client = reqwest::Client::new();
+
+    let send = |from: Address, id: u64| {
+        let client = client.clone();
+        let endpoint = endpoint.clone();
+        async move {
+            let payload = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "eth_sendTransaction",
+                "params": [{"from": from, "to": to, "value": "0x1"}],
+            });
+            let resp: serde_json::Value =
+                client.post(&endpoint).json(&payload).send().await.unwrap().json().await.unwrap();
+            resp.get("result").unwrap().as_str().unwrap().to_owned()
+        }
+    };
+
+    let h1 = send(from1, 1).await;
+    let b1 = poll_receipt_block(&client, &endpoint, &h1).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let h2 = send(from2, 2).await;
+    let b2 = poll_receipt_block(&client, &endpoint, &h2).await;
+
+    assert_ne!(b1, b2, "sequential sends with delay coalesced into the same block ({b1})");
 }


### PR DESCRIPTION
Fixes #14867.

`MiningMode::instant` could drain the pool between concurrent `eth_sendTransaction` insertions, splitting a JSON-RPC batch across multiple blocks. Adds a 5 ms coalescing window in `ReadyTransactionMiner` so near-simultaneous ready txs land in the same block. Sequential auto-mine is unchanged.