### PR TITLE
feat(forge): structured stdout contract for forge snapshot

### DIFF
--- a/crates/forge/src/cmd/snapshot.rs
+++ b/crates/forge/src/cmd/snapshot.rs
@@ -416,7 +416,7 @@ fn check(
         {
             let source_gas = test.result.kind.report();
             if !within_tolerance(source_gas.gas(), target_gas.gas(), tolerance) {
-                let _ = sh_println!(
+                let _ = sh_eprintln!(
                     "Diff in \"{}::{}\": consumed \"{}\" gas, expected \"{}\" gas ",
                     test.contract_name(),
                     test.signature,
@@ -426,7 +426,7 @@ fn check(
                 has_diff = true;
             }
         } else {
-            let _ = sh_println!(
+            let _ = sh_eprintln!(
                 "No matching snapshot entry found for \"{}::{}\" in snapshot file",
                 test.contract_name(),
                 test.signature
@@ -528,14 +528,14 @@ fn diff(
 
     // Display new tests if any
     if !new_tests.is_empty() {
-        sh_println!("\n{}", "New tests:".yellow())?;
+        sh_eprintln!("\n{}", "New tests:".yellow())?;
         for test in new_tests {
-            sh_println!("  {} {}", "+".green(), test)?;
+            sh_eprintln!("  {} {}", "+".green(), test)?;
         }
     }
 
     // Summary separator
-    sh_println!("\n{}", "-".repeat(80))?;
+    sh_eprintln!("\n{}", "-".repeat(80))?;
 
     let overall_gas_diff = if overall_gas_used > 0 {
         overall_gas_change as f64 / overall_gas_used as f64
@@ -543,7 +543,7 @@ fn diff(
         0.0
     };
 
-    sh_println!(
+    sh_eprintln!(
         "Total tests: {}, {} {}, {} {}, {} {}",
         diffs.len(),
         "↑".red().to_string(),
@@ -553,7 +553,7 @@ fn diff(
         "━",
         unchanged
     )?;
-    sh_println!(
+    sh_eprintln!(
         "Overall gas change: {} ({})",
         fmt_change(overall_gas_change),
         fmt_pct_change(overall_gas_diff)

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1583,6 +1583,77 @@ contract InvariantSnapshotTest {
     assert!(snapshot.contains("InvariantSnapshotTest:invariant_count_is_not_max()"));
 });
 
+// tests that `forge snapshot --diff` keeps per-test diff rows on stdout but moves summary to stderr
+forgetest!(snapshot_diff_summary_on_stderr, |prj, cmd| {
+    prj.insert_ds_test();
+
+    prj.add_source(
+        "ATest.t.sol",
+        r#"
+import "./test.sol";
+contract ATest is DSTest {
+    function testExample() public {
+        assertTrue(true);
+    }
+}
+   "#,
+    );
+
+    // Baseline snapshot.
+    cmd.args(["snapshot"]).assert_success();
+
+    // Re-run with --diff so the per-test diff row is emitted.
+    let assert = cmd.forge_fuse().args(["snapshot", "--diff"]).assert_success();
+    let output = assert.get_output();
+    let stdout = output.stdout_lossy();
+    let stderr = output.stderr_lossy();
+    assert!(
+        stdout.contains("ATest::testExample()"),
+        "expected diff row on stdout, got stdout: {stdout}"
+    );
+    assert!(
+        stderr.contains("Total tests:") && stderr.contains("Overall gas change:"),
+        "expected summary on stderr, got stderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("Total tests:") && !stdout.contains("Overall gas change:"),
+        "summary leaked to stdout: {stdout}"
+    );
+});
+
+// tests that `forge snapshot --check` reports mismatches on stderr
+forgetest!(snapshot_check_writes_diff_to_stderr, |prj, cmd| {
+    prj.insert_ds_test();
+
+    prj.add_source(
+        "ATest.t.sol",
+        r#"
+import "./test.sol";
+contract ATest is DSTest {
+    function testExample() public {
+        assertTrue(true);
+    }
+}
+   "#,
+    );
+
+    // Pre-seed an empty snapshot so `--check` triggers the "No matching snapshot entry" path.
+    fs::write(prj.root().join(".gas-snapshot"), "").unwrap();
+
+    let assert = cmd.args(["snapshot", "--check"]).assert_failure();
+    let output = assert.get_output();
+    let stdout = output.stdout_lossy();
+    let stderr = output.stderr_lossy();
+    assert!(
+        stderr.contains("No matching snapshot entry found for \"ATest::testExample()\""),
+        "expected diff on stderr, got stderr: {stderr}\nstdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("No matching snapshot entry"),
+        "diff prose leaked to stdout: {stdout}"
+    );
+});
+
 forgetest!(snapshot_reports_when_snap_file_is_not_written, |prj, cmd| {
     prj.insert_ds_test();
 

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -137,7 +137,7 @@ Each row's status is one of:
 | `forge eip712`         | (empty)                                              | JSON of types                              | migrated |
 | `forge geiger`         | Findings                                             | JSON                                       | migrated |
 | `forge lint`           | (empty; findings on stderr/exit code)                | JSON findings                              | migrated |
-| `forge snapshot`       | Snapshot file content / diff                         | JSON                                       | todo   |
+| `forge snapshot`       | Per-test diff lines (`--diff`); table (`--format table`); (empty) otherwise | n/a               | migrated |
 | `forge coverage`       | Coverage table or report                             | JSON / LCOV / etc. via `--report`          | todo   |
 | `forge cache`          | (empty) or paths                                     | JSON                                       | migrated |
 | `forge doc`            | (empty)                                              | n/a                                        | migrated |


### PR DESCRIPTION
Migrates `forge snapshot` to the stdout/stderr contract in `docs/dev/output-channels.md`.

- `--diff` mode: per-test diff rows (`↑ Contract::test() (gas: N → M | ...)`) stay on stdout as the primary data; `"New tests:"` header/bullets, separator, and `"Total tests:" / "Overall gas change:"` summary move to stderr.
- `--check` mode: `Diff in "..."` and `No matching snapshot entry found for "..."` move to stderr (the exit code already carries the pass/fail result).
- Default and `--format table` modes: unchanged (table stays on stdout).

Doc row updated to reflect actual behavior.

Part of OSS-224