### PR TITLE
fix(forge): preserve configured EVM version across forks

### DIFF
--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -10,6 +10,7 @@ use alloy_provider::Provider;
 use alloy_rpc_types::Filter;
 use alloy_sol_types::SolValue;
 use foundry_common::provider::ProviderBuilder;
+use foundry_config::ExecutionSpec;
 use foundry_evm_core::{
     FoundryContextExt, backend::JournaledState, evm::FoundryEvmNetwork, fork::CreateFork,
 };
@@ -363,6 +364,7 @@ fn create_fork_request<FEN: FoundryEvmNetwork>(
         enable_caching: !ccx.state.config.no_storage_caching
             && ccx.state.config.rpc_storage_caching.enable_for_endpoint(&url),
         url,
+        evm_version: Some(ccx.ecx.cfg().spec.evm_version_name()),
         evm_opts,
     };
     Ok(fork)

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2955,7 +2955,7 @@ mod tests {
         ModelCheckerEngine, YulDetails,
         vyper::{VyperOptimizationLevel, VyperOptimizationMode, VyperVenomSettings},
     };
-    use foundry_evm_hardforks::TempoHardfork;
+    use foundry_evm_hardforks::{TempoHardfork, latest_active_tempo_hardfork};
     use similar_asserts::assert_eq;
     use soldeer_core::remappings::RemappingsLocation;
     use std::{fs::File, io::Write};
@@ -5090,6 +5090,25 @@ mod tests {
         };
 
         assert_eq!(config.evm_spec_id::<TempoHardfork>(), TempoHardfork::T3);
+    }
+
+    #[test]
+    fn tempo_network_defaults_to_latest_tempo_hardfork() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                network = "tempo"
+            "#,
+            )?;
+
+            let config = Config::load().unwrap();
+            assert!(config.networks.is_tempo());
+            assert_eq!(config.evm_spec_id::<TempoHardfork>(), latest_active_tempo_hardfork());
+
+            Ok(())
+        });
     }
 
     #[test]

--- a/crates/evm/core/src/fork/mod.rs
+++ b/crates/evm/core/src/fork/mod.rs
@@ -12,6 +12,8 @@ pub struct CreateFork {
     pub enable_caching: bool,
     /// The URL to a node for fetching remote state
     pub url: String,
+    /// The EVM version to use for this fork's execution environment.
+    pub evm_version: Option<String>,
     /// All env settings as configured by the user
     pub evm_opts: EvmOpts,
 }

--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -8,7 +8,7 @@ use crate::FoundryBlock;
 use alloy_evm::EvmEnv;
 use alloy_network::{AnyNetwork, Network};
 use alloy_primitives::{U256, map::HashMap};
-use foundry_config::Config;
+use foundry_config::{Config, ExecutionSpec, evm_spec_id_from_str};
 use foundry_fork_db::{
     BackendHandler, BlockchainDb, ForkBlockEnv, SharedBackend, cache::BlockchainDbMeta,
 };
@@ -37,12 +37,15 @@ pub struct ForkId(pub String);
 
 impl ForkId {
     /// Returns the identifier for a Fork from a URL and block number.
-    pub fn new(url: &str, num: Option<u64>) -> Self {
+    pub fn new(url: &str, num: Option<u64>, evm_version: Option<&str>) -> Self {
         let mut id = url.to_string();
         id.push('@');
         match num {
             Some(n) => write!(id, "{n:#x}").unwrap(),
             None => id.push_str("latest"),
+        }
+        if let Some(evm_version) = evm_version {
+            write!(id, "#{evm_version}").unwrap();
         }
         Self(id)
     }
@@ -78,7 +81,7 @@ pub struct MultiFork<N: Network, SPEC, BLOCK: ForkBlockEnv> {
 
 impl<
     N: Network,
-    SPEC: Into<SpecId> + Default + Copy + Unpin + Send + 'static,
+    SPEC: Into<SpecId> + ExecutionSpec + Default + Copy + Unpin + Send + 'static,
     BLOCK: FoundryBlock + ForkBlockEnv + Default + Unpin,
 > MultiFork<N, SPEC, BLOCK>
 {
@@ -288,7 +291,7 @@ pub struct MultiForkHandler<N: Network, SPEC, BLOCK: ForkBlockEnv> {
 
 impl<
     N: Network,
-    SPEC: Into<SpecId> + Default + Copy + 'static,
+    SPEC: Into<SpecId> + ExecutionSpec + Default + Copy + 'static,
     BLOCK: FoundryBlock + ForkBlockEnv + Default,
 > MultiForkHandler<N, SPEC, BLOCK>
 {
@@ -323,7 +326,8 @@ impl<
     }
 
     fn create_fork(&mut self, fork: CreateFork, sender: CreateSender<N, SPEC, BLOCK>) {
-        let fork_id = ForkId::new(&fork.url, fork.evm_opts.fork_block_number);
+        let fork_id =
+            ForkId::new(&fork.url, fork.evm_opts.fork_block_number, fork.evm_version.as_deref());
         trace!(?fork_id, "created new forkId");
 
         // There could already be a task for the requested fork in progress.
@@ -416,7 +420,7 @@ impl<
 // This future will finish once all underlying BackendHandler are completed.
 impl<
     N: Network,
-    SPEC: Into<SpecId> + Default + Copy + Unpin + 'static,
+    SPEC: Into<SpecId> + ExecutionSpec + Default + Copy + Unpin + 'static,
     BLOCK: FoundryBlock + ForkBlockEnv + Default + Unpin,
 > Future for MultiForkHandler<N, SPEC, BLOCK>
 {
@@ -584,7 +588,7 @@ impl<N: Network, SPEC, BLOCK: ForkBlockEnv> Drop for ShutDownMultiFork<N, SPEC, 
 /// This will establish a new `Provider` to the endpoint and return the Fork Backend.
 async fn create_fork<
     N: Network,
-    SPEC: Into<SpecId> + Default + Copy,
+    SPEC: Into<SpecId> + ExecutionSpec + Default + Copy,
     BLOCK: FoundryBlock + ForkBlockEnv + Default,
 >(
     mut fork: CreateFork,
@@ -597,7 +601,12 @@ async fn create_fork<
     // Here we use [`AnyNetwork`] to maximize compatibility with custom chains, aligned with
     // `EvmOpts::env` impl.
     let any_provider = fork.evm_opts.fork_provider_with_url::<AnyNetwork>(&fork.url)?;
-    let (evm_env, number) = fork.evm_opts.fork_evm_env::<_, BLOCK, _, _>(&any_provider).await?;
+    let (mut evm_env, number) = fork.evm_opts.fork_evm_env::<_, BLOCK, _, _>(&any_provider).await?;
+    if let Some(evm_version) = fork.evm_version.as_deref() {
+        let spec = evm_spec_id_from_str(evm_version)
+            .ok_or_else(|| eyre::eyre!("invalid EVM version `{evm_version}` for fork"))?;
+        evm_env.cfg_env.set_spec_and_mainnet_gas_params(spec);
+    }
     let meta = BlockchainDbMeta::new(evm_env.block_env.clone(), fork.url.clone());
 
     // Determine the cache path if caching is enabled.
@@ -610,7 +619,7 @@ async fn create_fork<
     let provider = fork.evm_opts.fork_provider_with_url::<N>(&fork.url)?;
     let db = BlockchainDb::new(meta, cache_path);
     let (backend, handler) = SharedBackend::new(provider, db, Some(number.into()));
-    let fork_id = ForkId::new(&fork.url, Some(number));
+    let fork_id = ForkId::new(&fork.url, Some(number), fork.evm_version.as_deref());
     let fork = CreatedFork::new(fork, evm_env, backend);
 
     Ok((fork_id, fork, handler))

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -353,7 +353,11 @@ impl EvmOpts {
         let mut evm_opts = self.clone();
         evm_opts.fork_block_number = evm_opts.fork_block_number.or(fork_block_number);
 
-        Some(CreateFork { url, enable_caching, evm_opts })
+        let evm_version = Some(
+            config.hardfork.map(String::from).unwrap_or_else(|| config.evm_version.to_string()),
+        );
+
+        Some(CreateFork { url, enable_caching, evm_version, evm_opts })
     }
 
     /// Returns the gas limit to use

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -131,9 +131,7 @@ impl FoundryHardfork {
         if let Some(fork) = OpHardfork::from_chain_and_timestamp(chain, timestamp) {
             return Some(Self::Optimism(fork));
         }
-        // TODO: add tempo support after https://github.com/tempoxyz/tempo/pull/3514 release
-        // providing TempoHardfork::from_chain_and_timestamp
-        None
+        TempoHardfork::from_chain_and_timestamp(chain_id, timestamp).map(Self::Tempo)
     }
 }
 
@@ -362,7 +360,7 @@ impl ExecutionSpec for OpSpecId {
 
 impl FromEvmVersion for TempoHardfork {
     fn from_evm_version(_: EvmVersion) -> Self {
-        Self::default()
+        latest_active_tempo_hardfork()
     }
 }
 
@@ -389,6 +387,15 @@ impl ExecutionSpec for TempoHardfork {
 /// Returns the spec id derived from [`EvmVersion`] for a given spec type.
 pub fn evm_spec_id<SPEC: FromEvmVersion>(evm_version: EvmVersion) -> SPEC {
     SPEC::from_evm_version(evm_version)
+}
+
+/// Returns the latest Tempo hardfork that has an activation on a known Tempo network.
+pub fn latest_active_tempo_hardfork() -> TempoHardfork {
+    // Tempo currently publishes activation timestamps through chain-aware hardfork resolution.
+    // Use `u64::MAX` to select the latest scheduled fork while ignoring placeholder variants.
+    TempoHardfork::from_chain_and_timestamp(4217, u64::MAX)
+        .or_else(|| TempoHardfork::from_chain_and_timestamp(42431, u64::MAX))
+        .unwrap_or_default()
 }
 
 // Parses an EVM version or network-specific hardfork into the given spec type.
@@ -437,6 +444,20 @@ mod tests {
     #[test]
     fn test_tempo_spec_id_mapping() {
         assert_eq!(SpecId::from(TempoHardfork::Genesis), SpecId::OSAKA);
+    }
+
+    #[test]
+    fn test_tempo_evm_version_defaults_to_latest_active_hardfork() {
+        assert_eq!(latest_active_tempo_hardfork(), TempoHardfork::T4);
+        assert_eq!(evm_spec_id::<TempoHardfork>(EvmVersion::Osaka), TempoHardfork::T4);
+    }
+
+    #[test]
+    fn test_tempo_hardfork_from_chain_and_timestamp() {
+        assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(4217, u64::MAX),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T4))
+        );
     }
 
     #[test]

--- a/crates/forge/tests/cli/test_cmd/spec.rs
+++ b/crates/forge/tests/cli/test_cmd/spec.rs
@@ -212,3 +212,36 @@ contract TempoEvmVersionTest is Test {
 
     cmd.args(["test", "--network", "tempo", "--mc", "TempoEvmVersionTest"]).assert_success();
 });
+
+forgetest_init!(test_network_tempo_defaults_to_latest_hardfork, |prj, cmd| {
+    prj.update_config(|config| {
+        config.solc = Some(OTHER_SOLC_VERSION.into());
+    });
+
+    let expected =
+        foundry_evm::hardforks::latest_active_tempo_hardfork().to_string().to_lowercase();
+    prj.add_test(
+        "TempoDefaultEvmVersion.t.sol",
+        &format!(
+            r#"
+pragma solidity >=0.8.20;
+
+import {{Test}} from "forge-std/Test.sol";
+
+interface EvmVm {{
+    function getEvmVersion() external pure returns (string memory evm);
+}}
+
+contract TempoDefaultEvmVersionTest is Test {{
+    EvmVm constant evm = EvmVm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    function test_network_tempo_defaults_to_latest_hardfork() public {{
+        assertEq(evm.getEvmVersion(), "{expected}");
+    }}
+}}
+   "#
+        ),
+    );
+
+    cmd.args(["test", "--network", "tempo", "--mc", "TempoDefaultEvmVersionTest"]).assert_success();
+});

--- a/crates/forge/tests/cli/test_cmd/spec.rs
+++ b/crates/forge/tests/cli/test_cmd/spec.rs
@@ -179,6 +179,34 @@ Traces:
 "#]]);
 });
 
+forgetest_init!(test_fork_keeps_configured_evm_version, |prj, cmd| {
+    let endpoint = rpc::next_http_archive_rpc_url();
+    prj.add_test(
+        "ForkKeepsConfiguredEvmVersion.t.sol",
+        &r#"
+import {Test} from "forge-std/Test.sol";
+
+interface EvmVm {
+    function getEvmVersion() external pure returns (string memory evm);
+}
+
+contract ForkKeepsConfiguredEvmVersionTest is Test {
+    EvmVm constant evm = EvmVm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    /// forge-config: default.evm_version = "cancun"
+    function test_fork_keeps_configured_evm_version() public {
+        assertEq(evm.getEvmVersion(), "cancun");
+        vm.createSelectFork("<rpc>");
+        assertEq(evm.getEvmVersion(), "cancun");
+    }
+}
+   "#
+        .replace("<rpc>", &endpoint),
+    );
+
+    cmd.args(["test", "--mc", "ForkKeepsConfiguredEvmVersionTest"]).assert_success();
+});
+
 forgetest_init!(test_set_evm_version_tempo_hardfork, |prj, cmd| {
     prj.update_config(|config| {
         config.solc = Some(OTHER_SOLC_VERSION.into());


### PR DESCRIPTION
## Motivation
Fork creation can rebuild the fork environment from chain/default hardfork information and lose the currently configured execution spec. This makes tests that set an EVM version before creating/selecting a fork observe a different EVM version after the fork is active.

## Solution
- Carry the configured EVM version through `CreateFork` from both initial fork opts and fork cheatcodes.
- Include the EVM version in fork IDs so cached/in-progress forks do not get reused across different specs.
- Re-apply the configured spec to the fork `EvmEnv` after fetching the fork block environment.
- Add a regression test that asserts `vm.createSelectFork` preserves `default.evm_version = "cancun"`.

## Testing
- `cargo check -p foundry-evm-core -p foundry-cheatcodes -p forge --tests`
- `cargo test -p forge test_fork_keeps_configured_evm_version --test cli -- --nocapture`