### PR TITLE
fix(forge): drop `tempo:T3` hardfork pin on `MailRelayTest` template

### DIFF
--- a/crates/forge/assets/tempo/MailTemplate.t.sol
+++ b/crates/forge/assets/tempo/MailTemplate.t.sol
@@ -63,8 +63,7 @@ contract MailTest is Test {
     }
 }
 
-/// @notice Tests for relayed mail using the TIP-1020 SignatureVerifier precompile (requires T3).
-/// forge-config: default.hardfork = "tempo:T3"
+/// @notice Tests for relayed mail using the TIP-1020 SignatureVerifier precompile (requires T3+).
 contract MailRelayTest is MailTest {
     // secp256k1 keys (used by vm.sign / vm.addr)
     uint256 internal constant ALICE_PK = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;


### PR DESCRIPTION
## Problem

The Tempo project template installed by `forge init -n tempo` pins
`MailRelayTest` to `tempo:T3` via an inline `forge-config` annotation,
overriding any CLI / env / `foundry.toml` hardfork. On Tempo devnets
that activate a later fork (e.g. T6) at genesis, the T3 spec reads
T6-packed TIP20 `UserState` storage and fee accounting panics in
`setUp`:

```
[FAIL: EVM error; Panic(UnderOverflow)] setUp() (gas: 0)
```

## Fix

Drop the pin and reword the comment as "requires T3+" (the original
intent — TIP-1020 `SignatureVerifier` shipped in T3, so the test
needs at least T3, but pinning *exactly* to T3 was unnecessary and
now harmful).