### PR TITLE
chore: bump Tempo dependencies to 1.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,14 +84,14 @@ dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
@@ -120,10 +120,10 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-trie",
  "alloy-tx-macros",
  "auto_impl",
@@ -148,10 +148,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -243,7 +243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eace380e7f126613f493bb1e8ca5c9a89abe932ce9d965434db2dd393a2fc"
 dependencies = [
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
  "serde_json",
 ]
@@ -293,6 +293,29 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928 0.3.7",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 1.8.3",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "alloy-eips"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
@@ -303,7 +326,7 @@ dependencies = [
  "alloy-eip7928 0.3.7",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "auto_impl",
  "borsh",
  "c-kzg",
@@ -332,12 +355,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.35.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58673bde58f17022886547b618346aeae9b147ed398f9c847105fa91c49f97eb"
+checksum = "7f092eb6af80456e4ab41c9722e777d791335bc9c00b11bc3db7bf29a432dfd0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -345,7 +368,27 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "revm",
+ "revm 38.0.0",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-evm"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips 2.0.5",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "auto_impl",
+ "derive_more",
+ "revm 40.0.3",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -356,9 +399,9 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-trie",
  "borsh",
  "serde",
@@ -414,13 +457,13 @@ checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -439,39 +482,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
 [[package]]
 name = "alloy-op-evm"
 version = "0.32.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7a2fcc47abb62505ca4adc0ac271e220204b6b11f3209d64eff740aa9c579b"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-op-hardforks",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.33.3",
+ "alloy-op-hardforks 0.5.0",
  "alloy-primitives",
  "auto_impl",
  "op-alloy",
  "op-revm",
- "revm",
+ "revm 38.0.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.4.7"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+source = "git+https://github.com/foundry-rs/optimism?branch=alloy-2.0#a3632104e59345555fc0d566fa9fe9e4d52b1324"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
  "alloy-primitives",
  "auto_impl",
  "serde",
+]
+
+[[package]]
+name = "alloy-op-hardforks"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67c7461389613edc74c15edc7f0ca293f6bfdd51efb0685ab51212404b0eef2"
+dependencies = [
+ "alloy-chains",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "auto_impl",
 ]
 
 [[package]]
@@ -513,7 +569,7 @@ checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -634,7 +690,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -646,7 +702,7 @@ checksum = "2ff111a54268dc0bbd3b17f98571a7e27cc661dc081ad2999d91888647eb2e11"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -660,7 +716,7 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
  "serde_json",
 ]
@@ -671,7 +727,7 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a62f6ce2d95f59ed310bd90d5fd1566a29d1ec45cc219abbc5dcc807d31f136"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -701,10 +757,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eba59e1c069f168a01982f42a57797736923b76aa854194df4930be17867e1c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -722,11 +778,11 @@ checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
@@ -743,7 +799,7 @@ checksum = "514b4b1ce3354f65067b4fc7eb75358e0f2ec8be3340c96dea65d6894f9ca435"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -757,8 +813,19 @@ checksum = "76e34a42ebb4a71ab0bfdebc6d2f3c7bf809f01edf154d08fed159d10d1ef1d4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1183,7 +1250,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1207,7 +1274,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1218,8 +1285,8 @@ dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-dyn-abi",
- "alloy-eips",
- "alloy-evm",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.36.0",
  "alloy-genesis",
  "alloy-network",
  "alloy-op-evm",
@@ -1230,7 +1297,7 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -1259,14 +1326,14 @@ dependencies = [
  "futures",
  "hyper",
  "itertools 0.14.0",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
+ "op-alloy-consensus 0.24.0",
+ "op-alloy-rpc-types 0.24.0",
  "op-revm",
  "parking_lot",
  "rand 0.8.6",
  "rand 0.9.4",
  "reqwest 0.13.4",
- "revm",
+ "revm 40.0.3",
  "revm-inspectors",
  "serde",
  "serde_json",
@@ -1291,18 +1358,18 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eip5792",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "bytes",
  "foundry-common",
  "foundry-evm",
  "foundry-primitives",
  "rand 0.9.4",
- "revm",
+ "revm 40.0.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2574,7 +2641,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2752,9 +2819,9 @@ dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-ens",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-hardforks",
  "alloy-json-abi",
  "alloy-json-rpc",
@@ -2765,7 +2832,7 @@ dependencies = [
  "alloy-rpc-client",
  "alloy-rpc-types",
  "alloy-rpc-types-beacon",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -2792,14 +2859,14 @@ dependencies = [
  "foundry-wallets",
  "futures",
  "itertools 0.14.0",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "op-alloy-flz",
- "op-alloy-network",
+ "op-alloy-network 0.24.0",
  "rand 0.8.6",
  "rand 0.9.4",
  "rayon",
  "regex",
- "revm",
+ "revm 40.0.3",
  "rpassword",
  "semver 1.0.28",
  "serde",
@@ -3050,7 +3117,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3209,7 +3276,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4271,7 +4338,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4573,7 +4640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4931,7 +4998,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest 0.13.4",
- "revm",
+ "revm 40.0.3",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -5014,8 +5081,8 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips",
- "alloy-evm",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.36.0",
  "alloy-json-abi",
  "alloy-network",
  "alloy-primitives",
@@ -5094,7 +5161,7 @@ version = "1.7.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-provider",
@@ -5114,7 +5181,7 @@ dependencies = [
  "itertools 0.14.0",
  "regex",
  "reqwest 0.13.4",
- "revm",
+ "revm 40.0.3",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -5177,7 +5244,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-ens",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-genesis",
  "alloy-json-abi",
  "alloy-network",
@@ -5210,7 +5277,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.9.4",
- "revm",
+ "revm 40.0.3",
  "revm-inspectors",
  "semver 1.0.28",
  "serde",
@@ -5239,7 +5306,7 @@ version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-ens",
  "alloy-json-abi",
  "alloy-network",
@@ -5302,7 +5369,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-json-abi",
  "alloy-json-rpc",
  "alloy-network",
@@ -5343,12 +5410,12 @@ dependencies = [
  "k256",
  "mpp",
  "num-format",
- "op-alloy-network",
- "op-alloy-rpc-types",
+ "op-alloy-network 0.24.0",
+ "op-alloy-rpc-types 0.24.0",
  "path-slash",
  "regex",
  "reqwest 0.13.4",
- "revm",
+ "revm 40.0.3",
  "rustls",
  "semver 1.0.28",
  "serde",
@@ -5379,14 +5446,14 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "chrono",
  "comfy-table",
  "eyre",
  "foundry-macros",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
- "revm",
+ "op-alloy-consensus 0.24.0",
+ "op-alloy-rpc-types 0.24.0",
+ "revm 40.0.3",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -5546,7 +5613,7 @@ dependencies = [
  "foundry-evm-traces",
  "foundry-tui",
  "ratatui",
- "revm",
+ "revm 40.0.3",
  "revm-inspectors",
  "serde",
  "tracing",
@@ -5578,7 +5645,7 @@ dependencies = [
  "proptest",
  "rand 0.9.4",
  "rayon",
- "revm",
+ "revm 40.0.3",
  "revm-inspectors",
  "serde",
  "serde_json",
@@ -5609,7 +5676,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-json-abi",
@@ -5619,7 +5686,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-sol-types",
  "anvil",
  "auto_impl",
@@ -5634,12 +5701,12 @@ dependencies = [
  "foundry-test-utils",
  "futures",
  "itertools 0.14.0",
- "op-alloy-consensus",
- "op-alloy-network",
- "op-alloy-rpc-types",
+ "op-alloy-consensus 0.24.0",
+ "op-alloy-network 0.24.0",
+ "op-alloy-rpc-types 0.24.0",
  "op-revm",
  "parking_lot",
- "revm",
+ "revm 40.0.3",
  "revm-inspectors",
  "serde",
  "serde_json",
@@ -5664,7 +5731,7 @@ dependencies = [
  "foundry-compilers",
  "foundry-evm-core",
  "rayon",
- "revm",
+ "revm 40.0.3",
  "semver 1.0.28",
  "solar-compiler",
  "tracing",
@@ -5688,7 +5755,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.9.4",
- "revm",
+ "revm 40.0.3",
  "serde",
  "solar-compiler",
  "thiserror 2.0.18",
@@ -5701,11 +5768,11 @@ version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
- "alloy-op-hardforks",
+ "alloy-op-hardforks 0.4.7",
  "alloy-rpc-types",
  "foundry-compilers",
  "op-revm",
- "revm",
+ "revm 40.0.3",
  "serde",
  "tempo-chainspec",
 ]
@@ -5715,13 +5782,13 @@ name = "foundry-evm-networks"
 version = "1.7.2"
 dependencies = [
  "alloy-chains",
- "alloy-eips",
- "alloy-evm",
- "alloy-op-hardforks",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.36.0",
+ "alloy-op-hardforks 0.4.7",
  "alloy-primitives",
  "clap",
  "foundry-evm-hardforks",
- "revm",
+ "revm 40.0.3",
  "serde",
  "serde_json",
 ]
@@ -5751,7 +5818,7 @@ dependencies = [
  "memchr",
  "rayon",
  "reqwest 0.13.4",
- "revm",
+ "revm 40.0.3",
  "revm-inspectors",
  "serde",
  "serde_json",
@@ -5776,7 +5843,7 @@ dependencies = [
  "eyre",
  "futures",
  "parking_lot",
- "revm",
+ "revm 40.0.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -5812,7 +5879,7 @@ name = "foundry-primitives"
 version = "1.7.2"
 dependencies = [
  "alloy-consensus",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-network",
  "alloy-op-evm",
  "alloy-primitives",
@@ -5820,13 +5887,13 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-signer",
  "derive_more",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
+ "op-alloy-consensus 0.24.0",
+ "op-alloy-rpc-types 0.24.0",
  "op-revm",
- "revm",
+ "revm 40.0.3",
  "serde",
  "serde_json",
  "tempo-alloy",
@@ -6106,8 +6173,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -6588,7 +6655,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6935,7 +7002,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7858,7 +7925,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8111,32 +8178,52 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy"
-version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5432711015d1fe1afd3c1586a08ff63feed576ad7d261e85f49e2f379afcf823"
 dependencies = [
- "op-alloy-consensus",
- "op-alloy-network",
+ "op-alloy-consensus 2.0.0",
+ "op-alloy-network 2.0.0",
  "op-alloy-provider",
- "op-alloy-rpc-types",
+ "op-alloy-rpc-types 2.0.0",
  "op-alloy-rpc-types-engine",
 ]
 
 [[package]]
 name = "op-alloy-consensus"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+source = "git+https://github.com/foundry-rs/optimism?branch=alloy-2.0#a3632104e59345555fc0d566fa9fe9e4d52b1324"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
+ "derive_more",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-alloy-consensus"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ca73133d6cb8d0b1cd042433bca9a394e4eaeb8ec1f96c210adf3f45cb74040"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips 2.0.5",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-serde 2.0.5",
  "bytes",
  "derive_more",
- "reth-codecs 0.2.0",
- "reth-zstd-compressors 0.2.0",
+ "reth-codecs 0.3.1",
+ "reth-zstd-compressors 0.3.1",
  "serde",
  "serde_with",
  "thiserror 2.0.18",
@@ -8151,20 +8238,36 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-alloy-network"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+source = "git+https://github.com/foundry-rs/optimism?branch=alloy-2.0#a3632104e59345555fc0d566fa9fe9e4d52b1324"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "op-alloy-consensus 0.24.0",
+ "op-alloy-rpc-types 0.24.0",
+]
+
+[[package]]
+name = "op-alloy-network"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed826e61fdc7055162693615128c314b2dc3a57204ca525cb00ba8cc1a7f4ccd"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
  "alloy-provider",
  "alloy-rpc-types-eth",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
+ "op-alloy-consensus 2.0.0",
+ "op-alloy-rpc-types 2.0.0",
 ]
 
 [[package]]
 name = "op-alloy-provider"
-version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6690469bdcee37c638d0e91f4c557e851b9d310ebd2e674704c1f086d69c62"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -8178,18 +8281,37 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+source = "git+https://github.com/foundry-rs/optimism?branch=alloy-2.0#a3632104e59345555fc0d566fa9fe9e4d52b1324"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde 2.0.5",
+ "derive_more",
+ "op-alloy-consensus 0.24.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-alloy-rpc-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e322e7437d5fb4aea6d98879046d42516137fe489d867a1b0d53275da76cbd2d"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips 2.0.5",
  "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "derive_more",
- "op-alloy-consensus",
- "reth-rpc-traits 0.2.0",
+ "op-alloy-consensus 2.0.0",
+ "reth-rpc-traits 0.3.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -8197,19 +8319,20 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5039b25b7c9fad4871774faab4060b3fc0a05572f11082088b6b9cd4109f6d40"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "op-alloy-consensus",
+ "op-alloy-consensus 2.0.0",
  "serde",
  "sha2 0.10.9",
  "snap",
@@ -8222,7 +8345,7 @@ version = "20.0.0"
 source = "git+https://github.com/foundry-rs/op-revm?rev=4201f16a746f2da2df38f1eac477500d492eaed5#4201f16a746f2da2df38f1eac477500d492eaed5"
 dependencies = [
  "auto_impl",
- "revm",
+ "revm 40.0.3",
  "serde",
 ]
 
@@ -8967,7 +9090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9578,12 +9701,12 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.36.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -9597,20 +9720,20 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29541038ab108b2e9d527c66b565e717e252e4eef6675377fc21f9ba587f792"
+checksum = "fce542a96bf888f31854803e80b3340bc233927743aa580838014e8a88fe0d66"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
  "bytes",
  "modular-bitfield",
  "parity-scale-codec",
- "reth-codecs-derive 0.2.0",
- "reth-zstd-compressors 0.2.0",
+ "reth-codecs-derive 0.3.1",
+ "reth-zstd-compressors 0.3.1",
  "serde",
 ]
 
@@ -9621,7 +9744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f54468f34d9ed03356dee71bb182a2815a490934f1a291f58158053eee946ba"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -9635,9 +9758,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5646d4aff98bd51050fc920bc3ffdff209f2343def9ed31b56eea13c4245c4da"
+checksum = "634c90f1cc0f9887680ca785b0b21aa961070b9465917bf65afaec56a6d005bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9658,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9672,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9696,9 +9819,9 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
@@ -9710,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9723,10 +9846,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "reth-codecs 0.4.0",
@@ -9737,12 +9860,12 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
- "alloy-eips",
- "alloy-evm",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9754,17 +9877,17 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
- "revm",
+ "revm 40.0.3",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-chainspec",
@@ -9774,15 +9897,15 @@ dependencies = [
  "reth-execution-types",
  "reth-primitives-traits 0.4.0",
  "reth-storage-errors",
- "revm",
+ "revm 40.0.3",
 ]
 
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
@@ -9793,18 +9916,18 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
  "reth-ethereum-primitives",
  "reth-primitives-traits 0.4.0",
  "reth-trie-common",
- "revm",
+ "revm 40.0.3",
  "serde",
  "serde_with",
 ]
@@ -9812,7 +9935,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9824,12 +9947,12 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96ffdb2ce0cdcd814d39428dc1e9b660c85d85e0b75eb465a1ed0943a48c7bd"
+checksum = "8ee12e304adbacbb32248c9806ebafbe1e2811fbfefe53c5e5b710a8438b7ec0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -9839,9 +9962,9 @@ dependencies = [
  "derive_more",
  "once_cell",
  "quanta",
- "revm-bytecode 9.0.0",
- "revm-primitives 22.1.0",
- "revm-state 10.0.0",
+ "revm-bytecode 10.0.0",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.18",
@@ -9854,7 +9977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d1216ba179909d41d8d55c5eae6c1c33698bc7a3053c35fd425c7789a5de3c1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -9879,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9894,23 +10017,23 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "reth-primitives-traits 0.4.0",
  "reth-storage-api",
  "reth-storage-errors",
- "revm",
+ "revm 40.0.3",
 ]
 
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -9926,16 +10049,16 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c870f120b2e179e44906b7b288b0dea6577573010272adda8fff536e86fedd05"
+checksum = "860fe223501a76ff14aa3bf164f739f31008c2a2905ac85708bfd88f042e6151"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-signer",
- "reth-primitives-traits 0.2.0",
+ "reth-primitives-traits 0.3.1",
  "thiserror 2.0.18",
 ]
 
@@ -9957,7 +10080,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9970,7 +10093,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9984,11 +10107,11 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10002,16 +10125,16 @@ dependencies = [
  "reth-storage-errors",
  "reth-tokio-util",
  "reth-trie-common",
- "revm-database",
+ "revm-database 15.0.2",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -10019,7 +10142,7 @@ dependencies = [
  "reth-primitives-traits 0.4.0",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface",
+ "revm-database-interface 12.1.1",
  "revm-state 12.0.1",
  "thiserror 2.0.18",
 ]
@@ -10027,7 +10150,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10037,13 +10160,13 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-trie",
  "arrayvec",
  "bytes",
@@ -10052,16 +10175,16 @@ dependencies = [
  "nybbles",
  "reth-codecs 0.4.0",
  "reth-primitives-traits 0.4.0",
- "revm-database",
+ "revm-database 15.0.2",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3882441cf1d51fe24dfc6df9919e6f17edfdb6b121050bd34348e925e61c7af1"
+checksum = "c12fafa33d2f420a9d39249a3e0357b1928d09429f30758b85280409092873b2"
 dependencies = [
  "zstd",
 ]
@@ -10077,32 +10200,51 @@ dependencies = [
 
 [[package]]
 name = "revm"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91202d39dbe8e8d10e9e8f2b76c30da68ecd1d25be69ba6d853ad0d03a3a398a"
+dependencies = [
+ "revm-bytecode 10.0.0",
+ "revm-context 16.0.1",
+ "revm-context-interface 17.0.1",
+ "revm-database 13.0.1",
+ "revm-database-interface 11.0.1",
+ "revm-handler 18.1.0",
+ "revm-inspector 19.0.0",
+ "revm-interpreter 35.0.1",
+ "revm-precompile 34.0.0",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
+]
+
+[[package]]
+name = "revm"
 version = "40.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
 dependencies = [
  "revm-bytecode 11.0.1",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-precompile",
+ "revm-context 18.0.3",
+ "revm-context-interface 19.0.3",
+ "revm-database 15.0.2",
+ "revm-database-interface 12.1.1",
+ "revm-handler 20.0.3",
+ "revm-inspector 21.0.3",
+ "revm-interpreter 37.0.3",
+ "revm-precompile 36.0.3",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
 ]
 
 [[package]]
 name = "revm-bytecode"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
+checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
- "revm-primitives 22.1.0",
+ "revm-primitives 23.0.0",
  "serde",
 ]
 
@@ -10120,6 +10262,23 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
+version = "16.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode 10.0.0",
+ "revm-context-interface 17.0.1",
+ "revm-database-interface 11.0.1",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
 version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafa298114f3cab706945de14c04e73e6e6d7896302e4183dae273f968e52f80"
@@ -10128,10 +10287,26 @@ dependencies = [
  "cfg-if",
  "derive-where",
  "revm-bytecode 11.0.1",
- "revm-context-interface",
- "revm-database-interface",
+ "revm-context-interface 19.0.3",
+ "revm-database-interface 12.1.1",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "17.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface 11.0.1",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
  "serde",
 ]
 
@@ -10145,9 +10320,23 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface",
+ "revm-database-interface 12.1.1",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "13.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
+dependencies = [
+ "alloy-eips 1.8.3",
+ "revm-bytecode 10.0.0",
+ "revm-database-interface 11.0.1",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
  "serde",
 ]
 
@@ -10157,13 +10346,27 @@ version = "15.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "derive_more",
  "revm-bytecode 11.0.1",
- "revm-database-interface",
+ "revm-database-interface 12.1.1",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
  "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10182,6 +10385,25 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
+version = "18.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783e903d6922b7f5f9a940d1bb229530502d2924b1aed9d5ca5a94ebf065d460"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode 10.0.0",
+ "revm-context 16.0.1",
+ "revm-context-interface 17.0.1",
+ "revm-database-interface 11.0.1",
+ "revm-interpreter 35.0.1",
+ "revm-precompile 34.0.0",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
 version = "20.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
@@ -10189,14 +10411,32 @@ dependencies = [
  "auto_impl",
  "derive-where",
  "revm-bytecode 11.0.1",
- "revm-context",
- "revm-context-interface",
- "revm-database-interface",
- "revm-interpreter",
- "revm-precompile",
+ "revm-context 18.0.3",
+ "revm-context-interface 19.0.3",
+ "revm-database-interface 12.1.1",
+ "revm-interpreter 37.0.3",
+ "revm-precompile 36.0.3",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
  "serde",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8216ad58422090d0daa9eb430e0a081f7ad07e7fd30681dee71f8420c99624e0"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context 16.0.1",
+ "revm-database-interface 11.0.1",
+ "revm-handler 18.1.0",
+ "revm-interpreter 35.0.1",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -10207,10 +10447,10 @@ checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context",
- "revm-database-interface",
- "revm-handler",
- "revm-interpreter",
+ "revm-context 18.0.3",
+ "revm-database-interface 12.1.1",
+ "revm-handler 20.0.3",
+ "revm-interpreter 37.0.3",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
  "serde",
@@ -10231,10 +10471,23 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm",
+ "revm 40.0.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "35.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ece9f41b69658c15d748288a4dbdfc06a63f3ce93d983af440de3f1631dce6a"
+dependencies = [
+ "revm-bytecode 10.0.0",
+ "revm-context-interface 17.0.1",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
+ "serde",
 ]
 
 [[package]]
@@ -10244,10 +10497,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
 dependencies = [
  "revm-bytecode 11.0.1",
- "revm-context-interface",
+ "revm-context-interface 19.0.3",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
  "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a346a8cc6c8c39bd65306641c692191299c0a7b63d38810e39e8fe9b92378660"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "p256",
+ "revm-context-interface 17.0.1",
+ "revm-primitives 23.0.0",
+ "ripemd",
+ "secp256k1 0.31.1",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -10268,7 +10545,7 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-context-interface",
+ "revm-context-interface 19.0.3",
  "revm-primitives 24.0.1",
  "ripemd",
  "secp256k1 0.31.1",
@@ -10277,9 +10554,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "22.1.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
+checksum = "0c99bda77d9661521ba0b4bc04558c6692074f01e65dd420fa3b893033d9b8a2"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10300,14 +10577,14 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "10.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
+checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
 dependencies = [
  "alloy-eip7928 0.3.7",
  "bitflags 2.11.1",
- "revm-bytecode 9.0.0",
- "revm-primitives 22.1.0",
+ "revm-bytecode 10.0.0",
+ "revm-primitives 23.0.0",
  "serde",
 ]
 
@@ -10560,7 +10837,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10619,7 +10896,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11344,7 +11621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11412,7 +11689,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11424,7 +11701,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -11447,7 +11724,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11766,7 +12043,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
@@ -11894,24 +12171,24 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+source = "git+https://github.com/tempoxyz/tempo?rev=cae2a3c992755abc69eb05a259fe3a34a2bc92ee#cae2a3c992755abc69eb05a259fe3a34a2bc92ee"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-signer-local",
  "alloy-sol-types",
  "alloy-transport",
@@ -11933,10 +12210,10 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.5.4"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+source = "git+https://github.com/tempoxyz/tempo?rev=cae2a3c992755abc69eb05a259fe3a34a2bc92ee#cae2a3c992755abc69eb05a259fe3a34a2bc92ee"
 dependencies = [
- "alloy-eips",
- "alloy-evm",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.36.0",
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-primitives",
@@ -11956,7 +12233,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+source = "git+https://github.com/tempoxyz/tempo?rev=cae2a3c992755abc69eb05a259fe3a34a2bc92ee#cae2a3c992755abc69eb05a259fe3a34a2bc92ee"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11966,8 +12243,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cae2a3c992755abc69eb05a259fe3a34a2bc92ee#cae2a3c992755abc69eb05a259fe3a34a2bc92ee"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11978,11 +12255,11 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cae2a3c992755abc69eb05a259fe3a34a2bc92ee#cae2a3c992755abc69eb05a259fe3a34a2bc92ee"
 dependencies = [
  "alloy-consensus",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "alloy-rlp",
  "commonware-codec",
@@ -12004,15 +12281,15 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cae2a3c992755abc69eb05a259fe3a34a2bc92ee#cae2a3c992755abc69eb05a259fe3a34a2bc92ee"
 dependencies = [
  "alloy",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "commonware-codec",
  "commonware-cryptography",
  "derive_more",
- "revm",
+ "revm 40.0.3",
  "scoped-tls",
  "tempo-chainspec",
  "tempo-contracts",
@@ -12024,8 +12301,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cae2a3c992755abc69eb05a259fe3a34a2bc92ee#cae2a3c992755abc69eb05a259fe3a34a2bc92ee"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12036,15 +12313,15 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+source = "git+https://github.com/tempoxyz/tempo?rev=cae2a3c992755abc69eb05a259fe3a34a2bc92ee#cae2a3c992755abc69eb05a259fe3a34a2bc92ee"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "aws-lc-rs",
  "base64 0.22.1",
  "derive_more",
@@ -12057,7 +12334,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits 0.4.0",
  "reth-rpc-convert",
- "revm",
+ "revm 40.0.3",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -12066,11 +12343,11 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cae2a3c992755abc69eb05a259fe3a34a2bc92ee#cae2a3c992755abc69eb05a259fe3a34a2bc92ee"
 dependencies = [
  "alloy-consensus",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
@@ -12078,7 +12355,7 @@ dependencies = [
  "derive_more",
  "reth-evm",
  "reth-storage-api",
- "revm",
+ "revm 40.0.3",
  "serde",
  "tempo-chainspec",
  "tempo-contracts",
@@ -12105,7 +12382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13378,7 +13655,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13528,7 +13805,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14298,3 +14575,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "alloy-op-evm"
+version = "0.26.3"
+source = "git+https://github.com/foundry-rs/optimism?branch=alloy-2.0#a3632104e59345555fc0d566fa9fe9e4d52b1324"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -408,7 +408,7 @@ op-alloy-rpc-types = "0.24.0"
 op-alloy-flz = "0.13.1"
 
 ## alloy-evm
-alloy-evm = "0.35.1"
+alloy-evm = "0.36.0"
 alloy-op-evm = "0.32.0"
 
 # revm
@@ -515,17 +515,17 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "8d008eefacacf608b6ceb
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "cae2a3c992755abc69eb05a259fe3a34a2bc92ee", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "cae2a3c992755abc69eb05a259fe3a34a2bc92ee", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "cae2a3c992755abc69eb05a259fe3a34a2bc92ee", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "cae2a3c992755abc69eb05a259fe3a34a2bc92ee", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "cae2a3c992755abc69eb05a259fe3a34a2bc92ee", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "cae2a3c992755abc69eb05a259fe3a34a2bc92ee" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "cae2a3c992755abc69eb05a259fe3a34a2bc92ee" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -589,19 +589,19 @@ idna_adapter = "=1.1.0"
 ## op-revm / op-alloy / alloy-op-evm
 ## Pinned to foundry-rs forks until upstream optimism bumps to revm 40.
 op-revm = { git = "https://github.com/foundry-rs/op-revm", rev = "4201f16a746f2da2df38f1eac477500d492eaed5" }
-alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", branch = "revm-40" }
-op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", branch = "revm-40" }
-op-alloy-network = { git = "https://github.com/foundry-rs/optimism", branch = "revm-40" }
-op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", branch = "revm-40" }
-alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = "revm-40" }
+alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", branch = "alloy-2.0" }
+op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", branch = "alloy-2.0" }
+op-alloy-network = { git = "https://github.com/foundry-rs/optimism", branch = "alloy-2.0" }
+op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", branch = "alloy-2.0" }
+alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = "alloy-2.0" }
 
 ## foundry-fork-db
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "8027e5ccdfe55e562a1111495d2c9acb6e27a930" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "cae2a3c992755abc69eb05a259fe3a34a2bc92ee" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "cae2a3c992755abc69eb05a259fe3a34a2bc92ee" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "cae2a3c992755abc69eb05a259fe3a34a2bc92ee" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }


### PR DESCRIPTION
## Summary
- bump Foundry's `tempoxyz/tempo` git dependencies from `8b80b160` to `cae2a3c9` (`1.8.1`)
- refresh `Cargo.lock` for the new Tempo dependency graph
- switch Foundry's optimism fork patch from `revm-40` to `alloy-2.0` while trying to align the `alloy-evm` layer required by Tempo `1.8.1`

## Context
Tempo `tempo-tests-xpvds` is failing in the `tempo-foundry` leg on `Mail.t.sol` setup with `Panic(UnderOverflow)`. The workflow now runs `TEMPO_HARDFORK=T6` against a devnet reporting `tempo/v1.8.1-cae2a3c`, but Foundry `master` was still compiling Tempo crates pinned to `8b80b160` / `1.8.0`.

This draft captures the dependency bump and the next compatibility blocker.

## Validation
- `git diff --check`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo check --bin forge --bin cast --bin anvil` fails after the bump. First blocker with only Tempo bumped was duplicate `alloy-evm` traits (`0.35.1` vs `0.36.0`). After trying the `foundry-rs/optimism` `alloy-2.0` branch, the current blocker is:
  - `crates/common/fmt/src/ui.rs`: `op_alloy_consensus::TxPostExec` no longer exists
  - `OpTxEnvelope::PostExec` no longer exists

This PR is draft because the dependency layer needs a small follow-up compatibility adjustment before it can be merged.
