### PR TITLE
fix(symbolic): surface Keccak heuristic in incomplete results

### DIFF
--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -1493,11 +1493,16 @@ pub(crate) fn parse_and_validate_model(
     if constraints.iter().all(|constraint| eval_bool_expr(constraint, &model).unwrap_or(false)) {
         Ok(model)
     } else {
+        let reason = if constraints.iter().any(bool_contains_keccak) {
+            "solver model does not satisfy path constraints involving symbolic Keccak heuristic"
+        } else {
+            "solver model does not satisfy path constraints"
+        };
         debug!(
             constraint_count = constraints.len(),
-            "solver model does not satisfy path constraints"
+            reason, "solver model does not satisfy path constraints"
         );
-        Err(SymbolicError::Solver("solver model does not satisfy path constraints".to_string()))
+        Err(SymbolicError::Solver(reason.to_string()))
     }
 }
 

--- a/crates/forge/tests/cli/test_cmd/symbolic_opcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_opcodes.rs
@@ -323,19 +323,12 @@ incomplete symbolic execution (Stuck): unsupported symbolic execution feature: G
 // must surface explicit Keccak/SHA3 vocabulary — either tainted as
 // Incomplete or carrying a user-facing warning — because the engine does
 // not model SHA3 collision resistance as a real cryptographic proof.
-forgetest_init!(
-    #[ignore = "TODO: results that depend on heuristic Keccak modeling \
-                must surface explicit Keccak/SHA3 vocabulary in their \
-                Incomplete/warning; engine currently emits only a generic \
-                `solver error: solver model does not satisfy path \
-                constraints` with no Keccak attribution"]
-    symbolic_keccak_dependent_safe_result_must_taint_incomplete,
-    |prj, cmd| {
-        skip_unless_z3!("symbolic_keccak_dependent_safe_result_must_taint_incomplete");
+forgetest_init!(symbolic_keccak_dependent_safe_result_must_taint_incomplete, |prj, cmd| {
+    skip_unless_z3!("symbolic_keccak_dependent_safe_result_must_taint_incomplete");
 
-        prj.add_test(
-            "SymbolicKeccakHeuristic.t.sol",
-            r#"
+    prj.add_test(
+        "SymbolicKeccakHeuristic.t.sol",
+        r#"
 contract SymbolicKeccakHeuristic {
     // The engine treats keccak as an uninterpreted function whose output
     // is never zero by construction, so this assertion holds symbolically.
@@ -346,27 +339,33 @@ contract SymbolicKeccakHeuristic {
     }
 }
 "#,
-        );
+    );
 
-        let stdout = cmd
-            .args(["test", "--symbolic", "--match-test", "checkKeccakNeverZero"])
-            .assert()
-            .get_output()
-            .stdout_lossy();
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkKeccakNeverZero"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
 
-        // Require explicit Keccak/SHA3 vocabulary in the result line; a bare
-        // "incomplete" for unrelated reasons (e.g. solver-error) does not
-        // satisfy the plan's "heuristic paths are visible, not silently
-        // presented as proof-grade" acceptance criterion.
-        let lowered = stdout.to_lowercase();
-        let has_keccak_signal = lowered.contains("keccak heuristic")
-            || lowered.contains("sha3 heuristic")
-            || lowered.contains("symbolic keccak")
-            || lowered.contains("symbolic sha3")
-            || lowered.contains("heuristic keccak");
-        assert!(
-            has_keccak_signal,
-            "expected Keccak-heuristic taint or warning in output, got:\n{stdout}"
-        );
-    }
-);
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+incomplete symbolic execution (Error): solver error: solver model does not satisfy path constraints involving symbolic Keccak heuristic
+"#]],
+    );
+
+    // Require explicit Keccak/SHA3 vocabulary in the result line; a bare
+    // "incomplete" for unrelated reasons (e.g. solver-error) does not
+    // satisfy the plan's "heuristic paths are visible, not silently
+    // presented as proof-grade" acceptance criterion.
+    let lowered = stdout.to_lowercase();
+    let has_keccak_signal = lowered.contains("keccak heuristic")
+        || lowered.contains("sha3 heuristic")
+        || lowered.contains("symbolic keccak")
+        || lowered.contains("symbolic sha3")
+        || lowered.contains("heuristic keccak");
+    assert!(
+        has_keccak_signal,
+        "expected Keccak-heuristic taint or warning in output, got:\n{stdout}"
+    );
+});


### PR DESCRIPTION
## Summary

- attribute invalid solver models involving symbolic Keccak constraints to the symbolic Keccak heuristic
- unignore the Keccak surfacing regression from #14936
- keep existing symbolic Keccak/mapping behavior, but avoid generic incomplete errors with no Keccak vocabulary