### PR TITLE
fix(config): accept legacy invariant assert_all key

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6865,6 +6865,36 @@ mod tests {
     }
 
     #[test]
+    fn no_unknown_key_warning_for_legacy_invariant_assert_all() {
+        // Regression test: `invariant.assert_all` was a public config key before invariant
+        // campaigns were grouped by contract. Existing configs should continue to load quietly.
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [invariant]
+                assert_all = false
+
+                [profile.default.invariant]
+                assert_all = true
+                "#,
+            )?;
+
+            let cfg = Config::load().unwrap();
+            assert!(
+                !cfg.warnings.iter().any(|w| matches!(
+                    w,
+                    crate::Warning::UnknownSectionKey { key, section, .. }
+                        if key == "assert_all" && section == "invariant"
+                )),
+                "did not expect UnknownSectionKey warning for `invariant.assert_all`, got: {:?}",
+                cfg.warnings
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
     fn fails_on_ambiguous_version_in_compilation_restrictions() {
         figment::Jail::expect_with(|jail| {
             jail.create_file(

--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -53,6 +53,14 @@ const RESERVED_KEYS: &[&str] = &["extends"];
 /// still accepted on input but no longer serialized in the default config.
 const BACKWARD_COMPATIBLE_KEYS: &[&str] = &["solc_version", "tempo", "optimism"];
 
+/// Section-local keys kept for backward compatibility that should not trigger unknown key
+/// warnings.
+///
+/// `invariant.assert_all` was introduced as a public config key, but invariant campaigns are now
+/// grouped by contract and always report all broken invariants. Keep accepting the legacy key so
+/// existing `foundry.toml` files do not warn on every command.
+const BACKWARD_COMPATIBLE_SECTION_KEYS: &[(&str, &[&str])] = &[("invariant", &["assert_all"])];
+
 /// Generate warnings for unknown sections and deprecated keys
 pub struct WarningsProvider<P> {
     provider: P,
@@ -215,7 +223,9 @@ impl<P: Provider> WarningsProvider<P> {
                 let Some(default_section_dict) = default_section_value.as_dict() else {
                     continue;
                 };
-                default_section_dict.keys().cloned().collect()
+                let mut keys: BTreeSet<String> = default_section_dict.keys().cloned().collect();
+                add_backward_compatible_section_keys(section_name, &mut keys);
+                keys
             };
 
             for key in section_dict.keys() {
@@ -287,7 +297,9 @@ impl<P: Provider> WarningsProvider<P> {
                 let Some(default_nested_dict) = default_value.as_dict() else {
                     continue;
                 };
-                default_nested_dict.keys().cloned().collect()
+                let mut keys: BTreeSet<String> = default_nested_dict.keys().cloned().collect();
+                add_backward_compatible_section_keys(key, &mut keys);
+                keys
             };
 
             for nested_key in nested_dict.keys() {
@@ -314,6 +326,14 @@ impl<P: Provider> WarningsProvider<P> {
                 SETTINGS_OVERRIDES_KEYS.iter().map(|s| s.to_string()).collect()
             }
             _ => BTreeSet::new(),
+        }
+    }
+}
+
+fn add_backward_compatible_section_keys(section: &str, keys: &mut BTreeSet<String>) {
+    for (compatible_section, compatible_keys) in BACKWARD_COMPATIBLE_SECTION_KEYS {
+        if section == *compatible_section {
+            keys.extend(compatible_keys.iter().map(|key| (*key).to_string()));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Allows the legacy `invariant.assert_all` config key in warning validation for both standalone and profile-scoped invariant sections.
- Adds a regression test covering existing configs that still set `assert_all`.

## Why
`invariant.assert_all` was introduced as a public config key in #12587, then later removed from the serialized invariant config when invariant campaigns became contract-level. Existing projects now see an unknown-key warning on every forge command even though the config was previously valid.

## Changes
- Adds section-local backward-compatible config keys to the warning provider.
- Registers `assert_all` as a backward-compatible `invariant` key.
- Tests that `[invariant]` and `[profile.default.invariant]` usages do not emit unknown-key warnings.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p foundry-config no_unknown_key_warning_for_legacy_invariant_assert_all`
- `cargo test -p foundry-config unknown_key_warning`
- `cargo check -p foundry-config`

## Scope
- Warning validation only; this does not reintroduce a behavior toggle for invariant campaigns.

Closes #14987