### PR TITLE
chore: bump alloy-evm to 0.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.35.1"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58673bde58f17022886547b618346aeae9b147ed398f9c847105fa91c49f97eb"
+checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -448,7 +448,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.32.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.4.7"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -2574,7 +2574,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3050,7 +3050,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3209,7 +3209,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4271,7 +4271,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4573,7 +4573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6106,8 +6106,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -6588,7 +6588,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6935,7 +6935,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7858,7 +7858,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8112,7 +8112,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 [[package]]
 name = "op-alloy"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -8124,7 +8124,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-consensus"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8151,7 +8151,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-alloy-network"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -8164,7 +8164,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-provider"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -8178,7 +8178,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8198,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types-engine"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=revm-40#fb56cdbcba416bafde4cba8abb2143fb67878fe9"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8967,7 +8967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9136,7 +9136,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9578,7 +9578,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9658,7 +9658,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9672,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9696,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9710,7 +9710,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9723,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9737,7 +9737,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9760,7 +9760,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9780,7 +9780,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9793,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9812,7 +9812,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9894,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9907,7 +9907,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9957,7 +9957,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9970,7 +9970,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9984,7 +9984,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10009,7 +10009,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10027,7 +10027,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10037,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=6835254#6835254b289c48aa972651fafc26f8eb3b9b22f1"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10560,7 +10560,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10619,7 +10619,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11412,7 +11412,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11424,7 +11424,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -11447,7 +11447,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11766,7 +11766,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
@@ -11894,13 +11894,13 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11933,7 +11933,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.5.4"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11956,7 +11956,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11966,8 +11966,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11978,8 +11978,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12004,8 +12004,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12024,8 +12024,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12036,7 +12036,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12066,8 +12066,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=8b80b16023ae8ceb70a6b860c58d747e118448bc#8b80b16023ae8ceb70a6b860c58d747e118448bc"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12105,7 +12105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13378,7 +13378,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13528,7 +13528,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -408,7 +408,7 @@ op-alloy-rpc-types = "0.24.0"
 op-alloy-flz = "0.13.1"
 
 ## alloy-evm
-alloy-evm = "0.35.1"
+alloy-evm = "0.36.0"
 alloy-op-evm = "0.32.0"
 
 # revm
@@ -515,17 +515,17 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "8d008eefacacf608b6ceb
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -589,19 +589,19 @@ idna_adapter = "=1.1.0"
 ## op-revm / op-alloy / alloy-op-evm
 ## Pinned to foundry-rs forks until upstream optimism bumps to revm 40.
 op-revm = { git = "https://github.com/foundry-rs/op-revm", rev = "4201f16a746f2da2df38f1eac477500d492eaed5" }
-alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", branch = "revm-40" }
-op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", branch = "revm-40" }
-op-alloy-network = { git = "https://github.com/foundry-rs/optimism", branch = "revm-40" }
-op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", branch = "revm-40" }
-alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = "revm-40" }
+alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
+op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
+op-alloy-network = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
+op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
+alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
 
 ## foundry-fork-db
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "8027e5ccdfe55e562a1111495d2c9acb6e27a930" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -17,8 +17,7 @@ use alloy_evm::{
     Evm, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
     block::{
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockValidationError,
-        ExecutableTx, GasOutput, OnStateHook, StateChangePreBlockSource, StateChangeSource,
-        StateDB, TxResult,
+        ExecutableTx, GasOutput, OnStateHook, StateDB, TxResult,
     },
     eth::{
         EthTxResult,
@@ -177,10 +176,7 @@ where
                 .map_err(BlockExecutionError::other)?;
 
             if let Some(hook) = &mut self.state_hook {
-                hook.on_state(
-                    StateChangeSource::PreBlock(StateChangePreBlockSource::BlockHashesContract),
-                    &result.state,
-                );
+                hook.on_state(&result.state);
             }
             self.evm.db_mut().commit(result.state);
         }
@@ -227,7 +223,7 @@ where
         } = output;
 
         if let Some(hook) = &mut self.state_hook {
-            hook.on_state(StateChangeSource::Transaction(self.receipts.len()), &state);
+            hook.on_state(&state);
         }
 
         let gas_used = result.tx_gas_used();
@@ -291,10 +287,6 @@ where
                 blob_gas_used: self.blob_gas_used,
             },
         ))
-    }
-
-    fn set_state_hook(&mut self, hook: Option<Box<dyn OnStateHook>>) {
-        self.state_hook = hook;
     }
 
     fn evm_mut(&mut self) -> &mut Self::Evm {


### PR DESCRIPTION
## Summary
- Bump workspace `alloy-evm` to `0.36.0`
- Bump Tempo git dependencies to `32bb1d454f0fb70f8085c93bc04f35ed9715dc0c`, which requires the newer `alloy-evm` line
- Point OP dependency patches at `foundry-rs/optimism` branch `bump-alloy-evm-0-36-tempo` so `alloy-op-evm` also builds against `alloy-evm 0.36.0`
- Update Anvil state hook usage for the `alloy-evm 0.36` API
- Refresh `Cargo.lock`

## Validation
- `cargo fmt --all --check`
- `cargo build --profile dev --locked --bin forge --bin cast --bin anvil --bin chisel`
- `cargo clippy --workspace --all-targets --all-features --locked`

Prompted by: @0xrusowsky