### PR TITLE
fix(mutation): use source spans for unary targets

### DIFF
--- a/crates/forge/src/mutation/mutators/tests/unary_op_mutator_test.rs
+++ b/crates/forge/src/mutation/mutators/tests/unary_op_mutator_test.rs
@@ -8,5 +8,27 @@ mutator_tests!(UnaryOpMutator;
     post_inc:   "x++"       => Some(vec!["++x", "--x", "~x", "-x", "x--"]);
     post_dec:   "x--"       => Some(vec!["++x", "--x", "~x", "-x", "x++"]);
     bool_not:   "!x"        => Some(vec!["x"]);
+    indexed_post_inc: "arr[i]++" => Some(vec![
+        "++arr[i]",
+        "--arr[i]",
+        "~arr[i]",
+        "-arr[i]",
+        "arr[i]--",
+    ]);
+    member_post_inc: "boxValue.value++" => Some(vec![
+        "++boxValue.value",
+        "--boxValue.value",
+        "~boxValue.value",
+        "-boxValue.value",
+        "boxValue.value--",
+    ]);
+    chained_member_post_inc: "foo().bar++" => Some(vec![
+        "++foo().bar",
+        "--foo().bar",
+        "~foo().bar",
+        "-foo().bar",
+        "foo().bar--",
+    ]);
+    not_parenthesized_binary: "!(a == b)" => Some(vec!["(a == b)"]);
     non_unary:  "a = b + c" => None;
 );

--- a/crates/forge/src/mutation/mutators/unary_op_mutator.rs
+++ b/crates/forge/src/mutation/mutators/unary_op_mutator.rs
@@ -1,5 +1,5 @@
 use eyre::Result;
-use solar::ast::{ExprKind, LitKind, UnOpKind};
+use solar::ast::{ExprKind, Span, UnOpKind};
 
 use super::{MutationContext, Mutator};
 use crate::mutation::mutant::{Mutant, MutationType, UnaryOpMutated};
@@ -19,34 +19,21 @@ impl Mutator for UnaryOpMutator {
 
         let expr = context.expr.unwrap();
 
-        let target_kind;
         let op;
+        let target_span;
 
         match &expr.kind {
             ExprKind::Unary(un_op, target) => {
-                target_kind = &target.kind;
                 op = un_op.kind;
+                target_span = target.span;
             }
             _ => unreachable!(),
         };
 
-        let target_content = match target_kind {
-            ExprKind::Lit(lit, _) => match &lit.kind {
-                LitKind::Bool(val) => val.to_string(),
-                LitKind::Number(val) => val.to_string(),
-                _ => String::new(),
-            },
-            ExprKind::Ident(inner) => inner.to_string(),
-            ExprKind::Member(base, member) => {
-                match base.kind {
-                    ExprKind::Ident(inner) => {
-                        format!("{}.{}", inner.as_str(), member.as_str())
-                    } // @todo not supporting something like a.b[0]++
-                    _ => String::new(),
-                }
-            }
-            _ => String::new(),
-        };
+        let target_content = extract_span_text(context.source.unwrap_or(""), target_span);
+        if target_content.is_empty() {
+            return Ok(vec![]);
+        }
 
         let original = context.original_text();
         let source_line = context.source_line();
@@ -121,4 +108,10 @@ impl Mutator for UnaryOpMutator {
 
         false
     }
+}
+
+fn extract_span_text(source: &str, span: Span) -> String {
+    let lo = span.lo().0 as usize;
+    let hi = span.hi().0 as usize;
+    source.get(lo..hi).map(str::trim).unwrap_or_default().to_string()
 }


### PR DESCRIPTION
Uses source spans for unary operands so `indexed`/`member`/`call-chain`/`parenthesized` targets generate valid replacements.