### PR TITLE
feat(cast): migrate cast run to output channel contract

### DIFF
--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -247,9 +247,7 @@ impl RunArgs {
 
         // Set the state to the moment right before the transaction
         if !self.quick {
-            if !shell::is_json() {
-                sh_println!("Executing previous transactions from the block.")?;
-            }
+            sh_status!("Executing previous transactions from the block.")?;
 
             if let Some(block) = block {
                 let pb = init_progress(block.transactions().len() as u64, "tx");

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3155,13 +3155,18 @@ casttest!(flaky_test_non_mainnet_traces, |prj, cmd| {
     ])
     .assert_success()
     .stdout_eq(str![[r#"
-Executing previous transactions from the block.
 Traces:
   [33841] FiatTokenProxy::fallback(0x111111125421cA6dc452d289314280a0f8842A65, 164054805 [1.64e8])
     ├─ [26673] FiatTokenV2_2::approve(0x111111125421cA6dc452d289314280a0f8842A65, 164054805 [1.64e8]) [delegatecall]
     │   ├─ emit Approval(owner: 0x9a95Af47C51562acfb2107F44d7967DF253197df, spender: 0x111111125421cA6dc452d289314280a0f8842A65, amount: 164054805 [1.64e8])
     │   └─ ← [Return] true
     └─ ← [Return] true
+...
+
+"#]])
+    .stderr_eq(str![[r#"
+...
+Executing previous transactions from the block.
 ...
 
 "#]]);
@@ -3248,9 +3253,14 @@ contract LocalProjectScript is Script {
         .args(["run", "--la", format!("{tx_hash}").as_str(), "--rpc-url", &handle.http_endpoint()])
         .assert_success()
         .stdout_eq(str![[r#"
-Executing previous transactions from the block.
 Compiling project to generate artifacts
 Nothing to compile
+
+"#]])
+        .stderr_eq(str![[r#"
+...
+Executing previous transactions from the block.
+...
 
 "#]]);
 
@@ -3262,7 +3272,6 @@ Nothing to compile
         .args(["run", format!("{tx_hash}").as_str(), "--rpc-url", &handle.http_endpoint()])
         .assert_success()
         .stdout_eq(str![[r#"
-Executing previous transactions from the block.
 Traces:
   [..] → new <unknown>@0x5FbDB2315678afecb367f032d93F642f64180aa3
     ├─  emit topic 0: 0xa7263295d3a687d750d1fd377b5df47de69d7db8decc745aaa4bbee44dc1688d
@@ -3273,6 +3282,12 @@ Traces:
 Transaction successfully executed.
 [GAS]
 
+"#]])
+        .stderr_eq(str![[r#"
+...
+Executing previous transactions from the block.
+...
+
 "#]]);
 
     // Assert cast with local artifacts can decode traces.
@@ -3280,7 +3295,6 @@ Transaction successfully executed.
         .args(["run", "--la", format!("{tx_hash}").as_str(), "--rpc-url", &handle.http_endpoint()])
         .assert_success()
         .stdout_eq(str![[r#"
-Executing previous transactions from the block.
 Compiling project to generate artifacts
 No files changed, compilation skipped
 Traces:
@@ -3291,6 +3305,12 @@ Traces:
 
 Transaction successfully executed.
 [GAS]
+
+"#]])
+        .stderr_eq(str![[r#"
+...
+Executing previous transactions from the block.
+...
 
 "#]]);
 });
@@ -3345,7 +3365,6 @@ forgetest_async!(show_state_changes_in_traces, |prj, cmd| {
         ])
         .assert_success()
         .stdout_eq(str![[r#"
-Executing previous transactions from the block.
 Traces:
   [..] 0x5FbDB2315678afecb367f032d93F642f64180aa3::setNumber(111)
     ├─  storage changes:
@@ -3355,6 +3374,12 @@ Traces:
 
 Transaction successfully executed.
 [GAS]
+
+"#]])
+        .stderr_eq(str![[r#"
+...
+Executing previous transactions from the block.
+...
 
 "#]]);
 });
@@ -4985,7 +5010,6 @@ forgetest_async!(cast_send_with_data, |prj, cmd| {
         ])
         .assert_success()
         .stdout_eq(str![[r#"
-Executing previous transactions from the block.
 Traces:
   [..] 0x5FbDB2315678afecb367f032d93F642f64180aa3::setNumber(111)
     ├─  storage changes:
@@ -4995,6 +5019,12 @@ Traces:
 
 Transaction successfully executed.
 [GAS]
+
+"#]])
+        .stderr_eq(str![[r#"
+...
+Executing previous transactions from the block.
+...
 
 "#]]);
 });

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -101,7 +101,7 @@ Each row's status is one of:
 | `cast rpc`             | RPC result (JSON)                                    | JSON                                                           | todo   |
 | `cast storage`         | Single slot value                                    | JSON of layout                                                 | todo   |
 | `cast logs`            | One log per line                                     | JSON array                                                     | todo   |
-| `cast run`             | Trace / decoded output                               | JSON                                                           | todo   |
+| `cast run`             | Trace / decoded output                               | JSON                                                           | migrated |
 | `cast trace`           | Trace                                                | JSON trace                                                     | todo   |
 | `cast wallet new`      | Address                                              | JSON `{ "address": "…", "private_key": "…" (only with explicit flag) }` | todo |
 | `cast wallet sign`     | Signature                                            | JSON                                                           | todo   |


### PR DESCRIPTION
- `cast run` — `Executing previous transactions from the block.` status moved from stdout to stderr via `sh_status!`; the redundant `!shell::is_json()` guard is dropped since stderr is unaffected by JSON mode.
- 6 `cast run` test snapshots updated: line removed from `stdout_eq`, asserted on `stderr_eq` to preserve coverage.

Part of OSS-224