### PR TITLE
fix(mutation): handle cancellation without progress UI

### DIFF
--- a/crates/forge/src/mutation/orchestrator.rs
+++ b/crates/forge/src/mutation/orchestrator.rs
@@ -249,7 +249,7 @@ pub async fn run_mutation_testing(
         };
 
         // Run mutations in parallel using isolated workspaces
-        let results = run_mutations_parallel_with_progress(
+        let batch = run_mutations_parallel_with_progress(
             mutants_to_test.clone(),
             path.clone(),
             handler.src.clone(),
@@ -262,11 +262,12 @@ pub async fn run_mutation_testing(
             Arc::new(mutation_config.selected_sources_relative.clone()),
             mutation_config.isolate,
         )?;
+        let file_cancelled = batch.cancelled;
 
         // Collect results for caching
-        let mut results_vec = Vec::with_capacity(skipped_results.len() + results.len());
+        let mut results_vec = Vec::with_capacity(skipped_results.len() + batch.results.len());
         results_vec.extend(skipped_results);
-        for result in results {
+        for result in batch.results {
             results_vec.push((result.mutant.clone(), result.result.clone()));
             match result.result {
                 MutationResult::Dead => handler.add_dead_mutant(result.mutant),
@@ -284,7 +285,6 @@ pub async fn run_mutation_testing(
         // complete before persisting it. Without this guard a Ctrl+C mid-run
         // would write a *partial* results vector to the cache and the next run
         // would treat that subset as the full answer for this file.
-        let file_cancelled = progress.as_ref().is_some_and(|p| p.is_cancelled());
         let complete_run = !file_cancelled && results_vec.len() == mutants.len();
 
         // Persist results for caching only when the run for this file is

--- a/crates/forge/src/mutation/orchestrator.rs
+++ b/crates/forge/src/mutation/orchestrator.rs
@@ -6,7 +6,15 @@
 //! - Running mutations in parallel with caching
 //! - Aggregating results and reporting
 
-use std::{collections::HashSet, path::PathBuf, sync::Arc, time::Instant};
+use std::{
+    collections::HashSet,
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Instant,
+};
 
 use alloy_primitives::keccak256;
 use eyre::{Result, WrapErr};
@@ -152,8 +160,22 @@ pub async fn run_mutation_testing(
     let mut mutation_summary = MutationsSummary::new();
     let mut cancelled = false;
     let start_time = Instant::now();
+    let cancellation_requested = Arc::new(AtomicBool::new(false));
+    let ctrlc_handle = {
+        let cancellation_requested = Arc::clone(&cancellation_requested);
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                cancellation_requested.store(true, Ordering::SeqCst);
+            }
+        })
+    };
 
     for path in mutate_paths {
+        if cancellation_requested.load(Ordering::SeqCst) {
+            cancelled = true;
+            break;
+        }
+
         if !mutation_config.show_progress && !json_output {
             sh_println!("Running mutation tests for {}", path.display())?;
         }
@@ -261,6 +283,7 @@ pub async fn run_mutation_testing(
             mutation_config.filter_args.clone(),
             Arc::new(mutation_config.selected_sources_relative.clone()),
             mutation_config.isolate,
+            Arc::clone(&cancellation_requested),
         )?;
         let file_cancelled = batch.cancelled;
 
@@ -322,6 +345,7 @@ pub async fn run_mutation_testing(
             break;
         }
     }
+    cancelled |= cancellation_requested.load(Ordering::SeqCst);
 
     // Report results
     let duration = start_time.elapsed();
@@ -331,6 +355,8 @@ pub async fn run_mutation_testing(
     if !json_output {
         MutationReporter::new().report(&mutation_summary, duration);
     }
+
+    ctrlc_handle.abort();
 
     Ok(MutationRunResult { summary: mutation_summary, cancelled, duration_secs })
 }

--- a/crates/forge/src/mutation/runner.rs
+++ b/crates/forge/src/mutation/runner.rs
@@ -51,6 +51,13 @@ pub struct MutantTestResult {
     pub result: MutationResult,
 }
 
+/// Result of a parallel mutation batch.
+#[derive(Debug, Clone)]
+pub struct MutationBatchResult {
+    pub results: Vec<MutantTestResult>,
+    pub cancelled: bool,
+}
+
 /// Tracks progress and adaptive span skipping across parallel workers.
 pub struct SharedMutationState {
     /// Spans where mutations have survived - shared across workers for adaptive skipping.
@@ -192,10 +199,10 @@ pub fn run_mutations_parallel_with_progress(
     filter_args: FilterArgs,
     selected_sources_relative: Arc<Vec<PathBuf>>,
     isolate: bool,
-) -> Result<Vec<MutantTestResult>> {
+) -> Result<MutationBatchResult> {
     let total = mutants.len();
     if total == 0 {
-        return Ok(vec![]);
+        return Ok(MutationBatchResult { results: vec![], cancelled: false });
     }
 
     // Default to available parallelism if num_workers is 0
@@ -238,9 +245,18 @@ pub fn run_mutations_parallel_with_progress(
 
     workspace::ensure_safe_relative_path(&source_relative, "source", &source_abs)?;
 
-    // Set up Ctrl+C handler using a background thread with tokio signal
-    // This replaces ctrlc crate with tokio's built-in signal handling
-    let ctrlc_handle = shared_state.progress.is_some().then(|| {
+    // Configure rayon thread pool
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(num_workers)
+        .stack_size(16 * 1024 * 1024) // 16MB stack to avoid overflow in deep call chains
+        .build()
+        .map_err(|e| eyre::eyre!("Failed to create thread pool: {}", e))?;
+
+    // Set up Ctrl+C handling for every mutation run, not only the progress UI
+    // path. The shutdown channel lets us join the listener when this batch
+    // finishes instead of leaving a parked thread behind after each run.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let ctrlc_handle = {
         let state_for_ctrlc = Arc::clone(&shared_state);
         std::thread::spawn(move || {
             let rt = tokio::runtime::Builder::new_current_thread()
@@ -248,19 +264,17 @@ pub fn run_mutations_parallel_with_progress(
                 .build()
                 .expect("Failed to create tokio runtime for signal handler");
             rt.block_on(async {
-                if tokio::signal::ctrl_c().await.is_ok() {
-                    state_for_ctrlc.cancel();
+                tokio::select! {
+                    signal = tokio::signal::ctrl_c() => {
+                        if signal.is_ok() {
+                            state_for_ctrlc.cancel();
+                        }
+                    }
+                    _ = shutdown_rx => {}
                 }
             });
         })
-    });
-
-    // Configure rayon thread pool
-    let pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(num_workers)
-        .stack_size(16 * 1024 * 1024) // 16MB stack to avoid overflow in deep call chains
-        .build()
-        .map_err(|e| eyre::eyre!("Failed to create thread pool: {}", e))?;
+    };
 
     // Use a thread-safe collection to store results as they complete
     let completed_results: Arc<Mutex<Vec<MutantTestResult>>> =
@@ -337,22 +351,23 @@ pub fn run_mutations_parallel_with_progress(
         let _ = handle.join();
     }
 
+    let cancelled = shared_state.is_cancelled();
+
     // Clear progress and handle cancellation
     if let Some(ref progress) = shared_state.progress {
         progress.clear();
-        if shared_state.is_cancelled() && !shared_state.silent {
-            let _ = sh_println!(
-                "\nMutation testing cancelled. Showing results for {} completed mutants.\n",
-                results.len()
-            );
-        }
+    }
+    if cancelled && !shared_state.silent {
+        let _ = sh_println!(
+            "\nMutation testing cancelled. Showing results for {} completed mutants.\n",
+            results.len()
+        );
     }
 
-    // The signal handler thread will exit when the program exits,
-    // no need to join it since it's waiting on a signal that won't come after cancellation
-    drop(ctrlc_handle);
+    let _ = shutdown_tx.send(());
+    let _ = ctrlc_handle.join();
 
-    Ok(results)
+    Ok(MutationBatchResult { results, cancelled })
 }
 
 /// Test a single mutant in an isolated temporary workspace.

--- a/crates/forge/src/mutation/runner.rs
+++ b/crates/forge/src/mutation/runner.rs
@@ -82,55 +82,18 @@ pub struct SharedMutationState {
 }
 
 impl SharedMutationState {
-    pub fn new() -> Self {
-        Self::with_cancellation(Arc::new(AtomicBool::new(false)))
-    }
-
-    pub fn with_cancellation(cancelled: Arc<AtomicBool>) -> Self {
-        Self {
-            survived_spans: Mutex::new(SurvivedSpans::new()),
-            completed: AtomicUsize::new(0),
-            total: AtomicUsize::new(0),
-            cancelled,
-            progress: None,
-            silent: false,
-            pending_workers: Mutex::new(Vec::new()),
-            max_pending_workers: AtomicUsize::new(usize::MAX),
-        }
-    }
-
-    pub fn new_silent() -> Self {
-        Self::silent_with_cancellation(Arc::new(AtomicBool::new(false)))
-    }
-
-    pub fn silent_with_cancellation(cancelled: Arc<AtomicBool>) -> Self {
-        Self {
-            survived_spans: Mutex::new(SurvivedSpans::new()),
-            completed: AtomicUsize::new(0),
-            total: AtomicUsize::new(0),
-            cancelled,
-            progress: None,
-            silent: true,
-            pending_workers: Mutex::new(Vec::new()),
-            max_pending_workers: AtomicUsize::new(usize::MAX),
-        }
-    }
-
-    pub fn with_progress(progress: MutationProgress) -> Self {
-        Self::with_progress_and_cancellation(progress, Arc::new(AtomicBool::new(false)))
-    }
-
-    pub fn with_progress_and_cancellation(
-        progress: MutationProgress,
+    pub fn new(
         cancelled: Arc<AtomicBool>,
+        silent: bool,
+        progress: Option<MutationProgress>,
     ) -> Self {
         Self {
             survived_spans: Mutex::new(SurvivedSpans::new()),
             completed: AtomicUsize::new(0),
             total: AtomicUsize::new(0),
             cancelled,
-            progress: Some(progress),
-            silent: false,
+            progress,
+            silent,
             pending_workers: Mutex::new(Vec::new()),
             max_pending_workers: AtomicUsize::new(usize::MAX),
         }
@@ -196,7 +159,7 @@ impl SharedMutationState {
 
 impl Default for SharedMutationState {
     fn default() -> Self {
-        Self::new()
+        Self::new(Arc::new(AtomicBool::new(false)), false, None)
     }
 }
 
@@ -228,13 +191,7 @@ pub fn run_mutations_parallel_with_progress(
         num_workers
     };
 
-    let shared_state = Arc::new(if let Some(p) = progress {
-        SharedMutationState::with_progress_and_cancellation(p, cancellation_requested)
-    } else if silent {
-        SharedMutationState::silent_with_cancellation(cancellation_requested)
-    } else {
-        SharedMutationState::with_cancellation(cancellation_requested)
-    });
+    let shared_state = Arc::new(SharedMutationState::new(cancellation_requested, silent, progress));
     shared_state.total.store(total, Ordering::SeqCst);
     shared_state.set_max_pending_workers(num_workers);
 
@@ -766,7 +723,7 @@ mod tests {
 
     #[test]
     fn park_timed_out_worker_bounds_pending_handles() {
-        let state = SharedMutationState::new();
+        let state = SharedMutationState::default();
         state.set_max_pending_workers(1);
 
         state.park_timed_out_worker(std::thread::spawn(|| {}));

--- a/crates/forge/src/mutation/runner.rs
+++ b/crates/forge/src/mutation/runner.rs
@@ -66,7 +66,7 @@ pub struct SharedMutationState {
     pub completed: AtomicUsize,
     pub total: AtomicUsize,
     /// Cancellation flag (Ctrl+C)
-    pub cancelled: AtomicBool,
+    pub cancelled: Arc<AtomicBool>,
     /// Optional progress display
     pub progress: Option<MutationProgress>,
     /// Whether to suppress all output (for JSON mode)
@@ -83,11 +83,15 @@ pub struct SharedMutationState {
 
 impl SharedMutationState {
     pub fn new() -> Self {
+        Self::with_cancellation(Arc::new(AtomicBool::new(false)))
+    }
+
+    pub fn with_cancellation(cancelled: Arc<AtomicBool>) -> Self {
         Self {
             survived_spans: Mutex::new(SurvivedSpans::new()),
             completed: AtomicUsize::new(0),
             total: AtomicUsize::new(0),
-            cancelled: AtomicBool::new(false),
+            cancelled,
             progress: None,
             silent: false,
             pending_workers: Mutex::new(Vec::new()),
@@ -96,11 +100,15 @@ impl SharedMutationState {
     }
 
     pub fn new_silent() -> Self {
+        Self::silent_with_cancellation(Arc::new(AtomicBool::new(false)))
+    }
+
+    pub fn silent_with_cancellation(cancelled: Arc<AtomicBool>) -> Self {
         Self {
             survived_spans: Mutex::new(SurvivedSpans::new()),
             completed: AtomicUsize::new(0),
             total: AtomicUsize::new(0),
-            cancelled: AtomicBool::new(false),
+            cancelled,
             progress: None,
             silent: true,
             pending_workers: Mutex::new(Vec::new()),
@@ -109,11 +117,18 @@ impl SharedMutationState {
     }
 
     pub fn with_progress(progress: MutationProgress) -> Self {
+        Self::with_progress_and_cancellation(progress, Arc::new(AtomicBool::new(false)))
+    }
+
+    pub fn with_progress_and_cancellation(
+        progress: MutationProgress,
+        cancelled: Arc<AtomicBool>,
+    ) -> Self {
         Self {
             survived_spans: Mutex::new(SurvivedSpans::new()),
             completed: AtomicUsize::new(0),
             total: AtomicUsize::new(0),
-            cancelled: AtomicBool::new(false),
+            cancelled,
             progress: Some(progress),
             silent: false,
             pending_workers: Mutex::new(Vec::new()),
@@ -199,6 +214,7 @@ pub fn run_mutations_parallel_with_progress(
     filter_args: FilterArgs,
     selected_sources_relative: Arc<Vec<PathBuf>>,
     isolate: bool,
+    cancellation_requested: Arc<AtomicBool>,
 ) -> Result<MutationBatchResult> {
     let total = mutants.len();
     if total == 0 {
@@ -213,11 +229,11 @@ pub fn run_mutations_parallel_with_progress(
     };
 
     let shared_state = Arc::new(if let Some(p) = progress {
-        SharedMutationState::with_progress(p)
+        SharedMutationState::with_progress_and_cancellation(p, cancellation_requested)
     } else if silent {
-        SharedMutationState::new_silent()
+        SharedMutationState::silent_with_cancellation(cancellation_requested)
     } else {
-        SharedMutationState::new()
+        SharedMutationState::with_cancellation(cancellation_requested)
     });
     shared_state.total.store(total, Ordering::SeqCst);
     shared_state.set_max_pending_workers(num_workers);
@@ -251,30 +267,6 @@ pub fn run_mutations_parallel_with_progress(
         .stack_size(16 * 1024 * 1024) // 16MB stack to avoid overflow in deep call chains
         .build()
         .map_err(|e| eyre::eyre!("Failed to create thread pool: {}", e))?;
-
-    // Set up Ctrl+C handling for every mutation run, not only the progress UI
-    // path. The shutdown channel lets us join the listener when this batch
-    // finishes instead of leaving a parked thread behind after each run.
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    let ctrlc_handle = {
-        let state_for_ctrlc = Arc::clone(&shared_state);
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed to create tokio runtime for signal handler");
-            rt.block_on(async {
-                tokio::select! {
-                    signal = tokio::signal::ctrl_c() => {
-                        if signal.is_ok() {
-                            state_for_ctrlc.cancel();
-                        }
-                    }
-                    _ = shutdown_rx => {}
-                }
-            });
-        })
-    };
 
     // Use a thread-safe collection to store results as they complete
     let completed_results: Arc<Mutex<Vec<MutantTestResult>>> =
@@ -363,9 +355,6 @@ pub fn run_mutations_parallel_with_progress(
             results.len()
         );
     }
-
-    let _ = shutdown_tx.send(());
-    let _ = ctrlc_handle.join();
 
     Ok(MutationBatchResult { results, cancelled })
 }


### PR DESCRIPTION
## Summary

Fixes mutation testing cancellation when `--show-progress` is not enabled.

## Changes

- Install Ctrl+C handling for every mutation run, not only progress UI runs.
- Return cancellation state from the mutation runner batch result.
- Use that cancellation state in the orchestrator to avoid persisting partial result caches.