### PR TITLE
docs: update install curl URL to getfoundry.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Blazing fast, portable and modular toolkit for Ethereum application development,
 ## Installation
 
 ```sh
-curl -L https://foundry.paradigm.xyz | bash
+curl -L https://getfoundry.sh | bash
 foundryup
 ```
 


### PR DESCRIPTION
### What
Change the `curl` install command in `README.md` from `https://foundry.paradigm.xyz` to `https://getfoundry.sh`.

### Why
Every other link in the README already points to `getfoundry.sh` (the installation guide, all docs links, etc.). The curl snippet was the only place still referencing the old `foundry.paradigm.xyz` domain, creating an inconsistency for anyone copying the install command.

Small, scoped fix from kcolbchain contrib-bot.