### PR TITLE
fix(mutation): copy mutation compiler paths

### DIFF
--- a/crates/forge/src/mutation/runner.rs
+++ b/crates/forge/src/mutation/runner.rs
@@ -611,6 +611,16 @@ fn temp_config_for_mutation(config: &Config, temp_path: &Path) -> Config {
     temp_config.mutation_dir = rebase_project_path(&config.root, temp_path, &config.mutation_dir);
     temp_config.libs =
         config.libs.iter().map(|lib| rebase_project_path(&config.root, temp_path, lib)).collect();
+    temp_config.include_paths = config
+        .include_paths
+        .iter()
+        .map(|path| rebase_project_path(&config.root, temp_path, path))
+        .collect();
+    temp_config.allow_paths = config
+        .allow_paths
+        .iter()
+        .map(|path| rebase_project_path(&config.root, temp_path, path))
+        .collect();
 
     if let Some(path) = &config.fuzz.failure_persist_dir {
         temp_config.fuzz.failure_persist_dir =
@@ -784,6 +794,8 @@ mod tests {
             broadcast: root.join("custom-broadcast"),
             mutation_dir: root.join("custom-cache/mutation"),
             libs: vec![root.join("vendor")],
+            include_paths: vec![root.join("shared")],
+            allow_paths: vec![root.join("fixtures")],
             dynamic_test_linking: true,
             cache: true,
             ..Default::default()
@@ -807,6 +819,8 @@ mod tests {
         assert_eq!(temp_config.broadcast, temp.path().join("custom-broadcast"));
         assert_eq!(temp_config.mutation_dir, temp.path().join("custom-cache/mutation"));
         assert_eq!(temp_config.libs, vec![temp.path().join("vendor")]);
+        assert_eq!(temp_config.include_paths, vec![temp.path().join("shared")]);
+        assert_eq!(temp_config.allow_paths, vec![temp.path().join("fixtures")]);
         assert_eq!(
             temp_config.fuzz.failure_persist_dir,
             Some(temp.path().join("custom-cache/fuzz"))

--- a/crates/forge/src/mutation/runner.rs
+++ b/crates/forge/src/mutation/runner.rs
@@ -405,6 +405,22 @@ fn test_single_mutant_isolated(
             temp_path.join(lib_rel)
         })
         .collect();
+    temp_config.include_paths = config
+        .include_paths
+        .iter()
+        .map(|path| {
+            let rel = workspace::relative_to_root(&config.root, path);
+            if rel.is_absolute() { path.clone() } else { temp_path.join(rel) }
+        })
+        .collect();
+    temp_config.allow_paths = config
+        .allow_paths
+        .iter()
+        .map(|path| {
+            let rel = workspace::relative_to_root(&config.root, path);
+            if rel.is_absolute() { path.clone() } else { temp_path.join(rel) }
+        })
+        .collect();
 
     // Propagate the per-mutant timeout into the inner fuzz/invariant harness
     // so the hot test loop itself bails out at the deadline. Without this the

--- a/crates/forge/src/workspace.rs
+++ b/crates/forge/src/workspace.rs
@@ -83,8 +83,9 @@ pub fn copy_project(config: &Config, temp_dir: &Path) -> Result<()> {
         copy_dir_recursive(&config.test, &temp_dir.join(&test_rel))?;
     }
 
+    let handled_extra_roots = handled_project_roots(config)?;
     for extra_path in config.include_paths.iter().chain(config.allow_paths.iter()) {
-        copy_extra_project_path(&config.root, temp_dir, extra_path)?;
+        copy_extra_project_path(&config.root, temp_dir, extra_path, &handled_extra_roots)?;
     }
 
     // Copy `script/` too when present and distinct from src/test. Many real
@@ -144,11 +145,62 @@ pub fn copy_project(config: &Config, temp_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn copy_extra_project_path(root: &Path, temp_dir: &Path, path: &Path) -> Result<()> {
+fn handled_project_roots(config: &Config) -> Result<Vec<PathBuf>> {
+    let mut roots = Vec::new();
+    push_handled_project_root(&mut roots, &config.root, &config.src, "src")?;
+    push_handled_project_root(&mut roots, &config.root, &config.test, "test")?;
+
+    if config.script.exists() && config.script != config.src && config.script != config.test {
+        push_handled_project_root(&mut roots, &config.root, &config.script, "script")?;
+    }
+
+    for lib_path in &config.libs {
+        if lib_path.exists() {
+            push_handled_project_root(&mut roots, &config.root, lib_path, "lib")?;
+        }
+    }
+
+    for dep_dir in ["node_modules", "dependencies"] {
+        let dep_path = config.root.join(dep_dir);
+        if dep_path.exists() && dep_path.is_dir() {
+            roots.push(PathBuf::from(dep_dir));
+        }
+    }
+
+    Ok(roots)
+}
+
+fn push_handled_project_root(
+    roots: &mut Vec<PathBuf>,
+    root: &Path,
+    path: &Path,
+    label: &str,
+) -> Result<()> {
+    let rel = relative_to_root(root, path);
+    ensure_safe_relative_path(&rel, label, path)?;
+    ensure_within_root(root, path, label, path)?;
+    roots.push(rel);
+    Ok(())
+}
+
+fn is_covered_by_handled_root(rel: &Path, handled_roots: &[PathBuf]) -> bool {
+    handled_roots.iter().any(|root| !root.as_os_str().is_empty() && rel.starts_with(root))
+}
+
+fn copy_extra_project_path(
+    root: &Path,
+    temp_dir: &Path,
+    path: &Path,
+    handled_roots: &[PathBuf],
+) -> Result<()> {
     let resolved = if path.is_absolute() { path.to_path_buf() } else { root.join(path) };
     let rel = relative_to_root(root, &resolved);
     ensure_safe_relative_path(&rel, "include/allow", path)?;
     ensure_within_root(root, &resolved, "include/allow", path)?;
+
+    if is_covered_by_handled_root(&rel, handled_roots) {
+        return Ok(());
+    }
 
     if !resolved.exists() {
         return Ok(());
@@ -485,6 +537,32 @@ mod tests {
         copy_project(&config, &out).unwrap();
 
         assert!(out.join("include/Shared.sol").exists());
+    }
+
+    #[test]
+    fn test_copy_project_skips_include_paths_covered_by_libs() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("project");
+        let out = temp.path().join("workspace");
+        create_test_dir_structure(
+            &root,
+            &["src/Counter.sol", "test/Counter.t.sol", "lib/foo/Foo.sol", "lib/bar/Bar.sol"],
+        );
+
+        let config = Config {
+            root: root.clone(),
+            src: root.join("src"),
+            test: root.join("test"),
+            script: root.join("script"),
+            libs: vec![root.join("lib")],
+            include_paths: vec![root.join("lib/foo")],
+            ..Default::default()
+        };
+
+        copy_project(&config, &out).unwrap();
+
+        assert!(out.join("lib/foo/Foo.sol").exists());
+        assert!(out.join("lib/bar/Bar.sol").exists());
     }
 
     #[test]

--- a/crates/forge/src/workspace.rs
+++ b/crates/forge/src/workspace.rs
@@ -83,6 +83,10 @@ pub fn copy_project(config: &Config, temp_dir: &Path) -> Result<()> {
         copy_dir_recursive(&config.test, &temp_dir.join(&test_rel))?;
     }
 
+    for extra_path in config.include_paths.iter().chain(config.allow_paths.iter()) {
+        copy_extra_project_path(&config.root, temp_dir, extra_path)?;
+    }
+
     // Copy `script/` too when present and distinct from src/test. Many real
     // projects keep helper contracts, deployment scripts, or fixtures under
     // `script/` and reference them from tests via relative imports. Without
@@ -138,6 +142,28 @@ pub fn copy_project(config: &Config, temp_dir: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn copy_extra_project_path(root: &Path, temp_dir: &Path, path: &Path) -> Result<()> {
+    let resolved = if path.is_absolute() { path.to_path_buf() } else { root.join(path) };
+    let rel = relative_to_root(root, &resolved);
+    ensure_safe_relative_path(&rel, "include/allow", path)?;
+    ensure_within_root(root, &resolved, "include/allow", path)?;
+
+    if !resolved.exists() {
+        return Ok(());
+    }
+
+    let target = temp_dir.join(rel);
+    if resolved.is_dir() {
+        copy_dir_recursive(&resolved, &target)
+    } else {
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(&resolved, target)?;
+        Ok(())
+    }
 }
 
 /// Create a symlink to a directory (cross-platform).
@@ -435,6 +461,56 @@ mod tests {
 
         copy_dir_recursive(&src, &dst).unwrap();
         assert!(!dst.exists());
+    }
+
+    #[test]
+    fn test_copy_project_copies_include_paths_under_root() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("project");
+        let out = temp.path().join("workspace");
+        create_test_dir_structure(
+            &root,
+            &["src/Counter.sol", "test/Counter.t.sol", "include/Shared.sol"],
+        );
+
+        let config = Config {
+            root: root.clone(),
+            src: root.join("src"),
+            test: root.join("test"),
+            script: root.join("script"),
+            include_paths: vec![root.join("include")],
+            ..Default::default()
+        };
+
+        copy_project(&config, &out).unwrap();
+
+        assert!(out.join("include/Shared.sol").exists());
+    }
+
+    #[test]
+    fn test_copy_project_rejects_external_include_paths() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("project");
+        let outside = temp.path().join("outside");
+        let out = temp.path().join("workspace");
+        create_test_dir_structure(&root, &["src/Counter.sol", "test/Counter.t.sol"]);
+        create_test_dir_structure(&outside, &["Shared.sol"]);
+
+        let config = Config {
+            root: root.clone(),
+            src: root.join("src"),
+            test: root.join("test"),
+            script: root.join("script"),
+            include_paths: vec![outside],
+            ..Default::default()
+        };
+
+        let err = copy_project(&config, &out).unwrap_err();
+
+        assert!(
+            err.to_string().contains("requires include/allow directory under project root"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -1,6 +1,7 @@
 // CLI integration tests for mutation testing
 
 use foundry_test_utils::{str, util::OutputExt};
+use std::fs;
 
 fn mutation_summary(stdout: &str) -> serde_json::Value {
     serde_json::from_str::<serde_json::Value>(stdout.trim()).unwrap()["summary"].clone()
@@ -664,6 +665,77 @@ contract FooBrokenTest {
     assert!(
         killed + survived >= 1,
         "expected at least one Killed/Survived mutant from arithmetic ops; summary={summary}"
+    );
+});
+
+forgetest_init!(mutation_workspace_copies_include_paths, |prj, cmd| {
+    let include_dir = prj.root().join("include");
+    fs::create_dir_all(&include_dir).unwrap();
+    fs::write(
+        include_dir.join("Shared.sol"),
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+library Shared {
+    function value() internal pure returns (uint256) {
+        return 1;
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    prj.update_config(|config| {
+        config.include_paths = vec![include_dir.clone()];
+    });
+
+    prj.add_source(
+        "UsesShared.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "Shared.sol";
+
+contract UsesShared {
+    function value() public pure returns (uint256) {
+        return Shared.value() + 1;
+    }
+}
+"#,
+    );
+
+    prj.add_test(
+        "UsesShared.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "../src/UsesShared.sol";
+
+contract UsesSharedTest {
+    function test_Value() public {
+        UsesShared usesShared = new UsesShared();
+        assert(usesShared.value() == 2);
+    }
+}
+"#,
+    );
+
+    let out = cmd
+        .args(["test", "--mutate", "src/UsesShared.sol", "--mutation-jobs", "1", "--json"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let summary = mutation_summary(&out);
+    let total = summary["total"].as_u64().unwrap_or(0);
+    let invalid = summary["invalid"].as_u64().unwrap_or(u64::MAX);
+
+    assert!(total > 0, "expected mutation testing to generate mutants: summary={summary}");
+    assert!(
+        invalid < total,
+        "include_paths imports should compile inside mutant workspaces: summary={summary}"
     );
 });
 


### PR DESCRIPTION
Copies in-root `include_paths` and `allow_paths` into mutation workspaces and rejects external compiler paths with a clear error.