### PR TITLE
feat(cast): migrate prose to stderr across cast commands

### DIFF
--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -334,10 +334,10 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
             let sig = stdin::unwrap_line(sig)?;
             match optimize {
                 Some(opt) => {
-                    sh_println!("Starting to optimize signature...")?;
+                    sh_status!("Starting to optimize signature...")?;
                     let start_time = Instant::now();
                     let (selector, signature) = SimpleCast::get_selector(&sig, opt)?;
-                    sh_println!("Successfully generated in {:?}", start_time.elapsed())?;
+                    sh_status!("Successfully generated in {:?}", start_time.elapsed())?;
                     sh_println!("Selector: {selector}")?;
                     sh_println!("Optimized signature: {signature}")?;
                 }

--- a/crates/cast/src/cmd/artifact.rs
+++ b/crates/cast/src/cmd/artifact.rs
@@ -82,7 +82,7 @@ impl ArtifactArgs {
                 fs::create_dir_all(parent)?;
             }
             fs::write(&loc, artifact)?;
-            sh_println!("Saved artifact at {}", loc.display())?;
+            sh_status!("Saved artifact at {}", loc.display())?;
         } else {
             sh_println!("{artifact}")?;
         }

--- a/crates/cast/src/cmd/batch_mktx.rs
+++ b/crates/cast/src/cmd/batch_mktx.rs
@@ -96,7 +96,7 @@ impl BatchMakeTxArgs {
             );
         }
 
-        sh_println!("Building batch transaction with {} call(s)...", tempo_calls.len())?;
+        sh_status!("Building batch transaction with {} call(s)...", tempo_calls.len())?;
         tempo::print_expires(expires_at)?;
 
         // Preserve key_id for modes that do not call build_with_access_key, such as raw unsigned.

--- a/crates/cast/src/cmd/batch_send.rs
+++ b/crates/cast/src/cmd/batch_send.rs
@@ -97,7 +97,7 @@ impl BatchSendArgs {
             );
         }
 
-        sh_println!("Building batch transaction with {} call(s)...", tempo_calls.len())?;
+        sh_status!("Building batch transaction with {} call(s)...", tempo_calls.len())?;
         tempo::print_expires(expires_at)?;
 
         // Preserve key_id for modes that do not call build_with_access_key, such as unlocked.

--- a/crates/cast/src/cmd/create2.rs
+++ b/crates/cast/src/cmd/create2.rs
@@ -183,10 +183,10 @@ impl Create2Args {
             rng.fill_bytes(remaining);
         }
 
-        sh_println!("Configuration:")?;
-        sh_println!("Init code hash: {init_code_hash}")?;
-        sh_println!("Regex patterns: {:?}\n", regex.patterns())?;
-        sh_println!(
+        sh_status!("Configuration:")?;
+        sh_status!("Init code hash: {init_code_hash}")?;
+        sh_status!("Regex patterns: {:?}\n", regex.patterns())?;
+        sh_status!(
             "Starting to generate deterministic contract address with {n_threads} threads..."
         )?;
         let timer = Instant::now();
@@ -210,7 +210,7 @@ impl Create2Args {
             (regex.matches(s).into_iter().count() == regex_len).then_some((addr, salt))
         })
         .ok_or_else(|| eyre::eyre!("create2 salt mining failed: all threads panicked"))?;
-        sh_println!("Successfully found contract address in {:?}", timer.elapsed())?;
+        sh_status!("Successfully found contract address in {:?}", timer.elapsed())?;
         sh_println!("Address: {address}")?;
         sh_println!("Salt: {salt} ({})", U256::from_be_bytes(salt.0))?;
 

--- a/crates/cast/src/cmd/da_estimate.rs
+++ b/crates/cast/src/cmd/da_estimate.rs
@@ -57,8 +57,9 @@ pub async fn da_estimate<N: Network>(config: &Config, block_id: BlockId) -> Resu
     for tx in block.transactions().txns() {
         da_estimate += op_alloy_flz::tx_estimated_size_fjord(&tx.as_ref().encoded_2718());
     }
-    sh_println!(
-        "Estimated data availability size for block {block_number} with {tx_count} transactions: {da_estimate}"
+    sh_status!(
+        "Estimated data availability size for block {block_number} with {tx_count} transactions:"
     )?;
+    sh_println!("{da_estimate}")?;
     Ok(())
 }

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -369,7 +369,7 @@ impl Erc20Subcommand {
                     if print_sponsor_hash { None } else { tx_opts.tempo.sponsor_config().await? };
                 let needs_sponsor_payload = print_sponsor_hash || tempo_sponsor.is_some();
                 if let Some(ts) = expires_at {
-                    sh_println!("Transaction expires at unix timestamp {ts}")?;
+                    sh_status!("Transaction expires at unix timestamp {ts}")?;
                 }
 
                 let timeout = $send_tx.timeout.unwrap_or(config.transaction_timeout);

--- a/crates/cast/src/cmd/interface.rs
+++ b/crates/cast/src/cmd/interface.rs
@@ -104,7 +104,7 @@ impl InterfaceArgs {
                 fs::create_dir_all(parent)?;
             }
             fs::write(&loc, res)?;
-            sh_println!("Saved interface at {}", loc.display())?;
+            sh_status!("Saved interface at {}", loc.display())?;
         } else {
             sh_print!("{res}")?;
         }

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -2628,7 +2628,7 @@ async fn run_policy_add_call(
                 serde_json::json!({ "status": "already_present", "target": target.to_string() })
             )?;
         } else {
-            sh_println!("Allowed call already present for {}", address_label_with_address(target))?;
+            sh_status!("Allowed call already present for {}", address_label_with_address(target))?;
         }
         return Ok(());
     }

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -151,7 +151,7 @@ impl MakeTxArgs {
         }
 
         if let Some(ts) = expires_at {
-            sh_println!("Transaction expires at unix timestamp {ts}")?;
+            sh_status!("Transaction expires at unix timestamp {ts}")?;
         }
 
         if raw_unsigned {

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -189,7 +189,7 @@ impl SendTxArgs {
                 sh_warn!("{}", iso4217_warning_message(currency))?;
                 let response: String = foundry_common::prompt!("\nContinue anyway? [y/N] ")?;
                 if !matches!(response.trim(), "y" | "Y") {
-                    sh_println!("Aborted.")?;
+                    sh_status!("Aborted.")?;
                     return Ok(());
                 }
             }
@@ -240,7 +240,7 @@ impl SendTxArgs {
         }
 
         if let Some(ts) = expires_at {
-            sh_println!("Transaction expires at unix timestamp {ts}")?;
+            sh_status!("Transaction expires at unix timestamp {ts}")?;
         }
 
         let timeout = send_tx.timeout.unwrap_or(config.transaction_timeout);

--- a/crates/cast/src/cmd/tempo.rs
+++ b/crates/cast/src/cmd/tempo.rs
@@ -32,7 +32,7 @@ impl TempoSubcommand {
                     cfg.no_browser = true;
                 }
                 let outcome = ensure_access_key(cfg).await?;
-                let _ = foundry_common::sh_println!(
+                let _ = foundry_common::sh_status!(
                     "Authorized key {} for wallet {} on chain {}",
                     outcome.key_address,
                     outcome.wallet_address,

--- a/crates/cast/src/cmd/tip20/create.rs
+++ b/crates/cast/src/cmd/tip20/create.rs
@@ -75,7 +75,7 @@ pub(super) async fn run(
         sh_warn!("{}", super::iso4217_warning_message(&currency))?;
         let response: String = foundry_common::prompt!("\nContinue anyway? [y/N] ")?;
         if !matches!(response.trim(), "y" | "Y") {
-            sh_println!("Aborted.")?;
+            sh_status!("Aborted.")?;
             return Ok(());
         }
     }

--- a/crates/cast/src/cmd/tip20/mine.rs
+++ b/crates/cast/src/cmd/tip20/mine.rs
@@ -67,7 +67,7 @@ pub(super) fn run(
         rng.fill_bytes(&mut salt[..]);
     }
 
-    sh_println!("Mining TIP-1022 salt for {master} with {n_threads} threads...")?;
+    sh_status!("Mining TIP-1022 salt for {master} with {n_threads} threads...")?;
 
     let timer = Instant::now();
     let output = mine(master, salt, n_threads, POW_BYTES)?;
@@ -108,7 +108,7 @@ pub(super) async fn register(
     tempo::print_expires(expires_at)?;
     tx_opts.apply::<TempoNetwork>(&mut tx, get_chain(config.chain, &provider).await?.is_legacy());
 
-    sh_println!("Submitting registerVirtualMaster({salt}) on Tempo...")?;
+    sh_status!("Submitting registerVirtualMaster({salt}) on Tempo...")?;
 
     if let Some(ref access_key) = tempo_access_key {
         cast_send_with_access_key(

--- a/crates/cast/src/cmd/vaddr/create.rs
+++ b/crates/cast/src/cmd/vaddr/create.rs
@@ -72,12 +72,12 @@ pub(super) async fn run(
         }
 
         if !shell::is_json() {
-            sh_println!("Mining TIP-1022 salt for {owner} with {n_threads} threads...")?;
+            sh_status!("Mining TIP-1022 salt for {owner} with {n_threads} threads...")?;
         }
         let timer = Instant::now();
         let output = mine::mine(owner, start_salt, n_threads, POW_BYTES)?;
         if !shell::is_json() {
-            sh_println!("Found salt in {:?}", timer.elapsed())?;
+            sh_status!("Found salt in {:?}", timer.elapsed())?;
         }
         output
     };
@@ -161,7 +161,7 @@ async fn register(
     tempo::print_expires(expires_at)?;
     tx_opts.apply::<TempoNetwork>(&mut tx, get_chain(config.chain, &provider).await?.is_legacy());
 
-    sh_println!("Submitting registerVirtualMaster({salt})...")?;
+    sh_status!("Submitting registerVirtualMaster({salt})...")?;
 
     if let Some(ref access_key) = tempo_access_key {
         cast_send_with_access_key(

--- a/crates/cast/src/cmd/vaddr/watch.rs
+++ b/crates/cast/src/cmd/vaddr/watch.rs
@@ -43,7 +43,7 @@ pub(super) async fn run(
     }
 
     if !shell::is_json() {
-        sh_println!("Watching transfers to {addr}... (Ctrl-C to stop)")?;
+        sh_status!("Watching transfers to {addr}... (Ctrl-C to stop)")?;
     }
 
     // Fetch logs from the requested start block (historical when from_block is set)

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -127,9 +127,9 @@ fn run_revoke(session_id: B256) -> Result<()> {
             }))?
         )?;
     } else if removed {
-        sh_println!("Revoked Tempo session {}", session_id)?;
+        sh_status!("Revoked Tempo session {}", session_id)?;
     } else {
-        sh_println!("Tempo session {} was not found.", session_id)?;
+        sh_status!("Tempo session {} was not found.", session_id)?;
     }
 
     Ok(())

--- a/crates/cast/src/cmd/wallet/vanity.rs
+++ b/crates/cast/src/cmd/wallet/vanity.rs
@@ -100,7 +100,7 @@ impl VanityArgs {
             };
         }
 
-        sh_println!("Starting to generate vanity address...")?;
+        sh_status!("Starting to generate vanity address...")?;
         let timer = Instant::now();
 
         let wallet = match (left_exact_hex, left_regex, right_exact_hex, right_regex) {

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -2224,7 +2224,7 @@ impl SimpleCast {
         if let Some(path) = output_path {
             fs::create_dir_all(path.parent().unwrap())?;
             fs::write(&path, flattened)?;
-            sh_println!("Flattened file written at {}", path.display())?
+            sh_status!("Flattened file written at {}", path.display())?
         } else {
             sh_println!("{flattened}")?
         }

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -6,7 +6,7 @@ pub use foundry_common::tempo::{TempoSponsor, TempoSponsorPreview, resolve_tempo
 
 pub(crate) fn print_expires(expires_at: Option<u64>) -> Result<()> {
     if let Some(ts) = expires_at {
-        sh_println!("Transaction expires at unix timestamp {ts}")?;
+        sh_status!("Transaction expires at unix timestamp {ts}")?;
     }
     Ok(())
 }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -4153,7 +4153,11 @@ casttest!(
         cmd.args(["da-estimate", "30558838", "-r", "https://mainnet.base.org/"])
             .assert_success()
             .stdout_eq(str![[r#"
-Estimated data availability size for block 30558838 with 225 transactions: 52916546100
+52916546100
+
+"#]])
+            .stderr_eq(str![[r#"
+Estimated data availability size for block 30558838 with 225 transactions:
 
 "#]]);
     }

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -107,9 +107,9 @@ Each row's status is one of:
 | `cast wallet sign`     | Signature                                            | JSON                                                           | todo   |
 | `cast erc20 balance`   | Balance (decimal)                                    | JSON string                                                    | todo   |
 | `cast access-list`     | Access list                                          | JSON                                                           | migrated |
-| `cast da-estimate`     | Gas estimate                                         | JSON                                                           | todo   |
+| `cast da-estimate`     | Gas estimate                                         | JSON                                                           | migrated |
 | `cast find-block`      | Block number                                         | JSON                                                           | migrated |
-| `cast mktx`            | Signed RLP                                           | JSON                                                           | todo   |
+| `cast mktx`            | Signed RLP                                           | JSON                                                           | migrated |
 | `cast batch-send`      | One tx hash per line                                 | JSON array                                                     | todo   |
 
 ### `forge`


### PR DESCRIPTION
- `cast mktx`, `cast da-estimate` — prose moved from stdout to stderr via `sh_status!`; `cast da-estimate` numeric estimate stays on stdout; `flaky_estimate_base_da` updated to assert split stdout/stderr; doc rows flipped to `migrated`.
- `cast::tempo::print_expires` helper switched to `sh_status!`, covering `tip20`, `vaddr`, `batch_send`, `batch_mktx`, `keychain` callers.
- `cast send`, `cast erc20` — inline "Transaction expires at unix timestamp…" flipped to stderr.
- `cast sig --optimize`, `cast etherscan-source --flatten`, `cast batch-mktx`, `cast batch-send`, `cast create2`, `cast tip20 mine`, `cast tip20 create`, `cast vaddr create`, `cast vaddr watch`, `cast interface`, `cast artifact`, `cast wallet vanity`, `cast wallet session revoke`, `cast tempo login`, `cast keychain` — status/progress prose moved from stdout to stderr; result data stays on stdout.

Part of OSS-224