### PR TITLE
feat(forge): migrate forge cache to output channel contract

### DIFF
--- a/crates/forge/src/cmd/cache.rs
+++ b/crates/forge/src/cmd/cache.rs
@@ -105,7 +105,7 @@ impl LsArgs {
                 ChainOrAll::All => cache = Config::list_foundry_cache()?,
             }
         }
-        sh_print!("{cache}")?;
+        sh_eprint!("{cache}")?;
         Ok(())
     }
 }

--- a/crates/forge/tests/cli/cache.rs
+++ b/crates/forge/tests/cli/cache.rs
@@ -15,6 +15,10 @@ forgetest!(can_list_specific_chain, |_prj, cmd| {
     cmd.assert_success();
 });
 
+forgetest!(cache_ls_output_on_stderr, |_prj, cmd| {
+    cmd.args(["cache", "ls", "mainnet"]).assert_success().stdout_eq(str![""]);
+});
+
 forgetest_init!(can_test_no_cache, |prj, cmd| {
     prj.initialize_default_contracts();
     prj.clear_cache();

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -147,7 +147,7 @@ forgetest!(
         fs::write(block2_file, "{}").unwrap();
         fs::create_dir_all(etherscan_cache_dir).unwrap();
 
-        let output = cmd.args(["cache", "ls"]).assert_success().get_output().stdout_lossy();
+        let output = cmd.args(["cache", "ls"]).assert_success().get_output().stderr_lossy();
         let output_lines = output.split('\n').collect::<Vec<_>>();
         println!("{output}");
 

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -137,7 +137,7 @@ Each row's status is one of:
 | `forge lint`           | (empty; findings on stderr/exit code)                | JSON findings                              | todo   |
 | `forge snapshot`       | Snapshot file content / diff                         | JSON                                       | todo   |
 | `forge coverage`       | Coverage table or report                             | JSON / LCOV / etc. via `--report`          | todo   |
-| `forge cache`          | (empty) or paths                                     | JSON                                       | todo   |
+| `forge cache`          | (empty) or paths                                     | JSON                                       | migrated |
 | `forge doc`            | (empty)                                              | n/a                                        | todo   |
 | `forge generate`       | (empty) or generated path                            | n/a                                        | migrated |
 | `forge soldeer`        | (empty)                                              | n/a                                        | todo   |


### PR DESCRIPTION
Migrates `forge cache` per docs/dev/output-channels.md: the `cache ls` listing moves from stdout to stderr. `cache clean` was already compliant (only `sh_warn!`).

- `crates/forge/src/cmd/cache.rs`: `sh_print!("{cache}")` → `sh_eprint!("{cache}")`.
- `docs/dev/output-channels.md`: row flipped to `migrated`.
- Tests: `can_cache_ls` (ignored, modifies global cache) switched from `stdout_lossy()` to `stderr_lossy()`. Added focused lock-in test `cache_ls_output_on_stderr` asserting empty stdout.

Part of OSS-224