### PR TITLE
feat(symbolic): add tracing to executor and solver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5453,6 +5453,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/evm/symbolic/Cargo.toml
+++ b/crates/evm/symbolic/Cargo.toml
@@ -28,6 +28,7 @@ base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 [features]
 default = ["optimism"]

--- a/crates/evm/symbolic/src/executor/invariant.rs
+++ b/crates/evm/symbolic/src/executor/invariant.rs
@@ -131,6 +131,10 @@ impl SymbolicExecutor {
             if *completed_paths >= path_limit {
                 return Err(SymbolicError::Unsupported("symbolic path limit exceeded"));
             }
+            let _path_span =
+                trace_span!("symbolic_path", completed_paths, worklist_size = worklist.len())
+                    .entered();
+            trace!(completed_paths, worklist_size = worklist.len(), "exploring symbolic path");
 
             loop {
                 if state.depth >= depth_limit {
@@ -152,6 +156,7 @@ impl SymbolicExecutor {
                     break;
                 };
 
+                let _step_span = trace_span!("symbolic_step", pc = state.pc - 1, op).entered();
                 match self.step(
                     executor,
                     &code,

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -515,6 +515,8 @@ impl SymbolicExecutor {
                     }
                     Some(false) => Ok(StepOutcome::Continue),
                     None => {
+                        let op_pc = state.pc.saturating_sub(1);
+                        let _branch_span = trace_span!("jumpi_branch", pc = op_pc, dest).entered();
                         let true_cond = cond.nonzero_bool();
                         let false_cond = true_cond.clone().not();
                         let fallthrough = state.pc;
@@ -525,12 +527,14 @@ impl SymbolicExecutor {
                         false_state.constraints.push(false_cond);
                         false_state.pc = fallthrough;
 
-                        if self.take_loop_jump(&mut true_state, fallthrough, dest)
-                            && self.solver.is_sat(&true_state.constraints)?
-                        {
+                        let true_feasible = self.take_loop_jump(&mut true_state, fallthrough, dest)
+                            && self.solver.is_sat(&true_state.constraints)?;
+                        let false_feasible = self.solver.is_sat(&false_state.constraints)?;
+                        trace!(true_feasible, false_feasible, "JUMPI symbolic branch");
+                        if true_feasible {
                             worklist.push_back(true_state);
                         }
-                        if self.solver.is_sat(&false_state.constraints)? {
+                        if false_feasible {
                             worklist.push_back(false_state);
                         }
                         Ok(StepOutcome::Forked)

--- a/crates/evm/symbolic/src/executor/run.rs
+++ b/crates/evm/symbolic/src/executor/run.rs
@@ -137,15 +137,21 @@ impl SymbolicExecutor {
 
         while let Some(mut state) = pop_worklist(&mut worklist, self.config.exploration_order) {
             if completed_paths >= path_limit {
+                debug!(completed_paths, path_limit, "symbolic path limit reached");
                 return Ok(SymbolicRunResult::Incomplete {
                     kind: SymbolicStopReason::Stuck,
                     reason: format!("symbolic path limit exceeded ({path_limit})"),
                     stats: self.stats_with_paths(completed_paths),
                 });
             }
+            let _path_span =
+                trace_span!("symbolic_path", completed_paths, worklist_size = worklist.len())
+                    .entered();
+            trace!(completed_paths, worklist_size = worklist.len(), "exploring symbolic path");
 
             loop {
                 if state.depth >= depth_limit {
+                    debug!(depth = state.depth, depth_limit, "symbolic depth limit reached");
                     return Ok(SymbolicRunResult::Incomplete {
                         kind: SymbolicStopReason::Stuck,
                         reason: format!("symbolic depth limit exceeded ({depth_limit})"),
@@ -173,6 +179,7 @@ impl SymbolicExecutor {
                     break;
                 };
 
+                let _step_span = trace_span!("symbolic_step", pc = state.pc - 1, op).entered();
                 match self.step(
                     input.executor,
                     &code,
@@ -229,6 +236,7 @@ impl SymbolicExecutor {
         }
 
         if normal_paths == 0 && reverted_paths > 0 {
+            debug!(completed_paths, "all symbolic paths reverted");
             return Ok(SymbolicRunResult::Incomplete {
                 kind: SymbolicStopReason::RevertAll,
                 reason: "all symbolic paths reverted".to_string(),
@@ -236,6 +244,7 @@ impl SymbolicExecutor {
             });
         }
 
+        debug!(completed_paths, "symbolic execution safe");
         Ok(SymbolicRunResult::Safe(self.stats_with_paths(completed_paths)))
     }
 
@@ -246,6 +255,10 @@ impl SymbolicExecutor {
         function: &Function,
         state: &PathState,
     ) -> Result<(Vec<DynSolValue>, Bytes), SymbolicError> {
+        debug!(
+            constraint_count = state.constraints.len(),
+            "materializing counterexample from solver model"
+        );
         let model = self.solver.model(&state.constraints)?;
         let args = calldata.model_to_args(&model)?;
         let calldata_bytes = Bytes::from(function.abi_encode_input(&args)?);

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -46,6 +46,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
+use tracing::{debug, trace, trace_span, warn};
 
 macro_rules! selector {
     ($signature:literal) => {{

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -215,9 +215,18 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
     fn is_sat(&mut self, constraints: &[BoolExpr]) -> Result<bool, SymbolicError> {
         self.reserve_query()?;
         self.record_query();
+        let _span = trace_span!(
+            "solver_query",
+            query_id = self.queries,
+            constraint_count = constraints.len(),
+            kind = "is_sat"
+        )
+        .entered();
+        trace!(query_id = self.queries, constraint_count = constraints.len(), "solver is_sat");
         if constraints_prefer_fallback_first(constraints)
             && fallback_single_var_model(constraints).is_some()
         {
+            trace!("is_sat: fallback single-var model");
             return Ok(true);
         }
         let output = self.query(constraints, false)?;
@@ -235,9 +244,18 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
     fn model(&mut self, constraints: &[BoolExpr]) -> Result<BTreeMap<String, U256>, SymbolicError> {
         self.reserve_query()?;
         self.record_query();
+        let _span = trace_span!(
+            "solver_query",
+            query_id = self.queries,
+            constraint_count = constraints.len(),
+            kind = "model"
+        )
+        .entered();
+        trace!(query_id = self.queries, constraint_count = constraints.len(), "solver model");
         if constraints_prefer_fallback_first(constraints)
             && let Some(model) = fallback_single_var_model(constraints)
         {
+            trace!("model: fallback single-var model");
             return Ok(model);
         }
         let output = self.query(constraints, true)?;
@@ -786,6 +804,7 @@ fn run_solver_commands(
             SolverProcessOutcome::Output(output) => Ok(output),
             SolverProcessOutcome::Unknown => Err(SymbolicError::SolverUnknown),
             SolverProcessOutcome::Cancelled => {
+                warn!("solver query was cancelled");
                 Err(SymbolicError::Solver("solver query was cancelled".to_string()))
             }
             SolverProcessOutcome::Error(err) => Err(SymbolicError::Solver(err)),
@@ -1223,6 +1242,10 @@ pub(crate) fn parse_and_validate_model(
     if constraints.iter().all(|constraint| eval_bool_expr(constraint, &model).unwrap_or(false)) {
         Ok(model)
     } else {
+        debug!(
+            constraint_count = constraints.len(),
+            "solver model does not satisfy path constraints"
+        );
         Err(SymbolicError::Solver("solver model does not satisfy path constraints".to_string()))
     }
 }


### PR DESCRIPTION
## Description

Spans added:
- `symbolic_path` (`completed_paths`, `worklist_size`): wraps each worklist iteration in `run.rs`
- `symbolic_step` (`pc`, `op`): wraps each `step()` call, nested under `symbolic_path`
- `jumpi_branch` (`pc`, `dest`): wraps the symbolic `JUMPI` fork block in `opcodes.rs`
- `solver_query` (`query_id`, `constraint_count`, `kind`): wraps `is_sat`/`model` calls in `solver.rs`

Events added:
- trace per path pop and per solver query entry
- debug at path/depth limit exhaustion and final safe/revert-all outcome
- debug before counterexample model materialization
- debug (with `constraint_count`) on invalid solver model
