### PR TITLE
feat(forge): migrate forge fmt to output channel contract

### DIFF
--- a/crates/forge/src/cmd/fmt.rs
+++ b/crates/forge/src/cmd/fmt.rs
@@ -189,7 +189,7 @@ impl FmtArgs {
                             Ok(()) => {}
                             Err(e) => return Some(Err(e.into())),
                         }
-                        let _ = sh_println!("Formatted {}", path.display());
+                        let _ = sh_status!("Formatted {}", path.display());
                         None
                     } else {
                         unreachable!()

--- a/crates/forge/tests/cli/fmt.rs
+++ b/crates/forge/tests/cli/fmt.rs
@@ -40,7 +40,7 @@ forgetest_init!(fmt_exclude_libs_in_recursion, |prj, cmd| {
 forgetest_init!(fmt_file, |prj, cmd| {
     prj.add_raw_source("FmtTest.sol", UNFORMATTED);
     cmd.arg("fmt").arg("src/FmtTest.sol");
-    cmd.assert_success().stdout_eq(str![[r#"
+    cmd.assert_success().stdout_eq(str![""]).stderr_eq(str![[r#"
 Formatted [..]/src/FmtTest.sol
 
 "#]]);

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -128,7 +128,7 @@ Each row's status is one of:
 | `forge bind`           | (empty)                                              | (empty)                                    | migrated |
 | `forge bind-json`      | (empty) or generated path                            | JSON                                       | todo   |
 | `forge flatten`        | Flattened source                                     | n/a                                        | migrated |
-| `forge fmt`            | (empty) or formatted source with `--check`           | n/a                                        | todo   |
+| `forge fmt`            | (empty) or formatted source with `--check`           | n/a                                        | migrated |
 | `forge tree`           | Dependency tree                                      | JSON                                       | migrated |
 | `forge config`         | Config TOML                                          | JSON config                                | todo   |
 | `forge selectors`      | Selectors output                                     | JSON                                       | todo   |


### PR DESCRIPTION
Migrates `forge fmt` per docs/dev/output-channels.md: the "Formatted …" status (printed when writing files back to disk) moves from stdout to stderr via `sh_status!`. `--check` and stdin/`--raw` paths are untouched — agents consuming the diff/formatted source see no change.

- `crates/forge/src/cmd/fmt.rs`: single `sh_println!` → `sh_status!`.
- `docs/dev/output-channels.md`: row flipped to `migrated`.
- `crates/forge/tests/cli/fmt.rs`: `fmt_file` snapshot updated to assert empty stdout + the prose on stderr.

Part of OSS-224