### PR TITLE
fix(mutation): reject empty mutation selections

### DIFF
--- a/crates/forge/src/mutation/orchestrator.rs
+++ b/crates/forge/src/mutation/orchestrator.rs
@@ -439,9 +439,13 @@ fn resolve_mutate_paths(
 ) -> Result<Vec<PathBuf>> {
     // 1. Base path set.
     let base: Vec<PathBuf> = if let Some(pattern) = &mutation_config.mutate_path_pattern {
-        source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
+        let paths: Vec<_> = source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
             .filter(|entry| entry.is_sol() && !entry.is_sol_test() && pattern.is_match(entry))
-            .collect()
+            .collect();
+        if paths.is_empty() {
+            eyre::bail!("no source matched --mutate-path pattern `{pattern}`");
+        }
+        paths
     } else if !mutation_config.mutate_paths.is_empty() {
         let root_canon =
             config.root.canonicalize().wrap_err("failed to canonicalize project root")?;
@@ -488,8 +492,13 @@ fn resolve_mutate_paths(
             .collect();
         let paths: Vec<_> =
             base.into_iter().filter(|entry| matching_sources.contains(entry)).collect();
-        if paths.is_empty() && !mutation_config.mutate_paths.is_empty() {
-            eyre::bail!("no source matched --mutate-contract within the selected --mutate paths");
+        if paths.is_empty() {
+            if mutation_config.mutate_paths.is_empty()
+                && mutation_config.mutate_path_pattern.is_none()
+            {
+                eyre::bail!("no source matched --mutate-contract pattern `{contract_pattern}`");
+            }
+            eyre::bail!("no source matched --mutate-contract within the selected mutation paths");
         }
         paths
     } else {

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -164,6 +164,95 @@ contract CounterTest is Test {
     );
 });
 
+forgetest_init!(mutation_testing_rejects_empty_mutate_path_selection, |prj, cmd| {
+    prj.add_source(
+        "Counter.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract Counter {
+    uint256 public number;
+
+    function increment() public {
+        number++;
+    }
+}
+"#,
+    );
+
+    prj.add_test(
+        "Counter.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "../src/Counter.sol";
+
+contract CounterTest {
+    function test_Increment() public {
+        Counter counter = new Counter();
+        counter.increment();
+        assert(counter.number() == 1);
+    }
+}
+"#,
+    );
+
+    let output =
+        cmd.args(["test", "--mutate", "--mutate-path", "src/Missing*.sol"]).assert_failure();
+    let stderr = output.get_output().stderr_lossy();
+
+    assert!(
+        stderr.contains("no source matched --mutate-path pattern"),
+        "unexpected stderr:\n{stderr}"
+    );
+});
+
+forgetest_init!(mutation_testing_rejects_empty_mutate_contract_selection, |prj, cmd| {
+    prj.add_source(
+        "Counter.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract Counter {
+    uint256 public number;
+
+    function increment() public {
+        number++;
+    }
+}
+"#,
+    );
+
+    prj.add_test(
+        "Counter.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "../src/Counter.sol";
+
+contract CounterTest {
+    function test_Increment() public {
+        Counter counter = new Counter();
+        counter.increment();
+        assert(counter.number() == 1);
+    }
+}
+"#,
+    );
+
+    let output = cmd.args(["test", "--mutate", "--mutate-contract", "Missing"]).assert_failure();
+    let stderr = output.get_output().stderr_lossy();
+
+    assert!(
+        stderr.contains("no source matched --mutate-contract pattern"),
+        "unexpected stderr:\n{stderr}"
+    );
+});
+
 forgetest_init!(mutation_testing_with_parallel_workers, |prj, cmd| {
     prj.add_source(
         "Simple.sol",


### PR DESCRIPTION
Errors when explicit `--mutate-path` or `--mutate-contract` selects zero source files.
