### PR TITLE
fix(foundryup): create bin dir before activating version

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -3,7 +3,7 @@ set -eo pipefail
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-FOUNDRYUP_INSTALLER_VERSION="1.8.4"
+FOUNDRYUP_INSTALLER_VERSION="1.8.5"
 
 BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
 FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}
@@ -484,6 +484,7 @@ use() {
   if [ -d "$FOUNDRY_VERSION_DIR" ]; then
 
     check_bins_in_use
+    ensure mkdir -p "$FOUNDRY_BIN_DIR"
 
     for bin in "${BINS[@]}"; do
       bin_path="$FOUNDRY_BIN_DIR/$bin"


### PR DESCRIPTION
## Summary
- Ensure `foundryup --use` creates `$FOUNDRY_BIN_DIR` before copying activated binaries into it.
- Bump the foundryup installer version after modifying the script.

## Why
`foundryup --install` can skip downloading when a requested version is already present and verified, then immediately activate it. If `$FOUNDRY_BIN_DIR` does not exist yet (for example with `XDG_CONFIG_HOME` pointing at a fresh config directory), activation fails while copying binaries.

## Changes
- Add `mkdir -p "$FOUNDRY_BIN_DIR"` in the `use()` path before `cp`.
- Update `FOUNDRYUP_INSTALLER_VERSION` from `1.8.4` to `1.8.5`.

## Validation
- `bash -n foundryup/foundryup`
- `git diff --check`
- Created a temporary `FOUNDRY_DIR` with only `versions/test-version/{forge,cast,anvil,chisel}` and no `bin/`, then ran `FOUNDRY_DIR="$tmp/.foundry" bash foundryup/foundryup --use test-version`; verified it exited 0 and created executable `bin/{forge,cast,anvil,chisel}`.

## Scope
Small installer-only fix.

Closes #14153