### PR TITLE
fix(fmt): natspec comment wrapping

### DIFF
--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -708,14 +708,18 @@ impl<'sess> State<'sess, '_> {
 
                 // Check if next line is has the same prefix and is not empty
                 if next_line.starts_with(prefix) && !next_line.trim().is_empty() {
+                    let next_content = next_line[prefix.len()..].trim_start();
+                    if prefix == "///" && is_natspec_tag(next_content) {
+                        result.push(current_line.clone());
+                        i += 1;
+                        continue;
+                    }
+
                     // Only merge if the current line doesn't fit within available width
                     if estimate_line_width(current_line, self.config.tab_width) > self.space_left()
                     {
                         // Merge the lines and let the wrapper handle breaking if needed
-                        let merged_line = format!(
-                            "{current_line} {next_content}",
-                            next_content = next_line[prefix.len()..].trim_start()
-                        );
+                        let merged_line = format!("{current_line} {next_content}");
                         result.push(merged_line);
 
                         // Skip both lines since they are merged
@@ -1147,6 +1151,13 @@ fn snippet_with_tabs(s: String, tab_width: usize) -> String {
     }
 
     formatted
+}
+
+fn is_natspec_tag(content: &str) -> bool {
+    let Some(tag) = content.strip_prefix('@') else {
+        return false;
+    };
+    tag.chars().next().is_some_and(|c| c.is_ascii_alphabetic())
 }
 
 /// Formats a doc comment with the requested style.

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -250,3 +250,33 @@ contract ProofOfConcept {
 
     assert_eq!(formatted, expected, "Formatting mismatch");
 }
+
+#[test]
+fn test_wrapped_natspec_tags_do_not_merge() {
+    init_tracing();
+    let source = r#"pragma solidity ^0.8.0;
+
+contract ProofOfConcept {
+    /// @dev No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed.
+    /// @dev Zero checks are not systematically performed.
+    function run() external {}
+}
+"#;
+
+    let expected = r#"pragma solidity ^0.8.0;
+
+contract ProofOfConcept {
+    /// @dev No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops are allowed. No-ops
+    /// are allowed.
+    /// @dev Zero checks are not systematically performed.
+    function run() external {}
+}
+"#;
+
+    let fmt_config =
+        Arc::new(FormatterConfig { line_length: 120, wrap_comments: true, ..Default::default() });
+    let path = Path::new("test.sol");
+    let formatted = format(source, path, fmt_config);
+
+    assert_eq!(formatted, expected, "Formatting mismatch");
+}


### PR DESCRIPTION
## Summary

Fixes `forge fmt` comment wrapping so adjacent NatSpec line comments keep separate tags on separate doc lines.

## Root Cause

When `wrap_comments = true`, the formatter merges consecutive line comments before wrapping to avoid orphan words. That merge path also joined a long NatSpec line with the following `/// @dev` line, causing the second tag to become ordinary text on the wrapped continuation line.

## Changes

- Treat a following `/// @tag` NatSpec line as a boundary during line-comment merging.
- Add a regression test for the reported adjacent `@dev` case.

## Validation

- `cargo test -p forge-fmt test_wrapped_natspec_tags_do_not_merge`
- `cargo +nightly fmt`
- `cargo +nightly clippy --all --all-features --all-targets -- -D warnings`

Fixes #15025
