### PR TITLE
fix(mutation): filter no-op mutation outputs

### DIFF
--- a/crates/forge/src/mutation/mutators/assignment_mutator.rs
+++ b/crates/forge/src/mutation/mutators/assignment_mutator.rs
@@ -35,6 +35,7 @@ impl Mutator for AssignmentMutator {
                     line_number,
                     column_number,
                 }]),
+                OwnedLiteral::Number(val) if *val == U256::ZERO => Ok(vec![]),
                 OwnedLiteral::Number(val) => Ok(vec![
                     Mutant {
                         span: replacement_span,

--- a/crates/forge/src/mutation/mutators/require_mutator.rs
+++ b/crates/forge/src/mutation/mutators/require_mutator.rs
@@ -15,7 +15,7 @@
 //! - State preconditions (reentrancy guards, paused checks)
 
 use eyre::Result;
-use solar::ast::{CallArgsKind, ExprKind};
+use solar::ast::{CallArgsKind, Expr, ExprKind, UnOpKind};
 
 use super::{MutationContext, Mutator};
 use crate::mutation::mutant::{Mutant, MutationType};
@@ -59,9 +59,7 @@ impl Mutator for RequireMutator {
         let line_number = context.line_number();
         let column_number = context.column_number();
 
-        // Extract condition text from source
         let source = context.source.unwrap_or("");
-        let condition_text = extract_span_text(source, condition_expr.span);
 
         // Build the rest of the call (message and other arguments after the condition,
         // if any) using span-based extraction so that commas inside the condition
@@ -100,7 +98,7 @@ impl Mutator for RequireMutator {
         let mutated_false = format!("{func_name}(false{rest_args})");
         push_mutant(mutated_false, original.clone(), source_line.clone());
 
-        let inverted_condition = invert_condition_text(&condition_text);
+        let inverted_condition = invert_condition_text(source, condition_expr);
         let mutated_inverted = format!("{func_name}({inverted_condition}{rest_args})");
         push_mutant(mutated_inverted, original, source_line);
 
@@ -135,11 +133,14 @@ fn extract_span_text(source: &str, span: solar::ast::Span) -> String {
     source.get(lo..hi).map(|s| s.to_string()).unwrap_or_default()
 }
 
-fn invert_condition_text(condition: &str) -> String {
-    let condition = condition.trim();
-    if let Some(stripped) = condition.strip_prefix('!') {
-        stripped.trim().to_string()
-    } else {
-        format!("!({condition})")
+fn invert_condition_text(source: &str, condition_expr: &Expr<'_>) -> String {
+    match &condition_expr.kind {
+        ExprKind::Unary(op, inner) if op.kind == UnOpKind::Not => {
+            extract_span_text(source, inner.span)
+        }
+        _ => {
+            let condition = extract_span_text(source, condition_expr.span);
+            format!("!({})", condition.trim())
+        }
     }
 }

--- a/crates/forge/src/mutation/mutators/require_mutator.rs
+++ b/crates/forge/src/mutation/mutators/require_mutator.rs
@@ -77,43 +77,32 @@ impl Mutator for RequireMutator {
         };
 
         let mut mutants = Vec::new();
-
-        // Mutation 1: require(x) -> require(true)
-        // This is security-critical: if tests pass, the condition was never actually needed
-        let mutated_true = format!("{func_name}(true{rest_args})");
-        mutants.push(Mutant {
-            span: expr.span,
-            mutation: MutationType::RequireCondition { mutated_call: mutated_true },
-            path: context.path.clone(),
-            original: original.clone(),
-            source_line: source_line.clone(),
-            line_number,
-            column_number,
-        });
-
-        let mutated_false = format!("{func_name}(false{rest_args})");
-        mutants.push(Mutant {
-            span: expr.span,
-            mutation: MutationType::RequireCondition { mutated_call: mutated_false },
-            path: context.path.clone(),
-            original: original.clone(),
-            source_line: source_line.clone(),
-            line_number,
-            column_number,
-        });
-
-        if !condition_text.trim().starts_with('!') {
-            let mutated_inverted = format!("{func_name}(!({condition_text}){rest_args})");
+        let mut push_mutant = |mutated_call: String, original: String, source_line: String| {
+            if mutated_call.trim() == original.trim() {
+                return;
+            }
             mutants.push(Mutant {
                 span: expr.span,
-                mutation: MutationType::RequireCondition { mutated_call: mutated_inverted },
+                mutation: MutationType::RequireCondition { mutated_call },
                 path: context.path.clone(),
                 original,
                 source_line,
                 line_number,
                 column_number,
             });
-        }
+        };
+
+        // Mutation 1: require(x) -> require(true)
+        // This is security-critical: if tests pass, the condition was never actually needed
+        let mutated_true = format!("{func_name}(true{rest_args})");
+        push_mutant(mutated_true, original.clone(), source_line.clone());
+
+        let mutated_false = format!("{func_name}(false{rest_args})");
+        push_mutant(mutated_false, original.clone(), source_line.clone());
+
+        let inverted_condition = invert_condition_text(&condition_text);
+        let mutated_inverted = format!("{func_name}({inverted_condition}{rest_args})");
+        push_mutant(mutated_inverted, original, source_line);
 
         Ok(mutants)
     }
@@ -144,4 +133,13 @@ fn extract_span_text(source: &str, span: solar::ast::Span) -> String {
     let lo = span.lo().0 as usize;
     let hi = span.hi().0 as usize;
     source.get(lo..hi).map(|s| s.to_string()).unwrap_or_default()
+}
+
+fn invert_condition_text(condition: &str) -> String {
+    let condition = condition.trim();
+    if let Some(stripped) = condition.strip_prefix('!') {
+        stripped.trim().to_string()
+    } else {
+        format!("!({condition})")
+    }
 }

--- a/crates/forge/src/mutation/mutators/tests/assignment_mutator_test.rs
+++ b/crates/forge/src/mutation/mutators/tests/assignment_mutator_test.rs
@@ -8,8 +8,10 @@ use crate::mutation::mutators::{
 mutator_tests!(AssignmentMutator;
     assign_lit:     "x = y"            => Some(vec!["0", "-y"]);
     assign_number:  "x = 123"          => Some(vec!["0", "-123"]);
+    assign_zero:    "x = 0"            => None;
     assign_true:    "x = true"         => Some(vec!["false"]);
     assign_false:   "x = false"        => Some(vec!["true"]);
     assign_declare: "uint256 x = 123"  => Some(vec!["0", "-123"]);
+    declare_zero:   "uint256 x = 0"    => None;
     non_assign:     "a = b + c"        => None;
 );

--- a/crates/forge/src/mutation/mutators/tests/mod.rs
+++ b/crates/forge/src/mutation/mutators/tests/mod.rs
@@ -3,6 +3,7 @@ mod assignment_mutator_test;
 mod binary_op_mutator_test;
 mod delete_expression_mutator_test;
 mod elim_delegate_mutator_test;
+mod require_mutator_test;
 mod unary_op_mutator_test;
 
 mod helper;

--- a/crates/forge/src/mutation/mutators/tests/require_mutator_test.rs
+++ b/crates/forge/src/mutation/mutators/tests/require_mutator_test.rs
@@ -8,4 +8,9 @@ mutator_tests!(RequireMutator;
         "require(paused, \"paused\")",
         "require(true, \"paused\")",
     ]);
+    require_not_composite: "require(!paused && isOwner, \"paused\")" => Some(vec![
+        "require(!(!paused && isOwner), \"paused\")",
+        "require(false, \"paused\")",
+        "require(true, \"paused\")",
+    ]);
 );

--- a/crates/forge/src/mutation/mutators/tests/require_mutator_test.rs
+++ b/crates/forge/src/mutation/mutators/tests/require_mutator_test.rs
@@ -1,0 +1,11 @@
+use crate::mutation::mutators::{require_mutator::RequireMutator, tests::helper::mutator_tests};
+
+mutator_tests!(RequireMutator;
+    require_true:   "require(true)" => Some(vec!["require(false)", "require(!(true))"]);
+    require_false:  "require(false)" => Some(vec!["require(true)", "require(!(false))"]);
+    require_not:    "require(!paused, \"paused\")" => Some(vec![
+        "require(false, \"paused\")",
+        "require(paused, \"paused\")",
+        "require(true, \"paused\")",
+    ]);
+);

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -834,16 +834,16 @@ MUTATION TESTING RESULTS
 ╭──────────┬───────────┬────────────╮
 │ Status   ┆ # Mutants ┆ % of Total │
 ╞══════════╪═══════════╪════════════╡
-│ Survived ┆ 3         ┆ 5.2%       │
+│ Survived ┆ 3         ┆ 5.0%       │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Killed   ┆ 46        ┆ 79.3%      │
+│ Killed   ┆ 48        ┆ 80.0%      │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Invalid  ┆ 7         ┆ 12.1%      │
+│ Invalid  ┆ 7         ┆ 11.7%      │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Skipped  ┆ 2         ┆ 3.4%       │
+│ Skipped  ┆ 2         ┆ 3.3%       │
 ╰──────────┴───────────┴────────────╯
 ...
-Mutation Score: 93.9% (46/49 mutants killed); [ELAPSED]
+Mutation Score: 94.1% (48/51 mutants killed); [ELAPSED]
 ...
 "#]]);
 });


### PR DESCRIPTION
Filters no-op assignment and require mutants, including unchanged `require(true)` and `zero-to-zero` assignment replacements.