### PR TITLE
feat(anvil): migrate anvil to stdout/stderr contract

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -663,11 +663,11 @@ pub struct AnvilEvmArgs {
     #[arg(long, visible_alias = "tracing")]
     pub steps_tracing: bool,
 
-    /// Disable printing of `console.log` invocations to stdout.
+    /// Disable printing of `console.log` invocations to stderr.
     #[arg(long, visible_alias = "no-console-log")]
     pub disable_console_log: bool,
 
-    /// Enable printing of traces for executed transactions and `eth_call` to stdout.
+    /// Enable printing of traces for executed transactions and `eth_call` to stderr.
     #[arg(long, visible_alias = "enable-trace-printing")]
     pub print_traces: bool,
 

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -985,14 +985,14 @@ impl NodeConfig {
         self
     }
 
-    /// Sets whether to print `console.log` invocations to stdout.
+    /// Sets whether to print `console.log` invocations to stderr.
     #[must_use]
     pub const fn with_print_logs(mut self, print_logs: bool) -> Self {
         self.print_logs = print_logs;
         self
     }
 
-    /// Sets whether to print traces to stdout.
+    /// Sets whether to print traces to stderr.
     #[must_use]
     pub const fn with_print_traces(mut self, print_traces: bool) -> Self {
         self.print_traces = print_traces;
@@ -1040,7 +1040,7 @@ impl NodeConfig {
             foundry_common::fs::write_json_file(path, &value).wrap_err("failed writing JSON")?;
         }
         if !self.silent {
-            sh_println!("{}", self.as_string(fork))?;
+            sh_eprintln!("{}", self.as_string(fork))?;
         }
         Ok(())
     }
@@ -1100,7 +1100,7 @@ impl NodeConfig {
         self
     }
 
-    /// Makes the node silent to not emit anything on stdout
+    /// Makes the node silent to not emit any banner/status output
     #[must_use]
     pub const fn silent(self) -> Self {
         self.set_silent(true)

--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -37,9 +37,9 @@ pub struct AnvilInspector {
 /// Configuration for per-transaction inspector lifecycle.
 #[derive(Clone, Debug)]
 pub struct InspectorTxConfig {
-    /// Whether to print traces to stdout.
+    /// Whether to print traces to stderr.
     pub print_traces: bool,
-    /// Whether to print logs to stdout.
+    /// Whether to print logs to stderr.
     pub print_logs: bool,
     /// Whether to enable step-level tracing (with state diffs).
     pub enable_steps_tracing: bool,

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -323,9 +323,9 @@ impl NodeHandle {
         self.config.print(fork)?;
         if !self.config.silent {
             if let Some(ipc_path) = self.ipc_path() {
-                sh_println!("IPC path: {ipc_path}")?;
+                sh_eprintln!("IPC path: {ipc_path}")?;
             }
-            sh_println!(
+            sh_eprintln!(
                 "Listening on {}",
                 self.addresses
                     .iter()
@@ -484,7 +484,7 @@ pub fn init_tracing() -> LoggingManager {
             rust_log_val.parse().expect("failed to parse modified RUST_LOG");
         tracing_subscriber::registry()
             .with(env_filter)
-            .with(tracing_subscriber::fmt::layer())
+            .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
             .try_init()
     } else {
         tracing_subscriber::Registry::default()
@@ -493,7 +493,8 @@ pub fn init_tracing() -> LoggingManager {
                 tracing_subscriber::fmt::layer()
                     .without_time()
                     .with_target(false)
-                    .with_level(false),
+                    .with_level(false)
+                    .with_writer(std::io::stderr),
             )
             .try_init()
     };

--- a/crates/anvil/src/logging.rs
+++ b/crates/anvil/src/logging.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tracing::{Metadata, subscriber::Interest};
 use tracing_subscriber::{Layer, layer::Context};
 
-/// The target that identifies the events intended to be logged to stdout
+/// The target that identifies the events intended to be logged to stderr
 pub(crate) const NODE_USER_LOG_TARGET: &str = "node::user";
 
 /// The target that identifies the events coming from the `console.log` invocations.
@@ -14,7 +14,7 @@ pub(crate) const EVM_CONSOLE_LOG_TARGET: &str = "node::console";
 /// A logger that listens for node related events and displays them.
 ///
 /// This layer is intended to be used as filter for `NODE_USER_LOG_TARGET` events that will
-/// eventually be logged to stdout
+/// eventually be logged to stderr
 #[derive(Clone, Debug, Default)]
 pub struct NodeLogLayer {
     state: LoggingManager,

--- a/crates/anvil/tests/it/machine.rs
+++ b/crates/anvil/tests/it/machine.rs
@@ -4,7 +4,7 @@
 
 use std::{
     io::{BufRead, BufReader, Read},
-    process::{Child, Command, Stdio},
+    process::{Child, ChildStderr, Command, Stdio},
     time::{Duration, Instant},
 };
 
@@ -16,22 +16,22 @@ fn sigint(pid: u32) {
 
 /// Spawns `anvil --port 0` with extra args and waits for the startup
 /// handshake before returning the running child.
-fn spawn_anvil(extra: &[&str]) -> (Child, BufReader<std::process::ChildStdout>) {
+fn spawn_anvil(extra: &[&str]) -> (Child, BufReader<ChildStderr>) {
     let bin = env!("CARGO_BIN_EXE_anvil");
     let mut cmd = Command::new(bin);
     cmd.args(["--port", "0"]).args(extra).stdout(Stdio::piped()).stderr(Stdio::piped());
     let mut child = cmd.spawn().expect("anvil spawn");
-    let stdout = BufReader::new(child.stdout.take().unwrap());
+    let stderr = BufReader::new(child.stderr.take().unwrap());
 
     if extra.contains(&"--machine") {
         // `--machine` silences the "Listening on" banner and the structured
         // `session_start` handshake is not yet implemented; fall back to a
         // fixed grace period for bind + ctrlc-handler registration.
         std::thread::sleep(Duration::from_secs(5));
-        return (child, stdout);
+        return (child, stderr);
     }
 
-    let mut stdout = stdout;
+    let mut stderr = stderr;
     let deadline = Instant::now() + Duration::from_secs(30);
     loop {
         if Instant::now() > deadline {
@@ -39,7 +39,7 @@ fn spawn_anvil(extra: &[&str]) -> (Child, BufReader<std::process::ChildStdout>) 
             panic!("anvil did not start within 30s");
         }
         let mut line = String::new();
-        if stdout.read_line(&mut line).unwrap_or(0) == 0 {
+        if stderr.read_line(&mut line).unwrap_or(0) == 0 {
             std::thread::sleep(Duration::from_millis(20));
             continue;
         }
@@ -47,7 +47,7 @@ fn spawn_anvil(extra: &[&str]) -> (Child, BufReader<std::process::ChildStdout>) 
             break;
         }
     }
-    (child, stdout)
+    (child, stderr)
 }
 
 /// Waits up to 10s for the child to exit and returns its numeric exit code.
@@ -55,8 +55,11 @@ fn wait_for_exit(mut child: Child) -> i32 {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         if let Some(status) = child.try_wait().unwrap() {
-            // Drain residual output so the pipe never blocks the child.
+            // Drain residual output so the pipes never block the child.
             if let Some(mut s) = child.stdout.take() {
+                let _ = s.read_to_string(&mut String::new());
+            }
+            if let Some(mut s) = child.stderr.take() {
                 let _ = s.read_to_string(&mut String::new());
             }
             return status.code().unwrap_or(-1);
@@ -72,7 +75,7 @@ fn wait_for_exit(mut child: Child) -> i32 {
 // Legacy `anvil` exits 0 on SIGINT — the historical contract.
 #[test]
 fn anvil_sigint_legacy_exits_zero() {
-    let (child, _stdout) = spawn_anvil(&[]);
+    let (child, _stderr) = spawn_anvil(&[]);
     sigint(child.id());
     assert_eq!(wait_for_exit(child), 0);
 }
@@ -80,7 +83,58 @@ fn anvil_sigint_legacy_exits_zero() {
 // `anvil --machine` maps SIGINT to `ExitCode::Interrupted` (8).
 #[test]
 fn anvil_sigint_machine_exits_eight() {
-    let (child, _stdout) = spawn_anvil(&["--machine"]);
+    let (child, _stderr) = spawn_anvil(&["--machine"]);
     sigint(child.id());
     assert_eq!(wait_for_exit(child), 8);
+}
+
+// Locks the stdout/stderr contract in `docs/dev/output-channels.md`: a normal
+// `anvil` invocation must emit no bytes on stdout — banner, accounts, IPC
+// path, `Listening on …`, and runtime tracing all belong on stderr.
+#[test]
+fn anvil_default_stdout_is_empty() {
+    let bin = env!("CARGO_BIN_EXE_anvil");
+    let mut child = Command::new(bin)
+        .args(["--port", "0"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("anvil spawn");
+    let mut stdout = child.stdout.take().unwrap();
+    let mut stderr = BufReader::new(child.stderr.take().unwrap());
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            panic!("anvil did not start within 30s");
+        }
+        let mut line = String::new();
+        if stderr.read_line(&mut line).unwrap_or(0) == 0 {
+            std::thread::sleep(Duration::from_millis(20));
+            continue;
+        }
+        if line.contains("Listening on") {
+            break;
+        }
+    }
+
+    sigint(child.id());
+    let exit_deadline = Instant::now() + Duration::from_secs(10);
+    while child.try_wait().unwrap().is_none() {
+        if Instant::now() > exit_deadline {
+            let _ = child.kill();
+            panic!("anvil did not exit within 10s of SIGINT");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    let mut stdout_bytes = Vec::new();
+    let _ = stdout.read_to_end(&mut stdout_bytes);
+    assert!(
+        stdout_bytes.is_empty(),
+        "anvil stdout must be empty, got {} bytes: {}",
+        stdout_bytes.len(),
+        String::from_utf8_lossy(&stdout_bytes),
+    );
 }

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -151,9 +151,20 @@ Each row's status is one of:
 
 | Command       | Text mode stdout                              | `--json` stdout       | Status |
 | ------------- | --------------------------------------------- | --------------------- | ------ |
-| `anvil`       | Banner, accounts, RPC URL on stderr           | n/a                   | todo   |
+| `anvil`       | (empty)                                       | n/a                   | migrated |
 | `chisel`      | REPL output                                   | n/a                   | todo   |
 | `forge script`| Simulation/broadcast result                   | JSON                  | todo   |
+
+`anvil` startup/status output — banner, accounts, IPC path, RPC URL, mined
+block/tx logs, `console.log` output, and `--print-traces` — is diagnostic
+output emitted on stderr. `--config-out <path>` writes anvil's JSON
+configuration to the given file and does not affect stdout, and
+`--dump-state` / `--state` write state snapshots to files (`anvil_dumpState`
+returns its payload over the RPC connection, not process stdout). As with
+other commands, global discovery modes such as `--help`, `--version`, and
+machine-mode envelopes write their primary result to stdout. The
+`anvil completions <shell>` subcommand writes its shell completion script to
+stdout because that is its primary result.
 
 Commands not listed here have not been classified yet — please open an issue or
 PR before relying on their stdout format.


### PR DESCRIPTION
Migrates `anvil` to the stdout/stderr contract in `docs/dev/output-channels.md`.

- Startup banner, accounts, IPC path, and `Listening on …` move from stdout to stderr (`sh_println!` → `sh_eprintln!` in `Config::print` and `NodeHandle::print`).
- `init_tracing` routes both `fmt::layer()` branches to stderr via `.with_writer(std::io::stderr)`, so `node_info!`, mined block/tx logs, `console.log` output, and `--print-traces` no longer leak to stdout.
- Stale comments and CLI help in `cmd.rs` / `config.rs` / `logging.rs` / `inspector.rs` updated.
- Doc row flipped to `migrated`; stdout column is `(empty)`. Added a paragraph documenting the exceptions: `--config-out`, `--dump-state` / `--state`, `anvil_dumpState` RPC, discovery modes (`--help`, `--version`), machine-mode envelopes, and `anvil completions`.
- `tests/it/machine.rs::spawn_anvil` now reads the readiness handshake from stderr; new `anvil_default_stdout_is_empty` regression test spawns the real binary, waits for `Listening on` on stderr, SIGINTs, and asserts stdout is exactly 0 bytes.

Likely breaking: scripts that previously read `anvil` stdout for the `Listening on` line must now read stderr, redirect `2>&1`, or poll the RPC endpoint.

Part of OSS-224
