### PR TITLE
chore: remove redundant Bytes conversions

### DIFF
--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -203,7 +203,7 @@ pub trait Db:
             B256::from_slice(&keccak256(code.as_ref())[..])
         };
         info.code_hash = code_hash;
-        info.code = Some(Bytecode::new_raw(alloy_primitives::Bytes(code.0)));
+        info.code = Some(Bytecode::new_raw(code));
         self.insert_account(address, info);
         Ok(())
     }
@@ -243,7 +243,7 @@ pub trait Db:
                     code: if account.code.0.is_empty() {
                         None
                     } else {
-                        Some(Bytecode::new_raw(alloy_primitives::Bytes(account.code.0)))
+                        Some(Bytecode::new_raw(account.code))
                     },
                     nonce,
                     account_id: None,

--- a/crates/evm/fuzz/src/inspector.rs
+++ b/crates/evm/fuzz/src/inspector.rs
@@ -140,7 +140,7 @@ impl Fuzzer {
         }
 
         // Replace the call with a reentrant callback
-        call.input = CallInput::Bytes(tx.call_details.calldata.0.into());
+        call.input = CallInput::Bytes(tx.call_details.calldata);
         call.caller = tx.sender;
         call.target_address = tx.call_details.target;
         call.bytecode_address = tx.call_details.target;


### PR DESCRIPTION
## Motivation

A few paths still unpack `alloy_primitives::Bytes` through `.0` and wrap or convert the inner bytes back into the same `Bytes` type. The target APIs already accept `Bytes`, so the extra tuple-field access obscures that the value can be forwarded directly.

## Solution

Pass the existing `Bytes` values directly when constructing Anvil bytecode and fuzz reentrancy call input.