### PR TITLE
feat(forge): migrate forge install to stdout/stderr contract

### DIFF
--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -103,8 +103,7 @@ impl DependencyInstallOpts {
     pub async fn install_missing_dependencies(self, config: &mut Config) -> bool {
         let lib = config.install_lib_dir();
         if self.git(config).has_missing_dependencies(Some(lib)).unwrap_or(false) {
-            // The extra newline is needed, otherwise the compiler output will overwrite the message
-            let _ = sh_println!("Missing dependencies found. Installing now...\n");
+            let _ = sh_status!("Missing dependencies found. Installing now...");
 
             if self.install(config, Vec::new()).await.is_err() {
                 let _ =
@@ -145,7 +144,7 @@ impl DependencyInstallOpts {
             let root = Git::root_of(git.root)?;
             match git.has_submodules(Some(&root)) {
                 Ok(true) => {
-                    sh_println!("Updating dependencies in {}", libs.display())?;
+                    sh_status!("Updating dependencies in {}", libs.display())?;
 
                     // recursively fetch all submodules (without fetching latest)
                     git.submodule_update(false, false, false, true, Some(&libs))?;
@@ -176,7 +175,7 @@ impl DependencyInstallOpts {
             let rel_path = path
                 .strip_prefix(git.root)
                 .wrap_err("Library directory is not relative to the repository root")?;
-            sh_println!(
+            sh_status!(
                 "Installing {} in {} (url: {}, tag: {})",
                 dep.name,
                 path.display(),
@@ -269,7 +268,7 @@ impl DependencyInstallOpts {
                     msg.push_str(tag.as_str());
                 }
             }
-            sh_println!("{msg}")?;
+            sh_status!("{msg}")?;
 
             // Check if the dependency has soldeer.lock and install soldeer dependencies
             if let Err(e) = install_soldeer_deps_if_needed(&path).await {
@@ -296,7 +295,7 @@ async fn install_soldeer_deps_if_needed(dep_path: &Path) -> Result<()> {
     let soldeer_lock = dep_path.join("soldeer.lock");
 
     if soldeer_lock.exists() {
-        sh_println!("    Found soldeer.lock, installing soldeer dependencies...")?;
+        sh_status!("    Found soldeer.lock, installing soldeer dependencies...")?;
 
         // Change to the dependency directory and run soldeer install
         let original_dir = std::env::current_dir()?;
@@ -315,7 +314,7 @@ async fn install_soldeer_deps_if_needed(dep_path: &Path) -> Result<()> {
         std::env::set_current_dir(original_dir)?;
 
         result.map_err(|e| eyre::eyre!("Failed to run soldeer install: {e}"))?;
-        sh_println!("    Soldeer dependencies installed successfully")?;
+        sh_status!("    Soldeer dependencies installed successfully")?;
     }
 
     Ok(())
@@ -559,9 +558,9 @@ impl Installer<'_> {
 
         // multiple candidates, ask the user to choose one or skip
         candidates.insert(0, String::from("SKIP AND USE ORIGINAL TAG"));
-        sh_println!("There are multiple matching tags:")?;
+        sh_status!("There are multiple matching tags:")?;
         for (i, candidate) in candidates.iter().enumerate() {
-            sh_println!("[{i}] {candidate}")?;
+            sh_status!("[{i}] {candidate}")?;
         }
 
         let n_candidates = candidates.len();
@@ -576,7 +575,7 @@ impl Installer<'_> {
                 Ok(0) => return Ok(tag.into()),
                 Ok(i) if (1..=n_candidates).contains(&i) => {
                     let c = &candidates[i];
-                    sh_println!("[{i}] {c} selected")?;
+                    sh_status!("[{i}] {c} selected")?;
                     return Ok(c.clone());
                 }
                 _ => {}
@@ -621,9 +620,9 @@ impl Installer<'_> {
 
         // multiple candidates, ask the user to choose one or skip
         candidates.insert(0, format!("{tag} (original branch)"));
-        sh_println!("There are multiple matching branches:")?;
+        sh_status!("There are multiple matching branches:")?;
         for (i, candidate) in candidates.iter().enumerate() {
-            sh_println!("[{i}] {candidate}")?;
+            sh_status!("[{i}] {candidate}")?;
         }
 
         let n_candidates = candidates.len();
@@ -635,7 +634,7 @@ impl Installer<'_> {
 
         // default selection, return None
         if input.is_empty() {
-            sh_println!("Canceled branch matching")?;
+            sh_status!("Canceled branch matching")?;
             return Ok(None);
         }
 
@@ -644,7 +643,7 @@ impl Installer<'_> {
             Ok(0) => Ok(Some(tag.into())),
             Ok(i) if (1..=n_candidates).contains(&i) => {
                 let c = &candidates[i];
-                sh_println!("[{i}] {c} selected")?;
+                sh_status!("[{i}] {c} selected")?;
                 Ok(Some(c.clone()))
             }
             _ => Ok(None),

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -307,21 +307,17 @@ forgetest!(can_init_repo_with_config, |prj, cmd| {
     let foundry_toml = prj.root().join(Config::FILE_NAME);
     assert!(!foundry_toml.exists());
 
-    cmd.args(["init", "--force"])
-        .arg(prj.root())
-        .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
-        .stderr_eq(str![[r#"
+    cmd.args(["init", "--force"]).arg(prj.root()).assert_success().stdout_eq(str![""]).stderr_eq(
+        str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
-"#]]);
+"#]],
+    );
 
     let s = read_string(&foundry_toml);
     let _config: BasicConfig = parse_with_profile(&s).unwrap().unwrap().1;
@@ -359,21 +355,16 @@ ignore them in the `.gitignore` file.
 forgetest!(can_init_no_git, |prj, cmd| {
     prj.wipe();
 
-    cmd.arg("init")
-        .arg(prj.root())
-        .arg("--no-git")
-        .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
-        .stderr_eq(str![[r#"
+    cmd.arg("init").arg(prj.root()).arg("--no-git").assert_success().stdout_eq(str![""]).stderr_eq(
+        str![[r#"
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
-"#]]);
+"#]],
+    );
     prj.assert_config_exists();
 
     assert!(!prj.root().join(".git").exists());
@@ -389,14 +380,12 @@ forgetest!(can_init_with_no_commit, |prj, cmd| {
         .arg(prj.root())
         .arg("--no-commit")
         .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
+        .stdout_eq(str![""])
         .stderr_eq(str![[r#"
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
 "#]]);
@@ -476,17 +465,12 @@ Run with the `--force` flag to initialize regardless.
 
 "#]]);
 
-    cmd.arg("--force")
-        .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
-        .stderr_eq(str![[r#"
+    cmd.arg("--force").assert_success().stdout_eq(str![""]).stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
 "#]]);
@@ -516,17 +500,12 @@ Run with the `--force` flag to initialize regardless.
 
 "#]]);
 
-    cmd.arg("--force")
-        .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
-        .stderr_eq(str![[r#"
+    cmd.arg("--force").assert_success().stdout_eq(str![""]).stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
 "#]]);
@@ -558,17 +537,12 @@ Run with the `--force` flag to initialize regardless.
 
 "#]]);
 
-    cmd.arg("--force")
-        .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
-        .stderr_eq(str![[r#"
+    cmd.arg("--force").assert_success().stdout_eq(str![""]).stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
 "#]]);
@@ -605,14 +579,12 @@ forgetest!(can_init_using_parent_repo, |prj, cmd| {
         .arg("--force")
         .arg("--use-parent-git")
         .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
+        .stdout_eq(str![""])
         .stderr_eq(str![[r#"
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
 "#]]);
@@ -639,21 +611,16 @@ Initializing [..]...
 forgetest!(can_init_vscode, |prj, cmd| {
     prj.wipe();
 
-    cmd.arg("init")
-        .arg(prj.root())
-        .arg("--vscode")
-        .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
-        .stderr_eq(str![[r#"
+    cmd.arg("init").arg(prj.root()).arg("--vscode").assert_success().stdout_eq(str![""]).stderr_eq(
+        str![[r#"
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
-"#]]);
+"#]],
+    );
 
     let settings = prj.root().join(".vscode/settings.json");
     assert!(settings.is_file());
@@ -774,8 +741,6 @@ forgetest!(flaky_can_clone, |prj, cmd| {
     .arg(prj.root())
     .assert_success()
     .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
@@ -784,7 +749,9 @@ Compiler run successful!
     .stderr_eq(str![[r#"
 Downloading the source code of 0x044b75f554b886A065b9567891e45c79542d7357 from Etherscan...
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 Collecting the creation information of 0x044b75f554b886A065b9567891e45c79542d7357 from Etherscan...
 
@@ -835,8 +802,6 @@ forgetest!(flaky_can_clone_sourcify, |prj, cmd| {
         .arg(prj.root())
         .assert_success()
         .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
@@ -845,7 +810,9 @@ Compiler run successful!
         .stderr_eq(str![[r#"
 Downloading the source code of 0xDb53f47aC61FE54F456A4eb3E09832D08Dd7BEec from Sourcify...
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 Collecting the creation information of 0xDb53f47aC61FE54F456A4eb3E09832D08Dd7BEec from Sourcify...
 
@@ -872,8 +839,6 @@ forgetest!(flaky_can_clone_no_remappings_txt, |prj, cmd| {
     .arg(prj.root())
     .assert_success()
     .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
@@ -882,7 +847,9 @@ Compiler run successful!
     .stderr_eq(str![[r#"
 Downloading the source code of 0x33e690aEa97E4Ef25F0d140F1bf044d663091DAf from Etherscan...
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 Collecting the creation information of 0x33e690aEa97E4Ef25F0d140F1bf044d663091DAf from Etherscan...
 
@@ -935,17 +902,11 @@ forgetest!(flaky_can_clone_keep_directory_structure, |prj, cmd| {
 forgetest!(can_init_project, |prj, cmd| {
     prj.wipe();
 
-    cmd.args(["init"])
-        .arg(prj.root())
-        .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
-        .stderr_eq(str![[r#"
+    cmd.args(["init"]).arg(prj.root()).assert_success().stdout_eq(str![""]).stderr_eq(str![[r#"
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
 "#]]);
@@ -970,20 +931,16 @@ Initializing [..]...
 forgetest!(can_init_vyper_project, |prj, cmd| {
     prj.wipe();
 
-    cmd.args(["init", "--vyper"])
-        .arg(prj.root())
-        .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
-        .stderr_eq(str![[r#"
+    cmd.args(["init", "--vyper"]).arg(prj.root()).assert_success().stdout_eq(str![""]).stderr_eq(
+        str![[r#"
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
-"#]]);
+"#]],
+    );
 
     assert!(prj.root().join("foundry.toml").exists());
     assert!(prj.root().join("lib/forge-std").exists());
@@ -1009,16 +966,16 @@ forgetest!(can_init_tempo_project, |prj, cmd| {
     cmd.args(["init", "--network", "tempo"])
         .arg(prj.root())
         .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: None)
-    Installed tempo-std[..]
-
-"#]])
+        .stdout_eq(str![""])
         .stderr_eq(str![[r#"
 Initializing [..]...
 ...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
+...
+    Installed forge-std[..]
+Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: None)
+...
+    Installed tempo-std[..]
     Initialized forge project
 
 "#]]);
@@ -1114,8 +1071,6 @@ forgetest!(flaky_can_clone_with_node_modules, |prj, cmd| {
     .arg(prj.root())
     .assert_success()
     .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
@@ -1124,7 +1079,9 @@ Compiler run successful!
     .stderr_eq(str![[r#"
 Downloading the source code of 0xA3E217869460bEf59A1CfD0637e2875F9331e823 from Etherscan...
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 Collecting the creation information of 0xA3E217869460bEf59A1CfD0637e2875F9331e823 from Etherscan...
 
@@ -4559,7 +4516,6 @@ forgetest!(init_status_on_stderr, |prj, cmd| {
         .stdout_eq(str![""])
         .stderr_eq(str![[r#"
 Initializing [..]...
-...
     Initialized forge project
 
 "#]]);

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -499,11 +499,14 @@ forgetest_init!(can_parse_remappings_correctly, |prj, cmd| {
     assert_eq!(expected, output);
 
     let install = |cmd: &mut TestCommand, dep: &str| {
-        cmd.forge_fuse().args(["install", dep]).assert_success().stdout_eq(str![[r#"
+        cmd.forge_fuse().args(["install", dep]).assert_success().stdout_eq(str![""]).stderr_eq(
+            str![[r#"
 Installing solmate in [..] (url: https://github.com/transmissions11/solmate, tag: None)
+...
     Installed solmate[..]
 
-"#]]);
+"#]],
+        );
     };
 
     install(&mut cmd, "transmissions11/solmate");
@@ -1017,11 +1020,14 @@ forgetest!(can_update_libs_section, |prj, cmd| {
     // explicitly set gas_price
     prj.update_config(|config| config.libs = vec!["node_modules".into()]);
 
-    cmd.args(["install", "foundry-rs/forge-std"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["install", "foundry-rs/forge-std"]).assert_success().stdout_eq(str![""]).stderr_eq(
+        str![[r#"
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
+...
     Installed forge-std[..]
 
-"#]]);
+"#]],
+    );
 
     let config = cmd.forge_fuse().config();
     // `lib` was added automatically
@@ -1029,8 +1035,13 @@ Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag:
     assert_eq!(config.libs, expected);
 
     // additional install don't edit `libs`
-    cmd.forge_fuse().args(["install", "dapphub/ds-test"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse()
+        .args(["install", "dapphub/ds-test"])
+        .assert_success()
+        .stdout_eq(str![""])
+        .stderr_eq(str![[r#"
 Installing ds-test in [..] (url: https://github.com/dapphub/ds-test, tag: None)
+...
     Installed ds-test
 
 "#]]);
@@ -1044,11 +1055,14 @@ Installing ds-test in [..] (url: https://github.com/dapphub/ds-test, tag: None)
 forgetest!(config_emit_warnings, |prj, cmd| {
     cmd.git_init();
 
-    cmd.args(["install", "foundry-rs/forge-std"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["install", "foundry-rs/forge-std"]).assert_success().stdout_eq(str![""]).stderr_eq(
+        str![[r#"
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
+...
     Installed forge-std[..]
 
-"#]]);
+"#]],
+    );
 
     let faulty_toml = r"[default]
     src = 'src'

--- a/crates/forge/tests/cli/debug.rs
+++ b/crates/forge/tests/cli/debug.rs
@@ -10,15 +10,13 @@ forgetest!(
         cmd.args(["init", "--force"])
             .arg(prj.root())
             .assert_success()
-            .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
+            .stdout_eq(str![""])
             .stderr_eq(str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
 "#]]);

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -31,14 +31,18 @@ forgetest_init!(can_install_missing_deps_build, |prj, cmd| {
     pretty_err(&forge_std_dir, fs::remove_dir_all(&forge_std_dir));
 
     // Build the project
-    cmd.arg("build").assert_success().stdout_eq(str![[r#"
-Missing dependencies found. Installing now...
-
-[UPDATING_DEPENDENCIES]
+    cmd.arg("build")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 
+"#]])
+        .stderr_eq(str![[r#"
+Missing dependencies found. Installing now...
+[UPDATING_DEPENDENCIES]
+...
 "#]]);
 
     // assert lockfile
@@ -61,10 +65,9 @@ forgetest_init!(can_install_missing_deps_test, |prj, cmd| {
     let forge_std_dir = prj.root().join("lib/forge-std");
     pretty_err(&forge_std_dir, fs::remove_dir_all(&forge_std_dir));
 
-    cmd.arg("test").assert_success().stdout_eq(str![[r#"
-Missing dependencies found. Installing now...
-
-[UPDATING_DEPENDENCIES]
+    cmd.arg("test")
+        .assert_success()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
@@ -76,6 +79,11 @@ Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
 
+"#]])
+        .stderr_eq(str![[r#"
+Missing dependencies found. Installing now...
+[UPDATING_DEPENDENCIES]
+...
 "#]]);
 
     // assert lockfile
@@ -95,13 +103,16 @@ forgetest!(can_install_and_remove, |prj, cmd| {
     let forge_std_mod = git_mod.join("forge-std");
 
     let install = |cmd: &mut TestCommand| {
-        cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success().stdout_eq(
-            str![[r#"
+        cmd.forge_fuse()
+            .args(["install", "foundry-rs/forge-std"])
+            .assert_success()
+            .stdout_eq(str![""])
+            .stderr_eq(str![[r#"
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
+...
     Installed forge-std[..]
 
-"#]],
-        );
+"#]]);
 
         assert!(forge_std.exists());
         assert!(forge_std_mod.exists());
@@ -167,11 +178,15 @@ forgetest!(can_reinstall_after_manual_remove, |prj, cmd| {
     let forge_std_mod = git_mod.join("forge-std");
 
     let install = |cmd: &mut TestCommand| {
-        cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success().stdout_eq(
-            str![[r#"
+        cmd.forge_fuse()
+            .args(["install", "foundry-rs/forge-std"])
+            .assert_success()
+            .stdout_eq(str![""])
+            .stderr_eq(str![[r#"
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std tag=[..]"#]],
-        );
+...
+    Installed forge-std tag=[..]
+"#]]);
 
         assert!(forge_std.exists());
         assert!(forge_std_mod.exists());
@@ -393,13 +408,16 @@ forgetest!(
         let package_mod = git_mod.join("forge-5980-test");
 
         // install main dependency
-        cmd.forge_fuse().args(["install", "evalir/forge-5980-test"]).assert_success().stdout_eq(
-            str![[r#"
+        cmd.forge_fuse()
+            .args(["install", "evalir/forge-5980-test"])
+            .assert_success()
+            .stdout_eq(str![""])
+            .stderr_eq(str![[r#"
 Installing forge-5980-test in [..] (url: https://github.com/evalir/forge-5980-test, tag: None)
+...
     Installed forge-5980-test
 
-"#]],
-        );
+"#]]);
 
         // assert paths exist
         assert!(package.exists());

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1151,21 +1151,17 @@ struct Transaction {
 
 // test we output arguments <https://github.com/foundry-rs/foundry/issues/3053>
 forgetest_async!(can_execute_script_with_arguments, |prj, cmd| {
-    cmd.args(["init", "--force"])
-        .arg(prj.root())
-        .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
-        .stderr_eq(str![[r#"
+    cmd.args(["init", "--force"]).arg(prj.root()).assert_success().stdout_eq(str![""]).stderr_eq(
+        str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
-"#]]);
+"#]],
+    );
 
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let script = prj.add_script(
@@ -1279,21 +1275,17 @@ SIMULATION COMPLETE. To broadcast these transactions, add --broadcast and wallet
 
 // test we output arguments <https://github.com/foundry-rs/foundry/issues/3053>
 forgetest_async!(can_execute_script_with_arguments_nested_deploy, |prj, cmd| {
-    cmd.args(["init", "--force"])
-        .arg(prj.root())
-        .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
-        .stderr_eq(str![[r#"
+    cmd.args(["init", "--force"]).arg(prj.root()).assert_success().stdout_eq(str![""]).stderr_eq(
+        str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
-"#]]);
+"#]],
+    );
 
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let script = prj.add_script(
@@ -1449,21 +1441,17 @@ forgetest_async!(does_script_override_correctly, |prj, cmd| {
 });
 
 forgetest_async!(assert_tx_origin_is_not_overwritten, |prj, cmd| {
-    cmd.args(["init", "--force"])
-        .arg(prj.root())
-        .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
-        .stderr_eq(str![[r#"
+    cmd.args(["init", "--force"]).arg(prj.root()).assert_success().stdout_eq(str![""]).stderr_eq(
+        str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
-"#]]);
+"#]],
+    );
 
     let script = prj.add_script(
         "ScriptTxOrigin.s.sol",
@@ -1535,21 +1523,17 @@ If you wish to simulate on-chain transactions pass a RPC URL.
 });
 
 forgetest_async!(assert_can_create_multiple_contracts_with_correct_nonce, |prj, cmd| {
-    cmd.args(["init", "--force"])
-        .arg(prj.root())
-        .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
-        .stderr_eq(str![[r#"
+    cmd.args(["init", "--force"]).arg(prj.root()).assert_success().stdout_eq(str![""]).stderr_eq(
+        str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
-"#]]);
+"#]],
+    );
 
     let script = prj.add_script(
         "ScriptTxOrigin.s.sol",
@@ -1764,21 +1748,17 @@ Error: Multiple functions with the same name `run` found in the ABI
 });
 
 forgetest_async!(can_decode_custom_errors, |prj, cmd| {
-    cmd.args(["init", "--force"])
-        .arg(prj.root())
-        .assert_success()
-        .stdout_eq(str![[r#"
-Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
-    Installed forge-std[..]
-
-"#]])
-        .stderr_eq(str![[r#"
+    cmd.args(["init", "--force"]).arg(prj.root()).assert_success().stdout_eq(str![""]).stderr_eq(
+        str![[r#"
 Warning: Target directory is not empty, but `--force` was specified
 Initializing [..]...
+Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
 ...
+    Installed forge-std[..]
     Initialized forge project
 
-"#]]);
+"#]],
+    );
 
     let script = prj.add_script(
         "CustomErrorScript.s.sol",

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -122,7 +122,7 @@ Each row's status is one of:
 | `forge test`           | (empty; exit code = pass/fail)                       | JSON test results, JUnit XML with `--junit`| todo   |
 | `forge create`         | Deployed address                                     | JSON `{ "address": "…", "tx_hash": "…", … }` | todo |
 | `forge inspect <field>`| Just that field's value                              | JSON of that field                         | migrated |
-| `forge install`        | (empty)                                              | (empty)                                    | todo   |
+| `forge install`        | (empty)                                              | (empty)                                    | migrated |
 | `forge init`           | (empty)                                              | (empty)                                    | migrated |
 | `forge update`         | (empty)                                              | (empty)                                    | migrated |
 | `forge remove`         | (empty)                                              | (empty)                                    | migrated |


### PR DESCRIPTION
Migrates `forge install` to the stdout/stderr contract in `docs/dev/output-channels.md`.

- stdout: empty (no machine-readable result for this command).
- stderr: all status/progress prose (`Missing dependencies found...`, `Updating dependencies in ...`, `Installing <dep> in <path> (url: ..., tag: ...)`, `    Installed <dep> ...`, soldeer install prose) moved via `sh_status!`.
- Interactive tag/branch selection menus (`There are multiple matching tags:`, candidate rows, selected/cancel messages) also moved to stderr via `sh_status!`; prompts already write to stderr.
- Doc row flipped from `todo` to `migrated`.

Test snapshots updated across `install.rs`, `cmd.rs`, `config.rs`, `debug.rs`, `script.rs`: stdout asserted empty, install prose asserted on stderr (with `...` to absorb interleaved `git Cloning into ...` progress).

Part of OSS-224