### PR TITLE
feat(lint): add `encode-packed-collision`

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -12,6 +12,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `unchecked-call`: Low-level calls should check the success return value.
   - `erc20-unchecked-transfer`: ERC20 `transfer` and `transferFrom` calls should check the return value.
   - `arbitrary-send-erc20`: Flags `transferFrom`/`safeTransferFrom` calls whose `from` argument is not provably `msg.sender` or `address(this)`.
+  - `encode-packed-collision`: Flags `abi.encodePacked()` calls with multiple dynamic-type arguments (`string`, `bytes`, dynamic arrays) that can produce hash collisions.
   - `rtlo`: Flags Unicode bidirectional override characters ("Trojan Source", CVE-2021-42574) that can hide malicious code.
   - `reentrancy-unlimited-gas`: Flags uncapped ETH-transferring low-level calls followed by writes to state that was read before the call.
   - `unprotected-initializer`: Upgradeable initializers should not be callable on the implementation contract.

--- a/crates/lint/docs/encode-packed-collision.md
+++ b/crates/lint/docs/encode-packed-collision.md
@@ -21,6 +21,10 @@ Hash collisions allow an attacker to craft inputs that hash to an identifier the
 - Signature payloads: two different messages that produce the same signature hash
 - Access-control keys: two different (user, resource) pairs that map to the same key
 
+This lint is intentionally conservative and flags by argument type, not by proving exploitability.
+Some injective patterns, such as repeating the same dynamic value or manually adding length prefixes,
+may still be reported.
+
 ## Example
 
 ### Bad

--- a/crates/lint/docs/encode-packed-collision.md
+++ b/crates/lint/docs/encode-packed-collision.md
@@ -1,0 +1,42 @@
+# Encode Packed Collision
+
+**Severity**: `High`
+**ID**: `encode-packed-collision`
+
+`abi.encodePacked()` with multiple dynamic-type arguments produces ambiguous encodings. Because packed encoding concatenates values without length prefixes, different inputs can produce the same output — for example, `encodePacked("a", "bc") == encodePacked("ab", "c")`. When the result is hashed and used as a key or signature, this enables collision attacks.
+
+## What it does
+
+Flags calls to `abi.encodePacked()` where two or more arguments have dynamic types:
+
+- `string`
+- `bytes` (dynamic)
+- dynamic arrays (`T[]`)
+
+## Why is this bad?
+
+Hash collisions allow an attacker to craft inputs that hash to an identifier they do not own. Common vulnerable patterns include:
+
+- Merkle leaf construction: an attacker submits two adjacent leaves concatenated to match a sibling pair
+- Signature payloads: two different messages that produce the same signature hash
+- Access-control keys: two different (user, resource) pairs that map to the same key
+
+## Example
+
+### Bad
+
+```solidity
+function getKey(string memory a, string memory b) public pure returns (bytes32) {
+    return keccak256(abi.encodePacked(a, b)); // "a"+"bc" == "ab"+"c"
+}
+```
+
+### Good
+
+Use `abi.encode()` instead — it includes length prefixes that prevent collisions:
+
+```solidity
+function getKey(string memory a, string memory b) public pure returns (bytes32) {
+    return keccak256(abi.encode(a, b));
+}
+```

--- a/crates/lint/src/sol/high/encode_packed_collision.rs
+++ b/crates/lint/src/sol/high/encode_packed_collision.rs
@@ -105,8 +105,10 @@ fn call_return_type<'hir>(
             Some(&hir.variable(*ret).ty)
         }
         // Member call: token.name(), token.symbol(), etc.
-        // If multiple functions share the method name (overloads), return None to avoid
-        // false positives from picking the wrong overload.
+        // A contract may expose multiple entries for the same method name when a derived contract
+        // overrides an inherited function. In that case all candidates share the same return type,
+        // so we accept the match as long as every candidate agrees. If they disagree (genuine
+        // overloads with different return types) we bail to avoid false positives.
         ExprKind::Member(recv, method) => {
             let cid = contract_id_of(hir, recv)?;
             let matches: Vec<_> = hir
@@ -122,8 +124,13 @@ fn call_return_type<'hir>(
                     }
                 })
                 .collect();
-            let [ty] = matches.as_slice() else { return None };
-            Some(*ty)
+            let [first, rest @ ..] = matches.as_slice() else { return None };
+            // All candidates must agree on dynamic-ness; if any disagrees it's a genuine overload
+            // and we cannot determine which was called.
+            if rest.iter().any(|ty| is_dynamic_type(&ty.kind) != is_dynamic_type(&first.kind)) {
+                return None;
+            }
+            Some(*first)
         }
         // Indirect call via a function-typed value
         _ => match &expr_type(hir, callee)?.kind {

--- a/crates/lint/src/sol/high/encode_packed_collision.rs
+++ b/crates/lint/src/sol/high/encode_packed_collision.rs
@@ -1,0 +1,108 @@
+use super::EncodedPackedCollision;
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::{
+    interface::sym,
+    sema::hir::{ElementaryType, Expr, ExprKind, Hir, ItemId, Res, Type, TypeKind, VariableId},
+};
+
+declare_forge_lint!(
+    ENCODE_PACKED_COLLISION,
+    Severity::High,
+    "encode-packed-collision",
+    "`abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible"
+);
+
+impl<'hir> LateLintPass<'hir> for EncodedPackedCollision {
+    fn check_expr(&mut self, ctx: &LintContext, hir: &'hir Hir<'hir>, expr: &'hir Expr<'hir>) {
+        let ExprKind::Call(callee, args, _) = &expr.kind else { return };
+        let ExprKind::Member(base, member) = &callee.peel_parens().kind else { return };
+        if member.name != sym::encodePacked || !is_abi_builtin(base) {
+            return;
+        }
+        let dynamic_count = args.exprs().filter(|arg| is_dynamic_arg(hir, arg)).count();
+        if dynamic_count >= 2 {
+            ctx.emit(&ENCODE_PACKED_COLLISION, expr.span);
+        }
+    }
+}
+
+fn is_abi_builtin(expr: &Expr<'_>) -> bool {
+    matches!(
+        &expr.peel_parens().kind,
+        ExprKind::Ident(reses)
+            if reses.iter().any(|r| matches!(r, Res::Builtin(b) if b.name() == sym::abi))
+    )
+}
+
+fn is_dynamic_arg(hir: &Hir<'_>, expr: &Expr<'_>) -> bool {
+    let Some(ty) = expr_type(hir, expr) else { return false };
+    is_dynamic_type(&ty.kind)
+}
+
+const fn is_dynamic_type(kind: &TypeKind<'_>) -> bool {
+    match kind {
+        TypeKind::Elementary(ElementaryType::String | ElementaryType::Bytes) => true,
+        TypeKind::Array(arr) => arr.size.is_none(),
+        _ => false,
+    }
+}
+
+fn expr_type<'hir>(hir: &'hir Hir<'hir>, expr: &'hir Expr<'hir>) -> Option<&'hir Type<'hir>> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(resolutions) => {
+            let var_id = var_resolution(resolutions)?;
+            Some(&hir.variable(var_id).ty)
+        }
+        ExprKind::Call(callee, _, _) => call_return_type(hir, callee),
+        ExprKind::Index(base, _) => match &expr_type(hir, base)?.kind {
+            TypeKind::Array(array) => Some(&array.element),
+            TypeKind::Mapping(mapping) => Some(&mapping.value),
+            _ => None,
+        },
+        ExprKind::Member(base, member) => {
+            let base_ty = expr_type(hir, base)?;
+            let TypeKind::Custom(ItemId::Struct(sid)) = &base_ty.kind else { return None };
+            hir.strukt(*sid)
+                .fields
+                .iter()
+                .find(|&&fid| hir.variable(fid).name.is_some_and(|n| n.name == member.name))
+                .map(|&fid| &hir.variable(fid).ty)
+        }
+        _ => None,
+    }
+}
+
+fn call_return_type<'hir>(
+    hir: &'hir Hir<'hir>,
+    callee: &'hir Expr<'hir>,
+) -> Option<&'hir Type<'hir>> {
+    match &callee.peel_parens().kind {
+        // Type cast: bytes(x), string(x) — the result type is the cast target
+        ExprKind::Type(ty) => Some(ty),
+        // Direct function call: getString(), getBytes()
+        ExprKind::Ident(resolutions) => {
+            let fid = resolutions.iter().find_map(|r| {
+                if let Res::Item(ItemId::Function(fid)) = r { Some(*fid) } else { None }
+            })?;
+            let [ret] = hir.function(fid).returns else { return None };
+            Some(&hir.variable(*ret).ty)
+        }
+        // Indirect call via a function-typed value
+        _ => match &expr_type(hir, callee)?.kind {
+            TypeKind::Function(f) => {
+                let [ret] = f.returns else { return None };
+                Some(&hir.variable(*ret).ty)
+            }
+            _ => None,
+        },
+    }
+}
+
+fn var_resolution(resolutions: &[Res]) -> Option<VariableId> {
+    resolutions
+        .iter()
+        .find_map(|r| if let Res::Item(ItemId::Variable(vid)) = r { Some(*vid) } else { None })
+}

--- a/crates/lint/src/sol/high/encode_packed_collision.rs
+++ b/crates/lint/src/sol/high/encode_packed_collision.rs
@@ -59,11 +59,14 @@ fn is_dynamic_arg(hir: &Hir<'_>, expr: &Expr<'_>) -> bool {
         }
         // Calls: check well-known builtins that return bytes/string, then generic path.
         ExprKind::Call(callee, args, _) => is_dynamic_call(hir, callee, args.exprs().count()),
-        // Member access: check well-known dynamic builtin properties (msg.data, *.code, etc.)
-        // before the generic struct-field path in expr_type.
+        // Member access: prefer the resolved type so user-defined struct fields named like
+        // builtin properties (e.g. `code`) do not get treated as dynamic bytes.
         ExprKind::Member(base, member) => {
-            is_dynamic_builtin_member(base, member)
-                || expr_type(hir, expr).is_some_and(|ty| is_dynamic_type(&ty.kind))
+            if let Some(ty) = expr_type(hir, expr) {
+                is_dynamic_type(&ty.kind)
+            } else {
+                is_dynamic_builtin_member(base, member)
+            }
         }
         _ => expr_type(hir, expr).is_some_and(|ty| is_dynamic_type(&ty.kind)),
     }
@@ -140,7 +143,7 @@ fn expr_type<'hir>(hir: &'hir Hir<'hir>, expr: &'hir Expr<'hir>) -> Option<&'hir
             TypeKind::Mapping(mapping) => Some(&mapping.value),
             _ => None,
         },
-        // Slice expressions (e.g. `data[:4]`) preserve the element type of the base.
+        // Slice expressions (e.g. `data[:4]`) preserve the base type.
         ExprKind::Slice(base, ..) => expr_type(hir, base),
         ExprKind::Member(base, member) => {
             let base_ty = expr_type(hir, base)?;

--- a/crates/lint/src/sol/high/encode_packed_collision.rs
+++ b/crates/lint/src/sol/high/encode_packed_collision.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use solar::{
     ast,
-    interface::sym,
+    interface::{Ident, Symbol, sym},
     sema::hir::{
         ContractId, ElementaryType, Expr, ExprKind, Hir, ItemId, Res, Type, TypeKind, VariableId,
     },
@@ -25,7 +25,18 @@ impl<'hir> LateLintPass<'hir> for EncodedPackedCollision {
         if member.name != sym::encodePacked || !is_abi_builtin(base) {
             return;
         }
-        let dynamic_count = args.exprs().filter(|arg| is_dynamic_arg(hir, arg)).count();
+        // Only non-literal dynamic args count: a top-level string/hex/unicode literal is a
+        // compile-time constant. With at most one non-literal dynamic arg the packed encoding
+        // is still injective, so there is no collision risk.
+        let dynamic_count = args
+            .exprs()
+            .filter(|arg| {
+                !matches!(
+                    arg.peel_parens().kind,
+                    ExprKind::Lit(lit) if matches!(lit.kind, ast::LitKind::Str(..))
+                ) && is_dynamic_arg(hir, arg)
+            })
+            .count();
         if dynamic_count >= 2 {
             ctx.emit(&ENCODE_PACKED_COLLISION, expr.span);
         }
@@ -33,21 +44,78 @@ impl<'hir> LateLintPass<'hir> for EncodedPackedCollision {
 }
 
 fn is_abi_builtin(expr: &Expr<'_>) -> bool {
-    matches!(
-        &expr.peel_parens().kind,
-        ExprKind::Ident(reses)
-            if reses.iter().any(|r| matches!(r, Res::Builtin(b) if b.name() == sym::abi))
-    )
+    is_builtin_named(expr, sym::abi)
 }
 
 fn is_dynamic_arg(hir: &Hir<'_>, expr: &Expr<'_>) -> bool {
-    // String literals are always dynamic `string` type.
-    if matches!(&expr.peel_parens().kind, ExprKind::Lit(lit) if matches!(lit.kind, ast::LitKind::Str(..)))
-    {
-        return true;
+    let expr = expr.peel_parens();
+    match &expr.kind {
+        // String literals (and multi-line/hex string sequences) are always dynamic `string` type.
+        ExprKind::Lit(lit) if matches!(lit.kind, ast::LitKind::Str(..)) => true,
+        // Ternary: dynamic when both branches are dynamic. Handled here so that literal branches
+        // (which have no expr_type) are correctly identified as dynamic.
+        ExprKind::Ternary(_, then, else_) => {
+            is_dynamic_arg(hir, then) && is_dynamic_arg(hir, else_)
+        }
+        // Calls: check well-known builtins that return bytes/string, then generic path.
+        ExprKind::Call(callee, args, _) => is_dynamic_call(hir, callee, args.exprs().count()),
+        // Member access: check well-known dynamic builtin properties (msg.data, *.code, etc.)
+        // before the generic struct-field path in expr_type.
+        ExprKind::Member(base, member) => {
+            is_dynamic_builtin_member(base, member)
+                || expr_type(hir, expr).is_some_and(|ty| is_dynamic_type(&ty.kind))
+        }
+        _ => expr_type(hir, expr).is_some_and(|ty| is_dynamic_type(&ty.kind)),
     }
-    let Some(ty) = expr_type(hir, expr) else { return false };
-    is_dynamic_type(&ty.kind)
+}
+
+/// Returns `true` when `callee(args)` is statically known to return a dynamic type.
+fn is_dynamic_call<'hir>(hir: &'hir Hir<'hir>, callee: &'hir Expr<'hir>, n_args: usize) -> bool {
+    let callee = callee.peel_parens();
+    match &callee.kind {
+        // `new bytes(n)` / `new string(n)`: dynamic allocation.
+        ExprKind::New(ty) => return is_dynamic_type(&ty.kind),
+        ExprKind::Member(recv, method) => {
+            // abi.encode / abi.encodePacked / abi.encodeWithSelector / … -> bytes
+            if is_abi_builtin(recv) && is_abi_encode_method(method.name) {
+                return true;
+            }
+            // string.concat(…) -> string, bytes.concat(…) -> bytes
+            if method.name == sym::concat
+                && let ExprKind::Type(ty) = &recv.peel_parens().kind
+                && is_dynamic_type(&ty.kind)
+            {
+                return true;
+            }
+        }
+        _ => {}
+    }
+    call_return_type(hir, callee, Some(n_args)).is_some_and(|ty| is_dynamic_type(&ty.kind))
+}
+
+/// Returns `true` when `base.member` is a well-known builtin property of dynamic bytes type.
+fn is_dynamic_builtin_member(base: &Expr<'_>, member: &Ident) -> bool {
+    match member.name {
+        // msg.data -> bytes calldata
+        n if n == sym::data => is_builtin_named(base, sym::msg),
+        // <any>.code, type(C).creationCode, type(C).runtimeCode -> bytes
+        n if n == sym::code || n == sym::creationCode || n == sym::runtimeCode => true,
+        _ => false,
+    }
+}
+
+fn is_abi_encode_method(name: Symbol) -> bool {
+    name == sym::encode
+        || name == sym::encodePacked
+        || name == sym::encodeWithSelector
+        || name == sym::encodeWithSignature
+        || name == sym::encodeCall
+}
+
+fn is_builtin_named(expr: &Expr<'_>, name: Symbol) -> bool {
+    matches!(&expr.peel_parens().kind,
+        ExprKind::Ident(reses) if reses.iter().any(|r| matches!(r, Res::Builtin(b) if b.name() == name))
+    )
 }
 
 const fn is_dynamic_type(kind: &TypeKind<'_>) -> bool {

--- a/crates/lint/src/sol/high/encode_packed_collision.rs
+++ b/crates/lint/src/sol/high/encode_packed_collision.rs
@@ -4,8 +4,11 @@ use crate::{
     sol::{Severity, SolLint},
 };
 use solar::{
+    ast,
     interface::sym,
-    sema::hir::{ElementaryType, Expr, ExprKind, Hir, ItemId, Res, Type, TypeKind, VariableId},
+    sema::hir::{
+        ContractId, ElementaryType, Expr, ExprKind, Hir, ItemId, Res, Type, TypeKind, VariableId,
+    },
 };
 
 declare_forge_lint!(
@@ -38,6 +41,11 @@ fn is_abi_builtin(expr: &Expr<'_>) -> bool {
 }
 
 fn is_dynamic_arg(hir: &Hir<'_>, expr: &Expr<'_>) -> bool {
+    // String literals are always dynamic `string` type.
+    if matches!(&expr.peel_parens().kind, ExprKind::Lit(lit) if matches!(lit.kind, ast::LitKind::Str(..)))
+    {
+        return true;
+    }
     let Some(ty) = expr_type(hir, expr) else { return false };
     is_dynamic_type(&ty.kind)
 }
@@ -90,6 +98,20 @@ fn call_return_type<'hir>(
             let [ret] = hir.function(fid).returns else { return None };
             Some(&hir.variable(*ret).ty)
         }
+        // Member call: token.name(), token.symbol(), etc.
+        ExprKind::Member(recv, method) => {
+            let cid = contract_id_of(hir, recv)?;
+            hir.contract_item_ids(cid).find_map(|item| {
+                let fid = item.as_function()?;
+                let f = hir.function(fid);
+                if f.name.is_some_and(|n| n.name == method.name) {
+                    let [ret] = f.returns else { return None };
+                    Some(&hir.variable(*ret).ty)
+                } else {
+                    None
+                }
+            })
+        }
         // Indirect call via a function-typed value
         _ => match &expr_type(hir, callee)?.kind {
             TypeKind::Function(f) => {
@@ -98,6 +120,20 @@ fn call_return_type<'hir>(
             }
             _ => None,
         },
+    }
+}
+
+fn contract_id_of(hir: &Hir<'_>, expr: &Expr<'_>) -> Option<ContractId> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) => reses.iter().find_map(|r| match r {
+            Res::Item(ItemId::Variable(vid)) => match hir.variable(*vid).ty.kind {
+                TypeKind::Custom(ItemId::Contract(cid)) => Some(cid),
+                _ => None,
+            },
+            Res::Item(ItemId::Contract(cid)) => Some(*cid),
+            _ => None,
+        }),
+        _ => None,
     }
 }
 

--- a/crates/lint/src/sol/high/encode_packed_collision.rs
+++ b/crates/lint/src/sol/high/encode_packed_collision.rs
@@ -64,12 +64,16 @@ fn expr_type<'hir>(hir: &'hir Hir<'hir>, expr: &'hir Expr<'hir>) -> Option<&'hir
             let var_id = var_resolution(resolutions)?;
             Some(&hir.variable(var_id).ty)
         }
-        ExprKind::Call(callee, _, _) => call_return_type(hir, callee),
+        ExprKind::Call(callee, args, _) => {
+            call_return_type(hir, callee, Some(args.exprs().count()))
+        }
         ExprKind::Index(base, _) => match &expr_type(hir, base)?.kind {
             TypeKind::Array(array) => Some(&array.element),
             TypeKind::Mapping(mapping) => Some(&mapping.value),
             _ => None,
         },
+        // Slice expressions (e.g. `data[:4]`) preserve the element type of the base.
+        ExprKind::Slice(base, ..) => expr_type(hir, base),
         ExprKind::Member(base, member) => {
             let base_ty = expr_type(hir, base)?;
             let TypeKind::Custom(ItemId::Struct(sid)) = &base_ty.kind else { return None };
@@ -79,6 +83,12 @@ fn expr_type<'hir>(hir: &'hir Hir<'hir>, expr: &'hir Expr<'hir>) -> Option<&'hir
                 .find(|&&fid| hir.variable(fid).name.is_some_and(|n| n.name == member.name))
                 .map(|&fid| &hir.variable(fid).ty)
         }
+        // Ternary: use then-branch type if both branches agree on dynamic-ness.
+        ExprKind::Ternary(_, then, else_) => {
+            let then_ty = expr_type(hir, then)?;
+            let else_ty = expr_type(hir, else_)?;
+            (is_dynamic_type(&then_ty.kind) == is_dynamic_type(&else_ty.kind)).then_some(then_ty)
+        }
         _ => None,
     }
 }
@@ -86,18 +96,25 @@ fn expr_type<'hir>(hir: &'hir Hir<'hir>, expr: &'hir Expr<'hir>) -> Option<&'hir
 fn call_return_type<'hir>(
     hir: &'hir Hir<'hir>,
     callee: &'hir Expr<'hir>,
+    // Number of arguments in the outer call; used to disambiguate same-name overloads by arity.
+    n_call_args: Option<usize>,
 ) -> Option<&'hir Type<'hir>> {
     match &callee.peel_parens().kind {
-        // Type cast: bytes(x), string(x) — the result type is the cast target
+        // Type cast: bytes(x), string(x); the result type is the cast target
         ExprKind::Type(ty) => Some(ty),
         // Direct function call: getString(), getBytes()
-        // If multiple function resolutions exist (overloads), we can't determine which was
-        // called without argument types, return None to avoid false positives.
+        // If multiple function resolutions remain after arity filtering we can't determine which
+        // overload was called, so return None to avoid false positives.
         ExprKind::Ident(resolutions) => {
             let fids: Vec<_> = resolutions
                 .iter()
                 .filter_map(|r| {
-                    if let Res::Item(ItemId::Function(fid)) = r { Some(*fid) } else { None }
+                    if let Res::Item(ItemId::Function(fid)) = r {
+                        let f = hir.function(*fid);
+                        n_call_args.is_none_or(|n| f.parameters.len() == n).then_some(*fid)
+                    } else {
+                        None
+                    }
                 })
                 .collect();
             let [fid] = fids.as_slice() else { return None };
@@ -107,8 +124,9 @@ fn call_return_type<'hir>(
         // Member call: token.name(), token.symbol(), etc.
         // A contract may expose multiple entries for the same method name when a derived contract
         // overrides an inherited function. In that case all candidates share the same return type,
-        // so we accept the match as long as every candidate agrees. If they disagree (genuine
-        // overloads with different return types) we bail to avoid false positives.
+        // so we accept the match as long as every candidate agrees on dynamic-ness. If they
+        // disagree (genuine overloads with different return types) we bail to avoid false
+        // positives. Arity filtering further narrows candidates before the agreement check.
         ExprKind::Member(recv, method) => {
             let cid = contract_id_of(hir, recv)?;
             let matches: Vec<_> = hir
@@ -116,7 +134,9 @@ fn call_return_type<'hir>(
                 .filter_map(|item| {
                     let fid = item.as_function()?;
                     let f = hir.function(fid);
-                    if f.name.is_some_and(|n| n.name == method.name) {
+                    let name_matches = f.name.is_some_and(|n| n.name == method.name);
+                    let arity_matches = n_call_args.is_none_or(|n| f.parameters.len() == n);
+                    if name_matches && arity_matches {
                         let [ret] = f.returns else { return None };
                         Some(&hir.variable(*ret).ty)
                     } else {
@@ -145,6 +165,7 @@ fn call_return_type<'hir>(
 
 fn contract_id_of(hir: &Hir<'_>, expr: &Expr<'_>) -> Option<ContractId> {
     match &expr.peel_parens().kind {
+        // Bare identifier resolved to a contract variable or contract type.
         ExprKind::Ident(reses) => reses.iter().find_map(|r| match r {
             Res::Item(ItemId::Variable(vid)) => match hir.variable(*vid).ty.kind {
                 TypeKind::Custom(ItemId::Contract(cid)) => Some(cid),
@@ -153,7 +174,25 @@ fn contract_id_of(hir: &Hir<'_>, expr: &Expr<'_>) -> Option<ContractId> {
             Res::Item(ItemId::Contract(cid)) => Some(*cid),
             _ => None,
         }),
-        _ => None,
+        // Interface/contract cast: IERC20Metadata(addr) or MyContract(addr).
+        // The callee can be either an Ident resolving to a contract item or a Type node.
+        ExprKind::Call(callee, ..) => match &callee.peel_parens().kind {
+            ExprKind::Ident(reses) => reses.iter().find_map(|r| match r {
+                Res::Item(ItemId::Contract(cid)) => Some(*cid),
+                _ => None,
+            }),
+            ExprKind::Type(ty) => match &ty.kind {
+                TypeKind::Custom(ItemId::Contract(cid)) => Some(*cid),
+                _ => None,
+            },
+            _ => None,
+        },
+        // General fallback: compute the expression's type.
+        // This covers struct field access (cfg.token) and array index access (tokens[i]).
+        _ => match &expr_type(hir, expr)?.kind {
+            TypeKind::Custom(ItemId::Contract(cid)) => Some(*cid),
+            _ => None,
+        },
     }
 }
 

--- a/crates/lint/src/sol/high/encode_packed_collision.rs
+++ b/crates/lint/src/sol/high/encode_packed_collision.rs
@@ -91,26 +91,39 @@ fn call_return_type<'hir>(
         // Type cast: bytes(x), string(x) — the result type is the cast target
         ExprKind::Type(ty) => Some(ty),
         // Direct function call: getString(), getBytes()
+        // If multiple function resolutions exist (overloads), we can't determine which was
+        // called without argument types, return None to avoid false positives.
         ExprKind::Ident(resolutions) => {
-            let fid = resolutions.iter().find_map(|r| {
-                if let Res::Item(ItemId::Function(fid)) = r { Some(*fid) } else { None }
-            })?;
-            let [ret] = hir.function(fid).returns else { return None };
+            let fids: Vec<_> = resolutions
+                .iter()
+                .filter_map(|r| {
+                    if let Res::Item(ItemId::Function(fid)) = r { Some(*fid) } else { None }
+                })
+                .collect();
+            let [fid] = fids.as_slice() else { return None };
+            let [ret] = hir.function(*fid).returns else { return None };
             Some(&hir.variable(*ret).ty)
         }
         // Member call: token.name(), token.symbol(), etc.
+        // If multiple functions share the method name (overloads), return None to avoid
+        // false positives from picking the wrong overload.
         ExprKind::Member(recv, method) => {
             let cid = contract_id_of(hir, recv)?;
-            hir.contract_item_ids(cid).find_map(|item| {
-                let fid = item.as_function()?;
-                let f = hir.function(fid);
-                if f.name.is_some_and(|n| n.name == method.name) {
-                    let [ret] = f.returns else { return None };
-                    Some(&hir.variable(*ret).ty)
-                } else {
-                    None
-                }
-            })
+            let matches: Vec<_> = hir
+                .contract_item_ids(cid)
+                .filter_map(|item| {
+                    let fid = item.as_function()?;
+                    let f = hir.function(fid);
+                    if f.name.is_some_and(|n| n.name == method.name) {
+                        let [ret] = f.returns else { return None };
+                        Some(&hir.variable(*ret).ty)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            let [ty] = matches.as_slice() else { return None };
+            Some(*ty)
         }
         // Indirect call via a function-typed value
         _ => match &expr_type(hir, callee)?.kind {

--- a/crates/lint/src/sol/high/mod.rs
+++ b/crates/lint/src/sol/high/mod.rs
@@ -1,6 +1,7 @@
 use crate::sol::{EarlyLintPass, LateLintPass, SolLint};
 
 mod arbitrary_send_erc20;
+mod encode_packed_collision;
 mod incorrect_shift;
 mod reentrancy;
 mod rtlo;
@@ -8,6 +9,7 @@ mod unchecked_calls;
 mod unprotected_initializer;
 
 use arbitrary_send_erc20::ARBITRARY_SEND_ERC20;
+use encode_packed_collision::ENCODE_PACKED_COLLISION;
 use incorrect_shift::INCORRECT_SHIFT;
 use reentrancy::REENTRANCY_UNLIMITED_GAS;
 use rtlo::RTLO;
@@ -16,6 +18,7 @@ use unprotected_initializer::UNPROTECTED_INITIALIZER;
 
 register_lints!(
     (ArbitrarySendErc20, late, (ARBITRARY_SEND_ERC20)),
+    (EncodedPackedCollision, late, (ENCODE_PACKED_COLLISION)),
     (IncorrectShift, early, (INCORRECT_SHIFT)),
     (ReentrancyUnlimitedGas, late, (REENTRANCY_UNLIMITED_GAS)),
     (UncheckedCall, early, (UNCHECKED_CALL)),

--- a/crates/lint/testdata/EncodePackedCollision.sol
+++ b/crates/lint/testdata/EncodePackedCollision.sol
@@ -83,6 +83,24 @@ contract EncodePackedCollision {
     }
 }
 
+// SHOULD WARN: concrete contract overriding inherited name()/symbol(), both return string,
+// so even though contract_item_ids yields two entries per method the lint must still fire.
+interface IToken {
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+}
+
+contract ConcreteToken is IToken {
+    function name() external pure override returns (string memory) { return "Token"; }
+    function symbol() external pure override returns (string memory) { return "TKN"; }
+}
+
+contract OverrideCollision {
+    function tokenCollision(ConcreteToken token) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(token.name(), token.symbol())); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
 // SHOULD NOT WARN: overloaded function, must pick the correct overload based on arg type
 contract OverloadFP {
     function f(uint256) internal pure returns (string memory) { return ""; }

--- a/crates/lint/testdata/EncodePackedCollision.sol
+++ b/crates/lint/testdata/EncodePackedCollision.sol
@@ -83,6 +83,17 @@ contract EncodePackedCollision {
     }
 }
 
+// SHOULD NOT WARN: overloaded function, must pick the correct overload based on arg type
+contract OverloadFP {
+    function f(uint256) internal pure returns (string memory) { return ""; }
+    function f(bytes32) internal pure returns (uint256) { return 1; }
+
+    // f(x) resolves to f(bytes32) → returns uint256 (not dynamic); only s is dynamic → no warn
+    function g(bytes32 x, string memory s) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(f(x), s));
+    }
+}
+
 interface IERC20Metadata {
     function name() external view returns (string memory);
     function symbol() external view returns (string memory);

--- a/crates/lint/testdata/EncodePackedCollision.sol
+++ b/crates/lint/testdata/EncodePackedCollision.sol
@@ -71,4 +71,31 @@ contract EncodePackedCollision {
     function typeCasts(bytes32 a, bytes32 b) public pure returns (bytes32) {
         return keccak256(abi.encodePacked(bytes(abi.encode(a)), bytes(abi.encode(b)))); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
     }
+
+    // SHOULD WARN: string literals
+    function stringLiterals() public pure returns (bytes32) {
+        return keccak256(abi.encodePacked("a", "bc")); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+
+    // SHOULD PASS: single string literal
+    function singleLiteral() public pure returns (bytes32) {
+        return keccak256(abi.encodePacked("abc"));
+    }
+}
+
+interface IERC20Metadata {
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+}
+
+contract MemberCalls {
+    // SHOULD WARN: external member calls returning string
+    function tokenCollision(IERC20Metadata token) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(token.name(), token.symbol())); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+
+    // SHOULD PASS: single external member call
+    function singleMemberCall(IERC20Metadata token) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(token.name()));
+    }
 }

--- a/crates/lint/testdata/EncodePackedCollision.sol
+++ b/crates/lint/testdata/EncodePackedCollision.sol
@@ -72,14 +72,24 @@ contract EncodePackedCollision {
         return keccak256(abi.encodePacked(bytes(abi.encode(a)), bytes(abi.encode(b)))); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
     }
 
-    // SHOULD WARN: string literals
+    // SHOULD PASS: two string literals are compile-time constants; no runtime variability
     function stringLiterals() public pure returns (bytes32) {
-        return keccak256(abi.encodePacked("a", "bc")); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+        return keccak256(abi.encodePacked("a", "bc"));
     }
 
     // SHOULD PASS: single string literal
     function singleLiteral() public pure returns (bytes32) {
         return keccak256(abi.encodePacked("abc"));
+    }
+
+    // SHOULD PASS: one literal + one dynamic is still injective
+    function literalPrefixSafe(string memory s) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked("prefix:", s));
+    }
+
+    // SHOULD PASS: hex literal + one dynamic is still injective
+    function hexLiteralSafe(bytes memory b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(hex"dead", b));
     }
 }
 
@@ -182,3 +192,96 @@ contract SliceDynamic {
 // Fixed-size arrays with dynamic element types (e.g. string[2], bytes[2]).
 // Note: solc itself rejects these in abi.encodePacked with "Type not supported in packed mode",
 // so no lint fixture is needed, the compiler prevents the problematic pattern.
+
+// SHOULD WARN: ternary where one branch is a string literal (literal has no expr_type)
+contract TernaryLiteral {
+    function ternaryLiteralCollision(bool flag, string memory a, string memory b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(flag ? a : "x", b)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// SHOULD WARN: abi.encode() returns bytes, no explicit bytes() cast needed
+contract AbiEncodeNoCast {
+    function abiEncodeCollision(bytes32 a, bytes32 b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(abi.encode(a), abi.encode(b))); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+
+    // SHOULD WARN: nested abi.encodePacked returns bytes
+    function nestedEncodePackedCollision(string memory a, string memory b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(abi.encodePacked(a), abi.encodePacked(b))); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// SHOULD WARN: string.concat() returns string
+contract StringConcatArg {
+    function stringConcatCollision(string memory a, string memory b, string memory c) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(string.concat(a, b), c)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// SHOULD WARN: bytes.concat() returns bytes
+contract BytesConcatArg {
+    function bytesConcatCollision(bytes memory a, bytes memory b, bytes memory c) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(bytes.concat(a, b), c)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// SHOULD WARN: msg.data (bytes calldata) + string
+contract MsgDataCollision {
+    function msgDataAndString(string memory s) external pure returns (bytes32) {
+        return keccak256(abi.encodePacked(msg.data, s)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// SHOULD WARN: address.code (bytes memory) + string
+contract AddrCodeCollision {
+    function addrCodeAndString(address addr, string memory s) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(addr.code, s)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+
+    function thisCodeAndString(string memory s) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(address(this).code, s)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// SHOULD WARN: new bytes() + string
+contract NewBytesCollision {
+    function newBytesAndString(uint256 n, string memory s) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(new bytes(n), s)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// SHOULD WARN: public string state variable; synthesized getter returns string
+contract PublicGetterToken {
+    string public name = "Token";
+    string public symbol = "TKN";
+}
+contract PublicGetterCollision {
+    function getterCollision(PublicGetterToken t) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(t.name(), t.symbol())); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// SHOULD WARN: library function returning string
+library StringLib {
+    function toStr(uint256) internal pure returns (string memory) { return ""; }
+}
+contract LibraryCallCollision {
+    function libraryStringCollision(uint256 a, uint256 b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(StringLib.toStr(a), StringLib.toStr(b))); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// KNOWN FALSE NEGATIVE: overload where the selected overload returns string.
+// f(uint256) and f(bytes32) both have arity 1, so call_return_type cannot disambiguate
+// without full type-based overload resolution. It bails and produces no warning even though
+// f(x) with a uint256 argument resolves to the dynamic-returning overload.
+contract OverloadShouldWarnFN {
+    function f(uint256) internal pure returns (string memory) { return ""; }
+    function f(bytes32) internal pure returns (uint256) { return 0; }
+
+    // f(x) resolves to f(uint256) → string (dynamic); SHOULD warn but doesn't (known FN)
+    function g(uint256 x, string memory s) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(f(x), s));
+    }
+}

--- a/crates/lint/testdata/EncodePackedCollision.sol
+++ b/crates/lint/testdata/EncodePackedCollision.sol
@@ -1,0 +1,74 @@
+//@compile-flags: --only-lint encode-packed-collision
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+contract EncodePackedCollision {
+    // SHOULD WARN: two string args
+    function twoStrings(string memory a, string memory b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(a, b)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+
+    // SHOULD WARN: two bytes args
+    function twoBytes(bytes memory a, bytes memory b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(a, b)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+
+    // SHOULD WARN: string + bytes
+    function stringAndBytes(string memory a, bytes memory b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(a, b)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+
+    // SHOULD WARN: dynamic array + string
+    function arrayAndString(uint256[] memory a, string memory b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(a, b)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+
+    // SHOULD WARN: two dynamic arrays
+    function twoArrays(uint256[] memory a, address[] memory b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(a, b)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+
+    // SHOULD WARN: three dynamic args, still one call
+    function threeStrings(string memory a, string memory b, string memory c) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(a, b, c)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+
+    // SHOULD PASS: only one dynamic arg
+    function oneString(string memory a, uint256 b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(a, b));
+    }
+
+    // SHOULD PASS: no dynamic args
+    function noDynamic(uint256 a, address b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(a, b));
+    }
+
+    // SHOULD PASS: fixed bytes are not dynamic
+    function fixedBytes(bytes32 a, bytes32 b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(a, b));
+    }
+
+    // SHOULD PASS: fixed-size array is not dynamic
+    function fixedArray(uint256[3] memory a, uint256[3] memory b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(a, b));
+    }
+
+    // SHOULD PASS: single string arg
+    function singleString(string memory a) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(a));
+    }
+
+    // SHOULD WARN: call returning string/bytes
+    function getString() internal pure returns (string memory) { return "x"; }
+    function getBytes() internal pure returns (bytes memory) { return hex"ff"; }
+
+    function callReturns() public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(getString(), getBytes())); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+
+    // SHOULD WARN: explicit type casts to bytes/string
+    function typeCasts(bytes32 a, bytes32 b) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(bytes(abi.encode(a)), bytes(abi.encode(b)))); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}

--- a/crates/lint/testdata/EncodePackedCollision.sol
+++ b/crates/lint/testdata/EncodePackedCollision.sol
@@ -128,3 +128,57 @@ contract MemberCalls {
         return keccak256(abi.encodePacked(token.name()));
     }
 }
+
+// Explicit interface casts; IERC20Metadata(addr).name()
+contract InterfaceCast {
+    // SHOULD WARN: interface cast receiver
+    function castCollision(address addr) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(IERC20Metadata(addr).name(), IERC20Metadata(addr).symbol())); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// Contract-typed struct fields and array elements
+contract TokenRegistry {
+    struct Config { IERC20Metadata token; }
+
+    // SHOULD WARN: struct field receiver
+    function structField(Config memory cfg) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(cfg.token.name(), cfg.token.symbol())); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+
+    // SHOULD WARN: array index receiver
+    function arrayIndex(IERC20Metadata[] memory tokens) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(tokens[0].name(), tokens[0].symbol())); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// Member overloads with different arities; f() is dynamic, f(uint256) is not
+contract OverloadArity {
+    function f() internal pure returns (string memory) { return ""; }
+    function f(uint256) internal pure returns (uint256) { return 1; }
+
+    // SHOULD WARN: f() (0 args) unambiguously returns string; s is also dynamic
+    function g(string memory s) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(f(), s)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// Ternary expressions
+contract TernaryDynamic {
+    // SHOULD WARN: ternary where both branches are dynamic strings
+    function ternaryCollision(bool flag, string memory a, string memory b, string memory c) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(flag ? a : b, c)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// Calldata slices
+contract SliceDynamic {
+    // SHOULD WARN: calldata slice (still bytes) + another dynamic arg
+    function sliceCollision(bytes calldata data, string memory s) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(data[:4], s)); //~WARN: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+    }
+}
+
+// Fixed-size arrays with dynamic element types (e.g. string[2], bytes[2]).
+// Note: solc itself rejects these in abi.encodePacked with "Type not supported in packed mode",
+// so no lint fixture is needed, the compiler prevents the problematic pattern.

--- a/crates/lint/testdata/EncodePackedCollision.sol
+++ b/crates/lint/testdata/EncodePackedCollision.sol
@@ -244,6 +244,15 @@ contract AddrCodeCollision {
     }
 }
 
+// SHOULD PASS: a user-defined struct field named `code` is not address.code bytes.
+contract StructCodeField {
+    struct S { uint256 code; }
+
+    function structCodeAndString(S memory x, string memory s) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(x.code, s));
+    }
+}
+
 // SHOULD WARN: new bytes() + string
 contract NewBytesCollision {
     function newBytesAndString(uint256 n, string memory s) public pure returns (bytes32) {

--- a/crates/lint/testdata/EncodePackedCollision.stderr
+++ b/crates/lint/testdata/EncodePackedCollision.stderr
@@ -62,3 +62,19 @@ LL │ …     return keccak256(abi.encodePacked(bytes(abi.encode(a)), bytes(abi
    │
    ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
 
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked("a", "bc"));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(token.name(), token.symbol()));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+

--- a/crates/lint/testdata/EncodePackedCollision.stderr
+++ b/crates/lint/testdata/EncodePackedCollision.stderr
@@ -65,14 +65,6 @@ LL │ …     return keccak256(abi.encodePacked(bytes(abi.encode(a)), bytes(abi
 warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
    ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
    │
-LL │ …     return keccak256(abi.encodePacked("a", "bc"));
-   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
-
-warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
-   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
-   │
 LL │ …     return keccak256(abi.encodePacked(token.name(), token.symbol()));
    │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -131,6 +123,94 @@ warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dyna
    │
 LL │ …     return keccak256(abi.encodePacked(data[:4], s));
    │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(flag ? a : "x", b));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(abi.encode(a), abi.encode(b)));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(abi.encodePacked(a), abi.encodePacked(b)));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(string.concat(a, b), c));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(bytes.concat(a, b), c));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(msg.data, s));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(addr.code, s));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(address(this).code, s));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(new bytes(n), s));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(t.name(), t.symbol()));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(StringLib.toStr(a), StringLib.toStr(b)));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
 

--- a/crates/lint/testdata/EncodePackedCollision.stderr
+++ b/crates/lint/testdata/EncodePackedCollision.stderr
@@ -78,3 +78,11 @@ LL │ …     return keccak256(abi.encodePacked(token.name(), token.symbol()));
    │
    ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
 
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(token.name(), token.symbol()));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+

--- a/crates/lint/testdata/EncodePackedCollision.stderr
+++ b/crates/lint/testdata/EncodePackedCollision.stderr
@@ -86,3 +86,51 @@ LL │ …     return keccak256(abi.encodePacked(token.name(), token.symbol()));
    │
    ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
 
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(IERC20Metadata(addr).name(), IERC20Metadata(addr).symbol()));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(cfg.token.name(), cfg.token.symbol()));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(tokens[0].name(), tokens[0].symbol()));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(f(), s));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(flag ? a : b, c));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(data[:4], s));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+

--- a/crates/lint/testdata/EncodePackedCollision.stderr
+++ b/crates/lint/testdata/EncodePackedCollision.stderr
@@ -1,0 +1,64 @@
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(a, b));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(a, b));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(a, b));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(a, b));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(a, b));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(a, b, c));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(getString(), getBytes()));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+
+warning[encode-packed-collision]: `abi.encodePacked()` called with multiple dynamic type arguments; hash collisions possible
+   ╭▸ ROOT/testdata/EncodePackedCollision.sol:LL:CC
+   │
+LL │ …     return keccak256(abi.encodePacked(bytes(abi.encode(a)), bytes(abi.encode(b))));
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/encode-packed-collision
+


### PR DESCRIPTION
## Description
Closes OSS-58

Add `encode-packed-collision` lint.

Detects `abi.encodePacked()` calls with 2+ dynamic-type arguments (`string`, `bytes`, `T[]`) which can produce hash collisions, e.g. `encodePacked("a","bc") == encodePacked("ab","c")`.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
