### PR TITLE
feat(forge): migrate forge selectors to output channel contract

### DIFF
--- a/crates/forge/src/cmd/selectors.rs
+++ b/crates/forge/src/cmd/selectors.rs
@@ -88,11 +88,11 @@ impl SelectorsSubcommands {
         match self {
             Self::Cache { project_paths, extra_abis_path } => {
                 if let Some(extra_abis_path) = extra_abis_path {
-                    sh_println!("Caching selectors for ABIs at {extra_abis_path}")?;
+                    sh_status!("Caching selectors for ABIs at {extra_abis_path}")?;
                     cache_signatures_from_abis(extra_abis_path)?;
                 }
 
-                sh_println!("Caching selectors for contracts in the project...")?;
+                sh_status!("Caching selectors for contracts in the project...")?;
                 let build_args = BuildOpts {
                     project_paths,
                     compiler: CompilerOpts {
@@ -169,7 +169,7 @@ impl SelectorsSubcommands {
                         continue;
                     }
 
-                    sh_println!("Uploading selectors for {contract}...")?;
+                    sh_status!("Uploading selectors for {contract}...")?;
 
                     // upload abi to selector database
                     import_selectors(SelectorImportData::Abi(vec![abi])).await?.describe();
@@ -241,7 +241,7 @@ impl SelectorsSubcommands {
                 }
             }
             Self::List { contract, project_paths, no_group } => {
-                sh_println!("Listing selectors for contracts in the project...")?;
+                sh_status!("Listing selectors for contracts in the project...")?;
                 let build_args = BuildOpts {
                     project_paths,
                     compiler: CompilerOpts {
@@ -385,7 +385,7 @@ impl SelectorsSubcommands {
             }
 
             Self::Find { selector, project_paths } => {
-                sh_println!("Searching for selector {selector:?} in the project...")?;
+                sh_status!("Searching for selector {selector:?} in the project...")?;
 
                 let build_args = BuildOpts {
                     project_paths,
@@ -457,7 +457,7 @@ impl SelectorsSubcommands {
                 }
 
                 if table.row_count() > 0 {
-                    sh_println!("\nFound {} instance(s)...", table.row_count())?;
+                    sh_status!("Found {} instance(s)...", table.row_count())?;
                     sh_println!("\n{table}\n")?;
                 } else {
                     return Err(eyre::eyre!("\nSelector not found in the project."));

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -3499,16 +3499,19 @@ Error: No contract name provided.
     );
 
     // Upload single CounterV2.
-    cmd.forge_fuse().args(["selectors", "upload", "CounterV2"]).assert_success().stdout_eq(str![[
-        r#"
-...
-Uploading selectors for CounterV2...
+    cmd.forge_fuse()
+        .args(["selectors", "upload", "CounterV2"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 ...
 Selectors successfully uploaded to OpenChain
 ...
 
-"#
-    ]]);
+"#]])
+        .stderr_eq(str![[r#"
+Uploading selectors for CounterV2...
+
+"#]]);
 
     // Upload CounterV1 with path.
     cmd.forge_fuse()
@@ -3516,10 +3519,12 @@ Selectors successfully uploaded to OpenChain
         .assert_success()
         .stdout_eq(str![[r#"
 ...
-Uploading selectors for Counter...
-...
 Selectors successfully uploaded to OpenChain
 ...
+
+"#]])
+        .stderr_eq(str![[r#"
+Uploading selectors for Counter...
 
 "#]]);
 
@@ -3529,10 +3534,12 @@ Selectors successfully uploaded to OpenChain
         .assert_success()
         .stdout_eq(str![[r#"
 ...
-Uploading selectors for Counter...
-...
 Selectors successfully uploaded to OpenChain
 ...
+
+"#]])
+        .stderr_eq(str![[r#"
+Uploading selectors for Counter...
 
 "#]]);
 });
@@ -3574,8 +3581,9 @@ contract CounterV2 {
    ",
     );
 
-    cmd.args(["selectors", "list"]).assert_success().stdout_eq(str![[r#"
-Listing selectors for contracts in the project...
+    cmd.args(["selectors", "list"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 Counter
 
 ╭----------+----------------------+--------------------------------------------------------------------╮
@@ -3604,13 +3612,16 @@ CounterV2
 | Function | setNumberV2(uint256) | 0xb525b68c |
 ╰----------+----------------------+------------╯
 
+"#]])
+        .stderr_eq(str![[r#"
+Listing selectors for contracts in the project...
+
 "#]]);
 
     cmd.forge_fuse()
         .args(["selectors", "list", "--no-group"])
         .assert_success()
         .stdout_eq(str![[r#"
-Listing selectors for contracts in the project...
 
 ╭----------+----------------------+--------------------------------------------------------------------+-----------╮
 | Type     | Signature            | Selector                                                           | Contract  |
@@ -3631,6 +3642,10 @@ Listing selectors for contracts in the project...
 |----------+----------------------+--------------------------------------------------------------------+-----------|
 | Function | setNumberV2(uint256) | 0xb525b68c                                                         | CounterV2 |
 ╰----------+----------------------+--------------------------------------------------------------------+-----------╯
+
+"#]])
+        .stderr_eq(str![[r#"
+Listing selectors for contracts in the project...
 
 "#]]);
 });
@@ -3672,8 +3687,9 @@ contract CounterV2 {
    ",
     );
 
-    cmd.args(["selectors", "list", "--md"]).assert_success().stdout_eq(str![[r#"
-Listing selectors for contracts in the project...
+    cmd.args(["selectors", "list", "--md"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 Counter
 
 | Type     | Signature            | Selector                                                           |
@@ -3692,13 +3708,16 @@ CounterV2
 | Function | number()             | 0x8381f58a |
 | Function | setNumberV2(uint256) | 0xb525b68c |
 
+"#]])
+        .stderr_eq(str![[r#"
+Listing selectors for contracts in the project...
+
 "#]]);
 
     cmd.forge_fuse()
         .args(["selectors", "list", "--no-group", "--md"])
         .assert_success()
         .stdout_eq(str![[r#"
-Listing selectors for contracts in the project...
 
 | Type     | Signature            | Selector                                                           | Contract  |
 |----------|----------------------|--------------------------------------------------------------------|-----------|
@@ -3710,6 +3729,10 @@ Listing selectors for contracts in the project...
 | Function | incrementV2()        | 0x49365a69                                                         | CounterV2 |
 | Function | number()             | 0x8381f58a                                                         | CounterV2 |
 | Function | setNumberV2(uint256) | 0xb525b68c                                                         | CounterV2 |
+
+"#]])
+        .stderr_eq(str![[r#"
+Listing selectors for contracts in the project...
 
 "#]]);
 });

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -131,7 +131,7 @@ Each row's status is one of:
 | `forge fmt`            | (empty) or formatted source with `--check`           | n/a                                        | migrated |
 | `forge tree`           | Dependency tree                                      | JSON                                       | migrated |
 | `forge config`         | Config TOML                                          | JSON config                                | migrated |
-| `forge selectors`      | Selectors output                                     | JSON                                       | todo   |
+| `forge selectors`      | Selectors output                                     | JSON                                       | migrated |
 | `forge eip712`         | (empty)                                              | JSON of types                              | migrated |
 | `forge geiger`         | Findings                                             | JSON                                       | migrated |
 | `forge lint`           | (empty; findings on stderr/exit code)                | JSON findings                              | migrated |


### PR DESCRIPTION
- `forge selectors` — status prose (`Caching selectors…`, `Uploading selectors…`, `Listing selectors…`, `Searching for selector…`, `Found N instance(s)…`) moved from stdout to stderr via `sh_status!`; selectors output (tables, collision result, JSON) stays on stdout; doc row flipped to `migrated`.
- `selectors_list_cmd`, `selectors_list_cmd_md`, and the 3 `selectors upload` snapshots updated to assert the split stdout/stderr.

Part of OSS-224