### PR TITLE
feat: wire T5 implicit approval behavior and cheatcodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5216,6 +5216,8 @@ dependencies = [
  "serde",
  "serde_json",
  "solar-compiler",
+ "tempo-chainspec",
+ "tempo-precompiles",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "tracing",

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -69,6 +69,9 @@ walkdir.workspace = true
 proptest.workspace = true
 serde.workspace = true
 
+tempo-chainspec.workspace = true
+tempo-precompiles.workspace = true
+
 [features]
 default = ["optimism"]
 optimism = [

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -3182,6 +3182,26 @@
     },
     {
       "func": {
+        "id": "assumeImplicitApproval",
+        "description": "Skips a fuzz/invariant input unless `spender` is implicitly approved.",
+        "declaration": "function assumeImplicitApproval(address spender) external view;",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "assumeImplicitApproval(address)",
+        "selector": "0x7c8cd6d2",
+        "selectorBytes": [
+          124,
+          140,
+          214,
+          210
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "assumeNoRevert_0",
         "description": "Discard this run's fuzz inputs and generate new ones if next call reverted.",
         "declaration": "function assumeNoRevert() external pure;",
@@ -6801,6 +6821,26 @@
         ]
       },
       "group": "filesystem",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "isImplicitlyApproved",
+        "description": "Returns `true` if `spender` is on the active Tempo hardfork's implicit-approval list,\nmeaning it can pull TIP-20 tokens from `msg.sender` without a prior `approve()`.\nReturns `false` on non-Tempo networks.",
+        "declaration": "function isImplicitlyApproved(address spender) external view returns (bool implicitlyApproved);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "isImplicitlyApproved(address)",
+        "selector": "0xa8da6aa7",
+        "selectorBytes": [
+          168,
+          218,
+          106,
+          167
+        ]
+      },
+      "group": "evm",
       "status": "stable",
       "safety": "safe"
     },

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -629,6 +629,16 @@ interface Vm {
     #[cheatcode(group = Evm, safety = Safe)]
     function setEvmVersion(string calldata evm) external;
 
+    /// Returns `true` if `spender` is on the active Tempo hardfork's implicit-approval list,
+    /// meaning it can pull TIP-20 tokens from `msg.sender` without a prior `approve()`.
+    /// Returns `false` on non-Tempo networks.
+    #[cheatcode(group = Evm, safety = Safe)]
+    function isImplicitlyApproved(address spender) external view returns (bool implicitlyApproved);
+
+    /// Skips a fuzz/invariant input unless `spender` is implicitly approved.
+    #[cheatcode(group = Testing, safety = Safe)]
+    function assumeImplicitApproval(address spender) external view;
+
     // -------- Call Manipulation --------
     // --- Mocks ---
 

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -59,6 +59,8 @@ pub use script::{Wallets, WalletsInner};
 
 mod string;
 
+mod tempo;
+
 mod test;
 pub use test::expect::ExpectedCallTracker;
 

--- a/crates/cheatcodes/src/tempo.rs
+++ b/crates/cheatcodes/src/tempo.rs
@@ -1,0 +1,46 @@
+//! Cheatcodes that delegate to the imported Tempo precompile crates.
+
+use std::str::FromStr;
+
+use alloy_sol_types::SolValue;
+use foundry_evm_core::evm::FoundryEvmNetwork;
+use revm::context::ContextTr;
+use spec::Vm::{assumeImplicitApprovalCall, isImplicitlyApprovedCall};
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_precompiles::address_registry;
+
+use crate::{Cheatcode, CheatsCtxt, Error, Result};
+use foundry_config::ExecutionSpec;
+use foundry_evm_core::constants::MAGIC_ASSUME;
+
+/// Resolves the active Tempo hardfork from the cheatcode-visible spec, or `None` on non-Tempo
+/// networks. Goes through the spec's stable string name because the context is generic over
+/// the network type.
+fn active_tempo_hardfork<FEN: FoundryEvmNetwork>(
+    ccx: &CheatsCtxt<'_, '_, FEN>,
+) -> Option<TempoHardfork> {
+    let spec = *ccx.ecx.cfg().spec();
+    TempoHardfork::from_str(&spec.evm_version_name()).ok()
+}
+
+impl Cheatcode for isImplicitlyApprovedCall {
+    fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
+        let Self { spender } = *self;
+        let approved = match active_tempo_hardfork(ccx) {
+            Some(hardfork) => address_registry::is_implicitly_approved(spender, hardfork),
+            None => false,
+        };
+        Ok(approved.abi_encode())
+    }
+}
+
+impl Cheatcode for assumeImplicitApprovalCall {
+    fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
+        let Self { spender } = *self;
+        let approved = match active_tempo_hardfork(ccx) {
+            Some(hardfork) => address_registry::is_implicitly_approved(spender, hardfork),
+            None => false,
+        };
+        if approved { Ok(Default::default()) } else { Err(Error::from(MAGIC_ASSUME)) }
+    }
+}

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -27,12 +27,14 @@ use itertools::Itertools;
 use revm_inspectors::tracing::types::{DecodedCallLog, DecodedCallTrace};
 use std::{collections::BTreeMap, sync::OnceLock};
 use tempo_contracts::precompiles::{
-    IAccountKeychain, IFeeManager, IStablecoinDEX, ITIP20Factory, ITIP403Registry, IValidatorConfig,
+    IAccountKeychain, IAddressRegistry, IFeeManager, IReceivePolicyGuard, ISignatureVerifier,
+    IStablecoinDEX, ITIP20ChannelReserve, ITIP20Factory, ITIP403Registry, IValidatorConfig,
 };
 use tempo_precompiles::{
-    ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS, STABLECOIN_DEX_ADDRESS,
-    TIP_FEE_MANAGER_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS,
-    VALIDATOR_CONFIG_ADDRESS, nonce::INonce, tip20::ITIP20,
+    ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS,
+    RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, STABLECOIN_DEX_ADDRESS,
+    TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS,
+    TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS, nonce::INonce, tip20::ITIP20,
 };
 
 mod precompiles;
@@ -187,6 +189,21 @@ impl CallTraceDecoder {
 
     #[instrument(name = "CallTraceDecoder::init", level = "debug")]
     fn init() -> Self {
+        // Materialized once so the revert decoder can take references below.
+        let tempo_abis = [
+            IFeeManager::abi::contract(),
+            ITIP20::abi::contract(),
+            ITIP403Registry::abi::contract(),
+            ITIP20Factory::abi::contract(),
+            IStablecoinDEX::abi::contract(),
+            INonce::abi::contract(),
+            IValidatorConfig::abi::contract(),
+            IAccountKeychain::abi::contract(),
+            IAddressRegistry::abi::contract(),
+            ITIP20ChannelReserve::abi::contract(),
+            ISignatureVerifier::abi::contract(),
+            IReceivePolicyGuard::abi::contract(),
+        ];
         Self {
             contracts: Default::default(),
             labels: HashMap::from_iter([
@@ -220,6 +237,10 @@ impl CallTraceDecoder {
                 (NONCE_PRECOMPILE_ADDRESS, "Nonce".to_string()),
                 (VALIDATOR_CONFIG_ADDRESS, "ValidatorConfig".to_string()),
                 (ACCOUNT_KEYCHAIN_ADDRESS, "AccountKeychain".to_string()),
+                (ADDRESS_REGISTRY_ADDRESS, "AddressRegistry".to_string()),
+                (TIP20_CHANNEL_RESERVE_ADDRESS, "TIP20ChannelReserve".to_string()),
+                (SIGNATURE_VERIFIER_ADDRESS, "SignatureVerifier".to_string()),
+                (RECEIVE_POLICY_GUARD_ADDRESS, "ReceivePolicyGuard".to_string()),
                 (PATH_USD_ADDRESS, "PathUSD".to_string()),
             ]),
             receive_contracts: Default::default(),
@@ -238,6 +259,10 @@ impl CallTraceDecoder {
                 .chain(INonce::abi::functions().into_values())
                 .chain(IValidatorConfig::abi::functions().into_values())
                 .chain(IAccountKeychain::abi::functions().into_values())
+                .chain(IAddressRegistry::abi::functions().into_values())
+                .chain(ITIP20ChannelReserve::abi::functions().into_values())
+                .chain(ISignatureVerifier::abi::functions().into_values())
+                .chain(IReceivePolicyGuard::abi::functions().into_values())
                 .flatten()
                 .map(|func| (func.selector(), vec![func]))
                 .collect(),
@@ -253,10 +278,15 @@ impl CallTraceDecoder {
                 .chain(INonce::abi::events().into_values())
                 .chain(IValidatorConfig::abi::events().into_values())
                 .chain(IAccountKeychain::abi::events().into_values())
+                .chain(IAddressRegistry::abi::events().into_values())
+                .chain(ITIP20ChannelReserve::abi::events().into_values())
+                .chain(ISignatureVerifier::abi::events().into_values())
+                .chain(IReceivePolicyGuard::abi::events().into_values())
                 .flatten()
                 .map(|event| ((event.selector(), indexed_inputs(&event)), vec![event]))
                 .collect(),
-            revert_decoder: Default::default(),
+            // Decode Tempo precompile custom errors by name in traces.
+            revert_decoder: RevertDecoder::new().with_abis(tempo_abis.iter()),
 
             signature_identifier: None,
             verbosity: 0,

--- a/crates/forge/tests/cli/test_cmd/spec.rs
+++ b/crates/forge/tests/cli/test_cmd/spec.rs
@@ -1,4 +1,5 @@
 use foundry_compilers::artifacts::EvmVersion;
+use foundry_evm::hardforks::{FoundryHardfork, TempoHardfork};
 use foundry_test_utils::{rpc, util::OTHER_SOLC_VERSION};
 
 // Test evm version switch during tests / scripts.
@@ -245,6 +246,24 @@ contract TempoDefaultEvmVersionTest is Test {{
     );
 
     cmd.args(["test", "--network", "tempo", "--mc", "TempoDefaultEvmVersionTest"]).assert_success();
+});
+
+// Validates T5 implicit-approval wiring: the cheatcodes, the AddressRegistry selector,
+// unchanged standard approve/transferFrom behavior, an implicit pull through StablecoinDEX,
+// and a non-implicit spender control case.
+forgetest_init!(test_tempo_implicit_approval_t5, |prj, cmd| {
+    prj.update_config(|config| {
+        config.solc = Some(OTHER_SOLC_VERSION.into());
+        // The precompile registry snapshots `cfg.spec` at EVM construction, so pinning T5
+        // here is what activates the T5 precompiles and selectors. `vm.setEvmVersion` only
+        // flips the cheatcode-visible spec.
+        config.hardfork = Some(FoundryHardfork::Tempo(TempoHardfork::T5));
+    });
+
+    let fixture = include_str!("../../fixtures/TempoImplicitApproval.t.sol");
+    prj.add_test("TempoImplicitApproval.t.sol", fixture);
+
+    cmd.args(["test", "--network", "tempo", "--mc", "TempoImplicitApprovalTest"]).assert_success();
 });
 
 // Regression test for <https://github.com/foundry-rs/foundry/issues/13040>:

--- a/crates/forge/tests/fixtures/TempoImplicitApproval.t.sol
+++ b/crates/forge/tests/fixtures/TempoImplicitApproval.t.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.20;
+
+import {Test, Vm} from "forge-std/Test.sol";
+
+interface EvmVm {
+    function getEvmVersion() external pure returns (string memory evm);
+    function setEvmVersion(string calldata evm) external;
+    function isImplicitlyApproved(address spender) external view returns (bool);
+    function assumeImplicitApproval(address spender) external view;
+}
+
+interface IAddressRegistry {
+    function isImplicitlyApproved(address addr) external view returns (bool);
+}
+
+interface ITIP20 {
+    function approve(address spender, uint256 amount) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+}
+
+interface IStablecoinDEX {
+    function place(address token, uint128 amount, bool isBid, int16 tick)
+        external
+        returns (uint128 orderId);
+    function MIN_ORDER_AMOUNT() external pure returns (uint128);
+}
+
+contract TempoImplicitApprovalTest is Test {
+    EvmVm constant evm = EvmVm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    // Well-known Tempo precompile addresses (mirrors of `tempo-contracts` constants).
+    address constant TIP_FEE_MANAGER = 0xfeEC000000000000000000000000000000000000;
+    address constant STABLECOIN_DEX = 0xDEc0000000000000000000000000000000000000;
+    address constant TIP20_CHANNEL_RESERVE = 0x4d50500000000000000000000000000000000000;
+    address constant ADDRESS_REGISTRY = 0xfDC0000000000000000000000000000000000000;
+    address constant PATH_USD = 0x20C0000000000000000000000000000000000000;
+    // AlphaUSD has `quote_token = PATH_USD`, so a DEX bid on ALPHA escrows PATH_USD.
+    address constant ALPHA_USD = 0x20C0000000000000000000000000000000000001;
+
+    // Foundry's default test sender; genesis mints the fee tokens to this address.
+    address constant TEST_SENDER = 0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38;
+
+    /// On non-T5 specs the implicit list is empty.
+    function test_cheatcode_isImplicitlyApproved_reports_pre_t5() public {
+        evm.setEvmVersion("T4");
+        assertEq(evm.getEvmVersion(), "t4");
+        assertFalse(evm.isImplicitlyApproved(TIP_FEE_MANAGER));
+        assertFalse(evm.isImplicitlyApproved(STABLECOIN_DEX));
+        assertFalse(evm.isImplicitlyApproved(TIP20_CHANNEL_RESERVE));
+        assertFalse(evm.isImplicitlyApproved(address(0xBEEF)));
+    }
+
+    /// On T5 the three listed precompiles are implicitly approved; nothing else is.
+    function test_isImplicitlyApproved_t5() public view {
+        assertTrue(evm.isImplicitlyApproved(TIP_FEE_MANAGER));
+        assertTrue(evm.isImplicitlyApproved(STABLECOIN_DEX));
+        assertTrue(evm.isImplicitlyApproved(TIP20_CHANNEL_RESERVE));
+        assertFalse(evm.isImplicitlyApproved(address(0xBEEF)));
+        assertFalse(evm.isImplicitlyApproved(TEST_SENDER));
+    }
+
+    /// The cheatcode and the on-chain AddressRegistry selector agree.
+    function test_cheatcode_matches_registry_selector_t5() public view {
+        address[4] memory probes = [
+            TIP_FEE_MANAGER,
+            STABLECOIN_DEX,
+            TIP20_CHANNEL_RESERVE,
+            address(0xBEEF)
+        ];
+        for (uint256 i = 0; i < probes.length; i++) {
+            bool fromCheat = evm.isImplicitlyApproved(probes[i]);
+            bool fromRegistry = IAddressRegistry(ADDRESS_REGISTRY).isImplicitlyApproved(probes[i]);
+            assertEq(fromCheat, fromRegistry, "cheatcode and registry disagree");
+        }
+    }
+
+    /// Standard `approve` + `allowance` + `transferFrom` and their events are unchanged.
+    function test_standard_approve_flow_unchanged_t5() public {
+        ITIP20 token = ITIP20(PATH_USD);
+
+        address owner = TEST_SENDER;
+        address spender = address(0xCAFE);
+        address recipient = address(0xBEEF);
+
+        vm.recordLogs();
+
+        vm.prank(owner);
+        assertTrue(token.approve(spender, 1_000));
+        assertEq(token.allowance(owner, spender), 1_000);
+
+        uint256 ownerBefore = token.balanceOf(owner);
+        uint256 recipientBefore = token.balanceOf(recipient);
+
+        vm.prank(spender);
+        assertTrue(token.transferFrom(owner, recipient, 250));
+
+        assertEq(token.balanceOf(owner), ownerBefore - 250);
+        assertEq(token.balanceOf(recipient), recipientBefore + 250);
+        assertEq(token.allowance(owner, spender), 750);
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        bytes32 transferSig = keccak256("Transfer(address,address,uint256)");
+        bytes32 approvalSig = keccak256("Approval(address,address,uint256)");
+        bool sawTransfer;
+        bool sawApproval;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].emitter != PATH_USD) continue;
+            if (entries[i].topics.length == 0) continue;
+            if (entries[i].topics[0] == transferSig) sawTransfer = true;
+            if (entries[i].topics[0] == approvalSig) sawApproval = true;
+        }
+        assertTrue(sawTransfer, "standard Transfer event missing");
+        assertTrue(sawApproval, "standard Approval event missing");
+    }
+
+    /// A bid on the DEX pulls the quote token from the sender with no prior approve, leaves
+    /// allowance at zero, and still emits a standard `Transfer` event.
+    function test_implicit_spender_pulls_without_approve_t5() public {
+        IStablecoinDEX dex = IStablecoinDEX(STABLECOIN_DEX);
+        ITIP20 quote = ITIP20(PATH_USD);
+
+        address payer = TEST_SENDER;
+        uint128 amount = dex.MIN_ORDER_AMOUNT();
+
+        assertEq(quote.allowance(payer, STABLECOIN_DEX), 0, "precondition: no prior approval");
+
+        uint256 payerBefore = quote.balanceOf(payer);
+        uint256 dexBefore = quote.balanceOf(STABLECOIN_DEX);
+
+        // Fail if any `approve(STABLECOIN_DEX, *)` is made on PATH_USD during the flow.
+        vm.expectCall(
+            PATH_USD,
+            abi.encodeWithSelector(ITIP20.approve.selector, STABLECOIN_DEX),
+            0
+        );
+
+        vm.recordLogs();
+
+        // is_bid=true at tick=0 escrows `amount` units of the quote token (PATH_USD).
+        vm.prank(payer);
+        uint128 orderId = dex.place(ALPHA_USD, amount, true, 0);
+        assertGt(uint256(orderId), 0, "order id must be non-zero");
+
+        assertEq(quote.balanceOf(payer), payerBefore - amount, "payer balance not debited");
+        assertEq(quote.balanceOf(STABLECOIN_DEX), dexBefore + amount, "DEX balance not credited");
+        assertEq(quote.allowance(payer, STABLECOIN_DEX), 0, "allowance must remain zero");
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        bytes32 transferSig = keccak256("Transfer(address,address,uint256)");
+        bool sawTransfer;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].emitter != PATH_USD) continue;
+            if (entries[i].topics.length == 0) continue;
+            if (entries[i].topics[0] == transferSig) {
+                sawTransfer = true;
+                break;
+            }
+        }
+        assertTrue(sawTransfer, "Transfer event missing");
+    }
+
+    /// Control: an unlisted spender still needs a prior approve.
+    function test_non_implicit_spender_requires_approve_t5() public {
+        ITIP20 token = ITIP20(PATH_USD);
+        address payer = TEST_SENDER;
+        address spender = address(0xBEEF);
+
+        assertFalse(evm.isImplicitlyApproved(spender));
+        assertEq(token.allowance(payer, spender), 0);
+
+        vm.prank(spender);
+        vm.expectRevert();
+        token.transferFrom(payer, spender, 1);
+    }
+
+    /// `assumeImplicitApproval` is a no-op for a listed spender.
+    function test_assumeImplicitApproval_positive_t5() public view {
+        evm.assumeImplicitApproval(TIP_FEE_MANAGER);
+    }
+}

--- a/testdata/utils/Vm.sol
+++ b/testdata/utils/Vm.sol
@@ -152,6 +152,7 @@ interface Vm {
     function assertTrue(bool condition) external pure;
     function assertTrue(bool condition, string calldata err) external pure;
     function assume(bool condition) external pure;
+    function assumeImplicitApproval(address spender) external view;
     function assumeNoRevert() external pure;
     function assumeNoRevert(PotentialRevert calldata potentialRevert) external pure;
     function assumeNoRevert(PotentialRevert[] calldata potentialReverts) external pure;
@@ -333,6 +334,7 @@ interface Vm {
     function isContext(ForgeContext context) external view returns (bool result);
     function isDir(string calldata path) external view returns (bool result);
     function isFile(string calldata path) external view returns (bool result);
+    function isImplicitlyApproved(address spender) external view returns (bool implicitlyApproved);
     function isPersistent(address account) external view returns (bool persistent);
     function keyExists(string calldata json, string calldata key) external view returns (bool);
     function keyExistsJson(string calldata json, string calldata key) external view returns (bool);


### PR DESCRIPTION
Wires T5 implicit-approval behavior through the imported Tempo precompile crates. Adds `vm.isImplicitlyApproved` and `vm.assumeImplicitApproval` cheatcodes, trace-decoder labels/ABIs for the relevant precompiles, and a forge fixture covering positive and negative spender paths.

Closes OSS-270