### PR TITLE
fix(symbolic): fail closed on gasleft

### DIFF
--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -551,16 +551,7 @@ impl SymbolicExecutor {
                 state.stack.push(size)?;
                 Ok(StepOutcome::Continue)
             }
-            opcode::GAS => {
-                let gas = state.fresh_word("gasleft");
-                state.constraints.push(BoolExpr::cmp(
-                    BoolExprOp::Ule,
-                    gas.clone().into_expr(),
-                    Expr::Const(U256::from(executor.gas_limit())),
-                ));
-                state.stack.push(gas)?;
-                Ok(StepOutcome::Continue)
-            }
+            opcode::GAS => Err(SymbolicError::Unsupported("GAS/gasleft() not modeled")),
             opcode::JUMPDEST => Ok(StepOutcome::Continue),
             opcode::MCOPY => {
                 let dest = state.stack.pop()?;

--- a/crates/forge/tests/cli/test_cmd/symbolic_opcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_opcodes.rs
@@ -2,7 +2,7 @@ use super::symbolic_helpers::assert_relevant_lines;
 use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, util::OutputExt};
 
-use super::symbolic_helpers::{assert_symbolic_witness, z3_available};
+use super::symbolic_helpers::z3_available;
 use crate::skip_unless_z3;
 
 forgetest_init!(symbolic_opcode_byte_and_signextend_accept_symbolic_index, |prj, cmd| {
@@ -235,12 +235,11 @@ contract SymbolicExpWideExponent {
     assert!(!stdout.contains("symbolic EXP exponent"), "{stdout}");
 });
 
-// Regression for the `GAS` / `gasleft()` opcode: if it silently returned
-// `U256::MAX`, the assertion below would always hold and the test would falsely
-// pass. Correct symbolic behavior bounds `gasleft()` by the transaction gas
-// limit (far below 2**200), so a counterexample must exist.
-forgetest_init!(symbolic_gasleft_is_bounded_not_max, |prj, cmd| {
-    skip_unless_z3!("symbolic_gasleft_is_bounded_not_max");
+// The engine does not model gas consumption, so `GAS` / `gasleft()` must fail
+// closed instead of returning a concrete max value or a symbolic approximation
+// that can produce non-replaying counterexamples.
+forgetest_init!(symbolic_gasleft_reports_unsupported, |prj, cmd| {
+    skip_unless_z3!("symbolic_gasleft_reports_unsupported");
 
     prj.add_test(
         "SymbolicGasLeftBound.t.sol",
@@ -253,13 +252,18 @@ contract SymbolicGasLeftBound {
 "#,
     );
 
-    assert_symbolic_witness(cmd.args([
-        "test",
-        "--symbolic",
-        "--match-test",
-        "checkGasLeftIsBounded",
-    ]))
-    .failure();
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkGasLeftIsBounded"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+incomplete symbolic execution (Stuck): unsupported symbolic execution feature: GAS/gasleft() not modeled
+"#]],
+    );
 });
 
 // Plan-compliant target behavior for the `GAS` / `gasleft()` opcode: any
@@ -276,17 +280,12 @@ contract SymbolicGasLeftBound {
 // non-replaying counterexample (if it lets Z3 pick `gasleft = 50`), it should
 // emit a `[FAIL: incomplete symbolic execution (Stuck): unsupported symbolic
 // execution feature: GAS/gasleft() not modeled]` result.
-forgetest_init!(
-    #[ignore = "TODO: GAS/gasleft() should fail closed as Unsupported; engine \
-                currently returns a bounded symbolic `gasleft <= gas_limit` \
-                which produces phantom non-replaying counterexamples instead"]
-    symbolic_gasleft_branch_reports_unsupported,
-    |prj, cmd| {
-        skip_unless_z3!("symbolic_gasleft_branch_reports_unsupported");
+forgetest_init!(symbolic_gasleft_branch_reports_unsupported, |prj, cmd| {
+    skip_unless_z3!("symbolic_gasleft_branch_reports_unsupported");
 
-        prj.add_test(
-            "SymbolicGasLeftIncomplete.t.sol",
-            r#"
+    prj.add_test(
+        "SymbolicGasLeftIncomplete.t.sol",
+        r#"
 contract SymbolicGasLeftIncomplete {
     // The `gasleft() < 100` branch is concretely unreachable under any
     // normal forge transaction gas limit. A correct symbolic engine that
@@ -300,22 +299,21 @@ contract SymbolicGasLeftIncomplete {
     }
 }
 "#,
-        );
+    );
 
-        let stdout = cmd
-            .args(["test", "--symbolic", "--match-test", "checkGasGuardedBranch"])
-            .assert_failure()
-            .get_output()
-            .stdout_lossy();
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkGasGuardedBranch"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
 
-        assert_relevant_lines(
-            &stdout,
-            foundry_test_utils::str![[r#"
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
 incomplete symbolic execution (Stuck): unsupported symbolic execution feature: GAS/gasleft() not modeled
 "#]],
-        );
-    }
-);
+    );
+});
 
 // Plan-compliant target behavior for the symbolic Keccak heuristic: any
 // result reached on a path whose proof obligation reduces to a Keccak


### PR DESCRIPTION
## Summary

- return Unsupported for the EVM GAS opcode / Solidity gasleft() in symbolic execution