### PR TITLE
fix(bind): qualify shadowed event module paths

### DIFF
--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 // <https://github.com/foundry-rs/foundry/issues/9482>
 forgetest!(bind_unlinked_bytecode, |prj, cmd| {
     prj.add_source(
@@ -39,4 +41,51 @@ Generating bindings for [..] contracts
 Bindings have been generated to [..]
 
 "#]]);
+});
+
+// <https://github.com/foundry-rs/foundry/issues/11177>
+forgetest!(bind_event_module_name_shadowing, |prj, cmd| {
+    prj.add_source(
+        "IExampleContract.sol",
+        r#"
+interface IExampleContractEvents {
+    struct SomeEventData {
+        address sender;
+        address receiver;
+    }
+
+    event SomeEvent(SomeEventData eventData);
+}
+
+interface IExampleContract is IExampleContractEvents {}
+"#,
+    );
+
+    cmd.args(["bind", "--select", "^IExampleContract$", "--optimize"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+"#]])
+        .stderr_eq(str![[r#"
+Generating bindings for 1 contracts
+Bindings have been generated to [..]
+
+"#]]);
+
+    let bindings_path = prj.root().join("out/bindings");
+    let out = Command::new("cargo")
+        .arg("check")
+        .current_dir(&bindings_path)
+        .output()
+        .expect("failed to run cargo check");
+
+    assert!(
+        out.status.success(),
+        "generated bindings should compile\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
 });

--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -57,7 +57,15 @@ interface IExampleContractEvents {
     event SomeEvent(SomeEventData eventData);
 }
 
-interface IExampleContract is IExampleContractEvents {}
+interface MyIExampleContractEvents {
+    struct MyEventData {
+        address sender;
+    }
+
+    event MyEvent(MyEventData eventData);
+}
+
+interface IExampleContract is IExampleContractEvents, MyIExampleContractEvents {}
 "#,
     );
 
@@ -72,6 +80,16 @@ Compiler run successful!
         .stderr_eq(str![[r#"
 Generating bindings for 1 contracts
 Bindings have been generated to [..]
+
+"#]]);
+
+    cmd.forge_fuse()
+        .args(["bind", "--select", "^IExampleContract$", "--optimize"])
+        .assert_success()
+        .stderr_eq(str![[r#"
+Bindings found. Checking for consistency.
+Checking bindings for 1 contracts
+OK.
 
 "#]]);
 

--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -1,4 +1,19 @@
-use std::process::Command;
+use std::{path::Path, process::Command};
+
+fn assert_bindings_compile(bindings_path: &Path) {
+    let out = Command::new("cargo")
+        .arg("check")
+        .current_dir(bindings_path)
+        .output()
+        .expect("failed to run cargo check");
+
+    assert!(
+        out.status.success(),
+        "generated bindings should compile\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
 
 // <https://github.com/foundry-rs/foundry/issues/9482>
 forgetest!(bind_unlinked_bytecode, |prj, cmd| {
@@ -94,16 +109,33 @@ OK.
 "#]]);
 
     let bindings_path = prj.root().join("out/bindings");
-    let out = Command::new("cargo")
-        .arg("check")
-        .current_dir(&bindings_path)
-        .output()
-        .expect("failed to run cargo check");
+    assert_bindings_compile(&bindings_path);
+});
 
-    assert!(
-        out.status.success(),
-        "generated bindings should compile\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
+forgetest!(bind_event_module_prefix_does_not_shadow_aliases, |prj, cmd| {
+    prj.add_source(
+        "alloy_sol_types.sol",
+        r#"
+interface alloy_sol_types {
+    event Ping(address sender);
+}
+"#,
     );
+
+    cmd.args(["bind", "--select", "^alloy_sol_types$", "--optimize"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+"#]])
+        .stderr_eq(str![[r#"
+Generating bindings for 1 contracts
+Bindings have been generated to [..]
+
+"#]]);
+
+    let bindings_path = prj.root().join("out/bindings");
+    assert_bindings_compile(&bindings_path);
 });

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -183,7 +183,7 @@ edition = "2021"
             let path = src.join(format!("{name}.rs"));
             let file = syn::parse2(contents.clone())
                 .wrap_err_with(|| parse_error(&format!("{}:{}", path.display(), name)))?;
-            let contents = prettyplease::unparse(&file);
+            let contents = qualify_shadowed_sibling_module_paths(prettyplease::unparse(&file));
             if single_file {
                 write!(&mut lib_contents, "{contents}")?;
             } else {
@@ -251,7 +251,7 @@ edition = "2021"
                 write!(contents, "{}", instance.expansion.as_ref().unwrap())?;
                 let file = syn::parse_file(&contents)?;
 
-                let contents = prettyplease::unparse(&file);
+                let contents = qualify_shadowed_sibling_module_paths(prettyplease::unparse(&file));
                 fs::write(bindings_path.join(format!("{name}.rs")), contents)
                     .wrap_err("Failed to write file")?;
             }
@@ -259,7 +259,7 @@ edition = "2021"
 
         let mod_path = bindings_path.join("mod.rs");
         let mod_file = syn::parse_file(&mod_contents)?;
-        let mod_contents = prettyplease::unparse(&mod_file);
+        let mod_contents = qualify_shadowed_sibling_module_paths(prettyplease::unparse(&mod_file));
 
         fs::write(mod_path, mod_contents).wrap_err("Failed to write mod.rs")?;
 
@@ -397,4 +397,34 @@ fn write_mod_name(contents: &mut String, name: &str) -> Result<()> {
         write!(contents, "pub mod r#{name};")?;
     }
     Ok(())
+}
+
+/// Qualifies paths to sibling binding modules when a generated item in the current module shadows
+/// that module name.
+///
+/// Alloy names the event enum for a contract module by appending `Events` to the contract name. If
+/// the ABI also contains a sibling contract/interface with that exact name, inherited event
+/// parameter types such as `IExampleContractEvents::SomeEventData` resolve to the local event enum
+/// instead of the sibling module that owns `SomeEventData`. Qualifying those paths with `super::`
+/// keeps the generated binding compiling without changing the upstream `sol!` expansion.
+fn qualify_shadowed_sibling_module_paths(mut contents: String) -> String {
+    let module_names = top_level_module_names(&contents);
+
+    for module_name in module_names {
+        if contents.contains(&format!("pub enum {module_name}")) {
+            contents =
+                contents.replace(&format!("{module_name}::"), &format!("super::{module_name}::"));
+        }
+    }
+
+    contents
+}
+
+fn top_level_module_names(contents: &str) -> Vec<String> {
+    contents
+        .split("pub mod ")
+        .skip(1)
+        .filter_map(|rest| rest.split_whitespace().next())
+        .map(|name| name.trim_start_matches("r#").to_string())
+        .collect()
 }

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -332,7 +332,8 @@ edition = "2021"
         let formatted_file = prettyplease::unparse(&file_contents);
 
         let expected_contents = syn::parse_file(expected_contents)?;
-        let formatted_exp = prettyplease::unparse(&expected_contents);
+        let formatted_exp =
+            qualify_shadowed_sibling_module_paths(prettyplease::unparse(&expected_contents));
 
         eyre::ensure!(
             formatted_file == formatted_exp,
@@ -412,12 +413,39 @@ fn qualify_shadowed_sibling_module_paths(mut contents: String) -> String {
 
     for module_name in module_names {
         if contents.contains(&format!("pub enum {module_name}")) {
-            contents =
-                contents.replace(&format!("{module_name}::"), &format!("super::{module_name}::"));
+            contents = qualify_unqualified_module_paths(&contents, &module_name);
         }
     }
 
     contents
+}
+
+fn qualify_unqualified_module_paths(contents: &str, module_name: &str) -> String {
+    let needle = format!("{module_name}::");
+    let replacement = format!("super::{module_name}::");
+    let mut qualified = String::with_capacity(contents.len());
+    let mut rest = contents;
+
+    while let Some(index) = rest.find(&needle) {
+        let (before, after) = rest.split_at(index);
+        qualified.push_str(before);
+
+        let boundary = before
+            .chars()
+            .next_back()
+            .is_none_or(|c| !matches!(c, '_' | '0'..='9' | 'a'..='z' | 'A'..='Z' | ':'));
+
+        if boundary {
+            qualified.push_str(&replacement);
+        } else {
+            qualified.push_str(&needle);
+        }
+
+        rest = &after[needle.len()..];
+    }
+
+    qualified.push_str(rest);
+    qualified
 }
 
 fn top_level_module_names(contents: &str) -> Vec<String> {

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -410,9 +410,10 @@ fn write_mod_name(contents: &mut String, name: &str) -> Result<()> {
 /// keeps the generated binding compiling without changing the upstream `sol!` expansion.
 fn qualify_shadowed_sibling_module_paths(mut contents: String) -> String {
     let module_names = top_level_module_names(&contents);
+    let enum_names = public_enum_names(&contents);
 
     for module_name in module_names {
-        if contents.contains(&format!("pub enum {module_name}")) {
+        if enum_names.iter().any(|enum_name| enum_name == &module_name) {
             contents = qualify_unqualified_module_paths(&contents, &module_name);
         }
     }
@@ -451,6 +452,15 @@ fn qualify_unqualified_module_paths(contents: &str, module_name: &str) -> String
 fn top_level_module_names(contents: &str) -> Vec<String> {
     contents
         .split("pub mod ")
+        .skip(1)
+        .filter_map(|rest| rest.split_whitespace().next())
+        .map(|name| name.trim_start_matches("r#").to_string())
+        .collect()
+}
+
+fn public_enum_names(contents: &str) -> Vec<String> {
+    contents
+        .split("pub enum ")
         .skip(1)
         .filter_map(|rest| rest.split_whitespace().next())
         .map(|name| name.trim_start_matches("r#").to_string())


### PR DESCRIPTION
## Summary
- Fix generated `forge bind` Rust when an inherited interface name matches the generated event enum name.
- Qualify shadowed sibling binding module paths with `super::` after formatting generated bindings.
- Add a regression that runs `forge bind --select '^IExampleContract$' --optimize` and `cargo check` on the generated crate.

## Why
When a contract/interface inherits from a sibling named like `<Contract>Events`, Alloy also generates a local `<Contract>Events` event enum. Paths such as `IExampleContractEvents::SomeEventData` then resolved to the local enum instead of the sibling module, so generated bindings failed to compile.

## Changes
- Post-process formatted generated bindings to qualify paths for module names shadowed by generated local enums.
- Apply the same qualification for crate and module binding output paths.
- Cover the regression from #11177 in the forge bind CLI tests.

## Validation
- `cargo fmt --check` (passes; stable rustfmt prints existing warnings for nightly-only rustfmt options)
- `cargo test -p forge --test cli bind_event_module_name_shadowing -- --nocapture`
- Manual repro: `cargo run -q -p forge -- bind -C /tmp/foundry-bind-repro4/src -b /tmp/foundry-bind-repro4/bindings --select '^IExampleContract$' --optimize && cargo check --manifest-path /tmp/foundry-bind-repro4/bindings/Cargo.toml`

## Scope
Focused `forge bind` codegen fix for sibling module names shadowed by generated local event enums.

Closes #11177
