### PR TITLE
fix: make forge rerun filtering contract-aware

### DIFF
--- a/crates/common/src/traits.rs
+++ b/crates/common/src/traits.rs
@@ -15,6 +15,11 @@ pub trait TestFilter: Send + Sync {
 
     /// Returns a contract with the given path should be included.
     fn matches_path(&self, path: &Path) -> bool;
+
+    /// Returns whether the test should be included for the given contract.
+    fn matches_test_function_in_contract(&self, _contract_name: &str, func: &Function) -> bool {
+        func.is_any_test() && self.matches_test(&func.signature())
+    }
 }
 
 impl<'a> dyn TestFilter + 'a {

--- a/crates/common/src/traits.rs
+++ b/crates/common/src/traits.rs
@@ -17,7 +17,9 @@ pub trait TestFilter: Send + Sync {
     fn matches_path(&self, path: &Path) -> bool;
 
     /// Returns whether the test should be included for the given contract.
-    fn matches_test_function_in_contract(&self, _contract_name: &str, func: &Function) -> bool {
+    ///
+    /// `contract_id` is the full artifact identifier (`path:Contract`).
+    fn matches_test_function_in_contract(&self, _contract_id: &str, func: &Function) -> bool {
         func.is_any_test() && self.matches_test(&func.signature())
     }
 }

--- a/crates/forge/src/cmd/test/filter.rs
+++ b/crates/forge/src/cmd/test/filter.rs
@@ -1,6 +1,6 @@
 use alloy_json_abi::Function;
 use clap::Parser;
-use foundry_common::{TestFilter, TestFunctionExt, get_contract_name};
+use foundry_common::{TestFilter, TestFunctionExt};
 use foundry_compilers::{FileFilter, ProjectPathsConfig};
 use foundry_config::{Config, filter::GlobMatcher};
 use serde::{Deserialize, Serialize};
@@ -241,12 +241,6 @@ impl TestFilter for ProjectPathsAwareFilter {
 
     fn matches_contract(&self, contract_name: &str) -> bool {
         self.args_filter.matches_contract(contract_name)
-            && self.rerun_failures.as_ref().is_none_or(|failures| {
-                failures.iter().any(|failure| {
-                    failure.contract == contract_name
-                        || get_contract_name(&failure.contract) == contract_name
-                })
-            })
     }
 
     fn matches_path(&self, mut path: &Path) -> bool {
@@ -255,7 +249,7 @@ impl TestFilter for ProjectPathsAwareFilter {
         self.args_filter.matches_path(path) && !self.paths.has_library_ancestor(path)
     }
 
-    fn matches_test_function_in_contract(&self, contract_name: &str, func: &Function) -> bool {
+    fn matches_test_function_in_contract(&self, contract_id: &str, func: &Function) -> bool {
         if let Some(failures) = &self.rerun_failures {
             if !func.is_any_test() || !self.args_filter.matches_test(&func.signature()) {
                 return false;
@@ -263,8 +257,7 @@ impl TestFilter for ProjectPathsAwareFilter {
             let signature = func.signature();
             let name = signature.split('(').next().unwrap_or(&signature);
             failures.iter().any(|failure| {
-                (failure.contract == contract_name
-                    || get_contract_name(&failure.contract) == contract_name)
+                failure.contract == contract_id
                     && (failure.test == signature || failure.test == name)
             })
         } else {

--- a/crates/forge/src/cmd/test/filter.rs
+++ b/crates/forge/src/cmd/test/filter.rs
@@ -1,8 +1,26 @@
+use alloy_json_abi::Function;
 use clap::Parser;
-use foundry_common::TestFilter;
+use foundry_common::{TestFilter, TestFunctionExt, get_contract_name};
 use foundry_compilers::{FileFilter, ProjectPathsConfig};
 use foundry_config::{Config, filter::GlobMatcher};
+use serde::{Deserialize, Serialize};
 use std::{fmt, path::Path};
+
+/// A failed test persisted for `forge test --rerun`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RerunFailure {
+    /// The test suite identifier (`path:contract_name`).
+    pub contract: String,
+    /// The test signature or invariant predicate name.
+    pub test: String,
+}
+
+/// Persisted `forge test --rerun` failures.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RerunFailures {
+    pub version: u8,
+    pub failures: Vec<RerunFailure>,
+}
 
 /// The filter to use during testing.
 ///
@@ -78,7 +96,11 @@ impl FilterArgs {
         if self.coverage_pattern_inverse.is_none() {
             self.coverage_pattern_inverse = config.coverage_pattern_inverse.clone().map(Into::into);
         }
-        ProjectPathsAwareFilter { args_filter: self, paths: config.project_paths() }
+        ProjectPathsAwareFilter {
+            args_filter: self,
+            paths: config.project_paths(),
+            rerun_failures: None,
+        }
     }
 }
 
@@ -172,6 +194,7 @@ impl fmt::Display for FilterArgs {
 pub struct ProjectPathsAwareFilter {
     args_filter: FilterArgs,
     paths: ProjectPathsConfig,
+    rerun_failures: Option<Vec<RerunFailure>>,
 }
 
 impl ProjectPathsAwareFilter {
@@ -194,6 +217,11 @@ impl ProjectPathsAwareFilter {
     pub const fn paths(&self) -> &ProjectPathsConfig {
         &self.paths
     }
+
+    /// Sets exact contract/test pairs persisted by `forge test --rerun`.
+    pub fn set_rerun_failures(&mut self, failures: Vec<RerunFailure>) {
+        self.rerun_failures = Some(failures);
+    }
 }
 
 impl FileFilter for ProjectPathsAwareFilter {
@@ -213,12 +241,35 @@ impl TestFilter for ProjectPathsAwareFilter {
 
     fn matches_contract(&self, contract_name: &str) -> bool {
         self.args_filter.matches_contract(contract_name)
+            && self.rerun_failures.as_ref().is_none_or(|failures| {
+                failures.iter().any(|failure| {
+                    failure.contract == contract_name
+                        || get_contract_name(&failure.contract) == contract_name
+                })
+            })
     }
 
     fn matches_path(&self, mut path: &Path) -> bool {
         // we don't want to test files that belong to a library
         path = path.strip_prefix(&self.paths.root).unwrap_or(path);
         self.args_filter.matches_path(path) && !self.paths.has_library_ancestor(path)
+    }
+
+    fn matches_test_function_in_contract(&self, contract_name: &str, func: &Function) -> bool {
+        if let Some(failures) = &self.rerun_failures {
+            if !func.is_any_test() || !self.args_filter.matches_test(&func.signature()) {
+                return false;
+            }
+            let signature = func.signature();
+            let name = signature.split('(').next().unwrap_or(&signature);
+            failures.iter().any(|failure| {
+                (failure.contract == contract_name
+                    || get_contract_name(&failure.contract) == contract_name)
+                    && (failure.test == signature || failure.test == name)
+            })
+        } else {
+            func.is_any_test() && self.args_filter.matches_test(&func.signature())
+        }
     }
 }
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1,4 +1,8 @@
-use super::{install, test::filter::ProjectPathsAwareFilter, watch::WatchArgs};
+use super::{
+    install,
+    test::filter::{ProjectPathsAwareFilter, RerunFailure, RerunFailures},
+    watch::WatchArgs,
+};
 use crate::{
     MultiContractRunner, MultiContractRunnerBuilder,
     decode::decode_console_logs,
@@ -1157,8 +1161,11 @@ impl TestArgs {
     /// Loads and applies filter from file if only last test run failures performed.
     pub fn filter(&self, config: &Config) -> Result<ProjectPathsAwareFilter> {
         let mut filter = self.filter.clone();
+        let mut rerun_failures = None;
         if self.rerun {
-            filter.test_pattern = last_run_failures(config);
+            let failures = last_run_failures(config);
+            filter.test_pattern = failures.test_pattern;
+            rerun_failures = failures.failures;
         }
         if filter.path_pattern.is_some() {
             if self.path.is_some() {
@@ -1167,7 +1174,11 @@ impl TestArgs {
         } else {
             filter.path_pattern = self.path.clone();
         }
-        Ok(filter.merge_with_config(config))
+        let mut filter = filter.merge_with_config(config);
+        if let Some(failures) = rerun_failures {
+            filter.set_rerun_failures(failures);
+        }
+        Ok(filter)
     }
 
     /// Returns whether `BuildArgs` was configured with `--watch`
@@ -1271,33 +1282,66 @@ fn merge_outcomes(base: &mut TestOutcome, other: TestOutcome) {
     }
 }
 
+struct LastRunFailures {
+    test_pattern: Option<regex::Regex>,
+    failures: Option<Vec<RerunFailure>>,
+}
+
 /// Load persisted filter (with last test run failures) from file.
-fn last_run_failures(config: &Config) -> Option<regex::Regex> {
-    match fs::read_to_string(&config.test_failures_file) {
-        Ok(filter) => Regex::new(&filter)
-            .inspect_err(|e| {
-                _ = sh_warn!(
-                    "failed to parse test filter from {:?}: {e}",
-                    config.test_failures_file
-                )
+fn last_run_failures(config: &Config) -> LastRunFailures {
+    let Ok(filter) = fs::read_to_string(&config.test_failures_file) else {
+        return LastRunFailures { test_pattern: None, failures: None };
+    };
+
+    if let Ok(failures) = serde_json::from_str::<RerunFailures>(&filter) {
+        let test_pattern = (!failures.failures.is_empty())
+            .then(|| {
+                failures
+                    .failures
+                    .iter()
+                    .map(|failure| regex::escape(&failure.test))
+                    .collect::<Vec<_>>()
+                    .join("|")
             })
-            .ok(),
-        Err(_) => None,
+            .and_then(|filter| Regex::new(&filter).ok());
+        return LastRunFailures { test_pattern, failures: Some(failures.failures) };
     }
+
+    let test_pattern = Regex::new(&filter)
+        .inspect_err(|e| {
+            _ = sh_warn!("failed to parse test filter from {:?}: {e}", config.test_failures_file)
+        })
+        .ok();
+    LastRunFailures { test_pattern, failures: None }
 }
 
 /// Persist filter with last test run failures (only if there's any failure).
 fn persist_run_failures(config: &Config, outcome: &TestOutcome) {
     if outcome.failed() > 0 && fs::create_file(&config.test_failures_file).is_ok() {
-        let filter =
-            outcome.failures().flat_map(rerun_filter_matches).collect::<Vec<_>>().join("|");
-        let _ = fs::write(&config.test_failures_file, filter);
+        let failures = outcome
+            .results
+            .iter()
+            .flat_map(|(contract, suite)| {
+                suite.test_results.iter().filter(|(_, result)| result.status.is_failure()).flat_map(
+                    move |(test_name, test_result)| {
+                        rerun_filter_matches(test_name, test_result)
+                            .map(move |test| RerunFailure { contract: contract.clone(), test })
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let output = serde_json::to_string(&RerunFailures { version: 1, failures });
+        if let Ok(output) = output {
+            let _ = fs::write(&config.test_failures_file, output);
+        }
     }
 }
 
 fn rerun_filter_matches<'a>(
-    (test_name, test_result): (&'a String, &'a TestResult),
-) -> impl Iterator<Item = &'a str> {
+    test_name: &'a str,
+    test_result: &'a TestResult,
+) -> impl Iterator<Item = String> + 'a {
     let has_predicate_failures =
         test_result.invariant_failures.iter().any(|failure| failure.predicate_name().is_some());
     let predicate_failures =
@@ -1305,7 +1349,9 @@ fn rerun_filter_matches<'a>(
 
     let fallback = test_name.is_any_test().then(|| test_name.split('(').next()).flatten();
 
-    predicate_failures.chain(fallback.into_iter().filter(move |_| !has_predicate_failures))
+    predicate_failures
+        .chain(fallback.into_iter().filter(move |_| !has_predicate_failures))
+        .map(str::to_owned)
 }
 
 /// Generate test report in JUnit XML report format.

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -354,11 +354,19 @@ impl TestArgs {
             eyre::bail!("Compilation failed");
         }
 
+        // `MultiContractRunner::build` strips the root prefix from artifact source paths so the
+        // identifiers it constructs are project-relative. Match that here for the filter check
+        // (notably for the `--rerun` failure list, which is persisted relative) but return the
+        // original absolute source paths so downstream compilation can locate them.
         Ok(output
             .artifact_ids()
             .filter_map(|(id, artifact)| artifact.abi.as_ref().map(|abi| (id, abi)))
             .filter(|(id, abi)| {
-                id.source.starts_with(&config.src) || matches_artifact(test_filter, id, abi)
+                if id.source.starts_with(&config.src) {
+                    return true;
+                }
+                let stripped = id.clone().with_stripped_file_prefixes(&config.root);
+                matches_artifact(test_filter, &stripped, abi)
             })
             .map(|(id, _)| id.source)
             .collect())
@@ -1161,12 +1169,13 @@ impl TestArgs {
     /// Loads and applies filter from file if only last test run failures performed.
     pub fn filter(&self, config: &Config) -> Result<ProjectPathsAwareFilter> {
         let mut filter = self.filter.clone();
-        let mut rerun_failures = None;
-        if self.rerun {
+        let rerun_failures = if self.rerun {
             let failures = last_run_failures(config);
             filter.test_pattern = failures.test_pattern;
-            rerun_failures = failures.failures;
-        }
+            failures.failures
+        } else {
+            None
+        };
         if filter.path_pattern.is_some() {
             if self.path.is_some() {
                 bail!("Can not supply both --match-path and |path|");
@@ -1294,16 +1303,16 @@ fn last_run_failures(config: &Config) -> LastRunFailures {
     };
 
     if let Ok(failures) = serde_json::from_str::<RerunFailures>(&filter) {
-        let test_pattern = (!failures.failures.is_empty())
-            .then(|| {
-                failures
-                    .failures
-                    .iter()
-                    .map(|failure| regex::escape(&failure.test))
-                    .collect::<Vec<_>>()
-                    .join("|")
-            })
-            .and_then(|filter| Regex::new(&filter).ok());
+        if failures.failures.is_empty() {
+            return LastRunFailures { test_pattern: None, failures: None };
+        }
+        let test_pattern = failures
+            .failures
+            .iter()
+            .map(|failure| regex::escape(&failure.test))
+            .collect::<Vec<_>>()
+            .join("|");
+        let test_pattern = Regex::new(&test_pattern).ok();
         return LastRunFailures { test_pattern, failures: Some(failures.failures) };
     }
 

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -103,9 +103,12 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         &'a self,
         filter: &'b dyn TestFilter,
     ) -> impl Iterator<Item = &'a Function> + 'b {
-        self.matching_contracts(filter)
-            .flat_map(|(_, c)| c.abi.functions())
-            .filter(|func| filter.matches_test_function(func))
+        self.matching_contracts(filter).flat_map(move |(id, c)| {
+            let contract_name = id.identifier();
+            c.abi
+                .functions()
+                .filter(move |func| filter.matches_test_function_in_contract(&contract_name, func))
+        })
     }
 
     /// Returns an iterator over all test functions in contracts that match the filter.
@@ -129,7 +132,7 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
                 let tests = c
                     .abi
                     .functions()
-                    .filter(|func| filter.matches_test_function(func))
+                    .filter(|func| filter.matches_test_function_in_contract(&name, func))
                     .map(|func| func.name.clone())
                     .collect::<Vec<_>>();
                 (source, name, tests)
@@ -677,5 +680,7 @@ pub(crate) fn matches_contract(
     functions: impl IntoIterator<Item = impl std::borrow::Borrow<Function>>,
 ) -> bool {
     (filter.matches_path(path) && filter.matches_contract(contract_name))
-        && functions.into_iter().any(|func| filter.matches_test_function(func.borrow()))
+        && functions
+            .into_iter()
+            .any(|func| filter.matches_test_function_in_contract(contract_name, func.borrow()))
 }

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -104,10 +104,10 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         filter: &'b dyn TestFilter,
     ) -> impl Iterator<Item = &'a Function> + 'b {
         self.matching_contracts(filter).flat_map(move |(id, c)| {
-            let contract_name = id.identifier();
+            let identifier = id.identifier();
             c.abi
                 .functions()
-                .filter(move |func| filter.matches_test_function_in_contract(&contract_name, func))
+                .filter(move |func| filter.matches_test_function_in_contract(&identifier, func))
         })
     }
 
@@ -129,10 +129,11 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
             .map(|(id, c)| {
                 let source = id.source.as_path().display().to_string();
                 let name = id.name.clone();
+                let identifier = id.identifier();
                 let tests = c
                     .abi
                     .functions()
-                    .filter(|func| filter.matches_test_function_in_contract(&name, func))
+                    .filter(|func| filter.matches_test_function_in_contract(&identifier, func))
                     .map(|func| func.name.clone())
                     .collect::<Vec<_>>();
                 (source, name, tests)
@@ -670,17 +671,18 @@ impl MultiContractRunnerBuilder {
 }
 
 pub fn matches_artifact(filter: &dyn TestFilter, id: &ArtifactId, abi: &JsonAbi) -> bool {
-    matches_contract(filter, &id.source, &id.name, abi.functions())
+    matches_contract(filter, &id.source, &id.name, &id.identifier(), abi.functions())
 }
 
 pub(crate) fn matches_contract(
     filter: &dyn TestFilter,
     path: &Path,
     contract_name: &str,
+    contract_id: &str,
     functions: impl IntoIterator<Item = impl std::borrow::Borrow<Function>>,
 ) -> bool {
     (filter.matches_path(path) && filter.matches_contract(contract_name))
         && functions
             .into_iter()
-            .any(|func| filter.matches_test_function_in_contract(contract_name, func.borrow()))
+            .any(|func| filter.matches_test_function_in_contract(contract_id, func.borrow()))
 }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -446,7 +446,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             .contract
             .abi
             .functions()
-            .filter(|func| filter.matches_test_function(func))
+            .filter(|func| filter.matches_test_function_in_contract(self.name, func))
             .filter(|func| self.function_matches_network_pass(func))
             .collect::<Vec<_>>();
         debug!(

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -183,3 +183,47 @@ Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
 ...
 "#]]);
 });
+
+forgetest_init!(rerun_with_only_setup_failure_runs_all_tests, |prj, cmd| {
+    prj.add_test(
+        "RerunSetupFail.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract OnlySetupFails is Test {
+    function setUp() public {
+        assertTrue(false);
+    }
+
+    function testA() public {
+        assertTrue(true);
+    }
+}
+
+contract HealthyContract is Test {
+    function testC() public {
+        assertTrue(true);
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "-j1"]).assert_failure();
+
+    // With no replayable failures recorded, `--rerun` falls back to a regular run instead of
+    // selecting zero tests.
+    cmd.forge_fuse().args(["test", "--rerun", "-j1"]).assert_failure().stdout_eq(str![[r#"
+No files changed, compilation skipped
+
+Ran 1 test for test/RerunSetupFail.t.sol:HealthyContract
+[PASS] testC() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test for test/RerunSetupFail.t.sol:OnlySetupFails
+[FAIL: assertion failed] setUp() ([GAS])
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+
+Ran 2 test suites [ELAPSED]: 1 tests passed, 1 failed, 0 skipped (2 total tests)
+...
+"#]]);
+});

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -137,3 +137,49 @@ Tip: Run `forge test --rerun` to retry only the 1 failed test
 
 "#]]);
 });
+
+forgetest_init!(rerun_filters_same_named_tests_by_contract, |prj, cmd| {
+    prj.add_test(
+        "RerunSameName.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract FailingSameNameTest is Test {
+    function testSharedName() public {
+        assertTrue(false);
+    }
+}
+
+contract PassingSameNameTest is Test {
+    function testSharedName() public {
+        assertTrue(true);
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "-j1"]).assert_failure().stdout_eq(str![[r#"
+...
+Ran 1 test for test/RerunSameName.t.sol:FailingSameNameTest
+[FAIL: assertion failed] testSharedName() ([GAS])
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test for test/RerunSameName.t.sol:PassingSameNameTest
+[PASS] testSharedName() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 2 test suites [ELAPSED]: 1 tests passed, 1 failed, 0 skipped (2 total tests)
+...
+"#]]);
+
+    cmd.forge_fuse().args(["test", "--rerun", "-j1"]).assert_failure().stdout_eq(str![[r#"
+No files changed, compilation skipped
+
+Ran 1 test for test/RerunSameName.t.sol:FailingSameNameTest
+[FAIL: assertion failed] testSharedName() ([GAS])
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
+...
+"#]]);
+});


### PR DESCRIPTION
## Summary
- Persist `forge test --rerun` failures as JSON contract/test pairs instead of only a test-name regex.
- Use contract-aware test filtering when rerunning so same-named tests in other contracts are not selected.
- Keep compatibility with existing persisted rerun failure files by falling back to the legacy regex format when JSON parsing fails.

## Why
`forge test --rerun` could rerun too many tests when multiple contracts defined the same test function name and only one of them failed. The previous failure cache only captured test names, so collection could not distinguish the failed contract from passing contracts with the same test name.

## Changes
- Add a contract-aware test filter hook with a default behavior matching existing filtering.
- Thread contract names/identifiers through forge test collection and execution filtering.
- Add versioned JSON persistence for rerun failures while preserving legacy regex loading.
- Add a regression test with two contracts sharing `testSharedName()` where only the failed contract is rerun.

## Validation
- `cargo fmt --check` (passes; stable rustfmt prints existing warnings for nightly-only rustfmt options)
- `cargo test -p forge --test cli rerun_filters_same_named_tests_by_contract -- --nocapture`
- `cargo test -p forge --test cli replays_random_uint_failure -- --nocapture`

## Scope
Focused bugfix for `forge test --rerun` filtering and persisted failure loading. Regular match-test/match-contract filtering behavior is intended to remain unchanged.