### PR TITLE
feat(lint): add reentrancy-no-eth detector

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -23,6 +23,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `incorrect-erc20-interface`: Flags ERC20 interfaces and implementations with non-compliant function signatures.
   - `incorrect-erc721-interface`: Flags ERC721 interfaces and implementations with non-compliant function signatures.
   - `incorrect-strict-equality`: Dangerous strict equality check on an externally-influenced value (ETH balance, ERC-20 balance).
+  - `reentrancy-no-eth`: Flags non-ETH external calls followed by writes to state that was read before the call.
   - `tx-origin`: Flags use of `tx.origin` in authorization-like predicates.
   - `uninitialized-local`: Local variable is read before being explicitly initialized.
   - `uninitialized-state`: State variable is read in functions but never written, so it always returns its zero-value default.

--- a/crates/lint/docs/reentrancy-no-eth.md
+++ b/crates/lint/docs/reentrancy-no-eth.md
@@ -1,0 +1,46 @@
+# No-ETH read-before-write reentrancy
+
+**Severity**: `Medium`
+**ID**: `reentrancy-no-eth`
+
+Flags external calls that do not transfer ETH when state read before the call is written after the
+call on the same reachable path.
+
+## What it does
+
+Warns when a public or external entry point reads a state variable, performs a reentrant external
+call that does not send ETH, and later writes the same state variable. Local internal helper calls
+and modifiers are analyzed when their bodies are available. This uses Slither's
+`reentrancy-no-eth` detector name.
+
+## Why is this bad?
+
+Even without ETH transfer, an external call can invoke attacker-controlled code. If that code
+re-enters before later state changes occur, the original function may continue with stale state and
+overwrite or reuse values that changed during the reentrant execution.
+
+This lint is intentionally conservative to avoid noisy findings: it does not report ETH-transferring
+calls, view or pure interface calls, unrelated state writes, or constructor-time calls. It does not
+attempt to prove custom guard modifiers are effective.
+
+## Example
+
+### Bad
+
+```solidity
+function claim(IHook hook) external {
+    uint256 amount = balances[msg.sender];
+    hook.notify(amount);
+    balances[msg.sender] = 0;
+}
+```
+
+### Good
+
+```solidity
+function claim(IHook hook) external {
+    uint256 amount = balances[msg.sender];
+    balances[msg.sender] = 0;
+    hook.notify(amount);
+}
+```

--- a/crates/lint/src/sol/high/mod.rs
+++ b/crates/lint/src/sol/high/mod.rs
@@ -11,7 +11,7 @@ mod unprotected_initializer;
 use arbitrary_send_erc20::ARBITRARY_SEND_ERC20;
 use encode_packed_collision::ENCODE_PACKED_COLLISION;
 use incorrect_shift::INCORRECT_SHIFT;
-use reentrancy::REENTRANCY_ETH;
+use reentrancy::{REENTRANCY_ETH, REENTRANCY_NO_ETH};
 use rtlo::RTLO;
 use unchecked_calls::{ERC20_UNCHECKED_TRANSFER, UNCHECKED_CALL};
 use unprotected_initializer::UNPROTECTED_INITIALIZER;
@@ -20,7 +20,7 @@ register_lints!(
     (ArbitrarySendErc20, late, (ARBITRARY_SEND_ERC20)),
     (EncodedPackedCollision, late, (ENCODE_PACKED_COLLISION)),
     (IncorrectShift, early, (INCORRECT_SHIFT)),
-    (ReentrancyEth, late, (REENTRANCY_ETH)),
+    (ReentrancyEth, late, (REENTRANCY_ETH, REENTRANCY_NO_ETH)),
     (UncheckedCall, early, (UNCHECKED_CALL)),
     (UncheckedTransferERC20, late, (ERC20_UNCHECKED_TRANSFER)),
     (UnprotectedInitializer, late, (UNPROTECTED_INITIALIZER)),

--- a/crates/lint/src/sol/high/reentrancy.rs
+++ b/crates/lint/src/sol/high/reentrancy.rs
@@ -283,18 +283,18 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                     self.analyze_expr(lhs, state);
                 }
                 self.analyze_expr(rhs, state);
+                self.analyze_lhs_indices(lhs, state);
                 let written_vars = state_write_lhs_vars(self.hir, lhs);
                 if !written_vars.is_empty() {
                     self.emit_pending_calls(state, &written_vars);
                 }
-                self.analyze_lhs_indices(lhs, state);
             }
             ExprKind::Delete(inner) => {
+                self.analyze_lhs_indices(inner, state);
                 let written_vars = state_write_lhs_vars(self.hir, inner);
                 if !written_vars.is_empty() {
                     self.emit_pending_calls(state, &written_vars);
                 }
-                self.analyze_lhs_indices(inner, state);
             }
             ExprKind::Unary(op, inner)
                 if matches!(
@@ -505,7 +505,7 @@ fn is_uncapped_value_call(
     opts: Option<&[hir::NamedArg<'_>]>,
 ) -> bool {
     let Some(opts) = opts else { return false };
-    let ExprKind::Member(_, member) = &callee.kind else { return false };
+    let ExprKind::Member(_, member) = &callee.peel_parens().kind else { return false };
     if member.name != kw::Call {
         return false;
     }

--- a/crates/lint/src/sol/high/reentrancy.rs
+++ b/crates/lint/src/sol/high/reentrancy.rs
@@ -1,12 +1,14 @@
 use super::ReentrancyEth;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{Severity, SolLint},
+    sol::{Severity, SolLint, analysis::interface::receiver_contract_id},
 };
 use solar::{
     ast::{LitKind, StateMutability, UnOpKind, Visibility},
     interface::{Span, kw, sym},
-    sema::hir::{self, ExprKind, FunctionId, ItemId, Res, StmtKind, VariableId},
+    sema::hir::{
+        self, CallArgs, ExprKind, FunctionId, ItemId, Res, StmtKind, TypeKind, VariableId,
+    },
 };
 use std::collections::{BTreeSet, HashSet};
 
@@ -15,6 +17,13 @@ declare_forge_lint!(
     Severity::High,
     "reentrancy-eth",
     "state read before ETH transfer is written after the transfer"
+);
+
+declare_forge_lint!(
+    REENTRANCY_NO_ETH,
+    Severity::Med,
+    "reentrancy-no-eth",
+    "state read before external call is written after the call"
 );
 
 impl<'hir> LateLintPass<'hir> for ReentrancyEth {
@@ -52,13 +61,20 @@ fn is_entry_point(func: &hir::Function<'_>) -> bool {
 #[derive(Clone, Debug, Default)]
 struct FlowState {
     state_reads: BTreeSet<VariableId>,
-    pending_value_calls: Vec<PendingValueCall>,
+    pending_calls: Vec<PendingCall>,
 }
 
 #[derive(Clone, Debug)]
-struct PendingValueCall {
+struct PendingCall {
     span: Span,
+    kind: ReentrantCallKind,
     state_reads: BTreeSet<VariableId>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReentrantCallKind {
+    Eth,
+    NoEth,
 }
 
 impl FlowState {
@@ -66,16 +82,21 @@ impl FlowState {
         self.state_reads.insert(var_id);
     }
 
-    fn push_call(&mut self, span: Span) {
+    fn push_call(&mut self, span: Span, kind: ReentrantCallKind) {
         if self.state_reads.is_empty() {
             return;
         }
 
-        if let Some(existing) = self.pending_value_calls.iter_mut().find(|call| call.span == span) {
+        if let Some(existing) =
+            self.pending_calls.iter_mut().find(|call| call.span == span && call.kind == kind)
+        {
             existing.state_reads.extend(self.state_reads.iter().copied());
         } else {
-            self.pending_value_calls
-                .push(PendingValueCall { span, state_reads: self.state_reads.clone() });
+            self.pending_calls.push(PendingCall {
+                span,
+                kind,
+                state_reads: self.state_reads.clone(),
+            });
         }
     }
 }
@@ -295,8 +316,8 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                 for func_id in resolved_function_ids(callee) {
                     self.analyze_internal_call(func_id, state);
                 }
-                if is_uncapped_value_call(self.hir, callee, *opts) {
-                    state.push_call(expr.span);
+                if let Some(kind) = reentrant_call_kind(self.hir, callee, args, *opts) {
+                    state.push_call(expr.span, kind);
                 }
             }
             ExprKind::Binary(lhs, _, rhs) => {
@@ -401,8 +422,16 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
     }
 
     fn emit_pending_calls(&mut self, state: &FlowState, written_vars: &[VariableId]) {
-        for call in &state.pending_value_calls {
-            if self.emitted.contains(&call.span) {
+        for call in &state.pending_calls {
+            let (lint, msg_prefix) = match call.kind {
+                ReentrantCallKind::Eth => {
+                    (&REENTRANCY_ETH, "uncapped ETH transfer can be reentered before")
+                }
+                ReentrantCallKind::NoEth => {
+                    (&REENTRANCY_NO_ETH, "external call can be reentered before")
+                }
+            };
+            if !self.ctx.is_lint_enabled(lint.id) || self.emitted.contains(&call.span) {
                 continue;
             }
 
@@ -416,9 +445,9 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                     .map(|name| name.as_str().to_string())
                     .unwrap_or_else(|| "state".to_string());
                 self.ctx.emit_with_msg(
-                    &REENTRANCY_ETH,
+                    lint,
                     call.span,
-                    format!("uncapped ETH transfer can be reentered before `{name}` is updated"),
+                    format!("{msg_prefix} `{name}` is updated"),
                 );
                 self.emitted.insert(call.span);
             }
@@ -429,21 +458,35 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
 impl FlowState {
     fn clear(&mut self) {
         self.state_reads.clear();
-        self.pending_value_calls.clear();
+        self.pending_calls.clear();
     }
 
     fn merge(&mut self, other: &Self) {
         self.state_reads.extend(other.state_reads.iter().copied());
-        for call in &other.pending_value_calls {
-            if let Some(existing) =
-                self.pending_value_calls.iter_mut().find(|existing| existing.span == call.span)
+        for call in &other.pending_calls {
+            if let Some(existing) = self
+                .pending_calls
+                .iter_mut()
+                .find(|existing| existing.span == call.span && existing.kind == call.kind)
             {
                 existing.state_reads.extend(call.state_reads.iter().copied());
             } else {
-                self.pending_value_calls.push(call.clone());
+                self.pending_calls.push(call.clone());
             }
         }
     }
+}
+
+fn reentrant_call_kind(
+    hir: &hir::Hir<'_>,
+    callee: &hir::Expr<'_>,
+    args: &CallArgs<'_>,
+    opts: Option<&[hir::NamedArg<'_>]>,
+) -> Option<ReentrantCallKind> {
+    if is_uncapped_value_call(hir, callee, opts) {
+        return Some(ReentrantCallKind::Eth);
+    }
+    is_no_eth_reentrant_call(hir, callee, args, opts).then_some(ReentrantCallKind::NoEth)
 }
 
 fn is_uncapped_value_call(
@@ -468,6 +511,74 @@ fn is_uncapped_value_call(
     }
 
     value.is_some_and(|value| !is_zero_value(hir, value)) && gas.is_none_or(gas_option_forwards_all)
+}
+
+fn is_no_eth_reentrant_call(
+    hir: &hir::Hir<'_>,
+    callee: &hir::Expr<'_>,
+    args: &CallArgs<'_>,
+    opts: Option<&[hir::NamedArg<'_>]>,
+) -> bool {
+    if call_sends_eth(hir, opts) {
+        return false;
+    }
+
+    match &callee.peel_parens().kind {
+        ExprKind::Member(receiver, member) => match member.name {
+            kw::Call | kw::Callcode | kw::Delegatecall => true,
+            kw::Staticcall => false,
+            _ => external_member_call_can_reenter(hir, receiver, member.name, args.len()),
+        },
+        _ => external_function_pointer_can_reenter(hir, callee),
+    }
+}
+
+fn call_sends_eth(hir: &hir::Hir<'_>, opts: Option<&[hir::NamedArg<'_>]>) -> bool {
+    opts.is_some_and(|opts| {
+        opts.iter().any(|opt| opt.name.name == sym::value && !is_zero_value(hir, &opt.value))
+    })
+}
+
+fn external_member_call_can_reenter(
+    hir: &hir::Hir<'_>,
+    receiver: &hir::Expr<'_>,
+    member: solar::interface::Symbol,
+    arity: usize,
+) -> bool {
+    let Some(contract_id) = receiver_contract_id(hir, receiver) else { return false };
+    hir.contract_item_ids(contract_id).any(|item| {
+        let Some(func_id) = item.as_function() else { return false };
+        let func = hir.function(func_id);
+        func.name.is_some_and(|name| name.name == member)
+            && func.kind.is_function()
+            && func.parameters.len() == arity
+            && is_externally_callable(func)
+            && func.mutates_state()
+    })
+}
+
+fn external_function_pointer_can_reenter(hir: &hir::Hir<'_>, callee: &hir::Expr<'_>) -> bool {
+    let Some(ty) = expr_type(hir, callee) else { return false };
+    let TypeKind::Function(function) = ty.kind else { return false };
+    function.visibility == Visibility::External
+        && !matches!(function.state_mutability, StateMutability::Pure | StateMutability::View)
+}
+
+const fn is_externally_callable(func: &hir::Function<'_>) -> bool {
+    matches!(func.visibility, Visibility::Public | Visibility::External)
+}
+
+fn expr_type<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    expr: &hir::Expr<'hir>,
+) -> Option<&'hir hir::Type<'hir>> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) => reses.iter().find_map(|res| {
+            let var_id = res.as_variable()?;
+            Some(&hir.variable(var_id).ty)
+        }),
+        _ => None,
+    }
 }
 
 fn is_zero_value(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {

--- a/crates/lint/src/sol/high/reentrancy.rs
+++ b/crates/lint/src/sol/high/reentrancy.rs
@@ -1,13 +1,20 @@
 use super::ReentrancyEth;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{Severity, SolLint, analysis::interface::receiver_contract_id},
+    sol::{Severity, SolLint},
 };
 use solar::{
-    ast::{LitKind, StateMutability, UnOpKind, Visibility},
+    ast::{
+        DataLocation, ElementaryType, LitKind, StateMutability, StrKind, TypeSize, UnOpKind,
+        Visibility,
+    },
     interface::{Span, kw, sym},
-    sema::hir::{
-        self, CallArgs, ExprKind, FunctionId, ItemId, Res, StmtKind, TypeKind, VariableId,
+    sema::{
+        Gcx, Ty,
+        hir::{
+            self, CallArgs, CallArgsKind, ExprKind, FunctionId, ItemId, Res, StmtKind, VariableId,
+        },
+        ty::TyKind,
     },
 };
 use std::collections::{BTreeSet, HashSet};
@@ -27,9 +34,10 @@ declare_forge_lint!(
 );
 
 impl<'hir> LateLintPass<'hir> for ReentrancyEth {
-    fn check_function(
+    fn check_function_with_gcx(
         &mut self,
         ctx: &LintContext,
+        gcx: Gcx<'hir>,
         hir: &'hir hir::Hir<'hir>,
         func: &'hir hir::Function<'hir>,
     ) {
@@ -39,7 +47,7 @@ impl<'hir> LateLintPass<'hir> for ReentrancyEth {
 
         let Some(body) = func.body else { return };
 
-        let mut analyzer = Analyzer::new(ctx, hir);
+        let mut analyzer = Analyzer::new(ctx, gcx, hir);
         let mut state = FlowState::default();
         analyzer.analyze_callable(func, body, &mut state);
     }
@@ -103,14 +111,15 @@ impl FlowState {
 
 struct Analyzer<'ctx, 's, 'c, 'hir> {
     ctx: &'ctx LintContext<'s, 'c>,
+    gcx: Gcx<'hir>,
     hir: &'hir hir::Hir<'hir>,
     emitted: HashSet<Span>,
     call_stack: Vec<FunctionId>,
 }
 
 impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
-    fn new(ctx: &'ctx LintContext<'s, 'c>, hir: &'hir hir::Hir<'hir>) -> Self {
-        Self { ctx, hir, emitted: HashSet::new(), call_stack: Vec::new() }
+    fn new(ctx: &'ctx LintContext<'s, 'c>, gcx: Gcx<'hir>, hir: &'hir hir::Hir<'hir>) -> Self {
+        Self { ctx, gcx, hir, emitted: HashSet::new(), call_stack: Vec::new() }
     }
 
     fn analyze_callable(
@@ -316,7 +325,7 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                 for func_id in resolved_function_ids(callee) {
                     self.analyze_internal_call(func_id, state);
                 }
-                if let Some(kind) = reentrant_call_kind(self.hir, callee, args, *opts) {
+                if let Some(kind) = reentrant_call_kind(self.gcx, self.hir, callee, args, *opts) {
                     state.push_call(expr.span, kind);
                 }
             }
@@ -477,16 +486,17 @@ impl FlowState {
     }
 }
 
-fn reentrant_call_kind(
-    hir: &hir::Hir<'_>,
-    callee: &hir::Expr<'_>,
-    args: &CallArgs<'_>,
-    opts: Option<&[hir::NamedArg<'_>]>,
+fn reentrant_call_kind<'hir>(
+    gcx: Gcx<'hir>,
+    hir: &'hir hir::Hir<'hir>,
+    callee: &'hir hir::Expr<'hir>,
+    args: &CallArgs<'hir>,
+    opts: Option<&'hir [hir::NamedArg<'hir>]>,
 ) -> Option<ReentrantCallKind> {
     if is_uncapped_value_call(hir, callee, opts) {
         return Some(ReentrantCallKind::Eth);
     }
-    is_no_eth_reentrant_call(hir, callee, args, opts).then_some(ReentrantCallKind::NoEth)
+    is_no_eth_reentrant_call(gcx, hir, callee, args, opts).then_some(ReentrantCallKind::NoEth)
 }
 
 fn is_uncapped_value_call(
@@ -513,11 +523,12 @@ fn is_uncapped_value_call(
     value.is_some_and(|value| !is_zero_value(hir, value)) && gas.is_none_or(gas_option_forwards_all)
 }
 
-fn is_no_eth_reentrant_call(
-    hir: &hir::Hir<'_>,
-    callee: &hir::Expr<'_>,
-    args: &CallArgs<'_>,
-    opts: Option<&[hir::NamedArg<'_>]>,
+fn is_no_eth_reentrant_call<'hir>(
+    gcx: Gcx<'hir>,
+    hir: &'hir hir::Hir<'hir>,
+    callee: &'hir hir::Expr<'hir>,
+    args: &CallArgs<'hir>,
+    opts: Option<&'hir [hir::NamedArg<'hir>]>,
 ) -> bool {
     if call_sends_eth(hir, opts) {
         return false;
@@ -525,11 +536,11 @@ fn is_no_eth_reentrant_call(
 
     match &callee.peel_parens().kind {
         ExprKind::Member(receiver, member) => match member.name {
-            kw::Call | kw::Callcode | kw::Delegatecall => true,
+            kw::Call | kw::Callcode | kw::Delegatecall => is_address_like(gcx, hir, receiver),
             kw::Staticcall => false,
-            _ => external_member_call_can_reenter(hir, receiver, member.name, args.len()),
+            _ => external_member_call_can_reenter(gcx, hir, receiver, member.name, args),
         },
-        _ => external_function_pointer_can_reenter(hir, callee),
+        _ => external_function_pointer_can_reenter(gcx, hir, callee, args),
     }
 }
 
@@ -539,28 +550,50 @@ fn call_sends_eth(hir: &hir::Hir<'_>, opts: Option<&[hir::NamedArg<'_>]>) -> boo
     })
 }
 
-fn external_member_call_can_reenter(
-    hir: &hir::Hir<'_>,
-    receiver: &hir::Expr<'_>,
+fn external_member_call_can_reenter<'hir>(
+    gcx: Gcx<'hir>,
+    hir: &'hir hir::Hir<'hir>,
+    receiver: &'hir hir::Expr<'hir>,
     member: solar::interface::Symbol,
-    arity: usize,
+    args: &CallArgs<'hir>,
 ) -> bool {
-    let Some(contract_id) = receiver_contract_id(hir, receiver) else { return false };
-    hir.contract_item_ids(contract_id).any(|item| {
-        let Some(func_id) = item.as_function() else { return false };
-        let func = hir.function(func_id);
-        func.name.is_some_and(|name| name.name == member)
-            && func.kind.is_function()
-            && func.parameters.len() == arity
-            && is_externally_callable(func)
-            && func.mutates_state()
-    })
+    if is_super(receiver) {
+        return false;
+    }
+
+    let Some(receiver_ty) = expr_ty(gcx, hir, receiver) else { return false };
+    gcx.members_of(receiver_ty, base_item_source(hir, receiver), base_contract(hir, receiver))
+        .iter()
+        .filter(|candidate| candidate.name == member)
+        .any(|candidate| match (candidate.res, candidate.ty.kind) {
+            (Some(Res::Item(ItemId::Function(function_id))), _) => {
+                let function = hir.function(function_id);
+                is_externally_callable(function)
+                    && args_match_function(gcx, hir, args, function.parameters)
+                    && function.mutates_state()
+            }
+            (_, TyKind::FnPtr(function)) => {
+                is_externally_callable_fn_ptr(function.visibility)
+                    && args_match_types(gcx, hir, args, function.parameters)
+                    && !matches!(
+                        function.state_mutability,
+                        StateMutability::Pure | StateMutability::View
+                    )
+            }
+            _ => false,
+        })
 }
 
-fn external_function_pointer_can_reenter(hir: &hir::Hir<'_>, callee: &hir::Expr<'_>) -> bool {
-    let Some(ty) = expr_type(hir, callee) else { return false };
-    let TypeKind::Function(function) = ty.kind else { return false };
+fn external_function_pointer_can_reenter<'hir>(
+    gcx: Gcx<'hir>,
+    hir: &'hir hir::Hir<'hir>,
+    callee: &'hir hir::Expr<'hir>,
+    args: &CallArgs<'hir>,
+) -> bool {
+    let Some(ty) = expr_ty(gcx, hir, callee) else { return false };
+    let TyKind::FnPtr(function) = ty.kind else { return false };
     function.visibility == Visibility::External
+        && args_match_types(gcx, hir, args, function.parameters)
         && !matches!(function.state_mutability, StateMutability::Pure | StateMutability::View)
 }
 
@@ -568,17 +601,282 @@ const fn is_externally_callable(func: &hir::Function<'_>) -> bool {
     matches!(func.visibility, Visibility::Public | Visibility::External)
 }
 
-fn expr_type<'hir>(
+const fn is_externally_callable_fn_ptr(visibility: Visibility) -> bool {
+    matches!(visibility, Visibility::Public | Visibility::External)
+}
+
+fn args_match_function<'hir>(
+    gcx: Gcx<'hir>,
     hir: &'hir hir::Hir<'hir>,
-    expr: &hir::Expr<'hir>,
-) -> Option<&'hir hir::Type<'hir>> {
-    match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => reses.iter().find_map(|res| {
-            let var_id = res.as_variable()?;
-            Some(&hir.variable(var_id).ty)
+    args: &CallArgs<'hir>,
+    params: &'hir [VariableId],
+) -> bool {
+    if args.len() != params.len() {
+        return false;
+    }
+
+    match args.kind {
+        CallArgsKind::Unnamed(exprs) => exprs.iter().zip(params).all(|(arg, &param)| {
+            let param = hir.variable(param);
+            let param_ty =
+                gcx.type_of_hir_ty(&param.ty).with_loc_if_ref_opt(gcx, param.data_location);
+            arg_matches_type(gcx, hir, arg, param_ty)
         }),
+        CallArgsKind::Named(named_args) => named_args.iter().all(|arg| {
+            params
+                .iter()
+                .copied()
+                .find(|&param| {
+                    hir.variable(param).name.is_some_and(|name| name.name == arg.name.name)
+                })
+                .is_some_and(|param| {
+                    let param = hir.variable(param);
+                    let param_ty =
+                        gcx.type_of_hir_ty(&param.ty).with_loc_if_ref_opt(gcx, param.data_location);
+                    arg_matches_type(gcx, hir, &arg.value, param_ty)
+                })
+        }),
+    }
+}
+
+fn args_match_types<'hir>(
+    gcx: Gcx<'hir>,
+    hir: &'hir hir::Hir<'hir>,
+    args: &CallArgs<'hir>,
+    params: &'hir [Ty<'hir>],
+) -> bool {
+    if args.len() != params.len() {
+        return false;
+    }
+
+    match args.kind {
+        CallArgsKind::Unnamed(exprs) => {
+            exprs.iter().zip(params).all(|(arg, &param)| arg_matches_type(gcx, hir, arg, param))
+        }
+        CallArgsKind::Named(_) => false,
+    }
+}
+
+fn arg_matches_type<'hir>(
+    gcx: Gcx<'hir>,
+    hir: &'hir hir::Hir<'hir>,
+    arg: &'hir hir::Expr<'hir>,
+    param_ty: Ty<'hir>,
+) -> bool {
+    expr_ty(gcx, hir, arg).is_none_or(|arg_ty| arg_ty.convert_implicit_to(param_ty, gcx))
+}
+
+fn is_address_like<'hir>(
+    gcx: Gcx<'hir>,
+    hir: &'hir hir::Hir<'hir>,
+    expr: &'hir hir::Expr<'hir>,
+) -> bool {
+    match &expr.peel_parens().kind {
+        ExprKind::Payable(_) => true,
+        ExprKind::Call(callee, _, _) if is_address_type_expr(callee) => true,
+        _ => expr_ty(gcx, hir, expr).is_some_and(type_is_address_like),
+    }
+}
+
+fn is_address_type_expr(expr: &hir::Expr<'_>) -> bool {
+    matches!(
+        &expr.peel_parens().kind,
+        ExprKind::Type(hir::Type {
+            kind: hir::TypeKind::Elementary(ElementaryType::Address(_)),
+            ..
+        })
+    )
+}
+
+fn type_is_address_like(ty: Ty<'_>) -> bool {
+    matches!(ty.peel_refs().kind, TyKind::Elementary(ElementaryType::Address(_)))
+}
+
+fn expr_ty<'hir>(
+    gcx: Gcx<'hir>,
+    hir: &'hir hir::Hir<'hir>,
+    expr: &'hir hir::Expr<'hir>,
+) -> Option<Ty<'hir>> {
+    match &expr.peel_parens().kind {
+        ExprKind::Array(_) => None,
+        ExprKind::Call(callee, args, _) => {
+            let callee_ty = expr_ty(gcx, hir, callee)?;
+            match callee_ty.kind {
+                TyKind::FnPtr(func) => fn_call_return_type(gcx, func.returns),
+                TyKind::Type(to) => Some(explicit_cast_ty(gcx, to, args)),
+                _ => None,
+            }
+        }
+        ExprKind::Ident(reses) => {
+            let res = unique(reses.iter().filter(|res| !matches!(res, Res::Err(_))).copied())?;
+            match res {
+                Res::Builtin(builtin) if matches!(builtin.name(), sym::this | sym::super_) => None,
+                Res::Item(ItemId::Variable(var_id)) => Some(
+                    gcx.type_of_res(res)
+                        .with_loc_if_ref_opt(gcx, variable_data_location(hir, var_id)),
+                ),
+                _ => Some(gcx.type_of_res(res)),
+            }
+        }
+        ExprKind::Index(lhs, index) => {
+            let lhs_ty = expr_ty(gcx, hir, lhs)?;
+            if let Some(index) = index
+                && !expr_ty(gcx, hir, index)?.convert_implicit_to(gcx.types.uint(256), gcx)
+            {
+                return None;
+            }
+            index_ty(gcx, lhs_ty)
+        }
+        ExprKind::Lit(lit) => Some(match &lit.kind {
+            LitKind::Str(StrKind::Hex, s, _) => {
+                let size = TypeSize::try_new_fb_bytes(s.as_byte_str().len().min(32) as u8)?;
+                gcx.types.fixed_bytes(size.bytes())
+            }
+            LitKind::Str(_, s, _) => gcx.mk_ty_string_literal(s.as_byte_str()),
+            LitKind::Number(int) => gcx.mk_ty_int_literal(false, int.bit_len() as _)?,
+            LitKind::Rational(_) | LitKind::Err(_) => return None,
+            LitKind::Address(_) => gcx.types.address,
+            LitKind::Bool(_) => gcx.types.bool,
+        }),
+        ExprKind::Member(base, member) => member_ty(gcx, hir, base, member.name),
+        ExprKind::New(ty) => {
+            let ty = gcx.type_of_hir_ty(ty);
+            Some(gcx.mk_ty(TyKind::Type(ty)))
+        }
+        ExprKind::Payable(inner) => {
+            let inner_ty = expr_ty(gcx, hir, inner)?;
+            inner_ty
+                .convert_explicit_to(gcx.types.address_payable, gcx)
+                .then_some(gcx.types.address_payable)
+        }
+        ExprKind::Slice(lhs, ..) => {
+            let lhs_ty = expr_ty(gcx, hir, lhs)?;
+            lhs_ty.is_sliceable().then_some(gcx.mk_ty(TyKind::Slice(lhs_ty)))
+        }
+        ExprKind::Tuple(exprs) => {
+            let tys = exprs
+                .iter()
+                .map(|expr| expr.and_then(|expr| expr_ty(gcx, hir, expr)))
+                .collect::<Option<Vec<_>>>()?;
+            Some(gcx.mk_ty_tuple(gcx.mk_tys(&tys)))
+        }
+        ExprKind::Ternary(_, true_expr, false_expr) => {
+            let true_ty = expr_ty(gcx, hir, true_expr)?;
+            let false_ty = expr_ty(gcx, hir, false_expr)?;
+            common_ty(gcx, true_ty, false_ty)
+        }
+        ExprKind::Type(ty) | ExprKind::TypeCall(ty) => {
+            let ty = gcx.type_of_hir_ty(ty);
+            Some(gcx.mk_ty(TyKind::Type(ty)))
+        }
+        ExprKind::Unary(_, inner) => expr_ty(gcx, hir, inner),
+        ExprKind::Assign(..) | ExprKind::Binary(..) | ExprKind::Delete(..) | ExprKind::Err(_) => {
+            None
+        }
+    }
+}
+
+fn member_ty<'hir>(
+    gcx: Gcx<'hir>,
+    hir: &'hir hir::Hir<'hir>,
+    base: &'hir hir::Expr<'hir>,
+    member_name: solar::interface::Symbol,
+) -> Option<Ty<'hir>> {
+    if is_this(base) || is_super(base) {
+        return None;
+    }
+
+    let base_ty = expr_ty(gcx, hir, base)?;
+    unique(
+        gcx.members_of(base_ty, base_item_source(hir, base), base_contract(hir, base))
+            .iter()
+            .filter(|member| member.name == member_name)
+            .map(|member| member.ty),
+    )
+}
+
+fn common_ty<'hir>(gcx: Gcx<'hir>, lhs: Ty<'hir>, rhs: Ty<'hir>) -> Option<Ty<'hir>> {
+    if lhs.convert_implicit_to(rhs, gcx) {
+        Some(rhs)
+    } else {
+        rhs.convert_implicit_to(lhs, gcx).then_some(lhs)
+    }
+}
+
+fn fn_call_return_type<'hir>(gcx: Gcx<'hir>, returns: &'hir [Ty<'hir>]) -> Option<Ty<'hir>> {
+    Some(match returns {
+        [] => gcx.types.unit,
+        [ret] => *ret,
+        _ => gcx.mk_ty_tuple(returns),
+    })
+}
+
+fn explicit_cast_ty<'hir>(gcx: Gcx<'hir>, to: Ty<'hir>, args: &'hir CallArgs<'hir>) -> Ty<'hir> {
+    match args.exprs().next().and_then(|arg| expr_ty(gcx, &gcx.hir, arg)) {
+        Some(from) => from.try_convert_explicit_to(to, gcx).unwrap_or(to),
+        None => to,
+    }
+}
+
+fn index_ty<'hir>(gcx: Gcx<'hir>, base_ty: Ty<'hir>) -> Option<Ty<'hir>> {
+    let loc = indexed_base_data_location(base_ty);
+    match base_ty.peel_refs().kind {
+        TyKind::Mapping(_, value) => Some(value.with_loc_if_ref_opt(gcx, loc)),
+        _ => base_ty.base_type(gcx),
+    }
+}
+
+fn indexed_base_data_location(ty: Ty<'_>) -> Option<DataLocation> {
+    ty.loc().or_else(|| matches!(ty.kind, TyKind::Mapping(..)).then_some(DataLocation::Storage))
+}
+
+fn base_item_source(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> hir::SourceId {
+    referenced_item(expr)
+        .map(|id| hir.item(id).source())
+        .unwrap_or_else(|| hir.sources_enumerated().next().expect("HIR has a source").0)
+}
+
+fn base_contract(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<hir::ContractId> {
+    referenced_item(expr).and_then(|id| hir.item(id).contract())
+}
+
+fn referenced_item(expr: &hir::Expr<'_>) -> Option<ItemId> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident([Res::Item(id), ..]) => Some(*id),
         _ => None,
     }
+}
+
+fn variable_data_location(hir: &hir::Hir<'_>, var_id: VariableId) -> Option<DataLocation> {
+    let var = hir.variable(var_id);
+    var.data_location.or_else(|| {
+        (var.function.is_none() && var.contract.is_some()).then_some(DataLocation::Storage)
+    })
+}
+
+fn is_this(expr: &hir::Expr<'_>) -> bool {
+    matches!(
+        &expr.peel_parens().kind,
+        ExprKind::Ident(reses)
+            if reses.iter().any(|res| {
+                matches!(res, Res::Builtin(builtin) if builtin.name() == sym::this)
+            })
+    )
+}
+
+fn is_super(expr: &hir::Expr<'_>) -> bool {
+    matches!(
+        &expr.peel_parens().kind,
+        ExprKind::Ident(reses)
+            if reses.iter().any(|res| {
+                matches!(res, Res::Builtin(builtin) if builtin.name() == sym::super_)
+            })
+    )
+}
+
+fn unique<T>(mut iter: impl Iterator<Item = T>) -> Option<T> {
+    let first = iter.next()?;
+    iter.next().is_none().then_some(first)
 }
 
 fn is_zero_value(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {

--- a/crates/lint/src/sol/high/reentrancy.rs
+++ b/crates/lint/src/sol/high/reentrancy.rs
@@ -5,8 +5,8 @@ use crate::{
 };
 use solar::{
     ast::{
-        DataLocation, ElementaryType, LitKind, StateMutability, StrKind, TypeSize, UnOpKind,
-        Visibility,
+        BinOpKind, DataLocation, ElementaryType, LitKind, StateMutability, StrKind, TypeSize,
+        UnOpKind, Visibility,
     },
     interface::{Span, kw, sym},
     sema::{
@@ -663,7 +663,7 @@ fn arg_matches_type<'hir>(
     arg: &'hir hir::Expr<'hir>,
     param_ty: Ty<'hir>,
 ) -> bool {
-    expr_ty(gcx, hir, arg).is_none_or(|arg_ty| arg_ty.convert_implicit_to(param_ty, gcx))
+    expr_ty(gcx, hir, arg).is_some_and(|arg_ty| arg_ty.convert_implicit_to(param_ty, gcx))
 }
 
 fn is_address_like<'hir>(
@@ -769,11 +769,29 @@ fn expr_ty<'hir>(
             let ty = gcx.type_of_hir_ty(ty);
             Some(gcx.mk_ty(TyKind::Type(ty)))
         }
-        ExprKind::Unary(_, inner) => expr_ty(gcx, hir, inner),
+        ExprKind::Unary(op, inner) => match op.kind {
+            UnOpKind::Not => Some(gcx.types.bool),
+            _ => expr_ty(gcx, hir, inner),
+        },
+        ExprKind::Binary(_, op, _) if binary_op_returns_bool(op.kind) => Some(gcx.types.bool),
         ExprKind::Assign(..) | ExprKind::Binary(..) | ExprKind::Delete(..) | ExprKind::Err(_) => {
             None
         }
     }
+}
+
+const fn binary_op_returns_bool(op: BinOpKind) -> bool {
+    matches!(
+        op,
+        BinOpKind::Lt
+            | BinOpKind::Le
+            | BinOpKind::Gt
+            | BinOpKind::Ge
+            | BinOpKind::Eq
+            | BinOpKind::Ne
+            | BinOpKind::And
+            | BinOpKind::Or
+    )
 }
 
 fn member_ty<'hir>(

--- a/crates/lint/testdata/ReentrancyEth.sol
+++ b/crates/lint/testdata/ReentrancyEth.sol
@@ -67,6 +67,13 @@ contract ReentrancyEth {
         balances[receiver] = 0;
     }
 
+    function parenthesizedValueCall(address payable receiver) external {
+        uint256 amount = balances[receiver];
+        (bool ok,) = (receiver.call){value: amount}(""); //~WARN: uncapped ETH transfer can be reentered before `balances` is updated
+        require(ok, "transfer failed");
+        balances[receiver] = 0;
+    }
+
     function modifierStateChangeAfterCall() external recordAfter {
         uint256 amount = balances[msg.sender];
         (bool ok,) = payable(msg.sender).call{value: amount}(""); //~WARN: uncapped ETH transfer can be reentered before `balances` is updated

--- a/crates/lint/testdata/ReentrancyEth.stderr
+++ b/crates/lint/testdata/ReentrancyEth.stderr
@@ -41,6 +41,14 @@ LL │ …     (bool ok,) = receiver.call{value: amount, gas: gasleft()}("");
 warning[reentrancy-eth]: uncapped ETH transfer can be reentered before `balances` is updated
    ╭▸ ROOT/testdata/ReentrancyEth.sol:LL:CC
    │
+LL │         (bool ok,) = (receiver.call){value: amount}("");
+   │                      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-eth
+
+warning[reentrancy-eth]: uncapped ETH transfer can be reentered before `balances` is updated
+   ╭▸ ROOT/testdata/ReentrancyEth.sol:LL:CC
+   │
 LL │ …     (bool ok,) = payable(msg.sender).call{value: amount}("");
    │                    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/ReentrancyNoEth.sol
+++ b/crates/lint/testdata/ReentrancyNoEth.sol
@@ -5,6 +5,8 @@ pragma solidity ^0.8.18;
 
 interface IHook {
     function notify(uint256 amount) external;
+    function overloaded(uint256 amount) external;
+    function overloaded(bool flag) external view returns (bool);
     function balanceOf(address account) external view returns (uint256);
 }
 
@@ -59,6 +61,18 @@ contract ReentrancyNoEth {
     function viewCallThenWrite(IHook hook) external {
         uint256 amount = balances[msg.sender];
         hook.balanceOf(msg.sender);
+        balances[msg.sender] = amount;
+    }
+
+    function mutatingOverloadThenWrite(IHook hook) external {
+        uint256 amount = balances[msg.sender];
+        hook.overloaded(amount); //~WARN: external call can be reentered before `balances` is updated
+        balances[msg.sender] = 0;
+    }
+
+    function viewOverloadThenWrite(IHook hook) external {
+        uint256 amount = balances[msg.sender];
+        hook.overloaded(true);
         balances[msg.sender] = amount;
     }
 

--- a/crates/lint/testdata/ReentrancyNoEth.sol
+++ b/crates/lint/testdata/ReentrancyNoEth.sol
@@ -77,6 +77,12 @@ contract ReentrancyNoEth {
         balances[msg.sender] = amount;
     }
 
+    function viewOverloadWithBoolExpressionThenWrite(IHook hook, bool flag) external {
+        uint256 amount = balances[msg.sender];
+        hook.overloaded(flag && true);
+        balances[msg.sender] = amount;
+    }
+
     function unrelatedStateWriteAfterCall(IHook hook) external {
         uint256 amount = balances[msg.sender];
         hook.notify(amount);

--- a/crates/lint/testdata/ReentrancyNoEth.sol
+++ b/crates/lint/testdata/ReentrancyNoEth.sol
@@ -1,0 +1,99 @@
+//@compile-flags: --only-lint reentrancy-no-eth
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface IHook {
+    function notify(uint256 amount) external;
+    function balanceOf(address account) external view returns (uint256);
+}
+
+contract ReentrancyNoEth {
+    mapping(address => uint256) public balances;
+    mapping(address => uint256) public credits;
+    uint256 private locked;
+
+    function externalCallThenWrite(IHook hook) external {
+        uint256 amount = balances[msg.sender];
+        hook.notify(amount); //~WARN: external call can be reentered before `balances` is updated
+        balances[msg.sender] = 0;
+    }
+
+    function lowLevelCallThenWrite(address target) external {
+        uint256 amount = balances[msg.sender];
+        (bool ok,) = target.call(""); //~WARN: external call can be reentered before `balances` is updated
+        require(ok, "call failed");
+        balances[msg.sender] = amount + 1;
+    }
+
+    function delegateCallThenWrite(address target, bytes calldata data) external {
+        uint256 amount = credits[msg.sender];
+        (bool ok,) = target.delegatecall(data); //~WARN: external call can be reentered before `credits` is updated
+        require(ok, "delegatecall failed");
+        credits[msg.sender] = amount;
+    }
+
+    function internalHelperCallThenWrite(IHook hook) external {
+        uint256 amount = balances[msg.sender];
+        notifyHook(hook, amount);
+        balances[msg.sender] = 0;
+    }
+
+    function modifierWriteAfterCall(IHook hook) external writeAfter {
+        uint256 amount = balances[msg.sender];
+        hook.notify(amount); //~WARN: external call can be reentered before `balances` is updated
+    }
+
+    function guardedByNonReentrant(IHook hook) external nonReentrant {
+        uint256 amount = balances[msg.sender];
+        hook.notify(amount); //~WARN: external call can be reentered before `balances` is updated
+        balances[msg.sender] = 0;
+    }
+
+    function effectsBeforeInteraction(IHook hook) external {
+        uint256 amount = balances[msg.sender];
+        balances[msg.sender] = 0;
+        hook.notify(amount);
+    }
+
+    function viewCallThenWrite(IHook hook) external {
+        uint256 amount = balances[msg.sender];
+        hook.balanceOf(msg.sender);
+        balances[msg.sender] = amount;
+    }
+
+    function unrelatedStateWriteAfterCall(IHook hook) external {
+        uint256 amount = balances[msg.sender];
+        hook.notify(amount);
+        credits[msg.sender] = amount;
+    }
+
+    function ethTransferIsHandledByReentrancyEth(address payable target) external {
+        uint256 amount = balances[msg.sender];
+        (bool ok,) = target.call{value: amount}("");
+        require(ok, "transfer failed");
+        balances[msg.sender] = 0;
+    }
+
+    constructor(IHook hook) {
+        uint256 amount = balances[msg.sender];
+        hook.notify(amount);
+        balances[msg.sender] = 0;
+    }
+
+    modifier writeAfter() {
+        _;
+        balances[msg.sender] = 0;
+    }
+
+    modifier nonReentrant() {
+        require(locked == 0, "reentrant");
+        locked = 1;
+        _;
+        locked = 0;
+    }
+
+    function notifyHook(IHook hook, uint256 amount) internal {
+        hook.notify(amount); //~WARN: external call can be reentered before `balances` is updated
+    }
+}

--- a/crates/lint/testdata/ReentrancyNoEth.sol
+++ b/crates/lint/testdata/ReentrancyNoEth.sol
@@ -8,6 +8,7 @@ interface IHook {
     function overloaded(uint256 amount) external;
     function overloaded(bool flag) external view returns (bool);
     function balanceOf(address account) external view returns (uint256);
+    function key() external returns (address);
 }
 
 contract ReentrancyNoEth {
@@ -80,6 +81,16 @@ contract ReentrancyNoEth {
         uint256 amount = balances[msg.sender];
         hook.notify(amount);
         credits[msg.sender] = amount;
+    }
+
+    function callInAssignmentIndexThenWrite(IHook hook) external {
+        uint256 amount = balances[msg.sender];
+        balances[hook.key()] = amount; //~WARN: external call can be reentered before `balances` is updated
+    }
+
+    function callInDeleteIndexThenWrite(IHook hook) external {
+        uint256 amount = balances[msg.sender];
+        delete balances[hook.key()]; //~WARN: external call can be reentered before `balances` is updated
     }
 
     function ethTransferIsHandledByReentrancyEth(address payable target) external {

--- a/crates/lint/testdata/ReentrancyNoEth.stderr
+++ b/crates/lint/testdata/ReentrancyNoEth.stderr
@@ -46,3 +46,11 @@ LL │         hook.notify(amount);
    │
    ╰ help: https://getfoundry.sh/forge/linting/reentrancy-no-eth
 
+warning[reentrancy-no-eth]: external call can be reentered before `balances` is updated
+   ╭▸ ROOT/testdata/ReentrancyNoEth.sol:LL:CC
+   │
+LL │         hook.overloaded(amount);
+   │         ━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-no-eth
+

--- a/crates/lint/testdata/ReentrancyNoEth.stderr
+++ b/crates/lint/testdata/ReentrancyNoEth.stderr
@@ -1,0 +1,48 @@
+warning[reentrancy-no-eth]: external call can be reentered before `balances` is updated
+   ╭▸ ROOT/testdata/ReentrancyNoEth.sol:LL:CC
+   │
+LL │         hook.notify(amount);
+   │         ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-no-eth
+
+warning[reentrancy-no-eth]: external call can be reentered before `balances` is updated
+   ╭▸ ROOT/testdata/ReentrancyNoEth.sol:LL:CC
+   │
+LL │         (bool ok,) = target.call("");
+   │                      ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-no-eth
+
+warning[reentrancy-no-eth]: external call can be reentered before `credits` is updated
+   ╭▸ ROOT/testdata/ReentrancyNoEth.sol:LL:CC
+   │
+LL │         (bool ok,) = target.delegatecall(data);
+   │                      ━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-no-eth
+
+warning[reentrancy-no-eth]: external call can be reentered before `balances` is updated
+   ╭▸ ROOT/testdata/ReentrancyNoEth.sol:LL:CC
+   │
+LL │         hook.notify(amount);
+   │         ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-no-eth
+
+warning[reentrancy-no-eth]: external call can be reentered before `balances` is updated
+   ╭▸ ROOT/testdata/ReentrancyNoEth.sol:LL:CC
+   │
+LL │         hook.notify(amount);
+   │         ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-no-eth
+
+warning[reentrancy-no-eth]: external call can be reentered before `balances` is updated
+   ╭▸ ROOT/testdata/ReentrancyNoEth.sol:LL:CC
+   │
+LL │         hook.notify(amount);
+   │         ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-no-eth
+

--- a/crates/lint/testdata/ReentrancyNoEth.stderr
+++ b/crates/lint/testdata/ReentrancyNoEth.stderr
@@ -54,3 +54,19 @@ LL │         hook.overloaded(amount);
    │
    ╰ help: https://getfoundry.sh/forge/linting/reentrancy-no-eth
 
+warning[reentrancy-no-eth]: external call can be reentered before `balances` is updated
+   ╭▸ ROOT/testdata/ReentrancyNoEth.sol:LL:CC
+   │
+LL │         balances[hook.key()] = amount;
+   │                  ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-no-eth
+
+warning[reentrancy-no-eth]: external call can be reentered before `balances` is updated
+   ╭▸ ROOT/testdata/ReentrancyNoEth.sol:LL:CC
+   │
+LL │         delete balances[hook.key()];
+   │                         ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-no-eth
+


### PR DESCRIPTION
## Summary
- add the medium-severity `reentrancy-no-eth` lint for read-before-write reentrancy around external calls that do not transfer ETH
- reuse the existing reentrancy flow analyzer while tagging pending calls as ETH or no-ETH, keeping `reentrancy-eth` behavior separate
- add lint docs and UI coverage for typed external calls, low-level calls, delegatecall, modifiers, internal helper propagation, and ignored safe cases