### PR TITLE
feat(cast): migrate cast wallet sign and sign-auth to documented output channels

### DIFF
--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -638,26 +638,21 @@ impl WalletSubcommands {
                     wallet.sign_message(&Self::hex_str_to_bytes(&message)?).await?
                 };
 
-                if shell::verbosity() > 0 {
-                    if shell::is_json() {
-                        sh_println!(
-                            "{}",
-                            serde_json::to_string_pretty(&json!({
-                                "message": message,
-                                "address": wallet.address(),
-                                "signature": hex::encode(sig.as_bytes()),
-                            }))?
-                        )?;
-                    } else {
-                        sh_println!(
-                            "Successfully signed!\n   Message: {}\n   Address: {}\n   Signature: 0x{}",
-                            message,
-                            wallet.address(),
-                            hex::encode(sig.as_bytes()),
-                        )?;
-                    }
+                if shell::is_json() {
+                    sh_println!(
+                        "{}",
+                        serde_json::to_string_pretty(&json!({
+                            "message": message,
+                            "address": wallet.address(),
+                            "signature": hex::encode(sig.as_bytes()),
+                        }))?
+                    )?;
                 } else {
-                    // Pipe friendly output
+                    if shell::verbosity() > 0 {
+                        sh_status!("Successfully signed!")?;
+                        sh_status!("   Message: {message}")?;
+                        sh_status!("   Address: {}", wallet.address())?;
+                    }
                     sh_println!("0x{}", hex::encode(sig.as_bytes()))?;
                 }
             }
@@ -685,28 +680,23 @@ impl WalletSubcommands {
                 let signature = wallet.sign_hash(&auth.signature_hash()).await?;
                 let auth = auth.into_signed(signature);
 
-                if shell::verbosity() > 0 {
-                    if shell::is_json() {
-                        sh_println!(
-                            "{}",
-                            serde_json::to_string_pretty(&json!({
-                                "nonce": nonce,
-                                "chain_id": chain_id,
-                                "address": wallet.address(),
-                                "signature": hex::encode_prefixed(alloy_rlp::encode(&auth)),
-                            }))?
-                        )?;
-                    } else {
-                        sh_println!(
-                            "Successfully signed!\n   Nonce: {}\n   Chain ID: {}\n   Address: {}\n   Signature: {}",
-                            nonce,
-                            chain_id,
-                            wallet.address(),
-                            hex::encode_prefixed(alloy_rlp::encode(&auth)),
-                        )?;
-                    }
+                if shell::is_json() {
+                    sh_println!(
+                        "{}",
+                        serde_json::to_string_pretty(&json!({
+                            "nonce": nonce,
+                            "chain_id": chain_id,
+                            "address": wallet.address(),
+                            "signature": hex::encode_prefixed(alloy_rlp::encode(&auth)),
+                        }))?
+                    )?;
                 } else {
-                    // Pipe friendly output
+                    if shell::verbosity() > 0 {
+                        sh_status!("Successfully signed!")?;
+                        sh_status!("   Nonce: {nonce}")?;
+                        sh_status!("   Chain ID: {chain_id}")?;
+                        sh_status!("   Address: {}", wallet.address())?;
+                    }
                     sh_println!("{}", hex::encode_prefixed(alloy_rlp::encode(&auth)))?;
                 }
             }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -507,6 +507,27 @@ Error: Validation failed. Address 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf did
 "#]]);
 });
 
+// tests that `cast wallet sign --json` outputs JSON on stdout regardless of verbosity
+casttest!(wallet_sign_message_json, |_prj, cmd| {
+    cmd.args([
+        "wallet",
+        "sign",
+        "--json",
+        "--private-key",
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "test",
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+{
+  "message": "test",
+  "address": "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf",
+  "signature": "fe28833983d6faa0715c7e8c3873c725ddab6fa5bf84d40e780676e463e6bea20fc6aea97dc273a98eb26b0914e224c8dd5c615ceaab69ddddcf9b0ae3de0e371c"
+}
+
+"#]]);
+});
+
 // tests that `cast wallet sign message` outputs the expected signature, given a 0x-prefixed data
 casttest!(wallet_sign_message_hex_data, |_prj, cmd| {
     cmd.args([

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -104,7 +104,8 @@ Each row's status is one of:
 | `cast run`             | Trace / decoded output                               | JSON                                                           | migrated |
 | `cast trace`           | Trace                                                | JSON trace                                                     | migrated |
 | `cast wallet new`      | Address                                              | JSON `{ "address": "…", "private_key": "…" (only with explicit flag) }` | todo |
-| `cast wallet sign`     | Signature                                            | JSON                                                           | todo   |
+| `cast wallet sign`     | Signature                                            | JSON                                                           | migrated |
+| `cast wallet sign-auth`| Signed authorization RLP                             | JSON                                                           | migrated |
 | `cast erc20 balance`   | Balance (decimal)                                    | JSON string                                                    | todo   |
 | `cast access-list`     | Access list                                          | JSON                                                           | migrated |
 | `cast da-estimate`     | Gas estimate                                         | JSON                                                           | todo   |


### PR DESCRIPTION
Aligns `cast wallet sign` and `cast wallet sign-auth` with `docs/dev/output-channels.md`.

- `--json` now produces JSON on stdout regardless of verbosity.
- Verbose-mode prose ("Successfully signed!", Message/Address/Nonce/Chain ID) moves to stderr via `sh_status!`.
- Signature/RLP stays on stdout.
- Doc rows flipped to `migrated` (`sign-auth` added).

Part of OSS-224