### PR TITLE
fix(fmt): keep wrapped NatSpec tags separate

### DIFF
--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -706,16 +706,23 @@ impl<'sess> State<'sess, '_> {
             if i + 1 < lines.len() {
                 let next_line = &lines[i + 1];
 
-                // Check if next line is has the same prefix and is not empty
+                // Check if next line has the same prefix and is not empty.
                 if next_line.starts_with(prefix) && !next_line.trim().is_empty() {
+                    let next_content = next_line[prefix.len()..].trim_start();
+
+                    // Keep each NatSpec tag on its own doc-comment line. Merging a wrapped
+                    // `@dev`/`@param` line with the following tag changes the tag boundary.
+                    if next_content.starts_with('@') {
+                        result.push(current_line.clone());
+                        i += 1;
+                        continue;
+                    }
+
                     // Only merge if the current line doesn't fit within available width
                     if estimate_line_width(current_line, self.config.tab_width) > self.space_left()
                     {
                         // Merge the lines and let the wrapper handle breaking if needed
-                        let merged_line = format!(
-                            "{current_line} {next_content}",
-                            next_content = next_line[prefix.len()..].trim_start()
-                        );
+                        let merged_line = format!("{current_line} {next_content}");
                         result.push(merged_line);
 
                         // Skip both lines since they are merged

--- a/crates/fmt/testdata/DocComments/block.fmt.sol
+++ b/crates/fmt/testdata/DocComments/block.fmt.sol
@@ -64,6 +64,12 @@ contract HelloWorld {
      */
     function docLineOverflow() external {}
 
+    /**
+     * @dev No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed.
+     * @dev Zero checks are not systematically performed.
+     */
+    function adjacentDocTagsOverflow() external {}
+
     function docLinePostfixOverflow() external {}
 
     /**

--- a/crates/fmt/testdata/DocComments/fmt.sol
+++ b/crates/fmt/testdata/DocComments/fmt.sol
@@ -53,6 +53,10 @@ contract HelloWorld {
     /// A long doc line comment that will be wrapped
     function docLineOverflow() external {}
 
+    /// @dev No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed.
+    /// @dev Zero checks are not systematically performed.
+    function adjacentDocTagsOverflow() external {}
+
     function docLinePostfixOverflow() external {}
 
     /// A long doc line comment that will be wrapped

--- a/crates/fmt/testdata/DocComments/line.fmt.sol
+++ b/crates/fmt/testdata/DocComments/line.fmt.sol
@@ -46,6 +46,10 @@ contract HelloWorld {
     /// A long doc line comment that will be wrapped
     function docLineOverflow() external {}
 
+    /// @dev No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed.
+    /// @dev Zero checks are not systematically performed.
+    function adjacentDocTagsOverflow() external {}
+
     function docLinePostfixOverflow() external {}
 
     /// A long doc line comment that will be wrapped

--- a/crates/fmt/testdata/DocComments/original.sol
+++ b/crates/fmt/testdata/DocComments/original.sol
@@ -50,6 +50,10 @@ contract HelloWorld {
     /// A long doc line comment that will be wrapped
     function docLineOverflow() external {}
 
+    /// @dev No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed.
+    /// @dev Zero checks are not systematically performed.
+    function adjacentDocTagsOverflow() external {}
+
     function docLinePostfixOverflow() external {} /// A long doc line comment that will be wrapped
 
     /**

--- a/crates/fmt/testdata/DocComments/tab.fmt.sol
+++ b/crates/fmt/testdata/DocComments/tab.fmt.sol
@@ -54,6 +54,10 @@ contract HelloWorld {
 	/// A long doc line comment that will be wrapped
 	function docLineOverflow() external {}
 
+	/// @dev No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed.
+	/// @dev Zero checks are not systematically performed.
+	function adjacentDocTagsOverflow() external {}
+
 	function docLinePostfixOverflow() external {}
 
 	/// A long doc line comment that will be wrapped

--- a/crates/fmt/testdata/DocComments/wrap-comments.fmt.sol
+++ b/crates/fmt/testdata/DocComments/wrap-comments.fmt.sol
@@ -62,6 +62,15 @@ contract HelloWorld {
     /// wrapped
     function docLineOverflow() external {}
 
+    /// @dev No-ops are allowed. No-ops are
+    /// allowed. No-ops are allowed. No-ops
+    /// are allowed. No-ops are allowed.
+    /// No-ops are allowed.
+    /// @dev Zero checks are not
+    /// systematically performed.
+    function adjacentDocTagsOverflow()
+        external {}
+
     function docLinePostfixOverflow()
         external {}
 

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -227,6 +227,39 @@ fmt_tests! {
 }
 
 #[test]
+fn test_wrap_comments_preserves_natspec_tag_boundaries() {
+    init_tracing();
+    let source = r#"pragma solidity ^0.8.0;
+
+contract C {
+    /// @dev No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed.
+    /// @dev Zero checks are not systematically performed.
+    function f() external {}
+}
+"#;
+
+    let expected = r#"pragma solidity ^0.8.0;
+
+contract C {
+    /// @dev No-ops are allowed. No-ops are
+    /// allowed. No-ops are allowed. No-ops
+    /// are allowed. No-ops are allowed.
+    /// No-ops are allowed.
+    /// @dev Zero checks are not
+    /// systematically performed.
+    function f() external {}
+}
+"#;
+
+    let fmt_config =
+        Arc::new(FormatterConfig { line_length: 40, wrap_comments: true, ..Default::default() });
+    let path = Path::new("test.sol");
+    let formatted = format(source, path, fmt_config);
+
+    assert_eq!(formatted, expected, "Formatting mismatch");
+}
+
+#[test]
 fn test_comment_empty_line_bug() {
     init_tracing();
     let source = r#"pragma solidity ^0.8.0;

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -227,39 +227,6 @@ fmt_tests! {
 }
 
 #[test]
-fn test_wrap_comments_preserves_natspec_tag_boundaries() {
-    init_tracing();
-    let source = r#"pragma solidity ^0.8.0;
-
-contract C {
-    /// @dev No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed.
-    /// @dev Zero checks are not systematically performed.
-    function f() external {}
-}
-"#;
-
-    let expected = r#"pragma solidity ^0.8.0;
-
-contract C {
-    /// @dev No-ops are allowed. No-ops are
-    /// allowed. No-ops are allowed. No-ops
-    /// are allowed. No-ops are allowed.
-    /// No-ops are allowed.
-    /// @dev Zero checks are not
-    /// systematically performed.
-    function f() external {}
-}
-"#;
-
-    let fmt_config =
-        Arc::new(FormatterConfig { line_length: 40, wrap_comments: true, ..Default::default() });
-    let path = Path::new("test.sol");
-    let formatted = format(source, path, fmt_config);
-
-    assert_eq!(formatted, expected, "Formatting mismatch");
-}
-
-#[test]
 fn test_comment_empty_line_bug() {
     init_tracing();
     let source = r#"pragma solidity ^0.8.0;


### PR DESCRIPTION
## Summary
- fixes `wrap_comments = true` merging a following NatSpec tag into the previous wrapped doc comment
- preserves each `@...` NatSpec tag as its own doc-comment line before wrapping
- adds a regression test for adjacent `@dev` comments

## Why
With long NatSpec comments, `forge fmt` could wrap the first line and append the next tag body to it, turning the second `@dev` into regular text on the continuation line.

## Changes
- skip smart line-comment merging when the next line's content starts with a NatSpec tag
- keep existing wrapping behavior for ordinary continuation lines

## Validation
- `cargo fmt --check`
- `cargo test -p forge-fmt --test formatter test_wrap_comments_preserves_natspec_tag_boundaries -- --nocapture`
- `cargo test -p forge-fmt --test formatter DocComments -- --nocapture`

## Scope
Focused forge fmt regression fix.

Closes #15025