### PR TITLE
feat(cast): structured stdout for cast create2; document cast logs and cast erc20 balance

### DIFF
--- a/crates/cast/src/cmd/create2.rs
+++ b/crates/cast/src/cmd/create2.rs
@@ -116,7 +116,7 @@ impl Create2Args {
         if let Some(salt) = salt {
             let salt = hex::FromHex::from_hex(salt)?;
             let address = deployer.create2(salt, init_code_hash);
-            sh_println!("{address}")?;
+            sh_println!("{address}\t{salt}")?;
             return Ok(Create2Output { address, salt });
         }
 
@@ -211,8 +211,9 @@ impl Create2Args {
         })
         .ok_or_else(|| eyre::eyre!("create2 salt mining failed: all threads panicked"))?;
         sh_status!("Successfully found contract address in {:?}", timer.elapsed())?;
-        sh_println!("Address: {address}")?;
-        sh_println!("Salt: {salt} ({})", U256::from_be_bytes(salt.0))?;
+        sh_status!("Address: {address}")?;
+        sh_status!("Salt: {salt} ({})", U256::from_be_bytes(salt.0))?;
+        sh_println!("{address}\t{salt}")?;
 
         Ok(Create2Output { address, salt })
     }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1972,6 +1972,38 @@ casttest!(logs_chunked_large_range, |_prj, cmd| {
     .assert_success();
 });
 
+// tests that `cast create2` writes `address\tsalt` to stdout and prose to stderr
+casttest!(create2_output_channels, |_prj, cmd| {
+    cmd.args([
+        "create2",
+        "--starts-with",
+        "cc",
+        "--init-code-hash",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+0x[..]	0x[..]
+
+"#]]);
+});
+
+// tests that `cast create2 --salt` writes `address\tsalt` to stdout
+casttest!(create2_fixed_salt_output_channels, |_prj, cmd| {
+    cmd.args([
+        "create2",
+        "--salt",
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "--init-code-hash",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+0x[..]	0x0000000000000000000000000000000000000000000000000000000000000001
+
+"#]]);
+});
+
 casttest!(mktx, |_prj, cmd| {
     cmd.args([
         "mktx",

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -100,13 +100,14 @@ Each row's status is one of:
 | `cast estimate`        | Gas estimate (decimal)                               | JSON `{ "gas": "…" }`                                          | migrated |
 | `cast rpc`             | RPC result (JSON)                                    | JSON                                                           | migrated |
 | `cast storage`         | Single slot value                                    | JSON of layout                                                 | migrated |
-| `cast logs`            | One log per line                                     | JSON array                                                     | todo   |
+| `cast logs`            | Pretty-printed logs                                  | JSON array                                                     | migrated |
 | `cast run`             | Trace / decoded output                               | JSON                                                           | migrated |
 | `cast trace`           | Trace                                                | JSON trace                                                     | migrated |
 | `cast wallet new`      | One record per wallet: `address` (keystore) or `address\tprivate_key` (no keystore) | JSON array of `{ address, public_key, path }` (keystore) or `{ address, public_key, private_key }` (no keystore) | migrated |
 | `cast wallet sign`     | Signature                                            | JSON                                                           | migrated |
 | `cast wallet sign-auth`| Signed authorization RLP                             | JSON                                                           | migrated |
-| `cast erc20 balance`   | Balance (decimal)                                    | JSON string                                                    | todo   |
+| `cast erc20 balance`   | Balance (decimal)                                    | JSON string                                                    | migrated |
+| `cast create2`         | `address\tsalt` (tab-separated)                      | n/a                                                            | migrated |
 | `cast access-list`     | Access list                                          | JSON                                                           | migrated |
 | `cast da-estimate`     | Gas estimate                                         | JSON                                                           | migrated |
 | `cast find-block`      | Block number                                         | JSON                                                           | migrated |


### PR DESCRIPTION
Bundled stdout/stderr audit updates per `docs/dev/output-channels.md`.

- `cast create2`: text stdout now emits a single `address\tsalt` record (both mined and `--salt` branches). The `Address: …` / `Salt: …` prose is moved to stderr via `sh_status!`. New doc row added.
- `cast logs`: doc-only flip — source already emits primary log data on stdout with no diagnostic prose. Wording tightened to `Pretty-printed logs`.
- `cast erc20 balance`: doc-only flip — source already emits the decimal value (text) or JSON string (`--json`) with no diagnostic prose.

Part of OSS-224