### PR TITLE
fix(fmt): preserve braces to prevent dangling-else rebinding

### DIFF
--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -2527,13 +2527,16 @@ impl<'ast> State<'_, 'ast> {
     }
 
     /// Returns true if `then` is a block whose single statement, when printed without
-    /// the surrounding braces, would leave an inner `if` exposed to capture a trailing
-    /// `else`. Conservatively covers `if` and `while`, whose bodies may themselves be
-    /// inlined without braces.
+    /// the surrounding braces, could leave an inner `if` exposed to capture a trailing
+    /// `else`. Conservatively covers `if`, `while`, and `for`, whose bodies may carry
+    /// or expose a dangling inner `if`.
     fn then_block_can_capture_trailing_else(then: &'ast ast::Stmt<'ast>) -> bool {
         if let ast::StmtKind::Block(block) = &then.kind
             && block.stmts.len() == 1
-            && matches!(block.stmts[0].kind, ast::StmtKind::If(..) | ast::StmtKind::While(..))
+            && matches!(
+                block.stmts[0].kind,
+                ast::StmtKind::If(..) | ast::StmtKind::While(..) | ast::StmtKind::For { .. }
+            )
         {
             return true;
         }

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -2423,6 +2423,12 @@ impl<'ast> State<'_, 'ast> {
         then: &'ast ast::Stmt<'ast>,
         els_opt: Option<&'ast &'ast mut ast::Stmt<'ast>>,
     ) -> Decision {
+        // Dangling-else guard runs before the cache check so an inlined parent can't
+        // coerce this `if` into dropping braces and rebinding its `else`.
+        if Self::then_block_can_capture_trailing_else(then, els_opt.is_some()) {
+            return Decision { outcome: false, is_cached: false };
+        }
+
         // If a decision is already cached from a parent, use it directly.
         if let Some(cached_decision) = self.single_line_stmt {
             return Decision { outcome: cached_decision, is_cached: true };
@@ -2430,13 +2436,6 @@ impl<'ast> State<'_, 'ast> {
 
         // Empty statements are always printed as blocks.
         if std::slice::from_ref(then).is_empty() {
-            return Decision { outcome: false, is_cached: false };
-        }
-
-        // Keep braces when `then` is a block wrapping a single statement that could
-        // expose a trailing `if` after brace elision; otherwise the surrounding `else`
-        // would rebind to that inner `if`.
-        if els_opt.is_some() && Self::then_block_can_capture_trailing_else(then) {
             return Decision { outcome: false, is_cached: false };
         }
 
@@ -2526,21 +2525,21 @@ impl<'ast> State<'_, 'ast> {
         false
     }
 
-    /// Returns true if `then` is a block whose single statement, when printed without
-    /// the surrounding braces, could leave an inner `if` exposed to capture a trailing
-    /// `else`. Conservatively covers `if`, `while`, and `for`, whose bodies may carry
-    /// or expose a dangling inner `if`.
-    fn then_block_can_capture_trailing_else(then: &'ast ast::Stmt<'ast>) -> bool {
-        if let ast::StmtKind::Block(block) = &then.kind
-            && block.stmts.len() == 1
-            && matches!(
-                block.stmts[0].kind,
-                ast::StmtKind::If(..) | ast::StmtKind::While(..) | ast::StmtKind::For { .. }
-            )
-        {
-            return true;
+    /// Returns true if eliding the braces of `then` would expose an inner `if` to a
+    /// trailing `else` or change the AST shape on round-trip.
+    fn then_block_can_capture_trailing_else(
+        then: &'ast ast::Stmt<'ast>,
+        has_outer_else: bool,
+    ) -> bool {
+        let ast::StmtKind::Block(block) = &then.kind else { return false };
+        if block.stmts.len() != 1 {
+            return false;
         }
-        false
+        match &block.stmts[0].kind {
+            ast::StmtKind::If(_, _, inner_else) => has_outer_else || inner_else.is_some(),
+            ast::StmtKind::While(..) | ast::StmtKind::For { .. } => has_outer_else,
+            _ => false,
+        }
     }
 
     /// Checks if a block statement `{ ... }` contains more than one line of actual code.

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -2433,6 +2433,13 @@ impl<'ast> State<'_, 'ast> {
             return Decision { outcome: false, is_cached: false };
         }
 
+        // Keep braces when `then` is a block wrapping a single statement that could
+        // expose a trailing `if` after brace elision; otherwise the surrounding `else`
+        // would rebind to that inner `if`.
+        if els_opt.is_some() && Self::then_block_can_capture_trailing_else(then) {
+            return Decision { outcome: false, is_cached: false };
+        }
+
         // If possible, take an early decision based on the block style configuration.
         match self.config.single_line_statement_blocks {
             config::SingleLineBlockStyle::Preserve
@@ -2515,6 +2522,20 @@ impl<'ast> State<'_, 'ast> {
             if let Some((_, after_paren)) = snip.split_once(')') {
                 return after_paren.lines().count() > 1;
             }
+        }
+        false
+    }
+
+    /// Returns true if `then` is a block whose single statement, when printed without
+    /// the surrounding braces, would leave an inner `if` exposed to capture a trailing
+    /// `else`. Conservatively covers `if` and `while`, whose bodies may themselves be
+    /// inlined without braces.
+    fn then_block_can_capture_trailing_else(then: &'ast ast::Stmt<'ast>) -> bool {
+        if let ast::StmtKind::Block(block) = &then.kind
+            && block.stmts.len() == 1
+            && matches!(block.stmts[0].kind, ast::StmtKind::If(..) | ast::StmtKind::While(..))
+        {
+            return true;
         }
         false
     }

--- a/crates/fmt/testdata/IfStatement3/block-multi.fmt.sol
+++ b/crates/fmt/testdata/IfStatement3/block-multi.fmt.sol
@@ -1,0 +1,96 @@
+// config: single_line_statement_blocks = "multi"
+contract DanglingElse {
+    function f(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            if (b) {
+                return 1;
+            }
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function g(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            if (b) {
+                return 1;
+            } else {
+                return 7;
+            }
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function h(bool a, bool b, bool c) external pure returns (uint256) {
+        if (a) {
+            return 9;
+        } else if (b) {
+            if (c) {
+                return 1;
+            }
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function w(bool a, bool b, bool c) external pure returns (uint256) {
+        if (a) {
+            while (c) {
+                if (b) {
+                    return 1;
+                }
+            }
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function ok(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            if (b) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    function cIso(bool a, bool b) external pure returns (uint256) {
+        // isolated comment
+        if (a) {
+            if (b) {
+                return 1;
+            }
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function cMix(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            /* mixed */
+            if (b) {
+                return 1;
+            }
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function cTrl(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            if (b) {
+                return 1; // trailing
+            }
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+}

--- a/crates/fmt/testdata/IfStatement3/block-multi.fmt.sol
+++ b/crates/fmt/testdata/IfStatement3/block-multi.fmt.sol
@@ -50,6 +50,19 @@ contract DanglingElse {
         return 0;
     }
 
+    function fr(bool a, bool b, uint256 n) external pure returns (uint256) {
+        if (a) {
+            for (uint256 i; i < n; ++i) {
+                if (b) {
+                    return 1;
+                }
+            }
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
     function ok(bool a, bool b) external pure returns (uint256) {
         if (a) {
             if (b) {

--- a/crates/fmt/testdata/IfStatement3/block-multi.fmt.sol
+++ b/crates/fmt/testdata/IfStatement3/block-multi.fmt.sol
@@ -72,6 +72,19 @@ contract DanglingElse {
         return 0;
     }
 
+    function nested(bool x, bool a, bool b) external pure returns (uint256) {
+        if (x) {
+            if (a) {
+                if (b) {
+                    return 1;
+                }
+            } else {
+                return 2;
+            }
+        }
+        return 0;
+    }
+
     function cIso(bool a, bool b) external pure returns (uint256) {
         // isolated comment
         if (a) {

--- a/crates/fmt/testdata/IfStatement3/block-single.fmt.sol
+++ b/crates/fmt/testdata/IfStatement3/block-single.fmt.sol
@@ -39,6 +39,17 @@ contract DanglingElse {
         return 0;
     }
 
+    function fr(bool a, bool b, uint256 n) external pure returns (uint256) {
+        if (a) {
+            for (uint256 i; i < n; ++i) {
+                if (b) return 1;
+            }
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
     function ok(bool a, bool b) external pure returns (uint256) {
         if (a) if (b) return 1;
         return 0;

--- a/crates/fmt/testdata/IfStatement3/block-single.fmt.sol
+++ b/crates/fmt/testdata/IfStatement3/block-single.fmt.sol
@@ -1,0 +1,75 @@
+// config: single_line_statement_blocks = "single"
+contract DanglingElse {
+    function f(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            if (b) return 1;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function g(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            if (b) return 1;
+            else return 7;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function h(bool a, bool b, bool c) external pure returns (uint256) {
+        if (a) {
+            return 9;
+        } else if (b) {
+            if (c) return 1;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function w(bool a, bool b, bool c) external pure returns (uint256) {
+        if (a) {
+            while (c) if (b) return 1;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function ok(bool a, bool b) external pure returns (uint256) {
+        if (a) if (b) return 1;
+        return 0;
+    }
+
+    function cIso(bool a, bool b) external pure returns (uint256) {
+        // isolated comment
+        if (a) {
+            if (b) return 1;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function cMix(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            /* mixed */
+            if (b) return 1;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function cTrl(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            if (b) return 1; // trailing
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+}

--- a/crates/fmt/testdata/IfStatement3/block-single.fmt.sol
+++ b/crates/fmt/testdata/IfStatement3/block-single.fmt.sol
@@ -55,6 +55,17 @@ contract DanglingElse {
         return 0;
     }
 
+    function nested(bool x, bool a, bool b) external pure returns (uint256) {
+        if (x) {
+            if (a) {
+                if (b) return 1;
+            } else {
+                return 2;
+            }
+        }
+        return 0;
+    }
+
     function cIso(bool a, bool b) external pure returns (uint256) {
         // isolated comment
         if (a) {

--- a/crates/fmt/testdata/IfStatement3/fmt.sol
+++ b/crates/fmt/testdata/IfStatement3/fmt.sol
@@ -54,6 +54,17 @@ contract DanglingElse {
         return 0;
     }
 
+    function nested(bool x, bool a, bool b) external pure returns (uint256) {
+        if (x) {
+            if (a) {
+                if (b) return 1;
+            } else {
+                return 2;
+            }
+        }
+        return 0;
+    }
+
     function cIso(bool a, bool b) external pure returns (uint256) {
         // isolated comment
         if (a) {

--- a/crates/fmt/testdata/IfStatement3/fmt.sol
+++ b/crates/fmt/testdata/IfStatement3/fmt.sol
@@ -38,6 +38,17 @@ contract DanglingElse {
         return 0;
     }
 
+    function fr(bool a, bool b, uint256 n) external pure returns (uint256) {
+        if (a) {
+            for (uint256 i; i < n; ++i) {
+                if (b) return 1;
+            }
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
     function ok(bool a, bool b) external pure returns (uint256) {
         if (a) if (b) return 1;
         return 0;

--- a/crates/fmt/testdata/IfStatement3/fmt.sol
+++ b/crates/fmt/testdata/IfStatement3/fmt.sol
@@ -1,0 +1,74 @@
+contract DanglingElse {
+    function f(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            if (b) return 1;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function g(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            if (b) return 1;
+            else return 7;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function h(bool a, bool b, bool c) external pure returns (uint256) {
+        if (a) {
+            return 9;
+        } else if (b) {
+            if (c) return 1;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function w(bool a, bool b, bool c) external pure returns (uint256) {
+        if (a) {
+            while (c) if (b) return 1;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function ok(bool a, bool b) external pure returns (uint256) {
+        if (a) if (b) return 1;
+        return 0;
+    }
+
+    function cIso(bool a, bool b) external pure returns (uint256) {
+        // isolated comment
+        if (a) {
+            if (b) return 1;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function cMix(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            /* mixed */
+            if (b) return 1;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function cTrl(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            if (b) return 1; // trailing
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+}

--- a/crates/fmt/testdata/IfStatement3/original.sol
+++ b/crates/fmt/testdata/IfStatement3/original.sol
@@ -31,6 +31,11 @@ contract DanglingElse {
         return 0;
     }
 
+    function nested(bool x, bool a, bool b) external pure returns (uint256) {
+        if (x) { if (a) { if (b) return 1; } else return 2; }
+        return 0;
+    }
+
     function cIso(bool a, bool b) external pure returns (uint256) {
         // isolated comment
         if (a) { if (b) return 1; } else return 2;

--- a/crates/fmt/testdata/IfStatement3/original.sol
+++ b/crates/fmt/testdata/IfStatement3/original.sol
@@ -21,6 +21,11 @@ contract DanglingElse {
         return 0;
     }
 
+    function fr(bool a, bool b, uint256 n) external pure returns (uint256) {
+        if (a) { for (uint256 i; i < n; ++i) if (b) return 1; } else return 2;
+        return 0;
+    }
+
     function ok(bool a, bool b) external pure returns (uint256) {
         if (a) { if (b) return 1; }
         return 0;

--- a/crates/fmt/testdata/IfStatement3/original.sol
+++ b/crates/fmt/testdata/IfStatement3/original.sol
@@ -1,0 +1,45 @@
+contract DanglingElse {
+    function f(bool a, bool b) external pure returns (uint256) {
+        if (a) { if (b) return 1; } else return 2;
+        return 0;
+    }
+
+    function g(bool a, bool b) external pure returns (uint256) {
+        if (a) { if (b) return 1; else return 7; } else return 2;
+        return 0;
+    }
+
+    function h(bool a, bool b, bool c) external pure returns (uint256) {
+        if (a) return 9;
+        else if (b) { if (c) return 1; }
+        else return 2;
+        return 0;
+    }
+
+    function w(bool a, bool b, bool c) external pure returns (uint256) {
+        if (a) { while (c) if (b) return 1; } else return 2;
+        return 0;
+    }
+
+    function ok(bool a, bool b) external pure returns (uint256) {
+        if (a) { if (b) return 1; }
+        return 0;
+    }
+
+    function cIso(bool a, bool b) external pure returns (uint256) {
+        // isolated comment
+        if (a) { if (b) return 1; } else return 2;
+        return 0;
+    }
+
+    function cMix(bool a, bool b) external pure returns (uint256) {
+        if (a) { /* mixed */ if (b) return 1; } else return 2;
+        return 0;
+    }
+
+    function cTrl(bool a, bool b) external pure returns (uint256) {
+        if (a) { if (b) return 1; // trailing
+        } else return 2;
+        return 0;
+    }
+}

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -189,6 +189,7 @@ fmt_tests! {
     HexUnderscore,
     IfStatement,
     IfStatement2,
+    IfStatement3,
     ImportDirective,
     InlineDisable,
     IntTypes,
@@ -223,50 +224,6 @@ fmt_tests! {
     WhileStatement,
     Yul,
     YulStrings,
-}
-
-#[test]
-fn test_dangling_else_keeps_braces() {
-    init_tracing();
-    let source = r#"contract C {
-    function f(bool a, bool b) external pure returns (uint256) {
-        if (a) { if (b) return 1; } else return 2;
-        return 0;
-    }
-
-    function g(bool a, bool b, bool c) external pure returns (uint256) {
-        if (a) { while (c) if (b) return 1; } else return 2;
-        return 0;
-    }
-}
-"#;
-
-    let expected = r#"contract C {
-    function f(bool a, bool b) external pure returns (uint256) {
-        if (a) {
-            if (b) return 1;
-        } else {
-            return 2;
-        }
-        return 0;
-    }
-
-    function g(bool a, bool b, bool c) external pure returns (uint256) {
-        if (a) {
-            while (c) if (b) return 1;
-        } else {
-            return 2;
-        }
-        return 0;
-    }
-}
-"#;
-
-    let fmt_config = Arc::new(FormatterConfig { line_length: 80, ..Default::default() });
-    let path = Path::new("test.sol");
-    let formatted = format(source, path, fmt_config);
-
-    assert_eq!(formatted, expected, "Formatting mismatch");
 }
 
 #[test]

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -226,6 +226,50 @@ fmt_tests! {
 }
 
 #[test]
+fn test_dangling_else_keeps_braces() {
+    init_tracing();
+    let source = r#"contract C {
+    function f(bool a, bool b) external pure returns (uint256) {
+        if (a) { if (b) return 1; } else return 2;
+        return 0;
+    }
+
+    function g(bool a, bool b, bool c) external pure returns (uint256) {
+        if (a) { while (c) if (b) return 1; } else return 2;
+        return 0;
+    }
+}
+"#;
+
+    let expected = r#"contract C {
+    function f(bool a, bool b) external pure returns (uint256) {
+        if (a) {
+            if (b) return 1;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+
+    function g(bool a, bool b, bool c) external pure returns (uint256) {
+        if (a) {
+            while (c) if (b) return 1;
+        } else {
+            return 2;
+        }
+        return 0;
+    }
+}
+"#;
+
+    let fmt_config = Arc::new(FormatterConfig { line_length: 80, ..Default::default() });
+    let path = Path::new("test.sol");
+    let formatted = format(source, path, fmt_config);
+
+    assert_eq!(formatted, expected, "Formatting mismatch");
+}
+
+#[test]
 fn test_comment_empty_line_bug() {
     init_tracing();
     let source = r#"pragma solidity ^0.8.0;


### PR DESCRIPTION
`forge fmt` drops braces around a single-statement nested `if`, causing the `else` to rebind to the inner `if` and silently changing semantics.

Input:
```solidity
if (a) { if (b) return 1; } else return 2;
```

Output:
```solidity
if (a) if (b) return 1;
else return 2;
```

With `a=true, b=false`: original returns `0`, formatted version returns `2`.

Fix: in `is_single_line_block`, refuse to elide braces when the `then` block wraps a single `if` (or `while`, whose body has the same risk) and the surrounding `if` has an `else`.
