### PR TITLE
test: snapshot symbolic CLI output checks

### DIFF
--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -2,7 +2,7 @@ use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, str, util::OutputExt};
 use std::process::Command;
 
-use super::symbolic_helpers::assert_symbolic;
+use super::symbolic_helpers::{assert_relevant_lines, assert_symbolic};
 
 fn z3_available() -> bool {
     Command::new("z3").arg("--version").output().is_ok_and(|output| output.status.success())
@@ -26,7 +26,12 @@ contract SymbolicIgnored {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("No tests found") || stdout.contains("0 tests"));
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+No tests found
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_passes_scalar_test, |prj, cmd| {
@@ -50,8 +55,18 @@ contract SymbolicPass {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkNoop(uint256)"));
-    assert!(stdout.contains("(paths:"));
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkNoop(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+(paths:
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_loop_bound_limits_symbolic_unrolling, |prj, cmd| {
@@ -84,7 +99,12 @@ contract SymbolicLoopBound {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkLoopBound(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkLoopBound(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic depth limit exceeded"), "{stdout}");
 });
 
@@ -113,10 +133,30 @@ contract SymbolicAssert {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"));
-    assert!(stdout.contains("panic: assertion failed"));
-    assert!(stdout.contains("checkRejectsFortyTwo(uint256)"));
-    assert!(stdout.contains("args=[42]"));
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+panic: assertion failed
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkRejectsFortyTwo(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=[42]
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_finds_wrapping_arithmetic_riddle_counterexample, |prj, cmd| {
@@ -154,9 +194,24 @@ contract SymbolicRiddle {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("panic: assertion failed"), "{stdout}");
-    assert!(stdout.contains("check_riddle(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+panic: assertion failed
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+check_riddle(uint256)
+"#]],
+    );
     assert!(!stdout.contains("unsupported symbolic execution feature"), "{stdout}");
 });
 
@@ -185,8 +240,18 @@ contract SymbolicRequire {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkRequire(uint256)"));
-    assert!(stdout.contains("(paths:"));
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkRequire(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+(paths:
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_vm_assume_prunes_paths, |prj, cmd| {
@@ -216,8 +281,18 @@ contract SymbolicAssume is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkAssume(uint256)"));
-    assert!(stdout.contains("(paths:"));
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkAssume(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+(paths:
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_finds_bytes_counterexample_with_native_inline_config, |prj, cmd| {
@@ -248,8 +323,18 @@ contract SymbolicBytes {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkBytes(bytes)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkBytes(bytes)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_replays_string_counterexample, |prj, cmd| {
@@ -281,8 +366,18 @@ contract SymbolicString {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkString(string)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkString(string)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_uses_native_array_lengths, |prj, cmd| {
@@ -310,7 +405,12 @@ contract SymbolicNativeArrayLengths {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkArray(uint256[])"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkArray(uint256[])
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_uses_legacy_halmos_array_lengths, |prj, cmd| {
@@ -339,7 +439,12 @@ contract SymbolicHalmosLengths {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkArray(uint256[])"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkArray(uint256[])
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_handles_nested_struct_dynamic_input, |prj, cmd| {
@@ -374,7 +479,12 @@ contract SymbolicNestedStruct {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkStruct((uint256[],bytes))"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkStruct((uint256[],bytes))
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_allows_shorter_variants_with_positional_inner_lengths, |prj, cmd| {
@@ -464,8 +574,18 @@ contract SymbolicMalformedHalmos {
         .clone();
     let stderr = output.stderr_lossy();
 
-    assert!(stderr.contains("invalid @custom:halmos annotation"), "{stderr}");
-    assert!(stderr.contains("invalid length `nope`"), "{stderr}");
+    assert_relevant_lines(
+        &stderr,
+        foundry_test_utils::str![[r#"
+invalid @custom:halmos annotation
+"#]],
+    );
+    assert_relevant_lines(
+        &stderr,
+        foundry_test_utils::str![[r#"
+invalid length `nope`
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_selfdestruct_cancun_reports_incomplete, |prj, cmd| {
@@ -497,7 +617,12 @@ contract SymbolicSelfdestructCancun is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("SELFDESTRUCT/EIP-6780 not modeled"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+SELFDESTRUCT/EIP-6780 not modeled
+"#]],
+    );
 });
 forgetest_init!(symbolic_invariant_finds_single_step_counterexample, |prj, cmd| {
     if !z3_available() {
@@ -543,10 +668,30 @@ contract SymbolicInvariantSingle is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("invariant_counterNeverEleven()"), "{stdout}");
-    assert!(stdout.contains("set(uint256)"), "{stdout}");
-    assert!(stdout.contains("args=[7]"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+invariant_counterNeverEleven()
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+set(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=[7]
+"#]],
+    );
     assert!(!stdout.contains("No contracts to fuzz"), "{stdout}");
 });
 
@@ -601,11 +746,36 @@ contract SymbolicInvariantDepth is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("arm(uint256)"), "{stdout}");
-    assert!(stdout.contains("trip(uint256)"), "{stdout}");
-    assert!(stdout.contains("args=[1]"), "{stdout}");
-    assert!(stdout.contains("args=[2]"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+arm(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+trip(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=[1]
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=[2]
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_invariant_uses_target_sender, |prj, cmd| {
@@ -654,8 +824,18 @@ contract SymbolicInvariantSender is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("touch(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+touch(uint256)
+"#]],
+    );
     assert!(
         stdout.to_lowercase().contains("sender=0x0000000000000000000000000000000000000b0b"),
         "{stdout}"
@@ -726,11 +906,28 @@ contract SymbolicSoundnessHardening is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(
-        stdout.contains("[PASS] checkConstrainedStorageKeyUsesConcreteSlot(uint256)"),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkConstrainedStorageKeyUsesConcreteSlot(uint256)
+"#]],
     );
-    assert!(stdout.contains("symbolic randomUint bits"), "{stdout}");
-    assert!(stdout.contains("symbolic svm.create integer bits"), "{stdout}");
-    assert!(stdout.contains("symbolic prank delegatecall"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+symbolic randomUint bits
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+symbolic svm.create integer bits
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+symbolic prank delegatecall
+"#]],
+    );
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_calls.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_calls.rs
@@ -1,3 +1,4 @@
+use super::symbolic_helpers::assert_relevant_lines;
 use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, util::OutputExt};
 
@@ -38,7 +39,12 @@ contract SymbolicCalldataLoad {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicCalldataLoad(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicCalldataLoad(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CALLDATALOAD offset"), "{stdout}");
 });
 
@@ -78,7 +84,12 @@ contract SymbolicCalldataCopy {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicCalldataCopy(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicCalldataCopy(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CALLDATACOPY offset"), "{stdout}");
 });
 
@@ -115,7 +126,12 @@ contract SymbolicCalldataCopyDest {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicCalldataCopyDest(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicCalldataCopyDest(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CALLDATACOPY dest"), "{stdout}");
 });
 
@@ -158,7 +174,12 @@ contract SymbolicCalldataCopySize {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicCalldataCopySize(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicCalldataCopySize(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CALLDATACOPY size"), "{stdout}");
 });
 
@@ -199,9 +220,11 @@ contract SymbolicCalldataCopyDestAndSize {
         .get_output()
         .stdout_lossy();
 
-    assert!(
-        stdout.contains("[PASS] checkCalldataCopyDestAndSize(uint8,uint8,bytes32)"),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCalldataCopyDestAndSize(uint8,uint8,bytes32)
+"#]],
     );
     assert!(!stdout.contains("symbolic CALLDATACOPY dest"), "{stdout}");
     assert!(!stdout.contains("symbolic CALLDATACOPY size"), "{stdout}");
@@ -258,7 +281,12 @@ contract SymbolicCallInputOffset {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicCallInputOffset(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicCallInputOffset(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CALL input offset"), "{stdout}");
 });
 
@@ -313,7 +341,12 @@ contract SymbolicCallOutputSize {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicCallOutputSize(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicCallOutputSize(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CALL output size"), "{stdout}");
 });
 
@@ -368,7 +401,12 @@ contract SymbolicCallInputSize {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicCallInputSize(uint8,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicCallInputSize(uint8,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CALL input size"), "{stdout}");
 });
 
@@ -409,8 +447,18 @@ contract SymbolicExternalCall {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkExternal(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkExternal(uint256)
+"#]],
+    );
     assert!(!stdout.contains("unsupported symbolic execution feature: external CALL"), "{stdout}");
 });
 
@@ -455,8 +503,18 @@ contract SymbolicLowLevelCall {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkLowLevel(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkLowLevel(uint256)
+"#]],
+    );
     assert!(!stdout.contains("unsupported symbolic execution feature: external CALL"), "{stdout}");
 });
 
@@ -506,9 +564,24 @@ contract SymbolicSelectorBackdoor {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkNoBackdoor(bytes4,uint256)"), "{stdout}");
-    assert!(stdout.contains("args="), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkNoBackdoor(bytes4,uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=
+"#]],
+    );
     assert!(!stdout.contains("symbolic external CALL selector"), "{stdout}");
 });
 
@@ -565,9 +638,24 @@ contract SymbolicTargetBackdoor is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkNoBadTarget(address,uint256)"), "{stdout}");
-    assert!(stdout.contains("args="), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkNoBadTarget(address,uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=
+"#]],
+    );
     assert!(!stdout.contains("symbolic CALL target outside known contracts"), "{stdout}");
 });
 
@@ -615,7 +703,12 @@ contract SymbolicTargetDefaultAuto is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkTarget(address,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkTarget(address,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CALL target"), "{stdout}");
 });
 
@@ -647,7 +740,12 @@ contract SymbolicTargetDefaultOff {
             .get_output()
             .stdout_lossy();
 
-        assert!(stdout.contains("symbolic CALL target"), "{stdout}");
+        assert_relevant_lines(
+            &stdout,
+            foundry_test_utils::str![[r#"
+symbolic CALL target
+"#]],
+        );
     }
 );
 
@@ -684,7 +782,12 @@ contract SymbolicUnboundedTarget {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkUnbounded(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkUnbounded(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CALL target outside known contracts"), "{stdout}");
 });
 
@@ -741,8 +844,18 @@ contract SymbolicDelegateTarget is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkDelegateTarget(address,uint256)"), "{stdout}");
-    assert!(stdout.contains("checkDelegateTarget(address,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkDelegateTarget(address,uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkDelegateTarget(address,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CALL target"), "{stdout}");
 });
 
@@ -788,7 +901,12 @@ contract SymbolicUnknownSelector {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkUnknownSelector(bytes4)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkUnknownSelector(bytes4)
+"#]],
+    );
     assert!(!stdout.contains("symbolic external CALL selector"), "{stdout}");
 });
 
@@ -840,7 +958,12 @@ contract SymbolicSvmBytes4Selector {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSvmBytes4Selector()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSvmBytes4Selector()
+"#]],
+    );
     assert!(!stdout.contains("symbolic external CALL selector"), "{stdout}");
 });
 
@@ -899,7 +1022,12 @@ contract SymbolicSvmCreateCalldata {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSvmCreateCalldata()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSvmCreateCalldata()
+"#]],
+    );
     assert!(!stdout.contains("symbolic external CALL selector"), "{stdout}");
 });
 
@@ -948,7 +1076,12 @@ contract SymbolicExternalRequire {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkRequireCall(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkRequireCall(uint256)
+"#]],
+    );
     assert!(!stdout.contains("unsupported symbolic execution feature: external CALL"), "{stdout}");
 });
 
@@ -994,7 +1127,12 @@ contract SymbolicStaticCall {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkStatic(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkStatic(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_delegatecall_writes_caller_storage, |prj, cmd| {
@@ -1041,7 +1179,12 @@ contract SymbolicDelegateCall {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkDelegate(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkDelegate(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_call_transfers_value_and_checks_balance, |prj, cmd| {
@@ -1089,7 +1232,12 @@ contract SymbolicValueCall is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkValueTransfer()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkValueTransfer()
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_call_accepts_symbolic_value, |prj, cmd| {
@@ -1145,7 +1293,12 @@ contract SymbolicValueCall is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicValueTransfer(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicValueTransfer(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic external CALL value"), "{stdout}");
 });
 
@@ -1193,7 +1346,12 @@ contract SymbolicInsufficientValueCall is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicInsufficientValue(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicInsufficientValue(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic external CALL value"), "{stdout}");
 });
 
@@ -1249,6 +1407,11 @@ contract SymbolicCallcodeValue is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicCallcodeValue(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicCallcodeValue(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CALLCODE value"), "{stdout}");
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
@@ -1,3 +1,4 @@
+use super::symbolic_helpers::assert_relevant_lines;
 use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, util::OutputExt};
 
@@ -54,11 +55,18 @@ contract SymbolicAddressCheatcodes is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(
-        stdout.contains("[PASS] checkSymbolicDealStoreLoadAndNonce(address,bytes32)"),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicDealStoreLoadAndNonce(address,bytes32)
+"#]],
     );
-    assert!(stdout.contains("[PASS] checkSymbolicEtch(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicEtch(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.deal target"), "{stdout}");
     assert!(!stdout.contains("symbolic vm.store target"), "{stdout}");
     assert!(!stdout.contains("symbolic EXTCODESIZE target"), "{stdout}");
@@ -151,10 +159,30 @@ contract SymbolicPrankSender is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicPrank(address)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkSymbolicStartPrank(address)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkSymbolicPrankOrigin(address,address)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkSymbolicStartPrankOrigin(address,address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicPrank(address)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicStartPrank(address)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicPrankOrigin(address,address)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicStartPrankOrigin(address,address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.prank"), "{stdout}");
     assert!(!stdout.contains("symbolic vm.startPrank"), "{stdout}");
 });
@@ -190,7 +218,12 @@ contract SymbolicBalance is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicBalance(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicBalance(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic BALANCE target"), "{stdout}");
 });
 
@@ -225,7 +258,12 @@ contract SymbolicExtcodeSize is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicCodeLength(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicCodeLength(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic EXTCODESIZE target"), "{stdout}");
 });
 
@@ -260,7 +298,12 @@ contract SymbolicExtcodeHash is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicCodeHash(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicCodeHash(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic EXTCODEHASH target"), "{stdout}");
 });
 
@@ -301,7 +344,12 @@ contract SymbolicExtcodeCopy is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicExtcodeCopy(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicExtcodeCopy(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic EXTCODECOPY target"), "{stdout}");
 });
 
@@ -362,7 +410,12 @@ contract SymbolicPrank is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkPrank(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkPrank(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
 });
 
@@ -393,9 +446,24 @@ contract SymbolicVmAssert is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkVmAssert(uint256)"), "{stdout}");
-    assert!(stdout.contains("args=[42]"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkVmAssert(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=[42]
+"#]],
+    );
     assert!(!stdout.contains("counterexample did not replay"), "{stdout}");
 });
 
@@ -483,8 +551,18 @@ contract SymbolicRecordedLogs is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkRecordedLogs(uint256,bytes)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkRecordedLogsJson(uint256,bytes)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkRecordedLogs(uint256,bytes)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkRecordedLogsJson(uint256,bytes)
+"#]],
+    );
     assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
     assert!(!stdout.contains("symbolic vm.getRecordedLogsJson"), "{stdout}");
 });
@@ -608,11 +686,36 @@ contract SymbolicEnvCryptoConsole is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkEnvCryptoConsole(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkKeyUtilities()"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkBase64Utilities()"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkParseToStringUtilities()"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkStringUtilities()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkEnvCryptoConsole(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkKeyUtilities()
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkBase64Utilities()
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkParseToStringUtilities()
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkStringUtilities()
+"#]],
+    );
     assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
 });
 
@@ -644,7 +747,12 @@ contract SymbolicFfiDisabled is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("symbolic ffi disabled"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+symbolic ffi disabled
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_vm_ffi_success_when_enabled, |prj, cmd| {
@@ -682,7 +790,12 @@ contract SymbolicFfiEnabled is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkFfiEnabled(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkFfiEnabled(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic ffi disabled"), "{stdout}");
 });
 
@@ -745,8 +858,18 @@ contract SymbolicEtch is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkEtch(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkEtchSymbolicBytes(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkEtch(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkEtchSymbolicBytes(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.etch"), "{stdout}");
     assert!(!stdout.contains("symbolic vm.getCode artifact"), "{stdout}");
     assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
@@ -785,7 +908,12 @@ contract SymbolicCodeHash is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCodeHash(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCodeHash(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_extcodecopy_pads_partial_code_ranges, |prj, cmd| {
@@ -827,7 +955,12 @@ contract SymbolicExtcodeCopy is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkExtcodeCopy(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkExtcodeCopy(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_codecopy_accepts_symbolic_offset, |prj, cmd| {
@@ -865,7 +998,12 @@ contract SymbolicCodeCopy {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCodeCopy(uint16)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCodeCopy(uint16)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CODECOPY offset"), "{stdout}");
 });
 
@@ -909,7 +1047,12 @@ contract SymbolicExtcodeCopyOffset is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkExtcodeCopyOffset(uint16)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkExtcodeCopyOffset(uint16)
+"#]],
+    );
     assert!(!stdout.contains("symbolic EXTCODECOPY offset"), "{stdout}");
 });
 
@@ -950,7 +1093,12 @@ contract SymbolicCodeCopySize {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCodeCopySize(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCodeCopySize(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CODECOPY size"), "{stdout}");
 });
 
@@ -994,7 +1142,12 @@ contract SymbolicExtcodeCopySize is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkExtcodeCopySize(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkExtcodeCopySize(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic EXTCODECOPY size"), "{stdout}");
 });
 
@@ -1048,7 +1201,12 @@ contract SymbolicSelfdestruct is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSelfdestruct(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSelfdestruct(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_selfdestruct_accepts_symbolic_beneficiary, |prj, cmd| {
@@ -1098,7 +1256,12 @@ contract SymbolicSelfdestructBeneficiary is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSelfdestructBeneficiary(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSelfdestructBeneficiary(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic SELFDESTRUCT beneficiary"), "{stdout}");
     assert!(!stdout.contains("symbolic BALANCE target"), "{stdout}");
 });
@@ -1136,7 +1299,12 @@ contract SymbolicBlockhash is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSetBlockhash(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSetBlockhash(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_blockhash_accepts_symbolic_number, |prj, cmd| {
@@ -1173,7 +1341,12 @@ contract SymbolicBlockhashNumber is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicBlockhashNumber(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicBlockhashNumber(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic BLOCKHASH number"), "{stdout}");
 });
 
@@ -1207,7 +1380,12 @@ contract SymbolicBlockhashValue is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicBlockhashValue(bytes32)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicBlockhashValue(bytes32)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.setBlockhash hash"), "{stdout}");
 });
 
@@ -1266,7 +1444,12 @@ contract SymbolicBlockEnvironment is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkBlockEnvironment(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkBlockEnvironment(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_uses_prepared_executor_environment, |prj, cmd| {
@@ -1314,7 +1497,12 @@ contract SymbolicPreparedEnvironment is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkPreparedEnvironment(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkPreparedEnvironment(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_vm_state_snapshots, |prj, cmd| {
@@ -1373,7 +1561,12 @@ contract SymbolicStateSnapshots is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkStateSnapshots(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkStateSnapshots(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_vm_random_bytes, |prj, cmd| {
@@ -1410,7 +1603,12 @@ contract SymbolicRandomBytes is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkRandomBytes(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkRandomBytes(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_vm_random_bytes_accepts_bounded_symbolic_length, |prj, cmd| {
@@ -1445,7 +1643,12 @@ contract SymbolicRandomBytesLength is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkRandomBytesSymbolicLength(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkRandomBytesSymbolicLength(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic randomBytes len"), "{stdout}");
     assert!(!stdout.contains("symbolic randomBytes length"), "{stdout}");
 });
@@ -1490,8 +1693,18 @@ contract SymbolicConstrainedCheatcodes is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkConstrainedDeal(address,uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkConstrainedRandomBytes(uint16)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkConstrainedDeal(address,uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkConstrainedRandomBytes(uint16)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.deal target"), "{stdout}");
     assert!(!stdout.contains("symbolic vm.deal value"), "{stdout}");
     assert!(!stdout.contains("symbolic randomBytes len"), "{stdout}");
@@ -1535,7 +1748,12 @@ contract SymbolicCheatcodeInputSize is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkLowLevelAssumeSize(uint256,bool)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkLowLevelAssumeSize(uint256,bool)
+"#]],
+    );
     assert!(!stdout.contains("symbolic cheatcode CALL input size"), "{stdout}");
 });
 
@@ -1588,7 +1806,12 @@ contract SymbolicSvmCreators {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSvmCreators(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSvmCreators(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic Halmos compatibility cheatcode"), "{stdout}");
 });
 forgetest_init!(symbolic_vm_expect_revert_matches_external_reverts, |prj, cmd| {
@@ -1643,7 +1866,12 @@ contract SymbolicExpectRevert is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkExpectRevert(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkExpectRevert(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_vm_expect_revert_missing_is_counterexample, |prj, cmd| {
@@ -1684,8 +1912,18 @@ contract SymbolicExpectRevertMissing is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkMissingExpectedRevert(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkMissingExpectedRevert(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_vm_expect_revert_mismatch_is_counterexample, |prj, cmd| {
@@ -1730,8 +1968,18 @@ contract SymbolicExpectRevertMismatch is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkMismatchedExpectedRevert(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkMismatchedExpectedRevert(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_vm_expect_revert_accepts_symbolic_data, |prj, cmd| {
@@ -1806,9 +2054,24 @@ contract SymbolicExpectRevertSymbolicData is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicExpectedRevertPayload(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkSymbolicExpectedRevertSelector(bytes4)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkSymbolicExpectedReverter(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicExpectedRevertPayload(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicExpectedRevertSelector(bytes4)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicExpectedReverter(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.expectRevert"), "{stdout}");
 });
 
@@ -1859,8 +2122,18 @@ contract SymbolicExpectRevertSymbolicMismatch is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkSymbolicExpectedRevertMismatch(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkSymbolicExpectedRevertMismatch(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic expected revert data"), "{stdout}");
 
     let stdout = prj
@@ -1870,8 +2143,18 @@ contract SymbolicExpectRevertSymbolicMismatch is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkSymbolicExpectedReverterMismatch(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkSymbolicExpectedReverterMismatch(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.expectRevert"), "{stdout}");
 });
 
@@ -1927,8 +2210,18 @@ contract SymbolicExpectEmit is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkExpectEmit(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkExpectEmitSymbolicEmitter(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkExpectEmit(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkExpectEmitSymbolicEmitter(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.expectEmit"), "{stdout}");
 });
 
@@ -1983,8 +2276,18 @@ contract SymbolicExpectEmitMismatch is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkMismatchedExpectEmit(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkMismatchedExpectEmit(uint256)
+"#]],
+    );
 
     let stdout = prj
         .forge_command()
@@ -1993,8 +2296,18 @@ contract SymbolicExpectEmitMismatch is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkMismatchedExpectEmitSymbolicEmitter(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkMismatchedExpectEmitSymbolicEmitter(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.expectEmit"), "{stdout}");
 });
 
@@ -2094,7 +2407,12 @@ contract SymbolicExpectCall is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkExpectCallMatches(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkExpectCallMatches(uint256)
+"#]],
+    );
 
     let stdout = prj
         .forge_command()
@@ -2103,7 +2421,12 @@ contract SymbolicExpectCall is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkExpectCallSymbolicCallee(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkExpectCallSymbolicCallee(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.expectCall"), "{stdout}");
 
     let stdout = prj
@@ -2113,8 +2436,18 @@ contract SymbolicExpectCall is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkExpectCallMissing(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkExpectCallMissing(uint256)
+"#]],
+    );
 
     let stdout = prj
         .forge_command()
@@ -2123,8 +2456,18 @@ contract SymbolicExpectCall is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkSymbolicCalleeExpectedCallMismatch(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkSymbolicCalleeExpectedCallMismatch(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.expectCall"), "{stdout}");
 
     let stdout = prj
@@ -2134,8 +2477,18 @@ contract SymbolicExpectCall is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkExpectCallMinGasMissing(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkExpectCallMinGasMissing(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_vm_mock_call_returns_and_reverts, |prj, cmd| {
@@ -2250,8 +2603,18 @@ contract SymbolicMockCall is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkMockCall(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkMockCallSymbolicCallee(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMockCall(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMockCallSymbolicCallee(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
     assert!(!stdout.contains("symbolic vm.mockCall"), "{stdout}");
 
@@ -2262,7 +2625,12 @@ contract SymbolicMockCall is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSelectorMockCallsAndClear(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSelectorMockCallsAndClear(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
 
     let stdout = prj
@@ -2272,9 +2640,11 @@ contract SymbolicMockCall is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(
-        stdout.contains("[PASS] checkMockCallsAcceptsSymbolicData(address,uint256)"),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMockCallsAcceptsSymbolicData(address,uint256)
+"#]],
     );
     assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
     assert!(!stdout.contains("symbolic vm.mockCalls"), "{stdout}");
@@ -2286,8 +2656,18 @@ contract SymbolicMockCall is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkSymbolicCalleeMockMismatch(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkSymbolicCalleeMockMismatch(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.mockCall"), "{stdout}");
 });
 
@@ -2355,8 +2735,18 @@ contract SymbolicUnpinnedCallValue is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkExpectCallAllowsSymbolicValue(uint8)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkMockCallAllowsSymbolicValue(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkExpectCallAllowsSymbolicValue(uint8)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMockCallAllowsSymbolicValue(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic expected call value"), "{stdout}");
     assert!(!stdout.contains("symbolic mocked call value"), "{stdout}");
 });
@@ -2449,8 +2839,18 @@ contract SymbolicPinnedCallValue is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkExpectCallPinnedValueFindsMismatch(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkExpectCallPinnedValueFindsMismatch(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic expected call value"), "{stdout}");
 
     let stdout = prj
@@ -2460,7 +2860,12 @@ contract SymbolicPinnedCallValue is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkMockCallPinnedValueMatches(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMockCallPinnedValueMatches(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic mocked call value"), "{stdout}");
 
     let stdout = prj
@@ -2470,8 +2875,18 @@ contract SymbolicPinnedCallValue is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkMockCallPinnedValueFindsMismatch(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkMockCallPinnedValueFindsMismatch(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic mocked call value"), "{stdout}");
 });
 
@@ -2577,19 +2992,35 @@ contract SymbolicCallDataCheatcodes is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkExpectCallAcceptsSymbolicData(uint256)"), "{stdout}");
-    assert!(
-        stdout.contains("[PASS] checkMockCallAcceptsSymbolicDataAndReturn(uint256)"),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkExpectCallAcceptsSymbolicData(uint256)
+"#]],
     );
-    assert!(
-        stdout.contains("[PASS] checkMockCallAcceptsSymbolicBytes4Selector(bytes4)"),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMockCallAcceptsSymbolicDataAndReturn(uint256)
+"#]],
     );
-    assert!(stdout.contains("[PASS] checkMockFunctionAcceptsSymbolicData(uint256)"), "{stdout}");
-    assert!(
-        stdout.contains("[PASS] checkMockFunctionAcceptsSymbolicCallee(address,uint256)"),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMockCallAcceptsSymbolicBytes4Selector(bytes4)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMockFunctionAcceptsSymbolicData(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMockFunctionAcceptsSymbolicCallee(address,uint256)
+"#]],
     );
     assert!(!stdout.contains("symbolic vm.expectCall"), "{stdout}");
     assert!(!stdout.contains("symbolic vm.mockCall"), "{stdout}");
@@ -2707,8 +3138,13 @@ contract SymbolicCallDataMismatch is Test {
             .get_output()
             .stdout_lossy();
 
-        assert!(stdout.contains("[FAIL:"), "{stdout}");
-        assert!(stdout.contains(test), "{stdout}");
+        assert_relevant_lines(
+            &stdout,
+            foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+        );
+        assert_relevant_lines(&stdout, format!("{test}\n"));
         assert!(!stdout.contains("symbolic vm.expectCall"), "{stdout}");
         assert!(!stdout.contains("symbolic vm.mockCall"), "{stdout}");
         assert!(!stdout.contains("symbolic vm.mockFunction"), "{stdout}");
@@ -2787,7 +3223,12 @@ contract SymbolicMockFunction is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkMockFunction(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMockFunction(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
 });
 
@@ -2879,10 +3320,17 @@ contract SymbolicRecordAccesses is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkRecordAccesses(bytes32,bytes32)"), "{stdout}");
-    assert!(
-        stdout.contains("[PASS] checkRecordAccessesSymbolicTarget(address,bytes32,bytes32)"),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkRecordAccesses(bytes32,bytes32)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkRecordAccessesSymbolicTarget(address,bytes32,bytes32)
+"#]],
     );
     assert!(
         stdout
@@ -3047,9 +3495,24 @@ contract SymbolicBoundSkip is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkBoundSkipAndGasNoops(uint256,int256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkVmCompatibilityTail()"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkRuntimeNoopsAndArrayAssertions()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkBoundSkipAndGasNoops(uint256,int256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkVmCompatibilityTail()
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkRuntimeNoopsAndArrayAssertions()
+"#]],
+    );
     assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
 });
 
@@ -3084,9 +3547,24 @@ contract SymbolicBoundInvalid is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkInvalidUnsignedBound(uint256)"), "{stdout}");
-    assert!(stdout.contains("checkInvalidSignedBound(int256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkInvalidUnsignedBound(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkInvalidSignedBound(int256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.bound range"), "{stdout}");
     assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
 });
@@ -3132,7 +3610,12 @@ contract SymbolicAssumeNoRevert is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkAssumeNoRevertPrunes(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkAssumeNoRevertPrunes(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.assumeNoRevert"), "{stdout}");
     assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
 });
@@ -3254,8 +3737,18 @@ contract SymbolicAssumeNoRevertFilters is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkAssumeNoRevertExactFilterPrunes(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkAssumeNoRevertArrayFilterPrunes(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkAssumeNoRevertExactFilterPrunes(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkAssumeNoRevertArrayFilterPrunes(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.assumeNoRevert"), "{stdout}");
     assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
 
@@ -3267,8 +3760,13 @@ contract SymbolicAssumeNoRevertFilters is Test {
             .get_output()
             .stdout_lossy();
 
-        assert!(stdout.contains("[FAIL:"), "{stdout}");
-        assert!(stdout.contains(test), "{stdout}");
+        assert_relevant_lines(
+            &stdout,
+            foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+        );
+        assert_relevant_lines(&stdout, format!("{test}\n"));
         assert!(!stdout.contains("symbolic vm.assumeNoRevert"), "{stdout}");
         assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
     }

--- a/crates/forge/tests/cli/test_cmd/symbolic_conformance.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_conformance.rs
@@ -1,3 +1,4 @@
+use super::symbolic_helpers::assert_relevant_lines;
 use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, util::OutputExt};
 use std::{env, process::Command};
@@ -42,19 +43,39 @@ struct ConformanceMatrixCase<'a> {
 fn assert_conformance_matrix_case(stdout: &str, case: &ConformanceMatrixCase<'_>) {
     match case.expected {
         ConformanceStatus::Pass => {
-            assert!(stdout.contains("[PASS]"), "{}\n{stdout}", case.feature);
+            assert_relevant_lines(
+                &stdout,
+                foundry_test_utils::str![[r#"
+[PASS]
+"#]],
+            );
         }
         ConformanceStatus::Counterexample => {
-            assert!(stdout.contains("[FAIL"), "{}\n{stdout}", case.feature);
+            assert_relevant_lines(
+                &stdout,
+                foundry_test_utils::str![[r#"
+[FAIL
+"#]],
+            );
         }
         ConformanceStatus::RevertAll => {
-            assert!(stdout.contains("RevertAll"), "{}\n{stdout}", case.feature);
-            assert!(stdout.contains("all symbolic paths reverted"), "{}\n{stdout}", case.feature);
+            assert_relevant_lines(
+                &stdout,
+                foundry_test_utils::str![[r#"
+RevertAll
+"#]],
+            );
+            assert_relevant_lines(
+                &stdout,
+                foundry_test_utils::str![[r#"
+all symbolic paths reverted
+"#]],
+            );
         }
     }
 
     for required in case.required {
-        assert!(stdout.contains(required), "{} missing `{required}`\n{stdout}", case.feature);
+        assert_relevant_lines(stdout, format!("{required}\n"));
     }
     for forbidden in case.forbidden {
         assert!(
@@ -95,7 +116,12 @@ contract SymbolicConformanceBlock is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkBlock(uint256,uint256,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkBlock(uint256,uint256,uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_conformance_vm_store_load_symbolic_value, |prj, cmd| {
@@ -125,7 +151,12 @@ contract SymbolicConformanceStoreLoad is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkStoreLoad(bytes32)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkStoreLoad(bytes32)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_conformance_dstest_fail_store_is_counterexample, |prj, cmd| {
@@ -162,9 +193,24 @@ contract SymbolicConformanceFail {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL"), "{stdout}");
-    assert!(stdout.contains("checkFailSignal(uint256)"), "{stdout}");
-    assert!(stdout.contains("args=[7]"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkFailSignal(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=[7]
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_conformance_revert_all_is_reported, |prj, cmd| {
@@ -189,8 +235,18 @@ contract SymbolicConformanceRevertAll {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("RevertAll"), "{stdout}");
-    assert!(stdout.contains("all symbolic paths reverted"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+RevertAll
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+all symbolic paths reverted
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_conformance_riddle_finds_counterexample, |prj, cmd| {
@@ -226,8 +282,18 @@ contract SymbolicConformanceRiddle {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL"), "{stdout}");
-    assert!(stdout.contains("check_riddle(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+check_riddle(uint256)
+"#]],
+    );
     assert!(!stdout.contains("Stuck"), "{stdout}");
     assert!(!stdout.contains("RevertAll"), "{stdout}");
 });
@@ -480,8 +546,18 @@ contract SymbolicConformanceHalmosTotalPrice {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL"), "{stdout}");
-    assert!(stdout.contains("checkBuggyTotal(uint96,uint32)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkBuggyTotal(uint96,uint32)
+"#]],
+    );
     assert!(!stdout.contains("Stuck"), "{stdout}");
     assert!(!stdout.contains("RevertAll"), "{stdout}");
 
@@ -492,7 +568,12 @@ contract SymbolicConformanceHalmosTotalPrice {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkFixedTotal(uint96,uint32)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkFixedTotal(uint96,uint32)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_conformance_halmos_simple_power_of_two_loop, |prj, cmd| {
@@ -533,7 +614,12 @@ contract SymbolicConformanceHalmosPowerOfTwo {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkPowerOfTwoLoop(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkPowerOfTwoLoop(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic loop bound exceeded"), "{stdout}");
 });
 
@@ -602,7 +688,12 @@ contract SymbolicConformanceHalmosVault is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkDepositPreservesSharePrice()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkDepositPreservesSharePrice()
+"#]],
+    );
 
     let stdout = prj
         .forge_command()
@@ -611,8 +702,18 @@ contract SymbolicConformanceHalmosVault is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL"), "{stdout}");
-    assert!(stdout.contains("checkMintCanDiluteSharePrice()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkMintCanDiluteSharePrice()
+"#]],
+    );
     assert!(!stdout.contains("Stuck"), "{stdout}");
     assert!(!stdout.contains("RevertAll"), "{stdout}");
 });
@@ -666,7 +767,12 @@ contract SymbolicConformanceHalmosForkSetup is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkEtchedStorageInvariant(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkEtchedStorageInvariant(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.etch"), "{stdout}");
     assert!(!stdout.contains("symbolic SLOAD key"), "{stdout}");
 });
@@ -743,10 +849,17 @@ contract SymbolicConformanceHalmosElection is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL"), "{stdout}");
-    assert!(
-        stdout.contains("checkCannotVoteTwiceWithAlternateSignature(uint256,address)"),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkCannotVoteTwiceWithAlternateSignature(uint256,address)
+"#]],
     );
     assert!(!stdout.contains("symbolic Halmos compatibility cheatcode"), "{stdout}");
     assert!(!stdout.contains("Stuck"), "{stdout}");
@@ -853,7 +966,12 @@ contract SymbolicConformanceHalmosMulticaller {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkMulticallReturndata(uint64,bytes)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMulticallReturndata(uint64,bytes)
+"#]],
+    );
     assert!(!stdout.contains("unsupported external CALL"), "{stdout}");
     assert!(!stdout.contains("Stuck"), "{stdout}");
 
@@ -864,9 +982,24 @@ contract SymbolicConformanceHalmosMulticaller {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL"), "{stdout}");
-    assert!(stdout.contains("checkMulticallFindsFailedCall(uint64)"), "{stdout}");
-    assert!(stdout.contains("args=[13]"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkMulticallFindsFailedCall(uint64)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=[13]
+"#]],
+    );
     assert!(!stdout.contains("unsupported external CALL"), "{stdout}");
     assert!(!stdout.contains("RevertAll"), "{stdout}");
 });
@@ -929,14 +1062,54 @@ contract SymbolicConformanceHalmosSimpleState is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("invariant_phaseBelowThree()"), "{stdout}");
-    assert!(stdout.contains("open(uint256)"), "{stdout}");
-    assert!(stdout.contains("commit(uint256)"), "{stdout}");
-    assert!(stdout.contains("finalize(uint256)"), "{stdout}");
-    assert!(stdout.contains("args=[81]"), "{stdout}");
-    assert!(stdout.contains("args=[167]"), "{stdout}");
-    assert!(stdout.contains("args=[227]"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+invariant_phaseBelowThree()
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+open(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+commit(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+finalize(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=[81]
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=[167]
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=[227]
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_conformance_halmos_invariant_reentrancy_exploit, |prj, cmd| {
@@ -1019,10 +1192,30 @@ contract SymbolicConformanceHalmosReentrancy is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("invariant_vaultBacksAttackerAccounting()"), "{stdout}");
-    assert!(stdout.contains("depositOne()"), "{stdout}");
-    assert!(stdout.contains("withdrawOne()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+invariant_vaultBacksAttackerAccounting()
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+depositOne()
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+withdrawOne()
+"#]],
+    );
     assert!(!stdout.contains("Stuck"), "{stdout}");
 });
 
@@ -1053,7 +1246,12 @@ contract SymbolicConformanceTransient {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkTransient(bytes32)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkTransient(bytes32)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_conformance_mapping_storage_keys, |prj, cmd| {
@@ -1081,7 +1279,12 @@ contract SymbolicConformanceMappingStorage {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkNestedMapping(address,address,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkNestedMapping(address,address,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic SHA3"), "{stdout}");
     assert!(!stdout.contains("symbolic SSTORE key"), "{stdout}");
     assert!(!stdout.contains("symbolic SLOAD key"), "{stdout}");
@@ -1160,11 +1363,11 @@ contract SymbolicConformanceStorageBreadth is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(
-        stdout.contains(
-            "[PASS] checkStorageBreadth(address,address,uint256,uint256,uint128,uint128,bytes32)"
-        ),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkStorageBreadth(address,address,uint256,uint256,uint128,uint128,bytes32)
+"#]],
     );
     assert!(!stdout.contains("symbolic SHA3"), "{stdout}");
     assert!(!stdout.contains("symbolic SSTORE key"), "{stdout}");
@@ -1206,7 +1409,12 @@ contract SymbolicConformanceArithmetic {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkArithmetic(uint256,int8,bytes32)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkArithmetic(uint256,int8,bytes32)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_conformance_dynamic_abi_matrix, |prj, cmd| {
@@ -1241,9 +1449,11 @@ contract SymbolicConformanceDynamicAbi {
         .get_output()
         .stdout_lossy();
 
-    assert!(
-        stdout.contains("[PASS] checkDynamic(bytes,string,uint256[],(bytes,uint256[]))"),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkDynamic(bytes,string,uint256[],(bytes,uint256[]))
+"#]],
     );
 });
 
@@ -1304,8 +1514,18 @@ contract SymbolicConformanceCalls is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkExternalCall(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkCreate(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkExternalCall(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreate(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_conformance_symbolic_selector_backdoor, |prj, cmd| {
@@ -1349,10 +1569,30 @@ contract SymbolicConformanceSelector {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkNoBackdoor(bytes4,uint256)"), "{stdout}");
-    assert!(stdout.contains("args=[0x"), "{stdout}");
-    assert!(stdout.contains("42"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkNoBackdoor(bytes4,uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=[0x
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+42
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_conformance_stateful_erc20_invariant, |prj, cmd| {
@@ -1405,7 +1645,12 @@ contract SymbolicConformanceErc20Invariant is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] invariant_totalSupplyConstant()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] invariant_totalSupplyConstant()
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_conformance_stateful_erc721_invariant, |prj, cmd| {
@@ -1508,7 +1753,12 @@ contract SymbolicConformanceErc721Invariant is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] invariant_mintedOwnerIsNeverZero()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] invariant_mintedOwnerIsNeverZero()
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_conformance_stateful_reentrancy_sequence, |prj, cmd| {
@@ -1590,5 +1840,10 @@ contract SymbolicConformanceReentrancyInvariant is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] invariant_vaultBacksHandlerBalance()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] invariant_vaultBacksHandlerBalance()
+"#]],
+    );
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_conformance.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_conformance.rs
@@ -44,7 +44,7 @@ fn assert_conformance_matrix_case(stdout: &str, case: &ConformanceMatrixCase<'_>
     match case.expected {
         ConformanceStatus::Pass => {
             assert_relevant_lines(
-                &stdout,
+                stdout,
                 foundry_test_utils::str![[r#"
 [PASS]
 "#]],
@@ -52,7 +52,7 @@ fn assert_conformance_matrix_case(stdout: &str, case: &ConformanceMatrixCase<'_>
         }
         ConformanceStatus::Counterexample => {
             assert_relevant_lines(
-                &stdout,
+                stdout,
                 foundry_test_utils::str![[r#"
 [FAIL
 "#]],
@@ -60,13 +60,13 @@ fn assert_conformance_matrix_case(stdout: &str, case: &ConformanceMatrixCase<'_>
         }
         ConformanceStatus::RevertAll => {
             assert_relevant_lines(
-                &stdout,
+                stdout,
                 foundry_test_utils::str![[r#"
 RevertAll
 "#]],
             );
             assert_relevant_lines(
-                &stdout,
+                stdout,
                 foundry_test_utils::str![[r#"
 all symbolic paths reverted
 "#]],

--- a/crates/forge/tests/cli/test_cmd/symbolic_creates.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_creates.rs
@@ -1,3 +1,4 @@
+use super::symbolic_helpers::assert_relevant_lines;
 use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, util::OutputExt};
 
@@ -35,8 +36,18 @@ contract SymbolicCreate {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkCreate(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkCreate(uint256)
+"#]],
+    );
     assert!(!stdout.contains("unsupported opcode: 0xf0"), "{stdout}");
 });
 
@@ -74,7 +85,12 @@ contract SymbolicCreateConstructorArgs {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCreateConstructorArg(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreateConstructorArg(uint256)
+"#]],
+    );
     assert!(
         !stdout.contains("unsupported symbolic execution feature: symbolic CREATE initcode"),
         "{stdout}"
@@ -119,7 +135,12 @@ contract SymbolicCreateInitcodeOffset is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCreateInitcodeOffset(uint16)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreateInitcodeOffset(uint16)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CREATE initcode offset"), "{stdout}");
     assert!(!stdout.contains("symbolic bytecode opcode"), "{stdout}");
 });
@@ -156,8 +177,18 @@ contract SymbolicCreate2 {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkCreate2(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkCreate2(uint256)
+"#]],
+    );
     assert!(!stdout.contains("unsupported opcode: 0xf5"), "{stdout}");
 });
 
@@ -200,7 +231,12 @@ contract SymbolicCreate2Args {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCreate2ConstructorArg(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreate2ConstructorArg(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CREATE2 initcode"), "{stdout}");
 });
 
@@ -262,7 +298,12 @@ contract SymbolicExpectCreate is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCreateExpectation(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreateExpectation(uint256)
+"#]],
+    );
 
     let stdout = prj
         .forge_command()
@@ -271,7 +312,12 @@ contract SymbolicExpectCreate is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCreate2Expectation(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreate2Expectation(uint256)
+"#]],
+    );
 
     let stdout = prj
         .forge_command()
@@ -280,7 +326,12 @@ contract SymbolicExpectCreate is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicCreateExpectation(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicCreateExpectation(address)
+"#]],
+    );
 
     let stdout = prj
         .forge_command()
@@ -289,8 +340,18 @@ contract SymbolicExpectCreate is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkMismatchedSymbolicCreateExpectation(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkMismatchedSymbolicCreateExpectation(address)
+"#]],
+    );
 
     let stdout = prj
         .forge_command()
@@ -299,8 +360,18 @@ contract SymbolicExpectCreate is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkMissingCreateExpectation(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkMissingCreateExpectation(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_create2_supports_symbolic_salt_and_self_address, |prj, cmd| {
@@ -342,7 +413,12 @@ contract SymbolicCreate2SelfAddress {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCreate2SelfAddress(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreate2SelfAddress(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CREATE2 salt"), "{stdout}");
     assert!(!stdout.contains("symbolic CALL target"), "{stdout}");
 });
@@ -386,7 +462,12 @@ contract SymbolicCreate2Collision is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCreate2Collision()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreate2Collision()
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_create_failure_bumps_creator_nonce, |prj, cmd| {
@@ -426,7 +507,12 @@ contract SymbolicCreateFailureNonce is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCreateFailureNonce(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreateFailureNonce(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_compute_create_address_cheatcodes, |prj, cmd| {
@@ -521,23 +607,47 @@ contract SymbolicComputeCreateAddresses is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkComputeCreateAddress(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkSymbolicComputeCreateAddress(uint64)"), "{stdout}");
-    assert!(
-        stdout.contains("[PASS] checkSymbolicComputeCreateAddressDeployer(address,uint64)"),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkComputeCreateAddress(uint256)
+"#]],
     );
-    assert!(stdout.contains("[PASS] checkComputeCreate2Address(uint256)"), "{stdout}");
-    assert!(
-        stdout.contains("[PASS] checkSymbolicComputeCreate2Address(bytes32,bytes32)"),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicComputeCreateAddress(uint64)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicComputeCreateAddressDeployer(address,uint64)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkComputeCreate2Address(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicComputeCreate2Address(bytes32,bytes32)
+"#]],
     );
     assert!(
         stdout
             .contains("[PASS] checkSymbolicComputeCreate2AddressDeployer(address,bytes32,bytes32)"),
         "{stdout}"
     );
-    assert!(stdout.contains("[PASS] checkComputeCreate2DefaultDeployer()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkComputeCreate2DefaultDeployer()
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.computeCreateAddress nonce"), "{stdout}");
     assert!(!stdout.contains("symbolic vm.computeCreate2Address init code hash"), "{stdout}");
     assert!(!stdout.contains("symbolic vm.computeCreateAddress deployer"), "{stdout}");
@@ -596,8 +706,18 @@ contract SymbolicNonceCheatcodes is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSetNonceCheatcodes(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkResetNonceCheatcode(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSetNonceCheatcodes(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkResetNonceCheatcode(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_vm_set_nonce_rejects_decrement, |prj, cmd| {
@@ -630,8 +750,18 @@ contract SymbolicSetNonceRejectsDecrement is Test {
         .clone();
     let output = format!("{}{}", output.stdout_lossy(), output.stderr_lossy());
 
-    assert!(output.contains("[FAIL"), "{output}");
-    assert!(output.contains("checkSetNonceRejectsDecrement(uint256)"), "{output}");
+    assert_relevant_lines(
+        &output,
+        foundry_test_utils::str![[r#"
+[FAIL
+"#]],
+    );
+    assert_relevant_lines(
+        &output,
+        foundry_test_utils::str![[r#"
+checkSetNonceRejectsDecrement(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_create_transfers_value_and_checks_balance, |prj, cmd| {
@@ -675,7 +805,12 @@ contract SymbolicCreateValue is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCreateValue()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreateValue()
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_create_accepts_symbolic_value, |prj, cmd| {
@@ -720,7 +855,12 @@ contract SymbolicCreateSymbolicValue is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCreateSymbolicValue(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreateSymbolicValue(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CREATE value"), "{stdout}");
 });
 
@@ -769,7 +909,12 @@ contract SymbolicCreateInsufficientValue is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCreateInsufficientValue(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreateInsufficientValue(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CREATE value"), "{stdout}");
     assert!(!stdout.contains("symbolic CREATE balance"), "{stdout}");
 });
@@ -817,7 +962,12 @@ contract SymbolicCreate2SymbolicValue is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCreate2SymbolicValue(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreate2SymbolicValue(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CREATE value"), "{stdout}");
 });
 
@@ -857,7 +1007,12 @@ contract SymbolicCreateInitcodeSize is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkCreateInitcodeSize(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreateInitcodeSize(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic CREATE initcode size"), "{stdout}");
     assert!(!stdout.contains("symbolic bytecode opcode"), "{stdout}");
 });
@@ -904,5 +1059,10 @@ contract SymbolicStaticCreate {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkStaticCreate()"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkStaticCreate()
+"#]],
+    );
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_helpers.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_helpers.rs
@@ -61,5 +61,5 @@ pub fn assert_relevant_lines(stdout: &str, expected: impl IntoData) {
         actual.push('\n');
     }
 
-    assert_data_eq!(Data::from(actual), expected);
+    assert_data_eq!(Data::from(actual.trim_end_matches('\n')), expected);
 }

--- a/crates/forge/tests/cli/test_cmd/symbolic_helpers.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_helpers.rs
@@ -1,4 +1,7 @@
-use foundry_test_utils::{TestCommand, snapbox::cmd::OutputAssert};
+use foundry_test_utils::{
+    TestCommand,
+    snapbox::{Data, IntoData, assert_data_eq, cmd::OutputAssert},
+};
 use std::process::Command;
 
 pub fn z3_available() -> bool {
@@ -42,4 +45,21 @@ pub fn assert_symbolic_witness(cmd: &mut TestCommand) -> OutputAssert {
         // `args=[1234 [1.2e3], 5678 [5.6e3]]`, so allow one level of nesting.
         ("[ARGS]", r"args=\[(?:[^\[\]]|\[[^\]]*\])*\]"),
     ])
+}
+
+pub fn assert_relevant_lines(stdout: &str, expected: impl IntoData) {
+    let expected = expected.into_data();
+    let expected_lines = expected.to_string();
+    let mut actual = String::new();
+
+    for expected_line in expected_lines.lines().filter(|line| !line.is_empty()) {
+        stdout
+            .lines()
+            .find(|line| line.contains(expected_line))
+            .unwrap_or_else(|| panic!("missing line `{expected_line}` in stdout:\n{stdout}"));
+        actual.push_str(expected_line);
+        actual.push('\n');
+    }
+
+    assert_data_eq!(Data::from(actual), expected);
 }

--- a/crates/forge/tests/cli/test_cmd/symbolic_limits.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_limits.rs
@@ -1,3 +1,4 @@
+use super::symbolic_helpers::assert_relevant_lines;
 use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, util::OutputExt};
 use std::{env, process::Command};
@@ -67,10 +68,30 @@ contract SymbolicLimitsRiddle {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("panic: assertion failed"), "{stdout}");
-    assert!(stdout.contains("check_riddle(uint256)"), "{stdout}");
-    assert!(stdout.contains("(paths:"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+panic: assertion failed
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+check_riddle(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+(paths:
+"#]],
+    );
     assert!(!stdout.contains("symbolic counterexample did not replay"), "{stdout}");
     assert!(!stdout.contains("incomplete symbolic execution"), "{stdout}");
 });
@@ -105,9 +126,24 @@ contract SymbolicLimitsPathWidth {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("checkWidth(uint8)"), "{stdout}");
-    assert!(stdout.contains("symbolic path limit exceeded (2)"), "{stdout}");
-    assert!(stdout.contains("incomplete symbolic execution (Stuck)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkWidth(uint8)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+symbolic path limit exceeded (2)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+incomplete symbolic execution (Stuck)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_limits_reports_execution_depth_exhaustion, |prj, cmd| {
@@ -141,9 +177,24 @@ contract SymbolicLimitsDepth {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("checkDepth(uint256)"), "{stdout}");
-    assert!(stdout.contains("symbolic depth limit exceeded (8)"), "{stdout}");
-    assert!(stdout.contains("incomplete symbolic execution (Stuck)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkDepth(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+symbolic depth limit exceeded (8)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+incomplete symbolic execution (Stuck)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_limits_reports_calldata_budget_exhaustion, |prj, cmd| {
@@ -170,9 +221,24 @@ contract SymbolicLimitsCalldataBudget {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("checkCalldataBudget(bytes)"), "{stdout}");
-    assert!(stdout.contains("symbolic calldata size exceeds configured max"), "{stdout}");
-    assert!(stdout.contains("incomplete symbolic execution (Stuck)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkCalldataBudget(bytes)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+symbolic calldata size exceeds configured max
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+incomplete symbolic execution (Stuck)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_limits_invariant_depth_changes_result, |prj, _cmd| {
@@ -221,7 +287,12 @@ contract SymbolicLimitsInvariantDepth is Test {
         .assert_success()
         .get_output()
         .stdout_lossy();
-    assert!(passing.contains("[PASS] invariant_valueNeverTwo()"), "{passing}");
+    assert_relevant_lines(
+        &passing,
+        foundry_test_utils::str![[r#"
+[PASS] invariant_valueNeverTwo()
+"#]],
+    );
 
     let failing = prj
         .forge_command()
@@ -236,7 +307,22 @@ contract SymbolicLimitsInvariantDepth is Test {
         .assert_failure()
         .get_output()
         .stdout_lossy();
-    assert!(failing.contains("[FAIL:"), "{failing}");
-    assert!(failing.contains("symbolic invariant counterexample"), "{failing}");
-    assert!(failing.contains("invariant_valueNeverTwo()"), "{failing}");
+    assert_relevant_lines(
+        &failing,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &failing,
+        foundry_test_utils::str![[r#"
+symbolic invariant counterexample
+"#]],
+    );
+    assert_relevant_lines(
+        &failing,
+        foundry_test_utils::str![[r#"
+invariant_valueNeverTwo()
+"#]],
+    );
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_memory.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_memory.rs
@@ -1,3 +1,4 @@
+use super::symbolic_helpers::assert_relevant_lines;
 use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, util::OutputExt};
 
@@ -39,7 +40,12 @@ contract SymbolicMload {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicMload(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicMload(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic MLOAD offset"), "{stdout}");
 });
 
@@ -78,7 +84,12 @@ contract SymbolicMstoreConstrained is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkConstrainedMstore(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkConstrainedMstore(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic MSTORE offset"), "{stdout}");
 });
 
@@ -113,7 +124,12 @@ contract SymbolicMstoreUnconstrained {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL: panic: assertion failed"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL: panic: assertion failed
+"#]],
+    );
     assert!(!stdout.contains("symbolic MSTORE offset"), "{stdout}");
 });
 
@@ -148,7 +164,12 @@ contract SymbolicMstore8Unconstrained {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL: panic: assertion failed"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL: panic: assertion failed
+"#]],
+    );
     assert!(!stdout.contains("symbolic MSTORE8 offset"), "{stdout}");
 });
 
@@ -183,7 +204,12 @@ contract SymbolicMsizeAfterWrite {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicMsize(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicMsize(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic MSIZE after symbolic memory write"), "{stdout}");
 });
 
@@ -222,7 +248,12 @@ contract SymbolicSha3 {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicSha3(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicSha3(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic SHA3 offset"), "{stdout}");
 });
 
@@ -263,7 +294,12 @@ contract SymbolicSha3ConstrainedSize is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkConstrainedSha3Size(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkConstrainedSha3Size(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic SHA3 size"), "{stdout}");
 });
 
@@ -304,7 +340,12 @@ contract SymbolicSha3BoundedSize is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkBoundedSha3Size(uint8,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkBoundedSha3Size(uint8,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic SHA3 size"), "{stdout}");
 });
 
@@ -345,7 +386,12 @@ contract SymbolicLogOffset is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicLogOffset(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicLogOffset(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic LOG offset"), "{stdout}");
 });
 
@@ -381,7 +427,12 @@ contract SymbolicLogSize is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicLogSize(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicLogSize(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic LOG size"), "{stdout}");
 });
 
@@ -439,7 +490,12 @@ contract SymbolicReturndataCopyConstrained is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkConstrainedReturndataCopy(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkConstrainedReturndataCopy(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic RETURNDATACOPY offset"), "{stdout}");
 });
 
@@ -500,7 +556,12 @@ contract SymbolicReturndataCopyOffset is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicReturndataCopyOffset(uint8,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicReturndataCopyOffset(uint8,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic RETURNDATACOPY offset"), "{stdout}");
 });
 
@@ -550,7 +611,12 @@ contract SymbolicReturndataCopyDest {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicReturndataCopyDest(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicReturndataCopyDest(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic RETURNDATACOPY dest"), "{stdout}");
 });
 
@@ -611,7 +677,12 @@ contract SymbolicReturndataCopySize is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicReturndataCopySize(uint8,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicReturndataCopySize(uint8,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic RETURNDATACOPY size"), "{stdout}");
 });
 
@@ -674,8 +745,18 @@ contract SymbolicReturnRevertOffset {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicReturnOffset(uint16,uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkSymbolicRevertOffset(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicReturnOffset(uint16,uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicRevertOffset(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic RETURN offset"), "{stdout}");
     assert!(!stdout.contains("symbolic REVERT offset"), "{stdout}");
 });
@@ -714,7 +795,12 @@ contract SymbolicMcopy {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicMcopy(uint16,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicMcopy(uint16,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic MCOPY src"), "{stdout}");
 });
 
@@ -769,7 +855,12 @@ contract SymbolicReturnSize {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicReturnSize(uint8,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicReturnSize(uint8,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic RETURN size"), "{stdout}");
 });
 
@@ -824,6 +915,11 @@ contract SymbolicRevertSize {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicRevertSize(uint8,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicRevertSize(uint8,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic REVERT size"), "{stdout}");
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_opcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_opcodes.rs
@@ -1,3 +1,4 @@
+use super::symbolic_helpers::assert_relevant_lines;
 use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, util::OutputExt};
 
@@ -50,8 +51,18 @@ contract SymbolicByteSignextend {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicByteIndex(uint8)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkSymbolicSignextendIndex(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicByteIndex(uint8)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicSignextendIndex(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic BYTE index"), "{stdout}");
     assert!(!stdout.contains("symbolic SIGNEXTEND index"), "{stdout}");
 });
@@ -101,7 +112,12 @@ contract SymbolicShift {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicShiftAmount(uint16)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicShiftAmount(uint16)
+"#]],
+    );
     assert!(!stdout.contains("symbolic shift amount"), "{stdout}");
 });
 
@@ -133,7 +149,12 @@ contract SymbolicExp {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicExpBase(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicExpBase(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic EXP base"), "{stdout}");
 });
 
@@ -166,7 +187,12 @@ contract SymbolicExpExponent {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicExpExponent(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicExpExponent(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic EXP exponent"), "{stdout}");
 });
 
@@ -199,6 +225,11 @@ contract SymbolicExpWideExponent {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicExpWideExponent(uint8)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicExpWideExponent(uint8)
+"#]],
+    );
     assert!(!stdout.contains("symbolic EXP exponent"), "{stdout}");
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_precompiles.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_precompiles.rs
@@ -1,3 +1,4 @@
+use super::symbolic_helpers::assert_relevant_lines;
 use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, util::OutputExt};
 
@@ -83,12 +84,42 @@ contract SymbolicPrecompiles is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkHashPrecompiles(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkIdentityPrecompile(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkModexpPrecompile(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkBn254Precompiles(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkBlake2fPrecompile(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkEcrecoverPrecompile(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkHashPrecompiles(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkIdentityPrecompile(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkModexpPrecompile(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkBn254Precompiles(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkBlake2fPrecompile(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkEcrecoverPrecompile(uint256)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_hash_precompiles_accept_symbolic_input, |prj, cmd| {
@@ -135,10 +166,17 @@ contract SymbolicPrecompileInput {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicHashDeterminism(bytes)"), "{stdout}");
-    assert!(
-        stdout.contains("[PASS] checkSymbolicEcrecoverDeterminism(bytes32,uint8,bytes32,bytes32)"),
-        "{stdout}"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicHashDeterminism(bytes)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicEcrecoverDeterminism(bytes32,uint8,bytes32,bytes32)
+"#]],
     );
     assert!(!stdout.contains("symbolic precompile input"), "{stdout}");
 });
@@ -176,7 +214,12 @@ contract SymbolicIdentityPrecompileInput is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicIdentity(bytes)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicIdentity(bytes)
+"#]],
+    );
     assert!(!stdout.contains("symbolic precompile input"), "{stdout}");
 });
 
@@ -236,8 +279,18 @@ contract SymbolicAdvancedPrecompileInput is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicModexp(bytes1)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkSymbolicBlake2f(bytes1)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicModexp(bytes1)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicBlake2f(bytes1)
+"#]],
+    );
     assert!(!stdout.contains("symbolic precompile input"), "{stdout}");
     assert!(!stdout.contains("symbolic precompile length header"), "{stdout}");
 });
@@ -315,7 +368,17 @@ contract SymbolicPrecompileInputSize is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSymbolicIdentityInputSize(uint256)"), "{stdout}");
-    assert!(stdout.contains("[PASS] checkSymbolicShaInputSize(uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicIdentityInputSize(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicShaInputSize(uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic precompile CALL input size"), "{stdout}");
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_storage.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_storage.rs
@@ -1,3 +1,4 @@
+use super::symbolic_helpers::assert_relevant_lines;
 use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, str, util::OutputExt};
 
@@ -33,9 +34,24 @@ contract SymbolicMappingStorage {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkMapping(address,uint256)"), "{stdout}");
-    assert!(stdout.contains("args=["), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkMapping(address,uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+args=[
+"#]],
+    );
     assert!(!stdout.contains("symbolic SHA3"), "{stdout}");
     assert!(!stdout.contains("symbolic SSTORE key"), "{stdout}");
     assert!(!stdout.contains("symbolic SLOAD key"), "{stdout}");
@@ -69,7 +85,12 @@ contract SymbolicNestedMappingStorage {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkNestedMapping(address,address,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkNestedMapping(address,address,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic SHA3"), "{stdout}");
 });
 
@@ -101,7 +122,12 @@ contract SymbolicVmStoreLoadSlot is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkStoreLoad(bytes32,bytes32)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkStoreLoad(bytes32,bytes32)
+"#]],
+    );
     assert!(!stdout.contains("symbolic vm.store slot"), "{stdout}");
     assert!(!stdout.contains("symbolic vm.load slot"), "{stdout}");
 });
@@ -141,7 +167,12 @@ contract SymbolicMappingDynamicArrayStorage is Test {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkMappingArray(address,uint256,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMappingArray(address,uint256,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic SHA3"), "{stdout}");
     assert!(!stdout.contains("symbolic SSTORE key"), "{stdout}");
     assert!(!stdout.contains("symbolic SLOAD key"), "{stdout}");
@@ -185,7 +216,12 @@ contract SymbolicPackedStorage {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkPacked(uint128,uint128,bool,address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkPacked(uint128,uint128,bool,address)
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_erc20_storage_paths_round_trip, |prj, cmd| {
@@ -221,7 +257,12 @@ contract SymbolicErc20Storage {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkErc20Storage(address,address,uint256)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkErc20Storage(address,address,uint256)
+"#]],
+    );
     assert!(!stdout.contains("symbolic SHA3"), "{stdout}");
     assert!(!stdout.contains("symbolic SSTORE key"), "{stdout}");
     assert!(!stdout.contains("symbolic SLOAD key"), "{stdout}");
@@ -323,7 +364,12 @@ contract SymbolicSvmStorageHelpers {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[PASS] checkSvmStorageHelpers(bytes32,bytes32)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSvmStorageHelpers(bytes32,bytes32)
+"#]],
+    );
     assert!(!stdout.contains("symbolic Halmos compatibility cheatcode"), "{stdout}");
 });
 
@@ -366,9 +412,24 @@ contract SymbolicGenericStorage {
         .get_output()
         .stdout_lossy();
 
-    assert!(stdout.contains("[FAIL:"), "{stdout}");
-    assert!(stdout.contains("checkNativeGenericStorage(address)"), "{stdout}");
-    assert!(stdout.contains("checkSvmArbitraryStorage(address)"), "{stdout}");
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkNativeGenericStorage(address)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkSvmArbitraryStorage(address)
+"#]],
+    );
     assert!(!stdout.contains("symbolic SLOAD key"), "{stdout}");
     assert!(!stdout.contains("symbolic Halmos compatibility cheatcode"), "{stdout}");
 });

--- a/crates/lint/src/sol/gas/external_function.rs
+++ b/crates/lint/src/sol/gas/external_function.rs
@@ -287,20 +287,16 @@ impl<'hir> hir::Visit<'hir> for ParamEscapeFinder<'_, 'hir> {
                     return ControlFlow::Break(());
                 }
             }
-            ExprKind::Delete(inner) => {
-                if expr_root_is_param(inner, self.params) {
-                    return ControlFlow::Break(());
-                }
+            ExprKind::Delete(inner) if expr_root_is_param(inner, self.params) => {
+                return ControlFlow::Break(());
             }
             ExprKind::Unary(op, inner)
                 if matches!(
                     op.kind,
                     UnOpKind::PreInc | UnOpKind::PreDec | UnOpKind::PostInc | UnOpKind::PostDec
-                ) =>
+                ) && expr_root_is_param(inner, self.params) =>
             {
-                if expr_root_is_param(inner, self.params) {
-                    return ControlFlow::Break(());
-                }
+                return ControlFlow::Break(());
             }
             ExprKind::Call(callee, args, opts) if !is_type_conversion_callee(callee) => {
                 for arg in args.exprs() {


### PR DESCRIPTION
## Summary
- convert newly added symbolic CLI positive output checks to snapbox snapshots of relevant output snippets
- add a shared helper that verifies each relevant snippet is present while keeping snapshots focused
- keep negative unsupported-feature absence checks as direct assertions

## Test
- cargo test -p forge --test cli symbolic_tests_are_ignored_without_flag --no-run

Prompted by: @grandizzy