### PR TITLE
feat(evm): shard invariant campaign runs across workers

### DIFF
--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -38,7 +38,7 @@ pub struct InvariantConfig {
     pub failure_persist_dir: Option<PathBuf>,
     /// Whether to collect and display fuzzed selectors metrics.
     pub show_metrics: bool,
-    /// Optional timeout (in seconds) for each invariant test.
+    /// Optional campaign-global timeout (in seconds) for each invariant test.
     pub timeout: Option<u32>,
     /// Display counterexample as solidity calls.
     pub show_solidity: bool,
@@ -84,6 +84,17 @@ impl InvariantConfig {
     /// Creates invariant configuration to write failures in `{PROJECT_ROOT}/cache/fuzz` dir.
     pub fn new(cache_dir: PathBuf) -> Self {
         Self { failure_persist_dir: Some(cache_dir), ..Default::default() }
+    }
+
+    /// Returns why invariant campaigns for this config must run with one worker, if any.
+    pub const fn single_worker_reason(&self) -> Option<&'static str> {
+        if self.call_override {
+            Some("invariant.call_override is enabled")
+        } else if self.corpus.sancov_active() {
+            Some("sancov is enabled")
+        } else {
+            None
+        }
     }
 
     /// Returns true if generated invariant calls may advance block time or height.

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -86,17 +86,6 @@ impl InvariantConfig {
         Self { failure_persist_dir: Some(cache_dir), ..Default::default() }
     }
 
-    /// Returns why invariant campaigns for this config must run with one worker, if any.
-    pub const fn single_worker_reason(&self) -> Option<&'static str> {
-        if self.call_override {
-            Some("invariant.call_override is enabled")
-        } else if self.corpus.sancov_active() {
-            Some("sancov is enabled")
-        } else {
-            None
-        }
-    }
-
     /// Returns true if generated invariant calls may advance block time or height.
     pub const fn has_delay(&self) -> bool {
         self.max_block_delay.is_some() || self.max_time_delay.is_some()

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -11,6 +11,11 @@ pub struct InvariantConfig {
     pub runs: u32,
     /// The number of calls executed to attempt to break invariants in one run.
     pub depth: u32,
+    /// Number of workers used to shard invariant runs.
+    ///
+    /// Defaults to `1` to preserve seeded reproducibility unless the user explicitly opts into
+    /// parallel invariant campaigns.
+    pub workers: usize,
     /// Fails the invariant fuzzing if a revert occurs
     pub fail_on_revert: bool,
     /// Allows overriding an unsafe external call when running invariant tests. eg. reentrancy
@@ -56,6 +61,7 @@ impl Default for InvariantConfig {
         Self {
             runs: 256,
             depth: 500,
+            workers: 1,
             fail_on_revert: false,
             call_override: false,
             dictionary: FuzzDictionaryConfig { dictionary_weight: 80, ..Default::default() },

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -4173,6 +4173,7 @@ mod tests {
                 [invariant]
                 runs = 256
                 depth = 500
+                workers = 1
                 fail_on_revert = false
                 call_override = false
                 shrink_run_limit = 5000
@@ -4985,6 +4986,7 @@ mod tests {
                 [invariant]
                 runs = 512
                 depth = 10
+                workers = 4
             ",
             )?;
 
@@ -4994,6 +4996,7 @@ mod tests {
                 InvariantConfig {
                     runs: 512,
                     depth: 10,
+                    workers: 4,
                     failure_persist_dir: Some(PathBuf::from("cache/invariant")),
                     ..Default::default()
                 }
@@ -5020,11 +5023,13 @@ mod tests {
             jail.set_env("FOUNDRY_FMT_LINE_LENGTH", "95");
             jail.set_env("FOUNDRY_FUZZ_DICTIONARY_WEIGHT", "99");
             jail.set_env("FOUNDRY_INVARIANT_DEPTH", "5");
+            jail.set_env("FOUNDRY_INVARIANT_WORKERS", "3");
 
             let config = Config::load().unwrap();
             assert_eq!(config.fmt.line_length, 95);
             assert_eq!(config.fuzz.dictionary.dictionary_weight, 99);
             assert_eq!(config.invariant.depth, 5);
+            assert_eq!(config.invariant.workers, 3);
 
             Ok(())
         });

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -183,9 +183,9 @@ impl CorpusEntry {
     }
 }
 
-/// Corpus entry discovered by a worker and returned to the logical campaign for persistence.
+/// Corpus entry selected by a worker and returned for logical-campaign persistence.
 #[derive(Debug)]
-pub(crate) struct CorpusCampaignInput {
+pub(crate) struct CampaignCorpusEntry {
     tx_seq: Vec<BasicTxDetails>,
     cmp_seq: Vec<Vec<CmpOperands>>,
 }
@@ -537,17 +537,16 @@ impl WorkerCorpus {
         let _ = self.process_inputs_inner(inputs, cmp_seq, new_coverage, optimization, true);
     }
 
-    /// Updates in-memory corpus state for a worker and returns any campaign-level corpus
-    /// candidate without persisting it. The logical invariant campaign persists returned
-    /// candidates after worker outputs have merged.
+    /// Updates worker-local corpus state and returns any corpus entry to persist after the
+    /// logical campaign has merged worker outputs.
     #[instrument(skip_all)]
-    pub fn process_campaign_inputs(
+    pub fn process_inputs_for_campaign(
         &mut self,
         inputs: &[BasicTxDetails],
         cmp_seq: &[Vec<CmpOperands>],
         new_coverage: bool,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
-    ) -> Option<CorpusCampaignInput> {
+    ) -> Option<CampaignCorpusEntry> {
         self.process_inputs_inner(inputs, cmp_seq, new_coverage, optimization, false)
     }
 
@@ -558,7 +557,7 @@ impl WorkerCorpus {
         new_coverage: bool,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
         persist_now: bool,
-    ) -> Option<CorpusCampaignInput> {
+    ) -> Option<CampaignCorpusEntry> {
         // Check if this run improved the optimization value.
         let improved_optimization = optimization.as_ref().is_some_and(|(value, _)| {
             self.optimization_best_value.is_none_or(|best| *value > best)
@@ -619,7 +618,7 @@ impl WorkerCorpus {
         };
         let corpus_cmp_seq: Vec<Vec<CmpOperands>> =
             cmp_seq.iter().take(corpus_inputs.len()).cloned().collect();
-        let campaign_input = (!persist_now).then(|| CorpusCampaignInput {
+        let campaign_entry = (!persist_now).then(|| CampaignCorpusEntry {
             tx_seq: corpus_inputs.clone(),
             cmp_seq: corpus_cmp_seq.clone(),
         });
@@ -649,7 +648,7 @@ impl WorkerCorpus {
         self.metrics.corpus_count += 1;
         self.in_memory_corpus.push(corpus);
 
-        campaign_input
+        campaign_entry
     }
 
     /// Returns the previously persisted optimization best value and sequence (if any).
@@ -662,13 +661,13 @@ impl WorkerCorpus {
         let optimization_best = self
             .optimization_best_value
             .map(|value| (value, self.optimization_best_sequence.as_slice()));
-        Self::persist_campaign_output(&self.config, &[], optimization_best);
+        Self::persist_campaign_outputs(&self.config, &[], optimization_best);
     }
 
-    /// Persists campaign-level corpus and optimization outputs after worker results have merged.
-    pub(crate) fn persist_campaign_output(
+    /// Persists logical-campaign corpus and optimization outputs after worker results have merged.
+    pub(crate) fn persist_campaign_outputs(
         config: &FuzzCorpusConfig,
-        inputs: &[CorpusCampaignInput],
+        entries: &[CampaignCorpusEntry],
         optimization_best: Option<(I256, &[BasicTxDetails])>,
     ) {
         let Some(corpus_dir) = &config.corpus_dir else {
@@ -676,15 +675,15 @@ impl WorkerCorpus {
         };
         let root = corpus_dir;
         let corpus_dir = root.join(format!("{WORKER}0")).join(CORPUS_DIR);
-        if !inputs.is_empty()
+        if !entries.is_empty()
             && let Err(err) = foundry_common::fs::create_dir_all(&corpus_dir)
         {
             debug!(target: "corpus", %err, "failed to create campaign corpus dir");
         }
-        for input in inputs {
+        for entry in entries {
             let corpus = CorpusEntry::new_with_cmp(
-                input.tx_seq.clone(),
-                input.cmp_seq.clone(),
+                entry.tx_seq.clone(),
+                entry.cmp_seq.clone(),
                 Uuid::new_v4(),
             );
             let write_result = corpus.write_to_disk_in(&corpus_dir, config.corpus_gzip);
@@ -1586,7 +1585,7 @@ mod tests {
     }
 
     #[test]
-    fn campaign_inputs_update_worker_memory_without_persisting() {
+    fn campaign_processing_returns_corpus_without_writing_worker_file() {
         let corpus_root = temp_corpus_dir();
         let worker_subdir = corpus_root.join("worker1");
         fs::create_dir_all(worker_subdir.join(CORPUS_DIR)).unwrap();
@@ -1610,7 +1609,7 @@ mod tests {
             optimization_best_sequence: vec![],
         };
 
-        let record = manager.process_campaign_inputs(&[basic_tx()], &[], true, None);
+        let record = manager.process_inputs_for_campaign(&[basic_tx()], &[], true, None);
 
         assert!(record.is_some());
         assert_eq!(manager.in_memory_corpus.len(), 1);
@@ -1619,7 +1618,7 @@ mod tests {
     }
 
     #[test]
-    fn campaign_output_persists_corpus_and_optimization_to_master_dir() {
+    fn merged_campaign_outputs_write_corpus_and_optimization_to_master_dir() {
         let corpus_root = temp_corpus_dir();
         let mut manager = WorkerCorpus {
             id: 1,
@@ -1642,7 +1641,7 @@ mod tests {
         };
         let sequence = vec![basic_tx()];
         let record = manager
-            .process_campaign_inputs(
+            .process_inputs_for_campaign(
                 &sequence,
                 &[],
                 false,
@@ -1650,7 +1649,7 @@ mod tests {
             )
             .unwrap();
         let inputs = vec![record];
-        WorkerCorpus::persist_campaign_output(
+        WorkerCorpus::persist_campaign_outputs(
             &corpus_config(corpus_root.clone()),
             &inputs,
             Some((I256::try_from(7).unwrap(), &sequence)),

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -61,6 +61,7 @@ use proptest::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashSet,
     fmt,
     path::{Path, PathBuf},
     sync::{
@@ -280,37 +281,37 @@ impl WorkerCorpusSeed {
         let Some(executor) = executor else {
             return Ok(seed);
         };
-        for replay_dir in canonical_replay_dirs(corpus_dir) {
-            for entry in read_corpus_dir(&replay_dir) {
-                let tx_seq = entry.read_tx_seq()?;
-                if tx_seq.is_empty() {
-                    continue;
-                }
-
-                let target =
-                    ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic: dynamic.as_ref() };
-                let coverage = ReplayCoverage {
-                    history_map: &mut seed.history_map,
-                    edge_indices: &mut seed.edge_indices,
-                    sancov_history_map: &mut seed.sancov_history_map,
-                    metrics: Some(&mut seed.metrics),
-                };
-                let ReplayOutcome { keep_entry, cmp_seq, failed_replays, .. } =
-                    replay_corpus_sequence(&tx_seq, executor, target, coverage)?;
-                seed.failed_replays += failed_replays;
-                if !keep_entry {
-                    continue;
-                }
-
-                seed.metrics.corpus_count += 1;
-                debug!(
-                    target: "corpus",
-                    "load sequence with len {} from corpus file {}",
-                    tx_seq.len(),
-                    entry.path.display()
-                );
-                seed.in_memory_corpus.push(CorpusEntry::new_with_cmp(tx_seq, cmp_seq, entry.uuid));
+        let mut seen_entries =
+            seed.in_memory_corpus.iter().map(|entry| entry.uuid).collect::<HashSet<_>>();
+        for entry in unique_corpus_entries(&canonical_replay_dirs(corpus_dir), &mut seen_entries) {
+            let tx_seq = entry.read_tx_seq()?;
+            if tx_seq.is_empty() {
+                continue;
             }
+
+            let target =
+                ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic: dynamic.as_ref() };
+            let coverage = ReplayCoverage {
+                history_map: &mut seed.history_map,
+                edge_indices: &mut seed.edge_indices,
+                sancov_history_map: &mut seed.sancov_history_map,
+                metrics: Some(&mut seed.metrics),
+            };
+            let ReplayOutcome { keep_entry, cmp_seq, failed_replays, .. } =
+                replay_corpus_sequence(&tx_seq, executor, target, coverage)?;
+            seed.failed_replays += failed_replays;
+            if !keep_entry {
+                continue;
+            }
+
+            seed.metrics.corpus_count += 1;
+            debug!(
+                target: "corpus",
+                "load sequence with len {} from corpus file {}",
+                tx_seq.len(),
+                entry.path.display()
+            );
+            seed.in_memory_corpus.push(CorpusEntry::new_with_cmp(tx_seq, cmp_seq, entry.uuid));
         }
 
         Ok(seed)
@@ -1621,6 +1622,23 @@ fn has_legacy_invariant_corpus_dirs(path: &Path) -> bool {
     })
 }
 
+fn unique_corpus_entries(
+    replay_dirs: &[PathBuf],
+    seen_entries: &mut HashSet<Uuid>,
+) -> Vec<CorpusDirEntry> {
+    let mut entries = Vec::new();
+    for replay_dir in replay_dirs {
+        for entry in read_corpus_dir(replay_dir) {
+            if seen_entries.insert(entry.uuid) {
+                entries.push(entry);
+            } else {
+                trace!(target: "corpus", "skipping duplicate corpus entry {}", entry.uuid);
+            }
+        }
+    }
+    entries
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1772,6 +1790,26 @@ mod tests {
         assert_eq!(state.best_sequence[0].sender, sequence[0].sender);
         assert_eq!(state.best_sequence[0].call_details.target, sequence[0].call_details.target);
         assert_eq!(state.best_sequence[0].call_details.calldata, sequence[0].call_details.calldata);
+    }
+
+    #[test]
+    fn persisted_worker_corpus_entries_are_deduped_by_uuid() {
+        let corpus_root = temp_corpus_dir();
+        let corpus = CorpusEntry::new(vec![basic_tx()]);
+        let duplicate = corpus.clone();
+
+        let worker0_corpus = corpus_root.join("worker0").join(CORPUS_DIR);
+        let worker1_corpus = corpus_root.join("worker1").join(CORPUS_DIR);
+        fs::create_dir_all(&worker0_corpus).unwrap();
+        fs::create_dir_all(&worker1_corpus).unwrap();
+        corpus.write_to_disk_in(&worker0_corpus, false).unwrap();
+        duplicate.write_to_disk_in(&worker1_corpus, false).unwrap();
+
+        let mut seen = HashSet::new();
+        let entries = unique_corpus_entries(&canonical_replay_dirs(&corpus_root), &mut seen);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].uuid, corpus.uuid);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -1593,7 +1593,7 @@ mod tests {
             id: 1,
             tx_generator: Just(basic_tx()).boxed(),
             mutation_generator: Just(MutationType::Repeat).boxed(),
-            config: corpus_config(corpus_root.clone()).into(),
+            config: corpus_config(corpus_root).into(),
             in_memory_corpus: vec![],
             current_mutated: None,
             failed_replays: 0,

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -283,14 +283,13 @@ impl WorkerCorpusSeed {
         };
         let mut seen_entries =
             seed.in_memory_corpus.iter().map(|entry| entry.uuid).collect::<HashSet<_>>();
+        let target = ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic: dynamic.as_ref() };
         for entry in unique_corpus_entries(&canonical_replay_dirs(corpus_dir), &mut seen_entries) {
             let tx_seq = entry.read_tx_seq()?;
             if tx_seq.is_empty() {
                 continue;
             }
 
-            let target =
-                ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic: dynamic.as_ref() };
             let coverage = ReplayCoverage {
                 history_map: &mut seed.history_map,
                 edge_indices: &mut seed.edge_indices,
@@ -329,11 +328,10 @@ impl WorkerCorpusSeed {
         let mut edge_indices = self.edge_indices.clone();
         let mut sancov_history_map = self.sancov_history_map.clone();
         let mut filtered = Vec::new();
+        let target = ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic: dynamic.as_ref() };
 
         for entry in entries {
             if entry.dedupe_by_coverage {
-                let target =
-                    ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic: dynamic.as_ref() };
                 let coverage = ReplayCoverage {
                     history_map: &mut history_map,
                     edge_indices: &mut edge_indices,
@@ -1622,21 +1620,17 @@ fn has_legacy_invariant_corpus_dirs(path: &Path) -> bool {
     })
 }
 
-fn unique_corpus_entries(
-    replay_dirs: &[PathBuf],
-    seen_entries: &mut HashSet<Uuid>,
-) -> Vec<CorpusDirEntry> {
-    let mut entries = Vec::new();
-    for replay_dir in replay_dirs {
-        for entry in read_corpus_dir(replay_dir) {
-            if seen_entries.insert(entry.uuid) {
-                entries.push(entry);
-            } else {
-                trace!(target: "corpus", "skipping duplicate corpus entry {}", entry.uuid);
-            }
+fn unique_corpus_entries<'a>(
+    replay_dirs: &'a [PathBuf],
+    seen_entries: &'a mut HashSet<Uuid>,
+) -> impl Iterator<Item = CorpusDirEntry> + 'a {
+    replay_dirs.iter().flat_map(|replay_dir| read_corpus_dir(replay_dir)).filter(|entry| {
+        let is_new = seen_entries.insert(entry.uuid);
+        if !is_new {
+            trace!(target: "corpus", "skipping duplicate corpus entry {}", entry.uuid);
         }
-    }
-    entries
+        is_new
+    })
 }
 
 #[cfg(test)]
@@ -1806,7 +1800,8 @@ mod tests {
         duplicate.write_to_disk_in(&worker1_corpus, false).unwrap();
 
         let mut seen = HashSet::new();
-        let entries = unique_corpus_entries(&canonical_replay_dirs(&corpus_root), &mut seen);
+        let entries = unique_corpus_entries(&canonical_replay_dirs(&corpus_root), &mut seen)
+            .collect::<Vec<_>>();
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].uuid, corpus.uuid);

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -183,6 +183,53 @@ impl CorpusEntry {
     }
 }
 
+/// Corpus entry discovered by a worker and returned to the logical campaign for persistence.
+#[derive(Clone, Debug)]
+pub struct CorpusCampaignInput {
+    tx_seq: Vec<BasicTxDetails>,
+    cmp_seq: Vec<Vec<CmpOperands>>,
+}
+
+impl CorpusCampaignInput {
+    const fn new(tx_seq: Vec<BasicTxDetails>, cmp_seq: Vec<Vec<CmpOperands>>) -> Self {
+        Self { tx_seq, cmp_seq }
+    }
+}
+
+/// Corpus and optimization artifacts discovered by a worker during a campaign slice.
+#[derive(Clone, Debug, Default)]
+pub struct CorpusCampaignOutput {
+    pub inputs: Vec<CorpusCampaignInput>,
+    pub optimization_best_value: Option<I256>,
+    pub optimization_best_sequence: Vec<BasicTxDetails>,
+}
+
+impl CorpusCampaignOutput {
+    /// Keeps the best optimization value, using caller iteration order to break ties.
+    pub fn merge_optimization(&mut self, value: Option<I256>, sequence: Vec<BasicTxDetails>) {
+        let Some(value) = value else {
+            return;
+        };
+
+        if self.optimization_best_value.is_none_or(|best| value > best) {
+            self.optimization_best_value = Some(value);
+            self.optimization_best_sequence = sequence;
+        }
+    }
+}
+
+/// Result of recording one run in a [`WorkerCorpus`].
+#[derive(Clone, Debug, Default)]
+pub struct CorpusRunRecord {
+    campaign_input: Option<CorpusCampaignInput>,
+}
+
+impl CorpusRunRecord {
+    pub fn into_campaign_input(self) -> Option<CorpusCampaignInput> {
+        self.campaign_input
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct GlobalCorpusMetrics {
     // Number of edges seen during the invariant run.
@@ -527,11 +574,31 @@ impl WorkerCorpus {
         new_coverage: bool,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
     ) {
-        let Some(worker_corpus) = &self.worker_dir else {
-            return;
-        };
-        let worker_corpus = worker_corpus.join(CORPUS_DIR);
+        let _ = self.process_inputs_inner(inputs, cmp_seq, new_coverage, optimization, true);
+    }
 
+    /// Updates in-memory corpus state for a worker and returns any campaign-level corpus
+    /// candidate without persisting it. The logical invariant campaign persists returned
+    /// candidates after worker outputs have merged.
+    #[instrument(skip_all)]
+    pub fn process_campaign_inputs(
+        &mut self,
+        inputs: &[BasicTxDetails],
+        cmp_seq: &[Vec<CmpOperands>],
+        new_coverage: bool,
+        optimization: Option<(I256, Vec<BasicTxDetails>)>,
+    ) -> CorpusRunRecord {
+        self.process_inputs_inner(inputs, cmp_seq, new_coverage, optimization, false)
+    }
+
+    fn process_inputs_inner(
+        &mut self,
+        inputs: &[BasicTxDetails],
+        cmp_seq: &[Vec<CmpOperands>],
+        new_coverage: bool,
+        optimization: Option<(I256, Vec<BasicTxDetails>)>,
+        persist_now: bool,
+    ) -> CorpusRunRecord {
         // Check if this run improved the optimization value.
         let improved_optimization = optimization.as_ref().is_some_and(|(value, _)| {
             self.optimization_best_value.is_none_or(|best| *value > best)
@@ -562,18 +629,23 @@ impl WorkerCorpus {
             self.current_mutated = None;
         }
 
-        // Persist optimization state to disk if improved.
         if let Some((value, best_seq)) = optimization
             && improved_optimization
         {
             self.optimization_best_value = Some(value);
             self.optimization_best_sequence = best_seq;
-            self.persist_optimization_state();
+            if persist_now {
+                self.persist_optimization_state();
+            }
+        }
+
+        if !self.config.is_coverage_guided() {
+            return CorpusRunRecord::default();
         }
 
         // Collect inputs if current run produced new coverage or improved optimization.
         if !new_coverage && !improved_optimization {
-            return;
+            return CorpusRunRecord::default();
         }
 
         // When the run is interesting only because of optimization (no new coverage),
@@ -585,20 +657,25 @@ impl WorkerCorpus {
         } else {
             inputs.to_vec()
         };
-        let corpus_cmp_seq = cmp_seq.iter().take(corpus_inputs.len()).cloned().collect();
+        let corpus_cmp_seq: Vec<Vec<CmpOperands>> =
+            cmp_seq.iter().take(corpus_inputs.len()).cloned().collect();
+        let campaign_input =
+            CorpusCampaignInput::new(corpus_inputs.clone(), corpus_cmp_seq.clone());
         let corpus = CorpusEntry::new_with_cmp(corpus_inputs, corpus_cmp_seq, Uuid::new_v4());
 
-        // Persist to disk.
-        let write_result = corpus.write_to_disk_in(&worker_corpus, self.config.corpus_gzip);
-        if let Err(err) = write_result {
-            debug!(target: "corpus", %err, "failed to record call sequence {:?}", corpus.tx_seq);
-        } else {
-            trace!(
-                target: "corpus",
-                "persisted {} inputs for new coverage for {} corpus",
-                corpus.tx_seq.len(),
-                corpus.uuid,
-            );
+        if persist_now && let Some(worker_corpus) = &self.worker_dir {
+            let worker_corpus = worker_corpus.join(CORPUS_DIR);
+            let write_result = corpus.write_to_disk_in(&worker_corpus, self.config.corpus_gzip);
+            if let Err(err) = write_result {
+                debug!(target: "corpus", %err, "failed to record call sequence {:?}", corpus.tx_seq);
+            } else {
+                trace!(
+                    target: "corpus",
+                    "persisted {} inputs for new coverage for {} corpus",
+                    corpus.tx_seq.len(),
+                    corpus.uuid,
+                );
+            }
         }
 
         // Track in-memory corpus changes to update MasterWorker on sync.
@@ -609,6 +686,8 @@ impl WorkerCorpus {
         // them. We want this as it is new coverage and may help reach the other branch.
         self.metrics.corpus_count += 1;
         self.in_memory_corpus.push(corpus);
+
+        CorpusRunRecord { campaign_input: Some(campaign_input) }
     }
 
     /// Returns the previously persisted optimization best value and sequence (if any).
@@ -618,17 +697,55 @@ impl WorkerCorpus {
 
     /// Persists the current optimization best value and sequence to disk.
     fn persist_optimization_state(&self) {
-        let Some(value) = self.optimization_best_value else {
+        let output = CorpusCampaignOutput {
+            inputs: Vec::new(),
+            optimization_best_value: self.optimization_best_value,
+            optimization_best_sequence: self.optimization_best_sequence.clone(),
+        };
+        Self::persist_campaign_output(&self.config, &output);
+    }
+
+    /// Persists campaign-level corpus and optimization outputs after worker results have merged.
+    pub fn persist_campaign_output(config: &FuzzCorpusConfig, output: &CorpusCampaignOutput) {
+        let Some(corpus_dir) = &config.corpus_dir else {
             return;
         };
-        let Some(corpus_dir) = &self.config.corpus_dir else {
+        let corpus_dir = corpus_dir.join(format!("{WORKER}0")).join(CORPUS_DIR);
+        if !output.inputs.is_empty()
+            && let Err(err) = foundry_common::fs::create_dir_all(&corpus_dir)
+        {
+            debug!(target: "corpus", %err, "failed to create campaign corpus dir");
+        }
+        for input in &output.inputs {
+            let corpus = CorpusEntry::new_with_cmp(
+                input.tx_seq.clone(),
+                input.cmp_seq.clone(),
+                Uuid::new_v4(),
+            );
+            let write_result = corpus.write_to_disk_in(&corpus_dir, config.corpus_gzip);
+            if let Err(err) = write_result {
+                debug!(target: "corpus", %err, "failed to record call sequence {:?}", corpus.tx_seq);
+            } else {
+                trace!(
+                    target: "corpus",
+                    "persisted {} inputs for new coverage for {} corpus",
+                    corpus.tx_seq.len(),
+                    corpus.uuid,
+                );
+            }
+        }
+
+        let Some(value) = output.optimization_best_value else {
             return;
         };
         let state = OptimizationState {
             best_value: value,
-            best_sequence: self.optimization_best_sequence.clone(),
+            best_sequence: output.optimization_best_sequence.clone(),
         };
-        let path = corpus_dir.join(OPTIMIZATION_BEST_FILE);
+        let Some(root) = &config.corpus_dir else {
+            return;
+        };
+        let path = root.join(OPTIMIZATION_BEST_FILE);
         if let Err(err) = foundry_common::fs::write_json_file(&path, &state) {
             debug!(target: "corpus", %err, "failed to persist optimization state");
         } else {
@@ -636,7 +753,7 @@ impl WorkerCorpus {
                 target: "corpus",
                 "persisted optimization best value {} with sequence len {}",
                 value,
-                self.optimization_best_sequence.len()
+                output.optimization_best_sequence.len()
             );
         }
     }
@@ -1428,6 +1545,16 @@ mod tests {
         dir
     }
 
+    fn corpus_config(corpus_dir: PathBuf) -> FuzzCorpusConfig {
+        FuzzCorpusConfig {
+            corpus_dir: Some(corpus_dir),
+            corpus_gzip: false,
+            corpus_min_mutations: 0,
+            corpus_min_size: 0,
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn cmp_mutate_replaces_matching_calldata_operand() {
         let function = Function::parse("testCmp(uint256)").unwrap();
@@ -1465,13 +1592,7 @@ mod tests {
 
     fn new_manager_with_single_corpus() -> (WorkerCorpus, Uuid) {
         let tx_gen = Just(basic_tx()).boxed();
-        let config = FuzzCorpusConfig {
-            corpus_dir: Some(temp_corpus_dir()),
-            corpus_gzip: false,
-            corpus_min_mutations: 0,
-            corpus_min_size: 0,
-            ..Default::default()
-        };
+        let config = corpus_config(temp_corpus_dir());
 
         let tx_seq = vec![basic_tx()];
         let corpus = CorpusEntry::new(tx_seq);
@@ -1480,7 +1601,7 @@ mod tests {
         // Create corpus root dir and worker subdirectory.
         let corpus_root = config.corpus_dir.clone().unwrap();
         let worker_subdir = corpus_root.join("worker0");
-        let _ = fs::create_dir_all(&worker_subdir);
+        let _ = fs::create_dir_all(worker_subdir.join(CORPUS_DIR));
 
         let manager = WorkerCorpus {
             id: 0,
@@ -1496,13 +1617,104 @@ mod tests {
             metrics: CorpusMetrics::default(),
             new_entry_indices: Default::default(),
             last_sync_timestamp: 0,
-            worker_dir: Some(corpus_root),
+            worker_dir: Some(worker_subdir),
             last_sync_metrics: CorpusMetrics::default(),
             optimization_best_value: None,
             optimization_best_sequence: vec![],
         };
 
         (manager, seed_uuid)
+    }
+
+    #[test]
+    fn campaign_inputs_update_worker_memory_without_persisting() {
+        let corpus_root = temp_corpus_dir();
+        let worker_subdir = corpus_root.join("worker1");
+        fs::create_dir_all(worker_subdir.join(CORPUS_DIR)).unwrap();
+        let mut manager = WorkerCorpus {
+            id: 1,
+            tx_generator: Just(basic_tx()).boxed(),
+            mutation_generator: Just(MutationType::Repeat).boxed(),
+            config: corpus_config(corpus_root.clone()).into(),
+            in_memory_corpus: vec![],
+            current_mutated: None,
+            failed_replays: 0,
+            history_map: Vec::new(),
+            edge_indices: EdgeIndexMap::default(),
+            sancov_history_map: Vec::new(),
+            metrics: CorpusMetrics::default(),
+            new_entry_indices: Default::default(),
+            last_sync_timestamp: 0,
+            worker_dir: Some(worker_subdir.clone()),
+            last_sync_metrics: CorpusMetrics::default(),
+            optimization_best_value: None,
+            optimization_best_sequence: vec![],
+        };
+
+        let record = manager.process_campaign_inputs(&[basic_tx()], &[], true, None);
+
+        assert!(record.into_campaign_input().is_some());
+        assert_eq!(manager.in_memory_corpus.len(), 1);
+        assert_eq!(manager.metrics.corpus_count, 1);
+        assert_eq!(read_corpus_dir(&worker_subdir.join(CORPUS_DIR)).count(), 0);
+    }
+
+    #[test]
+    fn campaign_output_persists_corpus_and_optimization_to_master_dir() {
+        let corpus_root = temp_corpus_dir();
+        let mut manager = WorkerCorpus {
+            id: 1,
+            tx_generator: Just(basic_tx()).boxed(),
+            mutation_generator: Just(MutationType::Repeat).boxed(),
+            config: corpus_config(corpus_root.clone()).into(),
+            in_memory_corpus: vec![],
+            current_mutated: None,
+            failed_replays: 0,
+            history_map: Vec::new(),
+            edge_indices: EdgeIndexMap::default(),
+            sancov_history_map: Vec::new(),
+            metrics: CorpusMetrics::default(),
+            new_entry_indices: Default::default(),
+            last_sync_timestamp: 0,
+            worker_dir: Some(corpus_root.join("worker1")),
+            last_sync_metrics: CorpusMetrics::default(),
+            optimization_best_value: None,
+            optimization_best_sequence: vec![],
+        };
+        let sequence = vec![basic_tx()];
+        let record = manager
+            .process_campaign_inputs(
+                &sequence,
+                &[],
+                false,
+                Some((I256::try_from(7).unwrap(), sequence.clone())),
+            )
+            .into_campaign_input()
+            .unwrap();
+        let output = CorpusCampaignOutput {
+            inputs: vec![record],
+            optimization_best_value: Some(I256::try_from(7).unwrap()),
+            optimization_best_sequence: sequence.clone(),
+        };
+
+        WorkerCorpus::persist_campaign_output(&corpus_config(corpus_root.clone()), &output);
+
+        let master_corpus_dir = corpus_root.join("worker0").join(CORPUS_DIR);
+        let entries = read_corpus_dir(&master_corpus_dir).collect::<Vec<_>>();
+        assert_eq!(entries.len(), 1);
+        let persisted_sequence = entries[0].read_tx_seq().unwrap();
+        assert_eq!(persisted_sequence.len(), sequence.len());
+        assert_eq!(persisted_sequence[0].sender, sequence[0].sender);
+        assert_eq!(persisted_sequence[0].call_details.target, sequence[0].call_details.target);
+        assert_eq!(persisted_sequence[0].call_details.calldata, sequence[0].call_details.calldata);
+
+        let state: OptimizationState =
+            foundry_common::fs::read_json_file(&corpus_root.join(OPTIMIZATION_BEST_FILE)).unwrap();
+        assert_eq!(state.best_value, I256::try_from(7).unwrap());
+        assert_eq!(state.best_sequence.len(), sequence.len());
+        assert_eq!(state.best_sequence[0].sender, sequence[0].sender);
+        assert_eq!(state.best_sequence[0].call_details.target, sequence[0].call_details.target);
+        assert_eq!(state.best_sequence[0].call_details.calldata, sequence[0].call_details.calldata);
     }
 
     #[test]
@@ -1597,12 +1809,7 @@ mod tests {
     fn eviction_skips_favored_and_evicts_non_favored() {
         // Manager with two corpora.
         let tx_gen = Just(basic_tx()).boxed();
-        let config = FuzzCorpusConfig {
-            corpus_dir: Some(temp_corpus_dir()),
-            corpus_min_mutations: 0,
-            corpus_min_size: 0,
-            ..Default::default()
-        };
+        let config = corpus_config(temp_corpus_dir());
 
         let mut favored = CorpusEntry::new(vec![basic_tx()]);
         favored.total_mutations = 2;
@@ -1615,7 +1822,7 @@ mod tests {
 
         let corpus_root = temp_corpus_dir();
         let worker_subdir = corpus_root.join("worker0");
-        fs::create_dir_all(&worker_subdir).unwrap();
+        fs::create_dir_all(worker_subdir.join(CORPUS_DIR)).unwrap();
 
         let mut manager = WorkerCorpus {
             id: 0,
@@ -1631,7 +1838,7 @@ mod tests {
             metrics: CorpusMetrics::default(),
             new_entry_indices: Default::default(),
             last_sync_timestamp: 0,
-            worker_dir: Some(corpus_root),
+            worker_dir: Some(worker_subdir),
             last_sync_metrics: CorpusMetrics::default(),
             optimization_best_value: None,
             optimization_best_sequence: vec![],

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -397,10 +397,7 @@ impl WorkerCorpus {
         let mut optimization_best_value = None;
         let mut optimization_best_sequence = vec![];
 
-        if id == 0
-            && let Some(corpus_dir) = &config.corpus_dir
-        {
-            // Load persisted optimization state if it exists.
+        if let Some(corpus_dir) = &config.corpus_dir {
             let opt_path = corpus_dir.join(OPTIMIZATION_BEST_FILE);
             if opt_path.is_file() {
                 match foundry_common::fs::read_json_file::<OptimizationState>(&opt_path) {
@@ -422,7 +419,11 @@ impl WorkerCorpus {
                     }
                 }
             }
+        }
 
+        if id == 0
+            && let Some(corpus_dir) = &config.corpus_dir
+        {
             // Seed in-memory corpus with the persisted optimization best sequence
             // so the mutation engine can build on it in future runs.
             if !optimization_best_sequence.is_empty() {
@@ -1671,6 +1672,49 @@ mod tests {
         assert_eq!(state.best_sequence[0].sender, sequence[0].sender);
         assert_eq!(state.best_sequence[0].call_details.target, sequence[0].call_details.target);
         assert_eq!(state.best_sequence[0].call_details.calldata, sequence[0].call_details.calldata);
+    }
+
+    #[test]
+    fn non_master_campaign_worker_uses_persisted_optimization_baseline() {
+        let corpus_root = temp_corpus_dir();
+        let persisted_sequence = vec![basic_tx()];
+        let persisted_state = OptimizationState {
+            best_value: I256::try_from(100).unwrap(),
+            best_sequence: persisted_sequence,
+        };
+        foundry_common::fs::write_json_file(
+            &corpus_root.join(OPTIMIZATION_BEST_FILE),
+            &persisted_state,
+        )
+        .unwrap();
+        let mut manager = WorkerCorpus::new::<foundry_evm_core::evm::EthEvmNetwork>(
+            1,
+            corpus_config(corpus_root),
+            Just(basic_tx()).boxed(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let worse_sequence = vec![basic_tx()];
+        let worse = manager.process_inputs_for_campaign(
+            &worse_sequence,
+            &[],
+            false,
+            Some((I256::try_from(50).unwrap(), worse_sequence.clone())),
+        );
+        assert!(worse.is_none());
+
+        let better_sequence = vec![basic_tx()];
+        let better = manager.process_inputs_for_campaign(
+            &better_sequence,
+            &[],
+            false,
+            Some((I256::try_from(150).unwrap(), better_sequence.clone())),
+        );
+        assert!(better.is_some());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -184,50 +184,10 @@ impl CorpusEntry {
 }
 
 /// Corpus entry discovered by a worker and returned to the logical campaign for persistence.
-#[derive(Clone, Debug)]
-pub struct CorpusCampaignInput {
+#[derive(Debug)]
+pub(crate) struct CorpusCampaignInput {
     tx_seq: Vec<BasicTxDetails>,
     cmp_seq: Vec<Vec<CmpOperands>>,
-}
-
-impl CorpusCampaignInput {
-    const fn new(tx_seq: Vec<BasicTxDetails>, cmp_seq: Vec<Vec<CmpOperands>>) -> Self {
-        Self { tx_seq, cmp_seq }
-    }
-}
-
-/// Corpus and optimization artifacts discovered by a worker during a campaign slice.
-#[derive(Clone, Debug, Default)]
-pub struct CorpusCampaignOutput {
-    pub inputs: Vec<CorpusCampaignInput>,
-    pub optimization_best_value: Option<I256>,
-    pub optimization_best_sequence: Vec<BasicTxDetails>,
-}
-
-impl CorpusCampaignOutput {
-    /// Keeps the best optimization value, using caller iteration order to break ties.
-    pub fn merge_optimization(&mut self, value: Option<I256>, sequence: Vec<BasicTxDetails>) {
-        let Some(value) = value else {
-            return;
-        };
-
-        if self.optimization_best_value.is_none_or(|best| value > best) {
-            self.optimization_best_value = Some(value);
-            self.optimization_best_sequence = sequence;
-        }
-    }
-}
-
-/// Result of recording one run in a [`WorkerCorpus`].
-#[derive(Clone, Debug, Default)]
-pub struct CorpusRunRecord {
-    campaign_input: Option<CorpusCampaignInput>,
-}
-
-impl CorpusRunRecord {
-    pub fn into_campaign_input(self) -> Option<CorpusCampaignInput> {
-        self.campaign_input
-    }
 }
 
 #[derive(Default)]
@@ -587,7 +547,7 @@ impl WorkerCorpus {
         cmp_seq: &[Vec<CmpOperands>],
         new_coverage: bool,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
-    ) -> CorpusRunRecord {
+    ) -> Option<CorpusCampaignInput> {
         self.process_inputs_inner(inputs, cmp_seq, new_coverage, optimization, false)
     }
 
@@ -598,7 +558,7 @@ impl WorkerCorpus {
         new_coverage: bool,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
         persist_now: bool,
-    ) -> CorpusRunRecord {
+    ) -> Option<CorpusCampaignInput> {
         // Check if this run improved the optimization value.
         let improved_optimization = optimization.as_ref().is_some_and(|(value, _)| {
             self.optimization_best_value.is_none_or(|best| *value > best)
@@ -640,12 +600,12 @@ impl WorkerCorpus {
         }
 
         if !self.config.is_coverage_guided() {
-            return CorpusRunRecord::default();
+            return None;
         }
 
         // Collect inputs if current run produced new coverage or improved optimization.
         if !new_coverage && !improved_optimization {
-            return CorpusRunRecord::default();
+            return None;
         }
 
         // When the run is interesting only because of optimization (no new coverage),
@@ -659,8 +619,10 @@ impl WorkerCorpus {
         };
         let corpus_cmp_seq: Vec<Vec<CmpOperands>> =
             cmp_seq.iter().take(corpus_inputs.len()).cloned().collect();
-        let campaign_input =
-            CorpusCampaignInput::new(corpus_inputs.clone(), corpus_cmp_seq.clone());
+        let campaign_input = (!persist_now).then(|| CorpusCampaignInput {
+            tx_seq: corpus_inputs.clone(),
+            cmp_seq: corpus_cmp_seq.clone(),
+        });
         let corpus = CorpusEntry::new_with_cmp(corpus_inputs, corpus_cmp_seq, Uuid::new_v4());
 
         if persist_now && let Some(worker_corpus) = &self.worker_dir {
@@ -687,7 +649,7 @@ impl WorkerCorpus {
         self.metrics.corpus_count += 1;
         self.in_memory_corpus.push(corpus);
 
-        CorpusRunRecord { campaign_input: Some(campaign_input) }
+        campaign_input
     }
 
     /// Returns the previously persisted optimization best value and sequence (if any).
@@ -697,26 +659,29 @@ impl WorkerCorpus {
 
     /// Persists the current optimization best value and sequence to disk.
     fn persist_optimization_state(&self) {
-        let output = CorpusCampaignOutput {
-            inputs: Vec::new(),
-            optimization_best_value: self.optimization_best_value,
-            optimization_best_sequence: self.optimization_best_sequence.clone(),
-        };
-        Self::persist_campaign_output(&self.config, &output);
+        let optimization_best = self
+            .optimization_best_value
+            .map(|value| (value, self.optimization_best_sequence.as_slice()));
+        Self::persist_campaign_output(&self.config, &[], optimization_best);
     }
 
     /// Persists campaign-level corpus and optimization outputs after worker results have merged.
-    pub fn persist_campaign_output(config: &FuzzCorpusConfig, output: &CorpusCampaignOutput) {
+    pub(crate) fn persist_campaign_output(
+        config: &FuzzCorpusConfig,
+        inputs: &[CorpusCampaignInput],
+        optimization_best: Option<(I256, &[BasicTxDetails])>,
+    ) {
         let Some(corpus_dir) = &config.corpus_dir else {
             return;
         };
-        let corpus_dir = corpus_dir.join(format!("{WORKER}0")).join(CORPUS_DIR);
-        if !output.inputs.is_empty()
+        let root = corpus_dir;
+        let corpus_dir = root.join(format!("{WORKER}0")).join(CORPUS_DIR);
+        if !inputs.is_empty()
             && let Err(err) = foundry_common::fs::create_dir_all(&corpus_dir)
         {
             debug!(target: "corpus", %err, "failed to create campaign corpus dir");
         }
-        for input in &output.inputs {
+        for input in inputs {
             let corpus = CorpusEntry::new_with_cmp(
                 input.tx_seq.clone(),
                 input.cmp_seq.clone(),
@@ -735,16 +700,10 @@ impl WorkerCorpus {
             }
         }
 
-        let Some(value) = output.optimization_best_value else {
+        let Some((value, sequence)) = optimization_best else {
             return;
         };
-        let state = OptimizationState {
-            best_value: value,
-            best_sequence: output.optimization_best_sequence.clone(),
-        };
-        let Some(root) = &config.corpus_dir else {
-            return;
-        };
+        let state = OptimizationState { best_value: value, best_sequence: sequence.to_vec() };
         let path = root.join(OPTIMIZATION_BEST_FILE);
         if let Err(err) = foundry_common::fs::write_json_file(&path, &state) {
             debug!(target: "corpus", %err, "failed to persist optimization state");
@@ -753,7 +712,7 @@ impl WorkerCorpus {
                 target: "corpus",
                 "persisted optimization best value {} with sequence len {}",
                 value,
-                output.optimization_best_sequence.len()
+                sequence.len()
             );
         }
     }
@@ -1653,7 +1612,7 @@ mod tests {
 
         let record = manager.process_campaign_inputs(&[basic_tx()], &[], true, None);
 
-        assert!(record.into_campaign_input().is_some());
+        assert!(record.is_some());
         assert_eq!(manager.in_memory_corpus.len(), 1);
         assert_eq!(manager.metrics.corpus_count, 1);
         assert_eq!(read_corpus_dir(&worker_subdir.join(CORPUS_DIR)).count(), 0);
@@ -1689,15 +1648,13 @@ mod tests {
                 false,
                 Some((I256::try_from(7).unwrap(), sequence.clone())),
             )
-            .into_campaign_input()
             .unwrap();
-        let output = CorpusCampaignOutput {
-            inputs: vec![record],
-            optimization_best_value: Some(I256::try_from(7).unwrap()),
-            optimization_best_sequence: sequence.clone(),
-        };
-
-        WorkerCorpus::persist_campaign_output(&corpus_config(corpus_root.clone()), &output);
+        let inputs = vec![record];
+        WorkerCorpus::persist_campaign_output(
+            &corpus_config(corpus_root.clone()),
+            &inputs,
+            Some((I256::try_from(7).unwrap(), &sequence)),
+        );
 
         let master_corpus_dir = corpus_root.join("worker0").join(CORPUS_DIR);
         let entries = read_corpus_dir(&master_corpus_dir).collect::<Vec<_>>();

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -34,7 +34,7 @@
 //! - This all happens periodically, there is no clear order in which workers export or import
 //!   entries since it doesn't matter as long as the corpus eventually syncs across all workers
 
-use super::corpus_io::{CorpusDirEntry, read_corpus_dir};
+use super::corpus_io::{CorpusDirEntry, canonical_replay_dirs, read_corpus_dir};
 use crate::{
     executors::{Executor, RawCallResult, invariant::execute_tx},
     inspectors::{CmpOperands, EdgeIndexMap, MAX_EDGE_COUNT},
@@ -184,10 +184,174 @@ impl CorpusEntry {
 }
 
 /// Corpus entry selected by a worker and returned for logical-campaign persistence.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct CampaignCorpusEntry {
     tx_seq: Vec<BasicTxDetails>,
     cmp_seq: Vec<Vec<CmpOperands>>,
+    dedupe_by_coverage: bool,
+}
+
+struct ReplayOutcome {
+    keep_entry: bool,
+    new_coverage: bool,
+    cmp_seq: Vec<Vec<CmpOperands>>,
+    failed_replays: usize,
+}
+
+#[derive(Clone, Copy)]
+struct ReplayTarget<'a> {
+    fuzzed_function: Option<&'a Function>,
+    fuzzed_contracts: Option<&'a FuzzRunIdentifiedContracts>,
+    dynamic: Option<&'a DynamicTargetCtx<'a>>,
+}
+
+struct ReplayCoverage<'a> {
+    history_map: &'a mut Vec<u8>,
+    edge_indices: &'a mut EdgeIndexMap,
+    sancov_history_map: &'a mut Vec<u8>,
+    metrics: Option<&'a mut CorpusMetrics>,
+}
+
+/// Campaign-level corpus state produced by replaying persisted corpus entries once.
+///
+/// Parallel invariant workers clone this seed so every worker starts with the same warmed corpus
+/// and coverage maps. That avoids each worker rediscovering persisted coverage relative to an empty
+/// local map.
+#[derive(Clone, Default)]
+pub(crate) struct WorkerCorpusSeed {
+    in_memory_corpus: Vec<CorpusEntry>,
+    history_map: Vec<u8>,
+    edge_indices: EdgeIndexMap,
+    sancov_history_map: Vec<u8>,
+    metrics: CorpusMetrics,
+    failed_replays: usize,
+    optimization_best_value: Option<I256>,
+    optimization_best_sequence: Vec<BasicTxDetails>,
+}
+
+impl WorkerCorpusSeed {
+    fn empty(config: &FuzzCorpusConfig) -> Self {
+        // Hash mode always merges a fixed `MAX_EDGE_COUNT` bitmap, so preallocate to avoid moving
+        // the one-time 64 KiB resize into the first merge. Collision-free and sancov maps grow on
+        // demand and start empty.
+        let history_map =
+            if config.collect_evm_edge_coverage() && !config.evm_edge_coverage_collision_free() {
+                vec![0u8; MAX_EDGE_COUNT]
+            } else {
+                Vec::new()
+            };
+        Self { history_map, ..Default::default() }
+    }
+
+    fn with_optimization_state(mut self, config: &FuzzCorpusConfig) -> Self {
+        if let Some((value, sequence)) = load_optimization_state(config) {
+            self.optimization_best_value = Some(value);
+            self.optimization_best_sequence = sequence;
+        }
+        self
+    }
+
+    pub(crate) fn load_from_disk<FEN: FoundryEvmNetwork>(
+        config: &FuzzCorpusConfig,
+        executor: Option<&Executor<FEN>>,
+        fuzzed_function: Option<&Function>,
+        fuzzed_contracts: Option<&FuzzRunIdentifiedContracts>,
+        dynamic: Option<DynamicTargetCtx<'_>>,
+    ) -> Result<Self> {
+        let mut seed = Self::empty(config).with_optimization_state(config);
+        let Some(corpus_dir) = &config.corpus_dir else {
+            return Ok(seed);
+        };
+
+        // Seed in-memory corpus with the persisted optimization best sequence so the mutation
+        // engine can build on it in future runs.
+        if !seed.optimization_best_sequence.is_empty() {
+            seed.in_memory_corpus.push(CorpusEntry::new(seed.optimization_best_sequence.clone()));
+            seed.metrics.corpus_count += 1;
+        }
+
+        if fuzzed_contracts.is_some() && has_legacy_invariant_corpus_dirs(corpus_dir) {
+            let _ = sh_warn!(
+                "Ignoring legacy invariant corpus directories under {}; new corpus entries are persisted under the contract-level corpus directory.",
+                corpus_dir.display(),
+            );
+        }
+
+        let Some(executor) = executor else {
+            return Ok(seed);
+        };
+        for replay_dir in canonical_replay_dirs(corpus_dir) {
+            'corpus_replay: for entry in read_corpus_dir(&replay_dir) {
+                let tx_seq = entry.read_tx_seq()?;
+                if tx_seq.is_empty() {
+                    continue;
+                }
+
+                let target =
+                    ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic: dynamic.as_ref() };
+                let coverage = ReplayCoverage {
+                    history_map: &mut seed.history_map,
+                    edge_indices: &mut seed.edge_indices,
+                    sancov_history_map: &mut seed.sancov_history_map,
+                    metrics: Some(&mut seed.metrics),
+                };
+                let ReplayOutcome { keep_entry, cmp_seq, failed_replays, .. } =
+                    replay_corpus_sequence(&tx_seq, executor, target, coverage)?;
+                seed.failed_replays += failed_replays;
+                if !keep_entry {
+                    continue 'corpus_replay;
+                }
+
+                seed.metrics.corpus_count += 1;
+                debug!(
+                    target: "corpus",
+                    "load sequence with len {} from corpus file {}",
+                    tx_seq.len(),
+                    entry.path.display()
+                );
+                seed.in_memory_corpus.push(CorpusEntry::new_with_cmp(tx_seq, cmp_seq, entry.uuid));
+            }
+        }
+
+        Ok(seed)
+    }
+
+    pub(crate) fn filter_campaign_entries<FEN: FoundryEvmNetwork>(
+        &self,
+        entries: &[CampaignCorpusEntry],
+        executor: &Executor<FEN>,
+        fuzzed_function: Option<&Function>,
+        fuzzed_contracts: Option<&FuzzRunIdentifiedContracts>,
+        dynamic: Option<DynamicTargetCtx<'_>>,
+    ) -> Result<Vec<CampaignCorpusEntry>> {
+        let mut history_map = self.history_map.clone();
+        let mut edge_indices = self.edge_indices.clone();
+        let mut sancov_history_map = self.sancov_history_map.clone();
+        let mut filtered = Vec::new();
+
+        for entry in entries {
+            if !entry.dedupe_by_coverage {
+                filtered.push(entry.clone());
+                continue;
+            }
+
+            let target =
+                ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic: dynamic.as_ref() };
+            let coverage = ReplayCoverage {
+                history_map: &mut history_map,
+                edge_indices: &mut edge_indices,
+                sancov_history_map: &mut sancov_history_map,
+                metrics: None,
+            };
+            let ReplayOutcome { keep_entry, new_coverage, .. } =
+                replay_corpus_sequence(&entry.tx_seq, executor, target, coverage)?;
+            if keep_entry && new_coverage {
+                filtered.push(entry.clone());
+            }
+        }
+
+        Ok(filtered)
+    }
 }
 
 #[derive(Default)]
@@ -346,6 +510,99 @@ pub(crate) fn rollback_replay_created(
     }
 }
 
+fn load_optimization_state(config: &FuzzCorpusConfig) -> Option<(I256, Vec<BasicTxDetails>)> {
+    let corpus_dir = config.corpus_dir.as_ref()?;
+    let opt_path = corpus_dir.join(OPTIMIZATION_BEST_FILE);
+    if !opt_path.is_file() {
+        return None;
+    }
+
+    match foundry_common::fs::read_json_file::<OptimizationState>(&opt_path) {
+        Ok(state) => {
+            debug!(
+                target: "corpus",
+                "loaded optimization best value {} with sequence len {}",
+                state.best_value,
+                state.best_sequence.len()
+            );
+            Some((state.best_value, state.best_sequence))
+        }
+        Err(err) => {
+            let _ = sh_warn!(
+                "failed to load optimization state from {}: {err}; starting without persisted optimization seed",
+                opt_path.display()
+            );
+            None
+        }
+    }
+}
+
+fn replay_corpus_sequence<FEN: FoundryEvmNetwork>(
+    tx_seq: &[BasicTxDetails],
+    executor: &Executor<FEN>,
+    target: ReplayTarget<'_>,
+    mut coverage: ReplayCoverage<'_>,
+) -> Result<ReplayOutcome> {
+    let mut executor = executor.clone();
+    let mut cmp_seq = Vec::with_capacity(tx_seq.len());
+    let mut failed_replays = 0;
+    let mut new_coverage_for_entry = false;
+    let mut created: Vec<Address> = Vec::new();
+
+    for tx in tx_seq {
+        if WorkerCorpus::can_replay_tx(tx, target.fuzzed_function, target.fuzzed_contracts) {
+            let mut call_result = execute_tx(&mut executor, tx)?;
+            cmp_seq.push(call_result.evm_cmp_values.take().unwrap_or_default());
+            let (new_coverage, is_edge) = call_result.merge_all_coverage(
+                coverage.history_map,
+                coverage.edge_indices,
+                coverage.sancov_history_map,
+            );
+            if new_coverage {
+                new_coverage_for_entry = true;
+                if let Some(metrics) = coverage.metrics.as_deref_mut() {
+                    metrics.update_seen(is_edge);
+                }
+            }
+
+            register_replay_created(
+                &call_result.state_changeset,
+                target.dynamic,
+                target.fuzzed_contracts,
+                &mut created,
+            );
+
+            // Commit only when running invariant / stateful tests.
+            if target.fuzzed_contracts.is_some() {
+                executor.commit(&mut call_result);
+            }
+        } else {
+            cmp_seq.push(Vec::new());
+            failed_replays += 1;
+
+            // If the only input for fuzzed function cannot be replayed, then move to the next
+            // corpus entry without adding this one in memory.
+            if target.fuzzed_function.is_some() {
+                rollback_replay_created(target.fuzzed_contracts, created);
+                return Ok(ReplayOutcome {
+                    keep_entry: false,
+                    new_coverage: new_coverage_for_entry,
+                    cmp_seq,
+                    failed_replays,
+                });
+            }
+        }
+    }
+    rollback_replay_created(target.fuzzed_contracts, created);
+
+    Ok(ReplayOutcome {
+        keep_entry: true,
+        new_coverage: new_coverage_for_entry,
+        cmp_seq,
+        failed_replays,
+    })
+}
+
 impl WorkerCorpus {
     pub fn new<FEN: FoundryEvmNetwork>(
         id: usize,
@@ -357,6 +614,26 @@ impl WorkerCorpus {
         fuzzed_contracts: Option<&FuzzRunIdentifiedContracts>,
         dynamic: Option<DynamicTargetCtx<'_>>,
     ) -> Result<Self> {
+        let seed = if id == 0 {
+            WorkerCorpusSeed::load_from_disk(
+                &config,
+                executor,
+                fuzzed_function,
+                fuzzed_contracts,
+                dynamic,
+            )?
+        } else {
+            WorkerCorpusSeed::empty(&config).with_optimization_state(&config)
+        };
+        Ok(Self::from_seed(id, config, tx_generator, seed))
+    }
+
+    pub(crate) fn from_seed(
+        id: usize,
+        config: FuzzCorpusConfig,
+        tx_generator: BoxedStrategy<BasicTxDetails>,
+        seed: WorkerCorpusSeed,
+    ) -> Self {
         let mutation_generator = prop_oneof![
             Just(MutationType::Splice),
             Just(MutationType::Repeat),
@@ -380,137 +657,14 @@ impl WorkerCorpus {
             worker_dir
         });
 
-        let mut in_memory_corpus = vec![];
-        // Hash mode always merges a fixed `MAX_EDGE_COUNT` bitmap, so preallocate to
-        // avoid moving the one-time 64 KiB resize into the first merge. Collision-free
-        // and sancov maps grow on demand and start empty.
-        let mut history_map =
-            if config.collect_evm_edge_coverage() && !config.evm_edge_coverage_collision_free() {
-                vec![0u8; MAX_EDGE_COUNT]
-            } else {
-                Vec::new()
-            };
-        let mut edge_indices = EdgeIndexMap::default();
-        let mut sancov_history_map = Vec::new();
-        let mut metrics = CorpusMetrics::default();
-        let mut failed_replays = 0;
-        let mut optimization_best_value = None;
-        let mut optimization_best_sequence = vec![];
-
-        if let Some(corpus_dir) = &config.corpus_dir {
-            let opt_path = corpus_dir.join(OPTIMIZATION_BEST_FILE);
-            if opt_path.is_file() {
-                match foundry_common::fs::read_json_file::<OptimizationState>(&opt_path) {
-                    Ok(state) => {
-                        debug!(
-                            target: "corpus",
-                            "loaded optimization best value {} with sequence len {}",
-                            state.best_value,
-                            state.best_sequence.len()
-                        );
-                        optimization_best_value = Some(state.best_value);
-                        optimization_best_sequence = state.best_sequence;
-                    }
-                    Err(err) => {
-                        let _ = sh_warn!(
-                            "failed to load optimization state from {}: {err}; starting without persisted optimization seed",
-                            opt_path.display()
-                        );
-                    }
-                }
-            }
-        }
-
-        if id == 0
-            && let Some(corpus_dir) = &config.corpus_dir
-        {
-            // Seed in-memory corpus with the persisted optimization best sequence
-            // so the mutation engine can build on it in future runs.
-            if !optimization_best_sequence.is_empty() {
-                in_memory_corpus.push(CorpusEntry::new(optimization_best_sequence.clone()));
-                metrics.corpus_count += 1;
-            }
-
-            // Master worker loads the initial corpus, if it exists.
-            if fuzzed_contracts.is_some() && has_legacy_invariant_corpus_dirs(corpus_dir) {
-                let _ = sh_warn!(
-                    "Ignoring legacy invariant corpus directories under {}; new corpus entries are persisted under the contract-level corpus directory.",
-                    corpus_dir.display(),
-                );
-            }
-
-            // Then, [distribute]s it to workers.
-            let executor = executor.expect("Executor required for master worker");
-            'corpus_replay: for entry in read_corpus_dir(corpus_dir) {
-                let tx_seq = entry.read_tx_seq()?;
-                if tx_seq.is_empty() {
-                    continue;
-                }
-                // Warm up history map from loaded sequences.
-                let mut executor = executor.clone();
-                let mut cmp_seq = Vec::with_capacity(tx_seq.len());
-                // Targets deployed during this entry, cleared after the entry.
-                let mut created: Vec<Address> = Vec::new();
-                for tx in &tx_seq {
-                    if Self::can_replay_tx(tx, fuzzed_function, fuzzed_contracts) {
-                        let mut call_result = execute_tx(&mut executor, tx)?;
-                        cmp_seq.push(call_result.evm_cmp_values.take().unwrap_or_default());
-                        let (new_coverage, is_edge) = call_result.merge_all_coverage(
-                            &mut history_map,
-                            &mut edge_indices,
-                            &mut sancov_history_map,
-                        );
-                        if new_coverage {
-                            metrics.update_seen(is_edge);
-                        }
-
-                        register_replay_created(
-                            &call_result.state_changeset,
-                            dynamic.as_ref(),
-                            fuzzed_contracts,
-                            &mut created,
-                        );
-
-                        // Commit only when running invariant / stateful tests.
-                        if fuzzed_contracts.is_some() {
-                            executor.commit(&mut call_result);
-                        }
-                    } else {
-                        cmp_seq.push(Vec::new());
-                        failed_replays += 1;
-
-                        // If the only input for fuzzed function cannot be replied, then move to
-                        // next one without adding it in memory.
-                        if fuzzed_function.is_some() {
-                            rollback_replay_created(fuzzed_contracts, created);
-                            continue 'corpus_replay;
-                        }
-                    }
-                }
-                rollback_replay_created(fuzzed_contracts, created);
-
-                metrics.corpus_count += 1;
-
-                debug!(
-                    target: "corpus",
-                    "load sequence with len {} from corpus file {}",
-                    tx_seq.len(),
-                    entry.path.display()
-                );
-
-                // Populate in memory corpus with the sequence from corpus file.
-                in_memory_corpus.push(CorpusEntry::new_with_cmp(tx_seq, cmp_seq, entry.uuid));
-            }
-        }
-
-        Ok(Self {
+        Self {
             id,
-            in_memory_corpus,
-            history_map,
-            edge_indices,
-            sancov_history_map,
-            failed_replays,
-            metrics,
+            in_memory_corpus: seed.in_memory_corpus,
+            history_map: seed.history_map,
+            edge_indices: seed.edge_indices,
+            sancov_history_map: seed.sancov_history_map,
+            failed_replays: seed.failed_replays,
+            metrics: seed.metrics,
             tx_generator,
             mutation_generator,
             current_mutated: None,
@@ -519,9 +673,9 @@ impl WorkerCorpus {
             last_sync_timestamp: 0,
             worker_dir,
             last_sync_metrics: Default::default(),
-            optimization_best_value,
-            optimization_best_sequence,
-        })
+            optimization_best_value: seed.optimization_best_value,
+            optimization_best_sequence: seed.optimization_best_sequence,
+        }
     }
 
     /// Updates stats for the given call sequence, if new coverage produced.
@@ -622,6 +776,7 @@ impl WorkerCorpus {
         let campaign_entry = (!persist_now).then(|| CampaignCorpusEntry {
             tx_seq: corpus_inputs.clone(),
             cmp_seq: corpus_cmp_seq.clone(),
+            dedupe_by_coverage: new_coverage,
         });
         let corpus = CorpusEntry::new_with_cmp(corpus_inputs, corpus_cmp_seq, Uuid::new_v4());
 
@@ -1612,7 +1767,8 @@ mod tests {
 
         let record = manager.process_inputs_for_campaign(&[basic_tx()], &[], true, None);
 
-        assert!(record.is_some());
+        let record = record.unwrap();
+        assert!(record.dedupe_by_coverage);
         assert_eq!(manager.in_memory_corpus.len(), 1);
         assert_eq!(manager.metrics.corpus_count, 1);
         assert_eq!(read_corpus_dir(&worker_subdir.join(CORPUS_DIR)).count(), 0);
@@ -1715,6 +1871,41 @@ mod tests {
             Some((I256::try_from(150).unwrap(), better_sequence.clone())),
         );
         assert!(better.is_some());
+    }
+
+    #[test]
+    fn worker_can_initialize_from_warmed_seed() {
+        let corpus_root = temp_corpus_dir();
+        let tx_seq = vec![basic_tx()];
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(tx_seq.clone())],
+            history_map: vec![1, 2, 3],
+            edge_indices: EdgeIndexMap::default(),
+            sancov_history_map: vec![4, 5],
+            metrics: CorpusMetrics {
+                cumulative_edges_seen: 7,
+                cumulative_features_seen: 11,
+                corpus_count: 1,
+                favored_items: 0,
+            },
+            failed_replays: 13,
+            optimization_best_value: Some(I256::try_from(17).unwrap()),
+            optimization_best_sequence: tx_seq.clone(),
+        };
+
+        let manager =
+            WorkerCorpus::from_seed(1, corpus_config(corpus_root), Just(basic_tx()).boxed(), seed);
+
+        assert_eq!(manager.in_memory_corpus.len(), 1);
+        assert_eq!(manager.history_map, vec![1, 2, 3]);
+        assert_eq!(manager.sancov_history_map, vec![4, 5]);
+        assert_eq!(manager.metrics.cumulative_edges_seen, 7);
+        assert_eq!(manager.metrics.cumulative_features_seen, 11);
+        assert_eq!(manager.metrics.corpus_count, 1);
+        assert_eq!(manager.failed_replays, 13);
+        let (value, sequence) = manager.optimization_initial_state();
+        assert_eq!(value, Some(I256::try_from(17).unwrap()));
+        assert_eq!(sequence.len(), 1);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -281,7 +281,7 @@ impl WorkerCorpusSeed {
             return Ok(seed);
         };
         for replay_dir in canonical_replay_dirs(corpus_dir) {
-            'corpus_replay: for entry in read_corpus_dir(&replay_dir) {
+            for entry in read_corpus_dir(&replay_dir) {
                 let tx_seq = entry.read_tx_seq()?;
                 if tx_seq.is_empty() {
                     continue;
@@ -299,7 +299,7 @@ impl WorkerCorpusSeed {
                     replay_corpus_sequence(&tx_seq, executor, target, coverage)?;
                 seed.failed_replays += failed_replays;
                 if !keep_entry {
-                    continue 'corpus_replay;
+                    continue;
                 }
 
                 seed.metrics.corpus_count += 1;
@@ -330,24 +330,23 @@ impl WorkerCorpusSeed {
         let mut filtered = Vec::new();
 
         for entry in entries {
-            if !entry.dedupe_by_coverage {
-                filtered.push(entry.clone());
-                continue;
+            if entry.dedupe_by_coverage {
+                let target =
+                    ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic: dynamic.as_ref() };
+                let coverage = ReplayCoverage {
+                    history_map: &mut history_map,
+                    edge_indices: &mut edge_indices,
+                    sancov_history_map: &mut sancov_history_map,
+                    metrics: None,
+                };
+                let ReplayOutcome { keep_entry, new_coverage, .. } =
+                    replay_corpus_sequence(&entry.tx_seq, executor, target, coverage)?;
+                if !keep_entry || !new_coverage {
+                    continue;
+                }
             }
 
-            let target =
-                ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic: dynamic.as_ref() };
-            let coverage = ReplayCoverage {
-                history_map: &mut history_map,
-                edge_indices: &mut edge_indices,
-                sancov_history_map: &mut sancov_history_map,
-                metrics: None,
-            };
-            let ReplayOutcome { keep_entry, new_coverage, .. } =
-                replay_corpus_sequence(&entry.tx_seq, executor, target, coverage)?;
-            if keep_entry && new_coverage {
-                filtered.push(entry.clone());
-            }
+            filtered.push(entry.clone());
         }
 
         Ok(filtered)
@@ -541,9 +540,20 @@ fn replay_corpus_sequence<FEN: FoundryEvmNetwork>(
     tx_seq: &[BasicTxDetails],
     executor: &Executor<FEN>,
     target: ReplayTarget<'_>,
-    mut coverage: ReplayCoverage<'_>,
+    coverage: ReplayCoverage<'_>,
 ) -> Result<ReplayOutcome> {
     let mut executor = executor.clone();
+    replay_corpus_sequence_with_executor(tx_seq, &mut executor, target, coverage, false, true)
+}
+
+fn replay_corpus_sequence_with_executor<FEN: FoundryEvmNetwork>(
+    tx_seq: &[BasicTxDetails],
+    executor: &mut Executor<FEN>,
+    target: ReplayTarget<'_>,
+    mut coverage: ReplayCoverage<'_>,
+    trace_sync: bool,
+    reject_unmatched_function: bool,
+) -> Result<ReplayOutcome> {
     let mut cmp_seq = Vec::with_capacity(tx_seq.len());
     let mut failed_replays = 0;
     let mut new_coverage_for_entry = false;
@@ -551,7 +561,7 @@ fn replay_corpus_sequence<FEN: FoundryEvmNetwork>(
 
     for tx in tx_seq {
         if WorkerCorpus::can_replay_tx(tx, target.fuzzed_function, target.fuzzed_contracts) {
-            let mut call_result = execute_tx(&mut executor, tx)?;
+            let mut call_result = execute_tx(executor, tx)?;
             cmp_seq.push(call_result.evm_cmp_values.take().unwrap_or_default());
             let (new_coverage, is_edge) = call_result.merge_all_coverage(
                 coverage.history_map,
@@ -576,13 +586,20 @@ fn replay_corpus_sequence<FEN: FoundryEvmNetwork>(
             if target.fuzzed_contracts.is_some() {
                 executor.commit(&mut call_result);
             }
+
+            if trace_sync {
+                trace!(
+                    target: "corpus",
+                    %new_coverage,
+                    ?tx,
+                    "replayed tx for syncing",
+                );
+            }
         } else {
             cmp_seq.push(Vec::new());
             failed_replays += 1;
 
-            // If the only input for fuzzed function cannot be replayed, then move to the next
-            // corpus entry without adding this one in memory.
-            if target.fuzzed_function.is_some() {
+            if reject_unmatched_function && target.fuzzed_function.is_some() {
                 rollback_replay_created(target.fuzzed_contracts, created);
                 return Ok(ReplayOutcome {
                     keep_entry: false,
@@ -1360,54 +1377,25 @@ impl WorkerCorpus {
 
         let mut executor = executor.clone();
         for (entry, tx_seq) in self.load_sync_corpus()? {
-            let mut new_coverage_on_sync = false;
-            let mut cmp_seq = Vec::with_capacity(tx_seq.len());
-            // Targets deployed during this entry, cleared after the entry.
-            let mut created: Vec<Address> = Vec::new();
-            for tx in &tx_seq {
-                if !Self::can_replay_tx(tx, fuzzed_function, fuzzed_contracts) {
-                    cmp_seq.push(Vec::new());
-                    continue;
-                }
-
-                let mut call_result = execute_tx(&mut executor, tx)?;
-                cmp_seq.push(call_result.evm_cmp_values.take().unwrap_or_default());
-
-                // Check if this provides new coverage.
-                let (new_coverage, is_edge) = call_result.merge_all_coverage(
-                    &mut self.history_map,
-                    &mut self.edge_indices,
-                    &mut self.sancov_history_map,
-                );
-
-                if new_coverage {
-                    self.metrics.update_seen(is_edge);
-                    new_coverage_on_sync = true;
-                }
-
-                register_replay_created(
-                    &call_result.state_changeset,
-                    dynamic,
-                    fuzzed_contracts,
-                    &mut created,
-                );
-
-                // Commit only for stateful tests.
-                if fuzzed_contracts.is_some() {
-                    executor.commit(&mut call_result);
-                }
-
-                trace!(
-                    target: "corpus",
-                    %new_coverage,
-                    ?tx,
-                    "replayed tx for syncing",
-                );
-            }
-            rollback_replay_created(fuzzed_contracts, created);
+            let target = ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic };
+            let coverage = ReplayCoverage {
+                history_map: &mut self.history_map,
+                edge_indices: &mut self.edge_indices,
+                sancov_history_map: &mut self.sancov_history_map,
+                metrics: Some(&mut self.metrics),
+            };
+            let ReplayOutcome { keep_entry, new_coverage, cmp_seq, .. } =
+                replay_corpus_sequence_with_executor(
+                    &tx_seq,
+                    &mut executor,
+                    target,
+                    coverage,
+                    true,
+                    false,
+                )?;
 
             let sync_path = &entry.path;
-            if new_coverage_on_sync {
+            if keep_entry && new_coverage {
                 // Move file from sync/ to corpus/ directory.
                 let corpus_path = corpus_dir.join(sync_path.components().next_back().unwrap());
                 if let Err(err) = std::fs::rename(sync_path, &corpus_path) {
@@ -1669,6 +1657,26 @@ mod tests {
         }
     }
 
+    fn worker_corpus(id: usize, corpus_root: PathBuf, seed: WorkerCorpusSeed) -> WorkerCorpus {
+        WorkerCorpus::from_seed(id, corpus_config(corpus_root), Just(basic_tx()).boxed(), seed)
+    }
+
+    fn empty_worker_corpus(id: usize, corpus_root: PathBuf) -> WorkerCorpus {
+        worker_corpus(id, corpus_root, WorkerCorpusSeed::default())
+    }
+
+    fn seeded_worker_corpus(
+        id: usize,
+        corpus_root: PathBuf,
+        entries: Vec<CorpusEntry>,
+    ) -> WorkerCorpus {
+        worker_corpus(
+            id,
+            corpus_root,
+            WorkerCorpusSeed { in_memory_corpus: entries, ..Default::default() },
+        )
+    }
+
     #[test]
     fn cmp_mutate_replaces_matching_calldata_operand() {
         let function = Function::parse("testCmp(uint256)").unwrap();
@@ -1705,37 +1713,10 @@ mod tests {
     }
 
     fn new_manager_with_single_corpus() -> (WorkerCorpus, Uuid) {
-        let tx_gen = Just(basic_tx()).boxed();
-        let config = corpus_config(temp_corpus_dir());
-
-        let tx_seq = vec![basic_tx()];
-        let corpus = CorpusEntry::new(tx_seq);
+        let corpus = CorpusEntry::new(vec![basic_tx()]);
         let seed_uuid = corpus.uuid;
-
-        // Create corpus root dir and worker subdirectory.
-        let corpus_root = config.corpus_dir.clone().unwrap();
-        let worker_subdir = corpus_root.join("worker0");
-        let _ = fs::create_dir_all(worker_subdir.join(CORPUS_DIR));
-
-        let manager = WorkerCorpus {
-            id: 0,
-            tx_generator: tx_gen,
-            mutation_generator: Just(MutationType::Repeat).boxed(),
-            config: config.into(),
-            in_memory_corpus: vec![corpus],
-            current_mutated: Some(seed_uuid),
-            failed_replays: 0,
-            history_map: Vec::new(),
-            edge_indices: EdgeIndexMap::default(),
-            sancov_history_map: Vec::new(),
-            metrics: CorpusMetrics::default(),
-            new_entry_indices: Default::default(),
-            last_sync_timestamp: 0,
-            worker_dir: Some(worker_subdir),
-            last_sync_metrics: CorpusMetrics::default(),
-            optimization_best_value: None,
-            optimization_best_sequence: vec![],
-        };
+        let mut manager = seeded_worker_corpus(0, temp_corpus_dir(), vec![corpus]);
+        manager.current_mutated = Some(seed_uuid);
 
         (manager, seed_uuid)
     }
@@ -1744,26 +1725,7 @@ mod tests {
     fn campaign_processing_returns_corpus_without_writing_worker_file() {
         let corpus_root = temp_corpus_dir();
         let worker_subdir = corpus_root.join("worker1");
-        fs::create_dir_all(worker_subdir.join(CORPUS_DIR)).unwrap();
-        let mut manager = WorkerCorpus {
-            id: 1,
-            tx_generator: Just(basic_tx()).boxed(),
-            mutation_generator: Just(MutationType::Repeat).boxed(),
-            config: corpus_config(corpus_root).into(),
-            in_memory_corpus: vec![],
-            current_mutated: None,
-            failed_replays: 0,
-            history_map: Vec::new(),
-            edge_indices: EdgeIndexMap::default(),
-            sancov_history_map: Vec::new(),
-            metrics: CorpusMetrics::default(),
-            new_entry_indices: Default::default(),
-            last_sync_timestamp: 0,
-            worker_dir: Some(worker_subdir.clone()),
-            last_sync_metrics: CorpusMetrics::default(),
-            optimization_best_value: None,
-            optimization_best_sequence: vec![],
-        };
+        let mut manager = empty_worker_corpus(1, corpus_root);
 
         let record = manager.process_inputs_for_campaign(&[basic_tx()], &[], true, None);
 
@@ -1777,25 +1739,7 @@ mod tests {
     #[test]
     fn merged_campaign_outputs_write_corpus_and_optimization_to_master_dir() {
         let corpus_root = temp_corpus_dir();
-        let mut manager = WorkerCorpus {
-            id: 1,
-            tx_generator: Just(basic_tx()).boxed(),
-            mutation_generator: Just(MutationType::Repeat).boxed(),
-            config: corpus_config(corpus_root.clone()).into(),
-            in_memory_corpus: vec![],
-            current_mutated: None,
-            failed_replays: 0,
-            history_map: Vec::new(),
-            edge_indices: EdgeIndexMap::default(),
-            sancov_history_map: Vec::new(),
-            metrics: CorpusMetrics::default(),
-            new_entry_indices: Default::default(),
-            last_sync_timestamp: 0,
-            worker_dir: Some(corpus_root.join("worker1")),
-            last_sync_metrics: CorpusMetrics::default(),
-            optimization_best_value: None,
-            optimization_best_sequence: vec![],
-        };
+        let mut manager = empty_worker_corpus(1, corpus_root.clone());
         let sequence = vec![basic_tx()];
         let record = manager
             .process_inputs_for_campaign(
@@ -1890,7 +1834,7 @@ mod tests {
             },
             failed_replays: 13,
             optimization_best_value: Some(I256::try_from(17).unwrap()),
-            optimization_best_sequence: tx_seq.clone(),
+            optimization_best_sequence: tx_seq,
         };
 
         let manager =
@@ -1999,9 +1943,6 @@ mod tests {
     #[test]
     fn eviction_skips_favored_and_evicts_non_favored() {
         // Manager with two corpora.
-        let tx_gen = Just(basic_tx()).boxed();
-        let config = corpus_config(temp_corpus_dir());
-
         let mut favored = CorpusEntry::new(vec![basic_tx()]);
         favored.total_mutations = 2;
         favored.is_favored = true;
@@ -2011,29 +1952,7 @@ mod tests {
         non_favored.is_favored = false;
         let non_favored_uuid = non_favored.uuid;
 
-        let corpus_root = temp_corpus_dir();
-        let worker_subdir = corpus_root.join("worker0");
-        fs::create_dir_all(worker_subdir.join(CORPUS_DIR)).unwrap();
-
-        let mut manager = WorkerCorpus {
-            id: 0,
-            tx_generator: tx_gen,
-            mutation_generator: Just(MutationType::Repeat).boxed(),
-            config: config.into(),
-            in_memory_corpus: vec![favored, non_favored],
-            current_mutated: None,
-            failed_replays: 0,
-            history_map: Vec::new(),
-            edge_indices: EdgeIndexMap::default(),
-            sancov_history_map: Vec::new(),
-            metrics: CorpusMetrics::default(),
-            new_entry_indices: Default::default(),
-            last_sync_timestamp: 0,
-            worker_dir: Some(worker_subdir),
-            last_sync_metrics: CorpusMetrics::default(),
-            optimization_best_value: None,
-            optimization_best_sequence: vec![],
-        };
+        let mut manager = seeded_worker_corpus(0, temp_corpus_dir(), vec![favored, non_favored]);
 
         // First eviction should remove the non-favored one.
         manager.evict_oldest_corpus().unwrap();

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -106,7 +106,7 @@ pub struct InvariantWorkerOutput {
 
 impl InvariantWorkerOutput {
     #[cfg(test)]
-    pub fn new(plan: InvariantWorkerPlan, result: InvariantFuzzTestResult) -> Self {
+    pub const fn new(plan: InvariantWorkerPlan, result: InvariantFuzzTestResult) -> Self {
         Self { plan, result, corpus_entries: Vec::new() }
     }
 }

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -1,5 +1,5 @@
 use super::{InvariantFuzzError, InvariantFuzzTestResult, InvariantMetrics};
-use crate::executors::{EarlyExit, FuzzTestTimer, corpus::CampaignCorpusEntry};
+use crate::executors::{EarlyExit, corpus::CampaignCorpusEntry};
 use alloy_primitives::{Address, I256, Selector};
 use eyre::{Result, ensure};
 use foundry_evm_coverage::HitMaps;
@@ -68,28 +68,19 @@ pub struct InvariantWorkerPlan {
 pub struct InvariantCampaignState {
     total_runs: AtomicU32,
     global_early_exit: EarlyExit,
-    timer: FuzzTestTimer,
 }
 
 impl InvariantCampaignState {
-    pub fn new(timeout: Option<u32>, early_exit: EarlyExit) -> Self {
-        Self {
-            total_runs: AtomicU32::new(0),
-            global_early_exit: early_exit,
-            timer: FuzzTestTimer::new(timeout),
-        }
+    pub fn new(early_exit: EarlyExit) -> Self {
+        Self { total_runs: AtomicU32::new(0), global_early_exit: early_exit }
     }
 
     pub fn increment_runs(&self) -> u32 {
         self.total_runs.fetch_add(1, Ordering::Relaxed) + 1
     }
 
-    pub fn should_continue(&self) -> bool {
-        !(self.global_early_exit.should_stop() || self.timer.is_timed_out())
-    }
-
-    pub const fn is_timed_campaign(&self) -> bool {
-        self.timer.is_enabled()
+    pub fn should_stop(&self) -> bool {
+        self.global_early_exit.should_stop()
     }
 }
 
@@ -485,12 +476,6 @@ mod tests {
 
         let err = InvariantCampaignSpec::new(0).worker_plans(0).unwrap_err();
         assert!(err.to_string().contains("requires at least one worker"));
-    }
-
-    #[test]
-    fn campaign_state_reports_timed_campaigns() {
-        assert!(!InvariantCampaignState::new(None, EarlyExit::new(false)).is_timed_campaign());
-        assert!(InvariantCampaignState::new(Some(1), EarlyExit::new(false)).is_timed_campaign());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -6,7 +6,7 @@ use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::BasicTxDetails;
 use std::{
     collections::{HashMap, HashSet},
-    sync::atomic::{AtomicU32, Ordering},
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
 };
 
 /// Immutable plan-level description for an invariant campaign.
@@ -67,12 +67,17 @@ pub struct InvariantWorkerPlan {
 /// Shared state used only to coordinate invariant worker execution.
 pub struct InvariantCampaignState {
     total_runs: AtomicU32,
+    terminal_stop: AtomicBool,
     global_early_exit: EarlyExit,
 }
 
 impl InvariantCampaignState {
     pub const fn new(early_exit: EarlyExit) -> Self {
-        Self { total_runs: AtomicU32::new(0), global_early_exit: early_exit }
+        Self {
+            total_runs: AtomicU32::new(0),
+            terminal_stop: AtomicBool::new(false),
+            global_early_exit: early_exit,
+        }
     }
 
     pub fn increment_runs(&self) -> u32 {
@@ -80,7 +85,15 @@ impl InvariantCampaignState {
     }
 
     pub fn should_stop(&self) -> bool {
-        self.global_early_exit.should_stop()
+        self.global_early_exit.should_stop() || self.terminal_stop.load(Ordering::Relaxed)
+    }
+
+    pub fn request_terminal_stop(&self) {
+        self.terminal_stop.store(true, Ordering::Relaxed);
+    }
+
+    pub const fn early_exit(&self) -> &EarlyExit {
+        &self.global_early_exit
     }
 }
 
@@ -476,6 +489,16 @@ mod tests {
 
         let err = InvariantCampaignSpec::new(0).worker_plans(0).unwrap_err();
         assert!(err.to_string().contains("requires at least one worker"));
+    }
+
+    #[test]
+    fn campaign_state_stops_after_terminal_request() {
+        let state = InvariantCampaignState::new(EarlyExit::new(false));
+        assert!(!state.should_stop());
+
+        state.request_terminal_stop();
+
+        assert!(state.should_stop());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -70,6 +70,12 @@ pub struct InvariantWorkerOutput {
     pub result: InvariantFuzzTestResult,
 }
 
+impl InvariantWorkerOutput {
+    pub const fn new(plan: InvariantWorkerPlan, result: InvariantFuzzTestResult) -> Self {
+        Self { plan, result }
+    }
+}
+
 /// Merges worker outputs back into one logical invariant campaign result.
 ///
 /// Merge policy:
@@ -111,13 +117,16 @@ impl InvariantCampaignAggregator {
         let mut gas_report_traces = Vec::new();
         let mut line_coverage = None;
         let mut metrics = HashMap::default();
-        let mut failed_corpus_replays = 0;
+        let failed_corpus_replays = self
+            .outputs
+            .iter()
+            .find(|output| output.plan.worker_id == 0)
+            .expect("master worker output was validated")
+            .result
+            .failed_corpus_replays;
         let mut optimization_best = None;
 
-        for InvariantWorkerOutput { plan, result } in self.outputs {
-            if plan.worker_id == 0 {
-                failed_corpus_replays = result.failed_corpus_replays;
-            }
+        for InvariantWorkerOutput { result, .. } in self.outputs {
             for (invariant, error) in result.errors {
                 errors.entry(invariant).or_insert(error);
             }
@@ -156,27 +165,21 @@ fn ensure_outputs_cover_campaign(
     spec: InvariantCampaignSpec,
     outputs: &[InvariantWorkerOutput],
 ) -> Result<()> {
-    let mut seen = HashSet::with_capacity(outputs.len());
-    for output in outputs {
-        ensure!(
-            seen.insert(output.plan.worker_id),
-            "duplicate invariant worker output for worker {}",
-            output.plan.worker_id
-        );
-    }
-    ensure!(seen.contains(&0), "missing invariant master worker output");
+    ensure_worker_ids_are_valid(outputs)?;
 
-    ensure!(
-        spec.total_runs > 0 || outputs.len() == 1,
-        "invariant worker outputs do not cover the logical campaign"
-    );
+    if spec.total_runs == 0 {
+        ensure!(
+            outputs.len() == 1
+                && outputs[0].plan.first_global_run == 0
+                && outputs[0].plan.runs == 0,
+            "invariant worker outputs do not cover the logical campaign"
+        );
+        return Ok(());
+    }
 
     let mut next_global_run = 0;
     for output in outputs {
-        ensure!(
-            spec.total_runs == 0 || output.plan.runs > 0,
-            "invariant worker outputs do not cover the logical campaign"
-        );
+        ensure!(output.plan.runs > 0, "invariant worker outputs do not cover the logical campaign");
         ensure!(
             output.plan.first_global_run == next_global_run,
             "invariant worker outputs do not cover the logical campaign"
@@ -190,6 +193,20 @@ fn ensure_outputs_cover_campaign(
         next_global_run == spec.total_runs,
         "invariant worker outputs do not cover the logical campaign"
     );
+    Ok(())
+}
+
+fn ensure_worker_ids_are_valid(outputs: &[InvariantWorkerOutput]) -> Result<()> {
+    let mut seen = HashSet::with_capacity(outputs.len());
+    for output in outputs {
+        ensure!(
+            seen.insert(output.plan.worker_id),
+            "duplicate invariant worker output for worker {}",
+            output.plan.worker_id
+        );
+    }
+
+    ensure!(seen.contains(&0), "missing invariant master worker output");
     Ok(())
 }
 
@@ -348,59 +365,68 @@ mod tests {
         })
     }
 
-    fn plan(worker_id: u32, first_global_run: u32, runs: u32) -> InvariantWorkerPlan {
-        InvariantWorkerPlan { worker_id, first_global_run, runs }
-    }
-
-    fn worker(plan: InvariantWorkerPlan, result: InvariantFuzzTestResult) -> InvariantWorkerOutput {
-        InvariantWorkerOutput { plan, result }
-    }
-
-    fn finish(
-        total_runs: u32,
-        outputs: impl IntoIterator<Item = InvariantWorkerOutput>,
-    ) -> Result<InvariantFuzzTestResult> {
-        let mut aggregator =
-            InvariantCampaignAggregator::new(InvariantCampaignSpec::new(total_runs));
-        for output in outputs {
-            aggregator.push(output);
-        }
-        aggregator.finish()
+    fn one_worker_plan(total_runs: u32) -> InvariantWorkerPlan {
+        let mut plans = InvariantCampaignSpec::new(total_runs).worker_plans(1).unwrap();
+        assert_eq!(plans.len(), 1);
+        plans.pop().unwrap()
     }
 
     #[test]
     fn worker_plans_cover_logical_campaign_with_one_worker() {
-        let plans = InvariantCampaignSpec::new(3).worker_plans(1).unwrap();
+        let plan = one_worker_plan(3);
 
-        assert_eq!(plans, vec![plan(0, 0, 3)]);
+        assert_eq!(plan.worker_id, 0);
+        assert_eq!(plan.first_global_run, 0);
+        assert_eq!(plan.runs, 3);
     }
 
     #[test]
     fn worker_plans_split_runs_evenly() {
         let plans = InvariantCampaignSpec::new(100).worker_plans(4).unwrap();
 
-        assert_eq!(plans, vec![plan(0, 0, 25), plan(1, 25, 25), plan(2, 50, 25), plan(3, 75, 25),]);
+        assert_eq!(
+            plans,
+            vec![
+                InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 25 },
+                InvariantWorkerPlan { worker_id: 1, first_global_run: 25, runs: 25 },
+                InvariantWorkerPlan { worker_id: 2, first_global_run: 50, runs: 25 },
+                InvariantWorkerPlan { worker_id: 3, first_global_run: 75, runs: 25 },
+            ]
+        );
     }
 
     #[test]
     fn worker_plans_distribute_remainder_to_earlier_workers() {
         let plans = InvariantCampaignSpec::new(10).worker_plans(3).unwrap();
 
-        assert_eq!(plans, vec![plan(0, 0, 4), plan(1, 4, 3), plan(2, 7, 3)]);
+        assert_eq!(
+            plans,
+            vec![
+                InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 4 },
+                InvariantWorkerPlan { worker_id: 1, first_global_run: 4, runs: 3 },
+                InvariantWorkerPlan { worker_id: 2, first_global_run: 7, runs: 3 },
+            ]
+        );
     }
 
     #[test]
     fn worker_plans_do_not_create_empty_workers_when_runs_are_available() {
         let plans = InvariantCampaignSpec::new(2).worker_plans(8).unwrap();
 
-        assert_eq!(plans, vec![plan(0, 0, 1), plan(1, 1, 1)]);
+        assert_eq!(
+            plans,
+            vec![
+                InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+                InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+            ]
+        );
     }
 
     #[test]
     fn worker_plans_keep_zero_run_campaign_as_single_empty_plan() {
         let plans = InvariantCampaignSpec::new(0).worker_plans(4).unwrap();
 
-        assert_eq!(plans, vec![plan(0, 0, 0)]);
+        assert_eq!(plans, vec![InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 }]);
     }
 
     #[test]
@@ -414,7 +440,12 @@ mod tests {
 
     #[test]
     fn aggregator_returns_single_worker_result_without_rewriting() {
-        let result = finish(1, [worker(plan(0, 0, 1), empty_result(2, 3))]).unwrap();
+        let spec = InvariantCampaignSpec::new(1);
+        let worker = InvariantWorkerOutput::new(one_worker_plan(1), empty_result(2, 3));
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(worker);
+        let result = aggregator.finish().unwrap();
 
         assert_eq!(result.reverts, 2);
         assert_eq!(result.failed_corpus_replays, 3);
@@ -422,57 +453,67 @@ mod tests {
 
     #[test]
     fn aggregator_accepts_single_worker_output_for_zero_run_campaign() {
-        let result = finish(0, [worker(plan(0, 0, 0), empty_result(0, 0))]).unwrap();
+        let spec = InvariantCampaignSpec::new(0);
+        let worker = InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 },
+            empty_result(0, 0),
+        );
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(worker);
+        let result = aggregator.finish().unwrap();
 
         assert_eq!(result.reverts, 0);
     }
 
     #[test]
     fn aggregator_merges_multiple_worker_outputs_in_logical_run_order() {
-        let plans = [plan(0, 0, 1), plan(1, 1, 1), plan(2, 2, 1)];
+        let spec = InvariantCampaignSpec::new(3);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+            InvariantWorkerPlan { worker_id: 2, first_global_run: 2, runs: 1 },
+        ];
 
-        let result = finish(
-            3,
-            [
-                worker(
-                    plans[2],
-                    worker_result(
-                        30,
-                        3,
-                        0x30,
-                        "transfer(address)",
-                        InvariantMetrics { calls: 3, reverts: 1, discards: 0 },
-                        3,
-                        0,
-                    ),
-                ),
-                worker(
-                    plans[0],
-                    worker_result(
-                        10,
-                        1,
-                        0x10,
-                        "transfer(address)",
-                        InvariantMetrics { calls: 1, reverts: 0, discards: 2 },
-                        1,
-                        4,
-                    ),
-                ),
-                worker(
-                    plans[1],
-                    worker_result(
-                        20,
-                        2,
-                        0x20,
-                        "approve(address)",
-                        InvariantMetrics { calls: 2, reverts: 1, discards: 1 },
-                        2,
-                        0,
-                    ),
-                ),
-            ],
-        )
-        .unwrap();
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(
+            plans[2],
+            worker_result(
+                30,
+                3,
+                0x30,
+                "transfer(address)",
+                InvariantMetrics { calls: 3, reverts: 1, discards: 0 },
+                3,
+                0,
+            ),
+        ));
+        aggregator.push(InvariantWorkerOutput::new(
+            plans[0],
+            worker_result(
+                10,
+                1,
+                0x10,
+                "transfer(address)",
+                InvariantMetrics { calls: 1, reverts: 0, discards: 2 },
+                1,
+                4,
+            ),
+        ));
+        aggregator.push(InvariantWorkerOutput::new(
+            plans[1],
+            worker_result(
+                20,
+                2,
+                0x20,
+                "approve(address)",
+                InvariantMetrics { calls: 2, reverts: 1, discards: 1 },
+                2,
+                0,
+            ),
+        ));
+
+        let result = aggregator.finish().unwrap();
 
         let merged_case_gas =
             result.cases.iter().map(|cases| cases.last().unwrap().gas).collect::<Vec<_>>();
@@ -493,13 +534,20 @@ mod tests {
 
     #[test]
     fn aggregator_keeps_earlier_predicate_failure_for_each_invariant() {
-        let plans = [plan(0, 0, 1), plan(1, 1, 1)];
+        let spec = InvariantCampaignSpec::new(2);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+        ];
         let mut earlier = empty_result(0, 0);
         earlier.errors.insert("invariant_balance".to_string(), predicate_error("earlier", 3));
         let mut later = empty_result(0, 0);
         later.errors.insert("invariant_balance".to_string(), predicate_error("later", 1));
 
-        let result = finish(2, [worker(plans[1], later), worker(plans[0], earlier)]).unwrap();
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[1], later));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], earlier));
+        let result = aggregator.finish().unwrap();
 
         assert_eq!(result.errors.len(), 1);
         assert_eq!(result.errors["invariant_balance"].revert_reason().as_deref(), Some("earlier"));
@@ -507,14 +555,21 @@ mod tests {
 
     #[test]
     fn aggregator_dedupes_handler_assertions_by_site_and_keeps_shorter_sequence() {
-        let plans = [plan(0, 0, 1), plan(1, 1, 1)];
+        let spec = InvariantCampaignSpec::new(2);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+        ];
         let site = (Address::repeat_byte(0xaa), Selector::from([1, 2, 3, 4]));
         let mut longer = empty_result(0, 0);
         longer.handler_errors.insert(site, handler_error(site.0, site.1, 4, "longer"));
         let mut shorter = empty_result(0, 0);
         shorter.handler_errors.insert(site, handler_error(site.0, site.1, 2, "shorter"));
 
-        let result = finish(2, [worker(plans[1], shorter), worker(plans[0], longer)]).unwrap();
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[1], shorter));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], longer));
+        let result = aggregator.finish().unwrap();
 
         let failure = result.handler_errors[&site].as_handler_assertion().unwrap();
         assert_eq!(result.handler_errors.len(), 1);
@@ -524,14 +579,21 @@ mod tests {
 
     #[test]
     fn aggregator_keeps_earlier_handler_assertion_when_lengths_tie() {
-        let plans = [plan(0, 0, 1), plan(1, 1, 1)];
+        let spec = InvariantCampaignSpec::new(2);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+        ];
         let site = (Address::repeat_byte(0xaa), Selector::from([1, 2, 3, 4]));
         let mut earlier = empty_result(0, 0);
         earlier.handler_errors.insert(site, handler_error(site.0, site.1, 2, "earlier"));
         let mut later = empty_result(0, 0);
         later.handler_errors.insert(site, handler_error(site.0, site.1, 2, "later"));
 
-        let result = finish(2, [worker(plans[1], later), worker(plans[0], earlier)]).unwrap();
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[1], later));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], earlier));
+        let result = aggregator.finish().unwrap();
 
         let failure = result.handler_errors[&site].as_handler_assertion().unwrap();
         assert_eq!(result.handler_errors.len(), 1);
@@ -541,13 +603,20 @@ mod tests {
 
     #[test]
     fn aggregator_keeps_distinct_predicate_failures() {
-        let plans = [plan(0, 0, 1), plan(1, 1, 1)];
+        let spec = InvariantCampaignSpec::new(2);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+        ];
         let mut earlier = empty_result(0, 0);
         earlier.errors.insert("invariant_a".to_string(), predicate_error("a", 3));
         let mut later = empty_result(0, 0);
         later.errors.insert("invariant_b".to_string(), predicate_error("b", 2));
 
-        let result = finish(2, [worker(plans[1], later), worker(plans[0], earlier)]).unwrap();
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[1], later));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], earlier));
+        let result = aggregator.finish().unwrap();
 
         assert_eq!(result.errors.len(), 2);
         assert_eq!(result.errors["invariant_a"].revert_reason().as_deref(), Some("a"));
@@ -556,7 +625,12 @@ mod tests {
 
     #[test]
     fn aggregator_keeps_first_max_optimization_value_on_tie() {
-        let plans = [plan(0, 0, 1), plan(1, 1, 1), plan(2, 2, 1)];
+        let spec = InvariantCampaignSpec::new(3);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+            InvariantWorkerPlan { worker_id: 2, first_global_run: 2, runs: 1 },
+        ];
         let mut first = empty_result(0, 0);
         first.optimization_best_value = Some(I256::try_from(7).unwrap());
         first.optimization_best_sequence = sequence(1, 0x10);
@@ -567,11 +641,11 @@ mod tests {
         later_tie.optimization_best_value = Some(I256::try_from(9).unwrap());
         later_tie.optimization_best_sequence = sequence(1, 0x30);
 
-        let result = finish(
-            3,
-            [worker(plans[2], later_tie), worker(plans[0], first), worker(plans[1], earlier_best)],
-        )
-        .unwrap();
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[2], later_tie));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], first));
+        aggregator.push(InvariantWorkerOutput::new(plans[1], earlier_best));
+        let result = aggregator.finish().unwrap();
 
         assert_eq!(result.optimization_best_value, Some(I256::try_from(9).unwrap()));
         assert_eq!(result.optimization_best_sequence[0].sender, Address::repeat_byte(0x20));
@@ -579,73 +653,117 @@ mod tests {
 
     #[test]
     fn aggregator_rejects_overlapping_outputs() {
-        let err = finish(
-            1,
-            [worker(plan(0, 0, 1), empty_result(0, 0)), worker(plan(1, 0, 1), empty_result(0, 0))],
-        )
-        .unwrap_err();
+        let spec = InvariantCampaignSpec::new(1);
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            empty_result(0, 0),
+        ));
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 0, runs: 1 },
+            empty_result(0, 0),
+        ));
+        let err = aggregator.finish().unwrap_err();
 
         assert!(err.to_string().contains("do not cover the logical campaign"));
     }
 
     #[test]
     fn aggregator_rejects_duplicate_worker_ids() {
-        let err = finish(
-            2,
-            [worker(plan(0, 0, 1), empty_result(0, 0)), worker(plan(0, 1, 1), empty_result(0, 0))],
-        )
-        .unwrap_err();
+        let spec = InvariantCampaignSpec::new(2);
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            empty_result(0, 0),
+        ));
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 1, runs: 1 },
+            empty_result(0, 0),
+        ));
+        let err = aggregator.finish().unwrap_err();
 
         assert!(err.to_string().contains("duplicate invariant worker output"));
     }
 
     #[test]
     fn aggregator_allows_non_dense_worker_ids_with_contiguous_ranges() {
-        let result = finish(
-            2,
-            [worker(plan(0, 0, 1), empty_result(0, 0)), worker(plan(2, 1, 1), empty_result(2, 0))],
-        )
-        .unwrap();
+        let spec = InvariantCampaignSpec::new(2);
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            empty_result(0, 0),
+        ));
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 2, first_global_run: 1, runs: 1 },
+            empty_result(2, 0),
+        ));
+        let result = aggregator.finish().unwrap();
 
         assert_eq!(result.reverts, 2);
     }
 
     #[test]
     fn aggregator_rejects_missing_master_worker() {
-        let err = finish(
-            2,
-            [worker(plan(1, 0, 1), empty_result(0, 0)), worker(plan(2, 1, 1), empty_result(0, 0))],
-        )
-        .unwrap_err();
+        let spec = InvariantCampaignSpec::new(2);
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 0, runs: 1 },
+            empty_result(0, 0),
+        ));
+        aggregator.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 2, first_global_run: 1, runs: 1 },
+            empty_result(0, 0),
+        ));
+        let err = aggregator.finish().unwrap_err();
 
         assert!(err.to_string().contains("missing invariant master worker output"));
     }
 
     #[test]
     fn aggregator_ignores_failed_corpus_replays_from_non_master_worker() {
-        let plans = [plan(0, 0, 1), plan(1, 1, 1)];
+        let spec = InvariantCampaignSpec::new(2);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
+        ];
 
-        let result =
-            finish(2, [worker(plans[0], empty_result(0, 7)), worker(plans[1], empty_result(0, 1))])
-                .unwrap();
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[0], empty_result(0, 7)));
+        aggregator.push(InvariantWorkerOutput::new(plans[1], empty_result(0, 1)));
+        let result = aggregator.finish().unwrap();
 
         assert_eq!(result.failed_corpus_replays, 7);
     }
 
     #[test]
     fn aggregator_takes_failed_corpus_replays_from_master_worker() {
-        let plans = [plan(1, 0, 1), plan(0, 1, 1)];
+        let spec = InvariantCampaignSpec::new(2);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 1, runs: 1 },
+        ];
 
-        let result =
-            finish(2, [worker(plans[0], empty_result(0, 0)), worker(plans[1], empty_result(0, 7))])
-                .unwrap();
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[0], empty_result(0, 0)));
+        aggregator.push(InvariantWorkerOutput::new(plans[1], empty_result(0, 7)));
+        let result = aggregator.finish().unwrap();
 
         assert_eq!(result.failed_corpus_replays, 7);
     }
 
     #[test]
     fn aggregator_rejects_plan_that_does_not_cover_campaign() {
-        let err = finish(2, [worker(plan(0, 0, 1), empty_result(0, 0))]).unwrap_err();
+        let spec = InvariantCampaignSpec::new(2);
+        let plan = InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 };
+        let worker = InvariantWorkerOutput::new(plan, empty_result(0, 0));
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(worker);
+        let err = aggregator.finish().unwrap_err();
 
         assert!(err.to_string().contains("do not cover the logical campaign"));
     }

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -1,5 +1,5 @@
 use super::{InvariantFuzzError, InvariantFuzzTestResult, InvariantMetrics};
-use crate::executors::{EarlyExit, FuzzTestTimer, corpus::CorpusCampaignInput};
+use crate::executors::{EarlyExit, FuzzTestTimer, corpus::CampaignCorpusEntry};
 use alloy_primitives::{Address, I256, Selector};
 use eyre::{Result, ensure};
 use foundry_evm_coverage::HitMaps;
@@ -101,13 +101,13 @@ impl InvariantCampaignState {
 pub struct InvariantWorkerOutput {
     pub plan: InvariantWorkerPlan,
     pub result: InvariantFuzzTestResult,
-    pub corpus_inputs: Vec<CorpusCampaignInput>,
+    pub corpus_entries: Vec<CampaignCorpusEntry>,
 }
 
 impl InvariantWorkerOutput {
     #[cfg(test)]
     pub fn new(plan: InvariantWorkerPlan, result: InvariantFuzzTestResult) -> Self {
-        Self { plan, result, corpus_inputs: Vec::new() }
+        Self { plan, result, corpus_entries: Vec::new() }
     }
 }
 
@@ -140,14 +140,14 @@ impl InvariantCampaignAggregator {
     /// Validates the collected worker ranges and folds them into one logical campaign result.
     #[cfg(test)]
     pub fn finish(self) -> Result<InvariantFuzzTestResult> {
-        Ok(self.finish_with_corpus()?.0)
+        Ok(self.finish_with_corpus_entries()?.0)
     }
 
     /// Validates the collected worker ranges and folds them into one logical campaign result with
-    /// campaign-level corpus artifacts selected in logical worker order.
-    pub fn finish_with_corpus(
+    /// corpus artifacts selected in logical worker order.
+    pub fn finish_with_corpus_entries(
         mut self,
-    ) -> Result<(InvariantFuzzTestResult, Vec<CorpusCampaignInput>)> {
+    ) -> Result<(InvariantFuzzTestResult, Vec<CampaignCorpusEntry>)> {
         ensure!(!self.outputs.is_empty(), "missing invariant worker output");
 
         self.outputs.sort_by_key(|output| output.plan.first_global_run);
@@ -161,7 +161,7 @@ impl InvariantCampaignAggregator {
         let mut gas_report_traces = Vec::new();
         let mut line_coverage = None;
         let mut metrics = HashMap::default();
-        let mut corpus_inputs = Vec::new();
+        let mut corpus_entries = Vec::new();
         let failed_corpus_replays = self
             .outputs
             .iter()
@@ -171,12 +171,12 @@ impl InvariantCampaignAggregator {
             .failed_corpus_replays;
         let mut optimization_best = None;
 
-        for InvariantWorkerOutput { result, corpus_inputs: worker_inputs, .. } in self.outputs {
+        for InvariantWorkerOutput { result, corpus_entries: worker_entries, .. } in self.outputs {
             for (invariant, error) in result.errors {
                 errors.entry(invariant).or_insert(error);
             }
             merge_handler_errors(&mut handler_errors, result.handler_errors);
-            corpus_inputs.extend(worker_inputs);
+            corpus_entries.extend(worker_entries);
             cases.extend(result.cases);
             reverts += result.reverts;
             last_run_inputs = result.last_run_inputs;
@@ -205,7 +205,7 @@ impl InvariantCampaignAggregator {
                 optimization_best_value,
                 optimization_best_sequence,
             ),
-            corpus_inputs,
+            corpus_entries,
         ))
     }
 }
@@ -779,7 +779,7 @@ mod tests {
     }
 
     #[test]
-    fn aggregator_ignores_failed_corpus_replays_from_non_master_worker() {
+    fn aggregator_uses_master_failed_corpus_replays() {
         let spec = InvariantCampaignSpec::new(2);
         let plans = [
             InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
@@ -795,7 +795,7 @@ mod tests {
     }
 
     #[test]
-    fn aggregator_takes_failed_corpus_replays_from_master_worker() {
+    fn aggregator_uses_master_failed_corpus_replays_independent_of_output_order() {
         let spec = InvariantCampaignSpec::new(2);
         let plans = [
             InvariantWorkerPlan { worker_id: 1, first_global_run: 0, runs: 1 },

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -60,6 +60,18 @@ pub struct InvariantWorkerPlan {
     pub runs: u32,
 }
 
+impl InvariantWorkerPlan {
+    pub const MASTER_WORKER_ID: u32 = 0;
+
+    pub const fn is_master(self) -> bool {
+        self.worker_id == Self::MASTER_WORKER_ID
+    }
+
+    pub const fn worker_index(self) -> usize {
+        self.worker_id as usize
+    }
+}
+
 /// Output produced by one invariant worker.
 ///
 /// This is a data envelope for aggregation only. It does not imply that this module executed the
@@ -389,6 +401,8 @@ mod tests {
         assert_eq!(plan.worker_id, 0);
         assert_eq!(plan.first_global_run, 0);
         assert_eq!(plan.runs, 3);
+        assert!(plan.is_master());
+        assert_eq!(plan.worker_index(), 0);
     }
 
     #[test]
@@ -404,6 +418,9 @@ mod tests {
                 InvariantWorkerPlan { worker_id: 3, first_global_run: 75, runs: 25 },
             ]
         );
+        assert!(plans[0].is_master());
+        assert!(!plans[1].is_master());
+        assert_eq!(plans[3].worker_index(), 3);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -113,11 +113,6 @@ impl InvariantCampaignAggregator {
         for InvariantWorkerOutput { plan, result } in self.outputs {
             if plan.worker_id == 0 {
                 failed_corpus_replays = result.failed_corpus_replays;
-            } else {
-                ensure!(
-                    result.failed_corpus_replays == 0,
-                    "non-master invariant worker reported failed corpus replays"
-                );
             }
             for (invariant, error) in result.errors {
                 errors.entry(invariant).or_insert(error);
@@ -623,14 +618,14 @@ mod tests {
     }
 
     #[test]
-    fn aggregator_rejects_failed_corpus_replays_from_non_master_worker() {
+    fn aggregator_ignores_failed_corpus_replays_from_non_master_worker() {
         let plans = [plan(0, 0, 1), plan(1, 1, 1)];
 
-        let err =
-            finish(2, [worker(plans[0], empty_result(0, 0)), worker(plans[1], empty_result(0, 1))])
-                .unwrap_err();
+        let result =
+            finish(2, [worker(plans[0], empty_result(0, 7)), worker(plans[1], empty_result(0, 1))])
+                .unwrap();
 
-        assert!(err.to_string().contains("non-master invariant worker reported"));
+        assert_eq!(result.failed_corpus_replays, 7);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -27,7 +27,11 @@ impl InvariantCampaignSpec {
     pub fn worker_plans(self, workers: usize) -> Result<Vec<InvariantWorkerPlan>> {
         ensure!(workers > 0, "invariant campaign requires at least one worker");
 
-        let worker_count = workers.min(self.total_runs.max(1) as usize) as u32;
+        if self.total_runs == 0 {
+            return Ok(vec![InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 }]);
+        }
+
+        let worker_count = workers.min(self.total_runs as usize) as u32;
         let base_runs = self.total_runs / worker_count;
         let extra_runs = self.total_runs % worker_count;
 

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -1,5 +1,5 @@
 use super::{InvariantFuzzError, InvariantFuzzTestResult, InvariantMetrics};
-use crate::executors::{EarlyExit, FuzzTestTimer, corpus::CorpusCampaignOutput};
+use crate::executors::{EarlyExit, FuzzTestTimer, corpus::CorpusCampaignInput};
 use alloy_primitives::{Address, I256, Selector};
 use eyre::{Result, ensure};
 use foundry_evm_coverage::HitMaps;
@@ -101,21 +101,13 @@ impl InvariantCampaignState {
 pub struct InvariantWorkerOutput {
     pub plan: InvariantWorkerPlan,
     pub result: InvariantFuzzTestResult,
-    pub corpus: CorpusCampaignOutput,
+    pub corpus_inputs: Vec<CorpusCampaignInput>,
 }
 
 impl InvariantWorkerOutput {
     #[cfg(test)]
     pub fn new(plan: InvariantWorkerPlan, result: InvariantFuzzTestResult) -> Self {
-        Self { plan, result, corpus: CorpusCampaignOutput::default() }
-    }
-
-    pub const fn new_with_corpus(
-        plan: InvariantWorkerPlan,
-        result: InvariantFuzzTestResult,
-        corpus: CorpusCampaignOutput,
-    ) -> Self {
-        Self { plan, result, corpus }
+        Self { plan, result, corpus_inputs: Vec::new() }
     }
 }
 
@@ -148,12 +140,14 @@ impl InvariantCampaignAggregator {
     /// Validates the collected worker ranges and folds them into one logical campaign result.
     #[cfg(test)]
     pub fn finish(self) -> Result<InvariantFuzzTestResult> {
-        Ok(self.finish_with_corpus()?.result)
+        Ok(self.finish_with_corpus()?.0)
     }
 
     /// Validates the collected worker ranges and folds them into one logical campaign result with
     /// campaign-level corpus artifacts selected in logical worker order.
-    pub fn finish_with_corpus(mut self) -> Result<InvariantCampaignOutput> {
+    pub fn finish_with_corpus(
+        mut self,
+    ) -> Result<(InvariantFuzzTestResult, Vec<CorpusCampaignInput>)> {
         ensure!(!self.outputs.is_empty(), "missing invariant worker output");
 
         self.outputs.sort_by_key(|output| output.plan.first_global_run);
@@ -167,7 +161,7 @@ impl InvariantCampaignAggregator {
         let mut gas_report_traces = Vec::new();
         let mut line_coverage = None;
         let mut metrics = HashMap::default();
-        let mut corpus = CorpusCampaignOutput::default();
+        let mut corpus_inputs = Vec::new();
         let failed_corpus_replays = self
             .outputs
             .iter()
@@ -177,16 +171,12 @@ impl InvariantCampaignAggregator {
             .failed_corpus_replays;
         let mut optimization_best = None;
 
-        for InvariantWorkerOutput { result, corpus: worker_corpus, .. } in self.outputs {
+        for InvariantWorkerOutput { result, corpus_inputs: worker_inputs, .. } in self.outputs {
             for (invariant, error) in result.errors {
                 errors.entry(invariant).or_insert(error);
             }
             merge_handler_errors(&mut handler_errors, result.handler_errors);
-            corpus.inputs.extend(worker_corpus.inputs);
-            corpus.merge_optimization(
-                worker_corpus.optimization_best_value,
-                worker_corpus.optimization_best_sequence,
-            );
+            corpus_inputs.extend(worker_inputs);
             cases.extend(result.cases);
             reverts += result.reverts;
             last_run_inputs = result.last_run_inputs;
@@ -201,32 +191,23 @@ impl InvariantCampaignAggregator {
         }
         let (optimization_best_value, optimization_best_sequence) =
             optimization_best.map(|(value, sequence)| (Some(value), sequence)).unwrap_or_default();
-        let result = InvariantFuzzTestResult::new(
-            errors,
-            handler_errors,
-            cases,
-            reverts,
-            last_run_inputs,
-            gas_report_traces,
-            line_coverage,
-            metrics,
-            failed_corpus_replays,
-            optimization_best_value,
-            optimization_best_sequence,
-        );
-        corpus.merge_optimization(
-            result.optimization_best_value,
-            result.optimization_best_sequence.clone(),
-        );
-        Ok(InvariantCampaignOutput { result, corpus })
+        Ok((
+            InvariantFuzzTestResult::new(
+                errors,
+                handler_errors,
+                cases,
+                reverts,
+                last_run_inputs,
+                gas_report_traces,
+                line_coverage,
+                metrics,
+                failed_corpus_replays,
+                optimization_best_value,
+                optimization_best_sequence,
+            ),
+            corpus_inputs,
+        ))
     }
-}
-
-/// Logical campaign result plus artifacts that must be persisted only after worker merge.
-#[derive(Debug)]
-pub struct InvariantCampaignOutput {
-    pub result: InvariantFuzzTestResult,
-    pub corpus: CorpusCampaignOutput,
 }
 
 fn ensure_outputs_cover_campaign(

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -74,7 +74,7 @@ pub struct InvariantWorkerPlan {
 /// Shared state used only to coordinate invariant worker execution.
 pub struct InvariantCampaignState {
     started_at: Instant,
-    timeout: Option<(Instant, Duration)>,
+    timeout: Option<Duration>,
     total_runs: AtomicU32,
     total_txs: AtomicU64,
     total_gas: AtomicU64,
@@ -95,7 +95,7 @@ impl InvariantCampaignState {
         let started_at = Instant::now();
         Self {
             started_at,
-            timeout: timeout.map(|timeout| (started_at, Duration::from_secs(timeout.into()))),
+            timeout: timeout.map(|timeout| Duration::from_secs(timeout.into())),
             total_runs: AtomicU32::new(0),
             total_txs: AtomicU64::new(0),
             total_gas: AtomicU64::new(0),
@@ -133,7 +133,7 @@ impl InvariantCampaignState {
     }
 
     pub fn is_timed_out(&self) -> bool {
-        self.timeout.is_some_and(|(start, duration)| start.elapsed() > duration)
+        self.timeout.is_some_and(|duration| self.elapsed() > duration)
     }
 
     pub fn should_stop(&self) -> bool {
@@ -280,15 +280,13 @@ fn fold_outputs(
     let mut line_coverage = None;
     let mut metrics = HashMap::default();
     let mut corpus_entries = Vec::new();
-    let failed_corpus_replays = outputs
-        .iter()
-        .find(|output| output.plan.worker_id == 0)
-        .expect("master worker output was validated")
-        .result
-        .failed_corpus_replays;
+    let mut failed_corpus_replays = 0;
     let mut optimization_best = None;
 
-    for InvariantWorkerOutput { result, corpus_entries: worker_entries, .. } in outputs {
+    for InvariantWorkerOutput { plan, result, corpus_entries: worker_entries } in outputs {
+        if plan.worker_id == 0 {
+            failed_corpus_replays = result.failed_corpus_replays;
+        }
         for (invariant, error) in result.errors {
             errors.entry(invariant).or_insert(error);
         }

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -1,9 +1,13 @@
 use super::{InvariantFuzzError, InvariantFuzzTestResult, InvariantMetrics};
+use crate::executors::{EarlyExit, FuzzTestTimer, corpus::CorpusCampaignOutput};
 use alloy_primitives::{Address, I256, Selector};
 use eyre::{Result, ensure};
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::BasicTxDetails;
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::atomic::{AtomicU32, Ordering},
+};
 
 /// Immutable plan-level description for an invariant campaign.
 ///
@@ -60,6 +64,35 @@ pub struct InvariantWorkerPlan {
     pub runs: u32,
 }
 
+/// Shared state used only to coordinate invariant worker execution.
+pub struct InvariantCampaignState {
+    total_runs: AtomicU32,
+    global_early_exit: EarlyExit,
+    timer: FuzzTestTimer,
+}
+
+impl InvariantCampaignState {
+    pub fn new(timeout: Option<u32>, early_exit: EarlyExit) -> Self {
+        Self {
+            total_runs: AtomicU32::new(0),
+            global_early_exit: early_exit,
+            timer: FuzzTestTimer::new(timeout),
+        }
+    }
+
+    pub fn increment_runs(&self) -> u32 {
+        self.total_runs.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    pub fn should_continue(&self) -> bool {
+        !(self.global_early_exit.should_stop() || self.timer.is_timed_out())
+    }
+
+    pub const fn is_timed_campaign(&self) -> bool {
+        self.timer.is_enabled()
+    }
+}
+
 /// Output produced by one invariant worker.
 ///
 /// This is a data envelope for aggregation only. It does not imply that this module executed the
@@ -68,11 +101,21 @@ pub struct InvariantWorkerPlan {
 pub struct InvariantWorkerOutput {
     pub plan: InvariantWorkerPlan,
     pub result: InvariantFuzzTestResult,
+    pub corpus: CorpusCampaignOutput,
 }
 
 impl InvariantWorkerOutput {
-    pub const fn new(plan: InvariantWorkerPlan, result: InvariantFuzzTestResult) -> Self {
-        Self { plan, result }
+    #[cfg(test)]
+    pub fn new(plan: InvariantWorkerPlan, result: InvariantFuzzTestResult) -> Self {
+        Self { plan, result, corpus: CorpusCampaignOutput::default() }
+    }
+
+    pub const fn new_with_corpus(
+        plan: InvariantWorkerPlan,
+        result: InvariantFuzzTestResult,
+        corpus: CorpusCampaignOutput,
+    ) -> Self {
+        Self { plan, result, corpus }
     }
 }
 
@@ -103,7 +146,14 @@ impl InvariantCampaignAggregator {
     }
 
     /// Validates the collected worker ranges and folds them into one logical campaign result.
-    pub fn finish(mut self) -> Result<InvariantFuzzTestResult> {
+    #[cfg(test)]
+    pub fn finish(self) -> Result<InvariantFuzzTestResult> {
+        Ok(self.finish_with_corpus()?.result)
+    }
+
+    /// Validates the collected worker ranges and folds them into one logical campaign result with
+    /// campaign-level corpus artifacts selected in logical worker order.
+    pub fn finish_with_corpus(mut self) -> Result<InvariantCampaignOutput> {
         ensure!(!self.outputs.is_empty(), "missing invariant worker output");
 
         self.outputs.sort_by_key(|output| output.plan.first_global_run);
@@ -117,6 +167,7 @@ impl InvariantCampaignAggregator {
         let mut gas_report_traces = Vec::new();
         let mut line_coverage = None;
         let mut metrics = HashMap::default();
+        let mut corpus = CorpusCampaignOutput::default();
         let failed_corpus_replays = self
             .outputs
             .iter()
@@ -126,11 +177,16 @@ impl InvariantCampaignAggregator {
             .failed_corpus_replays;
         let mut optimization_best = None;
 
-        for InvariantWorkerOutput { result, .. } in self.outputs {
+        for InvariantWorkerOutput { result, corpus: worker_corpus, .. } in self.outputs {
             for (invariant, error) in result.errors {
                 errors.entry(invariant).or_insert(error);
             }
             merge_handler_errors(&mut handler_errors, result.handler_errors);
+            corpus.inputs.extend(worker_corpus.inputs);
+            corpus.merge_optimization(
+                worker_corpus.optimization_best_value,
+                worker_corpus.optimization_best_sequence,
+            );
             cases.extend(result.cases);
             reverts += result.reverts;
             last_run_inputs = result.last_run_inputs;
@@ -145,7 +201,7 @@ impl InvariantCampaignAggregator {
         }
         let (optimization_best_value, optimization_best_sequence) =
             optimization_best.map(|(value, sequence)| (Some(value), sequence)).unwrap_or_default();
-        Ok(InvariantFuzzTestResult::new(
+        let result = InvariantFuzzTestResult::new(
             errors,
             handler_errors,
             cases,
@@ -157,8 +213,20 @@ impl InvariantCampaignAggregator {
             failed_corpus_replays,
             optimization_best_value,
             optimization_best_sequence,
-        ))
+        );
+        corpus.merge_optimization(
+            result.optimization_best_value,
+            result.optimization_best_sequence.clone(),
+        );
+        Ok(InvariantCampaignOutput { result, corpus })
     }
+}
+
+/// Logical campaign result plus artifacts that must be persisted only after worker merge.
+#[derive(Debug)]
+pub struct InvariantCampaignOutput {
+    pub result: InvariantFuzzTestResult,
+    pub corpus: CorpusCampaignOutput,
 }
 
 fn ensure_outputs_cover_campaign(
@@ -436,6 +504,12 @@ mod tests {
 
         let err = InvariantCampaignSpec::new(0).worker_plans(0).unwrap_err();
         assert!(err.to_string().contains("requires at least one worker"));
+    }
+
+    #[test]
+    fn campaign_state_reports_timed_campaigns() {
+        assert!(!InvariantCampaignState::new(None, EarlyExit::new(false)).is_timed_campaign());
+        assert!(InvariantCampaignState::new(Some(1), EarlyExit::new(false)).is_timed_campaign());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -1,4 +1,7 @@
-use super::{InvariantFuzzError, InvariantFuzzTestResult, InvariantMetrics};
+use super::{
+    FailureKey, InvariantFailureMetrics, InvariantFailures, InvariantFuzzError,
+    InvariantFuzzTestResult, InvariantMetrics,
+};
 use crate::executors::{EarlyExit, corpus::CampaignCorpusEntry};
 use alloy_primitives::{Address, I256, Selector};
 use eyre::{Result, ensure};
@@ -6,7 +9,11 @@ use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::BasicTxDetails;
 use std::{
     collections::{HashMap, HashSet},
-    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+    sync::{
+        Mutex,
+        atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
 };
 
 /// Immutable plan-level description for an invariant campaign.
@@ -66,17 +73,36 @@ pub struct InvariantWorkerPlan {
 
 /// Shared state used only to coordinate invariant worker execution.
 pub struct InvariantCampaignState {
+    started_at: Instant,
+    timeout: Option<(Instant, Duration)>,
     total_runs: AtomicU32,
+    total_txs: AtomicU64,
+    total_gas: AtomicU64,
     terminal_stop: AtomicBool,
     global_early_exit: EarlyExit,
+    last_metrics_report: Mutex<Instant>,
+    failure_metrics: Mutex<CampaignFailureMetrics>,
+}
+
+#[derive(Default)]
+struct CampaignFailureMetrics {
+    metrics: InvariantFailureMetrics,
+    handler_sites: HashSet<(Address, Selector)>,
 }
 
 impl InvariantCampaignState {
-    pub const fn new(early_exit: EarlyExit) -> Self {
+    pub fn new(early_exit: EarlyExit, timeout: Option<u32>) -> Self {
+        let started_at = Instant::now();
         Self {
+            started_at,
+            timeout: timeout.map(|timeout| (started_at, Duration::from_secs(timeout.into()))),
             total_runs: AtomicU32::new(0),
+            total_txs: AtomicU64::new(0),
+            total_gas: AtomicU64::new(0),
             terminal_stop: AtomicBool::new(false),
             global_early_exit: early_exit,
+            last_metrics_report: Mutex::new(started_at),
+            failure_metrics: Mutex::new(CampaignFailureMetrics::default()),
         }
     }
 
@@ -84,12 +110,78 @@ impl InvariantCampaignState {
         self.total_runs.fetch_add(1, Ordering::Relaxed) + 1
     }
 
+    #[cfg(test)]
+    pub fn total_runs(&self) -> u32 {
+        self.total_runs.load(Ordering::Relaxed)
+    }
+
+    pub fn record_call(&self, gas_used: u64) {
+        self.total_txs.fetch_add(1, Ordering::Relaxed);
+        self.total_gas.fetch_add(gas_used, Ordering::Relaxed);
+    }
+
+    pub fn throughput_totals(&self) -> (u64, u64) {
+        (self.total_txs.load(Ordering::Relaxed), self.total_gas.load(Ordering::Relaxed))
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        self.started_at.elapsed()
+    }
+
+    pub const fn is_timed_campaign(&self) -> bool {
+        self.timeout.is_some()
+    }
+
+    pub fn is_timed_out(&self) -> bool {
+        self.timeout.is_some_and(|(start, duration)| start.elapsed() > duration)
+    }
+
     pub fn should_stop(&self) -> bool {
-        self.global_early_exit.should_stop() || self.terminal_stop.load(Ordering::Relaxed)
+        self.global_early_exit.should_stop()
+            || self.terminal_stop.load(Ordering::Relaxed)
+            || self.is_timed_out()
     }
 
     pub fn request_terminal_stop(&self) {
         self.terminal_stop.store(true, Ordering::Relaxed);
+    }
+
+    pub fn should_emit_metrics_report(&self, interval: Duration) -> bool {
+        let mut last_report =
+            self.last_metrics_report.lock().expect("metrics report lock poisoned");
+        if last_report.elapsed() <= interval {
+            return false;
+        }
+
+        *last_report = Instant::now();
+        true
+    }
+
+    pub(super) fn record_invariant_failure(
+        &self,
+        invariant_name: &str,
+        target: &str,
+        reason: &str,
+    ) {
+        let mut failure_metrics =
+            self.failure_metrics.lock().expect("failure metrics lock poisoned");
+        if !failure_metrics.metrics.unique_failures.contains(invariant_name) {
+            failure_metrics.metrics.record_failure(invariant_name, target, reason);
+        }
+    }
+
+    pub(super) fn sync_handler_failures(&self, failures: &InvariantFailures) {
+        let mut failure_metrics =
+            self.failure_metrics.lock().expect("failure metrics lock poisoned");
+        for key in failures.failures.keys() {
+            let FailureKey::Handler(addr, selector) = key else { continue };
+            failure_metrics.handler_sites.insert((*addr, *selector));
+        }
+        failure_metrics.metrics.broken_handlers = failure_metrics.handler_sites.len();
+    }
+
+    pub(super) fn failure_metrics(&self) -> InvariantFailureMetrics {
+        self.failure_metrics.lock().expect("failure metrics lock poisoned").metrics.clone()
     }
 
     pub const fn early_exit(&self) -> &EarlyExit {
@@ -156,62 +248,84 @@ impl InvariantCampaignAggregator {
 
         self.outputs.sort_by_key(|output| output.plan.first_global_run);
         ensure_outputs_cover_campaign(self.spec, &self.outputs)?;
-
-        let mut errors = HashMap::default();
-        let mut handler_errors = HashMap::default();
-        let mut cases = Vec::new();
-        let mut reverts = 0;
-        let mut last_run_inputs = Vec::new();
-        let mut gas_report_traces = Vec::new();
-        let mut line_coverage = None;
-        let mut metrics = HashMap::default();
-        let mut corpus_entries = Vec::new();
-        let failed_corpus_replays = self
-            .outputs
-            .iter()
-            .find(|output| output.plan.worker_id == 0)
-            .expect("master worker output was validated")
-            .result
-            .failed_corpus_replays;
-        let mut optimization_best = None;
-
-        for InvariantWorkerOutput { result, corpus_entries: worker_entries, .. } in self.outputs {
-            for (invariant, error) in result.errors {
-                errors.entry(invariant).or_insert(error);
-            }
-            merge_handler_errors(&mut handler_errors, result.handler_errors);
-            corpus_entries.extend(worker_entries);
-            cases.extend(result.cases);
-            reverts += result.reverts;
-            last_run_inputs = result.last_run_inputs;
-            gas_report_traces.extend(result.gas_report_traces);
-            HitMaps::merge_opt(&mut line_coverage, result.line_coverage);
-            merge_metrics(&mut metrics, result.metrics);
-            merge_optimization(
-                &mut optimization_best,
-                result.optimization_best_value,
-                result.optimization_best_sequence,
-            );
-        }
-        let (optimization_best_value, optimization_best_sequence) =
-            optimization_best.map(|(value, sequence)| (Some(value), sequence)).unwrap_or_default();
-        Ok((
-            InvariantFuzzTestResult::new(
-                errors,
-                handler_errors,
-                cases,
-                reverts,
-                last_run_inputs,
-                gas_report_traces,
-                line_coverage,
-                metrics,
-                failed_corpus_replays,
-                optimization_best_value,
-                optimization_best_sequence,
-            ),
-            corpus_entries,
-        ))
+        fold_outputs(self.outputs)
     }
+
+    /// Folds timeout worker outputs without requiring full logical campaign coverage.
+    ///
+    /// Timeout campaigns share a wall-clock deadline across workers. When the deadline hits, any
+    /// worker may have completed fewer than its assigned runs, so the original static ranges can
+    /// contain gaps. The merge still validates worker identity and preserves deterministic worker
+    /// order, but final run count is derived from the completed cases.
+    pub fn finish_partial_with_corpus_entries(
+        mut self,
+    ) -> Result<(InvariantFuzzTestResult, Vec<CampaignCorpusEntry>)> {
+        ensure!(!self.outputs.is_empty(), "missing invariant worker output");
+
+        self.outputs.sort_by_key(|output| output.plan.first_global_run);
+        ensure_worker_ids_are_valid(&self.outputs)?;
+        fold_outputs(self.outputs)
+    }
+}
+
+fn fold_outputs(
+    outputs: Vec<InvariantWorkerOutput>,
+) -> Result<(InvariantFuzzTestResult, Vec<CampaignCorpusEntry>)> {
+    let mut errors = HashMap::default();
+    let mut handler_errors = HashMap::default();
+    let mut cases = Vec::new();
+    let mut reverts = 0;
+    let mut last_run_inputs = Vec::new();
+    let mut gas_report_traces = Vec::new();
+    let mut line_coverage = None;
+    let mut metrics = HashMap::default();
+    let mut corpus_entries = Vec::new();
+    let failed_corpus_replays = outputs
+        .iter()
+        .find(|output| output.plan.worker_id == 0)
+        .expect("master worker output was validated")
+        .result
+        .failed_corpus_replays;
+    let mut optimization_best = None;
+
+    for InvariantWorkerOutput { result, corpus_entries: worker_entries, .. } in outputs {
+        for (invariant, error) in result.errors {
+            errors.entry(invariant).or_insert(error);
+        }
+        merge_handler_errors(&mut handler_errors, result.handler_errors);
+        corpus_entries.extend(worker_entries);
+        cases.extend(result.cases);
+        reverts += result.reverts;
+        if !result.last_run_inputs.is_empty() {
+            last_run_inputs = result.last_run_inputs;
+        }
+        gas_report_traces.extend(result.gas_report_traces);
+        HitMaps::merge_opt(&mut line_coverage, result.line_coverage);
+        merge_metrics(&mut metrics, result.metrics);
+        merge_optimization(
+            &mut optimization_best,
+            result.optimization_best_value,
+            result.optimization_best_sequence,
+        );
+    }
+    let (optimization_best_value, optimization_best_sequence) =
+        optimization_best.map(|(value, sequence)| (Some(value), sequence)).unwrap_or_default();
+    Ok((
+        InvariantFuzzTestResult::new(
+            errors,
+            handler_errors,
+            cases,
+            reverts,
+            last_run_inputs,
+            gas_report_traces,
+            line_coverage,
+            metrics,
+            failed_corpus_replays,
+            optimization_best_value,
+            optimization_best_sequence,
+        ),
+        corpus_entries,
+    ))
 }
 
 fn ensure_outputs_cover_campaign(
@@ -493,12 +607,27 @@ mod tests {
 
     #[test]
     fn campaign_state_stops_after_terminal_request() {
-        let state = InvariantCampaignState::new(EarlyExit::new(false));
+        let state = InvariantCampaignState::new(EarlyExit::new(false), None);
         assert!(!state.should_stop());
 
         state.request_terminal_stop();
 
         assert!(state.should_stop());
+    }
+
+    #[test]
+    fn campaign_state_uses_shared_timeout_and_global_throughput() {
+        let state = InvariantCampaignState::new(EarlyExit::new(false), Some(0));
+        std::thread::sleep(Duration::from_millis(1));
+
+        assert!(state.is_timed_campaign());
+        assert!(state.should_stop());
+
+        state.record_call(20);
+        state.record_call(30);
+        assert_eq!(state.throughput_totals(), (2, 50));
+        assert_eq!(state.increment_runs(), 1);
+        assert_eq!(state.total_runs(), 1);
     }
 
     #[test]
@@ -593,6 +722,67 @@ mod tests {
         let coverage = result.line_coverage.unwrap();
         assert_eq!(coverage.get(&B256::ZERO).unwrap().get(7).unwrap().get(), 6);
         assert_eq!(result.failed_corpus_replays, 4);
+    }
+
+    #[test]
+    fn timeout_aggregator_accepts_partial_outputs_with_range_gaps() {
+        fn result_with_cases(
+            gases: &[u64],
+            failed_corpus_replays: usize,
+        ) -> InvariantFuzzTestResult {
+            let mut result = empty_result(0, failed_corpus_replays);
+            result.cases = gases
+                .iter()
+                .map(|&gas| FuzzedCases::new(vec![FuzzCase { gas, stipend: 0 }]))
+                .collect();
+            result.last_run_inputs = gases.last().map_or_else(Vec::new, |_| vec![basic_tx(0x44)]);
+            result
+        }
+
+        let spec = InvariantCampaignSpec::new(10);
+        let outputs = [
+            InvariantWorkerOutput::new(
+                InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 2 },
+                result_with_cases(&[10, 11], 5),
+            ),
+            InvariantWorkerOutput::new(
+                InvariantWorkerPlan { worker_id: 1, first_global_run: 4, runs: 0 },
+                result_with_cases(&[], 0),
+            ),
+            InvariantWorkerOutput::new(
+                InvariantWorkerPlan { worker_id: 2, first_global_run: 7, runs: 1 },
+                result_with_cases(&[20], 0),
+            ),
+        ];
+
+        let mut strict = InvariantCampaignAggregator::new(spec);
+        for output in outputs {
+            strict.push(output);
+        }
+        let err = strict.finish().unwrap_err();
+        assert!(err.to_string().contains("do not cover the logical campaign"));
+
+        let mut partial = InvariantCampaignAggregator::new(spec);
+        partial.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 2 },
+            result_with_cases(&[10, 11], 5),
+        ));
+        partial.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 4, runs: 0 },
+            result_with_cases(&[], 0),
+        ));
+        partial.push(InvariantWorkerOutput::new(
+            InvariantWorkerPlan { worker_id: 2, first_global_run: 7, runs: 1 },
+            result_with_cases(&[20], 0),
+        ));
+
+        let (result, corpus_entries) = partial.finish_partial_with_corpus_entries().unwrap();
+
+        let merged_case_gas =
+            result.cases.iter().map(|cases| cases.last().unwrap().gas).collect::<Vec<_>>();
+        assert_eq!(merged_case_gas, vec![10, 11, 20]);
+        assert_eq!(result.failed_corpus_replays, 5);
+        assert!(corpus_entries.is_empty());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -71,7 +71,7 @@ pub struct InvariantCampaignState {
 }
 
 impl InvariantCampaignState {
-    pub fn new(early_exit: EarlyExit) -> Self {
+    pub const fn new(early_exit: EarlyExit) -> Self {
         Self { total_runs: AtomicU32::new(0), global_early_exit: early_exit }
     }
 

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -27,11 +27,7 @@ impl InvariantCampaignSpec {
     pub fn worker_plans(self, workers: usize) -> Result<Vec<InvariantWorkerPlan>> {
         ensure!(workers > 0, "invariant campaign requires at least one worker");
 
-        if self.total_runs == 0 {
-            return Ok(vec![InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 }]);
-        }
-
-        let worker_count = workers.min(self.total_runs as usize) as u32;
+        let worker_count = workers.min(self.total_runs.max(1) as usize) as u32;
         let base_runs = self.total_runs / worker_count;
         let extra_runs = self.total_runs % worker_count;
 
@@ -60,18 +56,6 @@ pub struct InvariantWorkerPlan {
     pub runs: u32,
 }
 
-impl InvariantWorkerPlan {
-    pub const MASTER_WORKER_ID: u32 = 0;
-
-    pub const fn is_master(self) -> bool {
-        self.worker_id == Self::MASTER_WORKER_ID
-    }
-
-    pub const fn worker_index(self) -> usize {
-        self.worker_id as usize
-    }
-}
-
 /// Output produced by one invariant worker.
 ///
 /// This is a data envelope for aggregation only. It does not imply that this module executed the
@@ -80,12 +64,6 @@ impl InvariantWorkerPlan {
 pub struct InvariantWorkerOutput {
     pub plan: InvariantWorkerPlan,
     pub result: InvariantFuzzTestResult,
-}
-
-impl InvariantWorkerOutput {
-    pub const fn new(plan: InvariantWorkerPlan, result: InvariantFuzzTestResult) -> Self {
-        Self { plan, result }
-    }
 }
 
 /// Merges worker outputs back into one logical invariant campaign result.
@@ -120,7 +98,6 @@ impl InvariantCampaignAggregator {
 
         self.outputs.sort_by_key(|output| output.plan.first_global_run);
         ensure_outputs_cover_campaign(self.spec, &self.outputs)?;
-        ensure_master_only_fields(&self.outputs)?;
 
         let mut errors = HashMap::default();
         let mut handler_errors = HashMap::default();
@@ -130,16 +107,18 @@ impl InvariantCampaignAggregator {
         let mut gas_report_traces = Vec::new();
         let mut line_coverage = None;
         let mut metrics = HashMap::default();
-        let failed_corpus_replays = self
-            .outputs
-            .iter()
-            .find(|output| output.plan.worker_id == 0)
-            .expect("master worker output was validated")
-            .result
-            .failed_corpus_replays;
+        let mut failed_corpus_replays = 0;
         let mut optimization_best = None;
 
-        for InvariantWorkerOutput { result, .. } in self.outputs {
+        for InvariantWorkerOutput { plan, result } in self.outputs {
+            if plan.worker_id == 0 {
+                failed_corpus_replays = result.failed_corpus_replays;
+            } else {
+                ensure!(
+                    result.failed_corpus_replays == 0,
+                    "non-master invariant worker reported failed corpus replays"
+                );
+            }
             for (invariant, error) in result.errors {
                 errors.entry(invariant).or_insert(error);
             }
@@ -178,21 +157,27 @@ fn ensure_outputs_cover_campaign(
     spec: InvariantCampaignSpec,
     outputs: &[InvariantWorkerOutput],
 ) -> Result<()> {
-    ensure_worker_ids_are_valid(outputs)?;
-
-    if spec.total_runs == 0 {
+    let mut seen = HashSet::with_capacity(outputs.len());
+    for output in outputs {
         ensure!(
-            outputs.len() == 1
-                && outputs[0].plan.first_global_run == 0
-                && outputs[0].plan.runs == 0,
-            "invariant worker outputs do not cover the logical campaign"
+            seen.insert(output.plan.worker_id),
+            "duplicate invariant worker output for worker {}",
+            output.plan.worker_id
         );
-        return Ok(());
     }
+    ensure!(seen.contains(&0), "missing invariant master worker output");
+
+    ensure!(
+        spec.total_runs > 0 || outputs.len() == 1,
+        "invariant worker outputs do not cover the logical campaign"
+    );
 
     let mut next_global_run = 0;
     for output in outputs {
-        ensure!(output.plan.runs > 0, "invariant worker outputs do not cover the logical campaign");
+        ensure!(
+            spec.total_runs == 0 || output.plan.runs > 0,
+            "invariant worker outputs do not cover the logical campaign"
+        );
         ensure!(
             output.plan.first_global_run == next_global_run,
             "invariant worker outputs do not cover the logical campaign"
@@ -206,30 +191,6 @@ fn ensure_outputs_cover_campaign(
         next_global_run == spec.total_runs,
         "invariant worker outputs do not cover the logical campaign"
     );
-    Ok(())
-}
-
-fn ensure_worker_ids_are_valid(outputs: &[InvariantWorkerOutput]) -> Result<()> {
-    let mut seen = HashSet::with_capacity(outputs.len());
-    for output in outputs {
-        ensure!(
-            seen.insert(output.plan.worker_id),
-            "duplicate invariant worker output for worker {}",
-            output.plan.worker_id
-        );
-    }
-
-    ensure!(seen.contains(&0), "missing invariant master worker output");
-    Ok(())
-}
-
-fn ensure_master_only_fields(outputs: &[InvariantWorkerOutput]) -> Result<()> {
-    for output in outputs {
-        ensure!(
-            output.plan.worker_id == 0 || output.result.failed_corpus_replays == 0,
-            "non-master invariant worker reported failed corpus replays"
-        );
-    }
     Ok(())
 }
 
@@ -388,73 +349,59 @@ mod tests {
         })
     }
 
-    fn one_worker_plan(total_runs: u32) -> InvariantWorkerPlan {
-        let mut plans = InvariantCampaignSpec::new(total_runs).worker_plans(1).unwrap();
-        assert_eq!(plans.len(), 1);
-        plans.pop().unwrap()
+    fn plan(worker_id: u32, first_global_run: u32, runs: u32) -> InvariantWorkerPlan {
+        InvariantWorkerPlan { worker_id, first_global_run, runs }
+    }
+
+    fn worker(plan: InvariantWorkerPlan, result: InvariantFuzzTestResult) -> InvariantWorkerOutput {
+        InvariantWorkerOutput { plan, result }
+    }
+
+    fn finish(
+        total_runs: u32,
+        outputs: impl IntoIterator<Item = InvariantWorkerOutput>,
+    ) -> Result<InvariantFuzzTestResult> {
+        let mut aggregator =
+            InvariantCampaignAggregator::new(InvariantCampaignSpec::new(total_runs));
+        for output in outputs {
+            aggregator.push(output);
+        }
+        aggregator.finish()
     }
 
     #[test]
     fn worker_plans_cover_logical_campaign_with_one_worker() {
-        let plan = one_worker_plan(3);
+        let plans = InvariantCampaignSpec::new(3).worker_plans(1).unwrap();
 
-        assert_eq!(plan.worker_id, 0);
-        assert_eq!(plan.first_global_run, 0);
-        assert_eq!(plan.runs, 3);
-        assert!(plan.is_master());
-        assert_eq!(plan.worker_index(), 0);
+        assert_eq!(plans, vec![plan(0, 0, 3)]);
     }
 
     #[test]
     fn worker_plans_split_runs_evenly() {
         let plans = InvariantCampaignSpec::new(100).worker_plans(4).unwrap();
 
-        assert_eq!(
-            plans,
-            vec![
-                InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 25 },
-                InvariantWorkerPlan { worker_id: 1, first_global_run: 25, runs: 25 },
-                InvariantWorkerPlan { worker_id: 2, first_global_run: 50, runs: 25 },
-                InvariantWorkerPlan { worker_id: 3, first_global_run: 75, runs: 25 },
-            ]
-        );
-        assert!(plans[0].is_master());
-        assert!(!plans[1].is_master());
-        assert_eq!(plans[3].worker_index(), 3);
+        assert_eq!(plans, vec![plan(0, 0, 25), plan(1, 25, 25), plan(2, 50, 25), plan(3, 75, 25),]);
     }
 
     #[test]
     fn worker_plans_distribute_remainder_to_earlier_workers() {
         let plans = InvariantCampaignSpec::new(10).worker_plans(3).unwrap();
 
-        assert_eq!(
-            plans,
-            vec![
-                InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 4 },
-                InvariantWorkerPlan { worker_id: 1, first_global_run: 4, runs: 3 },
-                InvariantWorkerPlan { worker_id: 2, first_global_run: 7, runs: 3 },
-            ]
-        );
+        assert_eq!(plans, vec![plan(0, 0, 4), plan(1, 4, 3), plan(2, 7, 3)]);
     }
 
     #[test]
     fn worker_plans_do_not_create_empty_workers_when_runs_are_available() {
         let plans = InvariantCampaignSpec::new(2).worker_plans(8).unwrap();
 
-        assert_eq!(
-            plans,
-            vec![
-                InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
-                InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
-            ]
-        );
+        assert_eq!(plans, vec![plan(0, 0, 1), plan(1, 1, 1)]);
     }
 
     #[test]
     fn worker_plans_keep_zero_run_campaign_as_single_empty_plan() {
         let plans = InvariantCampaignSpec::new(0).worker_plans(4).unwrap();
 
-        assert_eq!(plans, vec![InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 }]);
+        assert_eq!(plans, vec![plan(0, 0, 0)]);
     }
 
     #[test]
@@ -468,12 +415,7 @@ mod tests {
 
     #[test]
     fn aggregator_returns_single_worker_result_without_rewriting() {
-        let spec = InvariantCampaignSpec::new(1);
-        let worker = InvariantWorkerOutput::new(one_worker_plan(1), empty_result(2, 3));
-
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(worker);
-        let result = aggregator.finish().unwrap();
+        let result = finish(1, [worker(plan(0, 0, 1), empty_result(2, 3))]).unwrap();
 
         assert_eq!(result.reverts, 2);
         assert_eq!(result.failed_corpus_replays, 3);
@@ -481,67 +423,57 @@ mod tests {
 
     #[test]
     fn aggregator_accepts_single_worker_output_for_zero_run_campaign() {
-        let spec = InvariantCampaignSpec::new(0);
-        let worker = InvariantWorkerOutput::new(
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 0 },
-            empty_result(0, 0),
-        );
-
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(worker);
-        let result = aggregator.finish().unwrap();
+        let result = finish(0, [worker(plan(0, 0, 0), empty_result(0, 0))]).unwrap();
 
         assert_eq!(result.reverts, 0);
     }
 
     #[test]
     fn aggregator_merges_multiple_worker_outputs_in_logical_run_order() {
-        let spec = InvariantCampaignSpec::new(3);
-        let plans = [
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
-            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
-            InvariantWorkerPlan { worker_id: 2, first_global_run: 2, runs: 1 },
-        ];
+        let plans = [plan(0, 0, 1), plan(1, 1, 1), plan(2, 2, 1)];
 
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(InvariantWorkerOutput::new(
-            plans[2],
-            worker_result(
-                30,
-                3,
-                0x30,
-                "transfer(address)",
-                InvariantMetrics { calls: 3, reverts: 1, discards: 0 },
-                3,
-                0,
-            ),
-        ));
-        aggregator.push(InvariantWorkerOutput::new(
-            plans[0],
-            worker_result(
-                10,
-                1,
-                0x10,
-                "transfer(address)",
-                InvariantMetrics { calls: 1, reverts: 0, discards: 2 },
-                1,
-                4,
-            ),
-        ));
-        aggregator.push(InvariantWorkerOutput::new(
-            plans[1],
-            worker_result(
-                20,
-                2,
-                0x20,
-                "approve(address)",
-                InvariantMetrics { calls: 2, reverts: 1, discards: 1 },
-                2,
-                0,
-            ),
-        ));
-
-        let result = aggregator.finish().unwrap();
+        let result = finish(
+            3,
+            [
+                worker(
+                    plans[2],
+                    worker_result(
+                        30,
+                        3,
+                        0x30,
+                        "transfer(address)",
+                        InvariantMetrics { calls: 3, reverts: 1, discards: 0 },
+                        3,
+                        0,
+                    ),
+                ),
+                worker(
+                    plans[0],
+                    worker_result(
+                        10,
+                        1,
+                        0x10,
+                        "transfer(address)",
+                        InvariantMetrics { calls: 1, reverts: 0, discards: 2 },
+                        1,
+                        4,
+                    ),
+                ),
+                worker(
+                    plans[1],
+                    worker_result(
+                        20,
+                        2,
+                        0x20,
+                        "approve(address)",
+                        InvariantMetrics { calls: 2, reverts: 1, discards: 1 },
+                        2,
+                        0,
+                    ),
+                ),
+            ],
+        )
+        .unwrap();
 
         let merged_case_gas =
             result.cases.iter().map(|cases| cases.last().unwrap().gas).collect::<Vec<_>>();
@@ -562,20 +494,13 @@ mod tests {
 
     #[test]
     fn aggregator_keeps_earlier_predicate_failure_for_each_invariant() {
-        let spec = InvariantCampaignSpec::new(2);
-        let plans = [
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
-            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
-        ];
+        let plans = [plan(0, 0, 1), plan(1, 1, 1)];
         let mut earlier = empty_result(0, 0);
         earlier.errors.insert("invariant_balance".to_string(), predicate_error("earlier", 3));
         let mut later = empty_result(0, 0);
         later.errors.insert("invariant_balance".to_string(), predicate_error("later", 1));
 
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(InvariantWorkerOutput::new(plans[1], later));
-        aggregator.push(InvariantWorkerOutput::new(plans[0], earlier));
-        let result = aggregator.finish().unwrap();
+        let result = finish(2, [worker(plans[1], later), worker(plans[0], earlier)]).unwrap();
 
         assert_eq!(result.errors.len(), 1);
         assert_eq!(result.errors["invariant_balance"].revert_reason().as_deref(), Some("earlier"));
@@ -583,21 +508,14 @@ mod tests {
 
     #[test]
     fn aggregator_dedupes_handler_assertions_by_site_and_keeps_shorter_sequence() {
-        let spec = InvariantCampaignSpec::new(2);
-        let plans = [
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
-            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
-        ];
+        let plans = [plan(0, 0, 1), plan(1, 1, 1)];
         let site = (Address::repeat_byte(0xaa), Selector::from([1, 2, 3, 4]));
         let mut longer = empty_result(0, 0);
         longer.handler_errors.insert(site, handler_error(site.0, site.1, 4, "longer"));
         let mut shorter = empty_result(0, 0);
         shorter.handler_errors.insert(site, handler_error(site.0, site.1, 2, "shorter"));
 
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(InvariantWorkerOutput::new(plans[1], shorter));
-        aggregator.push(InvariantWorkerOutput::new(plans[0], longer));
-        let result = aggregator.finish().unwrap();
+        let result = finish(2, [worker(plans[1], shorter), worker(plans[0], longer)]).unwrap();
 
         let failure = result.handler_errors[&site].as_handler_assertion().unwrap();
         assert_eq!(result.handler_errors.len(), 1);
@@ -607,21 +525,14 @@ mod tests {
 
     #[test]
     fn aggregator_keeps_earlier_handler_assertion_when_lengths_tie() {
-        let spec = InvariantCampaignSpec::new(2);
-        let plans = [
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
-            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
-        ];
+        let plans = [plan(0, 0, 1), plan(1, 1, 1)];
         let site = (Address::repeat_byte(0xaa), Selector::from([1, 2, 3, 4]));
         let mut earlier = empty_result(0, 0);
         earlier.handler_errors.insert(site, handler_error(site.0, site.1, 2, "earlier"));
         let mut later = empty_result(0, 0);
         later.handler_errors.insert(site, handler_error(site.0, site.1, 2, "later"));
 
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(InvariantWorkerOutput::new(plans[1], later));
-        aggregator.push(InvariantWorkerOutput::new(plans[0], earlier));
-        let result = aggregator.finish().unwrap();
+        let result = finish(2, [worker(plans[1], later), worker(plans[0], earlier)]).unwrap();
 
         let failure = result.handler_errors[&site].as_handler_assertion().unwrap();
         assert_eq!(result.handler_errors.len(), 1);
@@ -631,20 +542,13 @@ mod tests {
 
     #[test]
     fn aggregator_keeps_distinct_predicate_failures() {
-        let spec = InvariantCampaignSpec::new(2);
-        let plans = [
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
-            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
-        ];
+        let plans = [plan(0, 0, 1), plan(1, 1, 1)];
         let mut earlier = empty_result(0, 0);
         earlier.errors.insert("invariant_a".to_string(), predicate_error("a", 3));
         let mut later = empty_result(0, 0);
         later.errors.insert("invariant_b".to_string(), predicate_error("b", 2));
 
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(InvariantWorkerOutput::new(plans[1], later));
-        aggregator.push(InvariantWorkerOutput::new(plans[0], earlier));
-        let result = aggregator.finish().unwrap();
+        let result = finish(2, [worker(plans[1], later), worker(plans[0], earlier)]).unwrap();
 
         assert_eq!(result.errors.len(), 2);
         assert_eq!(result.errors["invariant_a"].revert_reason().as_deref(), Some("a"));
@@ -653,12 +557,7 @@ mod tests {
 
     #[test]
     fn aggregator_keeps_first_max_optimization_value_on_tie() {
-        let spec = InvariantCampaignSpec::new(3);
-        let plans = [
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
-            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
-            InvariantWorkerPlan { worker_id: 2, first_global_run: 2, runs: 1 },
-        ];
+        let plans = [plan(0, 0, 1), plan(1, 1, 1), plan(2, 2, 1)];
         let mut first = empty_result(0, 0);
         first.optimization_best_value = Some(I256::try_from(7).unwrap());
         first.optimization_best_sequence = sequence(1, 0x10);
@@ -669,11 +568,11 @@ mod tests {
         later_tie.optimization_best_value = Some(I256::try_from(9).unwrap());
         later_tie.optimization_best_sequence = sequence(1, 0x30);
 
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(InvariantWorkerOutput::new(plans[2], later_tie));
-        aggregator.push(InvariantWorkerOutput::new(plans[0], first));
-        aggregator.push(InvariantWorkerOutput::new(plans[1], earlier_best));
-        let result = aggregator.finish().unwrap();
+        let result = finish(
+            3,
+            [worker(plans[2], later_tie), worker(plans[0], first), worker(plans[1], earlier_best)],
+        )
+        .unwrap();
 
         assert_eq!(result.optimization_best_value, Some(I256::try_from(9).unwrap()));
         assert_eq!(result.optimization_best_sequence[0].sender, Address::repeat_byte(0x20));
@@ -681,117 +580,73 @@ mod tests {
 
     #[test]
     fn aggregator_rejects_overlapping_outputs() {
-        let spec = InvariantCampaignSpec::new(1);
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-
-        aggregator.push(InvariantWorkerOutput::new(
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
-            empty_result(0, 0),
-        ));
-        aggregator.push(InvariantWorkerOutput::new(
-            InvariantWorkerPlan { worker_id: 1, first_global_run: 0, runs: 1 },
-            empty_result(0, 0),
-        ));
-        let err = aggregator.finish().unwrap_err();
+        let err = finish(
+            1,
+            [worker(plan(0, 0, 1), empty_result(0, 0)), worker(plan(1, 0, 1), empty_result(0, 0))],
+        )
+        .unwrap_err();
 
         assert!(err.to_string().contains("do not cover the logical campaign"));
     }
 
     #[test]
     fn aggregator_rejects_duplicate_worker_ids() {
-        let spec = InvariantCampaignSpec::new(2);
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-
-        aggregator.push(InvariantWorkerOutput::new(
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
-            empty_result(0, 0),
-        ));
-        aggregator.push(InvariantWorkerOutput::new(
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 1, runs: 1 },
-            empty_result(0, 0),
-        ));
-        let err = aggregator.finish().unwrap_err();
+        let err = finish(
+            2,
+            [worker(plan(0, 0, 1), empty_result(0, 0)), worker(plan(0, 1, 1), empty_result(0, 0))],
+        )
+        .unwrap_err();
 
         assert!(err.to_string().contains("duplicate invariant worker output"));
     }
 
     #[test]
     fn aggregator_allows_non_dense_worker_ids_with_contiguous_ranges() {
-        let spec = InvariantCampaignSpec::new(2);
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-
-        aggregator.push(InvariantWorkerOutput::new(
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
-            empty_result(0, 0),
-        ));
-        aggregator.push(InvariantWorkerOutput::new(
-            InvariantWorkerPlan { worker_id: 2, first_global_run: 1, runs: 1 },
-            empty_result(2, 0),
-        ));
-        let result = aggregator.finish().unwrap();
+        let result = finish(
+            2,
+            [worker(plan(0, 0, 1), empty_result(0, 0)), worker(plan(2, 1, 1), empty_result(2, 0))],
+        )
+        .unwrap();
 
         assert_eq!(result.reverts, 2);
     }
 
     #[test]
     fn aggregator_rejects_missing_master_worker() {
-        let spec = InvariantCampaignSpec::new(2);
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-
-        aggregator.push(InvariantWorkerOutput::new(
-            InvariantWorkerPlan { worker_id: 1, first_global_run: 0, runs: 1 },
-            empty_result(0, 0),
-        ));
-        aggregator.push(InvariantWorkerOutput::new(
-            InvariantWorkerPlan { worker_id: 2, first_global_run: 1, runs: 1 },
-            empty_result(0, 0),
-        ));
-        let err = aggregator.finish().unwrap_err();
+        let err = finish(
+            2,
+            [worker(plan(1, 0, 1), empty_result(0, 0)), worker(plan(2, 1, 1), empty_result(0, 0))],
+        )
+        .unwrap_err();
 
         assert!(err.to_string().contains("missing invariant master worker output"));
     }
 
     #[test]
     fn aggregator_rejects_failed_corpus_replays_from_non_master_worker() {
-        let spec = InvariantCampaignSpec::new(2);
-        let plans = [
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
-            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 1 },
-        ];
+        let plans = [plan(0, 0, 1), plan(1, 1, 1)];
 
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(InvariantWorkerOutput::new(plans[0], empty_result(0, 0)));
-        aggregator.push(InvariantWorkerOutput::new(plans[1], empty_result(0, 1)));
-        let err = aggregator.finish().unwrap_err();
+        let err =
+            finish(2, [worker(plans[0], empty_result(0, 0)), worker(plans[1], empty_result(0, 1))])
+                .unwrap_err();
 
         assert!(err.to_string().contains("non-master invariant worker reported"));
     }
 
     #[test]
     fn aggregator_takes_failed_corpus_replays_from_master_worker() {
-        let spec = InvariantCampaignSpec::new(2);
-        let plans = [
-            InvariantWorkerPlan { worker_id: 1, first_global_run: 0, runs: 1 },
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 1, runs: 1 },
-        ];
+        let plans = [plan(1, 0, 1), plan(0, 1, 1)];
 
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(InvariantWorkerOutput::new(plans[0], empty_result(0, 0)));
-        aggregator.push(InvariantWorkerOutput::new(plans[1], empty_result(0, 7)));
-        let result = aggregator.finish().unwrap();
+        let result =
+            finish(2, [worker(plans[0], empty_result(0, 0)), worker(plans[1], empty_result(0, 7))])
+                .unwrap();
 
         assert_eq!(result.failed_corpus_replays, 7);
     }
 
     #[test]
     fn aggregator_rejects_plan_that_does_not_cover_campaign() {
-        let spec = InvariantCampaignSpec::new(2);
-        let plan = InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 };
-        let worker = InvariantWorkerOutput::new(plan, empty_result(0, 0));
-
-        let mut aggregator = InvariantCampaignAggregator::new(spec);
-        aggregator.push(worker);
-        let err = aggregator.finish().unwrap_err();
+        let err = finish(2, [worker(plan(0, 0, 1), empty_result(0, 0))]).unwrap_err();
 
         assert!(err.to_string().contains("do not cover the logical campaign"));
     }

--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -360,16 +360,6 @@ impl InvariantFailures {
     pub fn has_handler_failure(&self, target: Address, selector: Selector) -> bool {
         self.failures.contains_key(&FailureKey::Handler(target, selector))
     }
-
-    /// Mutable iterator over handler-side assertion bug entries (post-campaign shrink loop).
-    pub fn handler_failures_mut(
-        &mut self,
-    ) -> impl Iterator<Item = ((Address, Selector), &mut InvariantFuzzError)> {
-        self.failures.iter_mut().filter_map(|(key, err)| match key {
-            FailureKey::Handler(addr, sel) => Some(((*addr, *sel), err)),
-            FailureKey::Invariant(_) => None,
-        })
-    }
 }
 
 impl fmt::Display for InvariantFailures {

--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -327,11 +327,9 @@ impl InvariantFailures {
         self.handler_count
     }
 
-    pub fn handler_failures_mut(
-        &mut self,
-    ) -> impl Iterator<Item = ((Address, Selector), &mut InvariantFuzzError)> {
+    pub fn handler_failures_mut(&mut self) -> impl Iterator<Item = &mut InvariantFuzzError> {
         self.failures.iter_mut().filter_map(|(key, error)| match key {
-            FailureKey::Handler(addr, selector) => Some(((*addr, *selector), error)),
+            FailureKey::Handler(_, _) => Some(error),
             FailureKey::Invariant(_) => None,
         })
     }

--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -327,6 +327,15 @@ impl InvariantFailures {
         self.handler_count
     }
 
+    pub fn handler_failures_mut(
+        &mut self,
+    ) -> impl Iterator<Item = ((Address, Selector), &mut InvariantFuzzError)> {
+        self.failures.iter_mut().filter_map(|(key, error)| match key {
+            FailureKey::Handler(addr, selector) => Some(((*addr, *selector), error)),
+            FailureKey::Invariant(_) => None,
+        })
+    }
+
     /// Records a handler-side assertion bug. Deduped by `(reverter, selector)` site;
     /// shortest sequence wins on collision.
     pub fn record_handler_failure(&mut self, failure: HandlerAssertionFailure) {

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     executors::{
-        DURATION_BETWEEN_METRICS_REPORT, EarlyExit, EvmError, Executor, FuzzTestTimer,
-        RawCallResult,
+        DURATION_BETWEEN_METRICS_REPORT, EarlyExit, EvmError, Executor, RawCallResult,
         corpus::{DynamicTargetCtx, WorkerCorpus, WorkerCorpusSeed},
     },
     inspectors::Fuzzer,
@@ -150,6 +149,7 @@ struct InvariantThroughputMetrics {
 }
 
 impl InvariantThroughputMetrics {
+    #[cfg(test)]
     const fn record_call(&mut self, gas_used: u64) {
         self.total_txs += 1;
         self.total_gas += gas_used;
@@ -169,11 +169,21 @@ fn max_invariant_workers_for_runs(runs: u32) -> usize {
 }
 
 fn invariant_worker_count(config: &InvariantConfig) -> usize {
-    if config.timeout.is_some() || config.call_override {
+    if config.single_worker_reason().is_some() {
         return 1;
     }
 
+    if config.timeout.is_some() {
+        return config.workers;
+    }
+
     config.workers.min(max_invariant_workers_for_runs(config.runs))
+}
+
+fn gas_report_samples_for_worker(total_samples: u32, worker_id: u32, worker_count: usize) -> usize {
+    let total_samples = total_samples as usize;
+    let worker_count = worker_count.max(1);
+    total_samples / worker_count + usize::from((worker_id as usize) < total_samples % worker_count)
 }
 
 fn invariant_worker_runner(runner: &mut TestRunner, worker_id: u32) -> TestRunner {
@@ -212,7 +222,7 @@ fn rate_per_sec(total: f64, elapsed: Duration) -> f64 {
 }
 
 /// Tracks invariant failure counts during a campaign.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct InvariantFailureMetrics {
     failures: u64,
     unique_failures: HashSet<String>,
@@ -243,15 +253,15 @@ impl InvariantFailureMetrics {
 /// `failure_metrics` so the live progress stream reflects breaks as they happen.
 /// Iterates in declaration order so the emitted "failure" events are deterministic.
 fn record_new_invariant_failures(
-    failure_metrics: &mut InvariantFailureMetrics,
+    campaign_state: &InvariantCampaignState,
     invariant_contract: &InvariantContract<'_>,
     failures: &InvariantFailures,
 ) {
     for (f, _) in &invariant_contract.invariant_fns {
-        if !failure_metrics.unique_failures.contains(&f.name) && failures.has_failure(f) {
+        if failures.has_failure(f) {
             let reason =
                 failures.get_failure(f).and_then(|e| e.revert_reason()).unwrap_or_default();
-            failure_metrics.record_failure(&f.name, invariant_contract.name, &reason);
+            campaign_state.record_invariant_failure(&f.name, invariant_contract.name, &reason);
         }
     }
 }
@@ -548,6 +558,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let campaign_spec = InvariantCampaignSpec::new(self.config.runs);
         let worker_count = invariant_worker_count(&self.config);
         let worker_plans = campaign_spec.worker_plans(worker_count)?;
+        let actual_worker_count = worker_plans.len();
         let campaign_seed =
             self.prepare_campaign_seed(&invariant_contract, initial_handler_failures)?;
         let replay_targets = FuzzRunIdentifiedContracts::new(
@@ -572,19 +583,25 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let setup_contracts = self.setup_contracts;
         let project_contracts = self.project_contracts;
         let base_executor = self.executor.clone();
-        let campaign_state = Arc::new(InvariantCampaignState::new(early_exit.clone()));
+        let campaign_state =
+            Arc::new(InvariantCampaignState::new(early_exit.clone(), self.config.timeout));
 
         let worker_outputs = if run_in_parallel {
             let worker_jobs = worker_plans
                 .into_iter()
                 .map(|worker_plan| {
                     let worker_runner = invariant_worker_runner(&mut runner, worker_plan.worker_id);
-                    (worker_plan, worker_runner)
+                    let gas_report_samples = gas_report_samples_for_worker(
+                        config.gas_report_samples,
+                        worker_plan.worker_id,
+                        actual_worker_count,
+                    );
+                    (worker_plan, worker_runner, gas_report_samples)
                 })
                 .collect::<Vec<_>>();
             worker_jobs
                 .into_par_iter()
-                .map(|(worker_plan, worker_runner)| {
+                .map(|(worker_plan, worker_runner, gas_report_samples)| {
                     let _guard =
                         info_span!("invariant_worker", id = worker_plan.worker_id).entered();
                     let timer = Instant::now();
@@ -603,19 +620,26 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         campaign_seed.clone(),
                         corpus_seed.clone(),
                         corpus_persistence,
+                        gas_report_samples,
                     );
                     debug!("finished in {:?}", timer.elapsed());
                     output
                 })
                 .collect::<Result<Vec<_>>>()?
         } else {
+            let worker_plan = worker_plans[0];
+            let gas_report_samples = gas_report_samples_for_worker(
+                config.gas_report_samples,
+                worker_plan.worker_id,
+                actual_worker_count,
+            );
             vec![Self::run_invariant_worker(
                 base_executor,
                 runner,
                 config,
                 setup_contracts,
                 project_contracts,
-                worker_plans[0],
+                worker_plan,
                 invariant_contract.clone(),
                 fuzz_fixtures,
                 fuzz_state,
@@ -624,22 +648,20 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 campaign_seed.clone(),
                 corpus_seed.clone(),
                 corpus_persistence,
+                gas_report_samples,
             )?]
         };
 
-        // Timeout-driven campaigns can execute beyond the initial configured run count. Preserve
-        // the existing single-worker reported run behavior by rebuilding the logical spec from the
-        // worker's final reported plan.
-        let total_reported_runs =
-            worker_outputs.iter().map(|output| output.plan.runs).try_fold(0u32, |acc, runs| {
-                acc.checked_add(runs).ok_or_else(|| eyre!("invariant worker run range overflows"))
-            })?;
-        let mut aggregator =
-            InvariantCampaignAggregator::new(InvariantCampaignSpec::new(total_reported_runs));
+        let is_timed_campaign = campaign_state.is_timed_campaign();
+        let mut aggregator = InvariantCampaignAggregator::new(campaign_spec);
         for worker_output in worker_outputs {
             aggregator.push(worker_output);
         }
-        let (result, corpus_entries) = aggregator.finish_with_corpus_entries()?;
+        let (result, corpus_entries) = if is_timed_campaign {
+            aggregator.finish_partial_with_corpus_entries()?
+        } else {
+            aggregator.finish_with_corpus_entries()?
+        };
         if corpus_persistence.is_deferred() {
             let replay_targets = FuzzRunIdentifiedContracts::new(
                 campaign_seed.targeted_contracts.clone(),
@@ -680,15 +702,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         campaign_seed: InvariantCampaignSeed,
         corpus_seed: WorkerCorpusSeed,
         corpus_persistence: InvariantCorpusPersistence,
+        gas_report_samples: usize,
     ) -> Result<InvariantWorkerOutput> {
         // Note: invariant function signatures (no inputs) are validated upstream in the
         // suite runner so parameterized `invariant_*` functions are rejected with a per-test
         // failure entry before any campaign runs.
-
-        // Runs reported to the campaign aggregator as this worker's logical range length.
-        // In normal sharded campaigns this stays equal to the assigned plan length; timed
-        // single-worker campaigns may grow it beyond the initially configured run count.
-        let mut reported_runs = plan.runs;
 
         let (mut invariant_test, mut corpus_manager) = Self::prepare_worker(
             &mut executor,
@@ -704,25 +722,15 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let mut corpus_entries = Vec::new();
         let progress_worker_id = corpus_persistence.progress_worker_id(plan.worker_id);
 
-        // Start timer for this invariant test.
-        let timer = FuzzTestTimer::new(config.timeout);
-        let is_timed_campaign = timer.is_enabled();
+        let is_timed_campaign = campaign_state.is_timed_campaign();
         let mut runs = 0;
-        let mut last_metrics_report = Instant::now();
-        let campaign_start = Instant::now();
-        let mut throughput = InvariantThroughputMetrics::default();
-        let mut failure_metrics = InvariantFailureMetrics::default();
-        let continue_campaign = |runs: u32| {
-            !campaign_state.should_stop()
-                && !timer.is_timed_out()
-                && (is_timed_campaign || runs < plan.runs)
-        };
+        let continue_campaign = |runs: u32| !campaign_state.should_stop() && runs < plan.runs;
+        campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
 
         // Invariant runs with edge coverage if corpus dir is set or showing edge coverage.
         let edge_coverage_enabled = config.corpus.collect_edge_coverage();
 
         'stop: while continue_campaign(runs) {
-            reported_runs = reported_runs.max(runs.saturating_add(1));
             // Per-run failure count snapshot used to gate `afterInvariant` below.
             let failures_before_run = invariant_test.test_data.failures.invariant_count();
             let mut stop_after_run = false;
@@ -749,7 +757,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
             while current_run.depth < config.depth {
                 // Check if the timeout has been reached.
-                if campaign_state.should_stop() || timer.is_timed_out() {
+                if campaign_state.should_stop() {
                     // Since we never record a revert here the test is still considered
                     // successful even though it timed out. We *want*
                     // this behavior for now, so that's ok, but
@@ -867,7 +875,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     current_run
                         .fuzz_runs
                         .push(FuzzCase { gas: call_result.gas_used, stipend: call_result.stipend });
-                    throughput.record_call(call_result.gas_used);
+                    campaign_state.record_call(call_result.gas_used);
 
                     // Determine if test can continue or should exit.
                     // Check invariants based on check_interval to improve deep run performance.
@@ -974,7 +982,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         || broken.is_some()
                     {
                         record_new_invariant_failures(
-                            &mut failure_metrics,
+                            campaign_state,
                             &invariant_contract,
                             &invariant_test.test_data.failures,
                         );
@@ -1039,7 +1047,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 if broken.is_some() {
                     // Bridge breaks into pulse metrics, mirroring the in-run path above.
                     record_new_invariant_failures(
-                        &mut failure_metrics,
+                        campaign_state,
                         &invariant_contract,
                         &invariant_test.test_data.failures,
                     );
@@ -1047,24 +1055,19 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             }
 
             // End current invariant test run.
-            invariant_test.end_run(current_run, config.gas_report_samples as usize);
+            invariant_test.end_run(current_run, gas_report_samples);
             runs += 1;
             let total_runs = campaign_state.increment_runs();
-            debug_assert!(
-                is_timed_campaign || total_runs <= config.runs,
-                "worker runs were not distributed correctly"
-            );
+            debug_assert!(total_runs <= config.runs, "worker runs were not distributed correctly");
             if let Some(progress) = progress {
                 progress.inc(1);
             }
             if let Some(progress) = progress {
+                campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
                 // Display current best value, corpus metrics, and failure counts.
                 let best = invariant_test.test_data.optimization_best_value;
-                let broken = invariant_test.test_data.failures.invariant_count();
-                // Live count of unique handler-side assertion bugs, separate from the
-                // predicate breaks in `broken`. Synced into `failure_metrics` so all
-                // campaign-level counters share one struct.
-                failure_metrics.broken_handlers = invariant_test.test_data.failures.handler_count();
+                let failure_metrics = campaign_state.failure_metrics();
+                let broken = failure_metrics.unique_failures.len();
                 let handler_bugs = failure_metrics.broken_handlers;
                 let total_invariants = invariant_contract.invariant_fns.len();
                 if edge_coverage_enabled || best.is_some() || broken > 0 || handler_bugs > 0 {
@@ -1098,11 +1101,12 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     progress.set_message(msg);
                 }
             } else if edge_coverage_enabled
-                && plan.worker_id == 0
-                && last_metrics_report.elapsed() > DURATION_BETWEEN_METRICS_REPORT
+                && campaign_state.should_emit_metrics_report(DURATION_BETWEEN_METRICS_REPORT)
             {
-                // Sync handler-bug count snapshot into failure_metrics before emitting.
-                failure_metrics.broken_handlers = invariant_test.test_data.failures.handler_count();
+                campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
+                let failure_metrics = campaign_state.failure_metrics();
+                let (total_txs, total_gas) = campaign_state.throughput_totals();
+                let throughput = InvariantThroughputMetrics { total_txs, total_gas };
                 // Display corpus metrics inline as JSON.
                 let metrics = build_invariant_progress_json(
                     SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
@@ -1111,10 +1115,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     invariant_test.test_data.optimization_best_value,
                     throughput,
                     &failure_metrics,
-                    campaign_start.elapsed(),
+                    campaign_state.elapsed(),
                 );
                 let _ = sh_println!("{}", serde_json::to_string(&metrics)?);
-                last_metrics_report = Instant::now();
             }
 
             if stop_after_run {
@@ -1150,14 +1153,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             result.optimization_best_sequence,
         );
         let reported_plan = if is_timed_campaign {
-            debug_assert_eq!(plan.worker_id, 0);
-            debug_assert_eq!(plan.first_global_run, 0);
-            InvariantWorkerPlan { runs: reported_runs, ..plan }
+            InvariantWorkerPlan { runs, ..plan }
         } else {
             // Sharded campaigns must report the original assigned range. Early worker exit changes
             // the number of executed runs, but it must not shrink `plan.runs`: following workers'
             // `first_global_run` offsets were computed from the original partition.
-            debug_assert_eq!(reported_runs, plan.runs);
             plan
         };
         Ok(InvariantWorkerOutput { plan: reported_plan, result: worker_result, corpus_entries })
@@ -1856,7 +1856,7 @@ mod tests {
         assert_eq!(invariant_worker_count(&config), 4);
 
         config.timeout = Some(1);
-        assert_eq!(invariant_worker_count(&config), 1);
+        assert_eq!(invariant_worker_count(&config), 4);
 
         config.timeout = None;
         config.call_override = true;
@@ -1869,6 +1869,31 @@ mod tests {
         config.corpus.show_edge_coverage = false;
         config.corpus.corpus_dir = Some(std::path::PathBuf::from("corpus"));
         assert_eq!(invariant_worker_count(&config), 4);
+
+        config.corpus.corpus_dir = None;
+        config.corpus.sancov_edges = true;
+        assert_eq!(invariant_worker_count(&config), 1);
+
+        config.corpus.sancov_edges = false;
+        config.corpus.sancov_trace_cmp = true;
+        assert_eq!(invariant_worker_count(&config), 1);
+
+        config.corpus.sancov_trace_cmp = false;
+        config.runs = MIN_RUNS_PER_INVARIANT_WORKER - 1;
+        config.timeout = Some(1);
+        assert_eq!(invariant_worker_count(&config), 4);
+    }
+
+    #[test]
+    fn gas_report_samples_are_split_across_workers() {
+        assert_eq!(gas_report_samples_for_worker(0, 0, 4), 0);
+        assert_eq!(gas_report_samples_for_worker(8, 0, 4), 2);
+        assert_eq!(gas_report_samples_for_worker(8, 3, 4), 2);
+        assert_eq!(gas_report_samples_for_worker(10, 0, 4), 3);
+        assert_eq!(gas_report_samples_for_worker(10, 1, 4), 3);
+        assert_eq!(gas_report_samples_for_worker(10, 2, 4), 2);
+        assert_eq!(gas_report_samples_for_worker(10, 3, 4), 2);
+        assert_eq!(gas_report_samples_for_worker(3, 3, 4), 0);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -490,8 +490,10 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             InvariantFuzzError,
         >,
     ) -> Result<InvariantFuzzTestResult> {
+        let campaign_spec = InvariantCampaignSpec::new(self.config.runs);
+        let worker_plan = campaign_spec.worker_plans(1)?.pop().expect("one worker plan requested");
         let worker_output = self.run_invariant_worker(
-            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: self.config.runs },
+            worker_plan,
             invariant_contract,
             fuzz_fixtures,
             fuzz_state,
@@ -550,8 +552,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let mut throughput = InvariantThroughputMetrics::default();
         let mut failure_metrics = InvariantFailureMetrics::default();
         let continue_campaign = |runs: u32| {
-            !early_exit.should_stop()
-                && if timer.is_enabled() { !timer.is_timed_out() } else { runs < plan.runs }
+            if early_exit.should_stop() {
+                return false;
+            }
+
+            if timer.is_enabled() { !timer.is_timed_out() } else { runs < plan.runs }
         };
 
         // Invariant runs with edge coverage if corpus dir is set or showing edge coverage.
@@ -975,23 +980,21 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
         let reverts = result.failures.reverts;
         let (errors, handler_errors) = result.failures.partition();
+        let worker_result = InvariantFuzzTestResult::new(
+            errors,
+            handler_errors,
+            result.fuzz_cases,
+            reverts,
+            result.last_run_inputs,
+            result.gas_report_traces,
+            result.line_coverage,
+            result.metrics,
+            if plan.worker_id == 0 { corpus_manager.failed_replays } else { 0 },
+            result.optimization_best_value,
+            result.optimization_best_sequence,
+        );
         plan.runs = planned_runs;
-        Ok(InvariantWorkerOutput {
-            plan,
-            result: InvariantFuzzTestResult::new(
-                errors,
-                handler_errors,
-                result.fuzz_cases,
-                reverts,
-                result.last_run_inputs,
-                result.gas_report_traces,
-                result.line_coverage,
-                result.metrics,
-                if plan.worker_id == 0 { corpus_manager.failed_replays } else { 0 },
-                result.optimization_best_value,
-                result.optimization_best_sequence,
-            ),
-        })
+        Ok(InvariantWorkerOutput::new(plan, worker_result))
     }
 
     /// Prepares certain structures to execute the invariant tests:

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -520,12 +520,13 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         >,
     ) -> Result<InvariantFuzzTestResult> {
         let campaign_spec = InvariantCampaignSpec::new(self.config.runs);
-        let use_parallel = self.config.timeout.is_none() && !self.config.call_override;
-        let worker_count = if use_parallel { invariant_worker_count(self.config.runs) } else { 1 };
+        let can_parallelize = self.config.timeout.is_none() && !self.config.call_override;
+        let worker_count =
+            if can_parallelize { invariant_worker_count(self.config.runs) } else { 1 };
         let worker_plans = campaign_spec.worker_plans(worker_count)?;
         let campaign_seed =
             self.prepare_campaign_seed(&invariant_contract, initial_handler_failures)?;
-        let use_parallel = worker_plans.len() > 1;
+        let run_in_parallel = worker_plans.len() > 1;
         let mut runner = self.runner.clone();
         let config = self.config.clone();
         let setup_contracts = self.setup_contracts;
@@ -534,7 +535,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let campaign_state =
             Arc::new(InvariantCampaignState::new(self.config.timeout, early_exit.clone()));
 
-        let worker_outputs = if use_parallel {
+        let worker_outputs = if run_in_parallel {
             let worker_jobs = worker_plans
                 .into_iter()
                 .map(|worker_plan| {
@@ -595,11 +596,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         for worker_output in worker_outputs {
             aggregator.push(worker_output);
         }
-        let (mut result, corpus_inputs) = aggregator.finish_with_corpus()?;
+        let (mut result, corpus_entries) = aggregator.finish_with_corpus_entries()?;
         self.shrink_handler_failures(&mut result, progress, early_exit);
-        WorkerCorpus::persist_campaign_output(
+        WorkerCorpus::persist_campaign_outputs(
             &self.config.corpus,
-            &corpus_inputs,
+            &corpus_entries,
             result
                 .optimization_best_value
                 .map(|value| (value, result.optimization_best_sequence.as_slice())),
@@ -641,7 +642,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             project_contracts,
             &campaign_seed,
         )?;
-        let mut corpus_inputs = Vec::new();
+        let mut corpus_entries = Vec::new();
 
         // Start timer for this invariant test.
         let mut runs = 0;
@@ -938,13 +939,13 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 let prefix = current_run.inputs[..current_run.optimization_prefix_len].to_vec();
                 (v, prefix)
             });
-            if let Some(input) = corpus_manager.process_campaign_inputs(
+            if let Some(input) = corpus_manager.process_inputs_for_campaign(
                 &current_run.inputs,
                 &current_run.cmp_seq,
                 current_run.new_coverage,
                 optimization,
             ) {
-                corpus_inputs.push(input);
+                corpus_entries.push(input);
             }
 
             // Call `afterInvariant` only if declared and the current run produced no new
@@ -1061,7 +1062,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             result.optimization_best_sequence,
         );
         plan.runs = planned_runs;
-        Ok(InvariantWorkerOutput { plan, result: worker_result, corpus_inputs })
+        Ok(InvariantWorkerOutput { plan, result: worker_result, corpus_entries })
     }
 
     fn shrink_handler_failures(

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     executors::{
         DURATION_BETWEEN_METRICS_REPORT, EarlyExit, EvmError, Executor, RawCallResult,
-        corpus::{CorpusCampaignOutput, DynamicTargetCtx, WorkerCorpus},
+        corpus::{DynamicTargetCtx, WorkerCorpus},
     },
     inspectors::Fuzzer,
 };
@@ -164,7 +164,7 @@ impl InvariantThroughputMetrics {
 }
 
 fn invariant_worker_count(runs: u32) -> usize {
-    let max_workers = if runs == 0 { 1 } else { Ord::max(1, runs / MIN_RUNS_PER_INVARIANT_WORKER) };
+    let max_workers = (runs / MIN_RUNS_PER_INVARIANT_WORKER).max(1);
     Ord::min(rayon::current_num_threads(), max_workers as usize)
 }
 
@@ -186,7 +186,7 @@ fn rate_per_sec(total: f64, elapsed: Duration) -> f64 {
 }
 
 /// Tracks invariant failure counts during a campaign.
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 struct InvariantFailureMetrics {
     failures: u64,
     unique_failures: HashSet<String>,
@@ -391,12 +391,6 @@ impl InvariantTest {
             self.test_data.optimization_best_sequence = sequence.to_vec();
         }
     }
-
-    fn merge_initial_optimization(&mut self, value: Option<I256>, sequence: Vec<BasicTxDetails>) {
-        if let Some(value) = value {
-            self.update_optimization_value(value, &sequence);
-        }
-    }
 }
 
 /// Contains data for an invariant test run.
@@ -473,8 +467,6 @@ pub struct InvariantExecutor<'a, FEN: FoundryEvmNetwork> {
     project_contracts: &'a ContractsByArtifact,
     /// Filters contracts to be fuzzed through their artifact identifiers.
     artifact_filters: ArtifactFilters,
-    /// Number of invariant workers used for large campaigns.
-    num_workers: usize,
 }
 
 impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
@@ -489,7 +481,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         Self {
             executor,
             runner,
-            num_workers: invariant_worker_count(config.runs),
             config,
             setup_contracts,
             project_contracts,
@@ -529,20 +520,19 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         >,
     ) -> Result<InvariantFuzzTestResult> {
         let campaign_spec = InvariantCampaignSpec::new(self.config.runs);
-        let worker_plans = campaign_spec.worker_plans(self.num_workers)?;
+        let use_parallel = self.config.timeout.is_none() && !self.config.call_override;
+        let worker_count = if use_parallel { invariant_worker_count(self.config.runs) } else { 1 };
+        let worker_plans = campaign_spec.worker_plans(worker_count)?;
         let campaign_seed =
             self.prepare_campaign_seed(&invariant_contract, initial_handler_failures)?;
-        let use_parallel =
-            worker_plans.len() > 1 && self.config.timeout.is_none() && !self.config.call_override;
+        let use_parallel = worker_plans.len() > 1;
         let mut runner = self.runner.clone();
         let config = self.config.clone();
         let setup_contracts = self.setup_contracts;
         let project_contracts = self.project_contracts;
         let base_executor = self.executor.clone();
-        let campaign_state = std::sync::Arc::new(InvariantCampaignState::new(
-            self.config.timeout,
-            early_exit.clone(),
-        ));
+        let campaign_state =
+            Arc::new(InvariantCampaignState::new(self.config.timeout, early_exit.clone()));
 
         let worker_outputs = if use_parallel {
             let worker_jobs = worker_plans
@@ -577,22 +567,13 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 })
                 .collect::<Result<Vec<_>>>()?
         } else {
-            let plan = if worker_plans.len() == 1 {
-                worker_plans[0]
-            } else {
-                InvariantWorkerPlan {
-                    worker_id: 0,
-                    first_global_run: 0,
-                    runs: campaign_spec.total_runs,
-                }
-            };
             vec![Self::run_invariant_worker(
                 base_executor,
                 runner,
                 config,
                 setup_contracts,
                 project_contracts,
-                plan,
+                worker_plans[0],
                 invariant_contract.clone(),
                 fuzz_fixtures,
                 fuzz_state,
@@ -614,10 +595,16 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         for worker_output in worker_outputs {
             aggregator.push(worker_output);
         }
-        let mut campaign_output = aggregator.finish_with_corpus()?;
-        self.shrink_handler_failures(&mut campaign_output.result, progress, early_exit);
-        WorkerCorpus::persist_campaign_output(&self.config.corpus, &campaign_output.corpus);
-        Ok(campaign_output.result)
+        let (mut result, corpus_inputs) = aggregator.finish_with_corpus()?;
+        self.shrink_handler_failures(&mut result, progress, early_exit);
+        WorkerCorpus::persist_campaign_output(
+            &self.config.corpus,
+            &corpus_inputs,
+            result
+                .optimization_best_value
+                .map(|value| (value, result.optimization_best_sequence.as_slice())),
+        );
+        Ok(result)
     }
 
     /// Runs one worker-local slice of an invariant campaign.
@@ -652,9 +639,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             &config,
             setup_contracts,
             project_contracts,
-            campaign_seed.clone(),
+            &campaign_seed,
         )?;
-        let mut corpus_output = CorpusCampaignOutput::default();
+        let mut corpus_inputs = Vec::new();
 
         // Start timer for this invariant test.
         let mut runs = 0;
@@ -951,14 +938,13 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 let prefix = current_run.inputs[..current_run.optimization_prefix_len].to_vec();
                 (v, prefix)
             });
-            let record = corpus_manager.process_campaign_inputs(
+            if let Some(input) = corpus_manager.process_campaign_inputs(
                 &current_run.inputs,
                 &current_run.cmp_seq,
                 current_run.new_coverage,
                 optimization,
-            );
-            if let Some(input) = record.into_campaign_input() {
-                corpus_output.inputs.push(input);
+            ) {
+                corpus_inputs.push(input);
             }
 
             // Call `afterInvariant` only if declared and the current run produced no new
@@ -1061,10 +1047,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let result = invariant_test.test_data;
         let reverts = result.failures.reverts;
         let (errors, handler_errors) = result.failures.partition();
-        corpus_output.merge_optimization(
-            result.optimization_best_value,
-            result.optimization_best_sequence.clone(),
-        );
         let worker_result = InvariantFuzzTestResult::new(
             errors,
             handler_errors,
@@ -1079,7 +1061,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             result.optimization_best_sequence,
         );
         plan.runs = planned_runs;
-        Ok(InvariantWorkerOutput::new_with_corpus(plan, worker_result, corpus_output))
+        Ok(InvariantWorkerOutput { plan, result: worker_result, corpus_inputs })
     }
 
     fn shrink_handler_failures(
@@ -1158,7 +1140,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         config: &InvariantConfig,
         setup_contracts: &ContractsByAddress,
         project_contracts: &ContractsByArtifact,
-        campaign_seed: InvariantCampaignSeed,
+        campaign_seed: &InvariantCampaignSeed,
     ) -> Result<(InvariantTest, WorkerCorpus)> {
         let fuzz_state = fuzz_state.into_invariant();
         let targeted_contracts = FuzzRunIdentifiedContracts::new(
@@ -1169,7 +1151,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // Creates the invariant strategy.
         let strategy = invariant_strat(
             fuzz_state.clone(),
-            campaign_seed.sender_filters,
+            campaign_seed.sender_filters.clone(),
             targeted_contracts.clone(),
             config.clone(),
             fuzz_fixtures.clone(),
@@ -1201,8 +1183,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // This does not count as a fuzz run. It will just register the revert.
         let mut failures = InvariantFailures::new();
         // Seed disk-recovered handler bugs so live counters reflect them from tick 0.
-        for ((addr, sel), err) in campaign_seed.initial_handler_failures {
-            failures.seed_handler_failure(addr, sel, err);
+        for (&(addr, sel), err) in &campaign_seed.initial_handler_failures {
+            failures.seed_handler_failure(addr, sel, err.clone());
         }
         invariant_preflight_check(
             invariant_contract,
@@ -1276,7 +1258,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // is a master-worker artifact loaded with the initial corpus.
         if is_master_worker && invariant_contract.is_optimization() {
             let (opt_best_value, opt_best_sequence) = worker.optimization_initial_state();
-            invariant_test.merge_initial_optimization(opt_best_value, opt_best_sequence);
+            if let Some(value) = opt_best_value {
+                invariant_test.update_optimization_value(value, &opt_best_sequence);
+            }
         }
 
         Ok((invariant_test, worker))

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -490,11 +490,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             InvariantFuzzError,
         >,
     ) -> Result<InvariantFuzzTestResult> {
-        let campaign_spec = InvariantCampaignSpec::new(self.config.runs);
-        let worker_plan = campaign_spec.worker_plans(1)?.pop().expect("one worker plan requested");
-        debug_assert!(worker_plan.is_master());
         let worker_output = self.run_invariant_worker(
-            worker_plan,
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: self.config.runs },
             invariant_contract,
             fuzz_fixtures,
             fuzz_state,
@@ -502,13 +499,12 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             early_exit,
             initial_handler_failures,
         )?;
-        debug_assert_eq!(worker_output.plan.first_global_run, 0);
 
         // Timeout-driven campaigns can execute beyond the initial configured run count. Preserve
         // the existing single-worker `planned_runs` behavior by rebuilding the logical spec
         // from the worker's final plan.
-        let campaign_spec = InvariantCampaignSpec::new(worker_output.plan.runs);
-        let mut aggregator = InvariantCampaignAggregator::new(campaign_spec);
+        let mut aggregator =
+            InvariantCampaignAggregator::new(InvariantCampaignSpec::new(worker_output.plan.runs));
         aggregator.push(worker_output);
         aggregator.finish()
     }
@@ -554,11 +550,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let mut throughput = InvariantThroughputMetrics::default();
         let mut failure_metrics = InvariantFailureMetrics::default();
         let continue_campaign = |runs: u32| {
-            if early_exit.should_stop() {
-                return false;
-            }
-
-            if timer.is_enabled() { !timer.is_timed_out() } else { runs < plan.runs }
+            !early_exit.should_stop()
+                && if timer.is_enabled() { !timer.is_timed_out() } else { runs < plan.runs }
         };
 
         // Invariant runs with edge coverage if corpus dir is set or showing edge coverage.
@@ -982,23 +975,23 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
         let reverts = result.failures.reverts;
         let (errors, handler_errors) = result.failures.partition();
-        let failed_corpus_replays =
-            if plan.is_master() { corpus_manager.failed_replays } else { 0 };
-        let worker_result = InvariantFuzzTestResult::new(
-            errors,
-            handler_errors,
-            result.fuzz_cases,
-            reverts,
-            result.last_run_inputs,
-            result.gas_report_traces,
-            result.line_coverage,
-            result.metrics,
-            failed_corpus_replays,
-            result.optimization_best_value,
-            result.optimization_best_sequence,
-        );
         plan.runs = planned_runs;
-        Ok(InvariantWorkerOutput::new(plan, worker_result))
+        Ok(InvariantWorkerOutput {
+            plan,
+            result: InvariantFuzzTestResult::new(
+                errors,
+                handler_errors,
+                result.fuzz_cases,
+                reverts,
+                result.last_run_inputs,
+                result.gas_report_traces,
+                result.line_coverage,
+                result.metrics,
+                if plan.worker_id == 0 { corpus_manager.failed_replays } else { 0 },
+                result.optimization_best_value,
+                result.optimization_best_sequence,
+            ),
+        })
     }
 
     /// Prepares certain structures to execute the invariant tests:
@@ -1107,18 +1100,15 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             }
         }
 
-        let is_master_worker = plan.is_master();
-        let master_executor = is_master_worker.then_some(&self.executor);
-        let replay_contracts = is_master_worker.then_some(&targeted_contracts);
-        let dynamic_target_ctx = is_master_worker.then_some(self.dynamic_target_ctx());
+        let is_master_worker = plan.worker_id == 0;
         let worker = WorkerCorpus::new(
-            plan.worker_index(),
+            plan.worker_id as usize,
             self.config.corpus.clone(),
             strategy.boxed(),
-            master_executor,
+            is_master_worker.then_some(&self.executor),
             None,
-            replay_contracts,
-            dynamic_target_ctx,
+            is_master_worker.then_some(&targeted_contracts),
+            is_master_worker.then_some(self.dynamic_target_ctx()),
         )?;
 
         let mut invariant_test =

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -74,7 +74,7 @@ pub use shrink::{
 /// Minimum number of logical runs assigned to each invariant worker.
 ///
 /// Keeps short campaigns single-threaded and avoids producing many small rayon jobs.
-const MIN_RUNS_PER_INVARIANT_WORKER: u32 = 64;
+const MIN_RUNS_PER_INVARIANT_WORKER: u32 = 1000;
 
 sol! {
     interface IInvariantTest {

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -75,7 +75,7 @@ pub use shrink::{
 /// Minimum number of logical runs assigned to each invariant worker.
 ///
 /// Keeps short campaigns single-threaded and avoids producing many small rayon jobs.
-const MIN_RUNS_PER_INVARIANT_WORKER: u32 = 1000;
+const MIN_RUNS_PER_INVARIANT_WORKER: u32 = 10_000;
 
 sol! {
     interface IInvariantTest {
@@ -164,9 +164,17 @@ impl InvariantThroughputMetrics {
     }
 }
 
-fn invariant_worker_count(runs: u32) -> usize {
-    let max_workers = (runs / MIN_RUNS_PER_INVARIANT_WORKER).max(1);
-    Ord::min(rayon::current_num_threads(), max_workers as usize)
+fn max_invariant_workers_for_runs(runs: u32) -> usize {
+    let max_workers = (runs / MIN_RUNS_PER_INVARIANT_WORKER).max(1) as usize;
+    max_workers.min(runs as usize).max(1)
+}
+
+fn invariant_worker_count(config: &InvariantConfig) -> usize {
+    if config.timeout.is_some() || config.call_override || config.corpus.collect_edge_coverage() {
+        return 1;
+    }
+
+    config.workers.min(max_invariant_workers_for_runs(config.runs))
 }
 
 fn invariant_worker_runner(runner: &mut TestRunner, worker_id: u32) -> TestRunner {
@@ -174,6 +182,24 @@ fn invariant_worker_runner(runner: &mut TestRunner, worker_id: u32) -> TestRunne
         runner.clone()
     } else {
         TestRunner::new_with_rng(runner.config().clone(), runner.new_rng())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InvariantCorpusPersistence {
+    /// Preserve the legacy single-worker behavior: each interesting input is written immediately.
+    Live,
+    /// Parallel workers return interesting inputs to the campaign coordinator for merged writes.
+    Deferred,
+}
+
+impl InvariantCorpusPersistence {
+    const fn is_deferred(self) -> bool {
+        matches!(self, Self::Deferred)
+    }
+
+    const fn progress_worker_id(self, worker_id: u32) -> Option<u32> {
+        if self.is_deferred() { Some(worker_id) } else { None }
     }
 }
 
@@ -521,13 +547,16 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         >,
     ) -> Result<InvariantFuzzTestResult> {
         let campaign_spec = InvariantCampaignSpec::new(self.config.runs);
-        let can_parallelize = self.config.timeout.is_none() && !self.config.call_override;
-        let worker_count =
-            if can_parallelize { invariant_worker_count(self.config.runs) } else { 1 };
+        let worker_count = invariant_worker_count(&self.config);
         let worker_plans = campaign_spec.worker_plans(worker_count)?;
         let campaign_seed =
             self.prepare_campaign_seed(&invariant_contract, initial_handler_failures)?;
         let run_in_parallel = worker_plans.len() > 1;
+        let corpus_persistence = if run_in_parallel {
+            InvariantCorpusPersistence::Deferred
+        } else {
+            InvariantCorpusPersistence::Live
+        };
         let mut runner = self.runner.clone();
         let config = self.config.clone();
         let setup_contracts = self.setup_contracts;
@@ -562,6 +591,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         progress,
                         &campaign_state,
                         campaign_seed.clone(),
+                        corpus_persistence,
                     );
                     debug!("finished in {:?}", timer.elapsed());
                     output
@@ -581,6 +611,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 progress,
                 &campaign_state,
                 campaign_seed,
+                corpus_persistence,
             )?]
         };
 
@@ -596,15 +627,16 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         for worker_output in worker_outputs {
             aggregator.push(worker_output);
         }
-        let (mut result, corpus_entries) = aggregator.finish_with_corpus_entries()?;
-        self.shrink_handler_failures(&mut result, progress, early_exit);
-        WorkerCorpus::persist_campaign_outputs(
-            &self.config.corpus,
-            &corpus_entries,
-            result
-                .optimization_best_value
-                .map(|value| (value, result.optimization_best_sequence.as_slice())),
-        );
+        let (result, corpus_entries) = aggregator.finish_with_corpus_entries()?;
+        if corpus_persistence.is_deferred() {
+            WorkerCorpus::persist_campaign_outputs(
+                &self.config.corpus,
+                &corpus_entries,
+                result
+                    .optimization_best_value
+                    .map(|value| (value, result.optimization_best_sequence.as_slice())),
+            );
+        }
         Ok(result)
     }
 
@@ -623,6 +655,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         progress: Option<&ProgressBar>,
         campaign_state: &InvariantCampaignState,
         campaign_seed: InvariantCampaignSeed,
+        corpus_persistence: InvariantCorpusPersistence,
     ) -> Result<InvariantWorkerOutput> {
         // Note: invariant function signatures (no inputs) are validated upstream in the
         // suite runner so parameterized `invariant_*` functions are rejected with a per-test
@@ -646,6 +679,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             &campaign_seed,
         )?;
         let mut corpus_entries = Vec::new();
+        let progress_worker_id = corpus_persistence.progress_worker_id(plan.worker_id);
 
         // Start timer for this invariant test.
         let timer = FuzzTestTimer::new(config.timeout);
@@ -686,6 +720,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
             // We stop the run immediately if we have reverted, and `fail_on_revert` is set.
             if config.fail_on_revert && invariant_test.reverts() > 0 {
+                campaign_state.request_terminal_stop();
                 return Err(eyre!("call reverted"));
             }
 
@@ -761,6 +796,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             invariant_contract.anchor(),
                             InvariantFuzzError::MaxAssumeRejects(config.max_assume_rejects),
                         );
+                        campaign_state.request_terminal_stop();
                         break 'stop;
                     }
                 } else {
@@ -924,6 +960,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         if invariant_contract.invariant_fns.len() > 1 && !config.fail_on_revert {
                             break;
                         }
+                        campaign_state.request_terminal_stop();
                         stop_after_run = true;
                         break;
                     }
@@ -945,13 +982,22 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 let prefix = current_run.inputs[..current_run.optimization_prefix_len].to_vec();
                 (v, prefix)
             });
-            if let Some(input) = corpus_manager.process_inputs_for_campaign(
-                &current_run.inputs,
-                &current_run.cmp_seq,
-                current_run.new_coverage,
-                optimization,
-            ) {
-                corpus_entries.push(input);
+            if corpus_persistence.is_deferred() {
+                if let Some(input) = corpus_manager.process_inputs_for_campaign(
+                    &current_run.inputs,
+                    &current_run.cmp_seq,
+                    current_run.new_coverage,
+                    optimization,
+                ) {
+                    corpus_entries.push(input);
+                }
+            } else {
+                corpus_manager.process_inputs(
+                    &current_run.inputs,
+                    &current_run.cmp_seq,
+                    current_run.new_coverage,
+                    optimization,
+                );
             }
 
             // Call `afterInvariant` only if declared and the current run produced no new
@@ -979,6 +1025,15 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
             // End current invariant test run.
             invariant_test.end_run(current_run, config.gas_report_samples as usize);
+            runs += 1;
+            let total_runs = campaign_state.increment_runs();
+            debug_assert!(
+                is_timed_campaign || total_runs <= config.runs,
+                "worker runs were not distributed correctly"
+            );
+            if let Some(progress) = progress {
+                progress.inc(1);
+            }
             if let Some(progress) = progress {
                 // Display current best value, corpus metrics, and failure counts.
                 let best = invariant_test.test_data.optimization_best_value;
@@ -1012,6 +1067,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         }
                         msg.push_str(&format!("⚠ {handler_bugs} handler bug(s)"));
                     }
+                    let msg = if let Some(worker_id) = progress_worker_id {
+                        format!("[w{worker_id}] {msg}")
+                    } else {
+                        msg
+                    };
                     progress.set_message(msg);
                 }
             } else if edge_coverage_enabled
@@ -1034,15 +1094,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 last_metrics_report = Instant::now();
             }
 
-            runs += 1;
-            let total_runs = campaign_state.increment_runs();
-            debug_assert!(
-                is_timed_campaign || total_runs <= config.runs,
-                "worker runs were not distributed correctly"
-            );
-            if let Some(progress) = progress {
-                progress.inc(1);
-            }
             if stop_after_run {
                 break 'stop;
             }
@@ -1050,6 +1101,14 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
         trace!(?fuzz_fixtures);
         invariant_test.fuzz_state.log_stats();
+
+        Self::shrink_handler_failures(
+            &config,
+            &executor,
+            &mut invariant_test.test_data,
+            progress,
+            campaign_state.early_exit(),
+        );
 
         let result = invariant_test.test_data;
         let reverts = result.failures.reverts;
@@ -1082,17 +1141,18 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
     }
 
     fn shrink_handler_failures(
-        &self,
-        result: &mut InvariantFuzzTestResult,
+        config: &InvariantConfig,
+        executor: &Executor<FEN>,
+        result: &mut InvariantTestData,
         progress: Option<&ProgressBar>,
         early_exit: &EarlyExit,
     ) {
-        let total = result.handler_errors.len();
+        let total = result.failures.handler_count();
         if total == 0 {
             return;
         }
 
-        for (idx, (_site, error)) in result.handler_errors.iter_mut().enumerate() {
+        for (idx, (_site, error)) in result.failures.handler_failures_mut().enumerate() {
             if early_exit.should_stop() {
                 break;
             }
@@ -1100,16 +1160,16 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 continue;
             };
             shrink::reset_shrink_progress(
-                &self.config,
+                config,
                 progress,
                 &format!("handler {:#x}::{}", failure.reverter, failure.selector),
                 Some((idx + 1, total)),
             );
             match shrink::shrink_handler_sequence(
-                &self.config,
+                config,
                 &failure.call_sequence,
                 failure.edge_fingerprint,
-                &self.executor,
+                executor,
                 progress,
                 early_exit,
             ) {
@@ -1763,6 +1823,35 @@ mod tests {
         assert!((payload["tx_per_sec"].as_f64().unwrap() - 0.2).abs() < 1e-12);
         assert!((payload["gas_per_sec"].as_f64().unwrap() - 5.0).abs() < 1e-12);
         assert_eq!(payload["optimization_best"], json!("42"));
+    }
+
+    #[test]
+    fn invariant_worker_count_keeps_short_campaigns_single_worker() {
+        assert_eq!(max_invariant_workers_for_runs(0), 1);
+        assert_eq!(max_invariant_workers_for_runs(MIN_RUNS_PER_INVARIANT_WORKER - 1), 1);
+        assert_eq!(max_invariant_workers_for_runs(MIN_RUNS_PER_INVARIANT_WORKER), 1);
+        assert_eq!(max_invariant_workers_for_runs(MIN_RUNS_PER_INVARIANT_WORKER * 2), 2);
+    }
+
+    #[test]
+    fn invariant_worker_count_is_explicit_and_disables_unsafe_parallel_modes() {
+        let mut config = InvariantConfig {
+            runs: MIN_RUNS_PER_INVARIANT_WORKER * 4,
+            workers: 4,
+            ..Default::default()
+        };
+        assert_eq!(invariant_worker_count(&config), 4);
+
+        config.timeout = Some(1);
+        assert_eq!(invariant_worker_count(&config), 1);
+
+        config.timeout = None;
+        config.call_override = true;
+        assert_eq!(invariant_worker_count(&config), 1);
+
+        config.call_override = false;
+        config.corpus.show_edge_coverage = true;
+        assert_eq!(invariant_worker_count(&config), 1);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -54,7 +54,9 @@ pub use error::{
 use foundry_evm_coverage::HitMaps;
 
 mod campaign;
-use campaign::{InvariantCampaignAggregator, InvariantCampaignSpec, InvariantWorkerOutput};
+use campaign::{
+    InvariantCampaignAggregator, InvariantCampaignSpec, InvariantWorkerOutput, InvariantWorkerPlan,
+};
 
 mod replay;
 pub use replay::{replay_error, replay_run};
@@ -488,11 +490,54 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             InvariantFuzzError,
         >,
     ) -> Result<InvariantFuzzTestResult> {
+        let worker_plan = InvariantCampaignSpec::new(self.config.runs)
+            .worker_plans(1)?
+            .pop()
+            .expect("one worker plan requested");
+        let worker_output = self.run_invariant_worker(
+            worker_plan,
+            invariant_contract,
+            fuzz_fixtures,
+            fuzz_state,
+            progress,
+            early_exit,
+            initial_handler_failures,
+        )?;
+        debug_assert_eq!(worker_output.plan.first_global_run, 0);
+
+        // Timeout-driven campaigns can execute beyond the initial configured run count. Preserve
+        // the existing single-worker `planned_runs` behavior by rebuilding the logical spec
+        // from the worker's final plan.
+        let campaign_spec = InvariantCampaignSpec::new(worker_output.plan.runs);
+        let mut aggregator = InvariantCampaignAggregator::new(campaign_spec);
+        aggregator.push(worker_output);
+        aggregator.finish()
+    }
+
+    /// Runs one worker-local slice of an invariant campaign.
+    ///
+    /// This is intentionally still dispatched with a single worker by `invariant_fuzz`; the worker
+    /// boundary exists so future changes can fan out multiple independent plans without changing
+    /// the campaign aggregation contract.
+    #[allow(clippy::too_many_arguments)]
+    fn run_invariant_worker(
+        &mut self,
+        mut plan: InvariantWorkerPlan,
+        invariant_contract: InvariantContract<'_>,
+        fuzz_fixtures: &FuzzFixtures,
+        fuzz_state: EvmFuzzState,
+        progress: Option<&ProgressBar>,
+        early_exit: &EarlyExit,
+        initial_handler_failures: std::collections::HashMap<
+            (Address, Selector),
+            InvariantFuzzError,
+        >,
+    ) -> Result<InvariantWorkerOutput> {
         // Note: invariant function signatures (no inputs) are validated upstream in the
         // suite runner so parameterized `invariant_*` functions are rejected with a per-test
         // failure entry before any campaign runs.
 
-        let mut planned_runs = self.config.runs;
+        let mut planned_runs = plan.runs;
 
         let (mut invariant_test, mut corpus_manager) = self.prepare_test(
             &invariant_contract,
@@ -513,7 +558,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 return false;
             }
 
-            if timer.is_enabled() { !timer.is_timed_out() } else { runs < self.config.runs }
+            if timer.is_enabled() { !timer.is_timed_out() } else { runs < plan.runs }
         };
 
         // Invariant runs with edge coverage if corpus dir is set or showing edge coverage.
@@ -950,12 +995,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             result.optimization_best_value,
             result.optimization_best_sequence,
         );
-        let campaign_spec = InvariantCampaignSpec::new(planned_runs);
-        let worker_plan = campaign_spec.worker_plans(1)?.pop().expect("one worker plan requested");
-        let worker_output = InvariantWorkerOutput::new(worker_plan, worker_result);
-        let mut aggregator = InvariantCampaignAggregator::new(campaign_spec);
-        aggregator.push(worker_output);
-        aggregator.finish()
+        plan.runs = planned_runs;
+        Ok(InvariantWorkerOutput::new(plan, worker_result))
     }
 
     /// Prepares certain structures to execute the invariant tests:

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -163,10 +163,6 @@ fn max_invariant_workers_for_runs(runs: u32) -> usize {
 }
 
 fn invariant_worker_count(config: &InvariantConfig) -> usize {
-    if config.single_worker_reason().is_some() {
-        return 1;
-    }
-
     if config.timeout.is_some() {
         return config.workers;
     }
@@ -1818,7 +1814,7 @@ mod tests {
     }
 
     #[test]
-    fn invariant_worker_count_is_explicit_and_disables_unsafe_parallel_modes() {
+    fn invariant_worker_count_uses_configured_workers_and_caps_short_campaigns() {
         let mut config = InvariantConfig {
             runs: MIN_RUNS_PER_INVARIANT_WORKER * 4,
             workers: 4,
@@ -1826,14 +1822,6 @@ mod tests {
         };
         assert_eq!(invariant_worker_count(&config), 4);
 
-        config.timeout = Some(1);
-        assert_eq!(invariant_worker_count(&config), 4);
-
-        config.timeout = None;
-        config.call_override = true;
-        assert_eq!(invariant_worker_count(&config), 1);
-
-        config.call_override = false;
         config.corpus.show_edge_coverage = true;
         assert_eq!(invariant_worker_count(&config), 4);
 
@@ -1841,16 +1829,10 @@ mod tests {
         config.corpus.corpus_dir = Some(std::path::PathBuf::from("corpus"));
         assert_eq!(invariant_worker_count(&config), 4);
 
-        config.corpus.corpus_dir = None;
-        config.corpus.sancov_edges = true;
-        assert_eq!(invariant_worker_count(&config), 1);
-
-        config.corpus.sancov_edges = false;
-        config.corpus.sancov_trace_cmp = true;
-        assert_eq!(invariant_worker_count(&config), 1);
-
-        config.corpus.sancov_trace_cmp = false;
         config.runs = MIN_RUNS_PER_INVARIANT_WORKER - 1;
+        config.timeout = None;
+        assert_eq!(invariant_worker_count(&config), 1);
+
         config.timeout = Some(1);
         assert_eq!(invariant_worker_count(&config), 4);
     }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -149,12 +149,6 @@ struct InvariantThroughputMetrics {
 }
 
 impl InvariantThroughputMetrics {
-    #[cfg(test)]
-    const fn record_call(&mut self, gas_used: u64) {
-        self.total_txs += 1;
-        self.total_gas += gas_used;
-    }
-
     fn tx_per_sec(self, elapsed: Duration) -> f64 {
         rate_per_sec(self.total_txs as f64, elapsed)
     }
@@ -206,10 +200,6 @@ impl InvariantCorpusPersistence {
     const fn is_deferred(self) -> bool {
         matches!(self, Self::Deferred)
     }
-
-    const fn progress_worker_id(self, worker_id: u32) -> Option<u32> {
-        if self.is_deferred() { Some(worker_id) } else { None }
-    }
 }
 
 /// Converts a cumulative campaign total into an average per-second rate.
@@ -258,9 +248,8 @@ fn record_new_invariant_failures(
     failures: &InvariantFailures,
 ) {
     for (f, _) in &invariant_contract.invariant_fns {
-        if failures.has_failure(f) {
-            let reason =
-                failures.get_failure(f).and_then(|e| e.revert_reason()).unwrap_or_default();
+        if let Some(failure) = failures.get_failure(f) {
+            let reason = failure.revert_reason().unwrap_or_default();
             campaign_state.record_invariant_failure(&f.name, invariant_contract.name, &reason);
         }
     }
@@ -556,8 +545,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         >,
     ) -> Result<InvariantFuzzTestResult> {
         let campaign_spec = InvariantCampaignSpec::new(self.config.runs);
-        let worker_count = invariant_worker_count(&self.config);
-        let worker_plans = campaign_spec.worker_plans(worker_count)?;
+        let worker_plans = campaign_spec.worker_plans(invariant_worker_count(&self.config))?;
         let actual_worker_count = worker_plans.len();
         let campaign_seed =
             self.prepare_campaign_seed(&invariant_contract, initial_handler_failures)?;
@@ -572,8 +560,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             Some(&replay_targets),
             Some(self.dynamic_target_ctx()),
         )?;
-        let run_in_parallel = worker_plans.len() > 1;
-        let corpus_persistence = if run_in_parallel {
+        let corpus_persistence = if actual_worker_count > 1 {
             InvariantCorpusPersistence::Deferred
         } else {
             InvariantCorpusPersistence::Live
@@ -586,7 +573,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let campaign_state =
             Arc::new(InvariantCampaignState::new(early_exit.clone(), self.config.timeout));
 
-        let worker_outputs = if run_in_parallel {
+        let worker_outputs = if corpus_persistence.is_deferred() {
             let worker_jobs = worker_plans
                 .into_iter()
                 .map(|worker_plan| {
@@ -628,11 +615,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 .collect::<Result<Vec<_>>>()?
         } else {
             let worker_plan = worker_plans[0];
-            let gas_report_samples = gas_report_samples_for_worker(
-                config.gas_report_samples,
-                worker_plan.worker_id,
-                actual_worker_count,
-            );
+            let gas_report_samples = config.gas_report_samples as usize;
             vec![Self::run_invariant_worker(
                 base_executor,
                 runner,
@@ -640,33 +623,28 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 setup_contracts,
                 project_contracts,
                 worker_plan,
-                invariant_contract.clone(),
+                invariant_contract,
                 fuzz_fixtures,
                 fuzz_state,
                 progress,
                 &campaign_state,
-                campaign_seed.clone(),
+                campaign_seed,
                 corpus_seed.clone(),
                 corpus_persistence,
                 gas_report_samples,
             )?]
         };
 
-        let is_timed_campaign = campaign_state.is_timed_campaign();
         let mut aggregator = InvariantCampaignAggregator::new(campaign_spec);
         for worker_output in worker_outputs {
             aggregator.push(worker_output);
         }
-        let (result, corpus_entries) = if is_timed_campaign {
+        let (result, corpus_entries) = if campaign_state.is_timed_campaign() {
             aggregator.finish_partial_with_corpus_entries()?
         } else {
             aggregator.finish_with_corpus_entries()?
         };
         if corpus_persistence.is_deferred() {
-            let replay_targets = FuzzRunIdentifiedContracts::new(
-                campaign_seed.targeted_contracts.clone(),
-                campaign_seed.targets_are_updatable,
-            );
             let corpus_entries = corpus_seed.filter_campaign_entries(
                 &corpus_entries,
                 &self.executor,
@@ -720,17 +698,14 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             corpus_seed,
         )?;
         let mut corpus_entries = Vec::new();
-        let progress_worker_id = corpus_persistence.progress_worker_id(plan.worker_id);
 
-        let is_timed_campaign = campaign_state.is_timed_campaign();
         let mut runs = 0;
-        let continue_campaign = |runs: u32| !campaign_state.should_stop() && runs < plan.runs;
         campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
 
         // Invariant runs with edge coverage if corpus dir is set or showing edge coverage.
         let edge_coverage_enabled = config.corpus.collect_edge_coverage();
 
-        'stop: while continue_campaign(runs) {
+        'stop: while !campaign_state.should_stop() && runs < plan.runs {
             // Per-run failure count snapshot used to gate `afterInvariant` below.
             let failures_before_run = invariant_test.test_data.failures.invariant_count();
             let mut stop_after_run = false;
@@ -1061,8 +1036,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             debug_assert!(total_runs <= config.runs, "worker runs were not distributed correctly");
             if let Some(progress) = progress {
                 progress.inc(1);
-            }
-            if let Some(progress) = progress {
                 campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
                 // Display current best value, corpus metrics, and failure counts.
                 let best = invariant_test.test_data.optimization_best_value;
@@ -1093,8 +1066,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         }
                         msg.push_str(&format!("⚠ {handler_bugs} handler bug(s)"));
                     }
-                    let msg = if let Some(worker_id) = progress_worker_id {
-                        format!("[w{worker_id}] {msg}")
+                    let msg = if corpus_persistence.is_deferred() {
+                        format!("[w{}] {msg}", plan.worker_id)
                     } else {
                         msg
                     };
@@ -1152,7 +1125,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             result.optimization_best_value,
             result.optimization_best_sequence,
         );
-        let reported_plan = if is_timed_campaign {
+        let reported_plan = if campaign_state.is_timed_campaign() {
             InvariantWorkerPlan { runs, ..plan }
         } else {
             // Sharded campaigns must report the original assigned range. Early worker exit changes
@@ -1813,9 +1786,7 @@ mod tests {
 
     #[test]
     fn invariant_progress_json_includes_throughput_fields() {
-        let mut throughput = InvariantThroughputMetrics::default();
-        throughput.record_call(20);
-        throughput.record_call(30);
+        let throughput = InvariantThroughputMetrics { total_txs: 2, total_gas: 50 };
 
         let payload = build_invariant_progress_json(
             123,
@@ -1898,8 +1869,7 @@ mod tests {
 
     #[test]
     fn invariant_progress_json_zero_elapsed_reports_zero_rates() {
-        let mut throughput = InvariantThroughputMetrics::default();
-        throughput.record_call(21_000);
+        let throughput = InvariantThroughputMetrics { total_txs: 1, total_gas: 21_000 };
 
         let payload = build_invariant_progress_json(
             456,

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -490,10 +490,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             InvariantFuzzError,
         >,
     ) -> Result<InvariantFuzzTestResult> {
-        let worker_plan = InvariantCampaignSpec::new(self.config.runs)
-            .worker_plans(1)?
-            .pop()
-            .expect("one worker plan requested");
+        let campaign_spec = InvariantCampaignSpec::new(self.config.runs);
+        let worker_plan = campaign_spec.worker_plans(1)?.pop().expect("one worker plan requested");
+        debug_assert!(worker_plan.is_master());
         let worker_output = self.run_invariant_worker(
             worker_plan,
             invariant_contract,
@@ -540,6 +539,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let mut planned_runs = plan.runs;
 
         let (mut invariant_test, mut corpus_manager) = self.prepare_test(
+            plan,
             &invariant_contract,
             fuzz_fixtures,
             fuzz_state,
@@ -982,6 +982,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
         let reverts = result.failures.reverts;
         let (errors, handler_errors) = result.failures.partition();
+        let failed_corpus_replays =
+            if plan.is_master() { corpus_manager.failed_replays } else { 0 };
         let worker_result = InvariantFuzzTestResult::new(
             errors,
             handler_errors,
@@ -991,7 +993,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             result.gas_report_traces,
             result.line_coverage,
             result.metrics,
-            corpus_manager.failed_replays,
+            failed_corpus_replays,
             result.optimization_best_value,
             result.optimization_best_sequence,
         );
@@ -1004,6 +1006,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
     /// * Invariant Corpus Manager.
     fn prepare_test(
         &mut self,
+        plan: InvariantWorkerPlan,
         invariant_contract: &InvariantContract<'_>,
         fuzz_fixtures: &FuzzFixtures,
         fuzz_state: EvmFuzzState,
@@ -1104,22 +1107,27 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             }
         }
 
+        let is_master_worker = plan.is_master();
+        let master_executor = is_master_worker.then_some(&self.executor);
+        let replay_contracts = is_master_worker.then_some(&targeted_contracts);
+        let dynamic_target_ctx = is_master_worker.then_some(self.dynamic_target_ctx());
         let worker = WorkerCorpus::new(
-            0,
+            plan.worker_index(),
             self.config.corpus.clone(),
             strategy.boxed(),
-            Some(&self.executor),
+            master_executor,
             None,
-            Some(&targeted_contracts),
-            Some(self.dynamic_target_ctx()),
+            replay_contracts,
+            dynamic_target_ctx,
         )?;
 
         let mut invariant_test =
             InvariantTest::new(fuzz_state, targeted_contracts, failures, self.runner.clone());
 
         // Seed invariant test with previously persisted optimization state,
-        // but only if the current invariant is in optimization mode.
-        if invariant_contract.is_optimization() {
+        // but only if the current invariant is in optimization mode. Persisted optimization state
+        // is a master-worker artifact loaded with the initial corpus.
+        if is_master_worker && invariant_contract.is_optimization() {
             let (opt_best_value, opt_best_sequence) = worker.optimization_initial_state();
             invariant_test.test_data.optimization_best_value = opt_best_value;
             invariant_test.test_data.optimization_best_sequence = opt_best_sequence;

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -585,14 +585,14 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         };
 
         // Timeout-driven campaigns can execute beyond the initial configured run count. Preserve
-        // the existing single-worker `planned_runs` behavior by rebuilding the logical spec
-        // from the worker's final plan.
-        let total_planned_runs =
+        // the existing single-worker reported run behavior by rebuilding the logical spec from the
+        // worker's final reported plan.
+        let total_reported_runs =
             worker_outputs.iter().map(|output| output.plan.runs).try_fold(0u32, |acc, runs| {
                 acc.checked_add(runs).ok_or_else(|| eyre!("invariant worker run range overflows"))
             })?;
         let mut aggregator =
-            InvariantCampaignAggregator::new(InvariantCampaignSpec::new(total_planned_runs));
+            InvariantCampaignAggregator::new(InvariantCampaignSpec::new(total_reported_runs));
         for worker_output in worker_outputs {
             aggregator.push(worker_output);
         }
@@ -616,7 +616,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         config: InvariantConfig,
         setup_contracts: &'a ContractsByAddress,
         project_contracts: &'a ContractsByArtifact,
-        mut plan: InvariantWorkerPlan,
+        plan: InvariantWorkerPlan,
         invariant_contract: InvariantContract<'_>,
         fuzz_fixtures: &FuzzFixtures,
         fuzz_state: EvmFuzzState,
@@ -628,7 +628,10 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // suite runner so parameterized `invariant_*` functions are rejected with a per-test
         // failure entry before any campaign runs.
 
-        let mut planned_runs = plan.runs;
+        // Runs reported to the campaign aggregator as this worker's logical range length.
+        // In normal sharded campaigns this stays equal to the assigned plan length; timed
+        // single-worker campaigns may grow it beyond the initially configured run count.
+        let mut reported_runs = plan.runs;
 
         let (mut invariant_test, mut corpus_manager) = Self::prepare_worker(
             &mut executor,
@@ -659,7 +662,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let edge_coverage_enabled = config.corpus.collect_edge_coverage();
 
         'stop: while continue_campaign(runs) {
-            planned_runs = planned_runs.max(runs.saturating_add(1));
+            reported_runs = reported_runs.max(runs.saturating_add(1));
             // Per-run failure count snapshot used to gate `afterInvariant` below.
             let failures_before_run = invariant_test.test_data.failures.invariant_count();
             let mut stop_after_run = false;
@@ -1061,8 +1064,18 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             result.optimization_best_value,
             result.optimization_best_sequence,
         );
-        plan.runs = planned_runs;
-        Ok(InvariantWorkerOutput { plan, result: worker_result, corpus_entries })
+        let reported_plan = if campaign_state.is_timed_campaign() {
+            debug_assert_eq!(plan.worker_id, 0);
+            debug_assert_eq!(plan.first_global_run, 0);
+            InvariantWorkerPlan { runs: reported_runs, ..plan }
+        } else {
+            // Sharded campaigns must report the original assigned range. Early worker exit changes
+            // the number of executed runs, but it must not shrink `plan.runs`: following workers'
+            // `first_global_run` offsets were computed from the original partition.
+            debug_assert_eq!(reported_runs, plan.runs);
+            plan
+        };
+        Ok(InvariantWorkerOutput { plan: reported_plan, result: worker_result, corpus_entries })
     }
 
     fn shrink_handler_failures(

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     executors::{
         DURATION_BETWEEN_METRICS_REPORT, EarlyExit, EvmError, Executor, FuzzTestTimer,
         RawCallResult,
-        corpus::{DynamicTargetCtx, WorkerCorpus},
+        corpus::{DynamicTargetCtx, WorkerCorpus, WorkerCorpusSeed},
     },
     inspectors::Fuzzer,
 };
@@ -170,7 +170,7 @@ fn max_invariant_workers_for_runs(runs: u32) -> usize {
 }
 
 fn invariant_worker_count(config: &InvariantConfig) -> usize {
-    if config.timeout.is_some() || config.call_override || config.corpus.collect_edge_coverage() {
+    if config.timeout.is_some() || config.call_override {
         return 1;
     }
 
@@ -551,6 +551,17 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let worker_plans = campaign_spec.worker_plans(worker_count)?;
         let campaign_seed =
             self.prepare_campaign_seed(&invariant_contract, initial_handler_failures)?;
+        let replay_targets = FuzzRunIdentifiedContracts::new(
+            campaign_seed.targeted_contracts.clone(),
+            campaign_seed.targets_are_updatable,
+        );
+        let corpus_seed = WorkerCorpusSeed::load_from_disk(
+            &self.config.corpus,
+            Some(&self.executor),
+            None,
+            Some(&replay_targets),
+            Some(self.dynamic_target_ctx()),
+        )?;
         let run_in_parallel = worker_plans.len() > 1;
         let corpus_persistence = if run_in_parallel {
             InvariantCorpusPersistence::Deferred
@@ -591,6 +602,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         progress,
                         &campaign_state,
                         campaign_seed.clone(),
+                        corpus_seed.clone(),
                         corpus_persistence,
                     );
                     debug!("finished in {:?}", timer.elapsed());
@@ -610,7 +622,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 fuzz_state,
                 progress,
                 &campaign_state,
-                campaign_seed,
+                campaign_seed.clone(),
+                corpus_seed.clone(),
                 corpus_persistence,
             )?]
         };
@@ -629,6 +642,17 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         }
         let (result, corpus_entries) = aggregator.finish_with_corpus_entries()?;
         if corpus_persistence.is_deferred() {
+            let replay_targets = FuzzRunIdentifiedContracts::new(
+                campaign_seed.targeted_contracts.clone(),
+                campaign_seed.targets_are_updatable,
+            );
+            let corpus_entries = corpus_seed.filter_campaign_entries(
+                &corpus_entries,
+                &self.executor,
+                None,
+                Some(&replay_targets),
+                Some(self.dynamic_target_ctx()),
+            )?;
             WorkerCorpus::persist_campaign_outputs(
                 &self.config.corpus,
                 &corpus_entries,
@@ -655,6 +679,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         progress: Option<&ProgressBar>,
         campaign_state: &InvariantCampaignState,
         campaign_seed: InvariantCampaignSeed,
+        corpus_seed: WorkerCorpusSeed,
         corpus_persistence: InvariantCorpusPersistence,
     ) -> Result<InvariantWorkerOutput> {
         // Note: invariant function signatures (no inputs) are validated upstream in the
@@ -674,9 +699,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             fuzz_state,
             &runner,
             &config,
-            setup_contracts,
-            project_contracts,
             &campaign_seed,
+            corpus_seed,
         )?;
         let mut corpus_entries = Vec::new();
         let progress_worker_id = corpus_persistence.progress_worker_id(plan.worker_id);
@@ -1215,9 +1239,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         fuzz_state: EvmFuzzState,
         runner: &TestRunner,
         config: &InvariantConfig,
-        setup_contracts: &ContractsByAddress,
-        project_contracts: &ContractsByArtifact,
         campaign_seed: &InvariantCampaignSeed,
+        corpus_seed: WorkerCorpusSeed,
     ) -> Result<(InvariantTest, WorkerCorpus)> {
         let fuzz_state = fuzz_state.into_invariant();
         let targeted_contracts = FuzzRunIdentifiedContracts::new(
@@ -1311,21 +1334,12 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             }
         }
 
-        let is_master_worker = plan.worker_id == 0;
-        let dynamic = DynamicTargetCtx {
-            project_contracts,
-            setup_contracts,
-            artifact_filters: &campaign_seed.artifact_filters,
-        };
-        let worker = WorkerCorpus::new(
+        let worker = WorkerCorpus::from_seed(
             plan.worker_id as usize,
             config.corpus.clone(),
             strategy.boxed(),
-            is_master_worker.then_some(&*executor),
-            None,
-            is_master_worker.then_some(&targeted_contracts),
-            is_master_worker.then_some(dynamic),
-        )?;
+            corpus_seed,
+        );
 
         let mut invariant_test =
             InvariantTest::new(fuzz_state, targeted_contracts, failures, runner.clone());
@@ -1333,7 +1347,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // Seed invariant test with previously persisted optimization state,
         // but only if the current invariant is in optimization mode. Persisted optimization state
         // is a master-worker artifact loaded with the initial corpus.
-        if is_master_worker && invariant_contract.is_optimization() {
+        if invariant_contract.is_optimization() {
             let (opt_best_value, opt_best_sequence) = worker.optimization_initial_state();
             if let Some(value) = opt_best_value {
                 invariant_test.update_optimization_value(value, &opt_best_sequence);
@@ -1851,7 +1865,11 @@ mod tests {
 
         config.call_override = false;
         config.corpus.show_edge_coverage = true;
-        assert_eq!(invariant_worker_count(&config), 1);
+        assert_eq!(invariant_worker_count(&config), 4);
+
+        config.corpus.show_edge_coverage = false;
+        config.corpus.corpus_dir = Some(std::path::PathBuf::from("corpus"));
+        assert_eq!(invariant_worker_count(&config), 4);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     executors::{
-        DURATION_BETWEEN_METRICS_REPORT, EarlyExit, EvmError, Executor, RawCallResult,
+        DURATION_BETWEEN_METRICS_REPORT, EarlyExit, EvmError, Executor, FuzzTestTimer,
+        RawCallResult,
         corpus::{DynamicTargetCtx, WorkerCorpus},
     },
     inspectors::Fuzzer,
@@ -532,8 +533,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let setup_contracts = self.setup_contracts;
         let project_contracts = self.project_contracts;
         let base_executor = self.executor.clone();
-        let campaign_state =
-            Arc::new(InvariantCampaignState::new(self.config.timeout, early_exit.clone()));
+        let campaign_state = Arc::new(InvariantCampaignState::new(early_exit.clone()));
 
         let worker_outputs = if run_in_parallel {
             let worker_jobs = worker_plans
@@ -648,14 +648,17 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let mut corpus_entries = Vec::new();
 
         // Start timer for this invariant test.
+        let timer = FuzzTestTimer::new(config.timeout);
+        let is_timed_campaign = timer.is_enabled();
         let mut runs = 0;
         let mut last_metrics_report = Instant::now();
         let campaign_start = Instant::now();
         let mut throughput = InvariantThroughputMetrics::default();
         let mut failure_metrics = InvariantFailureMetrics::default();
         let continue_campaign = |runs: u32| {
-            campaign_state.should_continue()
-                && (campaign_state.is_timed_campaign() || runs < plan.runs)
+            !campaign_state.should_stop()
+                && !timer.is_timed_out()
+                && (is_timed_campaign || runs < plan.runs)
         };
 
         // Invariant runs with edge coverage if corpus dir is set or showing edge coverage.
@@ -688,7 +691,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
             while current_run.depth < config.depth {
                 // Check if the timeout has been reached.
-                if !campaign_state.should_continue() {
+                if campaign_state.should_stop() || timer.is_timed_out() {
                     // Since we never record a revert here the test is still considered
                     // successful even though it timed out. We *want*
                     // this behavior for now, so that's ok, but
@@ -1034,7 +1037,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             runs += 1;
             let total_runs = campaign_state.increment_runs();
             debug_assert!(
-                campaign_state.is_timed_campaign() || total_runs <= config.runs,
+                is_timed_campaign || total_runs <= config.runs,
                 "worker runs were not distributed correctly"
             );
             if let Some(progress) = progress {
@@ -1064,7 +1067,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             result.optimization_best_value,
             result.optimization_best_sequence,
         );
-        let reported_plan = if campaign_state.is_timed_campaign() {
+        let reported_plan = if is_timed_campaign {
             debug_assert_eq!(plan.worker_id, 0);
             debug_assert_eq!(plan.first_global_run, 0);
             InvariantWorkerPlan { runs: reported_runs, ..plan }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1,8 +1,7 @@
 use crate::{
     executors::{
-        DURATION_BETWEEN_METRICS_REPORT, EarlyExit, EvmError, Executor, FuzzTestTimer,
-        RawCallResult,
-        corpus::{DynamicTargetCtx, WorkerCorpus},
+        DURATION_BETWEEN_METRICS_REPORT, EarlyExit, EvmError, Executor, RawCallResult,
+        corpus::{CorpusCampaignOutput, DynamicTargetCtx, WorkerCorpus},
     },
     inspectors::Fuzzer,
 };
@@ -36,6 +35,7 @@ use foundry_evm_traces::{CallTraceArena, SparsedTraceArena};
 use indicatif::ProgressBar;
 use parking_lot::RwLock;
 use proptest::{strategy::Strategy, test_runner::TestRunner};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use result::{assert_after_invariant, can_continue, did_fail_on_assert, invariant_preflight_check};
 use revm::{context::Block, state::Account};
 use serde::{Deserialize, Serialize};
@@ -55,7 +55,8 @@ use foundry_evm_coverage::HitMaps;
 
 mod campaign;
 use campaign::{
-    InvariantCampaignAggregator, InvariantCampaignSpec, InvariantWorkerOutput, InvariantWorkerPlan,
+    InvariantCampaignAggregator, InvariantCampaignSpec, InvariantCampaignState,
+    InvariantWorkerOutput, InvariantWorkerPlan,
 };
 
 mod replay;
@@ -69,6 +70,11 @@ pub use shrink::{
     CheckSequenceOptions, HandlerReplayOutcome, check_sequence, check_sequence_value,
     replay_handler_failure_sequence,
 };
+
+/// Minimum number of logical runs assigned to each invariant worker.
+///
+/// Keeps short campaigns single-threaded and avoids producing many small rayon jobs.
+const MIN_RUNS_PER_INVARIANT_WORKER: u32 = 64;
 
 sol! {
     interface IInvariantTest {
@@ -157,6 +163,19 @@ impl InvariantThroughputMetrics {
     }
 }
 
+fn invariant_worker_count(runs: u32) -> usize {
+    let max_workers = if runs == 0 { 1 } else { Ord::max(1, runs / MIN_RUNS_PER_INVARIANT_WORKER) };
+    Ord::min(rayon::current_num_threads(), max_workers as usize)
+}
+
+fn invariant_worker_runner(runner: &mut TestRunner, worker_id: u32) -> TestRunner {
+    if worker_id == 0 {
+        runner.clone()
+    } else {
+        TestRunner::new_with_rng(runner.config().clone(), runner.new_rng())
+    }
+}
+
 /// Converts a cumulative campaign total into an average per-second rate.
 ///
 /// Returns `0.0` during the initial zero-elapsed startup window to avoid
@@ -167,7 +186,7 @@ fn rate_per_sec(total: f64, elapsed: Duration) -> f64 {
 }
 
 /// Tracks invariant failure counts during a campaign.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct InvariantFailureMetrics {
     failures: u64,
     unique_failures: HashSet<String>,
@@ -372,6 +391,12 @@ impl InvariantTest {
             self.test_data.optimization_best_sequence = sequence.to_vec();
         }
     }
+
+    fn merge_initial_optimization(&mut self, value: Option<I256>, sequence: Vec<BasicTxDetails>) {
+        if let Some(value) = value {
+            self.update_optimization_value(value, &sequence);
+        }
+    }
 }
 
 /// Contains data for an invariant test run.
@@ -398,6 +423,16 @@ struct InvariantTestRun<FEN: FoundryEvmNetwork> {
     optimization_value: Option<I256>,
     // For optimization mode: the length of the input prefix that produced the best value.
     optimization_prefix_len: usize,
+}
+
+/// Immutable state selected once for a logical invariant campaign and cloned into each worker.
+#[derive(Clone)]
+struct InvariantCampaignSeed {
+    artifact_filters: ArtifactFilters,
+    sender_filters: SenderFilters,
+    targeted_contracts: TargetedContracts,
+    targets_are_updatable: bool,
+    initial_handler_failures: Map<(Address, Selector), InvariantFuzzError>,
 }
 
 impl<FEN: FoundryEvmNetwork> InvariantTestRun<FEN> {
@@ -438,6 +473,8 @@ pub struct InvariantExecutor<'a, FEN: FoundryEvmNetwork> {
     project_contracts: &'a ContractsByArtifact,
     /// Filters contracts to be fuzzed through their artifact identifiers.
     artifact_filters: ArtifactFilters,
+    /// Number of invariant workers used for large campaigns.
+    num_workers: usize,
 }
 
 impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
@@ -452,6 +489,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         Self {
             executor,
             runner,
+            num_workers: invariant_worker_count(config.runs),
             config,
             setup_contracts,
             project_contracts,
@@ -459,8 +497,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         }
     }
 
-    pub fn config(self) -> InvariantConfig {
-        self.config
+    pub fn config(&self) -> InvariantConfig {
+        self.config.clone()
     }
 
     /// Refs for tracking contracts deployed mid-sequence during corpus replay.
@@ -491,44 +529,112 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         >,
     ) -> Result<InvariantFuzzTestResult> {
         let campaign_spec = InvariantCampaignSpec::new(self.config.runs);
-        let worker_plan = campaign_spec.worker_plans(1)?.pop().expect("one worker plan requested");
-        let worker_output = self.run_invariant_worker(
-            worker_plan,
-            invariant_contract,
-            fuzz_fixtures,
-            fuzz_state,
-            progress,
-            early_exit,
-            initial_handler_failures,
-        )?;
+        let worker_plans = campaign_spec.worker_plans(self.num_workers)?;
+        let campaign_seed =
+            self.prepare_campaign_seed(&invariant_contract, initial_handler_failures)?;
+        let use_parallel =
+            worker_plans.len() > 1 && self.config.timeout.is_none() && !self.config.call_override;
+        let mut runner = self.runner.clone();
+        let config = self.config.clone();
+        let setup_contracts = self.setup_contracts;
+        let project_contracts = self.project_contracts;
+        let base_executor = self.executor.clone();
+        let campaign_state = std::sync::Arc::new(InvariantCampaignState::new(
+            self.config.timeout,
+            early_exit.clone(),
+        ));
+
+        let worker_outputs = if use_parallel {
+            let worker_jobs = worker_plans
+                .into_iter()
+                .map(|worker_plan| {
+                    let worker_runner = invariant_worker_runner(&mut runner, worker_plan.worker_id);
+                    (worker_plan, worker_runner)
+                })
+                .collect::<Vec<_>>();
+            worker_jobs
+                .into_par_iter()
+                .map(|(worker_plan, worker_runner)| {
+                    let _guard =
+                        info_span!("invariant_worker", id = worker_plan.worker_id).entered();
+                    let timer = Instant::now();
+                    let output = Self::run_invariant_worker(
+                        base_executor.clone(),
+                        worker_runner,
+                        config.clone(),
+                        setup_contracts,
+                        project_contracts,
+                        worker_plan,
+                        invariant_contract.clone(),
+                        fuzz_fixtures,
+                        fuzz_state.fork(),
+                        progress,
+                        &campaign_state,
+                        campaign_seed.clone(),
+                    );
+                    debug!("finished in {:?}", timer.elapsed());
+                    output
+                })
+                .collect::<Result<Vec<_>>>()?
+        } else {
+            let plan = if worker_plans.len() == 1 {
+                worker_plans[0]
+            } else {
+                InvariantWorkerPlan {
+                    worker_id: 0,
+                    first_global_run: 0,
+                    runs: campaign_spec.total_runs,
+                }
+            };
+            vec![Self::run_invariant_worker(
+                base_executor,
+                runner,
+                config,
+                setup_contracts,
+                project_contracts,
+                plan,
+                invariant_contract.clone(),
+                fuzz_fixtures,
+                fuzz_state,
+                progress,
+                &campaign_state,
+                campaign_seed,
+            )?]
+        };
 
         // Timeout-driven campaigns can execute beyond the initial configured run count. Preserve
         // the existing single-worker `planned_runs` behavior by rebuilding the logical spec
         // from the worker's final plan.
+        let total_planned_runs =
+            worker_outputs.iter().map(|output| output.plan.runs).try_fold(0u32, |acc, runs| {
+                acc.checked_add(runs).ok_or_else(|| eyre!("invariant worker run range overflows"))
+            })?;
         let mut aggregator =
-            InvariantCampaignAggregator::new(InvariantCampaignSpec::new(worker_output.plan.runs));
-        aggregator.push(worker_output);
-        aggregator.finish()
+            InvariantCampaignAggregator::new(InvariantCampaignSpec::new(total_planned_runs));
+        for worker_output in worker_outputs {
+            aggregator.push(worker_output);
+        }
+        let mut campaign_output = aggregator.finish_with_corpus()?;
+        self.shrink_handler_failures(&mut campaign_output.result, progress, early_exit);
+        WorkerCorpus::persist_campaign_output(&self.config.corpus, &campaign_output.corpus);
+        Ok(campaign_output.result)
     }
 
     /// Runs one worker-local slice of an invariant campaign.
-    ///
-    /// This is intentionally still dispatched with a single worker by `invariant_fuzz`; the worker
-    /// boundary exists so future changes can fan out multiple independent plans without changing
-    /// the campaign aggregation contract.
     #[allow(clippy::too_many_arguments)]
     fn run_invariant_worker(
-        &mut self,
+        mut executor: Executor<FEN>,
+        runner: TestRunner,
+        config: InvariantConfig,
+        setup_contracts: &'a ContractsByAddress,
+        project_contracts: &'a ContractsByArtifact,
         mut plan: InvariantWorkerPlan,
         invariant_contract: InvariantContract<'_>,
         fuzz_fixtures: &FuzzFixtures,
         fuzz_state: EvmFuzzState,
         progress: Option<&ProgressBar>,
-        early_exit: &EarlyExit,
-        initial_handler_failures: std::collections::HashMap<
-            (Address, Selector),
-            InvariantFuzzError,
-        >,
+        campaign_state: &InvariantCampaignState,
+        campaign_seed: InvariantCampaignSeed,
     ) -> Result<InvariantWorkerOutput> {
         // Note: invariant function signatures (no inputs) are validated upstream in the
         // suite runner so parameterized `invariant_*` functions are rejected with a per-test
@@ -536,31 +642,33 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
         let mut planned_runs = plan.runs;
 
-        let (mut invariant_test, mut corpus_manager) = self.prepare_test(
+        let (mut invariant_test, mut corpus_manager) = Self::prepare_worker(
+            &mut executor,
             plan,
             &invariant_contract,
             fuzz_fixtures,
             fuzz_state,
-            initial_handler_failures,
+            &runner,
+            &config,
+            setup_contracts,
+            project_contracts,
+            campaign_seed.clone(),
         )?;
+        let mut corpus_output = CorpusCampaignOutput::default();
 
         // Start timer for this invariant test.
         let mut runs = 0;
-        let timer = FuzzTestTimer::new(self.config.timeout);
         let mut last_metrics_report = Instant::now();
         let campaign_start = Instant::now();
         let mut throughput = InvariantThroughputMetrics::default();
         let mut failure_metrics = InvariantFailureMetrics::default();
         let continue_campaign = |runs: u32| {
-            if early_exit.should_stop() {
-                return false;
-            }
-
-            if timer.is_enabled() { !timer.is_timed_out() } else { runs < plan.runs }
+            campaign_state.should_continue()
+                && (campaign_state.is_timed_campaign() || runs < plan.runs)
         };
 
         // Invariant runs with edge coverage if corpus dir is set or showing edge coverage.
-        let edge_coverage_enabled = self.config.corpus.collect_edge_coverage();
+        let edge_coverage_enabled = config.corpus.collect_edge_coverage();
 
         'stop: while continue_campaign(runs) {
             planned_runs = planned_runs.max(runs.saturating_add(1));
@@ -578,18 +686,18 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             let mut current_run = InvariantTestRun::new(
                 initial_seq[0].clone(),
                 // Before each run, we must reset the backend state.
-                self.executor.clone(),
-                self.config.depth as usize,
+                executor.clone(),
+                config.depth as usize,
             );
 
             // We stop the run immediately if we have reverted, and `fail_on_revert` is set.
-            if self.config.fail_on_revert && invariant_test.reverts() > 0 {
+            if config.fail_on_revert && invariant_test.reverts() > 0 {
                 return Err(eyre!("call reverted"));
             }
 
-            while current_run.depth < self.config.depth {
+            while current_run.depth < config.depth {
                 // Check if the timeout has been reached.
-                if timer.is_timed_out() {
+                if !campaign_state.should_continue() {
                     // Since we never record a revert here the test is still considered
                     // successful even though it timed out. We *want*
                     // this behavior for now, so that's ok, but
@@ -627,7 +735,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 // assumes / pops below) get zero-length entries that the corpus side filters out.
                 let call_cmp_values = call_result.evm_cmp_values.take().unwrap_or_default();
                 let discarded = call_result.result.as_ref() == MAGIC_ASSUME;
-                if self.config.show_metrics {
+                if config.show_metrics {
                     invariant_test.record_metrics(
                         current_run.inputs.last().expect("checked above"),
                         call_result.reverted,
@@ -654,10 +762,10 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 if discarded {
                     current_run.inputs.pop();
                     current_run.rejects += 1;
-                    if current_run.rejects > self.config.max_assume_rejects {
+                    if current_run.rejects > config.max_assume_rejects {
                         invariant_test.set_error(
                             invariant_contract.anchor(),
-                            InvariantFuzzError::MaxAssumeRejects(self.config.max_assume_rejects),
+                            InvariantFuzzError::MaxAssumeRejects(config.max_assume_rejects),
                         );
                         break 'stop;
                     }
@@ -685,7 +793,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             &mut state_changeset,
                             current_run.inputs.last().expect("checked above"),
                             &call_result,
-                            self.config.depth,
+                            config.depth,
                             mapping_slots,
                         );
                     }
@@ -695,9 +803,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     if let Err(error) =
                         &invariant_test.targeted_contracts.collect_created_contracts(
                             &state_changeset,
-                            self.project_contracts,
-                            self.setup_contracts,
-                            &self.artifact_filters,
+                            project_contracts,
+                            setup_contracts,
+                            &campaign_seed.artifact_filters,
                             &mut current_run.created_contracts,
                         )
                     {
@@ -713,18 +821,17 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     // - check_interval=0: only assert on the last call
                     // - check_interval=1 (default): assert after every call
                     // - check_interval=N: assert every N calls AND always on the last call
-                    let is_last_call = current_run.depth == self.config.depth - 1;
+                    let is_last_call = current_run.depth == config.depth - 1;
                     // In optimization mode, always evaluate the invariant to track
                     // the best value at every prefix — check_interval only gates
                     // boolean invariant assertions.
                     let is_optimization = invariant_contract.is_optimization();
                     let should_check_invariant = is_optimization
-                        || if self.config.check_interval == 0 {
+                        || if config.check_interval == 0 {
                             is_last_call
                         } else {
-                            self.config.check_interval == 1
-                                || (current_run.depth + 1)
-                                    .is_multiple_of(self.config.check_interval)
+                            config.check_interval == 1
+                                || (current_run.depth + 1).is_multiple_of(config.check_interval)
                                 || is_last_call
                         };
 
@@ -734,7 +841,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             &invariant_contract,
                             &mut invariant_test,
                             &mut current_run,
-                            &self.config,
+                            &config,
                             call_result,
                             &state_changeset,
                             handler_target,
@@ -754,7 +861,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             let call_reverted = call_result.reverted;
                             error::record_handler_assertion_bug(
                                 &invariant_contract,
-                                &self.config,
+                                &config,
                                 &invariant_test.targeted_contracts,
                                 &mut invariant_test.test_data.failures,
                                 &mut current_run.inputs,
@@ -766,18 +873,18 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                                 invariant_contract.is_optimization(),
                             );
                             (true, None)
-                        } else if call_result.reverted && self.config.fail_on_revert {
+                        } else if call_result.reverted && config.fail_on_revert {
                             // Plain revert under fail_on_revert: attribute to the anchor.
                             let anchor = invariant_contract.anchor();
                             let case_data = error::InvariantRunCtx {
                                 contract: &invariant_contract,
-                                config: &self.config,
+                                config: &config,
                                 targeted_contracts: &invariant_test.targeted_contracts,
                                 calldata: &current_run.inputs,
                             }
                             .failed_case(
                                 anchor,
-                                self.config.fail_on_revert,
+                                config.fail_on_revert,
                                 false,
                                 call_result,
                                 &[],
@@ -789,7 +896,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             (false, Some(anchor))
                         } else if call_result.reverted
                             && !invariant_contract.is_optimization()
-                            && !self.config.has_delay()
+                            && !config.has_delay()
                         {
                             // Delay campaigns keep reverted calls so warp/roll survives shrinking.
                             current_run.inputs.pop();
@@ -805,7 +912,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         current_run.cmp_seq.push(call_cmp_values);
                     }
 
-                    if !continues || current_run.depth == self.config.depth - 1 {
+                    if !continues || current_run.depth == config.depth - 1 {
                         invariant_test.set_last_run_inputs(&current_run.inputs);
                     }
                     // Bridge newly-recorded predicate breaks into `failure_metrics` even when
@@ -820,8 +927,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         );
                     }
                     if !continues {
-                        if invariant_contract.invariant_fns.len() > 1 && !self.config.fail_on_revert
-                        {
+                        if invariant_contract.invariant_fns.len() > 1 && !config.fail_on_revert {
                             break;
                         }
                         stop_after_run = true;
@@ -845,12 +951,15 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 let prefix = current_run.inputs[..current_run.optimization_prefix_len].to_vec();
                 (v, prefix)
             });
-            corpus_manager.process_inputs(
+            let record = corpus_manager.process_campaign_inputs(
                 &current_run.inputs,
                 &current_run.cmp_seq,
                 current_run.new_coverage,
                 optimization,
             );
+            if let Some(input) = record.into_campaign_input() {
+                corpus_output.inputs.push(input);
+            }
 
             // Call `afterInvariant` only if declared and the current run produced no new
             // failure. Multi-predicate campaigns keep running after earlier failures, but the
@@ -862,7 +971,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     &invariant_contract,
                     &mut invariant_test,
                     &current_run,
-                    &self.config,
+                    &config,
                 )
                 .map_err(|_| eyre!("Failed to call afterInvariant"))?;
                 if broken.is_some() {
@@ -876,10 +985,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             }
 
             // End current invariant test run.
-            invariant_test.end_run(current_run, self.config.gas_report_samples as usize);
+            invariant_test.end_run(current_run, config.gas_report_samples as usize);
             if let Some(progress) = progress {
-                // If running with progress then increment completed runs.
-                progress.inc(1);
                 // Display current best value, corpus metrics, and failure counts.
                 let best = invariant_test.test_data.optimization_best_value;
                 let broken = invariant_test.test_data.failures.invariant_count();
@@ -915,6 +1022,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     progress.set_message(msg);
                 }
             } else if edge_coverage_enabled
+                && plan.worker_id == 0
                 && last_metrics_report.elapsed() > DURATION_BETWEEN_METRICS_REPORT
             {
                 // Sync handler-bug count snapshot into failure_metrics before emitting.
@@ -934,6 +1042,14 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             }
 
             runs += 1;
+            let total_runs = campaign_state.increment_runs();
+            debug_assert!(
+                campaign_state.is_timed_campaign() || total_runs <= config.runs,
+                "worker runs were not distributed correctly"
+            );
+            if let Some(progress) = progress {
+                progress.inc(1);
+            }
             if stop_after_run {
                 break 'stop;
             }
@@ -942,44 +1058,13 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         trace!(?fuzz_fixtures);
         invariant_test.fuzz_state.log_stats();
 
-        let mut result = invariant_test.test_data;
-
-        // Post-campaign: shrink each handler bug's call sequence to its minimal prefix.
-        let total = result.failures.handler_count();
-        if total > 0 {
-            for (idx, (_site, error)) in result.failures.handler_failures_mut().enumerate() {
-                if early_exit.should_stop() {
-                    break;
-                }
-                let Some(failure) = error.as_handler_assertion_mut() else {
-                    // Handler-keyed entries always store `HandlerAssertion` by construction.
-                    continue;
-                };
-                shrink::reset_shrink_progress(
-                    &self.config,
-                    progress,
-                    &format!("handler {:#x}::{}", failure.reverter, failure.selector),
-                    Some((idx + 1, total)),
-                );
-                match shrink::shrink_handler_sequence(
-                    &self.config,
-                    &failure.call_sequence,
-                    failure.edge_fingerprint,
-                    &self.executor,
-                    progress,
-                    early_exit,
-                ) {
-                    Ok(shrunk) if !shrunk.is_empty() => {
-                        failure.call_sequence = shrunk;
-                    }
-                    Ok(_) => {}
-                    Err(e) => trace!(target: "forge::test", "handler shrink failed: {e}"),
-                }
-            }
-        }
-
+        let result = invariant_test.test_data;
         let reverts = result.failures.reverts;
         let (errors, handler_errors) = result.failures.partition();
+        corpus_output.merge_optimization(
+            result.optimization_best_value,
+            result.optimization_best_sequence.clone(),
+        );
         let worker_result = InvariantFuzzTestResult::new(
             errors,
             handler_errors,
@@ -994,35 +1079,99 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             result.optimization_best_sequence,
         );
         plan.runs = planned_runs;
-        Ok(InvariantWorkerOutput::new(plan, worker_result))
+        Ok(InvariantWorkerOutput::new_with_corpus(plan, worker_result, corpus_output))
     }
 
-    /// Prepares certain structures to execute the invariant tests:
-    /// * Invariant Fuzz Test.
-    /// * Invariant Corpus Manager.
-    fn prepare_test(
+    fn shrink_handler_failures(
+        &self,
+        result: &mut InvariantFuzzTestResult,
+        progress: Option<&ProgressBar>,
+        early_exit: &EarlyExit,
+    ) {
+        let total = result.handler_errors.len();
+        if total == 0 {
+            return;
+        }
+
+        for (idx, (_site, error)) in result.handler_errors.iter_mut().enumerate() {
+            if early_exit.should_stop() {
+                break;
+            }
+            let Some(failure) = error.as_handler_assertion_mut() else {
+                continue;
+            };
+            shrink::reset_shrink_progress(
+                &self.config,
+                progress,
+                &format!("handler {:#x}::{}", failure.reverter, failure.selector),
+                Some((idx + 1, total)),
+            );
+            match shrink::shrink_handler_sequence(
+                &self.config,
+                &failure.call_sequence,
+                failure.edge_fingerprint,
+                &self.executor,
+                progress,
+                early_exit,
+            ) {
+                Ok(shrunk) if !shrunk.is_empty() => {
+                    failure.call_sequence = shrunk;
+                }
+                Ok(_) => {}
+                Err(e) => trace!(target: "forge::test", "handler shrink failed: {e}"),
+            }
+        }
+    }
+
+    fn prepare_campaign_seed(
         &mut self,
-        plan: InvariantWorkerPlan,
         invariant_contract: &InvariantContract<'_>,
-        fuzz_fixtures: &FuzzFixtures,
-        fuzz_state: EvmFuzzState,
         initial_handler_failures: std::collections::HashMap<
             (Address, Selector),
             InvariantFuzzError,
         >,
-    ) -> Result<(InvariantTest, WorkerCorpus)> {
-        // Finds out the chosen deployed contracts and/or senders.
+    ) -> Result<InvariantCampaignSeed> {
         self.select_contract_artifacts(invariant_contract.address)?;
-        let (targeted_senders, targeted_contracts) =
+        let (sender_filters, targeted_contracts) =
             self.select_contracts_and_senders(invariant_contract.address)?;
+        let targets_are_updatable = targeted_contracts.is_updatable;
+        let targeted_contracts = targeted_contracts.targets().clone();
+
+        Ok(InvariantCampaignSeed {
+            artifact_filters: self.artifact_filters.clone(),
+            sender_filters,
+            targeted_contracts,
+            targets_are_updatable,
+            initial_handler_failures,
+        })
+    }
+
+    /// Prepares worker-local structures to execute an invariant campaign slice.
+    #[allow(clippy::too_many_arguments)]
+    fn prepare_worker(
+        executor: &mut Executor<FEN>,
+        plan: InvariantWorkerPlan,
+        invariant_contract: &InvariantContract<'_>,
+        fuzz_fixtures: &FuzzFixtures,
+        fuzz_state: EvmFuzzState,
+        runner: &TestRunner,
+        config: &InvariantConfig,
+        setup_contracts: &ContractsByAddress,
+        project_contracts: &ContractsByArtifact,
+        campaign_seed: InvariantCampaignSeed,
+    ) -> Result<(InvariantTest, WorkerCorpus)> {
         let fuzz_state = fuzz_state.into_invariant();
+        let targeted_contracts = FuzzRunIdentifiedContracts::new(
+            campaign_seed.targeted_contracts.clone(),
+            campaign_seed.targets_are_updatable,
+        );
 
         // Creates the invariant strategy.
         let strategy = invariant_strat(
             fuzz_state.clone(),
-            targeted_senders,
+            campaign_seed.sender_filters,
             targeted_contracts.clone(),
-            self.config.clone(),
+            config.clone(),
             fuzz_fixtures.clone(),
         )
         .no_shrink();
@@ -1038,10 +1187,10 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // Set up fuzzer WITHOUT call_generator initially.
         // We defer call_override until after the initial invariant check to avoid
         // injecting random calls during setup which would break the invariant assertion.
-        self.executor.inspector_mut().set_fuzzer(Fuzzer {
+        executor.inspector_mut().set_fuzzer(Fuzzer {
             call_generator: None,
             collected_values: Vec::new(),
-            max_collected_values: self.config.dictionary.max_fuzz_dictionary_values,
+            max_collected_values: config.dictionary.max_fuzz_dictionary_values,
             mapping_slots,
             collect: true,
         });
@@ -1052,24 +1201,24 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // This does not count as a fuzz run. It will just register the revert.
         let mut failures = InvariantFailures::new();
         // Seed disk-recovered handler bugs so live counters reflect them from tick 0.
-        for ((addr, sel), err) in initial_handler_failures {
+        for ((addr, sel), err) in campaign_seed.initial_handler_failures {
             failures.seed_handler_failure(addr, sel, err);
         }
         invariant_preflight_check(
             invariant_contract,
-            &self.config,
+            config,
             &targeted_contracts,
-            &self.executor,
+            executor,
             &[],
             &mut failures,
         )?;
-        if let Some(fuzzer) = self.executor.inspector_mut().fuzzer.as_mut() {
+        if let Some(fuzzer) = executor.inspector_mut().fuzzer.as_mut() {
             fuzz_state.collect_values(fuzzer.drain_collected_values());
         }
         // NOW enable call_override after the initial invariant check has passed.
         // This allows `override_call_strat` to inject calls during actual fuzz runs
         // for reentrancy vulnerability detection.
-        if self.config.call_override {
+        if config.call_override {
             let target_contract_ref = Arc::new(RwLock::new(Address::ZERO));
 
             // Collect handler addresses - these are the contracts we want to inject
@@ -1088,7 +1237,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             let call_generator = RandomCallGenerator::new(
                 invariant_contract.address,
                 handler_addresses,
-                self.runner.clone(),
+                runner.clone(),
                 override_call_strat(
                     fuzz_state.snapshot(),
                     override_targets,
@@ -1098,32 +1247,36 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 target_contract_ref,
             );
 
-            if let Some(fuzzer) = self.executor.inspector_mut().fuzzer.as_mut() {
+            if let Some(fuzzer) = executor.inspector_mut().fuzzer.as_mut() {
                 fuzzer.call_generator = Some(call_generator);
             }
         }
 
         let is_master_worker = plan.worker_id == 0;
+        let dynamic = DynamicTargetCtx {
+            project_contracts,
+            setup_contracts,
+            artifact_filters: &campaign_seed.artifact_filters,
+        };
         let worker = WorkerCorpus::new(
             plan.worker_id as usize,
-            self.config.corpus.clone(),
+            config.corpus.clone(),
             strategy.boxed(),
-            is_master_worker.then_some(&self.executor),
+            is_master_worker.then_some(&*executor),
             None,
             is_master_worker.then_some(&targeted_contracts),
-            is_master_worker.then_some(self.dynamic_target_ctx()),
+            is_master_worker.then_some(dynamic),
         )?;
 
         let mut invariant_test =
-            InvariantTest::new(fuzz_state, targeted_contracts, failures, self.runner.clone());
+            InvariantTest::new(fuzz_state, targeted_contracts, failures, runner.clone());
 
         // Seed invariant test with previously persisted optimization state,
         // but only if the current invariant is in optimization mode. Persisted optimization state
         // is a master-worker artifact loaded with the initial corpus.
         if is_master_worker && invariant_contract.is_optimization() {
             let (opt_best_value, opt_best_sequence) = worker.optimization_initial_state();
-            invariant_test.test_data.optimization_best_value = opt_best_value;
-            invariant_test.test_data.optimization_best_sequence = opt_best_sequence;
+            invariant_test.merge_initial_optimization(opt_best_value, opt_best_sequence);
         }
 
         Ok((invariant_test, worker))

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -165,8 +165,7 @@ impl InvariantThroughputMetrics {
 }
 
 fn max_invariant_workers_for_runs(runs: u32) -> usize {
-    let max_workers = (runs / MIN_RUNS_PER_INVARIANT_WORKER).max(1) as usize;
-    max_workers.min(runs as usize).max(1)
+    (runs / MIN_RUNS_PER_INVARIANT_WORKER).max(1) as usize
 }
 
 fn invariant_worker_count(config: &InvariantConfig) -> usize {
@@ -1176,7 +1175,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             return;
         }
 
-        for (idx, (_site, error)) in result.failures.handler_failures_mut().enumerate() {
+        for (idx, error) in result.failures.handler_failures_mut().enumerate() {
             if early_exit.should_stop() {
                 break;
             }

--- a/crates/evm/fuzz/src/invariant/filters.rs
+++ b/crates/evm/fuzz/src/invariant/filters.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 
 /// Contains which contracts are to be targeted or excluded on an invariant test through their
 /// artifact identifiers.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct ArtifactFilters {
     /// List of `contract_path:contract_name` along with selectors, which are to be targeted. If
     /// list of functions is not empty, target only those.
@@ -55,7 +55,7 @@ impl ArtifactFilters {
 /// clashing.
 ///
 /// `address(0)` is excluded by default.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct SenderFilters {
     pub targeted: Vec<Address>,
     pub excluded: Vec<Address>,

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1294,15 +1294,7 @@ fn warn_unsupported_invariant_workers(config: &Config) -> Result<()> {
         return Ok(());
     }
 
-    let reason = if config.invariant.timeout.is_some() {
-        Some("invariant.timeout is configured")
-    } else if config.invariant.call_override {
-        Some("invariant.call_override is enabled")
-    } else {
-        None
-    };
-
-    if let Some(reason) = reason {
+    if let Some(reason) = config.invariant.single_worker_reason() {
         sh_warn!(
             "`invariant.workers = {}` was configured, but invariant campaigns with {reason} currently run with 1 worker",
             config.invariant.workers

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -414,6 +414,7 @@ impl TestArgs {
         if config.invariant.workers == 0 {
             bail!("`invariant.workers` must be greater than 0");
         }
+        warn_unsupported_invariant_workers(&config)?;
 
         // Explicitly enable isolation for gas reports for more correct gas accounting.
         if self.gas_report {
@@ -1290,6 +1291,28 @@ fn merge_outcomes(base: &mut TestOutcome, other: TestOutcome) {
     if let Some(decoder) = other.last_run_decoder {
         base.last_run_decoder = Some(decoder);
     }
+}
+
+fn warn_unsupported_invariant_workers(config: &Config) -> Result<()> {
+    if config.invariant.workers <= 1 {
+        return Ok(());
+    }
+
+    let reason = if config.invariant.timeout.is_some() {
+        Some("invariant.timeout is configured")
+    } else if config.invariant.call_override {
+        Some("invariant.call_override is enabled")
+    } else {
+        None
+    };
+
+    if let Some(reason) = reason {
+        sh_warn!(
+            "`invariant.workers = {}` was configured, but invariant campaigns with {reason} currently run with 1 worker",
+            config.invariant.workers
+        )?;
+    }
+    Ok(())
 }
 
 /// Load persisted filter (with last test run failures) from file.

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -192,6 +192,10 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_FUZZ_RUNS", value_name = "RUNS")]
     pub fuzz_runs: Option<u64>,
 
+    /// Number of workers to use for invariant test campaigns.
+    #[arg(long, env = "FOUNDRY_INVARIANT_WORKERS", value_name = "WORKERS")]
+    pub invariant_workers: Option<usize>,
+
     /// Run only the fuzz case at the given 1-based run index.
     #[arg(long, env = "FOUNDRY_FUZZ_RUN", value_name = "RUN")]
     pub fuzz_run: Option<u32>,
@@ -406,6 +410,9 @@ impl TestArgs {
     ) -> Result<TestOutcome> {
         if config.fuzz.run == Some(0) {
             bail!("`fuzz.run` must be greater than 0");
+        }
+        if config.invariant.workers == 0 {
+            bail!("`invariant.workers` must be greater than 0");
         }
 
         // Explicitly enable isolation for gas reports for more correct gas accounting.
@@ -700,6 +707,7 @@ impl TestArgs {
         output: &ProjectCompileOutput,
     ) -> eyre::Result<TestOutcome> {
         let fuzz_seed = config.fuzz.seed;
+        let invariant_workers = config.invariant.workers;
         if self.list {
             return list(runner, filter);
         }
@@ -777,14 +785,18 @@ impl TestArgs {
             }
             sh_println!("{}", serde_json::to_string(&results)?)?;
             let kc = runner.known_contracts.clone();
-            return Ok(TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed));
+            let mut outcome = TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed);
+            outcome.invariant_workers = invariant_workers;
+            return Ok(outcome);
         }
 
         if self.junit {
             let results = runner.test_collect(filter)?;
             sh_println!("{}", junit_xml_report(&results, verbosity).to_string()?)?;
             let kc = runner.known_contracts.clone();
-            return Ok(TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed));
+            let mut outcome = TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed);
+            outcome.invariant_workers = invariant_workers;
+            return Ok(outcome);
         }
 
         let remote_chain =
@@ -848,6 +860,7 @@ impl TestArgs {
 
         let mut outcome = TestOutcome::empty(None, self.allow_failure);
         outcome.fuzz_seed = fuzz_seed;
+        outcome.invariant_workers = invariant_workers;
 
         let mut any_test_failed = false;
         let mut backtrace_builder = None;
@@ -1213,6 +1226,14 @@ impl Provider for TestArgs {
         }
         dict.insert("fuzz".to_string(), fuzz_dict.into());
 
+        let mut invariant_dict = Dict::default();
+        if let Some(invariant_workers) = self.invariant_workers {
+            invariant_dict.insert("workers".to_string(), invariant_workers.into());
+        }
+        if !invariant_dict.is_empty() {
+            dict.insert("invariant".to_string(), invariant_dict.into());
+        }
+
         if let Some(etherscan_api_key) =
             self.etherscan_api_key.as_ref().filter(|s| !s.trim().is_empty())
         {
@@ -1536,6 +1557,15 @@ mod tests {
             TestArgs::parse_from(["foundry-cli", "--fuzz-run", "10", "--fuzz-worker", "2"]);
         assert_eq!(args.fuzz_run, Some(10));
         assert_eq!(args.fuzz_worker, Some(2));
+    }
+
+    #[test]
+    fn invariant_workers() {
+        let args = TestArgs::parse_from(["foundry-cli", "--invariant-workers", "4"]);
+        assert_eq!(args.invariant_workers, Some(4));
+
+        let figment = figment::Figment::from(&args);
+        assert_eq!(figment.extract_inner::<usize>("invariant.workers").unwrap(), 4);
     }
 
     #[test]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -415,6 +415,7 @@ impl TestArgs {
             bail!("`invariant.workers` must be greater than 0");
         }
         warn_unsupported_invariant_workers(&config)?;
+        let invariant_workers = config.invariant.workers;
 
         // Explicitly enable isolation for gas reports for more correct gas accounting.
         if self.gas_report {
@@ -532,6 +533,7 @@ impl TestArgs {
 
             (libraries, outcome)
         };
+        outcome.invariant_workers = invariant_workers;
 
         if should_draw {
             let (suite_name, test_name, mut test_result) =
@@ -708,7 +710,6 @@ impl TestArgs {
         output: &ProjectCompileOutput,
     ) -> eyre::Result<TestOutcome> {
         let fuzz_seed = config.fuzz.seed;
-        let invariant_workers = config.invariant.workers;
         if self.list {
             return list(runner, filter);
         }
@@ -786,18 +787,14 @@ impl TestArgs {
             }
             sh_println!("{}", serde_json::to_string(&results)?)?;
             let kc = runner.known_contracts.clone();
-            let mut outcome = TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed);
-            outcome.invariant_workers = invariant_workers;
-            return Ok(outcome);
+            return Ok(TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed));
         }
 
         if self.junit {
             let results = runner.test_collect(filter)?;
             sh_println!("{}", junit_xml_report(&results, verbosity).to_string()?)?;
             let kc = runner.known_contracts.clone();
-            let mut outcome = TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed);
-            outcome.invariant_workers = invariant_workers;
-            return Ok(outcome);
+            return Ok(TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed));
         }
 
         let remote_chain =
@@ -861,7 +858,6 @@ impl TestArgs {
 
         let mut outcome = TestOutcome::empty(None, self.allow_failure);
         outcome.fuzz_seed = fuzz_seed;
-        outcome.invariant_workers = invariant_workers;
 
         let mut any_test_failed = false;
         let mut backtrace_builder = None;

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -414,7 +414,6 @@ impl TestArgs {
         if config.invariant.workers == 0 {
             bail!("`invariant.workers` must be greater than 0");
         }
-        warn_unsupported_invariant_workers(&config)?;
         let invariant_workers = config.invariant.workers;
 
         // Explicitly enable isolation for gas reports for more correct gas accounting.
@@ -1287,20 +1286,6 @@ fn merge_outcomes(base: &mut TestOutcome, other: TestOutcome) {
     if let Some(decoder) = other.last_run_decoder {
         base.last_run_decoder = Some(decoder);
     }
-}
-
-fn warn_unsupported_invariant_workers(config: &Config) -> Result<()> {
-    if config.invariant.workers <= 1 {
-        return Ok(());
-    }
-
-    if let Some(reason) = config.invariant.single_worker_reason() {
-        sh_warn!(
-            "`invariant.workers = {}` was configured, but invariant campaigns with {reason} currently run with 1 worker",
-            config.invariant.workers
-        )?;
-    }
-    Ok(())
 }
 
 /// Load persisted filter (with last test run failures) from file.

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -54,6 +54,8 @@ pub struct TestOutcome {
     pub known_contracts: Option<ContractsByArtifact>,
     /// The fuzz seed used for the test run.
     pub fuzz_seed: Option<U256>,
+    /// Explicit invariant worker count used for the test run.
+    pub invariant_workers: usize,
 }
 
 impl TestOutcome {
@@ -71,6 +73,7 @@ impl TestOutcome {
             gas_report: None,
             known_contracts,
             fuzz_seed,
+            invariant_workers: 1,
         }
     }
 
@@ -149,6 +152,11 @@ impl TestOutcome {
     /// Returns `true` if any fuzz or invariant test failed.
     pub fn has_fuzz_failures(&self) -> bool {
         self.failures().any(|(_, t)| t.kind.is_fuzz() || t.kind.is_invariant())
+    }
+
+    /// Returns `true` if any invariant test failed.
+    pub fn has_invariant_failures(&self) -> bool {
+        self.failures().any(|(_, t)| t.kind.is_invariant())
     }
 
     /// Sums up all the durations of all individual test suites.
@@ -234,6 +242,13 @@ impl TestOutcome {
                 format!("{seed:#x}").cyan(),
                 "`--fuzz-seed`".cyan()
             )?;
+            if outcome.has_invariant_failures() && outcome.invariant_workers > 1 {
+                sh_println!(
+                    "Invariant workers: {} (use {} to reproduce)",
+                    outcome.invariant_workers,
+                    format!("`--invariant-workers {}`", outcome.invariant_workers).cyan()
+                )?;
+            }
         }
 
         std::process::exit(test_failure_exit_code());

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -205,6 +205,7 @@ show_logs = false
 [invariant]
 runs = 256
 depth = 500
+workers = 1
 fail_on_revert = false
 call_override = false
 dictionary_weight = 80
@@ -1372,6 +1373,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
   "invariant": {
     "runs": 256,
     "depth": 500,
+    "workers": 1,
     "fail_on_revert": false,
     "call_override": false,
     "dictionary_weight": 80,


### PR DESCRIPTION
Shard invariant campaign runs into contiguous worker plans and execute eligible campaigns in parallel. Timeout-driven campaigns and `call_override` campaigns remain single-worker to preserve existing execution semantics.

Each worker owns its local EVM state, runner, fuzz state, and corpus manager. Worker outputs are merged back into one logical invariant result with deterministic policies for:

- worker run range validation
- predicate failures
- handler assertion failures
- metrics, reverts, traces, and coverage
- optimization best value and sequence
- master-worker-only failed corpus replay counts

Corpus entries selected by workers are returned to the campaign aggregator and persisted once after worker outputs are merged, along with the merged optimization best state. 

Handler assertion shrinking also runs after merge so the final result is selected at the campaign boundary.