### PR TITLE
fix(script): honor merged `code_size_limit` config in `check_contract_sizes`

### DIFF
--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1,6 +1,6 @@
 //! Contains various tests related to `forge script`.
 
-use crate::constants::TEMPLATE_CONTRACT;
+use crate::{constants::TEMPLATE_CONTRACT, utils::generate_large_runtime_contract};
 use alloy_hardforks::EthereumHardfork;
 use alloy_network::Ethereum;
 use alloy_primitives::{Address, Bytes, address, hex};
@@ -3708,4 +3708,62 @@ forgetest!(can_execute_script_command_with_tempo, |prj, cmd| {
         .arg("--root")
         .arg(prj.root())
         .assert_success();
+});
+
+// Helper: write a script that deploys `LargeRuntime` with runtime > default limit via
+// `vm.startBroadcast`.
+fn write_large_runtime_deploy_script(prj: &foundry_test_utils::TestProject, runtime_bytes: usize) {
+    prj.add_source("LargeRuntime.sol", generate_large_runtime_contract(runtime_bytes).as_str());
+    prj.add_source(
+        "DeployLarge.s.sol",
+        r#"
+import "forge-std/Script.sol";
+import "./LargeRuntime.sol";
+
+contract DeployLarge is Script {
+    function run() external {
+        vm.startBroadcast();
+        new LargeRuntime();
+    }
+}
+"#,
+    );
+}
+
+// Tests that `forge script` reports a contract-size violation against the default runtime limit
+// when neither the CLI nor foundry.toml override `code_size_limit`.
+forgetest_async!(script_check_contract_sizes_warns_at_default_limit, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    write_large_runtime_deploy_script(&prj, 30_000);
+
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    cmd.set_current_dir(prj.root());
+    for var in ["FOUNDRY_CODE_SIZE_LIMIT", "DAPP_CODE_SIZE_LIMIT", "DAPP_TEST_CODE_SIZE_LIMIT"] {
+        cmd.unset_env(var);
+    }
+    cmd.args(["script", "DeployLarge", "--rpc-url", &handle.http_endpoint()])
+        .assert_success()
+        .stderr_eq(str![[r#"
+Error: `LargeRuntime` is above the contract size limit ([..] > 24576).
+
+"#]]);
+});
+
+// Tests that `forge script` honors `code_size_limit` configured via foundry.toml
+// (the bug fix: previously only the CLI flag was honored).
+forgetest_async!(script_check_contract_sizes_honors_config_limit, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    write_large_runtime_deploy_script(&prj, 30_000);
+    prj.update_config(|config| {
+        config.code_size_limit = Some(64_000);
+    });
+
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    cmd.set_current_dir(prj.root());
+    for var in ["FOUNDRY_CODE_SIZE_LIMIT", "DAPP_CODE_SIZE_LIMIT", "DAPP_TEST_CODE_SIZE_LIMIT"] {
+        cmd.unset_env(var);
+    }
+    cmd.args(["script", "DeployLarge", "--rpc-url", &handle.http_endpoint()])
+        .assert_success()
+        .stderr_eq(str![[r#""#]]);
 });

--- a/crates/forge/tests/cli/utils.rs
+++ b/crates/forge/tests/cli/utils.rs
@@ -210,3 +210,20 @@ contract LargeContract {{
 "
     )
 }
+
+/// Generates a Solidity contract with both runtime and initcode bytecode at
+/// least `n` bytes long, by embedding an `n`-byte hex constant returned from
+/// an external `pure` function.
+pub fn generate_large_runtime_contract(n: usize) -> String {
+    let data = vec![0xff; n];
+    let hex = alloy_primitives::hex::encode(data);
+    format!(
+        "\
+contract LargeRuntime {{
+    function data() external pure returns (bytes memory) {{
+        return hex\"{hex}\";
+    }}
+}}
+"
+    )
+}

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -401,7 +401,14 @@ impl ScriptArgs {
                 return Ok(None);
             }
 
+            let size_limits = pre_simulation
+                .script_config
+                .config
+                .code_size_limit
+                .map(ContractSizeLimits::with_runtime_limit)
+                .unwrap_or_default();
             pre_simulation.args.check_contract_sizes(
+                size_limits,
                 &pre_simulation.execution_result,
                 &pre_simulation.build_data.known_contracts,
                 create2_deployer,
@@ -517,6 +524,7 @@ impl ScriptArgs {
     /// the user.
     fn check_contract_sizes<N: Network>(
         &self,
+        size_limits: ContractSizeLimits,
         result: &ScriptResult<N>,
         known_contracts: &ContractsByArtifact,
         create2_deployer: Address,
@@ -551,7 +559,7 @@ impl ScriptArgs {
         }
 
         let mut prompt_user = false;
-        let max_size = self.contract_size_limits().runtime;
+        let max_size = size_limits.runtime;
 
         for (data, to) in result.transactions.iter().flat_map(|txes| {
             txes.iter().filter_map(|tx| {
@@ -597,10 +605,6 @@ impl ScriptArgs {
         }
 
         Ok(())
-    }
-
-    fn contract_size_limits(&self) -> ContractSizeLimits {
-        self.evm.env.code_size_limit.map(ContractSizeLimits::with_runtime_limit).unwrap_or_default()
     }
 
     /// We only broadcast transactions if --broadcast, --resume, or --verify was passed.
@@ -932,7 +936,10 @@ mod tests {
         let result = ScriptResult::<Ethereum>::default();
         let contracts = ContractsByArtifact::default();
         let create = Address::ZERO;
-        assert!(args.check_contract_sizes(&result, &contracts, create).is_ok());
+        assert!(
+            args.check_contract_sizes(ContractSizeLimits::default(), &result, &contracts, create)
+                .is_ok()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #14761. `forge script`'s contract-size check now reads `code_size_limit` from the merged `Config` (foundry.toml + env + CLI) instead of only the raw `--code-size-limit` CLI flag.