### PR TITLE
feat(lint): add `write-after-write`

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -66,6 +66,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `external-function`: `public` functions never called internally should be declared `external` to avoid copying reference-type arguments into memory.
   - `unused-state-variables`: State variables that are never used should be removed.
   - `var-read-using-this`: Reads of state variables (or other `view`/`pure` functions) via `this` cause an unnecessary `STATICCALL`; access them directly.
+  - `write-after-write`: Flags storage variables written consecutively without the first value ever being read; only the final write is needed.
 - **Code Size:**
   - `unwrapped-modifier-logic`: Recommends wrapping modifier logic to reduce contract code size.
 

--- a/crates/lint/docs/write-after-write.md
+++ b/crates/lint/docs/write-after-write.md
@@ -9,11 +9,19 @@ the second write overwrites it.
 
 ## What it does
 
-Within a flat sequence of statements (no intervening branches or loops), reports the first
-assignment to a simple state variable when that same variable is written a second time before being
-read. Only plain `=` assignments and `delete` expressions on bare state variable identifiers are
-checked; compound assignments (`+=`, `|=`, etc.) and index/member writes (`mapping[k]`,
-`struct.field`) are conservatively excluded to avoid false positives.
+Reports the first assignment to a state variable when that same variable is written a second time
+before being read. Detection covers:
+
+- Plain `=` assignments and `delete` on bare state variable identifiers
+- Tuple/destructuring assignments: `(x, y) = (1, 2)` tracks each component individually
+- Pre/post increment and decrement (`++x`, `x--`, etc.) — these read then write, so the write
+  they produce can itself become dead if immediately overwritten
+
+The analysis recurses into branch bodies (`if`/`else`, loops, `try` clauses) and modifier bodies
+with fresh state so intra-body pairs are still caught. Conditional boundaries (`&&`, `||`,
+ternary) are handled conservatively to avoid false positives across short-circuit paths. Compound
+assignments (`+=`, `|=`, etc.) and index/member writes (`mapping[k]`, `struct.field`) are
+excluded to avoid false positives.
 
 ## Why is this bad?
 

--- a/crates/lint/docs/write-after-write.md
+++ b/crates/lint/docs/write-after-write.md
@@ -1,0 +1,63 @@
+# Write after write
+
+**Severity**: `Gas`
+**ID**: `write-after-write`
+
+Flags storage variables that are written to consecutively without the first value ever being read.
+The first write is dead code; it pays the SSTORE cost but its value is immediately discarded when
+the second write overwrites it.
+
+## What it does
+
+Within a flat sequence of statements (no intervening branches or loops), reports the first
+assignment to a simple state variable when that same variable is written a second time before being
+read. Only plain `=` assignments and `delete` expressions on bare state variable identifiers are
+checked; compound assignments (`+=`, `|=`, etc.) and index/member writes (`mapping[k]`,
+`struct.field`) are conservatively excluded to avoid false positives.
+
+## Why is this bad?
+
+Every SSTORE costs at least 2,900 gas (warm slot) or 20,000 gas (cold slot). Writing a value to
+storage and then immediately overwriting it wastes that gas with no observable effect; only the
+final write matters.
+
+## Example
+
+### Bad
+
+```solidity
+contract C {
+    uint256 public x;
+
+    function bad(uint256 v) external {
+        x = 0;   // write-after-write: this value is never read
+        x = v;   // second write overwrites the first
+    }
+}
+```
+
+### Good
+
+```solidity
+contract C {
+    uint256 public x;
+
+    // Write once with the final value directly.
+    function good(uint256 v) external {
+        x = v;
+    }
+
+    // Reading between writes is fine.
+    function goodRead(uint256 v) external returns (uint256 prev) {
+        x = 1;
+        prev = x; // x is read here
+        x = v;
+    }
+
+    // Compound assignments read before writing, not flagged.
+    function goodCompound() external {
+        x = 1;
+        x += 1;
+    }
+}
+```

--- a/crates/lint/src/sol/gas/mod.rs
+++ b/crates/lint/src/sol/gas/mod.rs
@@ -8,6 +8,7 @@ mod immutable;
 mod keccak;
 mod unused_state_variables;
 mod var_read_using_this;
+mod write_after_write;
 use cache_array_length::CACHE_ARRAY_LENGTH;
 use costly_loop::COSTLY_LOOP;
 use custom_errors::CUSTOM_ERRORS;
@@ -16,6 +17,7 @@ use immutable::{COULD_BE_CONSTANT, COULD_BE_IMMUTABLE};
 use keccak::ASM_KECCAK256;
 use unused_state_variables::UNUSED_STATE_VARIABLES;
 use var_read_using_this::VAR_READ_USING_THIS;
+use write_after_write::WRITE_AFTER_WRITE;
 
 register_lints!(
     (AsmKeccak256, late, (ASM_KECCAK256)),
@@ -26,4 +28,5 @@ register_lints!(
     (ExternalFunction, late, (EXTERNAL_FUNCTION)),
     (UnusedStateVariables, late, (UNUSED_STATE_VARIABLES)),
     (VarReadUsingThis, late, (VAR_READ_USING_THIS)),
+    (WriteAfterWrite, late, (WRITE_AFTER_WRITE)),
 );

--- a/crates/lint/src/sol/gas/write_after_write.rs
+++ b/crates/lint/src/sol/gas/write_after_write.rs
@@ -7,7 +7,9 @@ use solar::{
     interface::Span,
     sema::{
         Hir,
-        hir::{Block, Expr, ExprKind, Function, ItemId, Res, Stmt, StmtKind, VariableId},
+        hir::{
+            BinOpKind, Block, Expr, ExprKind, Function, ItemId, Res, Stmt, StmtKind, VariableId,
+        },
     },
 };
 use std::collections::HashMap;
@@ -170,7 +172,12 @@ fn process_expr<'hir>(
         }
         // Any function/method call can observe state through re-entrancy or view
         // calls, so conservatively treat it as reading everything pending.
-        ExprKind::Call(_, _, _) => {
+        // Walk callee and arguments first — Solidity evaluates them before the call.
+        ExprKind::Call(callee, args, _) => {
+            collect_reads(ctx, hir, callee, pending);
+            for arg in args.exprs() {
+                collect_reads(ctx, hir, arg, pending);
+            }
             pending.clear();
         }
         // For any other expression used as a statement, scan for reads.
@@ -201,6 +208,14 @@ fn collect_reads<'hir>(
             // reads it. Delegate to process_expr so the write is tracked correctly.
             process_expr(ctx, hir, expr.peel_parens(), pending);
         }
+        // Short-circuit operators: LHS always evaluates, RHS may not.
+        // Clear outer pending before RHS to avoid false-positive WAW in the conditional path.
+        ExprKind::Binary(lhs, op, rhs) if matches!(op.kind, BinOpKind::And | BinOpKind::Or) => {
+            collect_reads(ctx, hir, lhs, pending);
+            pending.clear();
+            let mut rhs_pending = HashMap::default();
+            collect_reads(ctx, hir, rhs, &mut rhs_pending);
+        }
         ExprKind::Binary(lhs, _, rhs) => {
             collect_reads(ctx, hir, lhs, pending);
             collect_reads(ctx, hir, rhs, pending);
@@ -208,13 +223,23 @@ fn collect_reads<'hir>(
         ExprKind::Unary(_, inner) | ExprKind::Payable(inner) => {
             collect_reads(ctx, hir, inner, pending);
         }
+        // Ternary arms are mutually exclusive; analyze each independently with a fresh
+        // pending to avoid false-positive WAW between branches.
         ExprKind::Ternary(cond, t, f) => {
             collect_reads(ctx, hir, cond, pending);
-            collect_reads(ctx, hir, t, pending);
-            collect_reads(ctx, hir, f, pending);
+            pending.clear();
+            let mut then_pending = HashMap::default();
+            let mut else_pending = HashMap::default();
+            collect_reads(ctx, hir, t, &mut then_pending);
+            collect_reads(ctx, hir, f, &mut else_pending);
         }
         // Any call may observe storage through re-entrancy or view semantics.
-        ExprKind::Call(_, _, _) => {
+        // Walk callee and arguments first — Solidity evaluates them before the call.
+        ExprKind::Call(callee, args, _) => {
+            collect_reads(ctx, hir, callee, pending);
+            for arg in args.exprs() {
+                collect_reads(ctx, hir, arg, pending);
+            }
             pending.clear();
         }
         ExprKind::Index(base, index) => {

--- a/crates/lint/src/sol/gas/write_after_write.rs
+++ b/crates/lint/src/sol/gas/write_after_write.rs
@@ -43,6 +43,13 @@ fn check_block<'hir>(
 ) {
     for stmt in block.stmts {
         check_stmt(ctx, hir, stmt, pending);
+        // Stop at terminal statements; subsequent code is unreachable.
+        if matches!(
+            stmt.kind,
+            StmtKind::Return(_) | StmtKind::Revert(_) | StmtKind::Break | StmtKind::Continue
+        ) {
+            break;
+        }
     }
 }
 
@@ -76,7 +83,17 @@ fn check_stmt<'hir>(
             pending.clear();
         }
         StmtKind::Emit(expr) => {
-            collect_reads(ctx, hir, expr, pending);
+            // Emit only logs; it doesn't invoke external code that could observe state.
+            // Walk the call args directly so pending is not cleared.
+            if let ExprKind::Call(callee, args, named_args) = &expr.peel_parens().kind {
+                collect_reads(ctx, hir, callee, pending);
+                for arg in args.exprs() {
+                    collect_reads(ctx, hir, arg, pending);
+                }
+                walk_named_args(ctx, hir, named_args, pending);
+            } else {
+                collect_reads(ctx, hir, expr, pending);
+            }
         }
         StmtKind::Revert(expr) => {
             collect_reads(ctx, hir, expr, pending);
@@ -139,25 +156,19 @@ fn process_expr<'hir>(
             collect_reads(ctx, hir, rhs, pending);
 
             if op.is_none() {
-                // Plain `=`: check if LHS is a simple bare state variable.
-                if let Some(var_id) = simple_state_var_id(hir, lhs) {
-                    if let Some(&prev_span) = pending.get(&var_id) {
-                        ctx.emit(&WRITE_AFTER_WRITE, prev_span);
-                    }
-                    pending.insert(var_id, expr.span);
-                } else {
-                    // Non-simple LHS (index/member access): the base variable is read
-                    // as part of the slot computation, so treat it as a read.
-                    collect_reads(ctx, hir, lhs, pending);
-                }
+                // Plain `=`: recursively handle the LHS as a write target.
+                process_assignment_lhs(ctx, hir, lhs, expr.span, pending);
             } else {
                 // Compound assignment (+=, etc.) reads the current value of LHS first.
                 collect_reads(ctx, hir, lhs, pending);
             }
         }
         ExprKind::Unary(op, inner) if op.kind.has_side_effects() => {
-            // Pre/post inc/dec: read-then-write, so just consume any pending write.
+            // Pre/post inc/dec: reads the variable, then writes it.
             collect_reads(ctx, hir, inner, pending);
+            if let Some(var_id) = simple_state_var_id(hir, inner) {
+                pending.insert(var_id, expr.span);
+            }
         }
         ExprKind::Delete(inner) => {
             // `delete x` is a pure write with no read of the previous value.
@@ -172,16 +183,46 @@ fn process_expr<'hir>(
         }
         // Any function/method call can observe state through re-entrancy or view
         // calls, so conservatively treat it as reading everything pending.
-        // Walk callee and arguments first — Solidity evaluates them before the call.
-        ExprKind::Call(callee, args, _) => {
+        // Walk callee, arguments, and call options first — all are evaluated before the call.
+        ExprKind::Call(callee, args, named_args) => {
             collect_reads(ctx, hir, callee, pending);
             for arg in args.exprs() {
                 collect_reads(ctx, hir, arg, pending);
             }
+            walk_named_args(ctx, hir, named_args, pending);
             pending.clear();
         }
         // For any other expression used as a statement, scan for reads.
         _ => collect_reads(ctx, hir, expr, pending),
+    }
+}
+
+/// Recursively handle a plain-`=` assignment LHS, tracking each component as a write.
+/// For tuple destructuring `(x, y) = ...`, each element is processed independently.
+fn process_assignment_lhs<'hir>(
+    ctx: &LintContext,
+    hir: &'hir Hir<'hir>,
+    lhs: &'hir Expr<'hir>,
+    assign_span: Span,
+    pending: &mut HashMap<VariableId, Span>,
+) {
+    match &lhs.peel_parens().kind {
+        ExprKind::Tuple(exprs) => {
+            for e in exprs.iter().flatten() {
+                process_assignment_lhs(ctx, hir, e, assign_span, pending);
+            }
+        }
+        _ => {
+            if let Some(var_id) = simple_state_var_id(hir, lhs) {
+                if let Some(&prev_span) = pending.get(&var_id) {
+                    ctx.emit(&WRITE_AFTER_WRITE, prev_span);
+                }
+                pending.insert(var_id, assign_span);
+            } else {
+                // Non-simple LHS (index/member access): slot computation reads the base.
+                collect_reads(ctx, hir, lhs, pending);
+            }
+        }
     }
 }
 
@@ -234,12 +275,13 @@ fn collect_reads<'hir>(
             collect_reads(ctx, hir, f, &mut else_pending);
         }
         // Any call may observe storage through re-entrancy or view semantics.
-        // Walk callee and arguments first — Solidity evaluates them before the call.
-        ExprKind::Call(callee, args, _) => {
+        // Walk callee, arguments, and call options first — all evaluated before the call.
+        ExprKind::Call(callee, args, named_args) => {
             collect_reads(ctx, hir, callee, pending);
             for arg in args.exprs() {
                 collect_reads(ctx, hir, arg, pending);
             }
+            walk_named_args(ctx, hir, named_args, pending);
             pending.clear();
         }
         ExprKind::Index(base, index) => {
@@ -268,12 +310,28 @@ fn collect_reads<'hir>(
                 collect_reads(ctx, hir, e, pending);
             }
         }
-        ExprKind::Delete(inner) => collect_reads(ctx, hir, inner, pending),
-        ExprKind::Lit(_)
-        | ExprKind::New(_)
-        | ExprKind::TypeCall(_)
-        | ExprKind::Type(_)
-        | ExprKind::Err(_) => {}
+        // A nested `delete` is a write; delegate to process_expr for correct tracking.
+        ExprKind::Delete(_) => {
+            process_expr(ctx, hir, expr.peel_parens(), pending);
+        }
+        ExprKind::Lit(_) | ExprKind::New(_) | ExprKind::TypeCall(_) | ExprKind::Type(_) => {}
+        ExprKind::Err(_) => {
+            pending.clear();
+        }
+    }
+}
+
+/// Walk named call arguments (e.g. `{value: expr, gas: expr}`) for reads and writes.
+fn walk_named_args<'hir>(
+    ctx: &LintContext,
+    hir: &'hir Hir<'hir>,
+    named_args: &Option<&'hir [solar::sema::hir::NamedArg<'hir>]>,
+    pending: &mut HashMap<VariableId, Span>,
+) {
+    if let Some(named) = named_args {
+        for na in *named {
+            collect_reads(ctx, hir, &na.value, pending);
+        }
     }
 }
 

--- a/crates/lint/src/sol/gas/write_after_write.rs
+++ b/crates/lint/src/sol/gas/write_after_write.rs
@@ -56,35 +56,35 @@ fn check_stmt<'hir>(
         }
         StmtKind::DeclSingle(var_id) => {
             if let Some(init) = hir.variable(*var_id).initializer {
-                collect_reads(hir, init, pending);
+                collect_reads(ctx, hir, init, pending);
             }
         }
         StmtKind::DeclMulti(_, expr) => {
-            collect_reads(hir, expr, pending);
+            collect_reads(ctx, hir, expr, pending);
         }
         // return/revert/break/continue are terminal; code after them is unreachable,
         // so the "pending" writes will never be overwritten. Reads still matter for the
         // value carried by return/revert, but after processing we must clear because no
         // subsequent statement in the same block can execute.
         StmtKind::Return(Some(expr)) => {
-            collect_reads(hir, expr, pending);
+            collect_reads(ctx, hir, expr, pending);
             pending.clear();
         }
         StmtKind::Return(None) | StmtKind::Break | StmtKind::Continue => {
             pending.clear();
         }
         StmtKind::Emit(expr) => {
-            collect_reads(hir, expr, pending);
+            collect_reads(ctx, hir, expr, pending);
         }
         StmtKind::Revert(expr) => {
-            collect_reads(hir, expr, pending);
+            collect_reads(ctx, hir, expr, pending);
             pending.clear();
         }
         // Branches and loops: recurse with a fresh map so intra-body pairs are still
         // caught, then clear the outer pending conservatively since any branch may
         // observe or skip the outer write.
         StmtKind::If(cond, then_stmt, else_stmt) => {
-            collect_reads(hir, cond, pending);
+            collect_reads(ctx, hir, cond, pending);
             pending.clear();
             let mut branch_pending = HashMap::default();
             check_stmt(ctx, hir, then_stmt, &mut branch_pending);
@@ -99,7 +99,7 @@ fn check_stmt<'hir>(
             check_block(ctx, hir, *block, &mut loop_pending);
         }
         StmtKind::Try(try_stmt) => {
-            collect_reads(hir, &try_stmt.expr, pending);
+            collect_reads(ctx, hir, &try_stmt.expr, pending);
             pending.clear();
             for clause in try_stmt.clauses {
                 let mut clause_pending = HashMap::default();
@@ -134,7 +134,7 @@ fn process_expr<'hir>(
     match &expr.kind {
         ExprKind::Assign(lhs, op, rhs) => {
             // RHS is always evaluated (read) before the assignment takes effect.
-            collect_reads(hir, rhs, pending);
+            collect_reads(ctx, hir, rhs, pending);
 
             if op.is_none() {
                 // Plain `=`: check if LHS is a simple bare state variable.
@@ -146,16 +146,16 @@ fn process_expr<'hir>(
                 } else {
                     // Non-simple LHS (index/member access): the base variable is read
                     // as part of the slot computation, so treat it as a read.
-                    collect_reads(hir, lhs, pending);
+                    collect_reads(ctx, hir, lhs, pending);
                 }
             } else {
                 // Compound assignment (+=, etc.) reads the current value of LHS first.
-                collect_reads(hir, lhs, pending);
+                collect_reads(ctx, hir, lhs, pending);
             }
         }
         ExprKind::Unary(op, inner) if op.kind.has_side_effects() => {
             // Pre/post inc/dec: read-then-write, so just consume any pending write.
-            collect_reads(hir, inner, pending);
+            collect_reads(ctx, hir, inner, pending);
         }
         ExprKind::Delete(inner) => {
             // `delete x` is a pure write with no read of the previous value.
@@ -165,7 +165,7 @@ fn process_expr<'hir>(
                 }
                 pending.insert(var_id, expr.span);
             } else {
-                collect_reads(hir, inner, pending);
+                collect_reads(ctx, hir, inner, pending);
             }
         }
         // Any function/method call can observe state through re-entrancy or view
@@ -174,12 +174,14 @@ fn process_expr<'hir>(
             pending.clear();
         }
         // For any other expression used as a statement, scan for reads.
-        _ => collect_reads(hir, expr, pending),
+        _ => collect_reads(ctx, hir, expr, pending),
     }
 }
 
 /// Remove any state variable mentioned in `expr` from `pending` (it was read).
+/// For nested assignments, delegates to `process_expr` so writes are handled correctly.
 fn collect_reads<'hir>(
+    ctx: &LintContext,
     hir: &'hir Hir<'hir>,
     expr: &'hir Expr<'hir>,
     pending: &mut HashMap<VariableId, Span>,
@@ -194,53 +196,54 @@ fn collect_reads<'hir>(
                 }
             }
         }
-        ExprKind::Assign(lhs, _, rhs) => {
-            collect_reads(hir, lhs, pending);
-            collect_reads(hir, rhs, pending);
+        ExprKind::Assign(_, _, _) => {
+            // A nested assignment (e.g. `uint256 z = (x = v)`) writes to its LHS, not
+            // reads it. Delegate to process_expr so the write is tracked correctly.
+            process_expr(ctx, hir, expr.peel_parens(), pending);
         }
         ExprKind::Binary(lhs, _, rhs) => {
-            collect_reads(hir, lhs, pending);
-            collect_reads(hir, rhs, pending);
+            collect_reads(ctx, hir, lhs, pending);
+            collect_reads(ctx, hir, rhs, pending);
         }
         ExprKind::Unary(_, inner) | ExprKind::Payable(inner) => {
-            collect_reads(hir, inner, pending);
+            collect_reads(ctx, hir, inner, pending);
         }
         ExprKind::Ternary(cond, t, f) => {
-            collect_reads(hir, cond, pending);
-            collect_reads(hir, t, pending);
-            collect_reads(hir, f, pending);
+            collect_reads(ctx, hir, cond, pending);
+            collect_reads(ctx, hir, t, pending);
+            collect_reads(ctx, hir, f, pending);
         }
         // Any call may observe storage through re-entrancy or view semantics.
         ExprKind::Call(_, _, _) => {
             pending.clear();
         }
         ExprKind::Index(base, index) => {
-            collect_reads(hir, base, pending);
+            collect_reads(ctx, hir, base, pending);
             if let Some(idx) = index {
-                collect_reads(hir, idx, pending);
+                collect_reads(ctx, hir, idx, pending);
             }
         }
         ExprKind::Slice(base, start, end) => {
-            collect_reads(hir, base, pending);
+            collect_reads(ctx, hir, base, pending);
             if let Some(s) = start {
-                collect_reads(hir, s, pending);
+                collect_reads(ctx, hir, s, pending);
             }
             if let Some(e) = end {
-                collect_reads(hir, e, pending);
+                collect_reads(ctx, hir, e, pending);
             }
         }
-        ExprKind::Member(base, _) => collect_reads(hir, base, pending),
+        ExprKind::Member(base, _) => collect_reads(ctx, hir, base, pending),
         ExprKind::Tuple(exprs) => {
             for e in exprs.iter().flatten() {
-                collect_reads(hir, e, pending);
+                collect_reads(ctx, hir, e, pending);
             }
         }
         ExprKind::Array(exprs) => {
             for e in *exprs {
-                collect_reads(hir, e, pending);
+                collect_reads(ctx, hir, e, pending);
             }
         }
-        ExprKind::Delete(inner) => collect_reads(hir, inner, pending),
+        ExprKind::Delete(inner) => collect_reads(ctx, hir, inner, pending),
         ExprKind::Lit(_)
         | ExprKind::New(_)
         | ExprKind::TypeCall(_)

--- a/crates/lint/src/sol/gas/write_after_write.rs
+++ b/crates/lint/src/sol/gas/write_after_write.rs
@@ -1,0 +1,261 @@
+use super::WriteAfterWrite;
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::{
+    interface::Span,
+    sema::{
+        Hir,
+        hir::{Block, Expr, ExprKind, Function, ItemId, Res, Stmt, StmtKind, VariableId},
+    },
+};
+use std::collections::HashMap;
+
+declare_forge_lint!(
+    WRITE_AFTER_WRITE,
+    Severity::Gas,
+    "write-after-write",
+    "redundant storage write; value overwritten before being read"
+);
+
+impl<'hir> LateLintPass<'hir> for WriteAfterWrite {
+    fn check_function(
+        &mut self,
+        ctx: &LintContext,
+        hir: &'hir Hir<'hir>,
+        func: &'hir Function<'hir>,
+    ) {
+        if let Some(body) = func.body {
+            let mut pending = HashMap::default();
+            check_block(ctx, hir, body, &mut pending);
+        }
+    }
+}
+
+fn check_block<'hir>(
+    ctx: &LintContext,
+    hir: &'hir Hir<'hir>,
+    block: Block<'hir>,
+    pending: &mut HashMap<VariableId, Span>,
+) {
+    for stmt in block.stmts {
+        check_stmt(ctx, hir, stmt, pending);
+    }
+}
+
+fn check_stmt<'hir>(
+    ctx: &LintContext,
+    hir: &'hir Hir<'hir>,
+    stmt: &'hir Stmt<'hir>,
+    pending: &mut HashMap<VariableId, Span>,
+) {
+    match &stmt.kind {
+        StmtKind::Expr(expr) => {
+            process_expr(ctx, hir, expr.peel_parens(), pending);
+        }
+        StmtKind::DeclSingle(var_id) => {
+            if let Some(init) = hir.variable(*var_id).initializer {
+                collect_reads(hir, init, pending);
+            }
+        }
+        StmtKind::DeclMulti(_, expr) => {
+            collect_reads(hir, expr, pending);
+        }
+        // return/revert/break/continue are terminal; code after them is unreachable,
+        // so the "pending" writes will never be overwritten. Reads still matter for the
+        // value carried by return/revert, but after processing we must clear because no
+        // subsequent statement in the same block can execute.
+        StmtKind::Return(Some(expr)) => {
+            collect_reads(hir, expr, pending);
+            pending.clear();
+        }
+        StmtKind::Return(None) | StmtKind::Break | StmtKind::Continue => {
+            pending.clear();
+        }
+        StmtKind::Emit(expr) => {
+            collect_reads(hir, expr, pending);
+        }
+        StmtKind::Revert(expr) => {
+            collect_reads(hir, expr, pending);
+            pending.clear();
+        }
+        // Branches and loops: recurse with a fresh map so intra-body pairs are still
+        // caught, then clear the outer pending conservatively since any branch may
+        // observe or skip the outer write.
+        StmtKind::If(cond, then_stmt, else_stmt) => {
+            collect_reads(hir, cond, pending);
+            pending.clear();
+            let mut branch_pending = HashMap::default();
+            check_stmt(ctx, hir, then_stmt, &mut branch_pending);
+            if let Some(else_stmt) = else_stmt {
+                let mut else_pending = HashMap::default();
+                check_stmt(ctx, hir, else_stmt, &mut else_pending);
+            }
+        }
+        StmtKind::Loop(block, _) => {
+            pending.clear();
+            let mut loop_pending = HashMap::default();
+            check_block(ctx, hir, *block, &mut loop_pending);
+        }
+        StmtKind::Try(try_stmt) => {
+            collect_reads(hir, &try_stmt.expr, pending);
+            pending.clear();
+            for clause in try_stmt.clauses {
+                let mut clause_pending = HashMap::default();
+                check_block(ctx, hir, clause.block, &mut clause_pending);
+            }
+        }
+        // Nested blocks are sequential; share the same pending map so reads inside
+        // them properly invalidate outer writes.
+        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
+            check_block(ctx, hir, *block, pending);
+        }
+        // The placeholder `_` in a modifier body invokes the modified function, which
+        // can freely read any storage variable. Conservatively clear everything.
+        StmtKind::Placeholder => {
+            pending.clear();
+        }
+        // Inline assembly or parse errors: we can't reason about what is read or
+        // written, so clear conservatively (same approach as unprotected_initializer).
+        StmtKind::Err(_) => {
+            pending.clear();
+        }
+    }
+}
+
+/// Process an expression that appears as a statement, tracking writes and reads.
+fn process_expr<'hir>(
+    ctx: &LintContext,
+    hir: &'hir Hir<'hir>,
+    expr: &'hir Expr<'hir>,
+    pending: &mut HashMap<VariableId, Span>,
+) {
+    match &expr.kind {
+        ExprKind::Assign(lhs, op, rhs) => {
+            // RHS is always evaluated (read) before the assignment takes effect.
+            collect_reads(hir, rhs, pending);
+
+            if op.is_none() {
+                // Plain `=`: check if LHS is a simple bare state variable.
+                if let Some(var_id) = simple_state_var_id(hir, lhs) {
+                    if let Some(&prev_span) = pending.get(&var_id) {
+                        ctx.emit(&WRITE_AFTER_WRITE, prev_span);
+                    }
+                    pending.insert(var_id, expr.span);
+                } else {
+                    // Non-simple LHS (index/member access): the base variable is read
+                    // as part of the slot computation, so treat it as a read.
+                    collect_reads(hir, lhs, pending);
+                }
+            } else {
+                // Compound assignment (+=, etc.) reads the current value of LHS first.
+                collect_reads(hir, lhs, pending);
+            }
+        }
+        ExprKind::Unary(op, inner) if op.kind.has_side_effects() => {
+            // Pre/post inc/dec: read-then-write, so just consume any pending write.
+            collect_reads(hir, inner, pending);
+        }
+        ExprKind::Delete(inner) => {
+            // `delete x` is a pure write with no read of the previous value.
+            if let Some(var_id) = simple_state_var_id(hir, inner) {
+                if let Some(&prev_span) = pending.get(&var_id) {
+                    ctx.emit(&WRITE_AFTER_WRITE, prev_span);
+                }
+                pending.insert(var_id, expr.span);
+            } else {
+                collect_reads(hir, inner, pending);
+            }
+        }
+        // Any function/method call can observe state through re-entrancy or view
+        // calls, so conservatively treat it as reading everything pending.
+        ExprKind::Call(_, _, _) => {
+            pending.clear();
+        }
+        // For any other expression used as a statement, scan for reads.
+        _ => collect_reads(hir, expr, pending),
+    }
+}
+
+/// Remove any state variable mentioned in `expr` from `pending` (it was read).
+fn collect_reads<'hir>(
+    hir: &'hir Hir<'hir>,
+    expr: &'hir Expr<'hir>,
+    pending: &mut HashMap<VariableId, Span>,
+) {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(resolutions) => {
+            for res in *resolutions {
+                if let Res::Item(ItemId::Variable(id)) = res
+                    && hir.variable(*id).is_state_variable()
+                {
+                    pending.remove(id);
+                }
+            }
+        }
+        ExprKind::Assign(lhs, _, rhs) => {
+            collect_reads(hir, lhs, pending);
+            collect_reads(hir, rhs, pending);
+        }
+        ExprKind::Binary(lhs, _, rhs) => {
+            collect_reads(hir, lhs, pending);
+            collect_reads(hir, rhs, pending);
+        }
+        ExprKind::Unary(_, inner) | ExprKind::Payable(inner) => {
+            collect_reads(hir, inner, pending);
+        }
+        ExprKind::Ternary(cond, t, f) => {
+            collect_reads(hir, cond, pending);
+            collect_reads(hir, t, pending);
+            collect_reads(hir, f, pending);
+        }
+        // Any call may observe storage through re-entrancy or view semantics.
+        ExprKind::Call(_, _, _) => {
+            pending.clear();
+        }
+        ExprKind::Index(base, index) => {
+            collect_reads(hir, base, pending);
+            if let Some(idx) = index {
+                collect_reads(hir, idx, pending);
+            }
+        }
+        ExprKind::Slice(base, start, end) => {
+            collect_reads(hir, base, pending);
+            if let Some(s) = start {
+                collect_reads(hir, s, pending);
+            }
+            if let Some(e) = end {
+                collect_reads(hir, e, pending);
+            }
+        }
+        ExprKind::Member(base, _) => collect_reads(hir, base, pending),
+        ExprKind::Tuple(exprs) => {
+            for e in exprs.iter().flatten() {
+                collect_reads(hir, e, pending);
+            }
+        }
+        ExprKind::Array(exprs) => {
+            for e in *exprs {
+                collect_reads(hir, e, pending);
+            }
+        }
+        ExprKind::Delete(inner) => collect_reads(hir, inner, pending),
+        ExprKind::Lit(_)
+        | ExprKind::New(_)
+        | ExprKind::TypeCall(_)
+        | ExprKind::Type(_)
+        | ExprKind::Err(_) => {}
+    }
+}
+
+/// Returns `Some(id)` if the expression is a bare state variable identifier (no indexing/member).
+fn simple_state_var_id(hir: &Hir<'_>, expr: &Expr<'_>) -> Option<VariableId> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(resolutions) => resolutions.iter().find_map(|res| match res {
+            Res::Item(ItemId::Variable(id)) if hir.variable(*id).is_state_variable() => Some(*id),
+            _ => None,
+        }),
+        _ => None,
+    }
+}

--- a/crates/lint/src/sol/gas/write_after_write.rs
+++ b/crates/lint/src/sol/gas/write_after_write.rs
@@ -35,22 +35,25 @@ impl<'hir> LateLintPass<'hir> for WriteAfterWrite {
     }
 }
 
+/// Whether control flow continues past this statement/block.
+#[derive(PartialEq, Eq)]
+enum Flow {
+    Continue,
+    Stop,
+}
+
 fn check_block<'hir>(
     ctx: &LintContext,
     hir: &'hir Hir<'hir>,
     block: Block<'hir>,
     pending: &mut HashMap<VariableId, Span>,
-) {
+) -> Flow {
     for stmt in block.stmts {
-        check_stmt(ctx, hir, stmt, pending);
-        // Stop at terminal statements; subsequent code is unreachable.
-        if matches!(
-            stmt.kind,
-            StmtKind::Return(_) | StmtKind::Revert(_) | StmtKind::Break | StmtKind::Continue
-        ) {
-            break;
+        if check_stmt(ctx, hir, stmt, pending) == Flow::Stop {
+            return Flow::Stop;
         }
     }
+    Flow::Continue
 }
 
 fn check_stmt<'hir>(
@@ -58,7 +61,7 @@ fn check_stmt<'hir>(
     hir: &'hir Hir<'hir>,
     stmt: &'hir Stmt<'hir>,
     pending: &mut HashMap<VariableId, Span>,
-) {
+) -> Flow {
     match &stmt.kind {
         StmtKind::Expr(expr) => {
             process_expr(ctx, hir, expr.peel_parens(), pending);
@@ -78,9 +81,11 @@ fn check_stmt<'hir>(
         StmtKind::Return(Some(expr)) => {
             collect_reads(ctx, hir, expr, pending);
             pending.clear();
+            return Flow::Stop;
         }
         StmtKind::Return(None) | StmtKind::Break | StmtKind::Continue => {
             pending.clear();
+            return Flow::Stop;
         }
         StmtKind::Emit(expr) => {
             // Emit only logs; it doesn't invoke external code that could observe state.
@@ -98,24 +103,30 @@ fn check_stmt<'hir>(
         StmtKind::Revert(expr) => {
             collect_reads(ctx, hir, expr, pending);
             pending.clear();
+            return Flow::Stop;
         }
         // Branches and loops: recurse with a fresh map so intra-body pairs are still
         // caught, then clear the outer pending conservatively since any branch may
         // observe or skip the outer write.
+        // Propagate Stop only when both branches unconditionally stop (no else = Continue).
         StmtKind::If(cond, then_stmt, else_stmt) => {
             collect_reads(ctx, hir, cond, pending);
             pending.clear();
             let mut branch_pending = HashMap::default();
-            check_stmt(ctx, hir, then_stmt, &mut branch_pending);
+            let then_flow = check_stmt(ctx, hir, then_stmt, &mut branch_pending);
             if let Some(else_stmt) = else_stmt {
                 let mut else_pending = HashMap::default();
-                check_stmt(ctx, hir, else_stmt, &mut else_pending);
+                let else_flow = check_stmt(ctx, hir, else_stmt, &mut else_pending);
+                if then_flow == Flow::Stop && else_flow == Flow::Stop {
+                    return Flow::Stop;
+                }
             }
         }
         StmtKind::Loop(block, _) => {
             pending.clear();
             let mut loop_pending = HashMap::default();
             check_block(ctx, hir, *block, &mut loop_pending);
+            // A loop may execute zero times, so it never guarantees Stop for outer flow.
         }
         StmtKind::Try(try_stmt) => {
             collect_reads(ctx, hir, &try_stmt.expr, pending);
@@ -126,9 +137,9 @@ fn check_stmt<'hir>(
             }
         }
         // Nested blocks are sequential; share the same pending map so reads inside
-        // them properly invalidate outer writes.
+        // them properly invalidate outer writes. Propagate terminal flow outward.
         StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
-            check_block(ctx, hir, *block, pending);
+            return check_block(ctx, hir, *block, pending);
         }
         // The placeholder `_` in a modifier body invokes the modified function, which
         // can freely read any storage variable. Conservatively clear everything.
@@ -141,6 +152,7 @@ fn check_stmt<'hir>(
             pending.clear();
         }
     }
+    Flow::Continue
 }
 
 /// Process an expression that appears as a statement, tracking writes and reads.
@@ -209,7 +221,7 @@ fn process_assignment_lhs<'hir>(
     match &lhs.peel_parens().kind {
         ExprKind::Tuple(exprs) => {
             for e in exprs.iter().flatten() {
-                process_assignment_lhs(ctx, hir, e, assign_span, pending);
+                process_assignment_lhs(ctx, hir, e, e.span, pending);
             }
         }
         _ => {

--- a/crates/lint/testdata/WriteAfterWrite.sol
+++ b/crates/lint/testdata/WriteAfterWrite.sol
@@ -132,6 +132,59 @@ contract WriteAfterWrite {
         bool b = (v > 0) && (x = v) > 0;
         return b;
     }
+
+    // bad: tuple destructuring writes x; second write to x is dead
+    function bad7(uint256 v) public {
+        (x, y) = (1, 2);
+        x = v;
+    }
+
+    // bad: ++x writes x; x = v overwrites without reading
+    function bad8(uint256 v) public {
+        ++x;
+        x = v;
+    }
+
+    // bad: x = 1; x++ reads then writes; x = v overwrites the x++ write
+    function bad9(uint256 v) public {
+        x = 1;
+        x++;
+        x = v;
+    }
+
+    // bad: write inside call option named arg overwrites pending write
+    function bad10(address payable addr, uint256 v) public {
+        x = 1;
+        addr.call{value: (x = v)}("");
+    }
+
+    // bad: emit between two writes only reads args; pending should survive
+    event MyEvent(uint256 v);
+    function bad11(uint256 v) public {
+        x = 1;
+        emit MyEvent(v);
+        x = v;
+    }
+
+    // good: no false positive for writes after a return (unreachable code)
+    function good13(uint256 v) public returns (uint256) {
+        x = v;
+        return x;
+        x = 1;
+        x = 2;
+    }
+
+    // good: x++ reads x before writing, so prior x=1 write is live
+    function good14() public returns (uint256) {
+        x = 1;
+        return x++;
+    }
+
+    // good: pre-inc reads x before writing; write between two is fine
+    function good15(uint256 v) public {
+        x = v;
+        ++x;
+    }
 }
 
 // good: modifier placeholder clears pending so writes on both sides are live

--- a/crates/lint/testdata/WriteAfterWrite.sol
+++ b/crates/lint/testdata/WriteAfterWrite.sol
@@ -112,6 +112,26 @@ contract WriteAfterWrite {
         { y = x + v; }
         x = v;
     }
+
+    // bad: write in call argument is still overwritten before being read
+    function bad6(uint256 v) public {
+        x = 1;
+        helper2(x = v);
+    }
+    function helper2(uint256) internal pure {}
+
+    // good: ternary arms are exclusive; only one branch writes x
+    function good11(bool flag) public {
+        uint256 z = (flag ? (x = 1) : (x = 2));
+        z;
+    }
+
+    // good: && short-circuits; RHS write may not execute
+    function good12(uint256 v) public returns (bool) {
+        x = 1;
+        bool b = (v > 0) && (x = v) > 0;
+        return b;
+    }
 }
 
 // good: modifier placeholder clears pending so writes on both sides are live
@@ -125,4 +145,15 @@ contract ModifierTest {
     }
 
     function go() public guarded {}
+}
+
+// bad: write-after-write inside a modifier body
+contract ModifierBad {
+    uint256 public x;
+
+    modifier badMod() {
+        x = 1;
+        x = 2;
+        _;
+    }
 }

--- a/crates/lint/testdata/WriteAfterWrite.sol
+++ b/crates/lint/testdata/WriteAfterWrite.sol
@@ -32,6 +32,13 @@ contract WriteAfterWrite {
         x = v;
     }
 
+    // bad: nested assignment used as initializer; LHS is still a write
+    function bad5_nested(uint256 v) public {
+        x = 1;
+        uint256 z = (x = v);
+        z;
+    }
+
     // bad: intra-branch write-after-write inside an if body
     function bad5(bool flag, uint256 v) public {
         if (flag) {

--- a/crates/lint/testdata/WriteAfterWrite.sol
+++ b/crates/lint/testdata/WriteAfterWrite.sol
@@ -1,0 +1,121 @@
+//@compile-flags: --only-lint write-after-write
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract WriteAfterWrite {
+    uint256 public x;
+    uint256 public y;
+    mapping(address => uint256) public balances;
+
+    // bad: first write to x is dead
+    function bad1() public {
+        x = 1;
+        x = 2;
+    }
+
+    // bad: x written twice without read in between
+    function bad2(uint256 v) public {
+        x = 0;
+        x = v;
+    }
+
+    // bad: delete followed by write is also a redundant delete
+    function bad3(uint256 v) public {
+        delete x;
+        x = v;
+    }
+
+    // bad: parenthesized assignment statement is still caught
+    function bad4(uint256 v) public {
+        (x = 1);
+        x = v;
+    }
+
+    // bad: intra-branch write-after-write inside an if body
+    function bad5(bool flag, uint256 v) public {
+        if (flag) {
+            x = 0;
+            x = v;
+        }
+    }
+
+    // good: x is read between writes
+    function good1() public returns (uint256) {
+        x = 1;
+        return x;
+    }
+
+    // good: compound assignment reads x before writing
+    function good2() public {
+        x = 1;
+        x += 1;
+    }
+
+    // good: x written, then y written (different vars)
+    function good3(uint256 v) public {
+        x = v;
+        y = v;
+    }
+
+    // good: mapping writes may target different slots
+    function good4(address a, address b, uint256 v) public {
+        balances[a] = v;
+        balances[b] = v;
+    }
+
+    // good: write in one branch, then write after the if (outer pending is cleared)
+    function good5(bool flag, uint256 v) public {
+        if (flag) {
+            x = 1;
+        }
+        x = v;
+    }
+
+    // good: x used as RHS before second write
+    function good6(uint256 v) public {
+        x = 1;
+        y = x + v;
+        x = v;
+    }
+
+    // good: any function call conservatively clears pending
+    function helper() internal view returns (uint256) { return x; }
+    function good7(uint256 v) public {
+        x = 1;
+        helper();
+        x = v;
+    }
+
+    // good: return before second write; first write is not dead
+    function good8(uint256 v) public returns (uint256) {
+        x = v;
+        return x;
+    }
+
+    // good: revert before second write; first write is not dead
+    function good9(uint256 v) public {
+        x = v;
+        revert();
+    }
+
+    // good: inner block shares pending with outer so reads inside count
+    function good10(uint256 v) public {
+        x = 1;
+        { y = x + v; }
+        x = v;
+    }
+}
+
+// good: modifier placeholder clears pending so writes on both sides are live
+contract ModifierTest {
+    uint256 public x;
+
+    modifier guarded() {
+        x = 1;
+        _;
+        x = 0;
+    }
+
+    function go() public guarded {}
+}

--- a/crates/lint/testdata/WriteAfterWrite.sol
+++ b/crates/lint/testdata/WriteAfterWrite.sol
@@ -210,3 +210,83 @@ contract ModifierBad {
         _;
     }
 }
+
+// good: nested block return makes subsequent writes unreachable — no FP
+contract NestedReturn {
+    uint256 public x;
+
+    function nestedReturn(uint256 v) public {
+        { return; }
+        x = 1;
+        x = 2;
+    }
+
+    function bothBranchesExit(bool c, uint256 v) public {
+        if (c) return; else revert();
+        x = 1;
+        x = 2;
+    }
+
+    function nestedBreak(bool c, uint256 v) public {
+        while (c) {
+            { break; }
+            x = 1;
+            x = 2;
+        }
+    }
+
+    // bad (FP): solar does not yet lower inline assembly to HIR (TODO in solar),
+    // so the assembly statement is invisible and x = 1 appears overwritten.
+    function asmReadsX(uint256 v) public {
+        x = 1;
+        assembly { let z := sload(0) }
+        x = v;
+    }
+}
+
+// UX: tuple span should point at component `x`, not entire tuple LHS
+contract TupleSpanTest {
+    uint256 public x;
+    uint256 public y;
+
+    // bad: only the x component is dead; span should highlight `x`
+    function tuplePartial(uint256 v) public {
+        (x, y) = (1, 2);
+        x = v;
+    }
+}
+
+// Known false negatives (conservative design choices; documented for future updates)
+contract KnownFalseNegatives {
+    uint256 public x;
+    uint256 public y;
+
+    // FN: x = 1 is dead on both paths but the If arm clears outer pending conservatively.
+    function branchMiss(bool c, uint256 v) public {
+        x = 1;
+        if (c) { y = 2; }
+        x = v;
+    }
+
+    // FN: both branch writes are dead but branches are analyzed with fresh maps.
+    function bothBranchesAssign(bool c, uint256 v) public {
+        if (c) x = 1; else x = 2;
+        x = v;
+    }
+
+    // FN: short-circuit RHS clears pending to avoid FP in conditional path,
+    // which also drops the outer x = 1 even when && doesn't touch x.
+    function shortCircuitMiss(bool a, bool b) public {
+        x = 1;
+        bool z = a && b;
+        x = 2;
+    }
+
+    // FN: all calls clear pending (conservative re-entrancy assumption),
+    // so pure/view calls like abi.encode also suppress the WAW.
+    function pureCallMiss() public {
+        x = 1;
+        abi.encode(uint256(0));
+        x = 2;
+    }
+}

--- a/crates/lint/testdata/WriteAfterWrite.stderr
+++ b/crates/lint/testdata/WriteAfterWrite.stderr
@@ -1,0 +1,40 @@
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
+LL │         x = 1;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
+LL │         x = 0;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
+LL │         delete x;
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
+LL │         (x = 1);
+   │          ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
+LL │             x = 0;
+   │             ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+

--- a/crates/lint/testdata/WriteAfterWrite.stderr
+++ b/crates/lint/testdata/WriteAfterWrite.stderr
@@ -57,6 +57,46 @@ LL │         x = 1;
 note[write-after-write]: redundant storage write; value overwritten before being read
    ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
    │
+LL │         (x, y) = (1, 2);
+   │         ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
+LL │         ++x;
+   │         ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
+LL │         x++;
+   │         ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
+LL │         x = 1;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
+LL │         x = 1;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
 LL │         x = 1;
    │         ━━━━━
    │

--- a/crates/lint/testdata/WriteAfterWrite.stderr
+++ b/crates/lint/testdata/WriteAfterWrite.stderr
@@ -46,3 +46,19 @@ LL │             x = 0;
    │
    ╰ help: https://getfoundry.sh/forge/linting/write-after-write
 
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
+LL │         x = 1;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
+LL │         x = 1;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+

--- a/crates/lint/testdata/WriteAfterWrite.stderr
+++ b/crates/lint/testdata/WriteAfterWrite.stderr
@@ -33,6 +33,14 @@ LL │         (x = 1);
 note[write-after-write]: redundant storage write; value overwritten before being read
    ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
    │
+LL │         x = 1;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
 LL │             x = 0;
    │             ━━━━━
    │

--- a/crates/lint/testdata/WriteAfterWrite.stderr
+++ b/crates/lint/testdata/WriteAfterWrite.stderr
@@ -58,7 +58,7 @@ note[write-after-write]: redundant storage write; value overwritten before being
    ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
    │
 LL │         (x, y) = (1, 2);
-   │         ━━━━━━━━━━━━━━━
+   │          ━
    │
    ╰ help: https://getfoundry.sh/forge/linting/write-after-write
 
@@ -99,6 +99,22 @@ note[write-after-write]: redundant storage write; value overwritten before being
    │
 LL │         x = 1;
    │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
+LL │         x = 1;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/write-after-write
+
+note[write-after-write]: redundant storage write; value overwritten before being read
+   ╭▸ ROOT/testdata/WriteAfterWrite.sol:LL:CC
+   │
+LL │         (x, y) = (1, 2);
+   │          ━
    │
    ╰ help: https://getfoundry.sh/forge/linting/write-after-write
 


### PR DESCRIPTION
## Description

Closes OSS-84

Add `write-after-write` lint.

Detects redundant consecutive storage writes to the same variable where the first value is overwritten before being read, wasting an SSTORE.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
