### PR TITLE
feat(forge): migrate forge flatten to output channel contract

### DIFF
--- a/crates/forge/src/cmd/flatten.rs
+++ b/crates/forge/src/cmd/flatten.rs
@@ -45,7 +45,7 @@ impl FlattenArgs {
             Some(output) => {
                 fs::create_dir_all(output.parent().unwrap())?;
                 fs::write(&output, flattened)?;
-                sh_println!("Flattened file written at {}", output.display())?;
+                sh_status!("Flattened file written at {}", output.display())?;
             }
             None => sh_println!("{flattened}")?,
         };

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -4203,3 +4203,24 @@ Bindings have been generated to [..]"#]]);
 
     assert!(out.status.success(), "Cargo build should succeed");
 });
+
+// `forge flatten -o <path>` writes the file and emits its status string to stderr,
+// keeping stdout empty so agents can pipe the command without diagnostics.
+forgetest!(flatten_output_writes_status_to_stderr, |prj, cmd| {
+    prj.add_source(
+        "Counter",
+        r#"contract Counter { uint256 public n; function inc() external { n += 1; } }"#,
+    );
+
+    let out = prj.root().join("flat.sol");
+    cmd.args(["flatten", "src/Counter.sol", "-o"])
+        .arg(&out)
+        .assert_success()
+        .stdout_eq(str![""])
+        .stderr_eq(str![[r#"
+Flattened file written at [..]flat.sol
+
+"#]]);
+
+    assert!(out.exists(), "flattened file should have been written");
+});

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -127,7 +127,7 @@ Each row's status is one of:
 | `forge clone`          | (empty)                                              | (empty)                                    | todo   |
 | `forge bind`           | (empty)                                              | (empty)                                    | todo   |
 | `forge bind-json`      | (empty) or generated path                            | JSON                                       | todo   |
-| `forge flatten`        | Flattened source                                     | n/a                                        | todo   |
+| `forge flatten`        | Flattened source                                     | n/a                                        | migrated |
 | `forge fmt`            | (empty) or formatted source with `--check`           | n/a                                        | todo   |
 | `forge tree`           | Dependency tree                                      | JSON                                       | todo   |
 | `forge config`         | Config TOML                                          | JSON config                                | todo   |


### PR DESCRIPTION
Migrates `forge flatten` to the stdout/stderr contract from #14727.

Default mode was already compliant (flattened source on stdout). With `--output <path>`, the "Flattened file written at …" status string moved from stdout to stderr via `sh_status!` — the file is the result, stdout stays empty.

Verified:
- `forge flatten foo.sol 2>/dev/null` → flattened source
- `forge flatten foo.sol -o out.sol 2>/dev/null` → empty stdout, file written

Part of OSS-224