### PR TITLE
feat(forge): migrate forge generate to output channel contract

### DIFF
--- a/crates/forge/src/cmd/generate/mod.rs
+++ b/crates/forge/src/cmd/generate/mod.rs
@@ -46,7 +46,7 @@ impl GenerateTestArgs {
         // Write the test content to the test file.
         fs::write(&test_file_path, test_content)?;
 
-        sh_println!("{} test file: {}", "Generated".green(), test_file_path.to_str().unwrap())?;
+        sh_status!("{} test file: {}", "Generated".green(), test_file_path.to_str().unwrap())?;
         Ok(())
     }
 }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -4224,3 +4224,18 @@ Flattened file written at [..]flat.sol
 
     assert!(out.exists(), "flattened file should have been written");
 });
+
+// `forge generate test` writes the scaffolded file and emits its status string to stderr,
+// keeping stdout empty so agents can pipe the command without diagnostics.
+forgetest!(generate_test_writes_status_to_stderr, |prj, cmd| {
+    cmd.args(["generate", "test", "--contract-name", "Counter"])
+        .assert_success()
+        .stdout_eq(str![""])
+        .stderr_eq(str![[r#"
+Warning: `forge generate` is deprecated and will be removed in a future version
+Generated test file: test/Counter.t.sol
+
+"#]]);
+
+    assert!(prj.root().join("test/Counter.t.sol").exists(), "scaffolded test file should exist");
+});

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -139,7 +139,7 @@ Each row's status is one of:
 | `forge coverage`       | Coverage table or report                             | JSON / LCOV / etc. via `--report`          | todo   |
 | `forge cache`          | (empty) or paths                                     | JSON                                       | todo   |
 | `forge doc`            | (empty)                                              | n/a                                        | todo   |
-| `forge generate`       | (empty) or generated path                            | n/a                                        | todo   |
+| `forge generate`       | (empty) or generated path                            | n/a                                        | migrated |
 | `forge soldeer`        | (empty)                                              | n/a                                        | todo   |
 | `forge remappings`     | One remapping per line                               | n/a                                        | migrated |
 | `forge compiler`       | Compiler info                                        | JSON                                       | todo   |


### PR DESCRIPTION
Migrates `forge generate` to the stdout/stderr contract from #14727.

The "Generated test file: …" status string moved from stdout to stderr via `sh_status!` — the scaffolded file is the result, stdout stays empty.

Verified:
- `forge generate test -c Counter 2>/dev/null` → empty stdout, file written
- Stderr carries the existing deprecation warning + the status line

Includes a lock-in test asserting the contract.

Part of OSS-224