### PR TITLE
chore: default tempo check to T5

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -6,8 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Non-verification tempo checks: local tests, fork tests, cast commands, DEX operations
 
-# Hardfork version, defaults to T6 (latest features)
-HARDFORK="${TEMPO_HARDFORK:-T6}"
+# Hardfork version, defaults to T5.
+HARDFORK="${TEMPO_HARDFORK:-T5}"
 
 # Fee token address, defaults to native fee token
 FEE_TOKEN="${TEMPO_FEE_TOKEN:-0x20c0000000000000000000000000000000000000}"

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -6,8 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Non-verification tempo checks: local tests, fork tests, cast commands, DEX operations
 
-# Hardfork version, defaults to T3 (latest features)
-HARDFORK="${TEMPO_HARDFORK:-T3}"
+# Hardfork version, defaults to T6 (latest features)
+HARDFORK="${TEMPO_HARDFORK:-T6}"
 
 # Fee token address, defaults to native fee token
 FEE_TOKEN="${TEMPO_FEE_TOKEN:-0x20c0000000000000000000000000000000000000}"


### PR DESCRIPTION
## Summary
- change `.github/scripts/tempo-check.sh` default `TEMPO_HARDFORK` fallback from `T3` to `T5`


## Validation
- `git diff --check`
- `bash -n .github/scripts/tempo-check.sh`
