### PR TITLE
feat(forge): migrate forge remappings to output channel contract

### DIFF
--- a/crates/forge/src/cmd/remappings.rs
+++ b/crates/forge/src/cmd/remappings.rs
@@ -29,17 +29,18 @@ impl RemappingArgs {
                 groups.entry(remapping.context.clone()).or_default().push(remapping);
             }
             for (group, remappings) in groups {
+                // Prose headers are diagnostics — keep stdout to one remapping per line.
                 if let Some(group) = group {
-                    sh_println!("Context: {group}")?;
+                    sh_status!("Context: {group}")?;
                 } else {
-                    sh_println!("Global:")?;
+                    sh_status!("Global:")?;
                 }
 
                 for mut remapping in remappings {
                     remapping.context = None; // avoid writing context twice
-                    sh_println!("- {remapping}")?;
+                    sh_println!("{remapping}")?;
                 }
-                sh_println!()?;
+                sh_eprintln!()?;
             }
         } else {
             for remapping in config.remappings {

--- a/crates/forge/src/cmd/remappings.rs
+++ b/crates/forge/src/cmd/remappings.rs
@@ -29,15 +29,13 @@ impl RemappingArgs {
                 groups.entry(remapping.context.clone()).or_default().push(remapping);
             }
             for (group, remappings) in groups {
-                // Prose headers are diagnostics — keep stdout to one remapping per line.
                 if let Some(group) = group {
                     sh_status!("Context: {group}")?;
                 } else {
                     sh_status!("Global:")?;
                 }
 
-                for mut remapping in remappings {
-                    remapping.context = None; // avoid writing context twice
+                for remapping in remappings {
                     sh_println!("{remapping}")?;
                 }
                 sh_eprintln!()?;

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -952,14 +952,19 @@ forgetest_init!(can_prioritise_project_remappings, |prj, cmd| {
     let lib_toml_file = nested.join("foundry.toml");
     pretty_err(&lib_toml_file, fs::write(&lib_toml_file, lib_config.to_string_pretty().unwrap()));
 
-    cmd.args(["remappings", "--pretty"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["remappings", "--pretty"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+@utils/libraries/Contract.sol=src/Contract.sol
+@utils/=src/
+@openzeppelin/contracts/=lib/openzeppelin-contracts/
+@openzeppelin/contracts-upgradeable/=lib/dep1/lib/openzeppelin-upgradeable/
+dep1/=lib/dep1/src/
+forge-std/=lib/forge-std/src/
+
+"#]])
+        .stderr_eq(str![[r#"
 Global:
-- @utils/libraries/Contract.sol=src/Contract.sol
-- @utils/=src/
-- @openzeppelin/contracts/=lib/openzeppelin-contracts/
-- @openzeppelin/contracts-upgradeable/=lib/dep1/lib/openzeppelin-upgradeable/
-- dep1/=lib/dep1/src/
-- forge-std/=lib/forge-std/src/
 
 
 "#]]);

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -970,6 +970,46 @@ Global:
 "#]]);
 });
 
+// Verifies the contract invariant: `forge remappings` and `forge remappings --pretty` emit
+// identical stdout, even when remappings have contexts. The context prefix is part of the
+// machine-readable value and must survive `--pretty` mode.
+forgetest!(remappings_pretty_keeps_context_on_stdout, |prj, cmd| {
+    prj.update_config(|config| {
+        config.auto_detect_remappings = false;
+        config.remappings = vec![
+            Remapping::from_str("@global/=lib/global/").unwrap().into(),
+            Remapping::from_str("ctx-a:@scoped/=lib/a/").unwrap().into(),
+            Remapping::from_str("ctx-b:@scoped/=lib/b/").unwrap().into(),
+        ];
+    });
+
+    cmd.args(["remappings"]).assert_success().stdout_eq(str![[r#"
+@global/=lib/global/
+ctx-a:@scoped/=lib/a/
+ctx-b:@scoped/=lib/b/
+
+"#]]);
+
+    cmd.forge_fuse()
+        .args(["remappings", "--pretty"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+@global/=lib/global/
+ctx-a:@scoped/=lib/a/
+ctx-b:@scoped/=lib/b/
+
+"#]])
+        .stderr_eq(str![[r#"
+Global:
+
+Context: ctx-a
+
+Context: ctx-b
+
+
+"#]]);
+});
+
 // test to check that foundry.toml libs section updates on install
 forgetest!(can_update_libs_section, |prj, cmd| {
     cmd.git_init();

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -141,7 +141,7 @@ Each row's status is one of:
 | `forge doc`            | (empty)                                              | n/a                                        | todo   |
 | `forge generate`       | (empty) or generated path                            | n/a                                        | todo   |
 | `forge soldeer`        | (empty)                                              | n/a                                        | todo   |
-| `forge remappings`     | One remapping per line                               | n/a                                        | todo   |
+| `forge remappings`     | One remapping per line                               | n/a                                        | migrated |
 | `forge compiler`       | Compiler info                                        | JSON                                       | todo   |
 | `forge verify-contract`| Verification GUID / URL                              | JSON                                       | todo   |
 


### PR DESCRIPTION
Migrates `forge remappings --pretty` to the stdout/stderr contract from #14727.

- Prose headers (`Context:`, `Global:`) and the visual blank separator move to stderr via `sh_status!` / `sh_eprintln!`.
- Each remapping stays on stdout via `sh_println!`, with the `- ` bullet dropped.
- Default (non-pretty) mode unchanged — already compliant.

Result: `forge remappings 2>/dev/null` and `forge remappings --pretty 2>/dev/null` produce identical stdout (one remapping per line).

Snapshot test split into `.stdout_eq` / `.stderr_eq`. Contract doc row flipped `todo` → `migrated`.

Part of OSS-224