### PR TITLE
feat(symbolic): cache satisfiability queries

### DIFF
--- a/crates/evm/symbolic/src/consts.rs
+++ b/crates/evm/symbolic/src/consts.rs
@@ -40,6 +40,9 @@ pub(crate) const PORTFOLIO_SCHEDULER_MIN_RECENCY_WEIGHT: i64 = 1;
 pub(crate) const PORTFOLIO_SCHEDULER_SPEED_BONUS_CAP_MS: u128 = 100;
 pub(crate) const PORTFOLIO_SCHEDULER_MAX_SPEED_BONUS: i64 = 100;
 
+// Solver query cache limits
+pub(crate) const SYMBOLIC_SOLVER_SAT_CACHE_MAX_ENTRIES: usize = 4096;
+
 // Hard arithmetic witness search limits
 pub(crate) const HARD_ARITH_FALLBACK_MAX_VARS: usize = 4;
 pub(crate) const HARD_ARITH_FALLBACK_MAX_CANDIDATES_PER_VAR: usize = 24;

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -152,6 +152,7 @@ pub(crate) struct SmtLibSubprocessSolver {
     portfolio_diagnostics: PortfolioDiagnostics,
     captured_diagnostics: Option<String>,
     heuristic_witnesses: usize,
+    sat_cache: BTreeMap<Vec<BoolExpr>, bool>,
 }
 
 impl SmtLibSubprocessSolver {
@@ -173,6 +174,7 @@ impl SmtLibSubprocessSolver {
             portfolio_diagnostics: PortfolioDiagnostics::default(),
             captured_diagnostics: None,
             heuristic_witnesses: 0,
+            sat_cache: BTreeMap::new(),
         }
     }
 
@@ -240,6 +242,13 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
 
     /// Returns whether `is_sat` holds.
     fn is_sat(&mut self, constraints: &[BoolExpr]) -> Result<bool, SymbolicError> {
+        let smt_constraints = normalize_constraints_for_solver(constraints);
+        let cache_key = sat_cache_key(&smt_constraints);
+        if let Some(result) = self.sat_cache.get(&cache_key) {
+            trace!(result, "is_sat: normalized cache hit");
+            return Ok(*result);
+        }
+
         self.reserve_query()?;
         self.record_query();
         let _span = trace_span!(
@@ -250,9 +259,9 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
         )
         .entered();
         trace!(query_id = self.queries, constraint_count = constraints.len(), "solver is_sat");
-        let smt_constraints = normalize_constraints_for_solver(constraints);
         if product_monotonic_unsat_normalized(&smt_constraints) {
             trace!("is_sat: monotonic product contradiction");
+            self.cache_sat_result(cache_key, false);
             return Ok(false);
         }
         let output = match self.query_normalized(&smt_constraints, false, constraints) {
@@ -268,8 +277,14 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
             Err(err) => return Err(err),
         };
         match output.lines().next().unwrap_or_default().trim() {
-            "sat" => Ok(true),
-            "unsat" => Ok(false),
+            "sat" => {
+                self.cache_sat_result(cache_key, true);
+                Ok(true)
+            }
+            "unsat" => {
+                self.cache_sat_result(cache_key, false);
+                Ok(false)
+            }
             "unknown" => {
                 if hard_arith_fallback_model(&smt_constraints).is_some() {
                     self.heuristic_witnesses += 1;
@@ -366,6 +381,13 @@ impl SmtLibSubprocessSolver {
         }
     }
 
+    /// Caches a definitive normalized satisfiability result if the cache has room.
+    fn cache_sat_result(&mut self, key: Vec<BoolExpr>, result: bool) {
+        if self.sat_cache.len() < SYMBOLIC_SOLVER_SAT_CACHE_MAX_ENTRIES {
+            self.sat_cache.insert(key, result);
+        }
+    }
+
     /// Sends already-normalized constraints to the configured solver portfolio.
     pub(crate) fn query_normalized(
         &mut self,
@@ -419,6 +441,17 @@ impl SmtLibSubprocessSolver {
         }
         result.output
     }
+}
+
+/// Returns a structural key for normalized satisfiability cache lookups.
+fn sat_cache_key(constraints: &[BoolExpr]) -> Vec<BoolExpr> {
+    let mut key = constraints
+        .iter()
+        .filter(|constraint| !matches!(constraint, BoolExpr::Const(true)))
+        .cloned()
+        .collect::<Vec<_>>();
+    key.sort();
+    key
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2489,6 +2489,76 @@ fn portfolio_test_marker(name: &str) -> std::path::PathBuf {
 }
 
 #[cfg(unix)]
+/// Returns a fake solver command that counts invocations before emitting `response`.
+fn counted_solver_command(marker: &Path, response: &'static str) -> SolverCommand {
+    SolverCommand::new(
+        vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            format!(
+                "count=$(cat \"$1\" 2>/dev/null || printf 0); \
+                 count=$((count + 1)); printf '%s' \"$count\" > \"$1\"; \
+                 cat >/dev/null; printf '{response}\\n'"
+            ),
+            "sh".to_string(),
+            marker.display().to_string(),
+        ],
+        false,
+    )
+    .unwrap()
+}
+
+#[cfg(unix)]
+/// Returns how many times a counted fake solver command was invoked.
+fn counted_solver_invocations(marker: &Path) -> usize {
+    std::fs::read_to_string(marker).ok().and_then(|count| count.parse().ok()).unwrap_or_default()
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for normalized satisfiability query cache hits.
+fn sat_cache_reuses_normalized_is_sat_results() {
+    let marker = portfolio_test_marker("sat-cache");
+    let commands = vec![counted_solver_command(&marker, "sat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
+    let x = Expr::Var("x".to_string());
+    let y = Expr::Var("y".to_string());
+    let constraints = vec![
+        BoolExpr::Const(true),
+        BoolExpr::eq(x.clone(), Expr::Const(U256::from(1))),
+        BoolExpr::eq(y.clone(), Expr::Const(U256::from(2))),
+    ];
+    let reordered_constraints = vec![
+        BoolExpr::eq(y, Expr::Const(U256::from(2))),
+        BoolExpr::eq(x, Expr::Const(U256::from(1))),
+    ];
+
+    assert!(solver.is_sat(&constraints).unwrap());
+    assert!(solver.is_sat(&reordered_constraints).unwrap());
+
+    assert_eq!(solver.stats().solver_queries, 1);
+    assert_eq!(counted_solver_invocations(&marker), 1);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for leaving unknown satisfiability results uncached.
+fn sat_cache_does_not_cache_unknown_results() {
+    let marker = portfolio_test_marker("sat-cache-unknown");
+    let commands = vec![counted_solver_command(&marker, "unknown")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 4, false);
+    let constraints = vec![BoolExpr::eq(Expr::Var("x".to_string()), Expr::Const(U256::from(1)))];
+
+    assert!(matches!(solver.is_sat(&constraints), Err(SymbolicError::SolverUnknown)));
+    assert!(matches!(solver.is_sat(&constraints), Err(SymbolicError::SolverUnknown)));
+
+    assert_eq!(solver.stats().solver_queries, 2);
+    assert_eq!(counted_solver_invocations(&marker), 2);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
 #[test]
 /// Regression coverage for `portfolio_sat_beats_early_unsat`.
 fn portfolio_sat_beats_early_unsat() {


### PR DESCRIPTION
## Summary
- add a bounded per-executor cache for normalized `is_sat` results
- cache only definitive sat/unsat answers, not model queries, unknowns, errors, or heuristic fallback results
- use a conservative structural key that ignores top-level `true` constraints and sorts top-level conjuncts