### PR TITLE
fix(forge): expand invariant gas snapshots

### DIFF
--- a/crates/forge/src/cmd/snapshot.rs
+++ b/crates/forge/src/cmd/snapshot.rs
@@ -213,6 +213,7 @@ impl GasSnapshotConfig {
         let mut tests = outcome
             .into_tests()
             .filter(|test| self.is_in_gas_range(test.gas_used()))
+            .flat_map(expand_invariant_snapshot_entries)
             .collect::<Vec<_>>();
 
         if self.asc {
@@ -223,6 +224,23 @@ impl GasSnapshotConfig {
 
         tests
     }
+}
+
+/// Expands merged invariant campaigns into per-predicate gas snapshot rows.
+fn expand_invariant_snapshot_entries(test: SuiteTestResult) -> Vec<SuiteTestResult> {
+    if !test.result.kind.is_invariant() || test.result.invariant_predicate_results.len() <= 1 {
+        return vec![test];
+    }
+
+    test.result
+        .invariant_predicate_results
+        .iter()
+        .map(|predicate| {
+            let mut expanded = test.clone();
+            expanded.signature = format!("{}()", predicate.name);
+            expanded
+        })
+        .collect()
 }
 
 /// A general entry in a gas snapshot file

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1529,6 +1529,51 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 "#]]);
 });
 
+forgetest!(snapshot_expands_invariant_campaign_predicates, |prj, cmd| {
+    prj.add_test(
+        "InvariantSnapshot.t.sol",
+        r#"
+contract InvariantSnapshotHandler {
+    uint256 public count;
+
+    function increment() public {
+        count++;
+    }
+}
+
+contract InvariantSnapshotTest {
+    InvariantSnapshotHandler internal handler;
+
+    function setUp() public {
+        handler = new InvariantSnapshotHandler();
+    }
+
+    /// forge-config: default.invariant.runs = 2
+    /// forge-config: default.invariant.depth = 4
+    function invariant_count_is_non_negative() public view {
+        require(handler.count() >= 0);
+    }
+
+    /// forge-config: default.invariant.runs = 2
+    /// forge-config: default.invariant.depth = 4
+    function invariant_count_is_not_max() public view {
+        require(handler.count() != type(uint256).max);
+    }
+}
+   "#,
+    );
+
+    cmd.args(["snapshot"]).assert_success();
+
+    let snapshot = read_string(prj.root().join(".gas-snapshot"));
+    assert_eq!(
+        snapshot.lines().filter(|line| line.starts_with("InvariantSnapshotTest:")).count(),
+        2
+    );
+    assert!(snapshot.contains("InvariantSnapshotTest:invariant_count_is_non_negative()"));
+    assert!(snapshot.contains("InvariantSnapshotTest:invariant_count_is_not_max()"));
+});
+
 forgetest!(snapshot_reports_when_snap_file_is_not_written, |prj, cmd| {
     prj.insert_ds_test();
 


### PR DESCRIPTION
## Motivation

See https://github.com/foundry-rs/foundry/issues/14987#issuecomment-4586858911

After #14844, merged invariant campaigns still ran all predicates, but `forge snapshot` only wrote the anchor predicate to `.gas-snapshot`.

This expands merged invariant campaign results back into per-predicate snapshot rows and adds a regression test.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
