### PR TITLE
chore: simplify option equality checks

### DIFF
--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -3334,7 +3334,7 @@ fn print_key_entry(entry: &tempo::KeyEntry) -> Result<()> {
 }
 
 fn key_entry_to_json(entry: &tempo::KeyEntry) -> serde_json::Value {
-    let is_direct = entry.key_address.is_none() || entry.key_address == Some(entry.wallet_address);
+    let is_direct = entry.key_address.is_none_or(|key_address| key_address == entry.wallet_address);
 
     let limits: Vec<_> = entry
         .limits

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -790,7 +790,7 @@ pub(crate) fn handle_expect_emit<FEN: FoundryEvmNetwork>(
             && let Some(expected_log) = &expected_emit.log
             && checks_topics_and_data(expected_emit.checks, expected_log, log)
             // Check revert address 
-            && (expected_emit.address.is_none() || expected_emit.address == Some(log.address))
+            && (expected_emit.address.is_none_or(|address| address == log.address))
         {
             if let Some(interpreter) = &mut interpreter {
                 // This event was emitted but we expected it NOT to be (count=0)


### PR DESCRIPTION
## Motivation

Recent cleanup simplified non-minimal optional boolean checks with `Option::is_none_or(...)`. A couple of production paths still spell optional equality checks as `is_none() || value == Some(...)`.

## Solution

Use `Option::is_none_or(...)` for the expected emit address match and keychain direct-key detection, preserving the existing behavior while making the conditions direct.