### PR TITLE
feat(forge): migrate forge remove, update, tree to output channel contract

### DIFF
--- a/crates/forge/src/cmd/remove.rs
+++ b/crates/forge/src/cmd/remove.rs
@@ -44,7 +44,7 @@ impl RemoveArgs {
         for (Dependency { name, tag, .. }, path) in self.dependencies.iter().zip(&paths) {
             // Get the URL from git submodule config instead of using the parsed dependency URL
             let url = git.submodule_url(path).unwrap_or(None);
-            sh_println!(
+            sh_status!(
                 "Removing '{name}' in {}, (url: {}, tag: {})",
                 path.display(),
                 url.as_deref().unwrap_or("None"),

--- a/crates/forge/src/cmd/update.rs
+++ b/crates/forge/src/cmd/update.rs
@@ -172,7 +172,7 @@ impl UpdateArgs {
         // Print updates from => to
         for (path, prev) in prev_dep_ids {
             let curr = foundry_lock.get(&path).unwrap();
-            sh_println!(
+            sh_status!(
                 "Updated dep at '{}', (from: {prev}, to: {curr})",
                 path.display().green(),
                 prev = prev,

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -111,12 +111,14 @@ Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag:
     };
 
     let remove = |cmd: &mut TestCommand, target: &str| {
-        cmd.forge_fuse().args(["remove", "--force", target]).assert_success().stdout_eq(str![[
-            r#"
+        cmd.forge_fuse()
+            .args(["remove", "--force", target])
+            .assert_success()
+            .stdout_eq(str![""])
+            .stderr_eq(str![[r#"
 Removing 'forge-std' in [..], (url: https://github.com/foundry-rs/forge-std, tag: None)
 
-"#
-        ]]);
+"#]]);
 
         assert!(!forge_std.exists());
         assert!(!forge_std_mod.exists());
@@ -671,7 +673,8 @@ forgetest_init!(sync_on_forge_update, |prj, cmd| {
     cmd.forge_fuse()
         .args(["update", "foundry-rs/forge-std@master"])
         .assert_success()
-        .stdout_eq(expected_output);
+        .stdout_eq(str![""])
+        .stderr_eq(expected_output);
 
     let git = Git::new(&forge_std_path);
     assert_eq!(

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -122,14 +122,14 @@ Each row's status is one of:
 | `forge inspect <field>`| Just that field's value                              | JSON of that field                         | todo   |
 | `forge install`        | (empty)                                              | (empty)                                    | todo   |
 | `forge init`           | (empty)                                              | (empty)                                    | todo   |
-| `forge update`         | (empty)                                              | (empty)                                    | todo   |
-| `forge remove`         | (empty)                                              | (empty)                                    | todo   |
+| `forge update`         | (empty)                                              | (empty)                                    | migrated |
+| `forge remove`         | (empty)                                              | (empty)                                    | migrated |
 | `forge clone`          | (empty)                                              | (empty)                                    | todo   |
 | `forge bind`           | (empty)                                              | (empty)                                    | todo   |
 | `forge bind-json`      | (empty) or generated path                            | JSON                                       | todo   |
 | `forge flatten`        | Flattened source                                     | n/a                                        | migrated |
 | `forge fmt`            | (empty) or formatted source with `--check`           | n/a                                        | todo   |
-| `forge tree`           | Dependency tree                                      | JSON                                       | todo   |
+| `forge tree`           | Dependency tree                                      | JSON                                       | migrated |
 | `forge config`         | Config TOML                                          | JSON config                                | todo   |
 | `forge selectors`      | Selectors output                                     | JSON                                       | todo   |
 | `forge eip712`         | (empty)                                              | JSON of types                              | todo   |


### PR DESCRIPTION
Audit pass across the `(empty) stdout` commands in docs/dev/output-channels.md. Migrates the ones whose source change is small enough to review alongside the audit.

- `forge remove` — "Removing '…'" status moved from stdout to stderr via `sh_status!`.
- `forge update` — "Updated dep at '…'" status moved to stderr.
- `forge tree` — already compliant; output is written directly to stdout by foundry-compilers and contains no prose. Doc row flipped only.

Remaining `(empty) stdout` commands warrant their own PRs due to snapshot churn or external ownership.

Verified:
- `can_install_and_remove` and `sync_on_forge_update` pass.
- `cargo check -p forge --bin forge` clean.

Part of OSS-224