### PR TITLE
fix(fmt): preserve nested if blocks with multiple statements

### DIFF
--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -2463,6 +2463,13 @@ impl<'ast> State<'_, 'ast> {
         }
 
         // If the parent would fit, check all of its children.
+        if let ast::StmtKind::If(child_cond, child_then, child_els_opt) = &then.kind {
+            let child_decision =
+                self.is_single_line_block(child_cond, child_then, child_els_opt.as_ref());
+            if !child_decision.outcome {
+                return child_decision;
+            }
+        }
         if let Some(stmt) = els_opt {
             if let ast::StmtKind::If(child_cond, child_then, child_els_opt) = &stmt.kind {
                 return self.is_single_line_block(child_cond, child_then, child_els_opt.as_ref());

--- a/crates/fmt/testdata/IfStatement/block-multi.fmt.sol
+++ b/crates/fmt/testdata/IfStatement/block-multi.fmt.sol
@@ -93,6 +93,13 @@ contract IfStatement {
         }
 
         if (condition) {
+            if (anotherLongCondition) {
+                execute();
+                executeElse();
+            }
+        }
+
+        if (condition) {
             execute(); // comment18
         }
 

--- a/crates/fmt/testdata/IfStatement/block-single.fmt.sol
+++ b/crates/fmt/testdata/IfStatement/block-single.fmt.sol
@@ -68,6 +68,13 @@ contract IfStatement {
 
         if (condition) if (anotherLongCondition) execute();
 
+        if (condition) {
+            if (anotherLongCondition) {
+                execute();
+                executeElse();
+            }
+        }
+
         if (condition) execute(); // comment18
 
         if (condition) {

--- a/crates/fmt/testdata/IfStatement/fmt.sol
+++ b/crates/fmt/testdata/IfStatement/fmt.sol
@@ -83,6 +83,13 @@ contract IfStatement {
 
         if (condition) if (anotherLongCondition) execute();
 
+        if (condition) {
+            if (anotherLongCondition) {
+                execute();
+                executeElse();
+            }
+        }
+
         if (condition) execute(); // comment18
 
         if (condition) {

--- a/crates/fmt/testdata/IfStatement/original.sol
+++ b/crates/fmt/testdata/IfStatement/original.sol
@@ -74,6 +74,8 @@ contract IfStatement {
 
         if (condition) if (anotherLongCondition) execute();
 
+        if (condition) if (anotherLongCondition) { execute(); executeElse(); }
+
         if (condition) execute(); // comment18
 
         if (condition) executeWithMultipleParameters(condition, anotherLongCondition);

--- a/crates/fmt/testdata/WhileStatement/block-multi.fmt.sol
+++ b/crates/fmt/testdata/WhileStatement/block-multi.fmt.sol
@@ -59,6 +59,13 @@ contract WhileStatement {
         }
 
         while (condition) {
+            if (condition) {
+                doIt();
+                doIt();
+            }
+        }
+
+        while (condition) {
             doIt();
         }
 

--- a/crates/fmt/testdata/WhileStatement/block-single.fmt.sol
+++ b/crates/fmt/testdata/WhileStatement/block-single.fmt.sol
@@ -38,6 +38,13 @@ contract WhileStatement {
             doIt();
         }
 
+        while (condition) {
+            if (condition) {
+                doIt();
+                doIt();
+            }
+        }
+
         while (condition) doIt();
 
         while ( // comment1

--- a/crates/fmt/testdata/WhileStatement/fmt.sol
+++ b/crates/fmt/testdata/WhileStatement/fmt.sol
@@ -45,6 +45,13 @@ contract WhileStatement {
             doIt();
         }
 
+        while (condition) {
+            if (condition) {
+                doIt();
+                doIt();
+            }
+        }
+
         while (condition) doIt();
 
         while ( // comment1

--- a/crates/fmt/testdata/WhileStatement/original.sol
+++ b/crates/fmt/testdata/WhileStatement/original.sol
@@ -38,6 +38,8 @@ contract WhileStatement {
 
         while(condition) { doIt(); doIt(); }
 
+        while(condition) if (condition) { doIt(); doIt(); }
+
         while 
         (condition) doIt();
 


### PR DESCRIPTION
## Summary
- Prevent `forge fmt` from inlining an outer `if` when its nested `if` body needs braces.
- Add a formatter regression case for single-line nested `if` blocks containing multiple statements.

## Why
Eliding braces around `if (a) if (b) { stmt1; stmt2; }` can move `stmt2` outside of the inner `if`, changing control flow.

## Changes
- Recursively check the `then` branch when deciding if an `if` statement can be printed as a single-line block.
- Update the `IfStatement` formatter snapshots for default, single-line-block, and multi-line-block configurations.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p forge-fmt --test formatter IfStatement -- --exact --nocapture`
- `cargo test -p forge-fmt --test formatter -- --nocapture`

## Scope
Focused formatter behavior change for nested `if` statement block elision only.

Closes #13675