### PR TITLE
feat: route compile prose to stderr

### DIFF
--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3282,7 +3282,6 @@ Transaction successfully executed.
         .stdout_eq(str![[r#"
 Executing previous transactions from the block.
 Compiling project to generate artifacts
-No files changed, compilation skipped
 Traces:
   [..] → new LocalProjectContract@0x5FbDB2315678afecb367f032d93F642f64180aa3
     ├─ emit LocalProjectContractCreated(owner: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266)
@@ -3291,6 +3290,10 @@ Traces:
 
 Transaction successfully executed.
 [GAS]
+
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
 });

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -218,10 +218,10 @@ impl ProjectCompiler {
         if !quiet {
             if !shell::is_json() {
                 if output.is_unchanged() {
-                    sh_println!("No files changed, compilation skipped")?;
+                    sh_status!("No files changed, compilation skipped")?;
                 } else {
                     // print the compiler output / warnings
-                    sh_println!("{output}")?;
+                    sh_status!("{output}")?;
                 }
             }
 

--- a/crates/forge/tests/cli/backtrace.rs
+++ b/crates/forge/tests/cli/backtrace.rs
@@ -14,10 +14,10 @@ forgetest!(test_backtraces, |prj, cmd| {
 
     let output = cmd.args(["test", "-vvvvv"]).assert_failure();
 
-    output.stdout_eq(str![[r#"
+    output
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful with warnings:
 ...
 Ran 11 tests for test/Backtrace.t.sol:BacktraceTest
 [FAIL: panic: assertion failed (0x01)] testAssertFail() ([GAS])
@@ -95,6 +95,10 @@ Backtrace:
 
 Suite result: FAILED. 0 passed; 11 failed; 0 skipped; [ELAPSED]
 ...
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful with warnings:
+
 "#]]);
 });
 
@@ -297,10 +301,10 @@ forgetest!(test_library_backtrace, |prj, cmd| {
     let output =
         cmd.args(["test", "-vvv", "--ast", "--mc", "LibraryBacktraceTest"]).assert_failure();
 
-    output.stdout_eq(str![[r#"
+    output
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 9 tests for test/LibraryBacktrace.t.sol:LibraryBacktraceTest
 [FAIL: DivisionByZero()] testExternalDivisionByZero() ([GAS])
@@ -368,6 +372,10 @@ Backtrace:
 
 Suite result: FAILED. 0 passed; 9 failed; 0 skipped; [ELAPSED]
 ...
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 });
 
@@ -395,7 +403,6 @@ forgetest!(test_multiple_libraries_same_file, |prj, cmd| {
     output.stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 4 tests for test/MultipleLibraryBacktrace.t.sol:MultipleLibraryBacktraceTest
 [FAIL: FirstLibError()] testAllLibrariesFirstFails() ([GAS])
@@ -428,6 +435,9 @@ Backtrace:
 Suite result: FAILED. 0 passed; 4 failed; 0 skipped; [ELAPSED]
 
 ...
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 });
 
@@ -508,7 +518,6 @@ Suite result: FAILED. 0 passed; 5 failed; 0 skipped; [ELAPSED]
         ])
         .assert_failure()
         .stdout_eq(str![[r#"
-No files changed, compilation skipped
 ...
 Ran 1 test for test/ForkBacktrace.t.sol:ForkBacktraceTest
 [FAIL: ERC20: transfer amount exceeds allowance] testTransferFromWithoutApproval() ([GAS])
@@ -519,6 +528,10 @@ Backtrace:
   at ForkedERC20Wrapper.transferFromWithoutApproval (src/ForkedERC20Wrapper.sol:18:101)
   at ForkBacktraceTest.testTransferFromWithoutApproval (test/ForkBacktrace.t.sol:22:65)
 ...
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
+
 "#]]);
 });
 
@@ -611,7 +624,6 @@ Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
         .args(["test", "--mc", "BacktraceVerbosityTest", "-vvv"])
         .assert_failure()
         .stdout_eq(str![[r#"
-No files changed, compilation skipped
 
 Ran 1 test for test/BacktraceVerbosity.t.sol:BacktraceVerbosityTest
 [FAIL: Simple revert message] testRevert() ([GAS])
@@ -627,6 +639,10 @@ Backtrace:
 
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 ...
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
+
 "#]]);
 
     // -vvvv (verbosity 4): traces with setup and backtrace WITHOUT source locations.
@@ -634,7 +650,6 @@ Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
         .args(["test", "--mc", "BacktraceVerbosityTest", "-vvvv"])
         .assert_failure()
         .stdout_eq(str![[r#"
-No files changed, compilation skipped
 
 Ran 1 test for test/BacktraceVerbosity.t.sol:BacktraceVerbosityTest
 [FAIL: Simple revert message] testRevert() ([GAS])
@@ -655,6 +670,10 @@ Backtrace:
 
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 ...
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
+
 "#]]);
 
     // -vvvvv (verbosity 5): traces with setup, storage changes, and backtrace WITH source
@@ -663,7 +682,6 @@ Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
         .args(["test", "--mc", "BacktraceVerbosityTest", "-vvvvv"])
         .assert_failure()
         .stdout_eq(str![[r#"
-No files changed, compilation skipped
 
 Ran 1 test for test/BacktraceVerbosity.t.sol:BacktraceVerbosityTest
 [FAIL: Simple revert message] testRevert() ([GAS])
@@ -684,5 +702,9 @@ Backtrace:
 
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 ...
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
+
 "#]]);
 });

--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -16,11 +16,16 @@ contract SomeLibContract {
 }
    "#,
     );
-    cmd.args(["bind", "--select", "SomeLibContract"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["bind", "--select", "SomeLibContract"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Generating bindings for 1 contracts
 Bindings have been generated to [..]
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 });

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -73,10 +73,11 @@ contract Dummy {
 
 forgetest!(initcode_size_exceeds_limit, |prj, cmd| {
     prj.add_source("LargeContract.sol", generate_large_init_contract(50_000).as_str());
-    cmd.args(["build", "--sizes"]).assert_failure().stdout_eq(str![[r#"
+    cmd.args(["build", "--sizes"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 ╭---------------+------------------+-------------------+--------------------+---------------------╮
 | Contract      | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
@@ -84,6 +85,10 @@ Compiler run successful!
 | LargeContract | 62               | 50,125            | 24,514             | -973                |
 ╰---------------+------------------+-------------------+--------------------+---------------------╯
 
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -101,13 +106,19 @@ Compiler run successful!
         .is_json(),
     );
 
-    cmd.forge_fuse().args(["build", "--sizes", "--md"]).assert_failure().stdout_eq(str![[r#"
-No files changed, compilation skipped
+    cmd.forge_fuse()
+        .args(["build", "--sizes", "--md"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
 
 | Contract      | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
 |---------------|------------------|-------------------|--------------------|---------------------|
 | LargeContract | 62               | 50,125            | 24,514             | -973                |
 
+
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
 
@@ -148,12 +159,15 @@ No files changed, compilation skipped
         .args(["build", "--sizes", "--ignore-eip-3860", "--md"])
         .assert_success()
         .stdout_eq(str![[r#"
-No files changed, compilation skipped
 
 | Contract      | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
 |---------------|------------------|-------------------|--------------------|---------------------|
 | LargeContract | 62               | 50,125            | 24,514             | -973                |
 
+
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
 });
@@ -182,9 +196,14 @@ forgetest!(build_sizes_respects_configured_code_size_limit, |prj, cmd| {
 // tests build output is as expected
 forgetest_init!(exact_build_output, |prj, cmd| {
     prj.initialize_default_contracts();
-    cmd.args(["build", "--force"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["build", "--force"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -740,6 +740,9 @@ Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag:
 Collecting the creation information of 0x044b75f554b886A065b9567891e45c79542d7357 from Etherscan...
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+    .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -797,6 +800,9 @@ Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag:
 Collecting the creation information of 0xDb53f47aC61FE54F456A4eb3E09832D08Dd7BEec from Sourcify...
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -830,6 +836,9 @@ Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag:
 Collecting the creation information of 0x33e690aEa97E4Ef25F0d140F1bf044d663091DAf from Etherscan...
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+    .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -1049,6 +1058,9 @@ Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag:
 Collecting the creation information of 0xA3E217869460bEf59A1CfD0637e2875F9331e823 from Etherscan...
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+    .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -1076,9 +1088,14 @@ forgetest!(can_clean_hardhat, PathStyle::HardHat, |prj, cmd| {
 forgetest_init!(can_clean_config, |prj, cmd| {
     prj.initialize_default_contracts();
     prj.update_config(|config| config.out = "custom-out".into());
-    cmd.arg("build").assert_success().stdout_eq(str![[r#"
+    cmd.arg("build")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -1117,9 +1134,14 @@ forgetest_init!(can_emit_extra_output, |prj, cmd| {
     prj.initialize_default_contracts();
     prj.clear();
 
-    cmd.args(["build", "--extra-output", "metadata"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["build", "--extra-output", "metadata"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -1136,6 +1158,9 @@ Compiler run successful!
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -1161,6 +1186,9 @@ forgetest_init!(can_emit_multiple_extra_output, |prj, cmd| {
     .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+    .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -1188,6 +1216,9 @@ Compiler run successful!
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -1225,6 +1256,8 @@ contract Greeter {
     cmd.arg("build").assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]]).stderr_eq(str![[r#"
 Compiler run successful with warnings:
 Warning (5667): Unused function parameter. Remove or comment out the variable name to silence this warning.
  [FILE]:5:18:
@@ -1243,7 +1276,6 @@ Warning (2018): Function state mutability can be restricted to pure
   |
 5 |     function foo(uint256 a) public {
   |     ^ (Relevant source part starts here and spans across multiple lines).
-
 
 "#]]);
 });
@@ -1281,9 +1313,14 @@ library FooLib {
    "#,
     );
 
-    cmd.arg("build").assert_success().stdout_eq(str![[r#"
+    cmd.arg("build")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -1427,27 +1464,37 @@ contract ATest is DSTest {
    "#,
     );
 
-    cmd.args(["snapshot"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["snapshot"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for src/ATest.t.sol:ATest
 [PASS] testExample() ([GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
-    cmd.arg("--check").assert_success().stdout_eq(str![[r#"
-No files changed, compilation skipped
+    cmd.arg("--check")
+        .assert_success()
+        .stdout_eq(str![[r#"
 
 Ran 1 test for src/ATest.t.sol:ATest
 [PASS] testExample() ([GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
 });
@@ -1493,9 +1540,14 @@ contract A {
 ",
     );
 
-    cmd.args(["build", "--force"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["build", "--force"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -1506,11 +1558,12 @@ Compiler run successful!
     cmd.forge_fuse().args(["build", "--force"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]]).stderr_eq(str![[r#"
 Compiler run successful with warnings:
 Warning (1878): SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
 Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
 [FILE]
-
 
 "#]]);
 });
@@ -1530,9 +1583,14 @@ contract A {
    ",
     );
 
-    cmd.args(["build", "--force"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["build", "--force"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -1545,11 +1603,12 @@ Compiler run successful!
     cmd.forge_fuse().args(["build", "--force"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]]).stderr_eq(str![[r#"
 Compiler run successful with warnings:
 Warning (1878): SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
 Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
 [FILE]
-
 
 "#]]);
 });
@@ -1575,11 +1634,12 @@ contract A {
     cmd.args(["build", "--force"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]]).stderr_eq(str![[r#"
 Compiler run successful with warnings:
 Warning (1878): SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
 Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
 [FILE]
-
 
 "#]]);
 
@@ -1603,9 +1663,15 @@ Warning: SPDX license identifier not provided in source file. Before publishing,
         config.deny = DenyLevel::Warnings;
     });
 
-    cmd.forge_fuse().args(["build", "--force"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse()
+        .args(["build", "--force"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -1629,9 +1695,14 @@ contract A {}
         ];
     });
 
-    cmd.args(["build", "--force"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["build", "--force"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -1647,11 +1718,12 @@ Compiler run successful!
     cmd.forge_fuse().args(["build", "--force"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]]).stderr_eq(str![[r#"
 Compiler run successful with warnings:
 Warning (1878): SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
 Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
 [FILE]
-
 
 "#]]);
 });
@@ -1688,10 +1760,15 @@ contract BTest is DSTest {
    "#,
     );
 
-    cmd.arg("build").assert_success().stdout_eq(str![[r#"
+    cmd.arg("build")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 ...
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -1750,9 +1827,15 @@ contract CTest is DSTest {
    "#,
     );
 
-    cmd.forge_fuse().args(["build", "--force"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse()
+        .args(["build", "--force"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -3042,7 +3125,6 @@ contract CounterWithFallbackTest is Test {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/FallbackWithCalldataTest.sol:CounterWithFallbackTest
 [PASS] test_fallback_with_calldata() ([GAS])
@@ -3070,6 +3152,9 @@ Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -3283,9 +3368,14 @@ forgetest_init!(can_use_absolute_imports, |prj, cmd| {
    "#,
     );
 
-    cmd.arg("build").assert_success().stdout_eq(str![[r#"
+    cmd.arg("build")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -3326,9 +3416,14 @@ contract MyTest is IMyTest {}
     "#,
     );
 
-    cmd.arg("build").assert_success().stdout_eq(str![[r#"
+    cmd.arg("build")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -3391,12 +3486,17 @@ forgetest_init!(can_bind, |prj, cmd| {
     prj.initialize_default_contracts();
     prj.clear();
 
-    cmd.arg("bind").assert_success().stdout_eq(str![[r#"
+    cmd.arg("bind")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Generating bindings for [..] contracts
 Bindings have been generated to [..]
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -3407,17 +3507,25 @@ forgetest_init!(can_build_skip_contracts, |prj, cmd| {
     prj.clear();
 
     // Only builds the single template contract `src/*`
-    cmd.args(["build", "--skip", "tests", "--skip", "scripts"]).assert_success().stdout_eq(str![[
-        r#"
+    cmd.args(["build", "--skip", "tests", "--skip", "scripts"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
-"#
-    ]]);
+"#]]);
 
     // Expect compilation to be skipped as no files have changed
-    cmd.arg("build").assert_success().stdout_eq(str![[r#"
+    cmd.arg("build")
+        .assert_success()
+        .stdout_eq(str![[r#"
+
+"#]])
+        .stderr_eq(str![[r#"
 No files changed, compilation skipped
 
 "#]]);
@@ -3440,6 +3548,9 @@ function test_run() external {}
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -3450,6 +3561,9 @@ Compiler run successful!
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -3480,9 +3594,14 @@ function test_bar() external {}
 
     // Build 2 files within test dir
     prj.clear();
-    cmd.args(["build", "test", "--force"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["build", "test", "--force"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -3490,9 +3609,14 @@ Compiler run successful!
     // Build one file within src dir
     prj.clear();
     cmd.forge_fuse();
-    cmd.args(["build", "src", "--force"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["build", "src", "--force"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -3500,9 +3624,14 @@ Compiler run successful!
     // Build 3 files from test and src dirs
     prj.clear();
     cmd.forge_fuse();
-    cmd.args(["build", "src", "test", "--force"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["build", "src", "test", "--force"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -3510,9 +3639,14 @@ Compiler run successful!
     // Build single test file
     prj.clear();
     cmd.forge_fuse();
-    cmd.args(["build", "test/Bar.sol", "--force"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["build", "test/Bar.sol", "--force"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -3571,13 +3705,18 @@ forgetest_init!(can_build_names_repeatedly, |prj, cmd| {
     prj.initialize_default_contracts();
     prj.clear_cache();
 
-    cmd.args(["build", "--names"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["build", "--names"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
   compiler version: [..]
     - [..]
 ...
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -4174,23 +4313,31 @@ forgetest_init!(can_bind_enum_modules, |prj, cmd| {
     }"#,
     );
 
-    cmd.args(["bind", "--select", "^Enum$"]).assert_success().stdout_eq(str![[
-        r#"[COMPILING_FILES] with [SOLC_VERSION]
+    cmd.args(["bind", "--select", "^Enum$"])
+        .assert_success()
+        .stdout_eq(str![[r#"[COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Generating bindings for 1 contracts
-Bindings have been generated to [..]"#
-    ]]);
+Bindings have been generated to [..]"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
+"#]]);
 });
 
 // forge bind e2e
 forgetest_init!(can_bind_e2e, |prj, cmd| {
     prj.initialize_default_contracts();
-    cmd.args(["bind"]).assert_success().stdout_eq(str![[r#"[COMPILING_FILES] with [SOLC_VERSION]
+    cmd.args(["bind"])
+        .assert_success()
+        .stdout_eq(str![[r#"[COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Generating bindings for 2 contracts
-Bindings have been generated to [..]"#]]);
+Bindings have been generated to [..]"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
+"#]]);
 
     let bindings_path = prj.root().join("out/bindings");
 

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -630,9 +630,14 @@ contract Greeter {}
         config.solc = Some(OTHER_SOLC_VERSION.into());
     });
 
-    cmd.arg("build").assert_success().stdout_eq(str![[r#"
+    cmd.arg("build")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -648,9 +653,14 @@ contract Foo {}
    ",
     );
 
-    cmd.args(["build", "--use", OTHER_SOLC_VERSION]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["build", "--use", OTHER_SOLC_VERSION])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -662,6 +672,9 @@ Compiler run successful!
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -683,6 +696,9 @@ Error: `solc` this/solc/does/not/exist does not exist
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -2003,9 +2019,14 @@ forgetest_init!(test_exclude_lints_config, |prj, cmd| {
             "unwrapped-modifier-logic".to_string(),
         ]
     });
-    cmd.args(["lint"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["lint"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -11,11 +11,11 @@ fn assert_lcov(cmd: &mut TestCommand, data: impl IntoData) {
 }
 
 fn basic_base(prj: TestProject, mut cmd: TestCommand) {
-    cmd.args(["coverage", "--report=lcov", "--report=summary"]).assert_success().stdout_eq(str![[
-        r#"
+    cmd.args(["coverage", "--report=lcov", "--report=summary"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Analysing contracts...
 Running tests...
 
@@ -37,8 +37,11 @@ Wrote LCOV report.
 | Total                | 44.44% (4/9)  | 40.00% (2/5)  | 100.00% (0/0) | 50.00% (2/4)  |
 ╰----------------------+---------------+---------------+---------------+---------------╯
 
-"#
-    ]]);
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
+"#]]);
 
     let lcov = prj.root().join("lcov.info");
     assert!(lcov.exists(), "lcov.info was not created");

--- a/crates/forge/tests/cli/create.rs
+++ b/crates/forge/tests/cli/create.rs
@@ -149,10 +149,10 @@ forgetest_async!(can_create_template_contract, |prj, cmd| {
     ]);
 
     // Dry-run
-    cmd.assert().stdout_eq(str![[r#"
+    cmd.assert()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Contract: Counter
 Transaction: {
   "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
@@ -200,6 +200,10 @@ ABI: [
   }
 ]
 
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -269,11 +273,15 @@ ABI: [
         "--broadcast",
     ]);
 
-    cmd.assert().stdout_eq(str![[r#"
-No files changed, compilation skipped
+    cmd.assert()
+        .stdout_eq(str![[r#"
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
 [TX_HASH]
+
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
 });
@@ -337,21 +345,29 @@ forgetest_async!(can_create_using_unlocked, |prj, cmd| {
         "--broadcast",
     ]);
 
-    cmd.assert().stdout_eq(str![[r#"
+    cmd.assert()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
 [TX_HASH]
 
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 
-    cmd.assert().stdout_eq(str![[r#"
-No files changed, compilation skipped
+    cmd.assert()
+        .stdout_eq(str![[r#"
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Deployed to: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
 [TX_HASH]
+
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
 });
@@ -397,10 +413,13 @@ contract ConstructorContract {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
 [TX_HASH]
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -434,10 +453,13 @@ contract TupleArrayConstructorContract {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Deployed to: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
 [TX_HASH]
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -481,16 +503,18 @@ contract UniswapV2Swap {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+Deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
+[TX_HASH]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful with warnings:
 Warning (2018): Function state mutability can be restricted to pure
  [FILE]:6:5:
   |
 6 |     function pairInfo() public view returns (uint reserveA, uint reserveB, uint totalSupply) {
   |     ^ (Relevant source part starts here and spans across multiple lines).
-
-Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
-Deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
-[TX_HASH]
 
 "#]]);
 });

--- a/crates/forge/tests/cli/eip712.rs
+++ b/crates/forge/tests/cli/eip712.rs
@@ -158,10 +158,12 @@ Structs.sol > Structs2 > FooBar:
     );
 
     // Testing `solar_project` doesn't mess up cache.
-    cmd.forge_fuse().arg("test").assert_failure().stdout_eq(str![[r#"
+    cmd.forge_fuse()
+        .arg("test")
+        .assert_failure()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Structs.sol:DummyTest
 [FAIL: test] testDummy() ([GAS])
@@ -176,6 +178,10 @@ Encountered 1 failing test in test/Structs.sol:DummyTest
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });

--- a/crates/forge/tests/cli/failure_assertions.rs
+++ b/crates/forge/tests/cli/failure_assertions.rs
@@ -206,8 +206,7 @@ forgetest!(flaky_expect_emit_tests_should_fail, |prj, cmd| {
     cmd.forge_fuse().arg("build").assert_success();
     cmd.forge_fuse().args(["selectors", "cache"]).assert_success();
 
-    cmd.forge_fuse().args(["test", "--mc", "ExpectEmitFailureTest"]).assert_failure().stdout_eq(str![[r#"No files changed, compilation skipped
-...
+    cmd.forge_fuse().args(["test", "--mc", "ExpectEmitFailureTest"]).assert_failure().stdout_eq(str![[r#"...
 [FAIL: E != expected A] testShouldFailCanMatchConsecutiveEvents() ([GAS])
 [FAIL: log != expected SomethingElse] testShouldFailDifferentIndexedParameters() ([GAS])
 [FAIL: log != expected log] testShouldFailEmitOnlyAppliesToNextCall() ([GAS])
@@ -225,6 +224,9 @@ forgetest!(flaky_expect_emit_tests_should_fail, |prj, cmd| {
 [FAIL: log != expected log] testShouldFailNoEmitDirectlyOnNextCall() ([GAS])
 Suite result: FAILED. 0 passed; 15 failed; 0 skipped; [ELAPSED]
 ...
+"#]]).stderr_eq(str![[r#"
+No files changed, compilation skipped
+
 "#]]);
 
     cmd.forge_fuse()

--- a/crates/forge/tests/cli/inline_config.rs
+++ b/crates/forge/tests/cli/inline_config.rs
@@ -13,10 +13,11 @@ forgetest!(runs, |prj, cmd| {
     ",
     );
 
-    cmd.arg("test").assert_success().stdout_eq(str![[r#"
+    cmd.arg("test")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 2 tests for test/inline.sol:Inline
 [PASS] test1(bool) (runs: 2, [AVG_GAS])
@@ -25,13 +26,19 @@ Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
 
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 
     // Make sure inline config is parsed in coverage too.
-    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse()
+        .arg("coverage")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Analysing contracts...
 Running tests...
 
@@ -47,6 +54,10 @@ Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
 +=======================================================================+
 | Total | 100.00% (0/0) | 100.00% (0/0) | 100.00% (0/0) | 100.00% (0/0) |
 ╰-------+---------------+---------------+---------------+---------------╯
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -81,10 +92,12 @@ forgetest!(invalid_key, |prj, cmd| {
     ",
     );
 
-    cmd.arg("test").assert_failure().stderr_eq(str![[]]).stdout_eq(str![[r#"
+    cmd.arg("test").assert_failure().stderr_eq(str![[r#"
+Compiler run successful!
+
+"#]]).stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/inline.sol:Inline
 [FAIL: failed to get inline configuration: unknown config section `default`] test(bool) ([GAS])
@@ -112,10 +125,12 @@ forgetest!(invalid_key_2, |prj, cmd| {
     ",
     );
 
-    cmd.arg("test").assert_failure().stderr_eq(str![[]]).stdout_eq(str![[r#"
+    cmd.arg("test").assert_failure().stderr_eq(str![[r#"
+Compiler run successful!
+
+"#]]).stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/inline.sol:Inline
 [FAIL: failed to get inline configuration: unknown config section `default`] test(bool) ([GAS])
@@ -144,10 +159,12 @@ forgetest!(invalid_value, |prj, cmd| {
     ",
     );
 
-    cmd.arg("test").assert_failure().stderr_eq(str![[]]).stdout_eq(str![[r#"
+    cmd.arg("test").assert_failure().stderr_eq(str![[r#"
+Compiler run successful!
+
+"#]]).stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/inline.sol:Inline
 [FAIL: invalid type: found sequence, expected u32 for key "default.fuzz.runs" in inline config] setUp() ([GAS])
@@ -177,10 +194,12 @@ forgetest!(invalid_value_2, |prj, cmd| {
     ",
     );
 
-    cmd.arg("test").assert_failure().stderr_eq(str![[]]).stdout_eq(str![[r#"
+    cmd.arg("test").assert_failure().stderr_eq(str![[r#"
+Compiler run successful!
+
+"#]]).stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/inline.sol:Inline
 [FAIL: invalid type: found string "2", expected u32 for key "default.fuzz.runs" in inline config] setUp() ([GAS])
@@ -255,10 +274,11 @@ forgetest_init!(config_inline_isolate, |prj, cmd| {
     "#,
     );
 
-    cmd.args(["test", "-j1"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "-j1"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/inline.sol:ContractConfig
 [PASS] test_non_isolate() ([GAS])
@@ -270,6 +290,10 @@ Ran 2 tests for test/inline.sol:FunctionConfig
 Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 2 test suites [ELAPSED]: 3 tests passed, 0 failed, 0 skipped (3 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -504,10 +528,11 @@ forgetest!(per_test_network_routing, |prj, cmd| {
         "#,
     );
 
-    cmd.arg("test").assert_success().stdout_eq(str![[r#"
+    cmd.arg("test")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/inline.sol:[..]Network
 [PASS] test_fee_manager_absent_on_[..]() ([GAS])
@@ -526,6 +551,10 @@ Ran 1 test for test/inline.sol:[..]Network
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 3 test suites [ELAPSED]: 4 tests passed, 0 failed, 0 skipped (4 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -31,12 +31,17 @@ forgetest_init!(can_install_missing_deps_build, |prj, cmd| {
     pretty_err(&forge_std_dir, fs::remove_dir_all(&forge_std_dir));
 
     // Build the project
-    cmd.arg("build").assert_success().stdout_eq(str![[r#"
+    cmd.arg("build")
+        .assert_success()
+        .stdout_eq(str![[r#"
 Missing dependencies found. Installing now...
 
 [UPDATING_DEPENDENCIES]
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);
@@ -46,7 +51,13 @@ Compiler run successful!
     assert_eq!(forge_std.rev(), FORGE_STD_REVISION);
 
     // Expect compilation to be skipped as no files have changed
-    cmd.forge_fuse().arg("build").assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse()
+        .arg("build")
+        .assert_success()
+        .stdout_eq(str![[r#"
+
+"#]])
+        .stderr_eq(str![[r#"
 No files changed, compilation skipped
 
 "#]]);
@@ -61,13 +72,14 @@ forgetest_init!(can_install_missing_deps_test, |prj, cmd| {
     let forge_std_dir = prj.root().join("lib/forge-std");
     pretty_err(&forge_std_dir, fs::remove_dir_all(&forge_std_dir));
 
-    cmd.arg("test").assert_success().stdout_eq(str![[r#"
+    cmd.arg("test")
+        .assert_success()
+        .stdout_eq(str![[r#"
 Missing dependencies found. Installing now...
 
 [UPDATING_DEPENDENCIES]
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 2 tests for test/Counter.t.sol:CounterTest
 [PASS] testFuzz_SetNumber(uint256) (runs: 256, [AVG_GAS])
@@ -75,6 +87,10 @@ Ran 2 tests for test/Counter.t.sol:CounterTest
 Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -438,9 +454,15 @@ contract CounterCopy is Counter {
         );
 
         // build and check output
-        cmd.forge_fuse().arg("build").assert_success().stdout_eq(str![[r#"
+        cmd.forge_fuse()
+            .arg("build")
+            .assert_success()
+            .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+            .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -700,9 +700,6 @@ warning[divide-before-multiply]: multiplication should occur before division to 
    ╰ help: https://getfoundry.sh/forge/linting/divide-before-multiply
 
 
-"#]]).stdout_eq(str![[r#"
-[COMPILING_FILES] with [SOLC_VERSION]
-[SOLC_VERSION] [ELAPSED]
 Compiler run successful with warnings:
 Warning (2072): Unused local variable.
   [FILE]:13:9:
@@ -734,6 +731,9 @@ Warning (2018): Function state mutability can be restricted to pure
 18 |     function unoptimizedHashGas(uint256 a, uint256 b) public view {
    |     ^ (Relevant source part starts here and spans across multiple lines).
 
+"#]]).stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 
 "#]]);
 });
@@ -799,9 +799,9 @@ forgetest!(build_respects_lint_on_build_false, |prj, cmd| {
     });
 
     // Run forge build - should NOT show linting output because lint_on_build is false
-    cmd.arg("build").assert_success().stderr_eq(str![[""]]).stdout_eq(str![[r#"
-[COMPILING_FILES] with [SOLC_VERSION]
-[SOLC_VERSION] [ELAPSED]
+    cmd.arg("build")
+        .assert_success()
+        .stderr_eq(str![[r#"
 Compiler run successful with warnings:
 Warning (2072): Unused local variable.
   [FILE]:13:9:
@@ -833,6 +833,10 @@ Warning (2018): Function state mutability can be restricted to pure
 18 |     function unoptimizedHashGas(uint256 a, uint256 b) public view {
    |     ^ (Relevant source part starts here and spans across multiple lines).
 
+"#]])
+        .stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 
 "#]]);
 });
@@ -874,10 +878,9 @@ forgetest!(build_no_lint_flag_skips_lint, |prj, cmd| {
         };
     });
 
-    cmd.args(["build", "--no-lint"]).assert_success().stderr_eq(str![[r#""#]]).stdout_eq(str![[
-        r#"
-[COMPILING_FILES] with [SOLC_VERSION]
-[SOLC_VERSION] [ELAPSED]
+    cmd.args(["build", "--no-lint"])
+        .assert_success()
+        .stderr_eq(str![[r#"
 Compiler run successful with warnings:
 Warning (2072): Unused local variable.
   [FILE]:13:9:
@@ -909,9 +912,12 @@ Warning (2018): Function state mutability can be restricted to pure
 18 |     function unoptimizedHashGas(uint256 a, uint256 b) public view {
    |     ^ (Relevant source part starts here and spans across multiple lines).
 
+"#]])
+        .stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 
-"#
-    ]]);
+"#]]);
 });
 
 // `deny = notes` + an info-level lint forces the linter to return Err, exercising the same
@@ -1026,9 +1032,15 @@ forgetest!(can_lint_param_constants, |prj, cmd| {
     prj.add_source("Counter", COUNTER_WITH_CONST);
     prj.add_test("CounterTest", COUNTER_TEST_WITH_CONST);
 
-    cmd.forge_fuse().args(["build"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse()
+        .args(["build"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+
+"#]])
+        .stderr_eq(str![[r#"
 Compiler run successful!
 
 "#]]);

--- a/crates/forge/tests/cli/precompiles.rs
+++ b/crates/forge/tests/cli/precompiles.rs
@@ -215,10 +215,11 @@ contract CeloTransferTest is Test {
    "#,
     );
 
-    cmd.args(["test", "--mt", "testCeloBalance", "-vvv"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--mt", "testCeloBalance", "-vvv"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/CeloTransfer.t.sol:CeloTransferTest
 [PASS] testCeloBalance() ([GAS])
@@ -229,6 +230,10 @@ Logs:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -57,15 +57,21 @@ contract Demo {
    "#,
     );
 
-    cmd.arg("script").arg(script).assert_success().stdout_eq(str![[r#"
+    cmd.arg("script")
+        .arg(script)
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Script ran successfully.
 [GAS]
 
 == Logs ==
   script ran
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -260,7 +266,6 @@ contract DeployScript is Script {
     .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Traces:
   [..] DeployScript::run()
     ├─ [0] VM::startBroadcast()
@@ -306,6 +311,10 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 
 [SAVED_SENSITIVE_VALUES]
 
+
+"#]])
+    .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -358,13 +367,6 @@ contract DeployScript is Script {
     .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful with warnings:
-Warning (2018): Function state mutability can be restricted to view
- [FILE]:7:5:
-  |
-7 |     function wasteGas(uint256 minGas) public {
-  |     ^ (Relevant source part starts here and spans across multiple lines).
-
 Traces:
   [..] DeployScript::run()
     ├─ [0] VM::startBroadcast()
@@ -411,6 +413,15 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 [SAVED_SENSITIVE_VALUES]
 
 
+"#]])
+    .stderr_eq(str![[r#"
+Compiler run successful with warnings:
+Warning (2018): Function state mutability can be restricted to view
+ [FILE]:7:5:
+  |
+7 |     function wasteGas(uint256 minGas) public {
+  |     ^ (Relevant source part starts here and spans across multiple lines).
+
 "#]]);
 });
 
@@ -441,7 +452,6 @@ contract Demo {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Script ran successfully.
 [GAS]
 
@@ -449,6 +459,10 @@ Script ran successfully.
   script ran
   1
   2
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -471,10 +485,14 @@ contract Demo {
    "#,
     );
 
-    cmd.arg("script").arg(script).arg("1").arg("2").assert_success().stdout_eq(str![[r#"
+    cmd.arg("script")
+        .arg(script)
+        .arg("1")
+        .arg("2")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Script ran successfully.
 [GAS]
 
@@ -482,6 +500,10 @@ Script ran successfully.
   script ran
   1
   2
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -500,10 +522,12 @@ contract Demo {
 }"#,
     );
 
-    cmd.arg("script").arg(script).assert_success().stdout_eq(str![[r#"
+    cmd.arg("script")
+        .arg(script)
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Script ran successfully.
 [GAS]
 
@@ -513,6 +537,10 @@ result: uint256 255
 
 == Logs ==
   script ran
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -575,7 +603,6 @@ contract DeployScript is Script {
     .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Traces:
   [..] DeployScript::run()
     ├─ [0] VM::startBroadcast()
@@ -598,6 +625,10 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 
 [SAVED_SENSITIVE_VALUES]
 
+
+"#]])
+    .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -655,7 +686,6 @@ contract RunScript is Script {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Traces:
   [..] RunScript::run()
     ├─ [0] VM::startBroadcast()
@@ -726,6 +756,10 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 
 [SAVED_SENSITIVE_VALUES]
 
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1208,7 +1242,6 @@ contract Script0 is Script {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 ...
 Script ran successfully.
 
@@ -1232,6 +1265,9 @@ SIMULATION COMPLETE. To broadcast these transactions, add --broadcast and wallet
 
 [SAVED_SENSITIVE_VALUES]
 
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -1334,7 +1370,6 @@ contract Script0 is Script {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 ...
 Script ran successfully.
 
@@ -1358,6 +1393,9 @@ SIMULATION COMPLETE. To broadcast these transactions, add --broadcast and wallet
 
 [SAVED_SENSITIVE_VALUES]
 
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -1404,7 +1442,6 @@ contract Demo {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Script ran successfully.
 [GAS]
 
@@ -1414,6 +1451,10 @@ result: uint256 255
 
 == Logs ==
   script ran
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1507,11 +1548,14 @@ contract ContractC {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Script ran successfully.
 [GAS]
 
 If you wish to simulate on-chain transactions pass a RPC URL.
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1578,7 +1622,6 @@ contract NestedCreate is Script {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Script ran successfully.
 [GAS]
 
@@ -1588,6 +1631,10 @@ Script ran successfully.
   0x159E2f2F1C094625A2c6c8bF59526d91454c2F3c
 
 If you wish to simulate on-chain transactions pass a RPC URL.
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1604,12 +1651,18 @@ interface Interface {}
             "#,
     );
 
-    cmd.arg("script").arg(script).assert_success().stdout_eq(str![[r#"
+    cmd.arg("script")
+        .arg(script)
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Script ran successfully.
 [GAS]
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1630,14 +1683,20 @@ contract Script {
             "#,
     );
 
-    cmd.arg("script").arg(script).assert_success().stdout_eq(str![[r#"
+    cmd.arg("script")
+        .arg(script)
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Script ran successfully.
 [GAS]
 
 If you wish to simulate on-chain transactions pass a RPC URL.
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1834,7 +1893,6 @@ contract SimpleScript is Script {
     .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 ...
 Script ran successfully.
 
@@ -1866,6 +1924,8 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 
 
 "#]]).stderr_eq(str![[r#"
+Compiler run successful!
+
 Warning: Script contains a transaction to 0x0000000000000000000000000000000000000000 which does not contain any code.
 
 "#]]);
@@ -1885,7 +1945,6 @@ Warning: Script contains a transaction to 0x000000000000000000000000000000000000
         ])
         .assert_success()
         .stdout_eq(str![[r#"
-No files changed, compilation skipped
 ...
 Script ran successfully.
 
@@ -1917,6 +1976,8 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 
 
 "#]]).stderr_eq(str![[r#"
+No files changed, compilation skipped
+
 Warning: Script contains a transaction to 0x0000000000000000000000000000000000000000 which does not contain any code.
 
 "#]]);
@@ -2029,7 +2090,6 @@ contract SimpleScript is Script {
     .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 ...
 Script ran successfully.
 
@@ -2061,6 +2121,8 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 
 
 "#]]).stderr_eq(str![[r#"
+Compiler run successful!
+
 Warning: Script contains a transaction to 0x0000000000000000000000000000000000000000 which does not contain any code.
 
 "#]]);
@@ -2142,14 +2204,16 @@ contract SimpleScript is Script {
     .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
+Script ran successfully.
+
+"#]])
+    .stderr_eq(str![[r#"
 Compiler run successful with warnings:
 Warning (2018): Function state mutability can be restricted to view
   [FILE]:13:5:
    |
 13 |     function run() external {
    |     ^ (Relevant source part starts here and spans across multiple lines).
-
-Script ran successfully.
 
 "#]]);
 });
@@ -2245,10 +2309,10 @@ contract SimpleScript is Script {
         "SimpleScript",
     ]);
 
-    cmd.assert_success().stdout_eq(str![[r#"
+    cmd.assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Script ran successfully.
 
 ## Setting up 1 EVM.
@@ -2274,6 +2338,10 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 
 [SAVED_SENSITIVE_VALUES]
 
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -2313,12 +2381,15 @@ contract WalletScript is Script {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Script ran successfully.
 [GAS]
 
 == Logs ==
   0xa0Ee7A142d267C1f36714E4a8F75612F20a79720
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -2345,10 +2416,12 @@ contract WalletScript is Script {
     }
 }"#,
         );
-    cmd.arg("script").arg(script).assert_success().stdout_eq(str![[r#"
+    cmd.arg("script")
+        .arg(script)
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Script ran successfully.
 [GAS]
 
@@ -2356,6 +2429,10 @@ Script ran successfully.
   0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
   0x70997970C51812dc3A010C7d01b50e0d17dc79C8
   0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -2389,10 +2466,10 @@ contract SimpleScript is Script {
     );
 
     cmd.arg("script").args(["SimpleScript", "--fork-url", &handle.http_endpoint(), "-vvvv"]);
-    cmd.assert_success().stdout_eq(str![[r#"
+    cmd.assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Traces:
   [..] SimpleScript::run()
     ├─ [0] VM::startBroadcast()
@@ -2420,6 +2497,10 @@ Simulated On-chain Traces:
     │   └─ ← [Return] 100
     └─ ← [Return] 62 bytes of code
 ...
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 });
 
@@ -2552,7 +2633,6 @@ contract DryRunTest is Script {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Traces:
   [..] DryRunTest::run()
     ├─ [0] VM::startBroadcast()
@@ -2641,6 +2721,9 @@ SIMULATION COMPLETE. To broadcast these transactions, add --broadcast and wallet
 
 [SAVED_SENSITIVE_VALUES]
 
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -2796,7 +2879,6 @@ contract EIP7702Script is Script {
     .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Traces:
   [..] EIP7702Script::setUp()
     └─ ← [Stop]
@@ -2878,6 +2960,9 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 
 [SAVED_SENSITIVE_VALUES]
 
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -2974,7 +3059,6 @@ contract BatchCallDelegationScript is Script {
     .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Script ran successfully.
 
 ## Setting up 1 EVM.
@@ -3000,6 +3084,10 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 
 [SAVED_SENSITIVE_VALUES]
 
+
+"#]])
+    .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -3186,7 +3274,6 @@ contract CounterScript is Script {
     .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Traces:
   [..] → new CounterScript@[..]
     └─ ← [Return] 2162 bytes of code
@@ -3213,6 +3300,8 @@ Traces:
 
 "#]])
     .stderr_eq(str![[r#"
+Compiler run successful!
+
 Error: script failed: call to non-contract address [..]
 "#]]);
 });
@@ -3289,7 +3378,6 @@ contract CounterScript is Script {
     .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Traces:
   [..] CounterScript::run()
     ├─ [0] VM::startBroadcast()
@@ -3339,6 +3427,10 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 
 [SAVED_SENSITIVE_VALUES]
 
+
+"#]])
+    .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -3497,7 +3589,6 @@ contract DeployScript is Script {
     .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Traces:
   [9882] DeployScript::run()
     ├─ [0] 0x0000000000000000000000000000000000000000::fallback{value: 1000000000000000000}()
@@ -3538,6 +3629,10 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 
 [SAVED_SENSITIVE_VALUES]
 
+
+"#]])
+    .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -3609,11 +3704,14 @@ contract Foo is Script {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Setup
 Run 1
 Script ran successfully.
 [GAS]
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -3641,14 +3739,20 @@ contract Foo is Script {
     "#,
     );
 
-    cmd.forge_fuse().args(["script", "script/Foo.s.sol"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse()
+        .args(["script", "script/Foo.s.sol"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Setup
 Run 1
 Script ran successfully.
 [GAS]
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -116,10 +116,11 @@ contract PaymentFailureTest is Test {
 "#,
     );
 
-    cmd.arg("test").assert_failure().stdout_eq(str![[r#"
+    cmd.arg("test")
+        .assert_failure()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/PaymentFailure.t.sol:PaymentFailureTest
 [FAIL: EvmError: Revert] testCantPay() ([GAS])
@@ -134,6 +135,10 @@ Encountered 1 failing test in test/PaymentFailure.t.sol:PaymentFailureTest
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -98,16 +98,21 @@ contract FuzzTimeoutTest is Test {
    "#,
     );
 
-    cmd.args(["test", "-j2"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "-j2"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Contract.t.sol:FuzzTimeoutTest
 [PASS] test_fuzz_bound(uint256) (runs: [..], [AVG_GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -158,10 +163,11 @@ contract CounterTest is Test {
     );
 
     // Tests should not fail as revert happens in Counter contract.
-    cmd.args(["test", "--mc", "CounterTest"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--mc", "CounterTest"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 2 tests for test/CounterTest.t.sol:CounterTest
 [PASS] testFuzz_SetNumberAssert(uint256) (runs: 256, [AVG_GAS])
@@ -169,6 +175,10 @@ Ran 2 tests for test/CounterTest.t.sol:CounterTest
 Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -187,16 +197,21 @@ contract Counter {
     );
 
     // Tests should fail as revert happens in cheatcode (assert) and test (require) contract.
-    cmd.args(["-j1"]).assert_failure().stdout_eq(str![[r#"
+    cmd.args(["-j1"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 2 tests for test/CounterTest.t.sol:CounterTest
 [FAIL: assertion failed: [..]] testFuzz_SetNumberAssert(uint256) (runs: 0, [AVG_GAS])
 [FAIL: EvmError: Revert; [..]] testFuzz_SetNumberRequire(uint256) (runs: 0, [AVG_GAS])
 Suite result: FAILED. 0 passed; 2 failed; 0 skipped; [ELAPSED]
 ...
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -218,16 +233,21 @@ contract FuzzWithRejectsTest is Test {
     );
 
     // Tests should not fail as revert happens in Counter contract.
-    cmd.args(["test", "--mc", "FuzzWithRejectsTest"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--mc", "FuzzWithRejectsTest"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/FuzzWithRejectsTest.t.sol:FuzzWithRejectsTest
 [PASS] testFuzzWithRejects(uint256) (runs: 256, [AVG_GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -272,16 +292,22 @@ contract CounterTest is Test {
    "#,
     );
     // Test should pass when replay failure with changed assume logic.
-    cmd.forge_fuse().args(["test"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse()
+        .args(["test"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Counter.t.sol:CounterTest
 [PASS] testFuzz_SetNumber(uint256) (runs: 256, [AVG_GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -298,16 +324,22 @@ contract CounterTest is Test {
    "#,
     );
     // Test should pass when replay failure with changed function signature.
-    cmd.forge_fuse().args(["test"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse()
+        .args(["test"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Counter.t.sol:CounterTest
 [PASS] testFuzz_SetNumber(uint8) (runs: 256, [AVG_GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 

--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -136,10 +136,11 @@ contract InvariantAssume is Test {
 "#,
     );
 
-    assert_invariant(cmd.args(["test"])).success().stdout_eq(str![[r#"
+    assert_invariant(cmd.args(["test"]))
+        .success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/InvariantAssume.t.sol:InvariantAssume
 [PASS] invariant_dummy() ([RUNS])
@@ -150,6 +151,10 @@ Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 
     // Test that max_assume_rejects is respected.
@@ -157,8 +162,9 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
         config.invariant.max_assume_rejects = 1;
     });
 
-    assert_invariant(&mut cmd).failure().stdout_eq(str![[r#"
-No files changed, compilation skipped
+    assert_invariant(&mut cmd)
+        .failure()
+        .stdout_eq(str![[r#"
 
 Ran 1 test for test/InvariantAssume.t.sol:InvariantAssume
 [FAIL: `vm.assume` rejected too many inputs (1 allowed)] invariant_dummy() ([RUNS])
@@ -178,6 +184,10 @@ Encountered a total of 1 failing tests, 0 tests succeeded
 Tip: Run `forge test --rerun` to retry only the 1 failed test
 
 [SEED] (use `--fuzz-seed` to reproduce)
+
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
 });
@@ -417,10 +427,11 @@ contract InvariantExcludedSendersTest is Test {
 "#,
     );
 
-    assert_invariant(cmd.args(["test"])).success().stdout_eq(str![[r#"
+    assert_invariant(cmd.args(["test"]))
+        .success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/InvariantExcludedSenders.t.sol:InvariantExcludedSendersTest
 [PASS] invariant_check_sender() ([RUNS])
@@ -430,6 +441,10 @@ Ran 1 test for test/InvariantExcludedSenders.t.sol:InvariantExcludedSendersTest
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -812,8 +827,8 @@ Tip: Run `forge test --rerun` to retry only the 1 failed test
                     .join("persistence2"),
             );
         });
-        cmd.assert_failure().stdout_eq(str![[r#"
-No files changed, compilation skipped
+        cmd.assert_failure()
+            .stdout_eq(str![[r#"
 
 Ran 1 test for test/InvariantInnerContract.t.sol:InvariantInnerContract
 [FAIL: jesus betrayed]
@@ -822,6 +837,10 @@ Ran 1 test for test/InvariantInnerContract.t.sol:InvariantInnerContract
 		sender=[..] addr=[test/InvariantInnerContract.t.sol:Judas][..] calldata=betray() args=[]
  invariantHideJesus() (runs: 1, calls: 3, reverts: 1)
 ...
+"#]])
+            .stderr_eq(str![[r#"
+No files changed, compilation skipped
+
 "#]]);
     }
 );
@@ -1173,10 +1192,11 @@ contract InvariantRollForkStateTest is Test {
 "#,
     );
 
-    assert_invariant(cmd.args(["test", "-j1"])).failure().stdout_eq(str![[r#"
+    assert_invariant(cmd.args(["test", "-j1"]))
+        .failure()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/InvariantRollFork.t.sol:InvariantRollForkBlockTest
 [FAIL: too many blocks mined]
@@ -1214,6 +1234,10 @@ Encountered a total of 2 failing tests, 0 tests succeeded
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
 
 [SEED] (use `--fuzz-seed` to reproduce)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1991,13 +2015,15 @@ contract InvariantReplayKeepsInvariantAssertion is Test {
     cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/InvariantReplayKeepsInvariantAssertion.t.sol:InvariantReplayKeepsInvariantAssertion
 [FAIL: wrong counter assert]
 ...
  invariant_with_assert() ([..])
 ...
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 
     cmd.assert_failure().stdout_eq(str![[r#"
@@ -2053,23 +2079,27 @@ contract InvariantReplayKeepsAfterInvariantAssertion is Test {
     assert_invariant(cmd.args(["test"])).failure().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/InvariantReplayKeepsAfterInvariantAssertion.t.sol:InvariantReplayKeepsAfterInvariantAssertion
 [FAIL: afterInvariant assertion]
 	[SEQUENCE]
  invariant_success() ([RUNS])
 ...
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 
     assert_invariant(&mut cmd).failure().stdout_eq(str![[r#"
-No files changed, compilation skipped
 
 Ran 1 test for test/InvariantReplayKeepsAfterInvariantAssertion.t.sol:InvariantReplayKeepsAfterInvariantAssertion
 [FAIL: afterInvariant assertion]
 	[SEQUENCE]
  invariant_success() ([RUNS])
 ...
+"#]]).stderr_eq(str![[r#"
+No files changed, compilation skipped
+
 "#]]);
 });
 
@@ -2293,7 +2323,6 @@ contract HandlerWarpAndRoll {
     cmd.forge_fuse().args(["test", "--mt", "invariant_handler"]).assert_failure().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/HandlerWarpAndRoll.t.sol:HandlerWarpAndRoll
 [FAIL: max timestamp]
@@ -2306,6 +2335,9 @@ Ran 1 test for test/HandlerWarpAndRoll.t.sol:HandlerWarpAndRoll
  invariant_handler() (runs: 1, calls: 5, reverts: 1)
 
 ...
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/invariant/handler.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/handler.rs
@@ -401,19 +401,6 @@ contract MultiHandlerTest is Test {
     cmd.args(["test", "--mt", "invariant_ok"]).assert_failure().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful with warnings:
-Warning (2018): Function state mutability can be restricted to pure
- [FILE]:5:5:
-  |
-5 |     function boomA() external { assert(false); }
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Warning (2018): Function state mutability can be restricted to pure
- [FILE]:5:5:
-  |
-5 |     function boomB() external { assert(false); }
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 
 Ran 1 test for test/MultiHandlerTest.t.sol:MultiHandlerTest
 Assertion Tests: 2 assertion bug(s) found
@@ -453,6 +440,20 @@ Encountered a total of 1 failing tests, 0 tests succeeded
 Tip: Run `forge test --rerun` to retry only the 1 failed test
 
 [SEED] (use `--fuzz-seed` to reproduce)
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful with warnings:
+Warning (2018): Function state mutability can be restricted to pure
+ [FILE]:5:5:
+  |
+5 |     function boomA() external { assert(false); }
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Warning (2018): Function state mutability can be restricted to pure
+ [FILE]:5:5:
+  |
+5 |     function boomB() external { assert(false); }
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 "#]]);
 
@@ -528,7 +529,6 @@ contract ShrinkReplayTest is Test {
         config.invariant.runs = 0;
     });
     cmd.forge_fuse().args(["test", "--mt", "invariant_ok"]).assert_failure().stdout_eq(str![[r#"
-No files changed, compilation skipped
 
 Ran 1 test for test/ShrinkReplayTest.t.sol:ShrinkReplayTest
 Assertion Tests: 1 assertion bug(s) found
@@ -553,6 +553,9 @@ Encountered a total of 1 failing tests, 0 tests succeeded
 Tip: Run `forge test --rerun` to retry only the 1 failed test
 
 [SEED] (use `--fuzz-seed` to reproduce)
+
+"#]]).stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/invariant/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/mod.rs
@@ -270,10 +270,11 @@ contract TimeoutTest is Test {
      "#,
     );
 
-    cmd.args(["test", "--mt", "invariant_counter_timeout"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--mt", "invariant_counter_timeout"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/TimeoutTest.t.sol:TimeoutTest
 [PASS] invariant_counter_timeout() (runs: 0, calls: 0, reverts: 0)
@@ -287,6 +288,10 @@ Ran 1 test for test/TimeoutTest.t.sol:TimeoutTest
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -848,7 +853,6 @@ contract InvariantTargetTest is Test {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/InvariantTargetTest.t.sol:InvariantTargetTest
 [PASS]
@@ -868,6 +872,10 @@ Invariant/Property Tests:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -949,10 +957,11 @@ contract InvariantTargetExcludeTest is Test {
    "#,
     );
 
-    cmd.args(["test", "--mt", "invariant_include"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--mt", "invariant_include"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/InvariantTargetTest.t.sol:InvariantTargetIncludeTest
 [PASS] invariant_include() (runs: 10, calls: 1000, reverts: 0)
@@ -968,6 +977,10 @@ Ran 1 test for test/InvariantTargetTest.t.sol:InvariantTargetIncludeTest
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -997,7 +1010,6 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
         .args(["test", "--mt", "invariant_include", "--md"])
         .assert_success()
         .stdout_eq(str![[r#"
-No files changed, compilation skipped
 
 Ran 1 test for test/InvariantTargetTest.t.sol:InvariantTargetIncludeTest
 [PASS] invariant_include() (runs: 10, calls: 1000, reverts: 0)
@@ -1011,13 +1023,16 @@ Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
+
 "#]]);
 
     cmd.forge_fuse()
         .args(["test", "--mt", "invariant_exclude", "--md"])
         .assert_success()
         .stdout_eq(str![[r#"
-No files changed, compilation skipped
 
 Ran 1 test for test/InvariantTargetTest.t.sol:InvariantTargetExcludeTest
 [PASS] invariant_exclude() (runs: 10, calls: 1000, reverts: 0)
@@ -1030,6 +1045,10 @@ Ran 1 test for test/InvariantTargetTest.t.sol:InvariantTargetExcludeTest
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
 });
@@ -1642,10 +1661,11 @@ contract CounterTest is Test {
 
     // A wide filter that includes the contract's canonical predicate runs one contract-level
     // campaign and reports each selected predicate separately.
-    cmd.args(["test", "--mt", "invariant_cond[1-4]"]).assert_failure().stdout_eq(str![[r#"
+    cmd.args(["test", "--mt", "invariant_cond[1-4]"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/CounterTest.t.sol:CounterTest
 [FAIL: condition 1 met] invariant_cond1
@@ -1662,15 +1682,20 @@ Ran 1 test for test/CounterTest.t.sol:CounterTest
 Invariant/Property Tests: 3/4 invariants broken
 [FAIL: condition 1 met] invariant_cond1
 ...
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 
     // Re-running a single target replays cond3's persisted counterexample and exits without
     // running a fresh campaign — only the primary block, no secondary [FAIL]s, no
     // persisted-failures footer, no `Invariant/Property Tests` roll-up. A stderr warning calls out
     // the other selected predicate with a persisted failure if it would otherwise be included.
-    cmd.forge_fuse().args(["test", "--mt", "invariant_cond3"]).assert_failure().stdout_eq(str![[
-        r#"
-No files changed, compilation skipped
+    cmd.forge_fuse()
+        .args(["test", "--mt", "invariant_cond3"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
 ...
 Ran 1 test for test/CounterTest.t.sol:CounterTest
 [FAIL: condition 3 met]
@@ -1678,8 +1703,11 @@ Ran 1 test for test/CounterTest.t.sol:CounterTest
 ...
  invariant_cond3() (runs: 1, calls: 1, reverts: [..])
 ...
-"#
-    ]]);
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
+
+"#]]);
 });
 
 forgetest_init!(invariant_campaign_keeps_contract_boundary_with_no_match_test, |prj, cmd| {
@@ -2093,7 +2121,6 @@ contract StaleSecondaryTest is Test {
     // bug, the bare `.exists()` check filtered the secondary out and only the primary block
     // would render (no roll-up).
     cmd.forge_fuse().args(["test", "--mt", "invariant_"]).assert_failure().stdout_eq(str![[r#"
-No files changed, compilation skipped
 
 Ran 1 test for test/StaleSecondaryTest.t.sol:StaleSecondaryTest
 [FAIL: first broken] invariant_first
@@ -2147,6 +2174,9 @@ Encountered a total of 1 failing tests, 0 tests succeeded
 Tip: Run `forge test --rerun` to retry only the 1 failed test
 
 [SEED] (use `--fuzz-seed` to reproduce)
+
+"#]]).stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/invariant/storage.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/storage.rs
@@ -63,10 +63,11 @@ contract InvariantStorageTest is Test {
 "#,
     );
 
-    assert_invariant(cmd.args(["test"])).failure().stdout_eq(str![[r#"
+    assert_invariant(cmd.args(["test"]))
+        .failure()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/name.sol:InvariantStorageTest
 [FAIL: changedAddr] invariantChangeAddress
@@ -122,6 +123,10 @@ Encountered a total of 1 failing tests, 0 tests succeeded
 Tip: Run `forge test --rerun` to retry only the 1 failed test
 
 [SEED] (use `--fuzz-seed` to reproduce)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/logs.rs
+++ b/crates/forge/tests/cli/test_cmd/logs.rs
@@ -109,10 +109,11 @@ contract Fails is Test {
 "#,
     );
 
-    cmd.args(["test", "-vv"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "-vv"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 19 tests for test/DebugLogs.t.sol:DebugLogsTest
 [PASS] test1() ([GAS])
@@ -233,6 +234,10 @@ Logs:
 Suite result: ok. 19 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 19 tests passed, 0 failed, 0 skipped (19 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -777,7 +782,6 @@ contract Foo is Test {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Setup
 Test 1
 
@@ -786,6 +790,10 @@ Ran 1 test for test/Foo.t.sol:Foo
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -812,11 +820,12 @@ contract Foo is Test {
     "#,
     );
 
-    cmd.forge_fuse().args(["test", "--match-test", "test1"]).assert_success().stdout_eq(str![[
-        r#"
+    cmd.forge_fuse()
+        .args(["test", "--match-test", "test1"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Setup
 Test 1
 
@@ -826,8 +835,11 @@ Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 
-"#
-    ]]);
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
+"#]]);
 });
 
 forgetest_init!(test_can_run_with_live_logs_flag_race_condition, |prj, cmd| {
@@ -879,7 +891,6 @@ Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
             .args(["test", "--live-logs", "--threads", "1"])
             .assert_success()
             .stdout_eq(str![[r#"
-No files changed, compilation skipped
 Setup
 Test 1
 Test 2
@@ -890,6 +901,10 @@ Ran 2 tests for test/Foo.t.sol:Foo
 Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
+
+"#]])
+            .stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
     }

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -190,16 +190,21 @@ contract ATest is DSTest {
    "#,
     );
 
-    cmd.arg("test").assert_success().stdout_eq(str![[r#"
+    cmd.arg("test")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for src/ATest.t.sol:ATest
 [PASS] testArray(uint64[2]) (runs: 256, [AVG_GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -222,15 +227,20 @@ contract ATest is DSTest {
    "#,
     );
 
-    cmd.arg("test").assert_success().stdout_eq(str![[r#"
+    cmd.arg("test")
+        .assert_success()
+        .stdout_eq(str![[r#"
 ...
-Compiler run successful!
 
 Ran 1 test for src/ATest.t.sol:ATest
 [PASS] testArray(uint64[2]) (runs: 256, [AVG_GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -263,16 +273,21 @@ contract FailTest is DSTest {
    "#,
     );
 
-    cmd.args(["test", "--match-path", "*src/ATest.t.sol"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--match-path", "*src/ATest.t.sol"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for src/ATest.t.sol:ATest
 [PASS] testPass() ([GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -308,16 +323,21 @@ contract FailTest is DSTest {
     let test_path = prj.root().join("src/ATest.t.sol");
     let test_path = test_path.to_string_lossy();
 
-    cmd.args(["test", "--match-path", test_path.as_ref()]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--match-path", test_path.as_ref()])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for src/ATest.t.sol:ATest
 [PASS] testPass() ([GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -390,16 +410,21 @@ contract MyTest is DSTest {
    "#,
     );
 
-    cmd.arg("test").assert_success().stdout_eq(str![[r#"
+    cmd.arg("test")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for src/nested/forge-tests/MyTest.t.sol:MyTest
 [PASS] testTrue() ([GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -410,10 +435,11 @@ forgetest_init!(can_test_repeatedly, |prj, cmd| {
     prj.initialize_default_contracts();
     prj.clear();
 
-    cmd.arg("test").assert_success().stdout_eq(str![[r#"
+    cmd.arg("test")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 2 tests for test/Counter.t.sol:CounterTest
 [PASS] testFuzz_SetNumber(uint256) (runs: 256, [AVG_GAS])
@@ -421,12 +447,16 @@ Ran 2 tests for test/Counter.t.sol:CounterTest
 Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
     for _ in 0..5 {
-        cmd.assert_success().stdout_eq(str![[r#"
-No files changed, compilation skipped
+        cmd.assert_success()
+            .stdout_eq(str![[r#"
 
 Ran 2 tests for test/Counter.t.sol:CounterTest
 [PASS] testFuzz_SetNumber(uint256) (runs: 256, [AVG_GAS])
@@ -434,6 +464,10 @@ Ran 2 tests for test/Counter.t.sol:CounterTest
 Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
+
+"#]])
+            .stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
     }
@@ -465,16 +499,21 @@ contract ContractTest is DSTest {
         config.solc = Some(SOLC_VERSION.into());
     });
 
-    cmd.arg("test").assert_success().stdout_eq(str![[r#"
+    cmd.arg("test")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() ([GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 
@@ -483,16 +522,22 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
         config.solc = Some(OTHER_SOLC_VERSION.into());
     });
 
-    cmd.forge_fuse().arg("test").assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse()
+        .arg("test")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() ([GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -540,16 +585,21 @@ contract ContractTest is Test {
         .replace("<url>", &endpoint),
     );
 
-    cmd.arg("test").assert_success().stdout_eq(str![[r#"
+    cmd.arg("test")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Contract.t.sol:ContractTest
 [PASS] test() ([GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -679,10 +729,11 @@ contract USDTCallingTest is Test {
         .replace("<url>", &endpoint),
     );
 
-    cmd.args(["test", "-vvvv"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "-vvvv"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Contract.t.sol:USDTCallingTest
 [PASS] test() ([GAS])
@@ -697,6 +748,10 @@ Traces:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -749,10 +804,11 @@ contract CustomTypesTest is Test {
    "#,
     );
 
-    cmd.args(["test", "-vvvvv"]).assert_failure().stdout_eq(str![[r#"
+    cmd.args(["test", "-vvvvv"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 2 tests for test/Contract.t.sol:CustomTypesTest
 [FAIL: PoolNotInitialized()] testErr() ([GAS])
@@ -780,6 +836,10 @@ Encountered 1 failing test in test/Contract.t.sol:CustomTypesTest
 Encountered a total of 1 failing tests, 1 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -922,7 +982,6 @@ contract CounterTest is Test {
     cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/CounterFuzz.t.sol:CounterTest
 [FAIL: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=[..] args=[..]] testAddOne(uint256) (runs: [..], [AVG_GAS])
@@ -939,6 +998,9 @@ Encountered a total of 1 failing tests, 0 tests succeeded
 Tip: Run `forge test --rerun` to retry only the 1 failed test
 
 [SEED] (use `--fuzz-seed` to reproduce)
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -973,10 +1035,11 @@ contract CounterTest is Test {
 
     // make sure a pre-run invariant failure exits after the first campaign call and keeps the
     // predicate failure attribution.
-    cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
+    cmd.args(["test"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/CounterInvariant.t.sol:CounterTest
 [FAIL: wrong count] invariant_early_exit() (runs: 1, calls: 1, reverts: 0)
@@ -1000,6 +1063,10 @@ Encountered a total of 1 failing tests, 0 tests succeeded
 Tip: Run `forge test --rerun` to retry only the 1 failed test
 
 [SEED] (use `--fuzz-seed` to reproduce)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1030,10 +1097,11 @@ contract ReplayFailuresTest is Test {
      "#,
     );
 
-    cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
+    cmd.args(["test"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 4 tests for test/ReplayFailures.t.sol:ReplayFailuresTest
 [PASS] testA() ([GAS])
@@ -1053,14 +1121,20 @@ Encountered a total of 2 failing tests, 2 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
 
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 
     // Test failure filter should be persisted.
     assert!(prj.root().join("cache/test-failures").exists());
 
     // Perform only the 2 failing tests from last run.
-    cmd.forge_fuse().args(["test", "--rerun"]).assert_failure().stdout_eq(str![[r#"
-No files changed, compilation skipped
+    cmd.forge_fuse()
+        .args(["test", "--rerun"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
 
 Ran 2 tests for test/ReplayFailures.t.sol:ReplayFailuresTest
 [FAIL: testB failed] testB() ([GAS])
@@ -1077,6 +1151,10 @@ Encountered 2 failing tests in test/ReplayFailures.t.sol:ReplayFailuresTest
 Encountered a total of 2 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
+
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
 });
@@ -1136,7 +1214,6 @@ contract PrecompileLabelsTest is Test {
     cmd.args(["test", "-vvvv"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Contract.t.sol:PrecompileLabelsTest
 [PASS] testPrecompileLabels() ([GAS])
@@ -1178,6 +1255,9 @@ Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 });
 
@@ -1204,10 +1284,11 @@ contract ContractFuzz is Test {
 }
     "#,
     );
-    cmd.args(["test", "-vv"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "-vv"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/ContractFuzz.t.sol:ContractFuzz
 [PASS] testFuzzConsoleLog(uint256) (runs: 3, [AVG_GAS])
@@ -1219,6 +1300,10 @@ Logs:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1246,10 +1331,11 @@ contract ContractFuzz is Test {
 }
     "#,
     );
-    cmd.args(["test", "-vv"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "-vv"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/ContractFuzz.t.sol:ContractFuzz
 [PASS] testFuzzConsoleLog(uint256) (runs: 3, [AVG_GAS])
@@ -1261,6 +1347,10 @@ Logs:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1289,10 +1379,11 @@ forgetest_init!(should_not_show_logs_when_fuzz_test, |prj, cmd| {
      "#,
     );
     // At verbosity >= 2, logs from the last run should be shown even when show_logs is false
-    cmd.args(["test", "-vv"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "-vv"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/ContractFuzz.t.sol:ContractFuzz
 [PASS] testFuzzConsoleLog(uint256) (runs: 3, [AVG_GAS])
@@ -1302,6 +1393,10 @@ Logs:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1330,10 +1425,11 @@ contract ContractFuzz is Test {
      "#,
     );
     // At verbosity >= 2, logs from the last run should be shown even when show_logs is false
-    cmd.args(["test", "-vv"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "-vv"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/ContractFuzz.t.sol:ContractFuzz
 [PASS] testFuzzConsoleLog(uint256) (runs: 3, [AVG_GAS])
@@ -1343,6 +1439,10 @@ Logs:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1390,10 +1490,11 @@ contract SimpleContractTest is Test {
 }
      "#,
     );
-    cmd.args(["test", "-vvvv", "--decode-internal"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "-vvvv", "--decode-internal"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Simple.sol:SimpleContractTest
 [PASS] test() ([GAS])
@@ -1416,6 +1517,10 @@ Traces:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1611,16 +1716,21 @@ contract ATest is Test {
    "#,
     );
 
-    cmd.args(["test"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/ATest.t.sol:ATest
 [PASS] testSelfMeteringRevert() ([GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -2174,16 +2284,21 @@ contract SkipCounterSetup is Test {
     "#,
     );
 
-    cmd.args(["test", "--mc", "SkipCounterSetup"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--mc", "SkipCounterSetup"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Counter.t.sol:SkipCounterSetup
 [SKIP: skipped: skip counter test] setUp() ([GAS])
 Suite result: ok. 0 passed; 0 failed; 1 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 0 tests passed, 0 failed, 1 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -2432,10 +2547,11 @@ contract FooTest {
 "#,
     );
 
-    cmd.args(["test", "--mt", "testWalletScript", "-vvv"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--mt", "testWalletScript", "-vvv"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for src/Foo.sol:FooTest
 [PASS] testWalletScript() ([GAS])
@@ -2444,6 +2560,10 @@ Logs:
   0x70997970C51812dc3A010C7d01b50e0d17dc79C8
   0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC
 ...
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 });
 
@@ -2497,10 +2617,11 @@ contract MetadataTraceTest is Test {
    "#,
     );
 
-    cmd.args(["test", "--mt", "test_proxy_trace", "-vvvv"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--mt", "test_proxy_trace", "-vvvv"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/MetadataTraceTest.t.sol:MetadataTraceTest
 [PASS] test_proxy_trace() ([GAS])
@@ -2516,6 +2637,10 @@ Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 
     // Check consistent traces for running with no metadata.
@@ -2525,7 +2650,6 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/MetadataTraceTest.t.sol:MetadataTraceTest
 [PASS] test_proxy_trace() ([GAS])
@@ -2540,6 +2664,10 @@ Traces:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -2738,7 +2866,6 @@ contract ReverterTest is Test {
     cmd.args(["test", "--mc", "ReverterTest"]).assert_failure().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 8 tests for src/AssumeNoRevertTest.t.sol:ReverterTest
 [FAIL: call reverted with 'FOUNDRY::ASSUME' when it was expected not to revert; counterexample: [..] testAssumeThenExpectCountZeroFails(uint256) (runs: [..], [AVG_GAS])
@@ -2750,6 +2877,9 @@ Ran 8 tests for src/AssumeNoRevertTest.t.sol:ReverterTest
 [FAIL: RevertWithData(3); counterexample: [..]] testMultipleAssumes_OneWrong_fails(uint256) (runs: [..], [AVG_GAS])
 [FAIL: vm.assumeNoRevert: you must make another external call prior to calling assumeNoRevert again; counterexample: [..]] testMultipleAssumes_ThrowOnGenericNoRevert_AfterSpecific_fails(bytes4) (runs: [..], [AVG_GAS])
 ...
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -3202,7 +3332,6 @@ Tip: Run `forge test --rerun` to retry only the 1 failed test
         .args(["test", "--mc", "SuppressTracesTest", "-vvvv"])
         .assert_failure()
         .stdout_eq(str![[r#"
-No files changed, compilation skipped
 
 Ran 2 tests for test/SuppressTracesTest.t.sol:SuppressTracesTest
 [FAIL: assertion failed: 1 != 100] test_increment_failure() ([GAS])
@@ -3257,6 +3386,10 @@ Encountered 1 failing test in test/SuppressTracesTest.t.sol:SuppressTracesTest
 Encountered a total of 1 failing tests, 1 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+
+"#]])
+        .stderr_eq(str![[r#"
+No files changed, compilation skipped
 
 "#]]);
 });
@@ -3360,7 +3493,6 @@ contract SenderLogger {
     cmd.args(["test", "--mt", "test_stackPrank", "-vvvv"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Counter.t.sol:CounterTest
 [PASS] test_stackPrank() ([GAS])
@@ -3396,6 +3528,9 @@ Traces:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -3886,10 +4021,11 @@ contract CounterTest is Test {
         .replace("<url>", &rpc::next_http_archive_rpc_url()),
     );
 
-    cmd.args(["test", "--mc", "CounterTest"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--mc", "CounterTest"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 2 tests for test/Counter.t.sol:CounterTest
 [PASS] test_assert_storage() ([GAS])
@@ -3897,6 +4033,10 @@ Ran 2 tests for test/Counter.t.sol:CounterTest
 Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -3925,10 +4065,11 @@ contract CounterTest is Test {
     "#,
     );
 
-    cmd.args(["test", "--mc", "CounterTest"]).assert_failure().stdout_eq(str![[r#"
+    cmd.args(["test", "--mc", "CounterTest"])
+        .assert_failure()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Counter.t.sol:CounterTest
 [FAIL: EvmError: Revert] testCoolPanic() ([GAS])
@@ -3943,6 +4084,10 @@ Encountered 1 failing test in test/Counter.t.sol:CounterTest
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -3994,7 +4139,6 @@ contract NonContractCallRevertTest is Test {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 3 tests for test/NonContractCallRevertTest.t.sol:NonContractCallRevertTest
 [FAIL: call to non-contract address 0xdEADBEeF00000000000000000000000000000000] test_non_contract_call_failure() ([GAS])
@@ -4076,6 +4220,9 @@ Encountered a total of 3 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 3 failed tests
 
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 });
 
@@ -4125,7 +4272,6 @@ contract NonContractDelegateCallRevertTest is Test {
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/NonContractDelegateCallRevertTest.t.sol:NonContractDelegateCallRevertTest
 [FAIL: delegatecall to non-contract address 0xdEADBEeF00000000000000000000000000000000 (usually an unliked library)] test_unlinked_library_call_failure() ([GAS])
@@ -4161,6 +4307,9 @@ Encountered 1 failing test in test/NonContractDelegateCallRevertTest.t.sol:NonCo
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -4236,7 +4385,6 @@ contract PrankTest is Test {
     cmd.args(["test", "--mc", "PrankTest", "-vvvvv"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/PrankBug.t.sol:PrankTest
 [PASS] test_Increment() ([GAS])
@@ -4270,6 +4418,9 @@ Traces:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -4339,7 +4490,6 @@ contract CounterTest is Test {
     cmd.args(["test", "--fork-url", &endpoint]).assert_failure().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 2 tests for test/Counter.t.sol:CounterTest
 [FAIL: EvmError: Revert] test_roll_fork() ([GAS])
@@ -4356,6 +4506,9 @@ Encountered 2 failing tests in test/Counter.t.sol:CounterTest
 Encountered a total of 2 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/repros.rs
+++ b/crates/forge/tests/cli/test_cmd/repros.rs
@@ -43,7 +43,6 @@ contract Issue3055Test is Test {
     cmd.arg("test").assert_failure().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 3 tests for test/Issue3055.t.sol:Issue3055Test
 [FAIL] test_snapshot() ([GAS])
@@ -64,6 +63,9 @@ Encountered a total of 3 failing tests, 0 tests succeeded
 Tip: Run `forge test --rerun` to retry only the 3 failed tests
 
 [SEED] (use `--fuzz-seed` to reproduce)
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -249,10 +251,11 @@ contract Issue6170Test is Test {
 "#,
     );
 
-    cmd.arg("test").assert_failure().stdout_eq(str![[r#"
+    cmd.arg("test")
+        .assert_failure()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Issue6170.t.sol:Issue6170Test
 [FAIL: log != expected log] test() ([GAS])
@@ -267,6 +270,10 @@ Encountered 1 failing test in test/Issue6170.t.sol:Issue6170Test
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -351,10 +358,11 @@ contract Issue3347Test is Test {
 "#,
     );
 
-    cmd.args(["test", "-vvvv"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "-vvvv"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Issue3347.t.sol:Issue3347Test
 [PASS] test() ([GAS])
@@ -366,6 +374,10 @@ Traces:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1017,10 +1029,11 @@ contract BlobhashesPreOverrideSnapshotTest is Test {
 "#,
     );
 
-    cmd.args(["test", "--evm-version=cancun"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--evm-version=cancun"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 2 tests for test/BlobhashesPreOverride.t.sol:BlobhashesPreOverrideSnapshotTest
 [PASS] test_blobhashes_none_arm_revertToState() ([GAS])
@@ -1028,6 +1041,10 @@ Ran 2 tests for test/BlobhashesPreOverride.t.sol:BlobhashesPreOverrideSnapshotTe
 Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1071,10 +1088,11 @@ contract TxGasPricePreOverrideSnapshotTest is Test {
 "#,
     );
 
-    cmd.args(["test", "--evm-version=cancun"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--evm-version=cancun"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 2 tests for test/TxGasPricePreOverride.t.sol:TxGasPricePreOverrideSnapshotTest
 [PASS] test_pre_override_gas_price_restored_after_revert() ([GAS])
@@ -1082,6 +1100,10 @@ Ran 2 tests for test/TxGasPricePreOverride.t.sol:TxGasPricePreOverrideSnapshotTe
 Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/spec.rs
+++ b/crates/forge/tests/cli/test_cmd/spec.rs
@@ -52,7 +52,6 @@ contract TestEvmVersion is Test {
     cmd.args(["test", "--mc", "TestEvmVersion", "-vvvv"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/TestEvmVersion.t.sol:TestEvmVersion
 [PASS] test_evm_version() ([GAS])
@@ -85,6 +84,9 @@ Traces:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 

--- a/crates/forge/tests/cli/test_cmd/table.rs
+++ b/crates/forge/tests/cli/test_cmd/table.rs
@@ -66,7 +66,6 @@ contract CounterTableTest is Test {
     cmd.args(["test", "--mc", "CounterTable", "-vvvvv"]).assert_failure().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 8 tests for test/CounterTable.t.sol:CounterTableTest
 [FAIL: 2 fixtures defined for diffSwap (expected 10)] tableMultipleParamsDifferentFixturesFail(uint256,bool) ([GAS])
@@ -123,6 +122,9 @@ Encountered 6 failing tests in test/CounterTable.t.sol:CounterTableTest
 Encountered a total of 6 failing tests, 2 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 6 failed tests
+
+"#]]).stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -187,10 +189,11 @@ contract CounterTest is Test {
     "#,
     );
 
-    cmd.args(["test", "-vvv"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "-vvv"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/CounterTest.t.sol:CounterTest
 [PASS] tableSetNumberTest((uint256,uint256,uint256)) (runs: 4, [AVG_GAS])
@@ -204,12 +207,18 @@ Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
+
 "#]]);
 
-    cmd.forge_fuse().args(["coverage"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse()
+        .args(["coverage"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 Analysing contracts...
 Running tests...
 
@@ -226,6 +235,10 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 |-----------------+---------------+---------------+---------------+---------------|
 | Total           | 100.00% (8/8) | 100.00% (7/7) | 100.00% (6/6) | 100.00% (1/1) |
 ╰-----------------+---------------+---------------+---------------+---------------╯
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -14,10 +14,15 @@ Compiling 23 files with [..]
 
 "#]]);
     // No files are rebuilt.
-    cmd.with_no_redact().assert_success().stdout_eq(str![[r#"
+    cmd.with_no_redact()
+        .assert_success()
+        .stdout_eq(str![[r#"
 ...
+...
+
+"#]])
+        .stderr_eq(str![[r#"
 No files changed, compilation skipped
-...
 
 "#]]);
 
@@ -48,10 +53,15 @@ Compiling 21 files with [..]
 
 "#]]);
     // No files are rebuilt.
-    cmd.with_no_redact().assert_success().stdout_eq(str![[r#"
+    cmd.with_no_redact()
+        .assert_success()
+        .stdout_eq(str![[r#"
 ...
+...
+
+"#]])
+        .stderr_eq(str![[r#"
 No files changed, compilation skipped
-...
 
 "#]]);
 
@@ -678,10 +688,15 @@ Compiling 22 files with [..]
 ...
 
 "#]]);
-    cmd.with_no_redact().assert_success().stdout_eq(str![[r#"
+    cmd.with_no_redact()
+        .assert_success()
+        .stdout_eq(str![[r#"
 ...
+...
+
+"#]])
+        .stderr_eq(str![[r#"
 No files changed, compilation skipped
-...
 
 "#]]);
 
@@ -763,10 +778,15 @@ Compiling 21 files with [..]
 ...
 
 "#]]);
-    cmd.with_no_redact().assert_success().stdout_eq(str![[r#"
+    cmd.with_no_redact()
+        .assert_success()
+        .stdout_eq(str![[r#"
 ...
+...
+
+"#]])
+        .stderr_eq(str![[r#"
 No files changed, compilation skipped
-...
 
 "#]]);
 
@@ -1408,10 +1428,11 @@ contract CounterTest is Test {
     "#,
     );
 
-    cmd.args(["test", "--decode-internal", "-vvvv"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test", "--decode-internal", "-vvvv"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Counter.t.sol:CounterTest
 [PASS] test_Increment() ([GAS])
@@ -1434,6 +1455,10 @@ Traces:
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });
@@ -1645,16 +1670,21 @@ contract CounterTest is Test {
     "#,
     );
     // Test should pass.
-    cmd.args(["test"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["test"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful!
 
 Ran 1 test for test/Counter.t.sol:CounterTest
 [PASS] test_deployer() ([GAS])
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]])
+        .stderr_eq(str![[r#"
+Compiler run successful!
 
 "#]]);
 });


### PR DESCRIPTION
Split out from #14729.

Routes compile output prose (`Compiler run successful!`, `Compiler run successful with warnings: …`, `No files changed, compilation skipped`) through `sh_status!` so it lands on stderr instead of stdout.

Includes matching snapshot updates across forge/cast CLI tests.

PR 2 (cast commands + forge create + verify) stacked on this.