### PR TITLE
chore(lint): use find_map in return-bomb helper

### DIFF
--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -381,7 +381,7 @@ fn expr_type<'hir>(
 ) -> Option<&'hir hir::Type<'hir>> {
     match &expr.peel_parens().kind {
         ExprKind::Ident(reses) => {
-            let var = reses.iter().filter_map(hir::Res::as_variable).next()?;
+            let var = reses.iter().find_map(hir::Res::as_variable)?;
             Some(&hir.variable(var).ty)
         }
         ExprKind::Index(base, _) => match &expr_type(hir, base)?.kind {


### PR DESCRIPTION
## Motivation

The return-bomb lint helper only needs the first variable resolution from an iterator. The existing code expressed that as `filter_map(...).next()`.

## Solution

Use `find_map(...)` directly in the expression type helper.