### PR TITLE
fix(forge inspect): omit selector for anonymous events

### DIFF
--- a/crates/forge/src/cmd/inspect.rs
+++ b/crates/forge/src/cmd/inspect.rs
@@ -1,5 +1,4 @@
-use alloy_json_abi::{EventParam, InternalType, JsonAbi, Param};
-use alloy_primitives::{hex, keccak256};
+use alloy_json_abi::{Event, EventParam, InternalType, JsonAbi, Param};
 use clap::Parser;
 use comfy_table::{Cell, Table, modifiers::UTF8_ROUND_CORNERS, presets::ASCII_MARKDOWN};
 use eyre::{Result, eyre};
@@ -202,10 +201,15 @@ fn parse_events(abi: &JsonAbi) -> Map<String, Value> {
     let mut out = serde_json::Map::new();
     for ev in abi.events.values().flatten() {
         let types = parse_event_params(&ev.inputs);
-        let topic = hex::encode(keccak256(ev.signature()));
-        out.insert(format!("{}({})", ev.name, types), format!("0x{topic}").into());
+        let topic = event_topic(ev).map_or(Value::Null, Into::into);
+        out.insert(format!("{}({})", ev.name, types), topic);
     }
     out
+}
+
+/// Returns topic0 for non-anonymous events. Anonymous events have no signature topic.
+fn event_topic(ev: &Event) -> Option<String> {
+    (!ev.anonymous).then(|| ev.selector().to_string())
 }
 
 fn parse_event_params(ev_params: &[EventParam]) -> String {
@@ -233,8 +237,13 @@ fn print_abi(abi: &JsonAbi, should_wrap: bool) -> Result<()> {
             // Print events
             for ev in abi.events.values().flatten() {
                 let types = parse_event_params(&ev.inputs);
-                let selector = ev.selector().to_string();
-                table.add_row(["event", &format!("{}({})", ev.name, types), &selector]);
+                let signature = if ev.anonymous {
+                    format!("{}({}) anonymous", ev.name, types)
+                } else {
+                    format!("{}({})", ev.name, types)
+                };
+                let selector = event_topic(ev).unwrap_or_default();
+                table.add_row(["event", &signature, &selector]);
             }
 
             // Print errors
@@ -391,7 +400,7 @@ fn print_errors_events(map: &Map<String, Value>, is_err: bool, should_wrap: bool
         headers,
         |table| {
             for (method, selector) in map {
-                table.add_row([method, selector.as_str().unwrap()]);
+                table.add_row([method.as_str(), selector.as_str().unwrap_or("")]);
             }
         },
         should_wrap,

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3822,6 +3822,64 @@ forgetest!(inspect_custom_counter_errors, |prj, cmd| {
 "#]]);
 });
 
+forgetest!(inspect_anonymous_event_has_no_selector, |prj, cmd| {
+    prj.add_source(
+        "Counter.sol",
+        r#"
+contract Counter {
+    event FakeEvent(uint256 indexed topic0) anonymous;
+    event NormalEvent(uint256 indexed value);
+
+    function setNumber(uint256 newNumber) public {
+        emit FakeEvent(newNumber);
+        emit NormalEvent(newNumber);
+    }
+}
+    "#,
+    );
+
+    // `abi`: anonymous event must render with an empty selector and an `anonymous` marker.
+    cmd.args(["inspect", "Counter", "abi"]).assert_success().stdout_eq(str![[r#"
+
+╭----------+-------------------------------+--------------------------------------------------------------------╮
+| Type     | Signature                     | Selector                                                           |
++===============================================================================================================+
+| event    | FakeEvent(uint256) anonymous  |                                                                    |
+|----------+-------------------------------+--------------------------------------------------------------------|
+| event    | NormalEvent(uint256)          | 0x2e58689f6eed514b3003e0a132a1284ba04042a9d59d11c5db973fdb520d10c1 |
+|----------+-------------------------------+--------------------------------------------------------------------|
+| function | setNumber(uint256) nonpayable | 0x3fb5c1cb                                                         |
+╰----------+-------------------------------+--------------------------------------------------------------------╯
+
+
+"#]]);
+
+    // `events`: anonymous event must render with an empty topic.
+    cmd.forge_fuse().args(["inspect", "Counter", "events"]).assert_success().stdout_eq(str![[r#"
+
+╭----------------------+--------------------------------------------------------------------╮
+| Event                | Topic                                                              |
++===========================================================================================+
+| FakeEvent(uint256)   |                                                                    |
+|----------------------+--------------------------------------------------------------------|
+| NormalEvent(uint256) | 0x2e58689f6eed514b3003e0a132a1284ba04042a9d59d11c5db973fdb520d10c1 |
+╰----------------------+--------------------------------------------------------------------╯
+
+
+"#]]);
+
+    // `events --json`: anonymous event must serialize as `null`, not a fake hash.
+    cmd.forge_fuse().args(["inspect", "Counter", "events", "--json"]).assert_success().stdout_eq(
+        str![[r#"
+{
+  "FakeEvent(uint256)": null,
+  "NormalEvent(uint256)": "0x2e58689f6eed514b3003e0a132a1284ba04042a9d59d11c5db973fdb520d10c1"
+}
+
+"#]],
+    );
+});
+
 forgetest!(inspect_path_only_identifier, |prj, cmd| {
     prj.add_source("Counter.sol", CUSTOM_COUNTER);
 


### PR DESCRIPTION
Fixes #14980

Anonymous events don't emit `keccak256(signature)` as `topics[0]`, so `forge inspect ... abi` / `events` no longer shows it. The signature row is marked anonymous; JSON output emits null.