### PR TITLE
test: update flaky trace expectations

### DIFF
--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3417,7 +3417,7 @@ contract CounterInExternalLibScript is Script {
     .assert_success();
 
     let tx_hash = api
-        .transaction_by_block_number_and_index(BlockNumberOrTag::Latest, Index::from(0))
+        .transaction_by_block_number_and_index(BlockNumberOrTag::Latest, Index::from(1))
         .await
         .unwrap()
         .unwrap()
@@ -3891,8 +3891,11 @@ contract WETH9 {
 
 // <https://github.com/foundry-rs/foundry/issues/10553>
 // <https://basescan.org/tx/0x17b2de59ebd7dfd2452a3638a16737b6b65ae816c1c5571631dc0d80b63c41de>
-casttest!(flaky_osaka_can_run_p256_precompile, |_prj, cmd| {
-    cmd.args([
+casttest!(
+    #[ignore = "public Base RPC endpoint used in CI does not reliably serve this transaction"]
+    flaky_osaka_can_run_p256_precompile,
+    |_prj, cmd| {
+        cmd.args([
         "run",
         "0x17b2de59ebd7dfd2452a3638a16737b6b65ae816c1c5571631dc0d80b63c41de",
         "--rpc-url",
@@ -3967,7 +3970,8 @@ Transaction successfully executed.
 [GAS]
 
 "#]]);
-});
+    }
+);
 
 // tests cast send gas estimate execution failure message contains decoded custom error
 // <https://github.com/foundry-rs/foundry/issues/9789>
@@ -4039,14 +4043,18 @@ Error: Failed to estimate gas: server returned an error response: error code 3: 
 });
 
 // <https://basescan.org/block/30558838>
-casttest!(flaky_estimate_base_da, |_prj, cmd| {
-    cmd.args(["da-estimate", "30558838", "-r", "https://mainnet.base.org/"])
-        .assert_success()
-        .stdout_eq(str![[r#"
+casttest!(
+    #[ignore = "public Base RPC endpoint used in CI does not reliably serve this block"]
+    flaky_estimate_base_da,
+    |_prj, cmd| {
+        cmd.args(["da-estimate", "30558838", "-r", "https://mainnet.base.org/"])
+            .assert_success()
+            .stdout_eq(str![[r#"
 Estimated data availability size for block 30558838 with 225 transactions: 52916546100
 
 "#]]);
-});
+    }
+);
 
 // <https://github.com/foundry-rs/foundry/issues/10705>
 casttest!(cast_call_return_array_of_tuples, |_prj, cmd| {

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3500,7 +3500,7 @@ contract DeployScript is Script {
 Compiler run successful!
 Traces:
   [9882] DeployScript::run()
-    ├─ [0] 0x0000000000000000000000000000000000000000::fallback{value: 1000000000000000000}()
+    ├─ [0] 0x0000000000000000000000000000000000000000::receive{value: 1000000000000000000}()
     │   └─ ← [Stop]
     ├─ [0] VM::stopBroadcast()
     │   └─ ← [Return]
@@ -3513,7 +3513,7 @@ Script ran successfully.
 ==========================
 Simulated On-chain Traces:
 
-  [0] 0x0000000000000000000000000000000000000000::fallback{value: 1000000000000000000}()
+  [0] 0x0000000000000000000000000000000000000000::receive{value: 1000000000000000000}()
     └─ ← [Stop]
 
 

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -43,6 +43,10 @@ fn setup_testdata_cmd(cmd: &mut TestCommand) {
 /// Format: pipe-separated regex alternation, e.g. `"Foo|Bar|Baz"`.
 const FLAKY_TESTDATA_CONTRACTS: &str = "Issue4640Test|Issue14212Test";
 
+// Issue14212Test depends on Base transaction lookups that are not reliably served by the public
+// Base RPC endpoint used in CI.
+const FLAKY_TESTDATA_RUN_CONTRACTS: &str = "Issue4640Test";
+
 // Run `forge test` on `/testdata`.
 forgetest!(testdata, |_prj, cmd| {
     setup_testdata_cmd(&mut cmd);
@@ -85,7 +89,7 @@ forgetest!(testdata, |_prj, cmd| {
 // Picked up by the nightly `test-flaky` workflow via `cargo nextest run --profile flaky`.
 forgetest!(flaky_testdata, |_prj, cmd| {
     setup_testdata_cmd(&mut cmd);
-    let mc = format!("--mc=({FLAKY_TESTDATA_CONTRACTS})");
+    let mc = format!("--mc=({FLAKY_TESTDATA_RUN_CONTRACTS})");
     cmd.args(["test", &mc]).assert_success();
 });
 


### PR DESCRIPTION
## Summary
- update `flaky_can_deploy_with_broadcast_in_setup` expected traces from `fallback` to `receive` for empty-calldata value transfer rendering
- update `flaky_decode_external_libraries_with_cached_selectors` to replay the contract deployment tx instead of the preceding CREATE2 library predeploy tx
- ignore `flaky_osaka_can_run_p256_precompile` because the public Base RPC endpoint used in CI does not reliably serve its referenced transaction
- ignore `flaky_estimate_base_da` because the public Base RPC endpoint used in CI does not reliably serve its referenced block
- stop replaying `Issue14212Test` in `flaky_testdata` because its Base transaction lookups are not reliably served by the public Base RPC endpoint used in CI
- align the snapshots with `revm-inspectors` behavior introduced by paradigmxyz/revm-inspectors#394 and the existing CREATE2 library predeploy ordering
closes https://github.com/foundry-rs/foundry/issues/14946
closes https://github.com/foundry-rs/foundry/issues/14947

Prompted by: @grandizzy