### PR TITLE
fix(traces): retry Cloudflare blocks instead of aborting identification

### DIFF
--- a/crates/evm/traces/src/identifier/external.rs
+++ b/crates/evm/traces/src/identifier/external.rs
@@ -227,6 +227,10 @@ impl TraceIdentifier for ExternalIdentifier {
 type FetchFuture =
     Pin<Box<dyn Future<Output = (Address, Result<Option<Metadata>, EtherscanError>)>>>;
 
+/// Maximum number of times a single address is retried through a transient Cloudflare
+/// block before we give up on it. Bounded so a persistent block can't loop forever.
+const MAX_CLOUDFLARE_RETRIES: u32 = 5;
+
 /// A rate limit aware fetcher.
 ///
 /// Fetches information about multiple addresses concurrently, while respecting rate limits.
@@ -243,6 +247,8 @@ struct ExternalFetcher {
     queue: Vec<Address>,
     /// The in progress requests
     in_progress: FuturesUnordered<FetchFuture>,
+    /// Per-address retry counter for transient Cloudflare blocks.
+    attempts: HashMap<Address, u32>,
 }
 
 impl ExternalFetcher {
@@ -254,6 +260,7 @@ impl ExternalFetcher {
             fetcher,
             queue: to_fetch.to_vec(),
             in_progress: FuturesUnordered::new(),
+            attempts: HashMap::default(),
         }
     }
 
@@ -319,10 +326,24 @@ impl Stream for ExternalFetcher {
                             return Poll::Ready(None);
                         }
                         Err(EtherscanError::BlockedByCloudflare) => {
-                            warn!(target: "evm::traces::external", "blocked by cloudflare");
-                            // mark key as invalid
-                            pin.fetcher.invalid_api_key().store(true, Ordering::Relaxed);
-                            return Poll::Ready(None);
+                            // A Cloudflare block is transient rate limiting (often triggered
+                            // by request bursts), not a permanent failure like an invalid key.
+                            // Back off and retry the address a bounded number of times instead
+                            // of aborting the whole stream, which would abandon every still-
+                            // queued address and leave traces only partially decoded (#9880).
+                            let attempts = {
+                                let entry = pin.attempts.entry(addr).or_default();
+                                *entry += 1;
+                                *entry
+                            };
+                            if attempts <= MAX_CLOUDFLARE_RETRIES {
+                                warn!(target: "evm::traces::external", attempts, "blocked by cloudflare, backing off");
+                                pin.backoff = Some(tokio::time::interval(pin.timeout));
+                                pin.queue.push(addr);
+                            } else {
+                                warn!(target: "evm::traces::external", "blocked by cloudflare, giving up on address");
+                                return Poll::Ready(Some((addr, (pin.fetcher.kind(), None))));
+                            }
                         }
                         Err(err) => {
                             warn!(target: "evm::traces::external", ?err, "could not get info");
@@ -508,5 +529,56 @@ impl From<SourcifyMetadata> for Metadata {
             implementation: None,
             swarm_source: String::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{collections::HashSet as StdHashSet, sync::Mutex};
+
+    /// Fetcher that returns a transient Cloudflare block the first time it sees an address, then
+    /// succeeds. Mirrors Etherscan/Cloudflare throttling a burst of concurrent requests.
+    struct FlakyCloudflareFetcher {
+        seen: Mutex<StdHashSet<Address>>,
+        invalid: AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl ExternalFetcherT for FlakyCloudflareFetcher {
+        fn kind(&self) -> FetcherKind {
+            FetcherKind::Etherscan
+        }
+        fn timeout(&self) -> Duration {
+            Duration::from_millis(1)
+        }
+        fn concurrency(&self) -> usize {
+            1
+        }
+        fn invalid_api_key(&self) -> &AtomicBool {
+            &self.invalid
+        }
+        async fn fetch(&self, address: Address) -> Result<Option<Metadata>, EtherscanError> {
+            let first_time = self.seen.lock().unwrap().insert(address);
+            if first_time { Err(EtherscanError::BlockedByCloudflare) } else { Ok(None) }
+        }
+    }
+
+    /// Regression test for #9880: a transient Cloudflare block on one address must not abandon the
+    /// rest of the queue. Before the fix the fetcher returned `Poll::Ready(None)` on the first
+    /// block, ending the stream and leaving later addresses unidentified (partial trace decoding).
+    #[tokio::test]
+    async fn cloudflare_block_retries_instead_of_abandoning_queue() {
+        let addrs: Vec<Address> = (1u8..=4).map(Address::with_last_byte).collect();
+        let fetcher: Arc<dyn ExternalFetcherT> = Arc::new(FlakyCloudflareFetcher {
+            seen: Mutex::new(StdHashSet::new()),
+            invalid: AtomicBool::new(false),
+        });
+
+        let collected: Vec<_> = ExternalFetcher::new(fetcher, &addrs).collect().await;
+
+        let got: StdHashSet<Address> = collected.into_iter().map(|(addr, _)| addr).collect();
+        let want: StdHashSet<Address> = addrs.into_iter().collect();
+        assert_eq!(got, want, "every address must be yielded despite a transient cloudflare block");
     }
 }


### PR DESCRIPTION
## Motivation

Addresses #9880. Under load, `cast run --decode-internal` (and other tracing that
resolves verified sources) identifies contracts only partially and needs several
runs to produce a complete trace, filling in from the on-disk cache between runs.

## Solution

The trace `ExternalIdentifier` fetches contract metadata from Etherscan / Sourcify
through a rate-limit-aware stream (`ExternalFetcher`); `cast run --decode-internal`
then compiles those sources into source maps (`get_compiled_contracts`), so a
contract whose metadata never arrives is never decoded.

`RateLimitExceeded` is already handled with backoff and re-queue, but a
`BlockedByCloudflare` was routed into the `InvalidApiKey` handling (it set the
fetcher's invalid-key flag and returned `Poll::Ready(None)`, carrying the same
`// mark key as invalid` comment). That classifies a transient block as a
permanent auth failure: it ends the stream and abandons every address still queued
in that pass, and disables the fetcher for the rest of the process. Etherscan sits
behind Cloudflare, which returns this when a request burst trips its protection, so
a single transient block stops identification for every remaining contract. The
on-disk cache is why re-running fills the gaps progressively.

This treats a Cloudflare block as the transient rate limiting it is: back off and
retry the address, bounded by `MAX_CLOUDFLARE_RETRIES` (5) so a persistent block
can't hang the command in an infinite loop. After the bound is reached the address
is given up individually (yielded as `None`) instead of aborting the whole stream,
so one blocked contract no longer prevents the rest from being identified.
`InvalidApiKey` is left unchanged and still aborts, since retrying a bad key is
pointless.

## Additional context

Adds a regression test (`cloudflare_block_retries_instead_of_abandoning_queue`)
with a fetcher that returns a transient Cloudflare block on first contact with each
address and then succeeds. Before the change the stream aborts on the first block
and yields nothing; after it, every address is yielded in a single run. The test is
deterministic and does not hit the network.
