### PR TITLE
feat(lint): add missing events arithmetic lint

### DIFF
--- a/crates/lint/docs/missing-events-arithmetic.md
+++ b/crates/lint/docs/missing-events-arithmetic.md
@@ -1,0 +1,47 @@
+# Missing events arithmetic
+
+**Severity**: `Low`
+**ID**: `missing-events-arithmetic`
+
+Flags protected entry-point functions that update tainted integer state used in arithmetic by an
+unprotected function without emitting an event.
+
+## What it does
+
+This lint looks for scalar `int`/`uint` state variables that are:
+
+- written by a public or external state-mutating function with access control,
+- assigned from function input, directly or through local aliases/internal helpers,
+- used in arithmetic by an unprotected public or external function, and
+- changed along a path that does not emit an event.
+
+It intentionally skips fixed-value writes, constructors, unprotected setters, mappings/arrays, and
+functions that emit any event directly or through an internal helper. Those limits keep the rule
+focused on Slither's low-severity `events-maths` case while avoiding common false positives.
+
+## Why is this bad?
+
+Off-chain monitors, users, and auditors often rely on events to track changes to critical contract
+parameters such as prices, fees, caps, and rates. If a protected function silently changes a
+parameter used in calculations, downstream behavior can change without an easy audit trail.
+
+## Example
+
+### Bad
+
+```solidity
+function setBuyPrice(uint256 newBuyPrice) external onlyOwner {
+    buyPrice = newBuyPrice;
+}
+```
+
+### Good
+
+```solidity
+event BuyPriceUpdated(uint256 newBuyPrice);
+
+function setBuyPrice(uint256 newBuyPrice) external onlyOwner {
+    buyPrice = newBuyPrice;
+    emit BuyPriceUpdated(newBuyPrice);
+}
+```

--- a/crates/lint/docs/missing-events-arithmetic.md
+++ b/crates/lint/docs/missing-events-arithmetic.md
@@ -11,12 +11,13 @@ unprotected function without emitting an event.
 This lint looks for scalar `int`/`uint` state variables that are:
 
 - written by a public or external state-mutating function with access control,
-- assigned from function input, directly or through local aliases/internal helpers,
+- assigned from function input, directly or through local aliases/internal helpers, or changed with
+  an arithmetic assignment or increment/decrement,
 - used in arithmetic by an unprotected public or external function, and
 - changed along a path that does not emit an event.
 
 It intentionally skips fixed-value writes, constructors, unprotected setters, mappings/arrays, and
-functions that emit any event directly or through an internal helper. Those limits keep the rule
+update paths that emit an event directly or through an internal helper. Those limits keep the rule
 focused on Slither's low-severity `events-maths` case while avoiding common false positives.
 
 ## Why is this bad?

--- a/crates/lint/src/sol/low/missing_events_arithmetic.rs
+++ b/crates/lint/src/sol/low/missing_events_arithmetic.rs
@@ -164,7 +164,7 @@ struct WriteAnalyzer<'a, 'hir> {
 }
 
 impl<'a, 'hir> WriteAnalyzer<'a, 'hir> {
-    fn new(hir: &'hir hir::Hir<'hir>, targets: &'a HashSet<VariableId>) -> Self {
+    const fn new(hir: &'hir hir::Hir<'hir>, targets: &'a HashSet<VariableId>) -> Self {
         Self { hir, targets, call_stack: Vec::new() }
     }
 

--- a/crates/lint/src/sol/low/missing_events_arithmetic.rs
+++ b/crates/lint/src/sol/low/missing_events_arithmetic.rs
@@ -8,7 +8,7 @@ use solar::{
     interface::{Span, kw, sym},
     sema::hir::{
         self, BinOpKind, ElementaryType, ExprKind, FunctionId, ItemId, Res, StmtKind, TypeKind,
-        VariableId,
+        UnOpKind, VariableId,
     },
 };
 use std::collections::{HashMap, HashSet};
@@ -44,9 +44,7 @@ impl<'hir> LateLintPass<'hir> for MissingEventsArithmetic {
 
         for func_id in contract.all_functions() {
             let func = hir.function(func_id);
-            if !is_protected_entry_point(hir, func_id, func)
-                || function_emits_event(hir, func_id, &mut HashSet::new())
-            {
+            if !is_protected_entry_point(hir, func_id, func) {
                 continue;
             }
 
@@ -139,31 +137,49 @@ struct StateWrite {
     span: Span,
 }
 
+#[derive(Clone, Default)]
+struct WriteState {
+    taint: HashMap<VariableId, HashSet<VariableId>>,
+    pending_writes: Vec<StateWrite>,
+    emitted_event: bool,
+}
+
+impl WriteState {
+    fn record_write(&mut self, write: StateWrite) {
+        if !self.emitted_event {
+            self.pending_writes.push(write);
+        }
+    }
+
+    fn record_event(&mut self) {
+        self.emitted_event = true;
+        self.pending_writes.clear();
+    }
+}
+
 struct WriteAnalyzer<'a, 'hir> {
     hir: &'hir hir::Hir<'hir>,
     targets: &'a HashSet<VariableId>,
-    taint: HashMap<VariableId, HashSet<VariableId>>,
-    writes: Vec<StateWrite>,
     call_stack: Vec<FunctionId>,
 }
 
 impl<'a, 'hir> WriteAnalyzer<'a, 'hir> {
     fn new(hir: &'hir hir::Hir<'hir>, targets: &'a HashSet<VariableId>) -> Self {
-        Self { hir, targets, taint: HashMap::new(), writes: Vec::new(), call_stack: Vec::new() }
+        Self { hir, targets, call_stack: Vec::new() }
     }
 
     fn analyze_entry_point(&mut self, func_id: FunctionId) -> Vec<StateWrite> {
+        let mut state = WriteState::default();
         let func = self.hir.function(func_id);
-        self.taint.clear();
         for &param in func.parameters {
-            self.taint.insert(param, HashSet::from([param]));
+            state.taint.insert(param, HashSet::from([param]));
         }
 
-        self.analyze_function(func_id);
-        std::mem::take(&mut self.writes)
+        self.analyze_function(func_id, &mut state);
+        state.pending_writes
     }
 
-    fn analyze_function(&mut self, func_id: FunctionId) {
+    fn analyze_function(&mut self, func_id: FunctionId, state: &mut WriteState) {
         if self.call_stack.contains(&func_id) {
             return;
         }
@@ -173,131 +189,165 @@ impl<'a, 'hir> WriteAnalyzer<'a, 'hir> {
 
         self.call_stack.push(func_id);
         for stmt in body.stmts {
-            self.analyze_stmt(stmt);
+            self.analyze_stmt(stmt, state);
         }
         self.call_stack.pop();
     }
 
-    fn analyze_stmt(&mut self, stmt: &'hir hir::Stmt<'hir>) {
+    fn analyze_stmt(&mut self, stmt: &'hir hir::Stmt<'hir>, state: &mut WriteState) {
         match stmt.kind {
             StmtKind::DeclSingle(var_id) => {
                 let var = self.hir.variable(var_id);
                 if let Some(init) = var.initializer
                     && !var.kind.is_state()
                 {
-                    self.set_local_taint(var_id, self.taint_sources(init));
+                    self.analyze_expr(init, state);
+                    self.set_local_taint(state, var_id, self.taint_sources(state, init));
                 }
             }
             StmtKind::DeclMulti(vars, expr) => {
-                self.analyze_expr(expr);
-                let sources = self.taint_sources(expr);
+                self.analyze_expr(expr, state);
+                let sources = self.taint_sources(state, expr);
                 for var_id in vars.iter().flatten().copied() {
                     if !self.hir.variable(var_id).kind.is_state() {
-                        self.set_local_taint(var_id, sources.clone());
+                        self.set_local_taint(state, var_id, sources.clone());
                     }
                 }
             }
             StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
                 for stmt in block.stmts {
-                    self.analyze_stmt(stmt);
+                    self.analyze_stmt(stmt, state);
                 }
             }
             StmtKind::If(cond, then_stmt, else_stmt) => {
-                self.analyze_expr(cond);
-                self.analyze_stmt(then_stmt);
+                self.analyze_expr(cond, state);
+
+                let mut then_state = state.clone();
+                self.analyze_stmt(then_stmt, &mut then_state);
+
+                let mut else_state = state.clone();
                 if let Some(else_stmt) = else_stmt {
-                    self.analyze_stmt(else_stmt);
+                    self.analyze_stmt(else_stmt, &mut else_state);
                 }
+
+                state.taint = merge_taint(&then_state.taint, &else_state.taint);
+                state.pending_writes = then_state.pending_writes;
+                state.pending_writes.extend(else_state.pending_writes);
+                state.emitted_event = then_state.emitted_event && else_state.emitted_event;
             }
             StmtKind::Try(try_stmt) => {
-                self.analyze_expr(&try_stmt.expr);
+                self.analyze_expr(&try_stmt.expr, state);
                 for clause in try_stmt.clauses {
                     for stmt in clause.block.stmts {
-                        self.analyze_stmt(stmt);
+                        self.analyze_stmt(stmt, state);
                     }
                 }
             }
-            StmtKind::Expr(expr) | StmtKind::Emit(expr) | StmtKind::Revert(expr) => {
-                self.analyze_expr(expr);
+            StmtKind::Expr(expr) | StmtKind::Revert(expr) => {
+                self.analyze_expr(expr, state);
+            }
+            StmtKind::Emit(expr) => {
+                self.analyze_expr(expr, state);
+                state.record_event();
             }
             StmtKind::Return(expr) => {
                 if let Some(expr) = expr {
-                    self.analyze_expr(expr);
+                    self.analyze_expr(expr, state);
                 }
             }
             StmtKind::Break | StmtKind::Continue | StmtKind::Placeholder | StmtKind::Err(_) => {}
         }
     }
 
-    fn analyze_expr(&mut self, expr: &'hir hir::Expr<'hir>) {
+    fn analyze_expr(&mut self, expr: &'hir hir::Expr<'hir>, state: &mut WriteState) {
         match &expr.kind {
-            ExprKind::Assign(lhs, _op, rhs) => {
-                self.analyze_expr(rhs);
+            ExprKind::Assign(lhs, op, rhs) => {
+                self.analyze_expr(rhs, state);
 
-                let sources = self.taint_sources(rhs);
+                let sources = self.taint_sources(state, rhs);
+                let is_arithmetic_assignment = op.is_some_and(|op| is_arithmetic_op(op.kind));
                 for var_id in state_lhs_vars(self.hir, lhs) {
-                    if self.targets.contains(&var_id) && !sources.is_empty() {
-                        self.writes.push(StateWrite { var_id, span: lhs.span });
+                    if self.targets.contains(&var_id)
+                        && (is_arithmetic_assignment || !sources.is_empty())
+                    {
+                        state.record_write(StateWrite { var_id, span: lhs.span });
                     }
                 }
 
                 if let Some(local) = lhs_local_var(self.hir, lhs) {
-                    self.set_local_taint(local, sources);
+                    self.set_local_taint(state, local, sources);
                 } else {
-                    self.analyze_lhs_indices(lhs);
+                    self.analyze_lhs_indices(lhs, state);
                 }
             }
             ExprKind::Call(callee, args, opts) => {
-                self.analyze_expr(callee);
+                self.analyze_expr(callee, state);
                 if let Some(opts) = opts {
                     for opt in *opts {
-                        self.analyze_expr(&opt.value);
+                        self.analyze_expr(&opt.value, state);
                     }
                 }
                 for arg in args.exprs() {
-                    self.analyze_expr(arg);
+                    self.analyze_expr(arg, state);
                 }
 
                 for callee_id in resolved_function_ids(callee) {
-                    self.analyze_internal_call(callee_id, args);
+                    self.analyze_internal_call(callee_id, args, state);
                 }
             }
             ExprKind::Binary(lhs, _, rhs) => {
-                self.analyze_expr(lhs);
-                self.analyze_expr(rhs);
+                self.analyze_expr(lhs, state);
+                self.analyze_expr(rhs, state);
+            }
+            ExprKind::Unary(op, inner) if is_inc_dec_op(op.kind) => {
+                for var_id in state_lhs_vars(self.hir, inner) {
+                    if self.targets.contains(&var_id) {
+                        state.record_write(StateWrite { var_id, span: inner.span });
+                    }
+                }
+                self.analyze_lhs_indices(inner, state);
             }
             ExprKind::Unary(_, inner)
             | ExprKind::Delete(inner)
             | ExprKind::Member(inner, _)
-            | ExprKind::Payable(inner) => self.analyze_expr(inner),
+            | ExprKind::Payable(inner) => self.analyze_expr(inner, state),
             ExprKind::Index(base, index) => {
-                self.analyze_expr(base);
+                self.analyze_expr(base, state);
                 if let Some(index) = index {
-                    self.analyze_expr(index);
+                    self.analyze_expr(index, state);
                 }
             }
             ExprKind::Slice(base, start, end) => {
-                self.analyze_expr(base);
+                self.analyze_expr(base, state);
                 if let Some(start) = start {
-                    self.analyze_expr(start);
+                    self.analyze_expr(start, state);
                 }
                 if let Some(end) = end {
-                    self.analyze_expr(end);
+                    self.analyze_expr(end, state);
                 }
             }
             ExprKind::Ternary(cond, true_expr, false_expr) => {
-                self.analyze_expr(cond);
-                self.analyze_expr(true_expr);
-                self.analyze_expr(false_expr);
+                self.analyze_expr(cond, state);
+
+                let mut true_state = state.clone();
+                self.analyze_expr(true_expr, &mut true_state);
+
+                let mut false_state = state.clone();
+                self.analyze_expr(false_expr, &mut false_state);
+
+                state.taint = merge_taint(&true_state.taint, &false_state.taint);
+                state.pending_writes = true_state.pending_writes;
+                state.pending_writes.extend(false_state.pending_writes);
+                state.emitted_event = true_state.emitted_event && false_state.emitted_event;
             }
             ExprKind::Array(exprs) => {
                 for expr in *exprs {
-                    self.analyze_expr(expr);
+                    self.analyze_expr(expr, state);
                 }
             }
             ExprKind::Tuple(exprs) => {
                 for expr in exprs.iter().copied().flatten() {
-                    self.analyze_expr(expr);
+                    self.analyze_expr(expr, state);
                 }
             }
             ExprKind::New(_) | ExprKind::TypeCall(_) | ExprKind::Type(_) => {}
@@ -305,7 +355,12 @@ impl<'a, 'hir> WriteAnalyzer<'a, 'hir> {
         }
     }
 
-    fn analyze_internal_call(&mut self, callee_id: FunctionId, args: &hir::CallArgs<'hir>) {
+    fn analyze_internal_call(
+        &mut self,
+        callee_id: FunctionId,
+        args: &hir::CallArgs<'hir>,
+        state: &mut WriteState,
+    ) {
         if self.call_stack.contains(&callee_id) {
             return;
         }
@@ -313,56 +368,74 @@ impl<'a, 'hir> WriteAnalyzer<'a, 'hir> {
         let callee = self.hir.function(callee_id);
         let Some(_) = callee.body else { return };
 
-        let saved_taint = std::mem::take(&mut self.taint);
+        let saved_taint = std::mem::take(&mut state.taint);
         for (param, arg) in callee.parameters.iter().copied().zip(args.exprs()) {
             let sources = collect_input_taint_sources(&saved_taint, arg);
             if !sources.is_empty() {
-                self.taint.insert(param, sources);
+                state.taint.insert(param, sources);
             }
         }
 
-        self.analyze_function(callee_id);
-        self.taint = saved_taint;
+        self.analyze_function(callee_id, state);
+        state.taint = saved_taint;
     }
 
-    fn analyze_lhs_indices(&mut self, expr: &'hir hir::Expr<'hir>) {
+    fn analyze_lhs_indices(&mut self, expr: &'hir hir::Expr<'hir>, state: &mut WriteState) {
         match &expr.kind {
             ExprKind::Index(base, index) => {
-                self.analyze_lhs_indices(base);
+                self.analyze_lhs_indices(base, state);
                 if let Some(index) = index {
-                    self.analyze_expr(index);
+                    self.analyze_expr(index, state);
                 }
             }
             ExprKind::Slice(base, start, end) => {
-                self.analyze_lhs_indices(base);
+                self.analyze_lhs_indices(base, state);
                 if let Some(start) = start {
-                    self.analyze_expr(start);
+                    self.analyze_expr(start, state);
                 }
                 if let Some(end) = end {
-                    self.analyze_expr(end);
+                    self.analyze_expr(end, state);
                 }
             }
-            ExprKind::Member(base, _) | ExprKind::Payable(base) => self.analyze_lhs_indices(base),
+            ExprKind::Member(base, _) | ExprKind::Payable(base) => {
+                self.analyze_lhs_indices(base, state);
+            }
             ExprKind::Tuple(exprs) => {
                 for expr in exprs.iter().copied().flatten() {
-                    self.analyze_lhs_indices(expr);
+                    self.analyze_lhs_indices(expr, state);
                 }
             }
             _ => {}
         }
     }
 
-    fn taint_sources(&self, expr: &hir::Expr<'_>) -> HashSet<VariableId> {
-        collect_input_taint_sources(&self.taint, expr)
+    fn taint_sources(&self, state: &WriteState, expr: &hir::Expr<'_>) -> HashSet<VariableId> {
+        collect_input_taint_sources(&state.taint, expr)
     }
 
-    fn set_local_taint(&mut self, var_id: VariableId, sources: HashSet<VariableId>) {
+    fn set_local_taint(
+        &mut self,
+        state: &mut WriteState,
+        var_id: VariableId,
+        sources: HashSet<VariableId>,
+    ) {
         if sources.is_empty() {
-            self.taint.remove(&var_id);
+            state.taint.remove(&var_id);
         } else {
-            self.taint.insert(var_id, sources);
+            state.taint.insert(var_id, sources);
         }
     }
+}
+
+fn merge_taint(
+    lhs: &HashMap<VariableId, HashSet<VariableId>>,
+    rhs: &HashMap<VariableId, HashSet<VariableId>>,
+) -> HashMap<VariableId, HashSet<VariableId>> {
+    let mut merged = lhs.clone();
+    for (&var_id, sources) in rhs {
+        merged.entry(var_id).or_default().extend(sources.iter().copied());
+    }
+    merged
 }
 
 struct ArithmeticUseAnalyzer<'a, 'hir> {
@@ -809,6 +882,10 @@ const fn is_arithmetic_op(kind: BinOpKind) -> bool {
     )
 }
 
+const fn is_inc_dec_op(kind: UnOpKind) -> bool {
+    matches!(kind, UnOpKind::PreInc | UnOpKind::PostInc | UnOpKind::PreDec | UnOpKind::PostDec)
+}
+
 fn is_protected(hir: &hir::Hir<'_>, func_id: FunctionId, func: &hir::Function<'_>) -> bool {
     for modifier in func.modifiers {
         if let Some(modifier_id) = modifier.id.as_function()
@@ -864,9 +941,9 @@ fn stmt_has_access_guard(
 ) -> bool {
     match stmt.kind {
         StmtKind::If(cond, then_stmt, else_stmt) => {
-            (expr_looks_like_access_check(hir, cond)
-                && (stmt_exits_or_reverts(then_stmt)
-                    || else_stmt.is_some_and(stmt_exits_or_reverts)))
+            (expr_is_unauthorized_access_check(hir, cond) && stmt_exits_or_reverts(then_stmt))
+                || (expr_is_authorized_access_check(hir, cond)
+                    && else_stmt.is_some_and(stmt_exits_or_reverts))
                 || stmt_has_access_guard(hir, then_stmt, seen)
                 || else_stmt.is_some_and(|stmt| stmt_has_access_guard(hir, stmt, seen))
         }
@@ -913,7 +990,7 @@ fn expr_has_access_guard(
 ) -> bool {
     match &expr.peel_parens().kind {
         ExprKind::Call(callee, args, _) if is_require_or_assert(callee) => {
-            args.exprs().next().is_some_and(|cond| expr_looks_like_access_check(hir, cond))
+            args.exprs().next().is_some_and(|cond| expr_is_authorized_access_check(hir, cond))
         }
         ExprKind::Call(callee, args, opts) => {
             for callee_id in resolved_function_ids(callee) {
@@ -959,6 +1036,64 @@ fn expr_has_access_guard(
         ExprKind::Assign(_, _, rhs) => expr_has_access_guard(hir, rhs, seen),
         _ => false,
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AccessCheckPolarity {
+    Authorized,
+    Unauthorized,
+}
+
+fn expr_is_authorized_access_check(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    expr_access_check_polarity(hir, expr)
+        .is_some_and(|polarity| matches!(polarity, AccessCheckPolarity::Authorized))
+}
+
+fn expr_is_unauthorized_access_check(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    expr_access_check_polarity(hir, expr)
+        .is_some_and(|polarity| matches!(polarity, AccessCheckPolarity::Unauthorized))
+}
+
+fn expr_access_check_polarity(
+    hir: &hir::Hir<'_>,
+    expr: &hir::Expr<'_>,
+) -> Option<AccessCheckPolarity> {
+    match &expr.peel_parens().kind {
+        ExprKind::Unary(op, inner) if op.kind == UnOpKind::Not => {
+            Some(match expr_access_check_polarity(hir, inner)? {
+                AccessCheckPolarity::Authorized => AccessCheckPolarity::Unauthorized,
+                AccessCheckPolarity::Unauthorized => AccessCheckPolarity::Authorized,
+            })
+        }
+        ExprKind::Binary(lhs, op, rhs)
+            if matches!(op.kind, BinOpKind::Eq | BinOpKind::Ne)
+                && expr_compares_sender_to_authority(hir, lhs, rhs) =>
+        {
+            Some(if op.kind == BinOpKind::Eq {
+                AccessCheckPolarity::Authorized
+            } else {
+                AccessCheckPolarity::Unauthorized
+            })
+        }
+        _ if expr_looks_like_access_check(hir, expr) => Some(AccessCheckPolarity::Authorized),
+        _ => None,
+    }
+}
+
+fn expr_compares_sender_to_authority(
+    hir: &hir::Hir<'_>,
+    lhs: &hir::Expr<'_>,
+    rhs: &hir::Expr<'_>,
+) -> bool {
+    let mut seen = HashSet::new();
+    (expr_reads_sender(hir, lhs, &mut seen)
+        && (expr_reads_state_variable(hir, rhs) || expr_calls_non_sender_user_function(hir, rhs)))
+        || {
+            let mut seen = HashSet::new();
+            expr_reads_sender(hir, rhs, &mut seen)
+                && (expr_reads_state_variable(hir, lhs)
+                    || expr_calls_non_sender_user_function(hir, lhs))
+        }
 }
 
 fn expr_looks_like_access_check(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
@@ -1184,113 +1319,6 @@ fn name_looks_like_access_control(name: &str) -> bool {
 fn name_looks_like_sender_accessor(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
     lower == "_msgsender" || lower == "msgsender" || lower == "sender"
-}
-
-fn function_emits_event(
-    hir: &hir::Hir<'_>,
-    func_id: FunctionId,
-    seen: &mut HashSet<FunctionId>,
-) -> bool {
-    if !seen.insert(func_id) {
-        return false;
-    }
-
-    let func = hir.function(func_id);
-    for modifier in func.modifiers {
-        if let Some(modifier_id) = modifier.id.as_function()
-            && function_emits_event(hir, modifier_id, seen)
-        {
-            return true;
-        }
-    }
-
-    let Some(body) = func.body else { return false };
-    body.stmts.iter().any(|stmt| stmt_emits_event(hir, stmt, seen))
-}
-
-fn stmt_emits_event(
-    hir: &hir::Hir<'_>,
-    stmt: &hir::Stmt<'_>,
-    seen: &mut HashSet<FunctionId>,
-) -> bool {
-    match stmt.kind {
-        StmtKind::Emit(_) => true,
-        StmtKind::DeclSingle(var_id) => {
-            hir.variable(var_id).initializer.is_some_and(|init| expr_emits_event(hir, init, seen))
-        }
-        StmtKind::DeclMulti(_, expr)
-        | StmtKind::Expr(expr)
-        | StmtKind::Revert(expr)
-        | StmtKind::Return(Some(expr)) => expr_emits_event(hir, expr, seen),
-        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
-            block.stmts.iter().any(|stmt| stmt_emits_event(hir, stmt, seen))
-        }
-        StmtKind::If(cond, then_stmt, else_stmt) => {
-            expr_emits_event(hir, cond, seen)
-                || stmt_emits_event(hir, then_stmt, seen)
-                || else_stmt.is_some_and(|stmt| stmt_emits_event(hir, stmt, seen))
-        }
-        StmtKind::Try(try_stmt) => {
-            expr_emits_event(hir, &try_stmt.expr, seen)
-                || try_stmt.clauses.iter().any(|clause| {
-                    clause.block.stmts.iter().any(|stmt| stmt_emits_event(hir, stmt, seen))
-                })
-        }
-        StmtKind::Return(None)
-        | StmtKind::Break
-        | StmtKind::Continue
-        | StmtKind::Placeholder
-        | StmtKind::Err(_) => false,
-    }
-}
-
-fn expr_emits_event(
-    hir: &hir::Hir<'_>,
-    expr: &hir::Expr<'_>,
-    seen: &mut HashSet<FunctionId>,
-) -> bool {
-    match &expr.peel_parens().kind {
-        ExprKind::Call(callee, args, opts) => {
-            for callee_id in resolved_function_ids(callee) {
-                if function_emits_event(hir, callee_id, seen) {
-                    return true;
-                }
-            }
-
-            expr_emits_event(hir, callee, seen)
-                || opts.is_some_and(|opts| {
-                    opts.iter().any(|opt| expr_emits_event(hir, &opt.value, seen))
-                })
-                || args.exprs().any(|arg| expr_emits_event(hir, arg, seen))
-        }
-        ExprKind::Binary(lhs, _, rhs) => {
-            expr_emits_event(hir, lhs, seen) || expr_emits_event(hir, rhs, seen)
-        }
-        ExprKind::Unary(_, inner)
-        | ExprKind::Delete(inner)
-        | ExprKind::Member(inner, _)
-        | ExprKind::Payable(inner) => expr_emits_event(hir, inner, seen),
-        ExprKind::Index(base, index) => {
-            expr_emits_event(hir, base, seen)
-                || index.is_some_and(|index| expr_emits_event(hir, index, seen))
-        }
-        ExprKind::Slice(base, start, end) => {
-            expr_emits_event(hir, base, seen)
-                || start.is_some_and(|start| expr_emits_event(hir, start, seen))
-                || end.is_some_and(|end| expr_emits_event(hir, end, seen))
-        }
-        ExprKind::Ternary(cond, true_expr, false_expr) => {
-            expr_emits_event(hir, cond, seen)
-                || expr_emits_event(hir, true_expr, seen)
-                || expr_emits_event(hir, false_expr, seen)
-        }
-        ExprKind::Array(exprs) => exprs.iter().any(|expr| expr_emits_event(hir, expr, seen)),
-        ExprKind::Tuple(exprs) => {
-            exprs.iter().copied().flatten().any(|expr| expr_emits_event(hir, expr, seen))
-        }
-        ExprKind::Assign(_, _, rhs) => expr_emits_event(hir, rhs, seen),
-        _ => false,
-    }
 }
 
 fn resolved_function_ids<'hir>(

--- a/crates/lint/src/sol/low/missing_events_arithmetic.rs
+++ b/crates/lint/src/sol/low/missing_events_arithmetic.rs
@@ -1,0 +1,1307 @@
+use super::MissingEventsArithmetic;
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{Severity, SolLint, analysis::primitives::is_require_or_assert},
+};
+use solar::{
+    ast::{ContractKind, StateMutability, Visibility},
+    interface::{Span, kw, sym},
+    sema::hir::{
+        self, BinOpKind, ElementaryType, ExprKind, FunctionId, ItemId, Res, StmtKind, TypeKind,
+        VariableId,
+    },
+};
+use std::collections::{HashMap, HashSet};
+
+declare_forge_lint!(
+    MISSING_EVENTS_ARITHMETIC,
+    Severity::Low,
+    "missing-events-arithmetic",
+    "critical arithmetic state changes should emit events"
+);
+
+impl<'hir> LateLintPass<'hir> for MissingEventsArithmetic {
+    fn check_contract(
+        &mut self,
+        ctx: &LintContext,
+        hir: &'hir hir::Hir<'hir>,
+        contract: &'hir hir::Contract<'hir>,
+    ) {
+        if contract.kind != ContractKind::Contract {
+            return;
+        }
+
+        let candidate_vars: HashSet<_> =
+            contract.variables().filter(|&var_id| is_candidate_state_var(hir, var_id)).collect();
+        if candidate_vars.is_empty() {
+            return;
+        }
+
+        let arithmetic_vars = vars_used_in_unprotected_arithmetic(hir, contract, &candidate_vars);
+        if arithmetic_vars.is_empty() {
+            return;
+        }
+
+        for func_id in contract.all_functions() {
+            let func = hir.function(func_id);
+            if !is_protected_entry_point(hir, func_id, func)
+                || function_emits_event(hir, func_id, &mut HashSet::new())
+            {
+                continue;
+            }
+
+            let mut analyzer = WriteAnalyzer::new(hir, &arithmetic_vars);
+            let writes = analyzer.analyze_entry_point(func_id);
+            let mut emitted = HashSet::new();
+
+            for write in writes {
+                if !emitted.insert(write.var_id) {
+                    continue;
+                }
+
+                let name = hir
+                    .variable(write.var_id)
+                    .name
+                    .map(|name| name.as_str().to_string())
+                    .unwrap_or_else(|| "state variable".to_string());
+                ctx.emit_with_msg(
+                    &MISSING_EVENTS_ARITHMETIC,
+                    write.span,
+                    format!("`{name}` is changed without an event but is used in arithmetic"),
+                );
+            }
+        }
+    }
+}
+
+fn is_candidate_state_var(hir: &hir::Hir<'_>, var_id: VariableId) -> bool {
+    let var = hir.variable(var_id);
+    var.kind.is_state()
+        && !var.is_constant()
+        && !var.is_immutable()
+        && matches!(
+            var.ty.kind,
+            TypeKind::Elementary(ElementaryType::Int(_) | ElementaryType::UInt(_))
+        )
+}
+
+fn is_external_function(func: &hir::Function<'_>) -> bool {
+    func.kind.is_function()
+        && matches!(func.visibility, Visibility::Public | Visibility::External)
+        && !func.is_constructor()
+        && !func.is_special()
+}
+
+fn is_state_mutating_entry_point(func: &hir::Function<'_>) -> bool {
+    is_external_function(func)
+        && !matches!(func.state_mutability, StateMutability::Pure | StateMutability::View)
+}
+
+fn is_protected_entry_point(
+    hir: &hir::Hir<'_>,
+    func_id: FunctionId,
+    func: &hir::Function<'_>,
+) -> bool {
+    is_state_mutating_entry_point(func) && is_protected(hir, func_id, func)
+}
+
+fn is_unprotected_user_function(
+    hir: &hir::Hir<'_>,
+    func_id: FunctionId,
+    func: &hir::Function<'_>,
+) -> bool {
+    is_external_function(func) && !is_protected(hir, func_id, func)
+}
+
+fn vars_used_in_unprotected_arithmetic(
+    hir: &hir::Hir<'_>,
+    contract: &hir::Contract<'_>,
+    candidate_vars: &HashSet<VariableId>,
+) -> HashSet<VariableId> {
+    let mut used = HashSet::new();
+
+    for func_id in contract.all_functions() {
+        let func = hir.function(func_id);
+        if !is_unprotected_user_function(hir, func_id, func) {
+            continue;
+        }
+
+        let mut analyzer = ArithmeticUseAnalyzer::new(hir, candidate_vars);
+        used.extend(analyzer.analyze_entry_point(func_id));
+    }
+
+    used
+}
+
+#[derive(Clone, Copy, Debug)]
+struct StateWrite {
+    var_id: VariableId,
+    span: Span,
+}
+
+struct WriteAnalyzer<'a, 'hir> {
+    hir: &'hir hir::Hir<'hir>,
+    targets: &'a HashSet<VariableId>,
+    taint: HashMap<VariableId, HashSet<VariableId>>,
+    writes: Vec<StateWrite>,
+    call_stack: Vec<FunctionId>,
+}
+
+impl<'a, 'hir> WriteAnalyzer<'a, 'hir> {
+    fn new(hir: &'hir hir::Hir<'hir>, targets: &'a HashSet<VariableId>) -> Self {
+        Self { hir, targets, taint: HashMap::new(), writes: Vec::new(), call_stack: Vec::new() }
+    }
+
+    fn analyze_entry_point(&mut self, func_id: FunctionId) -> Vec<StateWrite> {
+        let func = self.hir.function(func_id);
+        self.taint.clear();
+        for &param in func.parameters {
+            self.taint.insert(param, HashSet::from([param]));
+        }
+
+        self.analyze_function(func_id);
+        std::mem::take(&mut self.writes)
+    }
+
+    fn analyze_function(&mut self, func_id: FunctionId) {
+        if self.call_stack.contains(&func_id) {
+            return;
+        }
+
+        let func = self.hir.function(func_id);
+        let Some(body) = func.body else { return };
+
+        self.call_stack.push(func_id);
+        for stmt in body.stmts {
+            self.analyze_stmt(stmt);
+        }
+        self.call_stack.pop();
+    }
+
+    fn analyze_stmt(&mut self, stmt: &'hir hir::Stmt<'hir>) {
+        match stmt.kind {
+            StmtKind::DeclSingle(var_id) => {
+                let var = self.hir.variable(var_id);
+                if let Some(init) = var.initializer
+                    && !var.kind.is_state()
+                {
+                    self.set_local_taint(var_id, self.taint_sources(init));
+                }
+            }
+            StmtKind::DeclMulti(vars, expr) => {
+                self.analyze_expr(expr);
+                let sources = self.taint_sources(expr);
+                for var_id in vars.iter().flatten().copied() {
+                    if !self.hir.variable(var_id).kind.is_state() {
+                        self.set_local_taint(var_id, sources.clone());
+                    }
+                }
+            }
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
+                for stmt in block.stmts {
+                    self.analyze_stmt(stmt);
+                }
+            }
+            StmtKind::If(cond, then_stmt, else_stmt) => {
+                self.analyze_expr(cond);
+                self.analyze_stmt(then_stmt);
+                if let Some(else_stmt) = else_stmt {
+                    self.analyze_stmt(else_stmt);
+                }
+            }
+            StmtKind::Try(try_stmt) => {
+                self.analyze_expr(&try_stmt.expr);
+                for clause in try_stmt.clauses {
+                    for stmt in clause.block.stmts {
+                        self.analyze_stmt(stmt);
+                    }
+                }
+            }
+            StmtKind::Expr(expr) | StmtKind::Emit(expr) | StmtKind::Revert(expr) => {
+                self.analyze_expr(expr);
+            }
+            StmtKind::Return(expr) => {
+                if let Some(expr) = expr {
+                    self.analyze_expr(expr);
+                }
+            }
+            StmtKind::Break | StmtKind::Continue | StmtKind::Placeholder | StmtKind::Err(_) => {}
+        }
+    }
+
+    fn analyze_expr(&mut self, expr: &'hir hir::Expr<'hir>) {
+        match &expr.kind {
+            ExprKind::Assign(lhs, _op, rhs) => {
+                self.analyze_expr(rhs);
+
+                let sources = self.taint_sources(rhs);
+                for var_id in state_lhs_vars(self.hir, lhs) {
+                    if self.targets.contains(&var_id) && !sources.is_empty() {
+                        self.writes.push(StateWrite { var_id, span: lhs.span });
+                    }
+                }
+
+                if let Some(local) = lhs_local_var(self.hir, lhs) {
+                    self.set_local_taint(local, sources);
+                } else {
+                    self.analyze_lhs_indices(lhs);
+                }
+            }
+            ExprKind::Call(callee, args, opts) => {
+                self.analyze_expr(callee);
+                if let Some(opts) = opts {
+                    for opt in *opts {
+                        self.analyze_expr(&opt.value);
+                    }
+                }
+                for arg in args.exprs() {
+                    self.analyze_expr(arg);
+                }
+
+                for callee_id in resolved_function_ids(callee) {
+                    self.analyze_internal_call(callee_id, args);
+                }
+            }
+            ExprKind::Binary(lhs, _, rhs) => {
+                self.analyze_expr(lhs);
+                self.analyze_expr(rhs);
+            }
+            ExprKind::Unary(_, inner)
+            | ExprKind::Delete(inner)
+            | ExprKind::Member(inner, _)
+            | ExprKind::Payable(inner) => self.analyze_expr(inner),
+            ExprKind::Index(base, index) => {
+                self.analyze_expr(base);
+                if let Some(index) = index {
+                    self.analyze_expr(index);
+                }
+            }
+            ExprKind::Slice(base, start, end) => {
+                self.analyze_expr(base);
+                if let Some(start) = start {
+                    self.analyze_expr(start);
+                }
+                if let Some(end) = end {
+                    self.analyze_expr(end);
+                }
+            }
+            ExprKind::Ternary(cond, true_expr, false_expr) => {
+                self.analyze_expr(cond);
+                self.analyze_expr(true_expr);
+                self.analyze_expr(false_expr);
+            }
+            ExprKind::Array(exprs) => {
+                for expr in *exprs {
+                    self.analyze_expr(expr);
+                }
+            }
+            ExprKind::Tuple(exprs) => {
+                for expr in exprs.iter().copied().flatten() {
+                    self.analyze_expr(expr);
+                }
+            }
+            ExprKind::New(_) | ExprKind::TypeCall(_) | ExprKind::Type(_) => {}
+            ExprKind::Ident(_) | ExprKind::Lit(_) | ExprKind::Err(_) => {}
+        }
+    }
+
+    fn analyze_internal_call(&mut self, callee_id: FunctionId, args: &hir::CallArgs<'hir>) {
+        if self.call_stack.contains(&callee_id) {
+            return;
+        }
+
+        let callee = self.hir.function(callee_id);
+        let Some(_) = callee.body else { return };
+
+        let saved_taint = std::mem::take(&mut self.taint);
+        for (param, arg) in callee.parameters.iter().copied().zip(args.exprs()) {
+            let sources = collect_input_taint_sources(&saved_taint, arg);
+            if !sources.is_empty() {
+                self.taint.insert(param, sources);
+            }
+        }
+
+        self.analyze_function(callee_id);
+        self.taint = saved_taint;
+    }
+
+    fn analyze_lhs_indices(&mut self, expr: &'hir hir::Expr<'hir>) {
+        match &expr.kind {
+            ExprKind::Index(base, index) => {
+                self.analyze_lhs_indices(base);
+                if let Some(index) = index {
+                    self.analyze_expr(index);
+                }
+            }
+            ExprKind::Slice(base, start, end) => {
+                self.analyze_lhs_indices(base);
+                if let Some(start) = start {
+                    self.analyze_expr(start);
+                }
+                if let Some(end) = end {
+                    self.analyze_expr(end);
+                }
+            }
+            ExprKind::Member(base, _) | ExprKind::Payable(base) => self.analyze_lhs_indices(base),
+            ExprKind::Tuple(exprs) => {
+                for expr in exprs.iter().copied().flatten() {
+                    self.analyze_lhs_indices(expr);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn taint_sources(&self, expr: &hir::Expr<'_>) -> HashSet<VariableId> {
+        collect_input_taint_sources(&self.taint, expr)
+    }
+
+    fn set_local_taint(&mut self, var_id: VariableId, sources: HashSet<VariableId>) {
+        if sources.is_empty() {
+            self.taint.remove(&var_id);
+        } else {
+            self.taint.insert(var_id, sources);
+        }
+    }
+}
+
+struct ArithmeticUseAnalyzer<'a, 'hir> {
+    hir: &'hir hir::Hir<'hir>,
+    targets: &'a HashSet<VariableId>,
+    taint: HashMap<VariableId, HashSet<VariableId>>,
+    used: HashSet<VariableId>,
+    call_stack: Vec<FunctionId>,
+}
+
+impl<'a, 'hir> ArithmeticUseAnalyzer<'a, 'hir> {
+    fn new(hir: &'hir hir::Hir<'hir>, targets: &'a HashSet<VariableId>) -> Self {
+        Self { hir, targets, taint: HashMap::new(), used: HashSet::new(), call_stack: Vec::new() }
+    }
+
+    fn analyze_entry_point(&mut self, func_id: FunctionId) -> HashSet<VariableId> {
+        self.taint.clear();
+        self.analyze_function(func_id);
+        std::mem::take(&mut self.used)
+    }
+
+    fn analyze_function(&mut self, func_id: FunctionId) {
+        if self.call_stack.contains(&func_id) {
+            return;
+        }
+
+        let func = self.hir.function(func_id);
+        let Some(body) = func.body else { return };
+
+        self.call_stack.push(func_id);
+        for stmt in body.stmts {
+            self.analyze_stmt(stmt);
+        }
+        self.call_stack.pop();
+    }
+
+    fn analyze_stmt(&mut self, stmt: &'hir hir::Stmt<'hir>) {
+        match stmt.kind {
+            StmtKind::DeclSingle(var_id) => {
+                let var = self.hir.variable(var_id);
+                if let Some(init) = var.initializer
+                    && !var.kind.is_state()
+                {
+                    self.analyze_expr(init);
+                    self.set_local_taint(var_id, self.taint_sources(init));
+                }
+            }
+            StmtKind::DeclMulti(vars, expr) => {
+                self.analyze_expr(expr);
+                let sources = self.taint_sources(expr);
+                for var_id in vars.iter().flatten().copied() {
+                    if !self.hir.variable(var_id).kind.is_state() {
+                        self.set_local_taint(var_id, sources.clone());
+                    }
+                }
+            }
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
+                for stmt in block.stmts {
+                    self.analyze_stmt(stmt);
+                }
+            }
+            StmtKind::If(cond, then_stmt, else_stmt) => {
+                self.analyze_expr(cond);
+                self.analyze_stmt(then_stmt);
+                if let Some(else_stmt) = else_stmt {
+                    self.analyze_stmt(else_stmt);
+                }
+            }
+            StmtKind::Try(try_stmt) => {
+                self.analyze_expr(&try_stmt.expr);
+                for clause in try_stmt.clauses {
+                    for stmt in clause.block.stmts {
+                        self.analyze_stmt(stmt);
+                    }
+                }
+            }
+            StmtKind::Expr(expr) | StmtKind::Emit(expr) | StmtKind::Revert(expr) => {
+                self.analyze_expr(expr);
+            }
+            StmtKind::Return(expr) => {
+                if let Some(expr) = expr {
+                    self.analyze_expr(expr);
+                }
+            }
+            StmtKind::Break | StmtKind::Continue | StmtKind::Placeholder | StmtKind::Err(_) => {}
+        }
+    }
+
+    fn analyze_expr(&mut self, expr: &'hir hir::Expr<'hir>) {
+        match &expr.kind {
+            ExprKind::Assign(lhs, _, rhs) => {
+                self.analyze_expr(rhs);
+                if let Some(local) = lhs_local_var(self.hir, lhs) {
+                    self.set_local_taint(local, self.taint_sources(rhs));
+                } else {
+                    self.analyze_lhs_indices(lhs);
+                }
+            }
+            ExprKind::Binary(lhs, op, rhs) => {
+                if is_arithmetic_op(op.kind) {
+                    self.used.extend(self.taint_sources(lhs));
+                    self.used.extend(self.taint_sources(rhs));
+                }
+                self.analyze_expr(lhs);
+                self.analyze_expr(rhs);
+            }
+            ExprKind::Call(callee, args, opts) => {
+                self.analyze_expr(callee);
+                if let Some(opts) = opts {
+                    for opt in *opts {
+                        self.analyze_expr(&opt.value);
+                    }
+                }
+                for arg in args.exprs() {
+                    self.analyze_expr(arg);
+                }
+
+                for callee_id in resolved_function_ids(callee) {
+                    self.analyze_internal_call(callee_id, args);
+                }
+            }
+            ExprKind::Unary(_, inner)
+            | ExprKind::Delete(inner)
+            | ExprKind::Member(inner, _)
+            | ExprKind::Payable(inner) => self.analyze_expr(inner),
+            ExprKind::Index(base, index) => {
+                self.analyze_expr(base);
+                if let Some(index) = index {
+                    self.analyze_expr(index);
+                }
+            }
+            ExprKind::Slice(base, start, end) => {
+                self.analyze_expr(base);
+                if let Some(start) = start {
+                    self.analyze_expr(start);
+                }
+                if let Some(end) = end {
+                    self.analyze_expr(end);
+                }
+            }
+            ExprKind::Ternary(cond, true_expr, false_expr) => {
+                self.analyze_expr(cond);
+                self.analyze_expr(true_expr);
+                self.analyze_expr(false_expr);
+            }
+            ExprKind::Array(exprs) => {
+                for expr in *exprs {
+                    self.analyze_expr(expr);
+                }
+            }
+            ExprKind::Tuple(exprs) => {
+                for expr in exprs.iter().copied().flatten() {
+                    self.analyze_expr(expr);
+                }
+            }
+            ExprKind::New(_) | ExprKind::TypeCall(_) | ExprKind::Type(_) => {}
+            ExprKind::Ident(_) | ExprKind::Lit(_) | ExprKind::Err(_) => {}
+        }
+    }
+
+    fn analyze_internal_call(&mut self, callee_id: FunctionId, args: &hir::CallArgs<'hir>) {
+        if self.call_stack.contains(&callee_id) {
+            return;
+        }
+
+        let callee = self.hir.function(callee_id);
+        let Some(_) = callee.body else { return };
+
+        let saved_taint = std::mem::take(&mut self.taint);
+        for (param, arg) in callee.parameters.iter().copied().zip(args.exprs()) {
+            let sources = collect_state_sources(self.hir, self.targets, &saved_taint, arg);
+            if !sources.is_empty() {
+                self.taint.insert(param, sources);
+            }
+        }
+
+        self.analyze_function(callee_id);
+        self.taint = saved_taint;
+    }
+
+    fn analyze_lhs_indices(&mut self, expr: &'hir hir::Expr<'hir>) {
+        match &expr.kind {
+            ExprKind::Index(base, index) => {
+                self.analyze_lhs_indices(base);
+                if let Some(index) = index {
+                    self.analyze_expr(index);
+                }
+            }
+            ExprKind::Slice(base, start, end) => {
+                self.analyze_lhs_indices(base);
+                if let Some(start) = start {
+                    self.analyze_expr(start);
+                }
+                if let Some(end) = end {
+                    self.analyze_expr(end);
+                }
+            }
+            ExprKind::Member(base, _) | ExprKind::Payable(base) => self.analyze_lhs_indices(base),
+            ExprKind::Tuple(exprs) => {
+                for expr in exprs.iter().copied().flatten() {
+                    self.analyze_lhs_indices(expr);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn taint_sources(&self, expr: &hir::Expr<'_>) -> HashSet<VariableId> {
+        collect_state_sources(self.hir, self.targets, &self.taint, expr)
+    }
+
+    fn set_local_taint(&mut self, var_id: VariableId, sources: HashSet<VariableId>) {
+        if sources.is_empty() {
+            self.taint.remove(&var_id);
+        } else {
+            self.taint.insert(var_id, sources);
+        }
+    }
+}
+
+fn collect_input_taint_sources(
+    taint: &HashMap<VariableId, HashSet<VariableId>>,
+    expr: &hir::Expr<'_>,
+) -> HashSet<VariableId> {
+    let mut out = HashSet::new();
+    collect_input_taint_sources_into(taint, expr, &mut out);
+    out
+}
+
+fn collect_input_taint_sources_into(
+    taint: &HashMap<VariableId, HashSet<VariableId>>,
+    expr: &hir::Expr<'_>,
+    out: &mut HashSet<VariableId>,
+) {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) => {
+            for res in *reses {
+                if let Res::Item(ItemId::Variable(var_id)) = res
+                    && let Some(sources) = taint.get(var_id)
+                {
+                    out.extend(sources.iter().copied());
+                }
+            }
+        }
+        ExprKind::Assign(_, _, rhs) => collect_input_taint_sources_into(taint, rhs, out),
+        ExprKind::Binary(lhs, _, rhs) => {
+            collect_input_taint_sources_into(taint, lhs, out);
+            collect_input_taint_sources_into(taint, rhs, out);
+        }
+        ExprKind::Unary(_, inner)
+        | ExprKind::Delete(inner)
+        | ExprKind::Member(inner, _)
+        | ExprKind::Payable(inner) => collect_input_taint_sources_into(taint, inner, out),
+        ExprKind::Index(base, index) => {
+            collect_input_taint_sources_into(taint, base, out);
+            if let Some(index) = index {
+                collect_input_taint_sources_into(taint, index, out);
+            }
+        }
+        ExprKind::Slice(base, start, end) => {
+            collect_input_taint_sources_into(taint, base, out);
+            if let Some(start) = start {
+                collect_input_taint_sources_into(taint, start, out);
+            }
+            if let Some(end) = end {
+                collect_input_taint_sources_into(taint, end, out);
+            }
+        }
+        ExprKind::Call(callee, args, opts) => {
+            collect_input_taint_sources_into(taint, callee, out);
+            if let Some(opts) = opts {
+                for opt in *opts {
+                    collect_input_taint_sources_into(taint, &opt.value, out);
+                }
+            }
+            for arg in args.exprs() {
+                collect_input_taint_sources_into(taint, arg, out);
+            }
+        }
+        ExprKind::Ternary(cond, true_expr, false_expr) => {
+            collect_input_taint_sources_into(taint, cond, out);
+            collect_input_taint_sources_into(taint, true_expr, out);
+            collect_input_taint_sources_into(taint, false_expr, out);
+        }
+        ExprKind::Array(exprs) => {
+            for expr in *exprs {
+                collect_input_taint_sources_into(taint, expr, out);
+            }
+        }
+        ExprKind::Tuple(exprs) => {
+            for expr in exprs.iter().copied().flatten() {
+                collect_input_taint_sources_into(taint, expr, out);
+            }
+        }
+        ExprKind::New(_) | ExprKind::TypeCall(_) | ExprKind::Type(_) => {}
+        ExprKind::Lit(_) | ExprKind::Err(_) => {}
+    }
+}
+
+fn collect_state_sources(
+    hir: &hir::Hir<'_>,
+    targets: &HashSet<VariableId>,
+    taint: &HashMap<VariableId, HashSet<VariableId>>,
+    expr: &hir::Expr<'_>,
+) -> HashSet<VariableId> {
+    let mut out = HashSet::new();
+    collect_state_sources_into(hir, targets, taint, expr, &mut out);
+    out
+}
+
+fn collect_state_sources_into(
+    hir: &hir::Hir<'_>,
+    targets: &HashSet<VariableId>,
+    taint: &HashMap<VariableId, HashSet<VariableId>>,
+    expr: &hir::Expr<'_>,
+    out: &mut HashSet<VariableId>,
+) {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) => {
+            for res in *reses {
+                if let Res::Item(ItemId::Variable(var_id)) = res {
+                    if targets.contains(var_id) && hir.variable(*var_id).kind.is_state() {
+                        out.insert(*var_id);
+                    }
+                    if let Some(sources) = taint.get(var_id) {
+                        out.extend(
+                            sources.iter().copied().filter(|source| targets.contains(source)),
+                        );
+                    }
+                }
+            }
+        }
+        ExprKind::Assign(_, _, rhs) => collect_state_sources_into(hir, targets, taint, rhs, out),
+        ExprKind::Binary(lhs, _, rhs) => {
+            collect_state_sources_into(hir, targets, taint, lhs, out);
+            collect_state_sources_into(hir, targets, taint, rhs, out);
+        }
+        ExprKind::Unary(_, inner)
+        | ExprKind::Delete(inner)
+        | ExprKind::Member(inner, _)
+        | ExprKind::Payable(inner) => collect_state_sources_into(hir, targets, taint, inner, out),
+        ExprKind::Index(base, index) => {
+            collect_state_sources_into(hir, targets, taint, base, out);
+            if let Some(index) = index {
+                collect_state_sources_into(hir, targets, taint, index, out);
+            }
+        }
+        ExprKind::Slice(base, start, end) => {
+            collect_state_sources_into(hir, targets, taint, base, out);
+            if let Some(start) = start {
+                collect_state_sources_into(hir, targets, taint, start, out);
+            }
+            if let Some(end) = end {
+                collect_state_sources_into(hir, targets, taint, end, out);
+            }
+        }
+        ExprKind::Call(callee, args, opts) => {
+            collect_state_sources_into(hir, targets, taint, callee, out);
+            if let Some(opts) = opts {
+                for opt in *opts {
+                    collect_state_sources_into(hir, targets, taint, &opt.value, out);
+                }
+            }
+            for arg in args.exprs() {
+                collect_state_sources_into(hir, targets, taint, arg, out);
+            }
+        }
+        ExprKind::Ternary(cond, true_expr, false_expr) => {
+            collect_state_sources_into(hir, targets, taint, cond, out);
+            collect_state_sources_into(hir, targets, taint, true_expr, out);
+            collect_state_sources_into(hir, targets, taint, false_expr, out);
+        }
+        ExprKind::Array(exprs) => {
+            for expr in *exprs {
+                collect_state_sources_into(hir, targets, taint, expr, out);
+            }
+        }
+        ExprKind::Tuple(exprs) => {
+            for expr in exprs.iter().copied().flatten() {
+                collect_state_sources_into(hir, targets, taint, expr, out);
+            }
+        }
+        ExprKind::New(_) | ExprKind::TypeCall(_) | ExprKind::Type(_) => {}
+        ExprKind::Lit(_) | ExprKind::Err(_) => {}
+    }
+}
+
+fn lhs_local_var(hir: &hir::Hir<'_>, lhs: &hir::Expr<'_>) -> Option<VariableId> {
+    if let ExprKind::Ident(reses) = &lhs.peel_parens().kind {
+        for res in *reses {
+            if let Res::Item(ItemId::Variable(var_id)) = res
+                && !hir.variable(*var_id).kind.is_state()
+            {
+                return Some(*var_id);
+            }
+        }
+    }
+    None
+}
+
+fn state_lhs_vars(hir: &hir::Hir<'_>, lhs: &hir::Expr<'_>) -> Vec<VariableId> {
+    let mut vars = Vec::new();
+    collect_state_lhs_vars(hir, lhs, &mut vars);
+    vars
+}
+
+fn collect_state_lhs_vars(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>, vars: &mut Vec<VariableId>) {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) => {
+            for res in *reses {
+                if let Res::Item(ItemId::Variable(var_id)) = res
+                    && hir.variable(*var_id).kind.is_state()
+                    && !vars.contains(var_id)
+                {
+                    vars.push(*var_id);
+                }
+            }
+        }
+        ExprKind::Index(base, _) | ExprKind::Slice(base, ..) => {
+            collect_state_lhs_vars(hir, base, vars);
+        }
+        ExprKind::Member(base, _)
+        | ExprKind::Payable(base)
+        | ExprKind::Unary(_, base)
+        | ExprKind::Delete(base) => collect_state_lhs_vars(hir, base, vars),
+        ExprKind::Tuple(exprs) => {
+            for expr in exprs.iter().copied().flatten() {
+                collect_state_lhs_vars(hir, expr, vars);
+            }
+        }
+        _ => {}
+    }
+}
+
+const fn is_arithmetic_op(kind: BinOpKind) -> bool {
+    matches!(
+        kind,
+        BinOpKind::Add
+            | BinOpKind::Sub
+            | BinOpKind::Mul
+            | BinOpKind::Div
+            | BinOpKind::Rem
+            | BinOpKind::Pow
+    )
+}
+
+fn is_protected(hir: &hir::Hir<'_>, func_id: FunctionId, func: &hir::Function<'_>) -> bool {
+    for modifier in func.modifiers {
+        if let Some(modifier_id) = modifier.id.as_function()
+            && modifier_has_access_control(hir, modifier_id)
+        {
+            return true;
+        }
+    }
+
+    function_has_access_guard(hir, func_id, &mut HashSet::new())
+}
+
+fn modifier_has_access_control(hir: &hir::Hir<'_>, modifier_id: FunctionId) -> bool {
+    let modifier = hir.function(modifier_id);
+    if let Some(body) = modifier.body {
+        for stmt in body.stmts {
+            if stmt_has_access_guard(hir, stmt, &mut HashSet::new()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    modifier.name.is_some_and(|name| name_looks_like_access_control(name.as_str()))
+}
+
+fn function_has_access_guard(
+    hir: &hir::Hir<'_>,
+    func_id: FunctionId,
+    seen: &mut HashSet<FunctionId>,
+) -> bool {
+    if !seen.insert(func_id) {
+        return false;
+    }
+
+    let func = hir.function(func_id);
+    let Some(body) = func.body else {
+        return func.name.is_some_and(|name| name_looks_like_access_control(name.as_str()));
+    };
+
+    for stmt in body.stmts {
+        if stmt_has_access_guard(hir, stmt, seen) {
+            return true;
+        }
+    }
+    false
+}
+
+fn stmt_has_access_guard(
+    hir: &hir::Hir<'_>,
+    stmt: &hir::Stmt<'_>,
+    seen: &mut HashSet<FunctionId>,
+) -> bool {
+    match stmt.kind {
+        StmtKind::If(cond, then_stmt, else_stmt) => {
+            (expr_looks_like_access_check(hir, cond)
+                && (stmt_exits_or_reverts(then_stmt)
+                    || else_stmt.is_some_and(stmt_exits_or_reverts)))
+                || stmt_has_access_guard(hir, then_stmt, seen)
+                || else_stmt.is_some_and(|stmt| stmt_has_access_guard(hir, stmt, seen))
+        }
+        StmtKind::Expr(expr) => expr_has_access_guard(hir, expr, seen),
+        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
+            block.stmts.iter().any(|stmt| stmt_has_access_guard(hir, stmt, seen))
+        }
+        StmtKind::Try(try_stmt) => try_stmt.clauses.iter().any(|clause| {
+            clause.block.stmts.iter().any(|stmt| stmt_has_access_guard(hir, stmt, seen))
+        }),
+        StmtKind::Return(Some(expr)) | StmtKind::Emit(expr) | StmtKind::Revert(expr) => {
+            expr_has_access_guard(hir, expr, seen)
+        }
+        StmtKind::DeclSingle(var_id) => hir
+            .variable(var_id)
+            .initializer
+            .is_some_and(|init| expr_has_access_guard(hir, init, seen)),
+        StmtKind::DeclMulti(_, expr) => expr_has_access_guard(hir, expr, seen),
+        StmtKind::Return(None)
+        | StmtKind::Break
+        | StmtKind::Continue
+        | StmtKind::Placeholder
+        | StmtKind::Err(_) => false,
+    }
+}
+
+fn stmt_exits_or_reverts(stmt: &hir::Stmt<'_>) -> bool {
+    match stmt.kind {
+        StmtKind::Return(_) | StmtKind::Revert(_) => true,
+        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
+            block.stmts.iter().any(stmt_exits_or_reverts)
+        }
+        StmtKind::If(_, then_stmt, else_stmt) => {
+            stmt_exits_or_reverts(then_stmt) || else_stmt.is_some_and(stmt_exits_or_reverts)
+        }
+        _ => false,
+    }
+}
+
+fn expr_has_access_guard(
+    hir: &hir::Hir<'_>,
+    expr: &hir::Expr<'_>,
+    seen: &mut HashSet<FunctionId>,
+) -> bool {
+    match &expr.peel_parens().kind {
+        ExprKind::Call(callee, args, _) if is_require_or_assert(callee) => {
+            args.exprs().next().is_some_and(|cond| expr_looks_like_access_check(hir, cond))
+        }
+        ExprKind::Call(callee, args, opts) => {
+            for callee_id in resolved_function_ids(callee) {
+                let func = hir.function(callee_id);
+                if func.name.is_some_and(|name| name_looks_like_access_control(name.as_str()))
+                    || function_has_access_guard(hir, callee_id, seen)
+                {
+                    return true;
+                }
+            }
+
+            expr_has_access_guard(hir, callee, seen)
+                || opts.is_some_and(|opts| {
+                    opts.iter().any(|opt| expr_has_access_guard(hir, &opt.value, seen))
+                })
+                || args.exprs().any(|arg| expr_has_access_guard(hir, arg, seen))
+        }
+        ExprKind::Binary(lhs, _, rhs) => {
+            expr_has_access_guard(hir, lhs, seen) || expr_has_access_guard(hir, rhs, seen)
+        }
+        ExprKind::Unary(_, inner)
+        | ExprKind::Delete(inner)
+        | ExprKind::Member(inner, _)
+        | ExprKind::Payable(inner) => expr_has_access_guard(hir, inner, seen),
+        ExprKind::Index(base, index) => {
+            expr_has_access_guard(hir, base, seen)
+                || index.is_some_and(|index| expr_has_access_guard(hir, index, seen))
+        }
+        ExprKind::Slice(base, start, end) => {
+            expr_has_access_guard(hir, base, seen)
+                || start.is_some_and(|start| expr_has_access_guard(hir, start, seen))
+                || end.is_some_and(|end| expr_has_access_guard(hir, end, seen))
+        }
+        ExprKind::Ternary(cond, true_expr, false_expr) => {
+            expr_has_access_guard(hir, cond, seen)
+                || expr_has_access_guard(hir, true_expr, seen)
+                || expr_has_access_guard(hir, false_expr, seen)
+        }
+        ExprKind::Array(exprs) => exprs.iter().any(|expr| expr_has_access_guard(hir, expr, seen)),
+        ExprKind::Tuple(exprs) => {
+            exprs.iter().copied().flatten().any(|expr| expr_has_access_guard(hir, expr, seen))
+        }
+        ExprKind::Assign(_, _, rhs) => expr_has_access_guard(hir, rhs, seen),
+        _ => false,
+    }
+}
+
+fn expr_looks_like_access_check(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    expr_reads_sender(hir, expr, &mut HashSet::new())
+        && (expr_reads_state_variable(hir, expr) || expr_calls_non_sender_user_function(hir, expr))
+}
+
+fn expr_reads_state_variable(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) => reses.iter().any(|res| {
+            let Res::Item(ItemId::Variable(var_id)) = res else { return false };
+            hir.variable(*var_id).kind.is_state()
+        }),
+        ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {
+            expr_reads_state_variable(hir, lhs) || expr_reads_state_variable(hir, rhs)
+        }
+        ExprKind::Unary(_, inner)
+        | ExprKind::Delete(inner)
+        | ExprKind::Member(inner, _)
+        | ExprKind::Payable(inner) => expr_reads_state_variable(hir, inner),
+        ExprKind::Index(base, index) => {
+            expr_reads_state_variable(hir, base)
+                || index.is_some_and(|index| expr_reads_state_variable(hir, index))
+        }
+        ExprKind::Slice(base, start, end) => {
+            expr_reads_state_variable(hir, base)
+                || start.is_some_and(|start| expr_reads_state_variable(hir, start))
+                || end.is_some_and(|end| expr_reads_state_variable(hir, end))
+        }
+        ExprKind::Call(callee, args, opts) => {
+            expr_reads_state_variable(hir, callee)
+                || opts.is_some_and(|opts| {
+                    opts.iter().any(|opt| expr_reads_state_variable(hir, &opt.value))
+                })
+                || args.exprs().any(|arg| expr_reads_state_variable(hir, arg))
+        }
+        ExprKind::Ternary(cond, true_expr, false_expr) => {
+            expr_reads_state_variable(hir, cond)
+                || expr_reads_state_variable(hir, true_expr)
+                || expr_reads_state_variable(hir, false_expr)
+        }
+        ExprKind::Array(exprs) => exprs.iter().any(|expr| expr_reads_state_variable(hir, expr)),
+        ExprKind::Tuple(exprs) => {
+            exprs.iter().copied().flatten().any(|expr| expr_reads_state_variable(hir, expr))
+        }
+        _ => false,
+    }
+}
+
+fn expr_calls_non_sender_user_function(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
+    match &expr.peel_parens().kind {
+        ExprKind::Call(callee, args, opts) => {
+            resolved_function_ids(callee).any(|func_id| {
+                hir.function(func_id)
+                    .name
+                    .is_some_and(|name| !name_looks_like_sender_accessor(name.as_str()))
+            }) || expr_calls_non_sender_user_function(hir, callee)
+                || opts.is_some_and(|opts| {
+                    opts.iter().any(|opt| expr_calls_non_sender_user_function(hir, &opt.value))
+                })
+                || args.exprs().any(|arg| expr_calls_non_sender_user_function(hir, arg))
+        }
+        ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {
+            expr_calls_non_sender_user_function(hir, lhs)
+                || expr_calls_non_sender_user_function(hir, rhs)
+        }
+        ExprKind::Unary(_, inner)
+        | ExprKind::Delete(inner)
+        | ExprKind::Member(inner, _)
+        | ExprKind::Payable(inner) => expr_calls_non_sender_user_function(hir, inner),
+        ExprKind::Index(base, index) => {
+            expr_calls_non_sender_user_function(hir, base)
+                || index.is_some_and(|index| expr_calls_non_sender_user_function(hir, index))
+        }
+        ExprKind::Slice(base, start, end) => {
+            expr_calls_non_sender_user_function(hir, base)
+                || start.is_some_and(|start| expr_calls_non_sender_user_function(hir, start))
+                || end.is_some_and(|end| expr_calls_non_sender_user_function(hir, end))
+        }
+        ExprKind::Ternary(cond, true_expr, false_expr) => {
+            expr_calls_non_sender_user_function(hir, cond)
+                || expr_calls_non_sender_user_function(hir, true_expr)
+                || expr_calls_non_sender_user_function(hir, false_expr)
+        }
+        ExprKind::Array(exprs) => {
+            exprs.iter().any(|expr| expr_calls_non_sender_user_function(hir, expr))
+        }
+        ExprKind::Tuple(exprs) => exprs
+            .iter()
+            .copied()
+            .flatten()
+            .any(|expr| expr_calls_non_sender_user_function(hir, expr)),
+        _ => false,
+    }
+}
+
+fn expr_reads_sender(
+    hir: &hir::Hir<'_>,
+    expr: &hir::Expr<'_>,
+    seen: &mut HashSet<FunctionId>,
+) -> bool {
+    if is_sender_member(expr) {
+        return true;
+    }
+
+    match &expr.peel_parens().kind {
+        ExprKind::Call(callee, args, opts) => {
+            for callee_id in resolved_function_ids(callee) {
+                if function_reads_sender(hir, callee_id, seen) {
+                    return true;
+                }
+            }
+
+            expr_reads_sender(hir, callee, seen)
+                || opts.is_some_and(|opts| {
+                    opts.iter().any(|opt| expr_reads_sender(hir, &opt.value, seen))
+                })
+                || args.exprs().any(|arg| expr_reads_sender(hir, arg, seen))
+        }
+        ExprKind::Binary(lhs, _, rhs) => {
+            expr_reads_sender(hir, lhs, seen) || expr_reads_sender(hir, rhs, seen)
+        }
+        ExprKind::Unary(_, inner)
+        | ExprKind::Delete(inner)
+        | ExprKind::Member(inner, _)
+        | ExprKind::Payable(inner) => expr_reads_sender(hir, inner, seen),
+        ExprKind::Index(base, index) => {
+            expr_reads_sender(hir, base, seen)
+                || index.is_some_and(|index| expr_reads_sender(hir, index, seen))
+        }
+        ExprKind::Slice(base, start, end) => {
+            expr_reads_sender(hir, base, seen)
+                || start.is_some_and(|start| expr_reads_sender(hir, start, seen))
+                || end.is_some_and(|end| expr_reads_sender(hir, end, seen))
+        }
+        ExprKind::Ternary(cond, true_expr, false_expr) => {
+            expr_reads_sender(hir, cond, seen)
+                || expr_reads_sender(hir, true_expr, seen)
+                || expr_reads_sender(hir, false_expr, seen)
+        }
+        ExprKind::Array(exprs) => exprs.iter().any(|expr| expr_reads_sender(hir, expr, seen)),
+        ExprKind::Tuple(exprs) => {
+            exprs.iter().copied().flatten().any(|expr| expr_reads_sender(hir, expr, seen))
+        }
+        ExprKind::Assign(_, _, rhs) => expr_reads_sender(hir, rhs, seen),
+        _ => false,
+    }
+}
+
+fn function_reads_sender(
+    hir: &hir::Hir<'_>,
+    func_id: FunctionId,
+    seen: &mut HashSet<FunctionId>,
+) -> bool {
+    if !seen.insert(func_id) {
+        return false;
+    }
+
+    let func = hir.function(func_id);
+    let Some(body) = func.body else { return false };
+    body.stmts.iter().any(|stmt| stmt_reads_sender(hir, stmt, seen))
+}
+
+fn stmt_reads_sender(
+    hir: &hir::Hir<'_>,
+    stmt: &hir::Stmt<'_>,
+    seen: &mut HashSet<FunctionId>,
+) -> bool {
+    match stmt.kind {
+        StmtKind::DeclSingle(var_id) => {
+            hir.variable(var_id).initializer.is_some_and(|init| expr_reads_sender(hir, init, seen))
+        }
+        StmtKind::DeclMulti(_, expr)
+        | StmtKind::Expr(expr)
+        | StmtKind::Emit(expr)
+        | StmtKind::Revert(expr) => expr_reads_sender(hir, expr, seen),
+        StmtKind::Return(Some(expr)) => expr_reads_sender(hir, expr, seen),
+        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
+            block.stmts.iter().any(|stmt| stmt_reads_sender(hir, stmt, seen))
+        }
+        StmtKind::If(cond, then_stmt, else_stmt) => {
+            expr_reads_sender(hir, cond, seen)
+                || stmt_reads_sender(hir, then_stmt, seen)
+                || else_stmt.is_some_and(|stmt| stmt_reads_sender(hir, stmt, seen))
+        }
+        StmtKind::Try(try_stmt) => {
+            expr_reads_sender(hir, &try_stmt.expr, seen)
+                || try_stmt.clauses.iter().any(|clause| {
+                    clause.block.stmts.iter().any(|stmt| stmt_reads_sender(hir, stmt, seen))
+                })
+        }
+        StmtKind::Return(None)
+        | StmtKind::Break
+        | StmtKind::Continue
+        | StmtKind::Placeholder
+        | StmtKind::Err(_) => false,
+    }
+}
+
+fn is_sender_member(expr: &hir::Expr<'_>) -> bool {
+    let ExprKind::Member(base, member) = &expr.peel_parens().kind else { return false };
+    let ExprKind::Ident(reses) = &base.peel_parens().kind else { return false };
+
+    reses.iter().any(|res| {
+        let Res::Builtin(builtin) = res else { return false };
+        matches!((builtin.name(), member.name), (sym::msg, sym::sender) | (sym::tx, kw::Origin))
+    })
+}
+
+fn name_looks_like_access_control(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower == "auth"
+        || lower == "requiresauth"
+        || lower == "restricted"
+        || lower.starts_with("onlyowner")
+        || lower.starts_with("onlyrole")
+        || lower.starts_with("checkowner")
+        || lower.starts_with("_checkowner")
+        || lower.starts_with("checkrole")
+        || lower.starts_with("_checkrole")
+}
+
+fn name_looks_like_sender_accessor(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower == "_msgsender" || lower == "msgsender" || lower == "sender"
+}
+
+fn function_emits_event(
+    hir: &hir::Hir<'_>,
+    func_id: FunctionId,
+    seen: &mut HashSet<FunctionId>,
+) -> bool {
+    if !seen.insert(func_id) {
+        return false;
+    }
+
+    let func = hir.function(func_id);
+    for modifier in func.modifiers {
+        if let Some(modifier_id) = modifier.id.as_function()
+            && function_emits_event(hir, modifier_id, seen)
+        {
+            return true;
+        }
+    }
+
+    let Some(body) = func.body else { return false };
+    body.stmts.iter().any(|stmt| stmt_emits_event(hir, stmt, seen))
+}
+
+fn stmt_emits_event(
+    hir: &hir::Hir<'_>,
+    stmt: &hir::Stmt<'_>,
+    seen: &mut HashSet<FunctionId>,
+) -> bool {
+    match stmt.kind {
+        StmtKind::Emit(_) => true,
+        StmtKind::DeclSingle(var_id) => {
+            hir.variable(var_id).initializer.is_some_and(|init| expr_emits_event(hir, init, seen))
+        }
+        StmtKind::DeclMulti(_, expr)
+        | StmtKind::Expr(expr)
+        | StmtKind::Revert(expr)
+        | StmtKind::Return(Some(expr)) => expr_emits_event(hir, expr, seen),
+        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
+            block.stmts.iter().any(|stmt| stmt_emits_event(hir, stmt, seen))
+        }
+        StmtKind::If(cond, then_stmt, else_stmt) => {
+            expr_emits_event(hir, cond, seen)
+                || stmt_emits_event(hir, then_stmt, seen)
+                || else_stmt.is_some_and(|stmt| stmt_emits_event(hir, stmt, seen))
+        }
+        StmtKind::Try(try_stmt) => {
+            expr_emits_event(hir, &try_stmt.expr, seen)
+                || try_stmt.clauses.iter().any(|clause| {
+                    clause.block.stmts.iter().any(|stmt| stmt_emits_event(hir, stmt, seen))
+                })
+        }
+        StmtKind::Return(None)
+        | StmtKind::Break
+        | StmtKind::Continue
+        | StmtKind::Placeholder
+        | StmtKind::Err(_) => false,
+    }
+}
+
+fn expr_emits_event(
+    hir: &hir::Hir<'_>,
+    expr: &hir::Expr<'_>,
+    seen: &mut HashSet<FunctionId>,
+) -> bool {
+    match &expr.peel_parens().kind {
+        ExprKind::Call(callee, args, opts) => {
+            for callee_id in resolved_function_ids(callee) {
+                if function_emits_event(hir, callee_id, seen) {
+                    return true;
+                }
+            }
+
+            expr_emits_event(hir, callee, seen)
+                || opts.is_some_and(|opts| {
+                    opts.iter().any(|opt| expr_emits_event(hir, &opt.value, seen))
+                })
+                || args.exprs().any(|arg| expr_emits_event(hir, arg, seen))
+        }
+        ExprKind::Binary(lhs, _, rhs) => {
+            expr_emits_event(hir, lhs, seen) || expr_emits_event(hir, rhs, seen)
+        }
+        ExprKind::Unary(_, inner)
+        | ExprKind::Delete(inner)
+        | ExprKind::Member(inner, _)
+        | ExprKind::Payable(inner) => expr_emits_event(hir, inner, seen),
+        ExprKind::Index(base, index) => {
+            expr_emits_event(hir, base, seen)
+                || index.is_some_and(|index| expr_emits_event(hir, index, seen))
+        }
+        ExprKind::Slice(base, start, end) => {
+            expr_emits_event(hir, base, seen)
+                || start.is_some_and(|start| expr_emits_event(hir, start, seen))
+                || end.is_some_and(|end| expr_emits_event(hir, end, seen))
+        }
+        ExprKind::Ternary(cond, true_expr, false_expr) => {
+            expr_emits_event(hir, cond, seen)
+                || expr_emits_event(hir, true_expr, seen)
+                || expr_emits_event(hir, false_expr, seen)
+        }
+        ExprKind::Array(exprs) => exprs.iter().any(|expr| expr_emits_event(hir, expr, seen)),
+        ExprKind::Tuple(exprs) => {
+            exprs.iter().copied().flatten().any(|expr| expr_emits_event(hir, expr, seen))
+        }
+        ExprKind::Assign(_, _, rhs) => expr_emits_event(hir, rhs, seen),
+        _ => false,
+    }
+}
+
+fn resolved_function_ids<'hir>(
+    callee: &'hir hir::Expr<'hir>,
+) -> impl Iterator<Item = FunctionId> + 'hir {
+    let reses = match &callee.peel_parens().kind {
+        ExprKind::Ident(reses) => *reses,
+        _ => &[],
+    };
+    reses.iter().filter_map(|res| match res {
+        Res::Item(ItemId::Function(func_id)) => Some(*func_id),
+        _ => None,
+    })
+}

--- a/crates/lint/src/sol/low/missing_events_arithmetic.rs
+++ b/crates/lint/src/sol/low/missing_events_arithmetic.rs
@@ -47,7 +47,10 @@ impl<'hir> LateLintPass<'hir> for MissingEventsArithmetic {
 
         for func_id in contract.all_functions() {
             let func = hir.function(func_id);
-            if !is_protected_entry_point(hir, func_id, func) {
+            if !is_external_function(func)
+                || matches!(func.state_mutability, StateMutability::Pure | StateMutability::View)
+                || !is_protected(hir, func_id, func)
+            {
                 continue;
             }
 
@@ -93,27 +96,6 @@ fn is_external_function(func: &hir::Function<'_>) -> bool {
         && !func.is_special()
 }
 
-fn is_state_mutating_entry_point(func: &hir::Function<'_>) -> bool {
-    is_external_function(func)
-        && !matches!(func.state_mutability, StateMutability::Pure | StateMutability::View)
-}
-
-fn is_protected_entry_point(
-    hir: &hir::Hir<'_>,
-    func_id: FunctionId,
-    func: &hir::Function<'_>,
-) -> bool {
-    is_state_mutating_entry_point(func) && is_protected(hir, func_id, func)
-}
-
-fn is_unprotected_user_function(
-    hir: &hir::Hir<'_>,
-    func_id: FunctionId,
-    func: &hir::Function<'_>,
-) -> bool {
-    is_external_function(func) && !is_protected(hir, func_id, func)
-}
-
 fn vars_used_in_unprotected_arithmetic(
     hir: &hir::Hir<'_>,
     contract: &hir::Contract<'_>,
@@ -123,7 +105,7 @@ fn vars_used_in_unprotected_arithmetic(
 
     for func_id in contract.all_functions() {
         let func = hir.function(func_id);
-        if !is_unprotected_user_function(hir, func_id, func) {
+        if !is_external_function(func) || is_protected(hir, func_id, func) {
             continue;
         }
 

--- a/crates/lint/src/sol/low/missing_events_arithmetic.rs
+++ b/crates/lint/src/sol/low/missing_events_arithmetic.rs
@@ -1,7 +1,10 @@
 use super::MissingEventsArithmetic;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{Severity, SolLint, analysis::primitives::is_require_or_assert},
+    sol::{
+        Severity, SolLint,
+        analysis::primitives::{branch_always_exits, is_require_or_assert},
+    },
 };
 use solar::{
     ast::{ContractKind, StateMutability, Visibility},
@@ -140,20 +143,33 @@ struct StateWrite {
 #[derive(Clone, Default)]
 struct WriteState {
     taint: HashMap<VariableId, HashSet<VariableId>>,
+    dynamic_taint: HashSet<VariableId>,
     pending_writes: Vec<StateWrite>,
-    emitted_event: bool,
 }
 
 impl WriteState {
     fn record_write(&mut self, write: StateWrite) {
-        if !self.emitted_event {
-            self.pending_writes.push(write);
-        }
+        self.pending_writes.push(write);
     }
 
     fn record_event(&mut self) {
-        self.emitted_event = true;
         self.pending_writes.clear();
+    }
+}
+
+#[derive(Default)]
+struct WriteFlow {
+    fallthrough: Vec<WriteState>,
+    returned: Vec<WriteState>,
+}
+
+impl WriteFlow {
+    fn fallthrough(state: WriteState) -> Self {
+        Self { fallthrough: vec![state], returned: Vec::new() }
+    }
+
+    fn returned(state: WriteState) -> Self {
+        Self { fallthrough: Vec::new(), returned: vec![state] }
     }
 }
 
@@ -174,88 +190,168 @@ impl<'a, 'hir> WriteAnalyzer<'a, 'hir> {
         for &param in func.parameters {
             state.taint.insert(param, HashSet::from([param]));
         }
+        let modifier_ids: Vec<_> =
+            func.modifiers.iter().filter_map(|modifier| modifier.id.as_function()).collect();
 
-        self.analyze_function(func_id, &mut state);
-        state.pending_writes
+        let flow = self.analyze_function(func_id, state);
+        let flow = self.analyze_modifier_suffixes(&modifier_ids, flow);
+        flow.fallthrough
+            .iter()
+            .chain(&flow.returned)
+            .flat_map(|state| state.pending_writes.iter().copied())
+            .collect()
     }
 
-    fn analyze_function(&mut self, func_id: FunctionId, state: &mut WriteState) {
+    fn analyze_function(&mut self, func_id: FunctionId, state: WriteState) -> WriteFlow {
         if self.call_stack.contains(&func_id) {
-            return;
+            return WriteFlow::fallthrough(state);
         }
 
         let func = self.hir.function(func_id);
-        let Some(body) = func.body else { return };
+        let Some(body) = func.body else {
+            return WriteFlow::fallthrough(state);
+        };
 
         self.call_stack.push(func_id);
-        for stmt in body.stmts {
-            self.analyze_stmt(stmt, state);
-        }
+        let flow = self.analyze_stmts(body.stmts, vec![state]);
         self.call_stack.pop();
+        flow
     }
 
-    fn analyze_stmt(&mut self, stmt: &'hir hir::Stmt<'hir>, state: &mut WriteState) {
+    fn analyze_modifier_suffixes(
+        &mut self,
+        modifier_ids: &[FunctionId],
+        mut flow: WriteFlow,
+    ) -> WriteFlow {
+        for &modifier_id in modifier_ids.iter().rev() {
+            flow = self.analyze_modifier_suffix(modifier_id, flow);
+        }
+        flow
+    }
+
+    fn analyze_modifier_suffix(&mut self, modifier_id: FunctionId, flow: WriteFlow) -> WriteFlow {
+        let modifier = self.hir.function(modifier_id);
+        let Some(body) = modifier.body else { return flow };
+        let Some(placeholder_pos) =
+            body.stmts.iter().position(|stmt| matches!(stmt.kind, StmtKind::Placeholder))
+        else {
+            return flow;
+        };
+        let suffix = &body.stmts[placeholder_pos + 1..];
+        if suffix.is_empty() {
+            return flow;
+        }
+
+        let fallthrough_flow = self.analyze_stmts(suffix, flow.fallthrough);
+        let returned_flow = self.analyze_stmts(suffix, flow.returned);
+
+        let mut returned = fallthrough_flow.returned;
+        returned.extend(returned_flow.fallthrough);
+        returned.extend(returned_flow.returned);
+        WriteFlow { fallthrough: fallthrough_flow.fallthrough, returned }
+    }
+
+    fn analyze_stmts(
+        &mut self,
+        stmts: &'hir [hir::Stmt<'hir>],
+        mut states: Vec<WriteState>,
+    ) -> WriteFlow {
+        let mut returned = Vec::new();
+
+        for stmt in stmts {
+            let mut next_states = Vec::new();
+            for state in states {
+                let flow = self.analyze_stmt(stmt, state);
+                next_states.extend(flow.fallthrough);
+                returned.extend(flow.returned);
+            }
+            states = merge_write_states(next_states);
+            if states.is_empty() {
+                break;
+            }
+        }
+
+        WriteFlow { fallthrough: states, returned }
+    }
+
+    fn analyze_stmt(&mut self, stmt: &'hir hir::Stmt<'hir>, mut state: WriteState) -> WriteFlow {
         match stmt.kind {
             StmtKind::DeclSingle(var_id) => {
                 let var = self.hir.variable(var_id);
                 if let Some(init) = var.initializer
                     && !var.kind.is_state()
                 {
-                    self.analyze_expr(init, state);
-                    self.set_local_taint(state, var_id, self.taint_sources(state, init));
+                    self.analyze_expr(init, &mut state);
+                    let sources = self.taint_sources(&state, init);
+                    let is_dynamic = self.expr_has_dynamic_value(&state, init);
+                    self.set_local_taint(&mut state, var_id, sources, is_dynamic);
                 }
+                WriteFlow::fallthrough(state)
             }
             StmtKind::DeclMulti(vars, expr) => {
-                self.analyze_expr(expr, state);
-                let sources = self.taint_sources(state, expr);
+                self.analyze_expr(expr, &mut state);
+                let sources = self.taint_sources(&state, expr);
+                let is_dynamic = self.expr_has_dynamic_value(&state, expr);
                 for var_id in vars.iter().flatten().copied() {
                     if !self.hir.variable(var_id).kind.is_state() {
-                        self.set_local_taint(state, var_id, sources.clone());
+                        self.set_local_taint(&mut state, var_id, sources.clone(), is_dynamic);
                     }
                 }
+                WriteFlow::fallthrough(state)
             }
             StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
-                for stmt in block.stmts {
-                    self.analyze_stmt(stmt, state);
-                }
+                self.analyze_stmts(block.stmts, vec![state])
             }
             StmtKind::If(cond, then_stmt, else_stmt) => {
-                self.analyze_expr(cond, state);
+                self.analyze_expr(cond, &mut state);
 
-                let mut then_state = state.clone();
-                self.analyze_stmt(then_stmt, &mut then_state);
+                let then_flow = self.analyze_stmt(then_stmt, state.clone());
 
-                let mut else_state = state.clone();
-                if let Some(else_stmt) = else_stmt {
-                    self.analyze_stmt(else_stmt, &mut else_state);
-                }
+                let else_flow = if let Some(else_stmt) = else_stmt {
+                    self.analyze_stmt(else_stmt, state)
+                } else {
+                    WriteFlow::fallthrough(state)
+                };
 
-                state.taint = merge_taint(&then_state.taint, &else_state.taint);
-                state.pending_writes = then_state.pending_writes;
-                state.pending_writes.extend(else_state.pending_writes);
-                state.emitted_event = then_state.emitted_event && else_state.emitted_event;
+                let mut returned = then_flow.returned;
+                returned.extend(else_flow.returned);
+                let mut fallthrough = then_flow.fallthrough;
+                fallthrough.extend(else_flow.fallthrough);
+                WriteFlow { fallthrough: merge_write_states(fallthrough), returned }
             }
             StmtKind::Try(try_stmt) => {
-                self.analyze_expr(&try_stmt.expr, state);
+                self.analyze_expr(&try_stmt.expr, &mut state);
+                let mut fallthrough = Vec::new();
+                let mut returned = Vec::new();
                 for clause in try_stmt.clauses {
-                    for stmt in clause.block.stmts {
-                        self.analyze_stmt(stmt, state);
-                    }
+                    let flow = self.analyze_stmts(clause.block.stmts, vec![state.clone()]);
+                    fallthrough.extend(flow.fallthrough);
+                    returned.extend(flow.returned);
                 }
+                WriteFlow { fallthrough: merge_write_states(fallthrough), returned }
             }
-            StmtKind::Expr(expr) | StmtKind::Revert(expr) => {
-                self.analyze_expr(expr, state);
+            StmtKind::Expr(expr) => {
+                self.analyze_expr(expr, &mut state);
+                WriteFlow::fallthrough(state)
+            }
+            StmtKind::Revert(expr) => {
+                self.analyze_expr(expr, &mut state);
+                WriteFlow::default()
             }
             StmtKind::Emit(expr) => {
-                self.analyze_expr(expr, state);
+                self.analyze_expr(expr, &mut state);
                 state.record_event();
+                WriteFlow::fallthrough(state)
             }
             StmtKind::Return(expr) => {
                 if let Some(expr) = expr {
-                    self.analyze_expr(expr, state);
+                    self.analyze_expr(expr, &mut state);
                 }
+                WriteFlow::returned(state)
             }
-            StmtKind::Break | StmtKind::Continue | StmtKind::Placeholder | StmtKind::Err(_) => {}
+            StmtKind::Break | StmtKind::Continue | StmtKind::Placeholder | StmtKind::Err(_) => {
+                WriteFlow::fallthrough(state)
+            }
         }
     }
 
@@ -265,17 +361,16 @@ impl<'a, 'hir> WriteAnalyzer<'a, 'hir> {
                 self.analyze_expr(rhs, state);
 
                 let sources = self.taint_sources(state, rhs);
+                let is_dynamic = self.expr_has_dynamic_value(state, rhs);
                 let is_arithmetic_assignment = op.is_some_and(|op| is_arithmetic_op(op.kind));
                 for var_id in state_lhs_vars(self.hir, lhs) {
-                    if self.targets.contains(&var_id)
-                        && (is_arithmetic_assignment || !sources.is_empty())
-                    {
+                    if self.targets.contains(&var_id) && (is_arithmetic_assignment || is_dynamic) {
                         state.record_write(StateWrite { var_id, span: lhs.span });
                     }
                 }
 
                 if let Some(local) = lhs_local_var(self.hir, lhs) {
-                    self.set_local_taint(state, local, sources);
+                    self.set_local_taint(state, local, sources, is_dynamic);
                 } else {
                     self.analyze_lhs_indices(lhs, state);
                 }
@@ -335,10 +430,9 @@ impl<'a, 'hir> WriteAnalyzer<'a, 'hir> {
                 let mut false_state = state.clone();
                 self.analyze_expr(false_expr, &mut false_state);
 
-                state.taint = merge_taint(&true_state.taint, &false_state.taint);
-                state.pending_writes = true_state.pending_writes;
-                state.pending_writes.extend(false_state.pending_writes);
-                state.emitted_event = true_state.emitted_event && false_state.emitted_event;
+                if let Some(merged) = merge_write_states(vec![true_state, false_state]).pop() {
+                    *state = merged;
+                }
             }
             ExprKind::Array(exprs) => {
                 for expr in *exprs {
@@ -368,16 +462,24 @@ impl<'a, 'hir> WriteAnalyzer<'a, 'hir> {
         let callee = self.hir.function(callee_id);
         let Some(_) = callee.body else { return };
 
-        let saved_taint = std::mem::take(&mut state.taint);
+        let saved_state = state.clone();
+        let mut callee_state = state.clone();
+        callee_state.taint.clear();
+        callee_state.dynamic_taint.clear();
         for (param, arg) in callee.parameters.iter().copied().zip(args.exprs()) {
-            let sources = collect_input_taint_sources(&saved_taint, arg);
-            if !sources.is_empty() {
-                state.taint.insert(param, sources);
-            }
+            let sources = self.taint_sources(&saved_state, arg);
+            let is_dynamic = self.expr_has_dynamic_value(&saved_state, arg);
+            self.set_local_taint(&mut callee_state, param, sources, is_dynamic);
         }
 
-        self.analyze_function(callee_id, state);
-        state.taint = saved_taint;
+        let flow = self.analyze_function(callee_id, callee_state);
+        let mut states = flow.fallthrough;
+        states.extend(flow.returned);
+        if let Some(mut merged) = merge_write_states(states).pop() {
+            merged.taint = saved_state.taint;
+            merged.dynamic_taint = saved_state.dynamic_taint;
+            *state = merged;
+        }
     }
 
     fn analyze_lhs_indices(&mut self, expr: &'hir hir::Expr<'hir>, state: &mut WriteState) {
@@ -410,7 +512,11 @@ impl<'a, 'hir> WriteAnalyzer<'a, 'hir> {
     }
 
     fn taint_sources(&self, state: &WriteState, expr: &hir::Expr<'_>) -> HashSet<VariableId> {
-        collect_input_taint_sources(&state.taint, expr)
+        collect_write_taint_sources(self.hir, &state.taint, expr)
+    }
+
+    fn expr_has_dynamic_value(&self, state: &WriteState, expr: &hir::Expr<'_>) -> bool {
+        expr_has_dynamic_value(self.hir, &state.taint, &state.dynamic_taint, expr)
     }
 
     fn set_local_taint(
@@ -418,13 +524,33 @@ impl<'a, 'hir> WriteAnalyzer<'a, 'hir> {
         state: &mut WriteState,
         var_id: VariableId,
         sources: HashSet<VariableId>,
+        is_dynamic: bool,
     ) {
         if sources.is_empty() {
             state.taint.remove(&var_id);
         } else {
             state.taint.insert(var_id, sources);
         }
+        if is_dynamic {
+            state.dynamic_taint.insert(var_id);
+        } else {
+            state.dynamic_taint.remove(&var_id);
+        }
     }
+}
+
+fn merge_write_states(mut states: Vec<WriteState>) -> Vec<WriteState> {
+    let Some(mut merged) = states.pop() else {
+        return Vec::new();
+    };
+
+    for state in states {
+        merged.taint = merge_taint(&merged.taint, &state.taint);
+        merged.dynamic_taint.extend(state.dynamic_taint);
+        merged.pending_writes.extend(state.pending_writes);
+    }
+
+    vec![merged]
 }
 
 fn merge_taint(
@@ -436,6 +562,18 @@ fn merge_taint(
         merged.entry(var_id).or_default().extend(sources.iter().copied());
     }
     merged
+}
+
+fn set_taint_entry(
+    taint: &mut HashMap<VariableId, HashSet<VariableId>>,
+    var_id: VariableId,
+    sources: HashSet<VariableId>,
+) {
+    if sources.is_empty() {
+        taint.remove(&var_id);
+    } else {
+        taint.insert(var_id, sources);
+    }
 }
 
 struct ArithmeticUseAnalyzer<'a, 'hir> {
@@ -480,7 +618,8 @@ impl<'a, 'hir> ArithmeticUseAnalyzer<'a, 'hir> {
                     && !var.kind.is_state()
                 {
                     self.analyze_expr(init);
-                    self.set_local_taint(var_id, self.taint_sources(init));
+                    let sources = self.taint_sources(init);
+                    self.set_local_taint(var_id, sources);
                 }
             }
             StmtKind::DeclMulti(vars, expr) => {
@@ -529,15 +668,18 @@ impl<'a, 'hir> ArithmeticUseAnalyzer<'a, 'hir> {
             ExprKind::Assign(lhs, _, rhs) => {
                 self.analyze_expr(rhs);
                 if let Some(local) = lhs_local_var(self.hir, lhs) {
-                    self.set_local_taint(local, self.taint_sources(rhs));
+                    let sources = self.taint_sources(rhs);
+                    self.set_local_taint(local, sources);
                 } else {
                     self.analyze_lhs_indices(lhs);
                 }
             }
             ExprKind::Binary(lhs, op, rhs) => {
                 if is_arithmetic_op(op.kind) {
-                    self.used.extend(self.taint_sources(lhs));
-                    self.used.extend(self.taint_sources(rhs));
+                    let lhs_sources = self.taint_sources(lhs);
+                    let rhs_sources = self.taint_sources(rhs);
+                    self.used.extend(lhs_sources);
+                    self.used.extend(rhs_sources);
                 }
                 self.analyze_expr(lhs);
                 self.analyze_expr(rhs);
@@ -644,7 +786,158 @@ impl<'a, 'hir> ArithmeticUseAnalyzer<'a, 'hir> {
     }
 
     fn taint_sources(&self, expr: &hir::Expr<'_>) -> HashSet<VariableId> {
-        collect_state_sources(self.hir, self.targets, &self.taint, expr)
+        let mut sources = collect_state_sources(self.hir, self.targets, &self.taint, expr);
+        self.collect_call_return_sources(expr, &mut sources);
+        sources
+    }
+
+    fn collect_call_return_sources(&self, expr: &hir::Expr<'_>, out: &mut HashSet<VariableId>) {
+        match &expr.peel_parens().kind {
+            ExprKind::Call(callee, args, opts) => {
+                self.collect_call_return_sources(callee, out);
+                if let Some(opts) = opts {
+                    for opt in *opts {
+                        self.collect_call_return_sources(&opt.value, out);
+                    }
+                }
+                for arg in args.exprs() {
+                    self.collect_call_return_sources(arg, out);
+                }
+                for callee_id in resolved_function_ids(callee) {
+                    self.collect_function_return_sources(callee_id, args, out);
+                }
+            }
+            ExprKind::Assign(_, _, rhs) => self.collect_call_return_sources(rhs, out),
+            ExprKind::Binary(lhs, _, rhs) => {
+                self.collect_call_return_sources(lhs, out);
+                self.collect_call_return_sources(rhs, out);
+            }
+            ExprKind::Unary(_, inner)
+            | ExprKind::Delete(inner)
+            | ExprKind::Member(inner, _)
+            | ExprKind::Payable(inner) => self.collect_call_return_sources(inner, out),
+            ExprKind::Index(base, index) => {
+                self.collect_call_return_sources(base, out);
+                if let Some(index) = index {
+                    self.collect_call_return_sources(index, out);
+                }
+            }
+            ExprKind::Slice(base, start, end) => {
+                self.collect_call_return_sources(base, out);
+                if let Some(start) = start {
+                    self.collect_call_return_sources(start, out);
+                }
+                if let Some(end) = end {
+                    self.collect_call_return_sources(end, out);
+                }
+            }
+            ExprKind::Ternary(cond, true_expr, false_expr) => {
+                self.collect_call_return_sources(cond, out);
+                self.collect_call_return_sources(true_expr, out);
+                self.collect_call_return_sources(false_expr, out);
+            }
+            ExprKind::Array(exprs) => {
+                for expr in *exprs {
+                    self.collect_call_return_sources(expr, out);
+                }
+            }
+            ExprKind::Tuple(exprs) => {
+                for expr in exprs.iter().copied().flatten() {
+                    self.collect_call_return_sources(expr, out);
+                }
+            }
+            ExprKind::New(_) | ExprKind::TypeCall(_) | ExprKind::Type(_) => {}
+            ExprKind::Ident(_) | ExprKind::Lit(_) | ExprKind::Err(_) => {}
+        }
+    }
+
+    fn collect_function_return_sources(
+        &self,
+        callee_id: FunctionId,
+        args: &hir::CallArgs<'_>,
+        out: &mut HashSet<VariableId>,
+    ) {
+        if self.call_stack.contains(&callee_id) {
+            return;
+        }
+
+        let callee = self.hir.function(callee_id);
+        let Some(body) = callee.body else { return };
+
+        let mut taint = HashMap::new();
+        for (param, arg) in callee.parameters.iter().copied().zip(args.exprs()) {
+            let sources = collect_state_sources(self.hir, self.targets, &self.taint, arg);
+            if !sources.is_empty() {
+                taint.insert(param, sources);
+            }
+        }
+
+        for stmt in body.stmts {
+            self.collect_stmt_return_sources(stmt, &mut taint, out);
+        }
+    }
+
+    fn collect_stmt_return_sources(
+        &self,
+        stmt: &hir::Stmt<'_>,
+        taint: &mut HashMap<VariableId, HashSet<VariableId>>,
+        out: &mut HashSet<VariableId>,
+    ) {
+        match stmt.kind {
+            StmtKind::DeclSingle(var_id) => {
+                let var = self.hir.variable(var_id);
+                if let Some(init) = var.initializer
+                    && !var.kind.is_state()
+                {
+                    let sources = collect_state_sources(self.hir, self.targets, taint, init);
+                    set_taint_entry(taint, var_id, sources);
+                }
+            }
+            StmtKind::DeclMulti(vars, expr) => {
+                let sources = collect_state_sources(self.hir, self.targets, taint, expr);
+                for var_id in vars.iter().flatten().copied() {
+                    if !self.hir.variable(var_id).kind.is_state() {
+                        set_taint_entry(taint, var_id, sources.clone());
+                    }
+                }
+            }
+            StmtKind::Return(Some(expr)) => {
+                out.extend(collect_state_sources(self.hir, self.targets, taint, expr));
+            }
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
+                for stmt in block.stmts {
+                    self.collect_stmt_return_sources(stmt, taint, out);
+                }
+            }
+            StmtKind::If(_, then_stmt, else_stmt) => {
+                let mut then_taint = taint.clone();
+                self.collect_stmt_return_sources(then_stmt, &mut then_taint, out);
+                if let Some(else_stmt) = else_stmt {
+                    let mut else_taint = taint.clone();
+                    self.collect_stmt_return_sources(else_stmt, &mut else_taint, out);
+                    *taint = merge_taint(&then_taint, &else_taint);
+                } else {
+                    *taint = merge_taint(taint, &then_taint);
+                }
+            }
+            StmtKind::Try(try_stmt) => {
+                for clause in try_stmt.clauses {
+                    let mut clause_taint = taint.clone();
+                    for stmt in clause.block.stmts {
+                        self.collect_stmt_return_sources(stmt, &mut clause_taint, out);
+                    }
+                    *taint = merge_taint(taint, &clause_taint);
+                }
+            }
+            StmtKind::Expr(_)
+            | StmtKind::Emit(_)
+            | StmtKind::Revert(_)
+            | StmtKind::Return(None)
+            | StmtKind::Break
+            | StmtKind::Continue
+            | StmtKind::Placeholder
+            | StmtKind::Err(_) => {}
+        }
     }
 
     fn set_local_taint(&mut self, var_id: VariableId, sources: HashSet<VariableId>) {
@@ -656,16 +949,18 @@ impl<'a, 'hir> ArithmeticUseAnalyzer<'a, 'hir> {
     }
 }
 
-fn collect_input_taint_sources(
+fn collect_write_taint_sources(
+    hir: &hir::Hir<'_>,
     taint: &HashMap<VariableId, HashSet<VariableId>>,
     expr: &hir::Expr<'_>,
 ) -> HashSet<VariableId> {
     let mut out = HashSet::new();
-    collect_input_taint_sources_into(taint, expr, &mut out);
+    collect_write_taint_sources_into(hir, taint, expr, &mut out);
     out
 }
 
-fn collect_input_taint_sources_into(
+fn collect_write_taint_sources_into(
+    hir: &hir::Hir<'_>,
     taint: &HashMap<VariableId, HashSet<VariableId>>,
     expr: &hir::Expr<'_>,
     out: &mut HashSet<VariableId>,
@@ -673,66 +968,134 @@ fn collect_input_taint_sources_into(
     match &expr.peel_parens().kind {
         ExprKind::Ident(reses) => {
             for res in *reses {
-                if let Res::Item(ItemId::Variable(var_id)) = res
-                    && let Some(sources) = taint.get(var_id)
-                {
-                    out.extend(sources.iter().copied());
+                if let Res::Item(ItemId::Variable(var_id)) = res {
+                    let var = hir.variable(*var_id);
+                    if var.kind.is_state() && !var.is_constant() && !var.is_immutable() {
+                        out.insert(*var_id);
+                    }
+                    if let Some(sources) = taint.get(var_id) {
+                        out.extend(sources.iter().copied());
+                    }
                 }
             }
         }
-        ExprKind::Assign(_, _, rhs) => collect_input_taint_sources_into(taint, rhs, out),
+        ExprKind::Assign(_, _, rhs) => collect_write_taint_sources_into(hir, taint, rhs, out),
         ExprKind::Binary(lhs, _, rhs) => {
-            collect_input_taint_sources_into(taint, lhs, out);
-            collect_input_taint_sources_into(taint, rhs, out);
+            collect_write_taint_sources_into(hir, taint, lhs, out);
+            collect_write_taint_sources_into(hir, taint, rhs, out);
         }
         ExprKind::Unary(_, inner)
         | ExprKind::Delete(inner)
         | ExprKind::Member(inner, _)
-        | ExprKind::Payable(inner) => collect_input_taint_sources_into(taint, inner, out),
+        | ExprKind::Payable(inner) => collect_write_taint_sources_into(hir, taint, inner, out),
         ExprKind::Index(base, index) => {
-            collect_input_taint_sources_into(taint, base, out);
+            collect_write_taint_sources_into(hir, taint, base, out);
             if let Some(index) = index {
-                collect_input_taint_sources_into(taint, index, out);
+                collect_write_taint_sources_into(hir, taint, index, out);
             }
         }
         ExprKind::Slice(base, start, end) => {
-            collect_input_taint_sources_into(taint, base, out);
+            collect_write_taint_sources_into(hir, taint, base, out);
             if let Some(start) = start {
-                collect_input_taint_sources_into(taint, start, out);
+                collect_write_taint_sources_into(hir, taint, start, out);
             }
             if let Some(end) = end {
-                collect_input_taint_sources_into(taint, end, out);
+                collect_write_taint_sources_into(hir, taint, end, out);
             }
         }
         ExprKind::Call(callee, args, opts) => {
-            collect_input_taint_sources_into(taint, callee, out);
+            collect_write_taint_sources_into(hir, taint, callee, out);
             if let Some(opts) = opts {
                 for opt in *opts {
-                    collect_input_taint_sources_into(taint, &opt.value, out);
+                    collect_write_taint_sources_into(hir, taint, &opt.value, out);
                 }
             }
             for arg in args.exprs() {
-                collect_input_taint_sources_into(taint, arg, out);
+                collect_write_taint_sources_into(hir, taint, arg, out);
             }
         }
         ExprKind::Ternary(cond, true_expr, false_expr) => {
-            collect_input_taint_sources_into(taint, cond, out);
-            collect_input_taint_sources_into(taint, true_expr, out);
-            collect_input_taint_sources_into(taint, false_expr, out);
+            collect_write_taint_sources_into(hir, taint, cond, out);
+            collect_write_taint_sources_into(hir, taint, true_expr, out);
+            collect_write_taint_sources_into(hir, taint, false_expr, out);
         }
         ExprKind::Array(exprs) => {
             for expr in *exprs {
-                collect_input_taint_sources_into(taint, expr, out);
+                collect_write_taint_sources_into(hir, taint, expr, out);
             }
         }
         ExprKind::Tuple(exprs) => {
             for expr in exprs.iter().copied().flatten() {
-                collect_input_taint_sources_into(taint, expr, out);
+                collect_write_taint_sources_into(hir, taint, expr, out);
             }
         }
         ExprKind::New(_) | ExprKind::TypeCall(_) | ExprKind::Type(_) => {}
         ExprKind::Lit(_) | ExprKind::Err(_) => {}
     }
+}
+
+fn expr_has_dynamic_value(
+    hir: &hir::Hir<'_>,
+    taint: &HashMap<VariableId, HashSet<VariableId>>,
+    dynamic_taint: &HashSet<VariableId>,
+    expr: &hir::Expr<'_>,
+) -> bool {
+    if !collect_write_taint_sources(hir, taint, expr).is_empty() {
+        return true;
+    }
+
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) => reses.iter().any(|res| {
+            let Res::Item(ItemId::Variable(var_id)) = res else { return false };
+            dynamic_taint.contains(var_id)
+        }),
+        ExprKind::Call(..) => true,
+        ExprKind::Member(_, _) if is_dynamic_builtin_member(expr) => true,
+        ExprKind::Assign(_, _, rhs) => expr_has_dynamic_value(hir, taint, dynamic_taint, rhs),
+        ExprKind::Binary(lhs, _, rhs) => {
+            expr_has_dynamic_value(hir, taint, dynamic_taint, lhs)
+                || expr_has_dynamic_value(hir, taint, dynamic_taint, rhs)
+        }
+        ExprKind::Unary(_, inner)
+        | ExprKind::Delete(inner)
+        | ExprKind::Member(inner, _)
+        | ExprKind::Payable(inner) => expr_has_dynamic_value(hir, taint, dynamic_taint, inner),
+        ExprKind::Index(base, index) => {
+            expr_has_dynamic_value(hir, taint, dynamic_taint, base)
+                || index
+                    .is_some_and(|index| expr_has_dynamic_value(hir, taint, dynamic_taint, index))
+        }
+        ExprKind::Slice(base, start, end) => {
+            expr_has_dynamic_value(hir, taint, dynamic_taint, base)
+                || start
+                    .is_some_and(|start| expr_has_dynamic_value(hir, taint, dynamic_taint, start))
+                || end.is_some_and(|end| expr_has_dynamic_value(hir, taint, dynamic_taint, end))
+        }
+        ExprKind::Ternary(cond, true_expr, false_expr) => {
+            expr_has_dynamic_value(hir, taint, dynamic_taint, cond)
+                || expr_has_dynamic_value(hir, taint, dynamic_taint, true_expr)
+                || expr_has_dynamic_value(hir, taint, dynamic_taint, false_expr)
+        }
+        ExprKind::Array(exprs) => {
+            exprs.iter().any(|expr| expr_has_dynamic_value(hir, taint, dynamic_taint, expr))
+        }
+        ExprKind::Tuple(exprs) => exprs
+            .iter()
+            .copied()
+            .flatten()
+            .any(|expr| expr_has_dynamic_value(hir, taint, dynamic_taint, expr)),
+        ExprKind::New(_) | ExprKind::TypeCall(_) | ExprKind::Type(_) => false,
+        ExprKind::Lit(_) | ExprKind::Err(_) => false,
+    }
+}
+
+fn is_dynamic_builtin_member(expr: &hir::Expr<'_>) -> bool {
+    let ExprKind::Member(base, _) = &expr.peel_parens().kind else { return false };
+    let ExprKind::Ident(reses) = &base.peel_parens().kind else { return false };
+    reses.iter().any(|res| {
+        let Res::Builtin(builtin) = res else { return false };
+        matches!(builtin.name(), sym::block | sym::msg | sym::tx)
+    })
 }
 
 fn collect_state_sources(
@@ -902,7 +1265,7 @@ fn modifier_has_access_control(hir: &hir::Hir<'_>, modifier_id: FunctionId) -> b
     let modifier = hir.function(modifier_id);
     if let Some(body) = modifier.body {
         for stmt in body.stmts {
-            if stmt_has_access_guard(hir, stmt, &mut HashSet::new()) {
+            if stmt_is_access_guard(hir, stmt, &mut HashSet::new()) {
                 return true;
             }
         }
@@ -922,64 +1285,42 @@ fn function_has_access_guard(
     }
 
     let func = hir.function(func_id);
-    let Some(body) = func.body else {
-        return func.name.is_some_and(|name| name_looks_like_access_control(name.as_str()));
-    };
+    let Some(body) = func.body else { return false };
 
     for stmt in body.stmts {
-        if stmt_has_access_guard(hir, stmt, seen) {
+        if stmt_is_access_guard(hir, stmt, seen) {
             return true;
         }
     }
     false
 }
 
-fn stmt_has_access_guard(
+fn stmt_is_access_guard(
     hir: &hir::Hir<'_>,
     stmt: &hir::Stmt<'_>,
     seen: &mut HashSet<FunctionId>,
 ) -> bool {
     match stmt.kind {
         StmtKind::If(cond, then_stmt, else_stmt) => {
-            (expr_is_unauthorized_access_check(hir, cond) && stmt_exits_or_reverts(then_stmt))
+            (expr_is_unauthorized_access_check(hir, cond) && branch_always_exits(then_stmt))
                 || (expr_is_authorized_access_check(hir, cond)
-                    && else_stmt.is_some_and(stmt_exits_or_reverts))
-                || stmt_has_access_guard(hir, then_stmt, seen)
-                || else_stmt.is_some_and(|stmt| stmt_has_access_guard(hir, stmt, seen))
+                    && else_stmt.is_some_and(branch_always_exits))
         }
         StmtKind::Expr(expr) => expr_has_access_guard(hir, expr, seen),
         StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
-            block.stmts.iter().any(|stmt| stmt_has_access_guard(hir, stmt, seen))
+            block.stmts.iter().any(|stmt| stmt_is_access_guard(hir, stmt, seen))
         }
-        StmtKind::Try(try_stmt) => try_stmt.clauses.iter().any(|clause| {
-            clause.block.stmts.iter().any(|stmt| stmt_has_access_guard(hir, stmt, seen))
-        }),
-        StmtKind::Return(Some(expr)) | StmtKind::Emit(expr) | StmtKind::Revert(expr) => {
-            expr_has_access_guard(hir, expr, seen)
-        }
-        StmtKind::DeclSingle(var_id) => hir
-            .variable(var_id)
-            .initializer
-            .is_some_and(|init| expr_has_access_guard(hir, init, seen)),
-        StmtKind::DeclMulti(_, expr) => expr_has_access_guard(hir, expr, seen),
+        StmtKind::Try(_)
+        | StmtKind::Return(Some(_))
+        | StmtKind::Emit(_)
+        | StmtKind::Revert(_)
+        | StmtKind::DeclSingle(_)
+        | StmtKind::DeclMulti(_, _) => false,
         StmtKind::Return(None)
         | StmtKind::Break
         | StmtKind::Continue
         | StmtKind::Placeholder
         | StmtKind::Err(_) => false,
-    }
-}
-
-fn stmt_exits_or_reverts(stmt: &hir::Stmt<'_>) -> bool {
-    match stmt.kind {
-        StmtKind::Return(_) | StmtKind::Revert(_) => true,
-        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
-            block.stmts.iter().any(stmt_exits_or_reverts)
-        }
-        StmtKind::If(_, then_stmt, else_stmt) => {
-            stmt_exits_or_reverts(then_stmt) || else_stmt.is_some_and(stmt_exits_or_reverts)
-        }
-        _ => false,
     }
 }
 
@@ -992,48 +1333,18 @@ fn expr_has_access_guard(
         ExprKind::Call(callee, args, _) if is_require_or_assert(callee) => {
             args.exprs().next().is_some_and(|cond| expr_is_authorized_access_check(hir, cond))
         }
-        ExprKind::Call(callee, args, opts) => {
+        ExprKind::Call(callee, _, _) => {
             for callee_id in resolved_function_ids(callee) {
                 let func = hir.function(callee_id);
-                if func.name.is_some_and(|name| name_looks_like_access_control(name.as_str()))
-                    || function_has_access_guard(hir, callee_id, seen)
-                {
+                let name_only_guard = func.body.is_none()
+                    && func.returns.is_empty()
+                    && func.name.is_some_and(|name| name_looks_like_access_control(name.as_str()));
+                if name_only_guard || function_has_access_guard(hir, callee_id, seen) {
                     return true;
                 }
             }
-
-            expr_has_access_guard(hir, callee, seen)
-                || opts.is_some_and(|opts| {
-                    opts.iter().any(|opt| expr_has_access_guard(hir, &opt.value, seen))
-                })
-                || args.exprs().any(|arg| expr_has_access_guard(hir, arg, seen))
+            false
         }
-        ExprKind::Binary(lhs, _, rhs) => {
-            expr_has_access_guard(hir, lhs, seen) || expr_has_access_guard(hir, rhs, seen)
-        }
-        ExprKind::Unary(_, inner)
-        | ExprKind::Delete(inner)
-        | ExprKind::Member(inner, _)
-        | ExprKind::Payable(inner) => expr_has_access_guard(hir, inner, seen),
-        ExprKind::Index(base, index) => {
-            expr_has_access_guard(hir, base, seen)
-                || index.is_some_and(|index| expr_has_access_guard(hir, index, seen))
-        }
-        ExprKind::Slice(base, start, end) => {
-            expr_has_access_guard(hir, base, seen)
-                || start.is_some_and(|start| expr_has_access_guard(hir, start, seen))
-                || end.is_some_and(|end| expr_has_access_guard(hir, end, seen))
-        }
-        ExprKind::Ternary(cond, true_expr, false_expr) => {
-            expr_has_access_guard(hir, cond, seen)
-                || expr_has_access_guard(hir, true_expr, seen)
-                || expr_has_access_guard(hir, false_expr, seen)
-        }
-        ExprKind::Array(exprs) => exprs.iter().any(|expr| expr_has_access_guard(hir, expr, seen)),
-        ExprKind::Tuple(exprs) => {
-            exprs.iter().copied().flatten().any(|expr| expr_has_access_guard(hir, expr, seen))
-        }
-        ExprKind::Assign(_, _, rhs) => expr_has_access_guard(hir, rhs, seen),
         _ => false,
     }
 }
@@ -1064,6 +1375,36 @@ fn expr_access_check_polarity(
                 AccessCheckPolarity::Authorized => AccessCheckPolarity::Unauthorized,
                 AccessCheckPolarity::Unauthorized => AccessCheckPolarity::Authorized,
             })
+        }
+        ExprKind::Binary(lhs, op, rhs) if op.kind == BinOpKind::And => {
+            let lhs = expr_access_check_polarity(hir, lhs);
+            let rhs = expr_access_check_polarity(hir, rhs);
+            if matches!(lhs, Some(AccessCheckPolarity::Authorized))
+                || matches!(rhs, Some(AccessCheckPolarity::Authorized))
+            {
+                Some(AccessCheckPolarity::Authorized)
+            } else if matches!(lhs, Some(AccessCheckPolarity::Unauthorized))
+                && matches!(rhs, Some(AccessCheckPolarity::Unauthorized))
+            {
+                Some(AccessCheckPolarity::Unauthorized)
+            } else {
+                None
+            }
+        }
+        ExprKind::Binary(lhs, op, rhs) if op.kind == BinOpKind::Or => {
+            let lhs = expr_access_check_polarity(hir, lhs);
+            let rhs = expr_access_check_polarity(hir, rhs);
+            if matches!(lhs, Some(AccessCheckPolarity::Authorized))
+                && matches!(rhs, Some(AccessCheckPolarity::Authorized))
+            {
+                Some(AccessCheckPolarity::Authorized)
+            } else if matches!(lhs, Some(AccessCheckPolarity::Unauthorized))
+                || matches!(rhs, Some(AccessCheckPolarity::Unauthorized))
+            {
+                Some(AccessCheckPolarity::Unauthorized)
+            } else {
+                None
+            }
         }
         ExprKind::Binary(lhs, op, rhs)
             if matches!(op.kind, BinOpKind::Eq | BinOpKind::Ne)

--- a/crates/lint/src/sol/low/mod.rs
+++ b/crates/lint/src/sol/low/mod.rs
@@ -12,6 +12,9 @@ use delegatecall_loop::DELEGATECALL_LOOP;
 mod missing_zero_check;
 use missing_zero_check::MISSING_ZERO_CHECK;
 
+mod missing_events_arithmetic;
+use missing_events_arithmetic::MISSING_EVENTS_ARITHMETIC;
+
 mod return_bomb;
 use return_bomb::RETURN_BOMB;
 
@@ -22,6 +25,7 @@ register_lints!(
     (BlockTimestamp, early, (BLOCK_TIMESTAMP)),
     (CallsLoop, late, (CALLS_LOOP)),
     (DelegatecallLoop, late, (DELEGATECALL_LOOP)),
+    (MissingEventsArithmetic, late, (MISSING_EVENTS_ARITHMETIC)),
     (MissingZeroCheck, late, (MISSING_ZERO_CHECK)),
     (ReturnBomb, late, (RETURN_BOMB)),
     (ReentrancyEvents, late, (REENTRANCY_EVENTS)),

--- a/crates/lint/testdata/MissingEventsArithmetic.sol
+++ b/crates/lint/testdata/MissingEventsArithmetic.sol
@@ -10,15 +10,22 @@ contract MissingEventsArithmetic {
     uint256 public sellFeeBps;
     uint256 public cap;
     uint256 public rewardRate;
+    uint256 public conditionallyEmittedValue;
+    uint256 public selfIncrementedValue;
+    uint256 public prefixIncrementedValue;
+    uint256 public postfixDecrementedValue;
+    uint256 public stateDelta;
     uint256 public plainValue;
     uint256 public fixedValue;
     uint256 public protectedOnlyValue;
     uint256 public senderObservedValue;
     uint256 public senderNonZeroValue;
+    uint256 public wrongPolarityValue;
     mapping(address => uint256) public balances;
 
     event BuyPriceUpdated(uint256 newBuyPrice);
     event CapUpdated(uint256 newCap);
+    event ConditionallyEmittedValueUpdated(uint256 newValue);
     event Touched();
 
     modifier onlyOwner() {
@@ -63,6 +70,31 @@ contract MissingEventsArithmetic {
         buyPrice = newBuyPrice; //~WARN: `buyPrice` is changed without an event but is used in arithmetic
     }
 
+    function setConditionallyEmittedValue(uint256 newValue, bool withEvent) external onlyOwner {
+        if (withEvent) {
+            conditionallyEmittedValue = newValue;
+            emit ConditionallyEmittedValueUpdated(newValue);
+        } else {
+            conditionallyEmittedValue = newValue; //~WARN: `conditionallyEmittedValue` is changed without an event but is used in arithmetic
+        }
+    }
+
+    function incrementSelf() external onlyOwner {
+        selfIncrementedValue += 1; //~WARN: `selfIncrementedValue` is changed without an event but is used in arithmetic
+    }
+
+    function incrementByStateDelta() external onlyOwner {
+        selfIncrementedValue += stateDelta; //~WARN: `selfIncrementedValue` is changed without an event but is used in arithmetic
+    }
+
+    function prefixIncrement() external onlyOwner {
+        ++prefixIncrementedValue; //~WARN: `prefixIncrementedValue` is changed without an event but is used in arithmetic
+    }
+
+    function postfixDecrement() external onlyOwner {
+        postfixDecrementedValue--; //~WARN: `postfixDecrementedValue` is changed without an event but is used in arithmetic
+    }
+
     // Arithmetic usage that makes the values critical.
 
     function buyQuote(uint256 amount) external view returns (uint256) {
@@ -80,6 +112,22 @@ contract MissingEventsArithmetic {
 
     function rewardQuote(uint256 amount) external view returns (uint256) {
         return _rewardQuote(amount, rewardRate);
+    }
+
+    function conditionallyEmittedQuote(uint256 amount) external view returns (uint256) {
+        return amount * conditionallyEmittedValue;
+    }
+
+    function selfIncrementedQuote(uint256 amount) external view returns (uint256) {
+        return amount + selfIncrementedValue;
+    }
+
+    function prefixIncrementedQuote(uint256 amount) external view returns (uint256) {
+        return amount * prefixIncrementedValue;
+    }
+
+    function postfixDecrementedQuote(uint256 amount) external view returns (uint256) {
+        return amount * postfixDecrementedValue;
     }
 
     function _rewardQuote(uint256 amount, uint256 rate) internal pure returns (uint256) {
@@ -157,6 +205,17 @@ contract MissingEventsArithmetic {
 
     function senderNonZeroQuote(uint256 amount) external view returns (uint256) {
         return amount * senderNonZeroValue;
+    }
+
+    // Returning on the authorized branch is not access control, so this setter stays out of scope.
+    function wrongPolaritySetWithEvent(uint256 newValue) external {
+        if (msg.sender == owner) return;
+        wrongPolarityValue = newValue;
+        emit ConditionallyEmittedValueUpdated(newValue);
+    }
+
+    function wrongPolarityQuote(uint256 amount) external view returns (uint256) {
+        return amount * wrongPolarityValue;
     }
 
     function setBalance(address account, uint256 amount) external onlyOwner {

--- a/crates/lint/testdata/MissingEventsArithmetic.sol
+++ b/crates/lint/testdata/MissingEventsArithmetic.sol
@@ -1,0 +1,181 @@
+//@compile-flags: --only-lint missing-events-arithmetic
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+contract MissingEventsArithmetic {
+    address public owner = msg.sender;
+
+    uint256 public buyPrice;
+    uint256 public sellFeeBps;
+    uint256 public cap;
+    uint256 public rewardRate;
+    uint256 public plainValue;
+    uint256 public fixedValue;
+    uint256 public protectedOnlyValue;
+    uint256 public senderObservedValue;
+    uint256 public senderNonZeroValue;
+    mapping(address => uint256) public balances;
+
+    event BuyPriceUpdated(uint256 newBuyPrice);
+    event CapUpdated(uint256 newCap);
+    event Touched();
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "not owner");
+        _;
+    }
+
+    modifier onlyOwnerViaCheck() {
+        _checkOwner();
+        _;
+    }
+
+    modifier onlyPositive(uint256 value) {
+        require(value > 0, "not positive");
+        _;
+    }
+
+    // SHOULD FAIL:
+
+    function setBuyPrice(uint256 newBuyPrice) external onlyOwner {
+        buyPrice = newBuyPrice; //~WARN: `buyPrice` is changed without an event but is used in arithmetic
+    }
+
+    function setSellFee(uint256 newFee) external onlyOwner {
+        uint256 fee = newFee;
+        sellFeeBps = fee; //~WARN: `sellFeeBps` is changed without an event but is used in arithmetic
+    }
+
+    function setCap(uint256 newCap) external onlyOwner {
+        _setCap(newCap);
+    }
+
+    function _setCap(uint256 newCap) internal {
+        cap = newCap; //~WARN: `cap` is changed without an event but is used in arithmetic
+    }
+
+    function increaseRewardRate(uint256 delta) external onlyOwner {
+        rewardRate += delta; //~WARN: `rewardRate` is changed without an event but is used in arithmetic
+    }
+
+    function setBuyPriceOZStyle(uint256 newBuyPrice) external onlyOwnerViaCheck {
+        buyPrice = newBuyPrice; //~WARN: `buyPrice` is changed without an event but is used in arithmetic
+    }
+
+    // Arithmetic usage that makes the values critical.
+
+    function buyQuote(uint256 amount) external view returns (uint256) {
+        return amount / buyPrice;
+    }
+
+    function feeQuote(uint256 amount) external view returns (uint256) {
+        uint256 fee = sellFeeBps;
+        return amount * fee / 10_000;
+    }
+
+    function cappedAmount(uint256 amount) external view returns (uint256) {
+        return amount + cap;
+    }
+
+    function rewardQuote(uint256 amount) external view returns (uint256) {
+        return _rewardQuote(amount, rewardRate);
+    }
+
+    function _rewardQuote(uint256 amount, uint256 rate) internal pure returns (uint256) {
+        return amount * rate;
+    }
+
+    // SHOULD PASS:
+
+    function setBuyPriceWithEvent(uint256 newBuyPrice) external onlyOwner {
+        buyPrice = newBuyPrice;
+        emit BuyPriceUpdated(newBuyPrice);
+    }
+
+    function setCapWithInternalEvent(uint256 newCap) external onlyOwner {
+        _setCapWithEvent(newCap);
+    }
+
+    function _setCapWithEvent(uint256 newCap) internal {
+        cap = newCap;
+        emit CapUpdated(newCap);
+    }
+
+    function setWithUnrelatedEvent(uint256 newBuyPrice) external onlyOwner {
+        emit Touched();
+        buyPrice = newBuyPrice;
+    }
+
+    function unprotectedSetBuyPrice(uint256 newBuyPrice) external {
+        buyPrice = newBuyPrice;
+    }
+
+    function setPlainValue(uint256 newValue) external onlyOwner {
+        plainValue = newValue;
+    }
+
+    function readPlainValue() external view returns (uint256) {
+        return plainValue;
+    }
+
+    function setFixedValue() external onlyOwner {
+        fixedValue = 100;
+    }
+
+    function fixedQuote(uint256 amount) external view returns (uint256) {
+        return amount * fixedValue;
+    }
+
+    function onlyPositiveSet(uint256 newFee) external onlyPositive(newFee) {
+        sellFeeBps = newFee;
+    }
+
+    function setProtectedOnlyValue(uint256 newValue) external onlyOwner {
+        protectedOnlyValue = newValue;
+    }
+
+    function protectedOnlyQuote(uint256 amount) external view onlyOwner returns (uint256) {
+        return amount * protectedOnlyValue;
+    }
+
+    function observesSenderButDoesNotRestrict(uint256 newValue) external {
+        if (msg.sender == owner) {
+            newValue += 1;
+        }
+        senderObservedValue = newValue;
+    }
+
+    function senderObservedQuote(uint256 amount) external view returns (uint256) {
+        return amount * senderObservedValue;
+    }
+
+    function requiresSenderNonZeroButDoesNotRestrict(uint256 newValue) external {
+        require(msg.sender != address(0), "zero sender");
+        senderNonZeroValue = newValue;
+    }
+
+    function senderNonZeroQuote(uint256 amount) external view returns (uint256) {
+        return amount * senderNonZeroValue;
+    }
+
+    function setBalance(address account, uint256 amount) external onlyOwner {
+        balances[account] = amount;
+    }
+
+    function balanceQuote(address account, uint256 amount) external view returns (uint256) {
+        return balances[account] * amount;
+    }
+
+    constructor(uint256 initialBuyPrice) {
+        buyPrice = initialBuyPrice;
+    }
+
+    function _checkOwner() internal view {
+        if (owner != _msgSender()) revert();
+    }
+
+    function _msgSender() internal view returns (address) {
+        return msg.sender;
+    }
+}

--- a/crates/lint/testdata/MissingEventsArithmetic.sol
+++ b/crates/lint/testdata/MissingEventsArithmetic.sol
@@ -152,7 +152,7 @@ contract MissingEventsArithmetic {
 
     function setWithUnrelatedEvent(uint256 newBuyPrice) external onlyOwner {
         emit Touched();
-        buyPrice = newBuyPrice;
+        buyPrice = newBuyPrice; //~WARN: `buyPrice` is changed without an event but is used in arithmetic
     }
 
     function unprotectedSetBuyPrice(uint256 newBuyPrice) external {
@@ -236,5 +236,218 @@ contract MissingEventsArithmetic {
 
     function _msgSender() internal view returns (address) {
         return msg.sender;
+    }
+}
+
+// Reproduction cases for oracle findings.
+
+contract ReproEmittedEventIsSticky {
+    address public owner = msg.sender;
+    uint256 public price;
+    event Touched();
+    event PriceUpdated(uint256);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    function buyQuote(uint256 amount) external view returns (uint256) {
+        return amount / price;
+    }
+
+    function setWithUnrelatedEmitBefore(uint256 newPrice) external onlyOwner {
+        emit Touched();
+        price = newPrice; //~WARN: `price` is changed without an event but is used in arithmetic
+    }
+
+    function setPriceWithEvent(uint256 newPrice) external onlyOwner {
+        price = newPrice;
+        emit PriceUpdated(newPrice);
+    }
+}
+
+contract ReproReturnNotTerminator {
+    address public owner = msg.sender;
+    uint256 public price;
+    event PriceUpdated(uint256);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    function buyQuote(uint256 amount) external view returns (uint256) {
+        return amount / price;
+    }
+
+    function setWithReturnBeforeEmit(uint256 newPrice, bool skip) external onlyOwner {
+        price = newPrice; //~WARN: `price` is changed without an event but is used in arithmetic
+        if (skip) return;
+        emit PriceUpdated(newPrice);
+    }
+}
+
+interface IOracle {
+    function getPrice() external view returns (uint256);
+}
+
+contract ReproTryClausesShareState {
+    address public owner = msg.sender;
+    uint256 public price;
+    address public oracle;
+    event PriceUpdated(uint256);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    function buyQuote(uint256 amount) external view returns (uint256) {
+        return amount / price;
+    }
+
+    function setViaOracle(uint256 fallbackPrice) external onlyOwner {
+        try IOracle(oracle).getPrice() returns (uint256 p) {
+            price = p;
+            emit PriceUpdated(p);
+        } catch {
+            price = fallbackPrice; //~WARN: `price` is changed without an event but is used in arithmetic
+        }
+    }
+}
+
+contract ReproUntaintedAssigns {
+    address public owner = msg.sender;
+    uint256 public price;
+    uint256 public referencePrice;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    function buyQuote(uint256 amount) external view returns (uint256) {
+        return amount / price;
+    }
+
+    function setPriceFromStateVar() external onlyOwner {
+        price = referencePrice; //~WARN: `price` is changed without an event but is used in arithmetic
+    }
+
+    function setPriceFromTimestamp() external onlyOwner {
+        price = block.timestamp; //~WARN: `price` is changed without an event but is used in arithmetic
+    }
+}
+
+contract ReproHelperReturnArithmetic {
+    address public owner = msg.sender;
+    uint256 public rate;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    function _getRate() internal view returns (uint256) {
+        return rate;
+    }
+
+    function rateQuote(uint256 amount) external view returns (uint256) {
+        return amount * _getRate();
+    }
+
+    function setRate(uint256 newRate) external onlyOwner {
+        rate = newRate; //~WARN: `rate` is changed without an event but is used in arithmetic
+    }
+}
+
+contract ReproAccessGuardTooLoose {
+    address public owner = msg.sender;
+    uint256 public price;
+    bool public flag;
+
+    function buyQuote(uint256 amount) external view returns (uint256) {
+        return amount / price;
+    }
+
+    function setWithNonDominatingGuard(uint256 newPrice) external {
+        if (flag) require(msg.sender == owner, "not owner");
+        price = newPrice;
+    }
+}
+
+contract ReproMayExitNotMustExit {
+    error NotOwner();
+
+    address public owner = msg.sender;
+    uint256 public price;
+    bool public flag;
+
+    function buyQuote(uint256 amount) external view returns (uint256) {
+        return amount / price;
+    }
+
+    function setWithWeakGuard(uint256 newPrice) external {
+        if (msg.sender != owner) {
+            if (flag) revert NotOwner();
+        }
+        price = newPrice;
+    }
+}
+
+contract ReproModifierBodyNotAnalyzed {
+    address public owner = msg.sender;
+    uint256 public price;
+    event PriceUpdated(uint256);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    modifier emitAfter() {
+        _;
+        emit PriceUpdated(price);
+    }
+
+    function buyQuote(uint256 amount) external view returns (uint256) {
+        return amount / price;
+    }
+
+    function setPriceWithModifierEvent(uint256 newPrice) external onlyOwner emitAfter {
+        price = newPrice;
+    }
+}
+
+contract ReproAccessCheckTooBroad {
+    address public owner = msg.sender;
+    uint256 public price;
+
+    function buyQuote(uint256 amount) external view returns (uint256) {
+        return amount / price;
+    }
+
+    function setWithOrCondition(uint256 newPrice, uint256 amount) external {
+        require(msg.sender == owner || amount > 0, "no access");
+        price = newPrice;
+    }
+}
+
+contract ReproAccessNameCalleeResultIgnored {
+    address public owner = msg.sender;
+    uint256 public price;
+
+    function buyQuote(uint256 amount) external view returns (uint256) {
+        return amount / price;
+    }
+
+    function _checkOwner() internal view returns (bool) {
+        return msg.sender == owner;
+    }
+
+    function setPrice(uint256 newPrice) external {
+        _checkOwner();
+        price = newPrice;
     }
 }

--- a/crates/lint/testdata/MissingEventsArithmetic.stderr
+++ b/crates/lint/testdata/MissingEventsArithmetic.stderr
@@ -78,3 +78,59 @@ LL │         postfixDecrementedValue--;
    │
    ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
 
+warning[missing-events-arithmetic]: `buyPrice` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         buyPrice = newBuyPrice;
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `price` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         price = newPrice;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `price` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         price = newPrice;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `price` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │             price = fallbackPrice;
+   │             ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `price` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         price = referencePrice;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `price` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         price = block.timestamp;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `rate` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         rate = newRate;
+   │         ━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+

--- a/crates/lint/testdata/MissingEventsArithmetic.stderr
+++ b/crates/lint/testdata/MissingEventsArithmetic.stderr
@@ -38,3 +38,43 @@ LL │         buyPrice = newBuyPrice;
    │
    ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
 
+warning[missing-events-arithmetic]: `conditionallyEmittedValue` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │ …     conditionallyEmittedValue = newValue;
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `selfIncrementedValue` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         selfIncrementedValue += 1;
+   │         ━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `selfIncrementedValue` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         selfIncrementedValue += stateDelta;
+   │         ━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `prefixIncrementedValue` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         ++prefixIncrementedValue;
+   │           ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `postfixDecrementedValue` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         postfixDecrementedValue--;
+   │         ━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+

--- a/crates/lint/testdata/MissingEventsArithmetic.stderr
+++ b/crates/lint/testdata/MissingEventsArithmetic.stderr
@@ -1,0 +1,40 @@
+warning[missing-events-arithmetic]: `buyPrice` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         buyPrice = newBuyPrice;
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `sellFeeBps` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         sellFeeBps = fee;
+   │         ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `cap` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         cap = newCap;
+   │         ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `rewardRate` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         rewardRate += delta;
+   │         ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+
+warning[missing-events-arithmetic]: `buyPrice` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         buyPrice = newBuyPrice;
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+


### PR DESCRIPTION
## Summary
- add low-severity `missing-events-arithmetic` lint for access-controlled arithmetic parameter updates without events
- keep the rule conservative to reduce false positives: skips fixed writes, constructors, unprotected setters, mappings/arrays, protected-only arithmetic reads, unrelated event emission, non-access modifiers, and superficial sender checks
- add lint docs and UI coverage for warning and suppression cases