### PR TITLE
fix(mutation): surface mutator generation errors

### DIFF
--- a/crates/forge/src/mutation/mod.rs
+++ b/crates/forge/src/mutation/mod.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashSet, hash_map::DefaultHasher},
     hash::{Hash, Hasher},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
@@ -16,6 +16,7 @@ pub use crate::mutation::{
     runner::run_mutations_parallel_with_progress,
 };
 use eyre::eyre;
+use foundry_common::sh_warn;
 use serde::{Deserialize, Serialize};
 use solar::{
     ast::{
@@ -25,6 +26,10 @@ use solar::{
     },
     parse::Parser,
 };
+
+fn failed_to_parse(path: &Path) -> eyre::Report {
+    eyre!("failed to parse {}", path.display())
+}
 
 #[derive(Clone, Copy)]
 enum CacheKind<'a> {
@@ -475,11 +480,11 @@ impl MutationHandler {
                 Parser::from_lazy_source_code(&sess, &arena, FileName::from(path.clone()), || {
                     Ok((*target_content).clone())
                 })
-                .map_err(|_e| eyre!("failed to parse {}", path.display()))?;
+                .map_err(|_e| failed_to_parse(path))?;
 
             let ast = parser.parse_file().map_err(|e| {
                 e.emit();
-                eyre!("failed to parse {}", path.display())
+                failed_to_parse(path)
             })?;
 
             let operators = self.config.mutation.enabled_operators();
@@ -492,8 +497,8 @@ impl MutationHandler {
             }
             let _ = mutant_visitor.visit_source_unit(&ast);
 
-            if let Some(err) = mutant_visitor.errors.into_iter().next() {
-                return Err(err);
+            for err in mutant_visitor.take_errors() {
+                let _ = sh_warn!("{err:?}");
             }
 
             Ok(mutant_visitor.mutation_to_conduct)

--- a/crates/forge/src/mutation/mod.rs
+++ b/crates/forge/src/mutation/mod.rs
@@ -15,6 +15,7 @@ pub use crate::mutation::{
     reporter::MutationReporter,
     runner::run_mutations_parallel_with_progress,
 };
+use eyre::eyre;
 use serde::{Deserialize, Serialize};
 use solar::{
     ast::{
@@ -468,14 +469,18 @@ impl MutationHandler {
 
         let contract_filter = self.contract_filter.clone();
 
-        let result = sess.enter(|| -> solar::interface::Result<Vec<Mutant>> {
+        let result = sess.enter(|| -> eyre::Result<Vec<Mutant>> {
             let arena = solar::ast::Arena::new();
             let mut parser =
                 Parser::from_lazy_source_code(&sess, &arena, FileName::from(path.clone()), || {
                     Ok((*target_content).clone())
-                })?;
+                })
+                .map_err(|_e| eyre!("failed to parse {}", path.display()))?;
 
-            let ast = parser.parse_file().map_err(|e| e.emit())?;
+            let ast = parser.parse_file().map_err(|e| {
+                e.emit();
+                eyre!("failed to parse {}", path.display())
+            })?;
 
             let operators = self.config.mutation.enabled_operators();
             let mut mutant_visitor = MutantVisitor::with_operators(path.clone(), &operators)
@@ -487,6 +492,10 @@ impl MutationHandler {
             }
             let _ = mutant_visitor.visit_source_unit(&ast);
 
+            if let Some(err) = mutant_visitor.errors.into_iter().next() {
+                return Err(err);
+            }
+
             Ok(mutant_visitor.mutation_to_conduct)
         });
 
@@ -495,9 +504,7 @@ impl MutationHandler {
                 self.mutations.extend(mutations);
                 Ok(())
             }
-            Err(_) => {
-                eyre::bail!("failed to parse {}", path.display());
-            }
+            Err(err) => Err(err),
         }
     }
 

--- a/crates/forge/src/mutation/mutators/mutator_registry.rs
+++ b/crates/forge/src/mutation/mutators/mutator_registry.rs
@@ -1,4 +1,5 @@
 use crate::mutation::mutant::Mutant;
+use eyre::Result;
 use foundry_config::MutatorType;
 
 use super::{
@@ -57,12 +58,44 @@ impl MutatorRegistry {
     }
 
     /// Find all applicable mutators for a given context and return the corresponding mutations
-    pub fn generate_mutations(&self, context: &MutationContext<'_>) -> Vec<Mutant> {
-        self.mutators
-            .iter()
-            .filter(|mutator| mutator.is_applicable(context))
-            .filter_map(|mutator| mutator.generate_mutants(context).ok())
-            .flatten()
-            .collect()
+    pub fn generate_mutations(&self, context: &MutationContext<'_>) -> Result<Vec<Mutant>> {
+        let mut mutations = Vec::new();
+        for mutator in self.mutators.iter().filter(|mutator| mutator.is_applicable(context)) {
+            mutations.extend(mutator.generate_mutants(context)?);
+        }
+        Ok(mutations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use eyre::eyre;
+    use solar::ast::Span;
+
+    use super::*;
+
+    struct FailingMutator;
+
+    impl Mutator for FailingMutator {
+        fn generate_mutants(&self, _ctxt: &MutationContext<'_>) -> Result<Vec<Mutant>> {
+            Err(eyre!("synthetic mutator failure"))
+        }
+
+        fn is_applicable(&self, _ctxt: &MutationContext<'_>) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn generate_mutations_surfaces_mutator_errors() {
+        let registry = MutatorRegistry::new_with_mutators(vec![Box::new(FailingMutator)]);
+        let context = MutationContext::builder()
+            .with_path("test.sol".into())
+            .with_span(Span::DUMMY)
+            .build()
+            .unwrap();
+
+        let err = registry.generate_mutations(&context).unwrap_err();
+        assert!(err.to_string().contains("synthetic mutator failure"));
     }
 }

--- a/crates/forge/src/mutation/mutators/mutator_registry.rs
+++ b/crates/forge/src/mutation/mutators/mutator_registry.rs
@@ -1,5 +1,5 @@
 use crate::mutation::mutant::Mutant;
-use eyre::Result;
+use eyre::Report;
 use foundry_config::MutatorType;
 
 use super::{
@@ -10,6 +10,11 @@ use super::{
 /// Registry of all available mutators (ie implementing the Mutator trait)
 pub struct MutatorRegistry {
     mutators: Vec<Box<dyn Mutator>>,
+}
+
+pub struct MutationGenerationResult {
+    pub mutations: Vec<Mutant>,
+    pub errors: Vec<Report>,
 }
 
 impl MutatorRegistry {
@@ -58,18 +63,23 @@ impl MutatorRegistry {
     }
 
     /// Find all applicable mutators for a given context and return the corresponding mutations
-    pub fn generate_mutations(&self, context: &MutationContext<'_>) -> Result<Vec<Mutant>> {
+    /// and any mutator errors encountered while generating them.
+    pub fn generate_mutations(&self, context: &MutationContext<'_>) -> MutationGenerationResult {
         let mut mutations = Vec::new();
+        let mut errors = Vec::new();
         for mutator in self.mutators.iter().filter(|mutator| mutator.is_applicable(context)) {
-            mutations.extend(mutator.generate_mutants(context)?);
+            match mutator.generate_mutants(context) {
+                Ok(generated) => mutations.extend(generated),
+                Err(err) => errors.push(err),
+            }
         }
-        Ok(mutations)
+        MutationGenerationResult { mutations, errors }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use eyre::eyre;
+    use eyre::{Result, eyre};
     use solar::ast::Span;
 
     use super::*;
@@ -87,7 +97,7 @@ mod tests {
     }
 
     #[test]
-    fn generate_mutations_surfaces_mutator_errors() {
+    fn generate_mutations_collects_mutator_errors() {
         let registry = MutatorRegistry::new_with_mutators(vec![Box::new(FailingMutator)]);
         let context = MutationContext::builder()
             .with_path("test.sol".into())
@@ -95,7 +105,9 @@ mod tests {
             .build()
             .unwrap();
 
-        let err = registry.generate_mutations(&context).unwrap_err();
+        let result = registry.generate_mutations(&context);
+        assert!(result.mutations.is_empty());
+        let err = result.errors.into_iter().next().unwrap();
         assert!(err.to_string().contains("synthetic mutator failure"));
     }
 }

--- a/crates/forge/src/mutation/visitor.rs
+++ b/crates/forge/src/mutation/visitor.rs
@@ -1,5 +1,6 @@
 use std::{ops::ControlFlow, path::PathBuf};
 
+use eyre::Report;
 use solar::ast::{Expr, ItemContract, VariableDefinition, visit::Visit, yul};
 
 #[cfg(test)]
@@ -20,6 +21,7 @@ pub enum AssignVarTypes {
 #[allow(clippy::type_complexity)]
 pub struct MutantVisitor<'src> {
     pub mutation_to_conduct: Vec<Mutant>,
+    pub errors: Vec<Report>,
     pub mutator_registry: MutatorRegistry,
     pub path: PathBuf,
     pub source: Option<&'src str>,
@@ -38,6 +40,7 @@ impl<'src> MutantVisitor<'src> {
     pub fn with_operators(path: PathBuf, operators: &[MutatorType]) -> Self {
         Self {
             mutation_to_conduct: Vec::new(),
+            errors: Vec::new(),
             mutator_registry: MutatorRegistry::from_enabled(operators),
             path,
             source: None,
@@ -51,6 +54,7 @@ impl<'src> MutantVisitor<'src> {
     pub fn default(path: PathBuf) -> Self {
         Self {
             mutation_to_conduct: Vec::new(),
+            errors: Vec::new(),
             mutator_registry: MutatorRegistry::default(),
             path,
             source: None,
@@ -64,6 +68,7 @@ impl<'src> MutantVisitor<'src> {
     pub fn new_with_mutators(path: PathBuf, mutators: Vec<Box<dyn Mutator>>) -> Self {
         Self {
             mutation_to_conduct: Vec::new(),
+            errors: Vec::new(),
             mutator_registry: MutatorRegistry::new_with_mutators(mutators),
             path,
             source: None,
@@ -86,6 +91,20 @@ impl<'src> MutantVisitor<'src> {
     {
         self.contract_filter = Some(Box::new(filter));
         self
+    }
+
+    fn collect_mutations(&mut self, context: &MutationContext<'_>) {
+        match self.mutator_registry.generate_mutations(context) {
+            Ok(mutations) => self.mutation_to_conduct.extend(mutations),
+            Err(err) => {
+                self.errors.push(
+                    err.wrap_err(format!(
+                        "failed to generate mutations for {}",
+                        self.path.display()
+                    )),
+                );
+            }
+        }
     }
 }
 
@@ -132,7 +151,7 @@ impl<'ast> Visit<'ast> for MutantVisitor<'ast> {
             .build()
             .expect("MutationContext requires both path and span for variable definition");
 
-        self.mutation_to_conduct.extend(self.mutator_registry.generate_mutations(&context));
+        self.collect_mutations(&context);
         self.walk_variable_definition(var)
     }
 
@@ -154,7 +173,7 @@ impl<'ast> Visit<'ast> for MutantVisitor<'ast> {
         let context =
             builder.build().expect("MutationContext requires both path and span for expression");
 
-        self.mutation_to_conduct.extend(self.mutator_registry.generate_mutations(&context));
+        self.collect_mutations(&context);
         self.walk_expr(expr)
     }
 
@@ -177,7 +196,7 @@ impl<'ast> Visit<'ast> for MutantVisitor<'ast> {
             .build()
             .expect("MutationContext requires both path and span for yul expression");
 
-        self.mutation_to_conduct.extend(self.mutator_registry.generate_mutations(&context));
+        self.collect_mutations(&context);
         self.walk_yul_expr(expr)
     }
 }

--- a/crates/forge/src/mutation/visitor.rs
+++ b/crates/forge/src/mutation/visitor.rs
@@ -21,7 +21,7 @@ pub enum AssignVarTypes {
 #[allow(clippy::type_complexity)]
 pub struct MutantVisitor<'src> {
     pub mutation_to_conduct: Vec<Mutant>,
-    pub errors: Vec<Report>,
+    errors: Vec<Report>,
     pub mutator_registry: MutatorRegistry,
     pub path: PathBuf,
     pub source: Option<&'src str>,
@@ -93,17 +93,21 @@ impl<'src> MutantVisitor<'src> {
         self
     }
 
+    pub fn take_errors(&mut self) -> Vec<Report> {
+        std::mem::take(&mut self.errors)
+    }
+
     fn collect_mutations(&mut self, context: &MutationContext<'_>) {
-        match self.mutator_registry.generate_mutations(context) {
-            Ok(mutations) => self.mutation_to_conduct.extend(mutations),
-            Err(err) => {
-                self.errors.push(
-                    err.wrap_err(format!(
-                        "failed to generate mutations for {}",
-                        self.path.display()
-                    )),
-                );
-            }
+        let result = self.mutator_registry.generate_mutations(context);
+        self.mutation_to_conduct.extend(result.mutations);
+
+        for err in result.errors {
+            self.errors.push(err.wrap_err(format!(
+                "failed to generate mutations for {}:{}:{}",
+                self.path.display(),
+                context.line_number(),
+                context.column_number()
+            )));
         }
     }
 }
@@ -198,5 +202,89 @@ impl<'ast> Visit<'ast> for MutantVisitor<'ast> {
 
         self.collect_mutations(&context);
         self.walk_yul_expr(expr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use eyre::{Result, eyre};
+    use solar::{
+        ast::{Arena, interface::source_map::FileName},
+        parse::Parser,
+    };
+
+    use super::*;
+    use crate::mutation::{Session, mutant::MutationType};
+
+    struct FailingExprMutator;
+
+    impl Mutator for FailingExprMutator {
+        fn generate_mutants(&self, _ctxt: &MutationContext<'_>) -> Result<Vec<Mutant>> {
+            Err(eyre!("synthetic visitor failure"))
+        }
+
+        fn is_applicable(&self, ctxt: &MutationContext<'_>) -> bool {
+            ctxt.expr.is_some()
+        }
+    }
+
+    struct PassingExprMutator;
+
+    impl Mutator for PassingExprMutator {
+        fn generate_mutants(&self, ctxt: &MutationContext<'_>) -> Result<Vec<Mutant>> {
+            Ok(vec![Mutant {
+                path: ctxt.path.clone(),
+                span: ctxt.span,
+                mutation: MutationType::DeleteExpression,
+                original: ctxt.original_text(),
+                source_line: ctxt.source_line(),
+                line_number: ctxt.line_number(),
+                column_number: ctxt.column_number(),
+            }])
+        }
+
+        fn is_applicable(&self, ctxt: &MutationContext<'_>) -> bool {
+            ctxt.expr.is_some()
+        }
+    }
+
+    #[test]
+    fn visitor_collects_mutations_and_surfaces_mutator_errors() {
+        let source = "\
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Test {
+    function test() public {
+        uint256 x = 1 + 2;
+    }
+}
+";
+        let path = PathBuf::from("test.sol");
+        let sess = Session::builder().with_silent_emitter(None).build();
+
+        sess.enter(|| {
+            let arena = Arena::new();
+            let mut parser =
+                Parser::from_lazy_source_code(&sess, &arena, FileName::Real(path.clone()), || {
+                    Ok(source.to_string())
+                })
+                .unwrap();
+            let ast = parser.parse_file().map_err(|e| e.emit()).unwrap();
+            let mut visitor = MutantVisitor::new_with_mutators(
+                path,
+                vec![Box::new(FailingExprMutator), Box::new(PassingExprMutator)],
+            )
+            .with_source(source);
+
+            let _ = visitor.visit_source_unit(&ast);
+            let errors = visitor.take_errors();
+
+            assert!(!visitor.mutation_to_conduct.is_empty());
+            assert!(!errors.is_empty());
+
+            let err = format!("{:?}", errors[0]);
+            assert!(err.contains("failed to generate mutations for test.sol:"));
+            assert!(err.contains("synthetic visitor failure"));
+        });
     }
 }


### PR DESCRIPTION
Changes `MutatorRegistry::generate_mutations` to return `Result` and threads mutator failures through AST generation instead of dropping them.