### PR TITLE
feat(forge): migrate forge inspect to documented output channels

### DIFF
--- a/crates/forge/src/cmd/inspect.rs
+++ b/crates/forge/src/cmd/inspect.rs
@@ -166,10 +166,10 @@ impl InspectArgs {
                 if shell::is_json() {
                     return print_json(&all_libs);
                 }
-                sh_println!(
-                    "Dynamically linked libraries:\n{}",
-                    all_libs.iter().map(|v| format!("  {v}")).collect::<Vec<String>>().join("\n")
-                )?;
+                sh_status!("Dynamically linked libraries:")?;
+                for lib in &all_libs {
+                    sh_println!("{lib}")?;
+                }
             }
             ContractArtifactField::Linearization => {
                 print_linearization(
@@ -732,7 +732,17 @@ fn print_json(obj: &impl serde::Serialize) -> Result<()> {
 }
 
 fn print_json_str(obj: &impl serde::Serialize, key: Option<&str>) -> Result<()> {
-    sh_println!("{}", get_json_str(obj, key)?)?;
+    let value = serde_json::to_value(obj)?;
+    let value = key.and_then(|k| value.get(k)).unwrap_or(&value);
+    if shell::is_json() {
+        sh_println!("{}", serde_json::to_string_pretty(value)?)?;
+    } else {
+        let s = match value.as_str() {
+            Some(s) => s.to_string(),
+            None => format!("{value:#}"),
+        };
+        sh_println!("{s}")?;
+    }
     Ok(())
 }
 
@@ -744,28 +754,19 @@ fn print_yul(yul: Option<&str>, strip_comments: bool) -> Result<()> {
     static YUL_COMMENTS: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(///.*\n\s*)|(\s*/\*\*.*?\*/)").unwrap());
 
-    if strip_comments {
-        sh_println!("{}", YUL_COMMENTS.replace_all(yul, ""))?;
+    let out = if strip_comments {
+        YUL_COMMENTS.replace_all(yul, "").into_owned()
     } else {
-        sh_println!("{yul}")?;
+        yul.to_string()
+    };
+
+    if shell::is_json() {
+        sh_println!("{}", serde_json::to_string(&out)?)?;
+    } else {
+        sh_println!("{out}")?;
     }
 
     Ok(())
-}
-
-fn get_json_str(obj: &impl serde::Serialize, key: Option<&str>) -> Result<String> {
-    let value = serde_json::to_value(obj)?;
-    let value = if let Some(key) = key
-        && let Some(value) = value.get(key)
-    {
-        value
-    } else {
-        &value
-    };
-    Ok(match value.as_str() {
-        Some(s) => s.to_string(),
-        None => format!("{value:#}"),
-    })
 }
 
 fn is_solidity_source(path: &Path) -> bool {

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1393,6 +1393,15 @@ contract Foo {
 
 "#
     ]]);
+
+    // `--json` wraps the bytecode hex as a JSON string
+    cmd.forge_fuse()
+        .args(["inspect", contract_name, "bytecode", "--json"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+"0x60806040[..]"
+
+"#]]);
 });
 
 forgetest!(can_inspect_linearization_markdown, |prj, cmd| {
@@ -3461,6 +3470,19 @@ object "Counter_21" {
         if callvalue() { revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb() }
 ...
 "#]]);
+
+    // `--json` wraps the IR source as a JSON string (one quoted line)
+    let json_out = cmd
+        .forge_fuse()
+        .args(["inspect", TEMPLATE_CONTRACT, "ir", "--json"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let json_out = json_out.trim();
+    assert!(json_out.starts_with('"'), "expected quoted JSON string, got {json_out:?}");
+    assert!(json_out.ends_with('"'), "expected quoted JSON string, got {json_out:?}");
+    let _: String =
+        serde_json::from_str(json_out).expect("ir --json stdout should be a valid JSON string");
 });
 
 // checks forge bind works correctly on the default project
@@ -4099,12 +4121,27 @@ forgetest_init!(can_inspect_libraries, |prj, cmd| {
     "#,
     );
 
-    cmd.args(["inspect", "Source", "libraries"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["inspect", "Source", "libraries"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+src/Lib.sol:Lib
+src/Source.sol:Lib2
+
+"#]])
+        .stderr_eq(str![[r#"
 Dynamically linked libraries:
-  src/Lib.sol:Lib
-  src/Source.sol:Lib2
 
 "#]]);
+
+    cmd.forge_fuse().args(["inspect", "Source", "libraries", "--json"]).assert_success().stdout_eq(
+        str![[r#"
+[
+  "src/Lib.sol:Lib",
+  "src/Source.sol:Lib2"
+]
+
+"#]],
+    );
 });
 
 // checks that `clean` also works with the "out" value set in Config

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -119,7 +119,7 @@ Each row's status is one of:
 | `forge build`          | (empty)                                              | JSON build output                          | todo   |
 | `forge test`           | (empty; exit code = pass/fail)                       | JSON test results, JUnit XML with `--junit`| todo   |
 | `forge create`         | Deployed address                                     | JSON `{ "address": "…", "tx_hash": "…", … }` | todo |
-| `forge inspect <field>`| Just that field's value                              | JSON of that field                         | todo   |
+| `forge inspect <field>`| Just that field's value                              | JSON of that field                         | migrated |
 | `forge install`        | (empty)                                              | (empty)                                    | todo   |
 | `forge init`           | (empty)                                              | (empty)                                    | migrated |
 | `forge update`         | (empty)                                              | (empty)                                    | migrated |


### PR DESCRIPTION
Aligns `forge inspect <field>` with `docs/dev/output-channels.md`.

- `libraries` text mode: "Dynamically linked libraries:" header moves to stderr via `sh_status!`; library list stays on stdout, one per line (no indent).
- `print_json_str` and `print_yul` now branch on `shell::is_json()` so `--json` emits valid JSON instead of raw text for `bytecode`, `deployedBytecode`, `assembly`, `legacyAssembly`, `ewasm`, `ir`, `irOptimized`. Text-mode behavior unchanged.
- Doc row flipped to `migrated`.

Part of OSS-224