### PR TITLE
feat(cli): migrate forge verify-bytecode and audit cast/forge output channels

### DIFF
--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -546,7 +546,7 @@ impl CreateArgs {
         }
 
         if let Some(ts) = expires_at {
-            sh_println!("Transaction expires at unix timestamp {ts}")?;
+            sh_status!("Transaction expires at unix timestamp {ts}")?;
         }
 
         let tempo_sponsor = self.tx.tempo.sponsor_config().await?;
@@ -628,7 +628,7 @@ impl CreateArgs {
             return Ok(());
         }
 
-        sh_println!("Starting contract verification...")?;
+        sh_status!("Starting contract verification...")?;
 
         let num_of_optimizations = if let Some(optimizer) = self.build.compiler.optimize {
             optimizer.then(|| self.build.compiler.optimizer_runs.unwrap_or(200))
@@ -673,7 +673,7 @@ impl CreateArgs {
             .map(|c| c.key)
             .or_else(|| verify_config.etherscan_api_key.clone());
         let resolved_verifier = verify.verifier.resolve(effective_key.as_deref(), Some(chain));
-        sh_println!("Waiting for {resolved_verifier} to detect contract deployment...")?;
+        sh_status!("Waiting for {resolved_verifier} to detect contract deployment...")?;
         verify.run().await
     }
 

--- a/crates/forge/tests/cli/create.rs
+++ b/crates/forge/tests/cli/create.rs
@@ -290,7 +290,7 @@ forgetest_async!(create_resolves_tempo_expires_before_broadcast, |prj, cmd| {
     // explicitly byte code hash for consistent checks
     prj.update_config(|c| c.bytecode_hash = BytecodeHash::None);
 
-    let output = cmd
+    let assert = cmd
         .forge_fuse()
         .args([
             "create",
@@ -303,15 +303,16 @@ forgetest_async!(create_resolves_tempo_expires_before_broadcast, |prj, cmd| {
             "--tempo.expires",
             "30",
         ])
-        .assert_success()
-        .get_output()
-        .stdout_lossy();
+        .assert_success();
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
 
     assert!(
-        output.contains("Transaction expires at unix timestamp "),
-        "expected create to print resolved tempo expiry, got:\n{output}",
+        stderr.contains("Transaction expires at unix timestamp "),
+        "expected create to print resolved tempo expiry, got:\n{stderr}",
     );
-    assert!(output.contains("Deployed to:"), "{output}");
+    assert!(stdout.contains("Deployed to:"), "{stdout}");
 });
 
 // tests that we can deploy the template contract

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -154,7 +154,7 @@ impl VerifyBytecodeArgs {
         }
 
         if !shell::is_json() {
-            sh_println!(
+            sh_status!(
                 "Verifying bytecode for contract {} at address {}",
                 self.contract.name,
                 self.address

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -88,7 +88,7 @@ pub fn build_project(
     config: &Config,
 ) -> Result<CompactContractBytecode> {
     let project = config.project()?;
-    let compiler = ProjectCompiler::new();
+    let compiler = ProjectCompiler::new().quiet(true);
 
     let mut output = compiler.compile(&project)?;
 

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -96,7 +96,7 @@ Each row's status is one of:
 | Command                | Text mode stdout                                     | `--json` stdout                                                | Status |
 | ---------------------- | ---------------------------------------------------- | -------------------------------------------------------------- | ------ |
 | `cast call`            | Return value (hex / decoded)                         | JSON of return value                                           | migrated |
-| `cast send`            | Tx hash                                              | JSON of receipt or `{ "hash": "0x…" }`                         | todo   |
+| `cast send`            | Receipt (or tx hash with `--async`)                  | JSON receipt (or hex tx hash with `--async`)                   | migrated |
 | `cast estimate`        | Gas estimate (decimal)                               | JSON `{ "gas": "…" }`                                          | migrated |
 | `cast rpc`             | RPC result (JSON)                                    | JSON                                                           | migrated |
 | `cast storage`         | Single slot value                                    | JSON of layout                                                 | migrated |
@@ -109,10 +109,17 @@ Each row's status is one of:
 | `cast erc20 balance`   | Balance (decimal)                                    | JSON string                                                    | migrated |
 | `cast create2`         | `address\tsalt` (tab-separated)                      | n/a                                                            | migrated |
 | `cast access-list`     | Access list                                          | JSON                                                           | migrated |
+| `cast interface`       | Solidity interface source                            | JSON ABI array                                                 | migrated |
+| `cast artifact`        | JSON artifact                                        | n/a                                                            | migrated |
+| `cast creation-code`   | Hex bytecode (or disassembly with `--disassemble`)   | n/a                                                            | migrated |
+| `cast constructor-args`| One constructor arg per line                         | n/a                                                            | migrated |
+| `cast b2e-payload`     | JSON execution payload                               | n/a                                                            | migrated |
+| `cast tx-pool`         | JSON                                                 | JSON                                                           | migrated |
 | `cast da-estimate`     | Gas estimate                                         | JSON                                                           | migrated |
 | `cast find-block`      | Block number                                         | JSON                                                           | migrated |
 | `cast mktx`            | Signed RLP                                           | JSON                                                           | migrated |
-| `cast batch-send`      | One tx hash per line                                 | JSON array                                                     | todo   |
+| `cast batch-mktx`      | Signed RLP (or unsigned RLP with `--raw-unsigned`)   | n/a                                                            | migrated |
+| `cast batch-send`      | Receipt (or tx hash with `--async`)                  | JSON receipt (or hex tx hash with `--async`)                   | migrated |
 
 ### `forge`
 
@@ -120,7 +127,7 @@ Each row's status is one of:
 | ---------------------- | ---------------------------------------------------- | ------------------------------------------ | ------ |
 | `forge build`          | (empty)                                              | JSON build output                          | todo   |
 | `forge test`           | (empty; exit code = pass/fail)                       | JSON test results, JUnit XML with `--junit`| todo   |
-| `forge create`         | Deployed address                                     | JSON `{ "address": "…", "tx_hash": "…", … }` | todo |
+| `forge create`         | Deploy: `Deployer:` / `Deployed to:` / `Transaction hash:` lines. Dry-run: `Contract:` / `Transaction:` / `ABI:` lines. Compiler output may precede (tracked under `forge build`). | JSON `{ deployer, deployedTo, transactionHash }` (or dry-run JSON `{ contract, transaction, abi }`) | todo |
 | `forge inspect <field>`| Just that field's value                              | JSON of that field                         | migrated |
 | `forge install`        | (empty)                                              | (empty)                                    | migrated |
 | `forge init`           | (empty)                                              | (empty)                                    | migrated |
@@ -140,12 +147,15 @@ Each row's status is one of:
 | `forge snapshot`       | Per-test diff lines (`--diff`); table (`--format table`); (empty) otherwise | n/a               | migrated |
 | `forge coverage`       | Coverage table or report                             | JSON / LCOV / etc. via `--report`          | todo   |
 | `forge cache`          | (empty) or paths                                     | JSON                                       | migrated |
+| `forge clean`          | (empty)                                              | n/a                                        | migrated |
+| `forge completions`    | Generated shell completion script                    | n/a                                        | migrated |
 | `forge doc`            | (empty)                                              | n/a                                        | migrated |
 | `forge generate`       | (empty) or generated path                            | n/a                                        | migrated |
-| `forge soldeer`        | (empty)                                              | n/a                                        | todo   |
+| `forge soldeer`        | Passthrough to `soldeer` crate; foundry adds no wrapper prose | n/a                               | migrated |
 | `forge remappings`     | One remapping per line                               | n/a                                        | migrated |
 | `forge compiler`       | Compiler info                                        | JSON                                       | migrated |
 | `forge verify-contract`| `<guid-or-job-id>\t<url>` on submission; empty if already verified | n/a                              | migrated |
+| `forge verify-bytecode`| `<type> code matched with status <kind>` lines       | JSON array of `{ bytecode_type, match_type, message }` | migrated |
 
 ### `anvil`, `chisel`, `script`
 


### PR DESCRIPTION
Bundled audit pass for the stdout/stderr contract in `docs/dev/output-channels.md`.

Source migrations:

- `forge create` — three prose lines (`Transaction expires at unix timestamp`, `Starting contract verification...`, `Waiting for <verifier> to detect contract deployment...`) moved from stdout to stderr via `sh_status!`. Row stays `todo` with a caveat because compiler output can still precede the deploy lines (tracked under `forge build`).
- `forge verify-bytecode` — `Verifying bytecode for contract <name> at <address>` prose moved to stderr; `build_project()` now uses `ProjectCompiler::new().quiet(true)` so the local compile no longer leaks to stdout. New row added as `migrated`.

Test fix:

- `create_resolves_tempo_expires_before_broadcast` now reads the expiry status from stderr and the deploy result from stdout.

Doc audits (already-compliant, no source changes):

- `cast send` and `cast batch-send` — flipped to `migrated`; description corrected to reflect actual behavior (receipt by default, hex tx hash with `--async`, JSON variants under `--json`).
- `cast batch-mktx` — new row; signed RLP (or unsigned RLP with `--raw-unsigned`).
- `cast interface`, `cast artifact`, `cast creation-code`, `cast constructor-args`, `cast b2e-payload`, `cast tx-pool` — new rows; already use `sh_status!` for prose and `sh_println!`/`sh_print!` only for primary data.
- `forge clean`, `forge completions` — new rows; stdout-clean by construction.
- `forge soldeer` — flipped to `migrated`; passthrough to the upstream `soldeer` crate, foundry adds no wrapper prose.

Part of OSS-224