### PR TITLE
feat(symbolic): support symbolic `vm.deal` values

### DIFF
--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -1237,9 +1237,12 @@ impl SymbolicExecutor {
         }
         if selector == selector!("deal(address,uint256)") {
             let target = read_abi_address_or_symbolic_slot_arg(state, args_offset, 0)?;
-            let value =
-                read_abi_constrained_word_arg(state, args_offset, 1, "symbolic vm.deal value")?;
-            state.world.set_balance(target, value);
+            let value = read_abi_word_arg(&state.memory, args_offset, 1)?;
+            if value.contains_gasleft() {
+                return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
+            }
+            let value = state.constrained_word(&value).map(SymWord::Concrete).unwrap_or(value);
+            state.world.set_balance_word(target, value);
             return Ok(CheatcodeOutcome::Continue(Vec::new()));
         }
         if selector == selector!("setNonce(address,uint64)")

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -1238,11 +1238,6 @@ impl SymbolicWorld {
         Ok(SymWord::Expr(result))
     }
 
-    /// Applies the `set_balance` symbolic state helper.
-    pub(crate) fn set_balance(&mut self, address: Address, value: U256) {
-        self.set_balance_word(address, SymWord::Concrete(value));
-    }
-
     /// Applies the `set_balance_word` symbolic state helper.
     pub(crate) fn set_balance_word(&mut self, address: Address, value: SymWord) {
         self.balances.insert(address, value.clone());

--- a/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
@@ -3,6 +3,7 @@ use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, util::OutputExt};
 
 use super::symbolic_helpers::z3_available;
+use crate::skip_unless_z3;
 
 forgetest_init!(symbolic_cheatcodes_accept_symbolic_address_targets, |prj, cmd| {
     if !z3_available() {
@@ -1676,6 +1677,32 @@ contract SymbolicConstrainedCheatcodes is Test {
         assertEq(address(0xbeef).balance, 7);
     }
 
+    function checkSymbolicDealValueFundsCall(uint256 amount) public {
+        address recipient = address(0xbeef);
+
+        vm.deal(address(this), amount);
+        assertEq(address(this).balance, amount);
+
+        (bool ok,) = recipient.call{value: amount}("");
+
+        assertTrue(ok);
+        assertEq(recipient.balance, amount);
+        assertEq(address(this).balance, 0);
+    }
+
+    function checkSymbolicDealInsufficientFunds(uint256 amount) public {
+        vm.assume(amount < type(uint256).max);
+        address recipient = address(0xbeef);
+
+        vm.deal(address(this), amount);
+
+        (bool ok,) = recipient.call{value: amount + 1}("");
+
+        assertFalse(ok);
+        assertEq(address(this).balance, amount);
+        assertEq(recipient.balance, 0);
+    }
+
     function checkConstrainedRandomBytes(uint16 len) public {
         vm.assume(len == 3);
 
@@ -1702,12 +1729,88 @@ contract SymbolicConstrainedCheatcodes is Test {
     assert_relevant_lines(
         &stdout,
         foundry_test_utils::str![[r#"
+[PASS] checkSymbolicDealValueFundsCall(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkSymbolicDealInsufficientFunds(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
 [PASS] checkConstrainedRandomBytes(uint16)
 "#]],
     );
     assert!(!stdout.contains("symbolic vm.deal target"), "{stdout}");
     assert!(!stdout.contains("symbolic vm.deal value"), "{stdout}");
     assert!(!stdout.contains("symbolic randomBytes len"), "{stdout}");
+});
+
+forgetest_init!(symbolic_cheatcodes_reject_gas_deal_value, |prj, cmd| {
+    skip_unless_z3!("symbolic_cheatcodes_reject_gas_deal_value");
+
+    prj.add_test(
+        "SymbolicDealGasValue.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicDealGasValue is Test {
+    function checkGasDealValue() public {
+        vm.deal(address(this), gasleft());
+    }
+
+    function checkDerivedGasDealValue() public {
+        vm.deal(address(this), gasleft() + 1);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkGasDealValue"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+incomplete symbolic execution (Stuck): unsupported symbolic execution feature: GAS/gasleft() not modeled
+"#]],
+    );
+});
+
+forgetest_init!(symbolic_cheatcodes_reject_derived_gas_deal_value, |prj, cmd| {
+    skip_unless_z3!("symbolic_cheatcodes_reject_derived_gas_deal_value");
+
+    prj.add_test(
+        "SymbolicDerivedDealGasValue.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicDerivedDealGasValue is Test {
+    function checkDerivedGasDealValue() public {
+        vm.deal(address(this), gasleft() + 1);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkDerivedGasDealValue"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+incomplete symbolic execution (Stuck): unsupported symbolic execution feature: GAS/gasleft() not modeled
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_cheatcodes_accept_bounded_symbolic_input_size, |prj, cmd| {


### PR DESCRIPTION
## Summary
- allow `vm.deal(address,uint256)` to store symbolic balance values instead of requiring the amount to be concrete/constrained
- re-concretize already-constrained deal values before writing balance state to preserve precision for existing cases
- reject gas-tainted deal values so opaque `GAS` cannot leak into world-state balances
- add CLI regressions for symbolic deal-funded value transfers, insufficient symbolic balances, and direct/derived gas-derived deal values failing closed

## Why
`vm.deal` is balance assignment, and the symbolic world already supports symbolic `BALANCE` reads, symbolic transfer arithmetic, and solver-backed value-transfer solvency checks. Requiring the deal amount to be concrete was overly conservative and blocked useful tests before they reached the property under test.

This keeps the model bounded: it supports symbolic balance/value-transfer semantics, but does not claim full account-existence path splitting for `amount == 0` vs `amount != 0` or gas-derived balance semantics.

## Generic coverage
This is not special-cased for a bug-suite contract. The regressions cover the general balance semantics:

- symbolic `vm.deal` balance can be read back through `BALANCE`
- symbolic balance can fund a value transfer of the same symbolic amount
- symbolic insufficient-balance transfer fails and preserves balances
- direct `gasleft()` and derived `gasleft() + 1` deal values fail closed

## Bug-suite check
Against `grandizzy/symbolic-bug-suite`, the previous remaining targeted blocker after #14942 was TheDAO stopping on `symbolic vm.deal value`. With this PR:

```text
forge test --symbolic --match-contract TheDAOReentrancyTest --match-test checkWithdrawCannotBeReentered
[FAIL: panic: assertion failed (0x01); counterexample: calldata=0xbdaea2a8... args=[36893488147419103232 [3.689e19]]]
```

So the test now reaches a real counterexample instead of an unsupported symbolic `vm.deal` value.
