### PR TITLE
fix clippy warnings

### DIFF
--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -569,12 +569,12 @@ impl WalletSubcommands {
                             if format_json {
                                 if insecure {
                                     accounts_json.as_array_mut().unwrap().push(json!({
-                                        "address": format!("{}", address),
+                                        "address": address.clone(),
                                         "private_key": format!("0x{}", private_key),
                                     }));
                                 } else {
                                     accounts_json.as_array_mut().unwrap().push(json!({
-                                        "address": format!("{}", address)
+                                        "address": address.clone()
                                     }));
                                 }
                             } else {

--- a/crates/common/src/comments/inline_config.rs
+++ b/crates/common/src/comments/inline_config.rs
@@ -216,7 +216,7 @@ impl<I: ItemIdIterator> InlineConfig<I> {
                 }
             }
             InlineConfigItem::DisableLine(ids) => {
-                let start = src[..comment_range.start].rfind('\n').map_or(0, |i| i);
+                let start = src[..comment_range.start].rfind('\n').unwrap_or(0);
                 let end = src[comment_range.end..]
                     .find('\n')
                     .map_or(src.len(), |i| comment_range.end + i);


### PR DESCRIPTION
## Summary
- Replace identity `map_or` with `unwrap_or` in inline config comment handling
- Replace useless address `format!` calls with direct string clones in wallet JSON output

## Tests
- `make lint-clippy`
- `cargo fmt --check`

Prompted by: @grandizzy