### PR TITLE
feat(forge): migrate forge bind to output channel contract

### DIFF
--- a/crates/forge/src/cmd/bind.rs
+++ b/crates/forge/src/cmd/bind.rs
@@ -128,7 +128,7 @@ impl BindArgs {
 
         if bindings_root.exists() {
             if !self.overwrite {
-                sh_println!("Bindings found. Checking for consistency.")?;
+                sh_status!("Bindings found. Checking for consistency.")?;
                 return self.check_existing_bindings(&artifacts, &bindings_root);
             }
 
@@ -138,7 +138,7 @@ impl BindArgs {
 
         self.generate_bindings(&artifacts, &bindings_root)?;
 
-        sh_println!("Bindings have been generated to {}", bindings_root.display())?;
+        sh_status!("Bindings have been generated to {}", bindings_root.display())?;
         Ok(())
     }
 
@@ -215,7 +215,7 @@ impl BindArgs {
     fn check_existing_bindings(&self, artifacts: &Path, bindings_root: &Path) -> Result<()> {
         let mut bindings = self.get_solmacrogen(artifacts)?;
         bindings.generate_bindings(!self.skip_extra_derives)?;
-        sh_println!("Checking bindings for {} contracts", bindings.instances.len())?;
+        sh_status!("Checking bindings for {} contracts", bindings.instances.len())?;
         bindings.check_consistency(
             &self.crate_name,
             &self.crate_version,
@@ -226,14 +226,14 @@ impl BindArgs {
             self.alloy_version.clone(),
             self.alloy_rev.clone(),
         )?;
-        sh_println!("OK.")?;
+        sh_status!("OK.")?;
         Ok(())
     }
 
     /// Generate the bindings
     fn generate_bindings(&self, artifacts: &Path, bindings_root: &Path) -> Result<()> {
         let mut solmacrogen = self.get_solmacrogen(artifacts)?;
-        sh_println!("Generating bindings for {} contracts", solmacrogen.instances.len())?;
+        sh_status!("Generating bindings for {} contracts", solmacrogen.instances.len())?;
 
         if self.module {
             trace!(single_file = self.single_file, "generating module");

--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -16,11 +16,27 @@ contract SomeLibContract {
 }
    "#,
     );
-    cmd.args(["bind", "--select", "SomeLibContract"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["bind", "--select", "SomeLibContract"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
+
+"#]])
+        .stderr_eq(str![[r#"
 Generating bindings for 1 contracts
 Bindings have been generated to [..]
+
+"#]]);
+});
+
+forgetest_init!(bind_status_on_stderr, |prj, cmd| {
+    prj.initialize_default_contracts();
+    prj.clear();
+    cmd.arg("bind").assert_success().stderr_eq(str![[r#"
+Generating bindings for [..] contracts
+Bindings have been generated to [..]
+
 "#]]);
 });

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3391,10 +3391,15 @@ forgetest_init!(can_bind, |prj, cmd| {
     prj.initialize_default_contracts();
     prj.clear();
 
-    cmd.arg("bind").assert_success().stdout_eq(str![[r#"
+    cmd.arg("bind")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
+
+"#]])
+        .stderr_eq(str![[r#"
 Generating bindings for [..] contracts
 Bindings have been generated to [..]
 
@@ -4174,23 +4179,37 @@ forgetest_init!(can_bind_enum_modules, |prj, cmd| {
     }"#,
     );
 
-    cmd.args(["bind", "--select", "^Enum$"]).assert_success().stdout_eq(str![[
-        r#"[COMPILING_FILES] with [SOLC_VERSION]
+    cmd.args(["bind", "--select", "^Enum$"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
+
+"#]])
+        .stderr_eq(str![[r#"
 Generating bindings for 1 contracts
-Bindings have been generated to [..]"#
-    ]]);
+Bindings have been generated to [..]
+
+"#]]);
 });
 
 // forge bind e2e
 forgetest_init!(can_bind_e2e, |prj, cmd| {
     prj.initialize_default_contracts();
-    cmd.args(["bind"]).assert_success().stdout_eq(str![[r#"[COMPILING_FILES] with [SOLC_VERSION]
+    cmd.args(["bind"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
+
+"#]])
+        .stderr_eq(str![[r#"
 Generating bindings for 2 contracts
-Bindings have been generated to [..]"#]]);
+Bindings have been generated to [..]
+
+"#]]);
 
     let bindings_path = prj.root().join("out/bindings");
 

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -125,7 +125,7 @@ Each row's status is one of:
 | `forge update`         | (empty)                                              | (empty)                                    | migrated |
 | `forge remove`         | (empty)                                              | (empty)                                    | migrated |
 | `forge clone`          | (empty)                                              | (empty)                                    | todo   |
-| `forge bind`           | (empty)                                              | (empty)                                    | todo   |
+| `forge bind`           | (empty)                                              | (empty)                                    | migrated |
 | `forge bind-json`      | (empty) or generated path                            | JSON                                       | todo   |
 | `forge flatten`        | Flattened source                                     | n/a                                        | migrated |
 | `forge fmt`            | (empty) or formatted source with `--check`           | n/a                                        | todo   |


### PR DESCRIPTION
Migrates `forge bind` per docs/dev/output-channels.md: status prose ("Generating bindings for …", "Bindings have been generated to …", "Checking bindings for …", "OK.", "Bindings found. Checking for consistency.") moves from stdout to stderr via `sh_status!`. `forge bind` produces no machine-readable data, so stdout is now empty (compile-reporter output stays on stdout pending its own migration).

- `crates/forge/src/cmd/bind.rs`: five `sh_println!` → `sh_status!`.
- `docs/dev/output-channels.md`: row flipped to `migrated`.
- Tests: `bind_unlinked_bytecode`, `can_bind`, `can_bind_enum_modules`, `can_bind_e2e` updated to assert bind prose on stderr. Added focused lock-in test `bind_status_on_stderr`.

Part of OSS-224