### PR TITLE
feat(cli): migrate forge doc and audit compliant forge compiler / cast erc20 balance

### DIFF
--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -523,7 +523,7 @@ impl Erc20Subcommand {
                 if shell::is_json() {
                     sh_println!("{}", serde_json::to_string(&balance.to_string())?)?
                 } else {
-                    sh_println!("{}", format_uint_exp(balance))?
+                    sh_println!("{balance}")?
                 }
             }
             Self::Name { token, block, .. } => {

--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -107,7 +107,7 @@ impl DocBuilder {
             .collect::<Vec<_>>();
 
         if sources.is_empty() {
-            sh_println!("No sources detected at {}", self.sources.display())?;
+            sh_status!("No sources detected at {}", self.sources.display())?;
             return Ok(());
         }
 

--- a/crates/forge/src/cmd/doc/server.rs
+++ b/crates/forge/src/cmd/doc/server.rs
@@ -74,7 +74,7 @@ impl Server {
             .unwrap_or_else(|| "404.html".to_string());
 
         let serving_url = format!("http://{address}");
-        sh_println!("Serving on: {serving_url}")?;
+        sh_status!("Serving on: {serving_url}")?;
 
         let thread_handle = std::thread::spawn(move || serve(build_dir, sockaddr, &file_404));
 

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -105,7 +105,7 @@ Each row's status is one of:
 | `cast trace`           | Trace                                                | JSON trace                                                     | migrated |
 | `cast wallet new`      | Address                                              | JSON `{ "address": "…", "private_key": "…" (only with explicit flag) }` | todo |
 | `cast wallet sign`     | Signature                                            | JSON                                                           | todo   |
-| `cast erc20 balance`   | Balance (decimal)                                    | JSON string                                                    | todo   |
+| `cast erc20 balance`   | Balance (decimal)                                    | JSON string                                                    | migrated |
 | `cast access-list`     | Access list                                          | JSON                                                           | migrated |
 | `cast da-estimate`     | Gas estimate                                         | JSON                                                           | todo   |
 | `cast find-block`      | Block number                                         | JSON                                                           | migrated |
@@ -138,11 +138,11 @@ Each row's status is one of:
 | `forge snapshot`       | Snapshot file content / diff                         | JSON                                       | todo   |
 | `forge coverage`       | Coverage table or report                             | JSON / LCOV / etc. via `--report`          | todo   |
 | `forge cache`          | (empty) or paths                                     | JSON                                       | migrated |
-| `forge doc`            | (empty)                                              | n/a                                        | todo   |
+| `forge doc`            | (empty)                                              | n/a                                        | migrated |
 | `forge generate`       | (empty) or generated path                            | n/a                                        | migrated |
 | `forge soldeer`        | (empty)                                              | n/a                                        | todo   |
 | `forge remappings`     | One remapping per line                               | n/a                                        | migrated |
-| `forge compiler`       | Compiler info                                        | JSON                                       | todo   |
+| `forge compiler`       | Compiler info                                        | JSON                                       | migrated |
 | `forge verify-contract`| Verification GUID / URL                              | JSON                                       | todo   |
 
 ### `anvil`, `chisel`, `script`


### PR DESCRIPTION
- `forge doc` — `No sources detected at ...` and `Serving on: ...` status moved from stdout to stderr via `sh_status!`; doc row flipped to `migrated`.
- `forge compiler` — already compliant after audit (every `sh_println!` emits compiler info or JSON, no status/progress prose); doc row flipped to `migrated`.
- `cast erc20 balance` — text mode switched from `format_uint_exp(balance)` (which appended `[1eN]` hint) to plain decimal so the row's `Balance (decimal)` contract is honored; JSON branch unchanged; doc row flipped to `migrated`.

Part of OSS-224
