### PR TITLE
refactor(symbolic): replace `String` errors in solver config with `enum`

### DIFF
--- a/crates/config/src/inline/natspec.rs
+++ b/crates/config/src/inline/natspec.rs
@@ -221,7 +221,8 @@ fn translate_halmos_config(args: &str, values: &mut Vec<String>) -> Result<(), S
 }
 
 fn split_halmos_args(args: &str) -> Result<Vec<String>, String> {
-    split_quoted_args(args, "@custom:halmos config")
+    split_quoted_args(args)
+        .map_err(|quote_ch| format!("unterminated {quote_ch} quote in @custom:halmos config"))
 }
 
 fn halmos_numeric_symbolic_field(flag: &str) -> Option<&'static str> {
@@ -1011,5 +1012,11 @@ contract SymbolicHalmosLengths {
             natspecs[0].halmos_config_values().unwrap(),
             vec!["default.symbolic.array_lengths = [3]"]
         );
+    }
+
+    #[test]
+    fn split_halmos_args_rejects_unterminated_quote() {
+        let err = split_halmos_args(r#"--width "unterm"#).unwrap_err();
+        assert_eq!(err, r#"unterminated " quote in @custom:halmos config"#);
     }
 }

--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -123,7 +123,9 @@ pub fn to_array_value(val: &str) -> Result<Value, figment::Error> {
 /// This supports whitespace separation, single and double quotes, and backslash escaping. It is
 /// intentionally smaller than a shell parser: expansions, redirection, pipelines, and command
 /// separators are treated as plain argument text by callers.
-pub fn split_quoted_args(args: &str, context: &str) -> Result<Vec<String>, String> {
+///
+/// Returns `Err(quote_char)` when the input contains an unterminated quote.
+pub fn split_quoted_args(args: &str) -> Result<Vec<String>, char> {
     let mut parts = Vec::new();
     let mut current = String::new();
     let mut quote = None;
@@ -166,7 +168,7 @@ pub fn split_quoted_args(args: &str, context: &str) -> Result<Vec<String>, Strin
     }
 
     if let Some(quote_ch) = quote {
-        return Err(format!("unterminated {quote_ch} quote in {context}"));
+        return Err(quote_ch);
     }
     if escaped {
         current.push('\\');

--- a/crates/evm/symbolic/src/runtime.rs
+++ b/crates/evm/symbolic/src/runtime.rs
@@ -25,7 +25,7 @@ pub(crate) use solver::{
 };
 #[cfg(test)]
 pub(crate) use solver::{
-    SolverCommand, SolverOutcome, SolverRunSummary, fallback_single_var_model,
+    SolverCommand, SolverConfigError, SolverOutcome, SolverRunSummary, fallback_single_var_model,
     named_solver_command, parse_model, solver_commands_for_config, split_solver_command,
     validate_solver_model_output,
 };

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -1,5 +1,16 @@
 use super::*;
 
+/// Errors that arise when parsing or constructing solver commands from configuration.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SolverConfigError {
+    /// The command string parsed to an empty argv.
+    #[error("symbolic solver command is empty")]
+    EmptyCommand,
+    /// The command string contains an unterminated quote character.
+    #[error("unterminated {0} quote in symbolic solver command")]
+    UnterminatedQuote(char),
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum SolverOutcome {
     Cancelled,
@@ -96,10 +107,10 @@ pub(crate) struct SolverCommand {
 
 impl SolverCommand {
     /// Constructs a solver command from a program plus arguments.
-    pub(crate) fn new(parts: Vec<String>, smt_timeout: bool) -> Result<Self, String> {
+    pub(crate) fn new(parts: Vec<String>, smt_timeout: bool) -> Result<Self, SolverConfigError> {
         let mut parts = parts.into_iter();
         let Some(program) = parts.next().filter(|part| !part.is_empty()) else {
-            return Err("symbolic solver command is empty".to_string());
+            return Err(SolverConfigError::EmptyCommand);
         };
         let args = parts.collect::<Vec<_>>();
         let display = std::iter::once(program.as_str())
@@ -111,7 +122,7 @@ impl SolverCommand {
 }
 
 pub(crate) struct SmtLibSubprocessSolver {
-    pub(crate) commands: Result<Vec<SolverCommand>, String>,
+    pub(crate) commands: Result<Vec<SolverCommand>, SolverConfigError>,
     pub(crate) timeout: Option<u32>,
     pub(crate) max_queries: usize,
     pub(crate) queries: usize,
@@ -125,7 +136,7 @@ pub(crate) struct SmtLibSubprocessSolver {
 impl SmtLibSubprocessSolver {
     /// Constructs a new instance.
     pub(crate) fn new(
-        commands: Result<Vec<SolverCommand>, String>,
+        commands: Result<Vec<SolverCommand>, SolverConfigError>,
         timeout: Option<u32>,
         max_queries: usize,
         dump_smt: bool,
@@ -243,7 +254,10 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
 impl SmtLibSubprocessSolver {
     /// Returns the resolved commands or the stored config error.
     pub(crate) fn commands(&self) -> Result<&[SolverCommand], SymbolicError> {
-        self.commands.as_ref().map(Vec::as_slice).map_err(|err| SymbolicError::Solver(err.clone()))
+        self.commands
+            .as_ref()
+            .map(Vec::as_slice)
+            .map_err(|err| SymbolicError::Solver(err.to_string()))
     }
 
     /// Emits one verbose solver diagnostic either live or into the deferred buffer.
@@ -433,7 +447,7 @@ impl PortfolioScheduler {
 /// Returns the subprocess commands for the configured SMT solver setup.
 pub(crate) fn solver_commands_for_config(
     config: &SymbolicConfig,
-) -> Result<Vec<SolverCommand>, String> {
+) -> Result<Vec<SolverCommand>, SolverConfigError> {
     if let Some(command) = config.solver_command.as_deref().filter(|command| !command.is_empty()) {
         return Ok(vec![SolverCommand::new(split_solver_command(command)?, false)?]);
     }
@@ -483,7 +497,7 @@ pub(crate) fn solver_portfolio_availability_warning(config: &SymbolicConfig) -> 
 }
 
 /// Returns the default command for a known solver name.
-pub(crate) fn named_solver_command(solver: &str) -> Result<SolverCommand, String> {
+pub(crate) fn named_solver_command(solver: &str) -> Result<SolverCommand, SolverConfigError> {
     let (parts, smt_timeout) = match solver {
         "z3" => (vec!["z3", "-in", "-smt2"], true),
         "yices" => (vec!["yices-smt2", "--bvconst-in-decimal"], false),
@@ -519,7 +533,9 @@ pub(crate) fn named_solver_command(solver: &str) -> Result<SolverCommand, String
 }
 
 /// Returns the command for one configured portfolio entry.
-pub(crate) fn solver_command_for_portfolio_entry(entry: &str) -> Result<SolverCommand, String> {
+pub(crate) fn solver_command_for_portfolio_entry(
+    entry: &str,
+) -> Result<SolverCommand, SolverConfigError> {
     if entry.chars().any(|ch| ch.is_whitespace() || matches!(ch, '"' | '\'' | '\\')) {
         SolverCommand::new(split_solver_command(entry)?, false)
     } else {
@@ -528,10 +544,10 @@ pub(crate) fn solver_command_for_portfolio_entry(entry: &str) -> Result<SolverCo
 }
 
 /// Splits a shell-like solver command into argv parts.
-pub(crate) fn split_solver_command(command: &str) -> Result<Vec<String>, String> {
-    let parts = split_quoted_args(command, "symbolic solver command")?;
+pub(crate) fn split_solver_command(command: &str) -> Result<Vec<String>, SolverConfigError> {
+    let parts = split_quoted_args(command).map_err(SolverConfigError::UnterminatedQuote)?;
     if parts.is_empty() {
-        return Err("symbolic solver command is empty".to_string());
+        return Err(SolverConfigError::EmptyCommand);
     }
 
     Ok(parts)

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2038,6 +2038,30 @@ fn split_solver_command_preserves_empty_quoted_args() {
 }
 
 #[test]
+/// Regression coverage for `split_solver_command_rejects_unterminated_double_quote`.
+fn split_solver_command_rejects_unterminated_double_quote() {
+    let err = split_solver_command(r#"z3 "unterm"#).unwrap_err();
+
+    assert!(
+        matches!(err, SolverConfigError::UnterminatedQuote('"')),
+        "expected UnterminatedQuote('\"'), got {err:?}"
+    );
+    assert_eq!(err.to_string(), r#"unterminated " quote in symbolic solver command"#);
+}
+
+#[test]
+/// Regression coverage for `split_solver_command_rejects_unterminated_single_quote`.
+fn split_solver_command_rejects_unterminated_single_quote() {
+    let err = split_solver_command("z3 'unterm").unwrap_err();
+
+    assert!(
+        matches!(err, SolverConfigError::UnterminatedQuote('\'')),
+        "expected UnterminatedQuote('\\''), got {err:?}"
+    );
+    assert_eq!(err.to_string(), "unterminated ' quote in symbolic solver command");
+}
+
+#[test]
 /// Regression coverage for `custom_solver_names_remain_z3_compatible`.
 fn custom_solver_names_remain_z3_compatible() {
     let commands = solver_commands_for_config(&SymbolicConfig {


### PR DESCRIPTION
## Motivation

Clean-up `String` based symbolic config errors

## Solution

Introduces `SolverConfigError` with `EmptyCommand` and `UnterminatedQuote(char)`
variants, replacing all `Result<T, String>`.

Also tightens `split_quoted_args` to return the offending `char` directly instead
of a pre-formatted string, letting callers own the message context.
