### PR TITLE
feat(forge): migrate forge eip712 to output channel contract

### DIFF
--- a/crates/forge/src/cmd/eip712.rs
+++ b/crates/forge/src/cmd/eip712.rs
@@ -72,7 +72,7 @@ impl Eip712Args {
                 sh_println!("{json}", json = serde_json::to_string_pretty(&outputs)?)?;
             } else {
                 for output in &outputs {
-                    sh_println!("{output}")?;
+                    sh_eprintln!("{output}")?;
                 }
             }
 

--- a/crates/forge/tests/cli/eip712.rs
+++ b/crates/forge/tests/cli/eip712.rs
@@ -59,11 +59,16 @@ contract DummyTest {
 "#,
     );
 
-    cmd.forge_fuse().args(["eip712", path.to_string_lossy().as_ref()]).assert_success().stdout_eq(
-        str![[r#"
+    cmd.forge_fuse()
+        .args(["eip712", path.to_string_lossy().as_ref()])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
+
+"#]])
+        .stderr_eq(str![[r#"
 Structs.sol > Structs > Foo:
  - type: Foo(Bar bar)Art(uint256 id)Bar(Art art)
  - hash: 0x6d9b732373bd999fde4072274c752e03f7437067dd75521eb406d8edf1d30f7d
@@ -101,8 +106,7 @@ Structs.sol > Structs2 > FooBar:
  - hash: 0xce88f333fe5b5d4901ceb2569922ffe741cda3afc383a63d34ed2c3d565e42d8
 
 
-"#]],
-    );
+"#]]);
 
     cmd.forge_fuse().args(["eip712", path.to_string_lossy().as_ref(), "--json"]).assert_success().stdout_eq(
         str![[r#"
@@ -204,11 +208,16 @@ library InsideLibrary {
 "#,
     );
 
-    cmd.forge_fuse().args(["eip712", path.to_string_lossy().as_ref()]).assert_success().stdout_eq(
-        str![[r#"
+    cmd.forge_fuse()
+        .args(["eip712", path.to_string_lossy().as_ref()])
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
+
+"#]])
+        .stderr_eq(str![[r#"
 FreeStanding:
  - type: FreeStanding(uint256 id,string name)
  - hash: 0xfb3c934b2382873277133498bde6eb3914ab323e3bef8b373ebcd423969bf1a2
@@ -222,8 +231,7 @@ FreeStandingStructs.sol > InsideLibrary > LibraryStruct:
  - hash: 0x81d6d25f4d37549244d76a68f23ecdcbf3ae81e5a361ed6c492b6a2e126a2843
 
 
-"#]],
-    );
+"#]]);
 });
 
 forgetest!(test_eip712_cheatcode_simple, |prj, cmd| {

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -132,7 +132,7 @@ Each row's status is one of:
 | `forge tree`           | Dependency tree                                      | JSON                                       | migrated |
 | `forge config`         | Config TOML                                          | JSON config                                | todo   |
 | `forge selectors`      | Selectors output                                     | JSON                                       | todo   |
-| `forge eip712`         | (empty)                                              | JSON of types                              | todo   |
+| `forge eip712`         | (empty)                                              | JSON of types                              | migrated |
 | `forge geiger`         | Findings                                             | JSON                                       | todo   |
 | `forge lint`           | (empty; findings on stderr/exit code)                | JSON findings                              | todo   |
 | `forge snapshot`       | Snapshot file content / diff                         | JSON                                       | todo   |


### PR DESCRIPTION
Migrates `forge eip712` text mode per docs/dev/output-channels.md: the per-struct prose summary ("Path > Name: / - type: / - hash:") moves from stdout to stderr via `sh_eprintln!`. `--json` mode is untouched — agents consuming JSON see no change.

- `crates/forge/src/cmd/eip712.rs`: single `sh_println!` → `sh_eprintln!` in the text branch.
- `docs/dev/output-channels.md`: row flipped to `migrated`.
- Tests: `test_eip712` and `test_eip712_free_standing_structs` snapshots split — compile-reporter output stays on stdout, struct prose moves to a new `.stderr_eq(...)`. JSON snapshot untouched.

Part of OSS-224