### PR TITLE
feat(forge): migrate forge init to output channel contract

### DIFF
--- a/crates/forge/src/cmd/init.rs
+++ b/crates/forge/src/cmd/init.rs
@@ -104,7 +104,7 @@ impl InitArgs {
             } else {
                 "https://github.com/".to_string() + &template
             };
-            sh_println!("Initializing {} from {}...", root.display(), template)?;
+            sh_status!("Initializing {} from {}...", root.display(), template)?;
             // initialize the git repository
             git.init()?;
 
@@ -146,7 +146,7 @@ impl InitArgs {
                 git.ensure_clean()?;
             }
 
-            sh_println!("Initializing {}...", root.display())?;
+            sh_status!("Initializing {}...", root.display())?;
 
             // make the dirs
             let src = root.join("src");
@@ -280,7 +280,7 @@ impl InitArgs {
             }
         }
 
-        sh_println!("{}", "    Initialized forge project".green())?;
+        sh_status!("{}", "    Initialized forge project".green())?;
         Ok(())
     }
 }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -311,15 +311,15 @@ forgetest!(can_init_repo_with_config, |prj, cmd| {
         .arg(prj.root())
         .assert_success()
         .stdout_eq(str![[r#"
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 
 "#]])
         .stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
+Initializing [..]...
 ...
+    Initialized forge project
 
 "#]]);
 
@@ -359,10 +359,18 @@ ignore them in the `.gitignore` file.
 forgetest!(can_init_no_git, |prj, cmd| {
     prj.wipe();
 
-    cmd.arg("init").arg(prj.root()).arg("--no-git").assert_success().stdout_eq(str![[r#"
-Initializing [..]...
+    cmd.arg("init")
+        .arg(prj.root())
+        .arg("--no-git")
+        .assert_success()
+        .stdout_eq(str![[r#"
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
+
+"#]])
+        .stderr_eq(str![[r#"
+Initializing [..]...
+...
     Initialized forge project
 
 "#]]);
@@ -377,10 +385,18 @@ Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag:
 forgetest!(can_init_with_no_commit, |prj, cmd| {
     prj.wipe();
 
-    cmd.arg("init").arg(prj.root()).arg("--no-commit").assert_success().stdout_eq(str![[r#"
-Initializing [..]...
+    cmd.arg("init")
+        .arg(prj.root())
+        .arg("--no-commit")
+        .assert_success()
+        .stdout_eq(str![[r#"
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
+
+"#]])
+        .stderr_eq(str![[r#"
+Initializing [..]...
+...
     Initialized forge project
 
 "#]]);
@@ -407,8 +423,10 @@ forgetest!(can_init_with_dir, |prj, cmd| {
 forgetest!(can_init_with_dir_and_template, |prj, cmd| {
     cmd.args(["init", "foobar", "--template", "foundry-rs/forge-template"])
         .assert_success()
-        .stdout_eq(str![[r#"
+        .stdout_eq(str![""])
+        .stderr_eq(str![[r#"
 Initializing [..] from https://github.com/foundry-rs/forge-template...
+...
     Initialized forge project
 
 "#]]);
@@ -433,8 +451,10 @@ forgetest!(can_init_with_dir_and_template_and_branch, |prj, cmd| {
         "test/deployments",
     ])
     .assert_success()
-    .stdout_eq(str![[r#"
+    .stdout_eq(str![""])
+    .stderr_eq(str![[r#"
 Initializing [..] from https://github.com/foundry-rs/forge-template...
+...
     Initialized forge project
 
 "#]]);
@@ -459,15 +479,15 @@ Run with the `--force` flag to initialize regardless.
     cmd.arg("--force")
         .assert_success()
         .stdout_eq(str![[r#"
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 
 "#]])
         .stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
+Initializing [..]...
 ...
+    Initialized forge project
 
 "#]]);
 
@@ -499,15 +519,15 @@ Run with the `--force` flag to initialize regardless.
     cmd.arg("--force")
         .assert_success()
         .stdout_eq(str![[r#"
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 
 "#]])
         .stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
+Initializing [..]...
 ...
+    Initialized forge project
 
 "#]]);
 
@@ -541,15 +561,15 @@ Run with the `--force` flag to initialize regardless.
     cmd.arg("--force")
         .assert_success()
         .stdout_eq(str![[r#"
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 
 "#]])
         .stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
+Initializing [..]...
 ...
+    Initialized forge project
 
 "#]]);
 
@@ -580,15 +600,22 @@ forgetest!(can_init_using_parent_repo, |prj, cmd| {
     prj.create_file(".gitignore", "not foundry .gitignore");
 
     let folder = "foundry-folder";
-    cmd.arg("init").arg(folder).arg("--force").arg("--use-parent-git").assert_success().stdout_eq(
-        str![[r#"
-Initializing [..]...
+    cmd.arg("init")
+        .arg(folder)
+        .arg("--force")
+        .arg("--use-parent-git")
+        .assert_success()
+        .stdout_eq(str![[r#"
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
+
+"#]])
+        .stderr_eq(str![[r#"
+Initializing [..]...
+...
     Initialized forge project
 
-"#]],
-    );
+"#]]);
 
     assert!(root.join(folder).join("lib/forge-std").exists());
 
@@ -612,10 +639,18 @@ Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag:
 forgetest!(can_init_vscode, |prj, cmd| {
     prj.wipe();
 
-    cmd.arg("init").arg(prj.root()).arg("--vscode").assert_success().stdout_eq(str![[r#"
-Initializing [..]...
+    cmd.arg("init")
+        .arg(prj.root())
+        .arg("--vscode")
+        .assert_success()
+        .stdout_eq(str![[r#"
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
+
+"#]])
+        .stderr_eq(str![[r#"
+Initializing [..]...
+...
     Initialized forge project
 
 "#]]);
@@ -644,8 +679,10 @@ forgetest!(can_init_template, |prj, cmd| {
     cmd.args(["init", "--template", "foundry-rs/forge-template"])
         .arg(prj.root())
         .assert_success()
-        .stdout_eq(str![[r#"
+        .stdout_eq(str![""])
+        .stderr_eq(str![[r#"
 Initializing [..] from https://github.com/foundry-rs/forge-template...
+...
     Initialized forge project
 
 "#]]);
@@ -665,8 +702,10 @@ forgetest!(can_init_template_with_branch, |prj, cmd| {
     cmd.args(["init", "--template", "foundry-rs/forge-template", "--branch", "test/deployments"])
         .arg(prj.root())
         .assert_success()
-        .stdout_eq(str![[r#"
+        .stdout_eq(str![""])
+        .stderr_eq(str![[r#"
 Initializing [..] from https://github.com/foundry-rs/forge-template...
+...
     Initialized forge project
 
 "#]]);
@@ -684,6 +723,7 @@ Initializing [..] from https://github.com/foundry-rs/forge-template...
 forgetest!(fail_init_nonexistent_template, |prj, cmd| {
     prj.wipe();
     cmd.args(["init", "--template", "a"]).arg(prj.root()).assert_failure().stderr_eq(str![[r#"
+Initializing [..] from https://github.com/a...
 remote: Not Found
 fatal: repository 'https://github.com/a/' not found
 Error: git fetch exited with code 128
@@ -697,8 +737,10 @@ forgetest!(can_init_template_with_no_commit, |prj, cmd| {
     cmd.args(["init", "--template", "foundry-rs/forge-template"])
         .arg(prj.root())
         .assert_success()
-        .stdout_eq(str![[r#"
+        .stdout_eq(str![""])
+        .stderr_eq(str![[r#"
 Initializing [..] from https://github.com/foundry-rs/forge-template...
+...
     Initialized forge project
 
 "#]]);
@@ -733,14 +775,18 @@ forgetest!(flaky_can_clone, |prj, cmd| {
     .assert_success()
     .stdout_eq(str![[r#"
 Downloading the source code of 0x044b75f554b886A065b9567891e45c79542d7357 from Etherscan...
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 Collecting the creation information of 0x044b75f554b886A065b9567891e45c79542d7357 from Etherscan...
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
+
+"#]])
+    .stderr_eq(str![[r#"
+Initializing [..]...
+...
+    Initialized forge project
 
 "#]]);
 
@@ -790,14 +836,18 @@ forgetest!(flaky_can_clone_sourcify, |prj, cmd| {
         .assert_success()
         .stdout_eq(str![[r#"
 Downloading the source code of 0xDb53f47aC61FE54F456A4eb3E09832D08Dd7BEec from Sourcify...
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 Collecting the creation information of 0xDb53f47aC61FE54F456A4eb3E09832D08Dd7BEec from Sourcify...
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
+
+"#]])
+        .stderr_eq(str![[r#"
+Initializing [..]...
+...
+    Initialized forge project
 
 "#]]);
 
@@ -823,14 +873,18 @@ forgetest!(flaky_can_clone_no_remappings_txt, |prj, cmd| {
     .assert_success()
     .stdout_eq(str![[r#"
 Downloading the source code of 0x33e690aEa97E4Ef25F0d140F1bf044d663091DAf from Etherscan...
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 Collecting the creation information of 0x33e690aEa97E4Ef25F0d140F1bf044d663091DAf from Etherscan...
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
+
+"#]])
+    .stderr_eq(str![[r#"
+Initializing [..]...
+...
+    Initialized forge project
 
 "#]]);
 
@@ -881,10 +935,17 @@ forgetest!(flaky_can_clone_keep_directory_structure, |prj, cmd| {
 forgetest!(can_init_project, |prj, cmd| {
     prj.wipe();
 
-    cmd.args(["init"]).arg(prj.root()).assert_success().stdout_eq(str![[r#"
-Initializing [..]...
+    cmd.args(["init"])
+        .arg(prj.root())
+        .assert_success()
+        .stdout_eq(str![[r#"
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
+
+"#]])
+        .stderr_eq(str![[r#"
+Initializing [..]...
+...
     Initialized forge project
 
 "#]]);
@@ -909,10 +970,17 @@ Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag:
 forgetest!(can_init_vyper_project, |prj, cmd| {
     prj.wipe();
 
-    cmd.args(["init", "--vyper"]).arg(prj.root()).assert_success().stdout_eq(str![[r#"
-Initializing [..]...
+    cmd.args(["init", "--vyper"])
+        .arg(prj.root())
+        .assert_success()
+        .stdout_eq(str![[r#"
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
+
+"#]])
+        .stderr_eq(str![[r#"
+Initializing [..]...
+...
     Initialized forge project
 
 "#]]);
@@ -938,17 +1006,22 @@ Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag:
 forgetest!(can_init_tempo_project, |prj, cmd| {
     prj.wipe();
 
-    cmd.args(["init", "--network", "tempo"]).arg(prj.root()).assert_success().stdout_eq(str![[
-        r#"
-Initializing [..]...
+    cmd.args(["init", "--network", "tempo"])
+        .arg(prj.root())
+        .assert_success()
+        .stdout_eq(str![[r#"
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
 Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: None)
     Installed tempo-std[..]
+
+"#]])
+        .stderr_eq(str![[r#"
+Initializing [..]...
+...
     Initialized forge project
 
-"#
-    ]]);
+"#]]);
 
     assert!(prj.root().join("foundry.toml").exists());
 
@@ -1042,14 +1115,18 @@ forgetest!(flaky_can_clone_with_node_modules, |prj, cmd| {
     .assert_success()
     .stdout_eq(str![[r#"
 Downloading the source code of 0xA3E217869460bEf59A1CfD0637e2875F9331e823 from Etherscan...
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 Collecting the creation information of 0xA3E217869460bEf59A1CfD0637e2875F9331e823 from Etherscan...
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
+
+"#]])
+    .stderr_eq(str![[r#"
+Initializing [..]...
+...
+    Initialized forge project
 
 "#]]);
 });
@@ -4238,4 +4315,24 @@ Generated test file: test/Counter.t.sol
 "#]]);
 
     assert!(prj.root().join("test/Counter.t.sol").exists(), "scaffolded test file should exist");
+});
+
+// `forge init` writes its status prose to stderr and keeps stdout empty so agents
+// can pipe the command without diagnostics. Uses `--offline` + `--no-git` to skip
+// network and git side-effects that would otherwise add prose to stdout.
+forgetest!(init_status_on_stderr, |prj, cmd| {
+    prj.wipe();
+
+    cmd.args(["init", "--offline", "--no-git"])
+        .arg(prj.root())
+        .assert_success()
+        .stdout_eq(str![""])
+        .stderr_eq(str![[r#"
+Initializing [..]...
+...
+    Initialized forge project
+
+"#]]);
+
+    assert!(prj.root().join("foundry.toml").exists());
 });

--- a/crates/forge/tests/cli/debug.rs
+++ b/crates/forge/tests/cli/debug.rs
@@ -11,15 +11,15 @@ forgetest!(
             .arg(prj.root())
             .assert_success()
             .stdout_eq(str![[r#"
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 
 "#]])
             .stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
+Initializing [..]...
 ...
+    Initialized forge project
 
 "#]]);
 

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1137,15 +1137,15 @@ forgetest_async!(can_execute_script_with_arguments, |prj, cmd| {
         .arg(prj.root())
         .assert_success()
         .stdout_eq(str![[r#"
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 
 "#]])
         .stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
+Initializing [..]...
 ...
+    Initialized forge project
 
 "#]]);
 
@@ -1265,15 +1265,15 @@ forgetest_async!(can_execute_script_with_arguments_nested_deploy, |prj, cmd| {
         .arg(prj.root())
         .assert_success()
         .stdout_eq(str![[r#"
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 
 "#]])
         .stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
+Initializing [..]...
 ...
+    Initialized forge project
 
 "#]]);
 
@@ -1435,15 +1435,15 @@ forgetest_async!(assert_tx_origin_is_not_overwritten, |prj, cmd| {
         .arg(prj.root())
         .assert_success()
         .stdout_eq(str![[r#"
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 
 "#]])
         .stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
+Initializing [..]...
 ...
+    Initialized forge project
 
 "#]]);
 
@@ -1521,15 +1521,15 @@ forgetest_async!(assert_can_create_multiple_contracts_with_correct_nonce, |prj, 
         .arg(prj.root())
         .assert_success()
         .stdout_eq(str![[r#"
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 
 "#]])
         .stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
+Initializing [..]...
 ...
+    Initialized forge project
 
 "#]]);
 
@@ -1750,15 +1750,15 @@ forgetest_async!(can_decode_custom_errors, |prj, cmd| {
         .arg(prj.root())
         .assert_success()
         .stdout_eq(str![[r#"
-Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-    Initialized forge project
 
 "#]])
         .stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
+Initializing [..]...
 ...
+    Initialized forge project
 
 "#]]);
 

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -121,7 +121,7 @@ Each row's status is one of:
 | `forge create`         | Deployed address                                     | JSON `{ "address": "…", "tx_hash": "…", … }` | todo |
 | `forge inspect <field>`| Just that field's value                              | JSON of that field                         | todo   |
 | `forge install`        | (empty)                                              | (empty)                                    | todo   |
-| `forge init`           | (empty)                                              | (empty)                                    | todo   |
+| `forge init`           | (empty)                                              | (empty)                                    | migrated |
 | `forge update`         | (empty)                                              | (empty)                                    | migrated |
 | `forge remove`         | (empty)                                              | (empty)                                    | migrated |
 | `forge clone`          | (empty)                                              | (empty)                                    | todo   |


### PR DESCRIPTION
Migrates `forge init` per docs/dev/output-channels.md: status prose ("Initializing …", "Initialized forge project") moves from stdout to stderr via `sh_status!`. `forge init` produces no machine-readable data, so stdout is now empty.

- `crates/forge/src/cmd/init.rs`: three `sh_println!` → `sh_status!`.
- `docs/dev/output-channels.md`: row flipped to `migrated`.
- Tests in `cmd.rs`, `debug.rs`, `script.rs`: init prose snapshots relocated from `.stdout_eq` to `.stderr_eq` (with `...` between Initializing/Initialized to tolerate git's clone output on the same channel). `fail_init_nonexistent_template` updated to include the new stderr line. Added focused lock-in test `init_status_on_stderr`.

Part of OSS-224