### PR TITLE
feat(symbolic): cache solver models

### DIFF
--- a/crates/evm/symbolic/src/consts.rs
+++ b/crates/evm/symbolic/src/consts.rs
@@ -42,6 +42,7 @@ pub(crate) const PORTFOLIO_SCHEDULER_MAX_SPEED_BONUS: i64 = 100;
 
 // Solver query cache limits
 pub(crate) const SYMBOLIC_SOLVER_SAT_CACHE_MAX_ENTRIES: usize = 4096;
+pub(crate) const SYMBOLIC_SOLVER_MODEL_CACHE_MAX_ENTRIES: usize = 512;
 
 // Hard arithmetic witness search limits
 pub(crate) const HARD_ARITH_FALLBACK_MAX_VARS: usize = 4;

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -203,8 +203,23 @@ pub enum SymbolicStopReason {
 pub struct SymbolicStats {
     /// Number of explored symbolic paths.
     pub paths: usize,
-    /// Number of solver queries issued during the run.
+    /// Number of normalized solver queries issued during the run.
     pub solver_queries: usize,
+    /// Number of satisfiability checks requested by the executor.
+    #[serde(default)]
+    pub sat_queries: usize,
+    /// Number of concrete model requests requested by the executor.
+    #[serde(default)]
+    pub model_queries: usize,
+    /// Number of satisfiability checks served from the normalized cache.
+    #[serde(default)]
+    pub sat_cache_hits: usize,
+    /// Number of model requests served from the normalized model cache.
+    #[serde(default)]
+    pub model_cache_hits: usize,
+    /// Wall-clock time spent waiting on backend solver subprocesses, in milliseconds.
+    #[serde(default)]
+    pub solver_time_ms: u64,
 }
 
 /// SMT-LIB-backed symbolic executor.

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -153,6 +153,12 @@ pub(crate) struct SmtLibSubprocessSolver {
     captured_diagnostics: Option<String>,
     heuristic_witnesses: usize,
     sat_cache: BTreeMap<Vec<BoolExpr>, bool>,
+    model_cache: BTreeMap<Vec<BoolExpr>, BTreeMap<String, U256>>,
+    sat_queries: usize,
+    model_queries: usize,
+    sat_cache_hits: usize,
+    model_cache_hits: usize,
+    solver_time: Duration,
 }
 
 impl SmtLibSubprocessSolver {
@@ -175,6 +181,12 @@ impl SmtLibSubprocessSolver {
             captured_diagnostics: None,
             heuristic_witnesses: 0,
             sat_cache: BTreeMap::new(),
+            model_cache: BTreeMap::new(),
+            sat_queries: 0,
+            model_queries: 0,
+            sat_cache_hits: 0,
+            model_cache_hits: 0,
+            solver_time: Duration::ZERO,
         }
     }
 
@@ -192,7 +204,15 @@ impl SmtLibSubprocessSolver {
 impl SymbolicSolver for SmtLibSubprocessSolver {
     /// Implements the `stats` solver helper.
     fn stats(&self) -> SymbolicStats {
-        SymbolicStats { paths: 0, solver_queries: self.queries }
+        SymbolicStats {
+            paths: 0,
+            solver_queries: self.queries,
+            sat_queries: self.sat_queries,
+            model_queries: self.model_queries,
+            sat_cache_hits: self.sat_cache_hits,
+            model_cache_hits: self.model_cache_hits,
+            solver_time_ms: self.solver_time.as_millis().try_into().unwrap_or(u64::MAX),
+        }
     }
 
     /// Registers a live query observer for progress rendering.
@@ -242,9 +262,11 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
 
     /// Returns whether `is_sat` holds.
     fn is_sat(&mut self, constraints: &[BoolExpr]) -> Result<bool, SymbolicError> {
+        self.sat_queries += 1;
         let smt_constraints = normalize_constraints_for_solver(constraints);
-        let cache_key = sat_cache_key(&smt_constraints);
+        let cache_key = constraint_cache_key(&smt_constraints);
         if let Some(result) = self.sat_cache.get(&cache_key) {
+            self.sat_cache_hits += 1;
             trace!(result, "is_sat: normalized cache hit");
             return Ok(*result);
         }
@@ -299,6 +321,30 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
 
     /// Implements the `model` solver helper.
     fn model(&mut self, constraints: &[BoolExpr]) -> Result<BTreeMap<String, U256>, SymbolicError> {
+        self.model_queries += 1;
+        let smt_constraints = normalize_constraints_for_solver(constraints);
+        let cache_key = constraint_cache_key(&smt_constraints);
+
+        if self.sat_cache.get(&cache_key) == Some(&false) {
+            self.model_cache.remove(&cache_key);
+            trace!("model: normalized sat cache says unsat");
+            return Err(SymbolicError::Solver("counterexample path became unsat".to_string()));
+        }
+
+        if let Some(model) = self.model_cache.get(&cache_key) {
+            if model_satisfies_constraints(model, constraints) {
+                let model = model.clone();
+                self.model_cache_hits += 1;
+                trace!("model: normalized cache hit");
+                self.cache_sat_result(cache_key.clone(), true);
+                return Ok(model);
+            }
+            trace!("model: normalized cache hit failed validation");
+        }
+        if self.model_cache.remove(&cache_key).is_some() {
+            self.sat_cache.remove(&cache_key);
+        }
+
         self.reserve_query()?;
         self.record_query();
         let _span = trace_span!(
@@ -309,7 +355,6 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
         )
         .entered();
         trace!(query_id = self.queries, constraint_count = constraints.len(), "solver model");
-        let smt_constraints = normalize_constraints_for_solver(constraints);
         if constraints_prefer_hard_arith_fallback_first(&smt_constraints)
             && let Some(model) = hard_arith_fallback_model(&smt_constraints)
         {
@@ -331,8 +376,17 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
         };
         let mut lines = output.lines();
         match lines.next().unwrap_or_default().trim() {
-            "sat" => parse_and_validate_model(&output, constraints),
-            "unsat" => Err(SymbolicError::Solver("counterexample path became unsat".to_string())),
+            "sat" => {
+                let model = parse_and_validate_model(&output, constraints)?;
+                self.cache_sat_result(cache_key.clone(), true);
+                self.cache_model_result(cache_key, model.clone());
+                Ok(model)
+            }
+            "unsat" => {
+                self.model_cache.remove(&cache_key);
+                self.cache_sat_result(cache_key, false);
+                Err(SymbolicError::Solver("counterexample path became unsat".to_string()))
+            }
             "unknown" => {
                 if let Some(model) = hard_arith_fallback_model(&smt_constraints) {
                     self.heuristic_witnesses += 1;
@@ -383,8 +437,19 @@ impl SmtLibSubprocessSolver {
 
     /// Caches a definitive normalized satisfiability result if the cache has room.
     fn cache_sat_result(&mut self, key: Vec<BoolExpr>, result: bool) {
-        if self.sat_cache.len() < SYMBOLIC_SOLVER_SAT_CACHE_MAX_ENTRIES {
+        if self.sat_cache.contains_key(&key)
+            || self.sat_cache.len() < SYMBOLIC_SOLVER_SAT_CACHE_MAX_ENTRIES
+        {
             self.sat_cache.insert(key, result);
+        }
+    }
+
+    /// Caches a validated normalized model result if the cache has room.
+    fn cache_model_result(&mut self, key: Vec<BoolExpr>, model: BTreeMap<String, U256>) {
+        if self.model_cache.contains_key(&key)
+            || self.model_cache.len() < SYMBOLIC_SOLVER_MODEL_CACHE_MAX_ENTRIES
+        {
+            self.model_cache.insert(key, model);
         }
     }
 
@@ -427,8 +492,10 @@ impl SmtLibSubprocessSolver {
             self.emit_diagnostic(format_args!("--- symbolic SMT query {query} ---\n{smt}\n"));
         }
 
+        let started = Instant::now();
         let result =
             run_solver_commands(&commands, &smt, self.timeout, model.then_some(model_constraints));
+        self.solver_time += started.elapsed();
         self.portfolio_scheduler.record(&ordered_commands, &result.summaries);
         if self.dump_smt {
             self.portfolio_diagnostics.record(&result.summaries);
@@ -443,15 +510,103 @@ impl SmtLibSubprocessSolver {
     }
 }
 
-/// Returns a structural key for normalized satisfiability cache lookups.
-fn sat_cache_key(constraints: &[BoolExpr]) -> Vec<BoolExpr> {
-    let mut key = constraints
-        .iter()
-        .filter(|constraint| !matches!(constraint, BoolExpr::Const(true)))
-        .cloned()
-        .collect::<Vec<_>>();
+/// Returns a structural key for normalized solver cache lookups.
+fn constraint_cache_key(constraints: &[BoolExpr]) -> Vec<BoolExpr> {
+    let mut key = Vec::new();
+    for constraint in constraints.iter().cloned().map(cache_key_bool) {
+        collect_cache_key_conjunct(constraint, &mut key);
+    }
     key.sort();
+    key.dedup();
     key
+}
+
+/// Returns a conservative canonical boolean expression for cache-key equality.
+fn cache_key_bool(expr: BoolExpr) -> BoolExpr {
+    match expr {
+        BoolExpr::Const(_) => expr,
+        BoolExpr::Not(value) => cache_key_bool(*value).not(),
+        BoolExpr::And(values) => {
+            let mut conjuncts = Vec::new();
+            for value in values.into_iter().map(cache_key_bool) {
+                collect_cache_key_conjunct(value, &mut conjuncts);
+            }
+            conjuncts.sort();
+            conjuncts.dedup();
+            BoolExpr::and(conjuncts)
+        }
+        BoolExpr::Eq(left, right) => {
+            let left = cache_key_expr(left);
+            let right = cache_key_expr(right);
+            if left <= right { BoolExpr::eq(left, right) } else { BoolExpr::eq(right, left) }
+        }
+        BoolExpr::Cmp(op, left, right) => {
+            cache_key_cmp(op, cache_key_expr(left), cache_key_expr(right))
+        }
+    }
+}
+
+/// Collects cache-key conjuncts, flattening conjunctions because path constraints are conjunctive.
+fn collect_cache_key_conjunct(expr: BoolExpr, out: &mut Vec<BoolExpr>) {
+    match expr {
+        BoolExpr::Const(true) => {}
+        BoolExpr::And(values) => {
+            for value in values {
+                collect_cache_key_conjunct(value, out);
+            }
+        }
+        value => out.push(value),
+    }
+}
+
+/// Returns a conservative canonical comparison for cache-key equality.
+const fn cache_key_cmp(op: BoolExprOp, left: Expr, right: Expr) -> BoolExpr {
+    match op {
+        BoolExprOp::Ugt => BoolExpr::cmp(BoolExprOp::Ult, right, left),
+        BoolExprOp::Uge => BoolExpr::cmp(BoolExprOp::Ule, right, left),
+        BoolExprOp::Sgt => BoolExpr::cmp(BoolExprOp::Slt, right, left),
+        BoolExprOp::Ult | BoolExprOp::Ule | BoolExprOp::Slt => BoolExpr::cmp(op, left, right),
+    }
+}
+
+/// Returns a conservative canonical word expression for cache-key equality.
+fn cache_key_expr(expr: Expr) -> Expr {
+    match expr {
+        Expr::Const(_) | Expr::Var(_) => expr,
+        Expr::Keccak { name, len, bytes } => Expr::Keccak {
+            name,
+            len: Box::new(cache_key_expr(*len)),
+            bytes: bytes.into_iter().map(cache_key_expr).collect(),
+        },
+        Expr::Hash { name, algorithm, bytes } => {
+            Expr::Hash { name, algorithm, bytes: bytes.into_iter().map(cache_key_expr).collect() }
+        }
+        Expr::Not(value) => Expr::Not(Box::new(cache_key_expr(*value))),
+        Expr::Op(op, left, right) => {
+            let left = cache_key_expr(*left);
+            let right = cache_key_expr(*right);
+            if expr_op_is_commutative(op) && right < left {
+                Expr::op(op, right, left)
+            } else {
+                Expr::op(op, left, right)
+            }
+        }
+        Expr::Ite(cond, left, right) => Expr::Ite(
+            Box::new(cache_key_bool(*cond)),
+            Box::new(cache_key_expr(*left)),
+            Box::new(cache_key_expr(*right)),
+        ),
+    }
+}
+
+/// Returns whether a word operation is safe to reorder for cache-key equality.
+const fn expr_op_is_commutative(op: ExprOp) -> bool {
+    matches!(op, ExprOp::Add | ExprOp::Mul | ExprOp::And | ExprOp::Or | ExprOp::Xor)
+}
+
+/// Returns whether a parsed model satisfies the current original constraints.
+fn model_satisfies_constraints(model: &BTreeMap<String, U256>, constraints: &[BoolExpr]) -> bool {
+    constraints.iter().all(|constraint| eval_bool_expr(constraint, model).unwrap_or(false))
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2536,8 +2536,142 @@ fn sat_cache_reuses_normalized_is_sat_results() {
     assert!(solver.is_sat(&constraints).unwrap());
     assert!(solver.is_sat(&reordered_constraints).unwrap());
 
-    assert_eq!(solver.stats().solver_queries, 1);
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.sat_queries, 2);
+    assert_eq!(stats.sat_cache_hits, 1);
+    assert_eq!(stats.model_queries, 0);
     assert_eq!(counted_solver_invocations(&marker), 1);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for nested canonical satisfiability query cache keys.
+fn sat_cache_reuses_nested_commutative_results() {
+    let marker = portfolio_test_marker("sat-cache-canonical");
+    let commands = vec![counted_solver_command(&marker, "sat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
+    let x = Expr::Var("x".to_string());
+    let y = Expr::Var("y".to_string());
+    let constraints = vec![BoolExpr::and(vec![
+        BoolExpr::eq(Expr::op(ExprOp::Add, x.clone(), y.clone()), Expr::Const(U256::from(3))),
+        BoolExpr::eq(x.clone(), Expr::Const(U256::from(1))),
+    ])];
+    let reordered_constraints = vec![BoolExpr::and(vec![
+        BoolExpr::eq(Expr::Const(U256::from(1)), x),
+        BoolExpr::eq(
+            Expr::Const(U256::from(3)),
+            Expr::op(ExprOp::Add, y, Expr::Var("x".to_string())),
+        ),
+    ])];
+
+    assert!(solver.is_sat(&constraints).unwrap());
+    assert!(solver.is_sat(&reordered_constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.sat_queries, 2);
+    assert_eq!(stats.sat_cache_hits, 1);
+    assert_eq!(counted_solver_invocations(&marker), 1);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for duplicate conjuncts sharing satisfiability cache keys.
+fn sat_cache_deduplicates_repeated_constraints() {
+    let marker = portfolio_test_marker("sat-cache-dedup");
+    let commands = vec![counted_solver_command(&marker, "sat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
+    let x = Expr::Var("x".to_string());
+    let constraint = BoolExpr::eq(x, Expr::Const(U256::from(1)));
+    let duplicated = vec![constraint.clone(), constraint.clone()];
+    let deduplicated = vec![constraint];
+
+    assert!(solver.is_sat(&duplicated).unwrap());
+    assert!(solver.is_sat(&deduplicated).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.sat_queries, 2);
+    assert_eq!(stats.sat_cache_hits, 1);
+    assert_eq!(counted_solver_invocations(&marker), 1);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for nested duplicate conjuncts sharing satisfiability cache keys.
+fn sat_cache_deduplicates_nested_repeated_constraints() {
+    let marker = portfolio_test_marker("sat-cache-nested-dedup");
+    let commands = vec![counted_solver_command(&marker, "sat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
+    let x = Expr::Var("x".to_string());
+    let constraint = BoolExpr::eq(x, Expr::Const(U256::from(1)));
+    let duplicated = vec![BoolExpr::And(vec![constraint.clone(), constraint.clone()])];
+    let deduplicated = vec![constraint];
+
+    assert!(solver.is_sat(&duplicated).unwrap());
+    assert!(solver.is_sat(&deduplicated).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.sat_queries, 2);
+    assert_eq!(stats.sat_cache_hits, 1);
+    assert_eq!(counted_solver_invocations(&marker), 1);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for grouped conjunctions sharing satisfiability cache keys.
+fn sat_cache_flattens_grouped_conjunction_keys() {
+    let marker = portfolio_test_marker("sat-cache-and-flatten");
+    let commands = vec![counted_solver_command(&marker, "sat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
+    let x = Expr::Var("x".to_string());
+    let y = Expr::Var("y".to_string());
+    let z = Expr::Var("z".to_string());
+    let a = BoolExpr::eq(x, Expr::Const(U256::from(1)));
+    let b = BoolExpr::eq(y, Expr::Const(U256::from(2)));
+    let c = BoolExpr::eq(z, Expr::Const(U256::from(3)));
+    let grouped = vec![BoolExpr::And(vec![BoolExpr::And(vec![b.clone(), c.clone()]), a.clone()])];
+    let split = vec![c, a, b];
+
+    assert!(solver.is_sat(&grouped).unwrap());
+    assert!(solver.is_sat(&split).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.sat_queries, 2);
+    assert_eq!(stats.sat_cache_hits, 1);
+    assert_eq!(counted_solver_invocations(&marker), 1);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for comparison-direction canonical satisfiability cache keys.
+fn sat_cache_reuses_reversed_comparisons() {
+    let marker = portfolio_test_marker("sat-cache-reversed-cmp");
+    let commands = vec![counted_solver_command(&marker, "sat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 3, false);
+    let x = Expr::Var("x".to_string());
+    let y = Expr::Var("y".to_string());
+
+    assert!(solver.is_sat(&[BoolExpr::cmp(BoolExprOp::Ugt, x.clone(), y.clone())]).unwrap());
+    assert!(solver.is_sat(&[BoolExpr::cmp(BoolExprOp::Ult, y.clone(), x.clone())]).unwrap());
+    assert!(solver.is_sat(&[BoolExpr::cmp(BoolExprOp::Uge, x.clone(), y.clone())]).unwrap());
+    assert!(solver.is_sat(&[BoolExpr::cmp(BoolExprOp::Ule, y.clone(), x.clone())]).unwrap());
+    assert!(solver.is_sat(&[BoolExpr::cmp(BoolExprOp::Sgt, x.clone(), y.clone())]).unwrap());
+    assert!(solver.is_sat(&[BoolExpr::cmp(BoolExprOp::Slt, y, x)]).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 3);
+    assert_eq!(stats.sat_queries, 6);
+    assert_eq!(stats.sat_cache_hits, 3);
+    assert_eq!(counted_solver_invocations(&marker), 3);
     let _ = std::fs::remove_file(&marker);
 }
 
@@ -2553,8 +2687,96 @@ fn sat_cache_does_not_cache_unknown_results() {
     assert!(matches!(solver.is_sat(&constraints), Err(SymbolicError::SolverUnknown)));
     assert!(matches!(solver.is_sat(&constraints), Err(SymbolicError::SolverUnknown)));
 
-    assert_eq!(solver.stats().solver_queries, 2);
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 2);
+    assert_eq!(stats.sat_queries, 2);
+    assert_eq!(stats.sat_cache_hits, 0);
     assert_eq!(counted_solver_invocations(&marker), 2);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for normalized solver model cache hits.
+fn model_cache_reuses_normalized_model_results() {
+    let marker = portfolio_test_marker("model-cache");
+    let model_output = "sat\n\
+        ((define-fun x () (_ BitVec 256) \
+        #x0000000000000000000000000000000000000000000000000000000000000001)\n\
+        (define-fun y () (_ BitVec 256) \
+        #x0000000000000000000000000000000000000000000000000000000000000002))";
+    let commands = vec![counted_solver_command(&marker, model_output)];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
+    let x = Expr::Var("x".to_string());
+    let y = Expr::Var("y".to_string());
+    let constraints = vec![
+        BoolExpr::Const(true),
+        BoolExpr::eq(x.clone(), Expr::Const(U256::from(1))),
+        BoolExpr::eq(y.clone(), Expr::Const(U256::from(2))),
+    ];
+    let reordered_constraints = vec![
+        BoolExpr::eq(y, Expr::Const(U256::from(2))),
+        BoolExpr::eq(x, Expr::Const(U256::from(1))),
+    ];
+
+    assert_eq!(solver.model(&constraints).unwrap().get("x"), Some(&U256::from(1)));
+    assert_eq!(solver.model(&reordered_constraints).unwrap().get("y"), Some(&U256::from(2)));
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.model_queries, 2);
+    assert_eq!(stats.model_cache_hits, 1);
+    assert_eq!(stats.sat_queries, 0);
+    assert_eq!(counted_solver_invocations(&marker), 1);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for model queries populating the satisfiability cache.
+fn model_query_populates_sat_cache() {
+    let marker = portfolio_test_marker("model-cache-sat");
+    let model_output = "sat\n\
+        ((define-fun x () (_ BitVec 256) \
+        #x0000000000000000000000000000000000000000000000000000000000000001))";
+    let commands = vec![counted_solver_command(&marker, model_output)];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
+    let constraints = vec![BoolExpr::eq(Expr::Var("x".to_string()), Expr::Const(U256::from(1)))];
+
+    assert_eq!(solver.model(&constraints).unwrap().get("x"), Some(&U256::from(1)));
+    assert!(solver.is_sat(&constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.model_queries, 1);
+    assert_eq!(stats.sat_queries, 1);
+    assert_eq!(stats.sat_cache_hits, 1);
+    assert_eq!(stats.model_cache_hits, 0);
+    assert_eq!(counted_solver_invocations(&marker), 1);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for satisfiability cache unsat results short-circuiting model queries.
+fn model_short_circuits_when_sat_cache_proved_unsat() {
+    let marker = portfolio_test_marker("model-cache-unsat");
+    let commands = vec![counted_solver_command(&marker, "unsat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
+    let constraints = vec![BoolExpr::eq(Expr::Var("x".to_string()), Expr::Const(U256::from(1)))];
+
+    assert!(!solver.is_sat(&constraints).unwrap());
+    assert!(
+        matches!(solver.model(&constraints), Err(SymbolicError::Solver(message)) if message.contains("unsat"))
+    );
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.sat_queries, 1);
+    assert_eq!(stats.sat_cache_hits, 0);
+    assert_eq!(stats.model_queries, 1);
+    assert_eq!(stats.model_cache_hits, 0);
+    assert_eq!(counted_solver_invocations(&marker), 1);
     let _ = std::fs::remove_file(&marker);
 }
 

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -18,7 +18,7 @@ use foundry_evm::{
     fuzz::{CounterExample, FuzzCase, FuzzFixtures, FuzzTestResult},
     traces::{CallTraceArena, CallTraceDecoder, TraceKind, Traces},
 };
-use foundry_evm_symbolic::PortfolioDiagnostics;
+use foundry_evm_symbolic::{PortfolioDiagnostics, SymbolicStats};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -1112,10 +1112,17 @@ impl TestResult {
         success: bool,
         reason: Option<String>,
         counterexample: Option<CounterExample>,
-        paths: usize,
-        solver_queries: usize,
+        stats: SymbolicStats,
     ) {
-        self.kind = TestKind::Symbolic { paths, solver_queries };
+        self.kind = TestKind::Symbolic {
+            paths: stats.paths,
+            solver_queries: stats.solver_queries,
+            sat_queries: stats.sat_queries,
+            model_queries: stats.model_queries,
+            sat_cache_hits: stats.sat_cache_hits,
+            model_cache_hits: stats.model_cache_hits,
+            solver_time_ms: stats.solver_time_ms,
+        };
         self.status = if success { TestStatus::Success } else { TestStatus::Failure };
         self.reason = reason;
         self.counterexample = counterexample;
@@ -1217,6 +1224,11 @@ pub enum TestKindReport {
     Symbolic {
         paths: usize,
         solver_queries: usize,
+        sat_queries: usize,
+        model_queries: usize,
+        sat_cache_hits: usize,
+        model_cache_hits: usize,
+        solver_time_ms: u64,
     },
 }
 
@@ -1259,8 +1271,19 @@ impl fmt::Display for TestKindReport {
             Self::Table { runs, mean_gas, median_gas } => {
                 write!(f, "(runs: {runs}, μ: {mean_gas}, ~: {median_gas})")
             }
-            Self::Symbolic { paths, solver_queries } => {
-                write!(f, "(paths: {paths}, queries: {solver_queries})")
+            Self::Symbolic {
+                paths,
+                solver_queries,
+                sat_queries,
+                model_queries,
+                sat_cache_hits,
+                model_cache_hits,
+                solver_time_ms,
+            } => {
+                write!(
+                    f,
+                    "(paths: {paths}, queries: {solver_queries}, sat: {sat_queries} ({sat_cache_hits} cached), models: {model_queries} ({model_cache_hits} cached), solver: {solver_time_ms}ms)"
+                )
             }
         }
     }
@@ -1306,7 +1329,20 @@ pub enum TestKind {
     /// A table test.
     Table { runs: usize, mean_gas: u64, median_gas: u64 },
     /// A symbolic test.
-    Symbolic { paths: usize, solver_queries: usize },
+    Symbolic {
+        paths: usize,
+        solver_queries: usize,
+        #[serde(default)]
+        sat_queries: usize,
+        #[serde(default)]
+        model_queries: usize,
+        #[serde(default)]
+        sat_cache_hits: usize,
+        #[serde(default)]
+        model_cache_hits: usize,
+        #[serde(default)]
+        solver_time_ms: u64,
+    },
 }
 
 impl Default for TestKind {
@@ -1356,9 +1392,23 @@ impl TestKind {
             Self::Table { runs, mean_gas, median_gas } => {
                 TestKindReport::Table { runs: *runs, mean_gas: *mean_gas, median_gas: *median_gas }
             }
-            Self::Symbolic { paths, solver_queries } => {
-                TestKindReport::Symbolic { paths: *paths, solver_queries: *solver_queries }
-            }
+            Self::Symbolic {
+                paths,
+                solver_queries,
+                sat_queries,
+                model_queries,
+                sat_cache_hits,
+                model_cache_hits,
+                solver_time_ms,
+            } => TestKindReport::Symbolic {
+                paths: *paths,
+                solver_queries: *solver_queries,
+                sat_queries: *sat_queries,
+                model_queries: *model_queries,
+                sat_cache_hits: *sat_cache_hits,
+                model_cache_hits: *model_cache_hits,
+                solver_time_ms: *solver_time_ms,
+            },
         }
     }
 }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -842,15 +842,14 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
 
         match result {
             SymbolicRunResult::Safe(stats) => {
-                self.result.symbolic_result(true, None, None, stats.paths, stats.solver_queries);
+                self.result.symbolic_result(true, None, None, stats);
             }
             SymbolicRunResult::Incomplete { kind, reason, stats } => {
                 self.result.symbolic_result(
                     false,
                     Some(format!("incomplete symbolic execution ({kind:?}): {reason}")),
                     None,
-                    stats.paths,
-                    stats.solver_queries,
+                    stats,
                 );
             }
             SymbolicRunResult::Counterexample { args, calldata, stats } => {
@@ -871,13 +870,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         return self.result;
                     }
                     Err(err) => {
-                        self.result.symbolic_result(
-                            false,
-                            Some(err.to_string()),
-                            None,
-                            stats.paths,
-                            stats.solver_queries,
-                        );
+                        self.result.symbolic_result(false, Some(err.to_string()), None, stats);
                         self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
                         self.result.symbolic_diagnostics = symbolic_diagnostics;
                         return self.result;
@@ -903,8 +896,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         reason
                     },
                     Some(counterexample),
-                    stats.paths,
-                    stats.solver_queries,
+                    stats,
                 );
             }
         }
@@ -1014,15 +1006,14 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
 
         match result {
             SymbolicInvariantRunResult::Safe(stats) => {
-                self.result.symbolic_result(true, None, None, stats.paths, stats.solver_queries);
+                self.result.symbolic_result(true, None, None, stats);
             }
             SymbolicInvariantRunResult::Incomplete { kind, reason, stats } => {
                 self.result.symbolic_result(
                     false,
                     Some(format!("incomplete symbolic invariant execution ({kind:?}): {reason}")),
                     None,
-                    stats.paths,
-                    stats.solver_queries,
+                    stats,
                 );
             }
             SymbolicInvariantRunResult::Counterexample { sequence, stats } => {
@@ -1036,8 +1027,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         Some("symbolic invariant counterexample did not replay".to_string())
                     },
                     Some(CounterExample::Sequence(replay_sequence.len(), replay_sequence)),
-                    stats.paths,
-                    stats.solver_queries,
+                    stats,
                 );
             }
         }

--- a/crates/forge/tests/cli/test_cmd/symbolic_helpers.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_helpers.rs
@@ -21,13 +21,13 @@ macro_rules! skip_unless_z3 {
 /// Run a symbolic test with redactions that mask solver-dependent / wall-clock
 /// noise so the snapshot is stable across solver versions and runs.
 ///
-/// - `[METRICS]` — `paths: N, queries: M` line suffix (engine internal metrics change with solver
+/// - `[METRICS]` — symbolic metrics line suffix (engine internal metrics change with solver
 ///   heuristic / engine path-pruning changes).
 /// - `[SENDER]` — `sender=0x...` symbolic invariant senders, which the solver picks freely from an
 ///   unconstrained address pool.
 pub fn assert_symbolic(cmd: &mut TestCommand) -> OutputAssert {
     cmd.assert_with(&[
-        ("[METRICS]", r"paths: \d+, queries: \d+"),
+        ("[METRICS]", r"paths: \d+, queries: \d+(?:, sat: \d+ \(\d+ cached\), models: \d+ \(\d+ cached\), solver: \d+ms)?"),
         ("[SENDER]", r"sender=0x[0-9a-fA-F]{40}"),
     ])
 }
@@ -38,7 +38,7 @@ pub fn assert_symbolic(cmd: &mut TestCommand) -> OutputAssert {
 /// *some* counterexample exists, not what it is.
 pub fn assert_symbolic_witness(cmd: &mut TestCommand) -> OutputAssert {
     cmd.assert_with(&[
-        ("[METRICS]", r"paths: \d+, queries: \d+"),
+        ("[METRICS]", r"paths: \d+, queries: \d+(?:, sat: \d+ \(\d+ cached\), models: \d+ \(\d+ cached\), solver: \d+ms)?"),
         ("[SENDER]", r"sender=0x[0-9a-fA-F]{40}"),
         ("[CALLDATA]", r"calldata=0x[0-9a-fA-F]+"),
         // `args=[...]` may contain nested scientific-notation brackets like


### PR DESCRIPTION
## Summary

- add a bounded normalized solver model cache for `model()` queries
- validate cached models against the original path constraints before reuse
- cross-populate the SAT cache from definitive model results
- canonicalize normalized cache keys a little further for grouped/nested `and`, equality operand order, and commutative BV ops

## Benchmark

Compared PR head `8d811b8cf` against `mattsse/native-symbolic-testing` at `42facf568`. Commands used debug `forge` binaries from each worktree, the same temp benchmark project as #14917, warm compilation cache, and `hyperfine --warmup 1 --runs 7 --ignore-failure`.

| Case | Base backend queries | PR backend queries | Query delta | PR SAT requests / hits | PR model requests / hits | Base mean | PR mean | Wall delta |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Magic constant | 3 | 3 | 0% | 2 / 0 | 1 / 0 | 68.0ms | 68.3ms | +0.5% |
| ERC4626 inflation | 27 | 24 | -11.1% | 32 / 9 | 1 / 0 | 2012.9ms | 1964.3ms | -2.4% |
| Repeated branch microcase | 35 | 11 | -68.6% | 38 / 28 | 1 / 0 | 228.1ms | 111.0ms | -51.3% |

These forge workloads mostly exercise repeated `is_sat()` feasibility checks, not repeated `model()` calls. The end-to-end query reductions here come from SAT cache hits enabled by normalized/canonical cache keys; all three workloads have `0` model-cache hits. The model-cache behavior is covered separately by the solver-level cache tests below.

The forge metric line now exposes the cache behavior directly, for example on the repeated-branch case:

```text
(paths: 4, queries: 11, sat: 38 (28 cached), models: 1 (0 cached), solver: 44ms)
```

Solver-level cache coverage verifies the model cache and SAT cross-population paths:

| Case | Requests | Backend queries | Cache hits |
|---|---:|---:|---:|
| normalized repeated `model()` | 2 model | 1 | 1 model hit |
| `model()` followed by `is_sat()` on the same constraints | 1 model + 1 sat | 1 | 1 SAT hit |
| `is_sat()` proves unsat before `model()` | 1 sat + 1 model | 1 | model short-circuits from SAT cache |

## Validation

- `cargo test -p foundry-evm-symbolic portfolio_scheduler -- --nocapture`
- `cargo test -p foundry-evm-symbolic cache -- --nocapture`
- `cargo test -p forge symbolic_engine_capabilities -- --nocapture`
- `cargo test -p forge symbolic_parity -- --nocapture`
- `cargo clippy -p foundry-evm-symbolic --all-targets -- -D warnings`
- `cargo clippy -p forge --all-targets -- -D warnings`
