### PR TITLE
refactor(common): extract wallet helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5448,6 +5448,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "base64 0.22.1",
+ "foundry-common",
  "foundry-config",
  "foundry-evm",
  "serde",

--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -11,6 +11,7 @@ use alloy_signer_local::{
     },
 };
 use alloy_sol_types::SolValue;
+use foundry_common::wallet::{derive_private_key, derive_private_key_with_language};
 use foundry_evm_core::evm::FoundryEvmNetwork;
 use k256::{
     FieldBytes, Scalar,
@@ -486,36 +487,14 @@ pub(super) fn parse_wallet(private_key: &U256) -> Result<PrivateKeySigner> {
 }
 
 fn derive_key_str(mnemonic: &str, path: &str, index: u32, language: &str) -> Result {
-    match language {
-        "chinese_simplified" => derive_key::<ChineseSimplified>(mnemonic, path, index),
-        "chinese_traditional" => derive_key::<ChineseTraditional>(mnemonic, path, index),
-        "czech" => derive_key::<Czech>(mnemonic, path, index),
-        "english" => derive_key::<English>(mnemonic, path, index),
-        "french" => derive_key::<French>(mnemonic, path, index),
-        "italian" => derive_key::<Italian>(mnemonic, path, index),
-        "japanese" => derive_key::<Japanese>(mnemonic, path, index),
-        "korean" => derive_key::<Korean>(mnemonic, path, index),
-        "portuguese" => derive_key::<Portuguese>(mnemonic, path, index),
-        "spanish" => derive_key::<Spanish>(mnemonic, path, index),
-        _ => Err(fmt_err!("unsupported mnemonic language: {language:?}")),
-    }
+    let private_key = derive_private_key_with_language(mnemonic, path, index, language)
+        .map_err(|e| fmt_err!("{e}"))?;
+    Ok(private_key.abi_encode())
 }
 
 fn derive_key<W: Wordlist>(mnemonic: &str, path: &str, index: u32) -> Result {
-    fn derive_key_path(path: &str, index: u32) -> String {
-        let mut out = path.to_string();
-        if !out.ends_with('/') {
-            out.push('/');
-        }
-        out.push_str(&index.to_string());
-        out
-    }
-
-    let wallet = MnemonicBuilder::<W>::default()
-        .phrase(mnemonic)
-        .derivation_path(derive_key_path(path, index))?
-        .build()?;
-    let private_key = U256::from_be_bytes(wallet.credential().to_bytes().into());
+    let private_key =
+        derive_private_key::<W>(mnemonic, path, index).map_err(|e| fmt_err!("{e}"))?;
     Ok(private_key.abi_encode())
 }
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -86,7 +86,7 @@ mpp.workspace = true
 foundry-wallets = { workspace = true, features = ["browser", "tempo"] }
 tokio-tungstenite.workspace = true
 futures.workspace = true
-alloy-signer-local.workspace = true
+alloy-signer-local = { workspace = true, features = ["mnemonic"] }
 base64.workspace = true
 sha2 = "0.10"
 tempfile.workspace = true

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -86,7 +86,7 @@ mpp.workspace = true
 foundry-wallets = { workspace = true, features = ["browser", "tempo"] }
 tokio-tungstenite.workspace = true
 futures.workspace = true
-alloy-signer-local = { workspace = true, features = ["mnemonic"] }
+alloy-signer-local = { workspace = true, features = ["mnemonic-all-languages"] }
 base64.workspace = true
 sha2 = "0.10"
 tempfile.workspace = true

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -38,6 +38,7 @@ pub mod traits;
 pub mod transactions;
 mod utils;
 pub mod version;
+pub mod wallet;
 
 pub use compile::Analysis;
 pub use constants::*;

--- a/crates/common/src/wallet.rs
+++ b/crates/common/src/wallet.rs
@@ -1,0 +1,68 @@
+use alloy_primitives::U256;
+use alloy_signer_local::{
+    MnemonicBuilder, PrivateKeySigner,
+    coins_bip39::{
+        ChineseSimplified, ChineseTraditional, Czech, English, French, Italian, Japanese, Korean,
+        Portuguese, Spanish, Wordlist,
+    },
+};
+
+/// Appends `index` to `path`, inserting a `/` separator when needed.
+pub fn derive_key_path(path: &str, index: u32) -> String {
+    let mut out = path.to_string();
+    if !out.ends_with('/') {
+        out.push('/');
+    }
+    out.push_str(&index.to_string());
+    out
+}
+
+/// Derives a private key from a BIP-39 mnemonic using the given BIP-32 path and index.
+pub fn derive_private_key<W: Wordlist>(
+    mnemonic: &str,
+    path: &str,
+    index: u32,
+) -> Result<U256, String> {
+    let wallet = MnemonicBuilder::<W>::default()
+        .phrase(mnemonic)
+        .derivation_path(derive_key_path(path, index))
+        .map_err(|e| e.to_string())?
+        .build()
+        .map_err(|e| e.to_string())?;
+    Ok(U256::from_be_bytes(wallet.credential().to_bytes().into()))
+}
+
+/// Derives a private key from a BIP-39 mnemonic, selecting the wordlist by name.
+///
+/// Recognised language names: `chinese_simplified`, `chinese_traditional`, `czech`, `english`,
+/// `french`, `italian`, `japanese`, `korean`, `portuguese`, `spanish`.
+pub fn derive_private_key_with_language(
+    mnemonic: &str,
+    path: &str,
+    index: u32,
+    language: &str,
+) -> Result<U256, String> {
+    match language {
+        "chinese_simplified" => derive_private_key::<ChineseSimplified>(mnemonic, path, index),
+        "chinese_traditional" => derive_private_key::<ChineseTraditional>(mnemonic, path, index),
+        "czech" => derive_private_key::<Czech>(mnemonic, path, index),
+        "english" => derive_private_key::<English>(mnemonic, path, index),
+        "french" => derive_private_key::<French>(mnemonic, path, index),
+        "italian" => derive_private_key::<Italian>(mnemonic, path, index),
+        "japanese" => derive_private_key::<Japanese>(mnemonic, path, index),
+        "korean" => derive_private_key::<Korean>(mnemonic, path, index),
+        "portuguese" => derive_private_key::<Portuguese>(mnemonic, path, index),
+        "spanish" => derive_private_key::<Spanish>(mnemonic, path, index),
+        _ => Err(format!("unsupported mnemonic language: {language:?}")),
+    }
+}
+
+/// Constructs a [`PrivateKeySigner`] from a raw private key value.
+///
+/// Returns `Err` when `private_key` is zero or its bytes are not a valid secp256k1 scalar.
+pub fn private_key_from_u256(private_key: U256) -> Result<PrivateKeySigner, String> {
+    if private_key.is_zero() {
+        return Err("private key cannot be zero".to_string());
+    }
+    PrivateKeySigner::from_slice(&private_key.to_be_bytes::<32>()).map_err(|e| e.to_string())
+}

--- a/crates/evm/symbolic/Cargo.toml
+++ b/crates/evm/symbolic/Cargo.toml
@@ -15,6 +15,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+foundry-common.workspace = true
 foundry-config.workspace = true
 foundry-evm.workspace = true
 

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -7,11 +7,8 @@ use alloy_json_abi::Function;
 use alloy_primitives::{Address, B256, Bytes, I256, U256, hex, keccak256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::{
-    MnemonicBuilder, PrivateKeySigner,
-    coins_bip39::{
-        ChineseSimplified, ChineseTraditional, Czech, English, French, Italian, Japanese, Korean,
-        Portuguese, Spanish, Wordlist,
-    },
+    PrivateKeySigner,
+    coins_bip39::{English, Wordlist},
 };
 use base64::prelude::*;
 use foundry_config::{

--- a/crates/evm/symbolic/src/runtime/cheatcodes.rs
+++ b/crates/evm/symbolic/src/runtime/cheatcodes.rs
@@ -1,3 +1,5 @@
+use foundry_common::wallet::private_key_from_u256;
+
 use super::*;
 
 /// Implements the `foundry_cheatcode_min_input_size` cheatcode runtime helper.
@@ -1139,10 +1141,7 @@ pub(crate) fn parse_env_address(value: &str) -> Result<Address, SymbolicError> {
 
 /// Implements the `private_key_signer` cheatcode runtime helper.
 pub(crate) fn private_key_signer(private_key: U256) -> Result<PrivateKeySigner, SymbolicError> {
-    if private_key.is_zero() {
-        return Err(SymbolicError::Unsupported("symbolic private key cannot be zero"));
-    }
-    PrivateKeySigner::from_slice(&private_key.to_be_bytes::<32>())
+    private_key_from_u256(private_key)
         .map_err(|_| SymbolicError::Unsupported("symbolic private key parse"))
 }
 
@@ -1182,29 +1181,14 @@ pub(crate) fn sign_compact_hash_words(
     Ok(vec![SymWord::Concrete(sig.r()), SymWord::Concrete(sig.s() | y_parity)])
 }
 
-/// Computes the `derive_key_path` cheatcode runtime helper result.
-pub(crate) fn derive_key_path(path: &str, index: u32) -> String {
-    let mut out = path.to_string();
-    if !out.ends_with('/') {
-        out.push('/');
-    }
-    out.push_str(&index.to_string());
-    out
-}
-
 /// Computes the `derive_private_key` cheatcode runtime helper result.
 pub(crate) fn derive_private_key<W: Wordlist>(
     mnemonic: &str,
     path: &str,
     index: u32,
 ) -> Result<U256, SymbolicError> {
-    let wallet = MnemonicBuilder::<W>::default()
-        .phrase(mnemonic)
-        .derivation_path(derive_key_path(path, index))
-        .map_err(|_| SymbolicError::Unsupported("symbolic vm.deriveKey"))?
-        .build()
-        .map_err(|_| SymbolicError::Unsupported("symbolic vm.deriveKey"))?;
-    Ok(U256::from_be_bytes(wallet.credential().to_bytes().into()))
+    foundry_common::wallet::derive_private_key::<W>(mnemonic, path, index)
+        .map_err(|_| SymbolicError::Unsupported("symbolic vm.deriveKey"))
 }
 
 /// Computes the `derive_private_key_with_language` cheatcode runtime helper result.
@@ -1214,19 +1198,8 @@ pub(crate) fn derive_private_key_with_language(
     index: u32,
     language: &str,
 ) -> Result<U256, SymbolicError> {
-    match language {
-        "chinese_simplified" => derive_private_key::<ChineseSimplified>(mnemonic, path, index),
-        "chinese_traditional" => derive_private_key::<ChineseTraditional>(mnemonic, path, index),
-        "czech" => derive_private_key::<Czech>(mnemonic, path, index),
-        "english" => derive_private_key::<English>(mnemonic, path, index),
-        "french" => derive_private_key::<French>(mnemonic, path, index),
-        "italian" => derive_private_key::<Italian>(mnemonic, path, index),
-        "japanese" => derive_private_key::<Japanese>(mnemonic, path, index),
-        "korean" => derive_private_key::<Korean>(mnemonic, path, index),
-        "portuguese" => derive_private_key::<Portuguese>(mnemonic, path, index),
-        "spanish" => derive_private_key::<Spanish>(mnemonic, path, index),
-        _ => Err(SymbolicError::Unsupported("symbolic vm.deriveKey language")),
-    }
+    foundry_common::wallet::derive_private_key_with_language(mnemonic, path, index, language)
+        .map_err(|_| SymbolicError::Unsupported("symbolic vm.deriveKey language"))
 }
 
 /// Implements the `artifact_json_path` cheatcode runtime helper.


### PR DESCRIPTION
## Motivation

Move `derive_key_path`, `derive_private_key<W>`, `derive_private_key_with_language`, and `private_key_from_u256` from `foundry-evm-symbolic` into `foundry-common` so that both `foundry-cheatcodes` and `foundry-evm-symbolic` share a single impl.
