### PR TITLE
fix(forge): resolve Tempo expiry for creates

### DIFF
--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -216,6 +216,7 @@ impl CreateArgs {
         // `<root>/tempo.lanes.toml`) and populate `self.tx.tempo.nonce_key` from the lane.
         // Must happen before `self.deploy(...)` so `TempoOpts::apply` picks up the nonce_key.
         let resolved_lane = resolve_lane(&mut self.tx.tempo, &config.root)?;
+        let expires_at = self.tx.tempo.resolve_expires();
 
         // Whether to broadcast the transaction or not
         let dry_run = !self.broadcast;
@@ -238,6 +239,7 @@ impl CreateArgs {
                 None,
                 Some(browser),
                 resolved_lane,
+                expires_at,
             )
             .await
         } else if self.unlocked {
@@ -255,6 +257,7 @@ impl CreateArgs {
                 None,
                 None,
                 resolved_lane,
+                expires_at,
             )
             .await
         } else if let Some(ak) = access_key {
@@ -276,6 +279,7 @@ impl CreateArgs {
                 Some((signer, ak)),
                 None,
                 resolved_lane,
+                expires_at,
             )
             .await
         } else {
@@ -300,6 +304,7 @@ impl CreateArgs {
                 None,
                 None,
                 resolved_lane,
+                expires_at,
             )
             .await
         }
@@ -381,6 +386,7 @@ impl CreateArgs {
         tempo_keychain: Option<(WalletSigner, TempoAccessKeyConfig)>,
         browser_signer: Option<BrowserSigner<N>>,
         resolved_lane: Option<ResolvedLane>,
+        expires_at: Option<u64>,
     ) -> Result<()>
     where
         N::TransactionRequest: FoundryTransactionBuilder<N> + serde::Serialize,
@@ -534,6 +540,10 @@ impl CreateArgs {
             }
 
             return Ok(());
+        }
+
+        if let Some(ts) = expires_at {
+            sh_println!("Transaction expires at unix timestamp {ts}")?;
         }
 
         let tempo_sponsor = self.tx.tempo.sponsor_config().await?;

--- a/crates/forge/tests/cli/create.rs
+++ b/crates/forge/tests/cli/create.rs
@@ -278,6 +278,42 @@ Deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
 "#]]);
 });
 
+forgetest_async!(create_resolves_tempo_expires_before_broadcast, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    prj.initialize_default_contracts();
+
+    let (_api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let pk = hex::encode(wallet.credential().to_bytes());
+
+    // explicitly byte code hash for consistent checks
+    prj.update_config(|c| c.bytecode_hash = BytecodeHash::None);
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "create",
+            format!("./src/{TEMPLATE_CONTRACT}.sol:{TEMPLATE_CONTRACT}").as_str(),
+            "--rpc-url",
+            rpc.as_str(),
+            "--private-key",
+            pk.as_str(),
+            "--broadcast",
+            "--tempo.expires",
+            "30",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(
+        output.contains("Transaction expires at unix timestamp "),
+        "expected create to print resolved tempo expiry, got:\n{output}",
+    );
+    assert!(output.contains("Deployed to:"), "{output}");
+});
+
 // tests that we can deploy the template contract
 forgetest_async!(can_create_using_unlocked, |prj, cmd| {
     foundry_test_utils::util::initialize(prj.root());


### PR DESCRIPTION
## Motivation

`forge create` accepts `--tempo.expires`, but leaves the relative expiry to be materialized when transaction options are applied. Other Tempo transaction commands resolve that value once and print the resulting unix timestamp before
submission.

## Solution

Resolve `--tempo.expires` in the create path before building the deployment transaction, then print the materialized timestamp when it is present.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes