### PR TITLE
fix: silence cargo install dependency warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7517,9 +7517,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -538,9 +538,6 @@ snapbox = { version = "0.6", features = ["json", "regex", "term-svg"] }
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
-# https://github.com/rust-cli/rexpect/pull/106
-rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6a85bedbae71a01cc578958fc" }
-
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
 # alloy-json-abi = { path = "../../alloy-rs/core/crates/json-abi" }

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -60,7 +60,8 @@ tracing-subscriber.workspace = true
 # REPL tests only work on Unix.
 [target.'cfg(unix)'.dev-dependencies]
 foundry-test-utils.workspace = true
-rexpect = "0.6"
+# https://github.com/rust-cli/rexpect/pull/106
+rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6a85bedbae71a01cc578958fc" }
 
 [features]
 default = ["jemalloc", "asm-keccak", "optimism"]


### PR DESCRIPTION
## Summary
- update the locked metrics crate from 0.24.5 to 0.24.6 so `cargo install --locked` no longer warns about a yanked package
- move the rexpect git override from the workspace-wide patch table to Chisel's Unix-only dev-dependency, where the REPL tests actually use it

## Motivation
```shell
cargo install --git https://github.com/foundry-rs/foundry --profile release --locked forge cast chisel anvil --force
```

```bash
Updating git repository `https://github.com/paradigmxyz/reth`
warning: package `metrics v0.24.5` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
warning: patch `rexpect v0.6.2 (https://github.com/rust-cli/rexpect?rev=2ed0b1898d7edaf6a85bedbae71a01cc578958fc#2ed0b189)` was not used in the crate graph
help: Check that the patched package version and available features are compatible
      with the dependency requirements. If the patch has a different version from
      what is locked in the Cargo.lock file, run `cargo update` to use the new
      version. This may also occur with an optional dependency that is not enabled.
```




