### PR TITLE
feat(cast): structured stdout contract for cast wallet new

### DIFF
--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -381,11 +381,11 @@ impl WalletSubcommands {
                                 for file in &existing_files {
                                     sh_eprintln!("   - {file}")?;
                                 }
-                                sh_print!(
+                                sh_eprint!(
                                     "\nDo you want to overwrite all {} file(s)? [y/N]: ",
                                     existing_files.len()
                                 )?;
-                                std::io::stdout().flush()?;
+                                std::io::stderr().flush()?;
 
                                 let mut input = String::new();
                                 std::io::stdin().read_line(&mut input)?;
@@ -411,30 +411,24 @@ impl WalletSubcommands {
                             let identifier = account_name_ref.as_deref().unwrap_or(&uuid);
 
                             if let Some(json) = json_values.as_mut() {
-                                json.push(if shell::verbosity() > 0 {
-                                json!({
+                                json.push(json!({
                                     "address": wallet.address().to_checksum(None),
                                     "public_key": format!("0x{}", hex::encode(wallet.public_key())),
                                     "path": format!("{}", path.join(identifier).display()),
-                                })
+                                }));
                             } else {
-                                json!({
-                                    "address": wallet.address().to_checksum(None),
-                                    "path": format!("{}", path.join(identifier).display()),
-                                })
-                            });
-                            } else {
-                                sh_println!(
+                                sh_status!(
                                     "Created new encrypted keystore file: {}",
                                     path.join(identifier).display()
                                 )?;
-                                sh_println!("Address:    {}", wallet.address().to_checksum(None))?;
+                                sh_status!("Address:    {}", wallet.address().to_checksum(None))?;
                                 if shell::verbosity() > 0 {
-                                    sh_println!(
+                                    sh_status!(
                                         "Public key: 0x{}",
                                         hex::encode(wallet.public_key())
                                     )?;
                                 }
+                                sh_println!("{}", wallet.address().to_checksum(None))?;
                             }
                         }
                     }
@@ -443,29 +437,27 @@ impl WalletSubcommands {
                             let wallet = PrivateKeySigner::random_with(&mut rng);
 
                             if let Some(json) = json_values.as_mut() {
-                                json.push(if shell::verbosity() > 0 {
-                                json!({
+                                json.push(json!({
                                     "address": wallet.address().to_checksum(None),
                                     "public_key": format!("0x{}", hex::encode(wallet.public_key())),
                                     "private_key": format!("0x{}", hex::encode(wallet.credential().to_bytes())),
-                                })
+                                }));
                             } else {
-                                json!({
-                                    "address": wallet.address().to_checksum(None),
-                                    "private_key": format!("0x{}", hex::encode(wallet.credential().to_bytes())),
-                                })
-                            });
-                            } else {
-                                sh_println!("Successfully created new keypair.")?;
-                                sh_println!("Address:     {}", wallet.address().to_checksum(None))?;
+                                sh_status!("Successfully created new keypair.")?;
+                                sh_status!("Address:     {}", wallet.address().to_checksum(None))?;
                                 if shell::verbosity() > 0 {
-                                    sh_println!(
+                                    sh_status!(
                                         "Public key:  0x{}",
                                         hex::encode(wallet.public_key())
                                     )?;
                                 }
-                                sh_println!(
+                                sh_status!(
                                     "Private key: 0x{}",
+                                    hex::encode(wallet.credential().to_bytes())
+                                )?;
+                                sh_println!(
+                                    "{}\t0x{}",
+                                    wallet.address().to_checksum(None),
                                     hex::encode(wallet.credential().to_bytes())
                                 )?;
                             }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -237,7 +237,13 @@ casttest!(finds_block, |_prj, cmd| {
 
 // tests that we can create a new wallet
 casttest!(new_wallet, |_prj, cmd| {
-    cmd.args(["wallet", "new"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["wallet", "new"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+0x[..]	0x[..]
+
+"#]])
+        .stderr_eq(str![[r#"
 Successfully created new keypair.
 [ADDRESS]
 [PRIVATE_KEY]
@@ -247,7 +253,13 @@ Successfully created new keypair.
 
 // tests that we can create a new wallet (verbose variant)
 casttest!(new_wallet_verbose, |_prj, cmd| {
-    cmd.args(["wallet", "new", "-v"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["wallet", "new", "-v"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+0x[..]	0x[..]
+
+"#]])
+        .stderr_eq(str![[r#"
 Successfully created new keypair.
 [ADDRESS]
 [PUBLIC_KEY]
@@ -263,6 +275,7 @@ casttest!(new_wallet_json, |_prj, cmd| {
 [
   {
     "address": "{...}",
+    "public_key": "{...}",
     "private_key": "{...}"
   }
 ]
@@ -272,7 +285,7 @@ casttest!(new_wallet_json, |_prj, cmd| {
     );
 });
 
-// tests that we can create a new wallet with json output (verbose variant)
+// tests that `--json -v` does not alter stdout (verbosity is stderr-only)
 casttest!(new_wallet_json_verbose, |_prj, cmd| {
     cmd.args(["wallet", "new", "--json", "-v"]).assert_success().stdout_eq(
         str![[r#"
@@ -289,11 +302,53 @@ casttest!(new_wallet_json_verbose, |_prj, cmd| {
     );
 });
 
+// tests that keystore `--json` output includes address, public_key, path
+casttest!(new_wallet_keystore_json, |_prj, cmd| {
+    cmd.args(["wallet", "new", ".", "test-account", "--unsafe-password", "test", "--json"])
+        .assert_success()
+        .stdout_eq(
+            str![[r#"
+[
+  {
+    "address": "{...}",
+    "public_key": "{...}",
+    "path": "{...}"
+  }
+]
+
+"#]]
+            .is_json(),
+        );
+});
+
+// tests that keystore `--json -v` does not alter stdout (verbosity is stderr-only)
+casttest!(new_wallet_keystore_json_verbose, |_prj, cmd| {
+    cmd.args(["wallet", "new", ".", "test-account", "--unsafe-password", "test", "--json", "-v"])
+        .assert_success()
+        .stdout_eq(
+            str![[r#"
+[
+  {
+    "address": "{...}",
+    "public_key": "{...}",
+    "path": "{...}"
+  }
+]
+
+"#]]
+            .is_json(),
+        );
+});
+
 // tests that we can create a new wallet with keystore
 casttest!(new_wallet_keystore_with_password, |_prj, cmd| {
     cmd.args(["wallet", "new", ".", "test-account", "--unsafe-password", "test"])
         .assert_success()
         .stdout_eq(str![[r#"
+0x[..]
+
+"#]])
+        .stderr_eq(str![[r#"
 Created new encrypted keystore file: [..]
 [ADDRESS]
 
@@ -305,6 +360,10 @@ casttest!(new_wallet_keystore_with_password_verbose, |_prj, cmd| {
     cmd.args(["wallet", "new", ".", "test-account", "--unsafe-password", "test", "-v"])
         .assert_success()
         .stdout_eq(str![[r#"
+0x[..]
+
+"#]])
+        .stderr_eq(str![[r#"
 Created new encrypted keystore file: [..]
 [ADDRESS]
 [PUBLIC_KEY]
@@ -323,10 +382,12 @@ casttest!(new_wallet_keystore_overwrite_protection, |prj, cmd| {
         .args(["wallet", "new", ".", "test-account", "--unsafe-password", "test"])
         .stdin("n\n")
         .assert_failure()
+        .stdout_eq(str![""])
         .stderr_eq(str![[r#"
 The following keystore file(s) already exist:
    - test-account
-Error: Operation cancelled. No keystores were modified.
+
+Do you want to overwrite all 1 file(s)? [y/N]: Error: Operation cancelled. No keystores were modified.
 
 "#]]);
 });
@@ -342,6 +403,10 @@ casttest!(new_wallet_keystore_overwrite_force, |prj, cmd| {
         .args(["wallet", "new", ".", "test-account", "--unsafe-password", "test", "--force"])
         .assert_success()
         .stdout_eq(str![[r#"
+0x[..]
+
+"#]])
+        .stderr_eq(str![[r#"
 Created new encrypted keystore file: [..]
 [ADDRESS]
 
@@ -360,24 +425,30 @@ casttest!(new_wallet_keystore_overwrite_protection_multiple, |prj, cmd| {
         .args(["wallet", "new", ".", "test-account", "--unsafe-password", "test", "-n", "2"])
         .stdin("n\n")
         .assert_failure()
+        .stdout_eq(str![""])
         .stderr_eq(str![[r#"
 The following keystore file(s) already exist:
    - test-account_1
    - test-account_2
-Error: Operation cancelled. No keystores were modified.
+
+Do you want to overwrite all 2 file(s)? [y/N]: Error: Operation cancelled. No keystores were modified.
 
 "#]]);
 });
 
 // tests that we can create a new wallet with default keystore location
 casttest!(new_wallet_default_keystore, |_prj, cmd| {
-    cmd.args(["wallet", "new", "--unsafe-password", "test"]).assert_success().stdout_eq(str![[
-        r#"
+    cmd.args(["wallet", "new", "--unsafe-password", "test"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+0x[..]
+
+"#]])
+        .stderr_eq(str![[r#"
 Created new encrypted keystore file: [..]
 [ADDRESS]
 
-"#
-    ]]);
+"#]]);
 
     // Verify the default keystore directory was created
     let keystore_path = dirs::home_dir().unwrap().join(".foundry").join("keystores");
@@ -387,7 +458,14 @@ Created new encrypted keystore file: [..]
 
 // tests that we can outputting multiple keys without a keystore path
 casttest!(new_wallet_multiple_keys, |_prj, cmd| {
-    cmd.args(["wallet", "new", "-n", "2"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["wallet", "new", "-n", "2"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+0x[..]	0x[..]
+0x[..]	0x[..]
+
+"#]])
+        .stderr_eq(str![[r#"
 Successfully created new keypair.
 [ADDRESS]
 [PRIVATE_KEY]
@@ -829,6 +907,19 @@ casttest!(wallet_list_local_accounts, |prj, cmd| {
         .args(["wallet", "new", "keystore", "-n", "10", "--unsafe-password", "test"])
         .assert_success()
         .stdout_eq(str![[r#"
+0x[..]
+0x[..]
+0x[..]
+0x[..]
+0x[..]
+0x[..]
+0x[..]
+0x[..]
+0x[..]
+0x[..]
+
+"#]])
+        .stderr_eq(str![[r#"
 Created new encrypted keystore file: [..]
 [ADDRESS]
 Created new encrypted keystore file: [..]

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -103,7 +103,7 @@ Each row's status is one of:
 | `cast logs`            | One log per line                                     | JSON array                                                     | todo   |
 | `cast run`             | Trace / decoded output                               | JSON                                                           | migrated |
 | `cast trace`           | Trace                                                | JSON trace                                                     | migrated |
-| `cast wallet new`      | Address                                              | JSON `{ "address": "…", "private_key": "…" (only with explicit flag) }` | todo |
+| `cast wallet new`      | One record per wallet: `address` (keystore) or `address\tprivate_key` (no keystore) | JSON array of `{ address, public_key, path }` (keystore) or `{ address, public_key, private_key }` (no keystore) | migrated |
 | `cast wallet sign`     | Signature                                            | JSON                                                           | migrated |
 | `cast wallet sign-auth`| Signed authorization RLP                             | JSON                                                           | migrated |
 | `cast erc20 balance`   | Balance (decimal)                                    | JSON string                                                    | todo   |


### PR DESCRIPTION
Migrates `cast wallet new` to the stdout/stderr contract in `docs/dev/output-channels.md`.

- Text mode (no-keystore): stdout = one `address\tprivate_key` record per wallet; prose/labels and the `-v` public key go to stderr.
- Text mode (keystore): stdout = one `address` per wallet; created-file message, labels, and `-v` public key go to stderr.
- JSON mode: single array on stdout, always including `public_key` for both keystore (`address`, `public_key`, `path`) and no-keystore (`address`, `public_key`, `private_key`). `--json` and `--json -v` are byte-identical.
- Overwrite prompt moved from stdout to stderr; cancel paths emit nothing on stdout.

Docs row updated accordingly.

Part of OSS-224