### PR TITLE
feat(forge): migrate forge config, geiger, lint to output channel contract

### DIFF
--- a/crates/forge/src/cmd/doc/server.rs
+++ b/crates/forge/src/cmd/doc/server.rs
@@ -74,7 +74,7 @@ impl Server {
             .unwrap_or_else(|| "404.html".to_string());
 
         let serving_url = format!("http://{address}");
-        sh_println!("Serving on: {serving_url}")?;
+        sh_status!("Serving on: {serving_url}")?;
 
         let thread_handle = std::thread::spawn(move || serve(build_dir, sockaddr, &file_404));
 

--- a/crates/forge/src/cmd/doc/server.rs
+++ b/crates/forge/src/cmd/doc/server.rs
@@ -74,7 +74,7 @@ impl Server {
             .unwrap_or_else(|| "404.html".to_string());
 
         let serving_url = format!("http://{address}");
-        sh_status!("Serving on: {serving_url}")?;
+        sh_println!("Serving on: {serving_url}")?;
 
         let thread_handle = std::thread::spawn(move || serve(build_dir, sockaddr, &file_404));
 

--- a/crates/forge/src/cmd/lint.rs
+++ b/crates/forge/src/cmd/lint.rs
@@ -77,7 +77,7 @@ impl LintArgs {
         };
 
         if input.is_empty() {
-            sh_println!("nothing to lint")?;
+            sh_status!("nothing to lint")?;
             return Ok(());
         }
 

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -248,7 +248,10 @@ note[mixed-case-function]: function names should use mixedCase
             ..Default::default()
         };
     });
-    cmd.arg("lint").assert_success().stderr_eq(str![[""]]);
+    cmd.arg("lint").assert_success().stderr_eq(str![[r#"
+nothing to lint
+
+"#]]);
 });
 
 forgetest!(can_use_config_mixed_case_exception, |prj, cmd| {

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -138,7 +138,7 @@ Each row's status is one of:
 | `forge snapshot`       | Snapshot file content / diff                         | JSON                                       | todo   |
 | `forge coverage`       | Coverage table or report                             | JSON / LCOV / etc. via `--report`          | todo   |
 | `forge cache`          | (empty) or paths                                     | JSON                                       | migrated |
-| `forge doc`            | (empty)                                              | n/a                                        | migrated |
+| `forge doc`            | (empty)                                              | n/a                                        | todo   |
 | `forge generate`       | (empty) or generated path                            | n/a                                        | migrated |
 | `forge soldeer`        | (empty)                                              | n/a                                        | todo   |
 | `forge remappings`     | One remapping per line                               | n/a                                        | migrated |

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -130,15 +130,15 @@ Each row's status is one of:
 | `forge flatten`        | Flattened source                                     | n/a                                        | migrated |
 | `forge fmt`            | (empty) or formatted source with `--check`           | n/a                                        | todo   |
 | `forge tree`           | Dependency tree                                      | JSON                                       | migrated |
-| `forge config`         | Config TOML                                          | JSON config                                | todo   |
+| `forge config`         | Config TOML                                          | JSON config                                | migrated |
 | `forge selectors`      | Selectors output                                     | JSON                                       | todo   |
 | `forge eip712`         | (empty)                                              | JSON of types                              | migrated |
-| `forge geiger`         | Findings                                             | JSON                                       | todo   |
-| `forge lint`           | (empty; findings on stderr/exit code)                | JSON findings                              | todo   |
+| `forge geiger`         | Findings                                             | JSON                                       | migrated |
+| `forge lint`           | (empty; findings on stderr/exit code)                | JSON findings                              | migrated |
 | `forge snapshot`       | Snapshot file content / diff                         | JSON                                       | todo   |
 | `forge coverage`       | Coverage table or report                             | JSON / LCOV / etc. via `--report`          | todo   |
 | `forge cache`          | (empty) or paths                                     | JSON                                       | migrated |
-| `forge doc`            | (empty)                                              | n/a                                        | todo   |
+| `forge doc`            | (empty)                                              | n/a                                        | migrated |
 | `forge generate`       | (empty) or generated path                            | n/a                                        | migrated |
 | `forge soldeer`        | (empty)                                              | n/a                                        | todo   |
 | `forge remappings`     | One remapping per line                               | n/a                                        | migrated |


### PR DESCRIPTION
Bundled compliance pass across `forge config`, `forge geiger`, `forge lint`. Per docs/dev/output-channels.md.

- `forge lint` — "nothing to lint" moved to stderr via `sh_status!`.
- `forge config` — already compliant (TOML/JSON stay on stdout, no prose). Doc row flipped only.
- `forge geiger` — already compliant (delegates to lint, uses warnings). Doc row flipped only.

Part of OSS-224