### PR TITLE
test(symbolic): avoid cache hits in scheduler tests

### DIFF
--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2841,11 +2841,14 @@ fn portfolio_scheduler_promotes_recent_sat_winner() {
     ];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 2, false);
 
-    assert!(solver.is_sat(&[]).unwrap());
+    let first = vec![BoolExpr::eq(Expr::Var("x".to_string()), Expr::Const(U256::from(1)))];
+    let second = vec![BoolExpr::eq(Expr::Var("x".to_string()), Expr::Const(U256::from(2)))];
+
+    assert!(solver.is_sat(&first).unwrap());
     assert!(marker.exists());
     let _ = std::fs::remove_file(&marker);
 
-    assert!(solver.is_sat(&[]).unwrap());
+    assert!(solver.is_sat(&second).unwrap());
     assert!(!marker.exists());
 }
 
@@ -2877,8 +2880,11 @@ fn portfolio_scheduler_promotes_recent_unsat_winner() {
 
     solver.capture_diagnostics();
 
-    assert!(!solver.is_sat(&[]).unwrap());
-    assert!(!solver.is_sat(&[]).unwrap());
+    let first = vec![BoolExpr::eq(Expr::Var("x".to_string()), Expr::Const(U256::from(1)))];
+    let second = vec![BoolExpr::eq(Expr::Var("x".to_string()), Expr::Const(U256::from(2)))];
+
+    assert!(!solver.is_sat(&first).unwrap());
+    assert!(!solver.is_sat(&second).unwrap());
 
     let diagnostics = solver.take_diagnostics().unwrap();
     let last_outcomes =
@@ -2918,10 +2924,12 @@ fn portfolio_scheduler_penalizes_invalid_models() {
         .unwrap(),
     ];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 16, false);
-    let constraints =
-        vec![BoolExpr::eq(Expr::Var("calldata_0".to_string()), Expr::Const(U256::from(1)))];
 
     for query in 0..=PORTFOLIO_SCHEDULER_HISTORY {
+        let constraints = vec![
+            BoolExpr::eq(Expr::Var("calldata_0".to_string()), Expr::Const(U256::from(1))),
+            BoolExpr::eq(Expr::Var(format!("portfolio_query_{query}")), Expr::Const(U256::ZERO)),
+        ];
         assert_eq!(solver.model(&constraints).unwrap().get("calldata_0"), Some(&U256::from(1)));
         if query == 0 {
             assert!(marker.exists());


### PR DESCRIPTION
## Summary

- keep adaptive portfolio scheduler tests from being satisfied by the new solver result caches
- use distinct cache keys for repeated SAT/model calls so the tests still exercise scheduler promotion/penalization

## Validation

- `cargo test -p foundry-evm-symbolic portfolio_scheduler -- --nocapture`
- `cargo test -p foundry-evm-symbolic cache -- --nocapture`
