### PR TITLE
feat(verify): migrate forge verify-contract to stdout/stderr contract

### DIFF
--- a/crates/forge/tests/cli/utils.rs
+++ b/crates/forge/tests/cli/utils.rs
@@ -183,12 +183,21 @@ pub fn parse_deployed_address(out: &str) -> Option<String> {
 }
 
 pub fn parse_verification_guid(out: &str) -> Option<String> {
-    for line in out.lines() {
-        if line.contains("GUID") {
-            return Some(line.replace("GUID:", "").replace('`', "").trim().to_string());
-        }
+    let mut lines = out.lines().map(str::trim).filter(|line| !line.is_empty());
+    let line = lines.next()?;
+    if lines.next().is_some() {
+        return None;
     }
-    None
+    let mut parts = line.split('\t').map(str::trim);
+    let id = parts.next()?;
+    let url = parts.next()?;
+    if parts.next().is_some() || id.is_empty() || url.is_empty() {
+        return None;
+    }
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        return None;
+    }
+    Some(id.to_string())
 }
 
 /// Generates a string containing the code of a Solidity contract.

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -74,16 +74,13 @@ fn parse_verification_result(cmd: &mut TestCommand, retries: u32) -> eyre::Resul
     // Give Etherscan some time to verify the contract.
     Retry::new(retries, Duration::from_secs(30)).run(|| -> eyre::Result<()> {
         let output = cmd.execute();
-        let out = String::from_utf8_lossy(&output.stdout);
-        test_debug!("{out}");
-        if out.contains("Contract successfully verified") {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        test_debug!("stdout: {stdout}\nstderr: {stderr}");
+        if stderr.contains("Contract successfully verified") {
             return Ok(());
         }
-        eyre::bail!(
-            "Failed to get verification, stdout: {}, stderr: {}",
-            out,
-            String::from_utf8_lossy(&output.stderr)
-        )
+        eyre::bail!("Failed to get verification, stdout: {stdout}, stderr: {stderr}")
     })
 }
 
@@ -232,15 +229,14 @@ fn create_verify_on_chain(info: Option<EnvExternalities>, prj: TestProject, mut 
         add_single_verify_target_file(&prj);
 
         let contract_path = "src/Verify.sol:Verify";
-        let output = cmd
+        let assert = cmd
             .arg("create")
             .args(info.create_args())
             .args([contract_path, "--etherscan-api-key", info.etherscan.as_str(), "--verify"])
-            .assert_success()
-            .get_output()
-            .stdout_lossy();
-
-        assert!(output.contains("Contract successfully verified"), "{}", output);
+            .assert_success();
+        let output = assert.get_output();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("Contract successfully verified"), "stderr: {stderr}");
     }
 }
 
@@ -330,6 +326,7 @@ forgetest_init!(can_validate_verifier_settings, |prj, cmd| {
         ])
         .assert_failure()
         .stderr_eq(str![[r#"
+Start verifying contract `0x19b248616E4964f43F611b5871CE1250f360E9d3` deployed on 4202
 Error: No verifier URL specified for verifier blockscout
 
 "#]]);
@@ -347,15 +344,29 @@ Error: No verifier URL specified for verifier blockscout
         ])
         .assert_failure()
         .stderr_eq(str![[r#"
+Start verifying contract `0x19b248616E4964f43F611b5871CE1250f360E9d3` deployed on 4202
 Error: No known Etherscan API URL for chain `4202`. To fix this, please:
 1. Specify a `url` when using Etherscan verifier
 2. Verify the chain `4202` is correct
 
 "#]]);
 
-    cmd.forge_fuse().args(["verify-contract", "--rpc-url", "https://rpc.sepolia-api.lisk.com", "--verifier", "blockscout", "--verifier-url", "https://sepolia-blockscout.lisk.com/api", "0x19b248616E4964f43F611b5871CE1250f360E9d3", "src/Counter.sol:Counter"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse()
+        .args([
+            "verify-contract",
+            "--rpc-url",
+            "https://rpc.sepolia-api.lisk.com",
+            "--verifier",
+            "blockscout",
+            "--verifier-url",
+            "https://sepolia-blockscout.lisk.com/api",
+            "0x19b248616E4964f43F611b5871CE1250f360E9d3",
+            "src/Counter.sol:Counter",
+        ])
+        .assert_success()
+        .stdout_eq(str![""])
+        .stderr_eq(str![[r#"
 Start verifying contract `0x19b248616E4964f43F611b5871CE1250f360E9d3` deployed on 4202
-
 Contract [src/Counter.sol:Counter] "0x19b248616E4964f43F611b5871CE1250f360E9d3" is already verified. Skipping verification.
 
 "#]]);

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -69,8 +69,8 @@ impl VerificationProvider for EtherscanVerificationProvider {
         if !args.skip_is_verified_check
             && self.is_contract_verified(&etherscan, &verify_args).await?
         {
-            sh_println!(
-                "\nContract [{}] {:?} is already verified. Skipping verification.",
+            sh_status!(
+                "Contract [{}] {:?} is already verified. Skipping verification.",
                 verify_args.contract_name,
                 verify_args.address.to_checksum(None)
             )?;
@@ -84,8 +84,8 @@ impl VerificationProvider for EtherscanVerificationProvider {
             .retry
             .into_retry()
             .run_async(|| async {
-                sh_println!(
-                    "\nSubmitting verification for [{}] {}.",
+                sh_status!(
+                    "Submitting verification for [{}] {}.",
                     verify_args.contract_name,
                     verify_args.address
                 )?;
@@ -131,12 +131,14 @@ impl VerificationProvider for EtherscanVerificationProvider {
             .await?;
 
         if let Some(resp) = resp {
-            sh_println!(
+            let url = etherscan.address_url(args.address);
+            sh_status!(
                 "Submitted contract for verification:\n\tResponse: `{}`\n\tGUID: `{}`\n\tURL: {}",
                 resp.message,
                 resp.result,
-                etherscan.address_url(args.address)
+                url
             )?;
+            sh_println!("{}\t{}", resp.result, url)?;
 
             if args.watch {
                 let check_args = VerifyCheckArgs {
@@ -148,7 +150,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
                 return self.check(check_args).await;
             }
         } else {
-            sh_println!("Contract source code already verified")?;
+            sh_status!("Contract source code already verified")?;
         }
 
         Ok(())
@@ -169,7 +171,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
 
                 trace!(?resp, "Received verification response");
 
-                let _ = sh_println!(
+                let _ = sh_status!(
                     "Contract verification status:\nResponse: `{}`\nDetails: `{}`",
                     resp.message,
                     resp.result
@@ -186,7 +188,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
                 }
 
                 if resp.result == "Already Verified" {
-                    let _ = sh_println!("Contract source code already verified");
+                    let _ = sh_status!("Contract source code already verified");
                     return Ok(());
                 }
 
@@ -199,7 +201,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
                 }
 
                 if resp.result == "Pass - Verified" {
-                    let _ = sh_println!("Contract successfully verified");
+                    let _ = sh_status!("Contract successfully verified");
                 }
 
                 Ok(())
@@ -450,7 +452,7 @@ impl EtherscanVerificationProvider {
         if maybe_creation_code.starts_with(bytecode) {
             let constructor_args = &maybe_creation_code[bytecode.len()..];
             let constructor_args = hex::encode(constructor_args);
-            sh_println!("Identified constructor arguments: {constructor_args}")?;
+            sh_status!("Identified constructor arguments: {constructor_args}")?;
             Ok(constructor_args)
         } else {
             eyre::bail!("Local bytecode doesn't match on-chain bytecode")

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -196,7 +196,7 @@ impl VerificationProviderType {
 
         // 1. Explicit `--verifier sourcify` always wins over ETHERSCAN_API_KEY.
         if is_explicit && self.is_sourcify() {
-            sh_println!(
+            sh_status!(
                 "Attempting to verify on Sourcify. Pass the --etherscan-api-key <API_KEY> to verify on Etherscan, \
             or use the --verifier flag to verify on another provider."
             )?;
@@ -251,7 +251,7 @@ impl VerificationProviderType {
                 }
                 // Fall through to branch 5 (Sourcify default) below.
             } else {
-                sh_eprintln!(
+                sh_status!(
                     "ETHERSCAN_API_KEY is set, defaulting to Etherscan verifier. \
                      Unset it or pass `--verifier sourcify` (or another provider) to override."
                 )?;
@@ -261,7 +261,7 @@ impl VerificationProviderType {
 
         // 5. No key, no explicit verifier: default to Sourcify.
         if self.is_sourcify() {
-            sh_println!(
+            sh_status!(
                 "Attempting to verify on Sourcify. Pass the --etherscan-api-key <API_KEY> to verify on Etherscan, \
             or use the --verifier flag to verify on another provider."
             )?;

--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -39,8 +39,8 @@ impl VerificationProvider for SourcifyVerificationProvider {
         let chain_id = args.etherscan.chain.unwrap_or_default().id();
 
         if !args.skip_is_verified_check && self.is_contract_verified(&args).await? {
-            sh_println!(
-                "\nContract [{}] {:?} is already verified. Skipping verification.",
+            sh_status!(
+                "Contract [{}] {:?} is already verified. Skipping verification.",
                 context.target_name,
                 args.address.to_string()
             )?;
@@ -59,8 +59,8 @@ impl VerificationProvider for SourcifyVerificationProvider {
             .into_retry()
             .run_async(|| {
                 async {
-                    sh_println!(
-                        "\nSubmitting verification for [{}] {:?}.",
+                    sh_status!(
+                        "Submitting verification for [{}] {:?}.",
                         context.target_name,
                         args.address.to_string()
                     )?;
@@ -74,7 +74,7 @@ impl VerificationProvider for SourcifyVerificationProvider {
                     let status = response.status();
                     match status {
                         StatusCode::CONFLICT => {
-                            sh_println!("Contract source code already fully verified")?;
+                            sh_status!("Contract source code already fully verified")?;
                             Ok(None)
                         }
                         StatusCode::ACCEPTED => {
@@ -104,11 +104,12 @@ impl VerificationProvider for SourcifyVerificationProvider {
                 args.verifier.verifier_url.as_deref(),
                 resp.verification_id.clone(),
             );
-            sh_println!(
+            sh_status!(
                 "Submitted contract for verification:\n\tVerification Job ID: `{}`\n\tURL: {}",
                 resp.verification_id,
                 job_url
             )?;
+            sh_println!("{}\t{}", resp.verification_id, job_url)?;
 
             if args.watch {
                 let check_args = VerifyCheckArgs {
@@ -161,7 +162,7 @@ impl VerificationProvider for SourcifyVerificationProvider {
 
                 if let Some(error) = job_response.error {
                     if error.custom_code == "already_verified" {
-                        let _ = sh_println!("Contract source code already verified");
+                        let _ = sh_status!("Contract source code already verified");
                         return Ok(());
                     }
 
@@ -173,7 +174,7 @@ impl VerificationProvider for SourcifyVerificationProvider {
                 }
 
                 if let Some(contract_status) = job_response.contract.match_status {
-                    let _ = sh_println!(
+                    let _ = sh_status!(
                         "Contract successfully verified:\nStatus: `{}`",
                         contract_status,
                     );

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -327,20 +327,20 @@ impl VerifyArgs {
         }
 
         let verifier_url = self.verifier.verifier_url.clone();
-        sh_println!("Start verifying contract `{}` deployed on {chain}", self.address)?;
+        sh_status!("Start verifying contract `{}` deployed on {chain}", self.address)?;
         if let Some(version) = &self.evm_version {
-            sh_println!("EVM version: {version}")?;
+            sh_status!("EVM version: {version}")?;
         }
         if let Some(version) = &self.compiler_version {
-            sh_println!("Compiler version: {version}")?;
+            sh_status!("Compiler version: {version}")?;
         }
         if let Some(optimizations) = &self.num_of_optimizations {
-            sh_println!("Optimizations:    {optimizations}")?
+            sh_status!("Optimizations:    {optimizations}")?
         }
         if let Some(args) = &self.constructor_args
             && !args.is_empty()
         {
-            sh_println!("Constructor args: {args}")?
+            sh_status!("Constructor args: {args}")?
         }
         let using_etherscan = resolved.is_etherscan();
         resolved
@@ -492,7 +492,7 @@ impl VerifyArgs {
             let provider = utils::get_provider(&config)?;
             let code = provider.get_code_at(self.address).await?;
 
-            let output = ProjectCompiler::new().compile(&project)?;
+            let output = ProjectCompiler::new().quiet(true).compile(&project)?;
             let contracts = ContractsByArtifact::new(
                 output.artifact_ids().map(|(id, artifact)| (id, artifact.clone().into())),
             );
@@ -557,10 +557,7 @@ impl_figment_convert_cast!(VerifyCheckArgs);
 impl VerifyCheckArgs {
     /// Run the verify command to submit the contract's source code for verification on etherscan
     pub async fn run(self) -> Result<()> {
-        sh_println!(
-            "Checking verification status on {}",
-            self.etherscan.chain.unwrap_or_default()
-        )?;
+        sh_status!("Checking verification status on {}", self.etherscan.chain.unwrap_or_default())?;
         self.verifier
             .effective_type()
             .client(

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -145,7 +145,7 @@ Each row's status is one of:
 | `forge soldeer`        | (empty)                                              | n/a                                        | todo   |
 | `forge remappings`     | One remapping per line                               | n/a                                        | migrated |
 | `forge compiler`       | Compiler info                                        | JSON                                       | migrated |
-| `forge verify-contract`| Verification GUID / URL                              | JSON                                       | todo   |
+| `forge verify-contract`| `<guid-or-job-id>\t<url>` on submission; empty if already verified | n/a                              | migrated |
 
 ### `anvil`, `chisel`, `script`
 


### PR DESCRIPTION
Migrates `forge verify-contract` to the stdout/stderr contract in `docs/dev/output-channels.md`.

- Submission: stdout is exactly `<guid-or-job-id>\t<url>` (Etherscan and Sourcify).
- Already-verified paths: stdout empty; prose goes to stderr.
- All status/progress prose (`Start verifying contract`, `EVM version`, `Compiler version`, `Optimizations`, `Constructor args`, `Checking verification status`, submitted/response/URL/success messages, identified constructor args, "Attempting to verify on Sourcify", Etherscan-default notice) moved to stderr via `sh_status!`.
- `--show-standard-json-input` keeps its JSON output on stdout (primary data).
- Autodetect compile path uses `ProjectCompiler::new().quiet(true)` so compiler chatter doesn't leak to stdout.

Test helper `parse_verification_guid` updated to enforce the new stdout contract (single `<id>\t<url>` line, http(s) URL); `parse_verification_result` and `can_validate_verifier_settings` updated to read prose from stderr.

Part of OSS-224