### PR TITLE
 feat(forge): add tempo session key support for scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5023,6 +5023,7 @@ dependencies = [
  "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",
+ "toml",
  "tracing",
  "yansi",
 ]

--- a/crates/cli/src/opts/tempo/session.rs
+++ b/crates/cli/src/opts/tempo/session.rs
@@ -66,6 +66,25 @@ impl TempoOpts {
         Ok(Some(resolve_session_signer(session_id, expected_sender, expected_chain_id)?))
     }
 
+    /// Resolves the configured Tempo wallet session for multi-chain commands.
+    ///
+    /// This validates the session and root sender without forcing a command-level chain. Callers
+    /// that select signers per transaction must scope the returned signer to
+    /// `session.chain_id`.
+    pub fn session_signer_for_multi_wallet_any_chain(
+        &self,
+        wallets: &MultiWalletOpts,
+        expected_sender: Option<Address>,
+    ) -> Result<Option<ResolvedSessionSigner>> {
+        let Some(session_id) = self.session_id()? else {
+            return Ok(None);
+        };
+        ensure_no_explicit_multi_wallet_signer(wallets)?;
+        let resolved = resolve_session(session_id)?;
+        ensure_expected_sender(expected_sender, resolved.access_key.wallet_address)?;
+        Ok(Some(resolved))
+    }
+
     /// Resolves only the root sender for a configured Tempo wallet session.
     ///
     /// Multi-chain scripts need the sender before execution so `vm.startBroadcast()` records the
@@ -395,6 +414,27 @@ mod tests {
             let sender = opts.session_sender_for_multi_wallet(&wallets, None).unwrap();
 
             assert_eq!(sender, Some(Address::from([0x11; 20])));
+        });
+    }
+
+    #[test]
+    fn tempo_session_signer_any_chain_returns_session_chain() {
+        with_clean_session_home(|| {
+            let id = session_id(0xaa);
+            upsert_session_entry(active_session_entry(id)).unwrap();
+            let opts = TempoOpts { session: Some(id), ..Default::default() };
+            let wallets = MultiWalletOpts::default();
+
+            let session = opts
+                .session_signer_for_multi_wallet_any_chain(
+                    &wallets,
+                    Some(Address::from([0x11; 20])),
+                )
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(session.session.chain_id, 4217);
+            assert_eq!(session.access_key.wallet_address, Address::from([0x11; 20]));
         });
     }
 

--- a/crates/cli/src/opts/tempo/session.rs
+++ b/crates/cli/src/opts/tempo/session.rs
@@ -65,6 +65,25 @@ impl TempoOpts {
         ensure_no_explicit_multi_wallet_signer(wallets)?;
         Ok(Some(resolve_session_signer(session_id, expected_sender, expected_chain_id)?))
     }
+
+    /// Resolves only the root sender for a configured Tempo wallet session.
+    ///
+    /// Multi-chain scripts need the sender before execution so `vm.startBroadcast()` records the
+    /// session root, but their chain validation must wait until broadcast sequences reveal the real
+    /// transaction chains.
+    pub fn session_sender_for_multi_wallet(
+        &self,
+        wallets: &MultiWalletOpts,
+        expected_sender: Option<Address>,
+    ) -> Result<Option<Address>> {
+        let Some(session_id) = self.session_id()? else {
+            return Ok(None);
+        };
+        ensure_no_explicit_multi_wallet_signer(wallets)?;
+        let resolved = resolve_session(session_id)?;
+        ensure_expected_sender(expected_sender, resolved.access_key.wallet_address)?;
+        Ok(Some(resolved.access_key.wallet_address))
+    }
 }
 
 /// Loads the live session signer and validates it against the command context.
@@ -76,10 +95,7 @@ fn resolve_session_signer(
     expected_sender: Option<Address>,
     expected_chain_id: u64,
 ) -> Result<ResolvedSessionSigner> {
-    let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("time went backwards");
-    let resolved = resolve_live_session_signer(session_id, now.as_secs())?.ok_or_else(|| {
-        eyre::eyre!("Tempo session {session_id:?} is not active or has no live key")
-    })?;
+    let resolved = resolve_session(session_id)?;
 
     if resolved.session.chain_id != expected_chain_id {
         eyre::bail!(
@@ -89,16 +105,24 @@ fn resolve_session_signer(
         );
     }
 
+    ensure_expected_sender(expected_sender, resolved.access_key.wallet_address)?;
+    Ok(resolved)
+}
+
+fn resolve_session(session_id: B256) -> Result<ResolvedSessionSigner> {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("time went backwards");
+    resolve_live_session_signer(session_id, now.as_secs())?
+        .ok_or_else(|| eyre::eyre!("Tempo session {session_id:?} is not active or has no live key"))
+}
+
+fn ensure_expected_sender(expected_sender: Option<Address>, session_sender: Address) -> Result<()> {
     if let Some(from) = expected_sender
-        && from != resolved.access_key.wallet_address
+        && from != session_sender
     {
-        eyre::bail!(
-            "sender {from} does not match Tempo session root account {}",
-            resolved.access_key.wallet_address
-        );
+        eyre::bail!("sender {from} does not match Tempo session root account {session_sender}");
     }
 
-    Ok(resolved)
+    Ok(())
 }
 
 /// Rejects single-wallet signer options when a Tempo session is already selected.
@@ -357,6 +381,20 @@ mod tests {
             let err = opts.session_signer_for_wallet(&WalletOpts::default(), 1).unwrap_err();
 
             assert!(err.to_string().contains("is for chain 4217"), "{err}");
+        });
+    }
+
+    #[test]
+    fn tempo_session_sender_does_not_validate_chain() {
+        with_clean_session_home(|| {
+            let id = session_id(0x99);
+            upsert_session_entry(active_session_entry(id)).unwrap();
+            let opts = TempoOpts { session: Some(id), ..Default::default() };
+            let wallets = MultiWalletOpts::default();
+
+            let sender = opts.session_sender_for_multi_wallet(&wallets, None).unwrap();
+
+            assert_eq!(sender, Some(Address::from([0x11; 20])));
         });
     }
 

--- a/crates/cli/src/opts/tempo/session.rs
+++ b/crates/cli/src/opts/tempo/session.rs
@@ -76,7 +76,13 @@ impl TempoOpts {
         wallets: &MultiWalletOpts,
         expected_sender: Option<Address>,
     ) -> Result<Option<ResolvedSessionSigner>> {
-        self.resolve_multi_wallet_session(wallets, expected_sender)
+        let Some(session_id) = self.session_id()? else {
+            return Ok(None);
+        };
+        ensure_no_explicit_multi_wallet_signer(wallets)?;
+        let resolved = resolve_session(session_id)?;
+        ensure_expected_sender(expected_sender, resolved.access_key.wallet_address)?;
+        Ok(Some(resolved))
     }
 
     /// Resolves only the root sender for a configured Tempo wallet session.
@@ -90,22 +96,8 @@ impl TempoOpts {
         expected_sender: Option<Address>,
     ) -> Result<Option<Address>> {
         Ok(self
-            .resolve_multi_wallet_session(wallets, expected_sender)?
+            .session_signer_for_multi_wallet_any_chain(wallets, expected_sender)?
             .map(|resolved| resolved.access_key.wallet_address))
-    }
-
-    fn resolve_multi_wallet_session(
-        &self,
-        wallets: &MultiWalletOpts,
-        expected_sender: Option<Address>,
-    ) -> Result<Option<ResolvedSessionSigner>> {
-        let Some(session_id) = self.session_id()? else {
-            return Ok(None);
-        };
-        ensure_no_explicit_multi_wallet_signer(wallets)?;
-        let resolved = resolve_session(session_id)?;
-        ensure_expected_sender(expected_sender, resolved.access_key.wallet_address)?;
-        Ok(Some(resolved))
     }
 }
 

--- a/crates/cli/src/opts/tempo/session.rs
+++ b/crates/cli/src/opts/tempo/session.rs
@@ -76,13 +76,7 @@ impl TempoOpts {
         wallets: &MultiWalletOpts,
         expected_sender: Option<Address>,
     ) -> Result<Option<ResolvedSessionSigner>> {
-        let Some(session_id) = self.session_id()? else {
-            return Ok(None);
-        };
-        ensure_no_explicit_multi_wallet_signer(wallets)?;
-        let resolved = resolve_session(session_id)?;
-        ensure_expected_sender(expected_sender, resolved.access_key.wallet_address)?;
-        Ok(Some(resolved))
+        self.resolve_multi_wallet_session(wallets, expected_sender)
     }
 
     /// Resolves only the root sender for a configured Tempo wallet session.
@@ -95,13 +89,23 @@ impl TempoOpts {
         wallets: &MultiWalletOpts,
         expected_sender: Option<Address>,
     ) -> Result<Option<Address>> {
+        Ok(self
+            .resolve_multi_wallet_session(wallets, expected_sender)?
+            .map(|resolved| resolved.access_key.wallet_address))
+    }
+
+    fn resolve_multi_wallet_session(
+        &self,
+        wallets: &MultiWalletOpts,
+        expected_sender: Option<Address>,
+    ) -> Result<Option<ResolvedSessionSigner>> {
         let Some(session_id) = self.session_id()? else {
             return Ok(None);
         };
         ensure_no_explicit_multi_wallet_signer(wallets)?;
         let resolved = resolve_session(session_id)?;
         ensure_expected_sender(expected_sender, resolved.access_key.wallet_address)?;
-        Ok(Some(resolved.access_key.wallet_address))
+        Ok(Some(resolved))
     }
 }
 

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -29,6 +29,7 @@ forge-script-sequence.workspace = true
 
 serde.workspace = true
 eyre.workspace = true
+toml.workspace = true
 serde_json.workspace = true
 dunce.workspace = true
 foundry-compilers.workspace = true

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -264,13 +264,6 @@ where
     }
 }
 
-struct ScriptSessionSigner {
-    chain: u64,
-    root_account: Address,
-    signer: WalletSigner,
-    access_key: TempoAccessKeyConfig,
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct SignerScope {
     chain: u64,
@@ -287,70 +280,32 @@ impl SignerScope {
     }
 }
 
-impl From<ResolvedSessionSigner> for ScriptSessionSigner {
-    fn from(resolved: ResolvedSessionSigner) -> Self {
-        Self {
-            chain: resolved.session.chain_id,
-            root_account: resolved.session.root_account,
-            signer: resolved.signer,
-            access_key: resolved.access_key,
-        }
-    }
-}
-
-impl ScriptSessionSigner {
-    /// Resolves the active Tempo session into the access-key signer used by script broadcast.
-    ///
-    /// The returned entry is keyed by the root account because script transactions still use the
-    /// root account as `from`; the temporary session key only changes how the transaction is
-    /// authorized and signed.
-    fn resolve_for_chain<FEN: FoundryEvmNetwork>(
-        script_config: &ScriptConfig<FEN>,
-        wallets: &foundry_wallets::MultiWalletOpts,
-        expected_sender: Option<Address>,
-        expected_chain_id: u64,
-    ) -> Result<Option<Self>> {
-        script_config
-            .tempo
-            .session_signer_for_multi_wallet(wallets, expected_sender, expected_chain_id)
-            .map(|session| session.map(Into::into))
-    }
-
-    /// Resolves the active Tempo session without imposing a command-level chain.
-    ///
-    /// The returned signer must be keyed by its own session chain before transaction selection.
-    fn resolve_any_chain<FEN: FoundryEvmNetwork>(
-        script_config: &ScriptConfig<FEN>,
-        wallets: &foundry_wallets::MultiWalletOpts,
-        expected_sender: Option<Address>,
-    ) -> Result<Option<Self>> {
-        script_config
-            .tempo
-            .session_signer_for_multi_wallet_any_chain(wallets, expected_sender)
-            .map(|session| session.map(Into::into))
-    }
-}
-
 fn insert_session_access_key_for_remaining_transactions(
     access_keys: &mut HashMap<SignerScope, (WalletSigner, TempoAccessKeyConfig)>,
-    session_signer: ScriptSessionSigner,
+    session: ResolvedSessionSigner,
     remaining_transactions: &[RemainingScriptTransaction],
 ) -> Result<()> {
-    if let Some(tx) = remaining_transactions
-        .iter()
-        .find(|tx| tx.from == session_signer.root_account && tx.chain != session_signer.chain)
-    {
-        eyre::bail!(
-            "Tempo session is for chain {}, but a remaining transaction from session root {} is on chain {}",
-            session_signer.chain,
-            session_signer.root_account,
-            tx.chain
-        );
+    let session_scope = SignerScope::new(session.session.chain_id, session.session.root_account);
+    let mut should_insert = false;
+    for tx in remaining_transactions {
+        if tx.from != session.session.root_account {
+            continue;
+        }
+
+        if tx.chain != session.session.chain_id {
+            eyre::bail!(
+                "Tempo session is for chain {}, but a remaining transaction from session root {} is on chain {}",
+                session.session.chain_id,
+                session.session.root_account,
+                tx.chain
+            );
+        }
+
+        should_insert = true;
     }
 
-    let scope = SignerScope::new(session_signer.chain, session_signer.root_account);
-    if remaining_transactions.iter().any(|tx| SignerScope::new(tx.chain, tx.from) == scope) {
-        access_keys.insert(scope, (session_signer.signer, session_signer.access_key));
+    if should_insert {
+        access_keys.insert(session_scope, (session.signer, session.access_key));
     }
 
     Ok(())
@@ -567,15 +522,15 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
             let mut access_keys: HashMap<SignerScope, (WalletSigner, TempoAccessKeyConfig)> =
                 HashMap::default();
             if let Some(expected_session_sender) = expected_session_sender
-                && let Some(session_signer) = ScriptSessionSigner::resolve_any_chain(
-                    &self.script_config,
-                    &self.args.wallets,
-                    Some(expected_session_sender),
-                )?
+                && let Some(session) =
+                    self.script_config.tempo.session_signer_for_multi_wallet_any_chain(
+                        &self.args.wallets,
+                        Some(expected_session_sender),
+                    )?
             {
                 insert_session_access_key_for_remaining_transactions(
                     &mut access_keys,
-                    session_signer,
+                    session,
                     &remaining_transactions,
                 )?;
             }
@@ -1000,16 +955,12 @@ impl BundledState<TempoEvmNetwork> {
 
         let batch_signer = if self.args.unlocked {
             BatchSigner::Unlocked
-        } else if let Some(session_signer) = ScriptSessionSigner::resolve_for_chain(
-            &self.script_config,
+        } else if let Some(session) = self.script_config.tempo.session_signer_for_multi_wallet(
             &self.args.wallets,
             Some(sender),
             chain_id,
         )? {
-            BatchSigner::TempoKeychain(
-                Box::new(session_signer.signer),
-                Box::new(session_signer.access_key),
-            )
+            BatchSigner::TempoKeychain(Box::new(session.signer), Box::new(session.access_key))
         } else {
             let mut signers = self.script_wallets.into_multi_wallet().into_signers()?;
             if let Some(signer) = signers.remove(&sender) {
@@ -1250,10 +1201,11 @@ mod tests {
     use super::*;
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
     use alloy_network::Ethereum;
-    use alloy_primitives::{Bloom, address};
+    use alloy_primitives::{B256, Bloom, address};
     use alloy_rpc_types::TransactionReceipt;
     use alloy_signer::Signer;
     use forge_script_sequence::TransactionWithMetadata;
+    use foundry_common::tempo::{KeyType, SessionEntry, SessionKeyMaterial, SessionStatus};
 
     const ROOT_PRIVATE_KEY: &str =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
@@ -1344,27 +1296,13 @@ mod tests {
 
     #[test]
     fn session_access_key_rejects_session_root_on_wrong_chain() {
-        let root = foundry_wallets::utils::create_private_key_signer(ROOT_PRIVATE_KEY).unwrap();
-        let root_address = root.address();
-        let access_key =
-            foundry_wallets::utils::create_private_key_signer(ACCESS_KEY_PRIVATE_KEY).unwrap();
-        let access_key_address = access_key.address();
-        let session_signer = ScriptSessionSigner {
-            chain: 4217,
-            root_account: root_address,
-            signer: access_key,
-            access_key: TempoAccessKeyConfig {
-                wallet_address: root_address,
-                key_address: access_key_address,
-                key_authorization: None,
-            },
-        };
+        let (session, root_address, _) = session_signer(4217);
         let remaining = [RemainingScriptTransaction { chain: 1, from: root_address }];
         let mut access_keys = HashMap::default();
 
         let err = insert_session_access_key_for_remaining_transactions(
             &mut access_keys,
-            session_signer,
+            session,
             &remaining,
         )
         .unwrap_err();
@@ -1378,30 +1316,12 @@ mod tests {
 
     #[test]
     fn session_access_key_is_inserted_for_session_chain() {
-        let root = foundry_wallets::utils::create_private_key_signer(ROOT_PRIVATE_KEY).unwrap();
-        let root_address = root.address();
-        let access_key =
-            foundry_wallets::utils::create_private_key_signer(ACCESS_KEY_PRIVATE_KEY).unwrap();
-        let access_key_address = access_key.address();
-        let session_signer = ScriptSessionSigner {
-            chain: 4217,
-            root_account: root_address,
-            signer: access_key,
-            access_key: TempoAccessKeyConfig {
-                wallet_address: root_address,
-                key_address: access_key_address,
-                key_authorization: None,
-            },
-        };
+        let (session, root_address, access_key_address) = session_signer(4217);
         let remaining = [RemainingScriptTransaction { chain: 4217, from: root_address }];
         let mut access_keys = HashMap::default();
 
-        insert_session_access_key_for_remaining_transactions(
-            &mut access_keys,
-            session_signer,
-            &remaining,
-        )
-        .unwrap();
+        insert_session_access_key_for_remaining_transactions(&mut access_keys, session, &remaining)
+            .unwrap();
 
         let (signer, config) =
             access_keys.get(&SignerScope::new(4217, root_address)).expect("session access key");
@@ -1485,6 +1405,36 @@ mod tests {
             from: Some(from),
             ..Default::default()
         }))
+    }
+
+    fn session_signer(chain_id: u64) -> (ResolvedSessionSigner, Address, Address) {
+        let root = foundry_wallets::utils::create_private_key_signer(ROOT_PRIVATE_KEY).unwrap();
+        let root_address = root.address();
+        let signer =
+            foundry_wallets::utils::create_private_key_signer(ACCESS_KEY_PRIVATE_KEY).unwrap();
+        let key_address = signer.address();
+        let access_key = TempoAccessKeyConfig {
+            wallet_address: root_address,
+            key_address,
+            key_authorization: None,
+        };
+        let session = SessionEntry {
+            session_id: B256::ZERO,
+            root_account: root_address,
+            chain_id,
+            key_address,
+            expiry: u64::MAX,
+            scope: None,
+            limits: None,
+            status: SessionStatus::Active,
+            key: Some(SessionKeyMaterial {
+                key_type: KeyType::Secp256k1,
+                key: ACCESS_KEY_PRIVATE_KEY.to_string(),
+                key_authorization: None,
+            }),
+        };
+
+        (ResolvedSessionSigner { session, signer, access_key }, root_address, key_address)
     }
 
     fn receipt() -> TransactionReceipt {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -341,6 +341,31 @@ impl ScriptSessionSigner {
     }
 }
 
+fn insert_session_access_key_for_remaining_transactions(
+    access_keys: &mut HashMap<SignerScope, (WalletSigner, TempoAccessKeyConfig)>,
+    session_signer: ScriptSessionSigner,
+    remaining_transactions: &[RemainingScriptTransaction],
+) -> Result<()> {
+    if let Some(tx) = remaining_transactions
+        .iter()
+        .find(|tx| tx.from == session_signer.root_account && tx.chain != session_signer.chain)
+    {
+        eyre::bail!(
+            "Tempo session is for chain {}, but a remaining transaction from session root {} is on chain {}",
+            session_signer.chain,
+            session_signer.root_account,
+            tx.chain
+        );
+    }
+
+    let scope = SignerScope::new(session_signer.chain, session_signer.root_account);
+    if remaining_transactions.iter().any(|tx| SignerScope::new(tx.chain, tx.from) == scope) {
+        access_keys.insert(scope, (session_signer.signer, session_signer.access_key));
+    }
+
+    Ok(())
+}
+
 /// Looks up a Tempo wallet signer scoped to the transaction chain.
 ///
 /// Tempo `keys.toml` entries are stored per `(wallet_address, chain_id)`, and access-key
@@ -552,13 +577,11 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
                     Some(expected_session_sender),
                 )?
             {
-                let scope = SignerScope::new(session_signer.chain, session_signer.root_account);
-                if remaining_transactions
-                    .iter()
-                    .any(|tx| SignerScope::new(tx.chain, tx.from) == scope)
-                {
-                    access_keys.insert(scope, (session_signer.signer, session_signer.access_key));
-                }
+                insert_session_access_key_for_remaining_transactions(
+                    &mut access_keys,
+                    session_signer,
+                    &remaining_transactions,
+                )?;
             }
 
             let signers: Vec<Address> = self
@@ -1333,6 +1356,74 @@ mod tests {
             }
             _ => panic!("expected root wallet signer for non-session chain"),
         }
+    }
+
+    #[test]
+    fn session_access_key_rejects_session_root_on_wrong_chain() {
+        let root = foundry_wallets::utils::create_private_key_signer(ROOT_PRIVATE_KEY).unwrap();
+        let root_address = root.address();
+        let access_key =
+            foundry_wallets::utils::create_private_key_signer(ACCESS_KEY_PRIVATE_KEY).unwrap();
+        let access_key_address = access_key.address();
+        let session_signer = ScriptSessionSigner {
+            chain: 4217,
+            root_account: root_address,
+            signer: access_key,
+            access_key: TempoAccessKeyConfig {
+                wallet_address: root_address,
+                key_address: access_key_address,
+                key_authorization: None,
+            },
+        };
+        let remaining = [RemainingScriptTransaction { chain: 1, from: root_address }];
+        let mut access_keys = HashMap::default();
+
+        let err = insert_session_access_key_for_remaining_transactions(
+            &mut access_keys,
+            session_signer,
+            &remaining,
+        )
+        .unwrap_err();
+
+        assert!(access_keys.is_empty());
+        let message = err.to_string();
+        assert!(message.contains("Tempo session is for chain 4217"), "{message}");
+        assert!(message.contains("transaction from session root"), "{message}");
+        assert!(message.contains("chain 1"), "{message}");
+    }
+
+    #[test]
+    fn session_access_key_is_inserted_for_session_chain() {
+        let root = foundry_wallets::utils::create_private_key_signer(ROOT_PRIVATE_KEY).unwrap();
+        let root_address = root.address();
+        let access_key =
+            foundry_wallets::utils::create_private_key_signer(ACCESS_KEY_PRIVATE_KEY).unwrap();
+        let access_key_address = access_key.address();
+        let session_signer = ScriptSessionSigner {
+            chain: 4217,
+            root_account: root_address,
+            signer: access_key,
+            access_key: TempoAccessKeyConfig {
+                wallet_address: root_address,
+                key_address: access_key_address,
+                key_authorization: None,
+            },
+        };
+        let remaining = [RemainingScriptTransaction { chain: 4217, from: root_address }];
+        let mut access_keys = HashMap::default();
+
+        insert_session_access_key_for_remaining_transactions(
+            &mut access_keys,
+            session_signer,
+            &remaining,
+        )
+        .unwrap();
+
+        let (signer, config) =
+            access_keys.get(&SignerScope::new(4217, root_address)).expect("session access key");
+        assert_eq!(signer.address(), access_key_address);
+        assert_eq!(config.wallet_address, root_address);
+        assert_eq!(config.key_address, access_key_address);
     }
 
     #[test]

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -89,12 +89,6 @@ where
     N::UnsignedTx: SignableTransaction<Signature>,
     N::TransactionRequest: FoundryTransactionBuilder<N>,
 {
-    fn set_access_key_id_for_estimation(&mut self) {
-        if let Self::AccessKey(tx, _, access_key) = self {
-            tx.set_key_id(access_key.key_address);
-        }
-    }
-
     /// Prepares the transaction for broadcasting by synchronizing nonce and estimating gas.
     ///
     /// This method performs two key operations:
@@ -110,75 +104,72 @@ where
         estimate_multiplier: u64,
         tempo_sponsor: Option<&TempoSponsor>,
     ) -> Result<()> {
-        let access_key_authorization = match self {
-            Self::AccessKey(_, _, access_key) => Some((
-                access_key.wallet_address,
-                access_key.key_address,
-                access_key.key_authorization.clone(),
-            )),
-            _ => None,
+        let (tx, access_key_authorization) = match self {
+            Self::Raw(tx, _) | Self::Unlocked(tx) | Self::Browser(tx, _) => (tx, None),
+            Self::AccessKey(tx, _, access_key) => {
+                tx.set_key_id(access_key.key_address);
+                (
+                    tx,
+                    Some((
+                        access_key.wallet_address,
+                        access_key.key_address,
+                        access_key.key_authorization.as_ref(),
+                    )),
+                )
+            }
+            Self::Signed(_) => return Ok(()),
         };
 
-        self.set_access_key_id_for_estimation();
+        if sequential_broadcast {
+            let from = tx.from().expect("no sender");
 
-        if let Self::Raw(tx, _)
-        | Self::Unlocked(tx)
-        | Self::Browser(tx, _)
-        | Self::AccessKey(tx, _, _) = self
-        {
-            if sequential_broadcast {
-                let from = tx.from().expect("no sender");
-
-                let tx_nonce = tx.nonce().expect("no nonce");
-                for attempt in 0..5 {
-                    let nonce = provider.get_transaction_count(from).await?;
-                    match nonce.cmp(&tx_nonce) {
-                        Ordering::Greater => {
+            let tx_nonce = tx.nonce().expect("no nonce");
+            for attempt in 0..5 {
+                let nonce = provider.get_transaction_count(from).await?;
+                match nonce.cmp(&tx_nonce) {
+                    Ordering::Greater => {
+                        bail!(
+                            "EOA nonce changed unexpectedly while sending transactions. Expected {tx_nonce} got {nonce} from provider."
+                        )
+                    }
+                    Ordering::Less => {
+                        if attempt == 4 {
                             bail!(
-                                "EOA nonce changed unexpectedly while sending transactions. Expected {tx_nonce} got {nonce} from provider."
+                                "After 5 attempts, provider nonce ({nonce}) is still behind expected nonce ({tx_nonce})."
                             )
                         }
-                        Ordering::Less => {
-                            if attempt == 4 {
-                                bail!(
-                                    "After 5 attempts, provider nonce ({nonce}) is still behind expected nonce ({tx_nonce})."
-                                )
-                            }
-                            warn!(
-                                "Expected nonce ({tx_nonce}) is ahead of provider nonce ({nonce}). Retrying in 1 second..."
-                            );
-                            tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
-                        }
-                        Ordering::Equal => {
-                            // Nonces are equal, we can proceed.
-                            break;
-                        }
+                        warn!(
+                            "Expected nonce ({tx_nonce}) is ahead of provider nonce ({nonce}). Retrying in 1 second..."
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+                    }
+                    Ordering::Equal => {
+                        // Nonces are equal, we can proceed.
+                        break;
                     }
                 }
             }
+        }
 
-            if let Some((wallet_address, key_address, key_authorization)) =
-                access_key_authorization.as_ref()
-            {
-                tx.prepare_access_key_authorization(
-                    provider,
-                    *wallet_address,
-                    *key_address,
-                    key_authorization.as_ref(),
-                )
-                .await?;
-            }
+        if let Some((wallet_address, key_address, key_authorization)) = access_key_authorization {
+            tx.prepare_access_key_authorization(
+                provider,
+                wallet_address,
+                key_address,
+                key_authorization,
+            )
+            .await?;
+        }
 
-            // Chains which use `eth_estimateGas` are being sent sequentially and require their
-            // gas to be re-estimated right before broadcasting.
-            if !is_fixed_gas_limit && estimate_via_rpc {
-                estimate_gas(tx, provider, estimate_multiplier).await?;
-            }
+        // Chains which use `eth_estimateGas` are being sent sequentially and require their
+        // gas to be re-estimated right before broadcasting.
+        if !is_fixed_gas_limit && estimate_via_rpc {
+            estimate_gas(tx, provider, estimate_multiplier).await?;
+        }
 
-            if let Some(sponsor) = tempo_sponsor {
-                let from = tx.from().expect("no sender");
-                sponsor.attach_and_print::<N>(tx, from).await?;
-            }
+        if let Some(sponsor) = tempo_sponsor {
+            let from = tx.from().expect("no sender");
+            sponsor.attach_and_print::<N>(tx, from).await?;
         }
 
         Ok(())
@@ -274,10 +265,6 @@ impl SignerScope {
     pub(crate) const fn new(chain: u64, sender: Address) -> Self {
         Self { chain, sender }
     }
-
-    pub(crate) const fn sender(&self) -> Address {
-        self.sender
-    }
 }
 
 fn insert_session_access_key_for_remaining_transactions(
@@ -285,23 +272,20 @@ fn insert_session_access_key_for_remaining_transactions(
     session: ResolvedSessionSigner,
     remaining_transactions: &[RemainingScriptTransaction],
 ) -> Result<()> {
-    let session_scope = SignerScope::new(session.session.chain_id, session.session.root_account);
-    let mut should_insert = false;
-    for tx in remaining_transactions.iter().filter(|tx| tx.from == session.session.root_account) {
-        if tx.chain != session.session.chain_id {
-            eyre::bail!(
-                "Tempo session is for chain {}, but a remaining transaction from session root {} is on chain {}",
-                session.session.chain_id,
-                session.session.root_account,
-                tx.chain
-            );
-        }
-
-        should_insert = true;
+    let chain = session.session.chain_id;
+    let root = session.session.root_account;
+    if let Some(tx) = remaining_transactions.iter().find(|tx| tx.from == root && tx.chain != chain)
+    {
+        eyre::bail!(
+            "Tempo session is for chain {}, but a remaining transaction from session root {} is on chain {}",
+            chain,
+            root,
+            tx.chain,
+        );
     }
 
-    if should_insert {
-        access_keys.insert(session_scope, (session.signer, session.access_key));
+    if remaining_transactions.iter().any(|tx| tx.from == root) {
+        access_keys.insert(SignerScope::new(chain, root), (session.signer, session.access_key));
     }
 
     Ok(())
@@ -333,17 +317,15 @@ pub(crate) fn lookup_signer_for_chain(from: Address, chain: u64) -> Result<Tempo
         };
 
         let signer = foundry_wallets::utils::create_private_key_signer(&key)?;
-        let is_direct = entry.key_address.is_none() || entry.key_address == Some(from);
-        if is_direct {
+        let Some(key_address) = entry.key_address.filter(|key_address| *key_address != from) else {
             return Ok(TempoLookup::Direct(signer));
-        }
+        };
 
         let key_authorization =
             entry.key_authorization.as_deref().map(decode_key_authorization).transpose()?;
         let config = TempoAccessKeyConfig {
             wallet_address: entry.wallet_address,
-            // SAFETY: `is_direct` was false, so `key_address` is `Some` and != wallet_address.
-            key_address: entry.key_address.unwrap(),
+            key_address,
             key_authorization,
         };
         return Ok(TempoLookup::Keychain(signer, Box::new(config)));
@@ -1366,8 +1348,8 @@ mod tests {
         assert_eq!(remaining[0].chain, 4217);
     }
 
-    #[test]
-    fn access_key_sets_key_id_before_estimation() {
+    #[tokio::test]
+    async fn access_key_sets_key_id_before_estimation() {
         let root_address = address!("0x1111111111111111111111111111111111111111");
         let access_key =
             foundry_wallets::utils::create_private_key_signer(ACCESS_KEY_PRIVATE_KEY).unwrap();
@@ -1385,8 +1367,10 @@ mod tests {
             &access_key,
             &access_key_config,
         );
+        let provider =
+            RootProvider::<TempoNetwork>::new_http("http://localhost:8545".parse().unwrap());
 
-        sender.set_access_key_id_for_estimation();
+        sender.prepare(&provider, false, true, false, 100, None).await.unwrap();
 
         match sender {
             SendTransactionKind::AccessKey(tx, _, _) => {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -545,15 +545,20 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
             // For addresses without an explicit signer, try Tempo keys.toml fallback.
             let mut access_keys: HashMap<SignerScope, (WalletSigner, TempoAccessKeyConfig)> =
                 HashMap::default();
-            if let Some(session_signer) = ScriptSessionSigner::resolve_any_chain(
-                &self.script_config,
-                &self.args.wallets,
-                expected_session_sender,
-            )? {
-                access_keys.insert(
-                    SignerScope::new(session_signer.chain, session_signer.root_account),
-                    (session_signer.signer, session_signer.access_key),
-                );
+            if let Some(expected_session_sender) = expected_session_sender
+                && let Some(session_signer) = ScriptSessionSigner::resolve_any_chain(
+                    &self.script_config,
+                    &self.args.wallets,
+                    Some(expected_session_sender),
+                )?
+            {
+                let scope = SignerScope::new(session_signer.chain, session_signer.root_account);
+                if remaining_transactions
+                    .iter()
+                    .any(|tx| SignerScope::new(tx.chain, tx.from) == scope)
+                {
+                    access_keys.insert(scope, (session_signer.signer, session_signer.access_key));
+                }
             }
 
             let signers: Vec<Address> = self

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -12,7 +12,7 @@ use alloy_network::{
 };
 use alloy_primitives::{
     Address, TxHash, TxKind, U256,
-    map::{AddressHashMap, AddressHashSet},
+    map::{AddressHashMap, AddressHashSet, HashMap},
     utils::format_units,
 };
 use alloy_provider::{Provider, RootProvider, utils::Eip1559Estimation};
@@ -27,14 +27,12 @@ use foundry_common::{
     FoundryTransactionBuilder, TransactionMaybeSigned,
     provider::{ProviderBuilder, try_get_http_provider},
     shell,
-    tempo::TempoSponsor,
+    tempo::{TempoSponsor, WALLET_KEYS_PATH, decode_key_authorization, tempo_home},
 };
 use foundry_config::Config;
 use foundry_evm::core::evm::{FoundryEvmNetwork, TempoEvmNetwork};
 use foundry_wallets::{
-    TempoAccessKeyConfig, WalletSigner,
-    tempo::{TempoLookup, lookup_signer},
-    wallet_browser::signer::BrowserSigner,
+    TempoAccessKeyConfig, WalletSigner, tempo::TempoLookup, wallet_browser::signer::BrowserSigner,
 };
 use futures::{FutureExt, StreamExt, future::join_all, stream::FuturesUnordered};
 use itertools::Itertools;
@@ -265,9 +263,22 @@ where
 }
 
 struct ScriptSessionSigner {
+    chain: u64,
     root_account: Address,
     signer: WalletSigner,
     access_key: TempoAccessKeyConfig,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct AccessKeyScope {
+    chain: u64,
+    sender: Address,
+}
+
+impl AccessKeyScope {
+    pub(crate) const fn new(chain: u64, sender: Address) -> Self {
+        Self { chain, sender }
+    }
 }
 
 impl ScriptSessionSigner {
@@ -276,7 +287,7 @@ impl ScriptSessionSigner {
     /// The returned entry is keyed by the root account because script transactions still use the
     /// root account as `from`; the temporary session key only changes how the transaction is
     /// authorized and signed.
-    fn resolve<FEN: FoundryEvmNetwork>(
+    fn resolve_for_chain<FEN: FoundryEvmNetwork>(
         script_config: &ScriptConfig<FEN>,
         wallets: &foundry_wallets::MultiWalletOpts,
         expected_sender: Option<Address>,
@@ -292,11 +303,80 @@ impl ScriptSessionSigner {
         };
 
         Ok(Some(Self {
+            chain: resolved.session.chain_id,
             root_account: resolved.session.root_account,
             signer: resolved.signer,
             access_key: resolved.access_key,
         }))
     }
+
+    /// Resolves the active Tempo session without imposing a command-level chain.
+    ///
+    /// The returned signer must be keyed by its own session chain before transaction selection.
+    fn resolve_any_chain<FEN: FoundryEvmNetwork>(
+        script_config: &ScriptConfig<FEN>,
+        wallets: &foundry_wallets::MultiWalletOpts,
+        expected_sender: Option<Address>,
+    ) -> Result<Option<Self>> {
+        let Some(resolved) = script_config
+            .tempo
+            .session_signer_for_multi_wallet_any_chain(wallets, expected_sender)?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(Self {
+            chain: resolved.session.chain_id,
+            root_account: resolved.session.root_account,
+            signer: resolved.signer,
+            access_key: resolved.access_key,
+        }))
+    }
+}
+
+/// Looks up a Tempo wallet signer scoped to the transaction chain.
+///
+/// Tempo `keys.toml` entries are stored per `(wallet_address, chain_id)`, and access-key
+/// authorizations are chain-specific. Script broadcast must preserve that scope instead of picking
+/// the first key for a wallet address.
+pub(crate) fn lookup_signer_for_chain(from: Address, chain: u64) -> Result<TempoLookup> {
+    let Some(path) = tempo_home().map(|home| home.join(WALLET_KEYS_PATH)) else {
+        return Ok(TempoLookup::NotFound);
+    };
+    if !path.is_file() {
+        return Ok(TempoLookup::NotFound);
+    }
+
+    let contents = std::fs::read_to_string(&path)?;
+    let file: foundry_common::tempo::KeysFile = toml::from_str(&contents)?;
+
+    for entry in file.keys {
+        if entry.wallet_address != from || entry.chain_id != chain {
+            continue;
+        }
+
+        let Some(key) = entry.key else {
+            continue;
+        };
+
+        let signer = foundry_wallets::utils::create_private_key_signer(&key)?;
+        let is_direct = entry.key_address.is_none() || entry.key_address == Some(from);
+        if is_direct {
+            return Ok(TempoLookup::Direct(signer));
+        }
+
+        let key_authorization =
+            entry.key_authorization.as_deref().map(decode_key_authorization).transpose()?;
+        let config = TempoAccessKeyConfig {
+            wallet_address: entry.wallet_address,
+            // SAFETY: `is_direct` was false, so `key_address` is `Some` and != wallet_address.
+            key_address: entry.key_address.unwrap(),
+            key_authorization,
+        };
+        return Ok(TempoLookup::Keychain(signer, Box::new(config)));
+    }
+
+    Ok(TempoLookup::NotFound)
 }
 
 /// Returns the single sender a Tempo session is allowed to cover.
@@ -340,7 +420,7 @@ pub enum SendTransactionsKind<N: Network> {
     Raw {
         eth_wallets: AddressHashMap<EthereumWallet>,
         browser: Option<BrowserSigner<N>>,
-        access_keys: AddressHashMap<(WalletSigner, TempoAccessKeyConfig)>,
+        access_keys: HashMap<AccessKeyScope, (WalletSigner, TempoAccessKeyConfig)>,
     },
 }
 
@@ -350,6 +430,7 @@ impl<N: Network> SendTransactionsKind<N> {
     /// Returns an error if no matching signer is found or the address is not unlocked
     pub fn for_sender(
         &self,
+        chain: u64,
         addr: &Address,
         tx: N::TransactionRequest,
     ) -> Result<SendTransactionKind<'_, N>> {
@@ -361,7 +442,8 @@ impl<N: Network> SendTransactionsKind<N> {
                 Ok(SendTransactionKind::Unlocked(tx))
             }
             Self::Raw { eth_wallets, browser, access_keys } => {
-                if let Some((signer, config)) = access_keys.get(addr) {
+                if let Some((signer, config)) = access_keys.get(&AccessKeyScope::new(chain, *addr))
+                {
                     Ok(SendTransactionKind::AccessKey(tx, signer, config))
                 } else if let Some(wallet) = eth_wallets.get(addr) {
                     Ok(SendTransactionKind::Raw(tx, wallet))
@@ -447,22 +529,19 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
             };
 
             // For addresses without an explicit signer, try Tempo keys.toml fallback.
-            let mut access_keys: AddressHashMap<(WalletSigner, TempoAccessKeyConfig)> =
-                AddressHashMap::default();
-            if has_session {
-                for chain in remaining_transactions.iter().map(|tx| tx.chain).unique() {
-                    if let Some(session_signer) = ScriptSessionSigner::resolve(
-                        &self.script_config,
-                        &self.args.wallets,
-                        expected_session_sender,
-                        chain,
-                    )? {
-                        access_keys.insert(
-                            session_signer.root_account,
-                            (session_signer.signer, session_signer.access_key),
-                        );
-                    }
-                }
+            let mut access_keys: HashMap<AccessKeyScope, (WalletSigner, TempoAccessKeyConfig)> =
+                HashMap::default();
+            if has_session
+                && let Some(session_signer) = ScriptSessionSigner::resolve_any_chain(
+                    &self.script_config,
+                    &self.args.wallets,
+                    expected_session_sender,
+                )?
+            {
+                access_keys.insert(
+                    AccessKeyScope::new(session_signer.chain, session_signer.root_account),
+                    (session_signer.signer, session_signer.access_key),
+                );
             }
 
             let signers: Vec<Address> = self
@@ -476,21 +555,25 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
             let mut direct_signers: AddressHashMap<WalletSigner> = AddressHashMap::default();
             let mut missing_addresses = Vec::new();
 
-            for addr in &required_addresses {
-                if !signers.contains(addr) && !access_keys.contains_key(addr) {
-                    match lookup_signer(*addr) {
+            for tx in &remaining_transactions {
+                let scope = AccessKeyScope::new(tx.chain, tx.from);
+                if !signers.contains(&tx.from) && !access_keys.contains_key(&scope) {
+                    match lookup_signer_for_chain(tx.from, tx.chain) {
                         Ok(TempoLookup::Direct(signer)) => {
-                            direct_signers.insert(*addr, signer);
+                            direct_signers.insert(tx.from, signer);
                         }
                         Ok(TempoLookup::Keychain(signer, config)) => {
-                            access_keys.insert(*addr, (signer, *config));
+                            access_keys.insert(scope, (signer, *config));
                         }
                         _ => {
-                            missing_addresses.push(addr);
+                            missing_addresses.push(tx.from);
                         }
                     }
                 }
             }
+
+            missing_addresses.sort_unstable();
+            missing_addresses.dedup();
 
             if !missing_addresses.is_empty() {
                 eyre::bail!(
@@ -638,7 +721,7 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
 
                                 self.script_config.tempo.apply::<FEN::Network>(&mut tx, None);
 
-                                send_kind.for_sender(&from, tx)?
+                                send_kind.for_sender(sequence.chain, &from, tx)?
                             }
                         };
 
@@ -893,7 +976,7 @@ impl BundledState<TempoEvmNetwork> {
 
         let batch_signer = if self.args.unlocked {
             BatchSigner::Unlocked
-        } else if let Some(session_signer) = ScriptSessionSigner::resolve(
+        } else if let Some(session_signer) = ScriptSessionSigner::resolve_for_chain(
             &self.script_config,
             &self.args.wallets,
             Some(sender),
@@ -909,7 +992,7 @@ impl BundledState<TempoEvmNetwork> {
                 BatchSigner::Wallet(EthereumWallet::new(signer))
             } else {
                 // Try Tempo keys.toml fallback
-                match lookup_signer(sender)? {
+                match lookup_signer_for_chain(sender, chain_id)? {
                     TempoLookup::Direct(signer) => BatchSigner::Wallet(EthereumWallet::new(signer)),
                     TempoLookup::Keychain(signer, config) => {
                         BatchSigner::TempoKeychain(Box::new(signer), config)
@@ -1162,9 +1245,9 @@ mod tests {
         let access_key_address = access_key.address();
         let mut eth_wallets = AddressHashMap::default();
         eth_wallets.insert(root_address, EthereumWallet::new(root));
-        let mut access_keys = AddressHashMap::default();
+        let mut access_keys = HashMap::default();
         access_keys.insert(
-            root_address,
+            AccessKeyScope::new(4217, root_address),
             (
                 access_key,
                 TempoAccessKeyConfig {
@@ -1178,7 +1261,7 @@ mod tests {
             SendTransactionsKind::<Ethereum>::Raw { eth_wallets, browser: None, access_keys };
 
         let tx = TransactionRequest { from: Some(root_address), ..Default::default() };
-        let sender = send_kind.for_sender(&root_address, tx).unwrap();
+        let sender = send_kind.for_sender(4217, &root_address, tx).unwrap();
 
         match sender {
             SendTransactionKind::AccessKey(_, signer, access_key) => {
@@ -1201,12 +1284,47 @@ mod tests {
     }
 
     #[test]
+    fn access_key_signer_is_scoped_to_chain() {
+        let root = foundry_wallets::utils::create_private_key_signer(ROOT_PRIVATE_KEY).unwrap();
+        let root_address = root.address();
+        let access_key =
+            foundry_wallets::utils::create_private_key_signer(ACCESS_KEY_PRIVATE_KEY).unwrap();
+        let access_key_address = access_key.address();
+        let mut eth_wallets = AddressHashMap::default();
+        eth_wallets.insert(root_address, EthereumWallet::new(root));
+        let mut access_keys = HashMap::default();
+        access_keys.insert(
+            AccessKeyScope::new(4217, root_address),
+            (
+                access_key,
+                TempoAccessKeyConfig {
+                    wallet_address: root_address,
+                    key_address: access_key_address,
+                    key_authorization: None,
+                },
+            ),
+        );
+        let send_kind =
+            SendTransactionsKind::<Ethereum>::Raw { eth_wallets, browser: None, access_keys };
+
+        let tx = TransactionRequest { from: Some(root_address), ..Default::default() };
+        let sender = send_kind.for_sender(1, &root_address, tx).unwrap();
+
+        match sender {
+            SendTransactionKind::Raw(_, wallet) => {
+                assert_eq!(wallet.default_signer().address(), root_address);
+            }
+            _ => panic!("expected root wallet signer for non-session chain"),
+        }
+    }
+
+    #[test]
     fn remaining_unsigned_transactions_skip_completed_transactions() {
         let completed = address!("0x1111111111111111111111111111111111111111");
-        let remaining = address!("0x2222222222222222222222222222222222222222");
+        let remaining_sender = address!("0x2222222222222222222222222222222222222222");
         let mut sequence = ScriptSequence::<Ethereum> {
             chain: 4217,
-            transactions: [script_tx(completed), script_tx(remaining)].into(),
+            transactions: [script_tx(completed), script_tx(remaining_sender)].into(),
             receipts: vec![receipt()],
             ..Default::default()
         };
@@ -1214,7 +1332,7 @@ mod tests {
         let remaining =
             remaining_unsigned_transactions(std::slice::from_ref(&sequence)).collect::<Vec<_>>();
         assert_eq!(remaining.len(), 1);
-        assert_eq!(remaining[0].from, remaining_addr());
+        assert_eq!(remaining[0].from, remaining_sender);
         assert_eq!(remaining[0].chain, 4217);
 
         sequence.receipts.push(receipt());
@@ -1230,7 +1348,7 @@ mod tests {
         };
         let remaining_sequence = ScriptSequence::<Ethereum> {
             chain: 4217,
-            transactions: [script_tx(remaining_addr())].into(),
+            transactions: [script_tx(remaining_sender)].into(),
             ..Default::default()
         };
 
@@ -1275,10 +1393,6 @@ mod tests {
             from: Some(from),
             ..Default::default()
         }))
-    }
-
-    fn remaining_addr() -> Address {
-        address!("0x2222222222222222222222222222222222222222")
     }
 
     fn receipt() -> TransactionReceipt {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -19,6 +19,7 @@ use alloy_provider::{Provider, RootProvider, utils::Eip1559Estimation};
 use alloy_rpc_types::TransactionRequest;
 use alloy_signer::Signature;
 use eyre::{Context, Result, bail};
+use forge_script_sequence::ScriptSequence;
 use forge_verify::provider::VerificationProviderType;
 use foundry_cheatcodes::Wallets;
 use foundry_cli::utils::{has_batch_support, has_different_gas_calc};
@@ -270,6 +271,11 @@ struct ScriptSessionSigner {
 }
 
 impl ScriptSessionSigner {
+    /// Resolves the active Tempo session into the access-key signer used by script broadcast.
+    ///
+    /// The returned entry is keyed by the root account because script transactions still use the
+    /// root account as `from`; the temporary session key only changes how the transaction is
+    /// authorized and signed.
     fn resolve<FEN: FoundryEvmNetwork>(
         script_config: &ScriptConfig<FEN>,
         wallets: &foundry_wallets::MultiWalletOpts,
@@ -292,17 +298,41 @@ impl ScriptSessionSigner {
         }))
     }
 
+    /// Converts the resolved session into the same representation used by persistent Tempo keys.
     fn into_access_key_entry(self) -> (WalletSigner, TempoAccessKeyConfig) {
         (self.signer, self.access_key)
     }
 }
 
+/// Returns the single sender a Tempo session is allowed to cover for this broadcast.
+///
+/// Session signing is intentionally fail-closed: a single session access key represents one root
+/// account, so scripts with multiple pending senders must use explicit signer configuration
+/// instead of silently mixing a session key with other wallets.
 fn script_session_expected_sender(required_addresses: &AddressHashSet) -> Result<Option<Address>> {
     required_addresses
         .iter()
         .copied()
         .at_most_one()
         .map_err(|_| eyre::eyre!("Tempo sessions require a single script sender"))
+}
+
+pub(crate) struct RemainingScriptTransaction {
+    pub(crate) chain: u64,
+    pub(crate) from: Address,
+}
+
+pub(crate) fn remaining_unsigned_transactions<N: Network>(
+    sequences: &[ScriptSequence<N>],
+) -> impl Iterator<Item = RemainingScriptTransaction> + '_ {
+    sequences.iter().flat_map(|sequence| {
+        sequence.transactions().skip(sequence.receipts.len()).filter(|tx| tx.is_unsigned()).map(
+            |tx| RemainingScriptTransaction {
+                chain: sequence.chain,
+                from: tx.from().expect("missing from"),
+            },
+        )
+    })
 }
 
 /// Represents how to send _all_ transactions
@@ -398,17 +428,10 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
 
     /// Broadcasts transactions from all sequences.
     pub async fn broadcast(mut self) -> Result<BroadcastedState<FEN>> {
-        let required_addresses = self
-            .sequence
-            .sequences()
-            .iter()
-            .flat_map(|sequence| {
-                sequence
-                    .transactions()
-                    .filter(|tx| tx.is_unsigned())
-                    .map(|tx| tx.from().expect("missing from"))
-            })
-            .collect::<AddressHashSet>();
+        let remaining_transactions =
+            remaining_unsigned_transactions(self.sequence.sequences()).collect::<Vec<_>>();
+        let required_addresses =
+            remaining_transactions.iter().map(|tx| tx.from).collect::<AddressHashSet>();
 
         if required_addresses.contains(&Config::DEFAULT_SENDER) {
             eyre::bail!(
@@ -428,12 +451,12 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
             let mut session_signers: AddressHashMap<ScriptSessionSigner> =
                 AddressHashMap::default();
             if has_session {
-                for sequence in self.sequence.sequences() {
+                for chain in remaining_transactions.iter().map(|tx| tx.chain).unique() {
                     if let Some(session_signer) = ScriptSessionSigner::resolve(
                         &self.script_config,
                         &self.args.wallets,
                         expected_session_sender,
-                        sequence.chain,
+                        chain,
                     )? {
                         session_signers.insert(session_signer.root_account, session_signer);
                     }
@@ -1122,9 +1145,12 @@ impl BundledState<TempoEvmNetwork> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
     use alloy_network::Ethereum;
-    use alloy_primitives::address;
+    use alloy_primitives::{Bloom, address};
+    use alloy_rpc_types::TransactionReceipt;
     use alloy_signer::Signer;
+    use forge_script_sequence::TransactionWithMetadata;
 
     const ROOT_PRIVATE_KEY: &str =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
@@ -1179,6 +1205,46 @@ mod tests {
     }
 
     #[test]
+    fn remaining_unsigned_transactions_skip_completed_transactions() {
+        let completed = address!("0x1111111111111111111111111111111111111111");
+        let remaining = address!("0x2222222222222222222222222222222222222222");
+        let mut sequence = ScriptSequence::<Ethereum> {
+            chain: 4217,
+            transactions: [script_tx(completed), script_tx(remaining)].into(),
+            receipts: vec![receipt()],
+            ..Default::default()
+        };
+
+        let remaining =
+            remaining_unsigned_transactions(std::slice::from_ref(&sequence)).collect::<Vec<_>>();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].from, remaining_addr());
+        assert_eq!(remaining[0].chain, 4217);
+
+        sequence.receipts.push(receipt());
+        let remaining =
+            remaining_unsigned_transactions(std::slice::from_ref(&sequence)).collect::<Vec<_>>();
+        assert!(remaining.is_empty());
+
+        let completed_sequence = ScriptSequence::<Ethereum> {
+            chain: 1,
+            transactions: [script_tx(completed)].into(),
+            receipts: vec![receipt()],
+            ..Default::default()
+        };
+        let remaining_sequence = ScriptSequence::<Ethereum> {
+            chain: 4217,
+            transactions: [script_tx(remaining_addr())].into(),
+            ..Default::default()
+        };
+
+        let remaining = remaining_unsigned_transactions(&[completed_sequence, remaining_sequence])
+            .collect::<Vec<_>>();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].chain, 4217);
+    }
+
+    #[test]
     fn access_key_sets_key_id_before_estimation() {
         let root_address = address!("0x1111111111111111111111111111111111111111");
         let access_key =
@@ -1205,6 +1271,41 @@ mod tests {
                 assert_eq!(tx.key_id, Some(access_key_address));
             }
             _ => panic!("expected access key transaction"),
+        }
+    }
+
+    fn script_tx(from: Address) -> TransactionWithMetadata<Ethereum> {
+        TransactionWithMetadata::from_tx_request(TransactionMaybeSigned::new(TransactionRequest {
+            from: Some(from),
+            ..Default::default()
+        }))
+    }
+
+    fn remaining_addr() -> Address {
+        address!("0x2222222222222222222222222222222222222222")
+    }
+
+    fn receipt() -> TransactionReceipt {
+        TransactionReceipt {
+            inner: ReceiptEnvelope::Legacy(ReceiptWithBloom {
+                receipt: Receipt {
+                    status: Eip658Value::success(),
+                    cumulative_gas_used: 0,
+                    logs: vec![],
+                },
+                logs_bloom: Bloom::ZERO,
+            }),
+            transaction_hash: Default::default(),
+            transaction_index: None,
+            block_hash: None,
+            block_number: None,
+            gas_used: 0,
+            effective_gas_price: 0,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: None,
+            contract_address: None,
         }
     }
 }

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -88,6 +88,12 @@ where
     N::UnsignedTx: SignableTransaction<Signature>,
     N::TransactionRequest: FoundryTransactionBuilder<N>,
 {
+    fn set_access_key_id_for_estimation(&mut self) {
+        if let Self::AccessKey(tx, _, access_key) = self {
+            tx.set_key_id(access_key.key_address);
+        }
+    }
+
     /// Prepares the transaction for broadcasting by synchronizing nonce and estimating gas.
     ///
     /// This method performs two key operations:
@@ -111,6 +117,8 @@ where
             )),
             _ => None,
         };
+
+        self.set_access_key_id_for_estimation();
 
         if let Self::Raw(tx, _)
         | Self::Unlocked(tx)
@@ -1168,5 +1176,35 @@ mod tests {
 
         assert_eq!(script_session_expected_sender(&single_sender).unwrap(), Some(one));
         assert!(script_session_expected_sender(&multiple_senders).is_err());
+    }
+
+    #[test]
+    fn access_key_sets_key_id_before_estimation() {
+        let root_address = address!("0x1111111111111111111111111111111111111111");
+        let access_key =
+            foundry_wallets::utils::create_private_key_signer(ACCESS_KEY_PRIVATE_KEY).unwrap();
+        let access_key_address = access_key.address();
+        let access_key_config = TempoAccessKeyConfig {
+            wallet_address: root_address,
+            key_address: access_key_address,
+            key_authorization: None,
+        };
+        let mut sender = SendTransactionKind::<TempoNetwork>::AccessKey(
+            TempoTransactionRequest {
+                inner: TransactionRequest { from: Some(root_address), ..Default::default() },
+                ..Default::default()
+            },
+            &access_key,
+            &access_key_config,
+        );
+
+        sender.set_access_key_id_for_estimation();
+
+        match sender {
+            SendTransactionKind::AccessKey(tx, _, _) => {
+                assert_eq!(tx.key_id, Some(access_key_address));
+            }
+            _ => panic!("expected access key transaction"),
+        }
     }
 }

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -310,16 +310,10 @@ impl ScriptSessionSigner {
         expected_sender: Option<Address>,
         expected_chain_id: u64,
     ) -> Result<Option<Self>> {
-        let Some(resolved) = script_config.tempo.session_signer_for_multi_wallet(
-            wallets,
-            expected_sender,
-            expected_chain_id,
-        )?
-        else {
-            return Ok(None);
-        };
-
-        Ok(Some(resolved.into()))
+        script_config
+            .tempo
+            .session_signer_for_multi_wallet(wallets, expected_sender, expected_chain_id)
+            .map(|session| session.map(Into::into))
     }
 
     /// Resolves the active Tempo session without imposing a command-level chain.
@@ -330,14 +324,10 @@ impl ScriptSessionSigner {
         wallets: &foundry_wallets::MultiWalletOpts,
         expected_sender: Option<Address>,
     ) -> Result<Option<Self>> {
-        let Some(resolved) = script_config
+        script_config
             .tempo
-            .session_signer_for_multi_wallet_any_chain(wallets, expected_sender)?
-        else {
-            return Ok(None);
-        };
-
-        Ok(Some(resolved.into()))
+            .session_signer_for_multi_wallet_any_chain(wallets, expected_sender)
+            .map(|session| session.map(Into::into))
     }
 }
 
@@ -439,6 +429,12 @@ pub(crate) fn script_session_expected_sender_if_configured<FEN: FoundryEvmNetwor
 pub(crate) struct RemainingScriptTransaction {
     pub(crate) chain: u64,
     pub(crate) from: Address,
+}
+
+impl RemainingScriptTransaction {
+    pub(crate) const fn scope(&self) -> SignerScope {
+        SignerScope::new(self.chain, self.from)
+    }
 }
 
 pub(crate) fn remaining_unsigned_transactions<N: Network>(
@@ -596,7 +592,7 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
             let mut missing_addresses = Vec::new();
 
             for tx in &remaining_transactions {
-                let scope = SignerScope::new(tx.chain, tx.from);
+                let scope = tx.scope();
                 if !signers.contains(&tx.from) && !access_keys.contains_key(&scope) {
                     match lookup_signer_for_chain(tx.from, tx.chain) {
                         Ok(TempoLookup::Direct(signer)) => {
@@ -635,19 +631,7 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
 
         let tempo_sponsor = self.script_config.tempo.sponsor_config().await?.map(Arc::new);
         if tempo_sponsor.is_some() && self.script_config.tempo.sponsor_sig.is_some() {
-            let remaining = self
-                .sequence
-                .sequences()
-                .iter()
-                .map(|sequence| {
-                    sequence
-                        .transactions()
-                        .skip(sequence.receipts.len())
-                        .filter(|tx| tx.is_unsigned())
-                        .count()
-                })
-                .sum::<usize>();
-            if remaining > 1 {
+            if remaining_transactions.len() > 1 {
                 eyre::bail!(
                     "--tempo.sponsor-sig can only sponsor one remaining script transaction; use --tempo.sponsor-signer for multi-transaction scripts"
                 );

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -442,25 +442,24 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
 
             // For addresses without an explicit signer, try Tempo keys.toml fallback.
             let mut access_keys: AddressHashMap<(WalletSigner, TempoAccessKeyConfig)> =
-                AddressHashMap::default();
+                session_signers
+                    .into_iter()
+                    .map(|(addr, signer)| (addr, signer.into_access_key_entry()))
+                    .collect();
             let mut direct_signers: AddressHashMap<WalletSigner> = AddressHashMap::default();
             let mut missing_addresses = Vec::new();
 
             for addr in &required_addresses {
                 if !signers.contains(addr) && !access_keys.contains_key(addr) {
-                    if let Some(session_signer) = session_signers.remove(addr) {
-                        access_keys.insert(*addr, session_signer.into_access_key_entry());
-                    } else {
-                        match lookup_signer(*addr) {
-                            Ok(TempoLookup::Direct(signer)) => {
-                                direct_signers.insert(*addr, signer);
-                            }
-                            Ok(TempoLookup::Keychain(signer, config)) => {
-                                access_keys.insert(*addr, (signer, *config));
-                            }
-                            _ => {
-                                missing_addresses.push(addr);
-                            }
+                    match lookup_signer(*addr) {
+                        Ok(TempoLookup::Direct(signer)) => {
+                            direct_signers.insert(*addr, signer);
+                        }
+                        Ok(TempoLookup::Keychain(signer, config)) => {
+                            access_keys.insert(*addr, (signer, *config));
+                        }
+                        _ => {
+                            missing_addresses.push(addr);
                         }
                     }
                 }
@@ -1109,5 +1108,65 @@ impl BundledState<TempoEvmNetwork> {
             build_data: self.build_data,
             sequence: self.sequence,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_network::Ethereum;
+    use alloy_primitives::address;
+    use alloy_signer::Signer;
+
+    const ROOT_PRIVATE_KEY: &str =
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    const ACCESS_KEY_PRIVATE_KEY: &str =
+        "0x59c6995e998f97a5a004497e5da3b5d2b2b66a87f064d39c44da0b6d6e4f8ff0";
+
+    #[test]
+    fn access_key_signer_takes_precedence_over_same_sender_wallet() {
+        let root = foundry_wallets::utils::create_private_key_signer(ROOT_PRIVATE_KEY).unwrap();
+        let root_address = root.address();
+        let access_key =
+            foundry_wallets::utils::create_private_key_signer(ACCESS_KEY_PRIVATE_KEY).unwrap();
+        let access_key_address = access_key.address();
+        let mut eth_wallets = AddressHashMap::default();
+        eth_wallets.insert(root_address, EthereumWallet::new(root));
+        let mut access_keys = AddressHashMap::default();
+        access_keys.insert(
+            root_address,
+            (
+                access_key,
+                TempoAccessKeyConfig {
+                    wallet_address: root_address,
+                    key_address: access_key_address,
+                    key_authorization: None,
+                },
+            ),
+        );
+        let send_kind =
+            SendTransactionsKind::<Ethereum>::Raw { eth_wallets, browser: None, access_keys };
+
+        let tx = TransactionRequest { from: Some(root_address), ..Default::default() };
+        let sender = send_kind.for_sender(&root_address, tx).unwrap();
+
+        match sender {
+            SendTransactionKind::AccessKey(_, signer, access_key) => {
+                assert_eq!(signer.address(), access_key_address);
+                assert_eq!(access_key.wallet_address, root_address);
+            }
+            _ => panic!("expected access key signer"),
+        }
+    }
+
+    #[test]
+    fn session_sender_requires_single_root_account() {
+        let one = address!("0x1111111111111111111111111111111111111111");
+        let two = address!("0x2222222222222222222222222222222222222222");
+        let single_sender = [one].into_iter().collect();
+        let multiple_senders = [one, two].into_iter().collect();
+
+        assert_eq!(script_session_expected_sender(&single_sender).unwrap(), Some(one));
+        assert!(script_session_expected_sender(&multiple_senders).is_err());
     }
 }

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -287,11 +287,7 @@ fn insert_session_access_key_for_remaining_transactions(
 ) -> Result<()> {
     let session_scope = SignerScope::new(session.session.chain_id, session.session.root_account);
     let mut should_insert = false;
-    for tx in remaining_transactions {
-        if tx.from != session.session.root_account {
-            continue;
-        }
-
+    for tx in remaining_transactions.iter().filter(|tx| tx.from == session.session.root_account) {
         if tx.chain != session.session.chain_id {
             eyre::bail!(
                 "Tempo session is for chain {}, but a remaining transaction from session root {} is on chain {}",

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -27,7 +27,9 @@ use foundry_common::{
     FoundryTransactionBuilder, TransactionMaybeSigned,
     provider::{ProviderBuilder, try_get_http_provider},
     shell,
-    tempo::{TempoSponsor, WALLET_KEYS_PATH, decode_key_authorization, tempo_home},
+    tempo::{
+        ResolvedSessionSigner, TempoSponsor, WALLET_KEYS_PATH, decode_key_authorization, tempo_home,
+    },
 };
 use foundry_config::Config;
 use foundry_evm::core::evm::{FoundryEvmNetwork, TempoEvmNetwork};
@@ -270,14 +272,29 @@ struct ScriptSessionSigner {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct AccessKeyScope {
+pub(crate) struct SignerScope {
     chain: u64,
     sender: Address,
 }
 
-impl AccessKeyScope {
+impl SignerScope {
     pub(crate) const fn new(chain: u64, sender: Address) -> Self {
         Self { chain, sender }
+    }
+
+    pub(crate) const fn sender(&self) -> Address {
+        self.sender
+    }
+}
+
+impl From<ResolvedSessionSigner> for ScriptSessionSigner {
+    fn from(resolved: ResolvedSessionSigner) -> Self {
+        Self {
+            chain: resolved.session.chain_id,
+            root_account: resolved.session.root_account,
+            signer: resolved.signer,
+            access_key: resolved.access_key,
+        }
     }
 }
 
@@ -302,12 +319,7 @@ impl ScriptSessionSigner {
             return Ok(None);
         };
 
-        Ok(Some(Self {
-            chain: resolved.session.chain_id,
-            root_account: resolved.session.root_account,
-            signer: resolved.signer,
-            access_key: resolved.access_key,
-        }))
+        Ok(Some(resolved.into()))
     }
 
     /// Resolves the active Tempo session without imposing a command-level chain.
@@ -325,12 +337,7 @@ impl ScriptSessionSigner {
             return Ok(None);
         };
 
-        Ok(Some(Self {
-            chain: resolved.session.chain_id,
-            root_account: resolved.session.root_account,
-            signer: resolved.signer,
-            access_key: resolved.access_key,
-        }))
+        Ok(Some(resolved.into()))
     }
 }
 
@@ -394,6 +401,16 @@ pub(crate) fn script_session_expected_sender(
         .map_err(|_| eyre::eyre!("Tempo sessions require a single script sender"))
 }
 
+pub(crate) fn script_session_expected_sender_if_configured<FEN: FoundryEvmNetwork>(
+    script_config: &ScriptConfig<FEN>,
+    required_addresses: &AddressHashSet,
+) -> Result<Option<Address>> {
+    script_config
+        .tempo
+        .session_id()?
+        .map_or(Ok(None), |_| script_session_expected_sender(required_addresses))
+}
+
 pub(crate) struct RemainingScriptTransaction {
     pub(crate) chain: u64,
     pub(crate) from: Address,
@@ -420,7 +437,7 @@ pub enum SendTransactionsKind<N: Network> {
     Raw {
         eth_wallets: AddressHashMap<EthereumWallet>,
         browser: Option<BrowserSigner<N>>,
-        access_keys: HashMap<AccessKeyScope, (WalletSigner, TempoAccessKeyConfig)>,
+        access_keys: HashMap<SignerScope, (WalletSigner, TempoAccessKeyConfig)>,
     },
 }
 
@@ -442,8 +459,7 @@ impl<N: Network> SendTransactionsKind<N> {
                 Ok(SendTransactionKind::Unlocked(tx))
             }
             Self::Raw { eth_wallets, browser, access_keys } => {
-                if let Some((signer, config)) = access_keys.get(&AccessKeyScope::new(chain, *addr))
-                {
+                if let Some((signer, config)) = access_keys.get(&SignerScope::new(chain, *addr)) {
                     Ok(SendTransactionKind::AccessKey(tx, signer, config))
                 } else if let Some(wallet) = eth_wallets.get(addr) {
                     Ok(SendTransactionKind::Raw(tx, wallet))
@@ -521,25 +537,21 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
         let send_kind = if self.args.unlocked {
             SendTransactionsKind::Unlocked(required_addresses.clone())
         } else {
-            let has_session = self.script_config.tempo.session_id()?.is_some();
-            let expected_session_sender = if has_session {
-                script_session_expected_sender(&required_addresses)?
-            } else {
-                None
-            };
+            let expected_session_sender = script_session_expected_sender_if_configured(
+                &self.script_config,
+                &required_addresses,
+            )?;
 
             // For addresses without an explicit signer, try Tempo keys.toml fallback.
-            let mut access_keys: HashMap<AccessKeyScope, (WalletSigner, TempoAccessKeyConfig)> =
+            let mut access_keys: HashMap<SignerScope, (WalletSigner, TempoAccessKeyConfig)> =
                 HashMap::default();
-            if has_session
-                && let Some(session_signer) = ScriptSessionSigner::resolve_any_chain(
-                    &self.script_config,
-                    &self.args.wallets,
-                    expected_session_sender,
-                )?
-            {
+            if let Some(session_signer) = ScriptSessionSigner::resolve_any_chain(
+                &self.script_config,
+                &self.args.wallets,
+                expected_session_sender,
+            )? {
                 access_keys.insert(
-                    AccessKeyScope::new(session_signer.chain, session_signer.root_account),
+                    SignerScope::new(session_signer.chain, session_signer.root_account),
                     (session_signer.signer, session_signer.access_key),
                 );
             }
@@ -556,7 +568,7 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
             let mut missing_addresses = Vec::new();
 
             for tx in &remaining_transactions {
-                let scope = AccessKeyScope::new(tx.chain, tx.from);
+                let scope = SignerScope::new(tx.chain, tx.from);
                 if !signers.contains(&tx.from) && !access_keys.contains_key(&scope) {
                     match lookup_signer_for_chain(tx.from, tx.chain) {
                         Ok(TempoLookup::Direct(signer)) => {
@@ -1247,7 +1259,7 @@ mod tests {
         eth_wallets.insert(root_address, EthereumWallet::new(root));
         let mut access_keys = HashMap::default();
         access_keys.insert(
-            AccessKeyScope::new(4217, root_address),
+            SignerScope::new(4217, root_address),
             (
                 access_key,
                 TempoAccessKeyConfig {
@@ -1294,7 +1306,7 @@ mod tests {
         eth_wallets.insert(root_address, EthereumWallet::new(root));
         let mut access_keys = HashMap::default();
         access_keys.insert(
-            AccessKeyScope::new(4217, root_address),
+            SignerScope::new(4217, root_address),
             (
                 access_key,
                 TempoAccessKeyConfig {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -255,6 +255,48 @@ where
     }
 }
 
+struct ScriptSessionSigner {
+    root_account: Address,
+    signer: WalletSigner,
+    access_key: TempoAccessKeyConfig,
+}
+
+impl ScriptSessionSigner {
+    fn resolve<FEN: FoundryEvmNetwork>(
+        script_config: &ScriptConfig<FEN>,
+        wallets: &foundry_wallets::MultiWalletOpts,
+        expected_sender: Option<Address>,
+        expected_chain_id: u64,
+    ) -> Result<Option<Self>> {
+        let Some(resolved) = script_config.tempo.session_signer_for_multi_wallet(
+            wallets,
+            expected_sender,
+            expected_chain_id,
+        )?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(Self {
+            root_account: resolved.session.root_account,
+            signer: resolved.signer,
+            access_key: resolved.access_key,
+        }))
+    }
+
+    fn into_access_key_entry(self) -> (WalletSigner, TempoAccessKeyConfig) {
+        (self.signer, self.access_key)
+    }
+}
+
+fn script_session_expected_sender(required_addresses: &AddressHashSet) -> Result<Option<Address>> {
+    required_addresses
+        .iter()
+        .copied()
+        .at_most_one()
+        .map_err(|_| eyre::eyre!("Tempo sessions require a single script sender"))
+}
+
 /// Represents how to send _all_ transactions
 pub enum SendTransactionsKind<N: Network> {
     /// Send via `eth_sendTransaction` and rely on the  `from` address being unlocked.
@@ -369,6 +411,27 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
         let send_kind = if self.args.unlocked {
             SendTransactionsKind::Unlocked(required_addresses.clone())
         } else {
+            let has_session = self.script_config.tempo.session_id()?.is_some();
+            let expected_session_sender = if has_session {
+                script_session_expected_sender(&required_addresses)?
+            } else {
+                None
+            };
+            let mut session_signers: AddressHashMap<ScriptSessionSigner> =
+                AddressHashMap::default();
+            if has_session {
+                for sequence in self.sequence.sequences() {
+                    if let Some(session_signer) = ScriptSessionSigner::resolve(
+                        &self.script_config,
+                        &self.args.wallets,
+                        expected_session_sender,
+                        sequence.chain,
+                    )? {
+                        session_signers.insert(session_signer.root_account, session_signer);
+                    }
+                }
+            }
+
             let signers: Vec<Address> = self
                 .script_wallets
                 .signers()
@@ -384,16 +447,20 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
             let mut missing_addresses = Vec::new();
 
             for addr in &required_addresses {
-                if !signers.contains(addr) {
-                    match lookup_signer(*addr) {
-                        Ok(TempoLookup::Direct(signer)) => {
-                            direct_signers.insert(*addr, signer);
-                        }
-                        Ok(TempoLookup::Keychain(signer, config)) => {
-                            access_keys.insert(*addr, (signer, *config));
-                        }
-                        _ => {
-                            missing_addresses.push(addr);
+                if !signers.contains(addr) && !access_keys.contains_key(addr) {
+                    if let Some(session_signer) = session_signers.remove(addr) {
+                        access_keys.insert(*addr, session_signer.into_access_key_entry());
+                    } else {
+                        match lookup_signer(*addr) {
+                            Ok(TempoLookup::Direct(signer)) => {
+                                direct_signers.insert(*addr, signer);
+                            }
+                            Ok(TempoLookup::Keychain(signer, config)) => {
+                                access_keys.insert(*addr, (signer, *config));
+                            }
+                            _ => {
+                                missing_addresses.push(addr);
+                            }
                         }
                     }
                 }
@@ -783,6 +850,7 @@ impl BundledState<TempoEvmNetwork> {
         }
 
         let sender = *senders.iter().next().unwrap();
+        let chain_id = sequence.chain;
 
         if sender == Config::DEFAULT_SENDER {
             bail!(
@@ -799,6 +867,16 @@ impl BundledState<TempoEvmNetwork> {
 
         let batch_signer = if self.args.unlocked {
             BatchSigner::Unlocked
+        } else if let Some(session_signer) = ScriptSessionSigner::resolve(
+            &self.script_config,
+            &self.args.wallets,
+            Some(sender),
+            chain_id,
+        )? {
+            BatchSigner::TempoKeychain(
+                Box::new(session_signer.signer),
+                Box::new(session_signer.access_key),
+            )
         } else {
             let mut signers = self.script_wallets.into_multi_wallet().into_signers()?;
             if let Some(signer) = signers.remove(&sender) {
@@ -863,7 +941,6 @@ impl BundledState<TempoEvmNetwork> {
 
         // Build the batch transaction request
         let nonce = provider.get_transaction_count(sender).await?;
-        let chain_id = sequence.chain;
 
         // Get gas prices - batch transactions are Tempo-only, always use EIP-1559 style fees
         let fees = provider.estimate_eip1559_fees().await?;

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -297,19 +297,16 @@ impl ScriptSessionSigner {
             access_key: resolved.access_key,
         }))
     }
-
-    /// Converts the resolved session into the same representation used by persistent Tempo keys.
-    fn into_access_key_entry(self) -> (WalletSigner, TempoAccessKeyConfig) {
-        (self.signer, self.access_key)
-    }
 }
 
-/// Returns the single sender a Tempo session is allowed to cover for this broadcast.
+/// Returns the single sender a Tempo session is allowed to cover.
 ///
 /// Session signing is intentionally fail-closed: a single session access key represents one root
-/// account, so scripts with multiple pending senders must use explicit signer configuration
-/// instead of silently mixing a session key with other wallets.
-fn script_session_expected_sender(required_addresses: &AddressHashSet) -> Result<Option<Address>> {
+/// account, so scripts with multiple pending senders must not silently mix the session key with
+/// other wallets.
+pub(crate) fn script_session_expected_sender(
+    required_addresses: &AddressHashSet,
+) -> Result<Option<Address>> {
     required_addresses
         .iter()
         .copied()
@@ -448,7 +445,9 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
             } else {
                 None
             };
-            let mut session_signers: AddressHashMap<ScriptSessionSigner> =
+
+            // For addresses without an explicit signer, try Tempo keys.toml fallback.
+            let mut access_keys: AddressHashMap<(WalletSigner, TempoAccessKeyConfig)> =
                 AddressHashMap::default();
             if has_session {
                 for chain in remaining_transactions.iter().map(|tx| tx.chain).unique() {
@@ -458,7 +457,10 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
                         expected_session_sender,
                         chain,
                     )? {
-                        session_signers.insert(session_signer.root_account, session_signer);
+                        access_keys.insert(
+                            session_signer.root_account,
+                            (session_signer.signer, session_signer.access_key),
+                        );
                     }
                 }
             }
@@ -471,12 +473,6 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
                 .chain(self.browser_wallet.as_ref().map(|b| b.address()))
                 .collect();
 
-            // For addresses without an explicit signer, try Tempo keys.toml fallback.
-            let mut access_keys: AddressHashMap<(WalletSigner, TempoAccessKeyConfig)> =
-                session_signers
-                    .into_iter()
-                    .map(|(addr, signer)| (addr, signer.into_access_key_entry()))
-                    .collect();
             let mut direct_signers: AddressHashMap<WalletSigner> = AddressHashMap::default();
             let mut missing_addresses = Vec::new();
 

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -374,13 +374,23 @@ pub(crate) fn remaining_unsigned_transactions<N: Network>(
     sequences: &[ScriptSequence<N>],
 ) -> impl Iterator<Item = RemainingScriptTransaction> + '_ {
     sequences.iter().flat_map(|sequence| {
-        sequence.transactions().skip(sequence.receipts.len()).filter(|tx| tx.is_unsigned()).map(
-            |tx| RemainingScriptTransaction {
+        remaining_transactions(sequence).filter(|tx| tx.is_unsigned()).map(|tx| {
+            RemainingScriptTransaction {
                 chain: sequence.chain,
                 from: tx.from().expect("missing from"),
-            },
-        )
+            }
+        })
     })
+}
+
+fn remaining_transaction_start<N: Network>(sequence: &ScriptSequence<N>) -> usize {
+    sequence.receipts.len().min(sequence.transactions.len())
+}
+
+fn remaining_transactions<N: Network>(
+    sequence: &ScriptSequence<N>,
+) -> impl Iterator<Item = &TransactionMaybeSigned<N>> + '_ {
+    sequence.transactions().skip(remaining_transaction_start(sequence))
 }
 
 /// Represents how to send _all_ transactions
@@ -563,12 +573,13 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
         };
 
         let tempo_sponsor = self.script_config.tempo.sponsor_config().await?.map(Arc::new);
-        if tempo_sponsor.is_some() && self.script_config.tempo.sponsor_sig.is_some() {
-            if remaining_transactions.len() > 1 {
-                eyre::bail!(
-                    "--tempo.sponsor-sig can only sponsor one remaining script transaction; use --tempo.sponsor-signer for multi-transaction scripts"
-                );
-            }
+        if tempo_sponsor.is_some()
+            && self.script_config.tempo.sponsor_sig.is_some()
+            && remaining_transactions.len() > 1
+        {
+            eyre::bail!(
+                "--tempo.sponsor-sig can only sponsor one remaining script transaction; use --tempo.sponsor-signer for multi-transaction scripts"
+            );
         }
 
         let progress = ScriptProgress::default();
@@ -896,12 +907,21 @@ impl BundledState<TempoEvmNetwork> {
         }
 
         let sequence = self.sequence.sequences_mut().get_mut(0).unwrap();
-        let provider = Arc::new(ProviderBuilder::<TempoNetwork>::new(sequence.rpc_url()).build()?);
-        let tempo_sponsor = self.script_config.tempo.sponsor_config().await?;
+        let total_transactions = sequence.transactions.len();
+        let remaining_start = remaining_transaction_start(sequence);
+
+        if remaining_start == total_transactions {
+            sh_println!("No transactions to broadcast in batch mode.")?;
+            return Ok(BroadcastedState {
+                args: self.args,
+                script_config: self.script_config,
+                build_data: self.build_data,
+                sequence: self.sequence,
+            });
+        }
 
         // Collect sender addresses - batch mode requires single sender
-        let senders: AddressHashSet = sequence
-            .transactions()
+        let senders: AddressHashSet = remaining_transactions(sequence)
             .filter(|tx| tx.is_unsigned())
             .filter_map(|tx| tx.from())
             .collect();
@@ -923,6 +943,9 @@ impl BundledState<TempoEvmNetwork> {
                 "You seem to be using Foundry's default sender. Be sure to set your own --sender."
             );
         }
+
+        let provider = Arc::new(ProviderBuilder::<TempoNetwork>::new(sequence.rpc_url()).build()?);
+        let tempo_sponsor = self.script_config.tempo.sponsor_config().await?;
 
         // Get wallet for signing
         enum BatchSigner {
@@ -961,15 +984,15 @@ impl BundledState<TempoEvmNetwork> {
         // Tempo batch transactions support CREATE only as the first call
         let mut calls: Vec<Call> = Vec::new();
         let mut has_create = false;
-        for (idx, tx) in sequence.transactions().enumerate() {
+        for (call_index, tx) in remaining_transactions(sequence).enumerate() {
             let to = match tx.to() {
                 Some(addr) => TxKind::Call(addr),
                 None => {
-                    if idx > 0 {
+                    if call_index > 0 {
                         bail!(
                             "Contract creation must be the first transaction in --batch mode. \
                              Found CREATE at position {}. Reorder your script or deploy separately.",
-                            idx + 1
+                            call_index + 1
                         );
                     }
                     if has_create {
@@ -983,16 +1006,6 @@ impl BundledState<TempoEvmNetwork> {
             let input = tx.input().cloned().unwrap_or_default();
 
             calls.push(Call { to, value, input });
-        }
-
-        if calls.is_empty() {
-            sh_println!("No transactions to broadcast in batch mode.")?;
-            return Ok(BroadcastedState {
-                args: self.args,
-                script_config: self.script_config,
-                build_data: self.build_data,
-                sequence: self.sequence,
-            });
         }
 
         sh_println!(
@@ -1132,7 +1145,7 @@ impl BundledState<TempoEvmNetwork> {
         }
 
         // Mark all transactions as pending with the batch tx hash
-        for i in 0..sequence.transactions.len() {
+        for i in remaining_start..total_transactions {
             sequence.add_pending(i, tx_hash);
         }
 
@@ -1346,6 +1359,27 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].chain, 4217);
+    }
+
+    #[test]
+    fn remaining_transactions_skip_receipt_prefix() {
+        let completed = address!("0x1111111111111111111111111111111111111111");
+        let second = address!("0x2222222222222222222222222222222222222222");
+        let third = address!("0x3333333333333333333333333333333333333333");
+        let mut sequence = ScriptSequence::<Ethereum> {
+            chain: 4217,
+            transactions: [script_tx(completed), script_tx(second), script_tx(third)].into(),
+            receipts: vec![receipt()],
+            ..Default::default()
+        };
+
+        let remaining =
+            remaining_transactions(&sequence).map(|tx| tx.from().unwrap()).collect::<Vec<_>>();
+
+        assert_eq!(remaining, vec![second, third]);
+
+        sequence.receipts = (0..4).map(|_| receipt()).collect();
+        assert!(remaining_transactions(&sequence).next().is_none());
     }
 
     #[tokio::test]

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -356,10 +356,8 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                     &self.script_config,
                     &remaining_froms,
                 )?;
-                let remaining_signers = remaining_transactions
-                    .iter()
-                    .map(|tx| SignerScope::new(tx.chain, tx.from))
-                    .collect::<HashSet<_>>();
+                let remaining_signers =
+                    remaining_transactions.iter().map(|tx| tx.scope()).collect::<HashSet<_>>();
                 let available_signers = available_script_signers(
                     &self.script_config,
                     &self.args.wallets,

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -3,7 +3,7 @@ use crate::{
     multi_sequence::MultiChainSequence, sequence::ScriptSequenceKind,
 };
 use alloy_network::AnyNetwork;
-use alloy_primitives::{B256, Bytes};
+use alloy_primitives::{Address, B256, Bytes, map::AddressHashSet};
 use alloy_provider::Provider;
 use eyre::{OptionExt, Result};
 use forge_script_sequence::ScriptSequence;
@@ -20,8 +20,39 @@ use foundry_compilers::{
 };
 use foundry_evm::{core::evm::FoundryEvmNetwork, traces::debug::ContractSources};
 use foundry_linking::Linker;
-use foundry_wallets::wallet_browser::signer::BrowserSigner;
+use foundry_wallets::{MultiWalletOpts, wallet_browser::signer::BrowserSigner};
 use std::{path::PathBuf, str::FromStr, sync::Arc};
+
+fn available_script_signers<FEN: FoundryEvmNetwork>(
+    script_config: &ScriptConfig<FEN>,
+    wallets: &MultiWalletOpts,
+    script_wallets: &Wallets,
+    expected_sender: Option<Address>,
+    chains: impl IntoIterator<Item = u64>,
+) -> Result<Vec<Address>> {
+    let mut signers = script_wallets
+        .signers()
+        .map_err(|e| eyre::eyre!("Failed to get available signers: {}", e))?;
+
+    for chain in chains {
+        if let Some(session) =
+            script_config.tempo.session_signer_for_multi_wallet(wallets, expected_sender, chain)?
+            && !signers.contains(&session.access_key.wallet_address)
+        {
+            signers.push(session.access_key.wallet_address);
+        }
+    }
+
+    Ok(signers)
+}
+
+fn tempo_session_expected_sender(required_addresses: &[Address]) -> Result<Option<Address>> {
+    let required_addresses = required_addresses.iter().copied().collect::<AddressHashSet>();
+    if required_addresses.len() > 1 {
+        eyre::bail!("Tempo sessions require a single script sender");
+    }
+    Ok(required_addresses.into_iter().next())
+}
 
 /// Container for the compiled contracts.
 #[derive(Debug)]
@@ -301,19 +332,31 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                     self.script_config,
                 )
             } else {
-                let mut froms = sequence.sequences().iter().flat_map(|s| {
-                    s.transactions
-                        .iter()
-                        .skip(s.receipts.len())
-                        .map(|t| t.transaction.from().expect("from is missing in script artifact"))
-                });
+                let remaining_froms = sequence
+                    .sequences()
+                    .iter()
+                    .flat_map(|s| {
+                        s.transactions.iter().skip(s.receipts.len()).map(|t| {
+                            t.transaction.from().expect("from is missing in script artifact")
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                let remaining_chains =
+                    sequence.sequences().iter().map(|s| s.chain).collect::<Vec<_>>();
+                let expected_session_sender = if self.script_config.tempo.session_id()?.is_some() {
+                    tempo_session_expected_sender(&remaining_froms)?
+                } else {
+                    None
+                };
+                let available_signers = available_script_signers(
+                    &self.script_config,
+                    &self.args.wallets,
+                    &self.script_wallets,
+                    expected_session_sender,
+                    remaining_chains,
+                )?;
 
-                let available_signers = self
-                    .script_wallets
-                    .signers()
-                    .map_err(|e| eyre::eyre!("Failed to get available signers: {}", e))?;
-
-                if froms.all(|from| available_signers.contains(&from)) {
+                if remaining_froms.iter().all(|from| available_signers.contains(from)) {
                     (
                         self.args,
                         self.build_data,

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -1,6 +1,9 @@
 use crate::{
-    ScriptArgs, ScriptConfig, broadcast::BundledState, execute::LinkedState,
-    multi_sequence::MultiChainSequence, sequence::ScriptSequenceKind,
+    ScriptArgs, ScriptConfig,
+    broadcast::{BundledState, remaining_unsigned_transactions},
+    execute::LinkedState,
+    multi_sequence::MultiChainSequence,
+    sequence::ScriptSequenceKind,
 };
 use alloy_network::AnyNetwork;
 use alloy_primitives::{Address, B256, Bytes, map::AddressHashSet};
@@ -23,6 +26,11 @@ use foundry_linking::Linker;
 use foundry_wallets::{MultiWalletOpts, wallet_browser::signer::BrowserSigner};
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
+/// Returns the signer addresses that can satisfy a resumed broadcast.
+///
+/// `Wallets` only tracks signers collected from CLI options and script cheatcodes. A Tempo
+/// session signer lives in the session registry instead, so resume needs to treat the session
+/// root account as available without mutating the script wallet set.
 fn available_script_signers<FEN: FoundryEvmNetwork>(
     script_config: &ScriptConfig<FEN>,
     wallets: &MultiWalletOpts,
@@ -46,6 +54,11 @@ fn available_script_signers<FEN: FoundryEvmNetwork>(
     Ok(signers)
 }
 
+/// Returns the single sender a Tempo session may cover during resume.
+///
+/// This mirrors broadcast-time session validation: one session access key represents one root
+/// account, so a resumed sequence with multiple remaining senders must not silently combine the
+/// session signer with other wallets.
 fn tempo_session_expected_sender(required_addresses: &[Address]) -> Result<Option<Address>> {
     let required_addresses = required_addresses.iter().copied().collect::<AddressHashSet>();
     if required_addresses.len() > 1 {
@@ -332,17 +345,12 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                     self.script_config,
                 )
             } else {
-                let remaining_froms = sequence
-                    .sequences()
-                    .iter()
-                    .flat_map(|s| {
-                        s.transactions.iter().skip(s.receipts.len()).map(|t| {
-                            t.transaction.from().expect("from is missing in script artifact")
-                        })
-                    })
-                    .collect::<Vec<_>>();
+                let remaining_transactions =
+                    remaining_unsigned_transactions(sequence.sequences()).collect::<Vec<_>>();
+                let remaining_froms =
+                    remaining_transactions.iter().map(|tx| tx.from).collect::<Vec<_>>();
                 let remaining_chains =
-                    sequence.sequences().iter().map(|s| s.chain).collect::<Vec<_>>();
+                    remaining_transactions.iter().map(|tx| tx.chain).collect::<Vec<_>>();
                 let expected_session_sender = if self.script_config.tempo.session_id()?.is_some() {
                     tempo_session_expected_sender(&remaining_froms)?
                 } else {

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -1,12 +1,18 @@
 use crate::{
     ScriptArgs, ScriptConfig,
-    broadcast::{BundledState, remaining_unsigned_transactions, script_session_expected_sender},
+    broadcast::{
+        BundledState, SignerScope, remaining_unsigned_transactions,
+        script_session_expected_sender_if_configured,
+    },
     execute::LinkedState,
     multi_sequence::MultiChainSequence,
     sequence::ScriptSequenceKind,
 };
 use alloy_network::AnyNetwork;
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_primitives::{
+    Address, B256, Bytes,
+    map::{AddressHashSet, HashSet},
+};
 use alloy_provider::Provider;
 use eyre::{OptionExt, Result};
 use forge_script_sequence::ScriptSequence;
@@ -26,18 +32,6 @@ use foundry_linking::Linker;
 use foundry_wallets::{MultiWalletOpts, wallet_browser::signer::BrowserSigner};
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-struct SignerScope {
-    chain: u64,
-    sender: Address,
-}
-
-impl SignerScope {
-    const fn new(chain: u64, sender: Address) -> Self {
-        Self { chain, sender }
-    }
-}
-
 /// Returns the scoped signers that can satisfy a resumed broadcast.
 ///
 /// `Wallets` only tracks signers collected from CLI options and script cheatcodes. A Tempo
@@ -49,29 +43,27 @@ fn available_script_signers<FEN: FoundryEvmNetwork>(
     script_wallets: &Wallets,
     expected_sender: Option<Address>,
     remaining: impl IntoIterator<Item = SignerScope>,
-) -> Result<Vec<SignerScope>> {
+) -> Result<HashSet<SignerScope>> {
     let signers = script_wallets
         .signers()
         .map_err(|e| eyre::eyre!("Failed to get available signers: {}", e))?;
-    let remaining = remaining.into_iter().collect::<Vec<_>>();
+    let remaining = remaining.into_iter().collect::<HashSet<_>>();
     let mut available = remaining
         .iter()
         .copied()
-        .filter(|scope| signers.contains(&scope.sender))
-        .collect::<Vec<_>>();
+        .filter(|scope| signers.contains(&scope.sender()))
+        .collect::<HashSet<_>>();
 
     if let Some(session) =
         script_config.tempo.session_signer_for_multi_wallet_any_chain(wallets, expected_sender)?
     {
         let session_scope =
             SignerScope::new(session.session.chain_id, session.access_key.wallet_address);
-        if remaining.contains(&session_scope) && !available.contains(&session_scope) {
-            available.push(session_scope);
+        if remaining.contains(&session_scope) {
+            available.insert(session_scope);
         }
     }
 
-    available.sort_unstable_by_key(|scope| (scope.chain, scope.sender));
-    available.dedup();
     Ok(available)
 }
 
@@ -356,18 +348,15 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                 let remaining_transactions =
                     remaining_unsigned_transactions(sequence.sequences()).collect::<Vec<_>>();
                 let remaining_froms =
-                    remaining_transactions.iter().map(|tx| tx.from).collect::<Vec<_>>();
-                let has_session = self.script_config.tempo.session_id()?.is_some();
-                let expected_session_sender = if has_session {
-                    let remaining_froms = remaining_froms.iter().copied().collect();
-                    script_session_expected_sender(&remaining_froms)?
-                } else {
-                    None
-                };
+                    remaining_transactions.iter().map(|tx| tx.from).collect::<AddressHashSet>();
+                let expected_session_sender = script_session_expected_sender_if_configured(
+                    &self.script_config,
+                    &remaining_froms,
+                )?;
                 let remaining_signers = remaining_transactions
                     .iter()
                     .map(|tx| SignerScope::new(tx.chain, tx.from))
-                    .collect::<Vec<_>>();
+                    .collect::<HashSet<_>>();
                 let available_signers = available_script_signers(
                     &self.script_config,
                     &self.args.wallets,
@@ -376,7 +365,7 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                     remaining_signers.iter().copied(),
                 )?;
 
-                if remaining_signers.iter().all(|scope| available_signers.contains(scope)) {
+                if remaining_signers.is_subset(&available_signers) {
                     (
                         self.args,
                         self.build_data,

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -6,7 +6,7 @@ use crate::{
     sequence::ScriptSequenceKind,
 };
 use alloy_network::AnyNetwork;
-use alloy_primitives::{Address, B256, Bytes, map::AddressHashSet};
+use alloy_primitives::{Address, B256, Bytes};
 use alloy_provider::Provider;
 use eyre::{OptionExt, Result};
 use forge_script_sequence::ScriptSequence;
@@ -26,32 +26,53 @@ use foundry_linking::Linker;
 use foundry_wallets::{MultiWalletOpts, wallet_browser::signer::BrowserSigner};
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
-/// Returns the signer addresses that can satisfy a resumed broadcast.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct SignerScope {
+    chain: u64,
+    sender: Address,
+}
+
+impl SignerScope {
+    const fn new(chain: u64, sender: Address) -> Self {
+        Self { chain, sender }
+    }
+}
+
+/// Returns the scoped signers that can satisfy a resumed broadcast.
 ///
 /// `Wallets` only tracks signers collected from CLI options and script cheatcodes. A Tempo
 /// session signer lives in the session registry instead, so resume needs to treat the session
-/// root account as available without mutating the script wallet set.
+/// root account as available only on the chain covered by the session.
 fn available_script_signers<FEN: FoundryEvmNetwork>(
     script_config: &ScriptConfig<FEN>,
     wallets: &MultiWalletOpts,
     script_wallets: &Wallets,
     expected_sender: Option<Address>,
-    chains: impl IntoIterator<Item = u64>,
-) -> Result<Vec<Address>> {
-    let mut signers = script_wallets
+    remaining: impl IntoIterator<Item = SignerScope>,
+) -> Result<Vec<SignerScope>> {
+    let signers = script_wallets
         .signers()
         .map_err(|e| eyre::eyre!("Failed to get available signers: {}", e))?;
+    let remaining = remaining.into_iter().collect::<Vec<_>>();
+    let mut available = remaining
+        .iter()
+        .copied()
+        .filter(|scope| signers.contains(&scope.sender))
+        .collect::<Vec<_>>();
 
-    for chain in chains {
-        if let Some(session) =
-            script_config.tempo.session_signer_for_multi_wallet(wallets, expected_sender, chain)?
-            && !signers.contains(&session.access_key.wallet_address)
-        {
-            signers.push(session.access_key.wallet_address);
+    if let Some(session) =
+        script_config.tempo.session_signer_for_multi_wallet_any_chain(wallets, expected_sender)?
+    {
+        let session_scope =
+            SignerScope::new(session.session.chain_id, session.access_key.wallet_address);
+        if remaining.contains(&session_scope) && !available.contains(&session_scope) {
+            available.push(session_scope);
         }
     }
 
-    Ok(signers)
+    available.sort_unstable_by_key(|scope| (scope.chain, scope.sender));
+    available.dedup();
+    Ok(available)
 }
 
 /// Container for the compiled contracts.
@@ -336,26 +357,26 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                     remaining_unsigned_transactions(sequence.sequences()).collect::<Vec<_>>();
                 let remaining_froms =
                     remaining_transactions.iter().map(|tx| tx.from).collect::<Vec<_>>();
-                let mut remaining_chains =
-                    remaining_transactions.iter().map(|tx| tx.chain).collect::<Vec<_>>();
-                remaining_chains.sort_unstable();
-                remaining_chains.dedup();
-                let expected_session_sender = if self.script_config.tempo.session_id()?.is_some() {
-                    let remaining_from_set =
-                        remaining_froms.iter().copied().collect::<AddressHashSet>();
-                    script_session_expected_sender(&remaining_from_set)?
+                let has_session = self.script_config.tempo.session_id()?.is_some();
+                let expected_session_sender = if has_session {
+                    let remaining_froms = remaining_froms.iter().copied().collect();
+                    script_session_expected_sender(&remaining_froms)?
                 } else {
                     None
                 };
+                let remaining_signers = remaining_transactions
+                    .iter()
+                    .map(|tx| SignerScope::new(tx.chain, tx.from))
+                    .collect::<Vec<_>>();
                 let available_signers = available_script_signers(
                     &self.script_config,
                     &self.args.wallets,
                     &self.script_wallets,
                     expected_session_sender,
-                    remaining_chains,
+                    remaining_signers.iter().copied(),
                 )?;
 
-                if remaining_froms.iter().all(|from| available_signers.contains(from)) {
+                if remaining_signers.iter().all(|scope| available_signers.contains(scope)) {
                     (
                         self.args,
                         self.build_data,

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -1,6 +1,6 @@
 use crate::{
     ScriptArgs, ScriptConfig,
-    broadcast::{BundledState, remaining_unsigned_transactions},
+    broadcast::{BundledState, remaining_unsigned_transactions, script_session_expected_sender},
     execute::LinkedState,
     multi_sequence::MultiChainSequence,
     sequence::ScriptSequenceKind,
@@ -52,19 +52,6 @@ fn available_script_signers<FEN: FoundryEvmNetwork>(
     }
 
     Ok(signers)
-}
-
-/// Returns the single sender a Tempo session may cover during resume.
-///
-/// This mirrors broadcast-time session validation: one session access key represents one root
-/// account, so a resumed sequence with multiple remaining senders must not silently combine the
-/// session signer with other wallets.
-fn tempo_session_expected_sender(required_addresses: &[Address]) -> Result<Option<Address>> {
-    let required_addresses = required_addresses.iter().copied().collect::<AddressHashSet>();
-    if required_addresses.len() > 1 {
-        eyre::bail!("Tempo sessions require a single script sender");
-    }
-    Ok(required_addresses.into_iter().next())
 }
 
 /// Container for the compiled contracts.
@@ -354,7 +341,9 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                 remaining_chains.sort_unstable();
                 remaining_chains.dedup();
                 let expected_session_sender = if self.script_config.tempo.session_id()?.is_some() {
-                    tempo_session_expected_sender(&remaining_froms)?
+                    let remaining_from_set =
+                        remaining_froms.iter().copied().collect::<AddressHashSet>();
+                    script_session_expected_sender(&remaining_from_set)?
                 } else {
                     None
                 };

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -42,12 +42,11 @@ fn available_script_signers<FEN: FoundryEvmNetwork>(
     wallets: &MultiWalletOpts,
     script_wallets: &Wallets,
     expected_sender: Option<Address>,
-    remaining: impl IntoIterator<Item = SignerScope>,
+    remaining: &HashSet<SignerScope>,
 ) -> Result<HashSet<SignerScope>> {
     let signers = script_wallets
         .signers()
         .map_err(|e| eyre::eyre!("Failed to get available signers: {}", e))?;
-    let remaining = remaining.into_iter().collect::<HashSet<_>>();
     let mut available = remaining
         .iter()
         .copied()
@@ -363,7 +362,7 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                     &self.args.wallets,
                     &self.script_wallets,
                     expected_session_sender,
-                    remaining_signers.iter().copied(),
+                    &remaining_signers,
                 )?;
 
                 if remaining_signers.is_subset(&available_signers) {
@@ -485,7 +484,7 @@ mod tests {
             &MultiWalletOpts::default(),
             &Wallets::new(Default::default(), None),
             None,
-            [],
+            &HashSet::default(),
         )
         .unwrap();
 

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -349,8 +349,10 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                     remaining_unsigned_transactions(sequence.sequences()).collect::<Vec<_>>();
                 let remaining_froms =
                     remaining_transactions.iter().map(|tx| tx.from).collect::<Vec<_>>();
-                let remaining_chains =
+                let mut remaining_chains =
                     remaining_transactions.iter().map(|tx| tx.chain).collect::<Vec<_>>();
+                remaining_chains.sort_unstable();
+                remaining_chains.dedup();
                 let expected_session_sender = if self.script_config.tempo.session_id()?.is_some() {
                     tempo_session_expected_sender(&remaining_froms)?
                 } else {

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -53,6 +53,9 @@ fn available_script_signers<FEN: FoundryEvmNetwork>(
         .copied()
         .filter(|scope| signers.contains(&scope.sender()))
         .collect::<HashSet<_>>();
+    if remaining.is_empty() {
+        return Ok(available);
+    }
 
     if let Some(session) =
         script_config.tempo.session_signer_for_multi_wallet_any_chain(wallets, expected_sender)?
@@ -376,7 +379,12 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                 } else {
                     // IF we are missing required signers, execute script as we might need to
                     // collect private keys from the execution.
-                    let executed = self.link().await?.prepare_execution().await?.execute().await?;
+                    let mut state = self;
+                    state
+                        .script_config
+                        .update_tempo_session_sender(&state.args.wallets, state.args.evm.sender)
+                        .await?;
+                    let executed = state.link().await?.prepare_execution().await?.execute().await?;
                     (
                         executed.args,
                         executed.build_data.build_data,
@@ -429,5 +437,60 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
             )?;
             Ok(ScriptSequenceKind::Multi(sequence))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use foundry_cli::opts::TEMPO_SESSION_ID_ENV;
+    use foundry_evm::core::evm::TempoEvmNetwork;
+    use std::sync::LazyLock;
+    use tokio::sync::{Mutex, MutexGuard};
+
+    static SESSION_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    struct SessionEnvGuard {
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl SessionEnvGuard {
+        async fn set(session_id: B256) -> Self {
+            let guard = SESSION_ENV_LOCK.lock().await;
+            // SAFETY: test-only environment override guarded by a process-wide mutex.
+            unsafe { std::env::set_var(TEMPO_SESSION_ID_ENV, format!("{session_id:?}")) };
+            Self { _guard: guard }
+        }
+    }
+
+    impl Drop for SessionEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: restore process environment after the guarded test section.
+            unsafe { std::env::remove_var(TEMPO_SESSION_ID_ENV) };
+        }
+    }
+
+    #[tokio::test]
+    async fn available_script_signers_skips_session_resolution_when_remaining_empty() {
+        let _guard = SessionEnvGuard::set(B256::from([0x99; 32])).await;
+        let script_config = ScriptConfig::<TempoEvmNetwork>::new(
+            Default::default(),
+            Default::default(),
+            false,
+            Default::default(),
+        )
+        .await
+        .unwrap();
+
+        let available = available_script_signers(
+            &script_config,
+            &MultiWalletOpts::default(),
+            &Wallets::new(Default::default(), None),
+            None,
+            [],
+        )
+        .unwrap();
+
+        assert!(available.is_empty());
     }
 }

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -1,7 +1,7 @@
 use crate::{
     ScriptArgs, ScriptConfig,
     broadcast::{
-        BundledState, SignerScope, remaining_unsigned_transactions,
+        BundledState, RemainingScriptTransaction, SignerScope, remaining_unsigned_transactions,
         script_session_expected_sender_if_configured,
     },
     execute::LinkedState,
@@ -9,10 +9,7 @@ use crate::{
     sequence::ScriptSequenceKind,
 };
 use alloy_network::AnyNetwork;
-use alloy_primitives::{
-    Address, B256, Bytes,
-    map::{AddressHashSet, HashSet},
-};
+use alloy_primitives::{Address, B256, Bytes, map::AddressHashSet};
 use alloy_provider::Provider;
 use eyre::{OptionExt, Result};
 use forge_script_sequence::ScriptSequence;
@@ -32,41 +29,33 @@ use foundry_linking::Linker;
 use foundry_wallets::{MultiWalletOpts, wallet_browser::signer::BrowserSigner};
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
-/// Returns the scoped signers that can satisfy a resumed broadcast.
+/// Returns whether every scoped signer needed for resume is already available.
 ///
 /// `Wallets` only tracks signers collected from CLI options and script cheatcodes. A Tempo
 /// session signer lives in the session registry instead, so resume needs to treat the session
 /// root account as available only on the chain covered by the session.
-fn available_script_signers<FEN: FoundryEvmNetwork>(
+fn has_available_script_signers<FEN: FoundryEvmNetwork>(
     script_config: &ScriptConfig<FEN>,
     wallets: &MultiWalletOpts,
     script_wallets: &Wallets,
     expected_sender: Option<Address>,
-    remaining: &HashSet<SignerScope>,
-) -> Result<HashSet<SignerScope>> {
+    remaining: &[RemainingScriptTransaction],
+) -> Result<bool> {
     let signers = script_wallets
         .signers()
         .map_err(|e| eyre::eyre!("Failed to get available signers: {}", e))?;
-    let mut available = remaining
-        .iter()
-        .copied()
-        .filter(|scope| signers.contains(&scope.sender()))
-        .collect::<HashSet<_>>();
     if remaining.is_empty() {
-        return Ok(available);
+        return Ok(true);
     }
 
-    if let Some(session) =
-        script_config.tempo.session_signer_for_multi_wallet_any_chain(wallets, expected_sender)?
-    {
-        let session_scope =
-            SignerScope::new(session.session.chain_id, session.access_key.wallet_address);
-        if remaining.contains(&session_scope) {
-            available.insert(session_scope);
-        }
-    }
+    let session_scope = script_config
+        .tempo
+        .session_signer_for_multi_wallet_any_chain(wallets, expected_sender)?
+        .map(|session| {
+            SignerScope::new(session.session.chain_id, session.access_key.wallet_address)
+        });
 
-    Ok(available)
+    Ok(remaining.iter().all(|tx| signers.contains(&tx.from) || Some(tx.scope()) == session_scope))
 }
 
 /// Container for the compiled contracts.
@@ -355,17 +344,15 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                     &self.script_config,
                     &remaining_froms,
                 )?;
-                let remaining_signers =
-                    remaining_transactions.iter().map(|tx| tx.scope()).collect::<HashSet<_>>();
-                let available_signers = available_script_signers(
+                let has_available_signers = has_available_script_signers(
                     &self.script_config,
                     &self.args.wallets,
                     &self.script_wallets,
                     expected_session_sender,
-                    &remaining_signers,
+                    &remaining_transactions,
                 )?;
 
-                if remaining_signers.is_subset(&available_signers) {
+                if has_available_signers {
                     (
                         self.args,
                         self.build_data,
@@ -468,7 +455,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn available_script_signers_skips_session_resolution_when_remaining_empty() {
+    async fn has_available_script_signers_skips_session_resolution_when_remaining_empty() {
         let _guard = SessionEnvGuard::set(B256::from([0x99; 32])).await;
         let script_config = ScriptConfig::<TempoEvmNetwork>::new(
             Default::default(),
@@ -479,15 +466,15 @@ mod tests {
         .await
         .unwrap();
 
-        let available = available_script_signers(
+        let has_available = has_available_script_signers(
             &script_config,
             &MultiWalletOpts::default(),
             &Wallets::new(Default::default(), None),
             None,
-            &HashSet::default(),
+            &[],
         )
         .unwrap();
 
-        assert!(available.is_empty());
+        assert!(has_available);
     }
 }

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -272,18 +272,9 @@ impl ScriptArgs {
     ) -> Result<PreprocessedState<FEN>> {
         let has_session = self.tempo.session_id()?.is_some();
         let session_sender = if has_session && !self.resume {
-            if self.multi {
-                self.tempo.session_sender_for_multi_wallet(&self.wallets, self.evm.sender)?
-            } else {
-                let expected_chain_id = Self::tempo_session_chain_id(&evm_opts).await;
-                self.tempo
-                    .session_signer_for_multi_wallet(
-                        &self.wallets,
-                        self.evm.sender,
-                        expected_chain_id,
-                    )?
-                    .map(|session| session.access_key.wallet_address)
-            }
+            // Initial scripts may only reveal multi-chain transactions during execution. Use the
+            // session root as the script sender here and validate chain scope during broadcast.
+            self.tempo.session_sender_for_multi_wallet(&self.wallets, self.evm.sender)?
         } else {
             None
         };
@@ -317,22 +308,6 @@ impl ScriptArgs {
 
         let script_config = ScriptConfig::new(config, evm_opts, self.batch, tempo).await?;
         Ok(PreprocessedState { args: self, script_config, script_wallets, browser_wallet })
-    }
-
-    /// Infers the command chain early enough to resolve a Tempo session during preprocessing.
-    ///
-    /// This is only used before normal single-chain script execution, where a command-level chain
-    /// is expected. Resume and multi-chain flows need to load or build their broadcast sequences
-    /// first, so they defer session chain validation until the transaction chains are known.
-    async fn tempo_session_chain_id(evm_opts: &EvmOpts) -> u64 {
-        if let Some(chain_id) = evm_opts.env.chain_id {
-            return chain_id;
-        }
-        evm_opts
-            .get_remote_chain_id()
-            .await
-            .map(|chain| chain.id())
-            .unwrap_or(foundry_common::DEV_CHAIN_ID)
     }
 
     /// Executes the script
@@ -1098,6 +1073,29 @@ mod tests {
             "foundry-cli",
             "Contract.sol",
             "--multi",
+            "--tempo.session",
+            &format!("{session_id:?}"),
+        ]);
+        let evm_opts = EvmOpts { networks: NetworkConfigs::with_tempo(), ..Default::default() };
+
+        let state = args.preprocess::<TempoEvmNetwork>(Config::default(), evm_opts).await.unwrap();
+        assert_eq!(state.script_config.evm_opts.sender, root);
+    }
+
+    #[tokio::test]
+    async fn tempo_session_initial_broadcast_sets_sender_without_chain_validation() {
+        let temp = tempdir().unwrap();
+        let session_id = B256::from([0x88; 32]);
+        let root = address!("0x1111111111111111111111111111111111111111");
+        let chain_id = 4217;
+
+        let _guard = TempoHomeGuard::set(temp.path()).await;
+        upsert_session_entry(active_session_entry(session_id, root, chain_id)).unwrap();
+
+        let args = ScriptArgs::parse_from([
+            "foundry-cli",
+            "Contract.sol",
+            "--broadcast",
             "--tempo.session",
             &format!("{session_id:?}"),
         ]);

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -271,7 +271,7 @@ impl ScriptArgs {
         mut evm_opts: EvmOpts,
     ) -> Result<PreprocessedState<FEN>> {
         let has_session = self.tempo.session_id()?.is_some();
-        let session_sender = if has_session && !self.resume && self.multi {
+        let session_sender = if has_session && (self.resume || self.multi) {
             self.tempo.session_sender_for_multi_wallet(&self.wallets, self.evm.sender)?
         } else if has_session && !self.resume {
             let expected_chain_id = Self::tempo_session_chain_id(&evm_opts).await;
@@ -1019,7 +1019,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tempo_session_resume_multi_defers_chain_validation_until_sequence_load() {
+    async fn tempo_session_resume_multi_sets_sender_without_chain_validation() {
         let temp = tempdir().unwrap();
         let session_id = B256::from([0x55; 32]);
         let root = address!("0x1111111111111111111111111111111111111111");
@@ -1039,7 +1039,30 @@ mod tests {
         let evm_opts = EvmOpts { networks: NetworkConfigs::with_tempo(), ..Default::default() };
 
         let state = args.preprocess::<TempoEvmNetwork>(Config::default(), evm_opts).await.unwrap();
-        assert_ne!(state.script_config.evm_opts.sender, root);
+        assert_eq!(state.script_config.evm_opts.sender, root);
+    }
+
+    #[tokio::test]
+    async fn tempo_session_resume_sets_sender_without_chain_validation() {
+        let temp = tempdir().unwrap();
+        let session_id = B256::from([0x77; 32]);
+        let root = address!("0x1111111111111111111111111111111111111111");
+        let chain_id = 4217;
+
+        let _guard = TempoHomeGuard::set(temp.path()).await;
+        upsert_session_entry(active_session_entry(session_id, root, chain_id)).unwrap();
+
+        let args = ScriptArgs::parse_from([
+            "foundry-cli",
+            "Contract.sol",
+            "--resume",
+            "--tempo.session",
+            &format!("{session_id:?}"),
+        ]);
+        let evm_opts = EvmOpts { networks: NetworkConfigs::with_tempo(), ..Default::default() };
+
+        let state = args.preprocess::<TempoEvmNetwork>(Config::default(), evm_opts).await.unwrap();
+        assert_eq!(state.script_config.evm_opts.sender, root);
     }
 
     #[tokio::test]

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -271,7 +271,7 @@ impl ScriptArgs {
         mut evm_opts: EvmOpts,
     ) -> Result<PreprocessedState<FEN>> {
         let has_session = self.tempo.session_id()?.is_some();
-        let session_sender = if has_session && !self.resume {
+        let session_sender = if has_session && !self.resume && !self.multi {
             let expected_chain_id = Self::tempo_session_chain_id(&evm_opts).await;
             self.tempo
                 .session_signer_for_multi_wallet(&self.wallets, self.evm.sender, expected_chain_id)?
@@ -314,8 +314,8 @@ impl ScriptArgs {
     /// Infers the command chain early enough to resolve a Tempo session during preprocessing.
     ///
     /// This is only used before normal script execution, where a single command-level chain is
-    /// expected. Resume flows may need to load the saved broadcast sequence first, so they defer
-    /// session chain validation until the remaining transaction chains are known.
+    /// expected. Resume and multi-chain flows need to load or build their broadcast sequences
+    /// first, so they defer session chain validation until the transaction chains are known.
     async fn tempo_session_chain_id(evm_opts: &EvmOpts) -> u64 {
         if let Some(chain_id) = evm_opts.env.chain_id {
             return chain_id;
@@ -1030,6 +1030,29 @@ mod tests {
             "foundry-cli",
             "Contract.sol",
             "--resume",
+            "--multi",
+            "--tempo.session",
+            &format!("{session_id:?}"),
+        ]);
+        let evm_opts = EvmOpts { networks: NetworkConfigs::with_tempo(), ..Default::default() };
+
+        let state = args.preprocess::<TempoEvmNetwork>(Config::default(), evm_opts).await.unwrap();
+        assert_ne!(state.script_config.evm_opts.sender, root);
+    }
+
+    #[tokio::test]
+    async fn tempo_session_non_resume_multi_defers_chain_validation_until_broadcast() {
+        let temp = tempdir().unwrap();
+        let session_id = B256::from([0x66; 32]);
+        let root = address!("0x1111111111111111111111111111111111111111");
+        let chain_id = 4217;
+
+        let _guard = TempoHomeGuard::set(temp.path()).await;
+        upsert_session_entry(active_session_entry(session_id, root, chain_id)).unwrap();
+
+        let args = ScriptArgs::parse_from([
+            "foundry-cli",
+            "Contract.sol",
             "--multi",
             "--tempo.session",
             &format!("{session_id:?}"),

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -270,12 +270,12 @@ impl ScriptArgs {
         config: Config,
         mut evm_opts: EvmOpts,
     ) -> Result<PreprocessedState<FEN>> {
-        let session_sender = if !self.resume {
+        let session_sender = if self.resume {
+            None
+        } else {
             // Initial scripts may only reveal multi-chain transactions during execution. Use the
             // session root as the script sender here and validate chain scope during broadcast.
             self.tempo.session_sender_for_multi_wallet(&self.wallets, self.evm.sender)?
-        } else {
-            None
         };
 
         let script_wallets = Wallets::new(self.wallets.get_multi_wallet().await?, self.evm.sender);

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -270,8 +270,7 @@ impl ScriptArgs {
         config: Config,
         mut evm_opts: EvmOpts,
     ) -> Result<PreprocessedState<FEN>> {
-        let has_session = self.tempo.session_id()?.is_some();
-        let session_sender = if has_session && !self.resume {
+        let session_sender = if !self.resume {
             // Initial scripts may only reveal multi-chain transactions during execution. Use the
             // session root as the script sender here and validate chain scope during broadcast.
             self.tempo.session_sender_for_multi_wallet(&self.wallets, self.evm.sender)?

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -311,6 +311,11 @@ impl ScriptArgs {
         Ok(PreprocessedState { args: self, script_config, script_wallets, browser_wallet })
     }
 
+    /// Infers the command chain early enough to resolve a Tempo session during preprocessing.
+    ///
+    /// This is only used before normal script execution, where a single command-level chain is
+    /// expected. Resume flows may need to load the saved broadcast sequence first, so they defer
+    /// session chain validation until the remaining transaction chains are known.
     async fn tempo_session_chain_id(evm_opts: &EvmOpts) -> u64 {
         if let Some(chain_id) = evm_opts.env.chain_id {
             return chain_id;

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -271,7 +271,9 @@ impl ScriptArgs {
         mut evm_opts: EvmOpts,
     ) -> Result<PreprocessedState<FEN>> {
         let has_session = self.tempo.session_id()?.is_some();
-        let session_sender = if has_session && !self.resume && !self.multi {
+        let session_sender = if has_session && !self.resume && self.multi {
+            self.tempo.session_sender_for_multi_wallet(&self.wallets, self.evm.sender)?
+        } else if has_session && !self.resume {
             let expected_chain_id = Self::tempo_session_chain_id(&evm_opts).await;
             self.tempo
                 .session_signer_for_multi_wallet(&self.wallets, self.evm.sender, expected_chain_id)?
@@ -313,8 +315,8 @@ impl ScriptArgs {
 
     /// Infers the command chain early enough to resolve a Tempo session during preprocessing.
     ///
-    /// This is only used before normal script execution, where a single command-level chain is
-    /// expected. Resume and multi-chain flows need to load or build their broadcast sequences
+    /// This is only used before normal single-chain script execution, where a command-level chain
+    /// is expected. Resume and multi-chain flows need to load or build their broadcast sequences
     /// first, so they defer session chain validation until the transaction chains are known.
     async fn tempo_session_chain_id(evm_opts: &EvmOpts) -> u64 {
         if let Some(chain_id) = evm_opts.env.chain_id {
@@ -1041,7 +1043,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tempo_session_non_resume_multi_defers_chain_validation_until_broadcast() {
+    async fn tempo_session_non_resume_multi_sets_sender_without_chain_validation() {
         let temp = tempdir().unwrap();
         let session_id = B256::from([0x66; 32]);
         let root = address!("0x1111111111111111111111111111111111111111");
@@ -1060,7 +1062,7 @@ mod tests {
         let evm_opts = EvmOpts { networks: NetworkConfigs::with_tempo(), ..Default::default() };
 
         let state = args.preprocess::<TempoEvmNetwork>(Config::default(), evm_opts).await.unwrap();
-        assert_ne!(state.script_config.evm_opts.sender, root);
+        assert_eq!(state.script_config.evm_opts.sender, root);
     }
 
     #[tokio::test]

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -270,7 +270,8 @@ impl ScriptArgs {
         config: Config,
         mut evm_opts: EvmOpts,
     ) -> Result<PreprocessedState<FEN>> {
-        let session_sender = if self.tempo.session_id()?.is_some() {
+        let has_session = self.tempo.session_id()?.is_some();
+        let session_sender = if has_session && !self.resume {
             let expected_chain_id = Self::tempo_session_chain_id(&evm_opts).await;
             self.tempo
                 .session_signer_for_multi_wallet(&self.wallets, self.evm.sender, expected_chain_id)?
@@ -1008,6 +1009,30 @@ mod tests {
 
         let state = args.preprocess::<TempoEvmNetwork>(Config::default(), evm_opts).await.unwrap();
         assert_eq!(state.script_config.evm_opts.sender, root);
+    }
+
+    #[tokio::test]
+    async fn tempo_session_resume_multi_defers_chain_validation_until_sequence_load() {
+        let temp = tempdir().unwrap();
+        let session_id = B256::from([0x55; 32]);
+        let root = address!("0x1111111111111111111111111111111111111111");
+        let chain_id = 4217;
+
+        let _guard = TempoHomeGuard::set(temp.path()).await;
+        upsert_session_entry(active_session_entry(session_id, root, chain_id)).unwrap();
+
+        let args = ScriptArgs::parse_from([
+            "foundry-cli",
+            "Contract.sol",
+            "--resume",
+            "--multi",
+            "--tempo.session",
+            &format!("{session_id:?}"),
+        ]);
+        let evm_opts = EvmOpts { networks: NetworkConfigs::with_tempo(), ..Default::default() };
+
+        let state = args.preprocess::<TempoEvmNetwork>(Config::default(), evm_opts).await.unwrap();
+        assert_ne!(state.script_config.evm_opts.sender, root);
     }
 
     #[tokio::test]

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -271,7 +271,7 @@ impl ScriptArgs {
         mut evm_opts: EvmOpts,
     ) -> Result<PreprocessedState<FEN>> {
         let has_session = self.tempo.session_id()?.is_some();
-        let session_sender = if has_session && (self.resume || self.multi) {
+        let session_sender = if has_session && !self.resume && self.multi {
             self.tempo.session_sender_for_multi_wallet(&self.wallets, self.evm.sender)?
         } else if has_session && !self.resume {
             let expected_chain_id = Self::tempo_session_chain_id(&evm_opts).await;
@@ -782,6 +782,19 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         Ok(())
     }
 
+    pub(crate) async fn update_tempo_session_sender(
+        &mut self,
+        wallets: &MultiWalletOpts,
+        expected_sender: Option<Address>,
+    ) -> Result<()> {
+        if let Some(sender) =
+            self.tempo.session_sender_for_multi_wallet(wallets, expected_sender)?
+        {
+            self.update_sender(sender).await?;
+        }
+        Ok(())
+    }
+
     async fn get_runner(&mut self) -> Result<ScriptRunner<FEN>> {
         self._get_runner(None, false).await
     }
@@ -1019,7 +1032,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tempo_session_resume_multi_sets_sender_without_chain_validation() {
+    async fn tempo_session_resume_multi_defers_session_sender_until_reexecution() {
         let temp = tempdir().unwrap();
         let session_id = B256::from([0x55; 32]);
         let root = address!("0x1111111111111111111111111111111111111111");
@@ -1039,11 +1052,11 @@ mod tests {
         let evm_opts = EvmOpts { networks: NetworkConfigs::with_tempo(), ..Default::default() };
 
         let state = args.preprocess::<TempoEvmNetwork>(Config::default(), evm_opts).await.unwrap();
-        assert_eq!(state.script_config.evm_opts.sender, root);
+        assert_ne!(state.script_config.evm_opts.sender, root);
     }
 
     #[tokio::test]
-    async fn tempo_session_resume_sets_sender_without_chain_validation() {
+    async fn tempo_session_resume_defers_session_sender_until_reexecution() {
         let temp = tempdir().unwrap();
         let session_id = B256::from([0x77; 32]);
         let root = address!("0x1111111111111111111111111111111111111111");
@@ -1062,7 +1075,7 @@ mod tests {
         let evm_opts = EvmOpts { networks: NetworkConfigs::with_tempo(), ..Default::default() };
 
         let state = args.preprocess::<TempoEvmNetwork>(Config::default(), evm_opts).await.unwrap();
-        assert_eq!(state.script_config.evm_opts.sender, root);
+        assert_ne!(state.script_config.evm_opts.sender, root);
     }
 
     #[tokio::test]

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -271,13 +271,19 @@ impl ScriptArgs {
         mut evm_opts: EvmOpts,
     ) -> Result<PreprocessedState<FEN>> {
         let has_session = self.tempo.session_id()?.is_some();
-        let session_sender = if has_session && !self.resume && self.multi {
-            self.tempo.session_sender_for_multi_wallet(&self.wallets, self.evm.sender)?
-        } else if has_session && !self.resume {
-            let expected_chain_id = Self::tempo_session_chain_id(&evm_opts).await;
-            self.tempo
-                .session_signer_for_multi_wallet(&self.wallets, self.evm.sender, expected_chain_id)?
-                .map(|session| session.access_key.wallet_address)
+        let session_sender = if has_session && !self.resume {
+            if self.multi {
+                self.tempo.session_sender_for_multi_wallet(&self.wallets, self.evm.sender)?
+            } else {
+                let expected_chain_id = Self::tempo_session_chain_id(&evm_opts).await;
+                self.tempo
+                    .session_signer_for_multi_wallet(
+                        &self.wallets,
+                        self.evm.sender,
+                        expected_chain_id,
+                    )?
+                    .map(|session| session.access_key.wallet_address)
+            }
         } else {
             None
         };

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -254,8 +254,8 @@ impl ScriptArgs {
     async fn resolved_evm_opts(&self) -> Result<(Config, EvmOpts)> {
         let (config, mut evm_opts) = self.load_config_and_evm_opts()?;
 
-        if self.tempo.is_tempo() {
-            // If fee token or expiry is set directly select tempo
+        if self.tempo.is_tempo() || self.tempo.session_id()?.is_some() {
+            // If Tempo tx options or a session are set, select the Tempo network.
             evm_opts.networks = NetworkConfigs::with_tempo();
         } else {
             // Auto-detect network from fork chain ID when not explicitly configured.
@@ -270,10 +270,21 @@ impl ScriptArgs {
         config: Config,
         mut evm_opts: EvmOpts,
     ) -> Result<PreprocessedState<FEN>> {
+        let session_sender = if self.tempo.session_id()?.is_some() {
+            let expected_chain_id = Self::tempo_session_chain_id(&evm_opts).await;
+            self.tempo
+                .session_signer_for_multi_wallet(&self.wallets, self.evm.sender, expected_chain_id)?
+                .map(|session| session.access_key.wallet_address)
+        } else {
+            None
+        };
+
         let script_wallets = Wallets::new(self.wallets.get_multi_wallet().await?, self.evm.sender);
         let browser_wallet = self.wallets.browser_signer::<FEN::Network>().await?;
 
-        if let Some(sender) = self.maybe_load_private_key()? {
+        if let Some(sender) = session_sender {
+            evm_opts.sender = sender;
+        } else if let Some(sender) = self.maybe_load_private_key()? {
             evm_opts.sender = sender;
         } else if self.evm.sender.is_none() {
             // If no sender was explicitly set via --sender, auto-detect it from available signers:
@@ -299,6 +310,17 @@ impl ScriptArgs {
         Ok(PreprocessedState { args: self, script_config, script_wallets, browser_wallet })
     }
 
+    async fn tempo_session_chain_id(evm_opts: &EvmOpts) -> u64 {
+        if let Some(chain_id) = evm_opts.env.chain_id {
+            return chain_id;
+        }
+        evm_opts
+            .get_remote_chain_id()
+            .await
+            .map(|chain| chain.id())
+            .unwrap_or(foundry_common::DEV_CHAIN_ID)
+    }
+
     /// Executes the script
     #[allow(clippy::large_stack_frames)]
     pub async fn run_script(self) -> Result<()> {
@@ -310,6 +332,10 @@ impl ScriptArgs {
 
         if self.batch && !is_tempo {
             eyre::bail!("--batch mode is only supported on Tempo networks");
+        }
+
+        if self.unlocked && self.tempo.session_id()?.is_some() {
+            eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --unlocked");
         }
 
         if is_tempo {
@@ -831,10 +857,69 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
 mod tests {
     use super::*;
     use alloy_network::Ethereum;
-    use alloy_primitives::address;
+    use alloy_primitives::{B256, address};
+    use foundry_cli::opts::TEMPO_SESSION_ID_ENV;
+    use foundry_common::tempo::{
+        KeyType, SessionEntry, SessionKeyMaterial, SessionStatus, TEMPO_HOME_ENV,
+        upsert_session_entry,
+    };
     use foundry_config::{NamedChain, UnresolvedEnvVarError};
-    use std::fs;
+    use std::{fs, sync::LazyLock};
     use tempfile::tempdir;
+    use tokio::sync::{Mutex, MutexGuard};
+
+    const SESSION_PRIVATE_KEY: &str =
+        "0x59c6995e998f97a5a004497e5da3b5d2b2b66a87f064d39c44da0b6d6e4f8ff0";
+    static TEMPO_HOME_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    fn active_session_entry(
+        session_id: B256,
+        root_account: Address,
+        chain_id: u64,
+    ) -> SessionEntry {
+        let key = foundry_wallets::utils::create_private_key_signer(SESSION_PRIVATE_KEY).unwrap();
+        SessionEntry {
+            session_id,
+            root_account,
+            chain_id,
+            key_address: key.address(),
+            expiry: u64::MAX,
+            scope: None,
+            limits: None,
+            status: SessionStatus::Active,
+            key: Some(SessionKeyMaterial {
+                key_type: KeyType::Secp256k1,
+                key: SESSION_PRIVATE_KEY.to_string(),
+                key_authorization: None,
+            }),
+        }
+    }
+
+    struct TempoHomeGuard {
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl TempoHomeGuard {
+        async fn set(path: &std::path::Path) -> Self {
+            let guard = TEMPO_HOME_LOCK.lock().await;
+            // SAFETY: test-only environment override for Tempo local state.
+            unsafe {
+                std::env::remove_var(TEMPO_SESSION_ID_ENV);
+                std::env::set_var(TEMPO_HOME_ENV, path);
+            }
+            Self { _guard: guard }
+        }
+    }
+
+    impl Drop for TempoHomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: restore process environment after the critical section.
+            unsafe {
+                std::env::remove_var(TEMPO_HOME_ENV);
+                std::env::remove_var(TEMPO_SESSION_ID_ENV);
+            }
+        }
+    }
 
     #[test]
     fn can_parse_sig() {
@@ -885,6 +970,89 @@ mod tests {
             ScriptArgs::parse_from(["foundry-cli", "Contract.sol", "--tempo.nonce-key", "1"]);
 
         assert_eq!(args.tempo.nonce_key, Some(U256::from(1)));
+    }
+
+    #[test]
+    fn can_parse_tempo_session_opt() {
+        let args = ScriptArgs::parse_from([
+            "foundry-cli",
+            "Contract.sol",
+            "--tempo.session",
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
+        ]);
+
+        assert_eq!(args.tempo.session, Some(B256::from([0x11; 32])),);
+    }
+
+    #[tokio::test]
+    async fn tempo_session_sets_script_sender_to_root_account() {
+        let temp = tempdir().unwrap();
+        let session_id = B256::from([0x22; 32]);
+        let root = address!("0x1111111111111111111111111111111111111111");
+        let chain_id = foundry_common::DEV_CHAIN_ID;
+
+        let _guard = TempoHomeGuard::set(temp.path()).await;
+        upsert_session_entry(active_session_entry(session_id, root, chain_id)).unwrap();
+
+        let args = ScriptArgs::parse_from([
+            "foundry-cli",
+            "Contract.sol",
+            "--tempo.session",
+            &format!("{session_id:?}"),
+        ]);
+        let evm_opts = EvmOpts {
+            networks: NetworkConfigs::with_tempo(),
+            env: foundry_evm::opts::Env { chain_id: Some(chain_id), ..Default::default() },
+            ..Default::default()
+        };
+
+        let state = args.preprocess::<TempoEvmNetwork>(Config::default(), evm_opts).await.unwrap();
+        assert_eq!(state.script_config.evm_opts.sender, root);
+    }
+
+    #[tokio::test]
+    async fn tempo_session_env_selects_tempo_network() {
+        let temp = tempdir().unwrap();
+        let _guard = TempoHomeGuard::set(temp.path()).await;
+        let session_id = B256::from([0x44; 32]);
+        // SAFETY: serialized by TempoHomeGuard.
+        unsafe { std::env::set_var(TEMPO_SESSION_ID_ENV, format!("{session_id:?}")) };
+
+        let args = ScriptArgs::parse_from(["foundry-cli", "Contract.sol"]);
+        let (_, evm_opts) = args.resolved_evm_opts().await.unwrap();
+
+        assert!(evm_opts.networks.is_tempo());
+    }
+
+    #[tokio::test]
+    async fn tempo_session_rejects_explicit_script_wallet_signer() {
+        let temp = tempdir().unwrap();
+        let session_id = B256::from([0x33; 32]);
+        let root = address!("0x1111111111111111111111111111111111111111");
+        let chain_id = foundry_common::DEV_CHAIN_ID;
+
+        let _guard = TempoHomeGuard::set(temp.path()).await;
+        upsert_session_entry(active_session_entry(session_id, root, chain_id)).unwrap();
+
+        let args = ScriptArgs::parse_from([
+            "foundry-cli",
+            "Contract.sol",
+            "--tempo.session",
+            &format!("{session_id:?}"),
+            "--private-key",
+            SESSION_PRIVATE_KEY,
+        ]);
+        let evm_opts = EvmOpts {
+            networks: NetworkConfigs::with_tempo(),
+            env: foundry_evm::opts::Env { chain_id: Some(chain_id), ..Default::default() },
+            ..Default::default()
+        };
+
+        let err = match args.preprocess::<TempoEvmNetwork>(Config::default(), evm_opts).await {
+            Ok(_) => panic!("expected --tempo.session with --private-key to fail"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("explicit wallet signer"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
This PR adds Tempo session key support to forge script, so scripts can run with a temporary, scoped access key instead of requiring a long-lived hot wallet signer. The implementation keeps the session flow narrow: it resolves the configured session only when needed, enforces that a session covers a single root sender, handles gas estimation for access-key transactions, and preserves valid --resume / multi-chain broadcasts by validating only the transactions that still need to be sent. 