### PR TITLE
feat(evm): add invariant campaign aggregation boundary

### DIFF
--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -3,6 +3,7 @@
 use super::{KeyType, registry::*, tempo_home};
 use alloy_primitives::{Address, B256, Selector, U256};
 use alloy_signer::Signer;
+use eyre::ensure;
 use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
 use serde::{Deserialize, Serialize};
 use std::{num::NonZeroU64, path::PathBuf};
@@ -301,14 +302,14 @@ fn validate_session_key_authorization(
     key: &SessionKeyMaterial,
     authorization: &SignedKeyAuthorization,
 ) -> eyre::Result<()> {
-    eyre::ensure!(
+    ensure!(
         authorization.authorization.key_id == session.key_address,
         "session {} key_authorization key_id is {}, expected {}",
         session.session_id,
         authorization.authorization.key_id,
         session.key_address
     );
-    eyre::ensure!(
+    ensure!(
         authorization.authorization.chain_id == session.chain_id,
         "session {} key_authorization chain_id is {}, expected {}",
         session.session_id,
@@ -316,7 +317,7 @@ fn validate_session_key_authorization(
         session.chain_id
     );
     let expected_key_type = key_type_to_signature_type(key.key_type);
-    eyre::ensure!(
+    ensure!(
         authorization.authorization.key_type == expected_key_type,
         "session {} key_authorization key_type is {:?}, expected {:?}",
         session.session_id,
@@ -326,7 +327,7 @@ fn validate_session_key_authorization(
     let recovered = authorization
         .recover_signer()
         .map_err(|err| eyre::eyre!("failed to recover session key_authorization signer: {err}"))?;
-    eyre::ensure!(
+    ensure!(
         recovered == session.root_account,
         "session {} key_authorization signer is {}, expected {}",
         session.session_id,
@@ -346,7 +347,7 @@ fn validate_session_authorization_policy(
 
     let expected_expiry = NonZeroU64::new(session.expiry)
         .ok_or_else(|| eyre::eyre!("session {} has invalid zero expiry", session.session_id))?;
-    eyre::ensure!(
+    ensure!(
         auth.expiry == Some(expected_expiry),
         "session {} key_authorization expiry is {:?}, expected {}",
         session.session_id,
@@ -356,7 +357,7 @@ fn validate_session_authorization_policy(
 
     let expected_limits = session_authorization_limits(session)?;
     let actual_limits = auth.limits.as_deref().map(authorization_limits);
-    eyre::ensure!(
+    ensure!(
         actual_limits == expected_limits,
         "session {} key_authorization limits do not match session limits",
         session.session_id
@@ -364,7 +365,7 @@ fn validate_session_authorization_policy(
 
     let expected_scope = session_authorization_scope(session);
     let actual_scope = auth.allowed_calls.as_deref().map(authorization_scope);
-    eyre::ensure!(
+    ensure!(
         actual_scope == expected_scope,
         "session {} key_authorization allowed_calls do not match session scope",
         session.session_id

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -3,7 +3,6 @@
 use super::{KeyType, registry::*, tempo_home};
 use alloy_primitives::{Address, B256, Selector, U256};
 use alloy_signer::Signer;
-use eyre::ensure;
 use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
 use serde::{Deserialize, Serialize};
 use std::{num::NonZeroU64, path::PathBuf};
@@ -302,14 +301,14 @@ fn validate_session_key_authorization(
     key: &SessionKeyMaterial,
     authorization: &SignedKeyAuthorization,
 ) -> eyre::Result<()> {
-    ensure!(
+    eyre::ensure!(
         authorization.authorization.key_id == session.key_address,
         "session {} key_authorization key_id is {}, expected {}",
         session.session_id,
         authorization.authorization.key_id,
         session.key_address
     );
-    ensure!(
+    eyre::ensure!(
         authorization.authorization.chain_id == session.chain_id,
         "session {} key_authorization chain_id is {}, expected {}",
         session.session_id,
@@ -317,7 +316,7 @@ fn validate_session_key_authorization(
         session.chain_id
     );
     let expected_key_type = key_type_to_signature_type(key.key_type);
-    ensure!(
+    eyre::ensure!(
         authorization.authorization.key_type == expected_key_type,
         "session {} key_authorization key_type is {:?}, expected {:?}",
         session.session_id,
@@ -327,7 +326,7 @@ fn validate_session_key_authorization(
     let recovered = authorization
         .recover_signer()
         .map_err(|err| eyre::eyre!("failed to recover session key_authorization signer: {err}"))?;
-    ensure!(
+    eyre::ensure!(
         recovered == session.root_account,
         "session {} key_authorization signer is {}, expected {}",
         session.session_id,
@@ -347,7 +346,7 @@ fn validate_session_authorization_policy(
 
     let expected_expiry = NonZeroU64::new(session.expiry)
         .ok_or_else(|| eyre::eyre!("session {} has invalid zero expiry", session.session_id))?;
-    ensure!(
+    eyre::ensure!(
         auth.expiry == Some(expected_expiry),
         "session {} key_authorization expiry is {:?}, expected {}",
         session.session_id,
@@ -357,7 +356,7 @@ fn validate_session_authorization_policy(
 
     let expected_limits = session_authorization_limits(session)?;
     let actual_limits = auth.limits.as_deref().map(authorization_limits);
-    ensure!(
+    eyre::ensure!(
         actual_limits == expected_limits,
         "session {} key_authorization limits do not match session limits",
         session.session_id
@@ -365,7 +364,7 @@ fn validate_session_authorization_policy(
 
     let expected_scope = session_authorization_scope(session);
     let actual_scope = auth.allowed_calls.as_deref().map(authorization_scope);
-    ensure!(
+    eyre::ensure!(
         actual_scope == expected_scope,
         "session {} key_authorization allowed_calls do not match session scope",
         session.session_id

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -114,7 +114,13 @@ impl InvariantCampaignAggregator {
         let mut gas_report_traces = Vec::new();
         let mut line_coverage = None;
         let mut metrics = HashMap::default();
-        let failed_corpus_replays = self.outputs[0].result.failed_corpus_replays;
+        let failed_corpus_replays = self
+            .outputs
+            .iter()
+            .find(|output| output.plan.worker_id == 0)
+            .expect("master worker output was validated")
+            .result
+            .failed_corpus_replays;
         let mut optimization_best = None;
 
         for InvariantWorkerOutput { result, .. } in self.outputs {
@@ -156,7 +162,7 @@ fn ensure_outputs_cover_campaign(
     spec: InvariantCampaignSpec,
     outputs: &[InvariantWorkerOutput],
 ) -> Result<()> {
-    ensure_worker_ids_are_dense(outputs)?;
+    ensure_worker_ids_are_valid(outputs)?;
 
     if spec.total_runs == 0 {
         ensure!(
@@ -169,11 +175,7 @@ fn ensure_outputs_cover_campaign(
     }
 
     let mut next_global_run = 0;
-    for (expected_worker_id, output) in outputs.iter().enumerate() {
-        ensure!(
-            output.plan.worker_id == expected_worker_id as u32,
-            "invariant worker outputs are not in dense worker order"
-        );
+    for output in outputs {
         ensure!(output.plan.runs > 0, "invariant worker outputs do not cover the logical campaign");
         ensure!(
             output.plan.first_global_run == next_global_run,
@@ -191,7 +193,7 @@ fn ensure_outputs_cover_campaign(
     Ok(())
 }
 
-fn ensure_worker_ids_are_dense(outputs: &[InvariantWorkerOutput]) -> Result<()> {
+fn ensure_worker_ids_are_valid(outputs: &[InvariantWorkerOutput]) -> Result<()> {
     let mut seen = HashSet::with_capacity(outputs.len());
     for output in outputs {
         ensure!(
@@ -202,9 +204,6 @@ fn ensure_worker_ids_are_dense(outputs: &[InvariantWorkerOutput]) -> Result<()> 
     }
 
     ensure!(seen.contains(&0), "missing invariant master worker output");
-    for expected in 0..outputs.len() as u32 {
-        ensure!(seen.contains(&expected), "missing invariant worker output for worker {expected}");
-    }
     Ok(())
 }
 
@@ -677,7 +676,7 @@ mod tests {
     }
 
     #[test]
-    fn aggregator_rejects_non_dense_worker_ids() {
+    fn aggregator_allows_non_dense_worker_ids_with_contiguous_ranges() {
         let spec = InvariantCampaignSpec::new(2);
         let mut aggregator = InvariantCampaignAggregator::new(spec);
 
@@ -687,11 +686,29 @@ mod tests {
         ));
         aggregator.push(InvariantWorkerOutput::new(
             InvariantWorkerPlan { worker_id: 2, first_global_run: 1, runs: 1 },
+            empty_result(2, 0),
+        ));
+        let result = aggregator.finish().unwrap();
+
+        assert_eq!(result.reverts, 2);
+    }
+
+    #[test]
+    fn aggregator_rejects_missing_master_worker() {
+        let spec = InvariantCampaignSpec::new(2);
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 0, runs: 1 },
+            empty_result(0, 0),
+        ));
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 2, first_global_run: 1, runs: 1 },
             empty_result(0, 0),
         ));
         let err = aggregator.finish().unwrap_err();
 
-        assert!(err.to_string().contains("missing invariant worker output for worker 1"));
+        assert!(err.to_string().contains("missing invariant master worker output"));
     }
 
     #[test]
@@ -714,13 +731,13 @@ mod tests {
     fn aggregator_takes_failed_corpus_replays_from_master_worker() {
         let spec = InvariantCampaignSpec::new(2);
         let plans = [
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
-            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 1, runs: 1 },
         ];
 
         let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(InvariantWorkerOutput::new(plans[1], empty_result(0, 0)));
-        aggregator.push(InvariantWorkerOutput::new(plans[0], empty_result(0, 7)));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], empty_result(0, 0)));
+        aggregator.push(InvariantWorkerOutput::new(plans[1], empty_result(0, 7)));
         let result = aggregator.finish().unwrap();
 
         assert_eq!(result.failed_corpus_replays, 7);

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -104,10 +104,8 @@ impl InvariantCampaignAggregator {
         let failed_corpus_replays = self.outputs[0].result.failed_corpus_replays;
         let mut optimization_best = None;
 
-        for InvariantWorkerOutput { plan, result } in self.outputs {
-            let run_key = RunChoice { first_global_run: plan.first_global_run };
-
-            merge_predicate_errors(&mut errors, result.errors, run_key);
+        for InvariantWorkerOutput { result, .. } in self.outputs {
+            merge_predicate_errors(&mut errors, result.errors);
             merge_handler_errors(&mut handler_errors, result.handler_errors);
             cases.extend(result.cases);
             reverts += result.reverts;
@@ -119,7 +117,6 @@ impl InvariantCampaignAggregator {
                 &mut optimization_best,
                 result.optimization_best_value,
                 result.optimization_best_sequence,
-                run_key,
             );
         }
         let (optimization_best_value, optimization_best_sequence) = optimization_best
@@ -144,26 +141,13 @@ impl InvariantCampaignAggregator {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-struct RunChoice {
-    first_global_run: u32,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-struct PredicateFailureChoice {
-    run: RunChoice,
-    sequence_len: usize,
-}
-
 struct PredicateFailureEntry {
     error: InvariantFuzzError,
-    choice: PredicateFailureChoice,
 }
 
 struct OptimizationChoice {
     value: I256,
     sequence: Vec<BasicTxDetails>,
-    run: RunChoice,
 }
 
 /// Returns the exclusive end of a worker's logical run range.
@@ -208,13 +192,9 @@ fn ensure_outputs_cover_campaign(
 fn merge_predicate_errors(
     merged: &mut HashMap<String, PredicateFailureEntry>,
     worker_errors: HashMap<String, InvariantFuzzError>,
-    run: RunChoice,
 ) {
     for (invariant, error) in worker_errors {
-        let candidate = PredicateFailureChoice { run, sequence_len: error_sequence_len(&error) };
-        if merged.get(&invariant).is_none_or(|existing| candidate < existing.choice) {
-            merged.insert(invariant, PredicateFailureEntry { error, choice: candidate });
-        }
+        merged.entry(invariant).or_insert(PredicateFailureEntry { error });
     }
 }
 
@@ -249,22 +229,15 @@ fn merge_optimization(
     best: &mut Option<OptimizationChoice>,
     candidate_value: Option<I256>,
     candidate_sequence: Vec<BasicTxDetails>,
-    candidate_key: RunChoice,
 ) {
     let Some(candidate_value) = candidate_value else {
         return;
     };
 
-    let should_replace = best.as_ref().is_none_or(|best| {
-        candidate_value > best.value || candidate_value == best.value && candidate_key < best.run
-    });
+    let should_replace = best.as_ref().is_none_or(|best| candidate_value > best.value);
 
     if should_replace {
-        *best = Some(OptimizationChoice {
-            value: candidate_value,
-            sequence: candidate_sequence,
-            run: candidate_key,
-        });
+        *best = Some(OptimizationChoice { value: candidate_value, sequence: candidate_sequence });
     }
 }
 
@@ -561,25 +534,18 @@ mod tests {
     }
 
     #[test]
-    fn predicate_failure_choice_uses_sequence_length_after_run() {
+    fn predicate_error_merge_keeps_first_duplicate_failure() {
         let mut merged = HashMap::default();
 
         let mut worker_errors = HashMap::default();
-        worker_errors.insert("invariant_balance".to_string(), predicate_error("later-run", 1));
-        merge_predicate_errors(&mut merged, worker_errors, RunChoice { first_global_run: 6 });
+        worker_errors.insert("invariant_balance".to_string(), predicate_error("first", 4));
+        merge_predicate_errors(&mut merged, worker_errors);
 
         let mut worker_errors = HashMap::default();
-        worker_errors.insert("invariant_balance".to_string(), predicate_error("earlier-run", 4));
-        merge_predicate_errors(&mut merged, worker_errors, RunChoice { first_global_run: 5 });
-        assert_eq!(
-            merged["invariant_balance"].error.revert_reason().as_deref(),
-            Some("earlier-run")
-        );
+        worker_errors.insert("invariant_balance".to_string(), predicate_error("second", 1));
+        merge_predicate_errors(&mut merged, worker_errors);
 
-        let mut worker_errors = HashMap::default();
-        worker_errors.insert("invariant_balance".to_string(), predicate_error("shorter", 2));
-        merge_predicate_errors(&mut merged, worker_errors, RunChoice { first_global_run: 5 });
-        assert_eq!(merged["invariant_balance"].error.revert_reason().as_deref(), Some("shorter"));
+        assert_eq!(merged["invariant_balance"].error.revert_reason().as_deref(), Some("first"));
     }
 
     #[test]
@@ -607,7 +573,7 @@ mod tests {
     }
 
     #[test]
-    fn aggregator_keeps_max_optimization_value_and_earlier_tie() {
+    fn aggregator_keeps_first_max_optimization_value_on_tie() {
         let spec = InvariantCampaignSpec::new(3);
         let plans = [
             InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -1,5 +1,10 @@
-use super::InvariantFuzzTestResult;
+use super::{InvariantFuzzError, InvariantFuzzTestResult, InvariantMetrics};
+use alloy_primitives::{Address, I256, Selector};
 use eyre::{Result, ensure};
+use foundry_evm_coverage::HitMaps;
+use foundry_evm_fuzz::BasicTxDetails;
+use proptest::test_runner::TestError;
+use std::collections::HashMap;
 
 /// Immutable plan-level description for an invariant campaign.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -65,42 +70,235 @@ impl InvariantWorkerOutput {
 }
 
 /// Merges worker outputs back into one logical invariant campaign result.
-///
-/// TODO: extend this to merge multiple worker outputs once invariant execution is parallelized.
 #[derive(Debug)]
 pub struct InvariantCampaignAggregator {
     spec: InvariantCampaignSpec,
-    output: Option<InvariantWorkerOutput>,
+    outputs: Vec<InvariantWorkerOutput>,
 }
 
 impl InvariantCampaignAggregator {
     pub const fn new(spec: InvariantCampaignSpec) -> Self {
-        Self { spec, output: None }
+        Self { spec, outputs: Vec::new() }
     }
 
     pub fn push(&mut self, output: InvariantWorkerOutput) -> Result<()> {
+        let end = worker_range_end(output.plan)?;
         ensure!(
-            self.output.is_none(),
-            "single-worker invariant aggregator received multiple outputs"
+            end <= self.spec.total_runs,
+            "invariant worker output exceeds the logical campaign"
         );
-        ensure!(
-            self.spec.worker_plans(1)?.first().is_some_and(|plan| *plan == output.plan),
-            "single-worker invariant output does not cover the logical campaign"
-        );
-        self.output = Some(output);
+        self.outputs.push(output);
         Ok(())
     }
 
-    pub fn finish(self) -> Result<InvariantFuzzTestResult> {
-        let output = self.output.ok_or_else(|| eyre::eyre!("missing invariant worker output"))?;
-        Ok(output.result)
+    pub fn finish(mut self) -> Result<InvariantFuzzTestResult> {
+        ensure!(!self.outputs.is_empty(), "missing invariant worker output");
+
+        self.outputs.sort_by_key(|output| (output.plan.first_global_run, output.plan.worker_id));
+        ensure_outputs_cover_campaign(self.spec, &self.outputs)?;
+
+        let mut errors = HashMap::default();
+        let mut error_choices = HashMap::default();
+        let mut handler_errors = HashMap::default();
+        let mut cases = Vec::new();
+        let mut reverts = 0;
+        let mut last_run_inputs = Vec::new();
+        let mut last_run_end = None;
+        let mut gas_report_traces = Vec::new();
+        let mut line_coverage = None;
+        let mut metrics = HashMap::default();
+        let mut failed_corpus_replays = 0;
+        let mut optimization_best_value = None;
+        let mut optimization_best_sequence = Vec::new();
+        let mut optimization_best_key = None;
+
+        for output in self.outputs {
+            let plan = output.plan;
+            let plan_end = worker_range_end(plan)?;
+            let run_key =
+                RunChoice { first_global_run: plan.first_global_run, worker_id: plan.worker_id };
+            let result = output.result;
+
+            merge_predicate_errors(&mut errors, &mut error_choices, result.errors, run_key);
+            merge_handler_errors(&mut handler_errors, result.handler_errors);
+            cases.extend(result.cases);
+            reverts += result.reverts;
+            if last_run_end.is_none_or(|end| plan_end > end) {
+                last_run_end = Some(plan_end);
+                last_run_inputs = result.last_run_inputs;
+            }
+            gas_report_traces.extend(result.gas_report_traces);
+            HitMaps::merge_opt(&mut line_coverage, result.line_coverage);
+            merge_metrics(&mut metrics, result.metrics);
+            if plan.first_global_run == 0 {
+                failed_corpus_replays = result.failed_corpus_replays;
+            }
+            merge_optimization(
+                &mut optimization_best_value,
+                &mut optimization_best_sequence,
+                &mut optimization_best_key,
+                result.optimization_best_value,
+                result.optimization_best_sequence,
+                run_key,
+            );
+        }
+
+        Ok(InvariantFuzzTestResult::new(
+            errors,
+            handler_errors,
+            cases,
+            reverts,
+            last_run_inputs,
+            gas_report_traces,
+            line_coverage,
+            metrics,
+            failed_corpus_replays,
+            optimization_best_value,
+            optimization_best_sequence,
+        ))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct RunChoice {
+    first_global_run: u32,
+    worker_id: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct PredicateFailureChoice {
+    run: RunChoice,
+    sequence_len: usize,
+}
+
+fn worker_range_end(plan: InvariantWorkerPlan) -> Result<u32> {
+    plan.first_global_run
+        .checked_add(plan.runs)
+        .ok_or_else(|| eyre::eyre!("invariant worker output range overflows"))
+}
+
+fn ensure_outputs_cover_campaign(
+    spec: InvariantCampaignSpec,
+    outputs: &[InvariantWorkerOutput],
+) -> Result<()> {
+    if spec.total_runs == 0 {
+        ensure!(
+            outputs.len() == 1
+                && outputs[0].plan.first_global_run == 0
+                && outputs[0].plan.runs == 0,
+            "invariant worker outputs do not cover the logical campaign"
+        );
+        return Ok(());
+    }
+
+    let mut next_global_run = 0;
+    for output in outputs {
+        ensure!(output.plan.runs > 0, "invariant worker outputs do not cover the logical campaign");
+        ensure!(
+            output.plan.first_global_run == next_global_run,
+            "invariant worker outputs do not cover the logical campaign"
+        );
+        next_global_run = worker_range_end(output.plan)?;
+    }
+
+    ensure!(
+        next_global_run == spec.total_runs,
+        "invariant worker outputs do not cover the logical campaign"
+    );
+    Ok(())
+}
+
+fn merge_predicate_errors(
+    merged: &mut HashMap<String, InvariantFuzzError>,
+    choices: &mut HashMap<String, PredicateFailureChoice>,
+    worker_errors: HashMap<String, InvariantFuzzError>,
+    run: RunChoice,
+) {
+    for (invariant, error) in worker_errors {
+        let candidate = PredicateFailureChoice { run, sequence_len: error_sequence_len(&error) };
+        if choices.get(&invariant).is_none_or(|existing| candidate < *existing) {
+            choices.insert(invariant.clone(), candidate);
+            merged.insert(invariant, error);
+        }
+    }
+}
+
+fn merge_handler_errors(
+    merged: &mut HashMap<(Address, Selector), InvariantFuzzError>,
+    worker_errors: HashMap<(Address, Selector), InvariantFuzzError>,
+) {
+    for (site, error) in worker_errors {
+        let candidate_len = error_sequence_len(&error);
+        match merged.get_mut(&site) {
+            Some(existing) if error_sequence_len(existing) <= candidate_len => {}
+            Some(existing) => *existing = error,
+            None => {
+                merged.insert(site, error);
+            }
+        }
+    }
+}
+
+fn merge_metrics(
+    merged: &mut HashMap<String, InvariantMetrics>,
+    worker_metrics: HashMap<String, InvariantMetrics>,
+) {
+    for (selector, metrics) in worker_metrics {
+        let entry = merged.entry(selector).or_default();
+        entry.calls += metrics.calls;
+        entry.reverts += metrics.reverts;
+        entry.discards += metrics.discards;
+    }
+}
+
+fn merge_optimization(
+    best_value: &mut Option<I256>,
+    best_sequence: &mut Vec<BasicTxDetails>,
+    best_key: &mut Option<RunChoice>,
+    candidate_value: Option<I256>,
+    candidate_sequence: Vec<BasicTxDetails>,
+    candidate_key: RunChoice,
+) {
+    let Some(candidate_value) = candidate_value else {
+        return;
+    };
+
+    let should_replace = best_value.is_none_or(|best_value| candidate_value > best_value)
+        || best_value.is_some_and(|best_value| {
+            candidate_value == best_value
+                && best_key.is_none_or(|best_key| candidate_key < best_key)
+        });
+
+    if should_replace {
+        *best_value = Some(candidate_value);
+        *best_sequence = candidate_sequence;
+        *best_key = Some(candidate_key);
+    }
+}
+
+const fn error_sequence_len(error: &InvariantFuzzError) -> usize {
+    match error {
+        InvariantFuzzError::BrokenInvariant(case_data) | InvariantFuzzError::Revert(case_data) => {
+            match &case_data.test_error {
+                TestError::Fail(_, sequence) => sequence.len(),
+                TestError::Abort(_) => usize::MAX,
+            }
+        }
+        InvariantFuzzError::HandlerAssertion(failure) => failure.call_sequence.len(),
+        InvariantFuzzError::MaxAssumeRejects(_) => usize::MAX,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::collections::HashMap;
+    use super::{
+        super::error::{FailedInvariantCaseData, HandlerAssertionFailure},
+        *,
+    };
+    use alloy_primitives::{B256, Bytes};
+    use foundry_evm_coverage::HitMap;
+    use foundry_evm_fuzz::{CallDetails, FuzzCase, FuzzedCases};
+    use revm_inspectors::tracing::CallTraceArena;
 
     fn empty_result(reverts: usize, failed_corpus_replays: usize) -> InvariantFuzzTestResult {
         InvariantFuzzTestResult::new(
@@ -116,6 +314,80 @@ mod tests {
             None,
             Vec::new(),
         )
+    }
+
+    fn basic_tx(sender: u8) -> BasicTxDetails {
+        BasicTxDetails {
+            warp: None,
+            roll: None,
+            sender: Address::repeat_byte(sender),
+            call_details: CallDetails {
+                target: Address::repeat_byte(sender.wrapping_add(1)),
+                calldata: Bytes::from(vec![0, 0, 0, sender]),
+                value: None,
+            },
+        }
+    }
+
+    fn hit_maps(pc: u32, hits: u32) -> HitMaps {
+        let mut hit_map = HitMap::new(Bytes::from_static(&[0]));
+        hit_map.hits(pc, hits);
+
+        let mut maps = HitMaps::default();
+        maps.insert(B256::ZERO, hit_map);
+        maps
+    }
+
+    fn worker_result(
+        case_gas: u64,
+        reverts: usize,
+        last_input_sender: u8,
+        metric_name: &str,
+        metrics: InvariantMetrics,
+        coverage_hits: u32,
+        failed_corpus_replays: usize,
+    ) -> InvariantFuzzTestResult {
+        let mut result = empty_result(reverts, failed_corpus_replays);
+        result.cases.push(FuzzedCases::new(vec![FuzzCase { gas: case_gas, stipend: 0 }]));
+        result.last_run_inputs = vec![basic_tx(last_input_sender)];
+        result.gas_report_traces.push(vec![CallTraceArena::default()]);
+        result.line_coverage = Some(hit_maps(7, coverage_hits));
+        result.metrics.insert(metric_name.to_string(), metrics);
+        result
+    }
+
+    fn sequence(len: usize, first_sender: u8) -> Vec<BasicTxDetails> {
+        (0..len).map(|idx| basic_tx(first_sender.wrapping_add(idx as u8))).collect()
+    }
+
+    fn predicate_error(reason: &str, sequence_len: usize) -> InvariantFuzzError {
+        InvariantFuzzError::BrokenInvariant(FailedInvariantCaseData {
+            test_error: TestError::Fail(reason.to_string().into(), sequence(sequence_len, 0x80)),
+            return_reason: reason.to_string().into(),
+            revert_reason: reason.to_string(),
+            addr: Address::repeat_byte(0x70),
+            calldata: Bytes::new(),
+            inner_sequence: Vec::new(),
+            shrink_run_limit: 0,
+            fail_on_revert: false,
+            assertion_failure: false,
+        })
+    }
+
+    fn handler_error(
+        reverter: Address,
+        selector: Selector,
+        sequence_len: usize,
+        reason: &str,
+    ) -> InvariantFuzzError {
+        InvariantFuzzError::HandlerAssertion(HandlerAssertionFailure {
+            reverter,
+            selector,
+            call_sequence: sequence(sequence_len, 0x90),
+            original_sequence_len: sequence_len,
+            revert_reason: reason.to_string(),
+            edge_fingerprint: B256::ZERO,
+        })
     }
 
     fn one_worker_plan(spec: InvariantCampaignSpec) -> InvariantWorkerPlan {
@@ -201,18 +473,199 @@ mod tests {
     }
 
     #[test]
-    fn aggregator_rejects_multiple_outputs() {
+    fn aggregator_merges_multiple_worker_outputs_in_logical_run_order() {
+        let spec = InvariantCampaignSpec::new(3);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+            InvariantWorkerPlan { worker_id: 2, first_global_run: 2, runs: 1 },
+        ];
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator
+            .push(InvariantWorkerOutput::new(
+                plans[2],
+                worker_result(
+                    30,
+                    3,
+                    0x30,
+                    "transfer(address)",
+                    InvariantMetrics { calls: 3, reverts: 1, discards: 0 },
+                    3,
+                    0,
+                ),
+            ))
+            .unwrap();
+        aggregator
+            .push(InvariantWorkerOutput::new(
+                plans[0],
+                worker_result(
+                    10,
+                    1,
+                    0x10,
+                    "transfer(address)",
+                    InvariantMetrics { calls: 1, reverts: 0, discards: 2 },
+                    1,
+                    4,
+                ),
+            ))
+            .unwrap();
+        aggregator
+            .push(InvariantWorkerOutput::new(
+                plans[1],
+                worker_result(
+                    20,
+                    2,
+                    0x20,
+                    "approve(address)",
+                    InvariantMetrics { calls: 2, reverts: 1, discards: 1 },
+                    2,
+                    0,
+                ),
+            ))
+            .unwrap();
+
+        let result = aggregator.finish().unwrap();
+
+        let merged_case_gas =
+            result.cases.iter().map(|cases| cases.last().unwrap().gas).collect::<Vec<_>>();
+        assert_eq!(merged_case_gas, vec![10, 20, 30]);
+        assert_eq!(result.reverts, 6);
+        assert_eq!(result.gas_report_traces.len(), 3);
+        assert_eq!(result.last_run_inputs[0].sender, Address::repeat_byte(0x30));
+
+        let transfer_metrics = result.metrics.get("transfer(address)").unwrap();
+        assert_eq!(transfer_metrics, &InvariantMetrics { calls: 4, reverts: 1, discards: 2 });
+        let approve_metrics = result.metrics.get("approve(address)").unwrap();
+        assert_eq!(approve_metrics, &InvariantMetrics { calls: 2, reverts: 1, discards: 1 });
+
+        let coverage = result.line_coverage.unwrap();
+        assert_eq!(coverage.get(&B256::ZERO).unwrap().get(7).unwrap().get(), 6);
+        assert_eq!(result.failed_corpus_replays, 4);
+    }
+
+    #[test]
+    fn aggregator_keeps_earlier_predicate_failure_for_each_invariant() {
+        let spec = InvariantCampaignSpec::new(2);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+        ];
+        let mut earlier = empty_result(0, 0);
+        earlier.errors.insert("invariant_balance".to_string(), predicate_error("earlier", 3));
+        let mut later = empty_result(0, 0);
+        later.errors.insert("invariant_balance".to_string(), predicate_error("later", 1));
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[1], later)).unwrap();
+        aggregator.push(InvariantWorkerOutput::new(plans[0], earlier)).unwrap();
+        let result = aggregator.finish().unwrap();
+
+        assert_eq!(result.errors.len(), 1);
+        assert_eq!(result.errors["invariant_balance"].revert_reason().as_deref(), Some("earlier"));
+    }
+
+    #[test]
+    fn predicate_failure_choice_uses_worker_id_then_sequence_length_after_run() {
+        let mut merged = HashMap::default();
+        let mut choices = HashMap::default();
+
+        let mut worker_errors = HashMap::default();
+        worker_errors.insert("invariant_balance".to_string(), predicate_error("worker-2", 1));
+        merge_predicate_errors(
+            &mut merged,
+            &mut choices,
+            worker_errors,
+            RunChoice { first_global_run: 5, worker_id: 2 },
+        );
+
+        let mut worker_errors = HashMap::default();
+        worker_errors.insert("invariant_balance".to_string(), predicate_error("worker-1", 4));
+        merge_predicate_errors(
+            &mut merged,
+            &mut choices,
+            worker_errors,
+            RunChoice { first_global_run: 5, worker_id: 1 },
+        );
+        assert_eq!(merged["invariant_balance"].revert_reason().as_deref(), Some("worker-1"));
+
+        let mut worker_errors = HashMap::default();
+        worker_errors.insert("invariant_balance".to_string(), predicate_error("shorter", 2));
+        merge_predicate_errors(
+            &mut merged,
+            &mut choices,
+            worker_errors,
+            RunChoice { first_global_run: 5, worker_id: 1 },
+        );
+        assert_eq!(merged["invariant_balance"].revert_reason().as_deref(), Some("shorter"));
+    }
+
+    #[test]
+    fn aggregator_dedupes_handler_assertions_by_site_and_keeps_shorter_sequence() {
+        let spec = InvariantCampaignSpec::new(2);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+        ];
+        let site = (Address::repeat_byte(0xaa), Selector::from([1, 2, 3, 4]));
+        let mut longer = empty_result(0, 0);
+        longer.handler_errors.insert(site, handler_error(site.0, site.1, 4, "longer"));
+        let mut shorter = empty_result(0, 0);
+        shorter.handler_errors.insert(site, handler_error(site.0, site.1, 2, "shorter"));
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[1], shorter)).unwrap();
+        aggregator.push(InvariantWorkerOutput::new(plans[0], longer)).unwrap();
+        let result = aggregator.finish().unwrap();
+
+        let failure = result.handler_errors[&site].as_handler_assertion().unwrap();
+        assert_eq!(result.handler_errors.len(), 1);
+        assert_eq!(failure.call_sequence.len(), 2);
+        assert_eq!(failure.revert_reason, "shorter");
+    }
+
+    #[test]
+    fn aggregator_keeps_max_optimization_value_and_earlier_tie() {
+        let spec = InvariantCampaignSpec::new(3);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+            InvariantWorkerPlan { worker_id: 2, first_global_run: 2, runs: 1 },
+        ];
+        let mut first = empty_result(0, 0);
+        first.optimization_best_value = Some(I256::try_from(7).unwrap());
+        first.optimization_best_sequence = sequence(1, 0x10);
+        let mut earlier_best = empty_result(0, 0);
+        earlier_best.optimization_best_value = Some(I256::try_from(9).unwrap());
+        earlier_best.optimization_best_sequence = sequence(1, 0x20);
+        let mut later_tie = empty_result(0, 0);
+        later_tie.optimization_best_value = Some(I256::try_from(9).unwrap());
+        later_tie.optimization_best_sequence = sequence(1, 0x30);
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[2], later_tie)).unwrap();
+        aggregator.push(InvariantWorkerOutput::new(plans[0], first)).unwrap();
+        aggregator.push(InvariantWorkerOutput::new(plans[1], earlier_best)).unwrap();
+        let result = aggregator.finish().unwrap();
+
+        assert_eq!(result.optimization_best_value, Some(I256::try_from(9).unwrap()));
+        assert_eq!(result.optimization_best_sequence[0].sender, Address::repeat_byte(0x20));
+    }
+
+    #[test]
+    fn aggregator_rejects_overlapping_outputs() {
         let spec = InvariantCampaignSpec::new(1);
         let mut aggregator = InvariantCampaignAggregator::new(spec);
 
         aggregator
             .push(InvariantWorkerOutput::new(one_worker_plan(spec), empty_result(0, 0)))
             .unwrap();
-        let err = aggregator
+        aggregator
             .push(InvariantWorkerOutput::new(one_worker_plan(spec), empty_result(0, 0)))
-            .unwrap_err();
+            .unwrap();
+        let err = aggregator.finish().unwrap_err();
 
-        assert!(err.to_string().contains("received multiple outputs"));
+        assert!(err.to_string().contains("do not cover the logical campaign"));
     }
 
     #[test]
@@ -222,9 +675,10 @@ mod tests {
         let worker = InvariantWorkerOutput::new(plan, empty_result(0, 0));
 
         let mut aggregator = InvariantCampaignAggregator::new(spec);
-        let err = aggregator.push(worker).unwrap_err();
+        aggregator.push(worker).unwrap();
+        let err = aggregator.finish().unwrap_err();
 
-        assert!(err.to_string().contains("does not cover the logical campaign"));
+        assert!(err.to_string().contains("do not cover the logical campaign"));
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -3,7 +3,6 @@ use alloy_primitives::{Address, I256, Selector};
 use eyre::{Result, ensure};
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::BasicTxDetails;
-use proptest::test_runner::TestError;
 use std::collections::HashMap;
 
 /// Immutable plan-level description for an invariant campaign.
@@ -77,13 +76,8 @@ impl InvariantCampaignAggregator {
         Self { spec, outputs: Vec::new() }
     }
 
-    pub fn push(&mut self, output: InvariantWorkerOutput) -> Result<()> {
-        ensure!(
-            worker_range_end(output.plan)? <= self.spec.total_runs,
-            "invariant worker output exceeds the logical campaign"
-        );
+    pub fn push(&mut self, output: InvariantWorkerOutput) {
         self.outputs.push(output);
-        Ok(())
     }
 
     /// Validates the collected worker ranges and folds them into one logical campaign result.
@@ -105,7 +99,9 @@ impl InvariantCampaignAggregator {
         let mut optimization_best = None;
 
         for InvariantWorkerOutput { result, .. } in self.outputs {
-            merge_predicate_errors(&mut errors, result.errors);
+            for (invariant, error) in result.errors {
+                errors.entry(invariant).or_insert(error);
+            }
             merge_handler_errors(&mut handler_errors, result.handler_errors);
             cases.extend(result.cases);
             reverts += result.reverts;
@@ -122,9 +118,6 @@ impl InvariantCampaignAggregator {
         let (optimization_best_value, optimization_best_sequence) = optimization_best
             .map(|choice| (Some(choice.value), choice.sequence))
             .unwrap_or_default();
-        let errors =
-            errors.into_iter().map(|(invariant, entry)| (invariant, entry.error)).collect();
-
         Ok(InvariantFuzzTestResult::new(
             errors,
             handler_errors,
@@ -141,20 +134,9 @@ impl InvariantCampaignAggregator {
     }
 }
 
-struct PredicateFailureEntry {
-    error: InvariantFuzzError,
-}
-
 struct OptimizationChoice {
     value: I256,
     sequence: Vec<BasicTxDetails>,
-}
-
-/// Returns the exclusive end of a worker's logical run range.
-fn worker_range_end(plan: InvariantWorkerPlan) -> Result<u32> {
-    plan.first_global_run
-        .checked_add(plan.runs)
-        .ok_or_else(|| eyre::eyre!("invariant worker output range overflows"))
 }
 
 fn ensure_outputs_cover_campaign(
@@ -178,7 +160,9 @@ fn ensure_outputs_cover_campaign(
             output.plan.first_global_run == next_global_run,
             "invariant worker outputs do not cover the logical campaign"
         );
-        next_global_run = worker_range_end(output.plan)?;
+        next_global_run = next_global_run
+            .checked_add(output.plan.runs)
+            .ok_or_else(|| eyre::eyre!("invariant worker output range overflows"))?;
     }
 
     ensure!(
@@ -188,24 +172,17 @@ fn ensure_outputs_cover_campaign(
     Ok(())
 }
 
-/// Keeps one predicate failure per invariant using the campaign's deterministic choice order.
-fn merge_predicate_errors(
-    merged: &mut HashMap<String, PredicateFailureEntry>,
-    worker_errors: HashMap<String, InvariantFuzzError>,
-) {
-    for (invariant, error) in worker_errors {
-        merged.entry(invariant).or_insert(PredicateFailureEntry { error });
-    }
-}
-
 /// Deduplicates handler assertion failures by site, keeping the shorter reproducer.
 fn merge_handler_errors(
     merged: &mut HashMap<(Address, Selector), InvariantFuzzError>,
     worker_errors: HashMap<(Address, Selector), InvariantFuzzError>,
 ) {
     for (site, error) in worker_errors {
-        let candidate_len = error_sequence_len(&error);
-        if merged.get(&site).is_none_or(|existing| error_sequence_len(existing) > candidate_len) {
+        let candidate_len = handler_error_sequence_len(&error);
+        if merged
+            .get(&site)
+            .is_none_or(|existing| handler_error_sequence_len(existing) > candidate_len)
+        {
             merged.insert(site, error);
         }
     }
@@ -234,24 +211,13 @@ fn merge_optimization(
         return;
     };
 
-    let should_replace = best.as_ref().is_none_or(|best| candidate_value > best.value);
-
-    if should_replace {
+    if best.as_ref().is_none_or(|best| candidate_value > best.value) {
         *best = Some(OptimizationChoice { value: candidate_value, sequence: candidate_sequence });
     }
 }
 
-const fn error_sequence_len(error: &InvariantFuzzError) -> usize {
-    match error {
-        InvariantFuzzError::BrokenInvariant(case_data) | InvariantFuzzError::Revert(case_data) => {
-            match &case_data.test_error {
-                TestError::Fail(_, sequence) => sequence.len(),
-                TestError::Abort(_) => usize::MAX,
-            }
-        }
-        InvariantFuzzError::HandlerAssertion(failure) => failure.call_sequence.len(),
-        InvariantFuzzError::MaxAssumeRejects(_) => usize::MAX,
-    }
+fn handler_error_sequence_len(error: &InvariantFuzzError) -> usize {
+    error.as_handler_assertion().map_or(usize::MAX, |failure| failure.call_sequence.len())
 }
 
 #[cfg(test)]
@@ -263,6 +229,7 @@ mod tests {
     use alloy_primitives::{B256, Bytes};
     use foundry_evm_coverage::HitMap;
     use foundry_evm_fuzz::{CallDetails, FuzzCase, FuzzedCases};
+    use proptest::test_runner::TestError;
     use revm_inspectors::tracing::CallTraceArena;
 
     fn empty_result(reverts: usize, failed_corpus_replays: usize) -> InvariantFuzzTestResult {
@@ -433,7 +400,7 @@ mod tests {
         let worker = InvariantWorkerOutput::new(one_worker_plan(spec), empty_result(2, 3));
 
         let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(worker).unwrap();
+        aggregator.push(worker);
         let result = aggregator.finish().unwrap();
 
         assert_eq!(result.reverts, 2);
@@ -450,48 +417,42 @@ mod tests {
         ];
 
         let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator
-            .push(InvariantWorkerOutput::new(
-                plans[2],
-                worker_result(
-                    30,
-                    3,
-                    0x30,
-                    "transfer(address)",
-                    InvariantMetrics { calls: 3, reverts: 1, discards: 0 },
-                    3,
-                    0,
-                ),
-            ))
-            .unwrap();
-        aggregator
-            .push(InvariantWorkerOutput::new(
-                plans[0],
-                worker_result(
-                    10,
-                    1,
-                    0x10,
-                    "transfer(address)",
-                    InvariantMetrics { calls: 1, reverts: 0, discards: 2 },
-                    1,
-                    4,
-                ),
-            ))
-            .unwrap();
-        aggregator
-            .push(InvariantWorkerOutput::new(
-                plans[1],
-                worker_result(
-                    20,
-                    2,
-                    0x20,
-                    "approve(address)",
-                    InvariantMetrics { calls: 2, reverts: 1, discards: 1 },
-                    2,
-                    0,
-                ),
-            ))
-            .unwrap();
+        aggregator.push(InvariantWorkerOutput::new(
+            plans[2],
+            worker_result(
+                30,
+                3,
+                0x30,
+                "transfer(address)",
+                InvariantMetrics { calls: 3, reverts: 1, discards: 0 },
+                3,
+                0,
+            ),
+        ));
+        aggregator.push(InvariantWorkerOutput::new(
+            plans[0],
+            worker_result(
+                10,
+                1,
+                0x10,
+                "transfer(address)",
+                InvariantMetrics { calls: 1, reverts: 0, discards: 2 },
+                1,
+                4,
+            ),
+        ));
+        aggregator.push(InvariantWorkerOutput::new(
+            plans[1],
+            worker_result(
+                20,
+                2,
+                0x20,
+                "approve(address)",
+                InvariantMetrics { calls: 2, reverts: 1, discards: 1 },
+                2,
+                0,
+            ),
+        ));
 
         let result = aggregator.finish().unwrap();
 
@@ -525,27 +486,12 @@ mod tests {
         later.errors.insert("invariant_balance".to_string(), predicate_error("later", 1));
 
         let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(InvariantWorkerOutput::new(plans[1], later)).unwrap();
-        aggregator.push(InvariantWorkerOutput::new(plans[0], earlier)).unwrap();
+        aggregator.push(InvariantWorkerOutput::new(plans[1], later));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], earlier));
         let result = aggregator.finish().unwrap();
 
         assert_eq!(result.errors.len(), 1);
         assert_eq!(result.errors["invariant_balance"].revert_reason().as_deref(), Some("earlier"));
-    }
-
-    #[test]
-    fn predicate_error_merge_keeps_first_duplicate_failure() {
-        let mut merged = HashMap::default();
-
-        let mut worker_errors = HashMap::default();
-        worker_errors.insert("invariant_balance".to_string(), predicate_error("first", 4));
-        merge_predicate_errors(&mut merged, worker_errors);
-
-        let mut worker_errors = HashMap::default();
-        worker_errors.insert("invariant_balance".to_string(), predicate_error("second", 1));
-        merge_predicate_errors(&mut merged, worker_errors);
-
-        assert_eq!(merged["invariant_balance"].error.revert_reason().as_deref(), Some("first"));
     }
 
     #[test]
@@ -562,8 +508,8 @@ mod tests {
         shorter.handler_errors.insert(site, handler_error(site.0, site.1, 2, "shorter"));
 
         let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(InvariantWorkerOutput::new(plans[1], shorter)).unwrap();
-        aggregator.push(InvariantWorkerOutput::new(plans[0], longer)).unwrap();
+        aggregator.push(InvariantWorkerOutput::new(plans[1], shorter));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], longer));
         let result = aggregator.finish().unwrap();
 
         let failure = result.handler_errors[&site].as_handler_assertion().unwrap();
@@ -591,9 +537,9 @@ mod tests {
         later_tie.optimization_best_sequence = sequence(1, 0x30);
 
         let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(InvariantWorkerOutput::new(plans[2], later_tie)).unwrap();
-        aggregator.push(InvariantWorkerOutput::new(plans[0], first)).unwrap();
-        aggregator.push(InvariantWorkerOutput::new(plans[1], earlier_best)).unwrap();
+        aggregator.push(InvariantWorkerOutput::new(plans[2], later_tie));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], first));
+        aggregator.push(InvariantWorkerOutput::new(plans[1], earlier_best));
         let result = aggregator.finish().unwrap();
 
         assert_eq!(result.optimization_best_value, Some(I256::try_from(9).unwrap()));
@@ -605,12 +551,8 @@ mod tests {
         let spec = InvariantCampaignSpec::new(1);
         let mut aggregator = InvariantCampaignAggregator::new(spec);
 
-        aggregator
-            .push(InvariantWorkerOutput::new(one_worker_plan(spec), empty_result(0, 0)))
-            .unwrap();
-        aggregator
-            .push(InvariantWorkerOutput::new(one_worker_plan(spec), empty_result(0, 0)))
-            .unwrap();
+        aggregator.push(InvariantWorkerOutput::new(one_worker_plan(spec), empty_result(0, 0)));
+        aggregator.push(InvariantWorkerOutput::new(one_worker_plan(spec), empty_result(0, 0)));
         let err = aggregator.finish().unwrap_err();
 
         assert!(err.to_string().contains("do not cover the logical campaign"));
@@ -623,7 +565,7 @@ mod tests {
         let worker = InvariantWorkerOutput::new(plan, empty_result(0, 0));
 
         let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(worker).unwrap();
+        aggregator.push(worker);
         let err = aggregator.finish().unwrap_err();
 
         assert!(err.to_string().contains("do not cover the logical campaign"));

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -23,15 +23,14 @@ impl InvariantCampaignSpec {
     /// Partitions the logical campaign into contiguous worker run ranges.
     ///
     /// This only describes work assignment. It does not start worker execution and does not
-    /// attribute failures to worker/run origins. A zero-run campaign has no worker work and
-    /// therefore produces no worker plans.
+    /// attribute failures to worker/run origins.
     pub fn worker_plans(self, workers: usize) -> Result<Vec<InvariantWorkerPlan>> {
         if self.total_runs == 0 {
-            return Ok(Vec::new());
+            return Ok(vec![InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 }]);
         }
         ensure!(workers > 0, "invariant campaign requires at least one worker");
 
-        let worker_count = workers.min(self.total_runs as usize) as u32;
+        let worker_count = workers.min(self.total_runs.max(1) as usize) as u32;
         let base_runs = self.total_runs / worker_count;
         let extra_runs = self.total_runs % worker_count;
 
@@ -167,6 +166,16 @@ fn ensure_outputs_cover_campaign(
     outputs: &[InvariantWorkerOutput],
 ) -> Result<()> {
     ensure_worker_ids_are_valid(outputs)?;
+
+    if spec.total_runs == 0 {
+        ensure!(
+            outputs.len() == 1
+                && outputs[0].plan.first_global_run == 0
+                && outputs[0].plan.runs == 0,
+            "invariant worker outputs do not cover the logical campaign"
+        );
+        return Ok(());
+    }
 
     let mut next_global_run = 0;
     for output in outputs {
@@ -424,17 +433,10 @@ mod tests {
     }
 
     #[test]
-    fn worker_plans_return_no_work_for_zero_run_campaign() {
+    fn worker_plans_keep_zero_run_campaign_as_single_empty_plan() {
         let plans = InvariantCampaignSpec::new(0).worker_plans(4).unwrap();
 
-        assert!(plans.is_empty());
-    }
-
-    #[test]
-    fn worker_plans_allow_zero_workers_for_zero_run_campaign() {
-        let plans = InvariantCampaignSpec::new(0).worker_plans(0).unwrap();
-
-        assert!(plans.is_empty());
+        assert_eq!(plans, vec![InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 }]);
     }
 
     #[test]
@@ -458,7 +460,7 @@ mod tests {
     }
 
     #[test]
-    fn aggregator_rejects_worker_output_for_zero_run_campaign() {
+    fn aggregator_accepts_single_worker_output_for_zero_run_campaign() {
         let spec = InvariantCampaignSpec::new(0);
         let worker = InvariantWorkerOutput::new(
             InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 },
@@ -467,9 +469,9 @@ mod tests {
 
         let mut aggregator = InvariantCampaignAggregator::new(spec);
         aggregator.push(worker);
-        let err = aggregator.finish().unwrap_err();
+        let result = aggregator.finish().unwrap();
 
-        assert!(err.to_string().contains("do not cover the logical campaign"));
+        assert_eq!(result.reverts, 0);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -31,7 +31,7 @@ impl InvariantCampaignSpec {
             return Ok(vec![InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 }]);
         }
 
-        let worker_count = workers.min(self.total_runs.max(1) as usize) as u32;
+        let worker_count = workers.min(self.total_runs as usize) as u32;
         let base_runs = self.total_runs / worker_count;
         let extra_runs = self.total_runs % worker_count;
 

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -25,19 +25,15 @@ impl InvariantCampaignSpec {
     pub fn worker_plans(self, workers: usize) -> Result<Vec<InvariantWorkerPlan>> {
         ensure!(workers > 0, "invariant campaign requires at least one worker");
 
-        if self.total_runs == 0 {
-            return Ok(vec![InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 }]);
-        }
-
-        let worker_count = workers.min(self.total_runs as usize);
-        let base_runs = self.total_runs / worker_count as u32;
-        let extra_runs = self.total_runs % worker_count as u32;
+        let worker_count = workers.min(self.total_runs.max(1) as usize) as u32;
+        let base_runs = self.total_runs / worker_count;
+        let extra_runs = self.total_runs % worker_count;
 
         let mut first_global_run = 0;
-        let mut plans = Vec::with_capacity(worker_count);
+        let mut plans = Vec::with_capacity(worker_count as usize);
         for worker_id in 0..worker_count {
-            let runs = base_runs + u32::from((worker_id as u32) < extra_runs);
-            plans.push(InvariantWorkerPlan { worker_id: worker_id as u32, first_global_run, runs });
+            let runs = base_runs + u32::from(worker_id < extra_runs);
+            plans.push(InvariantWorkerPlan { worker_id, first_global_run, runs });
             first_global_run += runs;
         }
 
@@ -82,9 +78,8 @@ impl InvariantCampaignAggregator {
     }
 
     pub fn push(&mut self, output: InvariantWorkerOutput) -> Result<()> {
-        let end = worker_range_end(output.plan)?;
         ensure!(
-            end <= self.spec.total_runs,
+            worker_range_end(output.plan)? <= self.spec.total_runs,
             "invariant worker output exceeds the logical campaign"
         );
         self.outputs.push(output);
@@ -99,7 +94,6 @@ impl InvariantCampaignAggregator {
         ensure_outputs_cover_campaign(self.spec, &self.outputs)?;
 
         let mut errors = HashMap::default();
-        let mut error_choices = HashMap::default();
         let mut handler_errors = HashMap::default();
         let mut cases = Vec::new();
         let mut reverts = 0;
@@ -108,17 +102,13 @@ impl InvariantCampaignAggregator {
         let mut line_coverage = None;
         let mut metrics = HashMap::default();
         let failed_corpus_replays = self.outputs[0].result.failed_corpus_replays;
-        let mut optimization_best_value = None;
-        let mut optimization_best_sequence = Vec::new();
-        let mut optimization_best_key = None;
+        let mut optimization_best = None;
 
-        for output in self.outputs {
-            let plan = output.plan;
+        for InvariantWorkerOutput { plan, result } in self.outputs {
             let run_key =
                 RunChoice { first_global_run: plan.first_global_run, worker_id: plan.worker_id };
-            let result = output.result;
 
-            merge_predicate_errors(&mut errors, &mut error_choices, result.errors, run_key);
+            merge_predicate_errors(&mut errors, result.errors, run_key);
             merge_handler_errors(&mut handler_errors, result.handler_errors);
             cases.extend(result.cases);
             reverts += result.reverts;
@@ -127,14 +117,17 @@ impl InvariantCampaignAggregator {
             HitMaps::merge_opt(&mut line_coverage, result.line_coverage);
             merge_metrics(&mut metrics, result.metrics);
             merge_optimization(
-                &mut optimization_best_value,
-                &mut optimization_best_sequence,
-                &mut optimization_best_key,
+                &mut optimization_best,
                 result.optimization_best_value,
                 result.optimization_best_sequence,
                 run_key,
             );
         }
+        let (optimization_best_value, optimization_best_sequence) = optimization_best
+            .map(|choice| (Some(choice.value), choice.sequence))
+            .unwrap_or_default();
+        let errors =
+            errors.into_iter().map(|(invariant, entry)| (invariant, entry.error)).collect();
 
         Ok(InvariantFuzzTestResult::new(
             errors,
@@ -162,6 +155,17 @@ struct RunChoice {
 struct PredicateFailureChoice {
     run: RunChoice,
     sequence_len: usize,
+}
+
+struct PredicateFailureEntry {
+    error: InvariantFuzzError,
+    choice: PredicateFailureChoice,
+}
+
+struct OptimizationChoice {
+    value: I256,
+    sequence: Vec<BasicTxDetails>,
+    run: RunChoice,
 }
 
 /// Returns the exclusive end of a worker's logical run range.
@@ -204,16 +208,14 @@ fn ensure_outputs_cover_campaign(
 
 /// Keeps one predicate failure per invariant using the campaign's deterministic choice order.
 fn merge_predicate_errors(
-    merged: &mut HashMap<String, InvariantFuzzError>,
-    choices: &mut HashMap<String, PredicateFailureChoice>,
+    merged: &mut HashMap<String, PredicateFailureEntry>,
     worker_errors: HashMap<String, InvariantFuzzError>,
     run: RunChoice,
 ) {
     for (invariant, error) in worker_errors {
         let candidate = PredicateFailureChoice { run, sequence_len: error_sequence_len(&error) };
-        if choices.get(&invariant).is_none_or(|existing| candidate < *existing) {
-            choices.insert(invariant.clone(), candidate);
-            merged.insert(invariant, error);
+        if merged.get(&invariant).is_none_or(|existing| candidate < existing.choice) {
+            merged.insert(invariant, PredicateFailureEntry { error, choice: candidate });
         }
     }
 }
@@ -225,12 +227,8 @@ fn merge_handler_errors(
 ) {
     for (site, error) in worker_errors {
         let candidate_len = error_sequence_len(&error);
-        match merged.get_mut(&site) {
-            Some(existing) if error_sequence_len(existing) <= candidate_len => {}
-            Some(existing) => *existing = error,
-            None => {
-                merged.insert(site, error);
-            }
+        if merged.get(&site).is_none_or(|existing| error_sequence_len(existing) > candidate_len) {
+            merged.insert(site, error);
         }
     }
 }
@@ -250,9 +248,7 @@ fn merge_metrics(
 
 /// Keeps the best optimization value, using logical run order to break ties.
 fn merge_optimization(
-    best_value: &mut Option<I256>,
-    best_sequence: &mut Vec<BasicTxDetails>,
-    best_key: &mut Option<RunChoice>,
+    best: &mut Option<OptimizationChoice>,
     candidate_value: Option<I256>,
     candidate_sequence: Vec<BasicTxDetails>,
     candidate_key: RunChoice,
@@ -261,16 +257,16 @@ fn merge_optimization(
         return;
     };
 
-    let should_replace = best_value.is_none_or(|best_value| candidate_value > best_value)
-        || best_value.is_some_and(|best_value| {
-            candidate_value == best_value
-                && best_key.is_none_or(|best_key| candidate_key < best_key)
-        });
+    let should_replace = best.as_ref().is_none_or(|best| {
+        candidate_value > best.value || candidate_value == best.value && candidate_key < best.run
+    });
 
     if should_replace {
-        *best_value = Some(candidate_value);
-        *best_sequence = candidate_sequence;
-        *best_key = Some(candidate_key);
+        *best = Some(OptimizationChoice {
+            value: candidate_value,
+            sequence: candidate_sequence,
+            run: candidate_key,
+        });
     }
 }
 
@@ -569,13 +565,11 @@ mod tests {
     #[test]
     fn predicate_failure_choice_uses_worker_id_then_sequence_length_after_run() {
         let mut merged = HashMap::default();
-        let mut choices = HashMap::default();
 
         let mut worker_errors = HashMap::default();
         worker_errors.insert("invariant_balance".to_string(), predicate_error("worker-2", 1));
         merge_predicate_errors(
             &mut merged,
-            &mut choices,
             worker_errors,
             RunChoice { first_global_run: 5, worker_id: 2 },
         );
@@ -584,21 +578,19 @@ mod tests {
         worker_errors.insert("invariant_balance".to_string(), predicate_error("worker-1", 4));
         merge_predicate_errors(
             &mut merged,
-            &mut choices,
             worker_errors,
             RunChoice { first_global_run: 5, worker_id: 1 },
         );
-        assert_eq!(merged["invariant_balance"].revert_reason().as_deref(), Some("worker-1"));
+        assert_eq!(merged["invariant_balance"].error.revert_reason().as_deref(), Some("worker-1"));
 
         let mut worker_errors = HashMap::default();
         worker_errors.insert("invariant_balance".to_string(), predicate_error("shorter", 2));
         merge_predicate_errors(
             &mut merged,
-            &mut choices,
             worker_errors,
             RunChoice { first_global_run: 5, worker_id: 1 },
         );
-        assert_eq!(merged["invariant_balance"].revert_reason().as_deref(), Some("shorter"));
+        assert_eq!(merged["invariant_balance"].error.revert_reason().as_deref(), Some("shorter"));
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -90,7 +90,7 @@ impl InvariantCampaignAggregator {
     pub fn finish(mut self) -> Result<InvariantFuzzTestResult> {
         ensure!(!self.outputs.is_empty(), "missing invariant worker output");
 
-        self.outputs.sort_by_key(|output| (output.plan.first_global_run, output.plan.worker_id));
+        self.outputs.sort_by_key(|output| output.plan.first_global_run);
         ensure_outputs_cover_campaign(self.spec, &self.outputs)?;
 
         let mut errors = HashMap::default();
@@ -105,8 +105,7 @@ impl InvariantCampaignAggregator {
         let mut optimization_best = None;
 
         for InvariantWorkerOutput { plan, result } in self.outputs {
-            let run_key =
-                RunChoice { first_global_run: plan.first_global_run, worker_id: plan.worker_id };
+            let run_key = RunChoice { first_global_run: plan.first_global_run };
 
             merge_predicate_errors(&mut errors, result.errors, run_key);
             merge_handler_errors(&mut handler_errors, result.handler_errors);
@@ -148,7 +147,6 @@ impl InvariantCampaignAggregator {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct RunChoice {
     first_global_run: u32,
-    worker_id: u32,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -563,33 +561,24 @@ mod tests {
     }
 
     #[test]
-    fn predicate_failure_choice_uses_worker_id_then_sequence_length_after_run() {
+    fn predicate_failure_choice_uses_sequence_length_after_run() {
         let mut merged = HashMap::default();
 
         let mut worker_errors = HashMap::default();
-        worker_errors.insert("invariant_balance".to_string(), predicate_error("worker-2", 1));
-        merge_predicate_errors(
-            &mut merged,
-            worker_errors,
-            RunChoice { first_global_run: 5, worker_id: 2 },
-        );
+        worker_errors.insert("invariant_balance".to_string(), predicate_error("later-run", 1));
+        merge_predicate_errors(&mut merged, worker_errors, RunChoice { first_global_run: 6 });
 
         let mut worker_errors = HashMap::default();
-        worker_errors.insert("invariant_balance".to_string(), predicate_error("worker-1", 4));
-        merge_predicate_errors(
-            &mut merged,
-            worker_errors,
-            RunChoice { first_global_run: 5, worker_id: 1 },
+        worker_errors.insert("invariant_balance".to_string(), predicate_error("earlier-run", 4));
+        merge_predicate_errors(&mut merged, worker_errors, RunChoice { first_global_run: 5 });
+        assert_eq!(
+            merged["invariant_balance"].error.revert_reason().as_deref(),
+            Some("earlier-run")
         );
-        assert_eq!(merged["invariant_balance"].error.revert_reason().as_deref(), Some("worker-1"));
 
         let mut worker_errors = HashMap::default();
         worker_errors.insert("invariant_balance".to_string(), predicate_error("shorter", 2));
-        merge_predicate_errors(
-            &mut merged,
-            worker_errors,
-            RunChoice { first_global_run: 5, worker_id: 1 },
-        );
+        merge_predicate_errors(&mut merged, worker_errors, RunChoice { first_global_run: 5 });
         assert_eq!(merged["invariant_balance"].error.revert_reason().as_deref(), Some("shorter"));
     }
 

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -103,18 +103,16 @@ impl InvariantCampaignAggregator {
         let mut cases = Vec::new();
         let mut reverts = 0;
         let mut last_run_inputs = Vec::new();
-        let mut last_run_end = None;
         let mut gas_report_traces = Vec::new();
         let mut line_coverage = None;
         let mut metrics = HashMap::default();
-        let mut failed_corpus_replays = 0;
+        let failed_corpus_replays = self.outputs[0].result.failed_corpus_replays;
         let mut optimization_best_value = None;
         let mut optimization_best_sequence = Vec::new();
         let mut optimization_best_key = None;
 
         for output in self.outputs {
             let plan = output.plan;
-            let plan_end = worker_range_end(plan)?;
             let run_key =
                 RunChoice { first_global_run: plan.first_global_run, worker_id: plan.worker_id };
             let result = output.result;
@@ -123,16 +121,10 @@ impl InvariantCampaignAggregator {
             merge_handler_errors(&mut handler_errors, result.handler_errors);
             cases.extend(result.cases);
             reverts += result.reverts;
-            if last_run_end.is_none_or(|end| plan_end > end) {
-                last_run_end = Some(plan_end);
-                last_run_inputs = result.last_run_inputs;
-            }
+            last_run_inputs = result.last_run_inputs;
             gas_report_traces.extend(result.gas_report_traces);
             HitMaps::merge_opt(&mut line_coverage, result.line_coverage);
             merge_metrics(&mut metrics, result.metrics);
-            if plan.first_global_run == 0 {
-                failed_corpus_replays = result.failed_corpus_replays;
-            }
             merge_optimization(
                 &mut optimization_best_value,
                 &mut optimization_best_sequence,

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -91,6 +91,7 @@ impl InvariantCampaignAggregator {
         Ok(())
     }
 
+    /// Validates the collected worker ranges and folds them into one logical campaign result.
     pub fn finish(mut self) -> Result<InvariantFuzzTestResult> {
         ensure!(!self.outputs.is_empty(), "missing invariant worker output");
 
@@ -163,6 +164,7 @@ struct PredicateFailureChoice {
     sequence_len: usize,
 }
 
+/// Returns the exclusive end of a worker's logical run range.
 fn worker_range_end(plan: InvariantWorkerPlan) -> Result<u32> {
     plan.first_global_run
         .checked_add(plan.runs)
@@ -200,6 +202,7 @@ fn ensure_outputs_cover_campaign(
     Ok(())
 }
 
+/// Keeps one predicate failure per invariant using the campaign's deterministic choice order.
 fn merge_predicate_errors(
     merged: &mut HashMap<String, InvariantFuzzError>,
     choices: &mut HashMap<String, PredicateFailureChoice>,
@@ -215,6 +218,7 @@ fn merge_predicate_errors(
     }
 }
 
+/// Deduplicates handler assertion failures by site, keeping the shorter reproducer.
 fn merge_handler_errors(
     merged: &mut HashMap<(Address, Selector), InvariantFuzzError>,
     worker_errors: HashMap<(Address, Selector), InvariantFuzzError>,
@@ -231,6 +235,7 @@ fn merge_handler_errors(
     }
 }
 
+/// Adds worker-local selector metrics into the logical campaign totals.
 fn merge_metrics(
     merged: &mut HashMap<String, InvariantMetrics>,
     worker_metrics: HashMap<String, InvariantMetrics>,
@@ -243,6 +248,7 @@ fn merge_metrics(
     }
 }
 
+/// Keeps the best optimization value, using logical run order to break ties.
 fn merge_optimization(
     best_value: &mut Option<I256>,
     best_sequence: &mut Vec<BasicTxDetails>,
@@ -330,6 +336,7 @@ mod tests {
         maps
     }
 
+    /// Builds a worker-local result fixture with the fields merged by the aggregator.
     fn worker_result(
         case_gas: u64,
         reverts: usize,
@@ -352,6 +359,7 @@ mod tests {
         (0..len).map(|idx| basic_tx(first_sender.wrapping_add(idx as u8))).collect()
     }
 
+    /// Builds a predicate failure fixture with a reproducible call sequence.
     fn predicate_error(reason: &str, sequence_len: usize) -> InvariantFuzzError {
         InvariantFuzzError::BrokenInvariant(FailedInvariantCaseData {
             test_error: TestError::Fail(reason.to_string().into(), sequence(sequence_len, 0x80)),
@@ -366,6 +374,7 @@ mod tests {
         })
     }
 
+    /// Builds a handler assertion fixture with a reproducible call sequence.
     fn handler_error(
         reverter: Address,
         selector: Selector,

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -23,11 +23,15 @@ impl InvariantCampaignSpec {
     /// Partitions the logical campaign into contiguous worker run ranges.
     ///
     /// This only describes work assignment. It does not start worker execution and does not
-    /// attribute failures to worker/run origins.
+    /// attribute failures to worker/run origins. A zero-run campaign has no worker work and
+    /// therefore produces no worker plans.
     pub fn worker_plans(self, workers: usize) -> Result<Vec<InvariantWorkerPlan>> {
+        if self.total_runs == 0 {
+            return Ok(Vec::new());
+        }
         ensure!(workers > 0, "invariant campaign requires at least one worker");
 
-        let worker_count = workers.min(self.total_runs.max(1) as usize) as u32;
+        let worker_count = workers.min(self.total_runs as usize) as u32;
         let base_runs = self.total_runs / worker_count;
         let extra_runs = self.total_runs % worker_count;
 
@@ -163,16 +167,6 @@ fn ensure_outputs_cover_campaign(
     outputs: &[InvariantWorkerOutput],
 ) -> Result<()> {
     ensure_worker_ids_are_valid(outputs)?;
-
-    if spec.total_runs == 0 {
-        ensure!(
-            outputs.len() == 1
-                && outputs[0].plan.first_global_run == 0
-                && outputs[0].plan.runs == 0,
-            "invariant worker outputs do not cover the logical campaign"
-        );
-        return Ok(());
-    }
 
     let mut next_global_run = 0;
     for output in outputs {
@@ -372,13 +366,15 @@ mod tests {
         })
     }
 
-    fn one_worker_plan(spec: InvariantCampaignSpec) -> InvariantWorkerPlan {
-        spec.worker_plans(1).unwrap().pop().unwrap()
+    fn one_worker_plan(total_runs: u32) -> InvariantWorkerPlan {
+        let mut plans = InvariantCampaignSpec::new(total_runs).worker_plans(1).unwrap();
+        assert_eq!(plans.len(), 1);
+        plans.pop().unwrap()
     }
 
     #[test]
     fn worker_plans_cover_logical_campaign_with_one_worker() {
-        let plan = one_worker_plan(InvariantCampaignSpec::new(3));
+        let plan = one_worker_plan(3);
 
         assert_eq!(plan.worker_id, 0);
         assert_eq!(plan.first_global_run, 0);
@@ -428,10 +424,17 @@ mod tests {
     }
 
     #[test]
-    fn worker_plans_keep_zero_run_campaign_as_single_empty_plan() {
+    fn worker_plans_return_no_work_for_zero_run_campaign() {
         let plans = InvariantCampaignSpec::new(0).worker_plans(4).unwrap();
 
-        assert_eq!(plans, vec![InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 }]);
+        assert!(plans.is_empty());
+    }
+
+    #[test]
+    fn worker_plans_allow_zero_workers_for_zero_run_campaign() {
+        let plans = InvariantCampaignSpec::new(0).worker_plans(0).unwrap();
+
+        assert!(plans.is_empty());
     }
 
     #[test]
@@ -444,7 +447,7 @@ mod tests {
     #[test]
     fn aggregator_returns_single_worker_result_without_rewriting() {
         let spec = InvariantCampaignSpec::new(1);
-        let worker = InvariantWorkerOutput::new(one_worker_plan(spec), empty_result(2, 3));
+        let worker = InvariantWorkerOutput::new(one_worker_plan(1), empty_result(2, 3));
 
         let mut aggregator = InvariantCampaignAggregator::new(spec);
         aggregator.push(worker);
@@ -452,6 +455,21 @@ mod tests {
 
         assert_eq!(result.reverts, 2);
         assert_eq!(result.failed_corpus_replays, 3);
+    }
+
+    #[test]
+    fn aggregator_rejects_worker_output_for_zero_run_campaign() {
+        let spec = InvariantCampaignSpec::new(0);
+        let worker = InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 },
+            empty_result(0, 0),
+        );
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(worker);
+        let err = aggregator.finish().unwrap_err();
+
+        assert!(err.to_string().contains("do not cover the logical campaign"));
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -134,9 +134,8 @@ impl InvariantCampaignAggregator {
                 result.optimization_best_sequence,
             );
         }
-        let (optimization_best_value, optimization_best_sequence) = optimization_best
-            .map(|choice| (Some(choice.value), choice.sequence))
-            .unwrap_or_default();
+        let (optimization_best_value, optimization_best_sequence) =
+            optimization_best.map(|(value, sequence)| (Some(value), sequence)).unwrap_or_default();
         Ok(InvariantFuzzTestResult::new(
             errors,
             handler_errors,
@@ -153,11 +152,6 @@ impl InvariantCampaignAggregator {
     }
 }
 
-struct OptimizationChoice {
-    value: I256,
-    sequence: Vec<BasicTxDetails>,
-}
-
 fn ensure_outputs_cover_campaign(
     spec: InvariantCampaignSpec,
     outputs: &[InvariantWorkerOutput],
@@ -167,7 +161,6 @@ fn ensure_outputs_cover_campaign(
     if spec.total_runs == 0 {
         ensure!(
             outputs.len() == 1
-                && outputs[0].plan.worker_id == 0
                 && outputs[0].plan.first_global_run == 0
                 && outputs[0].plan.runs == 0,
             "invariant worker outputs do not cover the logical campaign"
@@ -217,12 +210,10 @@ fn ensure_worker_ids_are_dense(outputs: &[InvariantWorkerOutput]) -> Result<()> 
 
 fn ensure_master_only_fields(outputs: &[InvariantWorkerOutput]) -> Result<()> {
     for output in outputs {
-        if output.plan.worker_id != 0 {
-            ensure!(
-                output.result.failed_corpus_replays == 0,
-                "non-master invariant worker reported failed corpus replays"
-            );
-        }
+        ensure!(
+            output.plan.worker_id == 0 || output.result.failed_corpus_replays == 0,
+            "non-master invariant worker reported failed corpus replays"
+        );
     }
     Ok(())
 }
@@ -260,7 +251,7 @@ fn merge_metrics(
 
 /// Keeps the best optimization value, using logical run order to break ties.
 fn merge_optimization(
-    best: &mut Option<OptimizationChoice>,
+    best: &mut Option<(I256, Vec<BasicTxDetails>)>,
     candidate_value: Option<I256>,
     candidate_sequence: Vec<BasicTxDetails>,
 ) {
@@ -268,8 +259,8 @@ fn merge_optimization(
         return;
     };
 
-    if best.as_ref().is_none_or(|best| candidate_value > best.value) {
-        *best = Some(OptimizationChoice { value: candidate_value, sequence: candidate_sequence });
+    if best.as_ref().is_none_or(|(best, _)| candidate_value > *best) {
+        *best = Some((candidate_value, candidate_sequence));
     }
 }
 

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -3,9 +3,12 @@ use alloy_primitives::{Address, I256, Selector};
 use eyre::{Result, ensure};
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::BasicTxDetails;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Immutable plan-level description for an invariant campaign.
+///
+/// This is only a planning contract for splitting one logical campaign into worker ranges. It does
+/// not start workers, choose worker counts, or decide corpus/failure persistence.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct InvariantCampaignSpec {
     /// Total logical runs configured for the campaign.
@@ -44,6 +47,8 @@ impl InvariantCampaignSpec {
 /// Static assignment of a contiguous logical run range to one worker.
 ///
 /// The assigned range is `[first_global_run, first_global_run + runs)`.
+/// Worker `0` is the master worker for master-only artifacts such as persisted corpus replay
+/// counts.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct InvariantWorkerPlan {
     pub worker_id: u32,
@@ -52,6 +57,9 @@ pub struct InvariantWorkerPlan {
 }
 
 /// Output produced by one invariant worker.
+///
+/// This is a data envelope for aggregation only. It does not imply that this module executed the
+/// worker, shrank failures, or wrote any persisted corpus/failure files.
 #[derive(Debug)]
 pub struct InvariantWorkerOutput {
     pub plan: InvariantWorkerPlan,
@@ -65,6 +73,16 @@ impl InvariantWorkerOutput {
 }
 
 /// Merges worker outputs back into one logical invariant campaign result.
+///
+/// Merge policy:
+/// - outputs are folded in `first_global_run` order;
+/// - predicate failures keep the first failure in logical run order;
+/// - handler assertion failures keep the shorter reproducer, with equal lengths preserving the
+///   earlier logical worker;
+/// - optimization mode keeps the maximum value, with ties preserving the earlier logical worker;
+/// - `failed_corpus_replays` is a master-worker-only value from worker `0`;
+/// - cases, reverts, gas traces, selector metrics, and line coverage accumulate into the logical
+///   campaign result.
 #[derive(Debug)]
 pub struct InvariantCampaignAggregator {
     spec: InvariantCampaignSpec,
@@ -86,6 +104,7 @@ impl InvariantCampaignAggregator {
 
         self.outputs.sort_by_key(|output| output.plan.first_global_run);
         ensure_outputs_cover_campaign(self.spec, &self.outputs)?;
+        ensure_master_only_fields(&self.outputs)?;
 
         let mut errors = HashMap::default();
         let mut handler_errors = HashMap::default();
@@ -143,9 +162,12 @@ fn ensure_outputs_cover_campaign(
     spec: InvariantCampaignSpec,
     outputs: &[InvariantWorkerOutput],
 ) -> Result<()> {
+    ensure_worker_ids_are_dense(outputs)?;
+
     if spec.total_runs == 0 {
         ensure!(
             outputs.len() == 1
+                && outputs[0].plan.worker_id == 0
                 && outputs[0].plan.first_global_run == 0
                 && outputs[0].plan.runs == 0,
             "invariant worker outputs do not cover the logical campaign"
@@ -154,7 +176,11 @@ fn ensure_outputs_cover_campaign(
     }
 
     let mut next_global_run = 0;
-    for output in outputs {
+    for (expected_worker_id, output) in outputs.iter().enumerate() {
+        ensure!(
+            output.plan.worker_id == expected_worker_id as u32,
+            "invariant worker outputs are not in dense worker order"
+        );
         ensure!(output.plan.runs > 0, "invariant worker outputs do not cover the logical campaign");
         ensure!(
             output.plan.first_global_run == next_global_run,
@@ -172,7 +198,38 @@ fn ensure_outputs_cover_campaign(
     Ok(())
 }
 
+fn ensure_worker_ids_are_dense(outputs: &[InvariantWorkerOutput]) -> Result<()> {
+    let mut seen = HashSet::with_capacity(outputs.len());
+    for output in outputs {
+        ensure!(
+            seen.insert(output.plan.worker_id),
+            "duplicate invariant worker output for worker {}",
+            output.plan.worker_id
+        );
+    }
+
+    ensure!(seen.contains(&0), "missing invariant master worker output");
+    for expected in 0..outputs.len() as u32 {
+        ensure!(seen.contains(&expected), "missing invariant worker output for worker {expected}");
+    }
+    Ok(())
+}
+
+fn ensure_master_only_fields(outputs: &[InvariantWorkerOutput]) -> Result<()> {
+    for output in outputs {
+        if output.plan.worker_id != 0 {
+            ensure!(
+                output.result.failed_corpus_replays == 0,
+                "non-master invariant worker reported failed corpus replays"
+            );
+        }
+    }
+    Ok(())
+}
+
 /// Deduplicates handler assertion failures by site, keeping the shorter reproducer.
+/// Equal-length reproducers keep the one already inserted, which is the earlier logical worker
+/// because the caller folds worker outputs in `first_global_run` order.
 fn merge_handler_errors(
     merged: &mut HashMap<(Address, Selector), InvariantFuzzError>,
     worker_errors: HashMap<(Address, Selector), InvariantFuzzError>,
@@ -519,6 +576,52 @@ mod tests {
     }
 
     #[test]
+    fn aggregator_keeps_earlier_handler_assertion_when_lengths_tie() {
+        let spec = InvariantCampaignSpec::new(2);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+        ];
+        let site = (Address::repeat_byte(0xaa), Selector::from([1, 2, 3, 4]));
+        let mut earlier = empty_result(0, 0);
+        earlier.handler_errors.insert(site, handler_error(site.0, site.1, 2, "earlier"));
+        let mut later = empty_result(0, 0);
+        later.handler_errors.insert(site, handler_error(site.0, site.1, 2, "later"));
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[1], later));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], earlier));
+        let result = aggregator.finish().unwrap();
+
+        let failure = result.handler_errors[&site].as_handler_assertion().unwrap();
+        assert_eq!(result.handler_errors.len(), 1);
+        assert_eq!(failure.call_sequence.len(), 2);
+        assert_eq!(failure.revert_reason, "earlier");
+    }
+
+    #[test]
+    fn aggregator_keeps_distinct_predicate_failures() {
+        let spec = InvariantCampaignSpec::new(2);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+        ];
+        let mut earlier = empty_result(0, 0);
+        earlier.errors.insert("invariant_a".to_string(), predicate_error("a", 3));
+        let mut later = empty_result(0, 0);
+        later.errors.insert("invariant_b".to_string(), predicate_error("b", 2));
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[1], later));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], earlier));
+        let result = aggregator.finish().unwrap();
+
+        assert_eq!(result.errors.len(), 2);
+        assert_eq!(result.errors["invariant_a"].revert_reason().as_deref(), Some("a"));
+        assert_eq!(result.errors["invariant_b"].revert_reason().as_deref(), Some("b"));
+    }
+
+    #[test]
     fn aggregator_keeps_first_max_optimization_value_on_tie() {
         let spec = InvariantCampaignSpec::new(3);
         let plans = [
@@ -551,11 +654,85 @@ mod tests {
         let spec = InvariantCampaignSpec::new(1);
         let mut aggregator = InvariantCampaignAggregator::new(spec);
 
-        aggregator.push(InvariantWorkerOutput::new(one_worker_plan(spec), empty_result(0, 0)));
-        aggregator.push(InvariantWorkerOutput::new(one_worker_plan(spec), empty_result(0, 0)));
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            empty_result(0, 0),
+        ));
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 0, runs: 1 },
+            empty_result(0, 0),
+        ));
         let err = aggregator.finish().unwrap_err();
 
         assert!(err.to_string().contains("do not cover the logical campaign"));
+    }
+
+    #[test]
+    fn aggregator_rejects_duplicate_worker_ids() {
+        let spec = InvariantCampaignSpec::new(2);
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            empty_result(0, 0),
+        ));
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 1, runs: 1 },
+            empty_result(0, 0),
+        ));
+        let err = aggregator.finish().unwrap_err();
+
+        assert!(err.to_string().contains("duplicate invariant worker output"));
+    }
+
+    #[test]
+    fn aggregator_rejects_non_dense_worker_ids() {
+        let spec = InvariantCampaignSpec::new(2);
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            empty_result(0, 0),
+        ));
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 2, first_global_run: 1, runs: 1 },
+            empty_result(0, 0),
+        ));
+        let err = aggregator.finish().unwrap_err();
+
+        assert!(err.to_string().contains("missing invariant worker output for worker 1"));
+    }
+
+    #[test]
+    fn aggregator_rejects_failed_corpus_replays_from_non_master_worker() {
+        let spec = InvariantCampaignSpec::new(2);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+        ];
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[0], empty_result(0, 0)));
+        aggregator.push(InvariantWorkerOutput::new(plans[1], empty_result(0, 1)));
+        let err = aggregator.finish().unwrap_err();
+
+        assert!(err.to_string().contains("non-master invariant worker reported"));
+    }
+
+    #[test]
+    fn aggregator_takes_failed_corpus_replays_from_master_worker() {
+        let spec = InvariantCampaignSpec::new(2);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+        ];
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[1], empty_result(0, 0)));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], empty_result(0, 7)));
+        let result = aggregator.finish().unwrap();
+
+        assert_eq!(result.failed_corpus_replays, 7);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -25,10 +25,11 @@ impl InvariantCampaignSpec {
     /// This only describes work assignment. It does not start worker execution and does not
     /// attribute failures to worker/run origins.
     pub fn worker_plans(self, workers: usize) -> Result<Vec<InvariantWorkerPlan>> {
+        ensure!(workers > 0, "invariant campaign requires at least one worker");
+
         if self.total_runs == 0 {
             return Ok(vec![InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 }]);
         }
-        ensure!(workers > 0, "invariant campaign requires at least one worker");
 
         let worker_count = workers.min(self.total_runs.max(1) as usize) as u32;
         let base_runs = self.total_runs / worker_count;
@@ -442,7 +443,9 @@ mod tests {
     #[test]
     fn worker_plans_reject_zero_workers() {
         let err = InvariantCampaignSpec::new(1).worker_plans(0).unwrap_err();
+        assert!(err.to_string().contains("requires at least one worker"));
 
+        let err = InvariantCampaignSpec::new(0).worker_plans(0).unwrap_err();
         assert!(err.to_string().contains("requires at least one worker"));
     }
 

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -950,10 +950,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             result.optimization_best_value,
             result.optimization_best_sequence,
         );
-        if planned_runs == 0 {
-            return Ok(worker_result);
-        }
-
         let campaign_spec = InvariantCampaignSpec::new(planned_runs);
         let worker_plan = campaign_spec.worker_plans(1)?.pop().expect("one worker plan requested");
         let worker_output = InvariantWorkerOutput::new(worker_plan, worker_result);

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -954,7 +954,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let worker_plan = campaign_spec.worker_plans(1)?.pop().expect("one worker plan requested");
         let worker_output = InvariantWorkerOutput::new(worker_plan, worker_result);
         let mut aggregator = InvariantCampaignAggregator::new(campaign_spec);
-        aggregator.push(worker_output)?;
+        aggregator.push(worker_output);
         aggregator.finish()
     }
 

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -950,6 +950,10 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             result.optimization_best_value,
             result.optimization_best_sequence,
         );
+        if planned_runs == 0 {
+            return Ok(worker_result);
+        }
+
         let campaign_spec = InvariantCampaignSpec::new(planned_runs);
         let worker_plan = campaign_spec.worker_plans(1)?.pop().expect("one worker plan requested");
         let worker_output = InvariantWorkerOutput::new(worker_plan, worker_result);


### PR DESCRIPTION
Inspired by https://github.com/0xalpharush/foundry/pull/6 ,
Step closer to OSS-273

Introduces a small invariant campaign planning and aggregation layer as a prerequisite for future invariant campaign sharding.

- `InvariantCampaignSpec` / `InvariantWorkerPlan` to describe logical run ranges.
- `InvariantWorkerOutput` as the result envelope for one worker.
- `InvariantCampaignAggregator` to merge worker outputs back into one logical invariant campaign result.

The aggregator defines deterministic merge policy up front:
- worker outputs are merged by `first_global_run` order;
- predicate failures keep the first logical failure;
- handler assertion failures keep the shorter reproducer, with ties keeping the earlier logical worker;
- optimization campaigns keep the maximum value, with ties keeping the earlier logical worker;
- `failed_corpus_replays` is reported only by master worker `0`;
- cases, reverts, gas traces, selector metrics, and line coverage are accumulated into one campaign result.